### PR TITLE
fix(gate): string literals beat comment openers in module-reachability's stripper

### DIFF
--- a/scripts/check-module-reachability.py
+++ b/scripts/check-module-reachability.py
@@ -71,6 +71,21 @@ def strip_comments(src: str) -> str:
 
     Raw strings get their hash count matched (`r#"…"#`) so a quoted `"` inside
     one does not end it early.
+
+    Char literals are tracked for the same reason strings are (#2732). A
+    `'"'` — an ordinary `match c { '"' => … }` arm, and this file has several
+    — puts a lone `"` in the source that is not a string boundary at all. Left
+    unrecognized, that `"` was mistaken for opening a real string, which then
+    swallowed forward looking for the next `"` to close it; whatever real code
+    fell inside that stolen span — including a later genuine `/*` — was
+    misread as string content instead of a comment opener, and the code
+    *after* that span had its lexer state shifted by one `"`, occasionally
+    landing exactly on a `/*` that would otherwise have paired correctly. That
+    is what happened to `crates/stella-tools/src/scripts.rs`'s
+    `pattern.strip_suffix("/*")`: not the `/*` itself, but an unrelated `'"'`
+    several hundred lines earlier. A `'` is tried as a char literal first
+    (an escape, or one plain character, then a closing `'`); a lifetime
+    (`'a`, `'static`) never closes that way and falls through untouched.
     """
     out: list[str] = []
     i, n = 0, len(src)
@@ -101,6 +116,32 @@ def strip_comments(src: str) -> str:
             out.append("  ")
             i += 2
             continue
+        if src[i] == "'":
+            # A char literal (`'"'`, `'\''`, `'\n'`, `'\u{2019}'`, `'a'`) is
+            # exactly one escape-or-char followed by a closing `'`. A
+            # lifetime (`'a`, `'static`) is not — nothing after its
+            # identifier closes it — so probe for the close before
+            # committing; on failure, fall through and consume the `'`
+            # itself as an ordinary character.
+            j = i + 1
+            if j < n and src[j] == "\\":
+                j += 1
+                if j < n and src[j] == "x":
+                    j += 3  # \xNN — the 'x' plus two hex digits
+                elif j < n and src[j] == "u":
+                    j += 1
+                    if j < n and src[j] == "{":
+                        while j < n and src[j] != "}":
+                            j += 1
+                        j += 1  # the closing brace
+                else:
+                    j += 1  # the escaped character itself
+            elif j < n:
+                j += 1  # one plain character
+            if j < n and src[j] == "'":
+                out.append(src[i : j + 1])
+                i = j + 1
+                continue
         if src[i] == '"':
             out.append('"')
             i += 1

--- a/scripts/test-module-reachability.sh
+++ b/scripts/test-module-reachability.sh
@@ -165,6 +165,69 @@ printf 'pub fn f() {}\n' >"$c/src/foo.rs"
 track "$TMP/raw_string"
 want "S2 the same through a raw string with an embedded quote" expect-pass "$TMP/raw_string"
 
+# #2732: a `'"'` char-literal match arm (e.g. `matches!(c, '"')`) puts a lone
+# `"` in the source that is not a string boundary. Unrecognized, the stripper
+# mistook it for one and searched forward for the next `"` to close it — which
+# turned out to be the opening quote of a real `"/*"` string later in the
+# file, so the genuine `/*` right after it was read as a comment-opener
+# instead of string content and never found its `*/`, blanking everything to
+# EOF and hiding the `mod foo;` at the end. This is the exact shape from
+# `crates/stella-tools/src/scripts.rs`'s `pattern.strip_suffix("/*")`.
+c="$(new_crate char_lit_quote)"
+{
+  printf 'fn is_quote(c: char) -> bool {\n'
+  printf "    matches!(c, '\"')\n"
+  printf '}\n\n'
+  printf 'fn expand(pattern: &str) -> Option<&str> {\n'
+  printf '    pattern.strip_suffix("/*").or_else(|| pattern.strip_suffix("/**"))\n'
+  printf '}\n\n'
+  printf 'mod foo;\n'
+} >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/char_lit_quote"
+want "S4 a '\"' char literal does not misalign a later \"/*\" string boundary" \
+  expect-pass "$TMP/char_lit_quote"
+
+# The nested variant: the second strip_suffix candidate is "/**" (Rust block
+# comments nest, so an unmatched "/*" plus a later "/**" would deepen rather
+# than close if either were misread as a comment).
+c="$(new_crate char_lit_quote_nested)"
+{
+  printf 'fn is_quote(c: char) -> bool {\n'
+  printf "    matches!(c, '\"')\n"
+  printf '}\n\n'
+  printf 'fn expand(pattern: &str) -> Option<&str> {\n'
+  printf '    let base = pattern\n'
+  printf '        .strip_suffix("/*")\n'
+  printf '        .or_else(|| pattern.strip_suffix("/**"));\n'
+  printf '    base\n'
+  printf '}\n\n'
+  printf 'mod foo;\n'
+} >"$c/src/lib.rs"
+printf 'pub fn f() {}\n' >"$c/src/foo.rs"
+track "$TMP/char_lit_quote_nested"
+want "S5 the nested \"/**\" variant on the following line is still reachable" \
+  expect-pass "$TMP/char_lit_quote_nested"
+
+# The `mod` declaration as the very last line after both strings — the shape
+# that silently orphaned crates/stella-tools/src/scripts/tests.rs.
+c="$(new_crate char_lit_quote_last_line)"
+{
+  printf 'fn is_quote(c: char) -> bool {\n'
+  printf "    matches!(c, '\"')\n"
+  printf '}\n\n'
+  printf 'fn expand(pattern: &str) -> Option<&str> {\n'
+  printf '    pattern.strip_suffix("/*").or_else(|| pattern.strip_suffix("/**"))\n'
+  printf '}\n\n'
+  printf 'pub fn a() {}\n'
+  printf '#[cfg(test)]\n'
+  printf 'mod tests;\n'
+} >"$c/src/lib.rs"
+printf '#[test]\nfn t() {}\n' >"$c/src/tests.rs"
+track "$TMP/char_lit_quote_last_line"
+want "S6 a mod declared as the file's last line survives both string shapes" \
+  expect-pass "$TMP/char_lit_quote_last_line"
+
 # The other direction: a real comment must still be stripped, so a `mod` named
 # only in prose does not count as a declaration.
 c="$(new_crate comment_mod)"


### PR DESCRIPTION
## What & why

`scripts/check-module-reachability.py`'s `strip_comments` had zero handling
for Rust char literals. A `'"'` match arm (`matches!(c, '"')`, `c == '"'`,
`'"' => { … }` — several exist in `crates/stella-tools/src/scripts.rs`) puts
a lone `"` in the source that is **not** a string boundary. The stripper
mistook it for one anyway and searched forward for the next real `"` to
close the fake string it thought it had opened — which, several hundred
lines later, turned out to be the *opening* quote of the real string in
`pattern.strip_suffix("/*")`. That stole the genuine `/*` right after it
into "string content" instead of recognizing it as a comment opener, so the
stripper's block-comment state never found a matching `*/` and blanked
everything to EOF — falsely orphaning every `mod` declaration after that
point, including `#[cfg(test)] mod tests;` at the bottom of the file.

So the actual trigger is not the `"/*"` string in isolation (a minimal file
containing only `pattern.strip_suffix("/*").or_else(|| pattern.strip_suffix("/**"))`
followed by `mod m;` already stripped correctly, verified below) — it's an
**unrelated** `'"'` char literal earlier in the same file shifting the
lexer's `"` parity by one, so a later, otherwise-harmless `/*` inside a
string lands exactly on the wrong side of that shift and gets read as a
real comment opener.

### Fix

`strip_comments` now tries a char literal first at a `'`: an escape (`\'`,
`\"`, `\n`, `\xNN`, `\u{...}`, …) or one plain character, followed by a
closing `'`, commits as a char literal — its content is copied through
untouched, the same treatment strings already get. Anything that doesn't
close that way (a lifetime like `'a` or `'static`) falls through to the
existing per-character path unchanged, so lifetimes are unaffected.

Closes #2732

## The witness

`scripts/test-module-reachability.sh` is this guard's own test harness (not
part of `make gate` — it builds throwaway fixture repos). Added three cases
reproducing the actual scripts.rs shape:

- **S4** — a `'"'` char literal followed by `pattern.strip_suffix("/*")`
- **S5** — the nested `"/**"` variant on the following line (issue's exact
  multi-line shape)
- **S6** — a `mod` declaration as the file's very last line, after both
  string forms (the shape that orphaned `scripts/tests.rs` for real)

**Fail-then-pass evidence** (`git stash` on `check-module-reachability.py`
only, harness unchanged):

Unfixed (`git stash push -- scripts/check-module-reachability.py`):
```
FAIL S4 a '"' char literal does not misalign a later "/*" string boundary — expected OK, got:
FAIL S5 the nested "/**" variant on the following line is still reachable — expected OK, got:
FAIL S6 a mod declared as the file's last line survives both string shapes — expected OK, got:
passed 14, failed 3
```

Fixed (`git stash pop`):
```
ok   S4 a '"' char literal does not misalign a later "/*" string boundary
ok   S5 the nested "/**" variant on the following line is still reachable
ok   S6 a mod declared as the file's last line survives both string shapes
passed 17, failed 0
```

All 14 pre-existing cases (O1-O2, N1-N7, S1-S3, P1, R1) still pass — no
regression to the string/raw-string/lifetime handling those cover.

### Reproducer output (issue's repro, adapted)

Before the fix, appending a temporary `mod x;` after
`crates/stella-tools/src/scripts.rs`'s `expand_member_pattern` trigger (in a
`/tmp` scratch copy, never the tracked file) showed the swallow directly:

```
stripped: []          # (or missing the appended mod, depending on file tail)
plain: ['gate', 'extra_test_mod']
```

After the fix, against the same scratch copy:

```
stripped: ['gate', 'extra_test_mod']
plain: ['gate', 'extra_test_mod']
```

## The gate

- [x] `bash scripts/test-module-reachability.sh` — 17 passed, 0 failed
- [x] `make module-reachability` — OK, 934 source file(s) across 23 crate(s)
- [x] `make guards-fast` — all toolchain-free guards pass (Python/shell-only
      change; no cargo build/test/clippy run, matching the change's scope)
- [ ] `cargo fmt --check` / clippy / `cargo test --workspace` — N/A, no Rust
      changed
- [x] `Closes #2732` appears above and as a commit trailer

## Nothing left behind

- [x] There is nothing new: everything I noticed is fixed in this PR.

PR #2714 (which works around this bug by declaring `mod tests;` earlier in
`crates/stella-tools/src/scripts.rs`, before the swallow point) is **still
open** (`gh pr view 2714` → `state: OPEN`, `mergedAt: null`) as of this PR.
Per the issue's step 5, the workaround removal is **deferred** — no comment
in `scripts.rs` currently references `#2732` to remove, and `scripts.rs`
itself is untouched by this PR. Whoever lands #2714's `mod tests;`
workaround later can drop it once this fix has merged; not tracked as a
separate issue since #2714 already owns that file's diff.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types touched (Python/shell gate script only)

## Anything reviewers should know?

This is marked **draft** per the task's instructions — not to be marked
ready by this session.

## Summary by Sourcery

Handle Rust char literals in the module-reachability comment stripper and add regression tests for the previously misparsed pattern.

Bug Fixes:
- Prevent lone '"' char literals from being misinterpreted as string boundaries that cause comment-stripping to swallow subsequent code.

Enhancements:
- Extend strip_comments to recognize and preserve Rust-style char literals, including escaped and Unicode forms, while leaving lifetimes unchanged.

Tests:
- Add three module-reachability harness cases that reproduce the char-literal and "/*" pattern scenario to guard against regressions.