### PR TITLE
feat(stella-core): anchor context-size accounting to provider-reported usage

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -130,6 +130,7 @@ use tokio::sync::mpsc::UnboundedSender;
 mod dispatch;
 mod drive;
 mod settlement;
+pub(crate) mod usage_anchor;
 mod waiting;
 use settlement::{BudgetWarnings, emit_budget_warning, record_settled_cost};
 
@@ -481,11 +482,10 @@ pub struct Engine<'a> {
     pub(crate) hooks: Option<HooksHandle<'a>>,
     /// Token-drift calibration (`crate::estimator::CalibrationMap`), off by
     /// default. Attached via [`Engine::with_calibration`]; the caller owns
-    /// the map across turns (and seeds it from persisted telemetry at
-    /// session start), the engine feeds it every committed step's
-    /// (estimated, actual) pair and reads the correction back into the
-    /// compaction decision. When `None` the turn path is exactly the
-    /// uncalibrated engine.
+    /// the map across turns (seeded from persisted telemetry at session
+    /// start), the engine feeds it every committed step's (estimated,
+    /// actual) pair and reads the correction back into the compaction
+    /// decision. When `None` the turn path is the uncalibrated engine.
     pub(crate) calibration: Option<&'a CalibrationMap>,
     /// Boundary pause gate ([`crate::ports::TurnGate`]), off by default.
     /// Attached via [`Engine::with_gate`]; consulted once per step, before
@@ -988,9 +988,12 @@ impl<'a> Engine<'a> {
         snapshot_result_identities(&state.messages, &mut state.memos.identities, revision);
         // Live while the calibration still answers identity, then latched at
         // the first corrected value (#1841, #2133): compaction and the
-        // manifest below always compare against the same settled number.
+        // manifest below compare against the same settled number. On top of
+        // that pair, the last usage report re-bases the budget so the
+        // estimator prices only the tail since it (#2681, `usage_anchor`).
         let fresh = self.effective_compaction_budget(state.calibration_model.as_deref());
-        let sized = state.latch_effective_budget(fresh);
+        let latched = state.latch_effective_budget(fresh);
+        let sized = state.anchored_budget(latched, self.config.compaction_budget_tokens);
         let pass = self
             .run_compaction_pass(
                 &mut state.messages,
@@ -1006,8 +1009,7 @@ impl<'a> Engine<'a> {
             state.mark_transcript_rewritten();
         }
         // The manifest reports the budget compaction just compared against —
-        // now the same latched value, not a second computation that happened
-        // to agree.
+        // the same anchored value, never a second computation.
         state.memos.receipts.set_effective_budget(sized.0, sized.1);
         // Set immediately after the pass that may have rewritten the
         // transcript, so the ledger's digest memo cannot serve a stale block.
@@ -1079,6 +1081,9 @@ impl<'a> Engine<'a> {
         });
         state.last_step = Some(step_started.elapsed());
         state.calibration_model = Some(committed.result.model.clone());
+        // Anchor the context measure to what the provider just attested for
+        // this exact prefix — before dispatch appends the reply to it.
+        state.anchor_usage(&committed.result.usage, committed.estimated_input_tokens);
         state.total_cost_usd += committed.result.cost_usd;
 
         if let Some(aborted) = self.handle_committed_result(
@@ -1104,8 +1109,7 @@ impl<'a> Engine<'a> {
         }
 
         // Only meaningful once a step has been timed and a budget configured:
-        // the forecast for one more continuation is what the last one cost, and
-        // without a deadline there is nothing to compare it against.
+        // the forecast for one more continuation is what the last one cost.
         let continuation_budget =
             self.config
                 .turn_budget
@@ -1176,22 +1180,21 @@ impl<'a> Engine<'a> {
         TurnState::from_checkpoint(checkpoint, &self.config)
     }
 
-    /// The compaction budget this turn's next step will actually compare
-    /// against, and the calibration factor that produced it. Single source of
-    /// truth for both the compaction pass and the step manifest, so the
-    /// receipt's `effective_budget_tokens` is exactly the number the decision
-    /// used (#364 item 1). Returns the configured budget with factor `1.0`
-    /// when calibration is off.
+    /// The calibrated compaction budget and the factor that produced it —
+    /// the configured budget with factor `1.0` when calibration is off.
+    /// `TurnState::anchored_budget` then re-bases this on the last usage
+    /// report, and THAT value is the single source of truth for both the
+    /// compaction pass and the step manifest, so the receipt's
+    /// `effective_budget_tokens` is exactly the number the decision used
+    /// (#364 item 1).
     ///
     /// Drift correction enters here: `compact` compares the RAW estimate
-    /// against the budget it is given, so dividing the configured budget
-    /// by the correction factor is exactly comparing the CALIBRATED
-    /// estimate (raw × factor) against the configured budget — including
-    /// the eviction loop's stopping condition — without threading a factor
-    /// through compaction's incremental bookkeeping. A factor > 1 (we
-    /// under-estimate this model's tokenizer) shrinks the effective budget
-    /// and compacts earlier; the factor's clamp (`crate::estimator`)
-    /// bounds how far either way a noisy sample can move this.
+    /// against the budget it is given, so dividing the configured budget by
+    /// the correction factor is exactly comparing the CALIBRATED estimate
+    /// (raw × factor) against the configured budget, without threading a
+    /// factor through compaction's bookkeeping. A factor > 1 (we
+    /// under-estimate this model's tokenizer) compacts earlier; the clamp
+    /// (`crate::estimator`) bounds how far a noisy sample can move this.
     fn effective_compaction_budget(&self, calibration_model: Option<&str>) -> (u64, f64) {
         match self.calibration {
             // Solves for the conversation size the budget allows, subtracting
@@ -1204,10 +1207,9 @@ impl<'a> Engine<'a> {
     }
 
     /// Compaction, before every model call, per the running estimate
-    /// (L-E3 dedup+evict, stable system prefix — the system message is
-    /// index 0 and `compact()` never touches it). The budget it compares
-    /// against is [`Self::effective_compaction_budget`]'s, so the pass and
-    /// the step manifest can never disagree about which number was used.
+    /// (L-E3 dedup+evict; the system message is index 0 and `compact()`
+    /// never touches it), against the caller's settled `sized` budget —
+    /// the same number the step manifest reports.
     ///
     /// Returns the summarizer's spend (0.0 on the overwhelmingly common
     /// no-summarization path) so `run_turn` folds it into the turn total.
@@ -1606,8 +1608,7 @@ impl<'a> Engine<'a> {
         // see `estimate_conversation_attachment_tokens`), and this value is
         // what StepUsage persists as the drift sample and what
         // `handle_committed_result` records. The compaction decision keeps
-        // the full attachment-weighted estimate via its own walk in
-        // `run_compaction_pass`.
+        // the full estimate via its own walk in `run_compaction_pass`.
         let estimated_input_tokens = estimate_conversation_tokens(messages).saturating_sub(
             crate::estimator::estimate_conversation_attachment_tokens(messages),
         );

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -20,9 +20,8 @@ impl Sleeper for NoopSleeper {
     async fn sleep(&self, _duration_ms: u64) {}
 }
 
-/// A `ToolExecutor` that always succeeds and counts real invocations —
-/// the counter is what `retry_never_re_executes_a_tool_call` asserts
-/// against.
+/// A `ToolExecutor` that always succeeds and counts real invocations — the
+/// counter is what `retry_never_re_executes_a_tool_call` asserts against.
 struct CountingTools {
     calls: Arc<AtomicU32>,
 }
@@ -3077,6 +3076,7 @@ mod loop_abort;
 mod parked_wait;
 mod provider_outcomes;
 mod steer_midturn;
+mod usage_anchor;
 mod usage_completeness;
 mod zero_copy_request;
 

--- a/crates/stella-core/src/driver/tests/usage_anchor.rs
+++ b/crates/stella-core/src/driver/tests/usage_anchor.rs
@@ -1,0 +1,141 @@
+//! Usage-anchor witnesses (#2681): context-size accounting re-bases on the
+//! provider's reported usage, so the byte estimator prices only the tail
+//! appended since the last report instead of the whole transcript — the
+//! 1.8×-drift class #2671 measured. Deliberately run WITHOUT a calibration
+//! map: the anchor is a per-step measurement, not a learned correction, and
+//! these witnesses must not be satisfiable by calibration alone (its factor
+//! clamps at 2×, so the fixtures put the truth beyond its reach).
+
+use super::*;
+
+/// A conversation with one old, evictable tool output — the shape compaction
+/// acts on (the LAST tool message is protected).
+fn compactable_history() -> Vec<CompletionMessage> {
+    let tool_msg = |call_id: &str, content: String| CompletionMessage {
+        role: MessageRole::Tool,
+        content: String::new(),
+        tool_calls: vec![],
+        tool_results: vec![ToolResult {
+            call_id: call_id.into(),
+            output: ToolOutput::Ok { content },
+        }],
+        attachments: Vec::new(),
+    };
+    let assistant_with_call = |call_id: &str| CompletionMessage {
+        role: MessageRole::Assistant,
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: call_id.into(),
+            name: "bash".into(),
+            input: serde_json::json!({"cmd": call_id}),
+        }],
+        tool_results: vec![],
+        attachments: Vec::new(),
+    };
+    vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do things"),
+        assistant_with_call("c1"),
+        tool_msg("c1", "old ".repeat(1000)),
+        assistant_with_call("c2"),
+        tool_msg("c2", "new ".repeat(1000)),
+    ]
+}
+
+/// Run a two-step turn whose first step reports `reported_input_tokens`
+/// against a budget of `3 × raw estimate`, and say whether any compaction
+/// fired. The raw estimate — even doubled by a maximally-warmed calibration —
+/// can never reach that budget, so a compaction can only mean the decision
+/// consumed the provider's report.
+async fn compaction_fired_with_report(usage: CompletionUsage) -> bool {
+    let mut first = tool_call_result("call_1", "bash");
+    first.usage = usage;
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(first), Ok(text_result("done"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let mut messages = compactable_history();
+    let raw = crate::estimator::estimate_conversation_tokens(&messages);
+    let config = EngineConfig {
+        compaction_budget_tokens: raw * 3,
+        // Keep the fixture pure-pass: an overflow summary would spend a
+        // scripted completion this two-entry script does not have.
+        summarize_overflow: false,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+    drain_events(&mut rx)
+        .iter()
+        .any(|e| matches!(e, AgentEvent::Compaction { .. }))
+}
+
+/// **Witness (#2681).** The compaction decision tracks the provider's
+/// reported usage, not the local estimate alone.
+///
+/// The transcript's raw estimate sits at a third of the budget, so on an
+/// estimate-only engine no compaction can ever fire here — while the
+/// provider attests that this exact prefix actually cost more than the whole
+/// budget (#2671 measured the estimator ~1.8× low; this fixture makes the
+/// gap decisive rather than marginal). Anchored, the next step's decision is
+/// `reported + estimate(tail) > budget` and must compact.
+#[tokio::test]
+async fn provider_reported_usage_rebases_the_compaction_decision() {
+    let raw = crate::estimator::estimate_conversation_tokens(&compactable_history());
+    assert!(
+        compaction_fired_with_report(CompletionUsage {
+            reported: true,
+            input_tokens: raw * 6, // 2× the whole budget
+            output_tokens: 50,
+            cached_input_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: None,
+        })
+        .await,
+        "the provider attested the prefix already exceeds the budget — \
+         compaction must fire before the next model call"
+    );
+}
+
+/// Control for the witness above: an envelope with no usage signal (the
+/// scripted default — reported, all counters zero) anchors nothing, and the
+/// same conversation under the same budget stays estimate-governed: no
+/// compaction, exactly the pre-anchor behavior.
+#[tokio::test]
+async fn an_absent_usage_report_leaves_the_estimator_in_charge() {
+    assert!(
+        !compaction_fired_with_report(CompletionUsage::reported_zero()).await,
+        "no report, and the raw estimate fits the budget three times over"
+    );
+}
+
+/// The anchor is a measurement of one exact prefix: cache-write tokens count
+/// toward it (they are prompt tokens the provider read — the same rule as
+/// the calibration feed), so a cache-writing first call anchors just as
+/// decisively as a plain one.
+#[tokio::test]
+async fn cache_write_tokens_count_toward_the_anchor() {
+    let raw = crate::estimator::estimate_conversation_tokens(&compactable_history());
+    assert!(
+        compaction_fired_with_report(CompletionUsage {
+            reported: true,
+            // Split so neither side alone exceeds the 3×raw budget.
+            input_tokens: raw * 2,
+            output_tokens: 50,
+            cached_input_tokens: 0,
+            cache_write_tokens: raw * 4,
+            reasoning_tokens: None,
+        })
+        .await,
+        "input + cache writes together exceed the budget — the anchor must \
+         total them"
+    );
+}

--- a/crates/stella-core/src/driver/usage_anchor.rs
+++ b/crates/stella-core/src/driver/usage_anchor.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Anchoring context-size accounting to provider-reported usage (#2681).
+//!
+//! Every committed model call returns the ground truth for the exact
+//! transcript prefix it was sent: the provider's own input-token count.
+//! The byte estimator — even corrected by `crate::estimator::Calibration`'s
+//! scalar factor — was measured running 1.8× low on whole transcripts
+//! (#2671), because a single ratio cannot capture content-dependent
+//! tokenizer variance (code, prose and JSON tokenize very differently). So
+//! instead of estimating the whole transcript, the compaction decision
+//! re-bases at each committed step: the anchored prefix is *measurement*,
+//! and the estimator prices only the tail appended since that report.
+//!
+//! # How the anchor enters the decision
+//!
+//! `crate::compaction::compact_measured` compares its own whole-transcript
+//! estimate against the budget it is handed, and the established seam for
+//! correcting the *measure* is adjusting the *budget* (calibration already
+//! divides the budget by its factor rather than threading a factor through
+//! compaction's bookkeeping). The anchor uses the same seam. The decision
+//! wanted is
+//!
+//! ```text
+//! reported + factor · (est_full − est_prefix) > budget
+//! ```
+//!
+//! which rearranges to `est_full > est_prefix + (budget − reported) / factor`
+//! — so [`UsageAnchor::effective_budget`] returns that right-hand side and
+//! compaction's unchanged `est_full > handed_budget` comparison computes
+//! exactly the anchored measure. The calibration factor now only ever
+//! corrects the tail estimate, and the fitted per-request overhead
+//! (`Calibration::line`'s intercept — tool schemas, provider framing) needs
+//! no model at all: it is inside `reported`, measured.
+//!
+//! # Validity
+//!
+//! An anchor describes one exact prefix, so it holds only while that prefix
+//! is untouched. Appends (the assistant reply, tool results, steering
+//! messages) extend the tail and leave it valid; any in-place rewrite —
+//! a compaction pass, the overflow summarizer, a host mutating through
+//! `TurnState::messages_mut` — invalidates it, and
+//! `TurnState::mark_transcript_rewritten` (which every rewrite path already
+//! calls, because the receipt memos have the same invariant) drops it. The
+//! next committed step re-anchors. A provider that omits usage
+//! ([`stella_protocol::CompletionUsage::reported`] is false, or the counters
+//! are all zero) never anchors, so scripted tests and usage-less providers
+//! keep the pure-estimator behavior byte-for-byte.
+
+use stella_protocol::{CompletionMessage, CompletionUsage};
+
+/// The provider's attested size of a transcript prefix, paired with the
+/// estimator's view of the same prefix so the two accountings can be
+/// exchanged inside one budget comparison (module docs).
+///
+/// Pure data — no I/O, no clock (invariant 2). Turn-scoped: it lives on
+/// `TurnState` and dies with the turn; a cold turn's first compaction
+/// decision runs on the estimator alone, exactly as before.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct UsageAnchor {
+    /// Every prompt token the provider read for the anchored prefix: fresh
+    /// input (cache reads included — `input_tokens` counts them) plus cache
+    /// writes, which adapters split out for pricing only. The same TRUE
+    /// total the calibration feed uses, for the same reason.
+    reported_tokens: u64,
+    /// The estimator's answer for the same prefix, attachment weight
+    /// included so it subtracts cleanly from compaction's own
+    /// attachment-inclusive walk.
+    estimated_tokens: u64,
+}
+
+impl UsageAnchor {
+    /// Anchor a just-committed step: `messages` is the transcript exactly as
+    /// sent (before dispatch appends to it) and `estimated_input_tokens` is
+    /// the same attachment-free pre-call estimate `StepUsage` reports.
+    ///
+    /// `None` when the usage envelope carries no signal — unreported, or
+    /// reported with zero prompt tokens — so an absent report can never
+    /// anchor the budget to zero and compact every step forever.
+    pub(crate) fn from_report(
+        usage: &CompletionUsage,
+        messages: &[CompletionMessage],
+        estimated_input_tokens: u64,
+    ) -> Option<Self> {
+        let reported_tokens = usage.input_tokens.saturating_add(usage.cache_write_tokens);
+        if !usage.reported || reported_tokens == 0 {
+            return None;
+        }
+        Some(Self {
+            reported_tokens,
+            estimated_tokens: estimated_input_tokens.saturating_add(
+                crate::estimator::estimate_conversation_attachment_tokens(messages),
+            ),
+        })
+    }
+
+    /// The budget to hand `compact_measured` so its whole-transcript
+    /// comparison computes `reported + factor · tail > configured_budget`
+    /// (module docs): the anchored prefix's estimate plus the calibrated
+    /// headroom the report leaves under the configured budget.
+    ///
+    /// Saturating on purpose: a report at or over the whole budget leaves
+    /// zero headroom, so the handed budget floors at the prefix estimate and
+    /// compaction fires on any non-empty tail — the transcript is measured
+    /// over budget, and shrinking it is the only correct answer. A
+    /// non-finite or non-positive `factor` (impossible from
+    /// `Calibration::factor`'s clamp, but this is arithmetic on runtime
+    /// data) degrades to the identity rather than poisoning the division.
+    pub(crate) fn effective_budget(&self, configured_budget: u64, factor: f64) -> u64 {
+        let factor = if factor.is_finite() && factor > 0.0 {
+            factor
+        } else {
+            1.0
+        };
+        let headroom = configured_budget.saturating_sub(self.reported_tokens) as f64 / factor;
+        self.estimated_tokens.saturating_add(headroom as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn reported(input_tokens: u64, cache_write_tokens: u64) -> CompletionUsage {
+        CompletionUsage {
+            reported: true,
+            input_tokens,
+            cache_write_tokens,
+            ..CompletionUsage::default()
+        }
+    }
+
+    fn anchor(reported_tokens: u64, estimated_tokens: u64) -> UsageAnchor {
+        UsageAnchor {
+            reported_tokens,
+            estimated_tokens,
+        }
+    }
+
+    #[test]
+    fn an_absent_or_empty_report_never_anchors() {
+        let unreported = CompletionUsage {
+            input_tokens: 5_000,
+            ..CompletionUsage::default()
+        };
+        assert!(
+            UsageAnchor::from_report(&unreported, &[], 1_000).is_none(),
+            "an unattested envelope is not a measurement"
+        );
+        assert!(
+            UsageAnchor::from_report(&CompletionUsage::reported_zero(), &[], 1_000).is_none(),
+            "zero prompt tokens carry no signal (scripted tests)"
+        );
+    }
+
+    #[test]
+    fn the_report_totals_fresh_input_plus_cache_writes() {
+        let anchor = UsageAnchor::from_report(&reported(10, 100_000), &[], 1_000)
+            .expect("a reported envelope anchors");
+        // Cache writes are prompt tokens the provider read; omitting them
+        // would under-anchor every cache-writing step (same rule as the
+        // calibration feed).
+        assert_eq!(anchor.reported_tokens, 100_010);
+    }
+
+    #[test]
+    fn the_prefix_estimate_carries_the_attachment_weight() {
+        let messages = vec![CompletionMessage::user_with_attachments(
+            "look",
+            vec![stella_protocol::Attachment::from_path(
+                "shot.png",
+                "image/png",
+                350_000,
+                "/tmp/shot.png",
+            )],
+        )];
+        let attachment = crate::estimator::estimate_conversation_attachment_tokens(&messages);
+        let anchor = UsageAnchor::from_report(&reported(4_000, 0), &messages, 1_000)
+            .expect("a reported envelope anchors");
+        // The text estimate and the attachment weight sum back to what
+        // compaction's own walk sees for the prefix — otherwise the prefix's
+        // attachment weight would leak into the tail term.
+        assert_eq!(anchor.estimated_tokens, 1_000 + attachment);
+    }
+
+    /// An estimator that happens to be exact changes nothing: anchoring is a
+    /// re-base, not a bias.
+    #[test]
+    fn an_exact_estimate_leaves_the_budget_unchanged() {
+        assert_eq!(anchor(2_000, 2_000).effective_budget(150_000, 1.0), 150_000);
+    }
+
+    /// The 1.8× drift shape from #2671: the provider read far more than the
+    /// estimator priced, so the handed budget shrinks by exactly the
+    /// measured gap and compaction fires earlier.
+    #[test]
+    fn an_under_estimated_prefix_shrinks_the_budget_by_the_measured_gap() {
+        // est 100k, reported 180k: the budget gives up the 80k the estimator
+        // could not see.
+        assert_eq!(
+            anchor(180_000, 100_000).effective_budget(200_000, 1.0),
+            120_000
+        );
+    }
+
+    #[test]
+    fn the_factor_calibrates_only_the_tail_headroom() {
+        // factor 2 halves the headroom (the tail estimate runs 2× low), but
+        // the prefix term is measurement and is not scaled.
+        assert_eq!(
+            anchor(50_000, 10_000).effective_budget(150_000, 2.0),
+            10_000 + 50_000
+        );
+    }
+
+    #[test]
+    fn a_report_over_the_whole_budget_floors_at_the_prefix_estimate() {
+        let anchored = anchor(400_000, 10_000).effective_budget(150_000, 1.0);
+        assert_eq!(
+            anchored, 10_000,
+            "no headroom is left — any tail must trigger compaction"
+        );
+    }
+
+    #[test]
+    fn a_degenerate_factor_degrades_to_identity_instead_of_poisoning() {
+        let anchored = anchor(50_000, 10_000).effective_budget(150_000, 1.0);
+        for factor in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert_eq!(
+                anchor(50_000, 10_000).effective_budget(150_000, factor),
+                anchored
+            );
+        }
+    }
+
+    proptest! {
+        /// The identity behind the whole module: for any anchored budget,
+        /// compaction's `est_full > handed_budget` comparison is exactly the
+        /// anchored measure `reported + factor·tail > configured_budget`
+        /// (integer division rounds the headroom down — the early-compaction
+        /// direction — so the equivalence is one-sided only at the boundary
+        /// token).
+        #[test]
+        fn the_handed_budget_computes_the_anchored_measure(
+            budget in 1_000u64..1_000_000,
+            reported_tokens in 1u64..1_000_000,
+            est_prefix in 0u64..1_000_000,
+            // Never 0 on the engine path: the committed step's assistant
+            // reply is appended before the next decision runs.
+            tail in 1u64..1_000_000,
+            // The clamped range Calibration::factor can actually produce.
+            factor in 0.5f64..=2.0,
+        ) {
+            let a = anchor(reported_tokens, est_prefix);
+            let est_full = est_prefix + tail;
+            let compaction_fires = est_full > a.effective_budget(budget, factor);
+            let anchored_measure =
+                reported_tokens as f64 + factor * tail as f64 > budget as f64;
+            if compaction_fires {
+                // Fired ⇒ the anchored measure is genuinely over (rounding
+                // down can only make firing MORE eager by under a token).
+                prop_assert!(
+                    reported_tokens as f64 + factor * (tail as f64 - 1.0) <= budget as f64
+                        || anchored_measure,
+                );
+            } else {
+                prop_assert!(!anchored_measure);
+            }
+        }
+
+        /// More reported tokens never yield a larger handed budget: the
+        /// anchor can only tighten as the measured prefix grows.
+        #[test]
+        fn the_budget_is_monotone_in_the_report(
+            budget in 0u64..1_000_000,
+            est_prefix in 0u64..1_000_000,
+            lo in 0u64..1_000_000,
+            delta in 0u64..1_000_000,
+            factor in 0.5f64..=2.0,
+        ) {
+            prop_assert!(
+                anchor(lo + delta, est_prefix).effective_budget(budget, factor)
+                    <= anchor(lo, est_prefix).effective_budget(budget, factor)
+            );
+        }
+    }
+}

--- a/crates/stella-core/src/estimator.rs
+++ b/crates/stella-core/src/estimator.rs
@@ -5,7 +5,11 @@
 //! estimator: [`Calibration`] tracks the observed actual/estimated
 //! input-token ratio per model and corrects the
 //! heuristic with a bounded factor, so the estimate converges on what the
-//! provider's tokenizer actually reports over a session. The uncalibrated
+//! provider's tokenizer actually reports over a session. Within a turn the
+//! same reports also re-base the compaction decision directly
+//! (`crate::driver::usage_anchor`, #2681): the last report is the measured
+//! size of the transcript prefix it covered, and this module's estimate then
+//! prices only the tail appended since. The uncalibrated
 //! functions remain the shared byte-heuristic baseline
 //! ([`stella_protocol::tokens`] — the one place the rule is written down, so
 //! this module and the receipts plane cannot disagree on what a token is made

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -49,11 +49,12 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use stella_protocol::{
-    AgentEvent, BudgetMode, CompletionMessage, CompletionResult, MessageRole, ProviderError,
-    ToolCall, ToolOutput, ToolResult,
+    AgentEvent, BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, MessageRole,
+    ProviderError, ToolCall, ToolOutput, ToolResult,
 };
 
 use crate::budget::BudgetGuard;
+use crate::driver::usage_anchor::UsageAnchor;
 use crate::driver::{EngineConfig, SPECULATION_DISCARD_ATTEMPT_FAILED, TurnMemos, TurnOutcome};
 use crate::event_sender::EventSender;
 use crate::loop_detect::LoopIdentity;
@@ -305,6 +306,17 @@ pub struct TurnState {
     /// for entire 40-step turns while the calibration underneath converged on
     /// 2×+ drift (#2133); see [`Self::latch_effective_budget`].
     pub(crate) effective_budget: Option<(u64, f64)>,
+    /// The last committed step's provider-attested prompt size, paired with
+    /// the estimator's view of the same transcript prefix
+    /// (`crate::driver::usage_anchor`, #2681). Applied on top of the latched
+    /// pair above by [`Self::anchored_budget`], so the estimator only ever
+    /// prices the tail appended since the report; dropped by
+    /// [`Self::mark_transcript_rewritten`] because a rewrite makes the
+    /// report describe bytes that no longer exist. Unlike the latch this
+    /// moves every committed step — it tracks a measurement of the growing
+    /// prefix, not a converging correction, so re-reading it cannot
+    /// oscillate the way #2133's factor did.
+    pub(crate) usage_anchor: Option<UsageAnchor>,
     /// The loop this turn's one stuck-loop steering warning was issued about
     /// (`driver::loop_escalation`), or `None` while the warning is unspent.
     /// The next detection after `Some` aborts instead of warning again;
@@ -364,6 +376,7 @@ impl TurnState {
             total_cost_usd: 0.0,
             calibration_model: None,
             effective_budget: None,
+            usage_anchor: None,
             loop_steered: None,
             transcript_rewrites: 0,
             step: 0,
@@ -390,6 +403,10 @@ impl TurnState {
             // the snapshot. Restoring it would pin the resumed turn to a
             // budget computed before that.
             effective_budget: None,
+            // Same reasoning: the resumed turn's first committed step
+            // re-anchors from a fresh provider report over the transcript
+            // as it is NOW, which a snapshot could only be staler than.
+            usage_anchor: None,
             loop_steered: checkpoint.loop_steered.then_some(LoopIdentity {
                 tools: checkpoint.loop_steered_pattern,
                 inputs: checkpoint.loop_steered_inputs,
@@ -428,6 +445,41 @@ impl TurnState {
             return fresh;
         }
         *self.effective_budget.get_or_insert(fresh)
+    }
+
+    /// Anchor the context measure to a just-committed step's usage report:
+    /// `self.messages` is the transcript exactly as sent (the caller invokes
+    /// this before dispatch appends the reply), and `estimated_input_tokens`
+    /// is the same pre-call estimate `StepUsage` reports. An envelope with
+    /// no signal keeps the previous anchor — the transcript has only been
+    /// appended to since it was taken, so it still describes a live prefix
+    /// and its tail simply grows.
+    pub(crate) fn anchor_usage(&mut self, usage: &CompletionUsage, estimated_input_tokens: u64) {
+        if let Some(anchor) =
+            UsageAnchor::from_report(usage, &self.messages, estimated_input_tokens)
+        {
+            self.usage_anchor = Some(anchor);
+        }
+    }
+
+    /// The compaction budget after re-basing on the last usage report
+    /// (`crate::driver::usage_anchor`, #2681): [`Self::latch_effective_budget`]'s
+    /// answer passes through untouched until a report anchors, then the
+    /// anchored budget replaces its token count while the factor — now
+    /// correcting only the tail estimate — rides along unchanged for the
+    /// manifest.
+    pub(crate) fn anchored_budget(
+        &self,
+        latched: (u64, f64),
+        configured_budget: u64,
+    ) -> (u64, f64) {
+        match &self.usage_anchor {
+            Some(anchor) => (
+                anchor.effective_budget(configured_budget, latched.1),
+                latched.1,
+            ),
+            None => latched,
+        }
     }
 
     /// Snapshot this turn for durable storage. Cheap-ish (it clones the
@@ -477,11 +529,14 @@ impl TurnState {
     }
 
     /// Declare that the transcript was rewritten in place rather than appended
-    /// to, invalidating both position-keyed memos. The engine calls this for
-    /// every rewrite it performs; a host only needs it after its own.
+    /// to, invalidating both position-keyed memos — and the usage anchor,
+    /// whose provider report describes a prefix that no longer exists. The
+    /// engine calls this for every rewrite it performs; a host only needs it
+    /// after its own.
     pub fn mark_transcript_rewritten(&mut self) {
         self.memos.mark_rewritten();
         self.transcript_rewrites = self.transcript_rewrites.saturating_add(1);
+        self.usage_anchor = None;
     }
 
     /// The money meter, including session-scoped spend.

--- a/crates/stella-core/src/step/tests.rs
+++ b/crates/stella-core/src/step/tests.rs
@@ -314,3 +314,46 @@ fn nothing_is_latched_while_the_model_is_still_unknown() {
     let latched = state.latch_effective_budget((118_000, 1.27));
     assert_eq!(state.latch_effective_budget((75_000, 2.0)), latched);
 }
+
+/// The usage anchor's turn-state lifecycle (#2681): a reported envelope
+/// anchors, an empty one keeps the previous anchor (the transcript has only
+/// been appended to, so the report still describes a live prefix), and any
+/// in-place rewrite drops it — the report names bytes that no longer exist.
+#[test]
+fn the_usage_anchor_survives_appends_and_dies_with_a_rewrite() {
+    let mut state = TurnState::new(
+        vec![CompletionMessage::system("sys")],
+        BudgetGuard::new(BudgetMode::Observed, None, None),
+        &EngineConfig::default(),
+    );
+    let latched = (150_000, 1.0);
+    assert_eq!(
+        state.anchored_budget(latched, 150_000),
+        latched,
+        "no report yet — the latched pair passes through untouched"
+    );
+
+    let mut usage = CompletionUsage::reported_zero();
+    usage.input_tokens = 200_000; // over the whole configured budget
+    state.anchor_usage(&usage, 1_000);
+    let (anchored, factor) = state.anchored_budget(latched, 150_000);
+    assert!(
+        anchored < latched.0,
+        "the report exceeds the budget, so the handed budget must tighten"
+    );
+    assert_eq!(factor, latched.1, "the factor rides along for the manifest");
+
+    state.anchor_usage(&CompletionUsage::reported_zero(), 1_000);
+    assert_eq!(
+        state.anchored_budget(latched, 150_000),
+        (anchored, factor),
+        "a signal-less envelope keeps the previous anchor"
+    );
+
+    state.mark_transcript_rewritten();
+    assert_eq!(
+        state.anchored_budget(latched, 150_000),
+        latched,
+        "a rewrite invalidates the report's prefix — back to the estimator"
+    );
+}


### PR DESCRIPTION
## What & why

Anchors the context-size accounting behind compaction/overflow decisions to provider-reported usage instead of the local byte estimator. #2671 measured the estimate running ~1.8x low with `calibration_factor: 1.0` — a scalar ratio cannot capture content-dependent tokenizer variance — which mis-times compaction in both directions. Every completed model call already reports ground truth for the exact transcript prefix it was sent, so the decision now re-bases at each committed step: `context_size = last_reported_prompt_tokens + estimate(tail appended since that report)`. The heuristic error is confined to a few thousand tokens of tail instead of the whole transcript, and the calibration machinery only ever corrects the tail.

**Where the anchor lives:** new pure module `crates/stella-core/src/driver/usage_anchor.rs` (the `driver/settlement.rs` sibling pattern; invariant 2 — no I/O, no clock). The anchor state rides `TurnState` (`crates/stella-core/src/step.rs`): set at each committed step from `input_tokens + cache_write_tokens` (the same TRUE total the calibration feed uses — cache writes are prompt tokens the provider read), kept across signal-less envelopes (appends only grow the tail), and dropped by `mark_transcript_rewritten` because a rewrite makes the report describe bytes that no longer exist. Cold turns, resumed checkpoints, and usage-less providers keep the pure-estimator behavior byte-for-byte.

**How it enters the decision:** through the exact seam calibration already uses — adjusting the budget handed to `compact_measured` rather than threading a second measure through compaction's bookkeeping (exemplar: the existing `effective_compaction_budget` divide-by-factor design). The handed budget becomes `est_prefix + (configured − reported)/factor`, so compaction's unchanged `est_full > handed` comparison computes exactly `reported + factor·est_tail > configured`. A pleasant consequence: the fitted per-request overhead from #1841 (tool schemas, provider framing) is *inside* the report while an anchor holds — measured, not modelled. The step manifest and `Compaction` events report the anchored budget, so receipts still name exactly the number the decision used. Unlike the #2133 latch, the anchored value moves every committed step by design — it tracks a measurement of the growing prefix, not a converging correction, so it cannot oscillate the way the mid-turn factor did.

Closes #2681
Closes #2671

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`driver::tests::usage_anchor::provider_reported_usage_rebases_the_compaction_decision`: a transcript whose raw estimate sits at a third of the budget (beyond even a maximally-warmed 2x calibration factor's reach, and no calibration map is attached) gets a provider report attesting the prefix cost 2x the whole budget — compaction must fire on the next step. Also `cache_write_tokens_count_toward_the_anchor` (neither side alone exceeds the budget; the total does). Flip verified by stashing the wiring (`driver.rs`, `step.rs`) while keeping the test: both fail with `main`'s behavior (`the provider attested the prefix already exceeds the budget — compaction must fire`), and the no-report control passes on both sides. Property tests in `usage_anchor.rs` pin the handed-budget/anchored-measure equivalence and monotonicity in the report; unit tests cover the zero-signal, over-budget saturation, degenerate-factor, and attachment-weight edges, plus the anchor's `TurnState` lifecycle (`step::tests::the_usage_anchor_survives_appends_and_dies_with_a_rewrite`).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core --all-targets -- -D warnings` (only crate touched)
- [x] `cargo test -p stella-core` (1095 lib tests) and `cargo test -p stella-protocol`; rustdoc `-D warnings` on stella-core; `check-file-size`/`check-god-files` green — `driver.rs` and `driver/tests.rs` stay at exactly their baseline ceilings (additions compensated by doc-comment compression in the same files)
- [x] Docs updated (estimator module doc, `effective_compaction_budget` doc, new module doc)
- [x] `Closes #N` appears both above and as commit trailers

## Nothing left behind

- [x] Filed: #2738 — the carve-out for what closing #2671 would otherwise strand: P7 (a real `web_search` tool, `web_fetch` byte/extraction modes) and the P8 leftovers this PR does not touch (progress-aware step cap, cost persisted on timeout, compaction pass sizing — the last to be re-measured on a bench trace after this lands, since the anchor fixes the timing input).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- Rejected alternative: computing the anchored context size directly and threading it into `compact_measured` — that would change compaction's eviction bookkeeping for the same arithmetic; the budget seam is exact (see the module doc's derivation) and already established by calibration.
- No new `AgentEvent` variants, so no consumers-ledger row is needed.
- The anchor deliberately dies at turn end and on checkpoint resume; the first committed step re-anchors from a report over the transcript as it is then, which a snapshot could only be staler than.

## Summary by Sourcery

Rebase compaction context-size decisions on provider-reported usage instead of solely on the local byte-based estimator, with a per-turn usage anchor tracked in turn state and integrated via the existing calibrated budget seam.

Enhancements:
- Introduce a pure `usage_anchor` module to derive an anchored effective budget from provider usage reports and estimator data, including property and unit tests for its arithmetic and invariants.
- Track and apply a per-turn usage anchor in `TurnState` so compaction budgets are re-based on the last usage report and cleared on transcript rewrites or checkpoint resumes.
- Adjust engine compaction flow and related documentation to route decisions through the anchored budget while keeping calibration behavior and receipts aligned.

Tests:
- Add driver-level usage-anchor witness tests that validate compaction firing based on provider-reported usage, including cache-write handling and no-report controls.
- Add a step-level test covering the lifecycle of the usage anchor across appends and transcript rewrites.