### PR TITLE
fix(stella-core): park the retry ladder under sustained rate limiting instead of aborting (#2677)

### DIFF
--- a/crates/stella-core/src/accounted_call.rs
+++ b/crates/stella-core/src/accounted_call.rs
@@ -193,6 +193,7 @@ pub async fn run_accounted_call(
     // window against the count at its end already gives each window its own
     // delta regardless of how many attempts ran inside it.
     let progress = StreamProgress::default();
+    let mut no_parking = crate::retry::NoParking;
     let future = retry_with_backoff_observed(
         &call.retry_policy,
         sleeper,
@@ -230,6 +231,13 @@ pub async fn run_accounted_call(
                 error.partial_usage().copied(),
             );
         },
+        // Auxiliary calls never park on a rate limit (#2677): only the
+        // engine's worker path converts sustained 429s into a budgeted wait.
+        // A summarizer/triage/authoring call failing fast is the same
+        // capacity-cascade posture the comparator takes for its background
+        // request sources — the caller falls through or retries at its own
+        // layer instead of amplifying pressure from inside a helper.
+        &mut no_parking,
     );
     let outcome = match call.timeout {
         Some(limit) => {

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -96,11 +96,11 @@ use crate::hooks::{HookEvent, HookPayload, HookRunner, Hooks, any_matcher_matche
 use crate::loop_detect::LoopDetectionConfig;
 use crate::ports::ToolExecutor;
 use crate::receipts::ReceiptLedger;
-use crate::retry::{RetryOutcome, RetryPolicy, Sleeper, retry_with_backoff_observed};
+use crate::retry::{RetryOutcome, RetryPolicy, Sleeper};
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::step::{
-    AbortKind, BorrowedTurn, CancelUsageGuard, CompactionPass, SpeculationDropGuard, StepOutcome,
-    StreamProgress, SummarizerHealth, TurnState, bounded_generation,
+    AbortKind, BorrowedTurn, CompactionPass, SpeculationDropGuard, StepOutcome, StreamProgress,
+    SummarizerHealth, TurnState, bounded_generation,
 };
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
 use truncation::{ContinuationBudget, ContinuationPlan, TIME_EXHAUSTED_PARTIAL, plan_continuation};
@@ -129,6 +129,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 mod dispatch;
 mod drive;
+mod rate_limit;
 mod settlement;
 mod waiting;
 use settlement::{BudgetWarnings, emit_budget_warning, record_settled_cost};
@@ -1707,98 +1708,18 @@ impl<'a> Engine<'a> {
             })
         });
 
-        let call_started = std::time::Instant::now();
-        // Armed for exactly the interval where a paid attempt may be in
-        // flight: a caller-side hard cancel that drops this future mid-await
-        // still leaves one content-free `Cancelled` envelope behind.
-        // Disarmed on BOTH normal exits — a success reports through its
-        // `StepUsage`, a terminal failure through the per-attempt observer
-        // below. The shared latch narrows "in flight" to the dispatch
-        // itself: a drop landing in a backoff sleep emits nothing.
-        let mut cancel_guard = CancelUsageGuard {
-            events: events.clone(),
-            role: self.call_role,
-            provider: self.provider.id().to_string(),
-            started: call_started,
-            armed: true,
-            attempt_in_flight,
-        };
-        let incomplete_events = events.clone();
-        // Every failed attempt's reason, accumulated through the observer:
-        // retry.rs returns retry history only for calls that COMMIT, so on
-        // exhaustion this is the sole record of the doomed attempts
-        // (receipts spec §6.3 — RetriesExhausted). A std Mutex, never held
-        // across an await and contention-free — the observer runs serially
-        // within this call.
-        let attempt_reasons: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        // The ladder itself — the cancellation usage guard, per-attempt
+        // incompleteness envelopes, parked rate-limit recovery (#2677),
+        // provider-outcome feedback (#2673), and the exhaustion event pair —
+        // lives in `driver/rate_limit.rs`.
+        let (call_started, outcome) = self
+            .drive_attempt_ladder(attempt, attempt_in_flight, budget, events)
+            .await?;
         let RetryOutcome {
             value: (result, speculation_future),
             retries,
             ..
-        } = match retry_with_backoff_observed(
-            &self.config.retry_policy,
-            self.sleeper,
-            attempt,
-            // Per-attempt duration (retry.rs times each dispatch
-            // individually): the failed call's own latency, never
-            // cumulative across earlier attempts or backoff sleeps.
-            |attempt, error, attempt_duration| {
-                attempt_reasons
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(error.to_string());
-                let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
-                    role: self.call_role,
-                    provider: self.provider.id().to_string(),
-                    model: "unknown".into(),
-                    reason: stella_protocol::UsageIncompleteReason::ProviderError,
-                    duration_ms: attempt_duration.as_millis() as u64,
-                    retries: Some(attempt.saturating_sub(1)),
-                    // Whatever the adapter salvaged from the dying stream.
-                    // This observer is the only place it can be read: retry.rs
-                    // returns history only for calls that COMMIT, so a doomed
-                    // attempt's accounting reaches the wire here or nowhere.
-                    partial: error.partial_usage().copied(),
-                });
-            },
-        )
-        .await
-        {
-            Ok(outcome) => {
-                cancel_guard.disarm();
-                outcome
-            }
-            Err(error) => {
-                cancel_guard.disarm();
-                let reasons =
-                    std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
-                // Shared with the paired `Error` event below: whether the
-                // FINAL attempt's error is of a retryable class. `false`
-                // means every attempt (typically just one — see
-                // `retry_with_backoff_observed`, which bails on the first
-                // non-retryable error) was doomed from the start, not
-                // exhausted by an actual retry loop (#926).
-                let retryable = error.is_retryable();
-                let _ = events.send(AgentEvent::RetriesExhausted {
-                    turn_instance: self.config.turn_instance,
-                    attempts: reasons.len() as u32,
-                    reasons,
-                    retryable,
-                });
-                let message = error.to_string();
-                let _ = events.send(AgentEvent::Error {
-                    message: message.clone(),
-                    retryable,
-                });
-                if let Some(outcomes) = self.outcomes {
-                    outcomes.record_failure(self.provider.id());
-                }
-                return Err(format!("model call failed: {message}"));
-            }
-        };
-        if let Some(outcomes) = self.outcomes {
-            outcomes.record_success(self.provider.id());
-        }
+        } = outcome;
         // One boundary read: the call's duration and the tick's clock axis.
         let now = std::time::Instant::now();
         let call_duration_ms = now.duration_since(call_started).as_millis() as u64;
@@ -2417,8 +2338,8 @@ impl<'a> Engine<'a> {
     }
 }
 
-/// The boxed-future shape [`retry_with_backoff_observed`] needs from its
-/// `attempt_fn` — named here purely to keep the call site in
+/// The boxed-future shape [`crate::retry::retry_with_backoff_observed`]
+/// needs from its `attempt_fn` — named here purely to keep the call site in
 /// [`Engine::run_model_call`] readable. Each attempt yields the completion
 /// AND its still-live speculation future as one value. The caller settles the billed completion synchronously before
 /// awaiting that future, closing the cancellation window without moving the

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -1,0 +1,244 @@
+//! The model-call attempt ladder and its rate-limit recovery (#2677): drive
+//! `retry_with_backoff_observed` for one step, and when sustained rate
+//! limiting outlives the inline ladder, park the turn — chunked engine-side
+//! sleeps bounded by the task deadline's real headroom — instead of aborting
+//! a run that still has budget to spend (#2667 measured exactly that loss:
+//! 7 attempts burned in 15s with 880s of budget left). A child module of
+//! `driver` (the `settlement.rs` pattern) so the engine internals stay
+//! reachable without growing `driver.rs` past the size gate.
+//!
+//! The decision arithmetic — when a park is affordable, how long it waits —
+//! is pure and lives in [`crate::retry`] (`plan_rate_limit_park`); this
+//! module owns the effects: the per-attempt usage envelopes, the
+//! `TurnParked`/`TurnWoken` span and per-chunk keep-alive narration, the
+//! soft-stop check that ends a multi-minute wait early, and the
+//! exhausted-ladder event pair. The park honors invariant 6's spirit the
+//! same way `driver/waiting.rs` does: the wait sits between model attempts,
+//! never mid-tool, and the budget's deadline bounds it from the outside.
+
+use stella_protocol::AgentEvent;
+
+use super::{CompletionResultAlias, Engine, RetryAttemptFn, SpeculationFuture, lifecycle};
+use crate::budget::BudgetGuard;
+use crate::bus;
+use crate::event_sender::EventSender;
+use crate::retry::{ParkDirective, ParkSupervisor, RetryOutcome, retry_with_backoff_observed};
+use crate::step::CancelUsageGuard;
+
+/// Absolute ceiling on the parked waiting one model call may accumulate,
+/// deadline or no deadline — six hours, matching the reset-aware extension
+/// the comparator lineage allows its unattended rate-limit retries. Without
+/// this, a deadline-less interactive session against a hard-down provider
+/// would park forever; with it, the session narrates its waits for six hours
+/// and then surfaces the rate limit.
+pub(super) const MAX_PARKED_WAIT_MS: u64 = 6 * 60 * 60 * 1000;
+
+/// Wall clock a park must leave unspent under a task deadline: waking with
+/// less than this left means the retried call itself would be aborted at the
+/// next safe boundary, so the wait would spend the budget and buy nothing.
+const PARK_DEADLINE_RESERVE_MS: u64 = 30_000;
+
+/// The engine's [`ParkSupervisor`]: allowance from the budget guard's task
+/// deadline (capped by [`MAX_PARKED_WAIT_MS`]), the `TurnParked`/`TurnWoken`
+/// span plus per-chunk keep-alive narration on the event stream, and the
+/// soft-stop latch as the early exit — a park must not make Esc wait out a
+/// provider brownout.
+struct RateLimitPark<'e, 'a> {
+    engine: &'e Engine<'a>,
+    budget: &'e BudgetGuard,
+    events: &'e EventSender,
+}
+
+impl ParkSupervisor for RateLimitPark<'_, '_> {
+    fn wait_allowance_ms(&mut self, waited_ms: u64) -> u64 {
+        let cap = MAX_PARKED_WAIT_MS.saturating_sub(waited_ms);
+        match self.budget.deadline_remaining(std::time::Instant::now()) {
+            Some(remaining) => {
+                let remaining_ms = u64::try_from(remaining.as_millis()).unwrap_or(u64::MAX);
+                cap.min(remaining_ms.saturating_sub(PARK_DEADLINE_RESERVE_MS))
+            }
+            None => cap,
+        }
+    }
+
+    fn park_opened(&mut self, planned_ms: u64, chunk_ms: u64, reason: &str) {
+        let deadline_secs = planned_ms.div_ceil(1000);
+        let _ = self.events.send(AgentEvent::TurnParked {
+            description: format!("provider rate limited — backing off {deadline_secs}s ({reason})"),
+            poll_interval_secs: chunk_ms / 1000,
+            deadline_secs,
+        });
+        self.engine
+            .emit_lifecycle(bus::names::AGENT_TURN_PARKED, || {
+                lifecycle::turn_parked_payload(chunk_ms / 1000, deadline_secs)
+            });
+    }
+
+    fn park_tick(&mut self, waited_ms: u64, planned_ms: u64) -> ParkDirective {
+        if self
+            .engine
+            .steering
+            .is_some_and(|steering| steering.soft_stop_requested())
+        {
+            return ParkDirective::Abort;
+        }
+        // The per-chunk keep-alive (#2677): a multi-minute wait announces
+        // its liveness at chunk cadence so no observer of the stream reads
+        // the parked turn as a dead one. Suppressed on the first tick — the
+        // `TurnParked` span-open just above it already said everything this
+        // would.
+        if waited_ms > 0 {
+            let _ = self.events.send(AgentEvent::Text {
+                text: format!(
+                    "\n⏳ Still rate limited — waited {}s of {}s before the next attempt.\n",
+                    waited_ms / 1000,
+                    planned_ms.div_ceil(1000),
+                ),
+            });
+        }
+        ParkDirective::Continue
+    }
+
+    // The waited duration already reached the wire through the keep-alive
+    // ticks; the span close carries only the chunk count, mirroring
+    // `driver/waiting.rs`'s poll accounting.
+    fn park_closed(&mut self, _waited_ms: u64, chunks: u64, aborted: bool) {
+        let reason = if aborted {
+            "soft_stop"
+        } else {
+            "retry_window_elapsed"
+        };
+        let _ = self.events.send(AgentEvent::TurnWoken {
+            reason: reason.to_string(),
+            polls_used: chunks,
+        });
+        self.engine
+            .emit_lifecycle(bus::names::AGENT_TURN_WOKEN, || {
+                lifecycle::turn_woken_payload(reason, chunks)
+            });
+    }
+}
+
+impl<'a> Engine<'a> {
+    /// Drive one step's attempt ladder to a committed completion or a clean
+    /// failure. Owns everything between "the attempt closure exists" and
+    /// "a result committed": the cancellation usage guard, the per-attempt
+    /// incompleteness envelopes, the parked rate-limit recovery above, and —
+    /// on exhaustion — the `RetriesExhausted` + `Error` event pair. Returns
+    /// the instant the ladder started (the committed call's duration axis)
+    /// alongside the outcome.
+    pub(super) async fn drive_attempt_ladder<'f>(
+        &self,
+        attempt: RetryAttemptFn<'f>,
+        attempt_in_flight: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        budget: &BudgetGuard,
+        events: &EventSender,
+    ) -> Result<
+        (
+            std::time::Instant,
+            RetryOutcome<(CompletionResultAlias, SpeculationFuture<'f>)>,
+        ),
+        String,
+    > {
+        let call_started = std::time::Instant::now();
+        // Armed for exactly the interval where a paid attempt may be in
+        // flight: a caller-side hard cancel that drops this future mid-await
+        // still leaves one content-free `Cancelled` envelope behind.
+        // Disarmed on BOTH normal exits — a success reports through its
+        // `StepUsage`, and a terminal failure's attempts already reported
+        // through the per-attempt observer below. The shared latch narrows
+        // "in flight" to the dispatch itself: a drop landing in a backoff
+        // sleep (or a parked wait) emits nothing, because the failed attempt
+        // before the sleep already reported its own envelope.
+        let mut cancel_guard = CancelUsageGuard {
+            events: events.clone(),
+            role: self.call_role,
+            provider: self.provider.id().to_string(),
+            started: call_started,
+            armed: true,
+            attempt_in_flight,
+        };
+        let incomplete_events = events.clone();
+        // Every failed attempt's reason, accumulated through the observer:
+        // retry.rs returns retry history only for calls that COMMIT, so on
+        // exhaustion this is the sole record of the doomed attempts
+        // (receipts spec §6.3 — RetriesExhausted). A std Mutex, never held
+        // across an await and contention-free — the observer runs serially
+        // within this call.
+        let attempt_reasons: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        let mut park = RateLimitPark {
+            engine: self,
+            budget,
+            events,
+        };
+        match retry_with_backoff_observed(
+            &self.config.retry_policy,
+            self.sleeper,
+            attempt,
+            // Per-attempt duration (retry.rs times each dispatch
+            // individually): the failed call's own latency, never
+            // cumulative across earlier attempts or backoff sleeps.
+            |attempt, error, attempt_duration| {
+                attempt_reasons
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(error.to_string());
+                let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
+                    role: self.call_role,
+                    provider: self.provider.id().to_string(),
+                    model: "unknown".into(),
+                    reason: stella_protocol::UsageIncompleteReason::ProviderError,
+                    duration_ms: attempt_duration.as_millis() as u64,
+                    retries: Some(attempt.saturating_sub(1)),
+                    // Whatever the adapter salvaged from the dying stream.
+                    // This observer is the only place it can be read: retry.rs
+                    // returns history only for calls that COMMIT, so a doomed
+                    // attempt's accounting reaches the wire here or nowhere.
+                    partial: error.partial_usage().copied(),
+                });
+            },
+            &mut park,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                cancel_guard.disarm();
+                // Call-outcome feedback (#2673): a committed step closes the
+                // routing circuit breaker's window for this provider.
+                if let Some(outcomes) = self.outcomes {
+                    outcomes.record_success(self.provider.id());
+                }
+                Ok((call_started, outcome))
+            }
+            Err(error) => {
+                cancel_guard.disarm();
+                let reasons =
+                    std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
+                // Shared with the paired `Error` event below: whether the
+                // FINAL attempt's error is of a retryable class. `false`
+                // means every attempt (typically just one — see
+                // `retry_with_backoff_observed`, which bails on the first
+                // non-retryable error) was doomed from the start, not
+                // exhausted by an actual retry loop (#926).
+                let retryable = error.is_retryable();
+                let _ = events.send(AgentEvent::RetriesExhausted {
+                    turn_instance: self.config.turn_instance,
+                    attempts: reasons.len() as u32,
+                    reasons,
+                    retryable,
+                });
+                let message = error.to_string();
+                let _ = events.send(AgentEvent::Error {
+                    message: message.clone(),
+                    retryable,
+                });
+                // Call-outcome feedback (#2673): an exhausted ladder is the
+                // signal the router's circuit breaker trips on.
+                if let Some(outcomes) = self.outcomes {
+                    outcomes.record_failure(self.provider.id());
+                }
+                Err(format!("model call failed: {message}"))
+            }
+        }
+    }
+}

--- a/crates/stella-core/src/driver/tests/parked_wait.rs
+++ b/crates/stella-core/src/driver/tests/parked_wait.rs
@@ -316,3 +316,178 @@ async fn a_non_read_only_probe_is_refused_not_replayed() {
     );
     assert!(refused, "the refusal must be visible on the stream");
 }
+
+// ---- rate-limit parks (#2677 / #2667): abort becomes recovery ------------
+
+/// Errors shaped like a provider brownout: HTTP 429 with no `Retry-After`.
+fn throttled() -> ProviderError {
+    ProviderError::RateLimited {
+        message: "throttled".into(),
+        retry_after_ms: None,
+    }
+}
+
+/// The witness for #2667's measured loss (7 attempts burned in 15s with 880s
+/// of budget left): sustained hint-less rate limiting that exhausts the
+/// inline ladder now parks — bounded by wall clock, narrated on the stream —
+/// and the step completes once the provider recovers. On the pre-#2677
+/// ladder this run dies at the seventh attempt with `RetriesExhausted`.
+#[tokio::test]
+async fn sustained_rate_limiting_parks_within_budget_and_recovers() {
+    // Nine 429s: six absorbed by the inline ladder, three more that only a
+    // park survives. The tenth call succeeds.
+    let mut script: Vec<Result<CompletionResultAlias, ProviderError>> =
+        (0..9).map(|_| Err(throttled())).collect();
+    script.push(Ok(text_result("recovered — done")));
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(script),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the task"),
+    ];
+    // No task deadline: the park allowance is the absolute six-hour cap.
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { ref text, .. } if text.contains("recovered")),
+        "sustained 429s with budget left must recover, not abort: {outcome:?}"
+    );
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        10,
+        "every scripted attempt must have been dispatched"
+    );
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::TurnParked { description, .. } if description.contains("rate limited")
+        )),
+        "the park must open a typed span naming the rate limit"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::TurnWoken { reason, .. } if reason == "retry_window_elapsed"
+        )),
+        "the elapsed park must close its span"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RetriesExhausted { .. })),
+        "a recovered brownout is not an exhaustion"
+    );
+}
+
+/// The witness for #2677's headline defect: a `Retry-After` past the 120s
+/// inline ceiling used to fail the call fast as `Terminal` even with hours
+/// of wall clock left. With headroom it is now honored as a parked wait.
+#[tokio::test]
+async fn a_long_retry_after_hint_is_honored_by_parking_when_budget_allows() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Err(ProviderError::RateLimited {
+                message: "hard limit".into(),
+                retry_after_ms: Some(300_000), // 5 minutes — past the 120s inline ceiling
+            }),
+            Ok(text_result("after the stated wait — done")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { ref text, .. } if text.contains("done")),
+        "a stated wait that fits the budget must be honored: {outcome:?}"
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    let events = drain_events(&mut rx);
+    let parked = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::TurnParked { deadline_secs, .. } => Some(*deadline_secs),
+            _ => None,
+        })
+        .expect("the honored hint must park, not sleep silently");
+    // The server asked for 300s; the park is that plus at most the additive
+    // hint jitter (an eighth), never less than asked.
+    assert!(
+        (300..=338).contains(&parked),
+        "park length must derive from the server hint: {parked}s"
+    );
+}
+
+/// The fail-fast half the issue keeps: a stated wait that cannot fit inside
+/// the task deadline's remaining headroom still fails fast — waiting less
+/// than the server asked guarantees a re-429, so the wait would spend the
+/// budget and buy nothing. The park machinery must not engage.
+#[tokio::test]
+async fn a_hint_past_the_remaining_deadline_still_fails_fast_without_parking() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Err(ProviderError::RateLimited {
+            message: "hard limit".into(),
+            retry_after_ms: Some(300_000),
+        })]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    // 60s of deadline left: after the 30s wake reserve, a 300s stated wait
+    // can never fit.
+    budget.set_task_deadline(Some(
+        std::time::Instant::now() + std::time::Duration::from_secs(60),
+    ));
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { ref reason, .. } if reason.contains("failing fast")),
+        "an unaffordable stated wait must abort cleanly: {outcome:?}"
+    );
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        1,
+        "must fail on the first attempt, not retry into the stated window"
+    );
+    assert!(
+        !drain_events(&mut rx)
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TurnParked { .. })),
+        "no park may open for a wait that cannot fit"
+    );
+}

--- a/crates/stella-core/src/retry.rs
+++ b/crates/stella-core/src/retry.rs
@@ -17,6 +17,12 @@
 //!   intentionally stricter: `retry_with_backoff_observed` synchronously
 //!   exposes every failed dispatched attempt so unknown provider usage can be
 //!   persisted even when a later attempt succeeds.
+//! - **#2677 — abort becomes recovery**: sustained rate limiting is bounded
+//!   by the caller's wall clock, not the attempt count. A 429 the inline
+//!   ladder cannot absorb parks through the injected [`ParkSupervisor`] —
+//!   chunked sleeps, per-chunk keep-alive, budget-derived allowance — and
+//!   only an unaffordable wait still fails fast. Nothing here reads a clock
+//!   or a budget directly; the supervisor is a port, like [`Sleeper`].
 //!
 //! Per-call timeouts (L-E4) are a caller concern layered on top of
 //! `attempt_fn`; this module owns "should we try again, and if so after how
@@ -43,6 +49,133 @@ pub trait Sleeper: Send + Sync {
     async fn sleep(&self, duration_ms: u64);
 }
 
+/// Milliseconds per parked-wait chunk: a long rate-limit wait is slept in
+/// pieces of this size so the supervisor is consulted (and can narrate
+/// liveness or end the park) at a human cadence rather than once per
+/// multi-minute sleep. 30s matches the keep-alive cadence the comparator
+/// lineage uses for its unattended rate-limit retries.
+pub const PARK_CHUNK_MS: u64 = 30_000;
+
+/// First parked-wait backoff when the server sent no `Retry-After` hint.
+/// Deliberately past the inline ladder's 8s cap: by the time a park is
+/// reached the inline ladder has already failed, so the brownout is minutes
+/// long, not seconds.
+const PARK_BACKOFF_FLOOR_MS: u64 = 30_000;
+
+/// Ceiling on the hint-less parked-wait backoff — 5 minutes, the same cap
+/// the comparator lineage uses for sustained 429 retries. A server hint
+/// larger than this is still honored verbatim (within the allowance): a
+/// stated window always beats a guessed one.
+const PARK_BACKOFF_CAP_MS: u64 = 300_000;
+
+/// What [`ParkSupervisor::park_tick`] tells the retry driver to do with the
+/// rest of a parked wait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParkDirective {
+    /// Keep waiting: sleep the next chunk.
+    Continue,
+    /// End the park now and surface the rate-limit error — the caller saw a
+    /// soft stop (or decided the wait is no longer worth it).
+    Abort,
+}
+
+/// The caller-side authority over parked rate-limit waits (#2677): how much
+/// wall clock a park may spend, and the per-chunk keep-alive hook. This is a
+/// port in the same sense as [`Sleeper`] — the retry driver stays pure
+/// decision logic plus injected effects, so the budget guard, the event
+/// stream, and the soft-stop latch never leak into this module.
+///
+/// A park happens only when a rate limit outlives the inline ladder (or its
+/// `Retry-After` exceeds [`RetryPolicy::max_server_hint_ms`]); the supervisor
+/// then bounds it. [`NoParking`] — the [`retry_with_backoff`] default —
+/// grants zero allowance, which preserves the pre-#2677 fail-fast exactly.
+/// `Send` because the retry future that borrows the supervisor crosses
+/// `tokio::spawn` in the hosts that drive turns on worker threads — the same
+/// bound [`Sleeper`] carries for the same reason.
+pub trait ParkSupervisor: Send {
+    /// Wall-clock milliseconds of parked waiting still affordable, asked
+    /// fresh before each park. `waited_ms` is the parked time this call has
+    /// already spent, so a deadline-less caller can still enforce an
+    /// absolute cap. Returning `0` declines the park and the rate-limit
+    /// error surfaces as it did before parking existed.
+    fn wait_allowance_ms(&mut self, waited_ms: u64) -> u64;
+    /// A park is starting: `planned_ms` total, slept in `chunk_ms` pieces.
+    /// `reason` is the rate-limit error's rendered message.
+    fn park_opened(&mut self, planned_ms: u64, chunk_ms: u64, reason: &str);
+    /// Consulted before every chunk (including the first, at
+    /// `waited_ms == 0`): the keep-alive/liveness hook, and the seam a soft
+    /// stop uses to end a multi-minute wait early.
+    fn park_tick(&mut self, waited_ms: u64, planned_ms: u64) -> ParkDirective;
+    /// The park ended after `waited_ms` across `chunks` sleeps; `aborted`
+    /// is true when a tick ended it early.
+    fn park_closed(&mut self, waited_ms: u64, chunks: u64, aborted: bool);
+}
+
+/// The zero-allowance supervisor: never parks, so every rate limit behaves
+/// exactly as it did before #2677 — the default for [`retry_with_backoff`]
+/// callers that have no budget authority to consult.
+pub struct NoParking;
+
+impl ParkSupervisor for NoParking {
+    fn wait_allowance_ms(&mut self, _waited_ms: u64) -> u64 {
+        0
+    }
+    // Unreachable while the allowance is 0, but no-ops rather than panics:
+    // this is library code on a provider-driven path (invariant 5).
+    fn park_opened(&mut self, _planned_ms: u64, _chunk_ms: u64, _reason: &str) {}
+    fn park_tick(&mut self, _waited_ms: u64, _planned_ms: u64) -> ParkDirective {
+        ParkDirective::Continue
+    }
+    fn park_closed(&mut self, _waited_ms: u64, _chunks: u64, _aborted: bool) {}
+}
+
+/// The pure park decision: how long to wait for a rate limit that outlived
+/// the inline ladder, given the (already jittered) server hint delay, how
+/// many parks this call has taken, and the supervisor's allowance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParkPlan {
+    /// Wait `total_ms`, then try again.
+    Wait { total_ms: u64 },
+    /// No affordable wait: surface the error.
+    GiveUp,
+}
+
+/// Plan one parked wait. Pure — all inputs are owned numbers, so the whole
+/// decision surface is property-testable without sleeping:
+///
+/// - A server hint that does not fit inside the allowance gives up: waiting
+///   less than the server's stated window guarantees a re-429, so the
+///   fail-fast the hint ceiling used to provide survives, now measured
+///   against real headroom instead of a fixed constant.
+/// - A hint that fits is honored, raised to the streak backoff when that is
+///   politer (waiting longer than asked is always safe), and clamped back to
+///   the allowance (which never dips below the hint itself).
+/// - With no hint, the wait is the streak backoff — doubling from
+///   `PARK_BACKOFF_FLOOR_MS` (30s) to `PARK_BACKOFF_CAP_MS` (5min) — clamped
+///   to the allowance, so the final park before an exhausted budget still
+///   gets its last, shorter chance.
+pub fn plan_rate_limit_park(
+    hint_delay_ms: Option<u64>,
+    park_streak: u32,
+    allowance_ms: u64,
+) -> ParkPlan {
+    if allowance_ms == 0 {
+        return ParkPlan::GiveUp;
+    }
+    let backoff = PARK_BACKOFF_FLOOR_MS
+        .saturating_mul(2u64.saturating_pow(park_streak))
+        .min(PARK_BACKOFF_CAP_MS);
+    match hint_delay_ms {
+        Some(hint) if hint > allowance_ms => ParkPlan::GiveUp,
+        Some(hint) => ParkPlan::Wait {
+            total_ms: hint.max(backoff).min(allowance_ms),
+        },
+        None => ParkPlan::Wait {
+            total_ms: backoff.min(allowance_ms),
+        },
+    }
+}
+
 /// Retry policy for one model or tool call: how many times to retry a
 /// retryable failure, and the backoff envelope between attempts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,20 +191,24 @@ pub struct RetryPolicy {
     /// bound by it; the hint has its own, much higher [`Self::max_server_hint_ms`]
     /// ceiling.
     pub max_delay_ms: u64,
-    /// Ceiling in milliseconds on a server-supplied `Retry-After` hint —
-    /// separate from, and far higher than, [`Self::max_delay_ms`]. Providers
-    /// legitimately ask for 30–60s on a hard rate limit; clamping that to the
-    /// computed-backoff cap fires the retry back inside the server's stated
-    /// window and re-429s. A hint at or under this ceiling is honored; a hint
-    /// past it is treated as unreasonable and fails the call fast (surfacing
-    /// the hint value) rather than silently parking the turn.
+    /// Ceiling in milliseconds on a server-supplied `Retry-After` hint the
+    /// *inline* ladder will sleep — separate from, and far higher than,
+    /// [`Self::max_delay_ms`]. Providers legitimately ask for 30–60s on a
+    /// hard rate limit; clamping that to the computed-backoff cap fires the
+    /// retry back inside the server's stated window and re-429s. A hint at
+    /// or under this ceiling is honored inline; a hint past it escalates to
+    /// the parked-wait path (#2677), where the caller's [`ParkSupervisor`]
+    /// decides whether the remaining wall-clock budget affords honoring it —
+    /// and only when it does not is the call failed fast (surfacing the hint
+    /// value).
     pub max_server_hint_ms: u64,
 }
 
-/// Default ceiling for a server `Retry-After` hint. High enough to obey the
-/// 30–60s waits providers hand out on hard rate limits (well past the 8s
-/// computed-backoff cap), low enough that a runaway multi-minute hint fails
-/// the call fast instead of parking the turn.
+/// Default ceiling for a server `Retry-After` hint slept inline. High
+/// enough to obey the 30–60s waits providers hand out on hard rate limits
+/// (well past the 8s computed-backoff cap), low enough that a multi-minute
+/// hint takes the supervised parked-wait path — chunked, narrated, and
+/// budget-bounded — instead of an unannounced inline sleep.
 const DEFAULT_MAX_SERVER_HINT_MS: u64 = 120_000;
 
 impl RetryPolicy {
@@ -227,9 +364,11 @@ fn server_hint_delay_ms(policy: &RetryPolicy, hint_ms: u64, rng: &mut impl Rng) 
 /// (floored at `policy.base_delay_ms`, nudged by a small jitter, and bounded
 /// by its own `policy.max_server_hint_ms` ceiling rather than the
 /// computed-backoff cap) instead of the computed jittered delay — respecting
-/// a server's stated backoff beats guessing at one. A hint past that ceiling
-/// fails the call fast (surfacing the hint value) rather than retrying back
-/// inside the server's stated window.
+/// a server's stated backoff beats guessing at one. This wrapper runs with
+/// [`NoParking`], so a rate limit that outlives the ladder (or a hint past
+/// the inline ceiling) fails the call fast, exactly as it did before #2677;
+/// callers with wall-clock authority use `retry_with_backoff_observed`'s
+/// [`ParkSupervisor`] to convert that abort into a bounded parked wait.
 ///
 /// On success, [`RetryOutcome::retries`] carries the full retry history so
 /// the caller (`driver.rs`) can walk it and emit one
@@ -248,7 +387,7 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, ProviderError>>,
 {
-    retry_with_backoff_observed(policy, sleeper, attempt_fn, |_, _, _| {}).await
+    retry_with_backoff_observed(policy, sleeper, attempt_fn, |_, _, _| {}, &mut NoParking).await
 }
 
 /// Retry while synchronously observing every failed dispatched attempt.
@@ -267,6 +406,7 @@ pub(crate) async fn retry_with_backoff_observed<F, Fut, T, O>(
     sleeper: &dyn Sleeper,
     mut attempt_fn: F,
     mut observe_failure: O,
+    park: &mut dyn ParkSupervisor,
 ) -> Result<RetryOutcome<T>, ProviderError>
 where
     F: FnMut() -> Fut,
@@ -275,6 +415,11 @@ where
 {
     let mut retries = Vec::new();
     let mut attempt: u32 = 0;
+    // Parked-wait accounting across the whole call: how much wall clock the
+    // parks have spent (fed back to the supervisor's allowance) and how many
+    // parks have been taken (drives the hint-less park backoff).
+    let mut parked_total_ms: u64 = 0;
+    let mut park_streak: u32 = 0;
     loop {
         let attempt_started = std::time::Instant::now();
         match attempt_fn().await {
@@ -287,30 +432,112 @@ where
             }
             Err(error) => {
                 observe_failure(attempt + 1, &error, attempt_started.elapsed());
-                if !error.is_retryable() || attempt >= policy.max_retries {
+                if !error.is_retryable() {
                     return Err(error);
                 }
+                let rate_limit_hint = match &error {
+                    ProviderError::RateLimited { retry_after_ms, .. } => Some(*retry_after_ms),
+                    _ => None,
+                };
 
-                let delay_ms = match &error {
-                    ProviderError::RateLimited {
-                        message,
-                        retry_after_ms: Some(hint),
-                    } => {
-                        if *hint > policy.max_server_hint_ms {
-                            // The provider's own message rides along — the
-                            // hint explains the wait, the message explains
-                            // the limit, and dropping either loses half the
-                            // diagnosis.
-                            return Err(ProviderError::Terminal(format!(
-                                "rate-limited ({message}) and the server asked to wait {hint}ms \
-                                 before retrying, past this call's {ceiling}ms server-hint \
-                                 ceiling — failing fast instead of parking the turn",
-                                ceiling = policy.max_server_hint_ms,
-                            )));
-                        }
-                        server_hint_delay_ms(policy, *hint, &mut rand::rng())
+                // The inline ladder — today's bounded backoff — handles
+                // every retryable failure while attempts remain, except a
+                // rate-limit hint past the inline ceiling (never sleepable
+                // inline). Anything the ladder cannot absorb either parks
+                // (a rate limit with wall-clock headroom, below) or
+                // surfaces: only rate limiting earns a park, because it is
+                // the one failure whose recovery is a function of waiting.
+                let ladder_open = attempt < policy.max_retries;
+                let inline_delay_ms = match rate_limit_hint {
+                    None if ladder_open => {
+                        Some(compute_backoff_delay_ms(policy, attempt, &mut rand::rng()))
                     }
-                    _ => compute_backoff_delay_ms(policy, attempt, &mut rand::rng()),
+                    None => return Err(error),
+                    Some(hint)
+                        if ladder_open && hint.is_none_or(|h| h <= policy.max_server_hint_ms) =>
+                    {
+                        Some(match hint {
+                            Some(h) => server_hint_delay_ms(policy, h, &mut rand::rng()),
+                            None => compute_backoff_delay_ms(policy, attempt, &mut rand::rng()),
+                        })
+                    }
+                    Some(_) => None,
+                };
+
+                let delay_ms = match inline_delay_ms {
+                    Some(delay_ms) => {
+                        sleeper.sleep(delay_ms).await;
+                        delay_ms
+                    }
+                    // The park path (#2677): a rate limit the inline ladder
+                    // could not absorb, converted into a supervised wait
+                    // when the caller's wall-clock budget affords one.
+                    None => {
+                        // L-M4 holds under rate limiting too: the
+                        // deterministic fast path never waits, never parks.
+                        if policy.max_retries == 0 {
+                            return Err(error);
+                        }
+                        let hint_ms = rate_limit_hint.flatten();
+                        let hint_delay_ms =
+                            hint_ms.map(|h| server_hint_delay_ms(policy, h, &mut rand::rng()));
+                        let allowance_ms = park.wait_allowance_ms(parked_total_ms);
+                        let total_ms =
+                            match plan_rate_limit_park(hint_delay_ms, park_streak, allowance_ms) {
+                                ParkPlan::Wait { total_ms } => total_ms,
+                                // An unaffordable stated window fails fast —
+                                // waiting less than the server asked
+                                // guarantees a re-429, so the wait would
+                                // spend the budget and buy nothing. The
+                                // provider's own message rides along: the
+                                // hint explains the wait, the message
+                                // explains the limit, and dropping either
+                                // loses half the diagnosis.
+                                ParkPlan::GiveUp => {
+                                    return Err(match hint_ms {
+                                        Some(hint) if hint > policy.max_server_hint_ms => {
+                                            ProviderError::Terminal(format!(
+                                                "{error}; the server asked to wait {hint}ms \
+                                                 before retrying, past this call's {ceiling}ms \
+                                                 inline ceiling and beyond the {allowance_ms}ms \
+                                                 of wall-clock headroom left for a parked wait — \
+                                                 failing fast instead of waiting past the budget",
+                                                ceiling = policy.max_server_hint_ms,
+                                            ))
+                                        }
+                                        // Exhaustion the headroom cannot
+                                        // absorb surfaces the rate limit
+                                        // itself, exactly as pre-park
+                                        // exhaustion did — the error class
+                                        // (and RetriesExhausted::retryable
+                                        // downstream) stays truthful.
+                                        _ => error,
+                                    });
+                                }
+                            };
+                        park.park_opened(total_ms, PARK_CHUNK_MS, &error.to_string());
+                        let mut waited_ms: u64 = 0;
+                        let mut chunks: u64 = 0;
+                        let aborted = loop {
+                            if waited_ms >= total_ms {
+                                break false;
+                            }
+                            if park.park_tick(waited_ms, total_ms) == ParkDirective::Abort {
+                                break true;
+                            }
+                            let chunk = PARK_CHUNK_MS.min(total_ms - waited_ms);
+                            sleeper.sleep(chunk).await;
+                            waited_ms += chunk;
+                            chunks += 1;
+                        };
+                        park.park_closed(waited_ms, chunks, aborted);
+                        parked_total_ms = parked_total_ms.saturating_add(waited_ms);
+                        if aborted {
+                            return Err(error);
+                        }
+                        park_streak = park_streak.saturating_add(1);
+                        waited_ms
+                    }
                 };
 
                 retries.push(RetryAttempt {
@@ -318,9 +545,7 @@ where
                     reason: error.to_string(),
                     delay_ms,
                 });
-
-                sleeper.sleep(delay_ms).await;
-                attempt += 1;
+                attempt = attempt.saturating_add(1);
             }
         }
     }
@@ -721,6 +946,236 @@ mod tests {
             sleeper.delays_ms.lock().unwrap().is_empty(),
             "must never sleep on a hint past the ceiling"
         );
+    }
+
+    // ---- parked rate-limit recovery (#2677) ------------------------------
+
+    /// A scripted [`ParkSupervisor`]: fixed allowance, full transcript of
+    /// hook calls, optional abort on the Nth tick.
+    #[derive(Default)]
+    struct RecordingSupervisor {
+        allowance_ms: u64,
+        opened: Vec<(u64, u64)>,
+        ticks: Vec<(u64, u64)>,
+        closed: Vec<(u64, u64, bool)>,
+        abort_on_tick: Option<usize>,
+    }
+
+    impl RecordingSupervisor {
+        fn with_allowance(allowance_ms: u64) -> Self {
+            Self {
+                allowance_ms,
+                ..Self::default()
+            }
+        }
+    }
+
+    impl ParkSupervisor for RecordingSupervisor {
+        fn wait_allowance_ms(&mut self, waited_ms: u64) -> u64 {
+            self.allowance_ms.saturating_sub(waited_ms)
+        }
+        fn park_opened(&mut self, planned_ms: u64, chunk_ms: u64, _reason: &str) {
+            self.opened.push((planned_ms, chunk_ms));
+        }
+        fn park_tick(&mut self, waited_ms: u64, planned_ms: u64) -> ParkDirective {
+            self.ticks.push((waited_ms, planned_ms));
+            match self.abort_on_tick {
+                Some(n) if self.ticks.len() >= n => ParkDirective::Abort,
+                _ => ParkDirective::Continue,
+            }
+        }
+        fn park_closed(&mut self, waited_ms: u64, chunks: u64, aborted: bool) {
+            self.closed.push((waited_ms, chunks, aborted));
+        }
+    }
+
+    #[test]
+    fn plan_honors_a_hint_that_fits_and_gives_up_on_one_that_does_not() {
+        // A stated window inside the allowance is honored (raised to the
+        // streak backoff, which is always safe); one outside it gives up.
+        assert_eq!(
+            plan_rate_limit_park(Some(90_000), 0, 3_600_000),
+            ParkPlan::Wait { total_ms: 90_000 }
+        );
+        assert_eq!(
+            plan_rate_limit_park(Some(90_000), 0, 60_000),
+            ParkPlan::GiveUp
+        );
+        // Hint-less waits follow the doubling backoff, clamped to the cap…
+        assert_eq!(
+            plan_rate_limit_park(None, 0, 3_600_000),
+            ParkPlan::Wait { total_ms: 30_000 }
+        );
+        assert_eq!(
+            plan_rate_limit_park(None, 10, 3_600_000),
+            ParkPlan::Wait {
+                total_ms: PARK_BACKOFF_CAP_MS
+            }
+        );
+        // …and to the allowance, so the last affordable wait still happens.
+        assert_eq!(
+            plan_rate_limit_park(None, 3, 45_000),
+            ParkPlan::Wait { total_ms: 45_000 }
+        );
+        assert_eq!(plan_rate_limit_park(None, 0, 0), ParkPlan::GiveUp);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn a_planned_park_never_exceeds_the_allowance_and_never_undercuts_the_hint(
+            hint in proptest::option::of(0u64..1_000_000),
+            streak in 0u32..20,
+            allowance in 0u64..10_000_000,
+        ) {
+            match plan_rate_limit_park(hint, streak, allowance) {
+                ParkPlan::Wait { total_ms } => {
+                    proptest::prop_assert!(total_ms <= allowance);
+                    proptest::prop_assert!(total_ms > 0);
+                    if let Some(hint) = hint {
+                        // Waiting less than the server asked guarantees a
+                        // re-429 — a plan may wait longer, never shorter.
+                        proptest::prop_assert!(total_ms >= hint);
+                    }
+                }
+                ParkPlan::GiveUp => {
+                    let unaffordable_hint = hint.is_some_and(|h| h > allowance);
+                    proptest::prop_assert!(allowance == 0 || unaffordable_hint);
+                }
+            }
+        }
+    }
+
+    /// The pure-loop witness for #2667: rate limiting that outlives the
+    /// inline ladder parks and recovers instead of exhausting — the attempt
+    /// count stops being the bound; the supervisor's wall clock is.
+    #[tokio::test]
+    async fn sustained_rate_limiting_beyond_the_ladder_parks_and_recovers() {
+        let policy = RetryPolicy::new(2, 1, 5);
+        let sleeper = NoopSleeper::default();
+        let mut park = RecordingSupervisor::with_allowance(3_600_000);
+        let calls = AtomicU32::new(0);
+
+        let outcome = retry_with_backoff_observed(
+            &policy,
+            &sleeper,
+            || {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if n < 5 {
+                        Err(ProviderError::RateLimited {
+                            message: "throttled".into(),
+                            retry_after_ms: None,
+                        })
+                    } else {
+                        Ok("recovered")
+                    }
+                }
+            },
+            |_, _, _| {},
+            &mut park,
+        )
+        .await
+        .expect("a brownout inside the allowance must recover");
+
+        assert_eq!(outcome.value, "recovered");
+        // 2 inline retries, then 3 parks (30s, 60s, 120s), each recorded in
+        // the committed retry history like any other wait.
+        assert_eq!(outcome.attempts, 6);
+        assert_eq!(outcome.retries.len(), 5);
+        assert_eq!(
+            park.opened
+                .iter()
+                .map(|(planned, _)| *planned)
+                .collect::<Vec<_>>(),
+            vec![30_000, 60_000, 120_000],
+            "hint-less parks follow the doubling backoff"
+        );
+        assert_eq!(
+            park.closed,
+            vec![(30_000, 1, false), (60_000, 2, false), (120_000, 4, false)],
+            "every park runs to its planned length in 30s chunks"
+        );
+    }
+
+    /// Long waits sleep in chunks with a tick before each one — the
+    /// keep-alive/soft-stop cadence — and an Abort tick ends the park and
+    /// surfaces the rate-limit error.
+    #[tokio::test]
+    async fn an_abort_tick_ends_the_park_and_surfaces_the_error() {
+        let policy = RetryPolicy::new(0, 1, 5);
+        // max_retries 0 would decline the park (L-M4), so use 1 with the
+        // ladder pre-burned by a first failure.
+        let policy = RetryPolicy {
+            max_retries: 1,
+            ..policy
+        };
+        let sleeper = NoopSleeper::default();
+        let mut park = RecordingSupervisor::with_allowance(3_600_000);
+        park.abort_on_tick = Some(3);
+        let calls = AtomicU32::new(0);
+
+        let result: Result<RetryOutcome<()>, _> = retry_with_backoff_observed(
+            &policy,
+            &sleeper,
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Err(ProviderError::RateLimited {
+                        message: "hard limit".into(),
+                        retry_after_ms: Some(300_000),
+                    })
+                }
+            },
+            |_, _, _| {},
+            &mut park,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ProviderError::RateLimited { .. })),
+            "an aborted park surfaces the rate limit itself: {result:?}"
+        );
+        let (waited, chunks, aborted) = *park.closed.last().expect("park must close");
+        assert!(aborted, "the close must record the abort");
+        assert_eq!(chunks, 2, "two chunks slept before the aborting third tick");
+        assert_eq!(waited, 60_000);
+        let slept = sleeper.delays_ms.lock().unwrap();
+        assert!(
+            slept.iter().all(|&d| d <= PARK_CHUNK_MS),
+            "no single park sleep may exceed the chunk: {slept:?}"
+        );
+    }
+
+    /// L-M4 survives #2677: the deterministic fast path never parks, no
+    /// matter how generous the supervisor's allowance is.
+    #[tokio::test]
+    async fn the_deterministic_policy_never_parks_even_with_allowance() {
+        let policy = RetryPolicy::deterministic();
+        let sleeper = NoopSleeper::default();
+        let mut park = RecordingSupervisor::with_allowance(3_600_000);
+        let calls = AtomicU32::new(0);
+
+        let result: Result<RetryOutcome<()>, _> = retry_with_backoff_observed(
+            &policy,
+            &sleeper,
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Err(ProviderError::RateLimited {
+                        message: "throttled".into(),
+                        retry_after_ms: None,
+                    })
+                }
+            },
+            |_, _, _| {},
+            &mut park,
+        )
+        .await;
+
+        assert!(matches!(result, Err(ProviderError::RateLimited { .. })));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(park.opened.is_empty(), "no park may open on the fast path");
+        assert!(sleeper.delays_ms.lock().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Under a sustained 429 brownout, `RetryPolicy::standard()`'s inline ladder (6 retries, ~16s total backoff) exhausted in seconds and a `Retry-After` past the fixed 120s ceiling failed `Terminal` outright — even with hundreds of seconds of task budget left. #2667 measured the loss: 7 attempts burned in 15s, killing a trial with 880s of its 900s budget remaining (8/16 cells in `turnloop-cert-panel1`). The comparator lineage retries 429s reset-aware for hours with chunked keep-alives.

**Abort becomes recovery.** A rate limit the inline ladder cannot absorb now *parks* instead of dying, bounded by real wall-clock headroom:

- **`crates/stella-core/src/retry.rs`** — a new `ParkSupervisor` port (the same seam shape as `Sleeper`: the retry driver stays pure decision logic; clock, budget, events, and the soft-stop latch never leak in). The pure planner `plan_rate_limit_park` decides the wait: a server `Retry-After` that fits the allowance is honored verbatim (waiting less than the server asked guarantees a re-429, so an unaffordable hint still fails fast — the fail-fast the old fixed ceiling provided survives, now measured against real headroom); hint-less parks follow a doubling 30s→5min backoff, the comparator's cap. Long waits sleep in 30s chunks with a supervisor tick before each one. Exemplar for the port-with-no-op-default shape: `tokio`'s injected-time seam / the crate's own `Sleeper`+`ports::Clock` discipline.
- **`crates/stella-core/src/driver/rate_limit.rs`** (new sibling module, the `settlement.rs` pattern) — the whole attempt-ladder block moves out of god-file `driver.rs` (which **shrinks by 76 lines**), and the engine's supervisor lands beside it: allowance = task-deadline remaining minus a 30s wake reserve, capped at an absolute 6h; `TurnParked`/`TurnWoken` span (**no new `AgentEvent` variant** — the existing #1857 span fits and keeps this orthogonal to #2720's ledger) plus a per-chunk keep-alive `Text` narration for liveness; soft stop ends the park at the next chunk.
- **L-M4 and invariant 6 hold**: `RetryPolicy::deterministic()` and every auxiliary call (`accounted_call.rs` — summarizer/triage/authoring) keep `NoParking`, matching the comparator's background-source posture; the park sits between model attempts, never mid-tool, and the budget's deadline bounds it from outside.

Anthropic's `Retry-After` already reaches `RateLimited::retry_after_ms` via `parse_retry_after_ms`/`classify_http_status` (`crates/stella-model/src/http.rs`, 429 arm — wiremock-covered there); this PR consumes that hint at the seam where the abort actually happened. `stella-model` does not link `stella-core`, so the recovery witness lives at the driver seam with a scripted provider.

Closes #2677
Closes #2667

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Verified the artisanal way — `git checkout origin/main -- crates/stella-core/src/{retry,driver,accounted_call}.rs && rm crates/stella-core/src/driver/rate_limit.rs` with the test file kept (the driver witnesses use only pre-existing API), then `cargo test -p stella-core --lib parked_wait`:

- `driver::tests::parked_wait::sustained_rate_limiting_parks_within_budget_and_recovers` — **fails on main** (`Aborted { reason: "model call failed: provider rate limited: throttled", kind: Failure }`), passes here: 9 hint-less 429s → 6 inline retries + 3 parks → completed step, `TurnParked`/`TurnWoken` on the stream, no `RetriesExhausted`.
- `driver::tests::parked_wait::a_long_retry_after_hint_is_honored_by_parking_when_budget_allows` — **fails on main** (`Terminal: …asked to wait 300000ms… past this call's 120000ms server-hint ceiling`), passes here: the 300s hint parks (span deadline 300–338s incl. jitter) and the step completes.
- `a_hint_past_the_remaining_deadline_still_fails_fast_without_parking` pins the kept fail-fast half (60s deadline vs 300s hint → clean abort, no park).
- Pure-logic coverage: `retry::tests::sustained_rate_limiting_beyond_the_ladder_parks_and_recovers`, `an_abort_tick_ends_the_park_and_surfaces_the_error`, `the_deterministic_policy_never_parks_even_with_allowance`, and property `a_planned_park_never_exceeds_the_allowance_and_never_undercuts_the_hint` (proptest, per the crate's pure-engine-logic testing idiom). All pre-existing retry tests pass unchanged — `retry_with_backoff` runs `NoParking`, preserving pre-#2677 behavior exactly for supervisor-less callers.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (stella-core + all dependents checked)
- [x] `cargo test -p stella-core` (1089 passed) — full workspace runs in CI
- [x] Docs updated where behavior changed (module docs in `retry.rs`, `max_server_hint_ms` semantics, new module doc)
- [x] CLA signed
- [x] `Closes #N` appears both above and as commit trailers

## Nothing left behind

- Filed: #2741 (runner-side halves of #2667: infrastructure classification of 429 aborts + fan-out token bucket), #2742 (529/overloaded classifies as `Transport`, so a sustained 529 brownout never reaches the park), #2743 (a soft stop during a park surfaces as a `Failure` abort instead of the graceful boundary soft-stop exit)

## Ground-rule check

- [x] No I/O added to `stella-core` (the supervisor is a port; the only clock read is `Instant::now` in the driver, matching the existing neighborhood); no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types (`TurnParked`/`TurnWoken` reused; nothing added to `stella-protocol`)

## Anything reviewers should know?

- `retry_with_backoff_observed` gained a required `&mut dyn ParkSupervisor` parameter (it is `pub(crate)`); the public `retry_with_backoff` signature is unchanged.
- The exhausted-ladder error class is preserved: a rate limit that gives up hint-less still surfaces `RateLimited` (so `RetriesExhausted::retryable` stays truthful per #926); only a genuinely oversized-and-unaffordable hint keeps the explanatory `Terminal`, now naming hint, inline ceiling, and remaining headroom.
- Deliberately **no new `AgentEvent` variant** to stay orthogonal to #2720's consumer ledger; if a typed per-chunk heartbeat is wanted later it should be added post-ledger.
- Alternative rejected: a `max_parked_wait_ms` field on `RetryPolicy` — the allowance is dynamic (deadline-derived), so a policy constant would either lie or duplicate the supervisor's answer.

## Summary by Sourcery

Add budget-aware parked waiting for sustained provider rate limiting and refactor the model-call retry ladder into a dedicated driver module.

Bug Fixes:
- Prevent sustained 429 rate limiting from prematurely aborting turns when there is remaining wall-clock budget.
- Ensure long Retry-After hints beyond the inline ceiling are honored via parked waits when affordable, and fail fast only when they cannot fit within the remaining deadline.

Enhancements:
- Introduce a pluggable ParkSupervisor interface and pure park planning logic to bound and narrate long rate-limit waits without coupling retry logic to clocks or budgets.
- Move the attempt ladder and its rate-limit handling out of driver.rs into a new driver::rate_limit module, reducing driver size and centralizing retry-related effects.
- Keep auxiliary accounted calls and deterministic retry policy on a no-parking path so background and helper traffic continue to fail fast under rate limiting.

Tests:
- Add unit and property tests for park planning behavior to guarantee waits respect allowances and server hints.
- Add integration-style driver tests covering sustained 429 recovery via parking, honoring long Retry-After hints within budget, and fail-fast behavior when hints exceed remaining headroom.