### PR TITLE
fix(stella-model): unbreak main — adapter_sources merge collision (#2748×#2752) + the dangling private doc link

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -130,6 +130,7 @@ use tokio::sync::mpsc::UnboundedSender;
 mod dispatch;
 mod drive;
 pub(crate) mod overflow_recovery;
+mod rate_limit;
 mod settlement;
 pub(crate) mod usage_anchor;
 mod waiting;
@@ -1712,8 +1713,7 @@ impl<'a> Engine<'a> {
         // The ladder itself — the cancellation usage guard, per-attempt
         // incompleteness envelopes, parked rate-limit recovery (#2677),
         // provider-outcome feedback (#2673), and the exhaustion event pair —
-        // lives in `driver/
-      .rs`.
+        // lives in `driver/rate_limit.rs`.
         let (call_started, outcome) = self
             .drive_attempt_ladder(attempt, attempt_in_flight, budget, events)
             .await?;
@@ -1721,82 +1721,7 @@ impl<'a> Engine<'a> {
             value: (result, speculation_future),
             retries,
             ..
-        } = match retry_with_backoff_observed(
-            &self.config.retry_policy,
-            self.sleeper,
-            attempt,
-            // Per-attempt duration (retry.rs times each dispatch
-            // individually): the failed call's own latency, never
-            // cumulative across earlier attempts or backoff sleeps.
-            |attempt, error, attempt_duration| {
-                attempt_reasons
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(error.to_string());
-                let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
-                    role: self.call_role,
-                    provider: self.provider.id().to_string(),
-                    model: "unknown".into(),
-                    reason: stella_protocol::UsageIncompleteReason::ProviderError,
-                    duration_ms: attempt_duration.as_millis() as u64,
-                    retries: Some(attempt.saturating_sub(1)),
-                    // Whatever the adapter salvaged from the dying stream.
-                    // This observer is the only place it can be read: retry.rs
-                    // returns history only for calls that COMMIT, so a doomed
-                    // attempt's accounting reaches the wire here or nowhere.
-                    partial: error.partial_usage().copied(),
-                });
-            },
-        )
-        .await
-        {
-            Ok(outcome) => {
-                cancel_guard.disarm();
-                outcome
-            }
-            Err(error) => {
-                cancel_guard.disarm();
-                let reasons =
-                    std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
-                // A context overflow is withheld from the terminal events and
-                // the breaker: the caller may still recover it, and an
-                // oversized request is the engine's accounting miss, not
-                // provider ill-health (`driver::overflow_recovery`, #2680).
-                if matches!(error, ProviderError::ContextOverflow { .. }) {
-                    return Err(ModelCallFailure::ContextOverflow {
-                        message: error.to_string(),
-                        attempt_reasons: reasons,
-                    });
-                }
-                // Shared with the paired `Error` event below: whether the
-                // FINAL attempt's error is of a retryable class. `false`
-                // means every attempt (typically just one — see
-                // `retry_with_backoff_observed`, which bails on the first
-                // non-retryable error) was doomed from the start, not
-                // exhausted by an actual retry loop (#926).
-                let retryable = error.is_retryable();
-                let _ = events.send(AgentEvent::RetriesExhausted {
-                    turn_instance: self.config.turn_instance,
-                    attempts: reasons.len() as u32,
-                    reasons,
-                    retryable,
-                });
-                let message = error.to_string();
-                let _ = events.send(AgentEvent::Error {
-                    message: message.clone(),
-                    retryable,
-                });
-                if let Some(outcomes) = self.outcomes {
-                    outcomes.record_failure(self.provider.id());
-                }
-                return Err(ModelCallFailure::Fatal {
-                    reason: format!("model call failed: {message}"),
-                });
-            }
-        };
-        if let Some(outcomes) = self.outcomes {
-            outcomes.record_success(self.provider.id());
-        }
+        } = outcome;
         // One boundary read: the call's duration and the tick's clock axis.
         let now = std::time::Instant::now();
         let call_duration_ms = now.duration_since(call_started).as_millis() as u64;

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -16,8 +16,9 @@
 //! same way `driver/waiting.rs` does: the wait sits between model attempts,
 //! never mid-tool, and the budget's deadline bounds it from the outside.
 
-use stella_protocol::AgentEvent;
+use stella_protocol::{AgentEvent, ProviderError};
 
+use super::overflow_recovery::ModelCallFailure;
 use super::{CompletionResultAlias, Engine, RetryAttemptFn, SpeculationFuture, lifecycle};
 use crate::budget::BudgetGuard;
 use crate::bus;
@@ -138,7 +139,7 @@ impl<'a> Engine<'a> {
             std::time::Instant,
             RetryOutcome<(CompletionResultAlias, SpeculationFuture<'f>)>,
         ),
-        String,
+        ModelCallFailure,
     > {
         let call_started = std::time::Instant::now();
         // Armed for exactly the interval where a paid attempt may be in
@@ -214,6 +215,16 @@ impl<'a> Engine<'a> {
                 cancel_guard.disarm();
                 let reasons =
                     std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
+                // A context overflow is withheld from the terminal events and
+                // the breaker: the caller may still recover it, and an
+                // oversized request is the engine's accounting miss, not
+                // provider ill-health (`driver::overflow_recovery`, #2680).
+                if matches!(error, ProviderError::ContextOverflow { .. }) {
+                    return Err(ModelCallFailure::ContextOverflow {
+                        message: error.to_string(),
+                        attempt_reasons: reasons,
+                    });
+                }
                 // Shared with the paired `Error` event below: whether the
                 // FINAL attempt's error is of a retryable class. `false`
                 // means every attempt (typically just one — see
@@ -237,7 +248,9 @@ impl<'a> Engine<'a> {
                 if let Some(outcomes) = self.outcomes {
                     outcomes.record_failure(self.provider.id());
                 }
-                Err(format!("model call failed: {message}"))
+                Err(ModelCallFailure::Fatal {
+                    reason: format!("model call failed: {message}"),
+                })
             }
         }
     }

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -613,8 +613,14 @@ mod tests {
     /// is a false alarm rather than the rotted proof it exists to catch. The
     /// parent `tests.rs` is over the file-size ratchet, so those splits keep
     /// happening — the list has to follow them.
-    fn adapter_sources() -> [&'static str; 15] {
-        [
+    /// Returned as a slice, not a sized array: the array length was one
+    /// shared cell every PR adding a source file had to write, and two green
+    /// PRs (#2748 adding `zai/tests/stream_fallback.rs`, #2752 adding
+    /// `http.rs`) composed into a red `main` when the merge kept both
+    /// entries and one length — the same shape that removed the spelled-out
+    /// total from `GATE_STEPS` (#1883).
+    fn adapter_sources() -> &'static [&'static str] {
+        &[
             // The overflow axis's witnesses live beside the classifier they
             // prove: overflow detection is shared plumbing
             // (`http::classify_http_status`), and its per-dialect tests

--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -1032,7 +1032,8 @@ impl ZaiProvider {
     /// aggregator, which announces each tool call as soon as the next one
     /// starts streaming. That is the only per-call boundary this dialect
     /// emits mid-stream, and it leaves the turn's last call unannounced —
-    /// see [`ToolCallAccumulator::announced`] for what that costs.
+    /// see `ToolCallAccumulator::announced` (`zai/stream.rs`) for what that
+    /// costs.
     async fn complete_inner(
         &self,
         req: CompletionRequestRef<'_>,


### PR DESCRIPTION
## What & why

**Main (f83692c82) is red**, from two independent residues of #2748's admin-merge, and this PR repairs both:

1. **Compile error under `--all-targets`** — a merge composition, not a bug in either parent: #2748 added `zai/tests/stream_fallback.rs` to `provider_parity.rs::adapter_sources` (bumping the array length to 15) and #2752 added `include_str!("http.rs")` from the other side; the textual merge kept **both entries and one length**, so the array literal has 16 items behind a `[&'static str; 15]` return type and `cargo test`/`clippy --all-targets` fail on main (`E0308` at `provider_parity.rs:617`). The length was a shared cell every source-adding PR had to write — the exact shape that removed the spelled-out total from `GATE_STEPS` (#1883) — so the fix returns `&'static [&'static str]` and **deletes the cell** instead of writing 16 into it, with a comment naming the incident.
2. **rustdoc `-D warnings` failure** — #2748 moved `ToolCallAccumulator` into the private `zai::stream` module but left `complete_inner`'s intra-doc link pointing at it. The doc-warnings gate documents private items (`Makefile:247`, `--document-private-items`), so main fails with `unresolved link to 'ToolCallAccumulator::announced'` while a plain `cargo doc --no-deps` stays green — which is how it slipped through #2748's local check. Repointed as plain code font naming the file.

## The witness

- [ ] Witness test
- [x] No witness needed — both are build/doc repairs whose oracle is the gate itself, red on `main` and green here:

```
cargo test -p stella-model              # main: E0308, could not compile → here: 390 passed
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-model --no-deps \
  --document-private-items --keep-going # main: unresolved link, exit 101 → here: exit 0
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-model --all-targets -- -D warnings` (exit 0)
- [x] `cargo test -p stella-model` — 390 passed, including #2748's fallback witnesses and #2752's overflow witnesses together
- [x] gate-identical rustdoc (above), exit 0

## Nothing left behind

Nothing new; the remaining-dialects extension of #2686 stays tracked in #2746.

Refs #2686, #2748, #2752