### PR TITLE
docs(agents): invariant #10 promises a red test, but #2730 made it a build error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,10 +337,12 @@ Append; do not renumber. `scripts/check-invariants.sh` enforces both halves.
    `crates/stella-protocol/src/event/consumers.rs`: one row per wire tag, each
    declaring a `ConsumerPosture` (`Behavioral` names the code that branches on
    it, `Surfaced` names the surfaces that select it, `RecordedOnly` and
-   `Unclassified` each cite the issue where the gap is being decided). Tests
-   enforce totality against `KNOWN_TYPE_TAGS` from both sides, so adding a
-   variant without declaring what consumes it is a red test, and
-   `MAX_UNCLASSIFIED` is a down-only ratchet on the unaudited backlog.
+   `Unclassified` each cite the issue where the gap is being decided). The
+   rows are generated from the same table as `KNOWN_TYPE_TAGS` and
+   `type_tag()` (`crates/stella-protocol/src/event/tags.rs`), so adding a
+   variant without declaring what consumes it is an `E0004` — a build error,
+   not a red test (#2730). `MAX_UNCLASSIFIED` is a down-only ratchet on the
+   unaudited backlog.
 
    Born from a repeated real defect, every instance of which was found by a
    bench run paying for it rather than by a test: `flip.json` written with
@@ -349,13 +351,13 @@ Append; do not renumber. `scripts/check-invariants.sh` enforces both halves.
    certification panel before #2661 wired it; the flip transition still
    emitting nothing durable, so a shipped halt cannot be measured in the
    field. This is invariant #3's discipline pointed at consumption instead of
-   egress — a reviewed table plus tests that enforce it from both sides
-   (#2701).
+   egress — a reviewed table plus enforcement from both sides (#2701).
 
    What it does **not** prove: that a `Behavioral` row's `site` still points
    at live code. That string is prose for a reviewer. The enforced half is
-   totality, uniqueness, issue citation, and posture coherence — enough to
-   make a PR author answer "what reads this?" before the merge.
+   totality (by the compiler) plus issue citation and posture coherence (by
+   test) — enough to make a PR author answer "what reads this?" before the
+   merge.
 ---
 
 ## The definition of done: witness tests


### PR DESCRIPTION
## What & why

Invariant #10 says the signal-consumer ledger's totality is enforced by tests — "adding a variant without declaring what consumes it is a red test." That was true when #2720 landed and stopped being true two commits later: #2737 generated the ledger rows from the tag table, so the check is now an `E0004` at `cargo build`.

Caught by re-reading main after both merges landed. Per CLAUDE.md a stale doc is a bug, and this one is mine — I wrote the prose in #2720 and changed the mechanism in #2737 without chasing the claim.

The correction is not cosmetic: it **understates** the guarantee, and it misdirects the next person adding an `AgentEvent` variant about where the failure will surface.

It also tightens the closing "what it does not prove" paragraph, which is the part most worth keeping exact — totality is now compiler-enforced, while issue citation and posture coherence remain test-enforced. Saying "tests" for both blurs the line that paragraph exists to draw.

## The witness

- [x] No witness needed — documentation only, correcting a claim about existing behavior. The behavior it now describes is witnessed in #2737, where a probe variant produces `error[E0004]: non-exhaustive patterns`.

## Deleted tests

None.

## The gate

- [x] `scripts/check-invariants.sh` — OK, 10 invariants, one normative home, 28 citations resolve

Refs #2701
Refs #2730

## Summary by Sourcery

Documentation:
- Clarify that adding an AgentEvent variant without a consumer now triggers a compile-time E0004 error rather than a failing test and tighten the distinction between compiler- and test-enforced guarantees in the invariant description.