### PR TITLE
fix(stella-core): unbreak main — repair the #2752 admin-merge artifact (torn comment, orphaned rate_limit module, doubled retry ladder)

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -130,6 +130,7 @@ use tokio::sync::mpsc::UnboundedSender;
 mod dispatch;
 mod drive;
 pub(crate) mod overflow_recovery;
+mod rate_limit;
 mod settlement;
 pub(crate) mod usage_anchor;
 mod waiting;
@@ -1712,8 +1713,7 @@ impl<'a> Engine<'a> {
         // The ladder itself — the cancellation usage guard, per-attempt
         // incompleteness envelopes, parked rate-limit recovery (#2677),
         // provider-outcome feedback (#2673), and the exhaustion event pair —
-        // lives in `driver/
-      .rs`.
+        // lives in `driver/rate_limit.rs`.
         let (call_started, outcome) = self
             .drive_attempt_ladder(attempt, attempt_in_flight, budget, events)
             .await?;
@@ -1721,82 +1721,7 @@ impl<'a> Engine<'a> {
             value: (result, speculation_future),
             retries,
             ..
-        } = match retry_with_backoff_observed(
-            &self.config.retry_policy,
-            self.sleeper,
-            attempt,
-            // Per-attempt duration (retry.rs times each dispatch
-            // individually): the failed call's own latency, never
-            // cumulative across earlier attempts or backoff sleeps.
-            |attempt, error, attempt_duration| {
-                attempt_reasons
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(error.to_string());
-                let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
-                    role: self.call_role,
-                    provider: self.provider.id().to_string(),
-                    model: "unknown".into(),
-                    reason: stella_protocol::UsageIncompleteReason::ProviderError,
-                    duration_ms: attempt_duration.as_millis() as u64,
-                    retries: Some(attempt.saturating_sub(1)),
-                    // Whatever the adapter salvaged from the dying stream.
-                    // This observer is the only place it can be read: retry.rs
-                    // returns history only for calls that COMMIT, so a doomed
-                    // attempt's accounting reaches the wire here or nowhere.
-                    partial: error.partial_usage().copied(),
-                });
-            },
-        )
-        .await
-        {
-            Ok(outcome) => {
-                cancel_guard.disarm();
-                outcome
-            }
-            Err(error) => {
-                cancel_guard.disarm();
-                let reasons =
-                    std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
-                // A context overflow is withheld from the terminal events and
-                // the breaker: the caller may still recover it, and an
-                // oversized request is the engine's accounting miss, not
-                // provider ill-health (`driver::overflow_recovery`, #2680).
-                if matches!(error, ProviderError::ContextOverflow { .. }) {
-                    return Err(ModelCallFailure::ContextOverflow {
-                        message: error.to_string(),
-                        attempt_reasons: reasons,
-                    });
-                }
-                // Shared with the paired `Error` event below: whether the
-                // FINAL attempt's error is of a retryable class. `false`
-                // means every attempt (typically just one — see
-                // `retry_with_backoff_observed`, which bails on the first
-                // non-retryable error) was doomed from the start, not
-                // exhausted by an actual retry loop (#926).
-                let retryable = error.is_retryable();
-                let _ = events.send(AgentEvent::RetriesExhausted {
-                    turn_instance: self.config.turn_instance,
-                    attempts: reasons.len() as u32,
-                    reasons,
-                    retryable,
-                });
-                let message = error.to_string();
-                let _ = events.send(AgentEvent::Error {
-                    message: message.clone(),
-                    retryable,
-                });
-                if let Some(outcomes) = self.outcomes {
-                    outcomes.record_failure(self.provider.id());
-                }
-                return Err(ModelCallFailure::Fatal {
-                    reason: format!("model call failed: {message}"),
-                });
-            }
-        };
-        if let Some(outcomes) = self.outcomes {
-            outcomes.record_success(self.provider.id());
-        }
+        } = outcome;
         // One boundary read: the call's duration and the tick's clock axis.
         let now = std::time::Instant::now();
         let call_duration_ms = now.duration_since(call_started).as_millis() as u64;

--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -118,9 +118,10 @@ impl OverflowRecovery {
 /// caller may still do about it, which is the branch
 /// [`Engine::settle_model_call_failure`] takes.
 pub(crate) enum ModelCallFailure {
-    /// Unrecoverable. `run_model_call` has already emitted the terminal
-    /// events (`RetriesExhausted`, `Error`) and fed the provider-outcomes
-    /// breaker; all that remains is the turn's abort.
+    /// Unrecoverable. The attempt ladder (`driver/rate_limit.rs`) has
+    /// already emitted the terminal events (`RetriesExhausted`, `Error`)
+    /// and fed the provider-outcomes breaker; all that remains is the
+    /// turn's abort.
     Fatal { reason: String },
     /// The provider rejected the request as exceeding its context window.
     /// Every event is withheld (module docs) — the caller decides between a

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -16,9 +16,11 @@
 //! same way `driver/waiting.rs` does: the wait sits between model attempts,
 //! never mid-tool, and the budget's deadline bounds it from the outside.
 
-use stella_protocol::AgentEvent;
+use stella_protocol::{AgentEvent, ProviderError};
 
-use super::{CompletionResultAlias, Engine, RetryAttemptFn, SpeculationFuture, lifecycle};
+use super::{
+    CompletionResultAlias, Engine, ModelCallFailure, RetryAttemptFn, SpeculationFuture, lifecycle,
+};
 use crate::budget::BudgetGuard;
 use crate::bus;
 use crate::event_sender::EventSender;
@@ -138,7 +140,7 @@ impl<'a> Engine<'a> {
             std::time::Instant,
             RetryOutcome<(CompletionResultAlias, SpeculationFuture<'f>)>,
         ),
-        String,
+        ModelCallFailure,
     > {
         let call_started = std::time::Instant::now();
         // Armed for exactly the interval where a paid attempt may be in
@@ -214,6 +216,16 @@ impl<'a> Engine<'a> {
                 cancel_guard.disarm();
                 let reasons =
                     std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
+                // A context overflow is withheld from the terminal events and
+                // the breaker: the caller may still recover it, and an
+                // oversized request is the engine's accounting miss, not
+                // provider ill-health (`driver::overflow_recovery`, #2680).
+                if matches!(error, ProviderError::ContextOverflow { .. }) {
+                    return Err(ModelCallFailure::ContextOverflow {
+                        message: error.to_string(),
+                        attempt_reasons: reasons,
+                    });
+                }
                 // Shared with the paired `Error` event below: whether the
                 // FINAL attempt's error is of a retryable class. `false`
                 // means every attempt (typically just one — see
@@ -237,7 +249,9 @@ impl<'a> Engine<'a> {
                 if let Some(outcomes) = self.outcomes {
                     outcomes.record_failure(self.provider.id());
                 }
-                Err(format!("model call failed: {message}"))
+                Err(ModelCallFailure::Fatal {
+                    reason: format!("model call failed: {message}"),
+                })
             }
         }
     }


### PR DESCRIPTION
## What & why

**Main is red at `f83692c82`** — stella-core does not compile. The admin merge of #2752 raced its in-flight rebase over #2744, and the squash text-merged a pre-#2744 branch onto post-#2744 main. Three artifacts in `crates/stella-core/src/driver.rs`:

1. A doc comment torn mid-word at line 1715–1716 (`// lives in `driver/` + a bare `.rs`.` line with no `//`) — the workspace-wide compile error.
2. `mod rate_limit;` was *replaced* by (instead of joined with) `pub(crate) mod overflow_recovery;`, orphaning `driver/rate_limit.rs` — the `check-module-reachability` failure.
3. `run_model_call` contained **both** retry ladders: #2744's extracted `drive_attempt_ladder` call *and* the dead pre-#2744 inline `retry_with_backoff_observed` block — and #2680's `ContextOverflow` interception lived only in the dead copy.

## The fix

Single-ladder shape restored, with the two features composed where they belong: `drive_attempt_ladder` (`driver/rate_limit.rs`) now returns `ModelCallFailure`, and on a `ContextOverflow` withholds the terminal events and the breaker feed (an oversized request is the engine's accounting miss, not provider ill-health) so `settle_model_call_failure`'s recovery rungs (#2680) work; every other terminal error keeps the `RetriesExhausted`/`Error` pair + `record_failure` and returns `Fatal`. `RateLimited` parking (#2677) is untouched inside the ladder — the two recoveries are disjoint by error class.

Net: −60 lines, driver.rs well under its ceiling.

## Evidence

- Both features' witnesses pass on the composition: `context_overflow` (3/3) and `parked_wait` (6/6).
- `cargo test -p stella-core --lib`: 1124 passed / 0 failed.
- clippy `--all-targets -- -D warnings` clean; `cargo fmt --all` applied; unpiped `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-core` exit 0.
- `check-module-reachability`: OK (954 files, all reachable). `check-file-size`: OK.

## Companion

The stella-model half of the red main (adapter_sources collision + doc link) is **PR #2754** — the two PRs touch different crates and compose; both are needed for green.

## Deleted tests

None. (The deleted inline block was production code duplicated by the merge, not tests.)

Refs #2752 #2744 #2680 #2677

## Summary by Sourcery

Restore stella-core’s model call retry ladder after a bad merge so main compiles and error handling is correctly composed.

New Features:
- Propagate model call failures from the rate-limit ladder via ModelCallFailure, including explicit ContextOverflow handling.

Bug Fixes:
- Fix a broken doc comment in driver.rs that prevented stella-core from compiling.
- Reintroduce the rate_limit module alongside overflow_recovery to restore module reachability.
- Ensure ContextOverflow and fatal error handling are wired through the unified drive_attempt_ladder path instead of duplicated inline logic.

Enhancements:
- Centralize terminal event emission and provider outcome recording inside the rate_limit ladder, reducing duplication and shrinking driver.rs.