### PR TITLE
feat(stella-core): auto-promotion tiers for ingested records — pinned / scoped / retrieved (#2709)

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -1245,6 +1245,78 @@ mod tests {
         );
     }
 
+    /// Witness for #2709 at the assembly level: an explicitly pinned
+    /// `may`-strength record reaches the byte-stable prefix under the
+    /// `### Pinned` heading — the "no gaps" half of the tier contract, proven
+    /// where the prompt is actually built rather than at the renderer alone.
+    #[test]
+    fn a_pinned_record_reaches_the_stable_prefix() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let root = workspace.path();
+        let rules_dir = root.join(".stella/rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        std::fs::write(
+            rules_dir.join("ctx.acme.style.toml"),
+            "schema = \"context-record/v0.1\"\nset_id = \"acme\"\n\
+             \n[[record]]\nlineage_id = \"ctx.acme.pinned-style\"\nkind = \"preference\"\n\
+             statement = \"ALWAYS_PIN_THIS_CONVENTION\"\nstatus = \"active\"\norigin = \"user\"\n\
+             \n[record.steering]\nforce = \"may\"\ntier = \"pinned\"\n",
+        )
+        .unwrap();
+        let authority = crate::settings::AuthorityPolicy {
+            project_prompts_allowed: true,
+            ..Default::default()
+        };
+        let rules = crate::rules::load_workspace_rules(root, &authority);
+        let prompt =
+            super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &rules, None);
+        assert!(
+            prompt.contains("### Pinned") && prompt.contains("ALWAYS_PIN_THIS_CONVENTION"),
+            "a pinned may-record must reach the stable prefix: {prompt}"
+        );
+    }
+
+    /// Witness for #2709's overflow contract: pinned records past the cached
+    /// budget are dropped by declared precedence and the omission NAMES itself
+    /// in the prefix — deterministic for the record set, so byte-stability
+    /// holds — instead of the set silently thinning.
+    #[test]
+    fn pinned_overflow_names_itself_in_the_prefix() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let root = workspace.path();
+        let rules_dir = root.join(".stella/rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        let mut contents = String::from("schema = \"context-record/v0.1\"\nset_id = \"acme\"\n");
+        // ~45 records x ~420 rendered chars comfortably exceeds the 16k budget.
+        for i in 0..45 {
+            let filler = "x".repeat(400);
+            contents.push_str(&format!(
+                "\n[[record]]\nlineage_id = \"ctx.acme.bulk-{i:02}\"\nkind = \"rule\"\n\
+                 statement = \"Rule {i:02} {filler}\"\nstatus = \"active\"\norigin = \"user\"\n\
+                 \n[record.steering]\nforce = \"must\"\nprecedence = {}\n",
+                100 - i
+            ));
+        }
+        std::fs::write(rules_dir.join("ctx.acme.toml"), contents).unwrap();
+        let authority = crate::settings::AuthorityPolicy {
+            project_prompts_allowed: true,
+            ..Default::default()
+        };
+        let rules = crate::rules::load_workspace_rules(root, &authority);
+        let first =
+            super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &rules, None);
+        assert!(
+            first.contains("exceeded the prefix budget and were omitted"),
+            "the drop must name itself in the prefix, never truncate silently"
+        );
+        let second =
+            super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &rules, None);
+        assert_eq!(
+            first, second,
+            "the overflow note is part of the prefix and must be byte-stable (L-E8)"
+        );
+    }
+
     /// Witness for #712 deliverable 6: forgetting a workspace memory stops it
     /// shipping in the system prompt.
     ///

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -349,13 +349,33 @@ pub(crate) fn assemble_system_prompt(
     // construction — the truth sweep already demoted or dropped anything whose
     // freshness is in question, so no clock and no per-turn text enters here
     // (docs/spec/adaptive-context/context-record-examples/07-agent-projection.md).
-    let rules_section = active_rules
-        .registry()
-        .render(stella_core::records::Channel::Cached, None)
-        .text;
-    if !rules_section.is_empty() {
+    let rules_section = active_rules.registry().render(
+        stella_core::records::Channel::Cached,
+        // Capped since #2709: a pinned record is guaranteed a prefix seat
+        // only while the set fits, and a runaway ingest must not flood every
+        // future prompt. No real record set has approached this budget.
+        Some(stella_core::records::CACHED_RECORD_BUDGET_CHARS),
+    );
+    if !rules_section.text.is_empty() {
         prompt.push('\n');
-        prompt.push_str(&rules_section);
+        prompt.push_str(&rules_section.text);
+    }
+    // Overflow is named, never silent — the same contract the memory budget
+    // above keeps, and the render-time half of the ingest-time pinned-overflow
+    // diagnostic. Deterministic for a given record set (the drop list comes
+    // from the same stable render), so the prefix stays byte-stable (L-E8).
+    if !rules_section.dropped.is_empty() {
+        let handles: Vec<String> = rules_section
+            .dropped
+            .iter()
+            .map(|handle| format!("^{handle}"))
+            .collect();
+        prompt.push_str(&format!(
+            "\n({} pinned record(s) exceeded the prefix budget and were omitted: {} — \
+             retier or trim them via `stella context review`)",
+            rules_section.dropped.len(),
+            handles.join(" ")
+        ));
     }
     prompt
 }

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -722,6 +722,7 @@ pub(crate) fn inferred_rule_record(
         steering: Some(rec::Steering {
             force: rec::Force::Should,
             precedence: None,
+            tier: None,
             applies_to: None,
         }),
         enforcement: None,

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -29,6 +29,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use stella_core::context_record::Origin;
 use stella_core::ingest::Tier;
+use stella_core::ingest::record::Tier as PromotionTier;
 use stella_core::ingest::{
     AppliesTo, ContextFile, Defaults, Enforcement, EnforcementMode, Force, Probe, ProbeKind,
     Proposal, Provenance, Record, RecordKind, Refutation, Steering, Truth, TruthBasis, Verdict,
@@ -158,6 +159,12 @@ pub(super) struct DocSummary {
     /// How many were withheld because this workspace already decided about them —
     /// declined within a cooldown, or already published as a record.
     pub withheld: usize,
+    /// The pinned footprint: statement characters across this document's
+    /// eligible pinned-tier proposals, measured against the cached-channel
+    /// budget for the overflow diagnostic (#2709). An approximation from
+    /// below — the rendered bullet adds a handle and markers — so a warning
+    /// here is never a false alarm.
+    pub pinned_chars: usize,
     /// The run cost in USD.
     pub cost_usd: f64,
     /// The candidate ids of every proposal written, so the source file's
@@ -296,6 +303,7 @@ async fn extract_document(
     let mut file = ContextFile::new_ingest(set_id, ingest_run_id, defaults.clone());
     let (mut eligible, mut refuted, mut dismissed) = (0usize, 0usize, 0usize);
     let mut withheld = 0usize;
+    let mut pinned_chars = 0usize;
     let mut asserted = Vec::new();
     for claim in claims {
         let proposal = build_proposal(root, set_id, &defaults, observed_at, eligibility, claim);
@@ -311,6 +319,9 @@ async fn extract_document(
             dismissed += 1;
         } else {
             eligible += 1;
+            if proposal.record.tier() == PromotionTier::Pinned {
+                pinned_chars += proposal.record.statement.chars().count();
+            }
             if proposal
                 .refutation
                 .as_ref()
@@ -335,6 +346,7 @@ async fn extract_document(
         refuted,
         dismissed,
         withheld,
+        pinned_chars,
         cost_usd,
         candidate_ids,
         asserted,
@@ -558,10 +570,16 @@ fn build_proposal(
         .clone()
         .filter(|p| gate::probe_honored(Origin::Imported, p.kind));
 
+    let applies = applies_to(&claim);
     let steering = Steering {
         force,
         precedence: Some(precedence_for(force)),
-        applies_to: applies_to(&claim),
+        // Stamped explicitly even though it equals what `Record::tier` would
+        // derive: explicit is what makes the classification visible in the
+        // proposal TOML and overridable at review, and it stops a later force
+        // edit from silently re-tiering the record (#2709).
+        tier: Some(promotion_tier_for(force, applies.as_ref())),
+        applies_to: applies,
     };
     let enforcement = Enforcement {
         mode,
@@ -703,6 +721,25 @@ fn report(doc: &NamedDoc, summary: &DocSummary) {
         dismissed,
         format!("(${:.4})", summary.cost_usd).dimmed()
     );
+    // The "no gaps without bloat" half of the tier contract (#2709): pinned
+    // records are guaranteed a prefix seat only while they fit the cached
+    // budget, so an ingest that mints more pinned content than the budget
+    // holds is told so HERE, where the classification can still be fixed at
+    // review — not discovered later as a silently thinner prefix.
+    if summary.pinned_chars > stella_core::records::CACHED_RECORD_BUDGET_CHARS {
+        println!(
+            "    {}",
+            format!(
+                "pinned overflow: this ingest's pinned records total {} characters, over \
+                 the {}-character cached-prefix budget — the lowest-precedence ones will \
+                 be dropped from the prefix at session open. Retier or trim them in \
+                 `stella context review` before keeping.",
+                summary.pinned_chars,
+                stella_core::records::CACHED_RECORD_BUDGET_CHARS
+            )
+            .yellow()
+        );
+    }
     // Said out loud, because a claim that silently vanished from a re-run reads as
     // the extractor having missed it.
     if summary.withheld > 0 {
@@ -773,6 +810,20 @@ fn precedence_for(force: Force) -> u32 {
         Force::Should => 40,
         Force::May => 20,
         Force::Info => 15,
+    }
+}
+
+/// The classifier-assigned promotion tier (#2709): binding forces pin, a
+/// trigger scopes, everything else rides ordinary recall. Deterministic —
+/// the model already chose the force and the scope, and the tier is a
+/// restatement of those two, not a second model judgment.
+fn promotion_tier_for(force: Force, applies_to: Option<&AppliesTo>) -> PromotionTier {
+    if force.is_always_injected() {
+        PromotionTier::Pinned
+    } else if applies_to.is_some_and(|applies| !applies.is_empty()) {
+        PromotionTier::Scoped
+    } else {
+        PromotionTier::Retrieved
     }
 }
 

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -573,3 +573,54 @@ fn only_a_retry_names_its_attempt() {
         "extracting AGENTS.md (attempt 2 of 2)"
     );
 }
+
+/// Witness for #2709: the classifier's promotion tier is stamped explicitly
+/// on every proposal — visible in the TOML a reviewer reads, overridable at
+/// review — and restates force + scope: binding forces pin, a trigger scopes,
+/// the rest ride recall.
+#[test]
+fn the_promotion_tier_is_stamped_explicitly_on_every_proposal() {
+    let root = temp_root("tier-stamp");
+    let pinned = build(
+        &root,
+        serde_json::json!({
+            "lineage_suffix": "no-force-push",
+            "kind": "constraint",
+            "statement": "Never force-push to main.",
+            "force": "must"
+        }),
+    );
+    assert_eq!(
+        pinned.record.steering.as_ref().and_then(|s| s.tier),
+        Some(stella_core::ingest::record::Tier::Pinned)
+    );
+
+    let scoped = build(
+        &root,
+        serde_json::json!({
+            "lineage_suffix": "api-style",
+            "kind": "preference",
+            "statement": "Handlers under src/api use the builder pattern.",
+            "force": "may",
+            "paths": ["src/api/**"]
+        }),
+    );
+    assert_eq!(
+        scoped.record.steering.as_ref().and_then(|s| s.tier),
+        Some(stella_core::ingest::record::Tier::Scoped)
+    );
+
+    let retrieved = build(
+        &root,
+        serde_json::json!({
+            "lineage_suffix": "staging-url",
+            "kind": "fact",
+            "statement": "The staging URL is https://stage.example.",
+            "force": "info"
+        }),
+    );
+    assert_eq!(
+        retrieved.record.steering.as_ref().and_then(|s| s.tier),
+        Some(stella_core::ingest::record::Tier::Retrieved)
+    );
+}

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -87,7 +87,7 @@ impl SessionMemory {
     /// gap #2709 requires to be observable rather than silent: a scoped rule
     /// that systematically loses its seat looks exactly like a rule that
     /// never applied, unless someone says otherwise.
-    fn turn_record_section_reporting(
+    pub(super) fn turn_record_section_reporting(
         &self,
         prompt: &str,
         mut report: impl FnMut(String),

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -74,15 +74,39 @@ impl SessionMemory {
     /// names. `None` when nothing applies — an empty section would only burn
     /// tokens (the channel is opt-out by emptiness, not by flag).
     fn turn_record_section(&self, prompt: &str) -> Option<String> {
+        self.turn_record_section_reporting(prompt, |message| {
+            eprintln!("  {} {message}", "!".yellow())
+        })
+    }
+
+    /// [`Self::turn_record_section`] with an injectable diagnostic sink, the
+    /// same split as [`Self::recalled_frames_reporting`] and for the same
+    /// reason: the eviction report must be testable without capturing global
+    /// stderr. A record reported here MATCHED this turn's facts — the
+    /// selector chose it and the budget evicted it — which is the coverage
+    /// gap #2709 requires to be observable rather than silent: a scoped rule
+    /// that systematically loses its seat looks exactly like a rule that
+    /// never applied, unless someone says otherwise.
+    fn turn_record_section_reporting(
+        &self,
+        prompt: &str,
+        mut report: impl FnMut(String),
+    ) -> Option<String> {
         let registry = self.record_registry.as_ref()?;
         let paths = turn_path_tokens(prompt);
         let facts = stella_core::records::TurnFacts {
             text: prompt,
             paths: &paths,
         };
-        let text = registry
-            .render_volatile_for_turn(&facts, Some(RECORD_CHANNEL_BUDGET))
-            .text;
+        let rendered = registry.render_volatile_for_turn(&facts, Some(RECORD_CHANNEL_BUDGET));
+        for handle in &rendered.dropped {
+            report(format!(
+                "a record applying to this turn did not fit the {RECORD_CHANNEL_BUDGET}-char \
+                 record budget: ^{handle} — raise its precedence, or trim the records that \
+                 outrank it"
+            ));
+        }
+        let text = rendered.text;
         (!text.trim().is_empty()).then(|| text.trim_start().to_string())
     }
 

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -761,3 +761,45 @@ fn inject_still_appends_content_the_history_has_never_held() {
         .count();
     assert_eq!(markers, 3, "three distinct blocks are three appends");
 }
+
+/// Witness for #2709's coverage signal: a record that MATCHED this turn's
+/// facts but lost its seat to the record budget is reported, not silently
+/// absent — a scoped rule that systematically loses the budget contest looks
+/// exactly like a rule that never applied, unless someone says otherwise.
+#[test]
+fn a_matched_record_evicted_by_the_budget_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut memory =
+        SessionMemory::open_with_workspace_skills(dir.path(), false, true).expect("session memory");
+
+    // Five records at ~550 rendered chars each against the 2000-char budget:
+    // the lowest-precedence one must lose its seat.
+    let mut contents = String::from("schema = \"context-record/v0.1\"\nset_id = \"acme\"\n");
+    for i in 0..5 {
+        let filler = "x".repeat(500);
+        contents.push_str(&format!(
+            "\n[[record]]\nlineage_id = \"ctx.acme.bulk-{i}\"\nkind = \"fact\"\n\
+             statement = \"Rule {i} {filler}\"\nstatus = \"active\"\norigin = \"user\"\n\
+             \n[record.steering]\nforce = \"may\"\nprecedence = {}\n",
+            50 - i
+        ));
+    }
+    let record_file = stella_core::rules::RuleFile {
+        path: ".stella/rules/ctx.acme.toml".to_string(),
+        contents,
+    };
+    memory.set_record_registry(stella_core::records::registry::load(
+        &[],
+        &[record_file],
+        &stella_core::records::Facts::default(),
+    ));
+
+    let mut reports = Vec::new();
+    let section =
+        memory.turn_record_section_reporting("anything at all", |message| reports.push(message));
+    assert!(section.is_some(), "the surviving records still render");
+    assert!(
+        reports.iter().any(|m| m.contains("did not fit")),
+        "the evicted record must be reported, never silently absent: {reports:?}"
+    );
+}

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -315,6 +315,29 @@ impl Record {
         Ok(())
     }
 
+    /// The record's promotion tier: the explicit declaration when present,
+    /// else derived from `force` + `applies_to` (#2709). The derivation IS
+    /// the pre-tier channel contract, restated: `must`/`should` always rode
+    /// the cached prefix (pinned), a scoped `may`/`info` rendered only when
+    /// its trigger matched (scoped), and an unscoped `may`/`info` rode
+    /// ordinary recall (retrieved) — so a record with no `tier` field
+    /// behaves exactly as it did before the field existed.
+    pub fn tier(&self) -> Tier {
+        let Some(steering) = self.steering.as_ref() else {
+            return Tier::Retrieved;
+        };
+        if let Some(tier) = steering.tier {
+            return tier;
+        }
+        if steering.force.is_always_injected() {
+            return Tier::Pinned;
+        }
+        match &steering.applies_to {
+            Some(applies) if !applies.is_empty() => Tier::Scoped,
+            _ => Tier::Retrieved,
+        }
+    }
+
     /// The truth probe that may be re-run to re-check this record's claim, if
     /// any. Returns the record's own probe only when it is **honored** for the
     /// record's origin — a gated probe (`command_succeeds`/`http_ok`) is never
@@ -411,6 +434,15 @@ pub struct Steering {
     /// [sel]: super::super::records::select
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub applies_to: Option<AppliesTo>,
+    /// The promotion tier, when declared explicitly (#2709). Absent — every
+    /// record written before the field existed, and most after — the tier
+    /// derives from `force` + `applies_to` exactly as the channels always
+    /// behaved, so this field changes nothing until someone sets it. Ingest
+    /// stamps the derived value explicitly so the classification is visible
+    /// in the proposal and overridable at review; `skip_serializing_if`
+    /// keeps the canonical hash of every existing record unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<Tier>,
 }
 
 /// The conditions under which a record applies. All fields are optional and
@@ -685,6 +717,42 @@ impl Force {
             Self::Should => 2,
             Self::May => 1,
             Self::Info => 0,
+        }
+    }
+}
+
+/// The promotion tier: where a record is guaranteed to surface (#2709, the
+/// "no gaps without bloat" mechanism from #2683).
+///
+/// The tier is an *override axis*: [`Record::tier`] derives it from
+/// `force` + `applies_to` when absent, reproducing the channel behavior that
+/// predates the field byte-for-byte. Declaring it explicitly is how a user
+/// (or ingest) moves a record between channels without contorting its force —
+/// a `may`-strength convention can be pinned, and a `must` that only matters
+/// under `src/api/**` can stop taxing every turn's prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Tier {
+    /// A standing constraint binding on every turn: rides the byte-stable
+    /// cached prefix. Cache-safe by construction — pinned content changes
+    /// only at explicit re-ingest or review, never mid-session.
+    Pinned,
+    /// A conditional rule: rides the volatile recall block, and only on turns
+    /// whose facts trip its `applies_to` trigger. A scoped record with no
+    /// trigger never fires — `records::validate` names that as a finding.
+    Scoped,
+    /// Everything else: ordinary relevance-ranked recall in the volatile
+    /// block, competing under the channel budget.
+    Retrieved,
+}
+
+impl Tier {
+    /// The canonical `snake_case` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pinned => "pinned",
+            Self::Scoped => "scoped",
+            Self::Retrieved => "retrieved",
         }
     }
 }

--- a/crates/stella-core/src/ingest/record/tests.rs
+++ b/crates/stella-core/src/ingest/record/tests.rs
@@ -24,6 +24,7 @@ fn constraint_record() -> Record {
         supersedes_record_id: None,
         provenance: None,
         steering: Some(Steering {
+            tier: None,
             force: Force::Must,
             precedence: Some(100),
             applies_to: Some(AppliesTo {
@@ -398,4 +399,57 @@ fn record_kind_maps_to_the_right_proposal_kind() {
         RecordKind::Constraint.proposal_kind(),
         RecordProposalKind::Directive
     );
+}
+
+/// Witness for #2709: the tier derives from `force` + `applies_to` exactly as
+/// the channels always behaved — binding forces pin, a trigger scopes, the
+/// rest ride recall — and an explicit declaration outranks the derivation.
+#[test]
+fn tier_derives_from_force_and_scope_and_an_explicit_tier_wins() {
+    let mut record = constraint_record();
+    assert_eq!(record.tier(), Tier::Pinned, "must + scope derives pinned");
+    record.steering.as_mut().unwrap().force = Force::May;
+    assert_eq!(record.tier(), Tier::Scoped, "may + trigger derives scoped");
+    record.steering.as_mut().unwrap().applies_to = None;
+    assert_eq!(
+        record.tier(),
+        Tier::Retrieved,
+        "unscoped may derives retrieved"
+    );
+    record.steering.as_mut().unwrap().tier = Some(Tier::Pinned);
+    assert_eq!(
+        record.tier(),
+        Tier::Pinned,
+        "an explicit tier outranks the derivation"
+    );
+    record.steering = None;
+    assert_eq!(
+        record.tier(),
+        Tier::Retrieved,
+        "no steering at all is retrieved"
+    );
+}
+
+/// Witness for #2709's hash-stability constraint: a record that declares no
+/// tier serializes without the key — so the canonical hash of every record
+/// published before the field existed is unchanged by its existence — while a
+/// declared tier round-trips.
+#[test]
+fn an_absent_tier_never_reaches_the_serialized_record() {
+    let record = constraint_record();
+    let toml = toml::to_string(&record).expect("serializes");
+    assert!(
+        !toml.contains("tier"),
+        "an undeclared tier must not appear in the canonical form: {toml}"
+    );
+
+    let mut declared = constraint_record();
+    declared.steering.as_mut().unwrap().tier = Some(Tier::Scoped);
+    let toml = toml::to_string(&declared).expect("serializes");
+    assert!(
+        toml.contains("tier = \"scoped\""),
+        "a declared tier is written: {toml}"
+    );
+    let parsed: Record = toml::from_str(&toml).expect("parses back");
+    assert_eq!(parsed.steering.unwrap().tier, Some(Tier::Scoped));
 }

--- a/crates/stella-core/src/records.rs
+++ b/crates/stella-core/src/records.rs
@@ -60,7 +60,9 @@ pub use bridge::{
 pub use decision::{Decision, DecisionEvent, should_repropose};
 pub use handle::assign_handles;
 pub use registry::{Entry, Facts, Registry};
-pub use render::{Channel, RenderInput, RenderedChannel, render_channel};
+pub use render::{
+    CACHED_RECORD_BUDGET_CHARS, Channel, RenderInput, RenderedChannel, render_channel,
+};
 pub use select::{TurnFacts, applies_this_turn};
 pub use sweep::{Disposition, ExpiryAction, SweepInput, disposition, honored_probe, probe_is_due};
 pub use trust::Trust;
@@ -151,6 +153,13 @@ pub enum RecordFinding {
     /// empty pattern, an unbounded scope. A guard that cannot be evaluated is a
     /// guard that silently never fires.
     GuardLint(String),
+    /// The record declares `tier = "scoped"` but no `applies_to` trigger, so
+    /// no turn can ever select it — a scoped record with nothing to fire on
+    /// is a silent gap wearing a classification (#2709). The record still
+    /// loads (and, having no trigger, renders on every turn like a retrieved
+    /// one), but the mismatch between what was declared and what will happen
+    /// deserves a name.
+    ScopedWithoutTrigger,
     /// The record carries content that must never enter a Git-tracked policy file
     /// (§10): a secret, a credential, raw tool output.
     ForbiddenData {
@@ -182,6 +191,7 @@ impl RecordFinding {
             | Self::GatedProbeRefused(_)
             | Self::BlockingRefused(_)
             | Self::Conflict { .. }
+            | Self::ScopedWithoutTrigger
             | Self::HashMismatch { .. } => Severity::Warning,
             Self::GuardLint(_) | Self::ForbiddenData { .. } => Severity::Blocking,
         }
@@ -205,6 +215,11 @@ impl std::fmt::Display for RecordFinding {
                  — it will never match, so it silently skews relevance"
             ),
             Self::GuardLint(detail) => write!(f, "guard cannot be evaluated: {detail}"),
+            Self::ScopedWithoutTrigger => write!(
+                f,
+                "tier is scoped but applies_to declares no trigger — no turn can ever \
+                 select it; add paths/tasks/keywords or retier it"
+            ),
             Self::ForbiddenData { field } => write!(
                 f,
                 "{field} contains data that must not enter a Git-tracked record \

--- a/crates/stella-core/src/records/registry.rs
+++ b/crates/stella-core/src/records/registry.rs
@@ -510,6 +510,7 @@ fn record_from_markdown(rule: &Rule, trust: Trust) -> LoadedRecord {
         supersedes_record_id: None,
         provenance: None,
         steering: Some(Steering {
+            tier: None,
             force: Force::Must,
             precedence: Some(50),
             applies_to: None,

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -51,7 +51,7 @@
 //! [cited]: super::super::context_record::context_use::ContextUseKind::Cited
 //! [nr]: super::super::context_record::context_use::MissingContextKind
 
-use super::super::ingest::record::Force;
+use super::super::ingest::record::{Force, Tier};
 use super::LoadedRecord;
 use super::sweep::Disposition;
 
@@ -956,6 +956,103 @@ mod tests {
             advisory.text.contains("^no-force-push"),
             "{}",
             advisory.text
+        );
+    }
+}
+
+#[cfg(test)]
+mod tier_tests {
+    use super::super::tests::{loaded_from, record_named, with_tier};
+    use super::*;
+    use crate::ingest::record::Tier;
+
+    fn input<'a>(record: &'a LoadedRecord, disposition: &'a Disposition) -> RenderInput<'a> {
+        RenderInput {
+            record,
+            disposition,
+            enforced: false,
+        }
+    }
+
+    /// Witness for #2709: an explicitly pinned `may`-strength record rides the
+    /// cached prefix — under its own `### Pinned` heading, so the Must/Should
+    /// bytes of every pre-tier record set are untouched — and leaves the
+    /// volatile channel entirely.
+    #[test]
+    fn an_explicitly_pinned_may_record_joins_the_cached_block() {
+        let record = loaded_from(with_tier(
+            record_named("ctx.acme.web.style"),
+            Force::May,
+            Tier::Pinned,
+        ));
+        let select = Disposition::Select;
+        let inputs = [input(&record, &select)];
+        let cached = render_channel(&inputs, Channel::Cached, None);
+        assert!(
+            cached.text.contains("### Pinned"),
+            "a pinned may-record earns the cached block: {}",
+            cached.text
+        );
+        assert!(
+            render_channel(&inputs, Channel::Volatile, None)
+                .text
+                .is_empty(),
+            "and no longer rides the volatile channel"
+        );
+    }
+
+    /// Witness for #2709: an explicitly scoped `must` record leaves the cached
+    /// prefix — its seat there was the whole cost the tier exists to avoid —
+    /// and rides the volatile channel, where per-turn selection gates it.
+    #[test]
+    fn an_explicitly_scoped_must_record_leaves_the_cached_block() {
+        let record = loaded_from(with_tier(
+            record_named("ctx.acme.web.api-only"),
+            Force::Must,
+            Tier::Scoped,
+        ));
+        let select = Disposition::Select;
+        let inputs = [input(&record, &select)];
+        assert!(
+            render_channel(&inputs, Channel::Cached, None)
+                .text
+                .is_empty(),
+            "a scoped must vacates the prefix"
+        );
+        let volatile = render_channel(&inputs, Channel::Volatile, None);
+        assert!(
+            volatile.text.contains("pnpm"),
+            "and renders in the volatile channel instead: {}",
+            volatile.text
+        );
+    }
+
+    /// The sweep constraint #2709 inherits: a stale-demoted pinned record
+    /// never enters the stable prefix — demotion outranks the tier exactly as
+    /// it outranked the declared force, because the reason for the demotion is
+    /// per-turn information the byte-stable block cannot carry.
+    #[test]
+    fn a_demoted_pinned_record_stays_out_of_the_cached_block() {
+        let record = loaded_from(with_tier(
+            record_named("ctx.acme.web.stale-pin"),
+            Force::May,
+            Tier::Pinned,
+        ));
+        let stale = Disposition::SelectStale {
+            reason: "ttl expired".to_string(),
+        };
+        let inputs = [input(&record, &stale)];
+        assert!(
+            render_channel(&inputs, Channel::Cached, None)
+                .text
+                .is_empty(),
+            "a demoted pinned record must never enter the stable prefix"
+        );
+        assert!(
+            !render_channel(&inputs, Channel::Volatile, None)
+                .text
+                .is_empty(),
+            "it demotes to the volatile channel rather than vanishing"
         );
     }
 }

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -69,6 +69,18 @@ use super::sweep::Disposition;
 /// that made grouping by force worth doing.
 const CACHED_HEADING: &str = "\n## Workspace rules (cite the ^handle of any you apply)";
 
+/// The default budget for the cached record channel, in characters (#2709).
+///
+/// One constant, consumed by BOTH the prompt assembler (which caps the
+/// `## Workspace rules` block it bakes into the prefix) and the ingest-time
+/// pinned-footprint diagnostic (which warns when an ingest's pinned records
+/// cannot all fit) — a second copy of this number is how the warning and the
+/// truncation would drift apart. Sized to match the workspace-memory budget
+/// that shares the same prefix: generous enough that no real record set has
+/// hit it, small enough that a runaway ingest cannot flood every future
+/// prompt.
+pub const CACHED_RECORD_BUDGET_CHARS: usize = 16_000;
+
 /// Which of the two prompt channels a record renders into.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Channel {
@@ -116,15 +128,24 @@ pub struct RenderedChannel {
 
 /// Which channel a record renders into, or `None` when it does not render at all.
 ///
-/// A sweep demotion outranks the declared force: a record whose freshness is in
-/// question cannot sit in a block that must stay byte-identical, because the reason
-/// it was demoted is per-turn information even when the renderer declines to print
-/// it.
-pub fn channel_of(force: Force, disposition: &Disposition) -> Option<Channel> {
+/// The promotion tier decides (#2709): `pinned` rides the cached prefix,
+/// `scoped` and `retrieved` ride the volatile block. A record with no explicit
+/// tier derives one from `force` + `applies_to` ([`Record::tier`][t]), which
+/// reproduces the pre-tier contract exactly — `must`/`should` cached,
+/// `may`/`info` volatile.
+///
+/// A sweep demotion outranks the tier, exactly as it outranked the declared
+/// force: a record whose freshness is in question cannot sit in a block that
+/// must stay byte-identical, because the reason it was demoted is per-turn
+/// information even when the renderer declines to print it. A stale-demoted
+/// pinned record therefore never enters the stable prefix.
+///
+/// [t]: super::super::ingest::record::Record::tier
+pub fn channel_of(tier: Tier, disposition: &Disposition) -> Option<Channel> {
     if !disposition.is_selected() {
         return None;
     }
-    if disposition.forces_volatile() || !force.is_always_injected() {
+    if disposition.forces_volatile() || tier != Tier::Pinned {
         return Some(Channel::Volatile);
     }
     Some(Channel::Cached)
@@ -169,12 +190,7 @@ pub fn render_channel(
 ) -> RenderedChannel {
     let mine: Vec<&RenderInput<'_>> = inputs
         .iter()
-        .filter(|input| {
-            channel_of(
-                effective_force(input.record, input.disposition),
-                input.disposition,
-            ) == Some(channel)
-        })
+        .filter(|input| channel_of(input.record.record.tier(), input.disposition) == Some(channel))
         .collect();
     if mine.is_empty() {
         return RenderedChannel::default();
@@ -197,11 +213,19 @@ fn render_cached(inputs: &[&RenderInput<'_>], budget_chars: Option<usize>) -> Re
         text: CACHED_HEADING.to_string(),
         ..RenderedChannel::default()
     };
-    for (force, heading) in [(Force::Must, "### Must"), (Force::Should, "### Should")] {
+    for (forces, heading) in [
+        (&[Force::Must][..], "### Must"),
+        (&[Force::Should][..], "### Should"),
+        // Explicitly-pinned records below `should` strength (#2709). Only an
+        // explicit `tier = "pinned"` can put a `may`/`info` record in this
+        // channel, so the heading never appears for a pre-tier record set and
+        // every existing prompt keeps its exact bytes.
+        (&[Force::May, Force::Info][..], "### Pinned"),
+    ] {
         let group: Vec<&RenderInput<'_>> = inputs
             .iter()
             .copied()
-            .filter(|input| effective_force(input.record, input.disposition) == force)
+            .filter(|input| forces.contains(&effective_force(input.record, input.disposition)))
             .collect();
         if group.is_empty() {
             continue;

--- a/crates/stella-core/src/records/tests.rs
+++ b/crates/stella-core/src/records/tests.rs
@@ -7,7 +7,7 @@
 use super::super::context_record::kind::{Origin, RecordStatus};
 use super::super::ingest::record::{
     AppliesTo, Enforcement, EnforcementMode, Force, Record, RecordKind, SharingScope, Steering,
-    Truth,
+    Tier, Truth,
 };
 use super::*;
 
@@ -26,6 +26,7 @@ pub(super) fn record_named(lineage: &str) -> Record {
         supersedes_record_id: None,
         provenance: None,
         steering: Some(Steering {
+            tier: None,
             force: Force::Must,
             precedence: Some(50),
             applies_to: None,
@@ -43,8 +44,20 @@ pub(super) fn with_truth(mut record: Record, truth: Truth) -> Record {
 }
 
 /// `record` at a different steering force.
+/// `record` with an explicit promotion tier on top of `force` (#2709).
+pub(super) fn with_tier(record: Record, force: Force, tier: Tier) -> Record {
+    let mut record = with_force(record, force);
+    record
+        .steering
+        .as_mut()
+        .expect("with_force set steering")
+        .tier = Some(tier);
+    record
+}
+
 pub(super) fn with_force(mut record: Record, force: Force) -> Record {
     record.steering = Some(Steering {
+        tier: None,
         force,
         precedence: Some(50),
         applies_to: None,
@@ -55,6 +68,7 @@ pub(super) fn with_force(mut record: Record, force: Force) -> Record {
 /// `record` scoped to `paths` at `precedence`.
 pub(super) fn with_scope(mut record: Record, paths: &[&str], precedence: u32) -> Record {
     record.steering = Some(Steering {
+        tier: None,
         force: Force::Must,
         precedence: Some(precedence),
         applies_to: Some(AppliesTo {
@@ -860,4 +874,34 @@ expect = "present"
             volatile.rendered
         );
     }
+}
+
+/// Witness for #2709: an explicit `tier = "scoped"` with no `applies_to`
+/// trigger is named — no turn can ever select it, so the declaration is a
+/// silent gap — while the derived tiers, which cannot produce the mismatch,
+/// stay finding-free.
+#[test]
+fn an_explicitly_scoped_record_without_a_trigger_is_named() {
+    let mut untriggered = loaded_from(with_tier(
+        record_named("ctx.acme.web.untriggered"),
+        Force::May,
+        Tier::Scoped,
+    ));
+    validate::check_record(&mut untriggered);
+    assert!(
+        untriggered
+            .findings
+            .contains(&RecordFinding::ScopedWithoutTrigger),
+        "scoped with nothing to fire on must be named: {:?}",
+        untriggered.findings
+    );
+
+    let mut derived = loaded_from(with_force(record_named("ctx.acme.web.plain"), Force::May));
+    validate::check_record(&mut derived);
+    assert!(
+        !derived
+            .findings
+            .contains(&RecordFinding::ScopedWithoutTrigger),
+        "a derived retrieved record carries no scoped-without-trigger finding"
+    );
 }

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -130,7 +130,27 @@ fn check_one(record: &Record) -> Vec<RecordFinding> {
     findings.extend(guard_lint(record));
     findings.extend(unknown_tasks(record));
     findings.extend(atomicity(record));
+    findings.extend(scoped_without_trigger(record));
     findings
+}
+
+/// An explicit `tier = "scoped"` with no `applies_to` trigger (#2709). Only
+/// the explicit declaration can produce this: a derived scoped tier requires a
+/// non-empty `applies_to` by construction ([`Record::tier`]).
+fn scoped_without_trigger(record: &Record) -> Vec<RecordFinding> {
+    let Some(steering) = record.steering.as_ref() else {
+        return Vec::new();
+    };
+    let scoped = steering.tier == Some(super::super::ingest::record::Tier::Scoped);
+    let untriggered = steering
+        .applies_to
+        .as_ref()
+        .is_none_or(super::super::ingest::record::AppliesTo::is_empty);
+    if scoped && untriggered {
+        vec![RecordFinding::ScopedWithoutTrigger]
+    } else {
+        Vec::new()
+    }
 }
 
 /// Secrets, credentials, and raw pasted text must never enter a Git-tracked policy


### PR DESCRIPTION
## What & why

Third slice of #2683: the "no gaps without bloat" mechanism. An ingest can produce hundreds of records all competing in relevance-ranked recall, so a binding constraint could lose a ranking contest and simply not ship on the turn where it mattered. This PR makes the guarantee explicit and overridable:

- **`tier` on `Steering`** (`pinned | scoped | retrieved`), optional and hash-preserving (`skip_serializing_if`, pinned by a serde-absence witness). `Record::tier()` derives the tier from `force` + `applies_to` when absent — and the derivation IS the pre-tier channel contract restated, so every existing record set keeps its exact behavior and prompt bytes. Explicit declaration overrides: a `may`-strength convention can be pinned; a `must` that only matters under `src/api/**` can stop taxing every turn's prefix.
- **Tier-driven channel routing** (`records/render.rs::channel_of`): pinned → cached prefix, scoped/retrieved → volatile. Sweep demotion still outranks the tier, so a stale-demoted pinned record never enters the stable prefix (witnessed). Explicitly-pinned `may`/`info` records render under a new `### Pinned` heading — Must/Should bytes untouched.
- **Budget-capped prefix, named overflow**: the cached record channel is capped at `CACHED_RECORD_BUDGET_CHARS` (16k, one shared constant) and an overflow *names itself in the prefix* — deterministic for the record set, so byte-stability (L-E8) holds (witnessed byte-for-byte) — never a silent truncation. Same contract, second half, at ingest time: `stella ingest` warns when a document's pinned footprint exceeds the budget, where the classification can still be fixed at review.
- **Classifier-assigned, user-overridable**: ingest stamps the derived tier explicitly on every proposal (visible in the proposal TOML, editable at review); a later force edit can no longer silently re-tier a record.
- **Coverage signal**: a scoped record whose trigger *matched* the turn but lost the record budget is reported (`turn_record_section_reporting`, mirroring `recalled_frames_reporting`'s injectable-sink shape) — a rule that systematically loses its seat no longer looks identical to a rule that never applied.
- **`ScopedWithoutTrigger` finding**: an explicit scoped tier with no `applies_to` can never fire; `records::validate` names it.

Closes #2709
Refs #2683
Refs #2761

## The witness

- [x] Witnesses per tier, none compiling on `main`: derivation + explicit-override + serde-absence (`ingest/record/tests.rs`), pinned-may-in-cached / scoped-must-out-of-cached / demoted-pinned-never-cached (`render.rs::tier_tests`), `ScopedWithoutTrigger` on explicit-only (`records/tests.rs`), tier stamped on all three proposal shapes (`extract/tests.rs`), pinned record reaching the assembled prefix + the overflow note with byte-stability (`prompt.rs` tests), and the matched-but-evicted report (`memory/tests.rs`). Backward compatibility is proven by the untouched pre-existing suites: all channel/byte-stability pins pass unmodified.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-core` (1116) / `-p stella-cli` (1696), including `make cache-correctness` goldens
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core` clean
- [x] `scripts/check-file-size.sh` green (no god file touched beyond same-line edits)
- [x] CLA signed
- [x] `Closes #N` in description and commit trailer

## Nothing left behind

- [x] Filed: #2761 — cumulative pinned-footprint accounting at ingest (today's diagnostic is per-document; the render-time note still catches the cumulative case), tier display in `stella context review`, and the `steering.tier` addition to the adaptive-context spec doc.

## Ground-rule check

- [x] No I/O added to `stella-core` — the tier, routing, validation, and budget are pure functions over owned data
- [x] No new outbound network calls; no new deps
- [x] The new record field round-trips through serde (witnessed) and is absent from the canonical form when undeclared, so no published record's hash changes

## Anything reviewers should know?

- The naming rule from #2683 is honored: nothing is keyed to any particular source filename; the vocabulary is tier/lineage. `extract.rs` aliases the record tier as `PromotionTier` locally because `ingest::Tier` (the model-free *document* classification) already lives there — the two are different axes.
- The cached channel was previously rendered UNCAPPED (`render(Cached, None)`) with the drop ledger discarded; both halves of `RenderedChannel` are now consumed. `RECORD_CHANNEL_BUDGET` (volatile, 2k) is unchanged.

## Summary by Sourcery

Introduce configurable promotion tiers for ingested records to control where they surface in prompts, add a shared prefix budget with explicit overflow reporting, and enhance validation and diagnostics around record coverage and tier usage.

New Features:
- Add promotion tiers (pinned, scoped, retrieved) to context records and use them to route records between cached and volatile prompt channels.
- Expose classifier-assigned promotion tiers in ingest proposals so reviewers can see and override how records will be promoted.
- Report records that matched a turn but were evicted by the recall budget to make coverage gaps observable.

Enhancements:
- Cap the cached rules prefix with a shared character budget and render an explicit, deterministic overflow note when pinned records are omitted.
- Derive promotion tiers from existing force and scope semantics when not explicitly declared to preserve pre-existing behavior and prompt byte stability.
- Extend record validation with a finding for scoped-tier records lacking triggers, highlighting configurations that can never fire.

Tests:
- Add tier-focused tests across ingest, rendering, prompt assembly, validation, and memory recall to prove tier behavior, hash stability, overflow naming, and backward compatibility.