### PR TITLE
fix(stella-tools): a correct long-running service survives the agent's own exit

### DIFF
--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -469,6 +469,40 @@ mod tests {
         }
     }
 
+    /// Witness for #2666: a command that backgrounds a child (`sleep 5 &`,
+    /// same shape as `nohup server &`) used to make `bash` hang until the
+    /// FULL `timeout_secs` — the backgrounded child still holds this call's
+    /// copy of the pipe open, so `wait_with_capped_output` waited for a true
+    /// EOF that could not arrive until the child itself exited. The command
+    /// the model actually asked for (`echo done_immediately`) finishes in
+    /// milliseconds; the tool call must return in roughly that time, not in
+    /// however long the backgrounded child happens to run.
+    #[tokio::test]
+    async fn does_not_block_on_a_backgrounded_child_holding_the_pipe_open() {
+        let dir = std::env::temp_dir();
+        let started = std::time::Instant::now();
+        let result = Bash::new(None)
+            .execute(
+                &serde_json::json!({
+                    "command": "sleep 5 & echo done_immediately",
+                    "timeout_secs": 10
+                }),
+                &dir,
+            )
+            .await;
+        let elapsed = started.elapsed();
+        match result {
+            ToolOutput::Ok { content } => {
+                assert!(content.contains("done_immediately"), "{content}")
+            }
+            ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
+        }
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "bash blocked on a backgrounded child holding the pipe open: {elapsed:?}"
+        );
+    }
+
     #[tokio::test]
     async fn captures_stderr() {
         let dir = std::env::temp_dir();

--- a/crates/stella-tools/src/exec.rs
+++ b/crates/stella-tools/src/exec.rs
@@ -282,54 +282,107 @@ impl CappedStream {
     }
 }
 
-/// Drain `reader` to EOF holding at most `cap` bytes (see [`CappedStream`]).
-async fn read_capped<R>(mut reader: R, cap: usize) -> std::io::Result<Vec<u8>>
+/// One `read` on a maybe-already-EOF'd stream. Never called with `reader ==
+/// None` in practice — every call site guards on `.is_some()` first — but
+/// takes the `Option` directly rather than an already-unwrapped reference so
+/// callers can hold the same slot across the two-phase wait below without a
+/// second `Option` wrapper at each call site.
+async fn read_into<R>(reader: &mut Option<R>, buf: &mut [u8]) -> std::io::Result<usize>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     use tokio::io::AsyncReadExt as _;
-    let mut acc = CappedStream::new(cap);
-    let mut buf = vec![0u8; 16 * 1024];
-    loop {
-        let n = reader.read(&mut buf).await?;
-        if n == 0 {
-            break;
-        }
-        acc.push(&buf[..n]);
+    match reader {
+        Some(r) => r.read(buf).await,
+        None => std::future::pending().await,
     }
-    Ok(acc.into_bytes())
 }
 
-/// [`tokio::process::Child::wait_with_output`] with a per-stream memory
-/// ceiling — see [`MAX_CAPTURE_BYTES`] for why the unbounded version is not
-/// safe on a path where the model chooses the command.
+/// After the direct child has exited, how much longer
+/// [`wait_with_capped_output`] keeps reading its stdout/stderr pipes before
+/// giving up on true EOF. A process that properly detaches (`setsid` with
+/// its streams redirected away, or anything spawned through
+/// [`crate::process::StartProcess`]) never touches this window: its own
+/// copy of the pipe's write end is already gone by the time we get here.
 ///
-/// Both pipes and the exit wait are polled concurrently, exactly as
-/// `wait_with_output` does, so a child that fills one pipe while the other is
-/// idle cannot deadlock.
+/// A plain `cmd &` backgrounded *inside* a `bash` invocation is different —
+/// it still holds THIS call's copy of the pipe open, because nothing told it
+/// to detach. Requiring true EOF from such a pipe used to mean the whole
+/// call hung until the caller's own timeout (seconds to minutes), even
+/// though the command the model actually asked for finished instantly:
+/// `nohup server &` inside `bash` blocked the tool for the full 120s
+/// default before the process-group kill on that timeout took the
+/// backgrounded server down with it (#2666). A short bounded drain gets the
+/// common case — output flushed before backgrounding — without paying that
+/// price for the uncommon one.
+const BACKGROUND_DRAIN_GRACE: Duration = Duration::from_millis(300);
+
+/// [`tokio::process::Child::wait_with_output`] with a per-stream memory
+/// ceiling (see [`MAX_CAPTURE_BYTES`]) and a bounded tolerance for a
+/// grandchild that outlives the direct child while still holding its
+/// inherited copy of the pipe (see [`BACKGROUND_DRAIN_GRACE`] and #2666).
+///
+/// Phase 1 races the exit wait against both pipes exactly as
+/// `wait_with_output` does, so a child that fills one pipe while the other
+/// is idle cannot deadlock. Phase 2 runs only once the direct child has
+/// exited and only for streams still open: it drains whatever is already
+/// sitting in the pipe, capped at [`BACKGROUND_DRAIN_GRACE`] rather than
+/// waiting for a holder that may never let go.
 pub(crate) async fn wait_with_capped_output(
     mut child: tokio::process::Child,
     cap: usize,
 ) -> std::io::Result<std::process::Output> {
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-    let out = async {
-        match stdout {
-            Some(reader) => read_capped(reader, cap).await,
-            None => Ok(Vec::new()),
+    let mut stdout = child.stdout.take();
+    let mut stderr = child.stderr.take();
+    let mut out = CappedStream::new(cap);
+    let mut err = CappedStream::new(cap);
+    let mut out_buf = [0u8; 16 * 1024];
+    let mut err_buf = [0u8; 16 * 1024];
+
+    let status = loop {
+        tokio::select! {
+            biased;
+            res = child.wait() => break res?,
+            res = read_into(&mut stdout, &mut out_buf), if stdout.is_some() => {
+                match res? {
+                    0 => stdout = None,
+                    n => out.push(&out_buf[..n]),
+                }
+            }
+            res = read_into(&mut stderr, &mut err_buf), if stderr.is_some() => {
+                match res? {
+                    0 => stderr = None,
+                    n => err.push(&err_buf[..n]),
+                }
+            }
         }
     };
-    let err = async {
-        match stderr {
-            Some(reader) => read_capped(reader, cap).await,
-            None => Ok(Vec::new()),
+
+    let drain_deadline = tokio::time::sleep(BACKGROUND_DRAIN_GRACE);
+    tokio::pin!(drain_deadline);
+    while stdout.is_some() || stderr.is_some() {
+        tokio::select! {
+            biased;
+            () = &mut drain_deadline => break,
+            res = read_into(&mut stdout, &mut out_buf), if stdout.is_some() => {
+                match res {
+                    Ok(0) | Err(_) => stdout = None,
+                    Ok(n) => out.push(&out_buf[..n]),
+                }
+            }
+            res = read_into(&mut stderr, &mut err_buf), if stderr.is_some() => {
+                match res {
+                    Ok(0) | Err(_) => stderr = None,
+                    Ok(n) => err.push(&err_buf[..n]),
+                }
+            }
         }
-    };
-    let (status, stdout, stderr) = tokio::try_join!(child.wait(), out, err)?;
+    }
+
     Ok(std::process::Output {
         status,
-        stdout,
-        stderr,
+        stdout: out.into_bytes(),
+        stderr: err.into_bytes(),
     })
 }
 

--- a/crates/stella-tools/src/process.rs
+++ b/crates/stella-tools/src/process.rs
@@ -200,10 +200,36 @@ impl ProcessEntry {
         buf
     }
 
-    /// Can this entry be dropped? Only once it has exited and every byte it
-    /// ever wrote has been delivered to a caller.
+    /// Can this entry be dropped? Only once it has exited, every byte it
+    /// ever wrote has been delivered to a caller, AND no other process in
+    /// its group is still alive holding the log open. `poll_exit` observes
+    /// only the DIRECT child; a `start_process(["sh","-c","server &"])`
+    /// backgrounds a grandchild that inherits the log fd and keeps writing
+    /// after the shell exits. Reaping (which deletes the log file) while
+    /// that grandchild is still alive would silently lose all of its
+    /// ongoing output, so the group check keeps the entry — and its log —
+    /// around until the whole group is gone.
     fn is_reapable(&mut self) -> bool {
-        self.poll_exit().is_some() && self.read_pos >= self.log_len()
+        self.poll_exit().is_some()
+            && self.read_pos >= self.log_len()
+            && !self.group_has_live_members()
+    }
+
+    /// Whether any process in this entry's process group is still alive.
+    /// The spawn places each child in its own session via `setsid`, so the
+    /// group id equals the direct child's pid; `kill(-pgid, 0)` sends no
+    /// signal but succeeds while any member (including an inherited-fd
+    /// grandchild) survives and fails with `ESRCH` once the group is empty.
+    /// Returns `false` when the pid was unavailable or off unix, falling
+    /// back to the drain-only gate.
+    fn group_has_live_members(&self) -> bool {
+        #[cfg(unix)]
+        if self.pid > 0 {
+            // SAFETY: signal 0 performs only the permission/existence check,
+            // delivering nothing; the negated pid targets the process group.
+            return unsafe { libc::kill(-self.pid, 0) } == 0;
+        }
+        false
     }
 }
 

--- a/crates/stella-tools/src/process.rs
+++ b/crates/stella-tools/src/process.rs
@@ -36,54 +36,73 @@
 //! - At most `MAX_LIVE_PROCESSES` processes may be LIVE at once; past
 //!   that `start_process` refuses with a named error rather than letting a
 //!   runaway loop spawn children without bound.
-//! - Output (stdout + stderr, interleaved by arrival) accumulates in a
-//!   capped ring buffer per process; when the cap overflows the oldest
-//!   bytes are dropped and the drop is FLAGGED on the next read.
-//! - `read_output` returns the output buffered since the last read —
-//!   middle-truncated at the shared 30 KB page cap, with the cut named —
-//!   and reports `running` / `exited (code N)`. Reading is itself
-//!   destructive: it drains the buffer it returns, exactly like
-//!   `clear_output` does, just without discarding the bytes unread. That
-//!   is why `read_output` stays `read_only: false` even after the split —
-//!   the engine's read-only concurrency contract
+//! - **Output survives the agent's own exit (#2666).** A child's stdout and
+//!   stderr are NOT an OS pipe this process owns the read end of — they are
+//!   redirected to a private log file, opened once and duplicated onto both
+//!   streams so writes interleave through one shared kernel file offset,
+//!   exactly like a shell's `2>&1`. A pipe's write end faults its writer
+//!   with `SIGPIPE`/`EPIPE` the moment the only reader goes away, which is
+//!   precisely what used to happen: Stella's own process exiting closed its
+//!   end of the pipe, and the next `print`/log line from a service the agent
+//!   had correctly started and left running killed it before the verifier
+//!   ever connected (kv-store-grpc, pypi-server — see #2666). A regular file
+//!   has no such reader; the child keeps writing to it, and keeps running,
+//!   whether or not anything is left to read the file back.
+//! - `read_output` returns the bytes written to the log since the last
+//!   read — middle-truncated at the shared 30 KB page cap, with the cut
+//!   named — and reports `running` / `exited (code N)`. A single call reads
+//!   at most `MAX_READ_BYTES`; unlike the old in-memory ring, anything
+//!   beyond that is never discarded — it simply waits in the file for the
+//!   next call. Reading is itself destructive in the sense that it advances
+//!   the read cursor past what it returns, exactly like `clear_output` does,
+//!   just without discarding the bytes unread. That is why `read_output`
+//!   stays `read_only: false` even after the split — the engine's read-only
+//!   concurrency contract
 //!   ([`stella_protocol::tool::ToolSchema::read_only`]) requires a call
 //!   to mutate no process/filesystem/environment state, and this one
-//!   always mutates the process table's buffer (and can reap the entry
-//!   into a tombstone) on every call, `clear` or not.
-//! - `clear_output` discards a process's buffered output without
-//!   returning it, for a caller that wants a clean slate before a noisy
-//!   step. It does not stop the process. Like `read_output`, it mutates
-//!   the table (and may reap a fully-drained, exited entry), so it is
-//!   also `read_only: false`.
-//! - Once a process has exited, both its pipes are at EOF, and its buffer
-//!   has been drained (by either `read_output` or `clear_output`), the
-//!   entry is REAPED — its `Child` and its buffer are released and a
-//!   small tombstone takes their place, so the handle still reports its
-//!   exit instead of degrading to "unknown handle".
+//!   always mutates the entry's read cursor (and can reap the entry into a
+//!   tombstone) on every call.
+//! - `clear_output` discards everything written to a process's log so far
+//!   without returning it, for a caller that wants a clean slate before a
+//!   noisy step. It does not stop the process. Like `read_output`, it
+//!   mutates the entry's read cursor (and may reap a fully-drained, exited
+//!   entry), so it is also `read_only: false`.
+//! - Once a process has exited and its log has been fully drained (by
+//!   either `read_output` or `clear_output`), the entry is REAPED — its
+//!   `Child` is released, its log file is deleted, and a small tombstone
+//!   takes their place, so the handle still reports its exit instead of
+//!   degrading to "unknown handle".
 //! - `stop_process` closes stdin, sends SIGTERM to the process group,
-//!   waits `STOP_GRACE_MS`, then SIGKILLs the group — and any process
-//!   still alive when the registry (and with it this table) drops is
-//!   killed the same way, so nothing outlives the session.
+//!   waits `STOP_GRACE_MS`, then SIGKILLs the group. This is the ONLY path
+//!   that kills a started process on Stella's own initiative — a process
+//!   the model never explicitly stopped is left running when the table
+//!   (and with it the whole tool registry) drops, on purpose, so that a
+//!   declared long-running service survives the turn that started it. A
+//!   process not reachable through this table at all (nothing spawned it
+//!   via `start_process`) is unaffected either way.
 //!
 //! All errors are typed and named: unknown handle, exited process, closed
 //! stdin, empty argv.
 
 use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, Command};
 
 use crate::registry::Tool;
 
-/// Byte cap on each process's buffered (unread) output.
-const MAX_BUFFER_BYTES: usize = 200_000;
-/// How much headroom an overflowing buffer reclaims in one drain — 25% of
-/// the cap, so the memmove amortizes instead of running per chunk.
-const BUFFER_DRAIN_SLACK: usize = MAX_BUFFER_BYTES / 4;
+/// Bytes read from a process's log in one `read_output`/`clear_output`
+/// call. Unlike the old in-memory ring this bounds only a single call —
+/// anything beyond it stays in the file for the next call, so nothing is
+/// ever permanently discarded except at reap time (see
+/// [`ProcessTombstone::discarded_bytes`]).
+const MAX_READ_BYTES: usize = 200_000;
 /// How long `stop_process` waits after SIGTERM before SIGKILL.
 const STOP_GRACE_MS: u64 = 2_000;
 /// How many LIVE processes one session may hold at once. Exited entries do
@@ -99,53 +118,17 @@ const MAX_TOMBSTONES: usize = 64;
 /// exempt from [`MAX_LIVE_PROCESSES`] on purpose (a finished process must
 /// never block a new start), but reaping only happens on `read_output` /
 /// `clear_output` — so without a bound of their own, a start/exit loop
-/// that never reads pins a `Child` plus up to [`MAX_BUFFER_BYTES`] per
-/// iteration for the rest of the session. 32 keeps twice the live cap's
-/// worth of recently finished output (~6.4 MB worst case) while bounding
-/// the table; the excess is evicted into a tombstone, so the handle still
-/// answers with its exit code.
+/// that never reads pins a `Child` plus its log file for the rest of the
+/// session. 32 keeps twice the live cap's worth of recently finished
+/// entries while bounding the table; the excess is evicted into a
+/// tombstone (and its log file deleted), so the handle still answers with
+/// its exit code.
 const MAX_EXITED_ENTRIES: usize = 32;
 
 /// The shared process table — held by the registry's five process tool
-/// instances, so it lives exactly as long as the registry and its `Drop`
-/// reaps whatever is still running when the session ends.
+/// instances, so it lives exactly as long as the registry. Its `Drop`
+/// deliberately does NOT kill what is still running — see the module doc.
 pub type ProcessTableHandle = Arc<Mutex<ProcessTable>>;
-
-/// Capped interleaved stdout+stderr buffer. Overflow drops the OLDEST
-/// bytes (a server's latest lines are the useful ones) and counts them so
-/// the next read can flag the gap.
-#[derive(Default)]
-struct OutputBuffer {
-    data: Vec<u8>,
-    dropped: u64,
-}
-
-impl OutputBuffer {
-    fn push(&mut self, chunk: &[u8]) {
-        self.data.extend_from_slice(chunk);
-        if self.data.len() > MAX_BUFFER_BYTES {
-            // Drain down to a slack line rather than to exactly the cap: at
-            // the cap, dropping only the excess memmoves the WHOLE 200 KB
-            // buffer for every arriving chunk (a chatty server at 8 KB
-            // chunks pays a 200 KB move 25 times per 200 KB of output).
-            // Draining a quantum amortizes that to one move per quantum, at
-            // the cost of reporting a few more dropped bytes — and dropped
-            // bytes are counted, never silent.
-            let excess = self.data.len() - (MAX_BUFFER_BYTES - BUFFER_DRAIN_SLACK);
-            self.data.drain(..excess);
-            self.dropped += excess as u64;
-        }
-    }
-
-    /// Take everything buffered since the last take, with the dropped-byte
-    /// count for the same window.
-    fn take(&mut self) -> (Vec<u8>, u64) {
-        (
-            std::mem::take(&mut self.data),
-            std::mem::take(&mut self.dropped),
-        )
-    }
-}
 
 /// One live (or recently exited) process.
 struct ProcessEntry {
@@ -163,11 +146,11 @@ struct ProcessEntry {
     /// resurrects the stdin the stop deliberately closed — revoking the EOF
     /// that lets a SIGTERM-ignoring REPL exit during the grace window.
     stdin_closed: bool,
-    output: Arc<Mutex<OutputBuffer>>,
-    /// Pumps still attached to this process's pipes. Zero means both pipes
-    /// hit EOF, so no further byte can ever arrive — the precondition for
-    /// reaping the entry without losing tail output.
-    pumps: Arc<std::sync::atomic::AtomicUsize>,
+    /// Where stdout+stderr are interleaved. Not a pipe this process reads:
+    /// see the module doc's #2666 note.
+    log_path: PathBuf,
+    /// Bytes of the log already delivered to a caller.
+    read_pos: u64,
     /// Group-kill target (unix); 0 when the pid was unavailable.
     pid: i32,
     /// Cached exit code once observed (signal exits report -1).
@@ -185,30 +168,56 @@ impl ProcessEntry {
         self.exit_code
     }
 
-    /// Can this entry be dropped? Only once it has exited, both pumps have
-    /// seen EOF, and the buffer they filled has been handed to the model.
+    /// Total bytes ever written to the log, or `read_pos` (nothing new) if
+    /// the file cannot be stat'd — a process that exited and had its log
+    /// already reaped by something else has nothing further to report.
+    fn log_len(&self) -> u64 {
+        std::fs::metadata(&self.log_path)
+            .map(|m| m.len())
+            .unwrap_or(self.read_pos)
+    }
+
+    /// Read up to [`MAX_READ_BYTES`] unread bytes from the log, advancing
+    /// the cursor. Returns empty on any I/O error rather than failing the
+    /// call — a log file that vanished (the process's own working directory
+    /// was recreated, say) is not a reason to error a status poll.
+    fn read_new(&mut self) -> Vec<u8> {
+        let Ok(mut file) = std::fs::File::open(&self.log_path) else {
+            return Vec::new();
+        };
+        let len = file.metadata().map(|m| m.len()).unwrap_or(self.read_pos);
+        if self.read_pos >= len {
+            return Vec::new();
+        }
+        if file.seek(SeekFrom::Start(self.read_pos)).is_err() {
+            return Vec::new();
+        }
+        let take = (len - self.read_pos).min(MAX_READ_BYTES as u64) as usize;
+        let mut buf = vec![0u8; take];
+        let n = file.read(&mut buf).unwrap_or(0);
+        buf.truncate(n);
+        self.read_pos += n as u64;
+        buf
+    }
+
+    /// Can this entry be dropped? Only once it has exited and every byte it
+    /// ever wrote has been delivered to a caller.
     fn is_reapable(&mut self) -> bool {
-        self.poll_exit().is_some()
-            && self.pumps.load(std::sync::atomic::Ordering::Acquire) == 0
-            && self
-                .output
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .data
-                .is_empty()
+        self.poll_exit().is_some() && self.read_pos >= self.log_len()
     }
 }
 
 /// What survives a reaped process: enough to keep answering about a handle
-/// the model still holds, without keeping its `Child` and its buffer alive.
+/// the model still holds, without keeping its `Child` or its log file
+/// alive.
 struct ProcessTombstone {
     name: Option<String>,
     display: String,
     exit_code: i32,
-    /// Buffered output the model never read, discarded at reap time. Zero on
-    /// the ordinary drain-then-reap path; non-zero only when the exited-entry
-    /// cap evicted the entry — counted so the tombstone can say so instead of
-    /// pretending the buffer was drained.
+    /// Bytes the model never read, discarded at reap time. Zero on the
+    /// ordinary drain-then-reap path; non-zero only when the exited-entry
+    /// cap evicted the entry — counted so the tombstone can say so instead
+    /// of pretending the log was drained.
     discarded_bytes: u64,
 }
 
@@ -254,21 +263,15 @@ impl ProcessTable {
     /// Drop `handle`'s entry, leaving a tombstone so `read_output` /
     /// `clear_output` / `stop_process` can still explain it. Callers must have established
     /// [`ProcessEntry::is_reapable`] — except [`Self::enforce_exited_cap`],
-    /// whose evictions knowingly discard an unread buffer and record the
+    /// whose evictions knowingly discard an unread log tail and record the
     /// discard on the tombstone.
     fn reap(&mut self, handle: &str) {
         let Some(mut entry) = self.entries.remove(handle) else {
             return;
         };
         let exit_code = entry.poll_exit().unwrap_or(-1);
-        let discarded_bytes = {
-            let (bytes, dropped) = entry
-                .output
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .take();
-            bytes.len() as u64 + dropped
-        };
+        let discarded_bytes = entry.log_len().saturating_sub(entry.read_pos);
+        let _ = std::fs::remove_file(&entry.log_path);
         self.tombstones.insert(
             handle.to_string(),
             ProcessTombstone {
@@ -326,27 +329,6 @@ impl ProcessTable {
     }
 }
 
-impl Drop for ProcessTable {
-    /// Reap every process still running when the table (and the registry
-    /// holding it) drops: group-SIGKILL on unix so grandchildren die too;
-    /// `kill_on_drop` on each `Child` backs this up for the direct child.
-    fn drop(&mut self) {
-        for entry in self.entries.values_mut() {
-            if entry.poll_exit().is_none() {
-                #[cfg(unix)]
-                if entry.pid > 0 {
-                    // SAFETY: plain libc::kill on a recorded child pgid;
-                    // guarded > 0 so we never signal our own group.
-                    unsafe {
-                        libc::kill(-entry.pid, libc::SIGKILL);
-                    }
-                }
-                let _ = entry.child.start_kill();
-            }
-        }
-    }
-}
-
 fn unknown_handle_error(table: &ProcessTable, handle: &str) -> ToolOutput {
     ToolOutput::Error {
         message: format!(
@@ -354,31 +336,6 @@ fn unknown_handle_error(table: &ProcessTable, handle: &str) -> ToolOutput {
             table.known_handles()
         ),
     }
-}
-
-/// Pump one child stream into the shared buffer until EOF. The lock is
-/// held only for the synchronous push, never across an await. `live` is
-/// decremented at EOF so the table can tell when no more output can arrive.
-fn spawn_pump<R>(
-    mut reader: R,
-    output: Arc<Mutex<OutputBuffer>>,
-    live: Arc<std::sync::atomic::AtomicUsize>,
-) where
-    R: tokio::io::AsyncRead + Unpin + Send + 'static,
-{
-    tokio::spawn(async move {
-        let mut buf = [0u8; 8192];
-        loop {
-            match reader.read(&mut buf).await {
-                Ok(0) | Err(_) => break,
-                Ok(n) => output
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(&buf[..n]),
-            }
-        }
-        live.fetch_sub(1, std::sync::atomic::Ordering::Release);
-    });
 }
 
 /// `start_process` — see the module doc.
@@ -394,8 +351,10 @@ impl Tool for StartProcess {
             name: "start_process".into(),
             description: "Start a LONG-RUNNING process (dev server, REPL, watcher) from an \
                           argv vector — no shell, cwd = workspace root. Returns a handle for \
-                          read_output / send_stdin / stop_process. For one-shot commands \
-                          prefer run_tests, build_project, or run_script instead."
+                          read_output / send_stdin / stop_process. The process is NOT stopped \
+                          when the turn ends — call stop_process when you are done with it. \
+                          For one-shot commands prefer run_tests, build_project, or run_script \
+                          instead."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -432,8 +391,8 @@ impl Tool for StartProcess {
             .map(str::to_string);
 
         // Refuse BEFORE spawning: nothing caps how many children a runaway
-        // loop can create, and each one holds a pipe pair and up to
-        // MAX_BUFFER_BYTES until it is stopped.
+        // loop can create, and each one holds a log file until it is
+        // stopped.
         {
             let mut table = self.handle.lock().unwrap_or_else(|p| p.into_inner());
             // Bound the exited-but-unread backlog before growing the table —
@@ -452,19 +411,55 @@ impl Tool for StartProcess {
             }
         }
 
+        // A private file, not a pipe: see the module doc's #2666 note on
+        // why the child's stdout/stderr must not depend on this process
+        // staying alive to read them.
+        let log_dir = self.scratch.clone().unwrap_or_else(std::env::temp_dir);
+        let named = match tempfile::Builder::new()
+            .prefix("stella-proc-")
+            .suffix(".log")
+            .tempfile_in(&log_dir)
+        {
+            Ok(named) => named,
+            Err(e) => {
+                return ToolOutput::Error {
+                    message: format!("failed to create a log file for the process: {e}"),
+                };
+            }
+        };
+        let (log_file, log_path) = match named.keep() {
+            Ok(kept) => kept,
+            Err(e) => {
+                return ToolOutput::Error {
+                    message: format!("failed to persist the process's log file: {e}"),
+                };
+            }
+        };
+        let stdout_stdio = match log_file.try_clone() {
+            Ok(f) => std::process::Stdio::from(f),
+            Err(e) => {
+                let _ = std::fs::remove_file(&log_path);
+                return ToolOutput::Error {
+                    message: format!("failed to duplicate the process log handle: {e}"),
+                };
+            }
+        };
+        let stderr_stdio = std::process::Stdio::from(log_file);
+
         let mut cmd = Command::new(&argv[0]);
         cmd.args(&argv[1..]);
         cmd.current_dir(root);
         // Full spawn policy: git-repo retargeting and forced-color overrides
         // are scrubbed along with credentials, exactly like `exec::drive` —
-        // a server's output lands in the captured buffer, never a terminal.
+        // a server's output lands in its log file, never a terminal.
         crate::subprocess_env::scrub_spawn_env(&mut cmd);
         crate::subprocess_env::inject_scratch_env(&mut cmd, self.scratch.as_deref());
         cmd.stdin(std::process::Stdio::piped());
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-        cmd.kill_on_drop(true);
-        // Own process group so stop/reap can take down grandchildren.
+        cmd.stdout(stdout_stdio);
+        cmd.stderr(stderr_stdio);
+        // No `kill_on_drop`: a started process is deliberately left running
+        // when this Rust value drops — see the module doc.
+        // Own process group so `stop_process` can take down grandchildren.
         #[cfg(unix)]
         unsafe {
             cmd.pre_exec(|| {
@@ -475,6 +470,7 @@ impl Tool for StartProcess {
         let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
+                let _ = std::fs::remove_file(&log_path);
                 return ToolOutput::Error {
                     message: format!("failed to spawn `{}`: {e}", argv.join(" ")),
                 };
@@ -482,16 +478,6 @@ impl Tool for StartProcess {
         };
         let pid = child.id().unwrap_or(0) as i32;
         let stdin = child.stdin.take();
-        let output: Arc<Mutex<OutputBuffer>> = Arc::default();
-        let pumps = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        if let Some(stdout) = child.stdout.take() {
-            pumps.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            spawn_pump(stdout, output.clone(), pumps.clone());
-        }
-        if let Some(stderr) = child.stderr.take() {
-            pumps.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            spawn_pump(stderr, output.clone(), pumps.clone());
-        }
 
         let display = argv.join(" ");
         let mut table = self.handle.lock().unwrap_or_else(|p| p.into_inner());
@@ -505,8 +491,8 @@ impl Tool for StartProcess {
                 child,
                 stdin,
                 stdin_closed: false,
-                output,
-                pumps,
+                log_path,
+                read_pos: 0,
                 pid,
                 exit_code: None,
             },
@@ -580,7 +566,7 @@ impl Tool for ReadOutput {
         let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(tomb) = table.tombstones.get(handle) {
             // Discarded bytes are reported, never silent — same contract as
-            // the ring buffer's drop flag.
+            // the old ring buffer's drop flag.
             let note = if tomb.discarded_bytes > 0 {
                 format!(
                     "[{} unread bytes were discarded when this exited process was reaped to \
@@ -609,22 +595,13 @@ impl Tool for ReadOutput {
             Some(code) => format!("exited (code {code})"),
             None => "running".to_string(),
         };
-        let (bytes, dropped) = entry
-            .output
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .take();
+        let bytes = entry.read_new();
         let label = entry
             .name
             .as_deref()
             .map(|n| format!(" ({n})"))
             .unwrap_or_default();
         let mut content = format!("{handle} `{}`{label}: {status}", entry.display);
-        if dropped > 0 {
-            content.push_str(&format!(
-                "\n[output truncated: {dropped} oldest bytes dropped before this read]"
-            ));
-        }
         if bytes.is_empty() {
             content.push_str("\n[no new output]");
         } else {
@@ -633,10 +610,9 @@ impl Tool for ReadOutput {
                 String::from_utf8_lossy(&bytes).into_owned(),
             ));
         }
-        // The entry has served its purpose: the process is gone, both pipes
-        // are at EOF, and everything they produced has now reached the
-        // model. Keeping it would hold a `Child` and up to MAX_BUFFER_BYTES
-        // for the rest of the session.
+        // The entry has served its purpose: the process is gone and
+        // everything it ever wrote has now reached the model. Keeping it
+        // would hold a `Child` and its log file for the rest of the session.
         if entry.is_reapable() {
             table.reap(handle);
         }
@@ -683,7 +659,7 @@ impl Tool for ClearOutput {
         };
         let mut table = self.0.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(tomb) = table.tombstones.get(handle) {
-            // Already reaped: its buffer was drained (and any unread bytes
+            // Already reaped: its log was drained (and any unread bytes
             // counted) when it was reaped, so there is nothing left to
             // discard. Answering rather than erroring matches `read_output`
             // and `stop_process`'s posture on a tombstoned handle — the
@@ -712,23 +688,14 @@ impl Tool for ClearOutput {
             .as_deref()
             .map(|n| format!(" ({n})"))
             .unwrap_or_default();
-        let (bytes, dropped) = entry
-            .output
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .take();
-        let mut content = format!(
-            "{handle} `{}`{label}: {status}\n[cleared {} buffered bytes]",
+        let cleared_len = entry.log_len().saturating_sub(entry.read_pos);
+        entry.read_pos = entry.log_len();
+        let content = format!(
+            "{handle} `{}`{label}: {status}\n[cleared {cleared_len} buffered bytes]",
             entry.display,
-            bytes.len()
         );
-        if dropped > 0 {
-            content.push_str(&format!(
-                " ({dropped} more were already dropped before this clear)"
-            ));
-        }
-        // Same reap contract as `read_output`: once exited, drained, and
-        // pump-quiet, nothing further can ever arrive on this handle.
+        // Same reap contract as `read_output`: once exited and drained,
+        // nothing further can ever be delivered from this handle.
         if entry.is_reapable() {
             table.reap(handle);
         }

--- a/crates/stella-tools/src/process/tests.rs
+++ b/crates/stella-tools/src/process/tests.rs
@@ -39,51 +39,30 @@ async fn start_with_scratch(
     }
 }
 
-#[test]
-fn output_buffer_caps_and_counts_dropped_bytes() {
-    let mut buf = OutputBuffer::default();
-    buf.push(&vec![b'a'; MAX_BUFFER_BYTES]);
-    buf.push(&[b'z'; 10]);
-    let (bytes, dropped) = buf.take();
-    assert!(bytes.len() <= MAX_BUFFER_BYTES, "capped at the max");
-    // An overflow reclaims a slack quantum, so `dropped` exceeds the
-    // strict minimum — but nothing vanishes unaccounted: every byte
-    // pushed is either still buffered or counted as dropped, which is
-    // what makes the gap flag on the next read honest.
-    assert_eq!(
-        bytes.len() as u64 + dropped,
-        MAX_BUFFER_BYTES as u64 + 10,
-        "every pushed byte is either kept or counted"
-    );
-    assert!(dropped >= 10, "the oldest bytes were dropped: {dropped}");
-    assert!(bytes.ends_with(b"zzzzzzzzzz"), "newest bytes survive");
-    // Take drains: a second take is empty with no drop count.
-    assert_eq!(buf.take(), (Vec::new(), 0));
-}
-
-/// The point of the slack: a chatty stream at the cap must not memmove
-/// the whole buffer per chunk. One drain per quantum, not per push.
-#[test]
-fn a_buffer_at_the_cap_drains_a_quantum_not_every_chunk() {
-    let mut buf = OutputBuffer::default();
-    buf.push(&vec![b'a'; MAX_BUFFER_BYTES]);
-    let before = buf.data.len();
-    buf.push(&[b'z'; 8192]);
-    assert!(
-        buf.data.len() < before,
-        "the overflow reclaimed headroom: {} → {}",
-        before,
-        buf.data.len()
-    );
-    // The next several chunks fit in the reclaimed slack and drop nothing.
-    let after_first_drain = buf.dropped;
-    for _ in 0..4 {
-        buf.push(&[b'z'; 8192]);
+/// Poll until `read_output` sees the given substring, or panic — bounded so
+/// a stuck test fails fast instead of hanging.
+async fn wait_for_output(
+    table: &ProcessTableHandle,
+    root: &std::path::Path,
+    handle: &str,
+    needle: &str,
+) -> String {
+    let mut observed = String::new();
+    for _ in 0..250 {
+        let out = ReadOutput(table.clone())
+            .execute(&serde_json::json!({"handle": handle}), root)
+            .await;
+        let ToolOutput::Ok { content } = out else {
+            panic!("read_output failed: {out:?}");
+        };
+        observed.push_str(&content);
+        observed.push('\n');
+        if observed.contains(needle) {
+            return observed;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    assert_eq!(
-        buf.dropped, after_first_drain,
-        "chunks inside the slack cost no further drops"
-    );
+    panic!("never observed {needle:?} in output: {observed}");
 }
 
 #[tokio::test]
@@ -148,30 +127,7 @@ async fn clear_output_discards_buffered_output_before_the_next_read() {
         &["sh", "-c", "echo written_before_clear; sleep 30"],
     )
     .await;
-
-    // Wait until the write has actually landed in the buffer, or
-    // clearing it would prove nothing.
-    let mut buffered = false;
-    for _ in 0..250 {
-        if table
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .entries
-            .get(&handle)
-            .is_some_and(|e| {
-                !e.output
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .data
-                    .is_empty()
-            })
-        {
-            buffered = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-    assert!(buffered, "the process never produced buffered output");
+    wait_for_output(&table, &root, &handle, "written_before_clear").await;
 
     let cleared = ClearOutput(table.clone())
         .execute(&serde_json::json!({"handle": handle}), &root)
@@ -207,28 +163,7 @@ async fn clear_output_discards_buffered_output_before_the_next_read() {
 async fn read_output_clear_true_is_a_named_deprecation_error() {
     let (table, root) = tools();
     let handle = start(&table, &root, &["sh", "-c", "echo still_here; sleep 30"]).await;
-
-    let mut buffered = false;
-    for _ in 0..250 {
-        if table
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .entries
-            .get(&handle)
-            .is_some_and(|e| {
-                !e.output
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .data
-                    .is_empty()
-            })
-        {
-            buffered = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-    assert!(buffered, "the process never produced buffered output");
+    wait_for_output(&table, &root, &handle, "still_here").await;
 
     let out = ReadOutput(table.clone())
         .execute(&serde_json::json!({"handle": handle, "clear": true}), &root)
@@ -336,22 +271,7 @@ async fn cat_echoes_stdin_and_stop_reports_the_lifecycle() {
         .await;
     assert!(!write.is_error(), "{write:?}");
 
-    // Poll until the pump has delivered the echo (bounded).
-    let mut echoed = String::new();
-    for _ in 0..50 {
-        let out = ReadOutput(table.clone())
-            .execute(&serde_json::json!({"handle": handle}), &root)
-            .await;
-        let ToolOutput::Ok { content } = out else {
-            panic!("read_output failed");
-        };
-        echoed.push_str(&content);
-        if echoed.contains("hello_process") {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    }
-    assert!(echoed.contains("hello_process"), "{echoed}");
+    let echoed = wait_for_output(&table, &root, &handle, "hello_process").await;
     assert!(echoed.contains("running"), "{echoed}");
 
     // Stop: cat exits on stdin EOF/SIGTERM; afterwards the state is
@@ -402,11 +322,11 @@ async fn a_naturally_exited_process_reports_its_code() {
     panic!("`true` never reported exit");
 }
 
-/// An exited process used to keep its `Child` and up to 200 KB of buffer
-/// until the whole registry dropped. Once its output has reached the
-/// model there is nothing left to hold — but the handle must keep
-/// answering, or a model polling a finished server sees "unknown handle"
-/// and concludes something is wrong.
+/// An exited process used to keep its `Child` and its log file until the
+/// whole registry dropped. Once its output has reached the model there is
+/// nothing left to hold — but the handle must keep answering, or a model
+/// polling a finished server sees "unknown handle" and concludes something
+/// is wrong.
 #[cfg(unix)]
 #[tokio::test]
 async fn a_drained_exited_process_is_reaped_but_its_handle_still_answers() {
@@ -501,11 +421,14 @@ async fn the_live_process_cap_refuses_a_runaway_and_a_stop_frees_a_slot() {
             .execute(&serde_json::json!({"handle": handle}), &root)
             .await;
     }
+    let _ = StopProcess(table)
+        .execute(&serde_json::json!({"handle": "proc-999"}), &root)
+        .await;
 }
 
 /// Exited entries are exempt from the live cap, so before the exited-entry
 /// bound a start/exit loop that never called read_output pinned a `Child`
-/// and up to 200 KB of buffer per iteration for the rest of the session.
+/// and its log file per iteration for the rest of the session.
 #[cfg(unix)]
 #[tokio::test]
 async fn exited_unread_entries_are_evicted_oldest_first_never_running_ones() {
@@ -516,21 +439,13 @@ async fn exited_unread_entries_are_evicted_oldest_first_never_running_ones() {
     let mut echo_handles = Vec::new();
     for _ in 0..MAX_EXITED_ENTRIES + 2 {
         let handle = start(&table, &root, &["sh", "-c", "echo unread_output"]).await;
-        // Wait until the exit is observable and the pump has delivered
-        // the output, so an eviction demonstrably discards unread bytes.
+        // Wait until the exit is observable and something has landed in
+        // the log, so an eviction demonstrably discards unread bytes.
         for _ in 0..250 {
             let ready = {
                 let mut t = table.lock().unwrap_or_else(|p| p.into_inner());
                 match t.entries.get_mut(&handle) {
-                    Some(e) => {
-                        e.poll_exit().is_some()
-                            && !e
-                                .output
-                                .lock()
-                                .unwrap_or_else(|p| p.into_inner())
-                                .data
-                                .is_empty()
-                    }
+                    Some(e) => e.poll_exit().is_some() && e.log_len() > 0,
                     None => true,
                 }
             };
@@ -610,24 +525,7 @@ async fn start_process_injects_stella_scratch_into_spawned_process() {
     )
     .await;
 
-    // Poll read_output until we see the STELLA_SCRATCH value in the output.
-    let mut observed = String::new();
-    for attempt in 0..100 {
-        let out = ReadOutput(table.clone())
-            .execute(&serde_json::json!({"handle": handle}), &root)
-            .await;
-        let ToolOutput::Ok { content } = out else {
-            panic!("read_output failed on attempt {attempt}");
-        };
-        observed.push_str(&content);
-        // The injected scratch path should appear in the output.
-        if observed.contains(&expected_path) {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-
-    // Verify the scratch path was actually injected.
+    let observed = wait_for_output(&table, &root, &handle, &expected_path).await;
     assert!(
         observed.contains(&expected_path),
         "STELLA_SCRATCH should be set to the scratch path. Expected substring '{}' in output:\n{}",
@@ -732,4 +630,59 @@ async fn long_running_process_scrubs_inherited_credentials() {
         .execute(&serde_json::json!({"handle": handle}), &root)
         .await;
     assert!(!stopped.is_error(), "{stopped:?}");
+}
+
+/// The witness for #2666: a `start_process`d child used to be SIGKILLed the
+/// moment the `ProcessTable` (and with it the whole tool registry) dropped
+/// — the exact moment a bench trial's agent finishes and the verifier goes
+/// looking for the service it just proved was running. This test spawns a
+/// process that logs a line once a second, drops the table (simulating the
+/// registry going away at the end of a turn) WITHOUT calling
+/// `stop_process`, and then proves the process is still alive by signalling
+/// it with `kill(pid, 0)` directly — outside the table entirely, since the
+/// table that would normally answer `read_output` is gone.
+///
+/// This fails against the old pipe-owned-by-us design (verified by hand:
+/// the child gets SIGKILLed by `ProcessTable::drop`) and passes once output
+/// is file-backed and the table no longer kills on drop.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_started_child_outlives_the_process_tables_drop() {
+    let root = std::env::temp_dir();
+    let table: ProcessTableHandle = Arc::default();
+    let handle = start(
+        &table,
+        &root,
+        &[
+            "sh",
+            "-c",
+            "i=0; while [ $i -lt 30 ]; do echo tick $i; i=$((i+1)); sleep 1; done",
+        ],
+    )
+    .await;
+    wait_for_output(&table, &root, &handle, "tick 0").await;
+
+    let pid = {
+        let mut t = table.lock().unwrap_or_else(|p| p.into_inner());
+        let entry = t.entries.get_mut(&handle).expect("entry still present");
+        entry.pid
+    };
+    assert!(pid > 0, "no pid recorded for the started process");
+
+    // Drop every reference to the table — this is what happens when the
+    // registry (and the whole tool set) is torn down at the end of a run,
+    // with no explicit `stop_process` call.
+    drop(table);
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    assert!(
+        unsafe { libc::kill(pid, 0) == 0 },
+        "the started process (pid {pid}) did not survive the ProcessTable's drop"
+    );
+
+    // Clean up: kill the process group directly since nothing in-process
+    // holds a handle to it anymore.
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the two mechanical causes behind #2666: a Terminal-Bench trial doing exactly the right thing — starting a service, proving it works, leaving it running — still scored 0 because the service was dead by the time the verifier connected.

- **`start_process` children no longer die with the agent.** They used to inherit an OS pipe *this* process owned the read end of; the moment Stella's own process exited (or `ProcessTable::drop` ran), either the pipe closing faulted the child with `SIGPIPE` on its next write, or the table's own `Drop` SIGKILLed it outright. Output is now redirected to a private log file (duplicated onto stdout+stderr so they interleave like a shell's `2>&1`) instead of a pipe, and `read_output`/`clear_output` tail it by cursor. `ProcessTable` no longer kills what's still running on drop, and the spawn drops `kill_on_drop` — a started process is deliberately left running unless the model calls `stop_process`.
- **`bash` no longer blocks for the full timeout on a backgrounded child.** The shared `wait_with_capped_output` required true EOF from both pipes; `nohup server &` inside a `bash` call (same process group, no `setsid`) held the tool call's copy of the pipe open for the entire `timeout_secs` even though the command the model asked for finished instantly — and the timeout's own process-group kill then took the backgrounded server down with it. It now completes once the direct child exits, draining whatever's already buffered for a short bounded grace period.

## Witness tests

- `a_started_child_outlives_the_process_tables_drop` (`process/tests.rs`): starts a process, drops the whole table without calling `stop_process`, and checks the child is still alive via `kill(pid, 0)`. Verified by hand: **fails** against the pre-fix `ProcessTable` (the child is SIGKILLed on drop), **passes** against this change.
- `does_not_block_on_a_backgrounded_child_holding_the_pipe_open` (`bash.rs`): backgrounds a `sleep 5` inside a `bash` call and asserts the tool returns in well under 2s. Verified by hand: **fails** (~5s hang) against the pre-fix `exec.rs`, **passes** against this change.

Both were confirmed the artisanal way — `git stash` the fix, rerun, watch it fail; restore, rerun, watch it pass.

## Scope note

#2666 also asks for an end-of-turn assertion warning the agent when a declared service is still running at turn end. That's a driver/pipeline-layer change (agent-loop crown architecture per AGENTS.md), not a `stella-tools` one, and isn't in this PR — tracked separately as #2764.

## Test plan

- [x] `cargo test -p stella-tools` — 801 passed, including the two witness tests and every existing `process::`/`bash::` test
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p stella-tools` — clean
- [x] `make guards-fast` — clean (file-size, god-files, left-behind, etc.)
- [x] `make gate CARGO_SCOPE="-p stella-tools"` — green
- [x] pre-push hook's own gate — green (pushed successfully)

Closes #2666

## Summary by Sourcery

Ensure long-running child processes started by stella-tools remain alive across the agent’s own exit while keeping their output accessible and bounded, and prevent bash invocations from blocking for the full timeout when backgrounding children.

New Features:
- Persist process output to per-process log files so services can keep running and emitting logs independently of the agent lifecycle.

Bug Fixes:
- Prevent started processes from being killed automatically when the process table or registry drops, allowing declared services to survive between turns.
- Avoid hangs in bash-based tool calls when commands background children that keep stdout/stderr pipes open, so calls return promptly once the requested command completes.

Enhancements:
- Simplify process output handling by replacing the in-memory ring buffer and pump tasks with file-backed logs and cursor-based reads, while maintaining truncation and reaping semantics.
- Tighten resource management around exited processes and their logs by reaping entries once all output has been delivered and deleting associated log files.
- Add helper utilities and tests to robustly await specific process output content, improving reliability of process-related tests.

Tests:
- Add witness tests proving that a started child outlives the process table’s drop without an explicit stop and that bash no longer blocks on a backgrounded child holding the pipe open.