### PR TITLE
fix(rules): resolve context-record validate findings on imported rules

### DIFF
--- a/.stella/rules/ctx.macanderson.stella.cite-doc-by-id.toml
+++ b/.stella/rules/ctx.macanderson.stella.cite-doc-by-id.toml
@@ -3,8 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.cite-doc-by-id"
-record_id = "rec_macanderson_stella_cite_doc_by_id_7d17012ac76c"
-record_hash = "sha256:4d5ef32113248adc1635ee0e3e5f39a4bc7199940888fafb419f8c25dd530640"
+record_id = "rec_macanderson_stella_cite_doc_by_id_3307f630b4a9"
+record_hash = "sha256:48c13aa824a66a568799c9be920ad3f987efcec79f4153c964e02fdba8299892"
 kind = "rule"
 statement = "A document under docs/ is cited by its stable frontmatter id (for example doc:context-reuse §4), not by its file path."
 origin = "imported"
@@ -30,10 +30,6 @@ paths = [
     "docs",
     "docs/manifest.json",
 ]
-tasks = [
-    "documentation",
-    "citation",
-]
 keywords = [
     "doc id",
     "citation",
@@ -41,7 +37,7 @@ keywords = [
 ]
 
 [record.enforcement]
-mode = "hard"
+mode = "none"
 
 [record.truth]
 basis = "decree"

--- a/.stella/rules/ctx.macanderson.stella.no-widen-deny-toml.toml
+++ b/.stella/rules/ctx.macanderson.stella.no-widen-deny-toml.toml
@@ -3,8 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.no-widen-deny-toml"
-record_id = "rec_macanderson_stella_no_widen_deny_toml_1ee6703bf2d2"
-record_hash = "sha256:5553c6a6850ec733814a72e3baf7162511bee78cd42362d8965d36c41583e611"
+record_id = "rec_macanderson_stella_no_widen_deny_toml_f155c01834a0"
+record_hash = "sha256:c75a7dc64e2633c8a9fe94ae86afb1aa614247989148cf56c132541068e4b9ad"
 kind = "rule"
 statement = "Widening the deny.toml allow-list to turn a gate green is prohibited."
 origin = "imported"
@@ -27,7 +27,7 @@ extractor = "anthropic/claude-opus-5"
 
 [record.steering]
 force = "must"
-precedence = 100
+precedence = 50
 
 [record.steering.applies_to]
 paths = ["deny.toml"]

--- a/.stella/rules/ctx.macanderson.stella.open-events-jsonl-first.toml
+++ b/.stella/rules/ctx.macanderson.stella.open-events-jsonl-first.toml
@@ -3,8 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.open-events-jsonl-first"
-record_id = "rec_macanderson_stella_open_events_jsonl_first_691f32a90dec"
-record_hash = "sha256:37f1f5e8b3f95b9b061d2cbdca6c3fd7b7fc20ffbc200e575d9737b646d7281d"
+record_id = "rec_macanderson_stella_open_events_jsonl_first_8901bf9ed5c6"
+record_hash = "sha256:3af1c4c6e9d8c10ca8faf97af9898d59bfb4b55b8f8ceb44a77d1d668de6a6e8"
 kind = "procedure"
 statement = "Open stella-events.jsonl before claiming anything about a bench run."
 origin = "imported"
@@ -31,10 +31,6 @@ precedence = 100
 
 [record.steering.applies_to]
 paths = ["stella-events.jsonl"]
-tasks = [
-    "benchmark",
-    "investigation",
-]
 keywords = [
     "stella-events.jsonl",
     "ground truth",

--- a/.stella/rules/ctx.macanderson.stella.pre-push-runs-gate.toml
+++ b/.stella/rules/ctx.macanderson.stella.pre-push-runs-gate.toml
@@ -3,8 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.pre-push-runs-gate"
-record_id = "rec_macanderson_stella_pre_push_runs_gate_2eb27e26c242"
-record_hash = "sha256:20b979cad42ffe161427ec3ea9817097e56c54b9909cddc09babb785587c634c"
+record_id = "rec_macanderson_stella_pre_push_runs_gate_8b481d0cc128"
+record_hash = "sha256:1d5432d70b7e07a3d4061eb9776a1abdaa606a1d719fb2471ed8be40f3d72091"
 kind = "fact"
 statement = "The pre-push hook runs the full gate automatically on every push and aborts the push if it fails."
 origin = "imported"
@@ -34,7 +34,7 @@ keywords = [
 ]
 
 [record.enforcement]
-mode = "hard"
+mode = "none"
 
 [record.truth]
 basis = "asserted"

--- a/.stella/rules/ctx.macanderson.stella.protocol-types-only.toml
+++ b/.stella/rules/ctx.macanderson.stella.protocol-types-only.toml
@@ -3,8 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.protocol-types-only"
-record_id = "rec_macanderson_stella_protocol_types_only_3e030b5ca792"
-record_hash = "sha256:b3e4a1be52cc6caad538e300e3b8437408da0b3f9ef371d2eed9751eaecad6da"
+record_id = "rec_macanderson_stella_protocol_types_only_8e85b17efcbe"
+record_hash = "sha256:8fd9ed72dada49c4bf80b31cb32be309f5fb80693b37a1d630c54c0b51f4badf"
 kind = "constraint"
 statement = "stella-protocol holds shared types only, with zero logic and zero I/O."
 origin = "imported"
@@ -34,7 +34,7 @@ keywords = [
 ]
 
 [record.enforcement]
-mode = "hard"
+mode = "none"
 
 [record.truth]
 basis = "decree"


### PR DESCRIPTION
## Summary
- `no-widen-deny-toml` duplicated `dependency-license-allowlist`'s claim over `deny.toml` at equal precedence (100) with weaker enforcement (soft, imported), which caused `stella context validate` to suspend the real first-party hard guard on the tie. Lowered its precedence to 50 so the first-party constraint wins uncontested — the designed resolution per `records::validate`'s own conflict-detection doc comment.
- Dropped `applies_to.tasks` values outside the closed `KNOWN_TASKS` vocabulary (ADR 0011) from `cite-doc-by-id` (`documentation`, `citation`) and `open-events-jsonl-first` (`benchmark`, `investigation`) — they never matched anything and only silently skewed relevance.
- Downgraded `cite-doc-by-id`, `pre-push-runs-gate`, and `protocol-types-only` from `enforcement.mode = "hard"` to `"none"` (advisory): an `imported`-origin record can never actually enforce a block (`Record::honored_probe`/validate's gating), so `hard` was asking for behavior the record structurally cannot deliver.
- Every edited record was re-stamped (`Record::stamp`) so `record_id`/`record_hash` match the new content — no hand-computed hashes.

All edits are to `.stella/rules/*.toml` only; no Rust source changed.

## Test plan
- [x] `cargo run -p stella-cli --quiet -- context validate` — before: 6 warnings, 1 conflict, 3 not-loaded/not-armed records. After: zero findings, zero conflicts, zero not-loaded records; "Every loaded record is schema-valid and currently believed."

## Summary by Sourcery

Adjust imported Stella context rules to resolve validation conflicts and align enforcement behavior with the records system.

Bug Fixes:
- Lower precedence of the imported no-widen-deny-toml rule so it no longer conflicts with the first-party deny.toml guard.
- Remove non-vocabulary task filters from imported rules so they no longer define ineffective applies_to.tasks entries.
- Downgrade imported rules from hard enforcement to advisory mode so their configuration matches the actual gating behavior of imported records.

Enhancements:
- Restamp all modified rule records so their IDs and hashes reflect the updated content.