### PR TITLE
feat(stella-core): mid-turn model fallback on retries-exhausted — re-resolve through the router, repair the transcript, continue the turn

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -46,6 +46,7 @@ use crate::runtime::{SystemClock, TokioSleeper};
 use crate::{OutputFormat, config::Config, resume_frame};
 use stella_context::EpisodeOutcome;
 
+mod budget;
 mod coverage;
 mod diagnostics;
 mod engine;
@@ -61,6 +62,7 @@ pub(crate) mod resume;
 mod skill_usage;
 mod tools;
 mod turn_close;
+pub(crate) use budget::{build_budget_guard, remaining_budget, settle_reflection_budget};
 
 pub(crate) use engine::*;
 pub(crate) use goal::*;
@@ -1829,60 +1831,6 @@ pub fn run_tools_validation(dir: Option<&std::path::Path>) -> Result<(), String>
     }
 }
 
-/// Construct the budget guard from `--budget`. The limit lands on the
-/// session axis, capping cumulative spend across every turn and goal round
-/// of the run — `begin_turn` resets only the turn-scoped counter. The turn
-/// axis is left unset on purpose: turn spend is a reset-to-zero subset of
-/// session spend, so an equal turn limit could never trip first and would
-/// only mislabel a session breach as a turn one. No limit at all still
-/// meters spend (`BudgetMode::Observed`) so the cost summary and
-/// `BudgetTick` events stay meaningful even when nothing is enforced.
-pub(crate) fn build_budget_guard(budget_limit: Option<f64>) -> BudgetGuard {
-    stella_runtime::budget_guard(budget_limit)
-}
-
-/// Headroom before the next configured cap trips, in USD — the smaller of
-/// the turn- and session-axis remainders when both are set, so the reported
-/// value is always the binding constraint. `None` when neither axis has a
-/// limit.
-pub(crate) fn remaining_budget(guard: &BudgetGuard) -> Option<f64> {
-    let turn = guard
-        .turn_limit_usd()
-        .map(|limit| (limit - guard.spent_usd()).max(0.0));
-    let session = guard
-        .session_limit_usd()
-        .map(|limit| (limit - guard.session_spent_usd()).max(0.0));
-    match (turn, session) {
-        (Some(turn), Some(session)) => Some(turn.min(session)),
-        (Some(remaining), None) | (None, Some(remaining)) => Some(remaining),
-        (None, None) => None,
-    }
-}
-
-pub(crate) fn settle_reflection_budget(report: &mut ReflectionReport, guard: &mut BudgetGuard) {
-    let had_accounting = report.events.iter().any(|event| {
-        matches!(
-            event,
-            AgentEvent::StepUsage { .. }
-                | AgentEvent::UsageIncomplete { .. }
-                | AgentEvent::BudgetTick { .. }
-        )
-    });
-    report
-        .events
-        .retain(|event| !matches!(event, AgentEvent::BudgetTick { .. }));
-    if report.cost_usd > 0.0 {
-        let _ = guard.record_spend(report.cost_usd);
-    }
-    if had_accounting {
-        // Through the guard's own constructor, not a literal: the session axis
-        // was hardcoded `None` here while this very guard tracked one, and the
-        // wall-clock axis (#2240) would have gone missing the same way.
-        report
-            .events
-            .push(guard.tick_event(std::time::Instant::now()));
-    }
-}
 /// Open the workspace SQLite store (`.stella/private/store.db`). Persistence is
 /// observability, not a work dependency: a store that won't open warns once
 /// and the session runs on without it — never a startup failure.
@@ -2010,6 +1958,9 @@ async fn run_turn(
         let _ = tx.send(event);
     }
 
+    // Mid-turn fallback (#2679): on an exhausted retry ladder the engine
+    // re-resolves the worker role through this session router.
+    let fallback = engine::SessionFallback::new(router);
     // The scoped tool set must drop its tx clone before awaiting the renderer.
     let outcome = if crate::enterprise_telemetry::process_free_authority_active() {
         // Even when process-free authority strips the MCP/custom/interactive
@@ -2021,7 +1972,8 @@ async fn run_turn(
         let config = engine::engine_config_for_kind(cfg, kind);
         let engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
             .with_calibration(calibration)
-            .with_provider_outcomes(router);
+            .with_provider_outcomes(router)
+            .with_fallback_resolver(&fallback);
         engine.run_turn_with_sender(messages, budget, &tx).await
     } else {
         let customs = CustomToolSet::new(
@@ -2048,7 +2000,8 @@ async fn run_turn(
         let config = engine::engine_config_for_kind(cfg, kind);
         let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
             .with_calibration(calibration)
-            .with_provider_outcomes(router);
+            .with_provider_outcomes(router)
+            .with_fallback_resolver(&fallback);
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/crates/stella-cli/src/agent/budget.rs
+++ b/crates/stella-cli/src/agent/budget.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Session budget helpers: the `--budget` guard's construction, the
+//! headroom read the deck and fleet surfaces report, and the post-turn
+//! reflection settlement. Split out of `agent.rs` (the `driver/settlement.rs`
+//! pattern) — the parent is a grandfathered god file closed to growth, and
+//! these three are the self-contained budget seam.
+
+use stella_core::BudgetGuard;
+use stella_protocol::AgentEvent;
+
+use crate::memory::ReflectionReport;
+
+/// Construct the budget guard from `--budget`. The limit lands on the
+/// session axis, capping cumulative spend across every turn and goal round
+/// of the run — `begin_turn` resets only the turn-scoped counter. The turn
+/// axis is left unset on purpose: turn spend is a reset-to-zero subset of
+/// session spend, so an equal turn limit could never trip first and would
+/// only mislabel a session breach as a turn one. No limit at all still
+/// meters spend (`BudgetMode::Observed`) so the cost summary and
+/// `BudgetTick` events stay meaningful even when nothing is enforced.
+pub(crate) fn build_budget_guard(budget_limit: Option<f64>) -> BudgetGuard {
+    stella_runtime::budget_guard(budget_limit)
+}
+
+/// Headroom before the next configured cap trips, in USD — the smaller of
+/// the turn- and session-axis remainders when both are set, so the reported
+/// value is always the binding constraint. `None` when neither axis has a
+/// limit.
+pub(crate) fn remaining_budget(guard: &BudgetGuard) -> Option<f64> {
+    let turn = guard
+        .turn_limit_usd()
+        .map(|limit| (limit - guard.spent_usd()).max(0.0));
+    let session = guard
+        .session_limit_usd()
+        .map(|limit| (limit - guard.session_spent_usd()).max(0.0));
+    match (turn, session) {
+        (Some(turn), Some(session)) => Some(turn.min(session)),
+        (Some(remaining), None) | (None, Some(remaining)) => Some(remaining),
+        (None, None) => None,
+    }
+}
+
+pub(crate) fn settle_reflection_budget(report: &mut ReflectionReport, guard: &mut BudgetGuard) {
+    let had_accounting = report.events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::StepUsage { .. }
+                | AgentEvent::UsageIncomplete { .. }
+                | AgentEvent::BudgetTick { .. }
+        )
+    });
+    report
+        .events
+        .retain(|event| !matches!(event, AgentEvent::BudgetTick { .. }));
+    if report.cost_usd > 0.0 {
+        let _ = guard.record_spend(report.cost_usd);
+    }
+    if had_accounting {
+        // Through the guard's own constructor, not a literal: the session axis
+        // was hardcoded `None` here while this very guard tracked one, and the
+        // wall-clock axis (#2240) would have gone missing the same way.
+        report
+            .events
+            .push(guard.tick_event(std::time::Instant::now()));
+    }
+}

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -1146,11 +1146,11 @@ pub(crate) fn resolve_cross_family_verifier(
 /// The session-scoped role [`Router`] for a bare (non-pipeline) loop — the
 /// same wiring the pipeline paths build per run, held for the whole session
 /// so its breaker accumulates the observed outcome of every turn's model
-/// calls (#2673). The bare loops feed this router today and do not yet
-/// resolve from it (their provider is fixed at session start), which is why
-/// wiring notices are deliberately not surfaced here: none of the routing
-/// decisions they describe are operative on this path until mid-turn
-/// fallback (#2679) starts consulting the breaker at resolution time.
+/// calls (#2673). The bare loops feed this router every turn and consult it
+/// when a retry ladder exhausts ([`SessionFallback`], #2679); their primary
+/// provider is still fixed at session start, which is why wiring notices are
+/// deliberately not surfaced here — the start-of-turn routing decisions they
+/// describe are not operative on this path yet.
 pub(crate) fn session_router(cfg: &Config, worker_ref: &ModelRef) -> Router {
     let configured = crate::config::discover_configured_providers();
     let wiring = resolve_engine_wiring(cfg, worker_ref, &configured);
@@ -1159,6 +1159,76 @@ pub(crate) fn session_router(cfg: &Config, worker_ref: &ModelRef) -> Router {
         wiring.profiles,
         CircuitBreaker::new(Box::new(SystemClock::new())),
     )
+}
+
+/// Mid-turn fallback resolution for the bare (non-pipeline) loops (#2679):
+/// when the worker's retry ladder exhausts, the engine asks this port for a
+/// replacement, and the answer is a fresh [`Router::resolve`] of the worker
+/// role — whose breaker the failing calls already fed via
+/// `with_provider_outcomes`, so resolution routes around the sick provider.
+/// The replacement adapter is built from the discovered credentials on
+/// first use and owned here (set-once), so the engine can borrow it for the
+/// rest of the turn. Every miss is soft, matching
+/// [`resolve_cross_family_verifier`]: a resolve error, a resolution landing
+/// back on the failed provider, an uncredentialed target, or an adapter
+/// build failure all yield `None` — the turn then aborts exactly as it did
+/// before this seam existed.
+pub(crate) struct SessionFallback<'r> {
+    router: &'r Router,
+    built: std::sync::OnceLock<Box<dyn Provider>>,
+}
+
+impl<'r> SessionFallback<'r> {
+    pub(crate) fn new(router: &'r Router) -> Self {
+        Self {
+            router,
+            built: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl stella_core::ports::FallbackResolver for SessionFallback<'_> {
+    fn resolve_fallback(
+        &self,
+        failed_provider_id: &str,
+    ) -> Option<stella_core::ports::ResolvedFallback<'_>> {
+        let decision = self.router.resolve(Role::Worker).ok()?;
+        if decision.model_ref.provider == failed_provider_id {
+            return None;
+        }
+        let reason = match decision.fallback {
+            Some(fallback) => fallback.reason,
+            None => format!(
+                "worker role re-resolved to `{}` after `{failed_provider_id}` exhausted its \
+                 retries",
+                decision.model_ref.provider
+            ),
+        };
+        let configured = crate::config::discover_configured_providers();
+        let entry = configured
+            .iter()
+            .find(|c| c.config.id == decision.model_ref.provider)?;
+        let provider = build_provider_parts(
+            &entry.config,
+            &decision.model_ref.model_id,
+            entry.api_key.clone(),
+            entry.config.base_url.to_string(),
+            None,
+            entry.aux.clone(),
+            // Same reasoning as the routed verifier above: burst-shaped
+            // calls within a run want the 5-minute window (#1839).
+            stella_model::CacheTtl::default(),
+        )
+        .ok()?;
+        // The engine's own latch consumes at most one resolution per engine,
+        // so the set-once slot cannot serve a stale adapter to a second,
+        // different resolution.
+        let slot = self.built.get_or_init(|| provider);
+        Some(stella_core::ports::ResolvedFallback {
+            provider: slot.as_ref(),
+            reason,
+        })
+    }
 }
 
 /// Where post-turn reflection dispatches, and on what posture.

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -129,6 +129,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 mod dispatch;
 mod drive;
+mod model_fallback;
 pub(crate) mod overflow_recovery;
 mod rate_limit;
 mod settlement;
@@ -517,6 +518,17 @@ pub struct Engine<'a> {
     /// model call reports its terminal verdict against `provider.id()` so a
     /// router's circuit breaker trips from observed outcomes (#2673).
     pub(crate) outcomes: Option<&'a dyn crate::ports::ProviderOutcomes>,
+    /// Mid-turn fallback resolution ([`crate::ports::FallbackResolver`]), off
+    /// by default. Attached via [`Engine::with_fallback_resolver`]; consulted
+    /// at the retries-exhausted settlement boundary, at most once per engine
+    /// (`driver::model_fallback`, #2679). `None` keeps the abort exactly as
+    /// it always was.
+    pub(crate) fallback: Option<&'a dyn crate::ports::FallbackResolver>,
+    /// The replacement provider once a fallback latched. Set-once by
+    /// construction — the cell IS the one-swap bound (`driver::model_fallback`);
+    /// every dispatch/attribution site reads it through
+    /// [`Engine::active_provider`], never `provider` directly.
+    pub(crate) provider_override: std::sync::OnceLock<&'a dyn Provider>,
 }
 
 /// Why a turn that never produced a terminal step ends. A function rather
@@ -604,6 +616,8 @@ impl<'a> Engine<'a> {
             steering: None,
             bus: None,
             outcomes: None,
+            fallback: None,
+            provider_override: std::sync::OnceLock::new(),
         }
     }
 
@@ -653,6 +667,11 @@ impl<'a> Engine<'a> {
             steering: self.steering,
             bus: self.bus,
             outcomes: self.outcomes,
+            fallback: self.fallback,
+            // Carries the latched replacement (and its spent latch) into the
+            // copy: a later turn on this execution must not re-attempt a
+            // primary the session already swapped away from (#2679).
+            provider_override: self.provider_override.clone(),
         }
     }
 
@@ -685,6 +704,11 @@ impl<'a> Engine<'a> {
             steering: self.steering,
             bus: self.bus,
             outcomes: self.outcomes,
+            fallback: self.fallback,
+            // Carries the latched replacement (and its spent latch) into the
+            // copy: a later turn on this execution must not re-attempt a
+            // primary the session already swapped away from (#2679).
+            provider_override: self.provider_override.clone(),
         }
     }
 
@@ -719,6 +743,18 @@ impl<'a> Engine<'a> {
         outcomes: &'a dyn crate::ports::ProviderOutcomes,
     ) -> Self {
         self.outcomes = Some(outcomes);
+        self
+    }
+
+    /// Attach mid-turn provider fallback, opt-in: when a model call's retry
+    /// ladder exhausts, the engine re-resolves through this port and
+    /// continues the turn on the replacement instead of aborting — at most
+    /// one swap per engine (`driver::model_fallback`, #2679).
+    pub fn with_fallback_resolver(
+        mut self,
+        fallback: &'a dyn crate::ports::FallbackResolver,
+    ) -> Self {
+        self.fallback = Some(fallback);
         self
     }
 
@@ -1365,7 +1401,7 @@ impl<'a> Engine<'a> {
         let estimated_input_tokens = estimate_conversation_tokens(&request.messages);
         let result = match run_accounted_call(
             AccountedCall {
-                provider: self.provider,
+                provider: self.active_provider(),
                 role: stella_protocol::ModelCallRole::Summarization,
                 model_hint: "unknown".into(),
                 request,
@@ -1680,7 +1716,9 @@ impl<'a> Engine<'a> {
                 let mut complete = Box::pin(async move {
                     let gate =
                         SpeculationGate::new(read_only, safe, gated, tx, delta_tx, gate_progress);
-                    self.provider.complete_observed_ref(req, &gate).await
+                    self.active_provider()
+                        .complete_observed_ref(req, &gate)
+                        .await
                     // `gate` (and its sender) drop here → the pump's
                     // stream ends once in-flight executions drain.
                 });
@@ -1748,7 +1786,7 @@ impl<'a> Engine<'a> {
             step,
             crate::receipts::ServedBy {
                 role: self.call_role,
-                provider: self.provider.id(),
+                provider: self.active_provider().id(),
                 model: &result.model,
             },
             events,
@@ -1760,7 +1798,7 @@ impl<'a> Engine<'a> {
         let _ = events.send(AgentEvent::StepUsage {
             step,
             role: self.call_role,
-            provider: self.provider.id().to_string(),
+            provider: self.active_provider().id().to_string(),
             // The engine's own step already streams its answer as a `Text`
             // event; duplicating it here would double the transcript.
             output_text: None,

--- a/crates/stella-core/src/driver/model_fallback.rs
+++ b/crates/stella-core/src/driver/model_fallback.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-turn provider fallback on an exhausted retry ladder (#2679).
+//!
+//! The engine holds one provider for the whole turn, so before this module a
+//! wedged provider ended the turn as `Aborted { Failure }` even when a
+//! healthy fallback was configured and resolvable — every completed step's
+//! work stranded in the transcript. This is the recovery rung for the
+//! failure classes [`overflow_recovery`](super::overflow_recovery) does not
+//! own: transport faults, 5xx, auth revocation, and rate limiting that
+//! outlived the parked ladder (`driver/rate_limit.rs`, #2677) — everything
+//! that surfaces as `ModelCallFailure::Exhausted`. A child module of
+//! `driver` (the `settlement.rs` pattern), so the seam stays out of the
+//! god-file ceiling.
+//!
+//! # How the fallback is chosen
+//!
+//! Through the same routing that chose the primary, never a hardcoded model
+//! list: the engine asks the [`crate::ports::FallbackResolver`] port, whose
+//! production impl re-resolves the engine's role via
+//! [`crate::router::Router::resolve`]. The failing calls already fed the
+//! router's circuit breaker through [`crate::ports::ProviderOutcomes`]
+//! (#2673) — the ladder records the failure *before* settlement asks for a
+//! fallback — so resolution naturally routes around the sick provider. A
+//! resolution that lands back on the failed provider is treated as "no
+//! fallback" and the turn aborts exactly as it did before this module.
+//!
+//! # The latch
+//!
+//! `Engine::provider_override` is a set-once cell, and the set IS the
+//! bound: at most one swap per engine, ever, so two sick providers can
+//! never ping-pong a turn between them. The override persists across the
+//! engine's remaining turns — the swap is a routing decision, not a
+//! one-call patch — and the router's breaker (cooldown, then a half-open
+//! trial) is what eventually routes fresh engines back to a recovered
+//! primary. Like the overflow ladder, the latch is deliberately not
+//! checkpointed: a resumed turn starts the allowance over, which only
+//! re-permits a bounded amount of work.
+//!
+//! # Transcript repair
+//!
+//! The failed call appended nothing, so the engine's own path is already
+//! well-paired at this boundary; history a caller handed in (or appended
+//! to) mid-turn can still carry an unanswered `tool_use`, which the next
+//! provider would reject outright. The swap closes those through the same
+//! [`crate::step::close_open_tool_calls`] repair the cancel and soft-stop
+//! exits use — deterministic, and mirrored onto the event stream. The other
+//! thing a naive provider switch replays into a 400 — model-signed
+//! thinking/reasoning blocks — cannot occur here structurally:
+//! `stella_protocol::CompletionMessage` carries only
+//! `role`/`content`/`tool_calls`/`tool_results`/`attachments`, so signed
+//! reasoning never enters the transcript the fallback replays. (The prompt
+//! cache is necessarily cold on the replacement provider; that is the cost
+//! of finishing the turn at all.)
+//!
+//! # What consumers see
+//!
+//! While the fallback is deciding, the terminal channels stay silent — the
+//! ladder withholds `RetriesExhausted`/`Error { retryable: false }`,
+//! exactly as overflow recovery withholds its own — so an observer never
+//! tears down a session that is about to recover. A latched swap announces
+//! itself as `AgentEvent::ProviderFallback` (L-M7: never a silent mid-turn
+//! family switch) plus a retryable `Error` notice on the same channel the
+//! overflow rungs use; a refused swap surfaces the terminal pair
+//! byte-identical to the pre-#2679 abort. Every discarded attempt was
+//! already billed through the ladder's per-attempt `UsageIncomplete`
+//! observer — the swap changes what happens *next*, never whether a failed
+//! attempt is accounted.
+
+use stella_protocol::AgentEvent;
+
+use super::Engine;
+use crate::event_sender::EventSender;
+use crate::step::TurnState;
+
+/// The `ToolOutput::Error` that closes a `tool_use` left unanswered by
+/// caller-supplied history when the turn switches providers — the same
+/// repair, at the same safe boundary, as `BUDGET_ABORT_TOOL_RESULT` and
+/// `SOFT_STOP_TOOL_RESULT`, with wording that names why.
+pub(crate) const FALLBACK_TOOL_RESULT: &str =
+    "not executed — the turn switched to a fallback provider after exhausted retries";
+
+impl<'a> Engine<'a> {
+    /// The provider this engine's calls go to: the constructor-time primary
+    /// until a fallback latches, the replacement afterwards. Every site that
+    /// dispatches or attributes a model call reads through this — a site
+    /// reading `provider` directly after a swap would call (or bill) the
+    /// dead primary.
+    pub(crate) fn active_provider(&self) -> &'a dyn stella_protocol::Provider {
+        self.provider_override
+            .get()
+            .copied()
+            .unwrap_or(self.provider)
+    }
+
+    /// Try to continue the turn on a replacement provider after `message`
+    /// exhausted the retry ladder against the active one. `true` latched the
+    /// swap — the caller re-runs the step against the replacement, terminal
+    /// events withheld. `false` means the turn must surface the failure
+    /// terminally: no resolver attached, the latch already spent, no healthy
+    /// alternative, or resolution landing back on the failed provider.
+    pub(crate) fn attempt_provider_fallback(
+        &self,
+        message: &str,
+        state: &mut TurnState,
+        events: &EventSender,
+    ) -> bool {
+        let Some(resolver) = self.fallback else {
+            return false;
+        };
+        // The latch is the bound (module docs): one swap per engine.
+        if self.provider_override.get().is_some() {
+            return false;
+        }
+        let from = self.active_provider().id().to_string();
+        let Some(resolved) = resolver.resolve_fallback(&from) else {
+            return false;
+        };
+        let to = resolved.provider.id().to_string();
+        if to == from {
+            return false;
+        }
+        if self.provider_override.set(resolved.provider).is_err() {
+            // Unreachable single-threaded (the step loop is the only
+            // writer), but a lost race must refuse rather than announce a
+            // swap that did not take.
+            return false;
+        }
+        crate::step::close_open_tool_calls(&mut state.messages, FALLBACK_TOOL_RESULT, events);
+        let _ = events.send(AgentEvent::ProviderFallback {
+            from: from.clone(),
+            to: to.clone(),
+            reason: resolved.reason.clone(),
+        });
+        // The same retryable-notice channel the overflow rungs announce on:
+        // an observer must read this as the turn continuing, never ending.
+        let _ = events.send(AgentEvent::Error {
+            message: format!(
+                "{message} — `{from}` exhausted its retries; continuing the turn on `{to}` \
+                 ({reason})",
+                reason = resolved.reason
+            ),
+            retryable: true,
+        });
+        // The retried call is a new step, mirroring overflow recovery: its
+        // receipts can never collide with what the failed step emitted.
+        state.step += 1;
+        true
+    }
+}

--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -118,11 +118,23 @@ impl OverflowRecovery {
 /// caller may still do about it, which is the branch
 /// [`Engine::settle_model_call_failure`] takes.
 pub(crate) enum ModelCallFailure {
-    /// Unrecoverable. The attempt ladder (`driver/rate_limit.rs`) has
-    /// already emitted the terminal events (`RetriesExhausted`, `Error`)
-    /// and fed the provider-outcomes breaker; all that remains is the
-    /// turn's abort.
-    Fatal { reason: String },
+    /// The retry ladder exhausted against the active provider — transport,
+    /// 5xx, rate limiting that outlived the parked recovery, or a
+    /// first-attempt bail on a non-retryable class (auth, malformed). The
+    /// ladder (`driver/rate_limit.rs`) already fed the provider-outcomes
+    /// breaker; the terminal events are withheld — the caller decides
+    /// between a mid-turn provider fallback (`driver::model_fallback`,
+    /// #2679) and the terminal surfacing, and emits accordingly.
+    Exhausted {
+        /// The final attempt's classified error rendering.
+        message: String,
+        /// Every failed attempt's reason, in order — the `RetriesExhausted`
+        /// payload if this surfaces terminally.
+        attempt_reasons: Vec<String>,
+        /// Whether the final attempt's error class was retryable, forwarded
+        /// onto the terminal events exactly as before (#926).
+        retryable: bool,
+    },
     /// The provider rejected the request as exceeding its context window.
     /// Every event is withheld (module docs) — the caller decides between a
     /// recovery rung and the terminal surfacing, and emits accordingly.
@@ -136,10 +148,10 @@ pub(crate) enum ModelCallFailure {
 }
 
 impl<'a> Engine<'a> {
-    /// Settle a model call that could not commit: either arm the next
-    /// overflow-recovery rung — returning `None` so the caller re-runs the
-    /// step, now against the clamped compaction budget — or produce the
-    /// turn's abort.
+    /// Settle a model call that could not commit: arm the next
+    /// overflow-recovery rung, or latch a mid-turn provider fallback
+    /// (`driver::model_fallback`, #2679) — either returns `None` so the
+    /// caller re-runs the step — or produce the turn's abort.
     ///
     /// On the recovery path the step index still advances: the retried call
     /// is a new step, so its compaction pass (and a possible overflow-
@@ -152,11 +164,37 @@ impl<'a> Engine<'a> {
         events: &EventSender,
     ) -> Option<StepOutcome> {
         let (message, attempt_reasons) = match failure {
-            ModelCallFailure::Fatal { reason } => {
+            ModelCallFailure::Exhausted {
+                message,
+                attempt_reasons,
+                retryable,
+            } => {
+                // The abort string keeps its pre-#2679 bytes: consumers and
+                // transcripts read this exact rendering.
+                let reason = format!("model call failed: {message}");
                 self.emit_lifecycle(
                     bus::names::MODEL_REQUEST_FAILED,
                     || serde_json::json!({ "step": state.step, "reason": reason }),
                 );
+                // Mid-turn provider fallback (#2679): re-resolve through the
+                // router port and continue the turn on the replacement.
+                // `true` latched the swap — the step re-runs and the
+                // terminal events stay withheld, exactly as an armed
+                // overflow rung withholds them below.
+                if self.attempt_provider_fallback(&message, state, events) {
+                    return None;
+                }
+                // No fallback: surface the pre-#2679 terminal shape.
+                let _ = events.send(AgentEvent::RetriesExhausted {
+                    turn_instance: self.config.turn_instance,
+                    attempts: attempt_reasons.len() as u32,
+                    reasons: attempt_reasons,
+                    retryable,
+                });
+                let _ = events.send(AgentEvent::Error {
+                    message: message.clone(),
+                    retryable,
+                });
                 return Some(StepOutcome::Aborted {
                     reason,
                     kind: AbortKind::Failure,
@@ -208,7 +246,7 @@ impl<'a> Engine<'a> {
                     retryable,
                 });
                 if let Some(outcomes) = self.outcomes {
-                    outcomes.record_failure(self.provider.id());
+                    outcomes.record_failure(self.active_provider().id());
                 }
                 Some(StepOutcome::Aborted {
                     reason: format!("model call failed: {message}"),

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -12,7 +12,10 @@
 //! module owns the effects: the per-attempt usage envelopes, the
 //! `TurnParked`/`TurnWoken` span and per-chunk keep-alive narration, the
 //! soft-stop check that ends a multi-minute wait early, and the
-//! exhausted-ladder event pair. The park honors invariant 6's spirit the
+//! exhausted-ladder breaker feedback. The terminal event pair itself is
+//! emitted by `Engine::settle_model_call_failure`, which may first recover
+//! the turn instead — forced compaction for a context overflow (#2680), a
+//! provider fallback for an exhausted ladder (#2679). The park honors invariant 6's spirit the
 //! same way `driver/waiting.rs` does: the wait sits between model attempts,
 //! never mid-tool, and the budget's deadline bounds it from the outside.
 
@@ -126,7 +129,10 @@ impl<'a> Engine<'a> {
     /// failure. Owns everything between "the attempt closure exists" and
     /// "a result committed": the cancellation usage guard, the per-attempt
     /// incompleteness envelopes, the parked rate-limit recovery above, and —
-    /// on exhaustion — the `RetriesExhausted` + `Error` event pair. Returns
+    /// on exhaustion — the breaker feedback plus the withheld
+    /// [`ModelCallFailure`] that `Engine::settle_model_call_failure` either
+    /// recovers (overflow compaction, provider fallback — #2680, #2679) or
+    /// surfaces as the terminal `RetriesExhausted` + `Error` pair. Returns
     /// the instant the ladder started (the committed call's duration axis)
     /// alongside the outcome.
     pub(super) async fn drive_attempt_ladder<'f>(
@@ -155,7 +161,7 @@ impl<'a> Engine<'a> {
         let mut cancel_guard = CancelUsageGuard {
             events: events.clone(),
             role: self.call_role,
-            provider: self.provider.id().to_string(),
+            provider: self.active_provider().id().to_string(),
             started: call_started,
             armed: true,
             attempt_in_flight,
@@ -187,7 +193,7 @@ impl<'a> Engine<'a> {
                     .push(error.to_string());
                 let _ = incomplete_events.send(AgentEvent::UsageIncomplete {
                     role: self.call_role,
-                    provider: self.provider.id().to_string(),
+                    provider: self.active_provider().id().to_string(),
                     model: "unknown".into(),
                     reason: stella_protocol::UsageIncompleteReason::ProviderError,
                     duration_ms: attempt_duration.as_millis() as u64,
@@ -208,7 +214,7 @@ impl<'a> Engine<'a> {
                 // Call-outcome feedback (#2673): a committed step closes the
                 // routing circuit breaker's window for this provider.
                 if let Some(outcomes) = self.outcomes {
-                    outcomes.record_success(self.provider.id());
+                    outcomes.record_success(self.active_provider().id());
                 }
                 Ok((call_started, outcome))
             }
@@ -226,31 +232,31 @@ impl<'a> Engine<'a> {
                         attempt_reasons: reasons,
                     });
                 }
-                // Shared with the paired `Error` event below: whether the
-                // FINAL attempt's error is of a retryable class. `false`
-                // means every attempt (typically just one — see
+                // Whether the FINAL attempt's error is of a retryable class,
+                // forwarded onto the eventual terminal events. `false` means
+                // every attempt (typically just one — see
                 // `retry_with_backoff_observed`, which bails on the first
                 // non-retryable error) was doomed from the start, not
                 // exhausted by an actual retry loop (#926).
                 let retryable = error.is_retryable();
-                let _ = events.send(AgentEvent::RetriesExhausted {
-                    turn_instance: self.config.turn_instance,
-                    attempts: reasons.len() as u32,
-                    reasons,
-                    retryable,
-                });
-                let message = error.to_string();
-                let _ = events.send(AgentEvent::Error {
-                    message: message.clone(),
-                    retryable,
-                });
                 // Call-outcome feedback (#2673): an exhausted ladder is the
-                // signal the router's circuit breaker trips on.
+                // signal the router's circuit breaker trips on. Fed HERE,
+                // before settlement, so a fallback resolution that follows
+                // (`driver::model_fallback`, #2679) already routes around
+                // this failure.
                 if let Some(outcomes) = self.outcomes {
-                    outcomes.record_failure(self.provider.id());
+                    outcomes.record_failure(self.active_provider().id());
                 }
-                Err(ModelCallFailure::Fatal {
-                    reason: format!("model call failed: {message}"),
+                // The terminal event pair (`RetriesExhausted`, `Error`) is
+                // withheld, exactly as the overflow arm above withholds its
+                // own: the caller may still continue the turn on a fallback
+                // provider, and an observer must not tear down a session
+                // that is about to recover. `Engine::settle_model_call_failure`
+                // emits the pair when no fallback fires.
+                Err(ModelCallFailure::Exhausted {
+                    message: error.to_string(),
+                    attempt_reasons: reasons,
+                    retryable,
                 })
             }
         }

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -3077,6 +3077,7 @@ mod context_efficiency;
 mod context_overflow;
 mod lifecycle_bus;
 mod loop_abort;
+mod model_fallback;
 mod parked_wait;
 mod provider_outcomes;
 mod steer_midturn;

--- a/crates/stella-core/src/driver/tests/model_fallback.rs
+++ b/crates/stella-core/src/driver/tests/model_fallback.rs
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-turn provider fallback on an exhausted retry ladder (#2679).
+//!
+//! Before `driver::model_fallback`, a provider whose retry ladder exhausted
+//! ended the turn as `Aborted { Failure }` even when a healthy fallback was
+//! configured and resolvable. These tests drive real turns through scripted
+//! providers and a scripted [`FallbackResolver`] and assert the contract
+//! from every side: the witness (a terminally failing primary is swapped for
+//! the resolver's replacement and the turn completes), the bound (one swap
+//! per engine — two sick providers never ping-pong), the repair (the
+//! transcript the replacement receives is well-paired), the accounting
+//! (every failed attempt is billed through `UsageIncomplete`), and the
+//! control (no resolver → the pre-#2679 terminal surfacing, byte-identical).
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use serde_json::Value;
+use stella_protocol::{CompletionResult, ToolCall, ToolSchema, UsageIncompleteReason};
+
+use super::super::*;
+use crate::ports::{FallbackResolver, ResolvedFallback};
+use crate::retry::RetryPolicy;
+
+/// Fails every call with the error `build` produces, counting the calls.
+struct AlwaysFailing {
+    id: &'static str,
+    build: fn() -> ProviderError,
+    calls: AtomicU32,
+}
+
+impl AlwaysFailing {
+    fn terminal(id: &'static str) -> Self {
+        Self {
+            id,
+            build: || ProviderError::Terminal("scripted terminal failure".to_string()),
+            calls: AtomicU32::new(0),
+        }
+    }
+
+    fn transport(id: &'static str) -> Self {
+        Self {
+            id,
+            build: || ProviderError::transport("scripted transport failure"),
+            calls: AtomicU32::new(0),
+        }
+    }
+
+    fn calls(&self) -> u32 {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for AlwaysFailing {
+    fn id(&self) -> &str {
+        self.id
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err((self.build)())
+    }
+}
+
+/// Completes every call with a fixed answer, recording the exact transcript
+/// each call was handed — the repair assertions read what the *replacement*
+/// really saw, not what the engine claims it sent.
+struct HealthyRecording {
+    id: &'static str,
+    calls: AtomicU32,
+    seen: Mutex<Vec<Vec<CompletionMessage>>>,
+}
+
+impl HealthyRecording {
+    fn new(id: &'static str) -> Self {
+        Self {
+            id,
+            calls: AtomicU32::new(0),
+            seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn calls(&self) -> u32 {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn transcripts(&self) -> Vec<Vec<CompletionMessage>> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for HealthyRecording {
+    fn id(&self) -> &str {
+        self.id
+    }
+
+    async fn complete_ref(
+        &self,
+        req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.seen.lock().unwrap().push(req.messages.to_vec());
+        Ok(CompletionResult {
+            text: "rescued".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage::default(),
+            model: "scripted-fallback".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Hands out its provider on every ask, counting resolutions — the count is
+/// how the bound test proves a second exhaustion never even *asks* again.
+struct ScriptedResolver<'p> {
+    to: &'p dyn Provider,
+    resolutions: AtomicU32,
+}
+
+impl<'p> ScriptedResolver<'p> {
+    fn new(to: &'p dyn Provider) -> Self {
+        Self {
+            to,
+            resolutions: AtomicU32::new(0),
+        }
+    }
+
+    fn resolutions(&self) -> u32 {
+        self.resolutions.load(Ordering::SeqCst)
+    }
+}
+
+impl FallbackResolver for ScriptedResolver<'_> {
+    fn resolve_fallback(&self, failed_provider_id: &str) -> Option<ResolvedFallback<'_>> {
+        self.resolutions.fetch_add(1, Ordering::SeqCst);
+        Some(ResolvedFallback {
+            provider: self.to,
+            reason: format!("scripted re-resolution away from `{failed_provider_id}`"),
+        })
+    }
+}
+
+struct NoTools;
+
+#[async_trait::async_trait]
+impl ToolExecutor for NoTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        Vec::new()
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: String::new(),
+        }
+    }
+}
+
+struct NoSleep;
+
+#[async_trait::async_trait]
+impl crate::retry::Sleeper for NoSleep {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+/// One real turn against `provider` with `resolver` attached (when given),
+/// returning the outcome and every event.
+async fn run_turn_collecting(
+    provider: &dyn Provider,
+    resolver: Option<&dyn FallbackResolver>,
+    mut messages: Vec<CompletionMessage>,
+    config: EngineConfig,
+) -> (TurnOutcome, Vec<AgentEvent>) {
+    let tools = NoTools;
+    let sleeper = NoSleep;
+    let mut engine = Engine::with_sleeper(provider, &tools, config, &sleeper);
+    if let Some(resolver) = resolver {
+        engine = engine.with_fallback_resolver(resolver);
+    }
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    drop(tx);
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    (outcome, events)
+}
+
+fn goal() -> Vec<CompletionMessage> {
+    vec![CompletionMessage::user("do the thing")]
+}
+
+/// The #2679 witness: on `main` a terminally failing provider aborts the
+/// turn (`model call failed: …`); with the fallback seam the engine
+/// re-resolves through the port, announces the swap, and the turn completes
+/// on the replacement — with the terminal channels silent.
+#[tokio::test]
+async fn exhausted_retries_swap_to_the_resolved_fallback_and_the_turn_completes() {
+    let primary = AlwaysFailing::terminal("primary");
+    let fallback = HealthyRecording::new("fallback");
+    let resolver = ScriptedResolver::new(&fallback);
+    let (outcome, events) =
+        run_turn_collecting(&primary, Some(&resolver), goal(), EngineConfig::default()).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { ref text, .. } if text == "rescued"),
+        "the turn must complete on the fallback, got {outcome:?}"
+    );
+    assert_eq!(primary.calls(), 1, "Terminal bails the ladder on attempt 1");
+    assert_eq!(fallback.calls(), 1, "one rescued re-issue");
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ProviderFallback { from, to, .. } if from == "primary" && to == "fallback"
+        )),
+        "the swap must be announced (L-M7): {events:?}"
+    );
+    // Withheld from the terminal channels: no observer should tear down a
+    // session that recovered.
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RetriesExhausted { .. })),
+        "a recovered exhaustion must not report exhausted retries: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error {
+                retryable: false,
+                ..
+            }
+        )),
+        "a recovered exhaustion must not surface a terminal error: {events:?}"
+    );
+    // …and announced on the same retryable-notice channel overflow recovery
+    // uses.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true } if message.contains("continuing the turn")
+        )),
+        "the swap must narrate itself: {events:?}"
+    );
+}
+
+/// The bound: the set-once latch means a fallback that is itself sick is
+/// never swapped again — each provider gets exactly one ladder, the resolver
+/// is asked exactly once, and the second exhaustion surfaces terminally.
+#[tokio::test]
+async fn a_sick_fallback_is_never_swapped_again() {
+    let primary = AlwaysFailing::terminal("primary");
+    let also_sick = AlwaysFailing::terminal("fallback");
+    let resolver = ScriptedResolver::new(&also_sick);
+    let (outcome, events) =
+        run_turn_collecting(&primary, Some(&resolver), goal(), EngineConfig::default()).await;
+
+    assert!(
+        matches!(
+            outcome,
+            TurnOutcome::Aborted { ref reason, kind: AbortKind::Failure, .. }
+                if reason.contains("model call failed")
+        ),
+        "the second exhaustion is terminal, got {outcome:?}"
+    );
+    assert_eq!(primary.calls(), 1);
+    assert_eq!(also_sick.calls(), 1);
+    assert_eq!(
+        resolver.resolutions(),
+        1,
+        "a spent latch must refuse before ever asking the resolver again"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ProviderFallback { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::RetriesExhausted { .. }))
+            .count(),
+        1,
+        "exactly one terminal surfacing: {events:?}"
+    );
+}
+
+/// The control: with no resolver attached the terminal surfacing is the
+/// pre-#2679 shape — one `RetriesExhausted`, one non-retryable `Error`, the
+/// same abort reason — so relocating the emission out of the attempt ladder
+/// changed nothing an observer can see.
+#[tokio::test]
+async fn without_a_resolver_the_terminal_surfacing_is_unchanged() {
+    let primary = AlwaysFailing::terminal("primary");
+    let (outcome, events) =
+        run_turn_collecting(&primary, None, goal(), EngineConfig::default()).await;
+
+    assert!(
+        matches!(
+            outcome,
+            TurnOutcome::Aborted { ref reason, kind: AbortKind::Failure, .. }
+                if reason.contains("model call failed: terminal provider error")
+        ),
+        "got {outcome:?}"
+    );
+    assert_eq!(primary.calls(), 1);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(
+                e,
+                AgentEvent::RetriesExhausted {
+                    retryable: false,
+                    ..
+                }
+            ))
+            .count(),
+        1,
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: false }
+                if message.contains("terminal provider error")
+        )),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ProviderFallback { .. })),
+        "no swap may be announced when none is possible: {events:?}"
+    );
+}
+
+/// The repair: an unanswered `tool_use` in caller-supplied history is closed
+/// with a synthetic result before the replacement sees the transcript, so
+/// the fallback call cannot be rejected for a pairing violation. Asserted on
+/// what the replacement provider actually received.
+#[tokio::test]
+async fn the_transcript_handed_to_the_fallback_is_well_paired() {
+    let primary = AlwaysFailing::terminal("primary");
+    let fallback = HealthyRecording::new("fallback");
+    let resolver = ScriptedResolver::new(&fallback);
+    let mut history = goal();
+    history.push(CompletionMessage {
+        role: MessageRole::Assistant,
+        content: String::new(),
+        tool_calls: vec![ToolCall {
+            call_id: "call_orphan".to_string(),
+            name: "bash".to_string(),
+            input: serde_json::json!({}),
+        }],
+        tool_results: Vec::new(),
+        attachments: Vec::new(),
+    });
+    let (outcome, _) =
+        run_turn_collecting(&primary, Some(&resolver), history, EngineConfig::default()).await;
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "{outcome:?}"
+    );
+
+    let transcripts = fallback.transcripts();
+    let seen = transcripts.first().expect("the fallback ran");
+    // Same pairing scan as `close_open_tool_calls`: every tool_use answered.
+    let mut unanswered: Vec<&ToolCall> = Vec::new();
+    for entry in seen {
+        match entry.role {
+            MessageRole::Assistant => unanswered.extend(entry.tool_calls.iter()),
+            MessageRole::Tool => {
+                for result in &entry.tool_results {
+                    if let Some(position) = unanswered
+                        .iter()
+                        .rposition(|call| call.call_id == result.call_id)
+                    {
+                        unanswered.remove(position);
+                    }
+                }
+            }
+            MessageRole::System | MessageRole::User => {}
+        }
+    }
+    assert!(
+        unanswered.is_empty(),
+        "the replacement must never see an unanswered tool_use: {seen:#?}"
+    );
+    // …and the stub names why it exists.
+    let stubbed = seen.iter().any(|entry| {
+        entry.tool_results.iter().any(|result| {
+            result.call_id == "call_orphan"
+                && matches!(
+                    &result.output,
+                    ToolOutput::Error { message }
+                        if message.contains("switched to a fallback provider")
+                )
+        })
+    });
+    assert!(stubbed, "the orphan must be closed by the fallback repair");
+}
+
+/// The accounting: every attempt the primary burned before the swap was a
+/// paid dispatch and leaves its content-free `UsageIncomplete` envelope —
+/// the swap changes what happens next, never whether a failed attempt is
+/// billed.
+#[tokio::test]
+async fn every_attempt_before_the_swap_is_billed_through_usage_incomplete() {
+    let primary = AlwaysFailing::transport("primary");
+    let fallback = HealthyRecording::new("fallback");
+    let resolver = ScriptedResolver::new(&fallback);
+    let config = EngineConfig {
+        retry_policy: RetryPolicy {
+            max_retries: 2,
+            ..RetryPolicy::standard()
+        },
+        ..EngineConfig::default()
+    };
+    let (outcome, events) = run_turn_collecting(&primary, Some(&resolver), goal(), config).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "{outcome:?}"
+    );
+    assert_eq!(
+        primary.calls(),
+        3,
+        "1 attempt + 2 retries, all on the primary"
+    );
+    let envelopes = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AgentEvent::UsageIncomplete {
+                    reason: UsageIncompleteReason::ProviderError,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(envelopes, 3, "one envelope per burned attempt: {events:?}");
+}
+
+/// A resolution landing back on the failed provider is a refusal, not a
+/// swap: nothing is announced and the failure surfaces terminally.
+#[tokio::test]
+async fn a_resolution_back_onto_the_failed_provider_is_refused() {
+    let primary = AlwaysFailing::terminal("primary");
+    // The resolver hands back a provider wearing the SAME id — e.g. a router
+    // whose only healthy profile is the one that just failed.
+    let same_id = AlwaysFailing::terminal("primary");
+    let resolver = ScriptedResolver::new(&same_id);
+    let (outcome, events) =
+        run_turn_collecting(&primary, Some(&resolver), goal(), EngineConfig::default()).await;
+
+    assert!(
+        matches!(
+            outcome,
+            TurnOutcome::Aborted {
+                kind: AbortKind::Failure,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert_eq!(same_id.calls(), 0, "the refused provider is never called");
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ProviderFallback { .. })),
+        "a refused swap must not be announced: {events:?}"
+    );
+}

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stella_protocol::{ToolOutput, ToolSchema};
+use stella_protocol::{Provider, ToolOutput, ToolSchema};
 
 /// Executes one tool call. Implemented by `stella-tools::ToolRegistry` (and
 /// by test doubles). The engine treats it as a black box that never panics.
@@ -204,6 +204,38 @@ pub trait ProviderOutcomes: Send + Sync {
     fn record_success(&self, provider_id: &str);
     /// A transport-class terminal failure from `provider_id`.
     fn record_failure(&self, provider_id: &str);
+}
+
+/// Mid-turn provider fallback (#2679) — the read half of the routing seam
+/// whose write half is [`ProviderOutcomes`]: when a model call's retry
+/// ladder exhausts against the active provider, the engine asks this port
+/// for a replacement instead of aborting the turn. The production impl
+/// re-resolves the engine's role through the same
+/// [`crate::router::Router::resolve`] that chose the primary — never a
+/// hardcoded model list — and the failing calls already fed that router's
+/// circuit breaker through [`ProviderOutcomes`] (#2673), so resolution
+/// naturally routes around the sick provider. `&self` for the same reason as
+/// [`ProviderOutcomes`]: the holder shares the router.
+pub trait FallbackResolver: Send + Sync {
+    /// Re-resolve the engine's role after `failed_provider_id` exhausted its
+    /// retry ladder. `None` means "no fallback": nothing else is configured,
+    /// every alternative is breaker-open, or resolution lands back on the
+    /// failed provider itself — the engine then surfaces the exhaustion
+    /// exactly as it did before this port existed.
+    fn resolve_fallback(&self, failed_provider_id: &str) -> Option<ResolvedFallback<'_>>;
+}
+
+/// A replacement provider from [`FallbackResolver::resolve_fallback`]. The
+/// adapter is owned by the resolver — the engine only borrows it for the
+/// rest of the turn — and `reason` is the resolver's human-readable account
+/// of why the route changed (e.g. [`crate::router::FallbackInfo::reason`]);
+/// it rides `AgentEvent::ProviderFallback` verbatim (L-M7: fallback is
+/// always visible, never a silent mid-turn family switch).
+pub struct ResolvedFallback<'p> {
+    /// The replacement adapter. Calls after the swap go here.
+    pub provider: &'p dyn Provider,
+    /// Why the route changed, verbatim onto the fallback event.
+    pub reason: String,
 }
 
 /// Boundary pause gate — polled by the engine between model calls, the same

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -698,6 +698,13 @@ impl Engine<'_> {
             // provider — the breaker they feed is session state, like the
             // calibration map above (#2673).
             outcomes: self.outcomes,
+            // Deliberately NOT inherited: the child's provider is the spec's
+            // explicit choice (possibly a pinned cross-family adapter), so a
+            // mid-turn re-route is not the engine's call to make here — a
+            // child that exhausts its ladder surfaces the failure into the
+            // parent's tool result instead (#2679).
+            fallback: None,
+            provider_override: std::sync::OnceLock::new(),
         };
 
         // The child's private transcript. It is a local: nothing outside

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -113,7 +113,7 @@ pub const COMPOSITION_SEAMS: &[&str] = &[
 /// forces this DOWN in the same PR (the win is recorded), and adding a new
 /// unwitnessed claim forces it UP — a visible review decision instead of a
 /// silent one.
-pub const UNWITNESSED_BASELINE: usize = 4;
+pub const UNWITNESSED_BASELINE: usize = 5;
 
 /// The matrix. Ordered by area; ids are stable and unique.
 pub static CAPABILITIES: &[Capability] = &[
@@ -571,6 +571,29 @@ pub static CAPABILITIES: &[Capability] = &[
                      threshold of consecutive calls surfaces as AllProvidersUnavailable until \
                      the cooldown's half-open trial (see stella-serve pipeline_run's WallClock \
                      doc), but cross-provider failover is the host's concern by design",
+        },
+    },
+    Capability {
+        id: "provider.midturn_fallback",
+        engine_home: "stella-core driver/model_fallback + the FallbackResolver port: a retry \
+                      ladder exhausting mid-turn re-resolves the role through the router — \
+                      whose breaker the failing calls already fed — and continues the turn on \
+                      the replacement, transcript repaired, at most one swap per engine (#2679)",
+        engine_entries: &["with_fallback_resolver"],
+        cli: SurfacePosture::ShippedUnwitnessed {
+            mechanism: "the bare loops attach a router-backed `SessionFallback` \
+                        (agent/engine.rs) beside the session router at both `run_turn` engine \
+                        sites — the seam itself is witnessed in stella-core by \
+                        `exhausted_retries_swap_to_the_resolved_fallback_and_the_turn_completes`, \
+                        which this sweep cannot see",
+            missing: "a CLI-side test pinning that `run_turn`'s engines actually attach the \
+                      resolver (#2733 tracks the same gap for the router attachment), and the \
+                      pipeline execute-stage engines do not attach the port at all yet (#2765)",
+        },
+        api: SurfacePosture::NotApplicable {
+            reason: "a served run remotes every model call to the host, which owns keys and \
+                     provider selection — the Stella side has nothing to swap TO; the same \
+                     posture, for the same reason, as provider.breaker_feedback",
         },
     },
     Capability {

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -681,9 +681,11 @@ pub enum AgentEvent {
         reasoning: String,
         cost_usd: f64,
     },
-    /// A provider's circuit breaker opened and the router fell back to the
-    /// next configured provider of the same role's tier. Never silent
-    /// (L-M7) — no mid-turn family switch happens without this event.
+    /// A provider substitution: the router fell back to the next configured
+    /// provider of the same role's tier at resolution time (a breaker-open
+    /// skip), or the engine swapped mid-turn after an exhausted retry ladder
+    /// (`stella-core`'s `driver/model_fallback`, #2679). Never silent
+    /// (L-M7) — no provider switch happens without this event.
     ProviderFallback {
         from: String,
         to: String,

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -2631,7 +2631,7 @@
       "type": "object"
     },
     {
-      "description": "A provider's circuit breaker opened and the router fell back to the\nnext configured provider of the same role's tier. Never silent\n(L-M7) — no mid-turn family switch happens without this event.",
+      "description": "A provider substitution: the router fell back to the next configured\nprovider of the same role's tier at resolution time (a breaker-open\nskip), or the engine swapped mid-turn after an exhausted retry ladder\n(`stella-core`'s `driver/model_fallback`, #2679). Never silent\n(L-M7) — no provider switch happens without this event.",
       "properties": {
         "from": {
           "type": "string"

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -765,7 +765,7 @@
           "type": "object"
         },
         {
-          "description": "A provider's circuit breaker opened and the router fell back to the\nnext configured provider of the same role's tier. Never silent\n(L-M7) — no mid-turn family switch happens without this event.",
+          "description": "A provider substitution: the router fell back to the next configured\nprovider of the same role's tier at resolution time (a breaker-open\nskip), or the engine swapped mid-turn after an exhausted retry ladder\n(`stella-core`'s `driver/model_fallback`, #2679). Never silent\n(L-M7) — no provider switch happens without this event.",
           "properties": {
             "from": {
               "type": "string"


### PR DESCRIPTION
## What & why

The engine held one provider for the whole turn, so a retry ladder exhausting against a wedged provider ended the turn `Aborted { Failure }` even when a healthy fallback was configured and resolvable (`driver.rs`'s abort path) — every completed step's work stranded. This PR is the last ticket of the Phase 2 reliability chain: on retries-exhausted the engine now re-resolves through the router and continues the turn on the replacement.

**Trigger classes.** Everything that surfaces as the new `ModelCallFailure::Exhausted` — transport, 5xx, auth, and rate limiting that outlived #2744's parked recovery. `ContextOverflow` keeps its own rung (#2752); #2748's stream fallback still runs below, inside the attempt. The park composes rather than races: parking happens *inside* the ladder, the fallback only after the ladder gives up, and a soft stop typed during a park still wins at the next step boundary.

**Router interplay (the #2734 seam, used as designed).** The fallback is a re-resolution via the new `stella_core::ports::FallbackResolver` port, never a hardcoded list. `drive_attempt_ladder` feeds `record_failure` **before** settlement asks for a fallback, so `Router::resolve` already routes around the sick provider; a resolution landing back on the failed provider is a refusal and the turn aborts exactly as before. The bare CLI loops attach a router-backed `SessionFallback` (`agent/engine.rs`) at both `run_turn` engine sites — the `session_router` doc's declared destiny for #2679.

**Transcript repair, deterministic.** The failed call appended nothing, so the engine's own path is already well-paired; caller-supplied history with an orphaned `tool_use` is closed through the same `close_open_tool_calls` repair the cancel/soft-stop exits use (stub named for the swap, mirrored onto the event stream). Model-signed thinking blocks — the other thing a naive switch replays into a 400 — are structurally absent: `CompletionMessage` carries no reasoning blocks, so there is nothing to strip; the module doc records that argument.

**Latch/bound.** `Engine::provider_override` is a set-once cell and the set IS the latch: at most one swap per engine, ever — two sick providers cannot ping-pong. The override persists for the engine's remaining turns; the breaker's cooldown/half-open cycle is what routes fresh engines back to a recovered primary.

**What consumers see.** The ladder now *withholds* the terminal `RetriesExhausted`/`Error` pair (mirroring #2752's overflow arm) and settlement emits it only when no fallback fires — byte-identical to the old shape, pinned by a control test. A latched swap emits the existing `AgentEvent::ProviderFallback` (+ a retryable `Error` notice), so **no new AgentEvent variant** and no new consumer-ledger row (invariant #10 satisfied by reuse); the variant's doc and the generated `docs/wire` descriptions are updated (description-only diff, no shape change).

**Accounting.** Every burned attempt still bills through the per-attempt `UsageIncomplete` observer — witnessed. No timings ride `ToolOutput`.

**God files.** New logic is in sibling modules (`driver/model_fallback.rs`, the `overflow_recovery.rs`/`settlement.rs` pattern; tests in `driver/tests/model_fallback.rs`). `agent.rs` sat exactly at its ceiling, so the self-contained budget helpers moved to a new `agent/budget.rs` (move, not rewrite; re-exported so every caller path is unchanged) — agent.rs lands 40 lines *under* its inherited size.

**Parity (invariant #8's cross-surface sibling).** `stella-parity` gains the `provider.midturn_fallback` row claiming `with_fallback_resolver` (the entry-point sweep enforces this); CLI posture is `ShippedUnwitnessed` with the gap cited (#2733 for the attachment witness, #2765 for pipeline wiring), API `NotApplicable` for the same reason as `provider.breaker_feedback`. `UNWITNESSED_BASELINE` 4 → 5 — the declared-debt direction the ratchet exists to make visible, not an expedient.

**Exemplar.** The module shape, withheld-events discipline, latch bound, and test suite deliberately mirror `driver/overflow_recovery.rs` + `driver/tests/context_overflow.rs` (#2752), this repo's canonical recovery-rung shape.

Closes #2679
Refs #2733, #2734, #2744, #2748, #2752, #2765

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-core/src/driver/tests/model_fallback.rs`:

- `exhausted_retries_swap_to_the_resolved_fallback_and_the_turn_completes` — the headline #2679 witness: terminally failing primary, healthy resolved fallback; on main the turn aborts, here it completes with the terminal channels silent and the swap announced.
- `a_sick_fallback_is_never_swapped_again` — the bound: one ladder per provider, the resolver asked exactly once, second exhaustion terminal (no ping-pong).
- `the_transcript_handed_to_the_fallback_is_well_paired` — pairing asserted on the transcript the replacement provider *actually received*, orphan stubbed with the swap's wording.
- `every_attempt_before_the_swap_is_billed_through_usage_incomplete` — 1 attempt + 2 retries = 3 envelopes, then the rescue.
- Controls: `without_a_resolver_the_terminal_surfacing_is_unchanged` (the relocated emission is byte-identical), `a_resolution_back_onto_the_failed_provider_is_refused`.

**Flip evidence, artisanal (the ablation form, as in #2752 — the true on-main run cannot compile because the port doesn't exist there):** with the one interception main lacks disabled (`if false && self.attempt_provider_fallback(...)` in `settle_model_call_failure`), the suite runs `2 passed; 4 failed` — all four behavior witnesses FAIL (turn aborts, exactly main's behavior) while both abort-path controls stay green; restored, `6 passed; 0 failed`.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, exit 0 — all toolchain-free guards incl. file-size, god-files, left-behind, typed-errors, module-reachability)
- [x] `cargo clippy -p stella-core -p stella-cli --all-targets -- -D warnings` — exit 0
- [x] `cargo test -p stella-core -p stella-cli -p stella-parity` — 1130 + 1693 + 9 (+ integration targets), 0 failed; `cargo test -p stella-pipeline -p stella-serve -p stella-protocol` — 0 failed
- [x] `make wire-schema` — regenerated, description-only diff (read above)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-core -p stella-cli -p stella-parity -p stella-protocol --document-private-items --keep-going` — exit code 0, checked unpiped
- [x] Docs updated where behavior changed (module docs, event doc, parity row, `session_router` doc un-staled)
- [x] CLA signed
- [x] `Closes #2679` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #2765 — pipeline execute-stage (and serve/runtime) wiring for the `FallbackResolver` port, written as a handoff. The CLI-attachment witness gap was already tracked in #2733 (cited by the parity row rather than duplicated).

## Ground-rule check

- [x] No I/O added to `stella-core` (the resolver is a port; the CLI impl owns the adapter build); no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `ProviderFallback` reused; `docs/wire` diff is description-only

## Anything reviewers should know?

- Terminal-event emission moved from `drive_attempt_ladder` into `settle_model_call_failure` (a settlement decision now that exhaustion has a recovery). The control test pins the observable shape; the one ordering change is that the `model.request.failed` bus signal now precedes the terminal pair — cross-channel (hook bus vs event stream), so no consumer can order them anyway.
- `ModelCallFailure::Fatal` is renamed/retyped to `Exhausted { message, attempt_reasons, retryable }` — it is `pub(crate)`, no external surface.
- Sub-agent child engines deliberately do NOT inherit the resolver: a child's provider is the spec's explicit (possibly pinned cross-family) choice; the commented decision is at `subagent.rs`'s engine assembly.
- The prompt cache is necessarily cold on the replacement provider — the documented cost of finishing the turn at all.

## Summary by Sourcery

Introduce mid-turn provider fallback in the engine so exhausted retry ladders can re-resolve through the router and continue the turn on a replacement provider, while preserving existing terminal behavior when no fallback is available.

New Features:
- Add a FallbackResolver port and mid-turn provider fallback mechanism that re-resolves the worker role via the router after retries are exhausted and continues the turn on a replacement provider.
- Wire bare CLI loops to attach a session-scoped router-backed SessionFallback so non-pipeline runs can benefit from mid-turn provider failover.

Bug Fixes:
- Ensure exhausted retry ladders no longer abort turns when a healthy fallback provider is configured and resolvable, preventing work from being stranded mid-turn.

Enhancements:
- Refine engine failure handling so retry exhaustion is settled in Engine::settle_model_call_failure, enabling either provider fallback or terminal surfacing with unchanged external shape.
- Ensure transcript repair and billing behavior around mid-turn provider swaps keep tool-call pairing valid and preserve per-attempt UsageIncomplete accounting.
- Add a one-swap-per-engine latch and route all dispatch/attribution through the active provider, avoiding provider ping-pong and mis-attribution after a fallback.
- Clarify AgentEvent::ProviderFallback semantics to cover both resolution-time and mid-turn provider substitutions without changing the wire shape.
- Keep sub-agent engines opt-out of fallback so their explicitly chosen providers surface failures back to the parent tool call.

Documentation:
- Update wire schema docs, parity capabilities, and session_router documentation to describe the new mid-turn fallback behavior and its current CLI and API posture.

Tests:
- Add driver/model_fallback tests that witness successful mid-turn fallback, enforce the one-swap bound, verify transcript repair and accounting, and confirm terminal behavior remains byte-identical when no fallback is attached.

Chores:
- Extract session budget helper functions from agent.rs into a dedicated agent/budget.rs module to keep the god file under its size ceiling.
- Extend stella-parity capabilities with a provider.midturn_fallback entry and bump the unwitnessed baseline to track the new unwitnessed CLI posture.