### PR TITLE
Add 'Self-Evolving Coding Agents' assessment and update docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -522,6 +522,20 @@
       "status": "proposed",
       "title": "Self-driving missions \u2014 the objective schema, the improvement contract, and the session scorecard"
     },
+    "self-evolving-coding-agents-assessment": {
+      "path": "docs/papers/self-evolving-coding-agents-assessment.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "status": "living",
+      "title": "Self-Evolving Coding Agents \u2014 comparison with Stella"
+    },
     "semantic-resolution-bridge": {
       "path": "docs/spec/semantic-resolution-bridge.md",
       "status": "implemented",

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -8,6 +8,10 @@ file and line.
 
 ## Papers
 
+- [**Self-Evolving Coding Agents — comparison with Stella**](./self-evolving-coding-agents-assessment.md)
+  — compares Stella 0.8.40's shipped and planned self-improvement surfaces
+  with Zhou et al.'s 2026 survey and extracts concrete backlog considerations.
+
 - [**Stella: A Defensible Technology Position**](./stella-defensible-position.md)
   — the capstone analysis. Identifies seven architectural invariants that make
   Stella's design expensive to replicate and shows why their *combination* —

--- a/docs/papers/self-evolving-coding-agents-assessment.md
+++ b/docs/papers/self-evolving-coding-agents-assessment.md
@@ -1,0 +1,228 @@
+---
+id: self-evolving-coding-agents-assessment
+title: "Self-Evolving Coding Agents — comparison with Stella"
+status: research-note
+---
+
+# *Self-Evolving Coding Agents* — comparison with Stella
+
+**Paper:** Hao Zhou, Haichuan Hu, Ye Shang, and Quanjun Zhang,
+[*Self-Evolving Coding Agents*](https://arxiv.org/abs/2608.03392),
+arXiv:2608.03392v1, 4 August 2026.
+
+**Assessment date:** 11 August 2026. **Code baseline:** Stella 0.8.40,
+commit `b51b2b3`. This note compares the supplied paper with code and designs in
+this tree. Live GitHub issue access was unavailable, so “backlog” means an issue
+or proposed design that the current tree still names as future work, not an
+independently verified GitHub state.
+
+## Executive finding
+
+The paper is a survey and taxonomy, not a new self-improvement algorithm. Most
+mechanisms it describes are shipped in Stella or represented in Stella's
+self-improvement track. Stella is particularly far along on post-task memory,
+skill/rule lifecycle, executable verification, trace/reward capture, reversible
+promotion, and self-authored tool gating. Proposed campaign/foundry work already
+covers framework, configuration, workflow, and eventual weight evolution.
+
+The paper nevertheless adds three useful design lenses that are not yet
+first-class backlog contracts:
+
+1. **A total evolution-object ledger.** No enforced matrix declares, for
+   framework, memory, skills, tools, models, and workflow/topology, whether
+   evolution is shipped, planned, or prohibited and which witness proves it.
+2. **Longitudinal and transfer evaluation.** Stella protects held-out splits,
+   cost, rollback, and paired comparison, but does not specify one transfer
+   panel across repositories, model families, languages, dependency eras, and
+   time-delayed re-evaluation.
+3. **Information-gain and feedback-reliability gates.** Stella labels outcomes
+   and deduplicates hypotheses, but a training campaign must also detect a
+   saturated/self-reinforcing corpus and preserve the distinction between
+   executable evidence, environment observations, and model-authored summaries.
+
+These are worth considering for the backlog. The paper's aggressive task-time
+scaffold, topology, and model mutation should not be copied without Stella's
+existing authority, witness, held-out evaluation, and human-sign-off boundaries.
+
+## 1. The paper's frame
+
+| Dimension | Paper's categories |
+|---|---|
+| Object that changes | framework; experience/repository memory; skills/tools; model; workflow/topology |
+| Time of change | task-time; post-task; stage-wise |
+| Evidence | outcome; environmental; trajectory-derived |
+
+This separates loops that are currently all called “self-improvement”: a lesson
+changes later context, an adopted tool changes the action space, `stella tune`
+changes configuration, and a trained checkpoint would change weights. They have
+different authorities and proof obligations.
+
+## 2. What Stella ships today
+
+### Memory and repository context
+
+After successful or failed real work, Stella reflects separately, extracts
+bounded lessons with applicability triggers and counterfactual “saves” evidence,
+stores novel lessons as graph memories, retains restatements for recurrence
+mining, and records an episodic summary. Later work retrieves relevant context
+instead of replaying raw trajectories.
+
+The lifecycle is stronger than the paper's broad memory category: lessons have
+domains, anchors, task/time provenance and recall tiers; duplicate paraphrases
+do not grow the graph; parse failures are durable; citations score usefulness
+and truthfulness; repeated negatives quarantine; and forget, restore, edit,
+reaffirm, retire, and compact are reversible. Forgotten paraphrases are
+suppressed at recall, recording, and mining. The limitation is epistemic: the
+initial abstraction is still model-authored, not executable proof.
+
+### Skills and rules
+
+Recurring reflections become skill candidates and rule proposals. Skills use
+caps and no-clobber publication; rules use inspectable proposal/promotion
+records. Selection-to-outcome appraisal, held candidates, retirement, and
+context-use extraction make this more than summarization. Memory promotion
+requires a sustained positive citation streak and publishes reviewable context.
+This covers the paper's skill-bank family, with unusually strong governance.
+
+### Tools
+
+The foundry detects repeated shell capability gaps, proposes and authors a typed
+tool, requires a fail→pass witness, records adoption, and still leaves the tool
+disabled until separate authority enables it. Receipts measure subsequent use
+and failures. Stella deliberately does not let an in-flight worker synthesize
+and immediately execute a privileged tool; the paper does not resolve the
+authority and rollback problems required to relax that gate.
+
+### Configuration/workflow
+
+`stella tune` A/B-tests a policy knob over loop-bench results, uses paired
+comparison with guard metrics, promotes only a confident winner, and records a
+reversible decision. The engine also calibrates token estimates from observations.
+This is bounded workflow/config evolution, not arbitrary topology search. The
+survey offers no general evidence that more agents or mutable graphs outperform
+a readable single loop under equal budgets.
+
+### Evidence and model-training substrate
+
+Stella captures full trajectories and stage paths, attaches reward labels from
+the deterministic verification ladder, reconstructs calls byte-exactly, and
+exports a redacted SFT dataset with a manifest and human-sign-off warning. A
+label names the verification rung that supports it; deterministic fail→pass
+proof is privileged over model judgment.
+
+This is not closed-loop model evolution. Trace capture defaults off, preference
+pairs are not exported, and there is no trainer port, weights registry, or
+automatic checkpoint promotion loop. Stella can edit its repository as an
+ordinary verified task, but does not preserve/select autonomous self-modified
+lineages; it can serve weights, but does not update them.
+
+## 3. What is already planned
+
+| Backlog/design | Object | Current-tree position |
+|---|---|---|
+| #830 tool foundry | tools | Detection, authorship, witness, adoption, authority, and efficacy slices ship. |
+| #831 self-tuning | workflow/config | `stella tune` is a first slice; broader policy search remains in the track. |
+| #832 Stella-maintains-Stella | framework | Gated pull requests against Stella's source are planned. |
+| #833 distillation | skill/model substrate | Trajectory distillation is planned. |
+| #834 causal self-model | framework/workflow diagnosis | Planned causal use of receipts and divergent outcomes. |
+| #835 curriculum | task selection | Planned capability curriculum for experiments/training. |
+| #836 weight-space adapters | model | Export/serving prerequisites exist; training, registry, evaluation, and promotion remain future. |
+| #2304 trace-replay harness | memory/skills/tools/rules evaluation | A deterministic test replayer exists; the epic/spec still gates a production-facing harness. |
+| #2483 reflection friction | environmental evidence | Staged one-shot is wired; other surfaces remain follow-up work. |
+| `doc:self-driving-foundry` | all objects | Proposed twin arena: plan → forge → arena → judge → promote → harvest → train → measure → gate. |
+| `doc:self-driving-missions` | curriculum/evaluation | Proposed hypotheses, declared dimensions, sibling twins, refutation retention, and lever composition. |
+
+All five paper objects are covered. The gap is not “add self-evolution,” but make
+coverage, evidence class, authority, and evaluation explicit across the tracks.
+
+## 4. Paper-to-Stella gap matrix
+
+| Paper category | Stella today | Net contribution from paper |
+|---|---|---|
+| Framework | Verified maintenance, no lineage search | Reinforces rollback, harness-integrity, and archive-selection requirements already planned. |
+| Experience memory | Reflection, episodes, recall, citations, quarantine, forgetting, retirement | Stella is ahead on governance; paper highlights transfer evaluation. |
+| Repository memory | Graph, anchors, domains, temporal facts and episodes | Commit/issue/co-change history is a distinct signal worth testing, not automatically ingesting. |
+| Skills | Recurrence mining, creation, appraisal, promotion/retirement | Mostly covered; motivates portable-vs-local transfer panels. |
+| Tools | Witnessed foundry plus separate enablement | Mostly covered; immediate task-time mutation should remain gated. |
+| Model | Reward traces, export, local serving | Already planned; learnable-information gain is a missing campaign health condition. |
+| Workflow/topology | One-knob tuning; deterministic pipeline | Arbitrary topology search is not justified by this survey alone. |
+| Post-task | Main shipped learning mode | Strong coverage. |
+| Stage-wise | Manual dataset/eval pieces | Strong planned coverage. |
+| Outcome evidence | Witness ladder, rewards, paired guards | Stronger than the survey baseline. |
+| Environmental evidence | Tool results, friction, validation, receipts | Reinforces completing cross-surface evidence wiring. |
+| Trajectory evidence | Full traces, reflection digest, episodes, replay | Strong, but evidence classes should survive abstraction. |
+
+## 5. Backlog additions worth considering
+
+### A. Enforced evolution-surface parity ledger
+
+Add a code-owned matrix analogous to provider parity. Each evolution object
+(`framework`, `memory`, `skill`, `tool`, `model`, `workflow`) declares posture
+(`Shipped`, `Experimental`, `Planned(issue)`, `Prohibited(reason)`), timing,
+accepted evidence, publication authority, rollback artifact, and named witness.
+
+**Done:** a new surface without a row fails; a shipped row with a missing witness
+fails; planned/prohibited rows require an issue or stable design citation.
+
+### B. Longitudinal transfer and decay panel
+
+Run promoted memories, skills, policies, and eventually weights across held-out
+repositories/versions, at least two model families for prompt artifacts,
+language/build strata, a dependency-upgraded snapshot, and unrelated repositories.
+Measure verification rate, cost, steps, retrieval precision, stale activation,
+and retirement. Add transfer/decay guards rather than one blended score.
+
+**Done:** a source-specific skill may improve its local panel but is blocked from
+global publication when it harms the unrelated panel; stale dependency advice is
+detected and retired or narrowed without deleting history.
+
+### C. Evidence-grade preservation and promotion policy
+
+Carry explicit provenance through every derived artifact: deterministic proof;
+environment observation; trajectory abstraction; model critique; human review.
+Several critiques must not become executable evidence by voting. Impact sets the
+required grade: prompt hints may be trialled from trajectory evidence, while a
+blocking guard or executable tool requires witness plus authority.
+
+**Done:** provenance survives reflection → proposal → skill/rule/tool → campaign;
+UI/export expose it; no artifact claims a stronger grade than its reproducible
+source.
+
+### D. Corpus information-gain and saturation gate
+
+Before #836 trains another checkpoint, measure whether the corpus adds learnable
+novelty: normalized trace/lesson/hypothesis novelty, new failure-cluster coverage,
+divergent outcome pairs, and held-out learning-curve lift. Suspend or redirect
+the curriculum when generations add neither new clusters nor lift.
+
+**Done:** duplicate successes cannot trigger training; new verified
+counterexamples can; the ledger names the corpus delta and held-out justification.
+
+### E. Bounded historical repository-memory experiment
+
+Race digest-pinned, cited frames mined from commits, linked issues, and co-change
+history against current graph/semantic recall on localization-heavy held-out
+tasks. Guard token cost, stale paths, and false co-change correlations.
+
+**Done:** the experiment can prove lift or a null result without default ingestion;
+losing evidence is retained so the hypothesis is not repeatedly funded.
+
+## 6. Not justified by this paper alone
+
+- Unbounded recursive self-modification.
+- Immediate execution of self-authored tools.
+- Automatic deployment of trained weights without evaluation and sign-off.
+- A learned verifier replacing executable tests.
+- Multi-agent topology search as a goal rather than an equal-budget challenger.
+
+## 7. Bottom line
+
+The paper validates Stella's direction more than it redirects it. Stella already
+implements the paper's most important software-specific insight: executable
+feedback should govern persistent learning, and learned artifacts need a
+lifecycle rather than permanent trust. Its backlog spans all five evolution
+objects. The useful additions are organizational and evaluative: total enforced
+coverage, preserved evidence grade, transfer/decay evaluation, and a stop rule
+for training cycles with no learnable information. These turn the survey's
+cautions into deterministic contracts without weakening Stella's witness,
+authority, privacy, or safe-boundary invariants.

--- a/docs/papers/self-evolving-coding-agents-assessment.md
+++ b/docs/papers/self-evolving-coding-agents-assessment.md
@@ -1,7 +1,7 @@
 ---
 id: self-evolving-coding-agents-assessment
 title: "Self-Evolving Coding Agents — comparison with Stella"
-status: research-note
+status: living
 ---
 
 # *Self-Evolving Coding Agents* — comparison with Stella

--- a/docs/prompts/reflection.md
+++ b/docs/prompts/reflection.md
@@ -266,12 +266,13 @@ not, while recalled ones are paid for only when retrieved.
 
 ## Known limits
 
-The digest this prompt reasons over is the last 12 messages, each truncated to
-300 characters. The expensive part of a turn is usually in its middle, and the
-middle is what the tail window drops — so the model is asked what would have
-made the turn faster by a witness that cannot see where it was slow. This caps
-how good any wording here can be; #2460 tracks selecting the digest from the
-event stream instead.
+The selection digest now preserves the goal, friction, and turn tail under a
+bounded budget rather than reading a fixed tail window. Its remaining evidence
+gap is surface coverage: the staged-pipeline one-shot supplies the event-derived
+friction ledger, while #2483 tracks wiring that ledger on the other three
+surfaces. On those surfaces the selector can still see errored tool results in
+the transcript, but not cost, retry, loop-detector, or latency signals that only
+the event stream carries.
 
 ## Related
 


### PR DESCRIPTION
### Motivation
- Add a research-grade assessment comparing Zhou et al.'s 2026 *Self-Evolving Coding Agents* survey with Stella's current design and backlog to capture concrete gaps and actionable backlog items.
- Surface a recommended set of organizational and evaluative additions (ledger, transfer panels, evidence-grade policies, saturation gates) for Stella's self-improvement track.
- Clarify the reflection prompt's selection-digest behavior and document remaining evidence coverage for reflection mining.

### Description
- Add `docs/papers/self-evolving-coding-agents-assessment.md`, a 228-line research note that compares the paper to Stella 0.8.40, enumerates gaps, and proposes backlog items and experiments.
- Update `docs/papers/README.md` to include a link to the new assessment under the Papers list.
- Edit `docs/prompts/reflection.md` to change the explanation of the selection digest to preserve goal, friction, and tail under a bounded budget and to note remaining event-stream evidence gaps.

### Testing
- No automated tests were run because this is a documentation-only change.
- Recommend running the repository's documentation build or link-checker as part of CI to validate rendering and internal links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a6eb032b88326859e765dfb9d58cc)

## Summary by Sourcery

Add a research-note assessment of Zhou et al.'s *Self-Evolving Coding Agents* survey in relation to Stella 0.8.40 and update documentation to reflect the new analysis and clarified reflection evidence wiring.

Documentation:
- Add a new research-note paper assessing self-evolving coding agents concepts against Stella's current design and backlog, highlighting gaps and proposed backlog items.
- Update the papers index to link to the new assessment and describe its scope.
- Clarify the reflection prompt documentation to describe the updated selection digest behavior and remaining evidence coverage gaps across surfaces.