### PR TITLE
fix(stella-pipeline): a triage outage must not route the turn below SingleTask

### DIFF
--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -94,10 +94,14 @@ async fn late_triage_is_abandoned_and_reported_incomplete() {
         .expect("a missed triage deadline is never a run-ending failure");
 
     // The abandoned answer never classifies, so triage lands on the
-    // deterministic floor rather than a guess from a call it did not await.
+    // deterministic floor rather than a guess from a call it did not await —
+    // clamped at `SingleTask`, because a call that was never awaited earned no
+    // downgrade onto the path that skips the planner and the verifier
+    // (`triage_outage_floor`). The subject here is still "no guess from an
+    // unawaited call", which the floor comparison keeps.
     assert_eq!(
         class.class,
-        resolve_task_class(None, "What is two plus two?")
+        resolve_task_class(None, "What is two plus two?").max(TaskClass::SingleTask)
     );
     // Nothing settled, so nothing is charged — an unknowable envelope is
     // reported as incomplete instead of being invented.

--- a/crates/stella-pipeline/src/pipeline/tests/usage.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/usage.rs
@@ -181,7 +181,11 @@ async fn triage_provider_error_emits_content_free_incompleteness() {
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (result, _, events) =
         run_triage_only(&ErrorProvider, PipelineConfig::default(), &mut budget).await;
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
     let usage = usage_events(&events);
     assert_eq!(usage.len(), 1);
     assert_eq!(usage[0]["type"], "usage_incomplete");
@@ -201,7 +205,11 @@ async fn triage_timeout_emits_content_free_incompleteness() {
         ..PipelineConfig::default()
     };
     let (result, _, events) = run_triage_only(&SlowProvider, config, &mut budget).await;
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
     let usage = usage_events(&events);
     assert_eq!(usage.len(), 1);
     assert_eq!(usage[0]["type"], "usage_incomplete");
@@ -415,7 +423,11 @@ async fn a_timed_out_triage_records_that_the_class_came_from_the_floor() {
 
     // The fallback itself is unchanged and load-bearing: never fail a run on
     // triage.
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
 
     let reasons = triage_degraded_reasons(&events);
     assert_eq!(reasons.len(), 1, "exactly one record per degraded triage");
@@ -442,7 +454,11 @@ async fn a_failed_triage_call_records_a_provider_failure_not_a_timeout() {
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (result, _, events) =
         run_triage_only(&ErrorProvider, PipelineConfig::default(), &mut budget).await;
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
     let reasons = triage_degraded_reasons(&events);
     assert_eq!(reasons.len(), 1);
     assert!(
@@ -460,7 +476,11 @@ async fn an_off_protocol_triage_response_records_the_same_degradation() {
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (result, _, events) =
         run_triage_only(&provider, PipelineConfig::default(), &mut budget).await;
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
     let reasons = triage_degraded_reasons(&events);
     assert_eq!(reasons.len(), 1, "{reasons:?}");
     assert!(reasons[0].contains("did not follow the classification protocol"));
@@ -496,7 +516,11 @@ async fn an_unroutable_triage_records_that_it_could_not_be_routed() {
         run_triage_with_resolver(&NoProviderResolver, PipelineConfig::default(), &mut budget).await;
 
     // The fallback is unchanged and load-bearing: never fail a run on triage.
-    assert_eq!(result.unwrap().class, TaskClass::SimpleLookup);
+    // `SingleTask`, not `SimpleLookup`: a triage that produced no
+    // classification cannot route the turn onto the path that skips the
+    // planner and the verifier (`triage_outage_floor`). The subject of this
+    // test is the recorded reason, not the class.
+    assert_eq!(result.unwrap().class, TaskClass::SingleTask);
     assert_eq!(total, 0.0, "an unroutable triage buys nothing");
 
     let reasons = triage_degraded_reasons(&events);
@@ -531,4 +555,40 @@ fn the_default_triage_ceiling_is_the_one_the_doc_comment_describes() {
         Duration::from_secs(30),
         "triage's ceiling regressed away from the measured value (#2414, #2429)"
     );
+}
+
+/// A triage outage must not route the turn onto the path that skips the
+/// planner and the verifier.
+///
+/// The measured defect. On the 2026-08-10 TB2.1 panel, four of eight pipeline
+/// trials met a rate-limited triage call, fell to the keyword floor, and ran
+/// with NO management roles at all — `SimpleLookup` skips both the planner and
+/// the verifier, so a provider hiccup silently turned the staged pipeline into
+/// a bare loop that still paid the pipeline's overhead. The trials still
+/// scored; they simply were not measuring the pipeline, and nothing in the
+/// solve count could show it.
+///
+/// The goal here carries no keyword the floor recognises, which is the whole
+/// hazard: the floor's evidence is absent, not cheap, and absence of a
+/// classification is not evidence that a task is simple. `resolve_task_class`
+/// errs toward planning everywhere else; the outage path is where it did not.
+#[tokio::test]
+async fn a_triage_outage_never_routes_the_turn_below_single_task() {
+    let off_protocol = ScriptedProvider::new(vec![text_result("Sure — happy to help.")]);
+    let cases: [(&str, &dyn stella_protocol::Provider); 2] = [
+        ("a provider error", &ErrorProvider),
+        ("an off-protocol answer", &off_protocol),
+    ];
+    for (label, provider) in cases {
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (result, _, _) =
+            run_triage_only(provider, PipelineConfig::default(), &mut budget).await;
+        let class = result.expect("triage never fails the run").class;
+
+        assert!(
+            class >= TaskClass::SingleTask,
+            "{label}: an outage routed the turn to {class:?}, which skips the \
+             verifier — the pipeline would run as a bare loop"
+        );
+    }
 }

--- a/crates/stella-pipeline/src/pipeline/triage_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/triage_stage.rs
@@ -94,7 +94,7 @@ impl Pipeline<'_> {
             // very census the record exists to feed (#2414).
             Assigned::Unresolvable => {
                 self.triage_degraded("the triage role could not be routed to a provider");
-                return Ok((self.triage_floor(goal), Vec::new()));
+                return Ok((self.triage_outage_floor(goal), Vec::new()));
             }
             Assigned::Withheld => {
                 return Ok((self.triage_floor(goal), Vec::new()));
@@ -185,7 +185,13 @@ impl Pipeline<'_> {
                 }
             }
             None => {
-                let class = resolve_task_class(None, goal);
+                // No classification earned a downgrade, so none is taken: the
+                // floor's upward evidence stands, clamped at `SingleTask` so a
+                // failed or unparseable triage cannot route this turn onto the
+                // lookup path that skips the planner and the verifier. See
+                // `triage_outage_floor` for the panel that measured the old
+                // behaviour collapsing the pipeline into a bare loop.
+                let class = self.triage_outage_floor(goal).class;
                 TaskAssessment {
                     conversational,
                     require_witness: Some(resolve_witness(None, class, goal)),
@@ -258,6 +264,34 @@ impl Pipeline<'_> {
         }
     }
 
+    /// The class an **outage** may fall back to: the keyword floor, clamped
+    /// the same way [`Self::triage_ablated`] clamps it.
+    ///
+    /// The floor used to stand alone here, on the reasoning that a broken
+    /// triage should "spend as little as the evidence justifies". The measured
+    /// consequence is the opposite of cheap. On the 2026-08-10 TB2.1 panel,
+    /// four of eight pipeline trials met a rate-limited triage call, took this
+    /// path, and ran with **no management roles at all** — the floor's cheapest
+    /// class skips the planner *and* the verifier, so a provider hiccup
+    /// silently turned the staged pipeline into a bare loop that still paid the
+    /// pipeline's overhead. The cells still scored; they simply were not
+    /// measuring the pipeline.
+    ///
+    /// The error in the old reasoning is treating a missing answer as evidence.
+    /// A 429 says nothing about the task — and [`resolve_task_class`] is built
+    /// on exactly that principle everywhere else ("errs toward planning, never
+    /// away"). So an outage now gets the ablation's rule, which already stated
+    /// it correctly: nothing routes down to the lookup path without a
+    /// classification that earned it. The floor's *upward* evidence still
+    /// applies, so a goal that reads multi-step still plans.
+    fn triage_outage_floor(&self, goal: &str) -> TaskAssessment {
+        let floor = self.triage_floor(goal);
+        TaskAssessment {
+            class: floor.class.max(TaskClass::SingleTask),
+            ..floor
+        }
+    }
+
     /// The assessment a turn gets when triage was **deliberately ablated**
     /// (#2381) — which is not the same thing as triage having failed, and the
     /// difference is the whole point of the roster.
@@ -282,10 +316,10 @@ impl Pipeline<'_> {
     /// so a bare `hi` must not enter the work pipeline merely because triage
     /// was ablated.
     fn triage_ablated(&self, goal: &str) -> TaskAssessment {
-        let floor = self.triage_floor(goal);
-        TaskAssessment {
-            class: floor.class.max(TaskClass::SingleTask),
-            ..floor
-        }
+        // Identical in effect to the outage rule, and deliberately expressed by
+        // calling it: an ablation and an outage reach the same place from
+        // different directions — neither produced a classification that earned
+        // a downgrade — and two copies of one clamp is how the two drift apart.
+        self.triage_outage_floor(goal)
     }
 }


### PR DESCRIPTION
Closes #2829

## The defect

A triage call that never answered landed on the bare keyword floor, whose cheapest class is `SimpleLookup` — which skips **the planner and the verifier**. So a provider hiccup silently turned the staged pipeline into a bare loop that still paid the pipeline's overhead.

## Measured, not theorised

On the 2026-08-10 TB2.1 panel (`mp2-*`, SUT `314344c`), **four of eight pipeline trials** met a rate-limited triage call and ran with no management roles at all. The correlation is exact, 4 for 4 — every trial whose trace carried `the triage call failed at the provider` shows only `worker` in its `step_usage` role census:

| Pipeline trial | triage failed | management roles that ran |
|---|---|---|
| build-pov-ray | yes | **none — worker only** |
| extract-elf | yes | **none — worker only** |
| path-tracing | yes | **none — worker only** |
| qemu-alpine-ssh | yes | **none — worker only** |
| cobol-modernization | no | triage, research, plan |
| kv-store-grpc | no | triage, plan |
| pypi-server | no | triage, plan |
| raman-fitting | no | triage, research, plan |

Those cells still scored, so **nothing in the solve count could show that half the arm had stopped measuring the pipeline**. It also skewed the arm's cost: the one cell where the pipeline genuinely ran (cobol-modernization) was 37% *cheaper* than bare with more tool calls, while the arm overall read +39%.

## The fix

The error was treating a missing answer as evidence. A 429 says nothing about the task, and `resolve_task_class` is built on exactly that principle everywhere else — it "errs toward planning, never away". The outage path was the one place it erred the other way.

`triage_ablated` had already worked this out for the ablation case, and stated it precisely: *nothing routes down to the lookup path without a classification that earned it.* An outage arrives at the same place from a different direction, so it now takes the same rule — and the ablation path **delegates** to it rather than keeping a second copy of the clamp, since two copies of one rule is how the two drift apart.

The floor's **upward** evidence is untouched: a goal that reads multi-step still plans.

## The cost, named

A genuinely trivial prompt that meets a triage outage now buys a verify pass it does not need. That is the trade the ablation path already accepts, and it is the right direction to be wrong in — the alternative is what this PR fixes.

## Witness test

`a_triage_outage_never_routes_the_turn_below_single_task` covers both outage shapes (provider error, off-protocol answer) on a goal carrying **no keyword the floor recognises** — absence of evidence, which is the actual hazard.

**Flip demonstrated:** with the clamp reverted it fails with

> `a provider error: an outage routed the turn to SimpleLookup, which skips the verifier — the pipeline would run as a bare loop`

and passes with the fix. 670 tests green in `stella-pipeline`.

## Tests changed (none deleted)

Seven existing tests asserted the old class as a **secondary** detail — their subject, per their names and docs, is the recorded degradation *reason*, which is unchanged. Their expectations move from `SimpleLookup` to `SingleTask`, each with a comment saying why:

- `usage.rs` — six assertions across the timeout / provider-error / unroutable / off-protocol cases.
- `management_accounting.rs::late_triage_is_abandoned_and_reported_incomplete` — now compares against the clamped floor, keeping its "no guess from an unawaited call" subject.

**No test was deleted.**

## Gate

`make gate` green end to end.

## Summary by Sourcery

Ensure triage outages and ablations cannot downgrade tasks onto the bare lookup path that skips planning and verification, keeping pipeline management roles active even under provider failures.

Bug Fixes:
- Prevent triage outages and unroutable or malformed triage responses from routing tasks below `SingleTask`, avoiding bare-loop executions that bypass planning and verification while still incurring pipeline overhead.

Enhancements:
- Unify outage and ablation fallback logic via a shared `triage_outage_floor` clamp that preserves upward evidence while enforcing a `SingleTask` minimum.
- Clarify and extend tests to assert the new minimum task class under triage outages and to document the distinction between degradation reasons and task-class fallbacks.

Tests:
- Add a witness test ensuring triage outages never route turns below `SingleTask`, and update existing triage degradation tests to expect the clamped class while preserving their original behavioral subjects.