### PR TITLE
fix(arenabench): reclaim a finished trial's network namespace instead of refusing the instance

### DIFF
--- a/arenabench/infra/runner/Dockerfile
+++ b/arenabench/infra/runner/Dockerfile
@@ -37,6 +37,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl git jq unzip gnupg procps \
+        iptables util-linux \
         python3 python3-pip ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 

--- a/arenabench/infra/runner/entrypoint.sh
+++ b/arenabench/infra/runner/entrypoint.sh
@@ -31,27 +31,71 @@ cleanup_dockerd() {
     [ -n "${JOB_SLUG:-}" ] && rm -rf "/scratch/$JOB_SLUG" 2>/dev/null || true
 }
 
-assert_sole_dockerd() {
-    # Batch runs EC2 jobs with ECS `networkMode: host`, so a second trial
-    # placed on this instance would share our network namespace — and
-    # Docker's filter chains are named globally within a namespace. The
-    # second dockerd then dies on `DOCKER-BRIDGE: Chain already exists`
-    # after a 60-second wait, reported as fifty lines of daemon log that
-    # name neither the neighbour nor the placement that created it.
+discard_dead_docker_chains() {
+    # Only ever reached while THIS trial holds the instance lock, so every
+    # DOCKER* chain in the shared namespace is residue from a trial that has
+    # already exited: `cleanup_dockerd` kills the daemon, and the daemon's
+    # iptables rules are not its to take with it. dockerd rebuilds what it
+    # needs at startup, so removing them restores the namespace to the state a
+    # first-on-this-instance trial finds.
+    for table in filter nat; do
+        iptables -w -t "$table" -S 2>/dev/null \
+            | awk '/^-N DOCKER/ { print $2 }' \
+            | while read -r chain; do
+                iptables -w -t "$table" -F "$chain" 2>/dev/null || true
+                iptables -w -t "$table" -X "$chain" 2>/dev/null || true
+            done
+    done
+}
+
+claim_instance_netns() {
+    # Batch runs EC2 jobs with ECS `networkMode: host`, so every trial placed
+    # on this instance shares one network namespace — and Docker's chains are
+    # named globally within a namespace. A second *concurrent* dockerd dies on
+    # `DOCKER-BRIDGE: Chain already exists` after a 60-second wait, reported as
+    # fifty lines of daemon log naming neither the neighbour nor the placement.
     #
-    # The job definition and both compute environments size a trial to the
-    # whole instance so this cannot happen; this is the backstop for the
-    # ways that guarantee can be bypassed anyway — a submit-time
-    # `--vcpus` override, a hand-written job definition, a compute
-    # environment edited to allow a larger instance type. Refusing here
-    # costs one iptables read and turns a mystifying crash into its cause.
-    if iptables -w -t filter -n -L DOCKER-BRIDGE >/dev/null 2>&1; then
-        log "FATAL: another dockerd already owns this network namespace."
-        log "  Batch uses host networking, so two trials on one instance"
-        log "  share it and only the first dockerd can start. Give this"
-        log "  trial the whole instance (4 vCPU on m6i.xlarge) or give each"
-        log "  dockerd its own netns. See TrialTopology in infra/core.yaml."
+    # This used to refuse whenever those chains existed, reasoning that the job
+    # definition sizes a trial to the whole instance, so only a bypass could
+    # produce them. That reasoning holds across SPACE and fails across TIME:
+    # Batch reuses a warm instance for the next trial, and the previous trial's
+    # chains are still there. On 2026-08-11 that took out 157 of 178 trials in
+    # one panel — the 16 placed first, each on a fresh instance, ran; every
+    # trial placed on a reused instance died in about five seconds. The guard
+    # was reading a dead neighbour's residue as a live neighbour.
+    #
+    # An exclusive lock on the instance-wide scratch volume answers the
+    # question the chains only hinted at, because the kernel drops it when the
+    # holder dies: held means a trial is running here NOW and the original
+    # refusal stands; free means whatever left those chains is gone.
+    if [ ! -d /scratch ]; then
+        # No shared volume, so no liveness signal — keep the conservative
+        # refusal rather than flushing chains that might belong to somebody.
+        if iptables -w -t filter -n -L DOCKER-BRIDGE >/dev/null 2>&1; then
+            log "FATAL: another dockerd already owns this network namespace,"
+            log "  and without /scratch there is no way to tell a live trial"
+            log "  from a finished one's leftovers. Mount the scratch volume"
+            log "  (see TrialTopology in infra/core.yaml), or give each dockerd"
+            log "  its own netns."
+            return 1
+        fi
+        return 0
+    fi
+    # fd 9 stays open for the life of this shell: the lock belongs to the
+    # trial, not to this function, and releasing it early would admit a
+    # neighbour while our dockerd is still running.
+    exec 9>>/scratch/.instance-netns.lock
+    if ! flock -n 9; then
+        log "FATAL: another trial is running on this instance right now."
+        log "  Batch uses host networking, so two concurrent trials share one"
+        log "  network namespace and only the first dockerd can start. Give"
+        log "  this trial the whole instance (4 vCPU on m6i.xlarge), or give"
+        log "  each dockerd its own netns. See TrialTopology in infra/core.yaml."
         return 1
+    fi
+    if iptables -w -t filter -n -L DOCKER-BRIDGE >/dev/null 2>&1; then
+        log "reclaiming the network namespace from a finished trial"
+        discard_dead_docker_chains
     fi
 }
 
@@ -80,7 +124,7 @@ prepare_cgroup2() {
 }
 
 start_dockerd() {
-    assert_sole_dockerd || return 1
+    claim_instance_netns || return 1
     prepare_cgroup2
     # Overlayfs cannot nest: with /var/lib/docker on the container's own
     # overlay root, the inner dockerd's mounts fail with EINVAL. The job

--- a/arenabench/tests/test_runner_netns.py
+++ b/arenabench/tests/test_runner_netns.py
@@ -1,0 +1,127 @@
+"""The runner's instance-netns claim: reclaim a dead trial's namespace, refuse a live one.
+
+Batch places trials on warm instances, and every trial on an instance shares
+one network namespace (ECS ``networkMode: host``). The claim has to separate
+two states that look identical from the outside — leftover Docker chains from a
+trial that already exited, versus a trial running right now — because getting
+it wrong is expensive in both directions:
+
+* Treating residue as a live neighbour refuses the trial. That is what took out
+  **157 of 178 trials** in the 2026-08-11 panel: the 16 placed first, each on a
+  fresh instance, ran; every trial placed on a reused instance died in ~5s.
+* Treating a live neighbour as residue would flush a running dockerd's chains
+  and break the trial that legitimately owns the instance.
+
+The discriminator is an exclusive lock on the instance-wide scratch volume,
+which the kernel releases when its holder dies. These exercise the lock
+protocol itself with real ``flock`` processes; the iptables half needs a
+namespace to manipulate and is covered by the smoke job.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "infra" / "runner" / "entrypoint.sh"
+
+#: The lock-protocol tests drive real ``flock(1)``, a util-linux tool absent on
+#: macOS. Scoped to those three deliberately: the wiring assertions below read
+#: the script and must run on every platform, or a local run would report six
+#: skips and prove nothing about the fix.
+needs_flock = pytest.mark.skipif(
+    sys.platform == "darwin", reason="flock(1) is a util-linux tool; the runner is Linux"
+)
+
+
+def _claim(scratch: Path) -> subprocess.CompletedProcess[str]:
+    """Run the claim's lock step exactly as the entrypoint does."""
+    script = f"""
+    set -eu
+    exec 9>>"{scratch}/.instance-netns.lock"
+    if ! flock -n 9; then echo REFUSED; exit 1; fi
+    echo CLAIMED
+    """
+    return subprocess.run(
+        ["sh", "-c", script], capture_output=True, text=True, timeout=30
+    )
+
+
+@needs_flock
+def test_a_free_instance_is_claimed(tmp_path: Path) -> None:
+    assert "CLAIMED" in _claim(tmp_path).stdout
+
+
+@needs_flock
+def test_a_lock_held_by_a_live_process_is_refused(tmp_path: Path) -> None:
+    lock = tmp_path / ".instance-netns.lock"
+    lock.touch()
+    # A neighbour that is genuinely still running: holds the lock and sleeps.
+    holder = subprocess.Popen(
+        ["flock", str(lock), "sleep", "30"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        # `flock` needs a moment to actually acquire before we race it.
+        subprocess.run(["sleep", "0.5"], check=True)
+        result = _claim(tmp_path)
+        assert result.returncode != 0, "a live neighbour must be refused"
+        assert "REFUSED" in result.stdout
+    finally:
+        holder.kill()
+        holder.wait(timeout=10)
+
+
+@needs_flock
+def test_a_lock_whose_holder_died_is_reclaimed(tmp_path: Path) -> None:
+    """The case the old guard got wrong.
+
+    The previous trial exited. Its lock file still exists — and under the old
+    logic its leftover iptables chains would have refused this trial — but the
+    kernel dropped the lock when the holder died, so the instance is free.
+    """
+    lock = tmp_path / ".instance-netns.lock"
+    holder = subprocess.Popen(
+        ["flock", str(lock), "sleep", "30"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(["sleep", "0.5"], check=True)
+    holder.kill()
+    holder.wait(timeout=10)
+
+    assert lock.exists(), "the file outlives the holder; only the lock is dropped"
+    assert "CLAIMED" in _claim(tmp_path).stdout
+
+
+class TestEntrypointWiring:
+    """The script says what these tests assume it says."""
+
+    def test_the_claim_replaced_the_residue_only_guard(self) -> None:
+        source = ENTRYPOINT.read_text()
+        assert "claim_instance_netns" in source
+        assert "assert_sole_dockerd" not in source, (
+            "the old guard refused on residue alone; it must not linger as a "
+            "second, contradictory path"
+        )
+
+    def test_the_lock_outlives_the_claim_function(self) -> None:
+        # Releasing at function exit would admit a neighbour while our dockerd
+        # is still running — the failure the guard exists to prevent.
+        source = ENTRYPOINT.read_text()
+        assert re.search(r"exec 9>>.*instance-netns\.lock", source)
+
+    def test_chains_are_only_discarded_under_the_lock(self) -> None:
+        source = ENTRYPOINT.read_text()
+        body = source.split("claim_instance_netns()", 1)[1]
+        flock_at = body.index("flock -n 9")
+        discard_at = body.index("discard_dead_docker_chains")
+        assert flock_at < discard_at, (
+            "chains must only be flushed after the lock proves nobody else is "
+            "using this namespace"
+        )


### PR DESCRIPTION
Closes #2843

## What broke

**157 of 178 trials died in about five seconds each**, before any agent work, in the 2026-08-11 full-panel run.

```
FATAL: another dockerd already owns this network namespace.
```

## Why

Every trial on an instance shares one network namespace (ECS `networkMode: host`), and the guard refused whenever it found Docker's chains there. Its premise, from its own comment:

> The job definition and both compute environments size a trial to the whole instance **so this cannot happen**

That holds across **space** and fails across **time**. Batch places the next trial on a **warm** instance, and `cleanup_dockerd` kills the daemon without removing its iptables rules. The second trial on an instance found the first one's chains and read a **dead** neighbour's residue as a **live** neighbour.

## The evidence distinguishes reuse from co-scheduling

This mattered, because "two trials packed onto one instance" and "one trial reusing a finished trial's instance" produce the identical error:

| | instances | timing |
|---|---|---|
| **16 successes** | 16 **distinct** instances, one trial each | all inside one 35s window |
| **157 failures** | the **same** ids repeating — one hosted 15+ | ~5s apart, all **after** the successes finished |

Reuse. A 16-trial panel earlier that day passed precisely because it was exactly one wave, which is why this stayed invisible: with 16 concurrent slots, anything larger than 16 trials reuses instances.

## The fix

Replace the inference with a fact. The chains were only ever a *hint*; an exclusive `flock` on the instance-wide `/scratch` volume is the *signal*, because the kernel drops it when its holder dies:

- **held** → a trial is running here now → refuse, exactly as before;
- **free** → whatever left those chains is gone → flush the `DOCKER*` chains and let dockerd rebuild them.

The lock rides **fd 9 for the life of the shell**: releasing it at function exit would admit a neighbour while our own dockerd is still running, which is the failure the guard exists to prevent.

With no `/scratch` mounted there is no liveness signal at all, so that path keeps the **conservative refusal** rather than flushing chains that might belong to somebody.

`flock` (util-linux) and `iptables` are now **declared** in the runner image rather than inherited from the base.

## Witness tests

`arenabench/tests/test_runner_netns.py` — the lock protocol against real `flock` processes:

| Test | Proves |
|---|---|
| `test_a_free_instance_is_claimed` | the happy path |
| `test_a_lock_held_by_a_live_process_is_refused` | a genuine concurrent neighbour still refuses |
| `test_a_lock_whose_holder_died_is_reclaimed` | **the case the old guard got wrong** — holder killed, lock file still present, instance correctly reclaimed |

Plus three wiring assertions that read the script and run on **every** platform — the lock tests need Linux, and a suite that skips wholesale on the developer's machine proves nothing about the fix.

**Flip demonstrated:** moving the flush above the lock fails `test_chains_are_only_discarded_under_the_lock` with "chains must only be flushed after the lock proves nobody else is using this namespace".

## No deleted tests

None.

## Residue

The runner image must be rebuilt (`arenabench-runner-image`) before this reaches a trial — the entrypoint ships **inside** the image, not from S3. Noted in #2843.

## Gate

`make gate` green end to end, `shellcheck` clean on the entrypoint.

## Summary by Sourcery

Guard runner trials sharing an instance-wide network namespace by reclaiming dead trials’ Docker iptables state while refusing truly concurrent neighbours, preventing spurious trial failures on reused instances.

Bug Fixes:
- Allow trials on reused instances to start dockerd by distinguishing leftover Docker chains from a concurrently running neighbour using an instance-wide lock.

Enhancements:
- Introduce an instance-level network namespace claim using an exclusive flock-based lock tied to the /scratch volume and reuse the namespace by flushing dead Docker chains when safe.

Build:
- Declare iptables and util-linux (for flock) as explicit dependencies in the runner Docker image.

Tests:
- Add Linux-only tests exercising the lock protocol that governs instance claims, plus wiring assertions ensuring the entrypoint uses the new claim logic and only flushes chains under the lock.