### PR TITLE
fix(arenabench): make the dead-holder netns test actually kill the lock holder

### DIFF
--- a/arenabench/tests/test_runner_netns.py
+++ b/arenabench/tests/test_runner_netns.py
@@ -38,6 +38,30 @@ needs_flock = pytest.mark.skipif(
 )
 
 
+def _holder(lock: Path) -> subprocess.Popen[bytes]:
+    """A neighbour holding the lock as ONE process, the way the entrypoint does.
+
+    ``--no-fork`` is load-bearing, not tidiness. Without it ``flock`` forks and
+    execs the command in a child, so two processes share the locked descriptor
+    — and an advisory lock is released only when the *last* one closes. Killing
+    the ``Popen`` pid then reaps the ``flock`` parent while the orphaned child
+    keeps the lock for the rest of its sleep, so "the holder died" is never
+    actually established and the reclaim is refused. Observed:
+
+        140  137  flock .instance-netns.lock sleep 30
+        142  140  sleep 30            # ppid becomes 1, still holding, after the kill
+
+    The single-process holder is also the truthful model: the entrypoint takes
+    the lock with ``exec 9>>`` in one shell, so its death is what the kernel
+    sees. The forking holder was an artifact of the scaffold, never the system.
+    """
+    return subprocess.Popen(
+        ["flock", "--no-fork", str(lock), "sleep", "30"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
 def _claim(scratch: Path) -> subprocess.CompletedProcess[str]:
     """Run the claim's lock step exactly as the entrypoint does."""
     script = f"""
@@ -61,11 +85,7 @@ def test_a_lock_held_by_a_live_process_is_refused(tmp_path: Path) -> None:
     lock = tmp_path / ".instance-netns.lock"
     lock.touch()
     # A neighbour that is genuinely still running: holds the lock and sleeps.
-    holder = subprocess.Popen(
-        ["flock", str(lock), "sleep", "30"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    holder = _holder(lock)
     try:
         # `flock` needs a moment to actually acquire before we race it.
         subprocess.run(["sleep", "0.5"], check=True)
@@ -86,13 +106,12 @@ def test_a_lock_whose_holder_died_is_reclaimed(tmp_path: Path) -> None:
     kernel dropped the lock when the holder died, so the instance is free.
     """
     lock = tmp_path / ".instance-netns.lock"
-    holder = subprocess.Popen(
-        ["flock", str(lock), "sleep", "30"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    holder = _holder(lock)
     subprocess.run(["sleep", "0.5"], check=True)
     holder.kill()
+    # `wait` reaps the holder, and with a single-process holder that is also
+    # the moment its descriptor is closed — so the lock is provably free here,
+    # with no sleep-and-hope between the kill and the claim.
     holder.wait(timeout=10)
 
     assert lock.exists(), "the file outlives the holder; only the lock is dropped"


### PR DESCRIPTION
## What & why

`main` is red. `tests/test_runner_netns.py::test_a_lock_whose_holder_died_is_reclaimed`, added by #2844, fails **deterministically** on `main` at 25e743121 (`assert 'CLAIMED' in 'REFUSED\n'`), which reds every open PR underneath it.

The test is right about the system and wrong about its own scaffold.

It builds the neighbour with `flock <lock> sleep 30`. util-linux `flock` **forks** and execs the command in a child (that is exactly what `-F/--no-fork` exists to suppress), so **two** processes share the locked descriptor — and a POSIX advisory lock is released only when the *last* descriptor referring to it closes. `Popen.kill()` reaps the `flock` parent while the orphaned `sleep 30` keeps the lock for the remaining ~29.5 seconds. So the test's premise — "the holder died" — is never actually established, and the claim is *correctly* refused.

Observed directly on `ubuntu:24.04`:

```
-- process tree while held --
    140    137  flock .instance-netns.lock sleep 30
    142    140  sleep 30
-- survivors after killing the flock pid --
    142      1  sleep 30          <- ppid is now 1, and it still holds the lock
-- claim result --
REFUSED
```

and with `--no-fork`, one process, no survivors, `CLAIMED`.

## The fix

Hold the lock with `flock --no-fork`, so the holder is a single process whose death *is* the lock's release.

This is not just a scaffold repair — it is the more truthful model. The entrypoint takes the lock with `exec 9>>` in one shell, so a one-process holder is what the kernel actually sees in production. The forking holder was an artifact of the test harness, never the system under test.

Both lock tests now go through one `_holder()` helper, which additionally stops `test_a_lock_held_by_a_live_process_is_refused` leaking the same orphaned `sleep 30` out of its `finally` — that test passes today for the wrong reason, since the orphan produces the REFUSED it asserts.

The `--no-fork` holder also removes a race rather than papering over one: `holder.wait()` reaping a single-process holder *is* the moment its descriptor closes, so the claim that follows needs no sleep-and-hope between the kill and the assertion.

## The witness

- [x] This PR includes a witness test (fails before, passes after)

No new test — the witness is #2844's own, which this makes able to fail for the right reason. Run on real Linux in `ubuntu:24.04`, since the suite skips on darwin (`needs_flock`):

| Tree | Result |
|---|---|
| with this fix | **6 passed** |
| pre-fix (`git show origin/main:…`) | **1 failed, 5 passed** — reproducing the CI assertion verbatim |

Both directions were run in the same container, in one invocation, against the same interpreter and util-linux build.

## The gate

`ruff check` clean on the changed file. `ruff format --check` reports one reformat in `_claim`, which is **pre-existing on `main`** and untouched here — the same diff is produced against `origin/main`'s copy of the file, so it is not introduced by this PR and is deliberately left rather than folded in as unrelated churn.

## Ground-rule check

- [x] No new dependencies (`--no-fork` has been in util-linux since 2.24)
- [x] Test-only change; no production behaviour altered — `infra/runner/entrypoint.sh` is untouched, and the wiring assertions that read it still pass

## Anything reviewers should know?

Two alternatives were considered and rejected:

- **Kill the process group** (`start_new_session=True` + `os.killpg`). It would also work, but the kill is asynchronous with respect to the descriptor actually closing, so it reintroduces exactly the sleep-and-hope race that `wait()` on a single-process holder eliminates.
- **Wait/retry around the claim.** That would make the test pass while leaving its stated premise false — the reclaim would be observed *after* the orphan's sleep expired, which is not the behaviour #2844 exists to prove.

Refs #2844

## Summary by Sourcery

Ensure netns lock reclaim tests use a single-process flock holder whose death reliably releases the lock.

Tests:
- Add a shared helper for starting a one-process lock holder using `flock --no-fork` and reuse it across netns lock tests.
- Make the dead-holder reclaim test actually kill the true lock holder and remove the timing race between killing and claiming.
- Stop the live-holder refusal test from leaking an orphaned sleeper process and ensure it validates the correct lock-holding behaviour.