### PR TITLE
fix(arenabench): kill the netns lock holder's child, not just the holder — main is red

### DIFF
--- a/arenabench/tests/test_runner_netns.py
+++ b/arenabench/tests/test_runner_netns.py
@@ -20,7 +20,9 @@ namespace to manipulate and is covered by the smoke job.
 
 from __future__ import annotations
 
+import os
 import re
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -57,15 +59,42 @@ def test_a_free_instance_is_claimed(tmp_path: Path) -> None:
 
 
 @needs_flock
+
+def _spawn_holder(lock: Path) -> subprocess.Popen[bytes]:
+    """A process that really holds ``lock``, and can really be killed.
+
+    ``flock <file> <cmd>`` opens the file, takes the lock, and runs ``cmd`` as a
+    **child** that inherits the open descriptor. So killing the `flock` pid
+    alone leaves that child alive still holding the descriptor — and therefore
+    still holding the lock. A test that did so would observe REFUSED after the
+    "holder" had died and read it as the guard being wrong, when what actually
+    survived was the test's own orphan. It also strands a `sleep` for the CI
+    runner to reap, which is the visible symptom.
+
+    So the holder gets its own session and is killed by process group.
+    """
+    return subprocess.Popen(
+        ["flock", str(lock), "sleep", "30"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _kill_holder(holder: "subprocess.Popen[bytes]") -> None:
+    """Kill the holder *and* the child holding the descriptor."""
+    try:
+        os.killpg(os.getpgid(holder.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    holder.wait(timeout=10)
+
+
 def test_a_lock_held_by_a_live_process_is_refused(tmp_path: Path) -> None:
     lock = tmp_path / ".instance-netns.lock"
     lock.touch()
     # A neighbour that is genuinely still running: holds the lock and sleeps.
-    holder = subprocess.Popen(
-        ["flock", str(lock), "sleep", "30"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    holder = _spawn_holder(lock)
     try:
         # `flock` needs a moment to actually acquire before we race it.
         subprocess.run(["sleep", "0.5"], check=True)
@@ -73,8 +102,7 @@ def test_a_lock_held_by_a_live_process_is_refused(tmp_path: Path) -> None:
         assert result.returncode != 0, "a live neighbour must be refused"
         assert "REFUSED" in result.stdout
     finally:
-        holder.kill()
-        holder.wait(timeout=10)
+        _kill_holder(holder)
 
 
 @needs_flock
@@ -86,14 +114,9 @@ def test_a_lock_whose_holder_died_is_reclaimed(tmp_path: Path) -> None:
     kernel dropped the lock when the holder died, so the instance is free.
     """
     lock = tmp_path / ".instance-netns.lock"
-    holder = subprocess.Popen(
-        ["flock", str(lock), "sleep", "30"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    holder = _spawn_holder(lock)
     subprocess.run(["sleep", "0.5"], check=True)
-    holder.kill()
-    holder.wait(timeout=10)
+    _kill_holder(holder)
 
     assert lock.exists(), "the file outlives the holder; only the lock is dropped"
     assert "CLAIMED" in _claim(tmp_path).stdout


### PR DESCRIPTION
## What & why

**`main` is red right now, and this is the one-file fix.** Split out of #2814 deliberately: `bench.yml` is a required check, so every open PR inherits this failure through its merge ref, and holding the fix inside a large draft PR keeps everyone blocked on it.

`test_a_lock_whose_holder_died_is_reclaimed` (added by #2844) fails **100% of the time**, and the test is wrong rather than the guard it covers.

`flock <file> <cmd>` opens the file, takes the lock, then forks and execs `cmd` as a **child that inherits the open descriptor**. flock(2) locks live on the *open file description*, so the lock survives the parent's death. The test spawned `flock <lock> sleep 30` and called `Popen.kill()`, which signals only the `flock` pid — `sleep` survived still holding the fd, the claim script correctly answered `REFUSED`, and the test read that as the guard failing to reclaim a dead holder's namespace. The instrument was broken, not the thing it measures.

**The runner had been saying so and nothing read it.** Every failing job ends with `Terminate orphan process: pid (…) (sleep)` — *twice*. One leak from this test, and one from its sibling `test_a_lock_held_by_a_live_process_is_refused`, whose `finally` has the same shape and leaks silently because a still-held lock is exactly what that test wants to observe. So the sibling was passing for the wrong reason and littering the runner while doing it.

Both now spawn through `_spawn_holder` with `start_new_session=True` and die through `_kill_holder`, which signals the process group. The reason is written at the helper, because the next person here will reach for `Popen.kill()` with exactly the same intuition and it is exactly wrong.

Closes #2846

## Evidence

**It is not a flake and not load-dependent** — that mattered, because "intermittent CI" was the tempting read and it would have been wrong:

- Reproduced deterministically on this machine: `assert 'CLAIMED' in 'REFUSED\n'` before the change; all six tests in the file pass after it.
- Independently reproduced 10/10 on util-linux 2.39.3, with the orphan confirmed holding the descriptor: `child_survived_kill=yes result=REFUSED`, and `/proc/<pid>/fd/3 -> …/.lock`.

**`main` is genuinely red, not just this branch:**

| Run | Ref | Result |
|---|---|---|
| `31466701528` | `main` @ `8355216` | success (predates the file) |
| `31466875713` | `main` @ `25e7431` (push) | **failure** — `FAILED tests/test_runner_netns.py::test_a_lock_whose_holder_died_is_reclaimed` |

Every earlier bench run on `main` (2691, 2690, 2688 … 2611) is green. The red starts exactly at `25e7431`.

## The witness

- [x] Witness test (fails before, passes after)

The test added by #2844 **is** the witness — it fails on `main` today and passes here. No new test is needed; what changed is that it now measures the guard instead of measuring its own orphan. The sibling gains no new assertion but stops leaking, which is what removes the `Terminate orphan process` lines.

## The gate

- [x] `pytest tests/test_runner_netns.py` — 6 passed, run against this branch's tip (i.e. on top of `main`, not on #2814's tree)
- No Rust touched, so `cargo` steps are unaffected; this is a single Python test file.

## Nothing left behind

- [x] There is nothing: the whole defect is fixed here.

One thing deliberately **not** changed: the production guard in `arenabench/infra/runner/entrypoint.sh`. #2844's logic is correct — the kernel does drop the lock when the holder dies — and the failing assertion was never evidence against it. Changing production code to satisfy a broken test is the inversion this repo's witness contract exists to prevent.

## Anything reviewers should know?

This was first misdiagnosed, twice, and the corrections are worth recording because both were the *comfortable* answer:

1. "Intermittent, CI runners are loaded" — wrong; it is deterministic.
2. "The file isn't in the tree, so it must come from a fetched dependency" — wrong; `25e7431` was `main`'s tip and reached the other branch through a `main` merge, while a `pull_request` checkout tests `refs/pull/N/merge`, which contained a file present in neither the PR head nor its branch. That is why tree searches came up empty.

Neither was settled by reasoning about it. Both were settled by running it and by reading the `push`-event run on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3KQx89MZY8MzYt3Rurhpz)_

## Summary by Sourcery

Fix netns lock-holder tests to correctly kill the actual lock-holding process group instead of only the parent, ensuring they accurately exercise the lock reclaim/refusal behavior without leaking orphan processes.

Enhancements:
- Introduce helper functions to spawn and reliably terminate flock-based lock holders using a dedicated session and process group, and reuse them across netns runner tests to avoid duplication and test flakiness.

Tests:
- Update netns runner lock-holder tests to use the new helpers so they correctly validate reclaiming a dead holder and refusing a live holder while no longer leaving orphan sleep processes in CI.