### PR TITLE
test(arenabench): pin that a completed sweep never stops a running seat

### DIFF
--- a/arenabench/tests/test_reauth.py
+++ b/arenabench/tests/test_reauth.py
@@ -169,6 +169,20 @@ def test_a_completed_sweep_reports_complete_even_with_voids_on_the_record():
     assert step.state is SeatState.COMPLETE
 
 
+def test_a_completed_sweep_never_stops_a_seat_that_is_still_running():
+    """Deciding a Harbor job is finished is Harbor's job, not this module's.
+
+    Every other terminal state stops the seat; this one must not. The two
+    disagree in ways that cost measurements — with `--n-attempts > 1` every
+    task is measured long before the sweep is over, and a job launched without
+    an explicit task list has a task set this snapshot cannot see at all. There
+    is nothing to gain either way: a job whose work is done exits on its own.
+    """
+    step = decide(snap(trials=tuple(done(t) for t in TASKS), seat_running=True))
+    assert step.state is SeatState.COMPLETE
+    assert not step.stop_seat
+
+
 def test_completion_wins_over_an_exhausted_budget():
     """Finishing on the last permitted round is COMPLETE, not EXHAUSTED."""
     step = decide(


### PR DESCRIPTION
## What & why

A one-test follow-up to #2814, which merged while I was mid-commit.

#2814 changed `reauth.decide` so the `COMPLETE` arm no longer stops a running seat, and landed the reasoning as a comment in `reauth.py` — but **the witness for it did not make the merge**. The behaviour is shipped and nothing asserts it, so the next edit to that arm reintroduces the defect silently. That is the "a witness that no longer exists cannot fail" shape, arriving by a race rather than by a rewrite.

The rule is narrow and worth pinning: every *other* terminal state stops the seat, and this one must not. Deciding a Harbor job is finished is Harbor's job, not this module's, and the two disagree in ways that cost measurements — with `--n-attempts > 1` every task is measured long before the sweep is over, and a job launched without an explicit task list has a task set the snapshot cannot see at all. Killing a healthy seat on either reading destroys exactly the trials the module exists to save, and there is nothing to gain either way, because a job whose work is done exits on its own.

Refs #2545, #2814

## The witness

- [x] Witness test (fails on the old behaviour, passes on the shipped one)

Confirmed by reverting the shipped fix rather than by assertion — re-adding `stop_seat=snap.seat_running` to the `COMPLETE` arm:

```
AssertionError: assert not True
  where True = Step(state=<SeatState.COMPLETE: 'complete'>, dispatch=(),
                    stop_seat=True, reason='all 3 tasks measured').stop_seat
FAILED tests/test_reauth.py::test_a_completed_sweep_never_stops_a_seat_that_is_still_running
```

Restored → 23 tests in `tests/test_reauth.py`, all green.

Note the direction this witness runs in: the code it pins is **already on `main`**, so this fails against a hypothetical regression rather than against today's tree. That is what a regression pin is, and it is worth saying explicitly rather than letting the checkbox imply it failed on `main` as-is.

## The gate

- [x] `pytest tests/test_reauth.py` — 23 passed
- Test-only change; one file, one function added. No production code touched, so the Rust gate steps are unaffected.

## Nothing left behind

- [x] There is nothing: this *is* the leftover, and it is now filed as code rather than as a note.

For context, #2814's own residue was filed as #2839, #2840, #2841, #2850, #2851, #2852, #2853, #2855, #2856, #2857, #2858, plus #2820, #2822, #2823, #2824 and #2828 — all still open and unaffected by this.

## Anything reviewers should know?

**Why this is a new PR and not a push to the old one:** #2814 is merged, so its branch cannot carry follow-up work. I restarted the branch from `origin/main` rather than pushing my local tip, which mattered: my local copy still held a **revert of the netns fix**, made deliberately when #2846 superseded my inferior version. `main` now has #2846's `flock --no-fork` fix, so pushing my tip would have reverted it. Restarting from `main` drops that cleanly, and I verified `main` carries `--no-fork` before doing so.

The only other delta between my local tip and `main` was this test, which is how the gap was found — by diffing the two rather than assuming the merge took everything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3KQx89MZY8MzYt3Rurhpz)_

## Summary by Sourcery

Tests:
- Add a test ensuring SeatState.COMPLETE leaves a running seat untouched, preventing future regressions in reauth decision logic.