### PR TITLE
release.minor: cut the 0.9.0 line — stamp 0.9.0 and write its releases-page section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,121 @@ are not user-facing and do not appear here.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-11
+
+Everything since 0.8.0 — the whole 0.8 line. Verification stopped buying model
+calls and started ending the turn the moment a proof lands; a turn now survives
+the provider failing underneath it instead of dying with it; and the tool
+surface grew a scratch state plane, environment probes, and an interactive
+approval/skill/hook layer a host process can drive.
+
+### Added
+
+- **Verification halts on proof.** Stop-on-proof kills in-flight tools the
+  moment the oracle flips, `verify_done` fires the halt rather than merely
+  being tallied, and task mode has to earn its declaration (#2662). A confirmed
+  `verify_done` now carries a deterministic pass (#2652).
+- **A turn survives its provider.** Mid-turn model fallback re-resolves through
+  the router when retries are exhausted, repairs the transcript, and continues
+  the turn (#2769) — wired into the pipeline in #2826. Alongside it: a
+  streaming→non-streaming fallback for hung or empty streams with a first-byte
+  deadline (#2686, #2748), reactive recovery from provider context-overflow
+  errors (#2680, #2752), a retry ladder that parks under sustained rate
+  limiting instead of aborting (#2677, #2744), and circuit-breaker feedback
+  wired so provider failover actually trips (#2673, #2734).
+- **A session scratch state plane** — `save_state` / `get_state` /
+  `list_state` / `delete_state`, the reference shape for the single-purpose
+  tool rule (#2696, #2714).
+- **Tools that answer what the environment is**: `get_environment` shares the
+  system prompt's own env probes (#2758), `probe_capability` does safe PATH
+  lookups (#2760), and `clear_output` is split out of `read_output` (#2717).
+  `repo_status` and `project_overview` were made worth calling (#2551), with
+  the three git readers turned into an explicit ladder (#2576).
+- **The interactive surface a host can drive** — approval flow, `invoke_skill`,
+  hook expansion, MCP auth and resources, working-set restore, and prompt
+  contracts (#2787), on top of four shared prompt contracts and a byte-stable
+  session-environment block (#2719).
+- **A signal-consumer ledger**: every `AgentEvent` variant declares what reads
+  it (#2720), generated from the tag table so totality is a compile error
+  rather than a red test (#2737). Diagnostics gained a generated code registry
+  with 43 codes documented and gated (#2693).
+- **Ingest grew a lifecycle.** Provenance lineages, staleness alerts, and
+  per-file dismissal (#2683, #2711); `--refresh` bitemporal retire-and-add with
+  supersession at keep and an accountable ledger (#2708, #2728, #2731); and
+  auto-promotion tiers for ingested records — pinned / scoped / retrieved
+  (#2709, #2762).
+- **Roles are configurable, so a stage can be ablated.** Research and plan are
+  independently configurable roles (#2553), and responsibility→agent binding is
+  configurable end to end (#2381, #2462).
+- **`/export` produces a replayable session transcript** in the row grammar the
+  page uses (#2606), scoped to one session rather than the whole workspace
+  store (#2573).
+- **The deck says more with less.** A `PROOF` panel that states its answer
+  replaces `DONE VERIFICATION` (#2568), a context recall renders as a table
+  instead of a paragraph (#2566), and the clock that will stop the run sits
+  beside the money (#2488). The plain surface renders markdown, stages,
+  reasoning, and git diffs (#2421, #2449).
+- **ArenaBench runs locally and records who served the call.** `arena-local`
+  launches a match with credentials resolved and a fresh SUT (#2655), the
+  opponent's harness is measured live and its product recorded (#2522), and the
+  gateway's upstream is pinned and carried through trial isolation (#2786,
+  #2788).
+- **A wall-clock journal axis and pipeline rung** (#2437), and tool-foundry
+  proposals ranked and gated on reuse ratio (#2441).
+
+### Changed
+
+- **Verification is model-free.** The model verdict and the distress-guidance
+  call are gone structurally, not by default — the roster rejects both keys, so
+  no configuration restores them (#2588, #2615, #2584). The one remaining
+  verifier-tier call authors the witness, because it creates the oracle rather
+  than substituting for one (#2637).
+- **Context-size accounting is anchored to provider-reported usage** rather
+  than estimated locally (#2739).
+- **Reflection asks the counterfactual**, not a proxy for it (#2465), and
+  selects its digest instead of truncating the tail — reading tool results for
+  the first time (#2460, #2494).
+- **MCP wire names are injective**, and colliding routes are dropped rather
+  than silently shadowed (#2675, #2729).
+- **The step loop is written once** — extracted as `Engine::drive` (#2452,
+  #2489).
+- **No benchmark trial carries a spend or token ceiling, for any agent**
+  (#2461), and a declared per-trial ceiling no longer blocks a launch (#2611).
+- **Every web surface stella renders is on one instrument palette** (#2597,
+  #2454, #2650).
+- **The tool-first, single-purpose rule is invariant #9**, written down instead
+  of enforced by habit (#2710).
+
+### Fixed
+
+- **A triage outage no longer routes the turn below `SingleTask`** — an
+  unavailable triage call downgraded the work it could not read (#2830).
+- **The witness stopped failing on the pipeline's own commits** (#2537), and
+  the evidence-routing chain that failed a correct git recovery was broken open
+  (#2531).
+- **A candidate worktree no longer moves the graded tree's refs** (#2643), and
+  an ambient `GIT_DIR` no longer retargets `project_overview` (#2561).
+  Read-only roles got a truthful route to git state (#2538).
+- **One roster answers who authors the witness, and a resume gets it back**
+  (#2458, #2467, #2493); a stage call the remaining task clock cannot fit is
+  declined (#2480), and the repair gate reads the clock that can actually stop
+  the run (#2470).
+- **Transcripts decode tool results and name the tool, on every surface**
+  (#2528).
+- **The observatory's ratings feed no longer lists turns the model never
+  graded** (#2443, #2501).
+- **A correct long-running service survives the agent's own exit** (#2766).
+- **Two open Dependabot alerts closed** (js-yaml, h2) (#2548).
+
+### Removed
+
+- **`STELLA_CONFIG_DIR`**, which named no resolver and quietly declined the
+  legacy-layout migration for processes sitting on the defaults (#2442, #2500).
+- **`Engine::run_session_start_hooks`** — `SessionStart` has one owner, the
+  host (#2674, #2727).
+- **The `require_independent_verifier` residue** (#2639) and the two inert
+  settings knobs left behind by the verdict removal (#2631).
+
 ## [0.8.0] — 2026-08-08
 
 Everything since 0.7.0 — the verification and scheduling gates got sharper,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-cli"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3139,11 +3139,11 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.8.44"
+version = "0.9.0"
 
 [[package]]
 name = "stella-engine"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "contextgraph-types",
  "notify",
@@ -3202,11 +3202,11 @@ dependencies = [
 
 [[package]]
 name = "stella-home"
-version = "0.8.44"
+version = "0.9.0"
 
 [[package]]
 name = "stella-mcp"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "libc",
  "rusqlite",
@@ -3293,14 +3293,14 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "stella-serve",
 ]
 
 [[package]]
 name = "stella-pipeline"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "schemars",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "base64 0.23.1",
  "libc",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui"
-version = "0.8.44"
+version = "0.9.0"
 dependencies = [
  "arboard",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.44"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.90"
 license = "AGPL-3.0-only"

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.8.44"
-  version "0.8.44"
+  url "https://github.com/macanderson/stella.git", tag: "v0.9.0"
+  version "0.9.0"
   license "AGPL-3.0-only"
   head "https://github.com/macanderson/stella.git", branch: "main"
   depends_on "rust" => :build

--- a/website/src/lib/changelog.0-9-0.test.ts
+++ b/website/src/lib/changelog.0-9-0.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { parseChangelog } from "./changelog.ts";
+
+/**
+ * Pins that /releases renders a real 0.9.0 card from the repo's own
+ * CHANGELOG.md, and that it is the card the page leads with.
+ *
+ * The sibling `changelog.0-8-0.test.ts` proves the same thing for the section
+ * that shipped before it; this file carries one assertion that one cannot,
+ * because it is about the file's ORDER rather than a section's contents.
+ * `/releases` takes `releases[0]` as the current line (see
+ * `src/app/releases/page.tsx`), so a section appended to the bottom of
+ * CHANGELOG.md — the natural mistake when writing a release section by hand
+ * rather than letting `scripts/changelog-roll.sh` insert it under
+ * `[Unreleased]` — parses perfectly and still renders the page as though the
+ * previous line were current.
+ *
+ *   pnpm test          (from website/)
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+function realReleases() {
+  const md = readFileSync(join(REPO_ROOT, "CHANGELOG.md"), "utf8");
+  return parseChangelog(md);
+}
+
+test("CHANGELOG.md's [0.9.0] section parses into a non-empty release", () => {
+  const releases = realReleases();
+  const release = releases.find((r) => r.version === "0.9.0");
+
+  assert.ok(release, "no [0.9.0] release found by the parser — heading shape or /releases will be missing it");
+  assert.ok(
+    release.entries.length > 0,
+    "[0.9.0] parsed but has zero entries — it would render as an empty card, which the roll script refuses to emit",
+  );
+  assert.ok(
+    release.summary.trim().length > 0,
+    "[0.9.0] has no lead paragraph",
+  );
+
+  for (const entry of release.entries) {
+    assert.ok(
+      ["Added", "Changed", "Fixed", "Removed", "Security"].includes(entry.kind),
+      `entry has an unexpected kind: ${entry.kind}`,
+    );
+  }
+});
+
+test("[0.9.0] is the newest section, so /releases leads with it", () => {
+  const releases = realReleases();
+
+  assert.equal(
+    releases[0]?.version,
+    "0.9.0",
+    "the newest section is not [0.9.0] — /releases takes releases[0] as the current line",
+  );
+});


### PR DESCRIPTION
## What

Cuts the 0.9.0 minor line.

- **`release.minor:` in the title is load-bearing.** `auto-tag.yml` computes the
  next version from the newest tag (`v0.8.44`), *not* from `Cargo.toml`, and
  reads the bump marker from the subjects of every commit since that tag. A
  squash merge makes this PR title the commit subject, so this is what makes the
  next release `v0.9.0` — after which the ordinary per-merge patch bumps run
  `0.9.1`, `0.9.2`, … off the corrected minor.
- **`scripts/sync-versions.sh` stamped 0.9.0** — `[workspace.package].version`,
  the workspace-member entries in `Cargo.lock`, and the build-from-source
  Homebrew formula. Running the canonical script rather than hand-editing four
  places keeps this byte-identical in effect to the release commit `auto-tag`
  will cut.
- **`CHANGELOG.md` gains the `[0.9.0]` section**, covering the whole 0.8 line
  (123 non-release commits, `v0.8.0..HEAD`). This is the "release PR that
  deliberately writes its own section" exception in `CHANGELOG.md`'s contributor
  note: `changelog-roll.sh` is idempotent and leaves a version that already has
  a section alone, so the roll at release time will neither duplicate nor
  overwrite it.
- **That section *is* the website release page.** `/releases` is a statically
  rendered server component over `getReleases()`, which parses `CHANGELOG.md` at
  build time — there is no second copy under `website/` to keep in sync, which
  is exactly the drift the hand-maintained MDX page it replaced suffered.

## Witness

`website/src/lib/changelog.0-9-0.test.ts`, following the
`changelog.0-8-0.test.ts` pattern, plus one assertion that file cannot carry:
that `[0.9.0]` is `releases[0]`. `/releases` takes the first parsed section as
the current line, so a hand-written section appended at the bottom of
`CHANGELOG.md` parses cleanly and still renders the *previous* line as current.

- Fails on `main`: `git show HEAD:CHANGELOG.md` contains no `## [0.9.0]`
  heading, and the parser is the test's only input.
- Passes here: `npm test` from `website/` — 18 passing, 0 failing.

`make guards-fast` green (27 gate steps + `cargo fmt --check`). No Rust source
changed.

## Deleted tests

None.

## Summary by Sourcery

Stamp the 0.9.0 release and ensure it is treated as the current line across changelog and website.

New Features:
- Add a detailed [0.9.0] section to CHANGELOG.md covering all changes since 0.8.0 and structured for the releases page.

Enhancements:
- Update workspace and Homebrew packaging metadata to version 0.9.0 so builds and tags align with the new minor line.
- Add a website test that parses CHANGELOG.md to verify the 0.9.0 section is non-empty and that the releases page leads with 0.9.0.