### PR TITLE
fix(stella-pipeline): a post-completion check may downgrade a claim, never discard a deliverable

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -782,13 +782,25 @@ impl GitCandidateWorkspace {
             .clone()
             .ok_or_else(|| fail("candidate has no verified seal".to_string()))?;
         let head = git(&self.dir, &["rev-parse", "HEAD"]).await.map_err(fail)?;
+        // `-z` and `--no-renames` so [`adopt::drifted_paths`] gets a total
+        // record shape: unquoted paths, one path per record. The scratch
+        // subtraction it applies is argued there — in short, a mutation
+        // adoption already excludes by pathspec cannot make the sealed tree
+        // disagree with the tree that was verified, and the oracle runs in
+        // this worktree immediately before this check.
         let status = git(
             &self.dir,
-            &["status", "--porcelain", "--untracked-files=all"],
+            &[
+                "status",
+                "--porcelain",
+                "--no-renames",
+                "-z",
+                "--untracked-files=all",
+            ],
         )
         .await
         .map_err(fail)?;
-        Ok(head.trim() == sealed && status.is_empty())
+        Ok(head.trim() == sealed && adopt::drifted_paths(&status).is_empty())
     }
 
     /// The teardown half of the ref repair (#2641): audit and restore the

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -21,31 +21,10 @@ use std::sync::atomic::Ordering;
 
 use stella_fleet::git::{GitCli, SystemGitCli};
 use stella_pipeline::ports::{AdoptedChange, WorkspaceError};
+use stella_pipeline::scratch::{TOOL_SCRATCH_DIRS, is_tool_scratch};
 use stella_protocol::FileChangeKind;
 
 use super::{GitCandidateWorkspace, SHADOW_SEQ, git, git_stdout_to_file};
-
-/// Tool scratch directories that `adopt` never carries into the user's tree.
-///
-/// Deliberately short, and deliberately NOT build outputs (`target`, `dist`,
-/// `build`) — producing one of those is frequently the whole job, and the same
-/// reasoning keeps them out of `stella_tools::shell_touch::SKIP_DIRS`. What is
-/// listed here is scratch written by *running* code, which no task asks for.
-///
-/// The seal is a blanket `git add -A`, so anything a candidate's test run left
-/// behind is committed into `sealed`. That is right for the seal — it is a
-/// forensic record of the candidate — and wrong for adoption, which is the
-/// user's tree. It also closes a gap the withhold list cannot: withholding an
-/// authored witness does not withhold the `__pycache__/<witness>.cpython-*.pyc`
-/// that running it produced, so a run could ship the shadow of a file it had
-/// deliberately kept back.
-const ADOPT_CACHE_EXCLUDES: &[&str] = &[
-    "__pycache__",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".tox",
-];
 
 impl GitCandidateWorkspace {
     /// Winner-only adoption: diff the immutable baseline→verified seal and
@@ -94,8 +73,12 @@ impl GitCandidateWorkspace {
         // vec as the withheld paths, so they reach the name-status listing and
         // the applied patch identically — the invariant above is what keeps the
         // event stream from claiming a file the user's tree does not have.
+        //
+        // The list itself lives in `stella_pipeline::scratch` (#2876) because
+        // two other checks have to answer the same question and answered it
+        // wrong while it lived here — see that module's docs.
         exclusions.extend(
-            ADOPT_CACHE_EXCLUDES
+            TOOL_SCRATCH_DIRS
                 .iter()
                 .map(|dir| format!(":(exclude,glob)**/{dir}/**")),
         );
@@ -270,6 +253,45 @@ impl GitCandidateWorkspace {
 /// the same three probes proactively.
 pub(super) fn blob_id(probe: Result<String, String>) -> Option<String> {
     probe.ok().map(|id| id.trim().to_string())
+}
+
+/// The paths a post-seal `git status --porcelain --no-renames -z
+/// --untracked-files=all` reports as having moved since the seal, minus tool
+/// scratch.
+///
+/// # Why scratch is subtracted here too
+///
+/// The seal check runs immediately after the flip oracle executed the test
+/// command in this very worktree, so a *test run's own leavings* are the
+/// expected content of that delta, not a signal about it. `sqlite-with-gcov`
+/// and `build-cython-ext` were both discarded whole — one of them carrying a
+/// 194,561-line built SQLite, the other a change a grader scored 9 of 11 —
+/// because the check read "not byte-identical" as "not trustworthy".
+///
+/// The subtraction is sound for exactly the paths [`is_tool_scratch`] names,
+/// and for a reason stronger than "they look like scratch": the adopted patch
+/// is `git diff baseline sealed`, computed from two immutable commit objects
+/// and *already* excluding these paths by pathspec. A mutation confined to
+/// them therefore cannot change one byte of what adoption delivers, so it
+/// cannot make the sealed tree disagree with the tree that was verified. A
+/// build artifact outside the list (a `.gcda`, an object file) still trips the
+/// check — that residue is #2877, and it needs a decision about what adoption
+/// carries, not a longer list here.
+///
+/// Records are `XY <space> path\0`. `--no-renames` is what makes that shape
+/// total: a rename record would carry two NUL-separated paths and shift every
+/// field after it.
+pub(crate) fn drifted_paths(status_z: &str) -> Vec<String> {
+    status_z
+        .split('\0')
+        .filter(|record| !record.is_empty())
+        // `XY ` — two status columns and a space. A record too short to hold
+        // them is not one git wrote, and is kept as drift rather than
+        // discarded: an unparseable status must fail the check, never pass it.
+        .map(|record| record.get(3..).unwrap_or(record))
+        .filter(|path| !is_tool_scratch(path))
+        .map(str::to_string)
+        .collect()
 }
 
 /// Parse `git diff --name-status --no-renames -z` output — `S\0path\0`
@@ -832,6 +854,47 @@ deleted file mode 100644
             reason.contains("only the first conflicting paths were examined"),
             "a bounded examination must say it was bounded: {reason}"
         );
+    }
+
+    /// The `build-cython-ext` shape (#2876), at the other check that read it
+    /// as tampering: the oracle ran in this worktree moments ago, and what it
+    /// left is its own byte-compilation. Adoption excludes those paths by
+    /// pathspec, so nothing they do can change one byte of the delivered
+    /// patch — which is exactly why they cannot invalidate the seal.
+    #[test]
+    fn the_oracles_own_leavings_are_not_post_seal_drift() {
+        assert!(
+            drifted_paths(
+                "?? __pycache__/test_numpy_compatibility.cpython-313-pytest-9.1.1.pyc\0\
+                 ?? pkg/__pycache__/mod.cpython-312.pyc\0\
+                 ?? .pytest_cache/v/cache/lastfailed\0"
+            )
+            .is_empty()
+        );
+    }
+
+    /// The check still has to fire on a real one. A source file rewritten
+    /// after verification is drift, and so — deliberately — is a build
+    /// artifact outside the scratch list: whether adoption should carry a
+    /// `.gcda` is a decision this parser must not make silently (#2877).
+    #[test]
+    fn a_real_mutation_after_the_seal_is_still_drift() {
+        assert_eq!(
+            drifted_paths(" M src/lib.rs\0?? notes.txt\0?? __pycache__/x.pyc\0"),
+            vec!["src/lib.rs".to_string(), "notes.txt".to_string()]
+        );
+        assert_eq!(
+            drifted_paths("?? build/sqlite3-shell.gcda\0"),
+            vec!["build/sqlite3-shell.gcda".to_string()]
+        );
+    }
+
+    /// An unparseable record must fail the check, never pass it: a status
+    /// line this cannot read is one whose path it cannot clear.
+    #[test]
+    fn an_unreadable_status_record_counts_as_drift() {
+        assert_eq!(drifted_paths("??\0"), vec!["??".to_string()]);
+        assert!(drifted_paths("").is_empty(), "a clean tree is clean");
     }
 
     #[test]

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -691,6 +691,59 @@ async fn post_verification_worktree_drift_is_rejected_and_never_adopted() {
     std::fs::remove_dir_all(&root).ok();
 }
 
+/// The other half of the drift rule (#2876): the flip oracle runs the test
+/// command *in this worktree* between the seal and this check, so its own
+/// byte-compilation is the expected content of that delta, not a signal about
+/// it. `sqlite-with-gcov` and `build-cython-ext` were both discarded whole for
+/// exactly this — one of them carrying a 194,561-line built SQLite.
+///
+/// Adoption already excludes these paths by pathspec, so the assertion is
+/// two-sided: the work lands, and the scratch does not ride in with it.
+#[tokio::test]
+async fn scratch_the_verification_run_wrote_does_not_discard_the_work() {
+    let root = scaffold("sealed-scratch");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+    std::fs::write(ws.dir().join("verified.txt"), "verified bytes\n").unwrap();
+
+    ws.seal()
+        .await
+        .expect("candidate state seals before verification");
+    // What running the witness test leaves behind, at two depths.
+    std::fs::create_dir_all(ws.dir().join("__pycache__")).unwrap();
+    std::fs::write(
+        ws.dir().join("__pycache__/test_witness.cpython-313.pyc"),
+        "compiled\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(ws.dir().join("pkg/__pycache__")).unwrap();
+    std::fs::write(ws.dir().join("pkg/__pycache__/mod.cpython-313.pyc"), "c\n").unwrap();
+
+    assert!(
+        ws.sealed_is_unchanged().await.unwrap(),
+        "the oracle's own leavings are not a tampering signal"
+    );
+    let adopted = ws.adopt(&[]).await.expect("the work is delivered");
+    assert_eq!(
+        adopted.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+        vec!["verified.txt"],
+        "the work lands and the scratch does not ride in with it"
+    );
+    assert_eq!(read(&root.join("verified.txt")), "verified bytes\n");
+    assert!(!root.join("__pycache__").exists());
+    assert!(!root.join("pkg/__pycache__").exists());
+
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+}
+
 #[tokio::test]
 async fn a_mid_run_user_edit_fails_adoption_atomically_naming_the_path() {
     let root = scaffold("conflict");

--- a/crates/stella-pipeline/src/lib.rs
+++ b/crates/stella-pipeline/src/lib.rs
@@ -106,6 +106,7 @@ pub mod research;
 pub mod reward;
 pub mod roster;
 pub mod scope;
+pub mod scratch;
 pub mod triage;
 pub mod verify;
 pub mod witness;

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2039,17 +2039,17 @@ impl<'a> Pipeline<'a> {
         // Buy the witness now, or not at all. Everything above this line has
         // already happened, so the diff is evidence rather than a prediction —
         // which is the whole reason authoring waits until here.
-        let witness = match self
+        //
+        // Infallible by construction (#2876): every witness-stage failure,
+        // integrity refusals included, degrades to `None` and lets the executed
+        // change finish on the unauthored ladder. Authoring runs afterwards in
+        // a pristine sibling snapshot, so nothing it discovers is evidence
+        // against work that was already done — and this used to return here
+        // with `AbortKind::DeliberateStop`, which cost a candidate its verdict
+        // and its adoption over a `.pyc` the pipeline's own oracle wrote.
+        let witness = self
             .witness_on_demand(frame.goal, authoring, surface, &mut state, spend)
-            .await
-        {
-            Ok(witness) => witness,
-            // A witness-stage budget stop: pipeline policy, so this abort is
-            // deliberate and still owes the stream its one error event.
-            Err(reason) => {
-                return CandidateResult::aborted(state.messages, reason, AbortKind::DeliberateStop);
-            }
-        };
+            .await;
 
         self.verify_candidate(frame, witness.as_ref(), engine, surface, spend, state)
             .await

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -441,23 +441,12 @@ impl<'a> Pipeline<'a> {
             // `authoring: None` — no pristine pre-execution snapshot exists
             // to author in (module docs), the same degradation every
             // shared-tree candidate already takes.
-            let witness = match self
+            // Infallible: `authoring: None` returns `None` immediately, and
+            // since #2876 no witness-stage outcome can end a candidate that
+            // has already executed.
+            let witness = self
                 .witness_on_demand(goal, None, surface, &mut state, &mut spend)
-                .await
-            {
-                Ok(witness) => witness,
-                Err(reason) => {
-                    let best =
-                        CandidateResult::aborted(state.messages, reason, AbortKind::DeliberateStop);
-                    return Ok(self.settle_outcome(
-                        best,
-                        task_class,
-                        total_cost,
-                        Some(worker_label),
-                        1,
-                    ));
-                }
-            };
+                .await;
             self.verify_candidate(frame, witness.as_ref(), &engine, surface, &mut spend, state)
                 .await
         };

--- a/crates/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -535,8 +535,45 @@ fn assert_aborted_because(status: &PipelineStatus, expected: &str) {
     );
 }
 
+/// Assert a witness-integrity refusal cost the run its *claim* and nothing
+/// else (#2876): no witness, no flip, an `Unverified` verdict that names the
+/// refusal on the rail — and the executed work still adopted.
+///
+/// This is the shape the three tests below used to assert the inverse of. A
+/// refusal is a fact about scaffolding authored afterwards in a pristine
+/// sibling snapshot; it is not evidence about the change the worker already
+/// made, and treating it as such threw away a `build-cython-ext` candidate
+/// that a grader independently scored 9 of 11 passing.
+fn assert_refused_but_adopted(
+    status: &PipelineStatus,
+    events: &[AgentEvent],
+    log: &[String],
+    expected: &str,
+) {
+    assert!(
+        matches!(status, PipelineStatus::Unverified { .. }),
+        "a refused witness leaves the work unproven, never discarded: {status:?}"
+    );
+    let refusal = events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Proof { step: stella_protocol::ProofStep::WitnessUnavailable { reason } }
+                if reason.contains("refused") && reason.contains(expected)
+        )
+    });
+    assert!(
+        refusal,
+        "the rail must state the refusal, not swallow it\n  expected to contain: \
+         {expected}\n  events: {events:?}"
+    );
+    assert!(
+        log.iter().any(|entry| entry.starts_with("adopt:")),
+        "the deliverable survives the refused claim: {log:?}"
+    );
+}
+
 #[tokio::test]
-async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
+async fn tracked_production_edit_by_witness_author_refuses_the_witness_and_still_adopts() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("worker done"),
@@ -558,20 +595,21 @@ async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
         FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
     let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
-    let (outcome, _, _) = run_isolated(
+    let (outcome, events, _) = run_isolated(
         &provider,
         &port,
         PipelineConfig::default(),
         "Fix the failing test",
     )
     .await;
-    let outcome = outcome.expect("author mutation is an aborted candidate");
-    assert_aborted_because(
+    let outcome = outcome.expect("an author mutation degrades, it does not error");
+    let log = log.lock().unwrap().clone();
+    assert_refused_but_adopted(
         &outcome.status,
+        &events,
+        &log,
         "witness author modified tracked file(s): src/lib.rs",
     );
-    let log = log.lock().unwrap().clone();
-    assert!(!log.iter().any(|entry| entry.starts_with("adopt:")));
     assert!(log.contains(&"remove:0".to_string()));
     assert!(
         log.contains(&"remove:1".to_string()),
@@ -579,12 +617,13 @@ async fn tracked_production_edit_by_witness_author_aborts_without_adoption() {
     );
 }
 
-/// An artifact whose language does not match its runner is rejected — and now
-/// rejected *after* the worker has run, because that is when authoring happens.
-/// The fail-closed decision is unchanged; what it costs changed, and this pins
-/// both halves so the trade is visible rather than assumed.
+/// An artifact whose language does not match its runner is refused — and
+/// refused *after* the worker has run, because that is when authoring happens.
+/// The fail-closed decision is unchanged; since #2876 what it costs is the
+/// witness claim alone, and this pins both halves so the trade is visible
+/// rather than assumed.
 #[tokio::test]
-async fn witness_language_mismatch_aborts_after_worker_execution() {
+async fn witness_language_mismatch_refuses_the_witness_and_still_adopts() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("worker done"),
@@ -602,28 +641,35 @@ async fn witness_language_mismatch_aborts_after_worker_execution() {
     );
     let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
-    let (outcome, _, _) = run_isolated(
+    let (outcome, events, _) = run_isolated(
         &provider,
         &port,
         PipelineConfig::default(),
         "Fix the failing test",
     )
     .await;
-    let outcome = outcome.expect("mismatch is a truthful candidate abort");
-    assert_aborted_because(
+    let outcome = outcome.expect("a mismatch degrades, it does not error");
+    let log = log.lock().unwrap().clone();
+    assert_refused_but_adopted(
         &outcome.status,
+        &events,
+        &log,
         "witness artifact `tests/test_authority.py` does not match test runner `cargo`",
     );
-    // Two snapshots, both torn down, nothing adopted: a rejected witness never
-    // reaches the real tree and never leaks a workspace.
-    assert_eq!(
-        *log.lock().unwrap(),
-        vec!["create", "create", "remove:1", "remove:0"]
+    // Both snapshots torn down: a refused witness never reaches the real tree
+    // — only the worker's own change does — and never leaks a workspace.
+    assert!(
+        log.contains(&"remove:1".to_string()) && log.contains(&"remove:0".to_string()),
+        "{log:?}"
+    );
+    assert!(
+        !log.iter().any(|entry| entry.starts_with("graft:")),
+        "the refused artifact is never grafted into the candidate: {log:?}"
     );
 }
 
 #[tokio::test]
-async fn symlink_witness_artifact_aborts_after_worker_execution() {
+async fn symlink_witness_artifact_refuses_the_witness_and_still_adopts() {
     let provider = ScriptedProvider::new(vec![
         text_result("single"),
         text_result("worker done"),
@@ -648,24 +694,26 @@ async fn symlink_witness_artifact_aborts_after_worker_execution() {
         FakeWorkspace::new(1, vec![false], Ok(vec![]), log.clone()).with_repo_status(status);
     let port = FakeWorkspacePort::new(vec![Ok(candidate), Ok(baseline)], log.clone());
 
-    let (outcome, _, _) = run_isolated(
+    let (outcome, events, _) = run_isolated(
         &provider,
         &port,
         PipelineConfig::default(),
         "Fix the failing test",
     )
     .await;
-    let outcome = outcome.expect("symlink is a truthful candidate abort");
-    // Rejected in the tree that authored it, before any copy — a symlink must
+    let outcome = outcome.expect("a symlink artifact degrades, it does not error");
+    let log = log.lock().unwrap().clone();
+    // Refused in the tree that authored it, before any copy — a symlink must
     // never be resolved by the graft into the candidate.
-    assert_aborted_because(
+    assert_refused_but_adopted(
         &outcome.status,
+        &events,
+        &log,
         "witness artifact `tests/authority_witness.rs` has an unsafe or unstable filesystem identity",
     );
-    let log = log.lock().unwrap().clone();
     assert!(
         !log.iter().any(|entry| entry.starts_with("graft:")),
-        "a symlink artifact is rejected before it can be grafted: {log:?}"
+        "a symlink artifact is refused before it can be grafted: {log:?}"
     );
 }
 

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -171,35 +171,51 @@ impl HookRunner for BoundHookRunner<'_> {
     }
 }
 
-/// Why an authored witness could not be produced or accepted, and whether the
-/// pipeline may degrade past it.
+/// Why an authored witness could not be produced or accepted.
 ///
-/// `degradable` = the witness simply couldn't be AUTHORED (no test command,
-/// an unusable command, a test that proves nothing, the author engine getting
-/// stuck, a budget stop mid-authoring — #1789: the worker's change is already
-/// done, and the budget guard still gates every later paid call, so degrading
-/// preserves the work without overspending). The task needs no witness to
-/// proceed, so the run degrades to a bare worker turn rather than dying. NOT
-/// degradable = an artifact-INTEGRITY violation (the author modified tracked
-/// files, produced a non-single-file / symlink artifact, or a runner/identity
-/// mismatch) — fail-closed decisions that surface the problem rather than
-/// silently completing unverified.
+/// # Both endings keep the work; they differ in what they say about it
+///
+/// [`Self::unauthorable`] = the witness simply couldn't be AUTHORED (no test
+/// command, an unusable command, a test that proves nothing, the author engine
+/// getting stuck, a budget stop mid-authoring — #1789: the worker's change is
+/// already done, and the budget guard still gates every later paid call, so
+/// degrading preserves the work without overspending).
+///
+/// [`Self::rejected`] = an artifact-INTEGRITY violation: the author modified
+/// tracked files, produced a non-single-file / symlink artifact, or a
+/// runner/identity mismatch. It stays fail-closed **for the claim** — no
+/// witness, no flip credit, and the refusal is stated on the rail — and it is
+/// deliberately fail-open **for the deliverable**.
+///
+/// That asymmetry is the correction. A refusal used to abort the candidate
+/// outright, which discarded an executed change on the strength of a fact
+/// about *scaffolding authored afterwards in a different snapshot*. Nothing
+/// the author does can corrupt the candidate's tree: it works in a pristine
+/// sibling that `witness_on_demand` deletes on every path. So the refusal was
+/// destroying work it had no evidence against — and did, on
+/// `build-cython-ext`, where the discarded change scored 9 of 11 on the
+/// grader's own tests. A post-hoc check may downgrade a claim; it must never
+/// discard a deliverable.
 pub(super) struct WitnessAbort {
     pub(super) reason: String,
-    pub(super) degradable: bool,
+    /// True when the artifact was refused on integrity grounds rather than
+    /// merely being unavailable. Selects how the degradation is worded on the
+    /// rail: a refusal is a defect in the run, not a fact about the workspace,
+    /// and a reader must be able to tell the two apart.
+    pub(super) refused: bool,
 }
 
 impl WitnessAbort {
-    pub(super) fn degradable(reason: String) -> Self {
+    pub(super) fn unauthorable(reason: String) -> Self {
         Self {
             reason,
-            degradable: true,
+            refused: false,
         }
     }
     pub(super) fn rejected(reason: String) -> Self {
         Self {
             reason,
-            degradable: false,
+            refused: true,
         }
     }
 }
@@ -240,6 +256,21 @@ impl<'a> Pipeline<'a> {
     pub(super) fn unproven(&self, reason: String) {
         self.warn(format!("continuing without an authored witness: {reason}"));
         self.emit_proof(stella_protocol::ProofStep::WitnessUnavailable { reason });
+    }
+
+    /// Record that a warranted witness was authored and then **refused** on
+    /// integrity grounds — the author touched tracked files, or produced an
+    /// artifact that is not one new test file with a safe filesystem identity.
+    ///
+    /// Routed through [`Self::unproven`] rather than a new event, because the
+    /// consequence is identical (no witness, no flip credit, the run continues
+    /// on the unauthored ladder) and only the account differs. The wording is
+    /// what carries the difference: "unavailable" is a fact about the
+    /// workspace a reader can do nothing about, while a refusal is a defect in
+    /// the run — the author misbehaved, or the validator is over-reading its
+    /// own oracle's leavings, and both are worth chasing.
+    pub(super) fn witness_refused(&self, reason: String) {
+        self.unproven(format!("the authored artifact was refused: {reason}"));
     }
 
     /// Record that verification could not be *performed*: every evidence
@@ -376,7 +407,7 @@ impl<'a> Pipeline<'a> {
         // now, honestly, with zero author spend.
         let available = runner_availability(baseline.tests).await;
         if available.is_empty() {
-            return Err(WitnessAbort::degradable(
+            return Err(WitnessAbort::unauthorable(
                 "no supported test runner is available in this workspace, so an authored \
                  witness could never be observed"
                     .to_string(),
@@ -391,7 +422,7 @@ impl<'a> Pipeline<'a> {
         // wiring a surface without a workspace is exactly such a case, and
         // the one stage designed to degrade must not be the one that panics.
         let Some(baseline_workspace) = baseline.workspace else {
-            return Err(WitnessAbort::degradable(
+            return Err(WitnessAbort::unauthorable(
                 "witness authoring requires a pristine baseline workspace and none was provided"
                     .to_string(),
             ));
@@ -477,25 +508,25 @@ impl<'a> Pipeline<'a> {
                 // deterministically-resolvable endings (a warranted waiver,
                 // an abstention) that need no further model spend at all.
                 if let Some(abort) = budget_abort(spend.budget.evaluate()) {
-                    return Err(WitnessAbort::degradable(format!(
+                    return Err(WitnessAbort::unauthorable(format!(
                         "witness authoring stopped by the budget ({}); the executed change \
                          stands unproven",
                         abort.reason
                     )));
                 }
-                return Err(WitnessAbort::degradable(format!(
+                return Err(WitnessAbort::unauthorable(format!(
                     "witness author turn aborted: {reason}"
                 )));
             }
         };
         let Some(mut command) = parse_witness_command(&text) else {
-            return Err(WitnessAbort::degradable(
+            return Err(WitnessAbort::unauthorable(
                 "witness author produced no TEST_COMMAND line".to_string(),
             ));
         };
 
         let Ok(mut invocation) = parse_test_invocation(&command) else {
-            return Err(WitnessAbort::degradable(format!(
+            return Err(WitnessAbort::unauthorable(format!(
                 "witness author produced an unsafe or unsupported test command `{command}`"
             )));
         };
@@ -504,7 +535,7 @@ impl<'a> Pipeline<'a> {
         // real reason — never by spending a baseline run to discover an
         // unobservable command and blaming generic infra.
         if !available.contains(&invocation.program) {
-            return Err(WitnessAbort::degradable(format!(
+            return Err(WitnessAbort::unauthorable(format!(
                 "witness author chose `{}`, which is not available in this workspace \
                  (available runners: {})",
                 invocation.program,
@@ -519,7 +550,7 @@ impl<'a> Pipeline<'a> {
         // and say why — cheaper and honest.
         let first_baseline = self.run_test_observed(baseline.tests, &invocation).await;
         if let Some(label) = first_baseline.infra_label() {
-            return Err(WitnessAbort::degradable(format!(
+            return Err(WitnessAbort::unauthorable(format!(
                 "witness baseline run was {label}; no assertion was observed, so a failing \
                  baseline cannot be established"
             )));
@@ -546,7 +577,7 @@ impl<'a> Pipeline<'a> {
             let repair_bound =
                 witness_repair_bound(self.remaining_wall_clock(spend.budget, Instant::now()));
             if repair_bound.is_zero() {
-                return Err(WitnessAbort::degradable(
+                return Err(WitnessAbort::unauthorable(
                     "no wall-clock room remains for a witness repair; the executed change \
                      stands unproven"
                         .to_string(),
@@ -590,7 +621,7 @@ impl<'a> Pipeline<'a> {
             // ceiling, not a budget stop.
             let repaired = match tokio::time::timeout(repair_bound, repair_turn).await {
                 Err(_elapsed) => {
-                    return Err(WitnessAbort::degradable(format!(
+                    return Err(WitnessAbort::unauthorable(format!(
                         "witness repair exceeded its wall-clock bound ({repair_bound:?}); \
                          the executed change stands unproven"
                     )));
@@ -606,13 +637,13 @@ impl<'a> Pipeline<'a> {
                     // Degradable for the same #1789 reason as the author
                     // turn's budget arm above.
                     if let Some(abort) = budget_abort(spend.budget.evaluate()) {
-                        return Err(WitnessAbort::degradable(format!(
+                        return Err(WitnessAbort::unauthorable(format!(
                             "witness repair stopped by the budget ({}); the executed change \
                              stands unproven",
                             abort.reason
                         )));
                     }
-                    return Err(WitnessAbort::degradable(format!(
+                    return Err(WitnessAbort::unauthorable(format!(
                         "witness repair turn aborted: {reason}"
                     )));
                 }
@@ -624,13 +655,13 @@ impl<'a> Pipeline<'a> {
             command = match parse_witness_command(&repaired) {
                 Some(repaired_command) => repaired_command,
                 None => {
-                    return Err(WitnessAbort::degradable(
+                    return Err(WitnessAbort::unauthorable(
                         "witness repair produced no TEST_COMMAND line".to_string(),
                     ));
                 }
             };
             let Ok(repaired_invocation) = parse_test_invocation(&command) else {
-                return Err(WitnessAbort::degradable(format!(
+                return Err(WitnessAbort::unauthorable(format!(
                     "witness repair produced an unsafe or unsupported test command `{command}`"
                 )));
             };
@@ -638,7 +669,7 @@ impl<'a> Pipeline<'a> {
             // may change the runner, and an unavailable one is just as
             // unobservable the second time.
             if !available.contains(&repaired_invocation.program) {
-                return Err(WitnessAbort::degradable(format!(
+                return Err(WitnessAbort::unauthorable(format!(
                     "witness repair chose `{}`, which is not available in this workspace \
                      (available runners: {})",
                     repaired_invocation.program,
@@ -648,12 +679,12 @@ impl<'a> Pipeline<'a> {
             invocation = repaired_invocation;
             let repaired_baseline = self.run_test_observed(baseline.tests, &invocation).await;
             if let Some(label) = repaired_baseline.infra_label() {
-                return Err(WitnessAbort::degradable(format!(
+                return Err(WitnessAbort::unauthorable(format!(
                     "witness baseline run after repair was {label}; no assertion was observed"
                 )));
             }
             if repaired_baseline.passed() {
-                return Err(WitnessAbort::degradable(
+                return Err(WitnessAbort::unauthorable(
                     "witness test still passes on the unmodified code after one repair".to_string(),
                 ));
             }
@@ -678,7 +709,7 @@ impl<'a> Pipeline<'a> {
             // PRODUCED must not throw it away. Everything else — tracked
             // mutations, wrong or multiple files — stays fail-closed.
             crate::witness::WitnessArtifactError::NothingCreated => {
-                WitnessAbort::degradable(error.to_string())
+                WitnessAbort::unauthorable(error.to_string())
             }
             _ => WitnessAbort::rejected(error.to_string()),
         })?;
@@ -707,7 +738,7 @@ impl<'a> Pipeline<'a> {
         // Same #1789 posture as the baseline workspace above: an absent
         // candidate workspace loses the witness, never the run.
         let Some(candidate_workspace) = candidate.workspace else {
-            return Err(WitnessAbort::degradable(
+            return Err(WitnessAbort::unauthorable(
                 "witness grafting requires the candidate workspace and none was provided"
                     .to_string(),
             ));
@@ -715,7 +746,7 @@ impl<'a> Pipeline<'a> {
         candidate_workspace
             .graft_witness(baseline_workspace.root(), path)
             .await
-            .map_err(|error| WitnessAbort::degradable(error.to_string()))?;
+            .map_err(|error| WitnessAbort::unauthorable(error.to_string()))?;
 
         // Re-pin against the *grafted* copy. Tamper exclusion runs against the
         // candidate's repo status for the rest of the run, so the baseline it
@@ -751,13 +782,15 @@ impl<'a> Pipeline<'a> {
     /// sometimes a repair turn) to produce a test for a change with nothing to
     /// prove, and only afterwards discovered the warrant.
     ///
-    /// `Err` is reserved for fail-closed integrity rejections. Everything else
-    /// — no isolation port for the baseline, an author that got stuck, an
-    /// artifact that could not be grafted — returns `Ok(None)` and lets the
-    /// candidate finish on the unauthored ladder. That asymmetry is new and
-    /// deliberate: the work is already done by the time this runs, so a witness
-    /// that cannot be *produced* must not throw away a real change, while a
-    /// witness that cannot be *trusted* must still stop the run.
+    /// **There is no failing return.** Every way this can go wrong — no
+    /// isolation port for the baseline, an author that got stuck, an artifact
+    /// that could not be grafted, and (since #2876) an artifact refused on
+    /// integrity grounds — answers `None` and lets the candidate finish on the
+    /// unauthored ladder, so its executed work still reaches a verdict and
+    /// still gets adopted. Nothing observed here is evidence about that work:
+    /// authoring happens afterwards, in a pristine sibling snapshot this
+    /// function deletes on every path. A refusal withholds the *witness*,
+    /// which is exactly what fail-closed should cost.
     pub(super) async fn witness_on_demand(
         &self,
         goal: &str,
@@ -765,17 +798,15 @@ impl<'a> Pipeline<'a> {
         surface: CandidateSurface<'_>,
         state: &mut CandidateState,
         spend: &mut Spend<'_>,
-    ) -> Result<Option<Witness>, String> {
-        let Some(authoring) = authoring else {
-            return Ok(None);
-        };
+    ) -> Option<Witness> {
+        let authoring = authoring?;
         if !warrant(&state.diff_text, state.signals).is_required() {
             // No Witness stage is emitted, because none runs. The reason is
             // not lost: `warranted_completion` reads the same warrant during
             // verification and records the sentence on the verdict, which is
             // the run's half of "a witness test, or a stated reason there
             // isn't one".
-            return Ok(None);
+            return None;
         }
 
         // A second snapshot of the same untouched tree. The candidate's edits
@@ -785,7 +816,7 @@ impl<'a> Pipeline<'a> {
             Ok(baseline) => baseline,
             Err(e) => {
                 self.unproven(format!("no pristine baseline to author against: {e}"));
-                return Ok(None);
+                return None;
             }
         };
         let baseline_surface = CandidateSurface {
@@ -810,12 +841,19 @@ impl<'a> Pipeline<'a> {
 
         let witness = match authored {
             Ok(Some(witness)) => witness,
-            Ok(None) => return Ok(None),
-            Err(abort) if abort.degradable => {
-                self.unproven(abort.reason.clone());
-                return Ok(None);
+            Ok(None) => return None,
+            // Both endings continue on the unauthored ladder: the executed
+            // change is already done and lives in a workspace the authoring
+            // snapshot never touched, so nothing learned here is evidence
+            // against it. What differs is the sentence the rail carries.
+            Err(abort) if abort.refused => {
+                self.witness_refused(abort.reason.clone());
+                return None;
             }
-            Err(abort) => return Err(abort.reason),
+            Err(abort) => {
+                self.unproven(abort.reason.clone());
+                return None;
+            }
         };
 
         // The artifact failed in the baseline — `witness_stage` cannot return
@@ -896,7 +934,7 @@ impl<'a> Pipeline<'a> {
                     .to_string(),
             );
         }
-        Ok(Some(witness))
+        Some(witness)
     }
 }
 

--- a/crates/stella-pipeline/src/scratch.rs
+++ b/crates/stella-pipeline/src/scratch.rs
@@ -1,0 +1,107 @@
+//! Tool scratch — the one list of directories that *running* a test writes
+//! into, and which therefore belong to no author and to no deliverable.
+//!
+//! # Why this is a module and not a constant beside its first caller
+//!
+//! Three places in the run have to answer the same question, and each of them
+//! answered it differently until this module existed:
+//!
+//! - **Adoption** (`stella_cli::candidate_ws::adopt`) must not carry a
+//!   `__pycache__/x.pyc` into the user's tree. It had the list.
+//! - **The witness artifact validator** ([`crate::witness::validate_witness_artifact`])
+//!   must not read the same `.pyc` as "the author created a second file". It
+//!   had no list, so a run whose *own baseline oracle* compiled the authored
+//!   Python test was rejected for an integrity violation it committed against
+//!   itself — and the executed work, which a grader independently scored 9 of
+//!   11 passing, was discarded with it.
+//! - **The post-verification seal check** (`sealed_unchanged_inner`) must not
+//!   read the same `.pyc` as "the worktree changed after verification". It had
+//!   no list either, for the same reason and with the same result.
+//!
+//! One copy, because the failure mode is precisely divergence: the second and
+//! third callers were each written by someone who did not know the first
+//! existed.
+//!
+//! # What is on the list, and what deliberately is not
+//!
+//! Only scratch written by *running* code. Build outputs (`target`, `dist`,
+//! `build`) are deliberately absent: producing one of those is frequently the
+//! whole job, and the same reasoning keeps them out of
+//! `stella_tools::shell_touch::SKIP_DIRS`. Coverage data (`.gcda`) is likewise
+//! absent — it is a *file suffix* rather than a directory, and whether a gcov
+//! task's coverage data is scratch or deliverable is a judgement this list
+//! cannot make (#2877 tracks it).
+
+/// Directory names that hold tool scratch, matched at **any depth**.
+///
+/// Deliberately short and deliberately not build outputs — see the module
+/// docs for the criterion. Consumed by adoption's git pathspecs (as
+/// `:(exclude,glob)**/<dir>/**`) and by [`is_tool_scratch`] for the two
+/// callers that work over plain paths.
+pub const TOOL_SCRATCH_DIRS: &[&str] = &[
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+];
+
+/// Whether a repository-relative path lies inside a [`TOOL_SCRATCH_DIRS`]
+/// directory at any depth.
+///
+/// Backslashes normalize to `/` so a Windows-shaped path is judged by the
+/// same rule; the comparison is over whole path components, so a file merely
+/// *named* `.tox` — or a directory named `mypy_cache_notes` — is not scratch.
+pub fn is_tool_scratch(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    let mut components = normalized.split('/');
+    // The final component is the file itself: a path IS scratch when one of
+    // its parent directories is, never when its own name happens to collide.
+    let Some(_file) = components.next_back() else {
+        return false;
+    };
+    components.any(|component| TOOL_SCRATCH_DIRS.contains(&component))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_pipelines_own_oracle_artifact_is_scratch() {
+        assert!(is_tool_scratch(
+            "__pycache__/test_numpy_compatibility.cpython-313-pytest-9.1.1.pyc"
+        ));
+        assert!(is_tool_scratch(
+            "pkg/tests/__pycache__/test_x.cpython-312.pyc"
+        ));
+        assert!(is_tool_scratch(".pytest_cache/v/cache/lastfailed"));
+        assert!(is_tool_scratch(".tox/py311/log/build.log"));
+    }
+
+    #[test]
+    fn a_deliverable_is_never_scratch() {
+        assert!(!is_tool_scratch("test_numpy_compatibility.py"));
+        assert!(!is_tool_scratch("src/lib.rs"));
+        // Build outputs are off the list on purpose: producing one is often
+        // the whole task.
+        assert!(!is_tool_scratch("target/release/stella"));
+        assert!(!is_tool_scratch("dist/app.js"));
+        assert!(!is_tool_scratch("build/sqlite3"));
+    }
+
+    #[test]
+    fn only_whole_components_match() {
+        assert!(!is_tool_scratch("notes/mypy_cache_notes.md"));
+        assert!(
+            !is_tool_scratch("scripts/.tox"),
+            "its own name is not a parent"
+        );
+        assert!(is_tool_scratch("scripts/.tox/run"));
+    }
+
+    #[test]
+    fn windows_separators_are_judged_by_the_same_rule() {
+        assert!(is_tool_scratch(r"pkg\__pycache__\test_x.pyc"));
+    }
+}

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -286,6 +286,18 @@ fn validate_local_args(program: &str, args: &[String]) -> Result<(), TestInvocat
 
 /// Validate the witness author's complete working-tree delta and return the
 /// content-hash baseline for the one accepted test artifact.
+///
+/// # The delta is not all the author's
+///
+/// The two `_after` maps are read *after the baseline oracle run*, not after
+/// the author's turn — the stage has to see the test fail before it will
+/// accept it. So the delta contains everything running that test produced, and
+/// on a Python workspace that is the interpreter's own
+/// `__pycache__/<witness>.cpython-*.pyc`. Judging that byte-compilation as a
+/// second authored file makes the run reject an artifact it created itself,
+/// which is what cost `build-cython-ext` a change a grader independently
+/// scored 9 of 11 passing. [`crate::scratch`] holds the one list of what
+/// running code writes, shared with adoption so the two cannot drift apart.
 pub fn validate_witness_artifact(
     tracked_before: &HashMap<String, String>,
     tracked_after: &HashMap<String, String>,
@@ -566,11 +578,20 @@ pub fn validate_witness_identity(
     }
 }
 
+/// The paths whose fingerprints differ between two snapshots, minus tool
+/// scratch.
+///
+/// The subtraction is here rather than at the call site because both sides of
+/// [`validate_witness_artifact`] need it and for the same reason: a snapshot
+/// pair that straddles a test run contains that run's own byte-compilation
+/// output, which no author wrote and no verdict depends on. See
+/// [`crate::scratch`] for the list and why adoption shares it.
 fn changed_paths(before: &HashMap<String, String>, after: &HashMap<String, String>) -> Vec<String> {
     let mut paths: Vec<String> = before
         .keys()
         .chain(after.keys())
         .filter(|path| before.get(*path) != after.get(*path))
+        .filter(|path| !crate::scratch::is_tool_scratch(path))
         .cloned()
         .collect();
     paths.sort();

--- a/crates/stella-pipeline/src/witness/tests.rs
+++ b/crates/stella-pipeline/src/witness/tests.rs
@@ -265,6 +265,68 @@ fn an_absent_artifact_is_nothing_created_not_an_integrity_violation() {
     assert!(matches!(error, WitnessArtifactError::NothingCreated));
 }
 
+/// The `build-cython-ext` loss (#2876). The `_after` snapshots are taken
+/// after the baseline oracle RAN the authored test, so on a Python workspace
+/// the delta contains CPython's own byte-compilation of it. Reading that as a
+/// second authored file made the run refuse an artifact it created itself —
+/// and the executed change it discarded scored 9 of 11 on the grader's tests.
+///
+/// The exact path is the one from the trace, `.pyc` tag and all.
+#[test]
+fn the_oracles_own_bytecode_is_not_a_second_authored_file() {
+    let accepted = validate_witness_artifact(
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &fps(&[
+            ("test_numpy_compatibility.py", "sha256:witness"),
+            (
+                "__pycache__/test_numpy_compatibility.cpython-313-pytest-9.1.1.pyc",
+                "sha256:compiled",
+            ),
+        ]),
+    )
+    .expect("the pipeline's own oracle artifact is not an author integrity violation");
+    assert_eq!(
+        accepted,
+        fps(&[("test_numpy_compatibility.py", "sha256:witness")]),
+        "only the authored test is pinned; scratch is neither accepted nor tracked"
+    );
+}
+
+/// The same subtraction on the tracked side, and the same reason: a
+/// repository that commits its `__pycache__` still has the oracle rewriting
+/// those bytes, and that is not the author editing production code.
+#[test]
+fn tracked_scratch_is_not_a_tracked_production_edit() {
+    let accepted = validate_witness_artifact(
+        &fps(&[("__pycache__/mod.cpython-313.pyc", "before")]),
+        &fps(&[("__pycache__/mod.cpython-313.pyc", "after")]),
+        &HashMap::new(),
+        &fps(&[("tests/authority_witness.rs", "sha256:witness")]),
+    )
+    .expect("committed scratch churn is not a tracked mutation");
+    assert_eq!(
+        accepted,
+        fps(&[("tests/authority_witness.rs", "sha256:witness")])
+    );
+}
+
+/// Scratch is subtracted, never *substituted*: a delta that is nothing but
+/// scratch has still created no witness, and must reach the degradable
+/// `NothingCreated` arm rather than an integrity refusal.
+#[test]
+fn a_delta_of_pure_scratch_is_nothing_created() {
+    let error = validate_witness_artifact(
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &fps(&[(".pytest_cache/v/cache/lastfailed", "sha256:junk")]),
+    )
+    .unwrap_err();
+    assert!(matches!(error, WitnessArtifactError::NothingCreated));
+}
+
 #[test]
 fn witness_artifact_rejects_tracked_production_edits() {
     let error = validate_witness_artifact(


### PR DESCRIPTION
**Nothing that runs after the work is done may destroy the work.** A post-hoc check may downgrade a *claim*; it must never discard a *deliverable*. Three checks were inverting that, and two measured Terminal-Bench trials (2026-08-11 panel, SUT `main@2193374`, run `f89p2`) paid for it with work the grader independently scored as substantially correct.

Closes #2876
Refs #2877

## What was wrong

**`build-cython-ext`** — after step 85 the trace carries `witness author must create exactly one new test file; changed: __pycache__/test_numpy_compatibility.cpython-313-pytest-9.1.1.pyc, test_numpy_compatibility.py`, `retryable: false`, no verdict, no adoption. The grader scored the **discarded** work **9/11 passing**. The `.pyc` was written by *the pipeline's own baseline oracle run*: `witness_stage.rs` snapshots `untracked_before` before the author turn and `untracked_after` after `run_test_observed` has executed the authored Python test.

**`sqlite-with-gcov`** — `candidate worktree changed after verification`, `retryable: false`, no adoption; `warrant diff_lines: 194561` (a fully built SQLite) thrown away, grader 2/3 passing. `sealed_unchanged_inner` demanded an empty `git status` from a worktree the flip oracle had just run a test command inside.

## Three changes

### (a) One scratch list, in one place — `crates/stella-pipeline/src/scratch.rs` (new)

`ADOPT_CACHE_EXCLUDES` lived beside its first caller in `stella-cli`, with a comment naming this exact hazard. Two other checks had to answer the same question and each answered it wrong, because neither knew the list existed. It now lives in **`stella-pipeline`**, and the dependency graph decides that: `stella-cli` already depends on `stella-pipeline` (`adopt.rs` imports `stella_pipeline::ports`) and the reverse edge does not and must not exist, so `stella-pipeline` is the only crate both callers can see. It adds no dependency to either. `stella-protocol` was rejected as a home — it is types-only, zero logic, and `is_tool_scratch` is logic.

`validate_witness_artifact` subtracts it, on both the tracked and untracked sides, inside `changed_paths` so the two call sites cannot diverge.

### (b) A witness refusal costs the claim, not the work — `witness_stage.rs`, `pipeline.rs`, `resume_stage.rs`

`WitnessAbort`'s `degradable` flag decided whether the *candidate* survived. Only `NothingCreated` degraded; every other artifact error became `CandidateResult::aborted(.., DeliberateStop)` — no verdict, no adoption.

The trade is wrong in one direction, and structurally so: authoring runs **after** execution, in a **pristine sibling snapshot** that `witness_on_demand` deletes on every path. Nothing the author does can reach the candidate's tree, so nothing learned there is evidence about the candidate's work.

Now both endings continue on the unauthored ladder. Fail-closed is preserved exactly where it belongs — no artifact is accepted, no flip is credited, and the refusal is stated on the rail through a distinctly-worded `WitnessUnavailable` (`the authored artifact was refused: …`) so a reader can still tell a defect in the run from a fact about the workspace. The flag is renamed `refused` and the constructor `degradable` → `unauthorable`, because "degradable" is no longer what distinguishes them. `witness_on_demand` is infallible as a result, so its `Result` is removed rather than left as an unreachable arm — which also takes lines *out* of the `pipeline.rs` god file.

Exemplar for the shape: this is the same posture `rust-analyzer` takes on a failed proc-macro expansion — the diagnostic is recorded and the rest of the analysis still runs, rather than the file being dropped.

### (c) The verification run's own leavings are not tampering — `candidate_ws.rs`, `adopt.rs`

`sealed_unchanged_inner` now parses `git status --porcelain --no-renames -z -uall` through a pure `drifted_paths` and subtracts the same list.

**Why exclusion rather than re-ordering the seal.** The argument for the subtraction is narrow and provable: the adopted patch is `git diff <baseline> <sealed>` over two immutable commit objects and *already* excludes those paths by pathspec, so a mutation confined to them cannot change one byte of what adoption delivers — it therefore cannot make the sealed tree disagree with the tree that was verified. Re-sealing after the oracle would prove less, not more: a test command that rewrites source would then be adopted silently.

That is deliberately a partial repair. `sqlite-with-gcov`'s `.gcda` files are *not* on the list, because they are a file suffix rather than a directory and because adoption carries them today — whether a gcov task's coverage data is a deliverable or scratch is a behavioural decision that needs its own witness. **That case is still broken and is filed as #2877** with both candidate designs written out.

## Witness tests — demonstrated fail→pass

Source files reverted to the parent commit, test files kept (`git checkout HEAD~1 -- <5 source files>`):

```
test witness::tests::the_oracles_own_bytecode_is_not_a_second_authored_file ... FAILED
test witness::tests::tracked_scratch_is_not_a_tracked_production_edit ... FAILED
test witness::tests::a_delta_of_pure_scratch_is_nothing_created ... FAILED
test pipeline::tests::witness_isolation::tracked_production_edit_by_witness_author_refuses_the_witness_and_still_adopts ... FAILED
test pipeline::tests::witness_isolation::witness_language_mismatch_refuses_the_witness_and_still_adopts ... FAILED
test pipeline::tests::witness_isolation::symlink_witness_artifact_refuses_the_witness_and_still_adopts ... FAILED
test result: FAILED. 0 passed; 6 failed

test candidate_ws::tests::scratch_the_verification_run_wrote_does_not_discard_the_work ... FAILED
test result: FAILED. 2 passed; 1 failed
```

With the change restored: `stella-pipeline` 709 passed / 0 failed, `stella-cli` 1733 passed / 0 failed.

`the_oracles_own_bytecode_is_not_a_second_authored_file` uses the exact path from the trace, `.pyc` tag and all.

## Tests renamed, not deleted (`check-deleted-tests`)

Three tests asserted the old contract and now assert the new one. Renamed to say what they check:

- `tracked_production_edit_by_witness_author_aborts_without_adoption` → `..._refuses_the_witness_and_still_adopts`
- `witness_language_mismatch_aborts_after_worker_execution` → `witness_language_mismatch_refuses_the_witness_and_still_adopts`
- `symlink_witness_artifact_aborts_after_worker_execution` → `symlink_witness_artifact_refuses_the_witness_and_still_adopts`

Each now asserts three things where it used to assert one: the run is `Unverified` (not aborted), the rail carries the refusal, and the work is adopted. `post_baseline_witness_tamper_is_hard_failure_even_if_verifier_would_pass` is untouched — a *worker* mutating the witness after it was pinned is a different authority violation, in the candidate's own tree, and stays fatal.

## Not done here

- `.gcda` and other build artifacts the oracle rewrites — #2877.
- `AdoptedChange` still cannot report that a delivery was lossy (F1 finding), so the drift subtraction has no channel to say "adopted, and the tree had moved". Unnecessary today because the subtraction is provably byte-neutral; it becomes necessary the moment #2877 widens it.

## Summary by Sourcery

Preserve executed work when witness authoring or post-verification checks fail, and centralize tool-scratch handling so pipeline checks no longer treat test-run artifacts as tampering.

Enhancements:
- Make witness-stage failures (including integrity refusals) degrade only the verification claim while still adopting the candidate’s executed changes.
- Refactor witness authoring to use a `WitnessAbort` mode that distinguishes unauthorable witnesses from integrity refusals, with dedicated rail messaging for refused artifacts.
- Introduce a shared `scratch` module that defines tool scratch directories and a helper for identifying scratch paths, reused across witness validation and adoption.
- Adjust witness artifact validation to ignore tool scratch changes on both tracked and untracked sides so oracle-generated bytecode is not treated as an extra authored file.
- Update the post-verification seal check to parse `git status` output, subtract tool scratch drift, and only reject genuine post-verification mutations.
- Simplify pipeline control flow by making `witness_on_demand` infallible and removing abort paths that previously discarded candidates based on witness-stage outcomes.

Documentation:
- Expand inline documentation around witness authoring, scratch handling, and seal drift to clarify the distinction between claims and deliverables, and to record the rationale for the new fail-open-for-work posture.

Tests:
- Add and update pipeline and witness tests to assert that integrity refusals leave runs unverified but still adopted, and that tool scratch from test runs does not cause adoption or seal failures.
- Rename and extend existing witness isolation tests to cover the new "refused but adopted" behaviour and ensure refused artifacts are never grafted into candidate workspaces.
- Add candidate workspace tests verifying that verification-run scratch files in known tool scratch directories do not cause post-verification drift rejections or get adopted into the user’s tree.