### PR TITLE
fix(stella-pipeline): git is the only authority on "the tree changed" — three ladder predicates stop reading a tool-call tally (#2873)

### DIFF
--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -28,7 +28,7 @@
 //! - **revise** on a clear failure (touched tests red), or on a turn that
 //!   never attempted anything (`NothingAttempted`);
 //! - **abstain** (`Unverifiable`) when every channel was blind — no flip, no
-//!   test result, an unreadable working tree, and no recorded file touch;
+//!   test result, and an unreadable working tree;
 //! - **report it unproven** (`Unverified`) on genuinely inconclusive evidence.
 //!
 //! That last rung used to escalate to a model verifier. It does not, and the
@@ -61,6 +61,16 @@
 //! abstain exists for is real: one of those eleven trials' siblings did the
 //! work entirely through shell redirects, recorded no touch, could not be
 //! diffed — and passed its Harbor verifier.
+//!
+//! # Git is the only authority on "the tree changed"
+//!
+//! Two streams in this codebase answer to that description and they disagree.
+//! `AgentEvent::FileChange` is emitted by tools whose *input* names a path, so
+//! it records what the agent touched **through tools** and misses every shell
+//! redirect, `patch` and `make`; the git diff of the tree misses nothing. Only
+//! the second may back a ladder decision. `LadderInputs::file_change_events`
+//! carries the first and is read by nothing here (#2873) — the ladder's
+//! channels are the flip receipt, the touched tests, and git.
 //!
 //! Linters and typecheckers are deliberately **excluded** from the flip
 //! oracle (L-E11): only a real test command's fail→pass counts. The pipeline
@@ -489,8 +499,36 @@ pub struct LadderInputs {
     /// answer `false`.
     pub diff_available: bool,
     /// Mutating file touches the recorder observed this turn, from the registry
-    /// that emitted the `FileChange` events (`FileTouchPort`). Non-zero is
-    /// positive proof the tree changed even when nothing can render *how*.
+    /// that emitted the `FileChange` events (`FileTouchPort`).
+    ///
+    /// **Recorded only: [`ladder_decision`] does not read it** (#2873). It is a
+    /// tally of what the agent touched **through tools**, which is a different
+    /// question from whether the tree changed — a `bash` heredoc mutates the
+    /// workspace and emits nothing here — and the ladder's authority on the
+    /// second question is git ([`Self::diff_available`] with
+    /// [`Self::diff_lines`]).
+    ///
+    /// Three predicates conjoined on it until #2873, each documented as if it
+    /// were a live channel, and it is **zero wherever the ladder actually
+    /// runs**. Measured, not inferred: on the 2026-08-11 Terminal-Bench panel,
+    /// across 53 pipeline trials that reached a verdict, the 49 that ran in a
+    /// candidate workspace **all** recorded `0` before the verdict and the 4
+    /// that did not **all** recorded a non-zero count — 53/53 — with
+    /// [`Self::mutating_actions`] between 6 and 147 beside it. Both operands of
+    /// the `max` in `observed_mutations` therefore read zero on every one of
+    /// those 49 runs; the tree's own account of the event half is
+    /// `verify_probes::DIFF_PROBE_FAILED` ("the engine emits no `FileChange`
+    /// events … inside a best-of-N or witness candidate the count is always
+    /// zero"), which `pipeline::tests::warrant` had already written down.
+    ///
+    /// It is deliberately not deleted with the read, for the same reason
+    /// [`Self::no_test_surface`] was not: the pipeline still sets it, the
+    /// snapshot still puts it on the wire, and `replay` still renders it,
+    /// because "the tools declared this many touches" is a fact worth reading
+    /// off a corpus of traces. Whether it should regain a decision role — which
+    /// needs a signal a candidate can actually feed, not a wider read of this
+    /// one — or be retired is #2873; what it must not do is keep claiming an
+    /// effect it never had.
     pub file_change_events: u32,
     /// Tool calls this turn that were *capable* of changing the workspace:
     /// every dispatched call except those whose tool the registry advertises
@@ -618,8 +656,8 @@ impl LadderInputs {
     }
 
     /// Whether every channel the ladder has was unable to observe anything:
-    /// no flip receipt, no test result, a diff probe that could not read the
-    /// tree, and no recorded file touch.
+    /// no flip receipt, no test result, and a diff probe that could not read
+    /// the tree.
     ///
     /// This is *not* "the turn changed nothing" — it is "nothing here can tell
     /// you either way", and the distinction is the whole value of the ladder.
@@ -629,19 +667,25 @@ impl LadderInputs {
     /// verifier asserted a file "likely does not exist" while it sat in the
     /// container.
     ///
-    /// Note the asymmetry: a *red* test or a non-zero touch count is real
-    /// evidence, so neither can be blind. Only the total absence qualifies.
+    /// Note the asymmetry: a *red* test is real evidence, so it cannot be
+    /// blind. Only the total absence qualifies.
     ///
     /// Reads [`Self::has_flip_receipt`] rather than [`Self::flip`]
     /// for the reason the abstention sits above the credit: a turn whose only
-    /// observation was a `verify_done` receipt satisfies all four dark
-    /// channels on the narrower predicate, so this rung would swallow it
-    /// before step 4 could ever look (#2618).
+    /// observation was a `verify_done` receipt satisfies every dark channel on
+    /// the narrower predicate, so this rung would swallow it before step 4
+    /// could ever look (#2618).
+    ///
+    /// Every conjunct is an **observation** channel. [`Self::mutating_actions`]
+    /// is absent because it is a dispatch record, not a look at the world, and
+    /// the rung above ([`Self::nothing_was_attempted`]) is where the ladder
+    /// reads it. [`Self::file_change_events`] was a fourth conjunct until
+    /// #2873 and belongs to that same dispatch side — it counts what the tools
+    /// declared, never what the tree did, and inside a candidate workspace it
+    /// is pinned at zero, so it contributed a constant `true` to a predicate
+    /// whose doc advertised it as a channel.
     pub fn evidence_is_blind(&self) -> bool {
-        !self.has_flip_receipt()
-            && self.touched_tests_passed.is_none()
-            && !self.diff_available
-            && self.file_change_events == 0
+        !self.has_flip_receipt() && self.touched_tests_passed.is_none() && !self.diff_available
     }
 
     /// Whether a model verifier's `passed` would be the *only* thing standing
@@ -692,12 +736,16 @@ impl LadderInputs {
     /// this state would otherwise satisfy on the way to reporting a pass.
     ///
     /// The remaining conjuncts are there so a single positive observation
-    /// always wins. A flip, a test result, a recorded touch or a non-empty
-    /// diff each mean *something* happened, whoever caused it — and a turn
-    /// with something to explain deserves a verdict, not this shortcut.
+    /// always wins. A flip, a test result or a non-empty diff each mean
+    /// *something* happened, whoever caused it — and a turn with something to
+    /// explain deserves a verdict, not this shortcut.
+    ///
+    /// [`Self::file_change_events`] was one of them until #2873, where it was
+    /// pure redundancy: every `FileChange` is emitted from a mutating tool
+    /// call, so a non-zero count implies a non-zero
+    /// [`Self::mutating_actions`], which the first conjunct already excludes.
     pub fn nothing_was_attempted(&self) -> bool {
         self.mutating_actions == 0
-            && self.file_change_events == 0
             && self.diff_lines == 0
             && !self.flip.is_achieved()
             && self.touched_tests_passed.is_none()
@@ -722,13 +770,21 @@ impl LadderInputs {
     /// will ever read — while the run collected a candidate root that stayed
     /// empty. Ten mutating calls, a readable zero-line diff, and a verdict of
     /// `passed: true, deterministic: true`. Note what does *not* reach here: a
-    /// flip, a green test, or a recorded touch each corroborate the work, and
-    /// any one of them sends the turn on to the rungs that can credit it.
+    /// flip or a green test each corroborate the work, and either one sends
+    /// the turn on to the rungs that can credit it.
+    ///
+    /// [`Self::file_change_events`] used to sit beside them as a third
+    /// corroborator, and it was pointing the wrong way (#2873). The premise of
+    /// this predicate is that git *looked at the collected tree and found it
+    /// unchanged*. A tool tally saying "I wrote files" against that reading is
+    /// evidence **for** the effects having landed somewhere this run does not
+    /// collect, not against it — so counting it as corroboration let a
+    /// tool-call tally overrule the one channel that had actually observed the
+    /// tree.
     pub fn effects_escaped_collection(&self) -> bool {
         self.mutating_actions > 0
             && self.diff_available
             && self.diff_lines == 0
-            && self.file_change_events == 0
             && !self.flip.is_achieved()
             && self.touched_tests_passed.is_none()
     }
@@ -940,8 +996,7 @@ pub fn unverifiable_evidence(inputs: &LadderInputs) -> VerdictEvidence {
              diff probe then read the tree and found it unchanged, so nothing here observed the \
              work and nothing is claimed about it (this is NOT a finding that the work is absent \
              or wrong): the effects landed outside what this run collects. No fail→pass flip was \
-             observed; no touched-test result; file-change events recorded = 0. Verify the result \
-             on its own merits.",
+             observed; no touched-test result. Verify the result on its own merits.",
             inputs.mutating_actions
         )
     } else {
@@ -949,8 +1004,9 @@ pub fn unverifiable_evidence(inputs: &LadderInputs) -> VerdictEvidence {
             "UNVERIFIABLE — no evidence channel could observe this turn, so nothing is claimed \
              about it (this is NOT a finding that the work is absent or wrong): flip oracle not \
              armed (no test command); touched tests not run; the diff probe could not read the \
-             working tree; file-change events recorded = {}. Verify the result on its own merits.",
-            inputs.file_change_events
+             working tree ({} mutating call(s) were dispatched). Verify the result on its own \
+             merits.",
+            inputs.mutating_actions
         )
     };
     VerdictEvidence {
@@ -1108,10 +1164,10 @@ pub fn nothing_attempted_evidence(inputs: &LadderInputs) -> VerdictEvidence {
     VerdictEvidence {
         summary: format!(
             "NO WORK ATTEMPTED — the turn ended without dispatching a single tool call that \
-             could change the workspace ({} mutating call(s), {} file-change event(s), {} \
-             diff line(s)). This is not an unverifiable result: nothing was asked to change, \
-             so nothing did, whatever the other channels could or could not see.",
-            inputs.mutating_actions, inputs.file_change_events, inputs.diff_lines
+             could change the workspace ({} mutating call(s), {} diff line(s)). This is not an \
+             unverifiable result: nothing was asked to change, so nothing did, whatever the \
+             other channels could or could not see.",
+            inputs.mutating_actions, inputs.diff_lines
         ),
         deterministic: true,
         evidence_refs: Vec::new(),

--- a/crates/stella-pipeline/src/verify/tests.rs
+++ b/crates/stella-pipeline/src/verify/tests.rs
@@ -5,6 +5,7 @@
 use super::*;
 use proptest::prelude::*;
 
+mod tool_tally;
 mod uncollected;
 mod witness_strip;
 mod witness_unsatisfiable;
@@ -261,13 +262,23 @@ fn every_channel_blind_abstains_instead_of_asking_a_verifier_to_guess() {
     );
 }
 
-/// The single signal that rescues the blind case, and the one the bug
-/// suppressed: the recorder saw the tree change even though nothing could
-/// render *how*. That is real evidence, so the ladder must report the turn
-/// unproven rather than abstain — the two are different claims, and only the
-/// first is true when something positively saw the tree move.
+/// The signal that was supposed to rescue the blind case, and could not
+/// (#2873). `a_recorded_file_touch_is_evidence_even_with_no_readable_diff`
+/// stood here and asserted the opposite: that six recorded touches lift a turn
+/// with no readable diff off the abstain rung.
+///
+/// They do not, for two reasons that compound. A `FileChange` is emitted by a
+/// tool whose *input* names a path, so the count is a tally of what the agent
+/// declared through tools and not an observation of the tree — `bash` writes
+/// most of a Terminal-Bench task's files and emits nothing. And inside a
+/// candidate workspace the count is pinned at zero besides, so the rescue this
+/// test described was unreachable on every run that reached the ladder.
+///
+/// The turn is genuinely unobserved, and `Unverifiable` is the honest answer.
+/// What the run does with it is unchanged: both rungs are terminal, neither is
+/// a failure, and the work is not touched by either.
 #[test]
-fn a_recorded_file_touch_is_evidence_even_with_no_readable_diff() {
+fn a_recorded_file_touch_is_not_evidence_of_a_changed_tree() {
     let inputs = LadderInputs {
         flip: FlipOutcome::NotAchieved,
         touched_tests_passed: None,
@@ -279,10 +290,10 @@ fn a_recorded_file_touch_is_evidence_even_with_no_readable_diff() {
         ..Default::default()
     };
     assert!(
-        !inputs.evidence_is_blind(),
-        "six observed mutations are not an absence of evidence"
+        inputs.evidence_is_blind(),
+        "no channel could observe this turn; a tool tally is not a channel"
     );
-    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverified);
+    assert_eq!(ladder_decision(&inputs), LadderDecision::Unverifiable);
 }
 
 /// A red test is a real observation, so a turn carrying one is never blind
@@ -444,6 +455,11 @@ fn a_blind_turn_that_did_act_still_abstains() {
 /// Any single positive observation outranks the no-op rung, whatever the
 /// dispatch count says. Something changed; something changed is a thing to
 /// explain, and this shortcut does not get to skip explaining it.
+///
+/// A recorded file touch was a fourth arm until #2873. It is not an
+/// independent observation: every `FileChange` is emitted from a mutating tool
+/// call, so a non-zero tally already implies a non-zero `mutating_actions` and
+/// the arm described a state the pipeline cannot produce.
 #[test]
 fn one_positive_observation_defeats_the_no_op_rung() {
     let base = LadderInputs {
@@ -458,10 +474,6 @@ fn one_positive_observation_defeats_the_no_op_rung() {
     };
     assert!(base.nothing_was_attempted());
 
-    let recorded_touch = LadderInputs {
-        file_change_events: 1,
-        ..base
-    };
     let visible_diff = LadderInputs {
         diff_lines: 12,
         ..base
@@ -475,7 +487,6 @@ fn one_positive_observation_defeats_the_no_op_rung() {
         ..base
     };
     for (label, inputs) in [
-        ("a recorded file touch", recorded_touch),
         ("a non-empty diff", visible_diff),
         ("a flip", flipped),
         ("a test result", tests_ran),

--- a/crates/stella-pipeline/src/verify/tests/tool_tally.rs
+++ b/crates/stella-pipeline/src/verify/tests/tool_tally.rs
@@ -1,0 +1,179 @@
+//! #2873: the ladder does not decide anything from a tool-call tally.
+//!
+//! `LadderInputs::file_change_events` counts `AgentEvent::FileChange`s, which
+//! are emitted only by tools whose *input* names a path. `bash` names nothing,
+//! and inside a candidate workspace the count is pinned at zero besides — the
+//! candidate's tools reach neither the emitter the pipeline tallies nor the
+//! session `FileTouchPort` it reads. Measured on the 2026-08-11 Terminal-Bench
+//! panel: of 53 pipeline trials that reached a verdict, the 49 that ran in a
+//! candidate all recorded `0` before the verdict, with `mutating_actions`
+//! between 6 and 147 beside it.
+//!
+//! Three predicates conjoined on it anyway, so three decisions branched on an
+//! input that could not vary. These tests pin the field out of the decision:
+//! git (`diff_available` with `diff_lines`) is the authority on whether the
+//! tree changed, and `mutating_actions` on whether anything was asked to.
+//!
+//! Its own module because the parent is a long way into its ratchet, and
+//! because these cases share a premise none of the others do: every assertion
+//! here is about a field the ladder is required to *ignore*.
+
+use crate::verify::{LadderDecision, LadderInputs, ladder_decision};
+use stella_protocol::FlipOutcome;
+
+/// Every `file_change_events` value a trial in the panel produced, plus the
+/// saturating edge. `0` and a small count are the two the traces actually
+/// contain; the rest guard against a predicate that reads the field through a
+/// threshold rather than a zero test.
+const TALLIES: [u32; 6] = [0, 1, 3, 19, 147, u32::MAX];
+
+/// The decision must be a function of the evidence channels alone. Sweeping
+/// the tally across a ladder input that reaches each of the five terminal
+/// outcomes, the answer may not move.
+///
+/// The witness for #2873's `evidence_is_blind` and `nothing_was_attempted`
+/// arms: before the fix, `nothing_attempted` and `unverifiable` below both
+/// changed answer at the first non-zero tally.
+#[test]
+fn the_decision_never_moves_with_the_tool_tally() {
+    let nothing_attempted = LadderInputs {
+        flip: FlipOutcome::NotAchieved,
+        touched_tests_passed: None,
+        mutating_actions: 0,
+        diff_lines: 0,
+        diff_available: false,
+        ..Default::default()
+    };
+    let unverifiable = LadderInputs {
+        // Every observation channel dark, and calls were dispatched — the
+        // blind rung, reached only after `nothing_was_attempted` declines.
+        mutating_actions: 12,
+        diff_available: false,
+        ..nothing_attempted
+    };
+    let escaped = LadderInputs {
+        // The probe ran and read an unchanged tree (#1701).
+        diff_available: true,
+        ..unverifiable
+    };
+    let revise = LadderInputs {
+        touched_tests_passed: Some(false),
+        ..escaped
+    };
+    let submit_fast = LadderInputs {
+        flip: FlipOutcome::Achieved,
+        touched_tests_passed: Some(true),
+        diff_lines: 4,
+        diff_budget: 100,
+        ..escaped
+    };
+
+    for (label, base, expected) in [
+        (
+            "no mutating call was dispatched",
+            &nothing_attempted,
+            LadderDecision::NothingAttempted,
+        ),
+        (
+            "every observation channel was dark",
+            &unverifiable,
+            LadderDecision::Unverifiable,
+        ),
+        (
+            "the probe read an unchanged tree (#1701)",
+            &escaped,
+            LadderDecision::Unverifiable,
+        ),
+        ("a touched test is red", &revise, LadderDecision::Revise),
+        (
+            "a flip with green tests inside budget",
+            &submit_fast,
+            LadderDecision::SubmitFast,
+        ),
+    ] {
+        for tally in TALLIES {
+            let inputs = LadderInputs {
+                file_change_events: tally,
+                ..*base
+            };
+            assert_eq!(
+                ladder_decision(&inputs),
+                expected,
+                "{label}: the decision moved when only file_change_events changed (= {tally})"
+            );
+        }
+    }
+}
+
+/// The three predicates that used to read it, asserted one by one — so a
+/// future edit that re-introduces the conjunct fails here with the predicate
+/// named, rather than as a decision that shifted somewhere down the ladder.
+#[test]
+fn no_predicate_reads_the_tool_tally() {
+    let blind = LadderInputs {
+        flip: FlipOutcome::NotAchieved,
+        touched_tests_passed: None,
+        diff_available: false,
+        mutating_actions: 12,
+        ..Default::default()
+    };
+    let attempted_nothing = LadderInputs {
+        mutating_actions: 0,
+        ..blind
+    };
+    let escaped = LadderInputs {
+        diff_available: true,
+        diff_lines: 0,
+        ..blind
+    };
+
+    for tally in TALLIES {
+        let with = |base: &LadderInputs| LadderInputs {
+            file_change_events: tally,
+            ..*base
+        };
+        assert!(
+            with(&blind).evidence_is_blind(),
+            "evidence_is_blind read the tally (= {tally}): no channel could look"
+        );
+        assert!(
+            with(&attempted_nothing).nothing_was_attempted(),
+            "nothing_was_attempted read the tally (= {tally}): no mutating call was dispatched"
+        );
+        assert!(
+            with(&escaped).effects_escaped_collection(),
+            "effects_escaped_collection read the tally (= {tally}): git read the tree and \
+             found it unchanged, which a tool tally cannot overrule"
+        );
+    }
+}
+
+/// The verdict a human reads must not present the tool tally as a statement
+/// about the tree. Both `UNVERIFIABLE` summaries carried the sentence
+/// "file-change events recorded = 0" — one of them hardcoded — and a reader of
+/// the panel's `configure-git-webserver` verdict saw it beside 24 mutating
+/// calls that had, in fact, changed files.
+#[test]
+fn the_unverifiable_summary_makes_no_file_change_count_claim() {
+    let escaped = LadderInputs {
+        mutating_actions: 24,
+        diff_available: true,
+        diff_lines: 0,
+        ..Default::default()
+    };
+    let blind = LadderInputs {
+        diff_available: false,
+        ..escaped
+    };
+    for (label, inputs) in [("escaped", &escaped), ("blind", &blind)] {
+        let summary = crate::verify::unverifiable_evidence(inputs).summary;
+        assert!(
+            !summary.contains("file-change event"),
+            "{label}: the summary still reports a tool tally as evidence: {summary}"
+        );
+        assert!(
+            summary.contains("24"),
+            "{label}: and the dispatch count that contradicts a clean tree has to stay: {summary}"
+        );
+    }
+}

--- a/crates/stella-pipeline/src/verify/tests/uncollected.rs
+++ b/crates/stella-pipeline/src/verify/tests/uncollected.rs
@@ -65,16 +65,16 @@ fn effects_that_escaped_collection_abstain_rather_than_claim_a_clean_tree() {
 /// The guard rails on the rung: any single corroborating observation takes the
 /// turn back to a rung that can credit it. Abstention is for the state where
 /// *nothing* saw the work, not for every empty diff.
+///
+/// A recorded file touch used to be a third arm here, and it was pointing the
+/// wrong way (#2873). The premise of this rung is that git read the collected
+/// tree and found it unchanged; a tool tally saying "I wrote files" against
+/// that reading is evidence *for* the effects having landed elsewhere, not
+/// corroboration that they landed here. `tool_tally.rs` now pins the opposite
+/// assertion.
 #[test]
 fn one_corroborating_observation_lifts_the_turn_off_the_abstain_rung() {
     for (label, inputs) in [
-        (
-            "a recorded file touch proves the tree moved",
-            LadderInputs {
-                file_change_events: 3,
-                ..escaped()
-            },
-        ),
         (
             "a green test is an observation of the work",
             LadderInputs {

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -705,8 +705,20 @@ pub enum AgentEvent {
         to: String,
         reason: String,
     },
-    /// A file was read/created/modified/deleted by the agent, carrying both
-    /// the authoritative line delta and a diff for display.
+    /// A file was read/created/modified/deleted by the agent **through a
+    /// tool**, carrying both the authoritative line delta and a diff for
+    /// display.
+    ///
+    /// **Observability, never evidence.** This stream records what the agent
+    /// touched through tools whose *input* names a path; it is **not** a
+    /// complete record of workspace mutation, and nothing may found a claim
+    /// about what changed on counting it. `bash` names nothing — a heredoc, a
+    /// `patch`, a `make`, or a `>` redirect mutates the tree and emits no event
+    /// here, which on Terminal-Bench is most of the work. The authority on what
+    /// changed is the git diff of the tree, and a consumer that needs that
+    /// answer takes it from there (#2873, which removed the last three
+    /// decisions that read a count of these events; the tally survives as a
+    /// recorded-only field on `LadderSnapshot`).
     ///
     /// The single emission point is `ToolRegistry::record_touch` — the same
     /// place that writes the session's file-touch ledger and its telemetry
@@ -1093,7 +1105,10 @@ impl<'de> Deserialize<'de> for AgentEvent {
     }
 }
 
-/// What happened to a file in a `FileChange` event.
+/// What happened to a file in a [`AgentEvent::FileChange`] event — as declared
+/// by the tool that touched it, which is why [`Self::is_mutation`] answers
+/// "was this call a write" and never "did the tree change". See the variant's
+/// doc for the difference and why only git can answer the second.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
@@ -1111,9 +1126,13 @@ pub enum FileChangeKind {
 }
 
 impl FileChangeKind {
-    /// Whether this kind mutated the file — what the pipeline's zero-diff
-    /// guard and inline transcript diffs key on. Reads are observability,
-    /// not change.
+    /// Whether the tool call that emitted this kind was a write — what the
+    /// inline transcript diffs and the files-touched panel key on. Reads are
+    /// listed here so one panel sees both; they carry `0/0` and no diff.
+    ///
+    /// A `true` here is not a licence to claim the tree changed: it is one
+    /// tool's declaration about one call, and the calls it cannot see are the
+    /// majority (see [`AgentEvent::FileChange`]).
     #[must_use]
     pub fn is_mutation(self) -> bool {
         !matches!(self, FileChangeKind::Read)

--- a/crates/stella-protocol/src/ladder.rs
+++ b/crates/stella-protocol/src/ladder.rs
@@ -337,7 +337,16 @@ pub struct LadderSnapshot {
     pub diff_budget: u32,
     /// Whether the diff probe could read the working tree at all.
     pub diff_available: bool,
-    /// Mutating file touches the recorder observed.
+    /// Mutating file touches the recorder observed — a tally of what the agent
+    /// touched **through tools**, which a shell redirect defeats, and which is
+    /// zero inside a candidate workspace.
+    ///
+    /// **Recorded only: no ladder predicate reads it** (#2873). It is here so a
+    /// corpus of traces can be read after the fact, exactly like
+    /// [`Self::no_test_surface`]. A consumer asking whether the tree changed
+    /// reads [`Self::diff_available`] with [`Self::diff_lines`] — git is the
+    /// authority — and one asking whether anything was attempted reads
+    /// [`Self::mutating_actions`].
     pub file_change_events: u32,
     /// Dispatched tool calls capable of changing the workspace.
     pub mutating_actions: u32,

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -65,9 +65,11 @@ async fn unknown_tool_returns_error_not_panic() {
 /// The measured defect: over a 20-task Terminal-Bench run, 757 of 1,063
 /// tool calls were `bash` and the ledger recorded none of them, because
 /// `classify_file_op` can only read a tool's *input* and a shell command
-/// is an opaque string. With the diff probe dark on a non-git task
-/// directory, `file_change_events` is the only channel left that can
-/// prove the tree changed — so a blind ledger there is a blind ladder.
+/// is an opaque string — so the ledger, the Files tab, and the authored-diff
+/// channel were all blind to the tool doing nearly all of the work. (It was
+/// once also the ladder's only channel on a non-git task directory; #2873
+/// retired that read, because a tally of tool-declared touches is not an
+/// authority on what the tree did. The ledger still has to be right.)
 #[tokio::test]
 async fn a_file_written_by_the_shell_reaches_the_ledger() {
     let (root, reg) = bare_registry(None);

--- a/crates/stella-tools/src/shell_touch.rs
+++ b/crates/stella-tools/src/shell_touch.rs
@@ -11,15 +11,16 @@
 //! The consequence was measured rather than assumed. Over a 20-task
 //! Terminal-Bench run, 757 of 1,063 tool calls were `bash` and the ledger
 //! recorded 131 events — one per CRUD-tool call, none from the shell. 71% of
-//! the agent's activity left no trace in the ledger, in the Files tab, or in
-//! the `file_change_events` channel the verification ladder reads.
+//! the agent's activity left no trace in the ledger or in the Files tab.
 //!
-//! That last one is why this matters beyond cosmetics. On Terminal-Bench the
-//! task directory is not a git repository, so the diff probe can only ever
-//! answer "I could not look" (`LadderInputs::diff_available == false`). With
-//! the diff channel dark, `file_change_events` is the *only* channel that can
-//! positively prove the tree changed — and it was blind to the exact tool
-//! doing nearly all of the changing.
+//! It once left no trace in the verification ladder either, and that framing is
+//! now wrong in a way worth stating: `LadderInputs::file_change_events` was
+//! read by three ladder predicates until #2873 and is read by none of them
+//! today. A tally of tool-declared touches cannot be an authority on whether
+//! the tree changed — this module exists because it is not one — so the ladder
+//! takes that answer from git and nowhere else. What this module buys is
+//! **observability**: the ledger, the Files tab, and the authored-diff channel
+//! see the tool that does nearly all of the changing.
 //!
 //! So this module answers the question the schema cannot: fingerprint the
 //! workspace either side of an opaque call and attribute the difference. The

--- a/docs/spec/remote-sandboxes.md
+++ b/docs/spec/remote-sandboxes.md
@@ -583,8 +583,8 @@ instead of quietly making remote sessions unusable.
 ### 9.3 The ladder must abstain, not fail
 
 **This is the trap most likely to be walked into.** If the workspace is
-unreachable, the diff probe and the `file_change_events` channel must
-report `NothingAttempted` / `Unverifiable` — **never `passed: false`.**
+unreachable, the diff probe and the dispatch record must report
+`NothingAttempted` / `Unverifiable` — **never `passed: false`.**
 A network partition is not a failed verification, and collapsing the two
 is exactly the distinction the abstain rung exists to preserve. Every new
 `SandboxError` path that feeds the ladder needs a test pinning it to the

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -315,7 +315,10 @@ export interface ContextUsage {
 }
 
 /**
- * What happened to a file in a `FileChange` event.
+ * What happened to a file in a [`AgentEvent::FileChange`] event — as declared
+ * by the tool that touched it, which is why [`Self::is_mutation`] answers
+ * "was this call a write" and never "did the tree change". See the variant's
+ * doc for the difference and why only git can answer the second.
  */
 export type FileChangeKind = "read" | "created" | "modified" | "deleted";
 

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -470,7 +470,16 @@ export interface LadderSnapshot {
    */
   errored_commands?: number;
   /**
-   * Mutating file touches the recorder observed.
+   * Mutating file touches the recorder observed — a tally of what the agent
+   * touched **through tools**, which a shell redirect defeats, and which is
+   * zero inside a candidate workspace.
+   *
+   * **Recorded only: no ladder predicate reads it** (#2873). It is here so a
+   * corpus of traces can be read after the fact, exactly like
+   * [`Self::no_test_surface`]. A consumer asking whether the tree changed
+   * reads [`Self::diff_available`] with [`Self::diff_lines`] — git is the
+   * authority — and one asking whether anything was attempted reads
+   * [`Self::mutating_actions`].
    */
   file_change_events: number;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -405,7 +405,7 @@
       "type": "object"
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a `FileChange` event.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`] event — as declared\nby the tool that touched it, which is why [`Self::is_mutation`] answers\n\"was this call a write\" and never \"did the tree change\". See the variant's\ndoc for the difference and why only git can answer the second.",
       "oneOf": [
         {
           "const": "read",
@@ -2694,7 +2694,7 @@
       "type": "object"
     },
     {
-      "description": "A file was read/created/modified/deleted by the agent, carrying both\nthe authoritative line delta and a diff for display.\n\nThe single emission point is `ToolRegistry::record_touch` — the same\nplace that writes the session's file-touch ledger and its telemetry\npayload — so the TUI, the audit log and the exported JSON can no longer\ndisagree about what a turn changed. (This doc once claimed one emission\npoint \"by construction\" while the deck in fact synthesized its own\nevents from tool inputs, in a wrapper that knew only four tool names and\nsat on one of three tool stacks. Files edited in bulk, or by a worker\nlane, were reported as `+0 -0`.)\n\n`added`/`removed` are the counts the recorder derived from the real pre-\nand post-images (`file_touch::line_diff`). Consumers **must** use them\nrather than counting `+`/`-` lines in `diff`: the diff is a bounded,\ndeliberately coarse rendering of the changed region, and re-deriving\nfrom it is what made the two disagree. Reads carry `0/0` and no diff;\nconsumers that only care about mutations filter on `kind`.",
+      "description": "A file was read/created/modified/deleted by the agent **through a\ntool**, carrying both the authoritative line delta and a diff for\ndisplay.\n\n**Observability, never evidence.** This stream records what the agent\ntouched through tools whose *input* names a path; it is **not** a\ncomplete record of workspace mutation, and nothing may found a claim\nabout what changed on counting it. `bash` names nothing — a heredoc, a\n`patch`, a `make`, or a `>` redirect mutates the tree and emits no event\nhere, which on Terminal-Bench is most of the work. The authority on what\nchanged is the git diff of the tree, and a consumer that needs that\nanswer takes it from there (#2873, which removed the last three\ndecisions that read a count of these events; the tally survives as a\nrecorded-only field on `LadderSnapshot`).\n\nThe single emission point is `ToolRegistry::record_touch` — the same\nplace that writes the session's file-touch ledger and its telemetry\npayload — so the TUI, the audit log and the exported JSON can no longer\ndisagree about what a turn changed. (This doc once claimed one emission\npoint \"by construction\" while the deck in fact synthesized its own\nevents from tool inputs, in a wrapper that knew only four tool names and\nsat on one of three tool stacks. Files edited in bulk, or by a worker\nlane, were reported as `+0 -0`.)\n\n`added`/`removed` are the counts the recorder derived from the real pre-\nand post-images (`file_touch::line_diff`). Consumers **must** use them\nrather than counting `+`/`-` lines in `diff`: the diff is a bounded,\ndeliberately coarse rendering of the changed region, and re-deriving\nfrom it is what made the two disagree. Reads carry `0/0` and no diff;\nconsumers that only care about mutations filter on `kind`.",
       "properties": {
         "added": {
           "default": 0,

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -573,7 +573,7 @@
           "type": "integer"
         },
         "file_change_events": {
-          "description": "Mutating file touches the recorder observed.",
+          "description": "Mutating file touches the recorder observed — a tally of what the agent\ntouched **through tools**, which a shell redirect defeats, and which is\nzero inside a candidate workspace.\n\n**Recorded only: no ladder predicate reads it** (#2873). It is here so a\ncorpus of traces can be read after the fact, exactly like\n[`Self::no_test_surface`]. A consumer asking whether the tree changed\nreads [`Self::diff_available`] with [`Self::diff_lines`] — git is the\nauthority — and one asking whether anything was attempted reads\n[`Self::mutating_actions`].",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -1047,7 +1047,10 @@ export interface ContextUsage {
 }
 
 /**
- * What happened to a file in a `FileChange` event.
+ * What happened to a file in a [`AgentEvent::FileChange`] event — as declared
+ * by the tool that touched it, which is why [`Self::is_mutation`] answers
+ * "was this call a write" and never "did the tree change". See the variant's
+ * doc for the difference and why only git can answer the second.
  */
 export type FileChangeKind = "read" | "created" | "modified" | "deleted";
 

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -1245,7 +1245,16 @@ export interface LadderSnapshot {
    */
   errored_commands?: number;
   /**
-   * Mutating file touches the recorder observed.
+   * Mutating file touches the recorder observed — a tally of what the agent
+   * touched **through tools**, which a shell redirect defeats, and which is
+   * zero inside a candidate workspace.
+   *
+   * **Recorded only: no ladder predicate reads it** (#2873). It is here so a
+   * corpus of traces can be read after the fact, exactly like
+   * [`Self::no_test_surface`]. A consumer asking whether the tree changed
+   * reads [`Self::diff_available`] with [`Self::diff_lines`] — git is the
+   * authority — and one asking whether anything was attempted reads
+   * [`Self::mutating_actions`].
    */
   file_change_events: number;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -2175,7 +2175,7 @@
           "type": "integer"
         },
         "file_change_events": {
-          "description": "Mutating file touches the recorder observed.",
+          "description": "Mutating file touches the recorder observed — a tally of what the agent\ntouched **through tools**, which a shell redirect defeats, and which is\nzero inside a candidate workspace.\n\n**Recorded only: no ladder predicate reads it** (#2873). It is here so a\ncorpus of traces can be read after the fact, exactly like\n[`Self::no_test_surface`]. A consumer asking whether the tree changed\nreads [`Self::diff_available`] with [`Self::diff_lines`] — git is the\nauthority — and one asking whether anything was attempted reads\n[`Self::mutating_actions`].",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -797,7 +797,7 @@
           "type": "object"
         },
         {
-          "description": "A file was read/created/modified/deleted by the agent, carrying both\nthe authoritative line delta and a diff for display.\n\nThe single emission point is `ToolRegistry::record_touch` — the same\nplace that writes the session's file-touch ledger and its telemetry\npayload — so the TUI, the audit log and the exported JSON can no longer\ndisagree about what a turn changed. (This doc once claimed one emission\npoint \"by construction\" while the deck in fact synthesized its own\nevents from tool inputs, in a wrapper that knew only four tool names and\nsat on one of three tool stacks. Files edited in bulk, or by a worker\nlane, were reported as `+0 -0`.)\n\n`added`/`removed` are the counts the recorder derived from the real pre-\nand post-images (`file_touch::line_diff`). Consumers **must** use them\nrather than counting `+`/`-` lines in `diff`: the diff is a bounded,\ndeliberately coarse rendering of the changed region, and re-deriving\nfrom it is what made the two disagree. Reads carry `0/0` and no diff;\nconsumers that only care about mutations filter on `kind`.",
+          "description": "A file was read/created/modified/deleted by the agent **through a\ntool**, carrying both the authoritative line delta and a diff for\ndisplay.\n\n**Observability, never evidence.** This stream records what the agent\ntouched through tools whose *input* names a path; it is **not** a\ncomplete record of workspace mutation, and nothing may found a claim\nabout what changed on counting it. `bash` names nothing — a heredoc, a\n`patch`, a `make`, or a `>` redirect mutates the tree and emits no event\nhere, which on Terminal-Bench is most of the work. The authority on what\nchanged is the git diff of the tree, and a consumer that needs that\nanswer takes it from there (#2873, which removed the last three\ndecisions that read a count of these events; the tally survives as a\nrecorded-only field on `LadderSnapshot`).\n\nThe single emission point is `ToolRegistry::record_touch` — the same\nplace that writes the session's file-touch ledger and its telemetry\npayload — so the TUI, the audit log and the exported JSON can no longer\ndisagree about what a turn changed. (This doc once claimed one emission\npoint \"by construction\" while the deck in fact synthesized its own\nevents from tool inputs, in a wrapper that knew only four tool names and\nsat on one of three tool stacks. Files edited in bulk, or by a worker\nlane, were reported as `+0 -0`.)\n\n`added`/`removed` are the counts the recorder derived from the real pre-\nand post-images (`file_touch::line_diff`). Consumers **must** use them\nrather than counting `+`/`-` lines in `diff`: the diff is a bounded,\ndeliberately coarse rendering of the changed region, and re-deriving\nfrom it is what made the two disagree. Reads carry `0/0` and no diff;\nconsumers that only care about mutations filter on `kind`.",
           "properties": {
             "added": {
               "default": 0,
@@ -1929,7 +1929,7 @@
       "type": "object"
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a `FileChange` event.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`] event — as declared\nby the tool that touched it, which is why [`Self::is_mutation`] answers\n\"was this call a write\" and never \"did the tree change\". See the variant's\ndoc for the difference and why only git can answer the second.",
       "oneOf": [
         {
           "const": "read",


### PR DESCRIPTION
Closes #2873
Refs #2874

## The problem

Stella carries two disagreeing notions of "what changed", and three ladder
predicates consumed the wrong one.

- `AgentEvent::FileChange` is emitted from `ToolRegistry::record_touch`, i.e.
  from tools whose **input names a path**. `bash` names nothing, so a heredoc,
  a `patch`, a `make` or a `>` redirect changes the tree and emits nothing.
- The git diff of the tree misses none of that.

`LadderInputs::file_change_events` carried the first and its own doc called it
*"positive proof the tree changed"*. `evidence_is_blind()`,
`nothing_was_attempted()` and `effects_escaped_collection()` all conjoined on
it.

## The measurement

Read off raw `stella-events.jsonl` from the 2026-08-11 Terminal-Bench 2.1
panel (SUT `main@2193374`), pipeline arms `f89p2` + `f89p3`, all 53 trials that
reached a verdict:

| | count |
|---|---|
| mutating `file_change` events **before** the first `verdict` | **29** |
| mutating `file_change` events **after** it (adoption-time promotions) | **345** |
| trials whose pre-verdict count was 0 | **49 / 53** |

The split is fully explained by one fact:

| ran in a candidate workspace | pre-verdict `file_change` > 0 | trials |
|---|---|---|
| yes | no | **49** |
| no | yes | **4** |

53/53. `mutating_actions` ran 6–147 beside those zeros. Verdicts printed
`"file_change_events": 0` next to `"mutating_actions": 24`, and
`unverifiable_evidence()` wrote the sentence **"file-change events recorded =
0"** into the verdict a human reads — hardcoded at `verify.rs:943`, rendered at
`:953`. Both read as *"the agent touched no files"*.

The tree had already written this down twice, in
`verify_probes::DIFF_PROBE_FAILED` and `pipeline::tests::warrant`: *"the engine
emits no `FileChange` events … inside a best-of-N or witness candidate the
count is always zero."* The ladder branched on it anyway.

## The decision, and why deletion rather than wiring

Wiring the input to a candidate-visible signal would still leave it a
**tool-call tally**, which is the wrong category for the question all three
predicates ask. Taken one at a time:

- **`nothing_was_attempted`** — pure redundancy. Every `FileChange` is emitted
  from a mutating tool call, so `file_change_events > 0` implies
  `mutating_actions > 0`, which the first conjunct already excludes. Removing
  it cannot change an answer, ever.
- **`effects_escaped_collection`** — it was pointing the wrong way. That rung's
  premise is `diff_available && diff_lines == 0`: git looked at the collected
  tree and found it unchanged. A tool tally saying "I wrote files" against that
  reading is evidence **for** the effects having landed outside what the run
  collects — not corroboration that they landed inside it. As written it let a
  tool tally overrule the one channel that had actually observed the tree.
- **`evidence_is_blind`** — it asked a dispatch-side question inside an
  observation-side predicate. `mutating_actions` is deliberately absent from
  this predicate for exactly that reason, and the rung above
  (`nothing_was_attempted`) is where the ladder reads the dispatch record.

So the field becomes **recorded-only** — the shape `LadderInputs::no_test_surface`
already established in this file: still set by the pipeline, still on the wire in
`LadderSnapshot`, still rendered by `replay`, read by no decision, with the issue
that decides its fate named at the field. #2873 stays open as the question
"should this regain a decision role, via a signal a candidate can feed?".

**No decision changes on any of the 53 observed trials.** All four live-channel
trials had a non-zero `diff_lines`, so every predicate already returned the same
answer with and without the conjunct.

## Also in this PR

- `AgentEvent::FileChange` and `FileChangeKind` now say **at the type** that the
  stream is observability and never evidence: it records what the agent touched
  through tools, is not a complete record of tree mutation, and must not back a
  claim about what changed. `FileChangeKind::Read` is untouched — it is
  documented as "no mutation, never a diff" and the files-touched panel needs
  it; the hazard is a consumer summing reads into a diff, which is a caller bug.
- The two `UNVERIFIABLE` summaries lose the file-change-count sentence and keep
  the dispatch count, which is the number that actually contradicts a clean
  tree.
- Stale prose repaired where it claimed the ladder reads this channel:
  `stella-tools/src/shell_touch.rs`, `registry/tests.rs`,
  `docs/spec/remote-sandboxes.md §9.3`.
- Regenerated `docs/wire/` — doc-comment text only, no shape change (the
  additive contract is intact; `FileChangeKind` is still
  `"read" | "created" | "modified" | "deleted"`).

**Deliberately not touched:** the read-before-edit staleness guard
(`crates/stella-tools/src/staleness.rs`, `edit.rs:246`), which refuses an edit
whose file changed out of band by comparing current bytes against the SHA-256 of
what the agent last saw. Coverage verified already present, so no test was added:
`drift_is_attributed_and_fresh_content_echoed`,
`unchanged_file_failure_is_not_drift_attributed`,
`own_successful_edit_is_not_later_misattributed_as_drift` (17/17 green).

## Witness — demonstrated fail→pass flip

`crates/stella-pipeline/src/verify/tests/tool_tally.rs`. Against the parent
commit's `verify.rs` with the new tests in place:

```
$ git show HEAD:crates/stella-pipeline/src/verify.rs > crates/stella-pipeline/src/verify.rs
$ cargo test -p stella-pipeline --lib verify::tests::tool_tally
test verify::tests::tool_tally::no_predicate_reads_the_tool_tally ... FAILED
test verify::tests::tool_tally::the_unverifiable_summary_makes_no_file_change_count_claim ... FAILED
test verify::tests::tool_tally::the_decision_never_moves_with_the_tool_tally ... FAILED
test result: FAILED. 0 passed; 3 failed
```

with, e.g.:

```
escaped: the summary still reports a tool tally as evidence: UNVERIFIABLE — this turn
dispatched 24 call(s) able to change the workspace, … file-change events recorded = 0.
```

And with the fix:

```
$ cargo test -p stella-pipeline
test result: ok. 705 passed; 0 failed
```

The central test sweeps `file_change_events` over `[0, 1, 3, 19, 147, u32::MAX]`
against inputs that reach each of the five terminal ladder outcomes and asserts
the decision does not move — so a future edit that re-introduces the conjunct
fails here, with the predicate named.

## Deleted test (named per `check-deleted-tests`)

`verify/tests.rs::a_recorded_file_touch_is_evidence_even_with_no_readable_diff`
is replaced by `a_recorded_file_touch_is_not_evidence_of_a_changed_tree` in the
same file — same fixture, reversed assertion, which is the change itself.
`uncollected.rs::one_corroborating_observation_lifts_the_turn_off_the_abstain_rung`
and `verify/tests.rs::one_positive_observation_defeats_the_no_op_rung` each lose
one loop arm (both survive as tests); the removals are documented in the doc
comment above each.

## Nothing left behind

- #2873 — this PR, closed.
- #2874 — filed: `FileChange` is `ConsumerPosture::Unclassified { issue: "#2703" }`
  and should be `Surfaced`, but the `Surface` vocabulary has only `Observatory`
  and `Serve` and the Observatory does not query `file_change`, so a correct
  classification needs a new `Surface` variant for the terminal surfaces.

## Summary by Sourcery

Stop using file-change event tallies as decision inputs in the verification ladder and reclassify them as observability-only, while tightening docs and tests to ensure git is the sole authority on workspace changes.

Bug Fixes:
- Ensure ladder predicates no longer treat file-change event counts as evidence about whether the workspace tree changed.
- Correct unverifiable verdict summaries to report mutating dispatch counts instead of file-change event tallies.

Enhancements:
- Clarify `AgentEvent::FileChange` and `FileChangeKind` semantics as tool-level observability signals, not authoritative tree-change evidence.
- Preserve `file_change_events` as a recorded-only field in ladder inputs and snapshots without letting it influence decisions.
- Improve ladder predicate documentation to distinguish dispatch records from observation channels and align behavior with measured terminal-bench traces.

Documentation:
- Update protocol and spec docs to reflect the observability-only role of file-change events and the ladder’s reliance on git for tree-change decisions.
- Regenerate wire documentation for `FileChangeKind` without changing its wire shape.

Tests:
- Add dedicated `tool_tally` tests to assert ladder decisions and predicates are invariant under changes to `file_change_events` and that summaries no longer treat it as evidence.
- Adjust or replace existing ladder tests to reflect that recorded file touches are not evidence of tree changes and remove unreachable or misleading test arms.