### PR TITLE
fix(stella-tools): confine the candidate shell to its own workspace — the graded tree and Stella's own refs are off limits

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -353,8 +353,13 @@ impl GitCandidateWorkspaces {
         let toplevel = git(&canon_root, &["rev-parse", "--show-toplevel"])
             .await
             .map_err(snap)?;
-        let toplevel = PathBuf::from(toplevel.trim());
-        let toplevel = toplevel.canonicalize().unwrap_or(toplevel);
+        // Kept before canonicalization: it is the spelling the operator and
+        // the task statement use, and the shell confinement below has to
+        // refuse it by that name too.
+        let toplevel_as_git_spells_it = PathBuf::from(toplevel.trim());
+        let toplevel = toplevel_as_git_spells_it
+            .canonicalize()
+            .unwrap_or_else(|_| toplevel_as_git_spells_it.clone());
         let head = git(&toplevel, &["rev-parse", "HEAD"]).await.map_err(|e| {
             snap(format!(
                 "candidate isolation requires a git repository with at least one commit: {e}"
@@ -395,11 +400,19 @@ impl GitCandidateWorkspaces {
                 // for what that is worth and what it cannot enforce. The
                 // TOPLEVEL, not `canon_root`: adoption applies against the
                 // whole repository, so everything under it is graded.
+                //
+                // Every spelling the tree answers to is registered, not just
+                // the canonical one: the audit compares names, and on macOS
+                // `/var/folders/…` and `/private/var/folders/…` are the same
+                // directory — a guard that knew only the canonical form let
+                // the other straight through.
                 let mut options = self.options.clone();
                 options.shell_confinement =
-                    stella_tools::bash::ShellConfinement::graded_tree(toplevel.clone());
-                let registry =
-                    crate::agent::new_tool_registry(ws_root.clone(), options).await;
+                    stella_tools::bash::ShellConfinement::graded_tree(toplevel.clone())
+                        .and_alias(toplevel_as_git_spells_it.clone())
+                        .and_alias(self.root.clone())
+                        .and_alias(canon_root.clone());
+                let registry = crate::agent::new_tool_registry(ws_root.clone(), options).await;
                 // Same governance as the session registry: workspace rules
                 // and the schema gate travel with the tree — best-of-N must
                 // not be a way around them. Applied while `registry` is still

--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -385,8 +385,21 @@ impl GitCandidateWorkspaces {
         match populate_snapshot(&toplevel, &dir, &root_rel).await {
             Ok((overlay_untracked, baseline)) => {
                 let ws_root = dir.join(&root_rel);
+                // This candidate's shell is the one tool that can still reach
+                // the real tree (#1300 removed the local sandbox), and two
+                // benchmark losses came of it: a wrong intermediate written
+                // straight to `/app/summary.csv`, and Stella's own
+                // witness-baseline ref rewritten from inside a candidate. The
+                // registry is told which tree it is delivering *into*, so the
+                // shell refuses to name it — see `stella_tools::bash::confine`
+                // for what that is worth and what it cannot enforce. The
+                // TOPLEVEL, not `canon_root`: adoption applies against the
+                // whole repository, so everything under it is graded.
+                let mut options = self.options.clone();
+                options.shell_confinement =
+                    stella_tools::bash::ShellConfinement::graded_tree(toplevel.clone());
                 let registry =
-                    crate::agent::new_tool_registry(ws_root.clone(), self.options.clone()).await;
+                    crate::agent::new_tool_registry(ws_root.clone(), options).await;
                 // Same governance as the session registry: workspace rules
                 // and the schema gate travel with the tree — best-of-N must
                 // not be a way around them. Applied while `registry` is still

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -764,3 +764,90 @@ async fn a_repo_without_commits_is_a_clean_snapshot_error() {
     assert_no_candidate_worktrees(&root);
     std::fs::remove_dir_all(&root).ok();
 }
+
+/// The `log-summary-date-ranges` loss, end to end through the real candidate
+/// tool surface (#2875): a candidate's shell must not be able to write the
+/// graded tree, whatever spelling it uses. That trial's escape was
+/// `write_file` refusing an absolute path and the model reissuing the same
+/// write through `bash`, so this asserts the two now agree — while the
+/// candidate's own tree stays writable, which is why the guard is not a
+/// blanket refusal of everything outside the workspace.
+#[tokio::test]
+async fn a_candidates_shell_cannot_write_the_graded_tree() {
+    let root = scaffold("shell-confinement");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+    let leaked = root.join("summary.csv");
+
+    let output = ws
+        .tools()
+        .execute(
+            "bash",
+            &serde_json::json!({
+                "command": format!("echo today,ERROR,414 > {}", leaked.display())
+            }),
+        )
+        .await;
+    let inside = ws
+        .tools()
+        .execute(
+            "bash",
+            &serde_json::json!({"command": "echo 370 > summary.csv"}),
+        )
+        .await;
+
+    let landed = leaked.exists();
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+
+    assert!(
+        !landed,
+        "a candidate's shell wrote the graded tree: {output:?}"
+    );
+    assert!(output.is_error(), "the write was not refused: {output:?}");
+    assert!(!inside.is_error(), "the candidate's own tree: {inside:?}");
+}
+
+/// `f89p3/code-from-image` steps 83–86, end to end: the ref `verify_done`
+/// pins its baseline to is not the candidate's to move (#2875).
+#[tokio::test]
+async fn a_candidates_shell_cannot_move_stellas_witness_baseline_ref() {
+    let root = scaffold("shell-ref-confinement");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+
+    let output = ws
+        .tools()
+        .execute(
+            "bash",
+            &serde_json::json!({
+                "command": format!(
+                    "git update-ref {} HEAD",
+                    stella_tools::verify::WITNESS_BASELINE_WORKTREE_REF
+                )
+            }),
+        )
+        .await;
+
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+
+    assert!(
+        output.is_error(),
+        "Stella's own ref was writable from a candidate: {output:?}"
+    );
+}

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -24,6 +24,13 @@
 //! running interpreter as well. An operator who needs shell execution actually
 //! contained wants that chain plus a boundary the whole process sits inside.
 //!
+//! **What confinement there is, is a literal audit of the command text**
+//! ([`confine`]), performed before the spawn: an isolated candidate's shell is
+//! refused a command that names the graded tree it delivers into, and every
+//! shell is refused one that writes Stella's own git refs. It is not a sandbox
+//! and does not pretend to be one — read [`confine`]'s header for what it
+//! cannot enforce.
+//!
 //! **There is no per-command OS confinement here.** `STELLA_BASH_SANDBOX` —
 //! the opt-in Seatbelt/`bwrap` wrapper that used to sit on this spawn — was
 //! removed (#1300). It wrapped this one tool while `build_project`,
@@ -43,6 +50,10 @@ use stella_protocol::tool::{ToolOutput, ToolSchema};
 use tokio::process::Command;
 
 use crate::registry::Tool;
+
+pub mod confine;
+
+pub use confine::ShellConfinement;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 /// Byte cap on one `bash` result before head+tail elision
@@ -206,7 +217,11 @@ fn bash_grep_is_symbol_shaped(command: &str) -> bool {
 /// `cd`-ing back to the original is the natural misreading — and it used to
 /// draw no response at all, leaving the turn's work split across two trees with
 /// the half outside this root silently uncollected.
-fn graph_advisory(command: &str, root: &Path) -> Option<String> {
+fn graph_advisory(
+    command: &str,
+    root: &Path,
+    confinement: &ShellConfinement,
+) -> Option<String> {
     let graphed = matches!(crate::graph::graph_available(root), Ok(true));
     if let Some(target) = cd_escape_target(command, root) {
         // Named only when the graph is real: pointing at graph_query as a
@@ -217,12 +232,30 @@ fn graph_advisory(command: &str, root: &Path) -> Option<String> {
         } else {
             ""
         };
+        // The remedy has to be one the *agent* can perform. "Re-root the
+        // session" is the user's move, not the model's, and offering it as
+        // the answer is how `build-cython-ext` step 5 concluded that the
+        // graded tree was its own workspace under another name and ran
+        // `rm -rf /app/pyknotid` — the exact two grader tests it then failed.
+        // Under a candidate the note also has to state the half it used to
+        // omit: work here is not stranded, it is *delivered* by adoption.
+        let remedy = match confinement.graded_root() {
+            Some(graded) => format!(
+                " Work under this session root is delivered to `{}` when the run \
+                 finishes, so bring what you need into this root and work here; \
+                 `{}` is not a second name for that tree.",
+                graded.display(),
+                root.display()
+            ),
+            None => " Copy what you need under the session root and work there; only the \
+                     user can re-root the session on another tree."
+                .to_string(),
+        };
         return Some(format!(
             "\n\nnote: this cd'd to `{target}`, outside the session root `{}`. Only \
              work under the session root is collected when the turn finishes — every \
              other tool is confined to it, so edits under `{target}` are invisible to \
-             the file tools, to this turn's diff, and to verification.{graph_note} To \
-             work on that tree, re-root the session on it (run stella from it).",
+             the file tools, to this turn's diff, and to verification.{graph_note}{remedy}",
             root.display()
         ));
     }
@@ -234,11 +267,27 @@ fn graph_advisory(command: &str, root: &Path) -> Option<String> {
 
 pub struct Bash {
     scratch: Option<std::path::PathBuf>,
+    confinement: ShellConfinement,
 }
 
 impl Bash {
     pub fn new(scratch: Option<std::path::PathBuf>) -> Self {
-        Self { scratch }
+        Self {
+            scratch,
+            confinement: ShellConfinement::unconfined(),
+        }
+    }
+
+    /// Keep this shell out of the territory `confinement` names — see
+    /// [`confine`] for what that is and what it is worth.
+    ///
+    /// A builder rather than a `new` parameter because the posture is set by
+    /// exactly one caller (the candidate-workspace registry) while every other
+    /// construction site wants the default, and a fourth positional argument
+    /// at ten call sites is how a default gets passed by accident.
+    pub fn confined_to(mut self, confinement: ShellConfinement) -> Self {
+        self.confinement = confinement;
+        self
     }
 }
 
@@ -271,6 +320,13 @@ impl Tool for Bash {
                 };
             }
         };
+        // Audited before the spawn, on the text the model wrote: a refusal
+        // that arrives after the process has run is a report, not a boundary.
+        if let Err(refusal) = self.confinement.audit(command, root) {
+            return ToolOutput::Error {
+                message: refusal.to_string(),
+            };
+        }
         let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         // trace: true prefixes `set -x` so every executed line echoes to
         // stderr — an execution trace a verifier can demand as evidence.
@@ -398,7 +454,7 @@ impl Tool for Bash {
         // Append after truncation so the steer is never the part that gets
         // cut: a cross-root `cd` warning or a symbol-shaped-grep graph_query
         // nudge, when an index exists.
-        if let Some(note) = graph_advisory(command, root) {
+        if let Some(note) = graph_advisory(command, root, &self.confinement) {
             combined.push_str(&note);
         }
 
@@ -892,6 +948,145 @@ mod tests {
         );
         assert!(!text.contains("graph_query"), "{text}");
         assert!(!text.contains("outside the session root"), "{text}");
+    }
+
+    /// The `log-summary-date-ranges` loss, reduced: a script that hardcodes a
+    /// path in the graded tree must not reach the disk. Before confinement the
+    /// write succeeded, the run was aborted before adoption, and the grader
+    /// read the leaked wrong intermediate — a solved task scoring zero.
+    #[tokio::test]
+    async fn a_write_into_the_graded_tree_never_reaches_the_disk() {
+        let graded = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let leaked = graded.path().join("summary.csv");
+        let tool = Bash::new(None)
+            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+
+        let text = text_of(
+            tool.execute(
+                &serde_json::json!({
+                    "command": format!("echo today,ERROR,414 > {}", leaked.display())
+                }),
+                workspace.path(),
+            )
+            .await,
+        );
+
+        assert!(!leaked.exists(), "the graded tree was written: {text}");
+        assert!(text.contains("refused before running"), "{text}");
+        // The remedy names the file's address in this shell's own workspace.
+        assert!(
+            text.contains(&workspace.path().join("summary.csv").display().to_string()),
+            "{text}"
+        );
+    }
+
+    /// The same escape re-issued as the heredoc the model actually reaches for
+    /// once `write_file` refuses it: the path is not a shell word at all, so a
+    /// word-level check alone would let it straight through.
+    #[tokio::test]
+    async fn a_graded_path_buried_in_a_script_body_is_still_refused() {
+        let graded = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let leaked = graded.path().join("summary.csv");
+        let command = format!(
+            "cat <<'EOF' > /dev/null\nignored\nEOF\nprintf 'x' > '{}'",
+            leaked.display()
+        );
+        let tool = Bash::new(None)
+            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+
+        let text = text_of(
+            tool.execute(&serde_json::json!({ "command": command }), workspace.path())
+                .await,
+        );
+
+        assert!(!leaked.exists(), "the graded tree was written: {text}");
+        assert!(text.contains("refused before running"), "{text}");
+    }
+
+    /// `f89p3/code-from-image` steps 83–86: the worker moved the very ref
+    /// `verify_done` pins its baseline to. Refused in every session, confined
+    /// or not — no task's work lives in Stella's ref namespace.
+    #[tokio::test]
+    async fn rewriting_stellas_own_ref_is_refused_and_leaves_the_ref_alone() {
+        let repo = tempfile::tempdir().unwrap();
+        let sentinel = repo.path().join("moved");
+        let text = text_of(
+            Bash::new(None)
+                .execute(
+                    &serde_json::json!({
+                        "command": format!(
+                            "touch {} && git update-ref {} HEAD",
+                            sentinel.display(),
+                            crate::verify::WITNESS_BASELINE_WORKTREE_REF
+                        )
+                    }),
+                    repo.path(),
+                )
+                .await,
+        );
+        assert!(
+            !sentinel.exists(),
+            "the command ran despite naming Stella's ref namespace: {text}"
+        );
+        assert!(text.contains(confine::STELLA_REF_NAMESPACE), "{text}");
+    }
+
+    /// The legitimate case a blanket refusal would break: `configure-git-webserver`
+    /// installs and configures system software, and that is the task, not an
+    /// escape. Confinement must leave every path outside the graded tree alone.
+    #[tokio::test]
+    async fn a_confined_shell_still_writes_system_paths_outside_the_graded_tree() {
+        let graded = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let system = tempfile::tempdir().unwrap();
+        let conf = system.path().join("nginx.conf");
+        let tool = Bash::new(None)
+            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+
+        let text = text_of(
+            tool.execute(
+                &serde_json::json!({
+                    "command": format!("echo 'server {{}}' > {}", conf.display())
+                }),
+                workspace.path(),
+            )
+            .await,
+        );
+
+        assert!(conf.exists(), "a system path outside the graded tree: {text}");
+    }
+
+    /// The advisory that sent `build-cython-ext` into `rm -rf /app/pyknotid`:
+    /// it said work outside the root is not collected (true of the diff) and
+    /// offered a remedy the agent cannot perform, while omitting that work in
+    /// the candidate IS delivered to the graded tree by adoption.
+    #[tokio::test]
+    async fn the_drift_note_states_adoption_and_offers_a_remedy_the_agent_can_perform() {
+        let graded = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let tool = Bash::new(None)
+            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+
+        let text = text_of(
+            tool.execute(
+                &serde_json::json!({ "command": format!("cd {} && pwd", elsewhere.path().display()) }),
+                workspace.path(),
+            )
+            .await,
+        );
+
+        assert!(text.contains("outside the session root"), "{text}");
+        assert!(
+            text.contains("is delivered to"),
+            "the note must state that work here reaches the graded tree: {text}"
+        );
+        assert!(
+            !text.contains("re-root the session on it"),
+            "the remedy must be one the agent can perform: {text}"
+        );
     }
 
     /// Witness test for #2696: verify STELLA_SCRATCH is injected via constructor

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -217,11 +217,7 @@ fn bash_grep_is_symbol_shaped(command: &str) -> bool {
 /// `cd`-ing back to the original is the natural misreading — and it used to
 /// draw no response at all, leaving the turn's work split across two trees with
 /// the half outside this root silently uncollected.
-fn graph_advisory(
-    command: &str,
-    root: &Path,
-    confinement: &ShellConfinement,
-) -> Option<String> {
+fn graph_advisory(command: &str, root: &Path, confinement: &ShellConfinement) -> Option<String> {
     let graphed = matches!(crate::graph::graph_available(root), Ok(true));
     if let Some(target) = cd_escape_target(command, root) {
         // Named only when the graph is real: pointing at graph_query as a
@@ -959,8 +955,8 @@ mod tests {
         let graded = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
         let leaked = graded.path().join("summary.csv");
-        let tool = Bash::new(None)
-            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+        let tool =
+            Bash::new(None).confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
 
         let text = text_of(
             tool.execute(
@@ -993,8 +989,8 @@ mod tests {
             "cat <<'EOF' > /dev/null\nignored\nEOF\nprintf 'x' > '{}'",
             leaked.display()
         );
-        let tool = Bash::new(None)
-            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+        let tool =
+            Bash::new(None).confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
 
         let text = text_of(
             tool.execute(&serde_json::json!({ "command": command }), workspace.path())
@@ -1042,8 +1038,8 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let system = tempfile::tempdir().unwrap();
         let conf = system.path().join("nginx.conf");
-        let tool = Bash::new(None)
-            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+        let tool =
+            Bash::new(None).confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
 
         let text = text_of(
             tool.execute(
@@ -1055,7 +1051,10 @@ mod tests {
             .await,
         );
 
-        assert!(conf.exists(), "a system path outside the graded tree: {text}");
+        assert!(
+            conf.exists(),
+            "a system path outside the graded tree: {text}"
+        );
     }
 
     /// The advisory that sent `build-cython-ext` into `rm -rf /app/pyknotid`:
@@ -1067,8 +1066,8 @@ mod tests {
         let graded = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
         let elsewhere = tempfile::tempdir().unwrap();
-        let tool = Bash::new(None)
-            .confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
+        let tool =
+            Bash::new(None).confined_to(ShellConfinement::graded_tree(graded.path().to_path_buf()));
 
         let text = text_of(
             tool.execute(

--- a/crates/stella-tools/src/bash/confine.rs
+++ b/crates/stella-tools/src/bash/confine.rs
@@ -1,0 +1,602 @@
+//! What a shell running inside an isolated candidate may not touch (#2875).
+//!
+//! [`crate::rootfd`] confines the *file tools* by held descriptors, and says so
+//! in its own header: it "is not a sandbox for the subprocesses they spawn —
+//! `bash` can still write wherever the user's own account can". That concession
+//! was paid for twice on the 2026-08-11 Terminal-Bench panel, in both of the
+//! two ways it can be:
+//!
+//! * **Through the filesystem.** On `log-summary-date-ranges` the worker's
+//!   first script hardcoded the task statement's `/app/summary.csv`, ran once,
+//!   and wrote a wrong intermediate straight into the graded tree. The worker
+//!   then computed the right answer *inside* its candidate, the run aborted
+//!   before adoption, and the grader read the leaked wrong file. Stella solved
+//!   the task and scored zero. `write_file` and `apply_edits` refuse that path
+//!   (`escapes workspace root`); the model simply reissued it as a heredoc.
+//! * **Through the git ref namespace.** On `code-from-image` the worker ran
+//!   `git update-ref refs/worktree/stella/witness-baseline <its own commit>` —
+//!   the exact ref `verify_done` pins its baseline to — then
+//!   `git reflog expire --expire=now --all && git gc --prune=now`. Nothing in
+//!   that trace shows a fabricated flip, but a benchmark the subject can edit
+//!   the scorer's state inside is not a measurement. The seal's own error text
+//!   already conceded the hole: "a candidate worktree isolates the working tree
+//!   but not the ref namespace."
+//!
+//! # The posture, and why it is not "refuse everything outside the root"
+//!
+//! Some tasks genuinely require system-level effects — `apt-get install nginx`,
+//! writing `/etc/nginx/sites-enabled`, populating `/var/www/html`. A blanket
+//! refusal of everything outside the workspace fails those outright, so what is
+//! protected is deliberately narrow and named:
+//!
+//! 1. **The graded tree** — the real workspace root the candidate's work is
+//!    delivered into by adoption. Writing there bypasses the delivery channel
+//!    and corrupts the artifact the run is judged against, which is a different
+//!    thing from doing the task.
+//! 2. **Stella's own git refs** ([`STELLA_REF_NAMESPACE`]) and, inside a
+//!    candidate, the git operations that destroy the objects those refs pin.
+//!    No task's work lives there; only the scorer's does.
+//!
+//! Everything else stays exactly as writable as it was. `/etc`, `/usr`, `/var`,
+//! `/tmp` and the package manager are untouched by this module — protection (1)
+//! arms only when a host declares a *distinct* graded tree, which today means a
+//! best-of-N candidate workspace, and protection (2) costs nothing anywhere
+//! because nothing legitimate names those refs.
+//!
+//! # What is enforced, and what is not
+//!
+//! This is a **literal audit of the command text**, performed before the spawn.
+//! It is honest about its own ceiling: a shell can compute a path at runtime,
+//! and `p=/ap; p=$p$'p'; printf x > "$p/f"` defeats every string check that
+//! will ever be written here. What it does buy:
+//!
+//! * an **accidental** escape — the dominant real shape, a path copied out of
+//!   the task statement — becomes impossible rather than silent, and
+//! * a **deliberate** one has to be obfuscated, which a trace reader can see.
+//!
+//! Total confinement of a shell is an OS boundary (a container, a seccomp
+//! profile), not a parser; `STELLA_BASH_SANDBOX` was removed in #1300 precisely
+//! because it claimed a session-wide bound it did not have, and this module
+//! does not re-make that claim. `crates/stella-cli/src/candidate_ws/escape.rs`
+//! remains the post-hoc backstop for what gets through.
+//!
+//! Two mechanisms were considered and rejected rather than shipped weak.
+//! `GIT_CEILING_DIRECTORIES` stops git's *upward* discovery, and a candidate
+//! worktree's `.git` file points into the shared common directory from the
+//! first component — there is no ascent to stop, so the variable would be
+//! decoration. A per-candidate `GIT_DIR`/`GIT_COMMON_DIR` would sever the
+//! worktree from the object store it is a worktree of. The mechanism that
+//! *would* be total for refs is a `reference-transaction` hook in the shared
+//! repository, which git enforces itself for every ref update from any
+//! worktree; it mutates the operator's repository, so it belongs to the
+//! candidate's setup rather than to a tool, and is tracked separately.
+//!
+//! # Deliberately out of scope
+//!
+//! Refs the graded tree merely *shares* (`refs/heads/*`): a candidate creating,
+//! moving or deleting a branch is ordinary task work, and the observed loss
+//! there (`query-optimize`) is a seal that refuses where it could repair, not
+//! an escape to prevent.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Stella's private per-worktree git ref namespace. `verify_done` pins the
+/// baseline commit of every witness run under it, so a command that writes
+/// here is editing the scorer's state, whatever it meant to do.
+///
+/// Kept as a prefix rather than a list of exact refs: a new Stella-owned ref
+/// under this namespace is protected the day it is introduced, with nothing
+/// to remember to add here.
+pub const STELLA_REF_NAMESPACE: &str = "refs/worktree/stella/";
+
+/// git subcommands that delete unreachable objects or the reflogs that keep
+/// them reachable. A candidate shares its object store with the graded tree,
+/// so any of these can drop the baseline commit the verification and the
+/// adoption both resolve against.
+const HISTORY_DESTROYING: &[&str] = &["gc", "prune", "repack"];
+
+/// Characters that continue a path literal. Everything else terminates one —
+/// quotes and shell operators most importantly, which is what lets an embedded
+/// `open('/app/summary.csv', 'w')` yield exactly `/app/summary.csv`.
+fn is_path_char(c: char) -> bool {
+    !(c.is_whitespace()
+        || matches!(
+            c,
+            '\'' | '"'
+                | '`'
+                | ';'
+                | '&'
+                | '|'
+                | '<'
+                | '>'
+                | '('
+                | ')'
+                | '$'
+                | '{'
+                | '}'
+                | ','
+                | '='
+                | ':'
+                | '*'
+                | '?'
+                | '['
+                | ']'
+                | '!'
+                | '#'
+                | '\\'
+        ))
+}
+
+/// Resolve `rel` against `base` **lexically** — `..` pops a component instead
+/// of asking the filesystem. Not a security primitive on its own (a symlink
+/// makes the lexical answer and the real one differ); it exists so a relative
+/// `../../app/x` is classified the same way the absolute spelling would be.
+fn lexical_join(base: &Path, rel: &Path) -> PathBuf {
+    let mut out = base.to_path_buf();
+    for component in rel.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Normal(name) => out.push(name),
+            Component::RootDir => out = PathBuf::from("/"),
+            Component::Prefix(prefix) => out = PathBuf::from(prefix.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Why a shell command was refused before it ran.
+///
+/// A typed value rather than a message, because the two halves have different
+/// audiences: the variant is what a caller would branch on (and what a future
+/// diagnostic record would carry), while [`Display`](std::fmt::Display) is the
+/// remediation the model reads. Every message names the substitute that *does*
+/// work — a refusal that only says "no" teaches the model to try a spelling
+/// that evades the check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Refusal {
+    /// The command names a path inside the graded tree.
+    GradedTree {
+        /// The literal as written, for the message.
+        literal: String,
+        /// The graded tree it falls under.
+        graded_root: PathBuf,
+        /// The same file inside this shell's own workspace, when the literal
+        /// is under the graded root by a path that can be rebased.
+        substitute: Option<PathBuf>,
+    },
+    /// The command names a ref in [`STELLA_REF_NAMESPACE`].
+    StellaRef { reference: String },
+    /// The command runs a git operation that destroys shared objects.
+    HistoryDestroying { subcommand: String },
+}
+
+impl std::fmt::Display for Refusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GradedTree {
+                literal,
+                graded_root,
+                substitute,
+            } => {
+                write!(
+                    f,
+                    "refused before running: `{literal}` is inside the graded tree `{}`, which \
+                     this shell may not touch. This shell's workspace is a snapshot of that \
+                     tree, and work done here IS delivered back to it when the run finishes; \
+                     work written directly into it is not part of that delivery and corrupts \
+                     the tree the result is judged against.",
+                    graded_root.display()
+                )?;
+                if let Some(substitute) = substitute {
+                    write!(f, " Use `{}` instead.", substitute.display())?;
+                }
+                write!(
+                    f,
+                    " Naming the graded tree at all — even inside a script body, an `echo`, or \
+                     a comment — trips this, so rewrite the path rather than quoting it \
+                     differently. Nothing else outside this workspace is restricted: system \
+                     paths such as /etc, /usr and /var are still writable."
+                )
+            }
+            Self::StellaRef { reference } => write!(
+                f,
+                "refused before running: `{reference}` is in `{STELLA_REF_NAMESPACE}`, Stella's \
+                 own git ref namespace rather than the task's. `verify_done` pins the baseline \
+                 of every witness run there, so a command that moves, deletes, or rewrites it \
+                 can fabricate a fail→pass flip — it is refused whatever it intended. Ordinary \
+                 work belongs under refs/heads/ and refs/tags/."
+            ),
+            Self::HistoryDestroying { subcommand } => write!(
+                f,
+                "refused before running: `git {subcommand}` destroys objects and reflogs in an \
+                 object store this workspace SHARES with the graded tree, including the \
+                 baseline commit this run's verification and its adoption both resolve \
+                 against. There is nothing to reclaim here — the workspace is discarded whole \
+                 when the run ends."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Refusal {}
+
+/// The territory a `bash` invocation may not name.
+///
+/// Default is [`unconfined`](Self::unconfined), which still enforces the two
+/// protections that have no legitimate use anywhere — see the module header
+/// for why the graded-tree half is opt-in and the ref half is not.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ShellConfinement {
+    /// The real workspace root this shell's work is *delivered into*, when
+    /// this shell is running somewhere else. `None` in an ordinary session,
+    /// where the workspace root and the graded tree are the same directory and
+    /// there is nothing to keep the shell out of.
+    graded_root: Option<PathBuf>,
+}
+
+impl ShellConfinement {
+    /// An ordinary session: the workspace root is the tree the work is judged
+    /// on, so a write into it is the work, not an escape.
+    pub fn unconfined() -> Self {
+        Self { graded_root: None }
+    }
+
+    /// Arm the graded-tree protection for a shell running in an isolated
+    /// workspace whose output reaches `graded_root` only by adoption.
+    ///
+    /// A root with no components of its own (`/`, or a relative path) does not
+    /// arm: "everything is protected" is the blanket refusal this module
+    /// exists not to be, and a relative root cannot be compared against the
+    /// absolute literals a command contains.
+    pub fn graded_tree(graded_root: impl Into<PathBuf>) -> Self {
+        let graded_root = graded_root.into();
+        let armed = graded_root.is_absolute()
+            && graded_root
+                .components()
+                .any(|c| matches!(c, Component::Normal(_)));
+        Self {
+            graded_root: armed.then_some(graded_root),
+        }
+    }
+
+    /// The graded tree this shell is kept out of, if any.
+    pub fn graded_root(&self) -> Option<&Path> {
+        self.graded_root.as_deref()
+    }
+
+    /// Refuse `command` if its text names protected territory, given the
+    /// workspace root the shell will run in.
+    ///
+    /// The two ref protections run whatever the posture; the graded-tree scan
+    /// runs only when armed, and never when the graded tree *is* this shell's
+    /// own root (a host that armed it redundantly gets the ordinary session
+    /// behaviour rather than a shell that cannot name its own files).
+    pub fn audit(&self, command: &str, session_root: &Path) -> Result<(), Refusal> {
+        if let Some(reference) = stella_ref_named(command) {
+            return Err(Refusal::StellaRef { reference });
+        }
+        let Some(graded_root) = self.graded_root.as_deref() else {
+            return Ok(());
+        };
+        if session_root == graded_root {
+            return Ok(());
+        }
+        if let Some(subcommand) = history_destroying_git(command) {
+            return Err(Refusal::HistoryDestroying { subcommand });
+        }
+        if let Some(literal) = graded_literal(command, graded_root, session_root) {
+            let substitute = Path::new(&literal)
+                .strip_prefix(graded_root)
+                .ok()
+                .map(|rel| session_root.join(rel));
+            return Err(Refusal::GradedTree {
+                literal,
+                graded_root: graded_root.to_path_buf(),
+                substitute,
+            });
+        }
+        // A relative spelling of the same escape: `cd ../..` out of a
+        // workspace that happens to sit beside the graded tree. Only words
+        // that climb are resolved — a plain relative path cannot leave the
+        // root it is joined to.
+        for word in super::shell_words(command) {
+            let path = Path::new(&word);
+            if path.is_absolute() || !word.contains("..") {
+                continue;
+            }
+            let resolved = lexical_join(session_root, path);
+            if resolved.starts_with(graded_root) && !resolved.starts_with(session_root) {
+                let substitute = resolved
+                    .strip_prefix(graded_root)
+                    .ok()
+                    .map(|rel| session_root.join(rel));
+                return Err(Refusal::GradedTree {
+                    literal: word,
+                    graded_root: graded_root.to_path_buf(),
+                    substitute,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The first ref in [`STELLA_REF_NAMESPACE`] the command names, read straight
+/// out of the text: the namespace is distinctive enough that no boundary test
+/// is needed, and every way of reaching it — plumbing, porcelain, a config
+/// file written by the command — spells it the same.
+fn stella_ref_named(command: &str) -> Option<String> {
+    let at = command.find(STELLA_REF_NAMESPACE)?;
+    let rest = &command[at..];
+    let end = rest
+        .find(|c: char| !is_path_char(c))
+        .unwrap_or(rest.len());
+    Some(rest[..end].to_string())
+}
+
+/// The first path literal under `graded_root` the command names.
+///
+/// Matched at path boundaries in both directions, so `/application` does not
+/// match a graded `/app` and `/tmp/app` does not match one either. A literal
+/// that is also under `session_root` is this shell's own file — that only
+/// arises if a host nests the two, and it must not be refused.
+fn graded_literal(command: &str, graded_root: &Path, session_root: &Path) -> Option<String> {
+    let needle = graded_root.to_str()?;
+    let mut from = 0usize;
+    while let Some(offset) = command[from..].find(needle) {
+        let at = from + offset;
+        let end = at + needle.len();
+        let before_ok = !command[..at]
+            .chars()
+            .next_back()
+            .is_some_and(is_path_char);
+        let after = command[end..].chars().next();
+        let after_ok = after == Some('/') || !after.is_some_and(is_path_char);
+        if before_ok && after_ok {
+            let rest = &command[at..];
+            let len = rest
+                .find(|c: char| !is_path_char(c))
+                .unwrap_or(rest.len());
+            let literal = &rest[..len];
+            if !Path::new(literal).starts_with(session_root) {
+                return Some(literal.to_string());
+            }
+        }
+        from = end;
+    }
+    None
+}
+
+/// The object-destroying git subcommand the command runs, if any.
+///
+/// Scans for a `git` word and reads the first word after it that is not a
+/// global flag, which is where every spelling — `git gc`, `git -C dir gc`,
+/// `git -c gc.auto=0 gc` — puts the subcommand. `reflog` counts only with a
+/// destructive verb after it, because `git reflog` alone is a read.
+fn history_destroying_git(command: &str) -> Option<String> {
+    let words = super::shell_words(command);
+    for (i, word) in words.iter().enumerate() {
+        if word != "git" && !word.ends_with("/git") {
+            continue;
+        }
+        let mut rest = words[i + 1..].iter();
+        let mut subcommand = None;
+        while let Some(next) = rest.next() {
+            if matches!(next.as_str(), ";" | "&" | "&&" | "|" | "||") {
+                break;
+            }
+            if matches!(next.as_str(), "-C" | "-c" | "--git-dir" | "--work-tree") {
+                // These take a separate argument; skip it too.
+                rest.next();
+                continue;
+            }
+            if next.starts_with('-') {
+                continue;
+            }
+            subcommand = Some(next.clone());
+            break;
+        }
+        let Some(subcommand) = subcommand else { continue };
+        if HISTORY_DESTROYING.contains(&subcommand.as_str()) {
+            return Some(subcommand);
+        }
+        if subcommand == "reflog"
+            && rest.any(|w| matches!(w.as_str(), "expire" | "delete"))
+        {
+            return Some("reflog expire".to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate() -> (ShellConfinement, PathBuf) {
+        (
+            ShellConfinement::graded_tree("/app"),
+            PathBuf::from("/tmp/stella_candidate_63_0"),
+        )
+    }
+
+    /// The namespace constant and the ref `verify_done` actually pins must not
+    /// drift apart: this guard is worthless if it protects a prefix nothing
+    /// uses.
+    #[test]
+    fn the_protected_namespace_covers_the_witness_baseline_ref() {
+        assert!(
+            crate::verify::WITNESS_BASELINE_WORKTREE_REF.starts_with(STELLA_REF_NAMESPACE),
+            "{} must live under {STELLA_REF_NAMESPACE}",
+            crate::verify::WITNESS_BASELINE_WORKTREE_REF
+        );
+    }
+
+    /// The `code-from-image` shape, in every spelling that reached it.
+    #[test]
+    fn writing_stellas_own_ref_is_refused_confined_or_not() {
+        let root = Path::new("/tmp/ws");
+        for command in [
+            "git update-ref refs/worktree/stella/witness-baseline 93f67c6",
+            "git symbolic-ref refs/worktree/stella/witness-baseline refs/heads/main",
+            "git update-ref -d refs/worktree/stella/witness-baseline",
+            "echo 93f67c6 > .git/refs/worktree/stella/witness-baseline",
+        ] {
+            let refusal = ShellConfinement::unconfined()
+                .audit(command, root)
+                .expect_err(command);
+            assert!(
+                matches!(refusal, Refusal::StellaRef { .. }),
+                "{command}: {refusal:?}"
+            );
+        }
+        // An ordinary branch is the task's business, not Stella's.
+        assert!(
+            ShellConfinement::unconfined()
+                .audit("git update-ref refs/heads/sol-branch 930948dd", root)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn object_destroying_git_is_refused_inside_a_candidate_only() {
+        let (confined, root) = candidate();
+        for command in [
+            "git gc --prune=now",
+            "git -C . gc",
+            "git reflog expire --expire=now --all",
+            "git prune",
+        ] {
+            assert!(
+                matches!(
+                    confined.audit(command, &root),
+                    Err(Refusal::HistoryDestroying { .. })
+                ),
+                "{command}"
+            );
+            // Unconfined, this is the user's own repository to maintain.
+            assert!(
+                ShellConfinement::unconfined().audit(command, &root).is_ok(),
+                "{command}"
+            );
+        }
+        // Reads are untouched.
+        assert!(confined.audit("git reflog", &root).is_ok());
+        assert!(confined.audit("git log --oneline", &root).is_ok());
+    }
+
+    #[test]
+    fn a_graded_tree_path_is_refused_in_every_position_it_was_observed_in() {
+        let (confined, root) = candidate();
+        for command in [
+            "echo today,ERROR,414 > /app/summary.csv",
+            "rm -rf /app/pyknotid",
+            "cd /app && make",
+            "cp -a povray-2.2 /app/povray-2.2",
+            // The heredoc body that word-splitting alone cannot see.
+            "python3 - <<'EOF'\nwith open('/app/summary.csv', 'w') as f:\n    f.write('x')\nEOF",
+        ] {
+            let refusal = confined.audit(command, &root).expect_err(command);
+            assert!(
+                matches!(refusal, Refusal::GradedTree { .. }),
+                "{command}: {refusal:?}"
+            );
+        }
+    }
+
+    /// The legitimate case the posture is built around: a task that installs
+    /// and configures system software is doing the job, not escaping.
+    #[test]
+    fn system_paths_outside_the_graded_tree_stay_writable() {
+        let (confined, root) = candidate();
+        for command in [
+            "apt-get install -y nginx",
+            "cp nginx.conf /etc/nginx/sites-enabled/default",
+            "mkdir -p /var/www/html && echo hi > /var/www/html/index.html",
+            "install -m 755 server /usr/local/bin/server",
+            "echo x > /tmp/scratch.txt",
+            "cd /tmp/stella_candidate_63_0/sub && ls",
+        ] {
+            assert!(confined.audit(command, &root).is_ok(), "{command}");
+        }
+    }
+
+    /// Boundary discipline in both directions — a refusal on a path that only
+    /// looks like the graded tree would be the false accusation #2058 spent a
+    /// benchmark cycle on.
+    #[test]
+    fn a_path_that_merely_resembles_the_graded_tree_is_not_refused() {
+        let (confined, root) = candidate();
+        for command in [
+            "ls /application/config",
+            "cat /tmp/app/notes",
+            "echo /appendix",
+            "grep -rn app .",
+        ] {
+            assert!(confined.audit(command, &root).is_ok(), "{command}");
+        }
+    }
+
+    #[test]
+    fn a_relative_climb_into_the_graded_tree_is_refused() {
+        let confined = ShellConfinement::graded_tree("/srv/graded");
+        let root = Path::new("/srv/graded_candidate/ws");
+        let refusal = confined
+            .audit("cp answer.txt ../../graded/answer.txt", root)
+            .expect_err("a climb into the graded tree");
+        assert!(matches!(refusal, Refusal::GradedTree { .. }), "{refusal:?}");
+        // A climb that stays outside the graded tree is ordinary.
+        assert!(confined.audit("ls ../..", root).is_ok());
+    }
+
+    #[test]
+    fn the_refusal_names_the_substitute_inside_this_workspace() {
+        let (confined, root) = candidate();
+        let refusal = confined
+            .audit("echo 370 > /app/summary.csv", &root)
+            .expect_err("graded write");
+        let Refusal::GradedTree {
+            literal,
+            substitute,
+            ..
+        } = &refusal
+        else {
+            panic!("{refusal:?}");
+        };
+        assert_eq!(literal, "/app/summary.csv");
+        assert_eq!(
+            substitute.as_deref(),
+            Some(Path::new("/tmp/stella_candidate_63_0/summary.csv"))
+        );
+        let message = refusal.to_string();
+        assert!(message.contains("/tmp/stella_candidate_63_0/summary.csv"), "{message}");
+        assert!(message.contains("delivered back to it"), "{message}");
+    }
+
+    /// A blanket root would make every absolute path a refusal — the failure
+    /// mode this module is defined against.
+    #[test]
+    fn a_root_that_would_protect_everything_does_not_arm() {
+        assert_eq!(ShellConfinement::graded_tree("/").graded_root(), None);
+        assert_eq!(ShellConfinement::graded_tree("relative").graded_root(), None);
+        assert_eq!(
+            ShellConfinement::graded_tree("/app").graded_root(),
+            Some(Path::new("/app"))
+        );
+    }
+
+    /// A host that arms the protection against the shell's own root gets the
+    /// ordinary session, not a shell that cannot name its own files.
+    #[test]
+    fn a_graded_root_equal_to_the_session_root_is_inert() {
+        let confined = ShellConfinement::graded_tree("/app");
+        assert!(
+            confined
+                .audit("echo x > /app/out.txt", Path::new("/app"))
+                .is_ok()
+        );
+    }
+}

--- a/crates/stella-tools/src/bash/confine.rs
+++ b/crates/stella-tools/src/bash/confine.rs
@@ -230,22 +230,35 @@ impl std::error::Error for Refusal {}
 /// for why the graded-tree half is opt-in and the ref half is not.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ShellConfinement {
-    /// The real workspace root this shell's work is *delivered into*, when
-    /// this shell is running somewhere else. `None` in an ordinary session,
-    /// where the workspace root and the graded tree are the same directory and
-    /// there is nothing to keep the shell out of.
-    graded_root: Option<PathBuf>,
+    /// Every spelling of the real workspace root this shell's work is
+    /// *delivered into*, when this shell is running somewhere else. Empty in
+    /// an ordinary session, where the workspace root and the graded tree are
+    /// the same directory and there is nothing to keep the shell out of.
+    ///
+    /// A list rather than one path because a text audit compares *names*, and
+    /// one directory has several: `/var/folders/…` and `/private/var/folders/…`
+    /// are the same tree on macOS, `/app` may be a symlink in a container, and
+    /// a task statement quotes whichever the operator configured. The first
+    /// entry is the canonical one and is what a refusal reports; the rest are
+    /// aliases that must refuse identically.
+    graded_roots: Vec<PathBuf>,
 }
 
 impl ShellConfinement {
     /// An ordinary session: the workspace root is the tree the work is judged
     /// on, so a write into it is the work, not an escape.
     pub fn unconfined() -> Self {
-        Self { graded_root: None }
+        Self {
+            graded_roots: Vec::new(),
+        }
     }
 
     /// Arm the graded-tree protection for a shell running in an isolated
     /// workspace whose output reaches `graded_root` only by adoption.
+    ///
+    /// The canonical spelling is registered alongside the given one when the
+    /// two differ, so a host that passes either gets both covered without
+    /// having to know which it holds.
     ///
     /// A root with no components of its own (`/`, or a relative path) does not
     /// arm: "everything is protected" is the blanket refusal this module
@@ -253,18 +266,41 @@ impl ShellConfinement {
     /// absolute literals a command contains.
     pub fn graded_tree(graded_root: impl Into<PathBuf>) -> Self {
         let graded_root = graded_root.into();
-        let armed = graded_root.is_absolute()
-            && graded_root
-                .components()
-                .any(|c| matches!(c, Component::Normal(_)));
+        let canonical = graded_root.canonicalize().ok();
         Self {
-            graded_root: armed.then_some(graded_root),
+            graded_roots: Vec::new(),
+        }
+        .and_alias(graded_root)
+        .and_alias_opt(canonical)
+    }
+
+    /// Register another name for the same graded tree — the spelling a host
+    /// held *before* it canonicalized, or the workspace root inside it. A
+    /// path that would not arm on its own is ignored rather than stored.
+    pub fn and_alias(mut self, alias: impl Into<PathBuf>) -> Self {
+        let alias = alias.into();
+        let arms = alias.is_absolute()
+            && alias
+                .components()
+                .any(|c| matches!(c, Component::Normal(_)))
+            && alias.to_str().is_some();
+        if arms && !self.graded_roots.contains(&alias) {
+            self.graded_roots.push(alias);
+        }
+        self
+    }
+
+    fn and_alias_opt(self, alias: Option<PathBuf>) -> Self {
+        match alias {
+            Some(alias) => self.and_alias(alias),
+            None => self,
         }
     }
 
-    /// The graded tree this shell is kept out of, if any.
+    /// The graded tree this shell is kept out of, if any — the first
+    /// registered spelling, which is what a refusal reports.
     pub fn graded_root(&self) -> Option<&Path> {
-        self.graded_root.as_deref()
+        self.graded_roots.first().map(PathBuf::as_path)
     }
 
     /// Refuse `command` if its text names protected territory, given the
@@ -278,25 +314,32 @@ impl ShellConfinement {
         if let Some(reference) = stella_ref_named(command) {
             return Err(Refusal::StellaRef { reference });
         }
-        let Some(graded_root) = self.graded_root.as_deref() else {
-            return Ok(());
-        };
-        if session_root == graded_root {
+        if self.graded_roots.is_empty()
+            || self
+                .graded_roots
+                .iter()
+                .any(|graded| session_root == graded)
+        {
             return Ok(());
         }
         if let Some(subcommand) = history_destroying_git(command) {
             return Err(Refusal::HistoryDestroying { subcommand });
         }
-        if let Some(literal) = graded_literal(command, graded_root, session_root) {
-            let substitute = Path::new(&literal)
-                .strip_prefix(graded_root)
-                .ok()
-                .map(|rel| session_root.join(rel));
-            return Err(Refusal::GradedTree {
-                literal,
-                graded_root: graded_root.to_path_buf(),
-                substitute,
-            });
+        // Every spelling refuses identically; the message reports the first
+        // registered one, so two refusals of the same tree read the same.
+        let reported = self.graded_root().unwrap_or(Path::new("/"));
+        for graded in &self.graded_roots {
+            if let Some(literal) = graded_literal(command, graded, session_root) {
+                let substitute = Path::new(&literal)
+                    .strip_prefix(graded)
+                    .ok()
+                    .map(|rel| session_root.join(rel));
+                return Err(Refusal::GradedTree {
+                    literal,
+                    graded_root: reported.to_path_buf(),
+                    substitute,
+                });
+            }
         }
         // A relative spelling of the same escape: `cd ../..` out of a
         // workspace that happens to sit beside the graded tree. Only words
@@ -308,16 +351,21 @@ impl ShellConfinement {
                 continue;
             }
             let resolved = lexical_join(session_root, path);
-            if resolved.starts_with(graded_root) && !resolved.starts_with(session_root) {
-                let substitute = resolved
-                    .strip_prefix(graded_root)
-                    .ok()
-                    .map(|rel| session_root.join(rel));
-                return Err(Refusal::GradedTree {
-                    literal: word,
-                    graded_root: graded_root.to_path_buf(),
-                    substitute,
-                });
+            if resolved.starts_with(session_root) {
+                continue;
+            }
+            for graded in &self.graded_roots {
+                if resolved.starts_with(graded) {
+                    let substitute = resolved
+                        .strip_prefix(graded)
+                        .ok()
+                        .map(|rel| session_root.join(rel));
+                    return Err(Refusal::GradedTree {
+                        literal: word,
+                        graded_root: reported.to_path_buf(),
+                        substitute,
+                    });
+                }
             }
         }
         Ok(())
@@ -331,9 +379,7 @@ impl ShellConfinement {
 fn stella_ref_named(command: &str) -> Option<String> {
     let at = command.find(STELLA_REF_NAMESPACE)?;
     let rest = &command[at..];
-    let end = rest
-        .find(|c: char| !is_path_char(c))
-        .unwrap_or(rest.len());
+    let end = rest.find(|c: char| !is_path_char(c)).unwrap_or(rest.len());
     Some(rest[..end].to_string())
 }
 
@@ -349,17 +395,12 @@ fn graded_literal(command: &str, graded_root: &Path, session_root: &Path) -> Opt
     while let Some(offset) = command[from..].find(needle) {
         let at = from + offset;
         let end = at + needle.len();
-        let before_ok = !command[..at]
-            .chars()
-            .next_back()
-            .is_some_and(is_path_char);
+        let before_ok = !command[..at].chars().next_back().is_some_and(is_path_char);
         let after = command[end..].chars().next();
         let after_ok = after == Some('/') || !after.is_some_and(is_path_char);
         if before_ok && after_ok {
             let rest = &command[at..];
-            let len = rest
-                .find(|c: char| !is_path_char(c))
-                .unwrap_or(rest.len());
+            let len = rest.find(|c: char| !is_path_char(c)).unwrap_or(rest.len());
             let literal = &rest[..len];
             if !Path::new(literal).starts_with(session_root) {
                 return Some(literal.to_string());
@@ -399,13 +440,13 @@ fn history_destroying_git(command: &str) -> Option<String> {
             subcommand = Some(next.clone());
             break;
         }
-        let Some(subcommand) = subcommand else { continue };
+        let Some(subcommand) = subcommand else {
+            continue;
+        };
         if HISTORY_DESTROYING.contains(&subcommand.as_str()) {
             return Some(subcommand);
         }
-        if subcommand == "reflog"
-            && rest.any(|w| matches!(w.as_str(), "expire" | "delete"))
-        {
+        if subcommand == "reflog" && rest.any(|w| matches!(w.as_str(), "expire" | "delete")) {
             return Some("reflog expire".to_string());
         }
     }
@@ -572,8 +613,48 @@ mod tests {
             Some(Path::new("/tmp/stella_candidate_63_0/summary.csv"))
         );
         let message = refusal.to_string();
-        assert!(message.contains("/tmp/stella_candidate_63_0/summary.csv"), "{message}");
+        assert!(
+            message.contains("/tmp/stella_candidate_63_0/summary.csv"),
+            "{message}"
+        );
         assert!(message.contains("delivered back to it"), "{message}");
+    }
+
+    /// One directory has several names, and a text audit compares names. The
+    /// macOS `/var` → `/private/var` symlink is the case that caught this in
+    /// development: the guard knew only the canonical spelling, and the
+    /// end-to-end candidate test wrote the graded tree straight through it.
+    #[test]
+    fn every_registered_spelling_of_the_graded_tree_refuses_identically() {
+        let confined = ShellConfinement::graded_tree("/private/var/graded")
+            .and_alias("/var/graded")
+            .and_alias("/private/var/graded");
+        let root = Path::new("/tmp/ws");
+        for command in [
+            "echo x > /private/var/graded/out.txt",
+            "echo x > /var/graded/out.txt",
+        ] {
+            let refusal = confined.audit(command, root).expect_err(command);
+            let Refusal::GradedTree {
+                graded_root,
+                substitute,
+                ..
+            } = &refusal
+            else {
+                panic!("{command}: {refusal:?}");
+            };
+            // Reported against one root whichever alias matched, so two
+            // refusals of the same tree read the same.
+            assert_eq!(graded_root, Path::new("/private/var/graded"), "{command}");
+            assert_eq!(substitute.as_deref(), Some(Path::new("/tmp/ws/out.txt")));
+        }
+        // Aliases are deduplicated, and one that would protect everything is
+        // dropped rather than stored as a root that matches every path.
+        let noisy = ShellConfinement::graded_tree("/graded")
+            .and_alias("/graded")
+            .and_alias("/")
+            .and_alias("relative");
+        assert!(noisy.audit("echo x > /etc/hosts", root).is_ok());
     }
 
     /// A blanket root would make every absolute path a refusal — the failure
@@ -581,7 +662,10 @@ mod tests {
     #[test]
     fn a_root_that_would_protect_everything_does_not_arm() {
         assert_eq!(ShellConfinement::graded_tree("/").graded_root(), None);
-        assert_eq!(ShellConfinement::graded_tree("relative").graded_root(), None);
+        assert_eq!(
+            ShellConfinement::graded_tree("relative").graded_root(),
+            None
+        );
         assert_eq!(
             ShellConfinement::graded_tree("/app").graded_root(),
             Some(Path::new("/app"))

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -495,6 +495,7 @@ impl ToolRegistry {
                 spawn_queue.clone(),
                 shadow_memo.clone(),
                 options.diagnostics.clone(),
+                options.shell_confinement.clone(),
             ));
             // The web family registers by default, like every other built-in.
             // A fetched page is untrusted input and an egress channel, which is

--- a/crates/stella-tools/src/registry/options.rs
+++ b/crates/stella-tools/src/registry/options.rs
@@ -44,6 +44,17 @@ pub struct RegistryOptions {
     /// the diagnostic plane, not that tool's private channel: a built-in with
     /// a decision worth explaining takes it from here too.
     pub diagnostics: Option<Arc<stella_diag::Dx>>,
+    /// Territory this registry's shell may not name — see
+    /// [`crate::bash::confine`]. Default
+    /// ([`ShellConfinement::unconfined`](crate::bash::ShellConfinement::unconfined))
+    /// is an ordinary session, where the workspace root *is* the tree the work
+    /// is judged on and there is nothing to keep the shell out of; a
+    /// best-of-N candidate arms it against the graded tree it delivers into.
+    ///
+    /// A construction input rather than a policy toggle, for the same reason
+    /// as everything else here: it is a fact about where this registry's tools
+    /// are running, which the operator cannot sensibly override.
+    pub shell_confinement: crate::bash::ShellConfinement,
 }
 
 impl RegistryOptions {

--- a/crates/stella-tools/src/registry/process_tools.rs
+++ b/crates/stella-tools/src/registry/process_tools.rs
@@ -10,6 +10,7 @@ pub(super) fn builtins(
     spawn_queue: crate::tasks::SpawnQueue,
     shadow_memo: crate::verify::ShadowMemoHandle,
     diagnostics: Option<Arc<stella_diag::Dx>>,
+    shell_confinement: crate::bash::ShellConfinement,
 ) -> Vec<Arc<dyn Tool>> {
     let processes: crate::process::ProcessTableHandle = Arc::default();
     let repo: Arc<dyn crate::repo::RepoBackend> = Arc::new(crate::repo::GitCli);
@@ -25,7 +26,8 @@ pub(super) fn builtins(
         // authority class as `run_script` and the process group beside it —
         // an operator who wants it gone writes `"tools": {"bash": "off"}`,
         // which the policy layer above enforces for MCP and custom tools too.
-        Arc::new(crate::bash::Bash::new(scratch_path.clone())) as Arc<dyn Tool>,
+        Arc::new(crate::bash::Bash::new(scratch_path.clone()).confined_to(shell_confinement))
+            as Arc<dyn Tool>,
         Arc::new(crate::capability::ProbeCapability::new()),
         Arc::new(crate::verify::VerifyDone::new(shadow_memo, diagnostics)),
         Arc::new(crate::project::BuildProject),


### PR DESCRIPTION
Closes #2875

## What this is

The candidate workspace was not an isolation boundary. `bash` is the one tool
that can still reach the real tree — `rootfd.rs` says so in its own header, and
`candidate_ws/escape.rs` exists only to notice the breach afterwards. The
2026-08-11 Terminal-Bench panel paid for it twice:

- **`log-summary-date-ranges / f89p2`** — the worker's first script hardcoded the
  task statement's `/app/summary.csv`, ran, and wrote `today,ERROR,414` straight
  into the graded tree. It then computed the correct `370` inside its candidate,
  the run aborted before adoption, and the grader read the leaked wrong file.
  Stella solved the task and scored 0. `write_file`/`apply_edits` refuse that
  path; the model reissued the write as a heredoc.
- **`f89p3/code-from-image` steps 83–86** — `git update-ref
  refs/worktree/stella/witness-baseline <its own commit>`, the exact ref
  `verify_done` pins its baseline to, then `git reflog expire --expire=now --all
  && git gc --prune=now`. No fabricated flip is visible in the trace, but a
  benchmark the subject can edit the scorer's state inside is not a measurement.

## The posture, and why it is not "refuse everything outside the root"

`configure-git-webserver / f89p3` installs nginx and populates `/var/www/html`;
other tasks `apt-get install` and write `/etc`. A blanket refusal fails those
outright, so exactly two things are protected:

1. **The graded tree** — the real workspace root the candidate delivers into by
   adoption. Armed only when a host declares a *distinct* one (today: a
   best-of-N candidate). Writing there bypasses the delivery channel and
   corrupts the artifact the run is judged against.
2. **Stella's own git refs** (`refs/worktree/stella/*`), always, plus the git
   operations that destroy the objects they pin (`gc`, `prune`, `repack`,
   `reflog expire`) inside a candidate. No task's work lives there.

Everything else stays exactly as writable as it was. Refs the graded tree merely
*shares* (`refs/heads/*`) are deliberately untouched — a candidate moving a
branch is ordinary task work, and the loss there (`query-optimize`) is a seal
that refuses where it could repair (#2641, #2812).

Every refusal names the substitute that works:

> refused before running: `/app/summary.csv` is inside the graded tree `/app`,
> which this shell may not touch. This shell's workspace is a snapshot of that
> tree, and work done here IS delivered back to it when the run finishes […]
> Use `/tmp/stella_candidate_63_0/summary.csv` instead. […] Nothing else outside
> this workspace is restricted: system paths such as /etc, /usr and /var are
> still writable.

A refusal that only says "no" teaches the model to find a spelling that evades
the check.

## Honest about the ceiling

This is a **literal audit of the command text**, before the spawn. A shell can
compute a path at runtime, and `p=/ap; p=$p$'p'; printf x > "$p/f"` defeats every
string check that will ever be written here. What it buys: an *accidental*
escape — the dominant real shape, a path copied out of the task statement —
becomes impossible rather than silent, and a *deliberate* one has to be
obfuscated, which a trace reader can see. Total confinement is an OS boundary
(#1383), and `STELLA_BASH_SANDBOX` was removed in #1300 for exactly this kind of
overclaim; the module header says all of this rather than implying otherwise.

Two mechanisms were **rejected rather than shipped weak**, and the header records
why: `GIT_CEILING_DIRECTORIES` stops git's *upward* discovery and a candidate
worktree's `.git` is found on the first component, so there is no ascent to stop;
a per-candidate `GIT_DIR`/`GIT_COMMON_DIR` would sever the worktree from the
object store it is a worktree of. The mechanism that *would* be total for refs is
a `reference-transaction` hook in the shared repository — it mutates the
operator's repo, so it belongs to the candidate's setup, not to a tool.

## The misleading advisory (also fixed)

`graph_advisory` told a drifting worker that work outside the session root "is
not collected" — true about the diff, false by omission about adoption — and
offered a remedy only the *user* can perform ("re-root the session on it").
`build-cython-ext / f89p2` step 5 read that as "`/app/pyknotid` maps to
`/tmp/stella_candidate_63_0/pyknotid` here", then ran `rm -rf /app/pyknotid`,
which is precisely the two grader tests it went on to fail. Under a candidate the
note now states that work here *is* delivered to the graded tree and names it;
elsewhere the remedy is one the agent can actually perform.

## Witness tests — demonstrated fail→pass flip

Production behaviour neutralized in place (`audit` returns `Ok` early; the
advisory's remedy restored to the old string), everything else unchanged:

```
$ cargo test -p stella-tools --lib bash::          # guard neutralized
test result: FAILED. 29 passed; 9 failed
    a_write_into_the_graded_tree_never_reaches_the_disk               FAILED
    a_graded_path_buried_in_a_script_body_is_still_refused            FAILED
    rewriting_stellas_own_ref_is_refused_and_leaves_the_ref_alone     FAILED
    the_drift_note_states_adoption_and_offers_a_remedy_...            FAILED
    confine::tests::{writing_stellas_own_ref..., object_destroying_git...,
      a_graded_tree_path_is_refused..., a_relative_climb..., the_refusal_names_the_substitute...}
    a_confined_shell_still_writes_system_paths_outside_the_graded_tree   ok   <- negative control

$ cargo test -p stella-cli --bin stella candidate_ws::tests::a_candidates_shell
test result: FAILED. 0 passed; 2 failed
```

Restored:

```
$ cargo test -p stella-tools --lib bash::      -> ok. 39 passed; 0 failed
$ cargo test -p stella-cli --bin stella candidate_ws:: -> ok. 76 passed; 0 failed
```

`a_confined_shell_still_writes_system_paths_outside_the_graded_tree` passes on
both sides on purpose: it is the control proving this is not a blanket refusal.

The two `stella-cli` tests are end-to-end through the real candidate tool
surface, and one of them found a genuine bug during development rather than
after: the guard knew only the canonical spelling of the graded root, and macOS's
`/var` → `/private/var` symlink walked straight past it. `ShellConfinement` now
holds every spelling (given, canonical, git's pre-canonicalization output, the
session root) and refuses on any while reporting one — second commit.

## Gate

`make gate CARGO_SCOPE="-p stella-tools -p stella-cli"` — exit 0, 24 test binaries
green, all 27 guards OK (file-size judged against the merge base; no baseline
touched, no god file grown — the new code is a sibling module,
`stella-tools/src/bash/confine.rs`).

## Deleted tests

None.

## Nothing left behind

- The `reference-transaction` hook (the only total ref enforcement) is named in
  the module header and in #2875's scope section rather than left implicit.
- A refusal emits no `stella-diag` record today — it is a tool error string like
  every other `bash` refusal. Worth a diagnostic code once #2875's family
  settles; noted in the issue.
- #2301 (the cd-escape detector's false positives on data) is adjacent: this
  guard deliberately accepts the same class of false positive for the graded
  root, because a refusal that fires on `echo "check /app"` costs one corrective
  tool call while a miss costs the run. Linked from #2875.

## Summary by Sourcery

Constrain bash execution in candidate workspaces to avoid corrupting the graded tree and Stella’s own git refs, and update registry wiring and tests to enforce and verify this confinement.

Bug Fixes:
- Prevent candidate bash commands from writing directly into the graded tree by auditing command text and refusing offending commands before execution.
- Block candidate and non-candidate bash commands from modifying Stella-owned git refs or running history-destroying git operations that could affect shared verification state.
- Fix candidate shell behavior so writes within the candidate workspace remain allowed while cross-tree escapes are refused, even when paths are embedded in script bodies or use relative climbs.
- Correct the cross-root drift advisory so it explains that candidate work is delivered to the graded tree and suggests remedies the agent can actually perform.

Enhancements:
- Introduce a ShellConfinement module and policy that describe and enforce what paths and git operations bash may not touch, including support for multiple graded-root spellings and clear refusal messages with suggested substitutes.
- Propagate shell confinement configuration through registry options and process tool construction so that only candidate workspaces enable graded-tree protection by default.

Tests:
- Add unit tests for ShellConfinement to cover graded tree path detection, ref protection, history-destroying git detection, alias handling, and edge cases like relative climbs and non-protected lookalike paths.
- Add end-to-end candidate workspace tests ensuring a candidate shell cannot write to the graded tree or move Stella’s witness-baseline ref, while still allowing legitimate system path writes.
- Extend bash tool tests to cover graded-tree write refusals, heredoc/script-body detection, ref protection behavior, system-path allowances, and the updated drift note messaging.