### PR TITLE
docs(website): add the oxagen vision microsite — stella as the engine

### DIFF
--- a/website/public/vision.html
+++ b/website/public/vision.html
@@ -1,0 +1,752 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>stella is the engine · oxagen vision</title>
+<meta name="description" content="stella is the engine — oxagen's operating system for verified AI work. The task loop, the laboratory that improves it, the factory that turns verified traces into private models, and the road to stella 2.0 and 3.0.">
+<meta property="og:title" content="stella is the engine · oxagen vision">
+<meta property="og:description" content="An agent is a loop. stella is the program that controls it — open source, deterministic, proven done. oxagen is the operating system around it: the laboratory, the model factory, and the control plane.">
+<link rel="icon" type="image/svg+xml" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96"><rect width="96" height="96" fill="%230B0B0C"/><path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="%23FFB000"/></svg>'>
+<style>
+/* ==========================================================================
+   stella brand kit v1.0 "the comet": Phosphor Gold on Ink, JetBrains Mono.
+   Gold is the signal, never the surface. Assemble, don't spin.
+
+   This page is the scrolling companion to presentations/investor-deck.html —
+   same tokens, same component idiom, one committed dark theme (it is brand
+   surface, not a doc). Every color is painted explicitly so the page holds on
+   any host ground. Values mirror docs/brand/ via src/app/tokens.css.
+   ========================================================================== */
+@font-face { font-family: "JetBrains Mono"; font-style: normal; font-weight: 400; font-display: swap; src: url("brand/fonts/jetbrains-mono-latin-400-normal.woff2") format("woff2"); }
+@font-face { font-family: "JetBrains Mono"; font-style: normal; font-weight: 500; font-display: swap; src: url("brand/fonts/jetbrains-mono-latin-500-normal.woff2") format("woff2"); }
+@font-face { font-family: "JetBrains Mono"; font-style: normal; font-weight: 700; font-display: swap; src: url("brand/fonts/jetbrains-mono-latin-700-normal.woff2") format("woff2"); }
+@font-face { font-family: "JetBrains Mono"; font-style: normal; font-weight: 800; font-display: swap; src: url("brand/fonts/jetbrains-mono-latin-800-normal.woff2") format("woff2"); }
+
+:root {
+  --gold: #FFB000;
+  --gold-deep: #A37200;
+  --gold-300: #FCD07D;
+  --ink: #0B0B0C;
+  --paper: #F4F1EA;
+  --surface: #131315;
+  --border: #232327;
+  --muted: #9B9890;
+  --pass: #2FD3C6;
+  --fail: #E4408F;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --ease-arrive: cubic-bezier(0.22, 0.9, 0.35, 1);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+::selection { background: var(--gold); color: var(--ink); }
+a { color: var(--paper); text-decoration-color: var(--gold); text-underline-offset: 3px; }
+a:hover { color: var(--gold); }
+a:focus-visible, button:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+code { font-family: var(--mono); font-size: 0.85em; color: var(--gold-deep); }
+em { font-style: normal; color: var(--gold); }
+svg { max-width: 100%; height: auto; }
+
+/* terminal grid + starfield, fixed behind everything */
+.texture {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image:
+    linear-gradient(rgb(244 241 234 / 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(244 241 234 / 0.03) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+.starfield { position: fixed; inset: 0; pointer-events: none; z-index: 0; }
+.starfield circle { fill: #F4F1EA; animation: twinkle 6s ease-in-out infinite; animation-delay: var(--td, 0s); }
+@keyframes twinkle { 0%, 100% { opacity: var(--o, 0.1); } 50% { opacity: calc(var(--o, 0.1) * 2.4); } }
+
+/* scroll progress hairline */
+.progress { position: fixed; top: 0; left: 0; height: 2px; width: 0%; background: var(--gold); z-index: 60; }
+
+/* ---- chrome ------------------------------------------------------------- */
+.chrome {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 50;
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 28px;
+  background: rgb(11 11 12 / 0.82); backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.78rem; font-weight: 500; letter-spacing: 0.1em;
+}
+.chrome .mark { display: flex; align-items: center; gap: 10px; color: var(--paper); text-decoration: none; }
+.chrome .mark strong { font-weight: 800; letter-spacing: 0.02em; }
+.chrome .mark span { color: var(--muted); }
+.chrome nav { margin-left: auto; display: flex; gap: 18px; }
+.chrome nav a { color: var(--muted); text-decoration: none; }
+.chrome nav a:hover { color: var(--gold); }
+@media (max-width: 900px) { .chrome nav { display: none; } }
+
+/* ---- page shell ---------------------------------------------------------- */
+.shell { position: relative; z-index: 1; max-width: 1180px; margin: 0 auto; padding: 0 28px; }
+section { padding: 108px 0 24px; }
+section.hero { min-height: 92vh; display: flex; flex-direction: column; justify-content: center; padding-top: 140px; }
+
+.overline { font-size: 0.78rem; font-weight: 500; letter-spacing: 0.2em; color: var(--gold); margin-bottom: 16px; }
+.overline .idx { color: var(--muted); }
+h1 { font-weight: 800; letter-spacing: -0.03em; line-height: 1.04; font-size: clamp(2.6rem, 7vw, 4.6rem); text-wrap: balance; }
+h2 { font-weight: 800; letter-spacing: -0.025em; line-height: 1.1; font-size: clamp(1.8rem, 4vw, 2.6rem); margin-bottom: 18px; text-wrap: balance; }
+h3 { font-weight: 700; font-size: 1.02rem; }
+.lead { font-size: 1.04rem; line-height: 1.72; max-width: 66ch; }
+.lead + .lead { margin-top: 0.8em; }
+.muted { color: var(--muted); }
+.kicker {
+  margin-top: 26px; padding-left: 16px; border-left: 3px solid var(--gold);
+  font-weight: 700; font-size: 1rem; line-height: 1.6; max-width: 62ch;
+}
+.fine { font-size: 0.72rem; line-height: 1.6; color: var(--muted); max-width: 100ch; }
+.fine a { color: var(--muted); }
+.foot { margin-top: 26px; display: flex; flex-direction: column; gap: 12px; }
+
+.cols { display: grid; gap: 24px; align-items: start; margin-top: 30px; }
+.c-2 { grid-template-columns: 1fr 1fr; }
+.c-5-7 { grid-template-columns: 5fr 7fr; }
+.c-7-5 { grid-template-columns: 7fr 5fr; }
+@media (max-width: 860px) { .c-2, .c-5-7, .c-7-5 { grid-template-columns: 1fr; } }
+
+/* ---- components (deck idiom) --------------------------------------------- */
+.tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-top: 30px; }
+.tiles.three { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 980px) { .tiles { grid-template-columns: repeat(2, 1fr); } .tiles.three { grid-template-columns: 1fr; } }
+@media (max-width: 560px) { .tiles { grid-template-columns: 1fr; } }
+.tile {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 14px; padding: 18px 20px; position: relative; overflow: hidden;
+}
+.tile::after {
+  content: ""; position: absolute; left: 0; top: 0; width: 100%; height: 2px;
+  background: linear-gradient(90deg, var(--gold), transparent);
+  transform: scaleX(0); transform-origin: left;
+}
+.in .tile::after { animation: swipe 620ms var(--ease-arrive) 260ms forwards; }
+@keyframes swipe { to { transform: scaleX(1); } }
+.tile .big { font-size: 2rem; font-weight: 800; letter-spacing: -0.03em; color: var(--gold); line-height: 1.15; font-variant-numeric: tabular-nums; }
+.tile .name { font-weight: 800; font-size: 0.98rem; }
+.tile .cap { font-size: 0.8rem; color: var(--muted); margin-top: 6px; line-height: 1.55; }
+.tile code { font-size: 0.7rem; word-break: break-all; }
+
+table.map { width: 100%; border-collapse: collapse; font-size: 0.84rem; margin-top: 30px; }
+table.map th, table.map td { text-align: left; padding: 11px 14px; border: 1px solid var(--border); vertical-align: top; line-height: 1.55; }
+table.map th { font-weight: 700; font-size: 0.7rem; letter-spacing: 0.16em; color: var(--muted); }
+table.map td:first-child { font-weight: 700; white-space: nowrap; }
+table.map td .gd { color: var(--gold); font-weight: 700; }
+table.map code { white-space: nowrap; }
+.tablewrap { overflow-x: auto; }
+.tablewrap table { min-width: 640px; }
+
+.term {
+  background: var(--ink); border: 1px solid var(--border); border-radius: 12px;
+  padding: 18px 22px; font-size: 0.84rem; line-height: 2.0;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.25), 0 8px 28px rgb(0 0 0 / 0.35);
+  overflow-x: auto;
+}
+.term .p { color: var(--muted); }
+.term .ok { color: var(--pass); }
+.term .no { color: var(--fail); }
+.term .gd { color: var(--gold); }
+.term .cursor { display: inline-block; width: 8px; height: 1em; background: var(--gold); vertical-align: -0.15em; animation: blink 1.1s steps(1) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+
+.badge {
+  display: inline-block; font-size: 0.64rem; font-weight: 700; letter-spacing: 0.14em;
+  border: 1px solid var(--border); border-radius: 999px; padding: 2px 12px;
+  vertical-align: middle; white-space: nowrap; color: var(--muted);
+}
+.badge.now { color: var(--pass); border-color: var(--pass); }
+.badge.next { color: var(--gold); border-color: var(--gold); }
+
+/* Bar chart (paired run). Two marks, and they are deliberately NOT a
+   categorical pair: gold is the entity under discussion, muted grey is the
+   comparator, per the kit's "gold is the signal, never the surface" law. That
+   is a stated deviation from a categorical palette (a grey mark fails a chroma
+   floor by construction), and it is legal here only because identity never
+   rests on hue: every bar carries a direct label AND its value, so the chart
+   reads identically in greyscale, in every CVD mode, and with CSS off. */
+.brow { margin-top: 14px; }
+.blabel { font-size: 0.8rem; margin-bottom: 6px; }
+.btrack { display: flex; align-items: center; gap: 12px; }
+.btrack .fill { flex: 1; background: rgb(244 241 234 / 0.06); border-radius: 4px; height: 22px; overflow: hidden; }
+.btrack .bar { height: 100%; width: 0; border-radius: 4px 3px 3px 4px; background: var(--muted); transition: width 900ms var(--ease-arrive) 200ms; }
+.btrack .bar.gold { background: var(--gold); }
+.in .bar { width: var(--w); }
+.bval { font-size: 0.84rem; font-weight: 700; font-variant-numeric: tabular-nums; min-width: 4.6em; }
+.delta { margin-top: 14px; font-weight: 800; color: var(--gold); font-size: 1.02rem; }
+.delta span { display: block; font-weight: 400; font-size: 0.72rem; color: var(--muted); margin-top: 2px; }
+.bh { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.16em; color: var(--muted); }
+
+/* figures / diagrams */
+figure { margin-top: 30px; }
+figure.scrollable { overflow-x: auto; }
+figure.scrollable svg { min-width: 720px; }
+figcaption { margin-top: 10px; font-size: 0.72rem; color: var(--muted); line-height: 1.6; max-width: 90ch; }
+.dia .box { fill: var(--surface); stroke: var(--border); }
+.dia .boxg { fill: rgb(255 176 0 / 0.06); stroke: var(--gold); }
+.dia .boxd { fill: none; stroke: var(--border); stroke-dasharray: 5 5; }
+.dia .lbl { fill: var(--paper); font-family: var(--mono); font-size: 14px; font-weight: 700; }
+.dia .sm { fill: var(--muted); font-family: var(--mono); font-size: 11.5px; }
+.dia .gd { fill: var(--gold); }
+.dia .ps { fill: var(--pass); }
+.dia .fl { fill: var(--fail); }
+.dia .ln { stroke: var(--gold); fill: none; }
+.dia .lnm { stroke: var(--muted); fill: none; }
+
+/* roadmap */
+.road { margin-top: 34px; display: grid; gap: 0; }
+.era { display: grid; grid-template-columns: 200px 1fr; gap: 24px; padding: 26px 0; border-top: 1px solid var(--border); }
+.era:last-child { border-bottom: 1px solid var(--border); }
+@media (max-width: 720px) { .era { grid-template-columns: 1fr; gap: 10px; } }
+.era .v { font-weight: 800; font-size: 1.5rem; letter-spacing: -0.02em; line-height: 1.3; }
+.era .v .sub { display: block; font-size: 0.74rem; font-weight: 500; letter-spacing: 0.16em; color: var(--muted); margin-top: 6px; }
+.era ul { list-style: none; display: grid; gap: 8px; }
+.era li { padding-left: 20px; position: relative; font-size: 0.9rem; line-height: 1.6; }
+.era li::before { content: "▸"; position: absolute; left: 0; color: var(--gold); }
+.era li .d { color: var(--muted); }
+
+/* hero specifics */
+.lockup { display: flex; align-items: center; gap: 16px; margin-bottom: 30px; }
+.links { display: flex; flex-wrap: wrap; gap: 12px 26px; margin-top: 34px; font-size: 0.9rem; font-weight: 700; }
+.hr-gold { border: 0; height: 1px; background: linear-gradient(90deg, var(--gold), transparent 70%); margin: 44px 0 0; opacity: 0.5; }
+
+/* closing */
+.close { text-align: left; padding-bottom: 140px; }
+
+/* motion — assemble, don't spin. Hidden states exist only when JS booted. */
+.js .rise { opacity: 0; transform: translateY(16px); transition: opacity 640ms var(--ease-arrive), transform 640ms var(--ease-arrive); transition-delay: calc(var(--d, 0) * 90ms); }
+.js .in .rise, .js .rise.in { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .js .rise { opacity: 1; transform: none; transition: none; }
+  .in .tile::after { animation: none; transform: scaleX(1); }
+  .btrack .bar { transition: none; } .in .bar { width: var(--w); }
+  .starfield circle, .term .cursor { animation: none; }
+  html { scroll-behavior: auto; }
+}
+</style>
+</head>
+<body>
+
+<div class="texture" aria-hidden="true"></div>
+<svg class="starfield" aria-hidden="true" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+  <circle cx="120" cy="90" r="1.2" style="--o:.14"/><circle cx="340" cy="200" r="0.9" style="--o:.1;--td:1.2s"/>
+  <circle cx="560" cy="60" r="1.1" style="--o:.12;--td:2.1s"/><circle cx="820" cy="150" r="0.8" style="--o:.09;--td:.6s"/>
+  <circle cx="1060" cy="80" r="1.3" style="--o:.15;--td:3s"/><circle cx="1290" cy="190" r="0.9" style="--o:.1;--td:1.7s"/>
+  <circle cx="1480" cy="70" r="1.1" style="--o:.12;--td:2.6s"/><circle cx="220" cy="420" r="0.8" style="--o:.08;--td:.9s"/>
+  <circle cx="700" cy="380" r="1" style="--o:.1;--td:2.3s"/><circle cx="1180" cy="430" r="0.9" style="--o:.09;--td:1.4s"/>
+  <circle cx="1520" cy="500" r="1.2" style="--o:.12;--td:.3s"/><circle cx="90" cy="700" r="1" style="--o:.11;--td:2.8s"/>
+  <circle cx="460" cy="760" r="0.9" style="--o:.09;--td:1.9s"/><circle cx="900" cy="820" r="1.1" style="--o:.12;--td:.8s"/>
+  <circle cx="1340" cy="740" r="0.8" style="--o:.08;--td:2.4s"/><circle cx="1560" cy="860" r="1" style="--o:.1;--td:1.1s"/>
+</svg>
+<div class="progress" aria-hidden="true"></div>
+
+<header class="chrome">
+  <a class="mark" href="#top" aria-label="stella, by oxagen — back to top">
+    <svg width="26" height="26" viewBox="0 0 96 96" fill="none" aria-hidden="true">
+      <line x1="10" y1="48" x2="30" y2="48" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="34" x2="30" y2="34" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="62" x2="30" y2="62" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#FFB000"/>
+    </svg>
+    <strong>stella</strong> <span>× oxagen</span>
+  </a>
+  <nav aria-label="sections">
+    <a href="#thesis">thesis</a>
+    <a href="#engine">engine</a>
+    <a href="#laboratory">laboratory</a>
+    <a href="#flywheel">flywheel</a>
+    <a href="#factory">factory</a>
+    <a href="#economics">economics</a>
+    <a href="#road">road</a>
+  </nav>
+</header>
+
+<main class="shell" id="top">
+
+<!-- ═══ hero ═══════════════════════════════════════════════════════════════ -->
+<section class="hero" aria-label="stella is the engine">
+  <div class="lockup rise">
+    <svg width="64" height="64" viewBox="0 0 96 96" fill="none" aria-hidden="true">
+      <line x1="10" y1="48" x2="30" y2="48" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="34" x2="30" y2="34" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="62" x2="30" y2="62" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#FFB000"/>
+    </svg>
+  </div>
+  <p class="overline rise" style="--d:1">oxagen <span class="idx">· the operating system for verified work</span></p>
+  <h1 class="rise" style="--d:2">stella is <em>the engine.</em></h1>
+  <p class="lead rise" style="--d:3; margin-top:24px">An agent is a loop: plan, act, observe, prove. stella is the program that controls that loop — open source, deterministic, and holding every task to a proof of done. oxagen is the company building the operating system around it: the laboratory that improves the engine, the factory that turns its verified work into private models, and the control plane an enterprise pays for.</p>
+  <div class="cols c-7-5">
+    <div class="term rise" style="--d:4" role="img" aria-label="stylized terminal transcript of one stella task: plan, tools, an independently authored witness test failing on the old code, the fail-to-pass flip, and a proven verdict">
+      <span class="p">$</span> stella run "make the retry loop idempotent"<br>
+      <span class="gd">plan</span>&nbsp;&nbsp;&nbsp;&nbsp;3 steps · budget enforced between steps, never mid-tool<br>
+      <span class="gd">tools</span>&nbsp;&nbsp;&nbsp;read_file ×4 · edit ×2 · bash: cargo test<br>
+      <span class="gd">witness</span>&nbsp;authored by an independent verifier · <span class="no">fails on the old code ✗</span><br>
+      <span class="gd">verify</span>&nbsp;&nbsp;<span class="no">fail</span> → <span class="ok">pass</span> · flip credited · worker never touched the witness<br>
+      <span class="gd">verdict</span>&nbsp;<span class="ok">done — proven, not claimed</span> <span class="cursor"></span>
+    </div>
+    <div class="rise" style="--d:5">
+      <p class="kicker" style="margin-top:0">verified done, not claimed done. The loop refuses to call work finished until a test flips <em>fail → pass</em> — and the worker never grades itself.</p>
+      <p class="links">
+        <a href="presentations/investor-deck.html">read the investor deck</a>
+        <a href="https://github.com/macanderson/stella">read the source</a>
+        <a href="https://stella.oxagen.sh/docs">read the docs</a>
+      </p>
+    </div>
+  </div>
+  <p class="fine rise" style="--d:6; margin-top:40px">The transcript above is a schematic of the shipped mechanism, not a recording. The mechanism itself — shadow-worktree witness replay, tamper exclusion, deterministic verdicts — is in the open tree today.</p>
+</section>
+
+<!-- ═══ §01 thesis ═════════════════════════════════════════════════════════ -->
+<section id="thesis" aria-label="the thesis: work needs an operating system">
+  <p class="overline rise"><span class="idx">§01 ·</span> the thesis</p>
+  <h2 class="rise" style="--d:1">Work is becoming a workload. Workloads get <em>operating systems.</em></h2>
+  <p class="lead rise" style="--d:2">Every generation of compute got an operating system the moment the workload outgrew hand management: batch jobs got schedulers, the desktop got windows, the cloud got orchestrators. Agentic work — software that does jobs, not just models that answer prompts — is the next workload, and today it is run by hand: unversioned prompts, unverified output, unmeasured spend, lessons lost when the session ends.</p>
+  <p class="lead rise" style="--d:3">An operating system for work has five obligations: <em>schedule</em> the work, <em>verify</em> the result, <em>remember</em> what was learned, <em>improve</em> with use, and <em>meter</em> what everything cost. stella already meets all five for one seat. oxagen's platform is those same five obligations at the scale of an organization.</p>
+  <div class="tablewrap rise" style="--d:4">
+  <table class="map" aria-label="mapping from classical operating system concepts to their shipped stella counterparts">
+    <tr><th>an operating system has</th><th>stella has — today, in the public tree</th></tr>
+    <tr><td>a kernel</td><td><span class="gd">stella-core</span> — the decision loop as pure functions over owned data. No I/O in the kernel is an enforced architectural invariant, not a style preference.</td></tr>
+    <tr><td>syscalls &amp; drivers</td><td>ports — a <code>Provider</code> trait for any model vendor, a <code>ToolExecutor</code> trait for any capability. Nine hosted providers plus any local server are adapters, never rewrites.</td></tr>
+    <tr><td>processes</td><td>sessions → turns → steps, every one journaled to a replayable event log. A run can be reconstructed after the fact, byte for byte.</td></tr>
+    <tr><td>a filesystem</td><td>local-first SQLite state: executions and cost telemetry, durable memories, episodic context, a tree-sitter code graph.</td></tr>
+    <tr><td>memory protection</td><td>the witness protocol — work is done when an independently authored test flips <span class="no" style="color:var(--fail)">fail</span> → <span style="color:var(--pass)">pass</span>. The worker cannot grade its own work.</td></tr>
+    <tr><td>a security model</td><td>zero telemetry egress by default. The exportable enterprise rollup is a reviewed, content-free allowlist enforced in CI — prompts, code, and paths are structurally unexportable.</td></tr>
+    <tr><td>a package manager</td><td>skills the agent mines from its own reflections, and tools it builds for itself — each new tool admitted only after a capability witness proves it does something genuinely new.</td></tr>
+  </table>
+  </div>
+  <p class="kicker rise" style="--d:5">The kernel is open — AGPL, bring-your-own-key, nothing phones home. <em>The operating system around it is the business.</em></p>
+</section>
+
+<!-- ═══ §02 engine ═════════════════════════════════════════════════════════ -->
+<section id="engine" aria-label="the engine, shipped today">
+  <p class="overline rise"><span class="idx">§02 ·</span> the engine, shipped</p>
+  <h2 class="rise" style="--d:1">One deterministic loop, behind <em>ports.</em></h2>
+  <p class="lead rise" style="--d:2">stella is a single-threaded engine: plan, fan tools out in parallel, observe, compact when noisy, repeat — with the budget consulted only at safe boundaries and every decision replayable from the event log. Everything vendor-shaped lives behind a port, which is why a new model provider or a new tool is an adapter, and why the engine that exists today can drive models that do not exist yet.</p>
+  <figure class="scrollable rise" style="--d:3">
+    <svg class="dia" viewBox="0 0 1080 330" role="img" aria-label="diagram: the stella-core kernel runs the deterministic task loop with no I/O; model providers, tools, and state connect only through ports; the witness gate sits on the only path to done">
+      <defs>
+        <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#FFB000"/>
+        </marker>
+        <marker id="arm" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#9B9890"/>
+        </marker>
+      </defs>
+      <!-- kernel -->
+      <rect class="boxg" x="360" y="70" width="360" height="190" rx="14" stroke-width="1.5"/>
+      <text class="lbl gd" x="540" y="102" text-anchor="middle">stella-core — the kernel</text>
+      <text class="sm" x="540" y="124" text-anchor="middle">no I/O · pure decision logic · property-tested</text>
+      <rect class="box" x="400" y="146" width="280" height="84" rx="10"/>
+      <text class="sm" x="540" y="172" text-anchor="middle" fill="#F4F1EA">the task loop</text>
+      <text class="sm" x="540" y="192" text-anchor="middle">plan → act → observe → compact</text>
+      <text class="sm" x="540" y="212" text-anchor="middle">budget checked between steps, never mid-tool</text>
+      <!-- providers port -->
+      <rect class="box" x="40" y="70" width="230" height="82" rx="10"/>
+      <text class="lbl" x="155" y="100" text-anchor="middle">model providers</text>
+      <text class="sm" x="155" y="120" text-anchor="middle">9 hosted + any local server</text>
+      <text class="sm" x="155" y="138" text-anchor="middle">bring your own key</text>
+      <path class="ln" d="M270 111 H356" stroke-width="1.5" marker-end="url(#ar)"/>
+      <text class="sm gd" x="313" y="94" text-anchor="middle">Provider</text>
+      <text class="sm gd" x="313" y="107" text-anchor="middle">port</text>
+      <!-- tools port -->
+      <rect class="box" x="40" y="188" width="230" height="82" rx="10"/>
+      <text class="lbl" x="155" y="218" text-anchor="middle">tools</text>
+      <text class="sm" x="155" y="238" text-anchor="middle">read · edit · bash · graph · MCP</text>
+      <text class="sm" x="155" y="256" text-anchor="middle">single-purpose by rule</text>
+      <path class="ln" d="M270 229 H356" stroke-width="1.5" marker-end="url(#ar)"/>
+      <text class="sm gd" x="313" y="212" text-anchor="middle">ToolExecutor</text>
+      <text class="sm gd" x="313" y="225" text-anchor="middle">port</text>
+      <!-- state -->
+      <rect class="box" x="430" y="288" width="220" height="34" rx="10"/>
+      <text class="sm" x="540" y="310" text-anchor="middle">local SQLite state — journaled, replayable</text>
+      <path class="lnm" d="M540 260 V284" stroke-width="1.5" marker-end="url(#arm)"/>
+      <!-- witness gate -->
+      <rect class="box" x="790" y="112" width="180" height="106" rx="10" stroke="#FFB000"/>
+      <text class="lbl gd" x="880" y="144" text-anchor="middle">witness gate</text>
+      <text class="sm" x="880" y="166" text-anchor="middle"><tspan class="fl">fail</tspan> → <tspan class="ps">pass</tspan>, or it is</text>
+      <text class="sm" x="880" y="184" text-anchor="middle">not done · tamper voids</text>
+      <text class="sm" x="880" y="202" text-anchor="middle">the credit</text>
+      <path class="ln" d="M720 165 H786" stroke-width="1.5" marker-end="url(#ar)"/>
+      <text class="sm" x="753" y="156" text-anchor="middle">claims</text>
+      <path class="ln" d="M970 165 H1046" stroke-width="1.5" marker-end="url(#ar)"/>
+      <text class="lbl gd" x="1008" y="150" text-anchor="middle">done</text>
+      <text class="sm" x="1008" y="188" text-anchor="middle">proven</text>
+    </svg>
+    <figcaption>The engine's shape. Decision logic is a kernel with no I/O; vendors and capabilities attach only through ports; the witness gate sits on the only path to "done". This separation is what makes runs deterministic and replayable — and what makes the engine model-agnostic by construction.</figcaption>
+  </figure>
+  <div class="tiles rise" style="--d:4">
+    <div class="tile"><div class="big">21</div><div class="cap">focused Rust crates in one workspace — every boundary a port, every crossing type serialized and round-trip tested</div></div>
+    <div class="tile"><div class="big">9 + local</div><div class="cap">model providers behind one trait, with cache, reasoning, and fallback parity declared per provider and witness-tested on the wire</div></div>
+    <div class="tile"><div class="big">0 bytes</div><div class="cap">of telemetry leaving a default install — local-first SQLite; the enterprise rollup is content-free by CI-enforced allowlist</div></div>
+    <div class="tile"><div class="big">1 loop</div><div class="cap">no coordinator, no swarm — a single deterministic step loop whose every run replays from its event log</div></div>
+  </div>
+  <div class="cols c-2">
+    <div class="rise" style="--d:5">
+      <div class="bh">the paired run · model held constant</div>
+      <div class="brow">
+        <div class="blabel"><strong>stella</strong> · 58/89 solved</div>
+        <div class="btrack"><div class="fill"><div class="bar gold" style="--w:65.2%"></div></div><span class="bval">65.2%</span></div>
+      </div>
+      <div class="brow">
+        <div class="blabel">Claude Code · 44/89 solved</div>
+        <div class="btrack"><div class="fill"><div class="bar" style="--w:49.4%"></div></div><span class="bval">49.4%</span></div>
+      </div>
+      <div class="delta">+15.7 points · 32% more tasks solved<span>the harness isolated — both arms ran the same open-weight model</span></div>
+    </div>
+    <div class="rise" style="--d:6">
+      <p class="lead" style="font-size:0.95rem">The engine is not a wrapper premium — it is measurable. On the full Terminal-Bench 2.1 suite, with the model held constant in both arms, the loop alone was worth 15.7 points over Claude Code. Every trial's cost, tokens, and outcome recorded; the number reproduces from the committed evidence directory alone.</p>
+    </div>
+  </div>
+  <div class="foot">
+    <p class="fine rise" style="--d:7">Run tb21-hh10-20260731 (2026-07-31) · all 89 Terminal-Bench 2.1 tasks, one attempt each, no retries · both arms glm-5.2 at max effort — same tasks, verifier, timeouts, resources, host, and day; the endpoint was the only permitted difference · preregistered before the first trial · stella $1.35 per solved task, inference only at list prices · both arms stock weights — nothing we trained touched this benchmark · witness tier off in this run, so 65.2% is a lower bound on the full verification ladder · a self-reported development baseline, not an audited leaderboard row. Full parity, digests, and per-task results: <a href="https://github.com/macanderson/stella/blob/main/website/public/presentations/BENCHMARK_METHODOLOGY.md">BENCHMARK_METHODOLOGY.md</a>.</p>
+  </div>
+</section>
+
+<!-- ═══ §03 laboratory ═════════════════════════════════════════════════════ -->
+<section id="laboratory" aria-label="the laboratory: improvement managed as experiments">
+  <p class="overline rise"><span class="idx">§03 ·</span> the laboratory</p>
+  <h2 class="rise" style="--d:1">Improvement is an experiment, <em>or it is an anecdote.</em></h2>
+  <p class="lead rise" style="--d:2">Most agent products improve by vibes: a prompt edit, a demo, a feeling. We run the other way. Every improvement to stella starts as a falsifiable hypothesis, bound to a feature branch, a pinned dataset, and a benchmark — preregistered before the first trial. Runs produce traces; the trace is ground truth; the conclusion comes from the trace or it is not drawn. That discipline is already written into this repository's contributor contract and practiced on stella itself — the paired run above shipped with its preregistration, its evidence directory, and a one-script reproduction.</p>
+  <figure class="scrollable rise" style="--d:3">
+    <svg class="dia" viewBox="0 0 1080 250" role="img" aria-label="diagram: a hypothesis binds to a feature branch, dataset, and benchmark; preregistered runs produce traces; a verdict from the traces promotes or discards the change, and either way feeds the next hypothesis">
+      <defs>
+        <marker id="ar2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#FFB000"/>
+        </marker>
+      </defs>
+      <rect class="box" x="0" y="60" width="180" height="96" rx="10"/>
+      <text class="lbl gd" x="90" y="94" text-anchor="middle">hypothesis</text>
+      <text class="sm" x="90" y="116" text-anchor="middle">falsifiable, filed,</text>
+      <text class="sm" x="90" y="134" text-anchor="middle">owned</text>
+      <path class="ln" d="M180 108 H240" stroke-width="1.5" marker-end="url(#ar2)"/>
+      <rect class="box" x="244" y="46" width="210" height="124" rx="10"/>
+      <text class="lbl" x="349" y="78" text-anchor="middle">experiment</text>
+      <text class="sm" x="349" y="102" text-anchor="middle">feature branch</text>
+      <text class="sm" x="349" y="120" text-anchor="middle">+ pinned dataset</text>
+      <text class="sm" x="349" y="138" text-anchor="middle">+ benchmark</text>
+      <path class="ln" d="M454 108 H514" stroke-width="1.5" marker-end="url(#ar2)"/>
+      <rect class="box" x="518" y="60" width="170" height="96" rx="10"/>
+      <text class="lbl" x="603" y="94" text-anchor="middle">runs</text>
+      <text class="sm" x="603" y="116" text-anchor="middle">repeated trials,</text>
+      <text class="sm" x="603" y="134" text-anchor="middle">costs metered</text>
+      <rect class="boxd" x="500" y="20" width="206" height="24" rx="6"/>
+      <text class="sm gd" x="603" y="37" text-anchor="middle">preregistered before trial one</text>
+      <path class="ln" d="M688 108 H748" stroke-width="1.5" marker-end="url(#ar2)"/>
+      <rect class="box" x="752" y="60" width="170" height="96" rx="10"/>
+      <text class="lbl gd" x="837" y="94" text-anchor="middle">traces</text>
+      <text class="sm" x="837" y="116" text-anchor="middle">the event log is</text>
+      <text class="sm" x="837" y="134" text-anchor="middle">ground truth</text>
+      <path class="ln" d="M922 108 H982" stroke-width="1.5" marker-end="url(#ar2)"/>
+      <rect class="box" x="986" y="60" width="94" height="96" rx="10" stroke="#FFB000"/>
+      <text class="lbl gd" x="1033" y="99" text-anchor="middle">verdict</text>
+      <text class="sm" x="1033" y="121" text-anchor="middle">promote</text>
+      <text class="sm" x="1033" y="139" text-anchor="middle">or discard</text>
+      <path class="ln" d="M1033 156 V206 H90 V160" stroke-width="1.5" stroke-dasharray="6 6" marker-end="url(#ar2)"/>
+      <text class="sm" x="560" y="226" text-anchor="middle">either answer feeds the next hypothesis — a discarded change is a result, not a loss</text>
+    </svg>
+    <figcaption>The experiment plane. Hypotheses, experiments, datasets, benchmark runs, and traces are linked objects with lineage — the same chain of custody a measurement needs anywhere. Today this is how stella itself is developed, in the open. stella 2.0 productizes the plane, so a customer's every deployment improvement runs through it too.</figcaption>
+  </figure>
+  <p class="kicker rise" style="--d:4">A benchmark number you cannot reproduce is marketing. <em>Ours reproduce from the evidence directory alone</em> — and the same machinery will manage our customers' experiments, not just ours.</p>
+</section>
+
+<!-- ═══ §04 flywheel ═══════════════════════════════════════════════════════ -->
+<section id="flywheel" aria-label="the flywheel: shipped self-improvement mechanisms">
+  <p class="overline rise"><span class="idx">§04 ·</span> the flywheel, already turning</p>
+  <h2 class="rise" style="--d:1">The engine <em>improves itself</em> — with receipts.</h2>
+  <p class="lead rise" style="--d:2">Self-improvement here is not a roadmap slide. The mechanisms are shipped features with tests and storage schemas behind them, reviewable in the open tree today. The agent's telemetry, state, memories, and histories are all first-class — journaled locally, loaded deterministically, measured for effect.</p>
+  <div class="tiles three rise" style="--d:3">
+    <div class="tile">
+      <div class="name">it mines its own skills</div>
+      <div class="cap">recurring lessons from its post-turn reflections auto-promote into versioned skill files it selects from on later tasks — memory that compounds instead of evaporating</div>
+      <div class="cap"><code>stella-core/src/skills.rs</code> · <code>stella-cli/src/memory/learning.rs</code></div>
+    </div>
+    <div class="tile">
+      <div class="name">it builds its own tools</div>
+      <div class="cap">a capability-gap detector authors new tools, and each must pass a capability witness proving it does something genuinely new before the adoption ledger accepts it</div>
+      <div class="cap"><code>stella-cli/src/tool_foundry.rs</code> · <code>stella-tools/src/foundry_witness.rs</code></div>
+    </div>
+    <div class="tile">
+      <div class="name">it checks whether that helped</div>
+      <div class="cap">an A/B control withholds recalled context on a share of turns, so a gain is measured against a control rather than assumed — improvement distinguishable from noise</div>
+      <div class="cap"><code>stella-cli/src/agent/skill_usage.rs</code></div>
+    </div>
+  </div>
+  <figure class="scrollable rise" style="--d:4">
+    <svg class="dia" viewBox="0 0 1080 110" role="img" aria-label="diagram: work passes the witness, the lesson is promoted, and the next cycle starts better; the loop closes through the commit history">
+      <defs>
+        <marker id="ar3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#FFB000"/>
+        </marker>
+      </defs>
+      <g text-anchor="middle" font-weight="700">
+        <text class="lbl" x="60" y="36">work</text>
+        <text class="lbl" x="400" y="36">witness</text>
+        <text class="lbl" x="710" y="36">lesson</text>
+        <text class="lbl gd" x="1010" y="36">next cycle</text>
+      </g>
+      <path class="ln" d="M105 30 H340" stroke-width="1.5" marker-end="url(#ar3)"/>
+      <path class="ln" d="M460 30 H650" stroke-width="1.5" marker-end="url(#ar3)"/>
+      <path class="ln" d="M765 30 H940" stroke-width="1.5" marker-end="url(#ar3)"/>
+      <path class="ln" d="M1010 48 C1050 100 60 100 60 52" stroke-width="1.5" stroke-dasharray="6 6" marker-end="url(#ar3)"/>
+      <text class="sm" x="540" y="82" text-anchor="middle">stella builds stella — the commit history is the audit trail</text>
+    </svg>
+    <figcaption>The development loop this repository already runs: stella does the work, the witness protocol gates it, the lesson is promoted, the next cycle starts better — and every improvement is a commit somebody can read.</figcaption>
+  </figure>
+</section>
+
+<!-- ═══ §05 factory ════════════════════════════════════════════════════════ -->
+<section id="factory" aria-label="the model factory: verified traces into private models">
+  <p class="overline rise"><span class="idx">§05 ·</span> the model factory</p>
+  <h2 class="rise" style="--d:1">Verified work <em>labels itself.</em> We turn it into your model.</h2>
+  <p class="lead rise" style="--d:2">Every witness flip yields a training example with ground truth attached at creation: the goal, the context, the diff, and a deterministic proof that it worked. No human labelers, no judge models, no scraping — the label is the flip. That makes a customer's own verified traces the highest-grade training corpus that exists for their work, and stella captures them as a side effect of doing the job.</p>
+  <figure class="scrollable rise" style="--d:3">
+    <svg class="dia" viewBox="0 0 1080 300" role="img" aria-label="diagram: goal, diff, and proof compose one labeled example; a curriculum of examples fine-tunes an open-weight baseline into a private model that serves inside the customer boundary and routes back into the engine">
+      <defs>
+        <marker id="ar4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#FFB000"/>
+        </marker>
+      </defs>
+      <rect class="box" x="0" y="20" width="150" height="52" rx="10"/>
+      <text class="lbl gd" x="75" y="44" text-anchor="middle">goal</text>
+      <text class="sm" x="75" y="62" text-anchor="middle">what was asked</text>
+      <rect class="box" x="0" y="92" width="150" height="52" rx="10"/>
+      <text class="lbl gd" x="75" y="116" text-anchor="middle">diff</text>
+      <text class="sm" x="75" y="134" text-anchor="middle">what changed</text>
+      <rect class="box" x="0" y="164" width="150" height="52" rx="10"/>
+      <text class="lbl gd" x="75" y="188" text-anchor="middle">proof</text>
+      <text class="sm" x="75" y="206" text-anchor="middle"><tspan class="fl">fail</tspan> → <tspan class="ps">pass</tspan></text>
+      <path class="lnm" d="M150 46 H210 V104" stroke-width="1.5"/>
+      <path class="lnm" d="M150 118 H210" stroke-width="1.5"/>
+      <path class="lnm" d="M150 190 H210 V132" stroke-width="1.5"/>
+      <path class="ln" d="M210 118 H264" stroke-width="2" marker-end="url(#ar4)"/>
+      <rect class="boxg" x="268" y="76" width="230" height="84" rx="12" stroke-width="1.5"/>
+      <text class="lbl gd" x="383" y="106" text-anchor="middle">one labeled example</text>
+      <text class="sm" x="383" y="126" text-anchor="middle">ground truth attached</text>
+      <text class="sm" x="383" y="142" text-anchor="middle">at creation</text>
+      <path class="ln" d="M498 118 H552" stroke-width="1.5" marker-end="url(#ar4)"/>
+      <rect class="box" x="556" y="76" width="180" height="84" rx="10"/>
+      <text class="lbl" x="646" y="106" text-anchor="middle">curriculum</text>
+      <text class="sm" x="646" y="126" text-anchor="middle">flips in · abstentions</text>
+      <text class="sm" x="646" y="144" text-anchor="middle">and voided flips out</text>
+      <path class="ln" d="M736 118 H790" stroke-width="1.5" marker-end="url(#ar4)"/>
+      <rect class="box" x="794" y="76" width="180" height="84" rx="10" stroke="#FFB000"/>
+      <text class="lbl gd" x="884" y="106" text-anchor="middle">fine-tune</text>
+      <text class="sm" x="884" y="126" text-anchor="middle">open-weight baseline</text>
+      <text class="sm" x="884" y="144" text-anchor="middle">→ your private model</text>
+      <rect class="boxd" x="794" y="8" width="180" height="44" rx="10"/>
+      <text class="sm" x="884" y="26" text-anchor="middle">open-weight baseline in</text>
+      <text class="sm" x="884" y="42" text-anchor="middle">no lab dependency</text>
+      <path class="lnm" d="M884 52 V72" stroke-width="1.5" marker-end="url(#ar4)"/>
+      <path class="ln" d="M974 118 H1040 V250 H500" stroke-width="1.5" stroke-dasharray="6 6" marker-end="url(#ar4)"/>
+      <text class="sm gd" x="770" y="242" text-anchor="middle">serves the routine work, on your hardware, inside your boundary</text>
+      <text class="sm" x="383" y="270" text-anchor="middle">back into the engine — frontier models called only where novelty earns them</text>
+    </svg>
+    <figcaption>The factory. Goal, diff, and proof compose one self-labeled example; the curriculum admits flips and excludes abstentions and voided flips; fine-tuning starts from an open-weight baseline, so no frontier lab sits in the dependency chain. The resulting model is the customer's asset, served on the customer's hardware — and the engine routes to it first, calling frontier models only where genuine novelty earns the spend. By protocol, public benchmark tasks are excluded from every training corpus.</figcaption>
+  </figure>
+  <div class="tiles three rise" style="--d:4">
+    <div class="tile"><div class="big">$0</div><div class="cap">deterministic tools — parse, edit, search, run, diff — do deterministic work with no model in the loop</div></div>
+    <div class="tile"><div class="big">$</div><div class="cap">your tuned model, trained on your verified traces, does the routine work on your hardware</div></div>
+    <div class="tile"><div class="big">$$$</div><div class="cap">frontier models are called only where genuine novelty earns them — routing is the cost lever</div></div>
+  </div>
+  <p class="kicker rise" style="--d:5">Your traces stop training the lab you rent — <em>they start training the model you own.</em> You can leave with the weights; what compounds for oxagen is the machine that made them.</p>
+</section>
+
+<!-- ═══ §06 economics ══════════════════════════════════════════════════════ -->
+<section id="economics" aria-label="the economics: customers bring infrastructure, oxagen sells the control plane">
+  <p class="overline rise"><span class="idx">§06 ·</span> the economics</p>
+  <h2 class="rise" style="--d:1">We sell no tokens and <em>serve no GPUs.</em></h2>
+  <p class="lead rise" style="--d:2">The engine is free and bring-your-own-key: frontier model spend flows from the customer to their provider, never through us. Private models are bring-your-own-infrastructure: training and serving run on compute, network, and disk the customer already pays for. oxagen operates no inference fleet — so what we sell carries no per-token cost of goods underneath it.</p>
+  <figure class="scrollable rise" style="--d:3">
+    <svg class="dia" viewBox="0 0 1080 300" role="img" aria-label="diagram: the customer boundary contains keys, compute, network, disk, traces, and the private model's serving; oxagen's boundary contains the protocol, curriculum recipes, training pipeline, and support; subscription and usage credits flow to oxagen, software and recipes flow back, and no data or serving crosses the boundary">
+      <defs>
+        <marker id="ar5" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#FFB000"/>
+        </marker>
+        <marker id="arm5" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="#9B9890"/>
+        </marker>
+      </defs>
+      <rect class="boxd" x="0" y="20" width="480" height="240" rx="14"/>
+      <text class="lbl" x="24" y="52">your boundary</text>
+      <rect class="box" x="24" y="70" width="208" height="76" rx="10"/>
+      <text class="sm" x="128" y="98" text-anchor="middle" fill="#F4F1EA">compute · network · disk</text>
+      <text class="sm" x="128" y="118" text-anchor="middle">yours already — you pay</text>
+      <text class="sm" x="128" y="134" text-anchor="middle">your cloud, not us</text>
+      <rect class="box" x="248" y="70" width="208" height="76" rx="10"/>
+      <text class="sm" x="352" y="98" text-anchor="middle" fill="#F4F1EA">provider keys</text>
+      <text class="sm" x="352" y="118" text-anchor="middle">frontier spend goes to</text>
+      <text class="sm" x="352" y="134" text-anchor="middle">your provider, direct</text>
+      <rect class="box" x="24" y="162" width="432" height="76" rx="10" stroke="#FFB000"/>
+      <text class="sm" x="240" y="190" text-anchor="middle" fill="#F4F1EA">traces · weights · the serving of your private model</text>
+      <text class="sm gd" x="240" y="212" text-anchor="middle">never leaves — zero egress by default, enforced in CI</text>
+      <rect class="boxg" x="640" y="20" width="440" height="240" rx="14" stroke-width="1.5"/>
+      <text class="lbl gd" x="664" y="52">oxagen</text>
+      <rect class="box" x="664" y="70" width="180" height="76" rx="10"/>
+      <text class="sm" x="754" y="98" text-anchor="middle" fill="#F4F1EA">the substrate</text>
+      <text class="sm" x="754" y="118" text-anchor="middle">protocol · oracles ·</text>
+      <text class="sm" x="754" y="134" text-anchor="middle">curriculum recipes</text>
+      <rect class="box" x="864" y="70" width="192" height="76" rx="10"/>
+      <text class="sm" x="960" y="98" text-anchor="middle" fill="#F4F1EA">training pipeline</text>
+      <text class="sm" x="960" y="118" text-anchor="middle">runs inside your</text>
+      <text class="sm" x="960" y="134" text-anchor="middle">boundary, licensed by us</text>
+      <rect class="box" x="664" y="162" width="392" height="76" rx="10"/>
+      <text class="sm" x="860" y="190" text-anchor="middle" fill="#F4F1EA">support · governance · the control plane</text>
+      <text class="sm" x="860" y="212" text-anchor="middle">people and software, no per-token cost underneath</text>
+      <path class="ln" d="M480 100 H636" stroke-width="2" marker-end="url(#ar5)"/>
+      <text class="sm gd" x="558" y="90" text-anchor="middle">support + credits</text>
+      <path class="lnm" d="M636 210 H480" stroke-width="1.5" marker-end="url(#arm5)"/>
+      <text class="sm" x="558" y="232" text-anchor="middle">software + recipes</text>
+      <text class="sm" x="540" y="288" text-anchor="middle">no data crosses right · no serving happens on the right — the boundary is the business model</text>
+    </svg>
+    <figcaption>Who pays for what. The customer supplies the compute, network, and disk they already own; frontier keys are theirs; their private model serves inside their boundary. oxagen sells the control plane — support tiers and usage credits — and operates no inference fleet, so credit revenue on private-model usage carries no serving cost of goods: structurally ~100% gross margin by construction. Stated as a unit-economics design, not as reported financials.</figcaption>
+  </figure>
+  <div class="tiles three rise" style="--d:4">
+    <div class="tile">
+      <div class="name">community <span class="badge now">open source</span></div>
+      <div class="cap">the whole engine, free forever — AGPL, bring-your-own-key, zero egress. The wedge that earns bottom-up trust among engineers who choose their own tools.</div>
+    </div>
+    <div class="tile">
+      <div class="name">pro <span class="badge next">support</span></div>
+      <div class="cap">paid technical support with a response SLA, upgrade guidance, and priority on the issue queue — people revenue, priced as such.</div>
+    </div>
+    <div class="tile">
+      <div class="name">enterprise <span class="badge next">control plane</span></div>
+      <div class="cap">managed governance, content-free operational telemetry, the training pipeline, and metered usage credits on the private models it produces — margin revenue, by construction.</div>
+    </div>
+  </div>
+  <p class="kicker rise" style="--d:5">A frontier vendor's revenue is your consumption — every retry is their upside. Ours is the inverse: <em>every token routing removes from your bill is our feature, not our lost revenue.</em></p>
+</section>
+
+<!-- ═══ §07 the road ═══════════════════════════════════════════════════════ -->
+<section id="road" aria-label="the road: stella 1.x, 2.0, 3.0">
+  <p class="overline rise"><span class="idx">§07 ·</span> the road</p>
+  <h2 class="rise" style="--d:1">The engine, the laboratory, <em>the compounding OS.</em></h2>
+  <p class="lead rise" style="--d:2">Each major version is the previous one's discipline, productized one level up: what we practice on ourselves in 1.x becomes what customers operate in 2.0; what 2.0 measures becomes what 3.0 compounds.</p>
+  <div class="road rise" style="--d:3">
+    <div class="era">
+      <div class="v">stella 1.x <span class="badge now">shipped line</span><span class="sub">the verified engine · v0.8 today</span></div>
+      <ul>
+        <li>the deterministic task loop behind ports — model-agnostic by construction, replayable from the event log <span class="d">· shipped</span></li>
+        <li>the witness protocol: independently authored tests, the fail → pass flip, tamper exclusion <span class="d">· shipped</span></li>
+        <li>skill mining, the tool foundry with capability witnesses, and the A/B control that measures both <span class="d">· shipped</span></li>
+        <li>local-first state: telemetry, memories, histories, the code graph — zero egress by default <span class="d">· shipped</span></li>
+        <li>fleet fan-out, the staged pipeline, budgets, and the Command Deck terminal UI <span class="d">· shipped</span></li>
+      </ul>
+    </div>
+    <div class="era">
+      <div class="v">stella 2.0 <span class="badge next">next</span><span class="sub">the laboratory, productized</span></div>
+      <ul>
+        <li>the experiment plane as a product: hypotheses, experiments, datasets, benchmark runs, and traces as governed, linked objects with lineage — for customer deployments, not just for us</li>
+        <li>the model factory GA: verified traces → curriculum → private fine-tunes of open-weight baselines, trained and served inside the customer boundary</li>
+        <li>the credits ledger and tiered support — the control plane an enterprise pays for</li>
+        <li>org-scale memory and governed context records: what one seat learns, the organization keeps</li>
+      </ul>
+    </div>
+    <div class="era">
+      <div class="v">stella 3.0 <span class="badge">direction</span><span class="sub">the compounding OS</span></div>
+      <ul>
+        <li>the foundry economy: agent-built tools and mined skills promoted across an organization, each admitted under a capability witness — the package manager that writes its own packages</li>
+        <li>co-evolved models: each release trained on the last release's verified work, per organization — the engine and its model improving as one system</li>
+        <li>autonomous improvement under proof: stella running the laboratory on itself, inside customer governance — the loop that builds the product, sold as the product</li>
+        <li>beyond software: every vertical with a checkable outcome runs the same engine — the loop underneath is act, verify, learn, and it was never only about code</li>
+      </ul>
+    </div>
+  </div>
+  <div class="foot">
+    <p class="fine rise" style="--d:4">Versions describe direction and sequence, not dated commitments. Nothing on this page carries a date, because no date here has a plan behind it yet — when one does, it will ship with the plan attached. "Shipped" means in the public tree at the commit this page shipped with.</p>
+  </div>
+</section>
+
+<hr class="hr-gold" aria-hidden="true">
+
+<!-- ═══ close ══════════════════════════════════════════════════════════════ -->
+<section class="close" aria-label="close">
+  <div class="lockup rise">
+    <svg width="56" height="56" viewBox="0 0 96 96" fill="none" aria-hidden="true">
+      <line x1="10" y1="48" x2="30" y2="48" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="34" x2="30" y2="34" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <line x1="18" y1="62" x2="30" y2="62" stroke="#FFB000" stroke-width="7" stroke-linecap="round"/>
+      <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#FFB000"/>
+    </svg>
+  </div>
+  <h2 class="rise" style="--d:1"><em>verified done,</em><br>not claimed done.</h2>
+  <p class="lead rise" style="--d:2">stella is the engine — the program that controls an agent's task loop, and the only part of this story you have to take on faith is none of it: the engine is open source, the mechanisms have file paths, and the numbers have evidence directories. oxagen is the operating system growing around that engine. This page is the map.</p>
+  <p class="links rise" style="--d:3">
+    <a href="https://stella.oxagen.sh">stella.oxagen.sh</a>
+    <a href="https://github.com/macanderson/stella">github.com/macanderson/stella</a>
+    <a href="presentations/investor-deck.html">the investor deck</a>
+    <a href="mailto:mac@oxagen.sh">mac@oxagen.sh</a>
+  </p>
+</section>
+
+</main>
+
+<script>
+(function () {
+  "use strict";
+  document.documentElement.classList.add("js");
+  var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // Reveal on scroll — assemble, don't spin.
+  //
+  // The hidden state is applied by CSS only under `.js`, so a no-JS reader
+  // gets the whole page painted. Two further rules keep "hidden" from ever
+  // becoming permanent, which is the failure mode that matters: content the
+  // reader cannot see is worse than content that does not animate.
+  //
+  //  1. Anything at or above the viewport bottom at boot is revealed outright.
+  //     An IntersectionObserver reports nothing for a container the page has
+  //     ALREADY scrolled past, so a deep link (/vision.html#road) or a
+  //     browser-restored scroll position would otherwise leave every earlier
+  //     section invisible until the reader happened to scroll back up.
+  //  2. Reduced motion and a missing IntersectionObserver both reveal
+  //     everything up front — the effect is the enhancement, never the
+  //     delivery mechanism.
+  var groups = document.querySelectorAll("section, figure, .tiles, .cols, .road, .tablewrap");
+  var revealAll = function () {
+    groups.forEach(function (s) { s.classList.add("in"); });
+  };
+
+  if (!("IntersectionObserver" in window) || reduce) {
+    revealAll();
+  } else {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); }
+      });
+    }, { rootMargin: "0px 0px -12% 0px", threshold: 0.05 });
+
+    groups.forEach(function (s) {
+      if (s.getBoundingClientRect().top < window.innerHeight) {
+        s.classList.add("in");
+      } else {
+        io.observe(s);
+      }
+    });
+  }
+
+  // scroll progress hairline
+  var bar = document.querySelector(".progress");
+  var onScroll = function () {
+    var h = document.documentElement;
+    var max = h.scrollHeight - h.clientHeight;
+    bar.style.width = (max > 0 ? (h.scrollTop / max) * 100 : 0) + "%";
+  };
+  document.addEventListener("scroll", onScroll, { passive: true });
+  onScroll();
+})();
+</script>
+
+</body>
+</html>

--- a/website/public/vision.html
+++ b/website/public/vision.html
@@ -389,7 +389,7 @@ figcaption { margin-top: 10px; font-size: 0.72rem; color: var(--muted); line-hei
     <div class="tile"><div class="big">21</div><div class="cap">focused Rust crates in one workspace — every boundary a port, every crossing type serialized and round-trip tested</div></div>
     <div class="tile"><div class="big">9 + local</div><div class="cap">model providers behind one trait, with cache, reasoning, and fallback parity declared per provider and witness-tested on the wire</div></div>
     <div class="tile"><div class="big">0 bytes</div><div class="cap">of telemetry leaving a default install — local-first SQLite; the enterprise rollup is content-free by CI-enforced allowlist</div></div>
-    <div class="tile"><div class="big">1 loop</div><div class="cap">no coordinator, no swarm — a single deterministic step loop whose every run replays from its event log</div></div>
+    <div class="tile"><div class="big">1 loop</div><div class="cap">no in-loop coordinator and no swarm inside the engine — one deterministic step loop, replayable from its event log. Fleet mode composes <em>many</em> workers, each running this same loop; it does not change what the loop is</div></div>
   </div>
   <div class="cols c-2">
     <div class="rise" style="--d:5">


### PR DESCRIPTION
## What & why

Adds `website/public/vision.html`: an investor-facing scrolling microsite that
frames **stella as the engine** — the program that controls an agent's task
loop — and **oxagen as the operating system built around it**.

It is the narrative companion to the existing deck
(`website/public/presentations/investor-deck.html`), which is a linear pitch. A
scrolling page does a different job: it can be sent as a link, read at the
reader's own pace, and deep-linked into a single section during diligence.

Seven sections:

| § | Claim |
|---|---|
| 01 thesis | agentic work is the next workload, and workloads get operating systems — with a table mapping each classical OS obligation to its shipped stella counterpart |
| 02 engine | the deterministic loop behind ports, plus the paired-run result |
| 03 laboratory | improvement managed as preregistered experiments with lineage |
| 04 flywheel | the self-improvement mechanisms that ship *today*, with file paths |
| 05 factory | verified traces → curriculum → a private fine-tune of an open-weight baseline |
| 06 economics | the customer/oxagen boundary, and why credit revenue carries no serving COGS |
| 07 road | stella 1.x / 2.0 / 3.0 |

No `Closes #N` — this PR adds a page and closes no issue. It **`Refs #2889`,
`Refs #2890`, `Refs #2891`**, the three issues filed for the infrastructure the
page depicts as roadmap.

### Placement

Deliberately **not** under `website/public/presentations/`. `deck-fit.yml`
measures every slide of every deck there against a fixed 1600x900 canvas
(`scripts/deck-fit.mjs`), and a scrolling page has no slides — it would either
fail that workflow or make it meaningless. Sitting at
`website/public/vision.html` also gives it a flat URL exactly like the deck's,
with no dependence on static-host directory-index behaviour for a
`/vision/index.html` form.

### Brand

Reuses the existing brand layer rather than inventing one: tokens mirrored from
`docs/brand/` via `website/src/app/tokens.css`, the same JetBrains Mono woff2
files already under `public/brand/fonts/`, and the deck's component idiom
(overlines, kickers, stat tiles, terminal card, inline SVG diagrams). One
committed dark theme — this is brand surface, not a document — with every color
painted explicitly so the page holds on any host ground.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this adds a
      single static HTML page and changes no Rust, no behavior, and no flags.

Verified instead by rendering it in Chromium at 1440x900, 1280x800, 768x1024
and 390x844 and measuring, rather than by looking at one screenshot:

- no body horizontal overflow at any width;
- no element wider than the viewport outside a deliberate `overflow-x: auto`
  container (the wide table and diagrams scroll inside their own);
- the webfont resolves (`document.fonts.check`) — no silent fallback;
- no console errors and no failed requests;
- **no content left invisible after a read** — 0 of 52 revealed-on-scroll
  elements remain at `opacity: 0`.

Two bugs the measurement caught and this PR fixes rather than ships:

1. A deep link such as `/vision.html#road` left every earlier section
   permanently invisible: an `IntersectionObserver` reports nothing for a
   container the page has *already* scrolled past. Anything at or above the
   viewport bottom at boot is now revealed outright. Re-checked: 43
   scrolled-past elements, 0 still invisible.
2. Two port labels in the engine diagram overlapped the kernel box edge, and
   one label in the factory diagram touched its box border. Both re-set onto
   two lines.

The hidden state is applied under a `.js` class only, so a reader without
JavaScript gets the whole page painted; `prefers-reduced-motion` reveals
everything up front.

## The gate

- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run; this
      PR contains no Rust
- [ ] `cargo test --workspace` — not run; this PR contains no Rust
- [x] Every toolchain-free guard green: `no-scratch`, `no-secrets`,
      `design-refs`, `action-pins`, `cargo-install-pins`,
      `license-allowlist-parity`, `repro-wiring`, `invariants`, `doc-links`,
      `command-docs`, `brand-case`, `file-size`, `god-files`, `gate-parity`,
      `left-behind`, `role-names`, `stat-portability`, `module-reachability`,
      `typed-errors`, `diagnostic-codes`
- [x] Docs updated where behavior/flags changed — n/a, no behavior or flags
      change

**One gate step could not run here and needs a reviewer's eye:** `shellcheck`
is not installed in this container, so `make guards-fast` aborts on it. This PR
touches no shell, so the step is not implicated by the change — but I did not
run it, and CI should be treated as the authority.

## Nothing left behind

- [x] Filed: #2889, #2890, #2891

The request this page came from asked for **the infrastructure** to manage
hypotheses, experiments, datasets, benchmarks, traces, fine-tuning and tiered
billing — *and* the microsite. This PR is the microsite. The infrastructure is a
multi-quarter program across `stella-store`, `stella-core` and a new training
adapter, and half-building it silently is the failure mode CLAUDE.md forbids, so
it is filed as three handoff issues instead:

- **#2889 — experiment plane.** Hypotheses, experiments, datasets, benchmark
  runs and traces as first-class linked objects with lineage. Today the
  discipline is real but lives in prose and hand-assembled `bench/evidence/`
  directories, which is exactly the lineage gap behind the two bench
  misreadings CLAUDE.md documents.
- **#2890 — model factory.** The extract → exclude → curriculum → fine-tune →
  evaluate pipeline. Includes the contamination exclusion as an enforced,
  witnessed property rather than a stated policy.
- **#2891 — commercial plane.** Entitlements, a hash-chained credit ledger, and
  metering for custom-model usage — with the trust-boundary question (is the
  local ledger evidence or authority?) called out as a decision to record in an
  ADR, not to leave implicit.

Each is written as a handoff: problem, file paths, the invariants and god-file
constraints already discovered, how to verify, and what "done" means.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification — no Rust
      changed, and the page adds no dependency of any kind
- [x] No new outbound network calls — the page loads no external resource. All
      CSS and JS are inline; the only subresources are the four woff2 files
      already in `public/brand/fonts/`. It satisfies the site's existing CSP
      (`next.config.mjs`), which locks `font-src`, `script-src` and `style-src`
      to `'self'`
- [x] New cross-boundary types round-trip through serde — n/a

## Anything reviewers should know?

**Every claim on the page is either sourced to a path in this tree or carries
its measurement**, and the ones that are neither are marked as direction:

- The paired-run figures (58/89 vs 44/89, +15.7 points, $1.35/solved task)
  repeat run `tb21-hh10-20260731` with **all** the qualifications the deck
  states, not a flattering subset: witness tier was off so 65.2% is a *lower
  bound*, the two arms are **not** cost-comparable, both arms ran stock weights,
  and it is a self-reported development baseline rather than an audited
  leaderboard row.
- §04's self-improvement claims each name the file that implements them, so a
  reader can check rather than trust.
- **The roadmap carries no dates**, and says so: no date here has a plan behind
  it yet. "Shipped" means in the public tree at this commit.
- The ~100% margin claim in §06 is labelled in the figure caption as a
  **unit-economics design, not reported financials**.

Two judgement calls worth a reviewer's disagreement:

1. **The paired-run bar chart uses gold against muted grey**, which fails a
   generic categorical-palette chroma floor by construction. That is deliberate
   and now commented in the stylesheet: the kit's law is "gold is the signal,
   never the surface", so the comparator is recessive rather than a peer hue. It
   is only legal because identity never rests on color — every bar carries a
   direct label *and* its value, so the chart reads identically in greyscale and
   in every CVD mode. If you'd rather have a second hue, that is a brand
   decision, not a chart decision.
2. **The page is not linked from the site navigation.** The investor deck isn't
   either — both are standalone artifacts under `public/` shared by URL. If you
   want `/vision.html` in the nav or the sitemap, say so and I'll wire it.

Not done, deliberately: no Open Graph image, and the page is not in
`sitemap.ts`. Both are easy follow-ups but are a marketing-distribution
decision rather than a content one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKhgavXXJS3nQvy79ZB4v1)_

## Summary by Sourcery

Add an investor-facing oxagen vision microsite presenting stella as the engine and oxagen as the operating system around it.

Enhancements:
- Implement an inline, JS-enhanced scrolling experience with reveal-on-scroll, scroll-progress indicator, and reduced-motion fallbacks while maintaining full content visibility without JavaScript.

Documentation:
- Introduce a standalone branded scrolling vision page at website/public/vision.html that narrates stella’s engine, lab, model factory, economics, and roadmap for investors.
- Document benchmark results, self-improvement mechanisms, and product roadmap in a linkable microsite complementary to the existing investor deck.