### PR TITLE
feat(website): /engine — an interactive tour of the agent engine

### DIFF
--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -206,8 +206,35 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── Providers ──────────────────────────────────────────────────── */}
+      {/* ── The tour ───────────────────────────────────────────────────── */}
       <section className="lp-section">
+        <div className="mx-auto w-full max-w-3xl px-4 py-16">
+          <h2 className="lp-eyebrow mb-5">Step inside</h2>
+          <p className="max-w-prose text-base">
+            The rest of this page tells you what{" "}
+            <span className="lp-brand-face">stella</span> is.{" "}
+            <Link href="/engine" className="underline underline-offset-4">
+              The engine tour
+            </Link>{" "}
+            shows you the machine: the turn loop, the tool bay,{" "}
+            <span className="lp-brand-face">vera</span>&apos;s deterministic
+            verification chamber, the governance plane, and the deck where{" "}
+            <span className="lp-brand-face">stella</span>{" "}
+            rebuilds itself from your team&apos;s traces.
+          </p>
+          <div className="mt-6">
+            <Link
+              href="/engine"
+              className="lp-cta inline-flex items-center rounded-md px-6 py-3 text-sm"
+            >
+              Take the engine tour
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Providers ──────────────────────────────────────────────────── */}
+      <section className="lp-section lp-band">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Providers</h2>
           <p className="max-w-prose text-base">
@@ -221,8 +248,13 @@ export default function HomePage() {
             ))}
           </p>
           <p className="mt-4 max-w-prose text-sm text-fd-muted-foreground">
-            <span className="lp-brand-face">stella</span> speaks each
-            vendor&apos;s own wire protocol rather than normalising everything
+            {/* The trailing `{" "}` is load-bearing: JSX trims the leading
+                whitespace of a text node's first line when the node spans
+                more than one line, so `</span> speaks each\n vendor's…`
+                shipped as "stellaspeaks each vendor's". */}
+            <span className="lp-brand-face">stella</span>{" "}
+            speaks each vendor&apos;s own wire protocol rather than normalising
+            everything
             through one OpenAI-shaped adapter, so thinking blocks, cache
             control, and tool-call shapes are native rather than emulated.
             Override any base URL, key, or model in{" "}
@@ -238,7 +270,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Doors into the docs ────────────────────────────────────────── */}
-      <section className="lp-section lp-band">
+      <section className="lp-section">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Start here</h2>
           <ul className="border-t border-fd-border">

--- a/website/src/app/engine/engine-stations.css
+++ b/website/src/app/engine/engine-stations.css
@@ -1,0 +1,972 @@
+/**
+ * The engine tour — the stations (`eng-`), styles for src/app/engine/.
+ *
+ * The second half of this route's stylesheet, split from engine.css when the
+ * single file crossed 1500 lines. AGENTS.md § "God files" is explicit that a
+ * file approaching that limit gets split rather than grown over it, and the
+ * split is along the seam the page already has: engine.css owns the **shell**
+ * that is the same at every stop (tokens, the ink ground, the HUD, the
+ * station rail, the station scaffolding and its entrances, and the shared
+ * primitives — head, lead, fact panel, telemetry feed); this file owns what
+ * is different at each stop, in tour order, 00 → 06.
+ *
+ * Worth stating plainly, because `make file-size` would not have caught it:
+ * the guard's ratchet covers `*.rs`, `*.py`, `*.sh` and `.githooks/*` only,
+ * so a 1519-line stylesheet passed the gate green. Its own header records
+ * that same blind spot biting twice before (#1563, when it watched only
+ * `*.rs`). Splitting on the documented rule rather than on what the guard
+ * happens to look at is the point.
+ *
+ * Every convention from engine.css's header applies here unchanged and is
+ * not restated: raw non-flipping palette tokens only, no hex literals, gold
+ * is the signal and never the surface, and hue is never the only cue. Read
+ * that header first — it is the normative one for both files.
+ *
+ * Both files are imported from the route's layout, engine.css first: this
+ * one consumes the `--eng-*` tokens that file defines, and a custom property
+ * is resolved at use, so the order is a readability convention rather than a
+ * correctness requirement. Keep it anyway.
+ */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 00 · intake
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-goal {
+  margin: 0 0 2rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--eng-accent-dim);
+  border-radius: 0.5rem;
+  background: var(--eng-surface-warm);
+  box-shadow: var(--stella-glow-gold);
+  max-width: 46rem;
+}
+.eng-goal-line {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+  color: var(--eng-fg);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.eng-goal-prompt {
+  color: var(--eng-accent);
+  font-weight: 700;
+}
+.eng-goal-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.6rem 0 0;
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+.eng-goal-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--eng-accent);
+  animation: eng-pulse 2.4s var(--stella-ease-arrive) infinite;
+}
+@keyframes eng-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--stella-gold) 55%, transparent);
+  }
+  50% {
+    opacity: 0.65;
+    box-shadow: 0 0 0 0.35rem
+      color-mix(in srgb, var(--stella-gold) 0%, transparent);
+  }
+}
+
+.eng-intake-facts {
+  margin: 0 0 2rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.4rem;
+  font-size: var(--stella-type-sm);
+  color: var(--eng-muted);
+}
+.eng-intake-facts li {
+  display: flex;
+  gap: 0.7rem;
+}
+.eng-intake-facts li::before {
+  content: "✦";
+  color: var(--eng-accent);
+  flex: none;
+}
+
+.eng-intake-ctas,
+.eng-exit-doors {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+/* The one gold surface per station: the primary action. */
+.eng-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.4rem;
+  border-radius: 0.375rem;
+  background: var(--eng-accent);
+  color: var(--stella-ink);
+  font-weight: 500;
+  font-size: var(--stella-type-sm);
+  text-decoration: none;
+  transition:
+    background-color var(--stella-duration-base) var(--stella-ease-arrive),
+    box-shadow var(--stella-duration-base) var(--stella-ease-arrive);
+}
+.eng-cta:hover {
+  background: var(--stella-gold-400);
+  color: var(--stella-ink);
+  box-shadow: var(--stella-glow-gold);
+  text-decoration: none;
+}
+
+.eng-cta-quiet {
+  font-size: var(--stella-type-sm);
+  color: var(--eng-muted);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 01 · the turn loop — the ring
+ *
+ * Three nodes on a circular track with the guards on the return edge and the
+ * pure core in the middle; a comet runs the track (left→right, per the kit —
+ * the orbit rotates clockwise, so the comet crosses the top moving right).
+ * The whole figure is `role="img"` with one sentence describing it, because
+ * a ring of absolutely-positioned labels is not a reading order.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-ring-scene {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 2.5rem 3rem;
+  align-items: center;
+  margin: 0 0 2.5rem;
+}
+
+.eng-ring {
+  position: relative;
+  width: min(100%, 21rem);
+  aspect-ratio: 1;
+  margin: 0 auto;
+}
+
+.eng-ring-track {
+  position: absolute;
+  inset: 12%;
+  border: 1px dashed var(--eng-rule-strong);
+  border-radius: 50%;
+}
+
+.eng-ring-orbit {
+  position: absolute;
+  inset: 12%;
+  animation: eng-orbit 9s linear infinite;
+}
+.eng-ring-comet {
+  position: absolute;
+  top: -0.3rem;
+  inset-inline-start: 50%;
+  width: 0.6rem;
+  height: 0.6rem;
+  margin-inline-start: -0.3rem;
+  border-radius: 50%;
+  background: var(--eng-accent);
+  box-shadow: var(--stella-glow-gold);
+}
+@keyframes eng-orbit {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.eng-ring-node,
+.eng-ring-gate {
+  position: absolute;
+  margin: 0;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--eng-rule-strong);
+  border-radius: 0.375rem;
+  background: var(--eng-surface-high);
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--eng-fg);
+  white-space: nowrap;
+}
+.eng-ring-node[data-pos="top"] {
+  top: 0;
+  inset-inline-start: 50%;
+  transform: translate(-50%, -50%);
+}
+.eng-ring-node[data-pos="right"] {
+  top: 50%;
+  inset-inline-end: 0;
+  transform: translate(35%, -50%);
+}
+.eng-ring-node[data-pos="bottom"] {
+  bottom: 0;
+  inset-inline-start: 50%;
+  transform: translate(-50%, 50%);
+}
+
+/* The guards sit on the return edge, styled as a gate rather than a node:
+ * dashed, quieter, and labelled — it is a condition, not a step. */
+.eng-ring-gate {
+  top: 50%;
+  inset-inline-start: 0;
+  /* Wraps into a narrow column and straddles the track. It cannot keep the
+   * `nowrap` its sibling nodes have: "compact · budget · loop-detect" sets
+   * ~200px on one line, which reached under the core circle — and the core
+   * comes later in the DOM, so it painted over the guard names. */
+  transform: translate(-55%, -50%);
+  max-width: 8rem;
+  white-space: normal;
+  border-style: dashed;
+  background: var(--eng-bg);
+  color: var(--eng-muted);
+  text-transform: none;
+  letter-spacing: 0.04em;
+  display: grid;
+  gap: 0.15rem;
+  text-align: center;
+}
+.eng-ring-gate-label {
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-accent);
+}
+
+.eng-ring-core {
+  position: absolute;
+  inset: 28%;
+  margin: 0;
+  display: grid;
+  align-content: center;
+  gap: 0.35rem;
+  text-align: center;
+  border: 1px solid var(--eng-accent-dim);
+  border-radius: 50%;
+  background: var(--eng-surface-warm);
+  font-size: var(--stella-type-xs);
+  font-weight: 700;
+  color: var(--eng-fg);
+  padding: 0.5rem;
+}
+.eng-ring-core span {
+  display: block;
+  font-size: var(--stella-type-2xs);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  color: var(--eng-faint);
+}
+
+.eng-ring-copy {
+  display: grid;
+  gap: 1.5rem;
+}
+
+/* ── the staged pipeline strip ───────────────────────────────────────────── */
+
+.eng-pipeline {
+  margin: 0 0 2.5rem;
+  padding: 1.25rem 0 0;
+  border-top: 1px solid var(--eng-rule);
+}
+.eng-pipeline-label {
+  margin: 0 0 0.9rem;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+
+.eng-pipeline-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0 0.9rem;
+  padding: 0;
+  list-style: none;
+  counter-reset: eng-stage;
+}
+.eng-pipeline-stage {
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--eng-rule-strong);
+  border-radius: 0.375rem;
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--eng-fg);
+  background: var(--eng-surface);
+}
+/* Dashed = conditional. The note under the strip spells it out in words, so
+ * the border style is never the only cue. */
+.eng-pipeline-stage[data-conditional] {
+  border-style: dashed;
+  color: var(--eng-muted);
+  background: transparent;
+}
+.eng-pipeline-note {
+  margin: 0;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-xs);
+  color: var(--eng-faint);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 02 · the tool bay
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-bay {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr));
+  gap: 1.75rem 2rem;
+  margin: 0 0 1.75rem;
+}
+
+.eng-bay-rack {
+  border-top: 1px solid var(--eng-rule);
+  padding-top: 0.9rem;
+}
+.eng-bay-rack-name {
+  margin: 0 0 0.7rem;
+  font-size: var(--stella-type-2xs);
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+
+.eng-bay-tools {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.3rem;
+}
+.eng-bay-tool {
+  padding: 0.2rem 0 0.2rem 0.6rem;
+  border-inline-start: 2px solid var(--eng-rule-strong);
+  font-size: var(--stella-type-sm);
+  color: var(--eng-muted);
+  overflow-wrap: anywhere;
+  transition: color var(--stella-duration-fast) var(--stella-ease-arrive);
+}
+.eng-bay-tool:hover {
+  color: var(--eng-fg);
+}
+/* A tool that can change your files carries the functional amber edge — the
+ * same convention the docs' tool cards use. The legend spells both words. */
+.eng-bay-tool[data-access="mutating"] {
+  border-inline-start-color: var(--stella-warning);
+}
+
+.eng-bay-mcp {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+  color: var(--eng-muted);
+}
+
+.eng-bay-legend {
+  margin: 0;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-xs);
+  color: var(--eng-faint);
+}
+.eng-bay-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-inline-end: 1rem;
+  color: var(--eng-muted);
+}
+.eng-bay-key::before {
+  content: "";
+  width: 0.7rem;
+  height: 2px;
+  background: var(--eng-rule-strong);
+}
+.eng-bay-key[data-access="mutating"]::before {
+  background: var(--stella-warning);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 03 · vera — the flip oracle, the ladder, the receipt
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-flip {
+  margin: 0 0 2.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--eng-rule-strong);
+  border-radius: 0.5rem;
+  background: var(--eng-surface);
+}
+.eng-flip-label {
+  margin: 0 0 1.25rem;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--eng-accent);
+}
+
+.eng-flip-track {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.eng-flip-run {
+  display: grid;
+  gap: 0.3rem;
+  justify-items: center;
+  padding: 1rem 0.75rem;
+  border: 1px solid var(--eng-rule-strong);
+  border-radius: 0.375rem;
+  text-align: center;
+}
+.eng-flip-state {
+  font-size: var(--stella-type-lg);
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+.eng-flip-when {
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+/* Functional hues, each carrying its own word — never hue alone. */
+.eng-flip-run[data-state="fail"] {
+  border-color: color-mix(in srgb, var(--stella-danger) 45%, transparent);
+}
+.eng-flip-run[data-state="fail"] .eng-flip-state {
+  color: var(--stella-danger);
+}
+.eng-flip-run[data-state="pass"] {
+  border-color: color-mix(in srgb, var(--stella-success) 45%, transparent);
+}
+.eng-flip-run[data-state="pass"] .eng-flip-state {
+  color: var(--stella-success);
+}
+
+.eng-flip-change {
+  display: grid;
+  justify-items: center;
+  gap: 0.35rem;
+}
+.eng-flip-arrow {
+  display: block;
+  width: 3.5rem;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    var(--stella-danger),
+    var(--eng-accent),
+    var(--stella-success)
+  );
+  position: relative;
+}
+.eng-flip-arrow::after {
+  content: "";
+  position: absolute;
+  inset-inline-end: -1px;
+  top: -0.2rem;
+  border-block: 0.25rem solid transparent;
+  border-inline-start: 0.35rem solid var(--stella-success);
+}
+.eng-flip-change-label {
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--eng-accent);
+}
+
+.eng-flip-note {
+  margin: 0;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-sm);
+  color: var(--eng-muted);
+}
+.eng-flip-note em {
+  font-style: normal;
+  color: var(--eng-fg);
+  font-weight: 700;
+}
+
+.eng-vera-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: 1.5rem 2rem;
+  margin: 0 0 2.5rem;
+}
+
+/* ── the ladder ───────────────────────────────────────────────────────────── */
+
+.eng-ladder {
+  margin: 0 0 2.5rem;
+}
+.eng-ladder-label {
+  margin: 0 0 1rem;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+.eng-ladder-rungs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--eng-rule);
+}
+.eng-ladder-rung {
+  padding: 1rem 1.25rem 1.25rem 0;
+  border-bottom: 1px solid var(--eng-rule);
+  border-inline-start: 2px solid var(--eng-rule-strong);
+  padding-inline-start: 0.9rem;
+}
+.eng-ladder-rung[data-tone="pass"] {
+  border-inline-start-color: var(--stella-success);
+}
+.eng-ladder-rung[data-tone="fail"] {
+  border-inline-start-color: var(--stella-danger);
+}
+.eng-ladder-rung[data-tone="abstain"] {
+  border-inline-start-color: var(--stella-warning);
+}
+.eng-ladder-rung-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin: 0 0 0.4rem;
+}
+.eng-ladder-num {
+  font-size: var(--stella-type-2xs);
+  font-weight: 700;
+  color: var(--eng-faint);
+}
+.eng-ladder-name {
+  font-size: var(--stella-type-sm);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--eng-fg);
+}
+.eng-ladder-body {
+  margin: 0;
+  font-size: var(--stella-type-xs);
+  line-height: 1.7;
+  color: var(--eng-muted);
+}
+
+/* ── the receipt ──────────────────────────────────────────────────────────── */
+
+.eng-receipt {
+  margin: 0 0 2.5rem;
+  padding: 1.25rem 0 1.25rem 1.25rem;
+  border-inline-start: 2px solid var(--eng-accent);
+  max-width: var(--eng-measure);
+}
+.eng-receipt p {
+  margin: 0 0 0.6rem;
+  font-size: var(--stella-type-sm);
+  line-height: 1.7;
+  color: var(--eng-fg);
+}
+.eng-receipt em {
+  font-style: normal;
+  font-weight: 700;
+}
+.eng-receipt strong {
+  color: var(--eng-accent);
+  font-weight: 800;
+}
+.eng-receipt footer {
+  font-size: var(--stella-type-xs);
+  color: var(--eng-faint);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 04 · the governance plane
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-gov {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: 1.5rem;
+  margin: 0 0 2.5rem;
+}
+
+.eng-gov-layer {
+  padding: 1.1rem 1.15rem;
+  border: 1px solid var(--eng-rule);
+  border-radius: 0.5rem;
+  background: var(--eng-surface);
+}
+.eng-gov-path {
+  margin: 0 0 0.5rem;
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.04em;
+  color: var(--eng-accent);
+  overflow-wrap: anywhere;
+}
+.eng-gov-name {
+  margin: 0 0 0.5rem;
+  font-size: var(--stella-type-sm);
+  font-weight: 700;
+  color: var(--eng-fg);
+}
+.eng-gov-body {
+  margin: 0;
+  font-size: var(--stella-type-xs);
+  line-height: 1.7;
+  color: var(--eng-muted);
+}
+
+/* ── egress ───────────────────────────────────────────────────────────────── */
+
+.eng-egress {
+  margin: 0 0 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--eng-accent-dim);
+  border-radius: 0.5rem;
+  background: var(--eng-surface-warm);
+}
+.eng-egress-title {
+  margin: 0 0 0.9rem;
+  font-size: var(--stella-type-lg);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--eng-fg);
+}
+.eng-egress-body {
+  margin: 0 0 0.9rem;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-sm);
+  line-height: 1.7;
+  color: var(--eng-muted);
+}
+.eng-egress-body strong {
+  color: var(--eng-fg);
+  font-weight: 700;
+}
+.eng-egress-enforced {
+  margin: 0;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--eng-rule);
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-xs);
+  line-height: 1.7;
+  color: var(--eng-muted);
+}
+.eng-egress-enforced-label {
+  display: block;
+  margin-bottom: 0.3rem;
+  font-size: var(--stella-type-2xs);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-accent);
+}
+
+.eng-gov-more {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 05 · the evolution deck
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-evo {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: 1.5rem;
+  margin: 0 0 2rem;
+}
+
+.eng-evo-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.25rem;
+  border: 1px solid var(--eng-rule);
+  border-radius: 0.5rem;
+  background: var(--eng-surface);
+  transition:
+    border-color var(--stella-duration-base) var(--stella-ease-arrive),
+    background-color var(--stella-duration-base) var(--stella-ease-arrive);
+}
+.eng-evo-card:hover {
+  border-color: var(--eng-accent-dim);
+  background: var(--eng-surface-high);
+}
+
+.eng-evo-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.eng-evo-name {
+  margin: 0;
+  font-size: var(--stella-type-md);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--eng-fg);
+}
+
+/* The availability chip. Three states, each spelled out in words as well as
+ * coloured — a reader must be able to tell a shipped capability from a
+ * designed one without decoding a hue. */
+.eng-evo-status {
+  flex: none;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  font-size: var(--stella-type-2xs);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.eng-evo-status[data-status="shipped"] {
+  color: var(--stella-success);
+}
+.eng-evo-status[data-status="partial"] {
+  color: var(--stella-warning);
+}
+.eng-evo-status[data-status="design"] {
+  color: var(--eng-faint);
+}
+
+.eng-evo-claim {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--eng-accent);
+}
+.eng-evo-body {
+  margin: 0;
+  font-size: var(--stella-type-xs);
+  line-height: 1.75;
+  color: var(--eng-muted);
+}
+.eng-evo-issue {
+  margin: auto 0 0;
+  padding-top: 0.5rem;
+  font-size: var(--stella-type-2xs);
+}
+
+.eng-evo-rails {
+  margin: 0 0 1.5rem;
+  padding: 1.25rem 0 0;
+  border-top: 1px solid var(--eng-rule);
+}
+.eng-evo-rails-label {
+  margin: 0 0 0.9rem;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+.eng-evo-rails-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr));
+  gap: 0.9rem 2rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-width: 60rem;
+}
+.eng-evo-rails-list li {
+  font-size: var(--stella-type-xs);
+  line-height: 1.7;
+  color: var(--eng-muted);
+  padding-inline-start: 0.9rem;
+  border-inline-start: 2px solid var(--eng-rule-strong);
+}
+.eng-evo-rails-list strong {
+  color: var(--eng-fg);
+  font-weight: 700;
+}
+
+/* The honesty note. Deliberately the last thing on the deck and deliberately
+ * not decorated into a footnote — a page that sells a roadmap owes the reader
+ * this paragraph at full strength. */
+.eng-evo-honest {
+  display: flex;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 1rem 1.15rem;
+  border: 1px dashed var(--eng-accent-dim);
+  border-radius: 0.5rem;
+  max-width: 60rem;
+  font-size: var(--stella-type-xs);
+  line-height: 1.75;
+  color: var(--eng-muted);
+}
+.eng-evo-honest-mark {
+  color: var(--eng-accent);
+  flex: none;
+}
+.eng-evo-honest strong {
+  color: var(--eng-fg);
+  font-weight: 700;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * 06 · the exit
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-exit-install {
+  max-width: 34rem;
+  margin: 0 0 2rem;
+}
+
+.eng-exit-coda {
+  margin: 2rem 0 0;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-sm);
+  color: var(--eng-faint);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Narrow viewports — the stations
+ *
+ * The shell's own narrow-viewport rules (the rail, the station box) live in
+ * engine.css. What follows is only the per-station reflow: the loop's ring
+ * and vera's flip track are the two figures whose *layout* is load-bearing,
+ * and both are drawn horizontally at desk width.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 60rem) {
+  .eng-ring-scene {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 48rem) {
+  /* The flip turns vertical: FAIL above, the diff between, PASS below. The
+   * arrow rotates with it, which means re-pointing its head — a border
+   * triangle has no notion of the direction its parent is running. */
+  .eng-flip-track {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+  }
+  .eng-flip-run {
+    width: 100%;
+  }
+  .eng-flip-arrow {
+    width: 1px;
+    height: 2.5rem;
+    background: linear-gradient(
+      180deg,
+      var(--stella-danger),
+      var(--eng-accent),
+      var(--stella-success)
+    );
+  }
+  .eng-flip-arrow::after {
+    inset-inline-end: -0.2rem;
+    top: auto;
+    bottom: -1px;
+    border-block: 0;
+    border-inline: 0.25rem solid transparent;
+    border-top: 0.35rem solid var(--stella-success);
+  }
+
+  /* The ring unstacks.
+   *
+   * Its nodes are absolutely positioned against the circle and then pushed
+   * *outward* past its edge (`translate(±35%)`, `translate(-55%)` for the
+   * gate) so they straddle the track — which means the figure is wider than
+   * the circle by however wide its widest label is. Below this breakpoint
+   * that pushed the "guards" gate 38px off the left of a 390px viewport and
+   * gave the whole page a horizontal scrollbar. Shrinking the type only moves
+   * the breakpoint; the circular layout is what does not fit.
+   *
+   * So the figure becomes a linear one: the same five labels in the same DOM
+   * order, stacked, with the orbit and its track dropped (a comet running a
+   * track that is no longer drawn is just a dot wandering the page). The
+   * `role="img"` sentence on the container describes the mechanism either
+   * way, so nothing is lost by anyone. */
+  .eng-ring {
+    width: 100%;
+    aspect-ratio: auto;
+    display: grid;
+    gap: 0.5rem;
+  }
+  .eng-ring-track,
+  .eng-ring-orbit {
+    display: none;
+  }
+  /* Qualified by `.eng-ring` on purpose. The circular placements above are
+   * written as `.eng-ring-node[data-pos="top"]` — class plus attribute, so
+   * (0,2,0) — and a media query adds no specificity of its own. An
+   * unqualified `.eng-ring-node` reset here is (0,1,0) and loses: the nodes
+   * went `static` but kept their `translate(-50%, -50%)`, which shifted a
+   * now-full-width block half its own width off the screen and made the
+   * overflow worse than the layout it was fixing. */
+  .eng-ring .eng-ring-node[data-pos],
+  .eng-ring .eng-ring-gate[data-pos],
+  .eng-ring .eng-ring-core {
+    position: static;
+    inset: auto;
+    transform: none;
+    max-width: none;
+    white-space: normal;
+    text-align: start;
+  }
+  .eng-ring-core {
+    border-radius: 0.375rem;
+    padding: 0.7rem;
+    text-align: center;
+  }
+  .eng-ring-gate {
+    justify-items: start;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Reduced motion — the stations stop moving.
+ *
+ * Two ambient loops live in this file: the comet orbiting the turn loop and
+ * the pulse on the goal entering the intake. Both are decoration — the ring's
+ * `role="img"` sentence and the intake's own words carry everything they
+ * illustrate — so both stop outright, resting in their visible state. The
+ * shell's entrance animations are stopped in engine.css, beside the rules
+ * that start them.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  .eng-ring-orbit,
+  .eng-goal-dot {
+    animation: none;
+  }
+  .eng-cta,
+  .eng-evo-card,
+  .eng-bay-tool {
+    transition: none;
+  }
+}

--- a/website/src/app/engine/engine.css
+++ b/website/src/app/engine/engine.css
@@ -1,0 +1,613 @@
+/**
+ * The engine tour (`eng-`) — styles for src/app/engine/.
+ *
+ * Imported once from this route's layout, the same pattern (and for the same
+ * reason) as src/app/releases/releases.css: it is used by exactly one route,
+ * and global.css is already sitewide chrome plus the docs card system.
+ *
+ * **This route's ground is always ink, in both site themes.** The product
+ * lives in a dark terminal and this page is a walk *inside* it — the same law
+ * `.term` and the docs' code blocks already follow, applied to a whole route.
+ * That has one consequence worth stating, because it is the trap: the
+ * theme-flipping aliases (`--stella-bg`, `--stella-muted-fg`, every
+ * `--color-fd-*`) resolve against whichever mode the reader has selected, so
+ * using one here would paint light-mode text on this page's ink ground. The
+ * `--eng-*` tokens below are therefore derived from the **raw, non-flipping**
+ * palette in tokens.css only, and the rest of the file uses nothing else.
+ *
+ * No hex literals — the site's standing rule. Tints are `color-mix()` over
+ * palette tokens (releases.css and global.css already rely on it), so the
+ * whole page still moves when the brand kit does.
+ *
+ * Colour discipline, from the kit: **gold is the signal, never the surface.**
+ * It marks the goal entering the engine, the flip that proves the work, the
+ * active station, and the one primary action. The racks, rails, and panels
+ * are all neutral. Hue is never the only cue: every state that carries a
+ * colour also carries its word (`FAIL`, `PASS`, `mutating`, `in design`).
+ */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Tokens and ground
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-tour {
+  /* Ink ground, paper text — pinned, not theme-derived (see the header). */
+  --eng-bg: var(--stella-ink);
+  --eng-fg: var(--stella-paper);
+
+  /* Text ramp on ink. neutral-400 lands ~7.5:1, neutral-500 ~5.8:1 — both
+   * clear AA for body text; neutral-600 (~4:1) is reserved for seams and
+   * large type, never for prose. */
+  --eng-muted: var(--stella-neutral-400);
+  --eng-faint: var(--stella-neutral-500);
+
+  /* Structure. `--eng-rule` is decorative; `--eng-rule-strong` is the one
+   * allowed to carry structure alone. */
+  --eng-rule: color-mix(in srgb, var(--stella-paper) 12%, var(--stella-ink));
+  --eng-rule-strong: var(--stella-neutral-700);
+
+  /* Lifted surfaces, warm rather than grey — ink with paper mixed in. */
+  --eng-surface: color-mix(in srgb, var(--stella-paper) 4%, var(--stella-ink));
+  --eng-surface-high: color-mix(
+    in srgb,
+    var(--stella-paper) 7%,
+    var(--stella-ink)
+  );
+  /* Ink warmed with gold — the hover/attention ground, as in global.css. */
+  --eng-surface-warm: color-mix(
+    in srgb,
+    var(--stella-gold) 8%,
+    var(--stella-ink)
+  );
+
+  --eng-accent: var(--stella-gold);
+  --eng-accent-dim: color-mix(
+    in srgb,
+    var(--stella-gold) 45%,
+    var(--stella-ink)
+  );
+
+  /* Layout constants the stations and the HUD both measure against. */
+  --eng-hud-h: 3.25rem;
+  --eng-rail-h: 3.5rem;
+  --eng-measure: 62ch;
+  --eng-gutter: 1.5rem;
+
+  position: relative;
+  min-height: 100vh;
+  background: var(--eng-bg);
+  color: var(--eng-fg);
+  font-family: var(--font-mono);
+  font-size: var(--stella-type-base);
+  line-height: 1.65;
+
+  /* The ambient field: a slow gold bloom at the top of the scroll. The grid
+   * is NOT painted here — it is the ::before overlay below, and having both
+   * was a real defect: a background layer has no opacity of its own, so the
+   * grid drew at full-strength paper and cut visibly through every line of
+   * body text. Opacity has to ride the element, not the colour. */
+  background-image: radial-gradient(
+    ellipse 80% 50% at 50% 0%,
+    color-mix(in srgb, var(--stella-gold) 6%, transparent),
+    transparent 70%
+  );
+  background-attachment: fixed;
+}
+
+/* The kit's terminal grid, at the kit's 5% — decoration behind every station
+ * (z-index 0, under `.eng-main`) and under `pointer-events: none`. */
+.eng-tour::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(currentColor 1px, transparent 1px),
+    linear-gradient(90deg, currentColor 1px, transparent 1px);
+  background-size: 44px 44px;
+  opacity: var(--stella-grid-opacity);
+  color: var(--eng-fg);
+}
+
+.eng-main {
+  position: relative;
+  z-index: 1;
+}
+.eng-main:focus {
+  outline: none;
+}
+
+.eng-tour a {
+  color: var(--eng-accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--eng-accent) 40%,
+    transparent
+  );
+}
+.eng-tour a:hover {
+  text-decoration-color: currentColor;
+}
+.eng-tour :focus-visible {
+  outline: 2px solid var(--eng-accent);
+  outline-offset: 3px;
+  border-radius: 0.125rem;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Top HUD — who you are inside, and the way back out
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-hud-top {
+  position: fixed;
+  top: 0;
+  inset-inline: 0;
+  z-index: 20;
+  height: var(--eng-hud-h);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 var(--eng-gutter);
+  border-bottom: 1px solid var(--eng-rule);
+  background: color-mix(in srgb, var(--stella-ink) 82%, transparent);
+}
+@supports (backdrop-filter: blur(1px)) {
+  .eng-hud-top {
+    backdrop-filter: blur(10px);
+  }
+}
+
+.eng-hud-lockup {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--eng-fg);
+}
+.eng-hud-lockup:hover {
+  text-decoration: none;
+}
+.eng-hud-mark {
+  height: 1.25rem;
+  width: auto;
+}
+.eng-hud-wordmark {
+  height: 1rem;
+  width: auto;
+  color: var(--eng-fg);
+}
+.eng-hud-qualifier {
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+}
+
+.eng-hud-exit {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  font-size: var(--stella-type-xs);
+}
+.eng-hud-exit a {
+  color: var(--eng-muted);
+  text-decoration: none;
+  letter-spacing: 0.08em;
+}
+.eng-hud-exit a:hover {
+  color: var(--eng-fg);
+  text-decoration: none;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Station rail — where you are in the engine
+ *
+ * The rail is a real <nav> of anchors, so it works as a jump list with no
+ * JavaScript; the shell only adds `aria-current` and moves the progress fill.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-rail {
+  position: fixed;
+  bottom: 0;
+  inset-inline: 0;
+  z-index: 20;
+  min-height: var(--eng-rail-h);
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0 var(--eng-gutter);
+  border-top: 1px solid var(--eng-rule);
+  background: color-mix(in srgb, var(--stella-ink) 82%, transparent);
+}
+@supports (backdrop-filter: blur(1px)) {
+  .eng-rail {
+    backdrop-filter: blur(10px);
+  }
+}
+
+/* The travelled distance, as a gold hairline along the top edge. */
+.eng-rail-progress {
+  position: absolute;
+  top: -1px;
+  inset-inline-start: 0;
+  height: 1px;
+  width: var(--eng-progress, 0%);
+  background: var(--eng-accent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--eng-accent) 60%, transparent);
+  transition: width var(--stella-duration-slow) var(--stella-ease-arrive);
+}
+
+.eng-rail-stops {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.eng-rail-stops::-webkit-scrollbar {
+  display: none;
+}
+
+.eng-rail-stop {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  color: var(--eng-faint);
+  white-space: nowrap;
+  transition:
+    color var(--stella-duration-base) var(--stella-ease-arrive),
+    background-color var(--stella-duration-base) var(--stella-ease-arrive);
+}
+.eng-rail-stop:hover {
+  color: var(--eng-fg);
+  background: var(--eng-surface-high);
+  text-decoration: none;
+}
+/* The station you are standing in is the signal — the one gold surface down
+ * here, same law as the docs sidebar's active pill. */
+.eng-rail-stop[aria-current="true"] {
+  background: var(--eng-accent);
+  color: var(--stella-ink);
+}
+.eng-rail-stop[aria-current="true"]:hover {
+  background: var(--stella-gold-400);
+  color: var(--stella-ink);
+}
+
+.eng-rail-code {
+  font-size: var(--stella-type-2xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  opacity: 0.75;
+}
+.eng-rail-name {
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.06em;
+}
+
+.eng-rail-compact {
+  display: none;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  flex: 1;
+  color: var(--eng-accent);
+}
+
+.eng-rail-hint {
+  margin: 0;
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--eng-faint);
+  white-space: nowrap;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Stations — the scroll
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-station {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 100vh;
+  padding: calc(var(--eng-hud-h) + 3.5rem) var(--eng-gutter)
+    calc(var(--eng-rail-h) + 3.5rem);
+  border-bottom: 1px solid var(--eng-rule);
+  scroll-margin-top: var(--eng-hud-h);
+}
+.eng-station:last-child {
+  border-bottom: 0;
+}
+
+/* vera's chamber runs warmer — the one station with its own light, because it
+ * is the one the whole product argument rests on. */
+.eng-station[data-tone="chamber"] {
+  background:
+    radial-gradient(
+      ellipse 70% 60% at 50% 45%,
+      color-mix(in srgb, var(--stella-gold) 7%, transparent),
+      transparent 72%
+    );
+}
+
+.eng-station-inner {
+  width: 100%;
+  max-width: 68rem;
+  margin: 0 auto;
+}
+
+/* ── entrances ──────────────────────────────────────────────────────────────
+ * Gated twice over, so the page never hides content it cannot reveal:
+ * `[data-eng-js]` is set by the shell after mount (no script → nothing is
+ * ever hidden), and `[data-inview]` is set once per station as it approaches
+ * (play once — assemble, don't spin). */
+
+.eng-tour[data-eng-js="true"] .eng-station:not([data-inview]) .eng-station-inner > * {
+  opacity: 0;
+  transform: translateY(1.25rem);
+}
+
+.eng-tour[data-eng-js="true"] .eng-station[data-inview] .eng-station-inner > * {
+  animation: eng-arrive 620ms var(--stella-ease-arrive) both;
+  animation-delay: var(--eng-stagger, 0ms);
+}
+
+.eng-station-inner > *:nth-child(2) {
+  --eng-stagger: 90ms;
+}
+.eng-station-inner > *:nth-child(3) {
+  --eng-stagger: 180ms;
+}
+.eng-station-inner > *:nth-child(4) {
+  --eng-stagger: 260ms;
+}
+.eng-station-inner > *:nth-child(5) {
+  --eng-stagger: 330ms;
+}
+.eng-station-inner > *:nth-child(n + 6) {
+  --eng-stagger: 390ms;
+}
+
+@keyframes eng-arrive {
+  from {
+    opacity: 0;
+    transform: translateY(1.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── station head ─────────────────────────────────────────────────────────── */
+
+.eng-head {
+  margin-bottom: 1.5rem;
+}
+
+.eng-overline {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0 0 0.9rem;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.eng-overline-code {
+  color: var(--eng-accent);
+  font-weight: 700;
+}
+.eng-overline-name {
+  color: var(--eng-faint);
+}
+.eng-overline-badge {
+  padding: 0.1rem 0.5rem;
+  border: 1px solid var(--eng-accent-dim);
+  border-radius: 0.25rem;
+  color: var(--eng-accent);
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.14em;
+}
+
+/* Display type, sized so a station's heading lands in two or three lines
+ * rather than four. The ceiling matters more than the floor here: at the old
+ * 3.25rem/4.5rem every heading ran to four lines on a 1440×900 screen and
+ * pushed each station's actual content — the ring, the ladder, the deck —
+ * below the fold, so the first thing a reader saw at every stop was type. */
+.eng-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.6vw, 2.75rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+  text-wrap: balance;
+  max-width: 26ch;
+}
+.eng-title-display {
+  font-size: clamp(2.1rem, 5.6vw, 3.75rem);
+  max-width: 17ch;
+}
+/* The one word each station is actually about. */
+.eng-title-accent {
+  color: var(--eng-accent);
+}
+
+.eng-lead {
+  margin: 0 0 2rem;
+  max-width: var(--eng-measure);
+  font-size: var(--stella-type-md);
+  line-height: 1.7;
+  color: var(--eng-muted);
+}
+.eng-lead em {
+  font-style: normal;
+  color: var(--eng-fg);
+}
+
+.eng-brand-face {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-transform: lowercase;
+  color: var(--eng-fg);
+}
+
+/* ── fact panels ──────────────────────────────────────────────────────────── */
+
+.eng-fact {
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--eng-rule);
+}
+.eng-fact-title {
+  margin: 0 0 0.4rem;
+  font-size: var(--stella-type-sm);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--eng-fg);
+}
+.eng-fact-body {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+  line-height: 1.65;
+  color: var(--eng-muted);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Telemetry feed — the shape of stella-events.jsonl, typed on
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.eng-feed {
+  margin: 2.5rem 0 0;
+  border: 1px solid var(--eng-rule);
+  border-radius: 0.5rem;
+  background: var(--eng-surface);
+  overflow: hidden;
+}
+
+.eng-feed-body {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  font-size: var(--stella-type-xs);
+  line-height: 1.9;
+  color: var(--eng-muted);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.eng-feed-line {
+  display: block;
+}
+.eng-tour[data-eng-js="true"] .eng-station:not([data-inview]) .eng-feed-line {
+  opacity: 0;
+}
+.eng-tour[data-eng-js="true"] .eng-station[data-inview] .eng-feed-line {
+  animation: eng-feed-line 320ms var(--stella-ease-arrive) both;
+  animation-delay: calc(400ms + var(--eng-i) * 110ms);
+}
+@keyframes eng-feed-line {
+  from {
+    opacity: 0;
+    transform: translateX(-0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.eng-feed-caption {
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--eng-rule);
+  font-size: var(--stella-type-2xs);
+  letter-spacing: 0.08em;
+  color: var(--eng-faint);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Narrow viewports — the shell
+ *
+ * The tour keeps every station and every word. What changes here is the
+ * chrome: the rail's stop list collapses into one live readout, and the
+ * full-viewport minimum becomes a floor rather than a target — a station
+ * whose content is taller than the screen must scroll, not clip. The intake
+ * keeps its full screen, because a hatch you step through should fill the
+ * view. Each station's own narrow-viewport rules live beside that station in
+ * engine-stations.css.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 48rem) {
+  .eng-tour {
+    --eng-gutter: 1.1rem;
+  }
+  .eng-station {
+    min-height: auto;
+    padding: calc(var(--eng-hud-h) + 2.5rem) var(--eng-gutter) 3rem;
+  }
+  .eng-station:first-child {
+    min-height: 100vh;
+  }
+  .eng-station:last-child {
+    padding-bottom: calc(var(--eng-rail-h) + 3rem);
+  }
+  .eng-rail-stops {
+    display: none;
+  }
+  .eng-rail-compact {
+    display: flex;
+  }
+  .eng-hud-qualifier {
+    display: none;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Reduced motion — the shell stops moving.
+ *
+ * Everything this file animates is an entrance: the station arrival and the
+ * feed's staggered lines. Neither carries information that is not also in the
+ * words, so both are dropped outright — but the *resting* state has to be the
+ * assembled one, which is why each rule below lands on the visible end rather
+ * than merely cancelling the animation. (The ambient loops — the orbiting
+ * comet, the intake pulse — are stopped in engine-stations.css, beside the
+ * rules that start them.)
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  .eng-tour {
+    scroll-behavior: auto;
+  }
+  .eng-tour[data-eng-js="true"] .eng-station:not([data-inview]) .eng-station-inner > *,
+  .eng-tour[data-eng-js="true"] .eng-station[data-inview] .eng-station-inner > * {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+  .eng-tour[data-eng-js="true"] .eng-station:not([data-inview]) .eng-feed-line,
+  .eng-tour[data-eng-js="true"] .eng-station[data-inview] .eng-feed-line {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+  .eng-rail-progress {
+    transition: none;
+  }
+  .eng-rail-stop {
+    transition: none;
+  }
+}

--- a/website/src/app/engine/layout.tsx
+++ b/website/src/app/engine/layout.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import type { Viewport } from "next";
+import "./engine.css";
+import "./engine-stations.css";
+
+/**
+ * Chrome for /engine: none.
+ *
+ * Every other route mounts the fumadocs shell; the tour deliberately does not.
+ * It is a walk through the inside of the machine, and a persistent docs nav
+ * would put the outside of the site in view the whole way — the same reasoning
+ * that lets the home page hide its bar behind the hero, taken one step
+ * further. The tour carries its own minimal HUD (top strip + station rail) in
+ * tour-shell.tsx, including the way back out.
+ *
+ * The route keeps its own stylesheets beside it, imported once here —
+ * `src/app/releases/releases.css` is the pattern — namespaced `eng-` so
+ * nothing leaks into /docs or the landing page. They are two files rather
+ * than one because a single one crossed the 1500-line ceiling AGENTS.md sets:
+ * `engine.css` is the shell that is the same at every stop, and
+ * `engine-stations.css` is what differs at each. Order matters only for
+ * readability — the second consumes tokens the first defines, and a custom
+ * property resolves at use — so keep the shell first.
+ */
+
+/**
+ * The tour is a window into the machine, so its ground is ALWAYS ink — the
+ * same law as `.term` and the docs' code blocks. The browser chrome should
+ * agree with it in both site themes, hence a route-level themeColor override
+ * (the root layout's is per-scheme). The hex mirrors `--stella-ink` in
+ * tokens.css, the same way the root layout's viewport block does — a CSS
+ * custom property cannot reach a meta tag.
+ */
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#0b0b0c", // --stella-ink
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/website/src/app/engine/page.tsx
+++ b/website/src/app/engine/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site";
+import { TourShell } from "./tour-shell";
+import {
+  IntakeStation,
+  ToolBayStation,
+  TurnLoopStation,
+} from "./stations-fore";
+import {
+  EvolutionStation,
+  ExitStation,
+  GovernanceStation,
+  VeraStation,
+} from "./stations-aft";
+
+/**
+ * /engine — the tour.
+ *
+ * A marketing page that argues by *showing the machine* rather than by
+ * listing features: the reader walks the engine from the intake hatch to the
+ * exit, meeting the turn loop, the tool bay, vera's verification chamber, the
+ * Oxagen governance plane, and the evolution deck on the way.
+ *
+ * Structurally it is seven server-rendered stations wrapped in one client
+ * shell (tour-shell.tsx) that does nothing but set attributes; every effect
+ * is CSS in engine.css. That split is deliberate — the whole argument of the
+ * page is legible to a crawler, a reader-mode extension, and a browser with
+ * JavaScript disabled, because the words are in the HTML and the shell only
+ * decorates them.
+ *
+ * The landing page at `/` keeps its job (what stella is, install it, four
+ * doors into the docs). This route is the one that takes a reader who wants
+ * to *understand the machine* and gives them the inside of it.
+ */
+
+const TOUR_TITLE = "stella — step inside the engine";
+const TOUR_DESCRIPTION =
+  "A tour of the inside of a terminal coding agent: the turn loop, the tool bay, vera's deterministic verification chamber, the Oxagen governance plane, and the evolution deck where stella rebuilds itself from your team's traces.";
+
+export const metadata: Metadata = {
+  // `absolute`, for the same reason the landing page's title is: the root
+  // layout's "%s — stella docs" template would append a section this page is
+  // not in, and disagree with the Open Graph title right below it.
+  title: { absolute: TOUR_TITLE },
+  description: TOUR_DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/engine` },
+  openGraph: {
+    title: TOUR_TITLE,
+    description: TOUR_DESCRIPTION,
+    url: `${SITE_URL}/engine`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TOUR_TITLE,
+    description: TOUR_DESCRIPTION,
+  },
+};
+
+export default function EnginePage() {
+  return (
+    <TourShell>
+      <IntakeStation />
+      <TurnLoopStation />
+      <ToolBayStation />
+      <VeraStation />
+      <GovernanceStation />
+      <EvolutionStation />
+      <ExitStation />
+    </TourShell>
+  );
+}

--- a/website/src/app/engine/station.tsx
+++ b/website/src/app/engine/station.tsx
@@ -1,0 +1,155 @@
+import type { ReactNode } from "react";
+
+/**
+ * Server-side primitives every station is built from. No state, no effects —
+ * the shell (tour-shell.tsx) drives everything interactive by setting
+ * attributes on the `data-station` sections these render, and engine.css
+ * does the rest.
+ */
+
+/**
+ * One full-viewport station of the tour.
+ *
+ * `data-station` is the hook the shell observes; `id` doubles as the deep
+ * link (`/engine#vera`) and the anchor target that keeps the page navigable
+ * with no JavaScript at all. `tone` lets a station shift its ambient
+ * lighting (vera's chamber runs warmer) without a second stylesheet.
+ */
+export function Station({
+  id,
+  tone,
+  children,
+}: {
+  id: string;
+  tone?: "chamber";
+  children: ReactNode;
+}) {
+  return (
+    <section
+      id={id}
+      data-station={id}
+      data-tone={tone}
+      className="eng-station"
+      aria-labelledby={`${id}-title`}
+    >
+      <div className="eng-station-inner">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * The station's header block: index + name as an overline, then the display
+ * heading. The heading carries the `aria-labelledby` target for the section.
+ */
+export function StationHead({
+  id,
+  code,
+  name,
+  title,
+  badge,
+}: {
+  id: string;
+  code: string;
+  name: string;
+  title: ReactNode;
+  badge?: string;
+}) {
+  return (
+    <header className="eng-head">
+      <p className="eng-overline">
+        <span className="eng-overline-code">{code}</span>
+        <span className="eng-overline-name">{name}</span>
+        {badge ? <span className="eng-overline-badge">{badge}</span> : null}
+      </p>
+      <h2 id={`${id}-title`} className="eng-title">
+        {title}
+      </h2>
+    </header>
+  );
+}
+
+/** The intake station is the document's h1; same shape, different rank. */
+export function StationHeadH1({
+  id,
+  code,
+  name,
+  title,
+}: {
+  id: string;
+  code: string;
+  name: string;
+  title: ReactNode;
+}) {
+  return (
+    <header className="eng-head">
+      <p className="eng-overline">
+        <span className="eng-overline-code">{code}</span>
+        <span className="eng-overline-name">{name}</span>
+      </p>
+      <h1 id={`${id}-title`} className="eng-title eng-title-display">
+        {title}
+      </h1>
+    </header>
+  );
+}
+
+/** A measured lead paragraph under the station heading. */
+export function Lead({ children }: { children: ReactNode }) {
+  return <p className="eng-lead">{children}</p>;
+}
+
+/** The brand names, set in the running-text face: lowercase, mono, 700. */
+export function BrandFace({ children }: { children: ReactNode }) {
+  return <span className="eng-brand-face">{children}</span>;
+}
+
+/**
+ * A strip of telemetry lines in the shape of stella-events.jsonl — the
+ * engine's ground-truth journal — typed on as the station comes into view.
+ *
+ * Illustrative by construction and labelled so: these are the *shapes* of
+ * real event lines, not a recorded run, and the caption says exactly that.
+ * The honesty rule is the home page's ("the figures illustrate a run rather
+ * than a benchmark"), applied to telemetry.
+ */
+export function EventFeed({ lines }: { lines: readonly string[] }) {
+  return (
+    <figure className="eng-feed" aria-label="Engine telemetry, illustrative">
+      <pre className="eng-feed-body">
+        {lines.map((line, i) => (
+          <span
+            key={line}
+            className="eng-feed-line"
+            style={{ "--eng-i": i } as React.CSSProperties}
+          >
+            {line}
+            {"\n"}
+          </span>
+        ))}
+      </pre>
+      <figcaption className="eng-feed-caption">
+        the shape of stella-events.jsonl — illustrative lines, not a recorded
+        run
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * A labelled fact panel: a short claim a reader can carry away, with the
+ * mechanism under it. The tour's argument is made of these.
+ */
+export function FactCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="eng-fact">
+      <h3 className="eng-fact-title">{title}</h3>
+      <p className="eng-fact-body">{children}</p>
+    </div>
+  );
+}

--- a/website/src/app/engine/stations-aft.tsx
+++ b/website/src/app/engine/stations-aft.tsx
@@ -1,0 +1,470 @@
+import Link from "next/link";
+import { InstallBlock } from "@/components/install-block";
+import { REPO_URL } from "@/lib/site";
+import {
+  BrandFace,
+  EventFeed,
+  FactCard,
+  Lead,
+  Station,
+  StationHead,
+} from "./station";
+
+/**
+ * The aft of the engine: vera's verification chamber, the Oxagen governance
+ * plane, the evolution deck, and the exit. The fore stations (intake, the
+ * turn loop, the tool bay) are in stations-fore.tsx.
+ *
+ * **The honesty rule this file is written under.** A marketing page is still
+ * a claim surface, and this repository's standard is that a claim ships with
+ * the evidence that establishes it. So every mechanism named here restates a
+ * documented one, and anything on the evolution deck that is a *design*
+ * rather than a shipped capability carries a status chip that says so —
+ * `shipped`, `partial`, or `in design`, sourced from
+ * /docs/self-improvement § "What is actually built today". Selling a
+ * roadmap as a feature is the one move that would make the rest of this
+ * page untrustworthy too.
+ */
+
+/* ── 03 · vera ───────────────────────────────────────────────────────────── */
+
+const VERA_FEED = [
+  '{"type":"witness_authored","by":"witness-author","tamper_watch":true}',
+  '{"type":"probe","command":"cargo test -p scheduler","phase":"pre","result":"FAIL"}',
+  '{"type":"probe","command":"cargo test -p scheduler","phase":"post","result":"PASS"}',
+  '{"type":"flip_oracle","state":"flipped","locked_command":"cargo test -p scheduler"}',
+  '{"type":"diff_budget","changed_lines":38,"limit":400,"within":true}',
+  '{"type":"verdict","rung":"SubmitFast","model_calls_spent":0}',
+] as const;
+
+/** The ladder, in the order it is walked. Every rung is terminal. */
+const LADDER = [
+  {
+    rung: "1",
+    name: "revise",
+    tone: "fail",
+    body: "Touched tests are red. That is already a deterministic failure — the evidence goes straight back into a revision turn. Nothing is spent confirming a failure nobody doubts.",
+  },
+  {
+    rung: "2",
+    name: "nothing attempted",
+    tone: "fail",
+    body: "The turn dispatched no call capable of changing the workspace, and nothing that could look saw a change. The one place an absence is read as evidence.",
+  },
+  {
+    rung: "3",
+    name: "unverifiable",
+    tone: "abstain",
+    body: "Every channel was blind — no flip, no test result, an unreadable tree. vera abstains. Nothing is claimed about the work, in particular not that it failed.",
+  },
+  {
+    rung: "4",
+    name: "submit fast",
+    tone: "pass",
+    body: "Flip achieved, touched tests green, diff within budget, no fresh diagnostics. The full deterministic pass — the only rung that means proven.",
+  },
+  {
+    rung: "5",
+    name: "unverified",
+    tone: "abstain",
+    body: "The probes looked, and what came back did not amount to a proof. vera's honest I do not know — stated, not dressed up as a pass.",
+  },
+] as const;
+
+export function VeraStation() {
+  return (
+    <Station id="vera" tone="chamber">
+      <StationHead
+        id="vera"
+        code="03"
+        name="the verification chamber"
+        badge="deterministic"
+        title={
+          <>
+            meet <span className="eng-title-accent">vera</span> — she does not
+            have an opinion about your code.
+          </>
+        }
+      />
+      <Lead>
+        Every other agent ends a task when the model says it is finished. That
+        is the whole problem: the thing that did the work is also the thing
+        grading it. <BrandFace>vera</BrandFace> is the deterministic verifier
+        at the back of the engine, and she never asks a model anything. She
+        runs commands and reads what happened.
+      </Lead>
+
+      {/* The flip oracle: the central mechanism, drawn as two runs of one
+          command with the change dropped in between. */}
+      <div className="eng-flip">
+        <p className="eng-flip-label">the flip oracle</p>
+        <div className="eng-flip-track">
+          <div className="eng-flip-run" data-state="fail">
+            <span className="eng-flip-state">FAIL</span>
+            <span className="eng-flip-when">before the change</span>
+          </div>
+          <div className="eng-flip-change" aria-hidden="true">
+            <span className="eng-flip-arrow" />
+            <span className="eng-flip-change-label">the diff</span>
+          </div>
+          <div className="eng-flip-run" data-state="pass">
+            <span className="eng-flip-state">PASS</span>
+            <span className="eng-flip-when">after the change</span>
+          </div>
+        </div>
+        <p className="eng-flip-note">
+          One command, locked by name, run on both sides. A suite that was
+          already green proves nothing — only the fail→pass flip proves the
+          change did the work. The oracle is a state machine: it locks onto
+          the first command it sees <em>fail</em>, and only a later pass of{" "}
+          <em>that same command</em>{" "}
+          moves it to flipped. The
+          &quot;it passed, ship it&quot; false positive is structurally
+          excluded.
+        </p>
+      </div>
+
+      <div className="eng-vera-facts">
+        <FactCard title="the witness is written by someone else">
+          With no test command configured, an independent model — never the
+          worker — authors a minimal <em>failing</em> test, working from a
+          pristine snapshot of the pre-change tree, blind to the diff, so it
+          cannot write a test that merely restates the patch. It gets exactly
+          three tools. Every other tool name returns an error.
+        </FactCard>
+        <FactCard title="tampering forfeits the credit">
+          The witness file&apos;s full filesystem identity is pinned where it
+          was written and re-pinned inside the candidate. A worker that edits
+          the witness does not get credit for passing it.
+        </FactCard>
+        <FactCard title="the witness does not stay">
+          It encodes a moment — &quot;this code doesn&apos;t do X yet&quot; —
+          not an invariant, so it lives and dies with the candidate workspace.
+          You never inherit an already-satisfied test nobody reviewed.{" "}
+          <BrandFace>--keep-witness</BrandFace> promotes it if it is worth
+          keeping.
+        </FactCard>
+        <FactCard title="verification buys no model call">
+          The ladder is arithmetic over measurements. Every rung is terminal,
+          no reviewer is consulted, and the verdict is emitted from the answer
+          directly.
+        </FactCard>
+      </div>
+
+      {/* The ladder. */}
+      <div className="eng-ladder">
+        <p className="eng-ladder-label">
+          five outcomes. every one of them terminal —
+        </p>
+        <ol className="eng-ladder-rungs">
+          {LADDER.map((rung) => (
+            <li key={rung.name} className="eng-ladder-rung" data-tone={rung.tone}>
+              <p className="eng-ladder-rung-head">
+                <span className="eng-ladder-num">{rung.rung}</span>
+                <span className="eng-ladder-name">{rung.name}</span>
+              </p>
+              <p className="eng-ladder-body">{rung.body}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      {/* The receipt: why the model verdict was removed. A number that costs
+          us something is the one worth printing. */}
+      <blockquote className="eng-receipt">
+        <p>
+          The last rung used to ask a second model for <em>PASS</em> or{" "}
+          <em>FAIL</em>. Over an 89-task Terminal-Bench run, that verdict
+          agreed with the benchmark&apos;s grader <strong>46%</strong> of the
+          time — a coin flip — and 17 of its false passes cost 5 tasks
+          outright. So it was removed structurally, not defaulted off.
+        </p>
+        <footer>
+          — why <BrandFace>vera</BrandFace> has no opinion,{" "}
+          <Link href="/docs/inference-pipeline">the deterministic ladder</Link>
+        </footer>
+      </blockquote>
+
+      <EventFeed lines={VERA_FEED} />
+    </Station>
+  );
+}
+
+/* ── 04 · governance ─────────────────────────────────────────────────────── */
+
+export function GovernanceStation() {
+  return (
+    <Station id="governance">
+      <StationHead
+        id="governance"
+        code="04"
+        name="the governance plane"
+        title={
+          <>
+            <span className="eng-title-accent">oxagen</span> is the plane above
+            the engine — the rules that travel with the repository.
+          </>
+        }
+      />
+      <Lead>
+        An agent that behaves differently on every laptop is not governed, it
+        is merely configured. The governance plane makes steering policy a{" "}
+        <em>reviewable artifact</em>: records that live in the repository,
+        travel with a clone, and are validated in CI on every pull request —
+        so a teammate&apos;s session obeys the same rules yours does, because
+        it read the same file.
+      </Lead>
+
+      <div className="eng-gov">
+        <div className="eng-gov-layer" data-layer="records">
+          <p className="eng-gov-path">.stella/rules/*.toml</p>
+          <h3 className="eng-gov-name">context records</h3>
+          <p className="eng-gov-body">
+            One record per file, tracked in git — the only part of{" "}
+            <BrandFace>.stella/</BrandFace>{" "}
+            that is. A record only steers a
+            teammate&apos;s session if it travels with the repository, so it
+            is committed like code and reviewed like code.
+          </p>
+        </div>
+        <div className="eng-gov-layer" data-layer="mode">
+          <p className="eng-gov-path">.stella/governance.toml</p>
+          <h3 className="eng-gov-name">the governance mode</h3>
+          <p className="eng-gov-body">
+            How much authority a record may hold. This repository runs{" "}
+            <BrandFace>regulated</BrandFace> — enforcement is a grant, not a
+            default, and a record earns it through promotion rather than by
+            existing.
+          </p>
+        </div>
+        <div className="eng-gov-layer" data-layer="ledger">
+          <p className="eng-gov-path">.stella/promotions.jsonl</p>
+          <h3 className="eng-gov-name">the hash-chained ledger</h3>
+          <p className="eng-gov-body">
+            Every enforcement grant, retirement, and supersession, chained so
+            the history cannot be quietly rewritten.{" "}
+            <BrandFace>stella context validate</BrandFace> re-verifies the
+            records and the chain in CI on every pull request.
+          </p>
+        </div>
+      </div>
+
+      {/* Egress. The strongest claim on the site, so it is stated as an
+          enforcement mechanism rather than a promise. */}
+      <div className="eng-egress">
+        <h3 className="eng-egress-title">zero telemetry egress by default</h3>
+        <p className="eng-egress-body">
+          Community <BrandFace>stella</BrandFace> sends telemetry nowhere. Your
+          prompts, paths, tool payloads, reasoning, errors, git state,
+          memories, and rules are <strong>never exportable</strong> — not
+          off by default, not exportable. There is no update check and no
+          anonymous analytics. Model-provider traffic is the normal network
+          exception you chose when you brought your own key.
+        </p>
+        <p className="eng-egress-body">
+          The one addition is an explicitly enrolled Oxagen Enterprise managed
+          mode: a signed org-managed document may authorize a minimal
+          content-free operational rollup to one exact allowlisted HTTPS sink.
+        </p>
+        <p className="eng-egress-enforced">
+          <span className="eng-egress-enforced-label">enforced, not assumed</span>
+          A reviewed allowlist of exportable columns plus a sentinel harness
+          every egress encoder registers with. Adding a field fails the build
+          until the allowlist is edited in the same change — so a human has to
+          answer &quot;is this content?&quot; before it can ship. A leak here
+          is a privacy incident, not a bug.
+        </p>
+      </div>
+
+      <p className="eng-gov-more">
+        <Link href="/docs/telemetry">what is metered, and where it stays</Link>
+      </p>
+    </Station>
+  );
+}
+
+/* ── 05 · evolution ──────────────────────────────────────────────────────── */
+
+/**
+ * The paid tier's three engines, each with an honest availability status.
+ *
+ * `status` maps to /docs/self-improvement § "What is actually built today":
+ * the Tool Foundry ships in slices (#830) and the dataset export ships
+ * (#872), skill mining ships but still promotes on recurrence rather than
+ * measured lift (#833), and weight-space adapters (#836) are not implemented.
+ * The chips exist so a reader can tell a shipped capability from a designed
+ * one without reading the issue tracker — the alternative is a page that is
+ * wrong the day someone checks.
+ */
+const EVOLUTION = [
+  {
+    key: "skills",
+    name: "skill mining",
+    status: "partial",
+    statusLabel: "ships · lift gate in design",
+    claim: "your team's recurring wins become reusable procedures",
+    body: "Every turn is reflected on and mined. A lesson that keeps recurring is promoted into a Skill — a parameterized procedure, not a recalled fact — and injected as volatile context when it is selected. Mining ships today; what is still in design is the evaluation run that promotes on measured lift instead of on recurrence.",
+    issue: "833",
+  },
+  {
+    key: "foundry",
+    name: "the tool foundry",
+    status: "shipped",
+    statusLabel: "ships in slices",
+    claim: "the engine builds the tool it keeps wishing it had",
+    body: "When stella reconstructs the same shell incantation for the third time, the capability-gap detector notices. The foundry authors a typed tool, proves it with a witness test, and files it for adoption. A proposed tool is inert until it is both adopted and enabled — new capability lands disabled, behind the same authority gate as any other.",
+    issue: "830",
+  },
+  {
+    key: "weights",
+    name: "your own weighted model",
+    status: "design",
+    statusLabel: "dataset ships · adapters in design",
+    claim: "frontier-quality work on a model your team's traces taught",
+    body: "Accepted, verified turns export as one JSONL record each, every string through the secret redactor, owner-only, with a manifest describing the filter that selected them. The frontier item is what comes next: train and evaluate open-weight adapters on that corpus offline, and — gated by eval and human sign-off — promote one that measurably improves behavior. The economics are the point: inference on a model you own is inference you are not renting.",
+    issue: "836",
+  },
+] as const;
+
+export function EvolutionStation() {
+  return (
+    <Station id="evolution">
+      <StationHead
+        id="evolution"
+        code="05"
+        name="the evolution deck"
+        badge="paid tier"
+        title={
+          <>
+            the engine that{" "}
+            <span className="eng-title-accent">rebuilds itself</span>{" "}
+            — from your team&apos;s traces, not from a vendor&apos;s.
+          </>
+        }
+      />
+      <Lead>
+        Most of what gets called agent self-improvement is recall: a note file
+        the agent writes and reads back. Useful — and not the same thing as
+        getting <em>better</em>. Each engine on this deck changes what{" "}
+        <BrandFace>stella</BrandFace> can <em>do</em>, and each one is gated on
+        a measured lift against data it did not train on.
+      </Lead>
+
+      <div className="eng-evo">
+        {EVOLUTION.map((engine) => (
+          <article key={engine.key} className="eng-evo-card">
+            <header className="eng-evo-head">
+              <h3 className="eng-evo-name">{engine.name}</h3>
+              <span className="eng-evo-status" data-status={engine.status}>
+                {engine.statusLabel}
+              </span>
+            </header>
+            <p className="eng-evo-claim">{engine.claim}</p>
+            <p className="eng-evo-body">{engine.body}</p>
+            <p className="eng-evo-issue">
+              <a href={`${REPO_URL}/issues/${engine.issue}`}>
+                design and status — #{engine.issue}
+              </a>
+            </p>
+          </article>
+        ))}
+      </div>
+
+      {/* The guardrails are the offer, not the footnote. */}
+      <div className="eng-evo-rails">
+        <p className="eng-evo-rails-label">
+          the conditions under which any of it is allowed to ship —
+        </p>
+        <ul className="eng-evo-rails-list">
+          <li>
+            <strong>promotion requires measured lift on held-out data.</strong>{" "}
+            Never frequency, never plausibility, never recency.
+          </li>
+          <li>
+            <strong>human sign-off on anything that sticks.</strong>{" "}
+            Self-authored pull requests open as drafts and never auto-merge.
+            An adapter is never promoted to default without a person approving
+            it.
+          </li>
+          <li>
+            <strong>reversibility.</strong> The prior state is kept, so every
+            promotion can be rolled back — a pinned adapter version, a prior
+            config overlay, a Skill that stopped helping and was retired.
+          </li>
+          <li>
+            <strong>provenance and redaction.</strong> Training data carries
+            its lineage and is scrubbed before it is stored. Never train on
+            secrets or PII.
+          </li>
+        </ul>
+      </div>
+
+      <p className="eng-evo-honest">
+        <span className="eng-evo-honest-mark" aria-hidden="true">
+          ✦
+        </span>
+        <span>
+          <strong>What this deck is, today.</strong> The chips above are
+          accurate as of this writing: some of this ships, some of it is a
+          design under active discussion in the open issue tracker, and the
+          details will change. We would rather you read a status chip than
+          discover the gap after you paid.{" "}
+          <Link href="/docs/self-improvement">
+            the full track, component by component
+          </Link>
+        </span>
+      </p>
+    </Station>
+  );
+}
+
+/* ── 06 · exit ───────────────────────────────────────────────────────────── */
+
+const INSTALL = "curl -fsSL https://stella.oxagen.sh/install.sh | sh";
+
+export function ExitStation() {
+  return (
+    <Station id="exit">
+      <StationHead
+        id="exit"
+        code="06"
+        name="the exit"
+        title={
+          <>
+            you have seen the engine.{" "}
+            <span className="eng-title-accent">now run it.</span>
+          </>
+        }
+      />
+      <Lead>
+        One binary, one API key you already have. No account, no sign-up,
+        nothing proxied. The engine you just walked through is the one that
+        installs.
+      </Lead>
+
+      <div className="eng-exit-install">
+        <InstallBlock command={INSTALL} />
+      </div>
+
+      <div className="eng-exit-doors">
+        <Link href="/docs/getting-started/installation" className="eng-cta">
+          install and authenticate
+        </Link>
+        <Link href="/docs" className="eng-cta-quiet">
+          read the docs
+        </Link>
+        <a href={REPO_URL} className="eng-cta-quiet">
+          source on github — agpl 3.0
+        </a>
+      </div>
+
+      <p className="eng-exit-coda">
+        <BrandFace>stella</BrandFace> is open source and built in the open by{" "}
+        <a href="https://github.com/macanderson">@macanderson</a>. Every
+        mechanism on this tour is documented in full, including the parts that
+        are still a design —{" "}
+        <Link href="/docs/inference-pipeline">start with the pipeline</Link>.
+      </p>
+    </Station>
+  );
+}

--- a/website/src/app/engine/stations-fore.tsx
+++ b/website/src/app/engine/stations-fore.tsx
@@ -1,0 +1,332 @@
+import Link from "next/link";
+import {
+  BrandFace,
+  EventFeed,
+  FactCard,
+  Lead,
+  Station,
+  StationHead,
+  StationHeadH1,
+} from "./station";
+
+/**
+ * The fore of the engine: intake (the hatch), the turn loop (the heart), and
+ * the tool bay. Aft stations — vera's chamber, the governance plane, the
+ * evolution deck, the exit — live in stations-aft.tsx; the split keeps each
+ * file a readable size rather than one god page.
+ *
+ * Copy discipline: every mechanical claim here restates a documented one —
+ * /docs/inference-pipeline for the loop and stages, /docs/agent-tools for the
+ * bay. The tour is allowed to be theatrical about *presentation*, never about
+ * *facts*.
+ */
+
+/* ── 00 · intake ─────────────────────────────────────────────────────────── */
+
+export function IntakeStation() {
+  return (
+    <Station id="intake">
+      <StationHeadH1
+        id="intake"
+        code="00"
+        name="intake"
+        title={
+          <>
+            you are standing inside
+            <br />a coding agent.
+          </>
+        }
+      />
+      <Lead>
+        Most sites tell you what their agent does. This one walks you through
+        the machine while it works. <BrandFace>stella</BrandFace> is a
+        terminal coding agent — fast, BYOK, model-agnostic — and it refuses to
+        call work done until the work is proven. Walk the engine and watch a
+        goal become verified work.
+      </Lead>
+
+      {/* The goal enters through the hatch: the one gold prompt on deck. */}
+      <div className="eng-goal" role="img" aria-label="A goal entering the engine">
+        <p className="eng-goal-line">
+          <span className="eng-goal-prompt">$ </span>
+          stella run &quot;make the flaky scheduler test deterministic&quot;
+        </p>
+        <p className="eng-goal-status">
+          <span className="eng-goal-dot" /> goal received — engine turning
+        </p>
+      </div>
+
+      <ul className="eng-intake-facts">
+        <li>runs on the API keys you already have</li>
+        <li>speaks ten providers&apos; native protocols — nothing emulated</li>
+        <li>nothing proxied through a hosted service</li>
+        <li>telemetry never leaves your disk</li>
+      </ul>
+
+      <div className="eng-intake-ctas">
+        <a href="#loop" className="eng-cta">
+          begin the tour ↓
+        </a>
+        <a href="#exit" className="eng-cta-quiet">
+          skip to the exit — install
+        </a>
+      </div>
+    </Station>
+  );
+}
+
+/* ── 01 · the turn loop ──────────────────────────────────────────────────── */
+
+const LOOP_FEED = [
+  '{"type":"step_manifest","turn":4,"step":2,"planned_tools":3}',
+  '{"type":"tool_start","tool":"read_file","call_seq":0}',
+  '{"type":"tool_start","tool":"grep","call_seq":0}',
+  '{"type":"tool_result","tool":"read_file","status":"ok"}',
+  '{"type":"tool_result","tool":"grep","status":"ok"}',
+  '{"type":"step_receipt","turn":4,"step":2,"outcome":"continue"}',
+  '{"type":"step_usage","role":"worker","tokens_in":18204,"cached":17651}',
+] as const;
+
+/** The staged pipeline, in canonical stage_rank order. Dashed = conditional. */
+const PIPELINE_STAGES = [
+  { name: "triage", conditional: false },
+  { name: "recall", conditional: false },
+  { name: "research", conditional: true },
+  { name: "plan", conditional: true },
+  { name: "scope", conditional: true },
+  { name: "execute", conditional: false },
+  { name: "witness", conditional: true },
+  { name: "verify", conditional: false },
+  { name: "verdict", conditional: false },
+] as const;
+
+export function TurnLoopStation() {
+  return (
+    <Station id="loop">
+      <StationHead
+        id="loop"
+        code="01"
+        name="the turn loop"
+        title={
+          <>
+            one loop. no coordinator, no hidden swarm —{" "}
+            <span className="eng-title-accent">and no I/O in the core.</span>
+          </>
+        }
+      />
+      <Lead>
+        At the heart of the engine is a single-threaded step loop: the model
+        proposes tool calls, the tools execute — independent reads fan out in
+        parallel — the results feed back, and the loop repeats until the work
+        is done. That is the entire trick. Everything else on this tour is
+        structure built on top of it.
+      </Lead>
+
+      {/* The loop, drawn: three stations on a ring, guards on the return
+          edge, the decision core in the middle, a comet running the track. */}
+      <div className="eng-ring-scene">
+        <div
+          className="eng-ring"
+          role="img"
+          aria-label="The turn loop: the model proposes, tools execute, results feed back — with compaction, budget, and loop-detection guards on the return edge, around a pure decision core"
+        >
+          <div className="eng-ring-track" aria-hidden="true" />
+          <div className="eng-ring-orbit" aria-hidden="true">
+            <span className="eng-ring-comet" />
+          </div>
+          <p className="eng-ring-node" data-pos="top">
+            model proposes
+          </p>
+          <p className="eng-ring-node" data-pos="right">
+            tools execute
+          </p>
+          <p className="eng-ring-node" data-pos="bottom">
+            results feed back
+          </p>
+          <p className="eng-ring-gate" data-pos="left">
+            <span className="eng-ring-gate-label">guards</span>
+            compact · budget · loop-detect
+          </p>
+          <p className="eng-ring-core">
+            pure decision core
+            <span>no network · no filesystem · no clock</span>
+          </p>
+        </div>
+
+        <div className="eng-ring-copy">
+          <FactCard title="decisions are pure functions">
+            Compaction, eviction, budget arithmetic, loop detection, retry,
+            skill selection — every decision the engine makes is a synchronous
+            function over owned data. No I/O can happen inside the core, so
+            the loop is property-tested, replayable, and deterministic enough
+            to prove things about.
+          </FactCard>
+          <FactCard title="guards fire at safe boundaries">
+            The budget guard is consulted between model calls and never
+            interrupts a tool in flight — a run stops at a seam, not
+            mid-motion. When the conversation gets noisy, the engine compacts
+            it and keeps going.
+          </FactCard>
+        </div>
+      </div>
+
+      {/* The staged pipeline the loop rides under `stella run`. */}
+      <div className="eng-pipeline">
+        <p className="eng-pipeline-label">
+          on <BrandFace>stella run</BrandFace>, the loop rides a staged
+          pipeline —
+        </p>
+        <ol className="eng-pipeline-strip">
+          {PIPELINE_STAGES.map((stage) => (
+            <li
+              key={stage.name}
+              className="eng-pipeline-stage"
+              data-conditional={stage.conditional || undefined}
+            >
+              {stage.name}
+            </li>
+          ))}
+        </ol>
+        <p className="eng-pipeline-note">
+          dashed stages are conditional: a task that does not need them skips
+          them — they are never performed for show.{" "}
+          <Link href="/docs/inference-pipeline">the full pipeline, staged</Link>
+        </p>
+      </div>
+
+      <EventFeed lines={LOOP_FEED} />
+    </Station>
+  );
+}
+
+/* ── 02 · the tool bay ───────────────────────────────────────────────────── */
+
+/**
+ * A walk of the racks — real built-in tool names and access levels from
+ * /docs/agent-tools, not the whole registry. `read` racks are plain; a
+ * `mutating` tool carries the amber edge, the same convention the docs'
+ * tool cards use.
+ */
+const TOOL_RACKS: readonly {
+  rack: string;
+  tools: readonly { name: string; access: "read" | "mutating" }[];
+}[] = [
+  {
+    rack: "files",
+    tools: [
+      { name: "read_file", access: "read" },
+      { name: "read_symbol", access: "read" },
+      { name: "grep", access: "read" },
+      { name: "glob", access: "read" },
+      { name: "write_file", access: "mutating" },
+      { name: "edit_file", access: "mutating" },
+      { name: "apply_edits", access: "mutating" },
+      { name: "delete_file", access: "mutating" },
+    ],
+  },
+  {
+    rack: "understanding",
+    tools: [
+      { name: "project_overview", access: "read" },
+      { name: "graph_query", access: "read" },
+      { name: "gather_context", access: "read" },
+      { name: "diagnostics", access: "read" },
+    ],
+  },
+  {
+    rack: "proving",
+    tools: [
+      { name: "run_tests", access: "mutating" },
+      { name: "build_project", access: "mutating" },
+      { name: "verify_done", access: "mutating" },
+      { name: "format_code", access: "mutating" },
+    ],
+  },
+  {
+    rack: "the world",
+    tools: [
+      { name: "bash", access: "mutating" },
+      { name: "web_fetch", access: "read" },
+      { name: "repo_status", access: "read" },
+      { name: "repo_diff", access: "read" },
+      { name: "repo_commit", access: "mutating" },
+      { name: "start_process", access: "mutating" },
+    ],
+  },
+  {
+    rack: "scratch state",
+    tools: [
+      { name: "save_state", access: "mutating" },
+      { name: "get_state", access: "read" },
+      { name: "list_state", access: "read" },
+      { name: "delete_state", access: "mutating" },
+    ],
+  },
+] as const;
+
+export function ToolBayStation() {
+  return (
+    <Station id="tools">
+      <StationHead
+        id="tools"
+        code="02"
+        name="the tool bay"
+        title={
+          <>
+            every capability is a tool.{" "}
+            <span className="eng-title-accent">
+              every tool does exactly one thing.
+            </span>
+          </>
+        }
+      />
+      <Lead>
+        A parameter may <em>scope</em> an operation — a path, a key, an offset.
+        It may never <em>select</em> one. A tool that can both edit and delete
+        is two tools wearing one schema, so <BrandFace>stella</BrandFace>{" "}
+        splits it: the model learns each verb properly, and policy can withhold
+        the destructive verb without withholding the benign one.
+      </Lead>
+
+      <div className="eng-bay">
+        {TOOL_RACKS.map((rack) => (
+          <div key={rack.rack} className="eng-bay-rack">
+            <h3 className="eng-bay-rack-name">{rack.rack}</h3>
+            <ul className="eng-bay-tools">
+              {rack.tools.map((tool) => (
+                <li
+                  key={tool.name}
+                  className="eng-bay-tool"
+                  data-access={tool.access}
+                >
+                  {tool.name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+        <div className="eng-bay-rack">
+          <h3 className="eng-bay-rack-name">docked via MCP</h3>
+          <p className="eng-bay-mcp">
+            your external tool servers merge into the same registry, behind the
+            same per-tool permissions — a guest tool follows house rules.
+          </p>
+        </div>
+      </div>
+
+      <p className="eng-bay-legend">
+        <span className="eng-bay-key" data-access="read">
+          read
+        </span>
+        <span className="eng-bay-key" data-access="mutating">
+          mutating
+        </span>{" "}
+        — every tool declares which it is, honestly: the engine&apos;s
+        concurrency contract depends on it. A selection of the racks, not the
+        registry;{" "}
+        <Link href="/docs/agent-tools">the full toolbelt and its permissions</Link>
+        .
+      </p>
+    </Station>
+  );
+}

--- a/website/src/app/engine/stations-meta.ts
+++ b/website/src/app/engine/stations-meta.ts
@@ -1,0 +1,26 @@
+/**
+ * The tour's station list — the one copy both the page (section order) and the
+ * shell (progress rail, keyboard jumps) read, so the rail can never disagree
+ * with the sections it points at.
+ *
+ * `id` is the section's DOM id and its deep-link hash (`/engine#vera`);
+ * `code` is the HUD's index label; `name` is the rail chip. Names are written
+ * lowercase in the data because the tour's display voice is lowercase — the
+ * CSS never has to transform what is already true in the markup (the same
+ * reasoning as releases.css's `.rl-title`).
+ */
+export type StationMeta = {
+  id: string;
+  code: string;
+  name: string;
+};
+
+export const STATIONS: readonly StationMeta[] = [
+  { id: "intake", code: "00", name: "intake" },
+  { id: "loop", code: "01", name: "turn loop" },
+  { id: "tools", code: "02", name: "tool bay" },
+  { id: "vera", code: "03", name: "vera" },
+  { id: "governance", code: "04", name: "governance" },
+  { id: "evolution", code: "05", name: "evolution" },
+  { id: "exit", code: "06", name: "exit" },
+] as const;

--- a/website/src/app/engine/tour-shell.tsx
+++ b/website/src/app/engine/tour-shell.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import Link from "next/link";
+import { Mark, Wordmark } from "@/components/brand";
+import { STATIONS } from "./stations-meta";
+
+/**
+ * The tour's one client component.
+ *
+ * The stations themselves are server-rendered markup passed in as children —
+ * this shell only *orchestrates*: it observes which station the reader is
+ * standing in, moves the HUD to match, arms the CSS entrance animations, and
+ * wires the keyboard. All motion lives in engine.css; the shell's whole
+ * output is attributes.
+ *
+ * Three progressive layers, so the page degrades instead of breaking:
+ *
+ *  - No JS at all: every station renders visible (the entrance-hidden states
+ *    in engine.css are gated on the `data-eng-js` attribute this component
+ *    sets), anchors still jump, the rail is just absent.
+ *  - JS, reduced motion: attributes still flow, engine.css declines to
+ *    animate, programmatic jumps use `behavior: "auto"` — the observer-driven
+ *    HUD keeps working because state is not motion.
+ *  - JS, full motion: the intended tour.
+ */
+
+/** One section either side of `-45%` counts as "standing in" the station —
+ * the same centre-band trick fumadocs' TOC uses, expressed as rootMargin. */
+const ACTIVE_BAND = "-45% 0px -45% 0px";
+
+/** Entrances arm a little before the station reaches centre, so the reader
+ * sees the arrival rather than the aftermath. */
+const INVIEW_MARGIN = "0px 0px -18% 0px";
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function TourShell({ children }: { children: ReactNode }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState<string>(STATIONS[0].id);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    // Arm the CSS entrances only now that a script is present to trigger them.
+    root.setAttribute("data-eng-js", "true");
+
+    const sections = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-station]"),
+    );
+
+    // Play-once entrances: the attribute is set the first time a station
+    // approaches and never removed, so scrolling back up replays nothing —
+    // assemble, don't spin.
+    const entrances = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.setAttribute("data-inview", "true");
+            entrances.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: INVIEW_MARGIN },
+    );
+
+    // Which station the reader is standing in, for the HUD and the hash.
+    // `replaceState` rather than assigning location.hash: the tour is one
+    // page, and forty scroll positions must not become forty history entries.
+    const tracker = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("data-station");
+            if (id) {
+              setActive(id);
+              history.replaceState(null, "", `#${id}`);
+            }
+          }
+        }
+      },
+      { rootMargin: ACTIVE_BAND },
+    );
+
+    for (const section of sections) {
+      entrances.observe(section);
+      tracker.observe(section);
+    }
+
+    // j/k walk the stations — the pager keys every terminal reader already
+    // has in their fingers. Arrows are left native: overriding the browser's
+    // own scroll keys is how a page starts fighting its reader.
+    const onKey = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target && /^(input|textarea|select)$/i.test(target.tagName)) return;
+      if (event.key !== "j" && event.key !== "k") return;
+      event.preventDefault();
+      const ids = STATIONS.map((s) => s.id);
+      const current = ids.indexOf(
+        root.getAttribute("data-eng-active") ?? ids[0],
+      );
+      const next = event.key === "j" ? current + 1 : current - 1;
+      const station = STATIONS[Math.max(0, Math.min(ids.length - 1, next))];
+      document.getElementById(station.id)?.scrollIntoView({
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+      });
+    };
+    window.addEventListener("keydown", onKey);
+
+    return () => {
+      entrances.disconnect();
+      tracker.disconnect();
+      window.removeEventListener("keydown", onKey);
+      root.removeAttribute("data-eng-js");
+    };
+  }, []);
+
+  // The keydown handler reads the live station from this attribute instead of
+  // closing over React state, so the listener is attached exactly once.
+  useEffect(() => {
+    rootRef.current?.setAttribute("data-eng-active", active);
+  }, [active]);
+
+  const activeIndex = Math.max(
+    0,
+    STATIONS.findIndex((s) => s.id === active),
+  );
+  const activeMeta = STATIONS[activeIndex];
+
+  return (
+    <div ref={rootRef} className="eng-tour" data-eng-active={active}>
+      {/* ── top HUD: who you are inside, and the way back out ─────────── */}
+      <header className="eng-hud-top">
+        <Link href="/" className="eng-hud-lockup" aria-label="stella home">
+          <Mark className="eng-hud-mark" />
+          <Wordmark className="eng-hud-wordmark" sparkle={false} />
+          <span className="eng-hud-qualifier">engine tour</span>
+        </Link>
+        <nav aria-label="Leave the tour" className="eng-hud-exit">
+          <Link href="/docs">docs</Link>
+          <Link href="/">exit tour</Link>
+        </nav>
+      </header>
+
+      {/* ── the stations ──────────────────────────────────────────────── */}
+      <main id="content" tabIndex={-1} className="eng-main">
+        {children}
+      </main>
+
+      {/* ── bottom HUD: the station rail ──────────────────────────────── */}
+      <nav className="eng-rail" aria-label="Tour stations">
+        <div
+          className="eng-rail-progress"
+          style={
+            {
+              "--eng-progress": `${(activeIndex / (STATIONS.length - 1)) * 100}%`,
+            } as React.CSSProperties
+          }
+          aria-hidden="true"
+        />
+        <ol className="eng-rail-stops">
+          {STATIONS.map((station) => (
+            <li key={station.id}>
+              <a
+                href={`#${station.id}`}
+                className="eng-rail-stop"
+                aria-current={station.id === active ? "true" : undefined}
+                onClick={(event) => {
+                  event.preventDefault();
+                  document.getElementById(station.id)?.scrollIntoView({
+                    behavior: prefersReducedMotion() ? "auto" : "smooth",
+                  });
+                }}
+              >
+                <span className="eng-rail-code">{station.code}</span>
+                <span className="eng-rail-name">{station.name}</span>
+              </a>
+            </li>
+          ))}
+        </ol>
+        {/* Mobile collapses the stops into one live readout. */}
+        <p className="eng-rail-compact" aria-hidden="true">
+          <span className="eng-rail-code">{activeMeta.code}</span>
+          <span className="eng-rail-name">{activeMeta.name}</span>
+        </p>
+        <p className="eng-rail-hint" aria-hidden="true">
+          j / k — walk the engine
+        </p>
+      </nav>
+    </div>
+  );
+}

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -594,9 +594,13 @@ figure.shiki ::selection,
   border-top: 1px solid var(--color-fd-border);
 }
 
-/* Alternating band: sections that carry evidence (the run, the doors) sit on
- * the muted ground so the page reads as panels rather than one long scroll —
- * warm cream on paper, lifted surface on ink. */
+/* Alternating band: every other section sits on the muted ground so the page
+ * reads as panels rather than one long scroll — warm cream on paper, lifted
+ * surface on ink. It is the alternation that does the work, so which sections
+ * carry the class is positional: inserting a section flips the parity of
+ * every one after it, and two banded sections in a row merge into one panel,
+ * which is the failure this is meant to prevent. Today: the run and the
+ * providers are banded; the tour, the doors, and the hero are not. */
 .lp-band {
   background: var(--color-fd-muted);
 }

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -104,6 +104,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly" as const,
       priority: 0.8,
     },
+    {
+      // The engine tour is a React route with no MDX source and no derived
+      // date to stand in for one — its copy tracks the pipeline and
+      // self-improvement docs, but nothing here can observe when it last
+      // did. `lastModified` is therefore omitted rather than guessed, which
+      // is the same rule the docs rows follow when git history is
+      // unavailable: no claim beats a false claim.
+      url: `${SITE_URL}/engine`,
+      changeFrequency: "monthly" as const,
+      priority: 0.9,
+    },
     ...docs,
   ];
 }


### PR DESCRIPTION
## What & why

A new marketing route, `/engine`, that argues by **showing the machine** rather
than by listing features. The reader walks seven stations from the intake hatch
to the exit:

| | Station | What it shows |
|---|---|---|
| 00 | intake | a goal entering the engine |
| 01 | the turn loop | the step loop as a ring, guards on the return edge, the pure decision core in the middle |
| 02 | the tool bay | racks of real built-in tools, `read` vs `mutating`, one-thing-per-tool |
| 03 | **vera** | the flip oracle, the witness discipline, the five-rung deterministic ladder |
| 04 | **oxagen** | context records, governance mode, the hash-chained ledger, zero telemetry egress |
| 05 | the evolution deck | skill mining, the tool foundry, your own weighted model — the paid tier |
| 06 | the exit | install |

The landing page keeps its job (what stella is, install it, four doors into the
docs) and gains one section pointing at the tour. `/engine` is the route for a
reader who wants to *understand the machine*.

There is no issue for this — it came in as a direct request.

### How it is built

Seven **server-rendered** stations wrapped in one client shell that does nothing
but set attributes (`IntersectionObserver` for the station rail and the
play-once entrances; `j`/`k` to walk the engine). Every effect is CSS. That
split is the point: the whole argument is in the HTML, so a crawler, reader
mode, and a browser with JavaScript disabled all get the full **12,410
characters** of copy, and the rail still works as a plain anchor jump list.

The route's ground is **always ink in both site themes** — the same law `.term`
and the docs' code blocks already follow, applied to a whole route. Its
`--eng-*` tokens are therefore derived only from the **raw, non-flipping**
palette in `tokens.css`: a theme-flipping alias (`--stella-bg`,
`--stella-muted-fg`, any `--color-fd-*`) would paint light-mode text on this
page's ink ground. No hex literals; tints are `color-mix()` over palette tokens.

Exemplars followed, per CLAUDE.md: `src/app/releases/` for the route-scoped
stylesheet imported from the route's own layout, and `src/lib/metadata.test.ts`
for the title-template opt-out (`title: { absolute: … }`) that its guard
enforces.

### Copy discipline — the part worth reviewing hardest

Every mechanical claim restates a documented one: `inference-pipeline.mdx` for
the loop, the ladder, the witness and the 46%/89-task Terminal-Bench receipt;
`agent-tools/index.mdx` for the bay's tool names and access levels; the
telemetry and governance docs for the egress claim.

**The evolution deck sells a paid tier, so it carries availability chips** —
`shipped`, `partial`, `in design` — sourced from `self-improvement.mdx`
§ "What is actually built today" (Tool Foundry ships in slices, #830; the
dataset export ships, #872; skill mining ships but still promotes on recurrence
rather than measured lift, #833; weight-space adapters are not implemented,
#836). It closes with a note in full-strength body copy, not a footnote, saying
which parts are a design under discussion. A page that sells a roadmap owes the
reader that paragraph, and shipping it as a feature list would have made
everything else on the page untrustworthy too.

**Two naming decisions need a human, and are the main reason this is a draft.**
"vera" as the name of the deterministic verifier, and Oxagen framed as "the
governance plane", are both new brand language — neither appears in
`docs/` or `crates/` today. The mechanisms behind them are real and documented;
the *names* are a product call, not something I should land silently. If they
stick, they want a follow-up PR teaching the docs the same vocabulary, because
a reader who arrives via the tour and then searches the docs for "vera" finds
nothing.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a
      website route with no engine behavior. The repo's convention for the site
      is `pnpm typecheck` + `pnpm build` + the `node --test` suite, all of which
      run in `docs.yml`. The one *behavioral* guard it must satisfy —
      `src/lib/metadata.test.ts`, "every non-docs page opts out of the docs
      title template" — walks `src/app/**/page.tsx` automatically, so `/engine`
      is covered by it and passes (16/16).

Because "it builds" proves very little about a page whose whole point is how it
renders, it was verified in a real browser (Chromium via `playwright-core`,
production build, `pnpm start`). Measured, not eyeballed:

| Check | Result |
|---|---|
| Station rail tracks the station in view | `aria-current` → `vera`, hash → `#vera`, progress fill 720px = 50% at station 3/6 |
| Entrances arm once per station | 7/7 |
| Horizontal overflow at 390×844 | `scrollWidth === 390`, zero overflowing elements |
| Light-mode reader still gets the ink ground | `.eng-tour` computed background `rgb(11, 11, 12)` |
| No-JS (`javaScriptEnabled: false`) | 12,410 chars of copy present, incl. vera and the evolution deck |
| Console errors | only `/_vercel/insights` + `/_vercel/speed-insights` 404s, which are sitewide and expected off-platform |

Screenshots were taken at every station at 1440×900, 390×844, and in light mode.

**Three real defects were found and fixed this way, none of which any existing
check would have caught:**

1. The ambient terminal grid was painted twice — once as a `background-image`
   layer, which has no opacity of its own, so it drew at full-strength paper and
   cut visibly through every line of body text. Now only the `::before` overlay
   at the kit's `--stella-grid-opacity`.
2. The ring diagram's absolutely-positioned labels overflowed a 390px viewport
   by 38px. The ring now unstacks into a linear figure below 48rem.
3. The first fix for (2) did not work and made it worse: the circular placements
   are `.eng-ring-node[data-pos="top"]` (0,2,0) and a media query adds no
   specificity, so an unqualified `.eng-ring-node` reset (0,1,0) lost — the
   nodes went `static` but kept `translate(-50%, -50%)` and shifted a
   now-full-width block half its own width off-screen. Fixed with a qualified
   selector, and the reasoning is a comment at the site.

## The gate

- [x] `make guards-fast` — passes except `shellcheck`, which is **not installed
      in this environment**; this diff touches no shell script. Every other
      guard was then run individually: `no-scratch`, `no-secrets`,
      `design-refs`, `action-pins`, `cargo-install-pins`,
      `license-allowlist-parity`, `repro-wiring`, `invariants`, `doc-links`,
      `command-docs`, `brand-case`, `file-size`, `god-files`, `gate-parity`,
      `left-behind`, `role-names`, `stat-portability`, `module-reachability` —
      all PASS.
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean; `/engine` prerenders as static (`○`)
- [x] `pnpm test` — 16/16
- [ ] `cargo fmt` / `clippy` / `test` — not run: no Rust file is touched, and
      `ci.yml` ignores `website/**` for exactly this reason (`docs.yml` is the
      workflow that fires here).
- [x] Docs updated where behavior changed — n/a, no behavior; `/engine` added to
      `sitemap.ts` with `lastModified` **omitted rather than guessed**, matching
      that file's stated rule.
- [ ] `Closes #N` — no issue to close.

### One thing I did that the gate did not ask for

`engine.css` reached **1519 lines** and `make file-size` reported **PASS** — its
ratchet covers `*.rs`, `*.py`, `*.sh` and `.githooks/*` only, so the whole
`website/` tree is invisible to it. I split it into `engine.css` (613, the shell
that is the same at every stop) + `engine-stations.css` (972, what differs at
each) on the documented rule in AGENTS.md rather than on what the guard happens
to inspect, and filed the blind spot as #2893.

The split was verified to be behavior-preserving rather than assumed: a
normalized rule-level diff shows the two files carry the same 202 rules as the
original, and screenshots of five of seven stations are **byte-identical**
before and after. The two that differ were chased to ground rather than waved
through — `eng-loop` differs in a 10×10 box (the orbiting comet's animation
phase), and `eng-mobile-vera` differs on border rows only because the split
also added `max-width: none` to the mobile ring reset, which stops the guards
gate wrapping to three lines, shortens the document by 37px, and lands vera
0.28px higher — sub-pixel border antialiasing, from an intended improvement. An
A/B control (rebuilding with the original single file) confirmed the causation
rather than leaving it inferred.

## Nothing left behind

- [x] Filed: **#2893** (the file-size ratchet ignores the web tier — same shape
      as #825 for Python and #1563 for shell, both closed by widening it) and
      **#2894** (nothing reads the rendered page: the swallowed-JSX-space class
      and horizontal overflow, with a recommendation modelled on `deck-fit.yml`).

Fixed in passing rather than filed, since it was a one-line fix in a file this
PR already edits: the providers paragraph on the landing page rendered as
**`stellaspeaks each vendor's own wire protocol`** — JSX trims the leading
whitespace of a text node's first line when the node spans more than one line,
so the space after `</span>` was swallowed. That was live. The same shape bit
the new copy twice; all three are fixed and the mechanism is commented at the
fix site. A sweep of all 109 built pages found no other genuine instance (the
other ~17 matches are deliberate: `<code>tool_request</code>s`,
`auto-<em>re</em>fresh`, `<code>0</code>–1`).

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies at all** — no
      animation library, no scroll library, no icon package. The shell is
      `IntersectionObserver` and the motion is CSS.
- [x] No new outbound network calls. The route adds no fetch, and the site's
      existing CSP (`connect-src 'self'`, `img-src 'self' data:`) is unchanged
      and not widened.
- [x] New cross-boundary types round-trip through serde — n/a, no Rust.

## Anything reviewers should know?

- **The two names are the open question**, as above: "vera" and "oxagen as the
  governance plane" are new vocabulary. Everything else on the page is a
  restatement of shipped, documented mechanism.
- **Accessibility choices worth a second opinion.** The ring and the flip are
  `role="img"` with a one-sentence description, because a ring of
  absolutely-positioned labels is not a reading order; the description carries
  the mechanism in both the circular and the stacked form. `j`/`k` are bound but
  arrows are left native, so the page never fights a reader's own scroll keys.
  Reduced motion drops every entrance and both ambient loops, resting in the
  assembled state.
- **Alternative rejected:** doing this as MDX under `/docs`. The tour needs a
  chromeless, always-ink, full-viewport scroll with its own HUD, which is a
  fight with the Fumadocs shell at every step — and the docs pages are
  reference material a reader arrives at with a question, which is a different
  job from the one this page does.
- The homepage's band/plain alternation shifts by one section because a section
  was inserted; `global.css`'s comment about which sections are banded was
  updated to say the parity is positional rather than naming a fixed set, since
  naming a set is what let it go stale.
- `deck-fit.yml` is untouched — it globs `website/public/presentations/**` and
  this PR adds no deck.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfTcEsB76CGcxEK1i5opCp)_

## Summary by Sourcery

Add a dedicated /engine marketing route that presents an interactive, scroll-based tour of the agent engine and link to it from the homepage, while updating layout, styling, and sitemap to support the new page.

New Features:
- Introduce a server-rendered /engine page composed of multiple stations that explain the agent engine’s loop, tools, verification, governance, evolution deck, and exit.
- Add a client-side tour shell with keyboard navigation, scroll-based station tracking, and a bottom HUD rail to guide users through the engine tour.
- Expose a new evolution deck section that describes self-improvement mechanisms and paid-tier capabilities with honest availability status indicators on the tour page.
- Add a prominent call-to-action section on the homepage that invites users to take the engine tour.

Enhancements:
- Refine homepage section banding and update global comments to describe banding as positional, keeping visual rhythm correct after inserting the tour section.
- Split the engine route’s CSS into shared shell styles and per-station styles to keep stylesheets maintainable and aligned with file-size guidelines.
- Ensure telemetry and governance concepts are surfaced consistently in the UI through structured fact panels and illustrative event feeds on the tour page.

Documentation:
- Document the /engine tour via route-level metadata (titles, descriptions, Open Graph and Twitter cards) and include it in the site’s sitemap without guessing last-modified dates.

Tests:
- Keep the new /engine route compatible with existing metadata and build guards by following the established title-template opt-out and static prerendering patterns.