### PR TITLE
fix(stella-cli): give the model today's date, the missing operand in the staleness clause

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -433,7 +433,11 @@ pub(crate) fn assemble_system_prompt(
 /// dialect (#2692). Every value is session-constant (a process cannot change
 /// its OS, and the workspace root is fixed at session open), so the block is
 /// compatible with the byte-stable prefix discipline (L-E8); the one
-/// genuinely volatile candidate, today's date, is deliberately absent.
+/// genuinely volatile candidate, today's date, is deliberately absent — it
+/// rides the volatile recall block instead
+/// (`crate::memory::recall::render_today_section`, #2901), which is the only
+/// place the knowledge-cutoff staleness clause below gets a second operand
+/// to measure against.
 ///
 /// That is the admission boundary, stated once so the next candidate line is
 /// judged against it rather than by taste (#2692, #2722): the block carries

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -91,7 +91,10 @@ use private_state::resolve_context_db_path;
 use projection::{is_suppressed_local_frame, project_recalled_frame};
 pub use recall::inject_recall_block;
 #[cfg(test)]
-use recall::{ab_control_turn, goal_path_anchors, render_context_section, turn_path_tokens};
+use recall::{
+    ab_control_turn, goal_path_anchors, render_context_section, render_today_section,
+    turn_path_tokens,
+};
 #[cfg(test)]
 pub(crate) use skill_files::load_workspace_skills;
 pub(crate) use skill_files::{

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -188,6 +188,12 @@ impl SessionMemory {
             sections.push(section);
         }
 
+        // The second operand of the knowledge-cutoff staleness clause
+        // (#2901): unconditional, unlike the sections above, because the
+        // model needs "now" to judge staleness on every turn, not only the
+        // ones that also recalled a memory or a record.
+        sections.push(render_today_section(now_unix_secs()));
+
         RecalledBlock {
             // Skills and draft claims can produce a block with no frames behind
             // it; frames can be recalled and then filtered out of the render by
@@ -243,6 +249,7 @@ impl SessionMemory {
         if let Some(section) = self.turn_record_section(prompt) {
             sections.push(section);
         }
+        sections.push(render_today_section(now_unix_secs()));
         (!sections.is_empty()).then(|| format!("{RECALL_MARKER}\n\n{}", sections.join("\n\n")))
     }
 
@@ -588,6 +595,45 @@ pub(super) fn render_context_section(frames: &[RecalledFrame]) -> Option<String>
         section.push_str(stella_pipeline::CITE_MEMORY_REQUEST);
     }
     Some(section)
+}
+
+/// The wall clock's current instant, in Unix seconds. The one `SystemTime`
+/// read in this module — everything downstream of it (`render_today_section`)
+/// takes the value as a parameter instead of reading the clock itself, so a
+/// test can inject two different instants without racing real time.
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Render today's date for the VOLATILE recall block: the second operand of
+/// the knowledge-cutoff staleness clause in
+/// `crate::agent::prompt::append_session_environment`, which names a cutoff
+/// but never a "now" to measure it against (#2901) — a model handed one
+/// endpoint of an interval cannot reason about its width.
+///
+/// This is why it lives here and not beside the cutoff it completes: the
+/// cutoff is session-constant (a model card fact, fixed at catalog load) and
+/// rides the byte-stable system prefix, but the date changes once a day —
+/// possibly mid-session — so putting it in the prefix would be a guaranteed
+/// prompt-cache miss at every UTC midnight for every session alive across it
+/// (invariant #7 / L-E8), and `the_assembled_prompt_names_the_session_environment`
+/// (`crates/stella-cli/src/agent/prompt.rs`) would start failing the moment a
+/// test ran across one. It belongs with the other genuinely volatile facts —
+/// draft claims, selected skills — that ride this per-turn block instead.
+///
+/// Takes Unix seconds rather than reading the clock itself so it stays a pure
+/// function of its input: two calls a day apart must render different text,
+/// and neither call may touch `SystemTime::now()` for that difference to be
+/// provable without racing real time.
+pub(super) fn render_today_section(unix_secs: i64) -> String {
+    let today = &stella_context::format_rfc3339(unix_secs)[..10];
+    format!(
+        "Today's date: {today} UTC — measure the knowledge-cutoff staleness clause in the \
+         session environment above against this."
+    )
 }
 
 /// Land the recalled-context message for this turn at the conversation

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -245,6 +245,71 @@ fn recall_section_without_memories_never_asks_for_citations() {
     assert!(render_context_section(&[]).is_none());
 }
 
+/// Witness for #2901: the model is handed a knowledge cutoff
+/// (`crate::agent::prompt::append_session_environment`) but never a "now" to
+/// measure it against. `render_today_section` is that second operand, and it
+/// must actually vary with the clock it is given — a constant string would
+/// satisfy every other assertion in this file while leaving the gap open.
+///
+/// The clock is injected as a plain `i64`, never read via `SystemTime::now()`
+/// inside the renderer, which is what makes this provable without racing
+/// real time or waiting for a UTC midnight in CI.
+#[test]
+fn todays_date_section_tracks_the_injected_clock_not_the_wall_clock() {
+    // 2026-08-11T00:00:00Z and the same instant one day later.
+    let day_one = 1_786_406_400;
+    let day_two = day_one + 86_400;
+
+    let first = render_today_section(day_one);
+    let second = render_today_section(day_two);
+
+    assert!(
+        first.contains("2026-08-11") && !first.contains("2026-08-12"),
+        "the section must name the day the injected clock reads: {first}"
+    );
+    assert!(
+        second.contains("2026-08-12") && !second.contains("2026-08-11"),
+        "a clock one day later must render a different day: {second}"
+    );
+    assert_ne!(
+        first, second,
+        "two instants a day apart must not render identical text"
+    );
+}
+
+/// Wiring witness for #2901: on a workspace with nothing else to recall (no
+/// memories, skills, drafts, or records), both doors a driver can take to
+/// inject the volatile block still carry today's date — the date is
+/// unconditional, unlike every other section in this block, because a model
+/// needs "now" on every turn to judge staleness, not only the turns that
+/// also recalled something.
+#[tokio::test]
+async fn an_otherwise_empty_recall_block_still_names_the_date() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".stella")).unwrap();
+    let memory = SessionMemory::open(dir.path(), false).expect("session memory");
+
+    let full = memory
+        .recall_block("hello")
+        .await
+        .expect("the date section alone makes the block non-empty");
+    assert!(
+        full.contains("Today's date:"),
+        "the worker's block must name the date even with nothing else to \
+         recall: {full}"
+    );
+
+    let pipeline = memory
+        .pipeline_recall_block("hello")
+        .await
+        .expect("the pipeline door carries the same unconditional section");
+    assert!(
+        pipeline.contains("Today's date:"),
+        "the pipeline-driven turn's frames-free block must also name the \
+         date: {pipeline}"
+    );
+}
+
 #[test]
 fn graph_frame_projection_preserves_provider_and_origin_provenance() {
     let mut graph = contextgraph_frame(

--- a/crates/stella-cli/src/memory/tests/quarantine.rs
+++ b/crates/stella-cli/src/memory/tests/quarantine.rs
@@ -34,9 +34,15 @@ async fn assert_no_prompt_or_pipeline_frames(memory: &SessionMemory, lesson: &st
         pipeline_frames.is_empty(),
         "pipeline recall must fail closed when suppression state is unknown: {pipeline_frames:?}"
     );
+    // #2901 gave the recall block an unconditional section (today's date),
+    // so it is no longer `None` on every content-free turn — only when
+    // nothing recall-derived rides it. The fail-closed property under test is
+    // that the lesson itself never reaches the block, not that the block is
+    // empty.
+    let block = memory.recall_block(lesson).await;
     assert!(
-        memory.recall_block(lesson).await.is_none(),
-        "prompt recall must fail closed when suppression state is unknown"
+        !block.as_deref().unwrap_or_default().contains(lesson),
+        "prompt recall must fail closed on the lesson when suppression state is unknown: {block:?}"
     );
 }
 


### PR DESCRIPTION
## What & why

`append_session_environment` (`crates/stella-cli/src/agent/prompt.rs`) names a model's
knowledge cutoff when the catalog knows it — *"knowledge cutoff 2025-01; treat anything
that may have moved since as unverified"* — but "since" never got a second operand.
Nothing in the assembled prompt or the volatile recall block named the current date, so
the model had no way to tell a six-week-old cutoff from a two-year-old one.

The date can't join the cutoff in the byte-stable system prefix (invariant #7 / L-E8): it
changes daily, possibly mid-session, and the prefix's whole point is that two assemblies
produce identical bytes. So it rides the **volatile recall block** instead — the same
channel draft claims and selected skills already use — via a new `render_today_section` in
`crates/stella-cli/src/memory/recall.rs`, wired unconditionally into both doors a driver can
take (`recall_block_reported`, `pipeline_recall_block`).

Closes #2901

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here) — `render_today_section`
  does not exist on `main`, so `todays_date_section_tracks_the_injected_clock_not_the_wall_clock`
  fails to compile there. It asserts two instants a day apart render different text, taking
  Unix seconds as a plain parameter so nothing under test ever calls `SystemTime::now()`.
  `an_otherwise_empty_recall_block_still_names_the_date` is the end-to-end wiring witness:
  on a workspace with nothing else to recall, both `recall_block` and `pipeline_recall_block`
  still carry `"Today's date:"`.
- [x] `the_assembled_prompt_names_the_session_environment` (`agent/prompt.rs`) — the
  byte-stability assertion over the cached prefix — passes **unchanged**, proving the date
  never reached the prefix.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-cli` (1737 passed, including all 25 `agent::prompt::` tests and
      268 `memory::` tests)
- [x] `cargo doc -p stella-cli --no-deps` with `-D warnings`
- [x] Docs updated where behavior changed — doc comment on `append_session_environment`
      now points at where the date landed instead of calling it "deliberately absent"
- [ ] CLA signed (bot will prompt)
- [x] `Closes #2901` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

One existing test's assertion needed updating for the new contract: `quarantine.rs`'s
`assert_no_prompt_or_pipeline_frames` used to assert `recall_block(...).is_none()` as a
coarse proxy for "nothing leaked" when session suppression state can't be verified. Since
the block now unconditionally carries the date, it's never `None` on a non-suppressed turn
— so the assertion now checks the actual security property directly (the quarantined lesson
never reaches the block), which the date obviously doesn't affect.

## Ground-rule check

- [x] No I/O added to `stella-core` (all changes are in `stella-cli`)
- [x] No new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Per the issue's open questions: date-only (not a timestamp), UTC, ISO-8601 — matching its
recommendation, since a timestamp would invite the model to reason about elapsed minutes it
can't measure, and UTC matches how the knowledge-cutoff field is recorded. The section is
rendered unconditionally (not opt-out-by-emptiness like the sibling sections) because the
model needs "now" on every turn to judge staleness, not only turns that also recalled a
memory or a record — the recall-block dedup in `inject_recall_block` means this doesn't
cost tokens on repeat turns within the same day, since unchanged content isn't re-appended.

## Summary by Sourcery

Add an unconditional "today's date" section to the volatile recall block so models can compare the session knowledge cutoff against the current date without affecting the byte-stable system prefix.

New Features:
- Expose a rendered current-date section in recall blocks for both worker and pipeline turns, based on an injected Unix-seconds clock.

Bug Fixes:
- Ensure the staleness clause in the session environment has a usable second operand by always providing the current date alongside the knowledge cutoff.

Enhancements:
- Refine quarantine tests to assert that suppressed lessons never reach recall blocks rather than assuming empty blocks, aligning with the new always-present date section.
- Update documentation on the session environment to reference the volatile date section instead of treating it as deliberately absent.

Tests:
- Add tests verifying that the rendered today section varies with the injected clock value and that otherwise-empty recall blocks still include the date for both recall paths.