### PR TITLE
fix(stella-pipeline): split the unproven ladder rungs out of pipeline.rs

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -135,6 +135,9 @@ mod scope_stage;
 mod stage_budget;
 mod task_frame;
 mod triage_stage;
+/// The `Unverifiable`/`Unverified` ladder rungs' settle logic (#2908) — in
+/// its own module because `pipeline.rs` is closed to growth.
+mod unproven;
 /// The worker's opening user message (recall, research findings, goal,
 /// verification contract) — pure text assembly, in its own module because
 /// `pipeline.rs` is closed to growth.
@@ -2392,81 +2395,21 @@ impl<'a> Pipeline<'a> {
                     }
                 }
                 LadderDecision::Unverifiable => {
-                    // The turn went unobserved — every channel blind, or every
-                    // channel clear-eyed and empty over dispatched mutating
-                    // calls (#1701). The verifier is not asked, because the
-                    // only thing it could do is guess from an empty record —
-                    // which in the wild it did, returning `FAIL … the file
-                    // likely does not exist` about a file that was in the
-                    // container (#973).
-                    //
-                    // `passed: true` because a run is not failed by the absence
-                    // of a way to check it, and this shape already exists for
-                    // the review-waived path. What keeps it from reading as a
-                    // pass is the pair beside it: the summary says UNVERIFIABLE
-                    // in its first word, and the score is `Unverified`, so this
-                    // candidate can never tie a genuinely verified sibling in
-                    // best-of-N and then win the smaller-diff tiebreak.
-                    //
-                    // The arm above is what makes this defensible. Reaching
-                    // here means the turn *did* dispatch mutating calls and no
-                    // channel saw their effect — a real state: a Terminal-Bench
-                    // trial that wrote its answer through shell redirects
-                    // recorded no touch, could not be diffed, landed here, and
-                    // scored 1.0 against its verifier. Failing that closed
-                    // would report a correct run as broken, and no revision can
-                    // clear it — that workspace never becomes observable.
-                    let mut evidence = unverifiable_evidence(&inputs);
-                    evidence.ladder = Some(Box::new(snapshot.clone()));
-                    self.unverifiable(&evidence.summary);
-                    self.emit(AgentEvent::Verdict {
-                        passed: true,
-                        evidence: evidence.clone(),
-                    });
-                    // #2908: `Unverifiable` is a claim, not a verdict on the
-                    // run — "we could not see" must not read as "stop here."
-                    // Scoped to `effective_cmd.is_none()` — no tracked command
-                    // AND no witness — because that is the evidenced failure:
-                    // a run with a real command that merely went blind this
-                    // round (infra noise on the confirmation, say) is a
-                    // narrower, already-tested shape, and widening to it too
-                    // is a separate change, not this one. Bounded exactly like
-                    // every other back-edge on this ladder (`affords_repair`'s
-                    // revision/budget/wall-clock gate), and additionally by
-                    // the worker's OWN stopping condition: a round that
-                    // dispatched no further mutating call and moved no diff
-                    // line answered the nudge by declining to act, which is
-                    // bare's own termination — adopting it here is what keeps
-                    // this from looping the full revision allowance against a
-                    // worker that is already done.
-                    if effective_cmd.is_none()
-                        && self.affords_repair(&state, &meter, *spend.total, spend.budget)
+                    let ladder_ctx = unproven::LadderContext {
+                        snapshot: &snapshot,
+                        inputs: &inputs,
+                        effective_cmd,
+                    };
+                    match self
+                        .settle_unverifiable(engine, surface, spend, &meter, state, ladder_ctx)
+                        .await
                     {
-                        let mutating_before = state.signals.mutating_actions;
-                        let diff_lines_before = state.diff_lines;
-                        if let Err(abort) = self
-                            .revise_candidate(
-                                engine,
-                                surface,
-                                RevisionCause::Deterministic(UNPROVEN_CONTINUE_NUDGE),
-                                spend,
-                                &mut state,
-                            )
-                            .await
-                        {
-                            return CandidateResult::turn_aborted(state.messages, abort);
-                        }
-                        if state.signals.mutating_actions != mutating_before
-                            || state.diff_lines != diff_lines_before
-                        {
+                        std::ops::ControlFlow::Break(result) => return result,
+                        std::ops::ControlFlow::Continue(next_state) => {
+                            state = next_state;
                             continue;
                         }
                     }
-                    return state.into_verified(
-                        true,
-                        &evidence,
-                        score_from_verification(false, None),
-                    );
                 }
                 LadderDecision::WitnessUnsatisfiable => {
                     // #2540: the authored witness failed identically on both
@@ -2625,75 +2568,24 @@ impl<'a> Pipeline<'a> {
                         // with the ask spent, and ends below.
                         continue;
                     }
-                    // Terminal. Nothing deterministic settled this turn, and
-                    // nothing else is going to: no model is asked, because the
-                    // evidence that reaches this arm is by construction the
-                    // evidence no oracle could settle, and a model handed it
-                    // would be guessing at it too — only with a verdict's
-                    // authority attached. Measured, that guess agreed with
-                    // Terminal-Bench's grader 46% of the time, and 17 of its
-                    // false passes cost 5 tasks outright.
-                    //
-                    // `passed: true` for exactly the reason the abstention arm
-                    // above uses it — a run is not failed by the absence of a
-                    // way to check it — and, exactly as there, what keeps it
-                    // from reading as a pass is the pair beside it: the
-                    // summary says UNVERIFIED in its first word and the score
-                    // is `Unverified`, so this candidate can never tie a
-                    // genuinely verified sibling in best-of-N and then win the
-                    // smaller-diff tiebreak.
-                    let mut evidence = unverified_evidence(&inputs, state.oracle.tracked_command());
-                    evidence.ladder = Some(Box::new(snapshot.clone()));
-                    self.unproven_verdict(&evidence.summary);
-                    self.emit(AgentEvent::Verdict {
-                        passed: true,
-                        evidence: evidence.clone(),
-                    });
-                    // #2908: scoped to `effective_cmd.is_none()` — no tracked
-                    // command AND no witness, the exact shape that let the
-                    // ladder end a run four minutes before the bare loop on
-                    // the same worker, on `pypi-server`. Where a command DOES
-                    // exist, either the evidence-demand arm above already
-                    // spent its one ask, or it declined to (off, or already
-                    // spent, or the pass does not stand alone) — those are
-                    // this arm's own established, separately-tested contract
-                    // and are unaffected here. The pipeline may downgrade the
-                    // CLAIM to unproven; it may not downgrade the RUN by
-                    // ending it a revision before the worker itself would
-                    // have stopped. Same bound as the `Unverifiable` arm
-                    // above: `affords_repair`'s existing revision/budget/
-                    // wall-clock gate, plus the worker's own stopping
-                    // condition (no further mutating call, no diff movement)
-                    // so a worker that is genuinely done is not walked
-                    // through the rest of its allowance for nothing.
-                    if effective_cmd.is_none()
-                        && self.affords_repair(&state, &meter, *spend.total, spend.budget)
+                    // Terminal by default — see `Pipeline::settle_unverified`
+                    // for why no model is asked, and how far the worker's own
+                    // handback is bounded (#2908).
+                    let ladder_ctx = unproven::LadderContext {
+                        snapshot: &snapshot,
+                        inputs: &inputs,
+                        effective_cmd,
+                    };
+                    match self
+                        .settle_unverified(engine, surface, spend, &meter, state, ladder_ctx)
+                        .await
                     {
-                        let mutating_before = state.signals.mutating_actions;
-                        let diff_lines_before = state.diff_lines;
-                        if let Err(abort) = self
-                            .revise_candidate(
-                                engine,
-                                surface,
-                                RevisionCause::Deterministic(UNPROVEN_CONTINUE_NUDGE),
-                                spend,
-                                &mut state,
-                            )
-                            .await
-                        {
-                            return CandidateResult::turn_aborted(state.messages, abort);
-                        }
-                        if state.signals.mutating_actions != mutating_before
-                            || state.diff_lines != diff_lines_before
-                        {
+                        std::ops::ControlFlow::Break(result) => return result,
+                        std::ops::ControlFlow::Continue(next_state) => {
+                            state = next_state;
                             continue;
                         }
                     }
-                    return state.into_verified(
-                        true,
-                        &evidence,
-                        score_from_verification(false, None),
-                    );
                 }
             }
         }

--- a/crates/stella-pipeline/src/pipeline/unproven.rs
+++ b/crates/stella-pipeline/src/pipeline/unproven.rs
@@ -1,0 +1,192 @@
+//! The two ladder rungs that could not observe the turn — `Unverifiable` and
+//! `Unverified` — settle here rather than in `pipeline.rs`'s
+//! `verify_candidate` loop, because `pipeline.rs` is closed to growth
+//! (AGENTS.md § "God files"). Pulled out verbatim: no behavior changed.
+//!
+//! Both rungs share one shape: build the rung's evidence, log and emit the
+//! `Verdict`, then — scoped to `effective_cmd.is_none()`, the exact shape
+//! that let the ladder end a run ahead of the bare loop on `pypi-server`
+//! (#2908) — offer the worker one more turn, bounded exactly like every
+//! other back-edge on this ladder (`affords_repair`'s revision/budget/
+//! wall-clock gate) plus the worker's own stopping condition (no further
+//! mutating call, no diff movement), before settling `Unverified`.
+//!
+//! [`std::ops::ControlFlow::Break`] carries the finished [`CandidateResult`],
+//! whether that is a settled verdict or a turn abort.
+//! [`std::ops::ControlFlow::Continue`] hands the mutated [`CandidateState`]
+//! back so the caller's loop can re-observe from the top — the same
+//! ownership `verify_candidate`'s own loop already had over `state`, just
+//! threaded through a call instead of inline.
+
+use std::ops::ControlFlow;
+
+use super::repair_gate::RepairMeter;
+use super::*;
+
+/// What this round's ladder decision knows about the turn, bundled so the
+/// two settle methods below stay under clippy's argument-count gate rather
+/// than growing an unexplained `#[allow]`.
+pub(super) struct LadderContext<'c> {
+    pub(super) snapshot: &'c LadderSnapshot,
+    pub(super) inputs: &'c LadderInputs,
+    pub(super) effective_cmd: Option<EffectiveTestCommand<'c>>,
+}
+
+impl Pipeline<'_> {
+    /// Settle the `LadderDecision::Unverifiable` rung: every channel blind,
+    /// or every channel clear-eyed and empty over dispatched mutating calls
+    /// (#1701). The verifier is not asked, because the only thing it could
+    /// do is guess from an empty record — which in the wild it did,
+    /// returning `FAIL … the file likely does not exist` about a file that
+    /// was in the container (#973).
+    ///
+    /// `passed: true` because a run is not failed by the absence of a way to
+    /// check it, and this shape already exists for the review-waived path.
+    /// What keeps it from reading as a pass is the pair beside it: the
+    /// summary says UNVERIFIABLE in its first word, and the score is
+    /// `Unverified`, so this candidate can never tie a genuinely verified
+    /// sibling in best-of-N and then win the smaller-diff tiebreak.
+    ///
+    /// `LadderDecision::NothingAttempted` is what makes this defensible.
+    /// Reaching here means the turn *did* dispatch mutating calls and no
+    /// channel saw their effect — a real state: a Terminal-Bench trial that
+    /// wrote its answer through shell redirects recorded no touch, could not
+    /// be diffed, landed here, and scored 1.0 against its verifier. Failing
+    /// that closed would report a correct run as broken, and no revision can
+    /// clear it — that workspace never becomes observable.
+    pub(super) async fn settle_unverifiable(
+        &self,
+        engine: &Engine<'_>,
+        surface: CandidateSurface<'_>,
+        spend: &mut Spend<'_>,
+        meter: &RepairMeter,
+        mut state: CandidateState,
+        ladder: LadderContext<'_>,
+    ) -> ControlFlow<CandidateResult, CandidateState> {
+        let mut evidence = unverifiable_evidence(ladder.inputs);
+        evidence.ladder = Some(Box::new(ladder.snapshot.clone()));
+        self.unverifiable(&evidence.summary);
+        self.emit(AgentEvent::Verdict {
+            passed: true,
+            evidence: evidence.clone(),
+        });
+        // #2908: `Unverifiable` is a claim, not a verdict on the run — "we
+        // could not see" must not read as "stop here." Scoped to
+        // `effective_cmd.is_none()` — no tracked command AND no witness —
+        // because that is the evidenced failure: a run with a real command
+        // that merely went blind this round (infra noise on the
+        // confirmation, say) is a narrower, already-tested shape, and
+        // widening to it too is a separate change, not this one. Bounded
+        // exactly like every other back-edge on this ladder
+        // (`affords_repair`'s revision/budget/wall-clock gate), and
+        // additionally by the worker's OWN stopping condition: a round that
+        // dispatched no further mutating call and moved no diff line
+        // answered the nudge by declining to act, which is bare's own
+        // termination — adopting it here is what keeps this from looping
+        // the full revision allowance against a worker that is already
+        // done.
+        if ladder.effective_cmd.is_none()
+            && self.affords_repair(&state, meter, *spend.total, spend.budget)
+        {
+            let mutating_before = state.signals.mutating_actions;
+            let diff_lines_before = state.diff_lines;
+            if let Err(abort) = self
+                .revise_candidate(
+                    engine,
+                    surface,
+                    RevisionCause::Deterministic(UNPROVEN_CONTINUE_NUDGE),
+                    spend,
+                    &mut state,
+                )
+                .await
+            {
+                return ControlFlow::Break(CandidateResult::turn_aborted(state.messages, abort));
+            }
+            if state.signals.mutating_actions != mutating_before
+                || state.diff_lines != diff_lines_before
+            {
+                return ControlFlow::Continue(state);
+            }
+        }
+        ControlFlow::Break(state.into_verified(
+            true,
+            &evidence,
+            score_from_verification(false, None),
+        ))
+    }
+
+    /// Settle the `LadderDecision::Unverified` rung: escalation on evidence
+    /// exhausted, or never warranted. Terminal by default — nothing
+    /// deterministic settled this turn, and nothing else is going to: no
+    /// model is asked, because the evidence that reaches this arm is by
+    /// construction the evidence no oracle could settle, and a model handed
+    /// it would be guessing at it too — only with a verdict's authority
+    /// attached. Measured, that guess agreed with Terminal-Bench's grader
+    /// 46% of the time, and 17 of its false passes cost 5 tasks outright.
+    ///
+    /// `passed: true` for exactly the reason [`Pipeline::settle_unverifiable`]
+    /// uses it — a run is not failed by the absence of a way to check it —
+    /// and, exactly as there, what keeps it from reading as a pass is the
+    /// pair beside it: the summary says UNVERIFIED in its first word and the
+    /// score is `Unverified`, so this candidate can never tie a genuinely
+    /// verified sibling in best-of-N and then win the smaller-diff tiebreak.
+    pub(super) async fn settle_unverified(
+        &self,
+        engine: &Engine<'_>,
+        surface: CandidateSurface<'_>,
+        spend: &mut Spend<'_>,
+        meter: &RepairMeter,
+        mut state: CandidateState,
+        ladder: LadderContext<'_>,
+    ) -> ControlFlow<CandidateResult, CandidateState> {
+        let mut evidence = unverified_evidence(ladder.inputs, state.oracle.tracked_command());
+        evidence.ladder = Some(Box::new(ladder.snapshot.clone()));
+        self.unproven_verdict(&evidence.summary);
+        self.emit(AgentEvent::Verdict {
+            passed: true,
+            evidence: evidence.clone(),
+        });
+        // #2908: scoped to `effective_cmd.is_none()` — no tracked command AND
+        // no witness, the exact shape that let the ladder end a run four
+        // minutes before the bare loop on the same worker, on `pypi-server`.
+        // Where a command DOES exist, either the evidence-demand back-edge
+        // already spent its one ask, or it declined to (off, or already
+        // spent, or the pass does not stand alone) — those are this arm's
+        // own established, separately-tested contract and are unaffected
+        // here. The pipeline may downgrade the CLAIM to unproven; it may not
+        // downgrade the RUN by ending it a revision before the worker itself
+        // would have stopped. Same bound as `settle_unverifiable`:
+        // `affords_repair`'s existing revision/budget/wall-clock gate, plus
+        // the worker's own stopping condition (no further mutating call, no
+        // diff movement) so a worker that is genuinely done is not walked
+        // through the rest of its allowance for nothing.
+        if ladder.effective_cmd.is_none()
+            && self.affords_repair(&state, meter, *spend.total, spend.budget)
+        {
+            let mutating_before = state.signals.mutating_actions;
+            let diff_lines_before = state.diff_lines;
+            if let Err(abort) = self
+                .revise_candidate(
+                    engine,
+                    surface,
+                    RevisionCause::Deterministic(UNPROVEN_CONTINUE_NUDGE),
+                    spend,
+                    &mut state,
+                )
+                .await
+            {
+                return ControlFlow::Break(CandidateResult::turn_aborted(state.messages, abort));
+            }
+            if state.signals.mutating_actions != mutating_before
+                || state.diff_lines != diff_lines_before
+            {
+                return ControlFlow::Continue(state);
+            }
+        }
+        ControlFlow::Break(state.into_verified(
+            true,
+            &evidence,
+            score_from_verification(false, None),
+        ))
+    }
+}

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -24,7 +24,7 @@
 1781 crates/stella-model/src/anthropic/tests.rs
 2094 crates/stella-model/src/openai.rs
 1895 crates/stella-model/src/zai/tests.rs
-3126 crates/stella-pipeline/src/pipeline.rs
+2940 crates/stella-pipeline/src/pipeline.rs
 2475 crates/stella-pipeline/src/pipeline/tests.rs
 1996 crates/stella-store/src/lib.rs
 2266 crates/stella-store/src/tests.rs


### PR DESCRIPTION
## What & why

PR #2915 (#2908's fix) added 102 lines to `crates/stella-pipeline/src/pipeline.rs`, a grandfathered god file AGENTS.md declares closed to growth (`file-size` ratchet passed only because it judges a change against what the file inherited from the base tree, not against the closed-to-growth rule — that half is a review question, and it slipped through).

Moves the `LadderDecision::Unverifiable` and `::Unverified` settle bodies into a new sibling module, `crates/stella-pipeline/src/pipeline/unproven.rs`, following the shape of the now-closed reference PR #2919 (a sibling module, plumbed through `std::ops::ControlFlow` so the caller's loop can still re-observe after a worker handback). This is a pure move — same evidence construction, same repair-gate bound, same worker-handback stopping condition. The two settle bodies were near-identical and shared enough surface that they now go through `LadderContext` to stay under clippy's argument-count gate rather than growing an unexplained `#[allow]`.

`pipeline.rs`: 3048 → 2940 lines. `scripts/file-size-baseline.txt` updates only the one line for `pipeline.rs`; every other entry is left at its prior value to avoid folding an unrelated baseline regeneration into this PR (a shared baseline cell is the #1 cause of red-main collisions here).

Closes #2920

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a mechanical extraction with no behavior change. Verified by the existing 715-test `stella-pipeline` suite passing unmodified, in particular `witness_no_test_command.rs` and the `golden_unproven_without_a_test_command` golden fixture, both of which exercise exactly the two rungs moved here and pass byte-for-byte unchanged.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (scoped: `-p stella-pipeline` and its 8 impacted dependents — full `cargo test --workspace` is blocked by the pre-existing, unrelated #2914 brand-token failure on `main`; see below)
- [x] `cargo test --workspace` (scoped to `-p stella-pipeline`: 715 passed, 0 failed)
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments) — N/A, no behavior changed
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included) — N/A, `LadderContext` is an internal `pub(super)` struct, never crosses a crate boundary

## Anything reviewers should know?

`make gate CARGO_SCOPE="-p stella-pipeline"` is fully green locally (guards, fmt, clippy, rustdoc, and the full test suite including the self-driving-test harness). The repo-wide pre-push hook widened scope to 8 impacted crates and failed on `stella-cli`'s `design_token_parity::identity_gold_comes_from_the_brand_ramp` — that's the pre-existing #2914 brand-token mismatch on `main` (`--stella-gold-500` resolves to `#ffb000` instead of `#c58a32`), unrelated to this change (no CSS/brand files touched here). Pushed with `GATE=fast` (guards + fmt + clippy only, no rustdoc/test rung) rather than skip the hook outright — full CI will still run server-side and should surface the same pre-existing #2914 failure independent of this PR.

## Summary by Sourcery

Extract the ladder rungs’ unproven-settle logic from the main pipeline loop into a dedicated module while keeping behavior unchanged and updating size baselines accordingly.

Enhancements:
- Move `LadderDecision::Unverifiable` and `LadderDecision::Unverified` settle logic into a new `pipeline::unproven` module wired via `ControlFlow` to the main verification loop.
- Introduce `LadderContext` to share ladder inputs between the unproven settle paths without increasing argument count in core pipeline methods.

Build:
- Adjust `scripts/file-size-baseline.txt` to reflect the reduced line count of `crates/stella-pipeline/src/pipeline.rs` without regenerating other baselines.