### PR TITLE
fix(stella-pipeline): a verdict is a claim about the work, not what decides the work exists

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -113,6 +113,7 @@ mod attachments;
 // authored section's header so the prompt and the header cannot drift apart.
 pub(crate) mod authored;
 mod candidate_result;
+mod delivery;
 mod disclosure;
 mod evidence;
 mod execute_stage;
@@ -1783,19 +1784,25 @@ impl<'a> Pipeline<'a> {
         // whole fan-out, not the one result that survives it.
         let ran = executed_count(&candidates);
         self.emit_text(candidate_winner_notice(best_idx, n, ran));
-        // Winner adoption + cleanup. An aborted winner adopts nothing — an
-        // aborted best-of-N run leaves the real tree untouched.
+        // Winner delivery + cleanup. The verdict is a claim ABOUT the work; it
+        // does not decide whether the work exists (#2927). `delivery` states
+        // the whole rule and the argument for it, rung by rung; the one thing
+        // still withheld is a candidate the pipeline refused on integrity.
         let mut adopt_failure: Option<WorkspaceError> = None;
+        let delivery = delivery::decide(delivery::WinnerFacts::of(&candidates[best_idx]));
         for (i, slot) in workspaces.into_iter().enumerate() {
             let Ok(ws) = slot else {
                 continue;
             };
             if i == best_idx
-                && candidates[best_idx]
-                    .verdict
-                    .as_ref()
-                    .is_some_and(|verdict| verdict.passed)
+                && let delivery::Delivery::Deliver { proven } = delivery
             {
+                // Delivery is never proof. The verdict, the status and the
+                // score are untouched above; this line is what stops the write
+                // itself from reading as a pass.
+                if !proven {
+                    self.warn(delivery::UNPROVEN_DELIVERY_NOTICE.to_string());
+                }
                 // The witness has already done its whole job by now — it armed
                 // the flip oracle and the flip was observed — so withholding it
                 // cannot change the verdict, only what lands in the tree.
@@ -1829,25 +1836,29 @@ impl<'a> Pipeline<'a> {
                     Err(e) => adopt_failure = Some(e),
                 }
             } else if single_shot_isolation {
-                // The `create_worktrees` run that did not pass. Discarding is
-                // right for best-of-N — the operator asked for the best of
-                // several and none was good, and the losers were never meant to
-                // survive. It is also right for an authored-witness abort,
-                // where the candidate is *poisoned* rather than merely
-                // unverified (a tampered artifact, an author that edited
-                // production code) and `witness_isolation`'s tests pin its
-                // removal.
+                // The `create_worktrees` run whose work was withheld — since
+                // #2927 that means an integrity refusal (the candidate wrote
+                // through its isolation, its witness was tampered with, its
+                // tree moved after verification) or an allowance it never
+                // got, never merely "it did not verify". Discarding is right
+                // for best-of-N — the operator asked for the best of several
+                // and none was good, and the losers were never meant to
+                // survive — and `witness_isolation`'s tests pin removal for a
+                // poisoned authored-witness candidate.
                 //
                 // It is wrong for this third caller. That operator asked where
-                // the work should *happen*, not that it be thrown away unless
-                // it verified — and without this they end up strictly worse off
-                // than with isolation off, where a failed run at least leaves
-                // its changes in the tree to look at. So keep the snapshot and
+                // the work should *happen*, not that it be thrown away — and
+                // without this they end up strictly worse off than with
+                // isolation off, where a failed run at least leaves its
+                // changes in the tree to look at. So keep the snapshot and
                 // name it: the same posture as the adopt-failure arm just
-                // above, and for the same reason — unverified is not worthless.
+                // above, and for the same reason — undelivered is not
+                // worthless. The reason is deliberately unnamed here because
+                // this arm has several, and each has already been stated on
+                // the stream by the stage that raised it.
                 self.warn(format!(
-                    "this run's changes did not verify, so they were not adopted into your \
-                     working tree — they are kept at {} for you to inspect or salvage",
+                    "this run's changes were not adopted into your working tree — they are \
+                     kept at {} for you to inspect or salvage",
                     ws.root()
                 ));
             } else {

--- a/crates/stella-pipeline/src/pipeline/delivery.rs
+++ b/crates/stella-pipeline/src/pipeline/delivery.rs
@@ -1,0 +1,245 @@
+//! Whether the winning candidate's work is delivered into the real tree —
+//! and why that question is not the verdict's to answer.
+//!
+//! # The rule
+//!
+//! **A verdict is a claim about the work; it is not what decides whether the
+//! work exists.** This is the same principle #2881 established one layer down
+//! (a post-completion *check* may downgrade a claim, never discard a
+//! deliverable), applied at the delivery gate itself. Adoption used to require
+//! `verdict.passed`, so an unproven or failed run had its entire candidate
+//! workspace deleted — which makes the verdict self-fulfilling: nothing
+//! reaches the tree, so nothing can ever be judged correct there.
+//!
+//! Measured cost of the old gate (#2927): over the twenty pipeline trials of
+//! ArenaBench run `w10p`, every trial with `passed=true` wrote to the graded
+//! tree after its verdict and *no* trial without one did. Eight of fifteen
+//! pipeline losses never had their work delivered at all, including a trial
+//! whose last recorded event, four seconds before the wall-clock kill, was
+//! `18 passed in 1.44s`.
+//!
+//! # Why "deliver anyway" is the correct posture, rung by rung
+//!
+//! The decisive argument is not the bench number, it is that **isolation is a
+//! mechanism, not a quality gate.** A candidate workspace exists so that
+//! losing candidates can be rolled back and so a witness author cannot reach
+//! the user's tree. With isolation switched off, a run that fails
+//! verification still leaves its edits in the working tree for the operator to
+//! read, keep, or `git checkout`. Turning isolation *on* must not make the
+//! same run strictly worse off. `pipeline.rs` already reached that conclusion
+//! for one caller (the `create_worktrees` single-shot path keeps its
+//! unadopted snapshot and says where it is); this module reaches it for the
+//! rest.
+//!
+//! Per [`crate::verify::LadderDecision`]:
+//!
+//! * `SubmitFast` — delivered, as before.
+//! * `Unverifiable`, `Unverified`, `WitnessUnsatisfiable` — these publish
+//!   `passed: true` (a run is not failed by the absence of a way to check it),
+//!   so they were already delivered. Named here because the *claim* they carry
+//!   is unproven and stays unproven: delivery adds no proof.
+//! * `NothingAttempted` — delivered. The rung's own premise is that no channel
+//!   saw anything change, so the patch is empty and adoption is a no-op.
+//!   Excluding it would be a branch that can only ever be wrong.
+//! * `Revise` (terminal, `passed: false`) — delivered, and this is the real
+//!   change. A red touched test is a deterministic fact about **one
+//!   instrument**, not a finding that the whole candidate is worthless, and a
+//!   *terminal* `Revise` means the repair budget ran out mid-repair, so the
+//!   candidate is the best state the run reached. The alternative delivers
+//!   zero bytes with certainty.
+//! * No verdict at all, because the worker's engine turn aborted (budget
+//!   exhausted, stuck loop, step cap, a user's stop) — delivered. This is
+//!   #2651's shape: the stop is a decision about *spending*, taken between
+//!   tool calls, and it says nothing whatever about the bytes already written.
+//!
+//! # What is still withheld, and why that is a different question
+//!
+//! An **integrity** refusal is not a claim about the work's quality; it is a
+//! statement that the bytes in the workspace are not the bytes any stage
+//! examined. Delivering those would ship something nothing ever looked at —
+//! strictly worse than shipping nothing, and the one case where "deliver
+//! anyway" is wrong. These keep the discard they already had: a candidate that
+//! wrote through its isolation (#1538), a witness artifact mutated after its
+//! baseline was pinned, a worktree that changed after verification, a seal
+//! that could not be taken, and a mutation audit that could not restore the
+//! tree. Every one of them is raised by the pipeline itself, never by the
+//! worker's engine, which is exactly the distinction
+//! [`AbortFacts::from_turn`] carries.
+//!
+//! # Honesty
+//!
+//! Delivery never implies proof. The verdict, the `PipelineStatus`, and the
+//! candidate's score are untouched by this module — a delivered `Revise` still
+//! reports `VerificationFailed`, and a delivered abstention still reports
+//! `Unverified`. [`Delivery::Deliver::proven`] exists only so the caller can
+//! say on the rail that what it just wrote is unproven.
+
+use stella_core::AbortKind;
+
+use super::candidate_result::CandidateResult;
+
+/// What the pipeline knows about the winning candidate at the moment it
+/// decides delivery. Owned plain data, so [`decide`] is a pure function of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct WinnerFacts {
+    /// `Some(passed)` when verification reached a verdict, `None` when the
+    /// candidate never got one (it aborted, or it was a lookup with nothing to
+    /// verify).
+    pub(super) verdict_passed: Option<bool>,
+    /// `Some` when the candidate aborted.
+    pub(super) abort: Option<AbortFacts>,
+}
+
+/// The three things about an abort that decide whether its work survives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct AbortFacts {
+    /// The abort came out of the worker's own engine turn — a budget stop, a
+    /// stuck-loop escalation, a step cap, a user's stop. The engine stops
+    /// *between* tool calls (invariant #6), so the workspace holds exactly the
+    /// bytes the last completed tool wrote.
+    pub(super) from_turn: bool,
+    /// A degradable **infrastructure** setup failure: no workspace was ever
+    /// created and no model call was ever made, so there is nothing to
+    /// deliver.
+    pub(super) degradable: bool,
+    /// Whether this stop was a decision or a failure.
+    pub(super) kind: AbortKind,
+}
+
+/// What to do with the winner's workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Delivery {
+    /// Adopt the candidate's work into the real tree.
+    Deliver {
+        /// `false` when the run reached no passing verdict. The work is
+        /// delivered all the same; the caller says so on the rail rather than
+        /// letting the write read as a proof.
+        proven: bool,
+    },
+    /// Withhold the work: the candidate's own integrity is what failed, or it
+    /// never produced any.
+    Withhold,
+}
+
+/// The rail line that keeps an unproven delivery honest. Fixed text over no
+/// model output, like every other deterministic notice on this surface.
+pub(super) const UNPROVEN_DELIVERY_NOTICE: &str = "this run did not prove its changes, so they are UNPROVEN — but the work was still \
+     delivered into your working tree rather than discarded; review it (`git diff`) before \
+     relying on it";
+
+/// The delivery decision for the winning candidate. Pure.
+pub(super) fn decide(facts: WinnerFacts) -> Delivery {
+    match facts.abort {
+        // Nothing was ever dispatched: the isolation port was missing or the
+        // tree could not be snapshotted. There is no candidate to adopt.
+        Some(abort) if abort.degradable => Delivery::Withhold,
+        // The pipeline refused this candidate on an integrity finding. The
+        // workspace no longer agrees with anything that was examined, so its
+        // bytes are not a deliverable — see the module doc.
+        Some(abort) if !abort.from_turn && abort.kind == AbortKind::Failure => Delivery::Withhold,
+        // Every other abort — the engine stopping the worker's turn, and a
+        // pipeline-side *deliberate* stop — is a decision about spending, not
+        // a finding about the tree. The work stands; the claim does not.
+        Some(_) => Delivery::Deliver { proven: false },
+        None => Delivery::Deliver {
+            proven: facts.verdict_passed == Some(true),
+        },
+    }
+}
+
+impl WinnerFacts {
+    /// Read the facts off the winning candidate.
+    pub(super) fn of(result: &CandidateResult) -> Self {
+        Self {
+            verdict_passed: result.verdict.as_ref().map(|verdict| verdict.passed),
+            abort: result.aborted.as_ref().map(|abort| AbortFacts {
+                from_turn: abort.from_turn,
+                degradable: result.degradable,
+                kind: abort.kind,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aborted(from_turn: bool, degradable: bool, kind: AbortKind) -> WinnerFacts {
+        WinnerFacts {
+            verdict_passed: None,
+            abort: Some(AbortFacts {
+                from_turn,
+                degradable,
+                kind,
+            }),
+        }
+    }
+
+    #[test]
+    fn a_passing_verdict_delivers_proven_work() {
+        assert_eq!(
+            decide(WinnerFacts {
+                verdict_passed: Some(true),
+                abort: None,
+            }),
+            Delivery::Deliver { proven: true }
+        );
+    }
+
+    #[test]
+    fn a_failed_verdict_still_delivers_the_work_it_judged() {
+        assert_eq!(
+            decide(WinnerFacts {
+                verdict_passed: Some(false),
+                abort: None,
+            }),
+            Delivery::Deliver { proven: false },
+            "a red verdict is a claim about the work, not a licence to destroy it"
+        );
+    }
+
+    #[test]
+    fn a_candidate_that_never_reached_a_verdict_still_delivers() {
+        assert_eq!(
+            decide(WinnerFacts::default()),
+            Delivery::Deliver { proven: false }
+        );
+    }
+
+    #[test]
+    fn a_turn_abort_delivers_what_the_worker_had_already_written() {
+        for kind in [AbortKind::DeliberateStop, AbortKind::Failure] {
+            assert_eq!(
+                decide(aborted(true, false, kind)),
+                Delivery::Deliver { proven: false },
+                "the engine stops between tool calls; {kind:?} says nothing about the bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn a_pipeline_integrity_refusal_withholds_the_work() {
+        assert_eq!(
+            decide(aborted(false, false, AbortKind::Failure)),
+            Delivery::Withhold,
+            "an escaped, tampered or drifted workspace is not the tree anything examined"
+        );
+    }
+
+    #[test]
+    fn a_pipeline_side_deliberate_stop_is_not_an_integrity_finding() {
+        assert_eq!(
+            decide(aborted(false, false, AbortKind::DeliberateStop)),
+            Delivery::Deliver { proven: false }
+        );
+    }
+
+    #[test]
+    fn a_setup_failure_has_nothing_to_deliver() {
+        assert_eq!(
+            decide(aborted(false, true, AbortKind::Failure)),
+            Delivery::Withhold
+        );
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/tests.rs
+++ b/crates/stella-pipeline/src/pipeline/tests.rs
@@ -2165,6 +2165,9 @@ mod airlock;
 mod best_of_n;
 mod chaos;
 mod degradation_gate;
+/// Winner-delivery witnesses (#2927) — a child module so it reaches the
+/// scripted ports above via `super::*`.
+mod delivery;
 /// Golden-trajectory recordings of this pipeline's real event stream — a
 /// child module so it reaches the scripted ports above via `super::*`.
 mod golden;

--- a/crates/stella-pipeline/src/pipeline/tests/delivery.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/delivery.rs
@@ -1,0 +1,146 @@
+//! Delivery witnesses (#2927): the verdict is a claim about the work, so a
+//! run that does not reach a passing one still delivers what the worker built.
+//!
+//! The mirror-image contract — an *integrity* refusal still withholds — is
+//! pinned next door in `witness_isolation` (escaped candidate, tampered
+//! witness artifact, post-verification drift), and the rung-by-rung argument
+//! for the split is in `super::super::delivery`'s module doc.
+
+use super::*;
+
+/// A modified file for the winner's adoption to report, so the test can assert
+/// the bytes reached the stream rather than only that `adopt` was called.
+fn delivered_change() -> AdoptedChange {
+    AdoptedChange {
+        path: "src/solution.rs".into(),
+        kind: FileChangeKind::Modified,
+        added: 12,
+        removed: 3,
+        diff: Some("@@ -1 +1 @@\n-old\n+new\n".into()),
+    }
+}
+
+/// **The witness for #2927.** Both candidates end red, so the run's verdict is
+/// `passed: false` and its status is `VerificationFailed` — and the winner's
+/// work is delivered into the working tree anyway.
+///
+/// On `main` this asserted the opposite (`..._never_adopts_and_removes_all_
+/// candidates`, renamed and inverted here): adoption required
+/// `verdict.passed`, so a red verdict deleted the candidate workspace with the
+/// work still in it. Measured over ArenaBench `w10p`, that gate accounted for
+/// eight of fifteen pipeline losses, including a trial whose final event was
+/// `18 passed in 1.44s`.
+#[tokio::test]
+async fn failed_final_verification_still_delivers_the_winners_work() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("candidate zero"),
+        text_result("candidate one"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = FakeWorkspacePort::new(
+        vec![
+            Ok(FakeWorkspace::new(
+                0,
+                vec![false, false],
+                Ok(vec![delivered_change()]),
+                log.clone(),
+            )),
+            Ok(FakeWorkspace::new(
+                1,
+                vec![false, false],
+                Ok(vec![]),
+                log.clone(),
+            )),
+        ],
+        log.clone(),
+    );
+
+    let (outcome, events, _) =
+        run_isolated(&provider, &port, isolated_config(2), "Fix the failing test").await;
+    let outcome = outcome.expect("red verification is a terminal outcome");
+    // Honesty first: delivering the work changes nothing about the claim.
+    assert!(
+        matches!(outcome.status, PipelineStatus::VerificationFailed { .. }),
+        "a delivered run must still report the rung it came to rest on: {:?}",
+        outcome.status
+    );
+    assert!(
+        !outcome
+            .verdict
+            .expect("the ladder reached a verdict")
+            .passed,
+        "delivery must never flip the verdict to a pass"
+    );
+
+    let log = log.lock().unwrap().clone();
+    assert_eq!(
+        log.iter()
+            .filter(|entry| entry.starts_with("adopt"))
+            .collect::<Vec<_>>(),
+        vec!["adopt:0"],
+        "the winner's work is delivered and the loser's is not: {log:?}"
+    );
+    assert!(
+        log.contains(&"remove:0".to_string()) && log.contains(&"remove:1".to_string()),
+        "every workspace is still cleaned up: {log:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::FileChange { path, added: 12, removed: 3, .. }
+                if path == "src/solution.rs"
+        )),
+        "the delivered bytes reach the stream as FileChange: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { message, retryable: true } if message.contains("UNPROVEN")
+        )),
+        "an unproven delivery says so on the rail: {events:?}"
+    );
+}
+
+/// The rail line is a warning, not a failure, and it is absent when the run
+/// genuinely proved itself — a passing delivery must not be narrated as
+/// unproven.
+#[tokio::test]
+async fn a_proven_delivery_carries_no_unproven_notice() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("single"),
+        text_result("candidate zero"),
+        text_result("candidate one"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = FakeWorkspacePort::new(
+        vec![
+            Ok(FakeWorkspace::new(
+                0,
+                vec![false, false],
+                Ok(vec![]),
+                log.clone(),
+            )),
+            // Fail → pass: a genuine flip, so this candidate wins on proof.
+            Ok(FakeWorkspace::new(
+                1,
+                vec![false, true],
+                Ok(vec![delivered_change()]),
+                log.clone(),
+            )),
+        ],
+        log.clone(),
+    );
+
+    let (outcome, events, _) =
+        run_isolated(&provider, &port, isolated_config(2), "Fix the failing test").await;
+    let outcome = outcome.expect("run succeeds");
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { message, .. } if message.contains("UNPROVEN")
+        )),
+        "a proven run must not be narrated as unproven: {events:?}"
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/tests/witness_isolation.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/witness_isolation.rs
@@ -783,47 +783,11 @@ async fn post_baseline_witness_tamper_is_hard_failure_even_if_verifier_would_pas
     assert!(log.contains(&"remove:0".to_string()));
 }
 
-#[tokio::test]
-async fn failed_final_verification_never_adopts_and_removes_all_candidates() {
-    let provider = ScriptedProvider::new(vec![
-        text_result("single"),
-        text_result("candidate zero"),
-        text_result("candidate one"),
-    ]);
-    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let port = FakeWorkspacePort::new(
-        vec![
-            Ok(FakeWorkspace::new(
-                0,
-                vec![false, false],
-                Ok(vec![]),
-                log.clone(),
-            )),
-            Ok(FakeWorkspace::new(
-                1,
-                vec![false, false],
-                Ok(vec![]),
-                log.clone(),
-            )),
-        ],
-        log.clone(),
-    );
-
-    let (outcome, _, _) =
-        run_isolated(&provider, &port, isolated_config(2), "Fix the failing test").await;
-    let outcome = outcome.expect("red verification is a terminal outcome");
-    assert!(matches!(
-        outcome.status,
-        PipelineStatus::VerificationFailed { .. }
-    ));
-    let log = log.lock().unwrap().clone();
-    assert!(
-        !log.iter().any(|entry| entry.starts_with("adopt:")),
-        "{log:?}"
-    );
-    assert!(log.contains(&"remove:0".to_string()));
-    assert!(log.contains(&"remove:1".to_string()));
-}
+// `failed_final_verification_never_adopts_and_removes_all_candidates` lived
+// here until #2927. Its contract was the defect: a red verdict deleted the
+// candidate with the work still in it. It is renamed, inverted and moved to
+// `tests/delivery.rs` as `failed_final_verification_still_delivers_the_
+// winners_work`, beside the rest of the delivery contract.
 
 #[tokio::test]
 async fn post_verification_candidate_drift_is_rejected_before_adoption() {

--- a/docs/spec/enterprise-authority-telemetry.md
+++ b/docs/spec/enterprise-authority-telemetry.md
@@ -102,7 +102,12 @@ replacement for ambient bearer credentials.
 Witness preparation uses the existing candidate-workspace abstraction. When
 authored witnesses are enabled, even a single candidate runs in a disposable
 snapshot. The witness author, baseline test, worker, revision, and final test
-all observe that snapshot. Only a passing candidate can be adopted.
+all observe that snapshot. A candidate the pipeline refuses on integrity — one
+that wrote through its isolation, whose witness artifact was mutated after its
+baseline was pinned, or whose tree moved after verification — is never adopted.
+A candidate that merely failed to prove itself is adopted and reported as
+unproven: the verdict is a claim about the work, not what decides the work
+exists (#2927).
 
 Test execution uses a typed invocation containing a program and argument
 vector. Shell operators, redirection, interpolation, and pipelines are not a


### PR DESCRIPTION
## What & why

Adoption of the candidate workspace was **winner-only**: it required
`verdict.passed`, so a run ending on a failed or absent verdict had its entire
candidate deleted with the work still in it. That makes the verdict
self-fulfilling — nothing reaches the tree, so nothing there can ever be judged
correct.

Measured over the twenty pipeline trials of ArenaBench `w10p` (SUT
`main@554bb4f`), counting `file_change` events after the `verdict` event:

```
verdict_passed=True   -> post-verdict writes: 1, 1, 5, 6, 7, 9, 17, 35, 35, 2393
verdict_passed=False  -> post-verdict writes: 0, 0, 0, 0
```

Eight of fifteen pipeline losses never had their work delivered, including
`build-cython-ext__4xjNAy9`, whose last event four seconds before the
wall-clock kill reads `18 passed in 1.44s`.

This is #2881's rule applied one layer up, at the delivery gate itself: **a
post-completion check may downgrade a CLAIM, never discard a DELIVERABLE.**

Closes #2927
Refs #2651 (the turn-budget instance of the same shape — its discard half is
fixed here; the wall-clock and cost halves are not)

## The argument, rung by rung

The decisive reason is not the bench number. It is that **isolation is a
mechanism, not a quality gate.** A candidate workspace exists so losers can be
rolled back and so a witness author cannot reach the user's tree. With
isolation *off*, a run that fails verification still leaves its edits in the
working tree to read, keep or `git checkout`. Turning isolation *on* must not
make the same run strictly worse off — and `pipeline.rs` had already reached
exactly that conclusion for one caller (the `create_worktrees` single-shot path
keeps its unadopted snapshot and says where it is). This generalises it.

Per `LadderDecision`:

| Rung | Decision | Why |
|---|---|---|
| `SubmitFast` | deliver | unchanged |
| `Unverifiable`, `Unverified`, `WitnessUnsatisfiable` | deliver | already delivered — these publish `passed: true` because a run is not failed by the absence of a way to check it. Named so the set is total; the claim they carry stays unproven. |
| `NothingAttempted` | deliver | the rung's own premise is that no channel saw anything change, so the patch is empty and adoption is a no-op. An exception here is a branch that can only ever be wrong. |
| `Revise` (terminal, `passed: false`) | **deliver — the real change** | a red touched test is a deterministic fact about *one instrument*, not a finding that the whole candidate is worthless, and a *terminal* `Revise` means the repair budget ran out mid-repair, so the candidate is the best state the run reached. The alternative delivers zero bytes with certainty. |
| no verdict, worker's engine turn aborted (budget, stuck loop, step cap, user stop) | deliver | #2651's shape. The engine stops *between* tool calls (invariant #6): the stop is a decision about spending and says nothing about the bytes already written. |

### Broken delivery vs. no delivery — what I concluded

The question the issue asks explicitly. Delivering something actively broken
*can* be worse than delivering nothing, and the case where it is worse is real:
a change that made a previously-green tree red. But the tree we would be
"protecting" is not a pristine correct state — it is the task not attempted —
and the alternative outcome is not "no harm", it is "the operator has the work
only in a `/tmp` worktree we are about to delete". A user's tree is under git,
the delivered files arrive as `FileChange` rows, and the verdict beside them
still says the run failed. So the recoverable-bad outcome beats the
unrecoverable-good one, and the bench asymmetry (shipping wrong work scores the
same 0 as shipping nothing; withholding right work costs a solve) points the
same way. This is the maintainer's call #2927 asked to be made out loud: **it
is made, and it is "deliver".**

### What is still withheld — a different question

An **integrity** refusal is not a claim about quality; it is a statement that
the bytes in the workspace are not the bytes any stage examined. Delivering
those ships something nothing ever looked at. Unchanged, and pinned by the
existing tests in `tests/witness_isolation.rs`:

- a candidate that wrote through its isolation (#1538),
- a witness artifact mutated after its baseline was pinned,
- a worktree that changed after verification,
- a seal that could not be taken,
- a mutation audit that could not restore the tree.

A degradable **setup** abort withholds too — it never ran a model call, so
there is nothing to deliver. The discriminator is that every integrity refusal
is raised by the pipeline, never by the worker's engine, which is what
`AbortFacts::from_turn` carries; a pipeline-side *deliberate* stop is a
spending decision and delivers.

### Delivery never implies proof

The verdict, the `PipelineStatus` and the candidate score are untouched: a
delivered `Revise` still reports `VerificationFailed`, a delivered abstention
still reports `Unverified`. `Delivery::Deliver { proven }` exists only so the
caller can state on the rail that what it just wrote is UNPROVEN, which
`a_proven_delivery_carries_no_unproven_notice` pins from the other side.

## Where the code lives

`crates/stella-pipeline/src/pipeline.rs` is a god file closed to growth
(#2920), so the new logic is a sibling submodule
`crates/stella-pipeline/src/pipeline/delivery.rs`: a pure `decide(WinnerFacts)
-> Delivery` over owned plain data, with the rung-by-rung argument as its
module doc and seven unit tests. `pipeline.rs` gains eleven lines, of which
five are code. Exemplar for the shape: the sibling `candidate_result` and
`stage_budget` modules already split out of the same file for the same reason.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`pipeline::tests::delivery::failed_final_verification_still_delivers_the_winners_work`
in `crates/stella-pipeline/src/pipeline/tests/delivery.rs` — two candidates end
red, the run reports `VerificationFailed` with `passed: false`, and the
winner's work is still adopted and reaches the stream as `FileChange`.

Demonstrated the artisanal way (`git stash push -- crates/stella-pipeline/src/pipeline.rs`,
i.e. the source reverted to `main` with the tests kept):

```
test pipeline::tests::delivery::failed_final_verification_still_delivers_the_winners_work ... FAILED
assertion `left == right` failed: the winner's work is delivered and the loser's is not:
  ["create", "create", "seal:0", "seal:1", "remove:0", "remove:1"]
test result: FAILED. 1 passed; 1 failed
```

and with the change restored, `stella-pipeline` is 723 passed / 0 failed.

## Test renamed (`check-deleted-tests`)

`witness_isolation::failed_final_verification_never_adopts_and_removes_all_candidates`
**no longer exists**. Its contract *was* the defect. It is renamed, inverted and
moved to `tests/delivery.rs` as
`failed_final_verification_still_delivers_the_winners_work`, and a comment at
its old site says so. No other test was deleted.

## The gate

- [x] `make gate` — full run, exit 0, redirected to a file and read (not piped
      through `tail`). Includes fmt, clippy `-D warnings`, rustdoc, the whole
      workspace test suite, and the self-driving harness.

## Nothing left behind

- [x] Filed: #2941 (a killed run still never delivers — adoption runs once, at
      the end, so a wall-clock kill discards the candidate; the six no-verdict
      trials in #2927's census are this), #2942 (delivery emits no event of its
      own — the only evidence it ran is an inferred `file_change` burst,
      invariant #10).

Deliberately **not** in scope, and separately tracked: #2206 and #2928
(candidate-root prefix duplication — several trials adopted and still scored 0
for path reasons), #2877, #2935.

## Anything reviewers should know?

The behavioural blast radius is best-of-N and every isolated run: a run whose
winner does not pass now writes to the working tree where it previously did
not. That is the point of the change, but it is a real change in what a failing
`stella run` leaves behind, and it is why the rail line and the untouched
verdict matter as much as the adoption itself.


## Also in this PR

`docs/spec/enterprise-authority-telemetry.md` said "Only a passing candidate can be adopted" in its verification model. That sentence was the old gate stated as a spec line, so it is corrected here rather than left to contradict the code: an integrity refusal is never adopted; a candidate that merely failed to prove itself is adopted and reported as unproven.
