### PR TITLE
fix(bench): relock harbor_adapter — #2937 added the lineage extra without it

### DIFF
--- a/bench/harbor_adapter/uv.lock
+++ b/bench/harbor_adapter/uv.lock
@@ -171,6 +171,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/8f/315e908f5abaab5deb77196117f66c1badc9093b03dc152b0b8231b0112b/boto3-1.43.69.tar.gz", hash = "sha256:76297a0b415849c63575ae08a4f1661b2dc8ee0100f104b86f98aa69b47fa2c7", size = 112666, upload-time = "2026-08-11T19:24:26.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/57/67ebb743ab0556c14db656e91e49024f3e1b0585f1a15c2d025176fb3c1e/boto3-1.43.69-py3-none-any.whl", hash = "sha256:4eb494d05b2bd08a7eee61b8ac4c34745c99e9bbce435c91f8d15d372dd8c2db", size = 140024, upload-time = "2026-08-11T19:24:25.022Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/da/726b23443ebc77078387fbf330ef7240bc6a96553e566e45a647cd8f714c/botocore-1.43.69.tar.gz", hash = "sha256:5caa46b740d9a886137146ffbb69edb691f702bfe74c64e85621947ae00181fd", size = 15911844, upload-time = "2026-08-11T19:24:20.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ef/a1effbe4ffabadc38ea9425c54601262eaac8cbb5b6089f8f76536d3c8b1/botocore-1.43.69-py3-none-any.whl", hash = "sha256:b1f0e01c53d6b84ee9c184ebf3636c3b3aef85e0ae8498c74afb8734ff224f87", size = 15596589, upload-time = "2026-08-11T19:24:18.283Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -916,6 +944,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2012,6 +2049,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2100,15 +2149,19 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+lineage = [
+    { name = "boto3" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'lineage'", specifier = ">=1.34" },
     { name = "harbor", specifier = "==0.6.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "lineage"]
 
 [[package]]
 name = "storage3"


### PR DESCRIPTION
## The problem

`main` is red. Run [31558425630](https://github.com/macanderson/stella/actions/runs/31558425630/job/93995501771) (push to `main` @ `87294b678`) fails in `bench.yml`'s `harbor_adapter — sync (locked) + pytest` step:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

747b1c403 (#2937) added `lineage = ["boto3>=1.34"]` to `bench/harbor_adapter/pyproject.toml`'s `[project.optional-dependencies]` and did not regenerate `bench/harbor_adapter/uv.lock`. uv locks **every** extra whether or not CI installs it, so the committed lock resolves to a different graph than the manifest asks for, and `uv sync --locked` — the drift assertion at `.github/workflows/bench.yml:97` — fails closed. That is the gate working as designed.

Worth noting for anyone who hits this next: this repo has three independent uv projects (`arenabench/`, `bench/harbor_adapter/`, `bench/terminal_bench_analysis/`), each with its own `pyproject.toml` + `uv.lock`. `uv lock` resolves whichever project contains the cwd and never descends into siblings, so relocking from `arenabench/` is a no-op against this failure.

## The change

`uv lock` in `bench/harbor_adapter`, nothing else. Adds `boto3` 1.43.69 and its transitive closure (`botocore`, `jmespath`, `s3transfer`) to the lock. No manifest change; the base dependency set is untouched, so a bench box that never opts into a lineage still does not install an AWS SDK — the property #2937's comment claims is preserved in fact as well as intent.

## Evidence

- `uv lock --check` in `bench/harbor_adapter` → clean (was: `needs to be updated`).
- `uv lock --check` in `bench/terminal_bench_analysis` and `arenabench` → already clean; neither had drifted.
- The exact CI step, run locally: `uv sync --locked --extra dev && uv run --no-sync pytest -q` → sync succeeds, suite reports **671 passed, 2 skipped**.

## Known residue

`tests/test_manifest_parity.py::test_the_bench_workflow_runs_when_a_caller_changes` fails **locally only**, on a gitignored `.stella/context/packs/*.json` that quotes `stella_harbor:StellaAgent` inside a cached search result. The sweep walks the filesystem without consulting gitignore, so it counts an untracked artifact as a caller. CI's clean checkout has no such file and the test passes there — it is not part of this failure and is filed separately rather than papered over here.

## Summary by Sourcery

Relock the bench/harbor_adapter uv project to incorporate the newly added lineage optional dependency and restore the bench CI workflow to a green state.

Build:
- Update bench/harbor_adapter uv.lock to include the boto3-based lineage extra and its transitive dependencies so the lockfile matches the project manifest.

Chores:
- Refresh the harbor_adapter dependency lockfile to resolve CI failures caused by drift between the manifest and the committed lock.