### PR TITLE
refactor(stella-pipeline): give back the god-file lines #2943 spent, and retighten the ratchet

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1787,25 +1787,21 @@ impl<'a> Pipeline<'a> {
         // whole fan-out, not the one result that survives it.
         let ran = executed_count(&candidates);
         self.emit_text(candidate_winner_notice(best_idx, n, ran));
-        // Winner delivery + cleanup. The verdict is a claim ABOUT the work; it
-        // does not decide whether the work exists (#2927). `delivery` states
-        // the whole rule and the argument for it, rung by rung; the one thing
-        // still withheld is a candidate the pipeline refused on integrity.
+        // Winner delivery + cleanup. The verdict is a claim ABOUT the work and
+        // does not decide whether the work exists (#2927); `delivery` holds the
+        // rule, its argument, and the one candidate still withheld. Delivery is
+        // never proof either — verdict, status and score are untouched, so the
+        // notice below is what stops the write reading as a pass.
         let mut adopt_failure: Option<WorkspaceError> = None;
         let delivery = delivery::decide(delivery::WinnerFacts::of(&candidates[best_idx]));
+        if matches!(delivery, delivery::Delivery::Deliver { proven: false }) {
+            self.warn(delivery::UNPROVEN_DELIVERY_NOTICE.to_string());
+        }
         for (i, slot) in workspaces.into_iter().enumerate() {
             let Ok(ws) = slot else {
                 continue;
             };
-            if i == best_idx
-                && let delivery::Delivery::Deliver { proven } = delivery
-            {
-                // Delivery is never proof. The verdict, the status and the
-                // score are untouched above; this line is what stops the write
-                // itself from reading as a pass.
-                if !proven {
-                    self.warn(delivery::UNPROVEN_DELIVERY_NOTICE.to_string());
-                }
+            if i == best_idx && matches!(delivery, delivery::Delivery::Deliver { .. }) {
                 // The witness has already done its whole job by now — it armed
                 // the flip oracle and the flip was observed — so withholding it
                 // cannot change the verdict, only what lands in the tree.
@@ -1840,25 +1836,19 @@ impl<'a> Pipeline<'a> {
                 }
             } else if single_shot_isolation {
                 // The `create_worktrees` run whose work was withheld — since
-                // #2927 that means an integrity refusal (the candidate wrote
-                // through its isolation, its witness was tampered with, its
-                // tree moved after verification) or an allowance it never
-                // got, never merely "it did not verify". Discarding is right
-                // for best-of-N — the operator asked for the best of several
-                // and none was good, and the losers were never meant to
-                // survive — and `witness_isolation`'s tests pin removal for a
-                // poisoned authored-witness candidate.
+                // #2927 an integrity refusal or an allowance it never got,
+                // never merely "it did not verify". Discarding is right for
+                // best-of-N (the losers were never meant to survive) and
+                // `witness_isolation` pins removal for a poisoned candidate.
                 //
                 // It is wrong for this third caller. That operator asked where
                 // the work should *happen*, not that it be thrown away — and
                 // without this they end up strictly worse off than with
                 // isolation off, where a failed run at least leaves its
                 // changes in the tree to look at. So keep the snapshot and
-                // name it: the same posture as the adopt-failure arm just
-                // above, and for the same reason — undelivered is not
-                // worthless. The reason is deliberately unnamed here because
-                // this arm has several, and each has already been stated on
-                // the stream by the stage that raised it.
+                // name it, for the reason the adopt-failure arm above does:
+                // undelivered is not worthless. Which reason is left unsaid —
+                // this arm has several, each already on the stream.
                 self.warn(format!(
                     "this run's changes were not adopted into your working tree — they are \
                      kept at {} for you to inspect or salvage",

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -24,7 +24,7 @@
 1781 crates/stella-model/src/anthropic/tests.rs
 2094 crates/stella-model/src/openai.rs
 1862 crates/stella-model/src/zai/tests.rs
-2951 crates/stella-pipeline/src/pipeline.rs
+2941 crates/stella-pipeline/src/pipeline.rs
 2394 crates/stella-pipeline/src/pipeline/tests.rs
 1750 crates/stella-store/src/lib.rs
 2266 crates/stella-store/src/tests.rs


### PR DESCRIPTION
## What & why

#2943 (the #2927 delivery fix) grew `crates/stella-pipeline/src/pipeline.rs`
by eleven lines at the same moment #2926 was splitting lines out of it. The two
composed into the shared-cell collision the ratchet exists to catch — the
`file size ratchet` check went red on #2943's head
([job 93994805206](https://github.com/macanderson/stella/actions/runs/31558195220/job/93994805206),
"crates/stella-pipeline/src/pipeline.rs grew to 2951 lines, over its baseline
ceiling of 2940") — and the merge absorbed it by regenerating the baseline at
2951. Raising a ceiling to turn a gate green is the expedient CLAUDE.md names,
and #2920 already asks specifically that this file not get worse. This gives
the lines back.

Refs #2927
Refs #2920

## What moved

No behaviour changes; the delivery decision is untouched and every delivery
test still passes unchanged.

- The rung-by-rung prose in `pipeline.rs` is condensed to a pointer at
  `pipeline/delivery.rs`, where the full argument already lives.
- The UNPROVEN notice moves **out of the per-workspace loop** to sit beside the
  decision it reports. It reads better as well as shorter: one decision, one
  emit, rather than an emit nested in a loop that can only ever match the
  winner. The `Deliver`/`Withhold` test inside the loop becomes a `matches!`.

`pipeline.rs` is now **2941** lines — one over what #2926 left it at. That one
line is `mod delivery;`, the module declaration AGENTS.md names as the
legitimate irreducible case; the only way to not spend it is to not have the
module, which would put the logic back in the god file.

## The baseline edit

`scripts/file-size-baseline.txt` is retightened for this one file, 2951 → 2941,
**by hand rather than by `make file-size-update`** — a full regeneration
retightens every other file to its current size at once, which is the
parallel-merge skew that has reddened `main` before. Down-only, one line, one
file.

## The witness

- [ ] Witness test needed — this is a pure refactor plus a ratchet tightening.
      The guard itself is the proof in both directions: `make file-size` fails
      on this branch if the baseline says 2940, and would fail on `main` today
      if `main` claimed 2941. `cargo test -p stella-pipeline` is 723 passed / 0
      failed, including every `#2927` delivery test, unchanged.

## The gate

- [x] `make gate` — full local run, every step green through the final
      `self-driving-test: OK`; `check-file-size: OK ... nothing went over by
      this change`.

## Nothing left behind

- [x] Nothing new. The two issues #2943 left open are #2941 (a killed run still
      never delivers) and #2942 (delivery emits no event of its own).

## Summary by Sourcery

Refactor pipeline delivery handling and tighten the file-size ratchet baseline for stella-pipeline.

Enhancements:
- Simplify winner delivery commentary and centralize the UNPROVEN delivery notice alongside the delivery decision instead of inside the workspace loop.
- Clarify delivery and isolation comments in the pipeline to better describe integrity refusals and non-adopted runs.

Build:
- Reduce the allowed line count for crates/stella-pipeline/src/pipeline.rs in scripts/file-size-baseline.txt to restore the stricter file-size gate.