### PR TITLE
docs: fix stale palette/data-mark citations after the bronze rebrand (#2923, #2924)

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -226,7 +226,7 @@ symlink *inside* the workspace pointing out of it is still followed — a narrow
 guarantee than the producer's canonicalising one, and the reason to keep the
 manifest a list of paths rather than anything more expressive.
 
-### The palette is a mirror, and one token in it is deliberately unused
+### The palette is a mirror, and one data-mark step is deliberately unused
 
 The `:root` block at the top of `index.html` mirrors the comet brand kit
 (v1.0) — Bronze Gold `#C58A32` on Ink `#0B0B0C` over warm neutrals, set in
@@ -236,22 +236,24 @@ source (`css/tokens.css` holds the values); the same tokens live in
 carries the whole core set even where this page uses only part of it. Do not
 prune it to the tokens currently referenced.
 
-One token is applied nowhere on purpose. `#E3B341`, the first categorical data
-mark, may not share a chart with the gold `#C58A32`: the two are hue 42° and
-hue 36° and measure 1.53:1 against each other — nothing but size tells them
-apart. Gold is the signal — the accent, the focus ring, the comet in the
-masthead — and never a data series, so `--c1` stands down: every chart on this
-page pairs `--c4` (hue 175) with `--c2` (hue 256), 81° apart at 1.99:1, and
-both clear the gold accent. Two further collisions the pairing avoids, both
-measured on `--surface`: `--c3` against `--bad` is Δhue 18 at 1.30:1, so
-magenta never appears in the tool-error chart, and `--c2` against the neutral
-mark is Δhue 148 at 1.08:1, so violet never appears in the stacked runs chart.
+The categorical data marks (`--c1`…`--c4`, plus the `--neutral-mark` tail) are
+a value ramp, not a hue wheel: `#EDEDED`, `#A1A1A1`, `#6E6E6E`, `#4A4A4A`,
+ordered light → dark so `--c1` reads as the most prominent series. Series are
+separated by lightness alone — the one channel that survives greyscale
+printing, colour-vision deficiency, and a projector — so there is no hue for
+any pairing of them to collide on, with each other or with `--identity`
+gold. Most charts pair `--c1` with `--c2` (input/output, resolved/calls); the
+code graph is capped at three crate colours (`--c1`…`--c3`) plus the neutral
+tail, skipping `--c4` because a fourth step reads as noise at a glance. Gold
+never enters this ramp at all — `--identity` is applied to exactly the
+wordmark, the favicon mark, and the footer's brand initial (`footer b`), never
+to a data series — so the old worry about a data mark reading as identity by
+hue doesn't apply here; there is nothing left for it to be confused with.
 
-The same constraint caps the code graph at three crate colours plus a neutral
-tail. That is fewer than the eight it wants; the previous eight were invented
-rather than drawn from the kit, and two of them read as "active" while
-`#008300` measured 2.4:1 on this surface. Widening the ramp needs new
-validated values in the brand kit, not new hexes here.
+Three crate colours is fewer than the eight the code graph wants; the
+previous eight were invented rather than drawn from the kit, and two of them
+read as "active" while `#008300` measured 2.4:1 on this surface. Widening the
+ramp needs new validated values in the brand kit, not new hexes here.
 
 Gold carries no status anywhere. Status is `--ok` / `--warn` / `--bad`, always
 paired with a glyph (`✓`, `◌`, `✕`), so hue is never the only carrier — which

--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -67,7 +67,14 @@ pub const HAIRLINE_STRONG: Color = Color::Rgb(0x33, 0x33, 0x38);
 // 1.83:1 and illegible.
 
 /// Phosphor Gold `#FFB81A` -- CRT amber, the gold star. 11.36:1 on ground.
-/// The kit's `#FFB000` lifted 10% in lightness; it may not drift.
+/// Held at this value across the 2026-08-11 bronze rebrand (`10781aa`), which
+/// moved `docs/brand/css/tokens.css`'s `--stella-gold` to `#C58A32` -- this
+/// constant does **not** track that hex. The TUI palette is deliberately not
+/// the web instrument palette (see the module doc): it needs a brighter,
+/// more saturated stop than paper or a browser does to read as CRT amber on
+/// ink at 11.36:1, so it is held apart rather than re-derived from the kit's
+/// current gold ramp. Whether the two golds should mean the same thing is
+/// #2592, still open; this value does not wait on it.
 pub const BRAND: Color = Color::Rgb(0xFF, 0xB8, 0x1A);
 
 /// The bright stop of the brand sweep (kit `gold-400`, the observatory's
@@ -87,14 +94,17 @@ pub const BRAND_DEEP: Color = Color::Rgb(0xE5, 0xA0, 0x00);
 // clears AA on [`PAPER`]. Applied by the per-frame theme remap in
 // [`crate::theme`], truecolor only.
 
-/// The light-theme brand hue (kit `gold-800` lifted 10% with the brand) --
-/// 5.22:1 on [`PAPER`].
+/// The light-theme brand hue -- 5.22:1 on [`PAPER`], held apart from the
+/// current web kit's gold ramp for the same reason as [`BRAND`] (see its
+/// doc): the two golds are not required to track hex-for-hex until #2592
+/// settles what they should mean to each other.
 ///
-/// Deliberately one step *below* the kit's `gold-deep` `#A37200`: that tone
-/// is the web kit's light-ground gold for UI-sized text and measures 3.79:1
-/// on the painted paper ground -- fine for chrome, under the 4.5:1 floor for
-/// terminal-cell text. `gold-deep` stays in the family as [`GOLD_INK`], the
-/// light theme's *chrome* gold.
+/// Deliberately one step *below* [`GOLD_INK`], a value this crate held onto
+/// from before the 2026-08-11 bronze rebrand -- it no longer matches
+/// `docs/brand/css/tokens.css`'s current `gold-deep`, `#8B5E1A`. [`GOLD_INK`]
+/// measures 3.79:1 on the painted paper ground -- fine for chrome, under the
+/// 4.5:1 floor for terminal-cell text. It stays in the family as
+/// [`GOLD_INK`], the light theme's *chrome* gold.
 pub const BRAND_INK: Color = Color::Rgb(0x85, 0x5E, 0x00);
 
 /// Pressed stop / leading progress stop on paper (kit `gold-900` lifted 10%,


### PR DESCRIPTION
## What & why

Two independent doc-drift fixes, bundled because both are small and both
surfaced from the same 2026-08-11 bronze rebrand aftermath:

1. `crates/stella-tui/src/palette.rs`'s `BRAND`/`BRAND_INK` doc comments cited
   the pre-rebrand kit hexes (`#FFB000`, `gold-deep` `#A37200`) as their
   derivation. The rebrand (`10781aa`) moved the kit's gold to `#C58A32` and
   `gold-deep` to `#8B5E1A`, so both citations — and the "lifted 10%" math
   built on them — no longer held. Per #2923's constraints, the TUI's own
   values are left unchanged (it needs a brighter stop than the kit for
   terminal legibility on ink, and #2592 — gold's dual meaning between
   "running" in the TUI and "identity only" on the web — is still open and
   shouldn't be pre-empted by quietly repointing the TUI ramp). Comment-only
   fix: the doc comments now say plainly these are held-apart values, not
   derived from the current kit hex, and name #2592 as the open question.

2. `crates/stella-observatory/README.md`'s "palette is a mirror" section
   described a hue-based categorical data-mark ramp (`#E3B341`, hue 175 vs
   hue 256, Δhue collision math) the page no longer ships. The `:root` block
   in `src/assets/index.html` has been achromatic since the Instrument
   recolour: `--c1:#EDEDED` through `--c4:#4A4A4A`, "a value ramp, not a hue
   wheel", separated by lightness alone. Rewrote the section from the live
   values and the file's own "Crate colours come from the palette's
   categorical ramp" comment: most charts pair `--c1` with `--c2`, the code
   graph is capped at three crate colours plus a neutral tail (skipping
   `--c4`), and gold never enters the data-mark ramp at all (`--identity` is
   applied only to the wordmark, favicon, and footer initial).

Closes #2923
Closes #2924

## The witness

- [x] No witness needed (pure docs) — doc comments / README only, no behavior
      change.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui` (9/9 palette-relevant tests pass)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps`
- [x] `cargo test -p stella-cli --test design_token_parity` (8/8 pass)
- [x] `make doc-links`
- [x] Docs updated (this is the doc fix)
- [x] `Closes #N` appears both above and as commit trailers

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR. The other
      `kit gold-NNN` comments in `palette.rs` don't cite a specific stale hex
      and are out of #2923's scope.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types changed

## Anything reviewers should know?

Verified both issues' `rg` checks:
- `rg -n "FFB000|A37200" crates/` finds nothing.
- `rg -n "E3B341|hue " crates/stella-observatory/README.md` no longer cites
  the retired hex; every remaining hue/value in that section is reproducible
  from `rg -n "c1:|c2:|c3:|c4:" crates/stella-observatory/src/assets/index.html`.

## Summary by Sourcery

Clarify documentation around palette and data-mark usage following the bronze rebrand, keeping terminal and web palettes explicitly decoupled while aligning docs with the current brand kit.

Documentation:
- Update stella-observatory README to describe the current achromatic categorical data-mark ramp and its relationship to identity gold and crate colours.
- Revise stella-tui palette doc comments to note that BRAND and BRAND_INK are held apart from the web brand kit’s updated gold values and reference the open design question about gold semantics (#2592).