### PR TITLE
fix(bench): persist a repo-local git identity for the task workspace baseline

### DIFF
--- a/bench/harbor_adapter/stella_harbor/git_baseline.py
+++ b/bench/harbor_adapter/stella_harbor/git_baseline.py
@@ -94,10 +94,14 @@ def git_baseline_script(workdir: str | None) -> str:
       have advanced (#2067). ``state=preexisting`` deliberately writes no
       ref: a task-owned repository is left alone.
 
-    The committer identity rides per-invocation ``-c`` flags, so no config
-    file the task or the agent could observe is written, and the commit is
-    made unsigned and without hooks: a task-supplied hook or a signing config
-    must not be able to decide whether the baseline exists.
+    The identity is written with a repo-local (never ``--global``)
+    ``git config`` before the baseline commit, not just carried on that one
+    commit's ``-c`` flags: the agent's own commits later in the trial invoke
+    plain ``git commit`` with no ``-c``, and a workspace with no persisted
+    identity fails those with "unable to auto-detect email address" — the
+    agent discovering, mid-task, that the repository it was handed cannot
+    commit (#2865). ``git config`` writes no signing or hook settings, so a
+    task-supplied hook still cannot decide whether the baseline exists.
     """
     prologue = ""
     if workdir:
@@ -106,10 +110,6 @@ def git_baseline_script(workdir: str | None) -> str:
             f"echo '{GIT_BASELINE_MARKER} state=error detail=workdir-unavailable'; "
             "exit 0; }; "
         )
-    ident = (
-        f"-c user.name={shlex.quote(GIT_BASELINE_IDENT)} "
-        f"-c user.email={shlex.quote(GIT_BASELINE_EMAIL)}"
-    )
     return (
         f"{prologue}"
         "if ! command -v git >/dev/null 2>&1; then "
@@ -124,8 +124,10 @@ def git_baseline_script(workdir: str | None) -> str:
         "elif git init -q >/dev/null 2>&1 "
         "&& mkdir -p .git/info "
         "&& printf '%s\\n' '.stella/' >> .git/info/exclude "
+        f"&& git config user.name {shlex.quote(GIT_BASELINE_IDENT)} "
+        f"&& git config user.email {shlex.quote(GIT_BASELINE_EMAIL)} "
         "&& git add -A >/dev/null 2>&1 "
-        f"&& git {ident} commit -q --allow-empty --no-verify --no-gpg-sign "
+        "&& git commit -q --allow-empty --no-verify --no-gpg-sign "
         f"-m {shlex.quote(GIT_BASELINE_COMMIT_MESSAGE)} >/dev/null 2>&1 "
         f"&& git update-ref {GIT_BASELINE_REF} HEAD >/dev/null 2>&1; then "
         f'echo "{GIT_BASELINE_MARKER} state=created '

--- a/bench/harbor_adapter/tests/test_git_baseline.py
+++ b/bench/harbor_adapter/tests/test_git_baseline.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -91,8 +92,12 @@ class TestScriptText:
         assert "--allow-empty" in script
         assert "--no-verify" in script
         assert "--no-gpg-sign" in script
-        assert "-c user.email=stella-harbor@bench.invalid" in script
-        assert "git config" not in script
+        # Persisted repo-local (never --global) so the agent's own later
+        # `git commit` — invoked with no `-c` flags — has an identity to
+        # find (#2865), not just the one baseline commit made here.
+        assert "git config user.name stella-harbor" in script
+        assert "git config user.email stella-harbor@bench.invalid" in script
+        assert "--global" not in script
         # Stella's own state stays out of the baseline and every later diff.
         assert ".git/info/exclude" in script
         assert ".stella/" in script
@@ -156,6 +161,33 @@ class TestScriptBehavior:
         (stella_dir / "store.db").write_bytes(b"db")
         assert _git(tmp_path, "status", "--short").stdout == ""
         assert not (tmp_path / ".gitignore").exists()
+
+        # #2865: the identity must be discoverable by a plain `git commit`
+        # with no `-c` flags — the shape of every commit the agent itself
+        # runs later in the trial — and with no ambient identity to fall
+        # back on (no ~/.gitconfig, no GIT_*_EMAIL). Isolate HOME so this
+        # assertion can only pass via the repo-local config the fix writes.
+        assert _git(tmp_path, "config", "--local", "user.name").stdout.strip() == (
+            "stella-harbor"
+        )
+        assert _git(tmp_path, "config", "--local", "user.email").stdout.strip() == (
+            "stella-harbor@bench.invalid"
+        )
+        isolated_home = tmp_path.parent / f"{tmp_path.name}-empty-home"
+        isolated_home.mkdir()
+        (tmp_path / "agent-file.txt").write_text("agent wrote this\n")
+        _git(tmp_path, "add", "agent-file.txt")
+        agent_commit = subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-q", "-m", "agent commit"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": str(isolated_home),
+            },
+        )
+        assert agent_commit.returncode == 0, agent_commit.stderr
 
     def test_an_existing_repository_is_left_untouched(self, tmp_path: Path) -> None:
         _git(tmp_path, "init", "-q")


### PR DESCRIPTION
## Summary

- Task workspaces reached the agent with no git identity: the baseline commit's `user.name`/`user.email` rode `-c` flags scoped to that one invocation, so no config file was ever written into the workspace.
- The agent's own `git commit` calls later in a trial carry no `-c` flags, so they failed with `fatal: unable to auto-detect email address` — a workaround the agent had to burn steps discovering mid-task instead of working on the actual task (observed on `kv-store-grpc__RpPZcUD` step 44).
- `git config user.name`/`user.email` now run repo-local (never `--global`) right after `git init`, before the baseline commit, so the identity is persisted for every commit made afterward — the adapter's own baseline commit and the agent's.
- Scope: only the `state=created` (bare-directory) path. `state=preexisting` — a task-owned repository — is untouched, per the existing "left alone" invariant and its tests.

## Witness

`test_bare_directory_gets_one_synthetic_baseline_commit` in `bench/harbor_adapter/tests/test_git_baseline.py` now asserts the repo-local config exists and that a plain `git commit` (no `-c` flags, `HOME` pointed at an empty directory so no ambient identity leaks in) succeeds against the created workspace. Verified the artisanal way: stashed the source fix, confirmed this assertion and the script-text assertion both fail on old code with the exact symptom in the issue, then restored the fix and confirmed green.

## Test plan

- [x] `python3 -m pytest bench/harbor_adapter/tests/test_git_baseline.py -q` — 14 passed
- [x] `python3 -m pytest bench/harbor_adapter -q` — 672 passed, 2 skipped (pre-existing, unrelated)
- [x] `ruff check` on the two changed files — clean (one pre-existing unrelated warning elsewhere in the file, not introduced by this change)
- [x] Witness check: fix stashed → new assertions fail with the issue's exact symptom; fix restored → green

Closes #2865
Refs #2668

## Summary by Sourcery

Persist a repo-local git identity for newly created task workspaces so both the baseline commit and later agent commits can succeed without per-invocation git -c flags.

Bug Fixes:
- Ensure plain git commit invocations in created task workspaces succeed by providing a repo-local user.name and user.email instead of relying on transient -c configuration flags.

Enhancements:
- Update the git baseline script to configure a local committer identity immediately after git init while keeping hooks and signing behavior unchanged.

Tests:
- Extend git baseline tests to assert the repo-local identity is present and that an agent-style commit without ambient git configuration succeeds in a created workspace.