### PR TITLE
fix(bench): read both task layouts, so the deadline is armed instead of silently skipped

### DIFF
--- a/bench/harbor_adapter/stella_harbor/turn_budget.py
+++ b/bench/harbor_adapter/stella_harbor/turn_budget.py
@@ -61,6 +61,30 @@ a version of Harbor. It **fails open**, always: any missing, unreadable, or
 mis-shaped input reads as "no deadline known" and leaves the flag off, which is
 exactly the behaviour that shipped before this module existed. Guessing a
 deadline is the one outcome that is worse than not having one.
+
+## The cost of that fail-open, and the one thing that makes it survivable (#2957)
+
+Failing open is right, and it is also **silent** — which is how this module
+spent a whole benchmark run arming nothing at all. `task.path` pointed into
+Harbor's download *cache*, where a content digest sits between the task and its
+definition (`<task>/<sha>/task.toml`); [`_task_agent_timeout`] read only the
+*export* shape (`<task>/task.toml`), the open raised `OSError`, and the
+fail-open did exactly what it says. Every trial ran with no wall clock of its
+own and the run died on Harbor's SIGKILL instead of stopping itself.
+
+The measurement, either side of the break:
+
+* 2026-08-09, three `fix-git` trials: **130 of 130** `budget_tick` events
+  carried `deadline_remaining_ms`, and one stopped itself with
+  `task deadline exceeded by 18.1s — stopping with partial work`.
+* 2026-08-11, the twenty pipeline trials of `w10p`: **0 of 1087**.
+
+Both layouts are now read. The lesson worth keeping is not "handle two paths",
+it is that a fail-open on a *derived* value needs the derived value **recorded**:
+what made this diagnosable at all was `stella_turn_budget_sec` in the adapter's
+own result, which said `"unarmed"` in plain text. Without that field the
+investigation is a bisect. Any future input added here should be recorded the
+same way.
 """
 
 from __future__ import annotations
@@ -219,18 +243,63 @@ def _task_agent_timeout(trial_config: Mapping[str, Any]) -> Any:
     ``None`` when the trial names no local task path — a dataset resolved from
     a registry ref rather than an offline export has ``task.path: null``, and
     the task definition is then not on this host at all.
+
+    **Harbor materialises a task in two layouts, and both have to be read.** An
+    *export* puts the definition directly at ``<task>/task.toml``; the download
+    *cache* interposes a content digest, ``<task>/<sha>/task.toml``. Reading
+    only the first is what silently disarmed the deadline: `task.path` pointed
+    into the cache, the open raised ``OSError``, the fail-open returned ``None``,
+    and every trial ran with no wall clock of its own while the adapter recorded
+    ``stella_turn_budget_sec: "unarmed"``. Measured either side of it — 130 of
+    130 `budget_tick` events armed on 2026-08-09, then 0 of 1087 on 2026-08-11.
+
+    ArenaBench already knew about both shapes and enumerates them for exactly
+    this reason (``arenabench/arenabench/registry.py::_iter_task_tomls``); this
+    is the same knowledge, applied on the deadline path where it was missing.
+    Deliberately **not** shared code: `stella_harbor` is the installed Harbor
+    adapter and does not import `arenabench` (the dependency runs the other
+    way), so the alternative to a second reader is a coupling that would make
+    the adapter unusable without ArenaBench.
     """
     task = trial_config.get("task")
     path = task.get("path") if isinstance(task, Mapping) else None
     if not path:
         return None
+    for candidate in _task_config_candidates(Path(path)):
+        try:
+            with open(candidate, "rb") as handle:
+                task_config = tomllib.load(handle)
+        except (OSError, ValueError):
+            continue
+        agent = task_config.get("agent")
+        timeout = agent.get("timeout_sec") if isinstance(agent, Mapping) else None
+        if timeout is not None:
+            return timeout
+    return None
+
+
+def _task_config_candidates(root: Path) -> list[Path]:
+    """Every place a task definition may sit under ``root``, nearest first.
+
+    The export layout is tried before the cache one so a directory holding both
+    resolves to the export — the same precedence ``resolve_turn_budget`` uses
+    throughout: the most specific statement of the deadline wins.
+
+    A digest directory is found by globbing rather than by pattern-matching the
+    name, because the digest's spelling is Harbor's business and a run that
+    changed it must not silently stop arming the deadline again. Sorted so the
+    choice is deterministic when a cache holds more than one digest for a task;
+    every candidate is then tried in turn, so an unreadable first entry costs
+    nothing.
+    """
+    candidates = [root / TASK_CONFIG_FILENAME]
     try:
-        with open(Path(path) / TASK_CONFIG_FILENAME, "rb") as handle:
-            task_config = tomllib.load(handle)
-    except (OSError, ValueError):
-        return None
-    agent = task_config.get("agent")
-    return agent.get("timeout_sec") if isinstance(agent, Mapping) else None
+        candidates.extend(sorted(root.glob("*/" + TASK_CONFIG_FILENAME)))
+    except OSError:
+        # An unreadable or non-existent root is "no deadline known", the same
+        # fail-open every other failure here takes.
+        pass
+    return candidates
 
 
 def resolve_turn_budget(

--- a/bench/harbor_adapter/tests/test_turn_budget.py
+++ b/bench/harbor_adapter/tests/test_turn_budget.py
@@ -36,6 +36,7 @@ def _trial_tree(
     *,
     task_timeout_sec: object = 900.0,
     trial_config: dict[str, object] | None = None,
+    digest: str | None = None,
 ) -> Path:
     """Lay out a Harbor single-step trial and return its agent ``logs_dir``.
 
@@ -44,11 +45,19 @@ def _trial_tree(
     immediately beneath it, and the task definition wherever ``task.path``
     says. Built on disk rather than mocked because the thing under test is a
     file layout, and a mock of it would agree with whatever the code does.
+
+    ``digest`` selects the **cache** layout — ``<task>/<sha>/task.toml`` — over
+    the export layout ``<task>/task.toml``. Both are real; Harbor writes the
+    first when a dataset is downloaded and the second when it is exported, and
+    reading only the export shape is what disarmed the deadline for a whole
+    benchmark run (#2957).
     """
     task_dir = tmp_path / "task"
     task_dir.mkdir()
+    definition_dir = task_dir if digest is None else task_dir / digest
+    definition_dir.mkdir(exist_ok=True)
     if task_timeout_sec is not None:
-        (task_dir / "task.toml").write_text(
+        (definition_dir / "task.toml").write_text(
             f'schema_version = "1.1"\n\n[agent]\ntimeout_sec = {task_timeout_sec}\n',
             encoding="utf-8",
         )
@@ -63,6 +72,90 @@ def _trial_tree(
     logs_dir.mkdir(parents=True)
     (trial_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
     return logs_dir
+
+
+class TestBothTaskLayoutsArmTheDeadline:
+    """**The witness for #2957.**
+
+    Harbor materialises a task definition two ways — an *export* puts it at
+    ``<task>/task.toml``, the download *cache* interposes a content digest at
+    ``<task>/<sha>/task.toml``. Reading only the export shape returned ``None``
+    for every cache-layout trial, and because the discovery fails open by
+    design, the deadline was simply never armed and nothing said so.
+
+    Measured either side of the break: 130 of 130 ``budget_tick`` events carried
+    ``deadline_remaining_ms`` on 2026-08-09 (and one trial stopped itself with
+    ``task deadline exceeded by 18.1s — stopping with partial work``), against
+    **0 of 1087** across the twenty pipeline trials of ``w10p`` on 2026-08-11,
+    where the adapter recorded ``stella_turn_budget_sec: "unarmed"``.
+
+    Every test here fails on ``main``: the cache cases return ``None`` there.
+    """
+
+    def test_the_export_layout_still_arms_it(self, tmp_path: Path) -> None:
+        """The control. Without this the cases below prove only that something
+        changed, not that the layout is what decides it."""
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=900.0)
+        assert turn_budget.discover_trial_deadline(logs_dir) == 900.0
+
+    def test_the_cache_layout_arms_it_too(self, tmp_path: Path) -> None:
+        logs_dir = _trial_tree(
+            tmp_path,
+            task_timeout_sec=900.0,
+            digest="8f14e45fceea167a5a36dedd4bea2543",
+        )
+        assert turn_budget.discover_trial_deadline(logs_dir) == 900.0
+
+    def test_a_cache_layout_trial_yields_a_turn_budget(self, tmp_path: Path) -> None:
+        """End to end: the argv value, reserve subtracted, is what was missing."""
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=900.0, digest="abc123")
+        assert resolve_turn_budget(None, None, logs_dir) == "840"
+
+    def test_the_digest_directory_name_is_not_pattern_matched(
+        self, tmp_path: Path
+    ) -> None:
+        """Found by globbing, so Harbor changing the digest's spelling cannot
+        silently disarm the deadline a fourth time."""
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=1800.0, digest="not-a-sha-at-all")
+        assert turn_budget.discover_trial_deadline(logs_dir) == 1800.0
+
+    def test_the_export_layout_wins_when_a_directory_holds_both(
+        self, tmp_path: Path
+    ) -> None:
+        """Most-specific-first, the same precedence the rest of this module uses.
+
+        Also the case that keeps the search from being order-dependent noise: a
+        cache directory left beside an export must not change the answer.
+        """
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=900.0)
+        stale = tmp_path / "task" / "0000stale"
+        stale.mkdir()
+        (stale / "task.toml").write_text(
+            'schema_version = "1.1"\n\n[agent]\ntimeout_sec = 60.0\n',
+            encoding="utf-8",
+        )
+        assert turn_budget.discover_trial_deadline(logs_dir) == 900.0
+
+    def test_a_digest_directory_missing_the_agent_table_falls_through(
+        self, tmp_path: Path
+    ) -> None:
+        """A readable but timeout-free definition must not end the search.
+
+        Returning ``None`` on the first *parseable* candidate would reintroduce
+        the bug for a cache holding one incomplete definition beside a good one.
+        """
+        task_dir = tmp_path / "task"
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=None, digest="0000empty")
+        (task_dir / "0000empty" / "task.toml").write_text(
+            'schema_version = "1.1"\n', encoding="utf-8"
+        )
+        good = task_dir / "9999good"
+        good.mkdir()
+        (good / "task.toml").write_text(
+            'schema_version = "1.1"\n\n[agent]\ntimeout_sec = 1800.0\n',
+            encoding="utf-8",
+        )
+        assert turn_budget.discover_trial_deadline(logs_dir) == 1800.0
 
 
 class TestTurnBudgetReachesTheEngine:
@@ -353,6 +446,13 @@ class TestDiscoveryFailsOpenNeverGuesses:
 
     def test_a_task_directory_with_no_task_toml(self, tmp_path: Path) -> None:
         logs_dir = _trial_tree(tmp_path, task_timeout_sec=None)
+        assert turn_budget.discover_trial_deadline(logs_dir) is None
+
+    def test_a_cache_layout_with_no_task_toml_under_the_digest(
+        self, tmp_path: Path
+    ) -> None:
+        """The second layout must fail open too, not merely be searched."""
+        logs_dir = _trial_tree(tmp_path, task_timeout_sec=None, digest="deadbeef")
         assert turn_budget.discover_trial_deadline(logs_dir) is None
 
     def test_a_task_toml_that_is_not_toml(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Harbor materialises a task definition two ways. An export puts it at
`<task>/task.toml`; the download cache interposes a content digest at
`<task>/<sha>/task.toml`. `_task_agent_timeout` read only the export shape, so
against a cache path the open raised OSError and the fail-open returned "no
deadline known" — correctly, quietly, and for every trial.

The consequence was that no ArenaBench trial armed a wall clock of its own, and
every over-run died on Harbor's SIGKILL rather than stopping itself with a
scorable partial. Measured either side of the break:

  2026-08-09, three fix-git trials:  130 of 130 budget_tick events armed,
                                     one stopping at "task deadline exceeded
                                     by 18.1s — stopping with partial work"
  2026-08-11, w10p (20 trials):        0 of 1087

ArenaBench already knew about both layouts and enumerates them for this exact
reason (registry.py::_iter_task_tomls). This is the same knowledge applied on
the deadline path, deliberately as a second reader rather than shared code:
stella_harbor is the installed Harbor adapter and must not depend on arenabench,
since the dependency runs the other way.

Candidates are tried nearest-first, so an export beside a stale cache directory
still wins — the most-specific-source-first precedence the rest of the module
uses. The digest directory is found by globbing rather than by matching the
digest's spelling, so a change in how Harbor names it cannot disarm the deadline
a fourth time. A parseable definition with no [agent] timeout_sec falls through
to the next candidate instead of ending the search.

Fail-open is preserved throughout: every failure still reads as "no deadline
known", because guessing a deadline remains worse than having none.

Witness: TestBothTaskLayoutsArmTheDeadline. Four of its six cases fail on main
with `assert None == 900.0` — the unarmed result itself — while the export-layout
control passes on both sides, which is what makes the layout the proven variable.

Closes #2957

## Deleted tests

None.

## Witness

`TestBothTaskLayoutsArmTheDeadline` in `bench/harbor_adapter/tests/test_turn_budget.py`. Verified the artisanal way — my tests against main's `turn_budget.py`:

```
FAILED test_the_cache_layout_arms_it_too              - assert None == 900.0
FAILED test_a_cache_layout_trial_yields_a_turn_budget - assert None == '840'
FAILED test_the_digest_directory_name_is_not_pattern_matched      - assert None == 1800.0
FAILED test_a_digest_directory_missing_the_agent_table_falls_through - assert None == 1800.0
4 failed, 2 passed
```

The two that pass on main are the export-layout control and the export-wins-over-cache case — they *should* pass there, and that is what makes the layout the proven variable rather than "something changed".

## Gate

`make guards-fast` green (no crate is touched, so this is the rung the pre-push hook picks). `pytest bench/harbor_adapter/tests/`: 679 passed, 2 skipped.

## Refs

Correction trail on #2957: my first diagnosis (registry-ref dataset → `task.path: null`) was **wrong** and is retracted in a comment there — `task.path` is a real local export path. The layout asymmetry is the actual cause, and it is why the failure was intermittent rather than permanent.

This is the cheap fix for #2927's "8 of 15 pipeline losses never had their work delivered" and it redirects #2941 — with the deadline armed, those runs stop at a safe boundary and, post-#2943, deliver.

Refs #2927, #2941, #2135, #2242

## Summary by Sourcery

Ensure ArenaBench Harbor adapter discovers task deadlines from both export and cache layouts so trials arm their wall-clock budget instead of silently running unarmed.

Bug Fixes:
- Fix deadline discovery for trials whose task definitions live under the Harbor download cache layout so they no longer return "no deadline known" and run without a wall-clock deadline.

Enhancements:
- Introduce a helper to search all plausible task definition locations under a task directory, preferring the export layout while still honoring cache entries and preserving fail-open semantics.
- Expand the Harbor adapter documentation to capture the fail-open behavior, its impact on benchmarking, and the importance of recording derived values like the turn budget.

Tests:
- Extend the trial layout test helper to model the cache layout explicitly and add focused tests validating deadline discovery and turn budget resolution across both export and cache task layouts, including precedence and fall-through cases.