### PR TITLE
fix(stella-pipeline): caution the worker when a witness red already matches its untouched baseline

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2326,12 +2326,7 @@ impl<'a> Pipeline<'a> {
             // failure. Both failing arms disclose from it, and nothing reaches
             // the worker except through `Pipeline::airlock_forward` or a
             // `redact` of this value.
-            let sealed = SealedFailure {
-                command: effective_cmd.map_or("", |cmd| cmd.command),
-                invocation: effective_cmd.map(|cmd| cmd.invocation),
-                output: &test_tail,
-                witness_paths: &witness_paths,
-            };
+            let sealed = Self::seal_failure(effective_cmd, &test_tail, &witness_paths);
 
             match ladder_decision(&inputs) {
                 LadderDecision::SubmitFast => {

--- a/crates/stella-pipeline/src/pipeline/disclosure.rs
+++ b/crates/stella-pipeline/src/pipeline/disclosure.rs
@@ -46,6 +46,38 @@ impl Pipeline<'_> {
         paths
     }
 
+    /// Everything the verification side knows about one round's failure.
+    ///
+    /// `unmoved_since_baseline` is computed here, not gated on
+    /// `state.revisions > 0` the way [`crate::verify::LadderInputs::witness_unmoved_by_revision`]
+    /// deliberately is (#2929): that gate protects a *terminal* rung
+    /// (`WitnessUnsatisfiable`) from firing on a red that only means the
+    /// worker hasn't finished — but this value feeds nothing but the
+    /// worker's own brief, so there is nothing to protect it from. Telling
+    /// the worker its first red already matches the untouched baseline can
+    /// only help it judge whether the check is the problem, one round before
+    /// a revision spent chasing that check gets the chance to delete a
+    /// correct deliverable to satisfy it — the `video-processing` shape this
+    /// issue was found on.
+    pub(super) fn seal_failure<'a>(
+        effective_cmd: Option<EffectiveTestCommand<'a>>,
+        test_tail: &'a str,
+        witness_paths: &'a [String],
+    ) -> SealedFailure<'a> {
+        let unmoved_since_baseline = effective_cmd
+            .and_then(|cmd| cmd.authored_baseline)
+            .is_some_and(|baseline| {
+                FailureFingerprint::of(baseline) == FailureFingerprint::of(test_tail)
+            });
+        SealedFailure {
+            command: effective_cmd.map_or("", |cmd| cmd.command),
+            invocation: effective_cmd.map(|cmd| cmd.invocation),
+            output: test_tail,
+            witness_paths,
+            unmoved_since_baseline,
+        }
+    }
+
     /// Turn one deterministic failure into the pair the revise loop needs: the
     /// operator-facing evidence, and the worker-facing brief.
     ///

--- a/crates/stella-pipeline/src/pipeline/tests/verification_hardening/witness_unsatisfiable.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/verification_hardening/witness_unsatisfiable.rs
@@ -163,3 +163,39 @@ async fn the_first_red_still_sends_the_worker_a_revision() {
         "the rung must not fire before the experiment has been run: {first:?}"
     );
 }
+
+/// …and the revision prompt that first red buys carries a caution the worker
+/// can act on itself (#2929), even though the terminal rung above correctly
+/// waits for a second round before it will call the witness unsatisfiable.
+///
+/// Same fixture as both tests above — `both_trees_fail()`'s candidate and
+/// baseline runs share one output, so the very first candidate observation
+/// already matches the witness's authored baseline. On `main` this fails:
+/// the revision prompt names only the ordinary deterministic-failure
+/// disclosure, with nothing telling the worker its check may be the broken
+/// half — which is exactly the gap that let a revision on `video-processing`
+/// delete a correct deliverable to chase a witness checking the wrong path.
+#[tokio::test]
+async fn the_first_revision_prompt_names_the_untouched_baseline_match() {
+    let provider = provider_with_one_revision();
+    let (outcome, _, _) = run_isolated_with_router(
+        &provider,
+        &both_trees_fail(),
+        PipelineConfig::default(),
+        "find my lost changes and merge them into master",
+        router(),
+    )
+    .await;
+    outcome.expect("run settles");
+
+    let prompts = provider.prompts();
+    let revision_prompt = prompts
+        .last()
+        .expect("the revision turn sent at least one request");
+    assert!(
+        revision_prompt.contains("Caution:")
+            && revision_prompt.contains("identical to what the check produced"),
+        "the revision prompt must warn that this failure matches the untouched \
+         baseline, before the worker acts on it: {revision_prompt}"
+    );
+}

--- a/crates/stella-pipeline/src/witness/airlock.rs
+++ b/crates/stella-pipeline/src/witness/airlock.rs
@@ -311,6 +311,18 @@ pub struct SealedFailure<'a> {
     /// Paths of the witness artifacts backing this run, withheld from every
     /// grain.
     pub witness_paths: &'a [String],
+    /// Whether this failure's normalized fingerprint already matches the
+    /// witness's *authored* baseline observation — the run against the
+    /// pristine, untouched tree the witness was proven to fail on when it was
+    /// created (#2929). Independent of revision count: `redact` always
+    /// carries it through, unlike [`crate::verify::LadderInputs::witness_unmoved_by_revision`],
+    /// which is deliberately gated on a prior revision so it can decide
+    /// [`crate::verify::LadderDecision::WitnessUnsatisfiable`] outright. This
+    /// field feeds a softer channel — a caveat in the worker's own brief — so
+    /// the same signal reaches the worker one round earlier, before a
+    /// revision spent chasing a check that cannot move has a chance to delete
+    /// correct work to satisfy it.
+    pub unmoved_since_baseline: bool,
 }
 
 impl SealedFailure<'_> {
@@ -339,6 +351,12 @@ pub struct FailureBrief {
     pub symptom: Option<SymptomClass>,
     /// How to reproduce it, at [`DisclosureGrain::Reproduction`].
     pub reproduction: Option<String>,
+    /// [`SealedFailure::unmoved_since_baseline`], carried through unredacted:
+    /// it is a boolean fact about the check's own behavior, not sealed
+    /// output, so it never needs scrubbing and is disclosed at every grain —
+    /// it matters most exactly when repetition has tightened the grain to
+    /// [`DisclosureGrain::Outcome`], the thrashing case #2929 was found in.
+    pub unmoved_since_baseline: bool,
 }
 
 impl FailureBrief {
@@ -350,6 +368,24 @@ impl FailureBrief {
     /// whole disclosure.
     pub fn message(&self) -> String {
         let mut lines = Vec::new();
+        // #2929: on `video-processing`, this warning is the one thing that
+        // was missing between "the check fails" and "the worker deleted its
+        // own correct deliverable to satisfy it" — the plan named an absolute
+        // path, the witness asserted a relative one, and the two never
+        // resolved to the same file. Said first, ahead of the symptom, so the
+        // worker reads it before deciding what to change.
+        if self.unmoved_since_baseline {
+            lines.push(
+                "Caution: this failure is identical to what the check produced before any of \
+                 your work existed — the same result an untouched tree would give. That can \
+                 mean the check is not observing your change at all (for example, asserting a \
+                 path relative to a working directory the check does not actually run from) \
+                 rather than your work being incomplete. Before changing your own code again, \
+                 read exactly what the check asserts and where, and confirm it would actually \
+                 see a correct change."
+                    .to_string(),
+            );
+        }
         if let Some(symptom) = self.symptom {
             lines.push(format!("Symptom: {}.", symptom.sentence()));
         }
@@ -640,6 +676,7 @@ pub fn redact(sealed: &SealedFailure<'_>, requested: DisclosureGrain) -> Failure
         command: admit(grain, DisclosureGrain::Command, command),
         symptom: admit(grain, DisclosureGrain::Symptom, symptom),
         reproduction: admit(grain, DisclosureGrain::Reproduction, reproduction),
+        unmoved_since_baseline: sealed.unmoved_since_baseline,
     }
 }
 

--- a/crates/stella-pipeline/src/witness/airlock/tests.rs
+++ b/crates/stella-pipeline/src/witness/airlock/tests.rs
@@ -27,6 +27,7 @@ fn sealed<'a>(
         invocation,
         output,
         witness_paths,
+        unmoved_since_baseline: false,
     }
 }
 
@@ -432,4 +433,69 @@ fn evidence_refs_name_the_grain_and_the_failure() {
     let refs = brief.evidence_refs(&failure.fingerprint());
     assert!(refs.iter().any(|r| r.starts_with("disclosure:L")));
     assert!(refs.iter().any(|r| r.starts_with("failure:")));
+}
+
+/// #2929: a witness whose first red already matches the untouched baseline is
+/// evidence about the check, not the work — and the worker should read that
+/// caution before it revises anything. This is deliberately a plain field
+/// flip on [`SealedFailure`], not a `sealed()` helper change, so every other
+/// call in this file stays `unmoved_since_baseline: false` unless a test asks
+/// for the opposite.
+fn sealed_unmoved<'a>(
+    command: &'a str,
+    output: &'a str,
+    witness_paths: &'a [String],
+) -> SealedFailure<'a> {
+    SealedFailure {
+        command,
+        invocation: None,
+        output,
+        witness_paths,
+        unmoved_since_baseline: true,
+    }
+}
+
+#[test]
+fn a_failure_unmoved_since_baseline_carries_the_caution() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed_unmoved("cargo test", ASSERTION_TAIL, &paths);
+    let brief = redact(&failure, DisclosureGrain::Reproduction);
+    assert!(brief.unmoved_since_baseline);
+    assert!(
+        brief.message().starts_with("Caution:"),
+        "the caution must lead the message, ahead of the symptom: {}",
+        brief.message()
+    );
+}
+
+/// The caution is not sealed material — it survives every tightening,
+/// including the terminal `Outcome` grain a thrashing worker earns. On
+/// `main` this fails: nothing about the flag reaches the message at all, at
+/// any grain.
+#[test]
+fn the_caution_survives_every_disclosure_grain() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed_unmoved("cargo test", ASSERTION_TAIL, &paths);
+    for grain in [
+        DisclosureGrain::Reproduction,
+        DisclosureGrain::Symptom,
+        DisclosureGrain::Command,
+        DisclosureGrain::Outcome,
+    ] {
+        let brief = redact(&failure, grain);
+        assert!(
+            brief.message().starts_with("Caution:"),
+            "grain {grain:?} dropped the caution: {}",
+            brief.message()
+        );
+    }
+}
+
+#[test]
+fn an_ordinary_failure_carries_no_caution() {
+    let paths: Vec<String> = Vec::new();
+    let failure = sealed("cargo test", ASSERTION_TAIL, None, &paths);
+    let brief = redact(&failure, DisclosureGrain::Reproduction);
+    assert!(!brief.unmoved_since_baseline);
+    assert!(!brief.message().starts_with("Caution:"));
 }

--- a/docs/spec/witness-protocol.md
+++ b/docs/spec/witness-protocol.md
@@ -139,10 +139,22 @@ timings, temporary paths, memory addresses, and line-number noise removed. Two
 runs that failed the same way share a fingerprint; two runs that failed
 differently do not.
 
-What it is used for today: the disclosure grain. Repetition of the *same*
-fingerprint is what tightens the ladder, so a worker thrashing against one
-failure stops being handed more surface to fit, while a worker making genuine
-progress — new failure each round — keeps full disclosure.
+What it is used for today: the disclosure grain, and — since #2929 — one
+grain-independent caveat. Repetition of the *same* fingerprint is what
+tightens the ladder, so a worker thrashing against one failure stops being
+handed more surface to fit, while a worker making genuine progress — new
+failure each round — keeps full disclosure. Separately, when a round's
+fingerprint already matches the witness's *authored* baseline observation —
+the run against the pristine, untouched tree the witness was proven to fail on
+when it was created — the brief leads with a fixed-vocabulary caution that the
+check may not be observing the change at all, whatever grain the ladder has
+settled on. This is deliberately not gated on the `revisions > 0` guard that
+`LadderInputs::witness_unmoved_by_revision` (§4.1's terminal rung) uses: that
+guard protects `WitnessUnsatisfiable` from a false positive on a worker that
+simply hasn't finished, but the caveat feeds only the worker's own brief, so
+nothing needs protecting from a true positive arriving one round earlier — the
+round a worker on `video-processing` instead deleted a correct deliverable to
+chase a witness checking the wrong path.
 
 What it is deliberately **not** used for yet: tightening the flip oracle to
 require that the failure it credits is the failure it first saw (ROADMAP §2,


### PR DESCRIPTION
## Summary

- On `video-processing` (ArenaBench w10p), the plan named an absolute deliverable path and the authored witness asserted the relative form, per #2130's own frame rules. The two never resolved to the same file, so the candidate's first-round failure was byte-identical to the witness's own authored-baseline failure. `WitnessUnsatisfiable` (#2540) exists for exactly this shape but is deliberately gated behind `state.revisions > 0` so it never false-positives on a worker that simply hasn't finished — so the worker got an ordinary "your test failed" and revised by deleting its own correct write to chase a check that could never pass.
- `SealedFailure`/`FailureBrief` gain `unmoved_since_baseline`, computed independent of the revision-count gate. When set, the worker's brief leads with a fixed-vocabulary caution — disclosed at every grain, since it carries no sealed material — one round before the terminal rung is allowed to fire.
- New logic lives in `pipeline/disclosure.rs` (the existing submodule for this exact class of concern) rather than growing the closed-for-growth `pipeline.rs` god file.

This is a mitigation (the worker can still choose to ignore the caution), not a structural fix. The harder question — detecting this without spending a revision at all — is already tracked in #2840 and stays open.

## Test plan

- [x] New unit tests in `witness/airlock/tests.rs`: caution appears when `unmoved_since_baseline` is set, survives every disclosure grain (including the tightest, `Outcome`), and is absent otherwise.
- [x] New pipeline-integration witness test in `pipeline/tests/verification_hardening/witness_unsatisfiable.rs`, extending #2540's own `both_trees_fail()` fixture: the first revision prompt now names the untouched-baseline match.
- [x] Confirmed fail→pass: all new tests fail to even resolve on unmodified `main` (`git stash` + `cargo test`) and pass with the change.
- [x] `cargo test -p stella-pipeline` — 727 passed, 0 failed.
- [x] `make gate CARGO_SCOPE="-p stella-pipeline"` — green.
- [x] Pre-push hook's wider `make gate` (8 impacted crates) — green.

Closes #2929
Refs #2840, #2540, #2130

## Summary by Sourcery

Add a baseline-match caution to worker-facing failure briefs when a witness’s initial red matches its untouched baseline, and integrate it into the pipeline’s disclosure flow.

New Features:
- Introduce an `unmoved_since_baseline` flag on failures so the system can detect when a run’s fingerprint matches the witness’s authored baseline observation.
- Surface a fixed-vocabulary caution in worker prompts whenever a failure is unchanged from the untouched baseline, across all disclosure grains.

Enhancements:
- Refactor pipeline failure sealing into a dedicated `seal_failure` helper in `pipeline/disclosure.rs` to centralize fingerprint-based baseline matching logic.

Documentation:
- Update the witness protocol specification to document the new use of failure fingerprints for baseline-match cautions and their relationship to the ladder and `WitnessUnsatisfiable`.

Tests:
- Add unit tests ensuring the baseline-match caution appears only when `unmoved_since_baseline` is set and survives all disclosure grains.
- Extend pipeline integration tests around `WitnessUnsatisfiable` to verify the first revision prompt now includes the untouched-baseline match caution.