### PR TITLE
fix(stella-core): bound one model call by the task's own remaining wall clock

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -101,7 +101,7 @@ use crate::retry::{RetryOutcome, RetryPolicy, Sleeper};
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::step::{
     AbortKind, BorrowedTurn, CompactionPass, SpeculationDropGuard, StepOutcome, StreamProgress,
-    SummarizerHealth, TurnState, bounded_generation,
+    SummarizerHealth, TurnState, deadline_bounded_generation,
 };
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
 use truncation::ContinuationBudget;
@@ -1490,6 +1490,7 @@ impl<'a> Engine<'a> {
         // from "the ladder is asleep between attempts".
         let attempt_in_flight = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let attempt_in_flight_latch = attempt_in_flight.clone();
+        let task_deadline = budget.task_deadline(); // #2021: bounds each attempt below.
         let attempt: RetryAttemptFn = Box::new(move || {
             let read_only = speculation_read_only.clone();
             let safe = speculation_safe.clone();
@@ -1524,7 +1525,7 @@ impl<'a> Engine<'a> {
                     // path, where invariant 5 (no panics on runtime data)
                     // outranks asserting a structural claim (#618 item 17).
                     biased;
-                    result = bounded_generation(self.config.model_timeout, &progress, &mut complete) => result,
+                    result = deadline_bounded_generation(self.config.model_timeout, task_deadline, &progress, &mut complete) => result,
                     _ = &mut pump => Err(ProviderError::Terminal(
                         "speculation pump ended before the model call that feeds it; \
                          the speculation gate holds the channel open for the whole call, \

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -1094,6 +1094,67 @@ where
     }
 }
 
+/// Bound one provider dispatch by what remains of the TASK's own wall-clock
+/// deadline ([`BudgetGuard::task_deadline`]), composed around
+/// [`bounded_generation`]'s idle bound rather than replacing it.
+///
+/// This is **not** the flat, unconditional wall-clock ceiling #1467 removed
+/// from [`crate::accounted_call::run_accounted_call`]: that one fired the
+/// instant a *fixed* duration elapsed, even while the provider was actively
+/// streaming, which cut a live generation off for a ceiling sized to catch
+/// silence and lost OpenRouter's trailing usage/cost frame in the process.
+/// This bound fires only when the *task* is out of time. `task_deadline` is
+/// `None` whenever no task deadline is armed (interactive CLI, no bench
+/// harness), so nothing changes for that shape — and a call that is actively
+/// answering well within the task's remaining budget is never touched by it.
+///
+/// What it closes (#2021): the between-step deadline check
+/// (`driver::settlement::check_budget`) is anticipatory but reactive — it
+/// looks at the *last* step's pace before opening a *new* one, and has no way
+/// to see a call that is itself about to outrun the clock once dispatched. A
+/// TB2.1 `fix-git` trial recorded exactly that on 2026-08-09: a call
+/// dispatched with 120.19s of task deadline left ran 120.43s, produced
+/// nothing, and the run died 15.9s past the deadline with otherwise-complete
+/// work sitting uncommitted. The idle bound cannot see this either — the
+/// provider was never silent, it was a connection that never completed.
+///
+/// Deliberately derived from [`BudgetGuard::task_deadline`] rather than a
+/// standalone `EngineConfig` field: a static ceiling set independently of the
+/// task's own deadline is exactly the kind of number that can drift from it,
+/// which is the failure mode #2021's own "what to do" list warns against.
+/// Reading the same `Instant` the between-step check already reads makes the
+/// two structurally unable to disagree. Takes the absolute `Instant` — not a
+/// pre-subtracted `Duration` — and reads the clock itself, so a caller may
+/// capture it once outside a per-attempt retry closure and still have each
+/// attempt bounded by what actually remains at ITS OWN dispatch.
+///
+/// The trip is [`ProviderError::Terminal`], for the same reason
+/// [`bounded_generation`]'s is: the task is out of time, so retrying only
+/// spends more of a deadline that has already run out.
+pub(crate) async fn deadline_bounded_generation<F>(
+    idle_limit: Option<Duration>,
+    task_deadline: Option<std::time::Instant>,
+    progress: &StreamProgress,
+    call: F,
+) -> Result<CompletionResult, ProviderError>
+where
+    F: Future<Output = Result<CompletionResult, ProviderError>>,
+{
+    let generation = bounded_generation(idle_limit, progress, call);
+    let Some(deadline) = task_deadline else {
+        return generation.await;
+    };
+    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+    match tokio::time::timeout(remaining, generation).await {
+        Ok(result) => result,
+        Err(_) => Err(ProviderError::Terminal(format!(
+            "generation exceeded the task's remaining wall clock ({}ms): \
+             the task deadline ran out mid-call",
+            remaining.as_millis()
+        ))),
+    }
+}
+
 /// Drop guard for the paid-call window ([`Engine`](crate::driver::Engine)'s `run_model_call`): armed
 /// before the retried provider dispatch, disarmed on both normal exits. It
 /// fires only when the turn future is dropped mid-await — the caller-side

--- a/crates/stella-core/src/step/tests.rs
+++ b/crates/stella-core/src/step/tests.rs
@@ -357,3 +357,106 @@ fn the_usage_anchor_survives_appends_and_dies_with_a_rewrite() {
         "a rewrite invalidates the report's prefix — back to the estimator"
     );
 }
+
+fn stub_completion_result() -> CompletionResult {
+    CompletionResult {
+        text: "ok".into(),
+        tool_calls: Vec::new(),
+        usage: CompletionUsage::reported_zero(),
+        model: "test".into(),
+        cost_usd: 0.0,
+        finish_reason: None,
+        upstream_provider: None,
+    }
+}
+
+/// #2021's witness: a call with no idle timeout at all — the shape a
+/// well-behaved streaming provider has, since it is always producing — is
+/// still cut off once the task's own remaining wall clock runs out. Before
+/// `deadline_bounded_generation` nothing in this module could express that:
+/// `bounded_generation`'s idle bound never fires on a call with `idle_limit:
+/// None`, no matter how long it runs.
+#[tokio::test]
+async fn a_call_with_no_idle_bound_is_still_cut_by_the_task_deadline() {
+    let progress = StreamProgress::default();
+    let result = deadline_bounded_generation(
+        None,
+        Some(std::time::Instant::now() + Duration::from_millis(30)),
+        &progress,
+        std::future::pending(),
+    )
+    .await;
+    match result {
+        Err(ProviderError::Terminal(message)) => {
+            assert!(
+                message.contains("deadline") || message.contains("wall clock"),
+                "the trip should name the task deadline, got {message:?}"
+            );
+        }
+        other => panic!("a call must not outlive the task deadline, got {other:?}"),
+    }
+}
+
+/// The fix-git shape itself: a call that keeps streaming fragments fast
+/// enough to reset a generous idle bound on every check — so the idle bound
+/// alone would wait the full 10s — is still cut at the task's much shorter
+/// remaining deadline. This is the failure #2021 measured: a provider
+/// trickling output, not a silent one, outrunning the deadline while the
+/// idle clock never once saw a gap worth tripping on.
+#[tokio::test]
+async fn a_trickling_generation_under_a_generous_idle_bound_is_still_cut_by_the_task_deadline() {
+    let progress = StreamProgress::default();
+    let trickle = async {
+        loop {
+            progress.record();
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        #[allow(unreachable_code)]
+        Ok(stub_completion_result())
+    };
+    let result = deadline_bounded_generation(
+        Some(Duration::from_secs(10)),
+        Some(std::time::Instant::now() + Duration::from_millis(30)),
+        &progress,
+        trickle,
+    )
+    .await;
+    match result {
+        Err(ProviderError::Terminal(message)) => {
+            assert!(
+                message.contains("deadline") || message.contains("wall clock"),
+                "the trip should name the task deadline, not the idle bound, got {message:?}"
+            );
+        }
+        other => panic!("a trickling call must still be cut by the task deadline, got {other:?}"),
+    }
+}
+
+/// The other side: with no task deadline armed (`deadline_remaining: None`)
+/// — an interactive CLI session with no bench harness — behavior is
+/// unchanged from `bounded_generation` alone. This pins the claim in
+/// `deadline_bounded_generation`'s doc comment that a call with no deadline
+/// armed is never touched by this bound.
+#[tokio::test]
+async fn no_armed_deadline_leaves_the_idle_bound_as_the_only_cut() {
+    let progress = StreamProgress::default();
+    let result = deadline_bounded_generation(
+        Some(Duration::from_millis(20)),
+        None,
+        &progress,
+        std::future::pending(),
+    )
+    .await;
+    match result {
+        Err(ProviderError::Terminal(message)) => {
+            assert!(
+                message.contains("stalled") || message.contains("idle"),
+                "with no deadline armed the trip must be the idle bound's own message, \
+                 got {message:?}"
+            );
+        }
+        other => {
+            panic!("an unarmed deadline must still leave the idle bound active, got {other:?}")
+        }
+    }
+}

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,7 +19,7 @@
 1729 crates/stella-cli/src/agent/tests.rs
 4377 crates/stella-cli/src/command_deck.rs
 1891 crates/stella-core/src/bus.rs
-1918 crates/stella-core/src/driver.rs
+1919 crates/stella-core/src/driver.rs
 2985 crates/stella-core/src/driver/tests.rs
 1781 crates/stella-model/src/anthropic/tests.rs
 2094 crates/stella-model/src/openai.rs


### PR DESCRIPTION
## Summary

`EngineConfig::model_timeout` only bounds *idle silence* between stream fragments — a call that keeps producing, however slowly, is never cut by it. #2021 measured this costing a real trial: a TB2.1 `fix-git` run on 2026-08-09 dispatched a model call with 120.19s of task deadline remaining; the call ran 120.43s and produced nothing; the run died 15.9s past the deadline with otherwise-correct, fully-merged work sitting uncommitted in the candidate tree — the between-step deadline check (`driver::settlement::check_budget`) is anticipatory but reactive, and has no way to see a call that is itself about to outrun the clock once dispatched.

This was investigated once already (see the issue's own comment thread): the originally-prescribed fix — writing an explicit `_MODEL_TIMEOUT_BY_SLUG` posture row per benchmarked model — was implemented and reverted as a behavioral no-op, because every model already inherits an 816s idle-silence default from `EngineConfig`, and idle silence was never the mechanism in play.

## Fix

- `step::deadline_bounded_generation` composes a new bound around the existing `bounded_generation` idle bound, rather than replacing it. It fires only when the *task's* own remaining wall clock (`BudgetGuard::task_deadline`) runs out mid-call.
- Deliberately **not** a new standalone `EngineConfig` field: it reads the same `Instant` the between-step check already reads, so a hand-set ceiling can never drift from the trial's real deadline — the exact failure mode the issue's own "what to do" list warned a static field risked.
- Deliberately **not** the flat, unconditional wall-clock ceiling `#1467` removed from `accounted_call::run_accounted_call` — that one fired the instant a *fixed* duration elapsed even while a provider was actively streaming, and lost OpenRouter's trailing usage/cost frame doing it. This bound only fires when the task itself is out of time; a call with no task deadline armed (interactive CLI, no bench harness) is untouched.
- `driver.rs` is a grandfathered god file closed to growth. The one line this required — capturing `budget.task_deadline()` before the retry closure, since the closure cannot borrow `budget` without conflicting with its later `&mut` use in `drive_attempt_ladder` — is structurally unavoidable (confirmed by trying several alternatives), so the baseline was retightened via `make file-size-update` rather than contorting the code around the ratchet.

## Witness

Three new unit tests in `crates/stella-core/src/step/tests.rs` exercise `deadline_bounded_generation` directly:
- a call with **no idle bound at all** is still cut once the task deadline runs out;
- a call **trickling under a generous idle bound** (the exact `fix-git` shape — producing just fast enough to keep resetting the idle clock) is still cut by the task deadline;
- with **no task deadline armed**, behavior is unchanged — the idle bound's own message surfaces, proving nothing regresses for interactive/non-bench sessions.

Verified the artisanal way: stashed the source fix (`step.rs`, `driver.rs`), confirmed the tests fail to even *compile* against old code (the function doesn't exist), restored the fix, confirmed green.

## Test plan

- [x] `cargo test -p stella-core --lib` — 1222 passed
- [x] `cargo clippy -p stella-core --lib --tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps --lib` — clean (new intra-doc links resolve)
- [x] `scripts/check-file-size.sh`, `scripts/check-left-behind.sh`, `scripts/check-invariants.sh` — all OK
- [x] Witness check: fix stashed → new tests fail to compile with the exact missing-function shape; fix restored → green

Refs #2021

## Summary by Sourcery

Bound model streaming calls by the task’s remaining wall-clock deadline while preserving existing idle-based generation limits.

Bug Fixes:
- Ensure provider calls that continually stream or have no idle bound are terminated when the task’s own deadline expires instead of overrunning the trial window.

Enhancements:
- Introduce a deadline-aware generation helper that composes task wall-clock limits with existing idle timeouts for model calls.
- Wire the engine’s model call path to use the new deadline-bound generation helper so each retry attempt respects the task deadline.
- Add unit tests validating behavior for calls with no idle bound, trickling output under a generous idle bound, and sessions without an armed task deadline.