### PR TITLE
refactor(stella-tui): split the transcript formatters out of model.rs, which had reached its ceiling

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -29,10 +29,19 @@ use std::collections::VecDeque;
 mod error_rows;
 pub mod file_state;
 pub mod recall;
+mod summarize;
+
 #[cfg(test)]
 pub use file_state::DIFF_HISTORY;
 pub use file_state::{FileState, MAX_TRACKED_FILES, RememberedDiff};
 pub use recall::{RecallBudget, RecalledFrameRow};
+// Re-imported rather than left qualified, so the split was a pure move: every
+// call site in the fold reads exactly as it did before (#2958). See
+// `summarize`'s module doc for why the seam is there and not elsewhere.
+use summarize::{
+    INPUT_BUDGET, OUTPUT_BUDGET, cap_input_json, cap_middle, format_tool_input, is_file_mutation,
+    summarize, tool_input_path,
+};
 
 /// How many characters of a tool input / output summary we retain on a
 /// transcript line before eliding — the full payload is never needed on the
@@ -1260,240 +1269,6 @@ impl SessionModel {
             self.files.push(state);
         }
     }
-}
-
-/// Compact a tool-call input `Value` to a single-line JSON string. Falls back
-/// to the empty string on the (impossible for `Value`) serialization error so
-/// the model never panics on a tool card.
-fn compact_json(value: &serde_json::Value) -> String {
-    serde_json::to_string(value).unwrap_or_default()
-}
-
-/// Char budget for a tool call's retained compact-JSON arguments.
-pub(crate) const INPUT_BUDGET: usize = 4_096;
-/// Char budget for a tool result's retained output (outputs are already
-/// capped upstream by the tools; this bounds transcript memory).
-pub(crate) const OUTPUT_BUDGET: usize = 16_384;
-
-/// Middle-out char cap preserving head and tail (first error + final summary
-/// both matter), on char boundaries.
-fn cap_middle(text: &str, budget: usize) -> String {
-    cap_middle_with(text, budget, "\n[… truncated …]\n")
-}
-
-/// [`cap_middle`] with a caller-chosen elision marker. Slices at
-/// `char_indices` boundaries instead of materializing a `Vec<char>`, so a
-/// multi-megabyte payload costs no allocation beyond the capped result.
-fn cap_middle_with(text: &str, budget: usize, marker: &str) -> String {
-    // Byte length bounds char count, so an in-budget payload returns without
-    // scanning; an over-budget one probes just past the boundary instead.
-    if text.len() <= budget || text.char_indices().nth(budget).is_none() {
-        return text.to_string();
-    }
-    let keep = budget.saturating_sub(marker.chars().count());
-    let head = keep / 2;
-    let tail = keep - head;
-    let head_end = text.char_indices().nth(head).map_or(text.len(), |(i, _)| i);
-    let tail_start = if tail == 0 {
-        text.len()
-    } else {
-        text.char_indices().nth_back(tail - 1).map_or(0, |(i, _)| i)
-    };
-    format!("{}{marker}{}", &text[..head_end], &text[tail_start..])
-}
-
-/// Per-leaf caps for [`cap_input_json`]: generous enough to keep any one
-/// argument readable, small enough that leaf capping alone usually lands the
-/// whole object under [`INPUT_BUDGET`].
-const INPUT_STR_CAP: usize = 512;
-const INPUT_ARR_CAP: usize = 32;
-
-/// Cap a tool call's retained arguments **inside** the JSON: long string
-/// leaves are middle-capped and oversized arrays elided, so the compact form
-/// stays *valid* JSON and ctrl+o can still pretty-print it. Only a
-/// pathological object that remains oversized after leaf capping falls back
-/// to the raw char cap (which the renderer shows as wrapped plain text).
-fn cap_input_json(value: &serde_json::Value, budget: usize) -> String {
-    let compact = compact_json(value);
-    if compact.len() <= budget {
-        return compact;
-    }
-    let mut capped = value.clone();
-    cap_json_leaves(&mut capped);
-    cap_middle(&compact_json(&capped), budget)
-}
-
-/// Recursively shrink the leaves of `value` in place (strings middle-capped
-/// on one line, arrays truncated with a `+N more` marker) without disturbing
-/// the object structure.
-fn cap_json_leaves(value: &mut serde_json::Value) {
-    match value {
-        serde_json::Value::String(s) => {
-            if s.len() > INPUT_STR_CAP {
-                *s = cap_middle_with(s, INPUT_STR_CAP, " […] ");
-            }
-        }
-        serde_json::Value::Array(items) => {
-            if items.len() > INPUT_ARR_CAP {
-                let dropped = items.len() - INPUT_ARR_CAP;
-                items.truncate(INPUT_ARR_CAP);
-                items.push(serde_json::Value::String(format!("[… +{dropped} more …]")));
-            }
-            for item in items.iter_mut() {
-                cap_json_leaves(item);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for item in map.values_mut() {
-                cap_json_leaves(item);
-            }
-        }
-        _ => {}
-    }
-}
-
-/// Format a tool-call input as a human-readable one-liner. Instead of raw
-/// JSON, this extracts the most relevant field(s) per tool name so the
-/// transcript reads naturally — `path` for file tools, `cmd` for shell, the
-/// query for search tools, and so on.
-fn format_tool_input(name: &str, input: &serde_json::Value) -> String {
-    let str_field = |key: &str| -> Option<String> {
-        input
-            .get(key)
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-    };
-
-    // apply_edits carries its paths in a batch; surface them instead of the
-    // raw-JSON fallback so the transcript row reads like other file tools.
-    if name == "apply_edits"
-        && let Some(edits) = input.get("edits").and_then(|v| v.as_array())
-    {
-        let mut paths: Vec<&str> = Vec::new();
-        for edit in edits {
-            if let Some(p) = edit.get("path").and_then(|v| v.as_str())
-                && !paths.contains(&p)
-            {
-                paths.push(p);
-            }
-        }
-        if !paths.is_empty() {
-            let labels: Vec<String> = paths.iter().map(|p| truncate_field(p, 48)).collect();
-            return if paths.len() == 1 {
-                labels.into_iter().next().unwrap()
-            } else {
-                format!("{}  ({} files)", labels.join(", "), paths.len())
-            };
-        }
-    }
-
-    // Primary field per tool — the one the user cares about at a glance.
-    if let Some(p) = str_field("path").or_else(|| str_field("file_path")) {
-        return match name {
-            // Just the path. The old/new strings used to ride along here,
-            // truncated to 40 characters each — long enough to fill the row,
-            // never long enough to read, and describing exactly the change the
-            // inline diff below renders properly.
-            "edit_file" => p,
-            "write_file" => {
-                let lines = str_field("content").map(|c| c.lines().count()).unwrap_or(0);
-                format!("{p}  ({lines} lines)")
-            }
-            _ => p,
-        };
-    }
-
-    if let Some(cmd) = str_field("cmd").or_else(|| str_field("command")) {
-        return truncate_field(&cmd, 120);
-    }
-
-    if let Some(query) = str_field("query")
-        .or_else(|| str_field("pattern"))
-        .or_else(|| str_field("symbol"))
-    {
-        return truncate_field(&query, 80);
-    }
-
-    if let Some(prompt) = str_field("question").or_else(|| str_field("prompt")) {
-        return truncate_field(&prompt, 80);
-    }
-
-    // An argument-less call has nothing to summarize. `compact_json` renders
-    // `{}` for it, which the transcript then printed beside the tool name —
-    // and an empty object next to `project_overview` reads as an empty
-    // *result*, not as "this tool takes no arguments". Both this and the
-    // renderer treat the empty string as "no argument column"; saying it here
-    // as well is what keeps every consumer of `input` (the trace tab, the
-    // accessible renderer) agreeing about it.
-    if input.as_object().is_some_and(serde_json::Map::is_empty) || input.is_null() {
-        return String::new();
-    }
-    // Fallback: compact JSON, summarized.
-    summarize(&compact_json(input))
-}
-
-/// Truncate a field value to `max` chars with an ellipsis. Cuts *before*
-/// flattening: the newline→space replacement is one char in, one char out, so
-/// slicing the raw text first yields the identical result without copying a
-/// multi-megabyte `content`/`old_string` argument in full (the same reason
-/// [`cap_middle_with`] walks `char_indices` instead of materializing chars).
-fn truncate_field(s: &str, max: usize) -> String {
-    // `nth(max)` is `None` exactly when the text is `max` chars or shorter.
-    if s.char_indices().nth(max).is_none() {
-        return s.replace(['\n', '\r'], " ");
-    }
-    let head_end = s
-        .char_indices()
-        .nth(max.saturating_sub(1))
-        .map_or(s.len(), |(i, _)| i);
-    format!("{}…", s[..head_end].replace(['\n', '\r'], " "))
-}
-
-/// The workspace-relative path a file tool targets. Every built-in file tool
-/// (`read_file`/`write_file`/`edit_file`/`delete_file`) takes its path under
-/// the `path` key, and the engine emits `FileChange` for that same path — so
-/// this is the join key between a tool result and its diff.
-fn tool_input_path(input: &serde_json::Value) -> Option<String> {
-    if let Some(path) = input
-        .get("path")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-    {
-        return Some(path);
-    }
-    // apply_edits carries its paths in a batch, not at the top level; the
-    // first edit's path stands in so a single-file batch still renders an
-    // inline diff under its result row.
-    input
-        .get("edits")
-        .and_then(serde_json::Value::as_array)
-        .and_then(|edits| edits.first())
-        .and_then(|e| e.get("path"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-}
-
-/// Whether a tool name is one of the file-*mutating* built-ins — the only
-/// tools whose result should carry an inline diff (reads must not). Must
-/// stay in lockstep with `file_change_of` in stella-cli's `command_deck.rs`,
-/// the `FileChange` emitter that owns this list.
-fn is_file_mutation(name: &str) -> bool {
-    matches!(
-        name,
-        "write_file" | "edit_file" | "apply_edits" | "delete_file"
-    )
-}
-
-/// Truncate a summary to [`SUMMARY_BUDGET`] chars with a middle-out elision —
-/// the head and tail both matter for a failing tool result (L-S3), so we keep
-/// both rather than head-truncating away the error tail.
-///
-/// Caps *before* flattening. `text` here is a raw tool payload that can be
-/// megabytes (the caller also passes it to [`cap_middle`]); replacing newlines
-/// first would copy the whole thing just to throw all but 200 chars away, and
-/// the replacement is one char in / one char out, so the two orders agree.
-fn summarize(text: &str) -> String {
-    cap_middle_with(text, SUMMARY_BUDGET, "...").replace(['\n', '\r'], " ")
 }
 
 #[cfg(test)]

--- a/crates/stella-tui/src/model/summarize.rs
+++ b/crates/stella-tui/src/model/summarize.rs
@@ -1,0 +1,266 @@
+//! Text and JSON shaping for a transcript line: the pure formatting the fold
+//! calls and holds no state for.
+//!
+//! # The seam
+//!
+//! Split out of `model.rs` when that file reached 1500 of the guard's 1500
+//! lines with no baseline entry (#2958), so the next addition to it would have
+//! failed the gate outright. The line count is the trigger, not the reason.
+//!
+//! The reason is that these two halves grow on different clocks.
+//! [`super::SessionModel::apply`] matches `AgentEvent` exhaustively and is one
+//! of the four compile-enforced stops when a variant is added
+//! (`stella_protocol::event::tags`), so **every** new event costs `model.rs` at
+//! least a line — the arm cannot be declined. Nothing here has a reason to grow
+//! when the vocabulary does: these are functions over borrowed strings and
+//! `serde_json::Value`, with no knowledge of events at all. Leaving them in one
+//! file meant the vocabulary's growth was paying rent on the formatter's
+//! length, and the ratchet was about to make an ordinary protocol change
+//! impossible.
+//!
+//! The precedents in this crate are the same move for the same reason:
+//! `deck/classify.rs` (extracted when #2007 pushed `deck.rs` against the
+//! ceiling) and `wire_contract/samples.rs` over in `stella-protocol`. As in
+//! both, this is a **pure move** — every function is byte-identical to the one
+//! it replaced apart from the `pub(super)` a sibling module needs, and
+//! [`super`] re-imports them so no call site changed.
+//!
+//! Splitting buys structure, not slack: `make file-size-update` retightens
+//! every ceiling to its file's current size, so the room this makes is room for
+//! the fold to keep absorbing variants, not a budget to spend on anything else.
+
+use super::SUMMARY_BUDGET;
+
+/// Compact a tool-call input `Value` to a single-line JSON string. Falls back
+/// to the empty string on the (impossible for `Value`) serialization error so
+/// the model never panics on a tool card.
+pub(super) fn compact_json(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+/// Char budget for a tool call's retained compact-JSON arguments.
+pub(crate) const INPUT_BUDGET: usize = 4_096;
+/// Char budget for a tool result's retained output (outputs are already
+/// capped upstream by the tools; this bounds transcript memory).
+pub(crate) const OUTPUT_BUDGET: usize = 16_384;
+
+/// Middle-out char cap preserving head and tail (first error + final summary
+/// both matter), on char boundaries.
+pub(super) fn cap_middle(text: &str, budget: usize) -> String {
+    cap_middle_with(text, budget, "\n[… truncated …]\n")
+}
+
+/// [`cap_middle`] with a caller-chosen elision marker. Slices at
+/// `char_indices` boundaries instead of materializing a `Vec<char>`, so a
+/// multi-megabyte payload costs no allocation beyond the capped result.
+pub(super) fn cap_middle_with(text: &str, budget: usize, marker: &str) -> String {
+    // Byte length bounds char count, so an in-budget payload returns without
+    // scanning; an over-budget one probes just past the boundary instead.
+    if text.len() <= budget || text.char_indices().nth(budget).is_none() {
+        return text.to_string();
+    }
+    let keep = budget.saturating_sub(marker.chars().count());
+    let head = keep / 2;
+    let tail = keep - head;
+    let head_end = text.char_indices().nth(head).map_or(text.len(), |(i, _)| i);
+    let tail_start = if tail == 0 {
+        text.len()
+    } else {
+        text.char_indices().nth_back(tail - 1).map_or(0, |(i, _)| i)
+    };
+    format!("{}{marker}{}", &text[..head_end], &text[tail_start..])
+}
+
+/// Per-leaf caps for [`cap_input_json`]: generous enough to keep any one
+/// argument readable, small enough that leaf capping alone usually lands the
+/// whole object under [`INPUT_BUDGET`].
+pub(super) const INPUT_STR_CAP: usize = 512;
+pub(super) const INPUT_ARR_CAP: usize = 32;
+
+/// Cap a tool call's retained arguments **inside** the JSON: long string
+/// leaves are middle-capped and oversized arrays elided, so the compact form
+/// stays *valid* JSON and ctrl+o can still pretty-print it. Only a
+/// pathological object that remains oversized after leaf capping falls back
+/// to the raw char cap (which the renderer shows as wrapped plain text).
+pub(super) fn cap_input_json(value: &serde_json::Value, budget: usize) -> String {
+    let compact = compact_json(value);
+    if compact.len() <= budget {
+        return compact;
+    }
+    let mut capped = value.clone();
+    cap_json_leaves(&mut capped);
+    cap_middle(&compact_json(&capped), budget)
+}
+
+/// Recursively shrink the leaves of `value` in place (strings middle-capped
+/// on one line, arrays truncated with a `+N more` marker) without disturbing
+/// the object structure.
+pub(super) fn cap_json_leaves(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => {
+            if s.len() > INPUT_STR_CAP {
+                *s = cap_middle_with(s, INPUT_STR_CAP, " […] ");
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if items.len() > INPUT_ARR_CAP {
+                let dropped = items.len() - INPUT_ARR_CAP;
+                items.truncate(INPUT_ARR_CAP);
+                items.push(serde_json::Value::String(format!("[… +{dropped} more …]")));
+            }
+            for item in items.iter_mut() {
+                cap_json_leaves(item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values_mut() {
+                cap_json_leaves(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Format a tool-call input as a human-readable one-liner. Instead of raw
+/// JSON, this extracts the most relevant field(s) per tool name so the
+/// transcript reads naturally — `path` for file tools, `cmd` for shell, the
+/// query for search tools, and so on.
+pub(super) fn format_tool_input(name: &str, input: &serde_json::Value) -> String {
+    let str_field = |key: &str| -> Option<String> {
+        input
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    };
+
+    // apply_edits carries its paths in a batch; surface them instead of the
+    // raw-JSON fallback so the transcript row reads like other file tools.
+    if name == "apply_edits"
+        && let Some(edits) = input.get("edits").and_then(|v| v.as_array())
+    {
+        let mut paths: Vec<&str> = Vec::new();
+        for edit in edits {
+            if let Some(p) = edit.get("path").and_then(|v| v.as_str())
+                && !paths.contains(&p)
+            {
+                paths.push(p);
+            }
+        }
+        if !paths.is_empty() {
+            let labels: Vec<String> = paths.iter().map(|p| truncate_field(p, 48)).collect();
+            return if paths.len() == 1 {
+                labels.into_iter().next().unwrap()
+            } else {
+                format!("{}  ({} files)", labels.join(", "), paths.len())
+            };
+        }
+    }
+
+    // Primary field per tool — the one the user cares about at a glance.
+    if let Some(p) = str_field("path").or_else(|| str_field("file_path")) {
+        return match name {
+            // Just the path. The old/new strings used to ride along here,
+            // truncated to 40 characters each — long enough to fill the row,
+            // never long enough to read, and describing exactly the change the
+            // inline diff below renders properly.
+            "edit_file" => p,
+            "write_file" => {
+                let lines = str_field("content").map(|c| c.lines().count()).unwrap_or(0);
+                format!("{p}  ({lines} lines)")
+            }
+            _ => p,
+        };
+    }
+
+    if let Some(cmd) = str_field("cmd").or_else(|| str_field("command")) {
+        return truncate_field(&cmd, 120);
+    }
+
+    if let Some(query) = str_field("query")
+        .or_else(|| str_field("pattern"))
+        .or_else(|| str_field("symbol"))
+    {
+        return truncate_field(&query, 80);
+    }
+
+    if let Some(prompt) = str_field("question").or_else(|| str_field("prompt")) {
+        return truncate_field(&prompt, 80);
+    }
+
+    // An argument-less call has nothing to summarize. `compact_json` renders
+    // `{}` for it, which the transcript then printed beside the tool name —
+    // and an empty object next to `project_overview` reads as an empty
+    // *result*, not as "this tool takes no arguments". Both this and the
+    // renderer treat the empty string as "no argument column"; saying it here
+    // as well is what keeps every consumer of `input` (the trace tab, the
+    // accessible renderer) agreeing about it.
+    if input.as_object().is_some_and(serde_json::Map::is_empty) || input.is_null() {
+        return String::new();
+    }
+    // Fallback: compact JSON, summarized.
+    summarize(&compact_json(input))
+}
+
+/// Truncate a field value to `max` chars with an ellipsis. Cuts *before*
+/// flattening: the newline→space replacement is one char in, one char out, so
+/// slicing the raw text first yields the identical result without copying a
+/// multi-megabyte `content`/`old_string` argument in full (the same reason
+/// [`cap_middle_with`] walks `char_indices` instead of materializing chars).
+pub(super) fn truncate_field(s: &str, max: usize) -> String {
+    // `nth(max)` is `None` exactly when the text is `max` chars or shorter.
+    if s.char_indices().nth(max).is_none() {
+        return s.replace(['\n', '\r'], " ");
+    }
+    let head_end = s
+        .char_indices()
+        .nth(max.saturating_sub(1))
+        .map_or(s.len(), |(i, _)| i);
+    format!("{}…", s[..head_end].replace(['\n', '\r'], " "))
+}
+
+/// The workspace-relative path a file tool targets. Every built-in file tool
+/// (`read_file`/`write_file`/`edit_file`/`delete_file`) takes its path under
+/// the `path` key, and the engine emits `FileChange` for that same path — so
+/// this is the join key between a tool result and its diff.
+pub(super) fn tool_input_path(input: &serde_json::Value) -> Option<String> {
+    if let Some(path) = input
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    {
+        return Some(path);
+    }
+    // apply_edits carries its paths in a batch, not at the top level; the
+    // first edit's path stands in so a single-file batch still renders an
+    // inline diff under its result row.
+    input
+        .get("edits")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|edits| edits.first())
+        .and_then(|e| e.get("path"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// Whether a tool name is one of the file-*mutating* built-ins — the only
+/// tools whose result should carry an inline diff (reads must not). Must
+/// stay in lockstep with `file_change_of` in stella-cli's `command_deck.rs`,
+/// the `FileChange` emitter that owns this list.
+pub(super) fn is_file_mutation(name: &str) -> bool {
+    matches!(
+        name,
+        "write_file" | "edit_file" | "apply_edits" | "delete_file"
+    )
+}
+
+/// Truncate a summary to [`SUMMARY_BUDGET`] chars with a middle-out elision —
+/// the head and tail both matter for a failing tool result (L-S3), so we keep
+/// both rather than head-truncating away the error tail.
+///
+/// Caps *before* flattening. `text` here is a raw tool payload that can be
+/// megabytes (the caller also passes it to [`cap_middle`]); replacing newlines
+/// first would copy the whole thing just to throw all but 200 chars away, and
+/// the replacement is one char in / one char out, so the two orders agree.
+pub(super) fn summarize(text: &str) -> String {
+    cap_middle_with(text, SUMMARY_BUDGET, "...").replace(['\n', '\r'], " ")
+}


### PR DESCRIPTION
`crates/stella-tui/src/model.rs` sat at **1500 of the guard's 1500 lines** with no baseline entry, so the next line added to it would have failed the gate outright. The line count is the trigger; it is not the reason to split *there*.

## The seam

The two halves grow on different clocks.

`SessionModel::apply` matches `AgentEvent` exhaustively and is one of the four **compile-enforced** stops when a variant is added (`stella_protocol::event::tags` § "Adding a variant"), so every new event costs this file at least a line and the arm cannot be declined. The trailing formatters — `compact_json`, `cap_middle`, `cap_input_json`, `format_tool_input`, `summarize` and friends — are functions over borrowed strings and `serde_json::Value` with no knowledge of events at all, and have no reason to grow when the vocabulary does.

Keeping them in one file meant the vocabulary's growth was paying rent on the formatter's length, and the ratchet was about to make an ordinary protocol change impossible. That is the interaction worth fixing, not the number.

**1500 → 1275**, with 225 lines of room for the fold to keep absorbing variants.

## A pure move

Every function is byte-identical to the one it replaced apart from the `pub(super)` a sibling module needs, and `model.rs` re-imports them so **no call site changed** — including in `model/tests.rs`. Exemplar: `deck/classify.rs`, extracted from `deck.rs` when #2007's parked-wait clock pushed it against the same ceiling, with the same "relieve the ratchet by extracting a coherent cluster, never by raising it" argument.

## No baseline entry

Deliberately. Per AGENTS.md § God files the baseline accepts no new entries, and adding one would also have obliged naming the file in AGENTS.md's table and in the crate README — a worse outcome than splitting. `check-god-files` still reports 19 god files across 7 crates, unchanged.

## Witness

This is a refactor, so there is no behavioural witness by design — and the meaningful verification is what did **not** change: the **13 deck render snapshots pass unblessed** (`tests/snapshots/deck/`). Not one rendered cell moved. A split that shifts a column is not a split.

`cargo test -p stella-tui`: all 12 test binaries green, 866 unit tests + 1 ignored. `cargo clippy -p stella-tui --all-targets -- -D warnings` clean. `make file-size`, `god-files`, `module-reachability` all OK.

## Deleted tests

None.

## Note on ordering

On `main` today the file is 1498, not 1500 — PR #2960 (#2942's delivery event) is what takes it to exactly the wall, because its new `AgentEvent` variant needs an arm in `apply`. This PR is branched off `main` and stands alone; landing it before or after #2960 both work, and landing it *first* means #2960's arm costs nothing.

Closes #2958

## Summary by Sourcery

Extract transcript formatting logic from stella-tui’s session model into a dedicated summarize module while preserving existing behavior and call sites.

Enhancements:
- Split text/JSON shaping and tool-input formatting helpers from model.rs into a new summarize.rs module to keep SessionModel focused on event handling and reduce god-file pressure.
- Re-export formatter functions from model.rs so existing callers and tests continue to use the same API without changes to call sites.