### PR TITLE
fix(stella-pipeline): deliver a candidate's work at each plan-step boundary, not only at the end (#2941)

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -106,7 +106,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -495,6 +495,7 @@ impl GitCandidateWorkspaces {
                     baseline,
                     refs_at_create,
                     sealed: Mutex::new(None),
+                    delivered: Mutex::new(None),
                     tools,
                     witness_tools,
                     diagnostics: GitDiagnosticRunner::new(ws_root.clone()),
@@ -512,6 +513,7 @@ impl GitCandidateWorkspaces {
                     changes: ChangeAnnounce {
                         registry: announce_target,
                         events: self.events.clone(),
+                        announced: AtomicBool::new(false),
                     },
                     omitted,
                 })
@@ -713,10 +715,17 @@ impl RepoStatusPort for SnapshotRepoStatus {
 struct ChangeAnnounce {
     registry: Arc<stella_tools::ToolRegistry>,
     events: Option<stella_core::EventSender>,
+    /// Mirrors the latest `set` call — a plain read of the same fact,
+    /// independent of whether an event sink was ever wired. Lets
+    /// [`GitCandidateWorkspace::deliver_checkpoint_inner`] ask "is this the
+    /// sole candidate in its fan-out" without adding a second flag the
+    /// pipeline would have to keep in sync with this one (#2941).
+    announced: AtomicBool,
 }
 
 impl ChangeAnnounce {
     fn set(&self, announce: bool) {
+        self.announced.store(announce, Ordering::Relaxed);
         let Some(events) = self.events.clone() else {
             return;
         };
@@ -725,6 +734,10 @@ impl ChangeAnnounce {
         } else {
             self.registry.attach_read_events(events);
         }
+    }
+
+    fn is_set(&self) -> bool {
+        self.announced.load(Ordering::Relaxed)
     }
 }
 
@@ -746,6 +759,15 @@ pub(crate) struct GitCandidateWorkspace {
     refs_at_create: BTreeMap<String, String>,
     /// Latest candidate commit whose exact bytes were verified.
     sealed: Mutex<Option<String>>,
+    /// Latest candidate commit whose bytes have already been applied to the
+    /// real tree — by [`CandidateWorkspace::deliver_checkpoint`] mid-run or
+    /// by [`CandidateWorkspace::adopt`] at the end — or `None` if nothing
+    /// has been delivered yet. The anchor [`GitCandidateWorkspace::escaped_paths_inner`]
+    /// and [`GitCandidateWorkspace::adopt_inner`] diff *from*, in place of
+    /// the workspace's original `baseline`, so a second delivery only ever
+    /// sends its own remainder and the escape check only ever looks at bytes
+    /// nothing has legitimately sent yet (#2941).
+    delivered: Mutex<Option<String>>,
     /// The candidate's tool surface: snapshot-rooted registry + custom tools,
     /// optionally layered under the session's `candidate_safe`-filtered MCP
     /// view (issue #248 Phase 1, see [`GitCandidateWorkspaces::with_candidate_mcp`]).
@@ -871,6 +893,46 @@ impl GitCandidateWorkspace {
         Ok(head.trim() == sealed && adopt::drifted_paths(&status).is_empty())
     }
 
+    /// The commit [`Self::adopt_inner`] and [`Self::escaped_paths_inner`]
+    /// diff *from*: the last commit this workspace actually delivered to the
+    /// real tree, or the original snapshot `baseline` if nothing has been
+    /// delivered yet. Reading `self.baseline` directly in either of those
+    /// would re-offer already-delivered bytes to `git apply` (a guaranteed
+    /// conflict) and would misread the real tree legitimately holding them
+    /// as an escape (#2941) — this is the one place either question is
+    /// answered, so the two callers cannot drift.
+    pub(super) fn delivery_anchor(&self) -> String {
+        self.delivered
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+            .unwrap_or_else(|| self.baseline.clone())
+    }
+
+    /// [`CandidateWorkspace::deliver_checkpoint`]: seal the current state,
+    /// fail closed on an escape exactly as the verify-stage seal does, then
+    /// adopt the remainder since [`Self::delivery_anchor`]. A no-op for any
+    /// candidate that is not the sole one in its fan-out — see the trait
+    /// doc for why that is decided here rather than by the caller.
+    async fn deliver_checkpoint_inner(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        if !self.changes.is_set() {
+            return Ok(Vec::new());
+        }
+        self.seal_inner().await?;
+        let escaped = self.escaped_paths_inner().await;
+        if !escaped.is_empty() {
+            return Err(WorkspaceError::Adopt {
+                reason: format!(
+                    "candidate wrote through its isolation into the real tree at: {}",
+                    escaped.join(", ")
+                ),
+                paths: escaped,
+                workspace: self.dir.display().to_string(),
+            });
+        }
+        self.adopt_inner(&[]).await
+    }
+
     /// The teardown half of the ref repair (#2641): audit and restore the
     /// shared ref namespace one last time, before `cleanup` removes the
     /// candidate.
@@ -958,6 +1020,10 @@ impl CandidateWorkspace for GitCandidateWorkspace {
 
     async fn escaped_paths(&self) -> Vec<String> {
         self.escaped_paths_inner().await
+    }
+
+    async fn deliver_checkpoint(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        self.deliver_checkpoint_inner().await
     }
 
     async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -82,19 +82,25 @@ impl GitCandidateWorkspace {
                 .iter()
                 .map(|dir| format!(":(exclude,glob)**/{dir}/**")),
         );
+        // The last commit already delivered to the real tree, not the
+        // workspace's original snapshot — a second delivery (mid-run
+        // checkpoint, then the final winner adoption) must only ever send
+        // its own remainder; re-offering already-applied bytes as this
+        // patch's preimage is a guaranteed `git apply` conflict (#2941).
+        let from = self.delivery_anchor();
         let mut name_args = vec![
             "diff",
             "--name-status",
             "--no-renames",
             "-z",
-            self.baseline.as_str(),
+            from.as_str(),
             sealed.as_str(),
         ];
         let mut patch_args = vec![
             "diff",
             "--binary",
             "--no-renames",
-            self.baseline.as_str(),
+            from.as_str(),
             sealed.as_str(),
         ];
         let mut numstat_args = vec![
@@ -102,19 +108,14 @@ impl GitCandidateWorkspace {
             "--numstat",
             "--no-renames",
             "-z",
-            self.baseline.as_str(),
+            from.as_str(),
             sealed.as_str(),
         ];
         // The patch that is APPLIED is `--binary`, streamed to a file so a huge
         // one never lands in memory. This one is text and in-memory: it exists
         // only to slice per-file diffs for display, so it is deliberately a
         // separate, smaller read.
-        let mut text_args = vec![
-            "diff",
-            "--no-renames",
-            self.baseline.as_str(),
-            sealed.as_str(),
-        ];
+        let mut text_args = vec!["diff", "--no-renames", from.as_str(), sealed.as_str()];
         if !exclusions.is_empty() {
             for args in [
                 &mut name_args,
@@ -132,6 +133,11 @@ impl GitCandidateWorkspace {
             .map_err(|e| fail(e, Vec::new()))?;
         let mut changes = parse_name_status(&names);
         if changes.is_empty() {
+            // Nothing to send, but `sealed` is still the newest state this
+            // workspace has certified — advance the anchor so a later,
+            // truly-empty re-seal (`--allow-empty` between two identical
+            // trees) never re-walks this same empty diff.
+            *self.delivered.lock().unwrap_or_else(|p| p.into_inner()) = Some(sealed);
             return Ok(Vec::new());
         }
         // How much each file moved, and what moved in it. Both best-effort: a
@@ -167,7 +173,10 @@ impl GitCandidateWorkspace {
             .await;
         let _ = tokio::fs::remove_file(&patch_file).await;
         match apply {
-            Ok(out) if out.success => Ok(changes),
+            Ok(out) if out.success => {
+                *self.delivered.lock().unwrap_or_else(|p| p.into_inner()) = Some(sealed);
+                Ok(changes)
+            }
             // `git apply` verifies every hunk's preimage before writing
             // anything, so a rejection means the real tree is not the tree this
             // patch was built against — and NOTHING was applied.
@@ -201,9 +210,10 @@ impl GitCandidateWorkspace {
 
     /// Name what actually broke the adoption precondition, by comparing the
     /// real tree's current bytes at each conflicting path against the two
-    /// states this candidate knows: the baseline it snapshotted and the commit
-    /// it sealed. See [`PathDivergence`] for why those two answer the question
-    /// git's stderr cannot.
+    /// states this candidate knows: [`Self::delivery_anchor`] (what should
+    /// already be in the real tree) and the commit it sealed. See
+    /// [`PathDivergence`] for why those two answer the question git's
+    /// stderr cannot.
     ///
     /// Best-effort throughout: every probe that fails leaves its side `None`,
     /// which classifies as "not the problem". A path this cannot read is one it
@@ -216,6 +226,7 @@ impl GitCandidateWorkspace {
         // failing. Bounded so a patch conflicting on hundreds of files cannot
         // fork hundreds of processes while reporting an error.
         const MAX_EXAMINED: usize = 24;
+        let from = self.delivery_anchor();
         let examined = paths.len().min(MAX_EXAMINED);
         let mut classified = Vec::with_capacity(examined);
         for path in paths.iter().take(examined) {
@@ -224,13 +235,7 @@ impl GitCandidateWorkspace {
             // filters would hash raw bytes and every path would look diverged.
             let real =
                 blob_id(git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await);
-            let baseline = blob_id(
-                git(
-                    &self.dir,
-                    &["rev-parse", &format!("{}:{path}", self.baseline)],
-                )
-                .await,
-            );
+            let baseline = blob_id(git(&self.dir, &["rev-parse", &format!("{from}:{path}")]).await);
             let sealed_blob =
                 blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);
             classified.push((

--- a/crates/stella-cli/src/candidate_ws/escape.rs
+++ b/crates/stella-cli/src/candidate_ws/escape.rs
@@ -60,16 +60,15 @@ impl GitCandidateWorkspace {
             // Never sealed: there are no candidate bytes to sign a match with.
             return Vec::new();
         };
+        // From the last commit already delivered to the real tree, not the
+        // workspace's original snapshot — bytes a checkpoint delivery
+        // already sent are legitimately in the real tree and must never be
+        // reported as this candidate having written through its isolation
+        // (#2941).
+        let from = self.delivery_anchor();
         let Ok(delta) = git(
             &self.dir,
-            &[
-                "diff",
-                "--name-only",
-                "--no-renames",
-                "-z",
-                &self.baseline,
-                &sealed,
-            ],
+            &["diff", "--name-only", "--no-renames", "-z", &from, &sealed],
         )
         .await
         else {
@@ -107,13 +106,7 @@ impl GitCandidateWorkspace {
             // and what it sealed. `--path` keeps clean filters in play.
             let real =
                 blob_id(git(&self.toplevel, &["hash-object", "--path", path, "--", path]).await);
-            let baseline = blob_id(
-                git(
-                    &self.dir,
-                    &["rev-parse", &format!("{}:{path}", self.baseline)],
-                )
-                .await,
-            );
+            let baseline = blob_id(git(&self.dir, &["rev-parse", &format!("{from}:{path}")]).await);
             let sealed_blob =
                 blob_id(git(&self.dir, &["rev-parse", &format!("{sealed}:{path}")]).await);
             if PathDivergence::classify(

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -650,6 +650,79 @@ async fn winner_adoption_lands_only_the_winners_changes() {
     std::fs::remove_dir_all(&root).ok();
 }
 
+/// #2941: a mid-run checkpoint delivers real bytes to the real tree, a
+/// second checkpoint after further edits sends only its own remainder
+/// (never re-offering the first round's bytes to `git apply`, which would
+/// conflict against a real tree that has already moved past them), the
+/// escape check never misreads either round's legitimately-delivered bytes
+/// as the candidate having written through its isolation, and the run's
+/// FINAL adoption — reached after both checkpoints — has nothing left to
+/// send.
+#[tokio::test]
+async fn incremental_delivery_is_idempotent_and_never_flags_itself_as_an_escape() {
+    let root = scaffold("checkpoint");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+    // Not announced: the first checkpoint call, before the pipeline marks
+    // this candidate as the sole one in its fan-out, must be a true no-op —
+    // the same gate `deliver_checkpoint`'s own doc states.
+    assert_eq!(
+        ws.deliver_checkpoint().await.unwrap(),
+        Vec::new(),
+        "an unannounced candidate's checkpoint must not touch the real tree"
+    );
+    assert!(
+        !root.join("step_one.txt").exists(),
+        "nothing was written before announce_changes"
+    );
+    ws.announce_changes(true);
+
+    // Step one's work.
+    std::fs::write(ws.dir().join("step_one.txt"), "first step\n").unwrap();
+    let first = ws.deliver_checkpoint().await.unwrap();
+    assert_eq!(
+        first.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+        vec!["step_one.txt"]
+    );
+    assert_eq!(read(&root.join("step_one.txt")), "first step\n");
+    // No escape: the real tree holds exactly what was just legitimately
+    // delivered, at a path the escape check's own delta window (baseline vs
+    // the workspace's LAST seal) no longer even considers.
+    assert_eq!(ws.escaped_paths().await, Vec::<String>::new());
+
+    // A second, empty checkpoint must not re-send step one's already-
+    // delivered bytes as a fresh patch — that patch's preimage (the
+    // original baseline) no longer matches the real tree, which is a
+    // guaranteed `git apply` conflict if the anchor did not advance.
+    assert_eq!(ws.deliver_checkpoint().await.unwrap(), Vec::new());
+
+    // Step two's work.
+    std::fs::write(ws.dir().join("step_two.txt"), "second step\n").unwrap();
+    let second = ws.deliver_checkpoint().await.unwrap();
+    assert_eq!(
+        second.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+        vec!["step_two.txt"],
+        "the second checkpoint must send only its own remainder"
+    );
+    assert_eq!(read(&root.join("step_one.txt")), "first step\n");
+    assert_eq!(read(&root.join("step_two.txt")), "second step\n");
+    assert_eq!(ws.escaped_paths().await, Vec::<String>::new());
+
+    // The run's final adoption reaches an unchanged tree: both checkpoints
+    // already delivered everything sealed so far.
+    assert_eq!(ws.adopt(&[]).await.unwrap(), Vec::new());
+
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+}
+
 #[tokio::test]
 async fn post_verification_worktree_drift_is_rejected_and_never_adopted() {
     let root = scaffold("sealed-drift");

--- a/crates/stella-pipeline/src/pipeline/execute_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/execute_stage.rs
@@ -184,6 +184,24 @@ impl<'a> Pipeline<'a> {
                 TurnOutcome::Completed { text, cost_usd } => {
                     *spend.total += cost_usd;
                     mark(i, TaskStatus::Completed);
+                    // #2941: a process killed between here and the run's
+                    // eventual verdict — the harness's wall-clock cap, a
+                    // SIGKILL, a crash — must not discard a step that
+                    // already finished. `deliver_checkpoint` is a no-op for
+                    // every candidate but the sole one in its fan-out (see
+                    // its doc), so this costs nothing on the common
+                    // multi-candidate path.
+                    if let Some(ws) = board
+                        && let Err(error) = ws.deliver_checkpoint().await
+                    {
+                        return Err(TurnAbort {
+                            reason: format!(
+                                "candidate could not deliver step {}'s work early: {error}",
+                                offset + i + 1
+                            ),
+                            kind: AbortKind::Failure,
+                        });
+                    }
                     // #1702: a worker that declares the whole goal done ends
                     // the walk — the remaining steps could only re-confirm
                     // finished work. The declaration is screened for polarity
@@ -219,6 +237,15 @@ impl<'a> Pipeline<'a> {
                     // flight after the run stopped — the same half-invariant
                     // `Plan::finish` holds on the TUI side.
                     mark(i, TaskStatus::Cancelled);
+                    // Best-effort, and deliberately not propagated: an
+                    // aborted turn can still have left real file writes
+                    // behind, and this is the last chance to save them
+                    // (#2941). The abort already has its own reason; a
+                    // delivery failure on top of it would only obscure why
+                    // the turn actually stopped.
+                    if let Some(ws) = board {
+                        let _ = ws.deliver_checkpoint().await;
+                    }
                     return Err(TurnAbort { reason, kind });
                 }
             }

--- a/crates/stella-pipeline/src/pipeline/test_doubles.rs
+++ b/crates/stella-pipeline/src/pipeline/test_doubles.rs
@@ -234,6 +234,19 @@ impl CandidateWorkspace for FakeWorkspace {
     async fn escaped_paths(&self) -> Vec<String> {
         self.escaped.clone()
     }
+    async fn deliver_checkpoint(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        // Mirrors the real workspace's own gate: a no-op, unlogged, for any
+        // candidate `announce_changes` never told it was the sole one in its
+        // fan-out — see `GitCandidateWorkspace::deliver_checkpoint_inner`.
+        if *self.announced.lock().unwrap() != Some(true) {
+            return Ok(Vec::new());
+        }
+        self.log
+            .lock()
+            .unwrap()
+            .push(format!("deliver:{}", self.id));
+        self.adopt_result.clone()
+    }
     async fn adopt(&self, withhold: &[String]) -> Result<Vec<AdoptedChange>, WorkspaceError> {
         // The withheld set is logged so tests can assert that an authored
         // witness never reaches the real tree, without reaching for real git.

--- a/crates/stella-pipeline/src/pipeline/tests/delivery.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/delivery.rs
@@ -102,6 +102,67 @@ async fn failed_final_verification_still_delivers_the_winners_work() {
     );
 }
 
+/// **The witness for #2941.** Candidate delivery used to happen exactly once,
+/// at the very end of the run, after a verdict — so a process killed before
+/// that point (the harness's wall-clock cap, a SIGKILL, a crash) discarded
+/// the whole candidate, work already finished included, because nothing this
+/// process had not yet executed could ever run. A unit test cannot simulate
+/// the kill itself (the test process would die with it); what it CAN show is
+/// the fact that makes the kill survivable — that a finished step's work
+/// reaches the real tree at the step boundary, not at the end of the run. If
+/// step one's `deliver:0` is already in the log before step two's turn even
+/// starts, then a kill at any point after step one — including one this
+/// process never gets to react to — has already lost nothing.
+///
+/// Fails on `main`: nothing but the final winner adoption ever writes to the
+/// real tree, so `deliver:0` never appears and only `adopt:0` — at the very
+/// end — would be in this log.
+#[tokio::test]
+async fn a_finished_steps_work_is_delivered_before_the_next_steps_turn_starts() {
+    let provider = ScriptedProvider::new(vec![
+        text_result("multi"),
+        text_result(r#"["step one","step two"]"#),
+        text_result("did step one"),
+        text_result("did step two"),
+    ]);
+    let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let port = FakeWorkspacePort::new(
+        vec![Ok(FakeWorkspace::new(
+            0,
+            vec![false, true],
+            Ok(vec![delivered_change()]),
+            log.clone(),
+        ))],
+        log.clone(),
+    );
+
+    // A lone candidate is not isolated by default (#1719) — `create_worktrees`
+    // is the deliberate trigger here; an authored witness is the other, and
+    // either reaches the same isolated path this fix lives on.
+    let config = PipelineConfig {
+        create_worktrees: crate::ports::WorktreePolicy::Always,
+        ..isolated_config(1)
+    };
+    let (outcome, _events, _) =
+        run_isolated(&provider, &port, config, "Fix the failing test").await;
+    let outcome = outcome.expect("run succeeds");
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+
+    let log = log.lock().unwrap().clone();
+    let first_delivery = log.iter().position(|entry| entry == "deliver:0");
+    let final_adoption = log.iter().position(|entry| entry == "adopt:0");
+    assert!(
+        first_delivery.is_some(),
+        "step one's finished work must be delivered at its own step boundary: {log:?}"
+    );
+    assert!(
+        first_delivery < final_adoption,
+        "the checkpoint delivery must land strictly before the run's final \
+         winner adoption, so a kill any time after it has already lost \
+         nothing: {log:?}"
+    );
+}
+
 /// The rail line is a warning, not a failure, and it is absent when the run
 /// genuinely proved itself — a passing delivery must not be narrated as
 /// unproven.

--- a/crates/stella-pipeline/src/ports/workspace.rs
+++ b/crates/stella-pipeline/src/ports/workspace.rs
@@ -217,6 +217,23 @@ pub trait CandidateWorkspace: Send + Sync {
     async fn escaped_paths(&self) -> Vec<String> {
         Vec::new()
     }
+    /// Seal the workspace's current state and apply everything produced
+    /// since the last delivery (the starting snapshot, on the first call) to
+    /// the real tree — the same all-or-nothing contract as [`Self::adopt`],
+    /// run at execute-stage step boundaries so a process killed before the
+    /// run ever reaches a verdict still has that step's work in the graded
+    /// tree (#2941). [`Self::adopt`]'s final delivery only has to send
+    /// whatever a checkpoint has not already sent.
+    ///
+    /// Deliberately gated on the same fact [`Self::announce_changes`]
+    /// already gates on, not on a caller-supplied flag: several candidates'
+    /// trees delivered piecemeal into one real tree would be nobody's tree,
+    /// so a substrate that is not the sole candidate in its fan-out answers
+    /// `Ok(empty)` without touching git. A substrate that cannot checkpoint
+    /// at all shares that answer by construction — the default below.
+    async fn deliver_checkpoint(&self) -> Result<Vec<AdoptedChange>, WorkspaceError> {
+        Ok(Vec::new())
+    }
     /// Apply this workspace's changes — relative to its starting snapshot —
     /// to the real tree. All-or-nothing: on conflict the real tree is left
     /// byte-identical and the error names the conflicting paths


### PR DESCRIPTION
## What & why

Candidate delivery ran exactly once, at the end of the run, after a verdict — so a process killed before that point (the harness's wall-clock cap, a SIGKILL, a crash) discarded the whole candidate, finished work included. #2943 fixed the *decision* half (a verdict no longer gates whether delivery happens); this fixes the *timing* half, which #2943 explicitly declined to guess at, per #2941's own framing: two designs both work, and picking the wrong one burns the isolation-escape check's safety margin.

## Which design, and why

#2941 named three candidate designs. Ruled out:
- **A SIGTERM handler** — the measured failures in #2941 are the harness's wall-clock kill, a hard `SIGKILL` with no signal to catch. Disqualified by the evidence in the issue itself.
- **Deadline-margin delivery** ("adopt when the deadline is within a margin") — cheap, but the margin estimate can be wrong under load, and a miss reproduces exactly the bug this is meant to fix. An expedient wearing a design's clothes.

That leaves **incremental delivery**: adopt at stage boundaries, unconditionally, so nothing after the last completed boundary can be lost regardless of *how* or *when* the process dies. Implemented at plan-step granularity (the execute stage's natural boundary).

## How

- `CandidateWorkspace::deliver_checkpoint` (new port method, default no-op) seals the workspace's current state and adopts everything since the last delivery into the real tree. Gated on the same "am I the sole candidate in this fan-out" latch `announce_changes` already tracks — several candidates' trees delivered piecemeal would be nobody's tree, so a wider fan-out costs nothing extra.
- A `delivered` anchor (distinct from `sealed`) on `GitCandidateWorkspace`. `adopt_inner` and the post-seal escape check (#1538) both diff from `delivery_anchor()` — the last legitimate delivery — instead of the workspace's original baseline. Without this, a second delivery would re-offer already-applied bytes to `git apply` (a guaranteed conflict), and the escape check would misread its own delivered bytes as the candidate having written through its isolation.
- `execute_stage.rs`'s `run_plan_steps` calls it after each step completes (aborting the candidate on a real delivery failure — a conflict there means something is genuinely wrong) and best-effort on an aborted turn (never masking the abort's real reason).

## Witnesses

- `crates/stella-pipeline/src/pipeline/tests/delivery.rs::a_finished_steps_work_is_delivered_before_the_next_steps_turn_starts` — fails on `main` (verified by stashing just the implementation and re-running against this test): a 2-step plan run's log holds `deliver:0` strictly before the final `adopt:0`, proving a kill any time after step one has already lost nothing. On `main`, nothing is delivered until the very end.
- `crates/stella-cli/src/candidate_ws/tests.rs::incremental_delivery_is_idempotent_and_never_flags_itself_as_an_escape` — real-git-backed: two checkpoint rounds each send only their own remainder, the escape check never misreads either round's delivered bytes as an escape, and the final `adopt` on an already-fully-delivered workspace is a true no-op.
- All 80 pre-existing `candidate_ws` tests (escape/adopt/ref-escape) pass unchanged — the anchor swap is backward-compatible wherever no checkpoint delivery happens (every non-lone candidate, and the unmodified verify-stage revise loop).

## Scope not covered here

Filed as #2969: the no-plan (single-turn) execute branch has no intermediate checkpoint opportunity, and the verify stage's revise loop isn't wired to `deliver_checkpoint` either. Both are real gaps, explicitly out of this change's scope (this PR covers the plan-step-walk case, which is the one #2941 measured).

Closes #2941
Refs #2969

## Test plan

- [x] `cargo test -p stella-pipeline` (1741... actually 724 for this crate alone, 1741 combined with stella-cli) — all green
- [x] `cargo test -p stella-cli candidate_ws` — all 80 pre-existing + 1 new test green
- [x] Witness verified to fail on `main` (stashed implementation, kept test)
- [x] `make gate CARGO_SCOPE="-p stella-cli -p stella-pipeline"` — green (fmt, clippy -D warnings, rustdoc -D warnings, file-size/god-files/left-behind/invariants guards, full test suite, self-driving-test harness)

## Summary by Sourcery

Deliver candidate workspace changes incrementally at execute-stage plan-step boundaries so completed work is preserved even if the process terminates before the final verdict.

New Features:
- Introduce a deliver_checkpoint operation on candidate workspaces to apply work produced since the last delivery to the real tree at step boundaries.

Bug Fixes:
- Ensure a finished step's work is delivered to the real tree before the next step runs, avoiding loss of completed work when the process is killed mid-run.
- Prevent checkpoint deliveries from re-sending already-applied changes or falsely treating legitimately delivered bytes as isolation escapes.

Enhancements:
- Track a separate delivery anchor commit in Git-backed candidate workspaces and reuse it across adoption and escape-check logic for consistent incremental delivery semantics.

Tests:
- Add pipeline and CLI tests that witness incremental delivery behavior, including idempotent multi-checkpoint runs and correct logging of mid-run deliveries in isolated executions.