### PR TITLE
feat(bench): make triage-bench-traces — a bench run in, GitHub issue activity out

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -127,6 +127,15 @@ jobs:
         if: steps.scope.outputs.changed == 'true'
         run: uv run --with pytest --no-project pytest -q bench/evidence/tests
 
+      # The bench-trace triage tool. Same `--no-project` reasoning as its
+      # neighbours — it is standard-library only so that the piece deciding what
+      # a run says about the product needs no harness to be testable. It is not
+      # a `make gate` step (it reads S3 and writes to GitHub), so this workflow
+      # is the only thing standing between it and silent rot.
+      - name: trace triage — pytest
+        if: steps.scope.outputs.changed == 'true'
+        run: uv run --with pytest --no-project pytest -q bench/trace_triage/tests
+
       # The Frontier-Bench run planner. No project to sync and no Harbor to
       # install: plan.py imports nothing outside the standard library, which is
       # deliberate — the piece that decides which tasks are allowed to run

--- a/Makefile
+++ b/Makefile
@@ -145,9 +145,22 @@ record-demo: ## Record a terminal timelapse (LIMIT=mins TARGET=secs CMD="..."; d
 	./scripts/record-demo.sh --limit $(LIMIT) --target $(TARGET) $(if $(CMD),-- bash -c '$(CMD)',)
 
 .PHONY: bench-test
-bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer)
+bench-test: ## Test the Python benchmark tooling (TB2.1 adapter + analyzer + trace triage)
 	cd bench/harbor_adapter && uv sync --locked --extra dev && uv run --no-sync pytest -q
 	cd bench/terminal_bench_analysis && uv sync --locked --extra dev && uv run --no-sync pytest -q
+	python3 -m pytest -q bench/trace_triage/tests
+
+# Deliberately NOT a `make gate` step: it reads S3 and talks to GitHub, and the
+# gate must stay runnable offline and side-effect-free. `gate-parity` would fail
+# the moment this joined GATE_STEPS, which is the guard working.
+#
+# The default is a dry run — it prints the exact issue bodies and comments it
+# would post and writes nothing. `ARGS=--apply` is the only thing that writes.
+.PHONY: triage-bench-traces
+triage-bench-traces: ## Triage a bench run's traces into issue activity (RUN=w10p MIRROR=path|FETCH=1; dry run unless ARGS=--apply)
+	@[ -n "$(RUN)" ] || { echo "usage: make triage-bench-traces RUN=<run-id> [MIRROR=path | FETCH=1] [ARGS=--apply]"; exit 2; }
+	python3 bench/trace_triage/triage_bench_traces.py --run $(RUN) \
+		$(if $(MIRROR),--mirror $(MIRROR),) $(if $(FETCH),--fetch,) $(ARGS)
 
 .PHONY: no-scratch
 no-scratch: ## Assert no tracked file is gitignored (agent scratch guard, #448)

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,7 +5,7 @@ with other agents, and standalone. Everything here is **BYOK** (bring your own
 key), makes **no phone-home**, and never hard-codes a secret. Claim runs use a
 secure launcher that consumes the selected credential before Harbor starts.
 
-Five entry points:
+Six entry points — five that produce a run, and one that reads one:
 
 | Path | What it does | Needs |
 |---|---|---|
@@ -14,6 +14,7 @@ Five entry points:
 | [`run_swebench.py`](run_swebench.py) | A standalone SWE-bench *prediction* harness — clone each instance, run Stella, emit the official predictions JSONL. No Harbor. | `git`, a provider key (Docker only for the official scoring step) |
 | [`loop-bench/`](loop-bench/) | A cheap **turn-loop + context-query correctness** harness: runs N tasks on a flash-tier model, budget-capped, and reports loop health (silent-death / zero-work / stuck-loop) and `project_overview`/`graph_query` adoption — the signals the pass-rate number hides. | `cargo`, Docker, `harbor`, a key |
 | [`smoke/smoke_test.py`](smoke/smoke_test.py) | An **offline, zero-cost** self-test of the adapter wiring for CI. | just the built `stella` binary |
+| [`trace_triage/`](trace_triage/) | `make triage-bench-traces` — reads a finished run's `stella-events.jsonl` and turns the defects in it into **GitHub issue activity**: a new issue for a new defect, a comment carrying fresh citable evidence onto one that already exists. Dry run by default; de-duplicates on a defect fingerprint, never on prose. | `aws` (to mirror a run), `gh` |
 
 For development and the offline smoke test, build the native binary:
 

--- a/bench/trace_triage/README.md
+++ b/bench/trace_triage/README.md
@@ -1,0 +1,154 @@
+# `make triage-bench-traces` — bench run in, issue activity out
+
+A repeatable pass over a finished ArenaBench run whose **input** is the run's
+traces and whose **output** is GitHub issue activity: a new issue for a
+genuinely new defect, a comment carrying fresh citable evidence onto an issue
+that already describes the behaviour.
+
+```sh
+make triage-bench-traces RUN=w10p FETCH=1          # dry run: prints the plan
+make triage-bench-traces RUN=w10p MIRROR=~/w10p    # a mirror you already have
+make triage-bench-traces RUN=w10p MIRROR=~/w10p ARGS=--apply   # writes
+```
+
+The default is a **dry run**. It prints, per finding, the de-duplication
+decision, what that decision was made on, and the exact title and body it would
+post — so the plan is readable before anything reaches the tracker.
+
+## Why it exists
+
+Every bench run surfaces defects, and until now they were found by a human
+reading traces by hand and then remembering to file something. That is how
+findings get lost, and how one defect gets filed three times in three different
+sets of words. This repository's own backlog carries the proof: #2929 and #2872
+describe a single defect — an oracle that fails on both trees and routes to
+`Revise` — with almost no shared vocabulary, found on different runs.
+
+So the hard requirement is: **the output is never a duplicate issue**, including
+against closed ones. A closed issue whose defect recurs gets a comment saying
+so, which is more valuable than either a second ticket or silence.
+
+## The fingerprint
+
+A defect is identified by a triple, hashed — never by its prose.
+
+```
+fp = sha256("<detector>\n<site>\n<variant>")[:12]
+```
+
+* **detector** — the event-level predicate that fired. Two findings from one
+  predicate are the same kind of defect by construction.
+* **site** — the repo-relative code site the detector implicates, declared on
+  the detector and never derived from the run.
+* **variant** — a *normalized* discriminator from the occurrence, so one
+  detector can still separate genuinely different defects. Normalization erases
+  everything that varies between two runs of one defect: quoted spans, absolute
+  paths, the `/tmp/stella_candidate_<n>_<n>` workspace root, digits, whitespace.
+
+None of the three holds a run id, a trial id, a task name, a timestamp, a cost,
+a model name or a line number — which is why a recurrence next week hashes to
+this week's value, and why two different reasons under one detector do not
+collide.
+
+**A variant discriminates defects, not payloads.** `witness_unavailable`
+reasons are a small closed set the engine authors, so the reason *is* the
+discriminator and each one is its own defect. A tool error message is command
+output — pure run data — so keying on it shattered one defect into 23 tickets
+the first time this was pointed at a real run; that detector's variant is a
+constant, and its predicate carries the whole identity.
+
+## The de-duplication gates
+
+Three, in order, each a fallback for the previous one failing:
+
+1. **The ledger** — [`fingerprints.json`](fingerprints.json), tracked in git.
+   A bound fingerprint is that issue. No search, no similarity, no judgement.
+2. **The marker** — every issue this tool opens carries
+   `<!-- stella-trace-fingerprint: fp_… -->` in its body, so a lost or reset
+   ledger is rebuilt from GitHub itself.
+3. **A search across open AND closed**, whose hits are printed as *candidates*
+   for a human to confirm. A candidate is never auto-bound: prose similarity is
+   the instrument that filed the duplicate above, and it does not get a vote.
+
+A finding that survives all three is new, and only then may an issue be opened.
+A search that **errored** is not a search that found nothing: it fails closed
+and blocks the new issue rather than risking the duplicate.
+
+## Editing the ledger
+
+`fingerprints.json` is meant to be corrected by hand. An entry whose `source` is
+anything but `auto` is a human decision and is never overwritten by a later run.
+Delete an entry to make the tool re-derive it from a search — the right move
+when a mapping was *wrong* rather than merely stale.
+
+`runs`, `tasks` and `peak_*` are the incidence already on the record. They are
+what lets a comment say what an occurrence **adds** — a new run, a task the
+issue never named, a higher rate — instead of restating the issue. When an
+occurrence adds nothing, nothing is posted; the run is still recorded so the
+next comparison is against the truth.
+
+## Detectors
+
+| Code | Fires on |
+|---|---|
+| `void-model-call` | `reasoning` deltas with zero `step_usage` — no model call ever completed |
+| `agent-timeout` | harbor's own `AgentTimeoutError` classification |
+| `witness-unavailable` | `proof` `step.kind == "witness_unavailable"`, split per reason |
+| `oracle-flip-ungraded` | an oracle flip (baseline fail, candidate pass) on a trial graded 0 |
+| `tool-error-envelope` | an error envelope wrapping substantial output before `[exit code: N]` |
+| `repeated-identical-tool-call` | adjacent identical `(tool, args)` with byte-identical output |
+| `role-model-census-mismatch` | `(role, model)` off `step_usage` against the run's declared seat |
+| `no-post-verdict-file-change` | no `verdict` at all, or a verdict with no `file_change` after it |
+
+`--list-detectors` prints the live registry.
+
+### Adding one
+
+One decorated function in [`detectors.py`](detectors.py), and nothing else:
+
+```python
+@detector(
+    code="my-shape",
+    title="what a new issue would be called",
+    site="crates/stella-pipeline/src/verify.rs",  # or "" if none implicated
+    search_terms=("phrase a reviewer would search",),
+)
+def _my_shape(run: Run) -> list[Finding]: ...
+```
+
+The decorator registers it; `run_all` picks it up; the plan, the rendering and
+the de-duplication need no change. `tests/test_detectors.py::test_every_detector_declares_its_contract`
+holds you to the contract.
+
+Three rules a detector must obey, each of which this repository has paid for:
+
+* **`proof` discriminates on `step.kind`**, not the top-level `type`. Use
+  `trial.proofs(kind=…)`.
+* **Carry a reason string in full.** They are truncated in every other surface
+  and the truncated half is usually the point.
+* **`file_change` is observability, never evidence.** `bash` names no path, so a
+  heredoc, `patch`, `make` or `>` mutates the tree silently. A detector keyed on
+  its absence reports an absent *event* and never an unchanged tree — and says
+  so in its own output, so the sentence reaches the issue.
+
+A detector that fires once must say "single occurrence" rather than quote
+`1/20 = 5%`. The percentage is arithmetically true and epistemically a lie.
+
+## Safety
+
+* Dry run by default; `--apply` is the only thing that writes.
+* `--max-new-issues` (default 5) caps one invocation. Anything past it is
+  printed as `SUPPRESSED` **with its full evidence** and logged — never
+  silently dropped.
+* `--offline` skips every GitHub read and refuses to write, because a tool that
+  cannot de-duplicate must not file.
+
+## Tests
+
+```sh
+uv run --with pytest --no-project pytest -q bench/trace_triage/tests
+```
+
+Standard library only, no network. Fixtures are transcribed from real artifacts
+under `runs/w10p/`, because a fixture that disagrees with the wire tests the
+fixture.

--- a/bench/trace_triage/conftest.py
+++ b/bench/trace_triage/conftest.py
@@ -1,0 +1,13 @@
+"""Make the triage modules importable from `tests/` without installing a package.
+
+`bench/trace_triage/` is a set of loose standard-library modules, deliberately —
+the piece that decides what a bench run says about the product should not need
+the benchmark harness installed to be testable. Pytest's default import mode
+only puts the *test* directory on `sys.path`, so this puts the package directory
+there too, the same way `bench/telemetry_store/conftest.py` does.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/bench/trace_triage/detectors.py
+++ b/bench/trace_triage/detectors.py
@@ -64,6 +64,19 @@ class Occurrence:
     excerpt: str
     location: str = ""
 
+    @property
+    def task_name(self) -> str:
+        """The dataset task, with the per-trial suffix stripped.
+
+        `code-from-image__UTUWFRc` is one *attempt*; the suffix is minted fresh
+        every run. A citation names the attempt (that is what a reader fetches),
+        but anything compared across runs — the ledger's `tasks` list, and so
+        every "a new affected task" claim — must use this. Keyed on the raw id,
+        the novelty check reports all twenty tasks of a rerun as new, which is
+        the loudest possible way to say nothing.
+        """
+        return self.task_id.split("__", 1)[0]
+
     def render(self) -> str:
         head = f"- **{self.task_id}** (trial `{self.trial_uuid}`)"
         if self.location:

--- a/bench/trace_triage/detectors.py
+++ b/bench/trace_triage/detectors.py
@@ -1,0 +1,827 @@
+"""The defect shapes `make triage-bench-traces` looks for, and the registry.
+
+Every detector is a pure function from a loaded `Run` to a list of `Finding`s.
+It reads `stella-events.jsonl` (plus `reward.txt`, `exception.txt` and
+`results.json`) and returns nothing but observations with citations attached —
+no GitHub, no network, no policy about what to do with what it found. That
+split is what makes the whole set testable against a fixture trace, and it is
+why adding a detector is one decorated function and nothing else.
+
+## Adding a detector
+
+    @detector(
+        code="my-shape",                       # stable; part of the fingerprint
+        title="what a new issue would be called",
+        site="crates/stella-pipeline/src/verify.rs",   # or "" if none implicated
+        search_terms=("phrase a reviewer would search",),
+    )
+    def _my_shape(run: Run) -> list[Finding]:
+        ...
+
+Register it by importing this module — the decorator appends to `DETECTORS`.
+`tests/test_detectors.py::test_every_detector_declares_its_contract` then holds
+you to the contract, so a detector cannot ship without a code, a title and the
+search terms the de-duplication step needs.
+
+Three rules a detector must obey, each of which this repository has paid for:
+
+1. **`proof` discriminates on `step.kind`.** Use `trial.proofs(kind=...)`.
+2. **Carry a reason string in FULL.** They are truncated in every projection
+   and the truncated half is usually the point, so an occurrence's excerpt is
+   the whole string. Never `[:80]`.
+3. **`file_change` is observability, never evidence.** `bash` names no path, so
+   a heredoc, `patch`, `make` or `>` mutates the tree without emitting one.
+   A detector keyed on its absence states what it observed — "no `file_change`
+   event was recorded" — and never concludes that the tree did not change. The
+   `no-post-verdict-file-change` detector below carries that caveat in its own
+   output so the sentence reaches the issue rather than dying here.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from fingerprint import Fingerprint, fingerprint_of
+from run_trace import Run, Trial
+
+# A `bash` error envelope whose message is at least this long, and this many
+# lines, before its `[exit code: N]` trailer is carrying real output that the
+# model now has to read as a failure.
+_SUBSTANTIAL_OUTPUT_CHARS = 200
+_SUBSTANTIAL_OUTPUT_LINES = 3
+
+
+@dataclass(frozen=True)
+class Occurrence:
+    """One citable instance: where it happened and the bytes that show it."""
+
+    trial_uuid: str
+    task_id: str
+    s3_key: str
+    excerpt: str
+    location: str = ""
+
+    def render(self) -> str:
+        head = f"- **{self.task_id}** (trial `{self.trial_uuid}`)"
+        if self.location:
+            head += f" — {self.location}"
+        return f"{head}\n  `{self.s3_key}`\n\n```\n{self.excerpt}\n```"
+
+
+@dataclass
+class Finding:
+    """What one detector saw, with everything needed to file or comment on it."""
+
+    detector: str
+    site: str
+    variant_source: str
+    title: str
+    summary: str
+    occurrences: list[Occurrence]
+    denominator: int
+    search_terms: tuple[str, ...] = ()
+    caveats: list[str] = field(default_factory=list)
+    detail: str = ""
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        return fingerprint_of(self.detector, self.site, self.variant_source)
+
+    @property
+    def count(self) -> int:
+        return len(self.occurrences)
+
+    @property
+    def single_occurrence(self) -> bool:
+        return self.count <= 1
+
+    def rate_line(self) -> str:
+        """The incidence, stated so it cannot be read as more than it is.
+
+        A one- or two-trial difference at n=20 is noise, and a detector that
+        fires once must say so rather than presenting `1/20 = 5%` as a rate —
+        the percentage is arithmetically true and epistemically a lie.
+        """
+        if self.denominator <= 0:
+            return f"{self.count} occurrence(s); no denominator recorded."
+        if self.single_occurrence:
+            return (
+                f"**Single occurrence** — {self.count} of {self.denominator} trials examined. "
+                "This is one trial, not a rate: do not read an incidence off it."
+            )
+        pct = 100.0 * self.count / self.denominator
+        line = f"{self.count} of {self.denominator} trials examined ({pct:.0f}%)."
+        if self.count <= 2:
+            line += (
+                " At this denominator two occurrences are within noise of one — treat the"
+                " count as the observation and the percentage as decoration."
+            )
+        return line
+
+
+@dataclass(frozen=True)
+class Detector:
+    code: str
+    title: str
+    site: str
+    search_terms: tuple[str, ...]
+    fn: Callable[[Run], list[Finding]]
+
+    def run(self, run: Run) -> list[Finding]:
+        return [f for f in self.fn(run) if f.occurrences]
+
+
+DETECTORS: list[Detector] = []
+
+
+def detector(
+    *, code: str, title: str, site: str = "", search_terms: Iterable[str] = ()
+) -> Callable[[Callable[[Run], list[Finding]]], Callable[[Run], list[Finding]]]:
+    def wrap(fn: Callable[[Run], list[Finding]]) -> Callable[[Run], list[Finding]]:
+        DETECTORS.append(
+            Detector(
+                code=code,
+                title=title,
+                site=site,
+                search_terms=tuple(search_terms),
+                fn=fn,
+            )
+        )
+        return fn
+
+    return wrap
+
+
+def run_all(run: Run) -> list[Finding]:
+    findings: list[Finding] = []
+    for det in DETECTORS:
+        findings.extend(det.run(run))
+    return findings
+
+
+def _brief(event: dict[str, Any], limit: int = 400) -> str:
+    """A one-line event excerpt for a citation, with reasons left whole.
+
+    The truncation here is on the *event*, never on a `reason`: a reason is
+    lifted out first and printed in full, because it is the half every other
+    surface cuts.
+    """
+    text = json.dumps(event, ensure_ascii=False)
+    return text if len(text) <= limit else text[:limit] + " …(event truncated)"
+
+
+# --------------------------------------------------------------------------
+# 1. A trial that thought, and never completed a model call
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="void-model-call",
+    title="a trial streamed reasoning and completed zero model calls",
+    site="crates/stella-model/src/provider_parity.rs",
+    search_terms=("step_usage reasoning deltas zero", "agent timeout no completed step"),
+)
+def _void_model_call(run: Run) -> list[Finding]:
+    """`reasoning` deltas with no `step_usage` at all.
+
+    `step_usage` is emitted only when a step *completes*, so a trial with
+    thousands of reasoning deltas and zero of them never got a single model call
+    back. That is an infrastructure void — the run measured the harness, not the
+    agent — and reporting it as a task loss is the flattering-artifact error.
+    """
+    occurrences = []
+    for trial in run.trials:
+        reasoning = len(trial.of_type("reasoning"))
+        usage = len(trial.of_type("step_usage"))
+        if reasoning > 0 and usage == 0:
+            occurrences.append(
+                Occurrence(
+                    trial_uuid=trial.trial_uuid,
+                    task_id=trial.task_id,
+                    s3_key=trial.s3_key(),
+                    location=f"{reasoning} reasoning deltas, 0 step_usage events",
+                    excerpt=(
+                        f"reasoning deltas : {reasoning}\n"
+                        f"step_usage       : 0   <- no model call ever completed\n"
+                        f"tool_start       : {len(trial.of_type('tool_start'))}\n"
+                        f"harbor exception : {', '.join(trial.exception_types) or 'none recorded'}"
+                    ),
+                )
+            )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="void-model-call",
+            site="crates/stella-model/src/provider_parity.rs",
+            variant_source="reasoning deltas present with zero completed model calls",
+            title="a trial streamed reasoning and completed zero model calls",
+            summary=(
+                "These trials emitted `reasoning` deltas but no `step_usage` at all. "
+                "`step_usage` fires only on a completed step, so not one model call "
+                "returned. This is an infrastructure void, not a task loss: scoring "
+                "these as agent failures measures the harness."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=("step_usage reasoning deltas zero", "agent timeout no completed step"),
+            caveats=[
+                "Reads only completed-step telemetry. A provider that streamed reasoning "
+                "and then timed out server-side is indistinguishable here from one that "
+                "never accepted the request; both are voids, but the cause is not decided "
+                "by this signal alone."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 2. Trials the harness killed
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="agent-timeout",
+    title="the run is dominated by AgentTimeoutError — it measures the timeout, not the agent",
+    site="",
+    search_terms=("AgentTimeoutError", "agent execution timed out"),
+)
+def _agent_timeout(run: Run) -> list[Finding]:
+    """Trials harbor recorded as `AgentTimeoutError`.
+
+    Taken from `results.json`'s `exception_stats` — harbor's own classification
+    — rather than by regexing the traceback, so the detector agrees with the
+    runner about what killed the trial instead of parsing prose about it.
+    """
+    occurrences = []
+    for trial in run.trials:
+        if "AgentTimeoutError" not in trial.exception_types:
+            continue
+        tail = trial.exception_text.strip().splitlines()[-3:]
+        occurrences.append(
+            Occurrence(
+                trial_uuid=trial.trial_uuid,
+                task_id=trial.task_id,
+                s3_key=trial.s3_key("exception.txt"),
+                location=(
+                    f"{len(trial.of_type('step_usage'))} completed steps, "
+                    f"{len(trial.of_type('tool_start'))} tool calls, reward "
+                    f"{trial.reward if trial.reward is not None else 'unrecorded'}"
+                ),
+                excerpt="\n".join(tail) or "exception.txt absent; class from results.json",
+            )
+        )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="agent-timeout",
+            site="",
+            variant_source="harbor recorded AgentTimeoutError for the trial",
+            title=(
+                "the run is dominated by AgentTimeoutError — it measures the timeout, "
+                "not the agent"
+            ),
+            summary=(
+                "Harbor killed these trials at the agent timeout. A run whose trials "
+                "predominantly end this way has an operational abort as its outcome "
+                "distribution: its solve rate is a measurement of the ceiling, and "
+                "comparing it against another arm compares two ceilings."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=("AgentTimeoutError", "agent execution timed out"),
+            caveats=[
+                "A timeout is not by itself a defect — it is a defect when it is the "
+                "run's dominant outcome, or when the trace shows work finished before "
+                "the kill. Read the per-trial step counts above before concluding."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 3. The witness that was never authored
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="witness-unavailable",
+    title="witness authoring failed",
+    site="crates/stella-pipeline/src/verify.rs",
+    search_terms=("witness_unavailable", "witness author", "no TEST_COMMAND"),
+)
+def _witness_unavailable(run: Run) -> list[Finding]:
+    """`proof` steps with `kind == "witness_unavailable"`, split by reason.
+
+    One finding per distinct **normalized** reason, because the reasons name
+    different defects: "produced no TEST_COMMAND line" is a parse contract
+    failure, "emitted a test command but created no file" is an authoring
+    failure, and "turn aborted: stuck-loop detected" is a loop defect. Filing
+    them under one ticket buries two of the three.
+    """
+    from fingerprint import normalize
+
+    if run.bare_loop:
+        return []  # no witness stage exists on the bare loop; see below.
+
+    groups: dict[str, list[tuple[Trial, str]]] = {}
+    for trial in run.trials:
+        for step in trial.proofs("witness_unavailable"):
+            reason = str(step.get("reason") or "(no reason recorded)")
+            groups.setdefault(normalize(reason), []).append((trial, reason))
+
+    authored = sum(len(t.proofs("witness_authored")) for t in run.trials)
+    attempted = authored + sum(len(g) for g in groups.values())
+
+    findings = []
+    for _, members in sorted(groups.items()):
+        reason_full = members[0][1]
+        occurrences = [
+            Occurrence(
+                trial_uuid=t.trial_uuid,
+                task_id=t.task_id,
+                s3_key=t.s3_key(),
+                location="proof step.kind == witness_unavailable",
+                # The reason is reproduced whole, deliberately: it is truncated
+                # in the deck, in result.json and in every summary view.
+                excerpt=f"reason (full):\n{r}",
+            )
+            for t, r in members
+        ]
+        rate = (
+            f"Run-level witness authoring: {authored} authored, "
+            f"{attempted - authored} unavailable, of {attempted} attempts."
+        )
+        findings.append(
+            Finding(
+                detector="witness-unavailable",
+                site="crates/stella-pipeline/src/verify.rs",
+                variant_source=reason_full,
+                title=f"witness authoring failed: {reason_full[:90]}",
+                summary=(
+                    "The witness stage recorded `witness_unavailable`, so the run had "
+                    "no fail->pass oracle and the verification ladder could not credit "
+                    "a flip. The full reason is reproduced with each occurrence below."
+                ),
+                occurrences=occurrences,
+                denominator=len(run.trials),
+                search_terms=("witness_unavailable", "witness author", "no TEST_COMMAND"),
+                detail=rate,
+            )
+        )
+    return findings
+
+
+# --------------------------------------------------------------------------
+# 4. A flip the oracle saw and the grader did not
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="oracle-flip-ungraded",
+    title="the oracle recorded a baseline->candidate flip on a trial the grader scored 0",
+    site="crates/stella-pipeline/src/verify.rs",
+    search_terms=("oracle flip reward 0", "flip achieved grader rejected"),
+)
+def _oracle_flip_ungraded(run: Run) -> list[Finding]:
+    """`proof` `step.kind == "oracle"` showing a flip, on a trial the grader failed.
+
+    The oracle is the pipeline's own proof that the change did something: a
+    `baseline` run that did not pass and a `candidate` run that did. When the
+    verifier then scores the trial 0, the witness proved something the grader
+    does not accept — either the witness is weaker than the task, or the proven
+    work never reached the graded tree. Both are defects, and the trace cannot
+    tell them apart on its own, which is stated rather than guessed.
+    """
+    if run.bare_loop:
+        return []  # no oracle exists on the bare loop; see below.
+
+    occurrences = []
+    for trial in run.trials:
+        if trial.reward is None or trial.reward > 0:
+            continue
+        oracles = trial.proofs("oracle")
+        baseline_failed = any(
+            o.get("tree") == "baseline" and o.get("passed") is False for o in oracles
+        )
+        candidate_passed = any(
+            o.get("tree") == "candidate" and o.get("passed") is True for o in oracles
+        )
+        if not (baseline_failed and candidate_passed):
+            continue
+        occurrences.append(
+            Occurrence(
+                trial_uuid=trial.trial_uuid,
+                task_id=trial.task_id,
+                s3_key=trial.s3_key(),
+                location=f"reward.txt = {trial.reward:g}",
+                excerpt="\n".join(_brief(o) for o in oracles),
+            )
+        )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="oracle-flip-ungraded",
+            site="crates/stella-pipeline/src/verify.rs",
+            variant_source="oracle observed baseline fail and candidate pass on a trial graded 0",
+            title="the oracle recorded a baseline->candidate flip on a trial the grader scored 0",
+            summary=(
+                "The witness oracle observed the flip it exists to observe — the check "
+                "failed on the baseline tree and passed on the candidate tree — and the "
+                "task verifier still scored the trial 0. The pipeline therefore held a "
+                "proof of work that the grader does not accept as solving the task."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.graded_trials),
+            search_terms=("oracle flip reward 0", "flip achieved grader rejected"),
+            caveats=[
+                "The trace cannot distinguish a witness weaker than the task from proven "
+                "work that never reached the graded tree. Deciding which needs the "
+                "witness body (`tool_start.call.input.content` on the `create_witness_test` "
+                "call — `witness_author` has `output_text: null`, so its product is only "
+                "in its tool calls) read against the task's own verifier."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 5. An ERROR envelope wrapped around output the model needed
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="tool-error-envelope",
+    title="a tool_result returned an ERROR envelope around substantial useful output",
+    site="crates/stella-tools/src/registry.rs",
+    search_terms=("tool_result error envelope exit code", "bash non-zero exit useful output"),
+)
+def _tool_error_envelope(run: Run) -> list[Finding]:
+    """`tool_result` carrying an error envelope whose message is real output.
+
+    The `bash` shape: a chained command whose last element exits non-zero
+    returns the whole transcript inside `output.error.message`, so the model is
+    handed a page of correct, useful output labelled as a failure.
+
+    **The variant is a constant here, and that is the point.** A variant exists
+    to separate defects, not payloads, and this detector's payload is command
+    output — pure run data, different in every trial. Keying the fingerprint on
+    it shattered one defect into 23 tickets on the first run this was pointed
+    at. So the predicate *is* the identity: everything it matches is the same
+    defect, and the discriminator is spent on nothing.
+
+    The `[exit code:` trailer is required rather than optional for the same
+    reason. A guard refusal (`refused before running: … graded tree …`) is also
+    an error envelope, and it is a different defect with its own issue — it
+    carries no useful output, only a refusal, so demanding the trailer keeps the
+    two apart without asking the normalizer to tell them apart by prose.
+    """
+    matches: list[tuple[Trial, Any]] = []
+    for trial in run.trials:
+        for call in trial.tool_calls:
+            message = call.error_message
+            if not message or "[exit code:" not in message:
+                continue
+            body = message.rsplit("[exit code:", 1)[0].strip()
+            if len(body) < _SUBSTANTIAL_OUTPUT_CHARS:
+                continue
+            if body.count("\n") + 1 < _SUBSTANTIAL_OUTPUT_LINES:
+                continue
+            matches.append((trial, call))
+    if not matches:
+        return []
+
+    occurrences = []
+    seen_trials = set()
+    for trial, call in matches:
+        if trial.trial_uuid in seen_trials:
+            continue
+        seen_trials.add(trial.trial_uuid)
+        occurrences.append(
+            Occurrence(
+                trial_uuid=trial.trial_uuid,
+                task_id=trial.task_id,
+                s3_key=trial.s3_key(),
+                location=(
+                    f"tool `{call.name}`, call_id `{call.call_id}`, "
+                    f"stella-events.jsonl:{call.result_index}"
+                ),
+                excerpt=(
+                    "call.input:\n"
+                    + json.dumps(call.input, ensure_ascii=False, indent=2)[:800]
+                    + "\n\noutput.error.message (full):\n"
+                    + call.error_message
+                ),
+            )
+        )
+    return [
+        Finding(
+            detector="tool-error-envelope",
+            site="crates/stella-tools/src/registry.rs",
+            variant_source=(
+                "error envelope wrapping substantial output before a nonzero exit trailer"
+            ),
+            title="a tool_result returned an ERROR envelope around substantial useful output",
+            summary=(
+                "These `tool_result` events carry an error envelope whose message is "
+                "mostly successful output — the `&&`/`;`-chain shape, where one element "
+                "exits non-zero and the whole transcript is relabelled a failure. The "
+                "model is handed correct information marked as an error: it cannot use "
+                "the output, and it retries a command that already answered."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=(
+                "tool_result error envelope exit code",
+                "bash non-zero exit useful output",
+            ),
+            detail=(
+                f"{len(matches)} matching tool results across "
+                f"{len(seen_trials)} trial(s) — one occurrence shown per trial."
+            ),
+            caveats=[
+                "Requires the `[exit code: N]` trailer, so a guard refusal is not counted "
+                "here: it is an error envelope too, but it wraps a refusal rather than "
+                "output, and it is a different defect."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 6. The same call, twice, with the same answer
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="repeated-identical-tool-call",
+    title="consecutive identical (tool, args) calls returned byte-identical output",
+    site="crates/stella-core/src/driver.rs",
+    search_terms=("identical consecutive tool call", "stuck loop repeated tool"),
+)
+def _repeated_identical_tool_call(run: Run) -> list[Finding]:
+    """Adjacent tool calls with the same `(tool, args)` and the same output.
+
+    Byte-identical on both sides is the strict form deliberately: a repeat with
+    a *different* answer is a legitimate poll (a build finishing, a port coming
+    up). A repeat with the same answer bought nothing and paid a full model call
+    for it.
+    """
+    occurrences = []
+    for trial in run.trials:
+        calls = [c for c in trial.tool_calls if c.result is not None]
+        for previous, current in zip(calls, calls[1:], strict=False):
+            if previous.signature() != current.signature():
+                continue
+            if previous.output_signature() != current.output_signature():
+                continue
+            occurrences.append(
+                Occurrence(
+                    trial_uuid=trial.trial_uuid,
+                    task_id=trial.task_id,
+                    s3_key=trial.s3_key(),
+                    location=(
+                        f"tool `{current.name}`, calls `{previous.call_id}` then "
+                        f"`{current.call_id}` (stella-events.jsonl:"
+                        f"{previous.result_index} and {current.result_index})"
+                    ),
+                    excerpt=(
+                        "identical call.input:\n"
+                        + json.dumps(current.input, ensure_ascii=False, indent=2)[:800]
+                        + "\n\nidentical output digest:\n"
+                        + current.output_signature()[:400]
+                    ),
+                )
+            )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="repeated-identical-tool-call",
+            site="crates/stella-core/src/driver.rs",
+            variant_source="consecutive identical tool call with byte-identical output",
+            title="consecutive identical (tool, args) calls returned byte-identical output",
+            summary=(
+                "The engine issued the same tool call twice in a row and got the same "
+                "bytes back. The second call bought no information and cost a full model "
+                "call to request, so loop detection did not fire on a repeat it should "
+                "see."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=("identical consecutive tool call", "stuck loop repeated tool"),
+            caveats=[
+                "Restricted to *adjacent* calls with identical output. A repeat separated "
+                "by other calls, or one whose answer changed, is not counted — polling a "
+                "build or a port is legitimate."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 7. The census that disagrees with the launch configuration
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="role-model-census-mismatch",
+    title="the (role, model) census disagrees with the run's declared seat configuration",
+    site="crates/stella-core/src/router.rs",
+    search_terms=("role model census mismatch", "router resolved unexpected model"),
+)
+def _role_model_mismatch(run: Run) -> list[Finding]:
+    """`(role, model)` from `step_usage` against the seat's declared roles.
+
+    The declaration is read from the run's own `results.json`
+    (`match.contestants[].engine`), which is the artifact copy of the match
+    file, so the comparison is against what the run carried rather than against
+    a config on someone's laptop. Model names are compared on their unqualified
+    tail — the declaration writes `openrouter/deepseek/deepseek-chat` and the
+    telemetry writes `deepseek/deepseek-chat` — because a provider prefix is a
+    spelling difference, not a routing defect.
+    """
+    if not run.declared_roles and not run.declared_worker_model:
+        return []
+
+    def tail(model: str) -> str:
+        parts = model.split("/")
+        return "/".join(parts[-2:]) if len(parts) > 2 else model
+
+    declared = {role: tail(model) for role, model in run.declared_roles.items()}
+    if run.declared_worker_model:
+        declared["worker"] = tail(run.declared_worker_model)
+
+    occurrences = []
+    for trial in run.trials:
+        for (role, model), count in sorted(trial.role_census().items()):
+            want = declared.get(role)
+            if want is None or tail(model) == want:
+                continue
+            occurrences.append(
+                Occurrence(
+                    trial_uuid=trial.trial_uuid,
+                    task_id=trial.task_id,
+                    s3_key=trial.s3_key(),
+                    location=f"role `{role}` ran {count} completed step(s)",
+                    excerpt=(
+                        f"declared (results.json match.contestants[].engine): {want}\n"
+                        f"observed (step_usage.model)                      : {tail(model)}\n"
+                        f"completed steps at the observed model            : {count}"
+                    ),
+                )
+            )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="role-model-census-mismatch",
+            site="crates/stella-core/src/router.rs",
+            variant_source="step_usage role model disagrees with the declared seat roles",
+            title="the (role, model) census disagrees with the run's declared seat configuration",
+            summary=(
+                "A `(role, model)` census taken off `step_usage` — completed calls only — "
+                "does not match the roles the run was launched with. Every conclusion "
+                "drawn from this run about a role's behaviour is a conclusion about a "
+                "different model than the one named in the match."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=("role model census mismatch", "router resolved unexpected model"),
+            caveats=[
+                "Compared on the unqualified model tail, so a provider prefix difference "
+                "is not reported. A role the seat does not declare is skipped rather than "
+                "reported as unexpected — an undeclared role falls back by design."
+            ],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# 8. A candidate that was never seen to be delivered
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="no-post-verdict-file-change",
+    title="a trial recorded no file_change after its verdict",
+    site="crates/stella-cli/src/candidate_ws/adopt.rs",
+    search_terms=("candidate adoption post-verdict file_change", "delivery emits no event"),
+)
+def _no_post_verdict_file_change(run: Run) -> list[Finding]:
+    """Two variants, deliberately kept apart.
+
+    A trial with **no `verdict` event at all** was killed before the pipeline
+    reached its single delivery point; a trial **with** a verdict and no
+    `file_change` after it reached delivery and recorded nothing. Those are
+    different defects with different fixes, and the repository has already split
+    them into two issues, so collapsing them into one finding would suppress
+    exactly the residual half that the nothing-left-behind rule exists to keep.
+
+    The caveat below is not decoration. `bash` names no path, so a heredoc, a
+    `patch`, a `make` or a `>` mutates the tree with no `file_change` emitted at
+    all. This detector reports **an absent event**, never an unchanged tree.
+    """
+    if run.bare_loop:
+        # The bare turn loop has no verify stage, so it emits no `verdict` and
+        # adopts no candidate. Running this detector against it reports 20/20 of
+        # an absence that is the arm working exactly as designed — a finding
+        # that is arithmetically true and entirely meaningless, and the kind of
+        # number that gets quoted once and never withdrawn.
+        return []
+
+    absent_verdict: list[Occurrence] = []
+    silent_delivery: list[Occurrence] = []
+    for trial in run.trials:
+        verdicts = trial.of_type("verdict")
+        mutations = [e for e in trial.of_type("file_change") if e.get("kind") != "read"]
+        if not verdicts:
+            if not trial.events:
+                continue
+            last = trial.events[-1]
+            absent_verdict.append(
+                Occurrence(
+                    trial_uuid=trial.trial_uuid,
+                    task_id=trial.task_id,
+                    s3_key=trial.s3_key(),
+                    location=(
+                        f"{len(trial.events)} events, no `verdict`; "
+                        f"{trial.malformed_lines} unreadable line(s) at the tail"
+                    ),
+                    excerpt="last event on the stream:\n" + _brief(last),
+                )
+            )
+            continue
+        verdict_ts = verdicts[-1].get("ts")
+        if not isinstance(verdict_ts, int):
+            continue
+        after = [e for e in mutations if isinstance(e.get("ts"), int) and e["ts"] >= verdict_ts]
+        if after:
+            continue
+        silent_delivery.append(
+            Occurrence(
+                trial_uuid=trial.trial_uuid,
+                task_id=trial.task_id,
+                s3_key=trial.s3_key(),
+                location=(
+                    f"verdict at ts={verdict_ts}, "
+                    f"{len(mutations)} mutating file_change events, 0 of them after it"
+                ),
+                excerpt="verdict event:\n" + _brief(verdicts[-1], limit=700),
+            )
+        )
+
+    blindness = (
+        "`file_change` is observability, never evidence: `bash` names no path, so a "
+        "heredoc, `patch`, `make` or `>` mutates the tree and emits nothing. This "
+        "finding reports an ABSENT EVENT. It does not, and cannot, establish that the "
+        "tree was unchanged or that delivery did not happen."
+    )
+
+    findings = []
+    if absent_verdict:
+        findings.append(
+            Finding(
+                detector="no-post-verdict-file-change",
+                site="crates/stella-cli/src/candidate_ws/adopt.rs",
+                variant_source="trial recorded no verdict event at all",
+                title="a trial ended with no verdict event — the delivery point was never reached",
+                summary=(
+                    "These trials carry no `verdict` event. The pipeline delivers a "
+                    "candidate once, after the verdict, so a trial killed before that "
+                    "point ends with its work still in the candidate workspace."
+                ),
+                occurrences=absent_verdict,
+                denominator=len(run.trials),
+                search_terms=("killed run never delivers", "no verdict event truncated"),
+                caveats=[blindness],
+            )
+        )
+    if silent_delivery:
+        findings.append(
+            Finding(
+                detector="no-post-verdict-file-change",
+                site="crates/stella-cli/src/candidate_ws/adopt.rs",
+                variant_source="verdict recorded and no mutating file_change followed it",
+                title="a trial recorded a verdict and no file_change after it",
+                summary=(
+                    "These trials reached a verdict and recorded no mutating "
+                    "`file_change` afterwards. Adoption emits no event of its own, so a "
+                    "withheld candidate and a delivered one that touched nothing are "
+                    "indistinguishable on the stream."
+                ),
+                occurrences=silent_delivery,
+                denominator=len(run.trials),
+                search_terms=(
+                    "candidate adoption post-verdict file_change",
+                    "delivery emits no event",
+                ),
+                caveats=[blindness],
+            )
+        )
+    return findings

--- a/bench/trace_triage/fingerprint.py
+++ b/bench/trace_triage/fingerprint.py
@@ -1,0 +1,289 @@
+"""Identify a defect by what it *is*, so the same one is never filed twice.
+
+The hard requirement on `make triage-bench-traces` is that its output is never
+a duplicate issue. Title similarity cannot deliver that: the repository's own
+backlog holds #2929 and #2872 describing one defect — an oracle that fails on
+both trees and routes to `Revise` — in almost no shared words, found on
+different runs and different SUTs. Anything keyed on prose would have filed
+both, and did.
+
+So a defect is identified by a **fingerprint**: a triple, hashed, of the three
+things that are properties of the defect rather than of the run that found it.
+
+    fingerprint = sha256("<detector>\\n<site>\\n<variant>")[:12]
+
+**detector** — the event signature that detects it. Not a description of the
+bug: the name of the predicate over `stella-events.jsonl` that fires. Two
+findings that the same predicate produced are the same *kind* of defect by
+construction.
+
+**site** — the code site the detector implicates, as a repo-relative path
+declared on the detector, never derived from the run. A detector that
+implicates nothing declares `""`; that is honest, and it simply means the
+variant carries the whole discrimination.
+
+**variant** — a normalized discriminator taken from the occurrence, so one
+detector can still separate genuinely different defects. This is the load
+bearing part, and normalization is what makes it stable: every token that
+varies between two runs of the same defect is erased before hashing —
+quoted spans, absolute paths, the `/tmp/stella_candidate_<n>_<n>` workspace
+root, digits, and whitespace — and only the leading skeleton of the string
+survives.
+
+Nothing in any of the three components is a run id, a trial id, a task name, a
+timestamp, a cost, a model name, or a line number, which is why next week's run
+hashes a recurrence to the same value as this week's, and why two different
+reasons under one detector do not collide. `witness author produced no
+TEST_COMMAND line` and `witness author emitted a test command but created no
+file` are two defects and get two fingerprints; the same reason seen in twelve
+trials across two runs is one defect and gets one.
+
+The mapping fingerprint -> issue is **persisted** (`fingerprints.json`) rather
+than re-derived, for two reasons. It improves: a human who corrects one binding
+corrects it for every future run. And it survives search going wrong — a GitHub
+search is a fuzzy instrument, and the day it fails to surface an existing issue
+is the day the tool would have opened a duplicate.
+
+The ledger is not the only recovery path. Every issue this tool opens carries
+an HTML-comment marker in its body:
+
+    <!-- stella-trace-fingerprint: fp_1a2b3c4d5e6f -->
+
+so a lost or reset ledger can be rebuilt from GitHub itself by searching for
+the marker. The marker is invisible in rendered Markdown and is not prose, so
+it cannot rot the way a title can.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+LEDGER_PATH = Path(__file__).resolve().parent / "fingerprints.json"
+
+MARKER_PREFIX = "<!-- stella-trace-fingerprint: "
+MARKER_SUFFIX = " -->"
+
+# How many normalized tokens of the variant survive into the hash. Long enough
+# that two distinct reasons diverge (the repository's witness reasons differ by
+# their fourth token), short enough that a reason whose tail gains a clause in a
+# later release still hashes to the same defect.
+_VARIANT_TOKENS = 14
+
+_QUOTED = re.compile(r"[`'\"]{1}[^`'\"]{1,200}[`'\"]{1}")
+_CANDIDATE_ROOT = re.compile(r"/tmp/stella_candidate_[0-9]+_[0-9]+[^\s,)`'\"]*")
+_ABS_PATH = re.compile(r"(?<![\w/])/[\w./-]{2,}")
+_NUMBER = re.compile(r"\b\d[\d_,.]*\b")
+_WS = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Reduce an emitted string to the part that is a property of the defect.
+
+    Order matters. Quoted spans go first because they are where run-specific
+    nouns hide (`/app/documents/`, `create_witness_test`), and the candidate
+    root goes before the general absolute-path rule because its trailing digits
+    would otherwise survive as `<path>` plus a stray number.
+    """
+    text = _QUOTED.sub(" <q> ", text)
+    text = _CANDIDATE_ROOT.sub(" <ws> ", text)
+    text = _ABS_PATH.sub(" <path> ", text)
+    text = _NUMBER.sub(" <n> ", text)
+    text = _WS.sub(" ", text).strip().lower()
+    return " ".join(text.split(" ")[:_VARIANT_TOKENS])
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    """A defect's identity, and the three readable parts it was built from."""
+
+    detector: str
+    site: str
+    variant: str
+
+    @property
+    def digest(self) -> str:
+        raw = f"{self.detector}\n{self.site}\n{self.variant}"
+        return "fp_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+
+    @property
+    def marker(self) -> str:
+        return f"{MARKER_PREFIX}{self.digest}{MARKER_SUFFIX}"
+
+    def readable(self) -> str:
+        return f"{self.detector} | {self.site or '(no site)'} | {self.variant or '(no variant)'}"
+
+
+def fingerprint_of(detector: str, site: str, variant_source: str) -> Fingerprint:
+    return Fingerprint(detector=detector, site=site, variant=normalize(variant_source))
+
+
+def markers_in(text: str) -> list[str]:
+    """Every fingerprint digest stamped into an issue body."""
+    return re.findall(r"<!--\s*stella-trace-fingerprint:\s*(fp_[0-9a-f]{12})\s*-->", text)
+
+
+@dataclass
+class LedgerEntry:
+    """One defect's binding, plus the incidence already on the record.
+
+    `runs`, `tasks` and `peak_*` are not bookkeeping for its own sake: they are
+    what lets a comment say *what this occurrence adds* instead of restating the
+    issue. A recurrence on a task the issue never named, or at a higher rate
+    than it ever recorded, is news; the same trial in the same run is noise, and
+    the tool has to be able to tell them apart without a human remembering.
+    """
+
+    digest: str
+    issue: int | None
+    detector: str
+    site: str
+    variant: str
+    first_seen_run: str
+    note: str = ""
+    source: str = "auto"
+    runs: list[str] = dc_field(default_factory=list)
+    tasks: list[str] = dc_field(default_factory=list)
+    peak_count: int = 0
+    peak_denominator: int = 0
+
+    def novelty(self, run_id: str, tasks: Iterable[str], count: int, denominator: int) -> list[str]:
+        """What this occurrence adds that the record did not already have."""
+        news: list[str] = []
+        if run_id not in self.runs:
+            news.append(f"a new run (`{run_id}`) — the record held {self.runs or 'no runs'}")
+        fresh = sorted(set(tasks) - set(self.tasks))
+        if fresh:
+            news.append("a new affected task: " + ", ".join(f"`{t}`" for t in fresh))
+        if denominator > 0 and self.peak_denominator > 0:
+            was = self.peak_count / self.peak_denominator
+            now = count / denominator
+            if now > was:
+                news.append(
+                    f"a higher incidence: {count}/{denominator} here against "
+                    f"{self.peak_count}/{self.peak_denominator} on the record"
+                )
+        elif self.peak_denominator == 0:
+            news.append(f"the first recorded incidence for this fingerprint: {count}/{denominator}")
+        return news
+
+    def observe(self, run_id: str, tasks: Iterable[str], count: int, denominator: int) -> None:
+        if run_id and run_id not in self.runs:
+            self.runs.append(run_id)
+        for task in sorted(set(tasks) - set(self.tasks)):
+            self.tasks.append(task)
+        if denominator > 0 and (
+            self.peak_denominator == 0
+            or count / denominator > self.peak_count / self.peak_denominator
+        ):
+            self.peak_count, self.peak_denominator = count, denominator
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "issue": self.issue,
+            "detector": self.detector,
+            "site": self.site,
+            "variant": self.variant,
+            "first_seen_run": self.first_seen_run,
+            "note": self.note,
+            "source": self.source,
+            "runs": self.runs,
+            "tasks": self.tasks,
+            "peak_count": self.peak_count,
+            "peak_denominator": self.peak_denominator,
+        }
+
+
+class Ledger:
+    """The persisted fingerprint -> issue mapping, tracked in git.
+
+    Two properties make it safe to let a program write a file a human also
+    edits. It **never overwrites a human binding**: an entry whose `source` is
+    anything but `auto` keeps its issue number, so a correction survives every
+    later run. And it is written sorted and pretty-printed, so a change to it
+    reads as a reviewable diff rather than a churned blob.
+    """
+
+    def __init__(self, path: Path = LEDGER_PATH) -> None:
+        self.path = path
+        self.entries: dict[str, LedgerEntry] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return
+        for digest, value in (raw.get("fingerprints") or {}).items():
+            if not isinstance(value, dict):
+                continue
+            issue = value.get("issue")
+            self.entries[digest] = LedgerEntry(
+                digest=digest,
+                issue=int(issue) if isinstance(issue, int) else None,
+                detector=str(value.get("detector") or ""),
+                site=str(value.get("site") or ""),
+                variant=str(value.get("variant") or ""),
+                first_seen_run=str(value.get("first_seen_run") or ""),
+                note=str(value.get("note") or ""),
+                source=str(value.get("source") or "auto"),
+                runs=[str(r) for r in (value.get("runs") or [])],
+                tasks=[str(t) for t in (value.get("tasks") or [])],
+                peak_count=int(value.get("peak_count") or 0),
+                peak_denominator=int(value.get("peak_denominator") or 0),
+            )
+
+    def lookup(self, fingerprint: Fingerprint) -> LedgerEntry | None:
+        return self.entries.get(fingerprint.digest)
+
+    def bind(
+        self,
+        fingerprint: Fingerprint,
+        issue: int | None,
+        run_id: str,
+        note: str = "",
+        source: str = "auto",
+    ) -> LedgerEntry:
+        """Record (or complete) a binding, never clobbering a human's."""
+        existing = self.entries.get(fingerprint.digest)
+        if existing is not None:
+            if existing.source != "auto" and existing.issue is not None:
+                return existing
+            if issue is not None:
+                existing.issue = issue
+            if note:
+                existing.note = note
+            return existing
+        entry = LedgerEntry(
+            digest=fingerprint.digest,
+            issue=issue,
+            detector=fingerprint.detector,
+            site=fingerprint.site,
+            variant=fingerprint.variant,
+            first_seen_run=run_id,
+            note=note,
+            source=source,
+        )
+        self.entries[entry.digest] = entry
+        return entry
+
+    def save(self) -> None:
+        payload = {
+            "schema": 1,
+            "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "fingerprints": {
+                digest: self.entries[digest].to_json() for digest in sorted(self.entries)
+            },
+        }
+        self.path.write_text(
+            json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+        )

--- a/bench/trace_triage/fingerprints.json
+++ b/bench/trace_triage/fingerprints.json
@@ -10,8 +10,9 @@
     "wrong rather than merely stale.",
     "`runs`, `tasks` and `peak_*` are the incidence already on the record. They are",
     "what lets a comment say what an occurrence ADDS instead of restating the issue,",
-    "so the seeds below transcribe what each issue already cites — an entry with an",
-    "empty task list would make the first triage run report every task as news."
+    "so the seeds below transcribe what each issue already cites \u2014 an entry with an",
+    "empty task list would make the first triage run report every task as news.",
+    "`tasks` holds DATASET task names, never the per-trial `task__SUFFIX` id: the suffix is minted fresh every run, so an id keyed here reports all twenty tasks of a rerun as new."
   ],
   "fingerprints": {
     "fp_0259c5928a38": {
@@ -22,7 +23,9 @@
       "first_seen_run": "h89b",
       "note": "Seeded from #2956, which established this signature on h89b (85/88 trials) and named the healthy control f89b2. Same predicate: reasoning deltas with zero step_usage means no model call ever completed.",
       "source": "seed",
-      "runs": ["h89b"],
+      "runs": [
+        "h89b"
+      ],
       "tasks": [],
       "peak_count": 85,
       "peak_denominator": 88
@@ -35,7 +38,9 @@
       "first_seen_run": "h89b",
       "note": "Seeded from #2956. The timeout census and the void-call census are two views of one operational abort there, so both fingerprints point at it; split them if a run ever shows timeouts without voids.",
       "source": "seed",
-      "runs": ["h89b"],
+      "runs": [
+        "h89b"
+      ],
       "tasks": [],
       "peak_count": 85,
       "peak_denominator": 88
@@ -46,16 +51,16 @@
       "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
       "variant": "trial recorded no verdict event at all",
       "first_seen_run": "w10p",
-      "note": "Seeded from #2941 (open), the residual half of #2927: a run killed at the wall-clock cap never reaches the single adoption point. Deliberately NOT bound to #2927 — that issue is the winner-only adoption defect and is closed; binding both variants to it would suppress exactly the follow-up the split exists for.",
+      "note": "Seeded from #2941 (open), the residual half of #2927: a run killed at the wall-clock cap never reaches the single adoption point. Deliberately NOT bound to #2927 \u2014 that issue is the winner-only adoption defect and is closed; binding both variants to it would suppress exactly the follow-up the split exists for.",
       "source": "seed",
-      "runs": ["w10p"],
+      "runs": [
+        "w10p"
+      ],
       "tasks": [
-        "build-cython-ext__4xjNAy9",
-        "build-cython-ext__DKWhU7q",
-        "code-from-image__UTUWFRc",
-        "query-optimize__87X4w9r",
-        "query-optimize__c2RngiP",
-        "video-processing__zjYR6QM"
+        "build-cython-ext",
+        "code-from-image",
+        "query-optimize",
+        "video-processing"
       ],
       "peak_count": 6,
       "peak_denominator": 20
@@ -66,14 +71,15 @@
       "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
       "variant": "verdict recorded and no mutating file_change followed it",
       "first_seen_run": "w10p",
-      "note": "Seeded from #2927 (CLOSED) — candidate adoption is winner-only, so a revise verdict discards the candidate. A recurrence on a SUT that already contains the fix is a regression; the tool comments and says so without asserting which, because the trace cannot tell a post-fix run from a pre-fix one.",
+      "note": "Seeded from #2927 (CLOSED) \u2014 candidate adoption is winner-only, so a revise verdict discards the candidate. A recurrence on a SUT that already contains the fix is a regression; the tool comments and says so without asserting which, because the trace cannot tell a post-fix run from a pre-fix one.",
       "source": "seed",
-      "runs": ["w10p"],
+      "runs": [
+        "w10p"
+      ],
       "tasks": [
-        "configure-git-webserver__9rDJ8td",
-        "configure-git-webserver__Fw9itty",
-        "sqlite-with-gcov__uvp6jz4",
-        "video-processing__pBadsUh"
+        "configure-git-webserver",
+        "sqlite-with-gcov",
+        "video-processing"
       ],
       "peak_count": 4,
       "peak_denominator": 20
@@ -86,12 +92,13 @@
       "first_seen_run": "w10p",
       "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim.",
       "source": "seed",
-      "runs": ["w10p"],
+      "runs": [
+        "w10p"
+      ],
       "tasks": [
-        "code-from-image__rmypedL",
-        "openssl-selfsigned-cert__VD5dP62",
-        "openssl-selfsigned-cert__n8kmHgk",
-        "pypi-server__CoGn9Sy"
+        "code-from-image",
+        "openssl-selfsigned-cert",
+        "pypi-server"
       ],
       "peak_count": 4,
       "peak_denominator": 20
@@ -104,8 +111,12 @@
       "first_seen_run": "w10p",
       "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim. A separate fingerprint from the sibling above on purpose: one is a parse-contract failure and one is an authoring failure, and #2908 may be fixed for one and not the other.",
       "source": "seed",
-      "runs": ["w10p"],
-      "tasks": ["log-summary-date-ranges__xx28aho"],
+      "runs": [
+        "w10p"
+      ],
+      "tasks": [
+        "log-summary-date-ranges"
+      ],
       "peak_count": 1,
       "peak_denominator": 20
     }

--- a/bench/trace_triage/fingerprints.json
+++ b/bench/trace_triage/fingerprints.json
@@ -1,0 +1,113 @@
+{
+  "schema": 1,
+  "updated_at": "2026-08-11T00:00:00Z",
+  "_comment": [
+    "fingerprint -> issue. Written by bench/trace_triage, and safe to edit by hand.",
+    "A binding whose `source` is anything other than `auto` is treated as a human",
+    "decision and is never overwritten by a later run, so correcting a wrong issue",
+    "number here is permanent. Deleting an entry makes the tool re-derive it from a",
+    "GitHub search on the next run, which is the right move when the mapping was",
+    "wrong rather than merely stale.",
+    "`runs`, `tasks` and `peak_*` are the incidence already on the record. They are",
+    "what lets a comment say what an occurrence ADDS instead of restating the issue,",
+    "so the seeds below transcribe what each issue already cites — an entry with an",
+    "empty task list would make the first triage run report every task as news."
+  ],
+  "fingerprints": {
+    "fp_0259c5928a38": {
+      "issue": 2956,
+      "detector": "void-model-call",
+      "site": "crates/stella-model/src/provider_parity.rs",
+      "variant": "reasoning deltas present with zero completed model calls",
+      "first_seen_run": "h89b",
+      "note": "Seeded from #2956, which established this signature on h89b (85/88 trials) and named the healthy control f89b2. Same predicate: reasoning deltas with zero step_usage means no model call ever completed.",
+      "source": "seed",
+      "runs": ["h89b"],
+      "tasks": [],
+      "peak_count": 85,
+      "peak_denominator": 88
+    },
+    "fp_ebb5bd1815bd": {
+      "issue": 2956,
+      "detector": "agent-timeout",
+      "site": "",
+      "variant": "harbor recorded agenttimeouterror for the trial",
+      "first_seen_run": "h89b",
+      "note": "Seeded from #2956. The timeout census and the void-call census are two views of one operational abort there, so both fingerprints point at it; split them if a run ever shows timeouts without voids.",
+      "source": "seed",
+      "runs": ["h89b"],
+      "tasks": [],
+      "peak_count": 85,
+      "peak_denominator": 88
+    },
+    "fp_91b19f844096": {
+      "issue": 2941,
+      "detector": "no-post-verdict-file-change",
+      "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
+      "variant": "trial recorded no verdict event at all",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2941 (open), the residual half of #2927: a run killed at the wall-clock cap never reaches the single adoption point. Deliberately NOT bound to #2927 — that issue is the winner-only adoption defect and is closed; binding both variants to it would suppress exactly the follow-up the split exists for.",
+      "source": "seed",
+      "runs": ["w10p"],
+      "tasks": [
+        "build-cython-ext__4xjNAy9",
+        "build-cython-ext__DKWhU7q",
+        "code-from-image__UTUWFRc",
+        "query-optimize__87X4w9r",
+        "query-optimize__c2RngiP",
+        "video-processing__zjYR6QM"
+      ],
+      "peak_count": 6,
+      "peak_denominator": 20
+    },
+    "fp_48fdf676b048": {
+      "issue": 2927,
+      "detector": "no-post-verdict-file-change",
+      "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
+      "variant": "verdict recorded and no mutating file_change followed it",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2927 (CLOSED) — candidate adoption is winner-only, so a revise verdict discards the candidate. A recurrence on a SUT that already contains the fix is a regression; the tool comments and says so without asserting which, because the trace cannot tell a post-fix run from a pre-fix one.",
+      "source": "seed",
+      "runs": ["w10p"],
+      "tasks": [
+        "configure-git-webserver__9rDJ8td",
+        "configure-git-webserver__Fw9itty",
+        "sqlite-with-gcov__uvp6jz4",
+        "video-processing__pBadsUh"
+      ],
+      "peak_count": 4,
+      "peak_denominator": 20
+    },
+    "fp_06b55889e526": {
+      "issue": 2908,
+      "detector": "witness-unavailable",
+      "site": "crates/stella-pipeline/src/verify.rs",
+      "variant": "witness author emitted a test command but created no file",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim.",
+      "source": "seed",
+      "runs": ["w10p"],
+      "tasks": [
+        "code-from-image__rmypedL",
+        "openssl-selfsigned-cert__VD5dP62",
+        "openssl-selfsigned-cert__n8kmHgk",
+        "pypi-server__CoGn9Sy"
+      ],
+      "peak_count": 4,
+      "peak_denominator": 20
+    },
+    "fp_0e3494035b33": {
+      "issue": 2908,
+      "detector": "witness-unavailable",
+      "site": "crates/stella-pipeline/src/verify.rs",
+      "variant": "witness author produced no test_command line",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim. A separate fingerprint from the sibling above on purpose: one is a parse-contract failure and one is an authoring failure, and #2908 may be fixed for one and not the other.",
+      "source": "seed",
+      "runs": ["w10p"],
+      "tasks": ["log-summary-date-ranges__xx28aho"],
+      "peak_count": 1,
+      "peak_denominator": 20
+    }
+  }
+}

--- a/bench/trace_triage/issues.py
+++ b/bench/trace_triage/issues.py
@@ -230,7 +230,7 @@ def _evidence_block(run: Run, finding: Finding, limit: int) -> str:
 
 def render_new_issue(run: Run, finding: Finding, limit: int = 6) -> str:
     """A handoff a fresh agent could execute with none of this session's context."""
-    tasks = sorted({o.task_id.split("__", 1)[0] for o in finding.occurrences})
+    tasks = sorted({o.task_name for o in finding.occurrences})
     parts = [
         "## Problem",
         "",
@@ -296,7 +296,7 @@ def render_comment(
     limit: int = 6,
 ) -> str:
     """A comment that says what is NEW, not what the issue already says."""
-    tasks = [o.task_id for o in finding.occurrences]
+    tasks = [o.task_name for o in finding.occurrences]
     news = (
         entry.novelty(run.run_id, tasks, finding.count, finding.denominator)
         if entry
@@ -427,7 +427,7 @@ def plan_actions(
             novelty = (
                 entry.novelty(
                     run.run_id,
-                    [o.task_id for o in finding.occurrences],
+                    [o.task_name for o in finding.occurrences],
                     finding.count,
                     finding.denominator,
                 )
@@ -493,7 +493,7 @@ def apply_actions(
     log: list[str] = []
     for action in actions:
         finding = action.finding
-        tasks = [o.task_id for o in finding.occurrences]
+        tasks = [o.task_name for o in finding.occurrences]
         if action.decision is Decision.SUPPRESSED:
             log.append(
                 f"suppressed (cap): {finding.detector} {action.fingerprint.digest} "

--- a/bench/trace_triage/issues.py
+++ b/bench/trace_triage/issues.py
@@ -1,0 +1,528 @@
+"""Turn findings into GitHub issue activity — and never into a duplicate.
+
+Two halves, kept apart so the decision is testable without a network:
+
+* `GitHubClient` — the only thing here that talks to `gh`. Tests inject a fake.
+* `plan_actions` — the de-duplication decision, a pure function of the findings,
+  the ledger and whatever the client returned.
+
+## How a duplicate is prevented
+
+Three gates, tried in order, each one a fallback for the previous one failing:
+
+1. **The ledger** (`fingerprints.json`). A fingerprint already bound to an issue
+   is that issue, full stop. No search, no similarity, no judgement.
+2. **The fingerprint marker.** Every issue this tool opens carries
+   `<!-- stella-trace-fingerprint: fp_… -->` in its body, so a search that
+   surfaces an issue carrying this finding's digest is an exact hit even when
+   the ledger has been lost or reset — and the ledger is repaired from it.
+3. **A search across open AND closed**, whose hits are reported as *candidates*
+   for a human to confirm. A candidate is never auto-bound: prose similarity is
+   the instrument that filed #2929 and #2872 for one defect, and it does not get
+   a vote here.
+
+A finding that survives all three is new, and only then may an issue be opened.
+
+## A closed issue that recurs
+
+It is a comment on that issue, never a new ticket. The comment is headed
+`RECURRENCE` and says so explicitly, because "this closed issue's defect is back"
+is more valuable than either a silent duplicate or a silent omission.
+
+What the comment does **not** do is assert a regression. Whether a recurrence is
+a regression depends on whether the run's SUT already contained the fix, and the
+trace cannot answer that: a run recorded before the fix merged shows the same
+bytes as a run after it. So the comment states the SUT ref the run carried and
+names the command that settles it, and leaves the call to a human. Reopening is
+likewise a human action — the tool prints the `gh issue reopen` line rather than
+running it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Protocol
+
+from detectors import Finding
+from fingerprint import Fingerprint, Ledger, LedgerEntry, markers_in
+from run_trace import Run
+
+REPO = "macanderson/stella"
+
+
+class Decision(StrEnum):
+    NEW = "NEW ISSUE"
+    COMMENT = "COMMENT (open issue)"
+    RECURRENCE = "COMMENT (closed issue — recurrence)"
+    SUPPRESSED = "SUPPRESSED (new-issue cap reached)"
+    NO_NEWS = "NOTHING POSTED (occurrence adds nothing to the record)"
+
+
+@dataclass
+class Action:
+    finding: Finding
+    fingerprint: Fingerprint
+    decision: Decision
+    title: str
+    body: str
+    issue: int | None = None
+    issue_state: str = ""
+    issue_title: str = ""
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+    novelty: list[str] = field(default_factory=list)
+    matched_by: str = ""
+
+
+# --------------------------------------------------------------------------
+# The GitHub side
+# --------------------------------------------------------------------------
+
+
+class GitHubClient(Protocol):
+    def search_issues(self, terms: Sequence[str]) -> list[dict[str, Any]]: ...
+
+    def view_issue(self, number: int) -> dict[str, Any]: ...
+
+    def create_issue(self, title: str, body: str) -> int: ...
+
+    def comment_issue(self, number: int, body: str) -> None: ...
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain_env() -> dict[str, str]:
+    """An environment in which `gh --json` emits JSON and nothing else.
+
+    `CLICOLOR_FORCE` is set in some developer shells, and `gh` honours it even
+    when its stdout is a pipe — so `--json` comes back wrapped in ANSI colour
+    codes and `json.loads` raises. Clearing it (and setting `NO_COLOR`) is the
+    fix; the `_ANSI` strip below is the belt to that braces, because the failure
+    mode is a crash in the middle of a run rather than a wrong answer, and it
+    cost one debugging round already.
+    """
+    env = dict(os.environ)
+    env.pop("CLICOLOR_FORCE", None)
+    env.pop("GH_FORCE_TTY", None)
+    env["NO_COLOR"] = "1"
+    return env
+
+
+class GhCli:
+    """`gh` over `subprocess`. The only component in this package that writes."""
+
+    def __init__(self, repo: str = REPO) -> None:
+        self.repo = repo
+
+    def _json(self, args: list[str]) -> Any:
+        result = subprocess.run(args, capture_output=True, text=True, check=False, env=_plain_env())
+        if result.returncode != 0:
+            raise RuntimeError(f"{' '.join(args)} failed: {result.stderr.strip()}")
+        try:
+            return json.loads(_ANSI.sub("", result.stdout) or "[]")
+        except ValueError as exc:
+            raise RuntimeError(f"{' '.join(args)} returned unparseable JSON") from exc
+
+    def search_issues(self, terms: Sequence[str]) -> list[dict[str, Any]]:
+        """Search open AND closed.
+
+        `--state` is deliberately absent: `gh search issues` accepts only
+        `open` or `closed` there, and *omitting* it is what searches both.
+        Passing `--state open` — the reading a reviewer expects to be the safe
+        one — would hide every closed issue and turn each closed defect that
+        recurs into a duplicate ticket, which is the one outcome this tool
+        exists to prevent.
+        """
+        hits: dict[int, dict[str, Any]] = {}
+        for term in terms:
+            rows = self._json(
+                [
+                    "gh",
+                    "search",
+                    "issues",
+                    "--repo",
+                    self.repo,
+                    "--limit",
+                    "20",
+                    "--json",
+                    "number,title,state,url",
+                    term,
+                ]
+            )
+            for row in rows or []:
+                if isinstance(row, dict) and isinstance(row.get("number"), int):
+                    hits[row["number"]] = row
+        return [hits[n] for n in sorted(hits)]
+
+    def view_issue(self, number: int) -> dict[str, Any]:
+        return self._json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                self.repo,
+                "--json",
+                "number,title,state,body,url",
+            ]
+        )
+
+    def create_issue(self, title: str, body: str) -> int:
+        result = subprocess.run(
+            ["gh", "issue", "create", "--repo", self.repo, "--title", title, "--body", body],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_plain_env(),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue create failed: {result.stderr.strip()}")
+        url = _ANSI.sub("", result.stdout).strip().splitlines()[-1]
+        return int(url.rsplit("/", 1)[-1])
+
+    def comment_issue(self, number: int, body: str) -> None:
+        result = subprocess.run(
+            ["gh", "issue", "comment", str(number), "--repo", self.repo, "--body", body],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_plain_env(),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue comment failed: {result.stderr.strip()}")
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+def _evidence_block(run: Run, finding: Finding, limit: int) -> str:
+    lines = [
+        "### Evidence",
+        "",
+        f"- run: `{run.run_id}`  ({run.match_name or 'unnamed match'})",
+        f"- SUT: `{run.sut_ref or 'not recorded in the artifacts'}`",
+        f"- artifacts: `{run.s3_prefix()}`",
+        f"- incidence: {finding.rate_line()}",
+    ]
+    if finding.detail:
+        lines.append(f"- {finding.detail}")
+    lines += ["", "#### Occurrences", ""]
+    for occurrence in finding.occurrences[:limit]:
+        lines.append(occurrence.render())
+        lines.append("")
+    if finding.count > limit:
+        lines.append(
+            f"_{finding.count - limit} further occurrence(s) not reproduced here; the "
+            f"detector `{finding.detector}` reproduces the full list from the run._"
+        )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render_new_issue(run: Run, finding: Finding, limit: int = 6) -> str:
+    """A handoff a fresh agent could execute with none of this session's context."""
+    tasks = sorted({o.task_id.split("__", 1)[0] for o in finding.occurrences})
+    parts = [
+        "## Problem",
+        "",
+        finding.summary,
+        "",
+        _evidence_block(run, finding, limit),
+        "## Where",
+        "",
+        (
+            f"- implicated site: `{finding.site}`"
+            if finding.site
+            else "- no single code site is implicated by the detector; the evidence above "
+            "is the starting point."
+        ),
+        f"- detector: `bench/trace_triage/detectors.py` -> `{finding.detector}`",
+        "",
+        "## Reproduce / verify",
+        "",
+        "```sh",
+        f"aws s3 sync {run.s3_prefix()} /tmp/{run.run_id}/ \\",
+        "  --exclude '*' --include '*stella-events.jsonl' --include '*reward.txt' \\",
+        "  --include '*exception.txt' --include '*result*.json'",
+        f"make triage-bench-traces RUN={run.run_id} MIRROR=/tmp/{run.run_id}",
+        "```",
+        "",
+        f"The dry run prints this finding with every occurrence. Affected tasks: "
+        f"{', '.join(f'`{t}`' for t in tasks)}.",
+        "",
+        "## Constraints already discovered",
+        "",
+        "- `proof` events discriminate on `step.kind`, not the top-level `type`.",
+        "- `witness_author` has `output_text: null` — its product is in "
+        "`tool_start.call.input.content`, not in `step_usage`.",
+        "- `file_change` is observability, never evidence: `bash` names no path, so a "
+        "heredoc, `patch`, `make` or `>` mutates the tree silently.",
+    ]
+    for caveat in finding.caveats:
+        parts.append(f"- {caveat}")
+    parts += [
+        "",
+        "## Definition of done",
+        "",
+        "- A witness test that fails on the current code and passes with the fix.",
+        f"- Re-running `make triage-bench-traces` over a run recorded on the fixed SUT "
+        f"produces no `{finding.detector}` finding with this fingerprint.",
+        "",
+        "---",
+        "",
+        f"Filed by `make triage-bench-traces` from run `{run.run_id}`. "
+        "The marker below is how the tool recognises this defect next time — "
+        "please leave it in place.",
+        "",
+        finding.fingerprint.marker,
+    ]
+    return "\n".join(parts)
+
+
+def render_comment(
+    run: Run,
+    finding: Finding,
+    entry: LedgerEntry | None,
+    recurrence: bool,
+    limit: int = 6,
+) -> str:
+    """A comment that says what is NEW, not what the issue already says."""
+    tasks = [o.task_id for o in finding.occurrences]
+    news = (
+        entry.novelty(run.run_id, tasks, finding.count, finding.denominator)
+        if entry
+        else [f"a fresh occurrence in run `{run.run_id}`: {finding.count}/{finding.denominator}"]
+    )
+    if recurrence:
+        # On a closed issue the recurrence is itself the news, and always the
+        # headline item — otherwise the section reads "adds nothing" directly
+        # under a heading announcing that a closed defect came back.
+        news.insert(
+            0,
+            f"the signature fired again on a CLOSED issue, in run `{run.run_id}` "
+            f"(SUT `{run.sut_ref or 'unrecorded'}`)",
+        )
+    header = (
+        "## RECURRENCE — this closed issue's defect signature fired again"
+        if recurrence
+        else "## Fresh evidence from a bench run"
+    )
+    parts = [header, "", "**What this occurrence adds:**", ""]
+    parts += [f"- {item}" for item in (news or ["nothing the record did not already hold"])]
+    if not news:
+        parts.append(
+            "  (kept anyway so the incidence stays auditable — read it as a repeat "
+            "observation, not as news.)"
+        )
+    parts += ["", _evidence_block(run, finding, limit)]
+    if recurrence:
+        parts += [
+            "### Is this a regression?",
+            "",
+            "**Not decided here, and deliberately not guessed.** This run carries SUT "
+            f"`{run.sut_ref or 'unrecorded'}`. If that commit already contains the fix "
+            "that closed this issue, the signature firing on it is a regression; if the "
+            "run predates the fix, it is additional evidence from before it. The trace "
+            "shows the same bytes either way, so it cannot distinguish the two.",
+            "",
+            "```sh",
+            f"git merge-base --is-ancestor <the-fixing-commit> {run.sut_ref or '<sut-ref>'} \\",
+            '  && echo "SUT contains the fix — regression" || echo "SUT predates the fix"',
+            "```",
+            "",
+            "Reopening is a human call; this tool does not reopen. If it is a regression:",
+            "",
+            "```sh",
+            "gh issue reopen <this issue> --repo macanderson/stella",
+            "```",
+            "",
+        ]
+    for caveat in finding.caveats:
+        parts.append(f"> {caveat}")
+        parts.append("")
+    parts += [
+        "---",
+        "",
+        f"Posted by `make triage-bench-traces` from run `{run.run_id}`.",
+        "",
+        finding.fingerprint.marker,
+    ]
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------
+# The decision
+# --------------------------------------------------------------------------
+
+
+def plan_actions(
+    run: Run,
+    findings: Sequence[Finding],
+    ledger: Ledger,
+    client: GitHubClient | None,
+    max_new_issues: int,
+    excerpt_limit: int = 6,
+    comment_anyway: bool = False,
+) -> list[Action]:
+    """Decide, per finding, between commenting and opening — never duplicating.
+
+    Pure with respect to GitHub state changes: it reads (search, view) and
+    decides. Nothing is written until `apply_actions`.
+    """
+    actions: list[Action] = []
+    opened = 0
+    for finding in sorted(findings, key=lambda f: (f.detector, f.variant_source)):
+        fingerprint = finding.fingerprint
+        entry = ledger.lookup(fingerprint)
+        issue: int | None = entry.issue if entry else None
+        matched_by = "ledger" if issue is not None else ""
+        candidates: list[dict[str, Any]] = []
+        search_failed = False
+        search_error = ""
+
+        if issue is None and client is not None:
+            try:
+                candidates = client.search_issues(finding.search_terms)
+            except RuntimeError as exc:
+                # Fail CLOSED. A search that did not run is not a search that
+                # found nothing, and treating it as one is precisely how a
+                # duplicate gets opened — the ledger is the only other gate, and
+                # a fingerprint it has never seen is exactly the case where the
+                # search was load-bearing.
+                search_failed = True
+                search_error = str(exc)
+            for candidate in candidates:
+                body = candidate.get("body")
+                if body is None:
+                    try:
+                        body = client.view_issue(int(candidate["number"])).get("body") or ""
+                    except (RuntimeError, KeyError, ValueError):
+                        body = ""
+                if fingerprint.digest in markers_in(str(body)):
+                    issue = int(candidate["number"])
+                    matched_by = "fingerprint marker in the issue body"
+                    break
+
+        state = ""
+        issue_title = ""
+        if issue is not None and client is not None:
+            try:
+                view = client.view_issue(issue)
+                state = str(view.get("state") or "").upper()
+                issue_title = str(view.get("title") or "")
+            except RuntimeError:
+                state = ""
+
+        if issue is not None:
+            recurrence = state == "CLOSED"
+            novelty = (
+                entry.novelty(
+                    run.run_id,
+                    [o.task_id for o in finding.occurrences],
+                    finding.count,
+                    finding.denominator,
+                )
+                if entry
+                else []
+            )
+            # An occurrence the record already holds is not evidence, it is a
+            # repeat, and a comment that restates the issue is noise on someone
+            # else's ticket. A recurrence on a CLOSED issue is always news,
+            # because "the closed thing came back" is the finding.
+            # `entry is None` means the binding came from the issue's marker
+            # rather than the ledger, so there is no record of what was already
+            # reported — silence would then be a guess, and the wrong one.
+            silent = entry is not None and not novelty and not recurrence and not comment_anyway
+            decision = (
+                Decision.NO_NEWS
+                if silent
+                else (Decision.RECURRENCE if recurrence else Decision.COMMENT)
+            )
+            actions.append(
+                Action(
+                    finding=finding,
+                    fingerprint=fingerprint,
+                    decision=decision,
+                    title=issue_title,
+                    body=render_comment(run, finding, entry, recurrence, excerpt_limit),
+                    issue=issue,
+                    issue_state=state,
+                    issue_title=issue_title,
+                    candidates=candidates,
+                    novelty=novelty,
+                    matched_by=matched_by,
+                )
+            )
+            continue
+
+        blocked = search_failed or opened >= max_new_issues
+        if not blocked:
+            opened += 1
+        actions.append(
+            Action(
+                finding=finding,
+                fingerprint=fingerprint,
+                decision=Decision.SUPPRESSED if blocked else Decision.NEW,
+                title=finding.title,
+                body=render_new_issue(run, finding, excerpt_limit),
+                candidates=candidates,
+                matched_by=(
+                    f"search unavailable ({search_error}) — refusing to open an issue "
+                    "it could not de-duplicate"
+                    if search_failed
+                    else ""
+                ),
+            )
+        )
+    return actions
+
+
+def apply_actions(
+    run: Run, actions: Sequence[Action], ledger: Ledger, client: GitHubClient
+) -> list[str]:
+    """Execute the plan. Only reached behind an explicit `--apply`."""
+    log: list[str] = []
+    for action in actions:
+        finding = action.finding
+        tasks = [o.task_id for o in finding.occurrences]
+        if action.decision is Decision.SUPPRESSED:
+            log.append(
+                f"suppressed (cap): {finding.detector} {action.fingerprint.digest} "
+                f"— {finding.count} occurrence(s), NOT filed"
+            )
+            continue
+        if action.decision is Decision.NO_NEWS:
+            # Still observed: the ledger records that this run saw it, so the
+            # next run's novelty check is measured against the truth.
+            entry = ledger.bind(action.fingerprint, action.issue, run.run_id)
+            entry.observe(run.run_id, tasks, finding.count, finding.denominator)
+            log.append(
+                f"no news for #{action.issue}: {finding.detector} "
+                f"{action.fingerprint.digest} — recorded, not posted"
+            )
+            continue
+        if action.decision is Decision.NEW:
+            number = client.create_issue(action.title, action.body)
+            entry = ledger.bind(action.fingerprint, number, run.run_id)
+            entry.observe(run.run_id, tasks, finding.count, finding.denominator)
+            log.append(f"opened #{number}: {action.title}")
+            continue
+        assert action.issue is not None
+        client.comment_issue(action.issue, action.body)
+        entry = ledger.bind(action.fingerprint, action.issue, run.run_id)
+        entry.observe(run.run_id, tasks, finding.count, finding.denominator)
+        log.append(
+            f"commented on #{action.issue} "
+            f"({'recurrence' if action.decision is Decision.RECURRENCE else 'open'})"
+        )
+    ledger.save()
+    return log

--- a/bench/trace_triage/run_trace.py
+++ b/bench/trace_triage/run_trace.py
@@ -1,0 +1,417 @@
+"""Read one ArenaBench run off disk as trials, events, rewards and exceptions.
+
+This is the ground-truth layer of `make triage-bench-traces`. Everything a
+detector concludes has to come from here, because `stella-events.jsonl` is the
+only artifact that is not a projection: `result.json`'s verdict cell is
+either/or and hides an exception when a task passes, the UI reads the same
+projections, and a `reward.txt` of `0` says nothing about *why*.
+
+Layout, as written by the cloud runner and mirrored from
+`s3://arenabench-artifacts-578673726240/runs/<run_id>/`:
+
+    <run_root>/
+      <trial_uuid>/
+        results.json                      <- harbor stats, incl. exception_stats
+        ws/matches/<match_id>/
+          spec.json                       <- the seated contestants + role models
+          provenance.json                 <- dataset digest, SUT commit
+          jobs/<job_name>/
+            <task_id>/                    <- e.g. code-from-image__UTUWFRc
+              agent/stella-events.jsonl   <- ground truth
+              exception.txt               <- present only when the trial threw
+              verifier/reward.txt         <- "0" or "1"
+
+One `<trial_uuid>` holds exactly one graded task in every run recorded so far,
+but nothing in the layout promises that, so a trial dir yielding several task
+directories yields several `Trial`s rather than one arbitrary winner.
+
+Two rules this module exists to enforce, both of which the repository has been
+burned by:
+
+* **Guard every `json.loads`.** A run still streaming has a half-written last
+  line, and a `JSONDecodeError` there would take out the whole triage of a run
+  whose other 39 trials are complete. Malformed lines are counted, never fatal,
+  and the count is reported so a reader can tell "no such event" from "the tail
+  was unreadable".
+* **`proof` discriminates on `step.kind`, not the top-level `type`.** Every
+  `proof` event carries `"type": "proof"`; what it *proves* lives in
+  `step.kind` (`oracle`, `warrant`, `witness_unavailable`, ...). Reading the
+  top-level tag gives one undifferentiated bucket.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+S3_BUCKET = "arenabench-artifacts-578673726240"
+
+# Event tags this module indexes eagerly. Everything else stays in `events` and
+# is still reachable — the index is a convenience, never a filter.
+_INDEXED = (
+    "step_usage",
+    "step_manifest",
+    "proof",
+    "tool_start",
+    "tool_result",
+    "file_change",
+    "verdict",
+    "error",
+    "reasoning",
+    "stage",
+    "complete",
+    "loop_detected",
+)
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A `tool_start` joined to its `tool_result` by `call_id`.
+
+    The join is what makes a tool observation citable: `tool_result` carries
+    only the id, so a result quoted without its call says nothing about what
+    was asked. `result` is `None` for a call whose result never landed (the
+    process died mid-tool), which is itself a finding rather than a gap.
+    """
+
+    call_id: str
+    name: str
+    input: dict[str, Any]
+    result: dict[str, Any] | None
+    start_index: int
+    result_index: int | None
+
+    @property
+    def error(self) -> dict[str, Any] | None:
+        """The error envelope, if the result carried one."""
+        if not self.result:
+            return None
+        output = self.result.get("output")
+        if not isinstance(output, dict):
+            return None
+        err = output.get("error")
+        return err if isinstance(err, dict) else None
+
+    @property
+    def error_message(self) -> str:
+        err = self.error
+        if not err:
+            return ""
+        message = err.get("message")
+        return message if isinstance(message, str) else ""
+
+    @property
+    def ok_content(self) -> str:
+        if not self.result:
+            return ""
+        output = self.result.get("output")
+        if not isinstance(output, dict):
+            return ""
+        ok = output.get("ok")
+        if not isinstance(ok, dict):
+            return ""
+        content = ok.get("content")
+        return content if isinstance(content, str) else ""
+
+    def signature(self) -> str:
+        """Byte-stable `(tool, args)` identity, for spotting a repeat."""
+        return json.dumps([self.name, self.input], sort_keys=True)
+
+    def output_signature(self) -> str:
+        return json.dumps(self.result.get("output") if self.result else None, sort_keys=True)
+
+
+@dataclass
+class Trial:
+    """One graded task attempt, with its events already read and indexed."""
+
+    run_id: str
+    trial_uuid: str
+    task_id: str
+    root: Path
+    run_root: Path
+    events: list[dict[str, Any]] = field(default_factory=list)
+    malformed_lines: int = 0
+    by_type: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    reward: float | None = None
+    exception_text: str = ""
+    exception_types: tuple[str, ...] = ()
+
+    # ---------------------------------------------------------------- views
+
+    @property
+    def task_name(self) -> str:
+        """The dataset task, with the per-trial suffix stripped.
+
+        `code-from-image__UTUWFRc` is one *attempt* at `code-from-image`; the
+        suffix is fresh every run, so anything that must be stable across runs
+        (a fingerprint, a rate keyed by task) uses this and not `task_id`.
+        """
+        return self.task_id.split("__", 1)[0]
+
+    def of_type(self, tag: str) -> list[dict[str, Any]]:
+        return self.by_type.get(tag, [])
+
+    def proofs(self, kind: str | None = None) -> list[dict[str, Any]]:
+        """`proof` steps, discriminated on `step.kind` — never the top tag."""
+        steps = []
+        for event in self.of_type("proof"):
+            step = event.get("step")
+            if not isinstance(step, dict):
+                continue
+            if kind is None or step.get("kind") == kind:
+                steps.append(step)
+        return steps
+
+    def role_census(self) -> dict[tuple[str, str], int]:
+        """`(role, model)` counted off `step_usage` — completed calls only.
+
+        `step_manifest` records a call the engine *intended*; `step_usage`
+        records one that returned. A census off the manifest counts calls that
+        never completed as if they had run.
+        """
+        census: dict[tuple[str, str], int] = {}
+        for event in self.of_type("step_usage"):
+            key = (str(event.get("role") or "?"), str(event.get("model") or "?"))
+            census[key] = census.get(key, 0) + 1
+        return census
+
+    # ------------------------------------------------------------- citation
+
+    def s3_key(self, relative: str = "agent/stella-events.jsonl") -> str:
+        """The fetchable S3 key for an artifact of this trial.
+
+        A finding without one of these is a claim a reader cannot check, which
+        is the failure mode this whole tool exists to prevent.
+        """
+        prefix = self.root.relative_to(self.run_root).as_posix()
+        return f"s3://{S3_BUCKET}/runs/{self.run_id}/{prefix}/{relative}"
+
+    @property
+    def events_path(self) -> Path:
+        return self.root / "agent" / "stella-events.jsonl"
+
+
+@dataclass
+class Run:
+    """A whole run: its trials, and the seat configuration it was launched with."""
+
+    run_id: str
+    root: Path
+    trials: list[Trial] = field(default_factory=list)
+    declared_roles: dict[str, str] = field(default_factory=dict)
+    declared_worker_model: str = ""
+    sut_ref: str = ""
+    match_name: str = ""
+    bare_loop: bool = False
+    """Whether the seat ran the bare turn loop instead of the staged pipeline.
+
+    Load-bearing, not decoration. A bare-loop arm has no verify stage, so it
+    emits no `verdict` and authors no witness — and a pipeline detector run
+    against it reports 20/20 of an absence that is the arm working as designed.
+    That exact false positive was live here until a bare run was pointed at it.
+    """
+
+    @property
+    def graded_trials(self) -> list[Trial]:
+        return [t for t in self.trials if t.reward is not None]
+
+    def s3_prefix(self) -> str:
+        return f"s3://{S3_BUCKET}/runs/{self.run_id}/"
+
+
+# --------------------------------------------------------------------------
+# Reading
+# --------------------------------------------------------------------------
+
+
+def iter_events(path: Path) -> Iterator[tuple[int, dict[str, Any] | None]]:
+    """Yield `(line_number, event_or_None)`; `None` marks an unreadable line.
+
+    Line numbers are 1-based so a finding can cite `stella-events.jsonl:4217`
+    and a reader can `sed -n 4217p` it.
+    """
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except (ValueError, UnicodeDecodeError):
+                yield lineno, None
+                continue
+            yield lineno, event if isinstance(event, dict) else None
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _read_reward(task_dir: Path) -> float | None:
+    path = task_dir / "verifier" / "reward.txt"
+    try:
+        return float(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _exception_types(results: dict[str, Any], task_id: str) -> tuple[str, ...]:
+    """Exception class names harbor recorded for `task_id`.
+
+    Harbor buckets these per eval under `stats.evals.<eval>.exception_stats`,
+    as `{"AgentTimeoutError": ["code-from-image__UTUWFRc"]}`. Reading the class
+    name from here rather than regexing `exception.txt` keeps the detector on
+    the runner's own classification instead of on traceback prose.
+
+    Note the file: this is harbor's **job-level** `result.json`
+    (`ws/matches/*/jobs/*/result.json`), not the trial-root `results.json`,
+    which is arenabench's and carries the match/dataset/provenance instead.
+    The two are one character apart in the name and hold different documents;
+    reading the wrong one reports no exceptions at all on a run where ten
+    trials threw.
+    """
+    found: list[str] = []
+    stats = results.get("stats")
+    evals = (stats or {}).get("evals") if isinstance(stats, dict) else None
+    if not isinstance(evals, dict):
+        return ()
+    for entry in evals.values():
+        if not isinstance(entry, dict):
+            continue
+        stats = entry.get("exception_stats")
+        if not isinstance(stats, dict):
+            continue
+        for name, tasks in stats.items():
+            if isinstance(tasks, list) and task_id in tasks:
+                found.append(str(name))
+    return tuple(sorted(set(found)))
+
+
+def load_trial(run_id: str, run_root: Path, trial_uuid: str, task_dir: Path) -> Trial:
+    trial = Trial(
+        run_id=run_id,
+        trial_uuid=trial_uuid,
+        task_id=task_dir.name,
+        root=task_dir,
+        run_root=run_root,
+        reward=_read_reward(task_dir),
+        # The job directory is the task directory's parent.
+        exception_types=_exception_types(
+            _read_json(task_dir.parent / "result.json"), task_dir.name
+        ),
+    )
+    exception_path = task_dir / "exception.txt"
+    if exception_path.exists():
+        trial.exception_text = exception_path.read_text(encoding="utf-8", errors="replace")
+
+    events_path = trial.events_path
+    if events_path.exists():
+        starts: dict[str, tuple[dict[str, Any], int]] = {}
+        pending: dict[str, ToolCall] = {}
+        for lineno, event in iter_events(events_path):
+            if event is None:
+                trial.malformed_lines += 1
+                continue
+            trial.events.append(event)
+            tag = event.get("type")
+            if tag in _INDEXED:
+                trial.by_type.setdefault(str(tag), []).append(event)
+            if tag == "tool_start":
+                call = event.get("call")
+                if isinstance(call, dict) and call.get("call_id"):
+                    starts[str(call["call_id"])] = (call, lineno)
+            elif tag == "tool_result":
+                call_id = str(event.get("call_id") or "")
+                call, start_line = starts.pop(call_id, ({}, -1))
+                trial.tool_calls.append(
+                    ToolCall(
+                        call_id=call_id,
+                        name=str(call.get("name") or "?"),
+                        input=call.get("input") if isinstance(call.get("input"), dict) else {},
+                        result=event,
+                        start_index=start_line,
+                        result_index=lineno,
+                    )
+                )
+        # A `tool_start` with no `tool_result` is a tool the process died
+        # inside. It is evidence, so it is kept rather than dropped.
+        for call_id, (call, start_line) in starts.items():
+            pending[call_id] = ToolCall(
+                call_id=call_id,
+                name=str(call.get("name") or "?"),
+                input=call.get("input") if isinstance(call.get("input"), dict) else {},
+                result=None,
+                start_index=start_line,
+                result_index=None,
+            )
+        trial.tool_calls.extend(pending.values())
+    return trial
+
+
+def _declared_seat(results: dict[str, Any]) -> tuple[str, dict[str, str], str, str, bool]:
+    """Pull the launched configuration out of a trial's `results.json`.
+
+    This is the run's copy of what the match file asked for — the thing a
+    `(role, model)` census is checked against. Reading it from the artifact
+    rather than from a `match.toml` on someone's laptop is deliberate: the
+    artifact is what the run actually carried.
+    """
+    match = results.get("match")
+    if not isinstance(match, dict):
+        return "", {}, "", "", False
+    contestants = match.get("contestants")
+    if not isinstance(contestants, list) or not contestants:
+        return "", {}, "", str(match.get("name") or ""), False
+    engine = contestants[0].get("engine") if isinstance(contestants[0], dict) else None
+    if not isinstance(engine, dict):
+        return "", {}, "", str(match.get("name") or ""), False
+    roles: dict[str, str] = {}
+    declared = engine.get("roles")
+    if isinstance(declared, dict):
+        for role, spec in declared.items():
+            if isinstance(spec, dict) and spec.get("model"):
+                roles[str(role)] = str(spec["model"])
+    return (
+        str(engine.get("qualified_model") or engine.get("model") or ""),
+        roles,
+        str(match.get("sut_ref") or ""),
+        str(match.get("name") or ""),
+        bool(engine.get("bare_loop")),
+    )
+
+
+def load_run(root: Path, run_id: str | None = None) -> Run:
+    """Load every trial under a mirrored run directory.
+
+    `root` is the directory holding the per-trial UUID directories — i.e. a
+    local mirror of `runs/<run_id>/`. `run_id` defaults to the directory name,
+    which is what `aws s3 sync` produces.
+    """
+    root = root.resolve()
+    run = Run(run_id=run_id or root.name, root=root)
+    for trial_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        results = _read_json(trial_dir / "results.json")
+        if not run.declared_worker_model:
+            worker, roles, sut_ref, name, bare = _declared_seat(results)
+            if worker:
+                run.declared_worker_model = worker
+                run.declared_roles = roles
+                run.sut_ref = sut_ref
+                run.match_name = name
+                run.bare_loop = bare
+        for task_dir in sorted(trial_dir.glob("ws/matches/*/jobs/*/*")):
+            if not task_dir.is_dir():
+                continue
+            if not (task_dir / "agent").exists() and not (task_dir / "verifier").exists():
+                continue
+            run.trials.append(load_trial(run.run_id, root, trial_dir.name, task_dir))
+    return run

--- a/bench/trace_triage/tests/fixtures.py
+++ b/bench/trace_triage/tests/fixtures.py
@@ -1,0 +1,116 @@
+"""Build a run directory on disk that looks exactly like a mirrored S3 run.
+
+Every test here is offline by construction: no test may reach S3 or GitHub, so
+the traces are written rather than fetched. The shapes below are transcribed
+from real artifacts under
+`s3://arenabench-artifacts-578673726240/runs/w10p/` — the field spellings, the
+`proof`/`step.kind` nesting, the `output.ok.content` / `output.error.message`
+envelopes and harbor's `exception_stats` bucket are copied, not invented,
+because a fixture that disagrees with the wire tests the fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+MATCH_ID = "abc123abc123"
+JOB = f"{MATCH_ID}-stella-glm-5-2-pipeline-openrouter"
+
+
+def event(**fields: Any) -> dict[str, Any]:
+    return fields
+
+
+def proof(kind: str, **step: Any) -> dict[str, Any]:
+    """A `proof` event. Note the nesting: the kind is on `step`, not the top."""
+    return {"ts": 1, "type": "proof", "step": {"kind": kind, **step}}
+
+
+def tool_pair(call_id: str, name: str, args: dict[str, Any], output: dict[str, Any]):
+    return [
+        {"ts": 1, "type": "tool_start", "call": {"call_id": call_id, "name": name, "input": args}},
+        {"ts": 2, "type": "tool_result", "call_id": call_id, "output": output},
+    ]
+
+
+def ok(content: str) -> dict[str, Any]:
+    return {"ok": {"content": content}}
+
+
+def err(message: str) -> dict[str, Any]:
+    return {"error": {"message": message}}
+
+
+def write_run(
+    root: Path,
+    trials: list[dict[str, Any]],
+    *,
+    declared_worker: str = "openrouter/z-ai/glm-5.2",
+    declared_roles: dict[str, str] | None = None,
+    sut_ref: str = "554bb4f774515297273b25a919bfbfe10bea6974",
+    bare_loop: bool = False,
+) -> Path:
+    """Write `runs/<run_id>/` from a list of trial descriptors.
+
+    Each descriptor: `{"task": str, "events": [...], "reward": float|None,
+    "exception": str|None, "raw_tail": str|None}`. `raw_tail` appends a line
+    verbatim, which is how the half-written-JSON case is exercised.
+    """
+    declared_roles = declared_roles or {
+        "triage": "openrouter/z-ai/glm-4.7-flash",
+        "plan": "openrouter/deepseek/deepseek-chat",
+    }
+    root.mkdir(parents=True, exist_ok=True)
+    for index, spec in enumerate(trials):
+        uuid = f"0000000{index}-0000-4000-8000-00000000000{index}"
+        task_id = spec["task"]
+        job_dir = root / uuid / "ws" / "matches" / MATCH_ID / "jobs" / JOB
+        task_dir = job_dir / task_id
+        (task_dir / "agent").mkdir(parents=True, exist_ok=True)
+        (task_dir / "verifier").mkdir(parents=True, exist_ok=True)
+
+        lines = [json.dumps(e) for e in spec.get("events", [])]
+        if spec.get("raw_tail"):
+            lines.append(spec["raw_tail"])
+        (task_dir / "agent" / "stella-events.jsonl").write_text("\n".join(lines) + "\n")
+
+        if spec.get("reward") is not None:
+            (task_dir / "verifier" / "reward.txt").write_text(f"{spec['reward']:g}\n")
+        if spec.get("exception"):
+            (task_dir / "exception.txt").write_text("Traceback\n  ...\n" + spec["exception"] + "\n")
+
+        # Harbor's job-level result.json — where the exception CLASS lives. Not
+        # the trial-root results.json below, which is arenabench's.
+        exception_stats: dict[str, list[str]] = {}
+        if spec.get("exception_class"):
+            exception_stats[spec["exception_class"]] = [task_id]
+        (job_dir / "result.json").write_text(
+            json.dumps({"stats": {"evals": {"e": {"exception_stats": exception_stats}}}})
+        )
+
+        (root / uuid / "results.json").write_text(
+            json.dumps(
+                {
+                    "match": {
+                        "id": MATCH_ID,
+                        "name": "fixture match",
+                        "sut_ref": sut_ref,
+                        "contestants": [
+                            {
+                                "engine": {
+                                    "qualified_model": declared_worker,
+                                    "bare_loop": bare_loop,
+                                    "roles": {
+                                        role: {"model": model}
+                                        for role, model in declared_roles.items()
+                                    },
+                                }
+                            }
+                        ],
+                    }
+                }
+            )
+        )
+    return root

--- a/bench/trace_triage/tests/test_dedup.py
+++ b/bench/trace_triage/tests/test_dedup.py
@@ -1,0 +1,339 @@
+"""The de-duplication decision and the dry-run default.
+
+The requirement this file exists to hold: **the output is never a duplicate
+issue.** Everything below is one of the ways that can fail — a fingerprint seen
+twice, a ledger that was lost, a closed issue that came back, a search that did
+not run — with a fake `gh` so no test reaches the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import triage_bench_traces
+from detectors import run_all
+from fingerprint import Ledger, fingerprint_of, markers_in, normalize
+from fixtures import proof, write_run
+from issues import Decision, apply_actions, plan_actions
+from run_trace import load_run
+
+REASON = "witness author produced no TEST_COMMAND line"
+
+
+class FakeGitHub:
+    """A `gh` that records rather than calls."""
+
+    def __init__(
+        self, hits: list[dict[str, Any]] | None = None, states: dict[int, str] | None = None
+    ):
+        self.hits = hits or []
+        self.states = states or {}
+        self.bodies: dict[int, str] = {}
+        self.created: list[tuple[str, str]] = []
+        self.comments: list[tuple[int, str]] = []
+        self.next_number = 5000
+        self.search_raises = False
+
+    def search_issues(self, terms):
+        if self.search_raises:
+            raise RuntimeError("gh search issues failed: rate limited")
+        return list(self.hits)
+
+    def view_issue(self, number: int):
+        return {
+            "number": number,
+            "title": f"issue {number}",
+            "state": self.states.get(number, "OPEN"),
+            "body": self.bodies.get(number, ""),
+        }
+
+    def create_issue(self, title: str, body: str) -> int:
+        number = self.next_number
+        self.next_number += 1
+        self.created.append((title, body))
+        self.bodies[number] = body
+        self.states[number] = "OPEN"
+        return number
+
+    def comment_issue(self, number: int, body: str) -> None:
+        self.comments.append((number, body))
+
+
+def _witness_failure_events(reason: str = REASON) -> list:
+    """One witness failure, and nothing else a detector would also fire on.
+
+    The trailing verdict and post-verdict `file_change` are load-bearing: a
+    trial with neither would additionally trip `no-post-verdict-file-change`,
+    and these tests are about the de-duplication decision, not about how many
+    shapes one trial can carry.
+    """
+    return [
+        proof("witness_unavailable", reason=reason),
+        {"ts": 8, "type": "verdict", "passed": False, "evidence": {}},
+        {"ts": 9, "type": "file_change", "path": "out", "kind": "created"},
+    ]
+
+
+def _run_with_witness_failure(tmp_path, name: str, tasks: list[str], run_id: str):
+    root = tmp_path / name
+    write_run(root, [{"task": t, "reward": 0, "events": _witness_failure_events()} for t in tasks])
+    return load_run(root, run_id)
+
+
+def _ledger(tmp_path) -> Ledger:
+    ledger = Ledger(tmp_path / "ledger.json")
+    return ledger
+
+
+# --------------------------------------------------------------------------
+# The headline requirement
+# --------------------------------------------------------------------------
+
+
+def test_the_same_fingerprint_twice_opens_one_issue_and_then_comments(tmp_path):
+    """Two runs, one defect: issue first, comment second. Never two issues."""
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+
+    first = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    actions = plan_actions(first, run_all(first), ledger, client, max_new_issues=5)
+    assert [a.decision for a in actions] == [Decision.NEW]
+    apply_actions(first, actions, ledger, client)
+    assert len(client.created) == 1
+    issue_number = 5000
+
+    second = _run_with_witness_failure(tmp_path, "r2", ["beta__BBB"], "run-two")
+    actions = plan_actions(second, run_all(second), ledger, client, max_new_issues=5)
+    assert [a.decision for a in actions] == [Decision.COMMENT]
+    assert actions[0].issue == issue_number
+    assert actions[0].matched_by == "ledger"
+    apply_actions(second, actions, ledger, client)
+
+    assert len(client.created) == 1, "the second occurrence must not open a second issue"
+    assert len(client.comments) == 1
+    assert client.comments[0][0] == issue_number
+
+
+def test_the_fingerprint_survives_a_lost_ledger_via_the_issue_marker(tmp_path):
+    """The ledger is a cache of a fact GitHub also holds. Losing it is recoverable."""
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    first = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    actions = plan_actions(first, run_all(first), ledger, client, max_new_issues=5)
+    apply_actions(first, actions, ledger, client)
+    body = client.created[0][1]
+    assert markers_in(body), "an opened issue must carry its fingerprint marker"
+
+    # Wipe the ledger; the search now has to carry the de-duplication alone.
+    fresh = Ledger(tmp_path / "gone.json")
+    client.hits = [{"number": 5000, "title": "completely different words", "state": "OPEN"}]
+    second = _run_with_witness_failure(tmp_path, "r2", ["beta__BBB"], "run-two")
+    actions = plan_actions(second, run_all(second), fresh, client, max_new_issues=5)
+    assert actions[0].decision is Decision.COMMENT
+    assert actions[0].matched_by == "fingerprint marker in the issue body"
+
+
+def test_a_closed_issue_that_recurs_is_a_comment_not_a_new_ticket(tmp_path):
+    client = FakeGitHub(states={4242: "CLOSED"})
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    finding = run_all(run)[0]
+    ledger.bind(finding.fingerprint, 4242, "older-run", source="seed")
+
+    (action,) = plan_actions(run, [finding], ledger, client, max_new_issues=5)
+    assert action.decision is Decision.RECURRENCE
+    assert action.issue == 4242
+    apply_actions(run, [action], ledger, client)
+    assert client.created == [], "a recurring closed issue must never become a new ticket"
+    assert client.comments[0][0] == 4242
+
+    body = client.comments[0][1]
+    assert "RECURRENCE" in body
+    # The comment must not assert a regression it cannot establish from a trace.
+    assert "Not decided here" in body
+    assert "gh issue reopen" in body
+
+
+def test_a_search_that_did_not_run_blocks_a_new_issue(tmp_path):
+    """A failed search is not an empty search. Fail closed."""
+    client = FakeGitHub()
+    client.search_raises = True
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    (action,) = plan_actions(run, run_all(run), ledger, client, max_new_issues=5)
+    assert action.decision is Decision.SUPPRESSED
+    assert "search unavailable" in action.matched_by
+    apply_actions(run, [action], ledger, client)
+    assert client.created == []
+
+
+def test_a_repeat_that_adds_nothing_posts_nothing(tmp_path):
+    """A comment restating the issue is noise on someone else's ticket."""
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    actions = plan_actions(run, run_all(run), ledger, client, max_new_issues=5)
+    apply_actions(run, actions, ledger, client)
+
+    again = plan_actions(run, run_all(run), ledger, client, max_new_issues=5)
+    assert again[0].decision is Decision.NO_NEWS
+    apply_actions(run, again, ledger, client)
+    assert client.comments == []
+
+    forced = plan_actions(run, run_all(run), ledger, client, max_new_issues=5, comment_anyway=True)
+    assert forced[0].decision is Decision.COMMENT
+
+
+def test_a_new_task_is_news_and_says_which(tmp_path):
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    first = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    apply_actions(first, plan_actions(first, run_all(first), ledger, client, 5), ledger, client)
+
+    second = _run_with_witness_failure(tmp_path, "r2", ["gamma__GGG"], "run-two")
+    (action,) = plan_actions(second, run_all(second), ledger, client, 5)
+    assert action.decision is Decision.COMMENT
+    assert any("gamma__GGG" in item for item in action.novelty)
+    assert any("run-two" in item for item in action.novelty)
+
+
+def test_the_new_issue_cap_suppresses_loudly_rather_than_truncating(tmp_path):
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    root = tmp_path / "many"
+    # Distinct WORDS, not distinct digits: the normalizer erases digits on
+    # purpose, so `failure 1` and `failure 2` are one defect and would make this
+    # test assert the opposite of the design.
+    reasons = [
+        "witness author produced no TEST_COMMAND line",
+        "witness author emitted a test command but created no file",
+        "witness author turn aborted: the model returned an empty response",
+        "witness author turn aborted: stuck-loop detected after a steering warning",
+    ]
+    write_run(
+        root,
+        [
+            {"task": f"t{i}__X{i}", "reward": 0, "events": _witness_failure_events(reason)}
+            for i, reason in enumerate(reasons)
+        ],
+    )
+    run = load_run(root, "run-many")
+    findings = run_all(run)
+    assert len(findings) == 4, "four distinct reasons are four distinct defects"
+
+    actions = plan_actions(run, findings, ledger, client, max_new_issues=2)
+    assert sum(a.decision is Decision.NEW for a in actions) == 2
+    assert sum(a.decision is Decision.SUPPRESSED for a in actions) == 2
+    log = apply_actions(run, actions, ledger, client)
+    assert len(client.created) == 2
+    assert sum("suppressed (cap)" in line for line in log) == 2, "suppression is logged, not silent"
+
+
+def test_a_human_correction_in_the_ledger_is_never_overwritten(tmp_path):
+    ledger = _ledger(tmp_path)
+    fingerprint = fingerprint_of("d", "s", "v")
+    ledger.bind(fingerprint, 111, "run-one", note="corrected by hand", source="human")
+    ledger.bind(fingerprint, 222, "run-two")
+    assert ledger.lookup(fingerprint).issue == 111
+
+
+# --------------------------------------------------------------------------
+# Fingerprint stability
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        # The same defect, different runs: workspace root, digits, quoted nouns.
+        (
+            "candidate wrote outside `/tmp/stella_candidate_460_0/out.toml` after 12 steps",
+            "candidate wrote outside `/tmp/stella_candidate_77_3/other.json` after 4109 steps",
+        ),
+        # The same defect, different quoted tool name.
+        (
+            "stuck-loop detected: the same `create_witness_test` call was issued 4 times",
+            "stuck-loop detected: the same `apply_edits` call was issued 9 times",
+        ),
+    ],
+)
+def test_run_varying_tokens_do_not_change_the_fingerprint(left, right):
+    assert normalize(left) == normalize(right)
+    assert fingerprint_of("d", "s", left).digest == fingerprint_of("d", "s", right).digest
+
+
+def test_genuinely_different_reasons_do_not_collide():
+    a = "witness author produced no TEST_COMMAND line"
+    b = "witness author emitted a test command but created no file"
+    assert (
+        fingerprint_of("witness-unavailable", "x", a).digest
+        != fingerprint_of("witness-unavailable", "x", b).digest
+    )
+
+
+def test_the_site_is_part_of_the_identity():
+    assert fingerprint_of("d", "a.rs", "v").digest != fingerprint_of("d", "b.rs", "v").digest
+
+
+def test_the_ledger_round_trips_through_disk(tmp_path):
+    path = tmp_path / "l.json"
+    ledger = Ledger(path)
+    fingerprint = fingerprint_of("d", "s", "v")
+    entry = ledger.bind(fingerprint, 9, "run-one", note="n")
+    entry.observe("run-one", ["a__A"], 3, 20)
+    ledger.save()
+
+    reloaded = Ledger(path)
+    again = reloaded.lookup(fingerprint)
+    assert again.issue == 9
+    assert again.runs == ["run-one"]
+    assert again.peak_count == 3 and again.peak_denominator == 20
+
+
+# --------------------------------------------------------------------------
+# The dry-run default
+# --------------------------------------------------------------------------
+
+
+def test_the_default_invocation_writes_nothing(tmp_path, monkeypatch, capsys):
+    """No `--apply`: the plan is printed and neither GitHub nor the ledger moves."""
+    root = tmp_path / "runx"
+    write_run(root, [{"task": "alpha__AAA", "reward": 0, "events": _witness_failure_events()}])
+    ledger_path = tmp_path / "ledger.json"
+    client = FakeGitHub()
+    monkeypatch.setattr(triage_bench_traces, "GhCli", lambda repo: client)
+
+    code = triage_bench_traces.main(
+        ["--run", "runx", "--mirror", str(root), "--ledger", str(ledger_path)]
+    )
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert client.created == [] and client.comments == []
+    assert not ledger_path.exists(), "a dry run must not touch the tracked ledger"
+    assert "DRY RUN" in out
+    assert "body it would post" in out
+    assert REASON in out, "the plan must show the exact text that would be posted"
+
+
+def test_apply_is_the_only_thing_that_writes(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "runx"
+    write_run(root, [{"task": "alpha__AAA", "reward": 0, "events": _witness_failure_events()}])
+    ledger_path = tmp_path / "ledger.json"
+    client = FakeGitHub()
+    monkeypatch.setattr(triage_bench_traces, "GhCli", lambda repo: client)
+
+    triage_bench_traces.main(
+        ["--run", "runx", "--mirror", str(root), "--ledger", str(ledger_path), "--apply"]
+    )
+    assert len(client.created) == 1
+    assert ledger_path.exists()
+    assert "DRY RUN" not in capsys.readouterr().out
+
+
+def test_offline_cannot_write(tmp_path):
+    root = tmp_path / "runx"
+    write_run(root, [{"task": "alpha__AAA", "reward": 0, "events": []}])
+    with pytest.raises(SystemExit):
+        triage_bench_traces.main(["--run", "runx", "--mirror", str(root), "--offline", "--apply"])

--- a/bench/trace_triage/tests/test_dedup.py
+++ b/bench/trace_triage/tests/test_dedup.py
@@ -185,6 +185,25 @@ def test_a_repeat_that_adds_nothing_posts_nothing(tmp_path):
     assert forced[0].decision is Decision.COMMENT
 
 
+def test_the_same_task_under_a_fresh_trial_suffix_is_not_news(tmp_path):
+    """`code-from-image__AAA` and `code-from-image__ZZZ` are one task, two attempts.
+
+    Harbor mints the suffix per trial, so keying novelty on the raw id makes
+    every task of a rerun read as newly affected — the loudest possible way to
+    report nothing, on someone else's issue.
+    """
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    first = _run_with_witness_failure(tmp_path, "r1", ["code-from-image__AAA"], "run-one")
+    apply_actions(first, plan_actions(first, run_all(first), ledger, client, 5), ledger, client)
+
+    second = _run_with_witness_failure(tmp_path, "r2", ["code-from-image__ZZZ"], "run-two")
+    (action,) = plan_actions(second, run_all(second), ledger, client, 5)
+    assert not any("code-from-image" in item for item in action.novelty)
+    # The run itself is still news — that part is real.
+    assert any("run-two" in item for item in action.novelty)
+
+
 def test_a_new_task_is_news_and_says_which(tmp_path):
     client = FakeGitHub()
     ledger = _ledger(tmp_path)
@@ -194,7 +213,7 @@ def test_a_new_task_is_news_and_says_which(tmp_path):
     second = _run_with_witness_failure(tmp_path, "r2", ["gamma__GGG"], "run-two")
     (action,) = plan_actions(second, run_all(second), ledger, client, 5)
     assert action.decision is Decision.COMMENT
-    assert any("gamma__GGG" in item for item in action.novelty)
+    assert any("`gamma`" in item for item in action.novelty)
     assert any("run-two" in item for item in action.novelty)
 
 

--- a/bench/trace_triage/tests/test_detectors.py
+++ b/bench/trace_triage/tests/test_detectors.py
@@ -1,0 +1,480 @@
+"""The detectors, against a fixture trace. No network, by construction.
+
+What these hold onto is not "the detector fires" — a detector that fires on
+everything also passes that — but the three discriminations each one has to
+make, because every one of them has been got wrong in this repository before:
+
+* a `proof` read on the top-level `type` instead of `step.kind` sees one
+  undifferentiated bucket;
+* a reason string cut to fit a column loses the half that names the defect;
+* an absent `file_change` read as an unchanged tree is a conclusion the event
+  stream cannot support.
+"""
+
+from __future__ import annotations
+
+from detectors import run_all
+from fixtures import err, ok, proof, tool_pair, write_run
+from run_trace import load_run
+
+
+def _findings(root, code):
+    return [f for f in run_all(load_run(root, "testrun")) if f.detector == code]
+
+
+# --------------------------------------------------------------------------
+# void-model-call
+# --------------------------------------------------------------------------
+
+
+def test_void_model_call_fires_on_reasoning_without_completed_steps(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "exception_class": "AgentTimeoutError",
+                "events": [
+                    {"ts": 1, "type": "reasoning", "delta": "thinking"},
+                    {"ts": 2, "type": "reasoning", "delta": "more"},
+                ],
+            }
+        ],
+    )
+    found = _findings(tmp_path, "void-model-call")
+    assert len(found) == 1
+    assert found[0].count == 1
+    assert "2 reasoning deltas, 0 step_usage" in found[0].occurrences[0].location
+
+
+def test_void_model_call_is_silent_when_a_step_completed(tmp_path):
+    """One completed step means the model answered — that is not a void."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    {"ts": 1, "type": "reasoning", "delta": "thinking"},
+                    {"ts": 2, "type": "step_usage", "role": "worker", "model": "m"},
+                ],
+            }
+        ],
+    )
+    assert _findings(tmp_path, "void-model-call") == []
+
+
+# --------------------------------------------------------------------------
+# witness-unavailable
+# --------------------------------------------------------------------------
+
+
+LONG_REASON = (
+    "witness author turn aborted: stuck-loop detected (persisted after a steering "
+    "warning): the same `create_witness_test` call was issued four times with "
+    "byte-identical arguments and the loop did not break"
+)
+
+
+def test_witness_unavailable_reads_step_kind_not_the_top_level_type(tmp_path):
+    """The discrimination is on `step.kind`; the top tag is `proof` for all of them."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    proof("assurance", witness=True, verifier=True),
+                    proof("warrant", required=True),
+                    proof(
+                        "witness_unavailable", reason="witness author produced no TEST_COMMAND line"
+                    ),
+                ],
+            }
+        ],
+    )
+    found = _findings(tmp_path, "witness-unavailable")
+    assert len(found) == 1, "the assurance and warrant proofs must not be counted"
+
+
+def test_witness_unavailable_splits_distinct_reasons_into_distinct_defects(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    proof(
+                        "witness_unavailable", reason="witness author produced no TEST_COMMAND line"
+                    )
+                ],
+            },
+            {
+                "task": "beta__BBB",
+                "reward": 0,
+                "events": [
+                    proof(
+                        "witness_unavailable",
+                        reason="witness author emitted a test command but created no file",
+                    )
+                ],
+            },
+        ],
+    )
+    found = _findings(tmp_path, "witness-unavailable")
+    assert len(found) == 2
+    assert len({f.fingerprint.digest for f in found}) == 2
+
+
+def test_the_reason_string_reaches_the_issue_whole(tmp_path):
+    """Reasons are truncated in every other surface; here they must not be."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [proof("witness_unavailable", reason=LONG_REASON)],
+            }
+        ],
+    )
+    (finding,) = _findings(tmp_path, "witness-unavailable")
+    assert LONG_REASON in finding.occurrences[0].excerpt
+
+
+# --------------------------------------------------------------------------
+# oracle-flip-ungraded
+# --------------------------------------------------------------------------
+
+
+def test_oracle_flip_ungraded_needs_both_trees_and_a_zero_reward(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "flip__AAA",
+                "reward": 0,
+                "events": [
+                    proof("oracle", tree="baseline", passed=False),
+                    proof("oracle", tree="candidate", passed=True),
+                ],
+            },
+            {
+                # Same flip, but the grader agreed — not a finding.
+                "task": "graded__BBB",
+                "reward": 1,
+                "events": [
+                    proof("oracle", tree="baseline", passed=False),
+                    proof("oracle", tree="candidate", passed=True),
+                ],
+            },
+            {
+                # Failed on both trees: no flip was ever observed.
+                "task": "bothfail__CCC",
+                "reward": 0,
+                "events": [
+                    proof("oracle", tree="baseline", passed=False),
+                    proof("oracle", tree="candidate", passed=False),
+                ],
+            },
+        ],
+    )
+    (finding,) = _findings(tmp_path, "oracle-flip-ungraded")
+    assert [o.task_id for o in finding.occurrences] == ["flip__AAA"]
+
+
+# --------------------------------------------------------------------------
+# tool-error-envelope
+# --------------------------------------------------------------------------
+
+
+CHAIN_OUTPUT = "total 3960\n" + "\n".join(
+    f"-rw-rw-rw-. 1 root root {i} f{i}.jpg" for i in range(12)
+)
+
+
+def test_error_envelope_around_substantial_output_fires(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": tool_pair(
+                    "c1",
+                    "bash",
+                    {"command": "ls -la docs/; file docs/*"},
+                    err(
+                        CHAIN_OUTPUT + "\nbash: line 1: file: command not found\n\n[exit code: 127]"
+                    ),
+                ),
+            }
+        ],
+    )
+    (finding,) = _findings(tmp_path, "tool-error-envelope")
+    assert CHAIN_OUTPUT in finding.occurrences[0].excerpt
+
+
+def test_a_guard_refusal_is_not_this_defect(tmp_path):
+    """A refusal wraps a refusal, not output, and is a different ticket."""
+    refusal = (
+        "refused before running: `/app/documents/` is inside the graded tree `/app`, which "
+        "this shell may not touch.\nThis shell's workspace is a snapshot of that tree.\n"
+        "Use the candidate workspace instead.\nNothing else outside is restricted."
+    )
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": tool_pair("c1", "bash", {"command": "ls /app"}, err(refusal)),
+            }
+        ],
+    )
+    assert _findings(tmp_path, "tool-error-envelope") == []
+
+
+def test_one_defect_stays_one_fingerprint_across_different_payloads(tmp_path):
+    """The payload is command output — run data. Keying on it shatters one defect.
+
+    Checked ACROSS runs as well as within one, because within a single run a
+    per-payload key still yields one `Finding` per group and the count alone
+    cannot tell the two designs apart. Two runs whose only difference is the
+    bytes the command printed must hash to the same defect, or next week's
+    occurrence opens a second ticket for this week's bug.
+    """
+    first = tmp_path / "r1"
+    second = tmp_path / "r2"
+    write_run(
+        first,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": tool_pair(
+                    "c1", "bash", {"command": "a"}, err(CHAIN_OUTPUT + "\n\n[exit code: 1]")
+                ),
+            }
+        ],
+    )
+    write_run(
+        second,
+        [
+            {
+                "task": "beta__BBB",
+                "reward": 0,
+                "events": tool_pair(
+                    "c2",
+                    "bash",
+                    {"command": "b"},
+                    err(
+                        "wholly different\nlines of\noutput here "
+                        + "x" * 300
+                        + "\n\n[exit code: 2]"
+                    ),
+                ),
+            }
+        ],
+    )
+    (a,) = _findings(first, "tool-error-envelope")
+    (b,) = _findings(second, "tool-error-envelope")
+    assert a.fingerprint.digest == b.fingerprint.digest
+
+
+# --------------------------------------------------------------------------
+# repeated-identical-tool-call
+# --------------------------------------------------------------------------
+
+
+def test_repeat_needs_identical_args_and_identical_output(tmp_path):
+    same = tool_pair("c1", "bash", {"command": "make"}, ok("built")) + tool_pair(
+        "c2", "bash", {"command": "make"}, ok("built")
+    )
+    polling = tool_pair("d1", "bash", {"command": "curl :8000"}, ok("refused")) + tool_pair(
+        "d2", "bash", {"command": "curl :8000"}, ok("hello")
+    )
+    write_run(
+        tmp_path,
+        [
+            {"task": "repeat__AAA", "reward": 0, "events": same},
+            {"task": "poll__BBB", "reward": 0, "events": polling},
+        ],
+    )
+    (finding,) = _findings(tmp_path, "repeated-identical-tool-call")
+    assert [o.task_id for o in finding.occurrences] == ["repeat__AAA"]
+
+
+# --------------------------------------------------------------------------
+# role-model-census-mismatch
+# --------------------------------------------------------------------------
+
+
+def test_census_mismatch_ignores_a_provider_prefix_but_catches_a_wrong_model(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    # Declared as openrouter/z-ai/glm-4.7-flash — a prefix difference only.
+                    {
+                        "ts": 1,
+                        "type": "step_usage",
+                        "role": "triage",
+                        "model": "z-ai/glm-4.7-flash",
+                    },
+                    # Declared as openrouter/deepseek/deepseek-chat — genuinely different.
+                    {"ts": 2, "type": "step_usage", "role": "plan", "model": "z-ai/glm-5.2"},
+                ],
+            }
+        ],
+    )
+    (finding,) = _findings(tmp_path, "role-model-census-mismatch")
+    assert finding.count == 1
+    assert "role `plan`" in finding.occurrences[0].location
+
+
+# --------------------------------------------------------------------------
+# no-post-verdict-file-change
+# --------------------------------------------------------------------------
+
+
+def test_absent_verdict_and_silent_delivery_are_different_defects(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "killed__AAA",
+                "reward": 0,
+                "events": [{"ts": 9, "type": "tool_result", "call_id": "x", "output": ok("done")}],
+            },
+            {
+                "task": "silent__BBB",
+                "reward": 0,
+                "events": [
+                    {"ts": 5, "type": "file_change", "path": "a", "kind": "created"},
+                    {"ts": 9, "type": "verdict", "passed": False, "evidence": {}},
+                ],
+            },
+        ],
+    )
+    found = _findings(tmp_path, "no-post-verdict-file-change")
+    assert len(found) == 2, "collapsing these two would bury the residual half"
+    assert len({f.fingerprint.digest for f in found}) == 2
+
+
+def test_absence_of_file_change_is_never_reported_as_an_unchanged_tree(tmp_path):
+    """`bash` names no path, so the event's absence proves nothing about the tree."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "silent__BBB",
+                "reward": 0,
+                "events": [{"ts": 9, "type": "verdict", "passed": True, "evidence": {}}],
+            }
+        ],
+    )
+    (finding,) = [f for f in _findings(tmp_path, "no-post-verdict-file-change") if f.count]
+    blob = " ".join(finding.caveats) + finding.summary
+    assert "observability, never evidence" in blob
+    assert "ABSENT EVENT" in blob
+
+
+# --------------------------------------------------------------------------
+# agent-timeout
+# --------------------------------------------------------------------------
+
+
+def test_the_pipeline_detectors_are_silent_on_a_bare_loop_arm(tmp_path):
+    """A bare arm has no verify stage: its absences are the design, not a defect.
+
+    Without this the bare arm reports 20/20 "no verdict event", which is
+    arithmetically true and entirely meaningless — exactly the flattering (here,
+    alarming) measurement artifact a bench conclusion must never be drawn from.
+    """
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": f"t{i}__X{i}",
+                "reward": 0,
+                "events": [{"ts": 1, "type": "text", "text": "hi"}],
+            }
+            for i in range(4)
+        ],
+        bare_loop=True,
+    )
+    for code in ("no-post-verdict-file-change", "witness-unavailable", "oracle-flip-ungraded"):
+        assert _findings(tmp_path, code) == [], code
+
+
+def test_agent_timeout_reads_harbors_own_classification(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "exception_class": "AgentTimeoutError",
+                "exception": (
+                    "harbor.trial.trial.AgentTimeoutError: "
+                    "Agent execution timed out after 900.0 seconds"
+                ),
+                "events": [{"ts": 1, "type": "step_usage", "role": "worker", "model": "m"}],
+            },
+            {
+                "task": "beta__BBB",
+                "reward": 0,
+                "exception_class": "VerifierTimeoutError",
+                "exception": "harbor.trial.trial.VerifierTimeoutError",
+                "events": [{"ts": 1, "type": "step_usage", "role": "worker", "model": "m"}],
+            },
+        ],
+    )
+    (finding,) = _findings(tmp_path, "agent-timeout")
+    assert [o.task_id for o in finding.occurrences] == ["alpha__AAA"]
+    assert "timed out after 900.0 seconds" in finding.occurrences[0].excerpt
+
+
+# --------------------------------------------------------------------------
+# Reporting discipline
+# --------------------------------------------------------------------------
+
+
+def test_a_single_occurrence_says_so_instead_of_quoting_a_rate(tmp_path):
+    write_run(
+        tmp_path,
+        [{"task": f"t{i}__X{i}", "reward": 0, "events": []} for i in range(19)]
+        + [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    proof(
+                        "witness_unavailable", reason="witness author produced no TEST_COMMAND line"
+                    )
+                ],
+            }
+        ],
+    )
+    (finding,) = _findings(tmp_path, "witness-unavailable")
+    assert finding.denominator == 20
+    assert "Single occurrence" in finding.rate_line()
+    assert "5%" not in finding.rate_line()
+
+
+def test_every_detector_declares_its_contract():
+    from detectors import DETECTORS
+
+    assert DETECTORS, "the registry is populated by importing the module"
+    for det in DETECTORS:
+        assert det.code and det.title, det
+        assert det.search_terms, f"{det.code} needs terms for the de-duplication search"
+        assert det.code == det.code.lower().replace(" ", "-")

--- a/bench/trace_triage/tests/test_run_trace.py
+++ b/bench/trace_triage/tests/test_run_trace.py
@@ -1,0 +1,157 @@
+"""Reading a run off disk — the layer every conclusion rests on.
+
+Three of these pin defects that were live in this module during development,
+which is why they are here rather than left to the detector tests: a loader
+that silently reads nothing produces a run with no findings, and a run with no
+findings looks exactly like a healthy one.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fixtures import ok, proof, tool_pair, write_run
+from run_trace import load_run
+
+
+def test_a_half_written_tail_is_counted_not_fatal(tmp_path):
+    """A run still streaming has an incomplete last line. It must not abort triage."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [{"ts": 1, "type": "step_usage", "role": "worker", "model": "m"}],
+                "raw_tail": '{"ts": 2, "type": "tool_st',
+            }
+        ],
+    )
+    run = load_run(tmp_path, "r")
+    (trial,) = run.trials
+    assert trial.malformed_lines == 1
+    assert len(trial.of_type("step_usage")) == 1, "the readable events survive the bad line"
+
+
+def test_the_exception_class_comes_from_harbors_job_result_json(tmp_path):
+    """`result.json` (harbor, job level) — NOT `results.json` (arenabench, trial root).
+
+    Reading the wrong one is not a crash: it reports zero exceptions on a run
+    where every trial threw, which reads as a clean run.
+    """
+    write_run(
+        tmp_path,
+        [{"task": "alpha__AAA", "reward": 0, "exception_class": "AgentTimeoutError", "events": []}],
+    )
+    (trial,) = load_run(tmp_path, "r").trials
+    assert trial.exception_types == ("AgentTimeoutError",)
+
+
+def test_the_declared_seat_is_read_from_the_run_not_from_a_local_config(tmp_path):
+    write_run(
+        tmp_path,
+        [{"task": "alpha__AAA", "reward": 0, "events": []}],
+        declared_worker="openrouter/z-ai/glm-5.2",
+        declared_roles={"plan": "openrouter/deepseek/deepseek-chat"},
+    )
+    run = load_run(tmp_path, "r")
+    assert run.declared_worker_model == "openrouter/z-ai/glm-5.2"
+    assert run.declared_roles == {"plan": "openrouter/deepseek/deepseek-chat"}
+    assert run.sut_ref.startswith("554bb4f")
+
+
+def test_every_occurrence_can_be_fetched_by_the_reader(tmp_path):
+    """A citation that is not a key is a claim nobody can check."""
+    write_run(tmp_path, [{"task": "alpha__AAA", "reward": 1, "events": []}])
+    (trial,) = load_run(tmp_path, "myrun").trials
+    key = trial.s3_key()
+    assert key.startswith("s3://arenabench-artifacts-578673726240/runs/myrun/")
+    assert key.endswith("alpha__AAA/agent/stella-events.jsonl")
+
+
+def test_tool_calls_join_start_to_result_and_keep_an_unanswered_call(tmp_path):
+    """A `tool_start` with no result is the process dying mid-tool — evidence, not a gap."""
+    events = tool_pair("c1", "bash", {"command": "ls"}, ok("a\nb"))
+    events.append(
+        {"ts": 5, "type": "tool_start", "call": {"call_id": "c2", "name": "bash", "input": {}}}
+    )
+    write_run(tmp_path, [{"task": "alpha__AAA", "reward": 0, "events": events}])
+    (trial,) = load_run(tmp_path, "r").trials
+    by_id = {c.call_id: c for c in trial.tool_calls}
+    assert by_id["c1"].ok_content == "a\nb"
+    assert by_id["c2"].result is None
+
+
+def test_the_task_name_drops_the_per_trial_suffix(tmp_path):
+    write_run(tmp_path, [{"task": "code-from-image__UTUWFRc", "reward": 0, "events": []}])
+    (trial,) = load_run(tmp_path, "r").trials
+    assert trial.task_id == "code-from-image__UTUWFRc"
+    assert trial.task_name == "code-from-image"
+
+
+def test_the_role_census_counts_completed_calls_only(tmp_path):
+    """`step_manifest` is a call the engine intended; `step_usage` is one that returned."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    {"ts": 1, "type": "step_manifest", "role": "worker", "model": "never-returned"},
+                    {"ts": 2, "type": "step_usage", "role": "worker", "model": "m"},
+                    {"ts": 3, "type": "step_usage", "role": "worker", "model": "m"},
+                ],
+            }
+        ],
+    )
+    (trial,) = load_run(tmp_path, "r").trials
+    assert trial.role_census() == {("worker", "m"): 2}
+
+
+def test_proofs_are_selected_by_kind(tmp_path):
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": [
+                    proof("oracle", tree="baseline", passed=False),
+                    proof("assurance", witness=True),
+                ],
+            }
+        ],
+    )
+    (trial,) = load_run(tmp_path, "r").trials
+    assert len(trial.proofs()) == 2
+    assert len(trial.proofs("oracle")) == 1
+    assert trial.proofs("oracle")[0]["tree"] == "baseline"
+
+
+def test_a_trial_with_no_reward_file_is_not_counted_as_a_zero(tmp_path):
+    """An unrecorded reward and a reward of 0 are different facts."""
+    write_run(tmp_path, [{"task": "alpha__AAA", "reward": None, "events": []}])
+    (trial,) = load_run(tmp_path, "r").trials
+    assert trial.reward is None
+    assert load_run(tmp_path, "r").graded_trials == []
+
+
+def test_an_unreadable_results_json_does_not_stop_the_load(tmp_path):
+    write_run(tmp_path, [{"task": "alpha__AAA", "reward": 0, "events": []}])
+    trial_dir = next(p for p in tmp_path.iterdir() if p.is_dir())
+    (trial_dir / "results.json").write_text("{ not json")
+    run = load_run(tmp_path, "r")
+    assert len(run.trials) == 1
+    assert run.declared_roles == {}
+
+
+def test_json_arrays_on_a_line_are_ignored_rather_than_crashing(tmp_path):
+    """A line that parses but is not an object is not an event."""
+    write_run(
+        tmp_path,
+        [{"task": "alpha__AAA", "reward": 0, "events": [], "raw_tail": json.dumps([1, 2])}],
+    )
+    (trial,) = load_run(tmp_path, "r").trials
+    assert trial.events == []
+    assert trial.malformed_lines == 1

--- a/bench/trace_triage/triage_bench_traces.py
+++ b/bench/trace_triage/triage_bench_traces.py
@@ -1,0 +1,271 @@
+"""`make triage-bench-traces` — a bench run in, GitHub issue activity out.
+
+    python3 bench/trace_triage/triage_bench_traces.py --run w10p            # dry run
+    python3 bench/trace_triage/triage_bench_traces.py --run w10p --apply    # writes
+
+The default is a **dry run**, and that is not a convenience: this writes to a
+real tracker that other people read. A dry run prints, for every finding, the
+exact title and the exact body it would post, the de-duplication decision and
+what that decision was made on, so the plan can be read before anything reaches
+GitHub. `--apply` is the only thing that writes, and even then it will not open
+more than `--max-new-issues` issues in one invocation — anything past the cap is
+printed as SUPPRESSED with its full evidence, never silently dropped.
+
+Artifacts are read from a local mirror. `--fetch` populates one with `aws s3
+sync`, excluding the multi-hundred-megabyte `stella-run.json` and stdout copies
+that are re-renderings of the event stream:
+
+    --run w10p --fetch                      # mirror to ./.trace-mirror/w10p
+    --run w10p --mirror ~/w10p              # a mirror you already have
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from detectors import DETECTORS, Finding, run_all  # noqa: E402
+from fingerprint import LEDGER_PATH, Ledger  # noqa: E402
+from issues import (  # noqa: E402
+    REPO,
+    Action,
+    Decision,
+    GhCli,
+    apply_actions,
+    plan_actions,
+)
+from run_trace import S3_BUCKET, Run, load_run  # noqa: E402
+
+DEFAULT_MIRROR = Path(".trace-mirror")
+
+# What a mirror needs. `stella-run.json` and `stella-run.stdout.txt` are
+# re-renderings of the event stream and can each exceed 70 MB per trial, so
+# fetching them would cost gigabytes to answer questions the JSONL answers.
+_INCLUDES = (
+    "*stella-events.jsonl",
+    "*reward.txt",
+    "*exception.txt",
+    "*/result.json",
+    "*/results.json",
+    "*config.json",
+    "*spec.json",
+    "*seat.json",
+    "*provenance.json",
+)
+
+
+def fetch_run(run_id: str, mirror: Path) -> Path:
+    destination = mirror / run_id
+    destination.mkdir(parents=True, exist_ok=True)
+    args = [
+        "aws",
+        "s3",
+        "sync",
+        f"s3://{S3_BUCKET}/runs/{run_id}/",
+        str(destination) + "/",
+        "--exclude",
+        "*",
+        "--no-progress",
+    ]
+    for pattern in _INCLUDES:
+        args += ["--include", pattern]
+    result = subprocess.run(args, check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"aws s3 sync failed for run {run_id} (exit {result.returncode})")
+    return destination
+
+
+def _print_action(action: Action, index: int, total: int) -> None:
+    finding = action.finding
+    bar = "=" * 78
+    print(f"\n{bar}")
+    print(f"[{index}/{total}] {action.decision.value}")
+    print(bar)
+    print(f"detector    : {finding.detector}")
+    print(f"fingerprint : {finding.fingerprint.digest}")
+    print(f"              {finding.fingerprint.readable()}")
+    print(f"incidence   : {finding.rate_line()}")
+    if action.issue is not None:
+        print(
+            f"issue       : #{action.issue} [{action.issue_state or 'state unknown'}] "
+            f"{action.issue_title}"
+        )
+        print(f"matched by  : {action.matched_by}")
+    if action.candidates:
+        print("candidates  : (search hits — NOT auto-bound; confirm before trusting)")
+        for candidate in action.candidates[:8]:
+            print(
+                f"              #{candidate.get('number')} "
+                f"[{str(candidate.get('state') or '?').upper()}] {candidate.get('title')}"
+            )
+    if action.novelty:
+        print("adds        : " + "; ".join(action.novelty))
+    if action.decision is Decision.NEW:
+        print(f"title       : {action.title}")
+    if action.decision is Decision.NO_NEWS:
+        print(
+            "\nNothing would be posted: this occurrence adds nothing the record does not\n"
+            "already hold, and a comment restating the issue is noise on it. The run and\n"
+            "task list are still recorded in the ledger under --apply, so the next run's\n"
+            "novelty check is measured against the truth. Force it with --comment-anyway."
+        )
+        print("-" * 78)
+        return
+    print(f"\n--- body it would post {'-' * 55}")
+    print(action.body)
+    print("-" * 78)
+
+
+def _summarise(actions: list[Action], apply: bool) -> None:
+    counts: dict[str, int] = {}
+    for action in actions:
+        counts[action.decision.value] = counts.get(action.decision.value, 0) + 1
+    print("\n" + "=" * 78)
+    print("SUMMARY")
+    print("=" * 78)
+    for decision in Decision:
+        if counts.get(decision.value):
+            print(f"  {counts[decision.value]:3d}  {decision.value}")
+    if not counts:
+        print("  no findings — nothing to file or comment on")
+    suppressed = [a for a in actions if a.decision is Decision.SUPPRESSED]
+    if suppressed:
+        print("\nSuppressed by the new-issue cap (raise --max-new-issues to file them):")
+        for action in suppressed:
+            print(
+                f"  {action.fingerprint.digest}  {action.finding.detector}  "
+                f"{action.finding.count} occurrence(s)  — {action.finding.title}"
+            )
+    if not apply:
+        print(
+            "\nDRY RUN — nothing was written to GitHub and the fingerprint ledger was "
+            "not updated.\nRe-run with --apply to post exactly the bodies printed above."
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="triage-bench-traces",
+        description="Triage a bench run's traces into GitHub issue activity.",
+    )
+    parser.add_argument("--run", required=True, help="run id, e.g. w10p")
+    parser.add_argument("--mirror", type=Path, help="local mirror of runs/<run_id>/")
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help=f"populate the mirror with aws s3 sync (default {DEFAULT_MIRROR})",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually create issues and post comments (default: dry run)",
+    )
+    parser.add_argument(
+        "--max-new-issues",
+        type=int,
+        default=5,
+        help="cap on issues one invocation may open; the rest are printed as SUPPRESSED",
+    )
+    parser.add_argument("--repo", default=REPO)
+    parser.add_argument(
+        "--detector",
+        action="append",
+        default=[],
+        help="restrict to these detector codes (repeatable)",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="skip every GitHub read; ledger-only de-duplication. Implies a dry run.",
+    )
+    parser.add_argument(
+        "--comment-anyway",
+        action="store_true",
+        help=(
+            "post a comment even when the occurrence adds nothing the record did not "
+            "already hold (default: record it and stay quiet)"
+        ),
+    )
+    parser.add_argument("--ledger", type=Path, default=LEDGER_PATH)
+    parser.add_argument("--list-detectors", action="store_true", help="print the registry and exit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.list_detectors:
+        for det in DETECTORS:
+            print(f"{det.code:32s} site={det.site or '-'}")
+            print(f"{'':32s} {det.title}")
+        return 0
+
+    if args.offline and args.apply:
+        raise SystemExit("--offline cannot write: it never reads GitHub, so it cannot de-duplicate")
+
+    if args.fetch:
+        root = fetch_run(args.run, args.mirror or DEFAULT_MIRROR)
+    elif args.mirror:
+        root = args.mirror
+    else:
+        raise SystemExit("give --mirror <path> or --fetch")
+    if not root.is_dir():
+        raise SystemExit(f"no such mirror directory: {root}")
+
+    run: Run = load_run(root, args.run)
+    if not run.trials:
+        raise SystemExit(f"no trials found under {root} — is this a mirror of runs/{args.run}/ ?")
+
+    unreadable = sum(t.malformed_lines for t in run.trials)
+    print(f"run        : {run.run_id}  ({run.match_name or 'unnamed match'})")
+    print(f"mirror     : {root}")
+    print(f"SUT        : {run.sut_ref or 'not recorded'}")
+    print(
+        "arm        : "
+        + (
+            "bare turn loop — the pipeline detectors are silent, because a bare arm "
+            "has no verify stage and its absences are the design"
+            if run.bare_loop
+            else "staged pipeline"
+        )
+    )
+    print(f"trials     : {len(run.trials)} ({len(run.graded_trials)} with a reward)")
+    if unreadable:
+        print(
+            f"unreadable : {unreadable} malformed JSONL line(s) skipped — a run still "
+            "streaming has a half-written tail; absence of an event below may be that."
+        )
+
+    findings: list[Finding] = run_all(run)
+    if args.detector:
+        findings = [f for f in findings if f.detector in set(args.detector)]
+
+    ledger = Ledger(args.ledger)
+    client = None if args.offline else GhCli(args.repo)
+    actions = plan_actions(
+        run,
+        findings,
+        ledger,
+        client,
+        args.max_new_issues,
+        comment_anyway=args.comment_anyway,
+    )
+
+    for index, action in enumerate(actions, start=1):
+        _print_action(action, index, len(actions))
+
+    if args.apply:
+        assert client is not None
+        for line in apply_actions(run, actions, ledger, client):
+            print("applied:", line)
+
+    _summarise(actions, args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/trace_triage/triage_bench_traces.py
+++ b/bench/trace_triage/triage_bench_traces.py
@@ -134,12 +134,18 @@ def _summarise(actions: list[Action], apply: bool) -> None:
         print("  no findings — nothing to file or comment on")
     suppressed = [a for a in actions if a.decision is Decision.SUPPRESSED]
     if suppressed:
-        print("\nSuppressed by the new-issue cap (raise --max-new-issues to file them):")
+        # Two reasons land here and they mean different things: the cap is a
+        # budget a human can raise, a failed search is a de-duplication the tool
+        # could not perform. Printing both under one heading would invite
+        # "just raise the cap" at exactly the moment that is the wrong move.
+        print("\nSuppressed — not filed, and listed here rather than silently dropped:")
         for action in suppressed:
+            reason = action.matched_by or "the new-issue cap (raise --max-new-issues to file it)"
             print(
                 f"  {action.fingerprint.digest}  {action.finding.detector}  "
                 f"{action.finding.count} occurrence(s)  — {action.finding.title}"
             )
+            print(f"      reason: {reason}")
     if not apply:
         print(
             "\nDRY RUN — nothing was written to GitHub and the fingerprint ledger was "


### PR DESCRIPTION
## What this is

`make triage-bench-traces` — a repeatable process whose **input** is a bench run
and whose **output** is GitHub issue activity: a new issue for a genuinely new
defect, a comment carrying fresh citable evidence onto an issue that already
describes the behaviour.

```sh
make triage-bench-traces RUN=w10p FETCH=1                      # dry run
make triage-bench-traces RUN=w10p MIRROR=~/w10p ARGS=--apply   # writes
```

Until now defects were found by a human reading traces by hand and then
remembering to file something. That is how findings get lost, and how one defect
gets filed three times in three different sets of words.

## The fingerprint, and why it is stable across runs

**The hard requirement is that the output is never a duplicate, including
against closed issues.** Title similarity cannot deliver that, and this backlog
is the proof: #2929 and #2872 describe a single defect — an oracle failing on
both trees and routing to `Revise` — with almost no shared vocabulary, found on
different runs and different SUTs. A prose matcher would have filed both, and
did.

So a defect is identified by a triple, hashed:

```
fp = sha256("<detector>\n<site>\n<variant>")[:12]
```

- **detector** — the event-level predicate that fired. Not a description of the
  bug: the name of the thing that detects it. Two findings from one predicate
  are the same *kind* of defect by construction.
- **site** — the repo-relative code site the detector implicates, declared on
  the detector and never derived from the run. `""` when nothing is implicated,
  which is honest and simply means the variant carries the discrimination.
- **variant** — a *normalized* discriminator from the occurrence. Normalization
  erases every token that varies between two runs of one defect: quoted spans,
  absolute paths, the `/tmp/stella_candidate_<n>_<n>` root, digits, whitespace;
  the leading skeleton survives.

**Why it is stable:** none of the three holds a run id, a trial id, a task name,
a timestamp, a cost, a model name or a line number. So next week's recurrence
hashes to this week's value, and two different reasons under one detector do not
collide — `witness author produced no TEST_COMMAND line` and `witness author
emitted a test command but created no file` are two defects and get two
fingerprints, which matters because #2908 may be fixed for one and not the other.

**The design rule the first real run taught us:** a variant discriminates
*defects*, not *payloads*. `witness_unavailable` reasons are a small closed set
the engine authors, so the reason is the discriminator. A tool error message is
command output — pure run data — and keying on it shattered one defect into 23
tickets the first time this was pointed at `w10p`. That detector's variant is now
a constant and its predicate carries the whole identity. `test_one_defect_stays_
one_fingerprint_across_different_payloads` pins it *across two runs*, because
within one run a per-payload key still yields one `Finding` per group and the
count alone cannot tell the two designs apart.

**Alternatives considered.** A pure event-signature key (detector only) merges
the four `witness_unavailable` reasons into one ticket and buries three of them.
A raw-string key shatters as above. An embedding/similarity key reintroduces
exactly the fuzziness that produced #2929/#2872, and cannot be reviewed or
corrected by a human. The triple is the smallest thing that separates defects
without separating occurrences.

**The mapping is persisted, not re-derived** (`bench/trace_triage/fingerprints.json`,
tracked). It improves — a human correction is permanent, because an entry whose
`source` is not `auto` is never overwritten — and it survives search going wrong,
which is the day a duplicate would otherwise be opened. It also records `runs`,
`tasks` and `peak_*`, which is what lets a comment say what an occurrence *adds*
rather than restating the issue; when it adds nothing, **nothing is posted** and
the sighting is recorded so the next comparison is against the truth.

## The three de-duplication gates

1. **The ledger.** A bound fingerprint is that issue. No search, no judgement.
2. **The marker.** Every issue this tool opens carries
   `<!-- stella-trace-fingerprint: fp_… -->`, so a lost or reset ledger is rebuilt
   from GitHub itself. Invisible in rendered Markdown, and not prose, so it
   cannot rot the way a title can.
3. **A search across open AND closed**, printed as *candidates* for a human to
   confirm. Never auto-bound. (`gh search issues` takes only `open`/`closed` for
   `--state`; *omitting* it is what searches both — the reading that looks safe,
   `--state open`, is the one that files duplicates for every closed defect.)

A search that **errored** is not a search that found nothing: it fails closed and
blocks the new issue rather than risking the duplicate.

## A closed issue that recurs

A comment, never a new ticket, headed `RECURRENCE`. What the comment does **not**
do is assert a regression: whether a recurrence is one depends on whether the
run's SUT already contained the fix, and the trace shows the same bytes either
way. It states the SUT ref, names the `git merge-base --is-ancestor` command that
settles it, and leaves both that call and the reopen to a human.

Verified live against the real tracker (reads only): #2927 and #2908 are both
CLOSED, and w10p's signatures route to `RECURRENCE` comments on them rather than
to new issues.

## Detectors shipped

| Code | Fires on |
|---|---|
| `void-model-call` | `reasoning` deltas with zero `step_usage` — no model call ever completed |
| `agent-timeout` | harbor's own `AgentTimeoutError` classification (from the **job-level** `result.json`) |
| `witness-unavailable` | `proof` `step.kind == "witness_unavailable"`, one finding per reason |
| `oracle-flip-ungraded` | an oracle flip (baseline fail, candidate pass) on a trial graded 0 |
| `tool-error-envelope` | an error envelope wrapping substantial output before `[exit code: N]` |
| `repeated-identical-tool-call` | adjacent identical `(tool, args)` with byte-identical output |
| `role-model-census-mismatch` | `(role, model)` off `step_usage` vs the run's declared seat |
| `no-post-verdict-file-change` | no `verdict` at all, **or** a verdict with no `file_change` after it |

Adding one is a single decorated function in `detectors.py` — the decorator
registers it, and the plan, rendering and de-duplication need no change.
`test_every_detector_declares_its_contract` holds a new one to the contract.

Three rules a detector obeys, each of which this repo has paid for:
`proof` discriminates on `step.kind`; reason strings are carried **whole**
(they are truncated in every other surface and the truncated half is the point);
and **`file_change` is observability, never evidence** — the detector keyed on
its absence reports an absent *event*, and carries that caveat in its own output
so the sentence reaches the issue rather than dying in a docstring.

Reporting discipline is enforced too: a detector that fires once prints
"**Single occurrence** — 1 of 20 trials examined. This is one trial, not a rate",
because `5%` is arithmetically true and epistemically a lie.

## Three correctness defects found while building this, and fixed

- **The exception class lives in harbor's job-level `result.json`, not the
  trial-root `results.json`.** The two are one character apart and hold different
  documents. Reading the wrong one is not a crash: it reported *zero* exceptions
  on `w10p`, where ten of twenty trials threw — a clean-looking run.
  (`test_the_exception_class_comes_from_harbors_job_result_json`)
- **The pipeline detectors fired on the bare-loop arm.** `w10b` is bare, has no
  verify stage, and so emits no `verdict` — the detector reported `20/20 (100%)`
  of an absence that is the arm working as designed. Now gated on the seat's
  `bare_loop`, and the dry run says which arm it is looking at.
  (`test_the_pipeline_detectors_are_silent_on_a_bare_loop_arm`)

- **The novelty check keyed on `task_id`, whose per-trial suffix is minted fresh
  every run.** `code-from-image__AAA` and `code-from-image__ZZZ` are one task and
  two attempts, so every task of a rerun read as "a new affected task" — the
  loudest possible way to report nothing, on someone else's issue. Citations
  still name the attempt, because that is what a reader fetches; the ledger
  holds the dataset name.
  (`test_the_same_task_under_a_fresh_trial_suffix_is_not_news`)

Also: `gh --json` returns ANSI-wrapped output under a shell with `CLICOLOR_FORCE`
set, which crashed `json.loads` mid-run. Fixed in the subprocess environment,
with a strip as belt to that braces.

## Safety

- Dry run by default. It prints, per finding, the decision, **what the decision
  was made on**, and the exact title and body it would post.
- `--max-new-issues` (default 5). Anything past the cap prints as `SUPPRESSED`
  **with its full evidence** and is logged — never silently truncated.
- `--offline` skips every GitHub read and refuses to write, because a tool that
  cannot de-duplicate must not file.
- **This PR files nothing.** The ledger is seeded from the analysis in #2908,
  #2927, #2941 and #2956, and every run above was a dry run.

## Tests

45, standard library only, no network — fixtures are transcribed from real
artifacts under `runs/w10p/`, because a fixture that disagrees with the wire
tests the fixture.

Covered as required: the de-dup decision (same fingerprint twice → one issue,
second becomes a comment), the dry-run default, and every one of the eight
detectors against a fixture trace. Plus: the marker recovery path, the
closed-issue recurrence, fail-closed on a failed search, the new-issue cap, the
human-correction guard, fingerprint stability across runs, and the half-written
JSONL tail.

**Every one was seen to fail before it passed.** Thirteen behaviours were removed
one at a time and the named test went red for each:

```
RED (good)   marker stamped into a new issue
RED (good)   ledger consulted before filing
RED (good)   search failure fails closed
RED (good)   closed issue -> recurrence, not new
RED (good)   proof reads step.kind
RED (good)   error-envelope variant is not the payload
RED (good)   guard refusal excluded
RED (good)   dry run is the default
RED (good)   single occurrence is not a rate
RED (good)   absent verdict vs silent delivery split
RED (good)   new-issue cap
RED (good)   human ledger binding preserved
RED (good)   normalizer erases run-varying tokens
```

Two of those were caught *not* witnessing their behaviour on the first pass and
were rewritten until they did.

## Wiring

`make triage-bench-traces` sits beside the other bench targets and is
**deliberately not in `GATE_STEPS`** — it reads S3 and writes to GitHub, and
`gate-parity` would fail the moment it joined. `make bench-test` and
`.github/workflows/bench.yml` run the suite, which is the only thing standing
between a non-gate tool and silent rot.

Exemplar for the registry-plus-pure-function shape: `stella-parity`'s capability
matrix — a declared row per subject, enforced from both sides, with the
judgement left legible to a reviewer.

## Filed while building this (nothing left behind)

- **#2972** — the `site` component is hashed into the fingerprint but nothing
  checks the path exists, so a file rename silently repartitions the identity
  space and the recovery marker in the existing issue carries the *old* digest.
  Three fixes proposed, with the one that actually removes the duplicate hazard
  named.
- **#2973** — five confirmed shapes (#2912, #2931, #2932, #2933, #2934) have no
  detector, so their incidence is not tracked run-over-run. Written as a
  transcription handoff with the predicate, the constraints and the ledger seed
  for each.
- **#2974** — the ledger has no posture for a defect that is known and
  accepted, so such a finding is re-proposed as a new issue on every run
  forever; and `--fetch`'s include-list can drop a file `load_run` reads (losing
  `reward.txt` makes every trial load as ungraded and reads as a healthy run).
