### PR TITLE
fix: stop five Tier C bench-waste mechanisms (#2869 #2928 #2933 #2932 #2559 #2022)

### DIFF
--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -120,6 +120,7 @@ mod execute_stage;
 mod fallback;
 use fallback::{FallbackPosture, RoleFallbacks};
 mod fanout_stage;
+mod plan_stage;
 mod plan_steps;
 mod raw_usage;
 mod repair_gate;
@@ -1486,99 +1487,9 @@ impl<'a> Pipeline<'a> {
         })
     }
 
-    // Stage: plan
-
-    /// `revision` is the reviewer's note from a rejected scope card, or `None`
-    /// for a turn's first plan. `spend` bundles budget + total as downstream
-    /// does: #1778's `research` param took the pair one over clippy's cap.
-    async fn plan_stage(
-        &self,
-        goal: &str,
-        recall: &[RecalledFrame],
-        research: &[ResearchFinding],
-        repo_structure: &str,
-        revision: Option<&str>,
-        spend: &mut Spend<'_>,
-    ) -> Result<Vec<PlanStep>, PipelineStageAbort> {
-        self.emit(AgentEvent::Stage {
-            name: StageKind::Plan,
-        });
-        let fallback_plan = || vec![PlanStep::new(goal)];
-
-        let resolved = match self.assigned(ModelCallRole::Plan) {
-            Assigned::To(r) => r,
-            Assigned::Withheld | Assigned::Unresolvable => return Ok(fallback_plan()),
-        };
-        if let Some(fb) = &resolved.fallback {
-            self.emit_fallback(fb);
-        }
-
-        let prompt = build_planner_prompt(goal, recall, research, repo_structure, revision);
-        // The planner's own row, which the caller resolves as `agents.plan`
-        // over `agents.worker` field by field — so plan still rides the
-        // worker's settings whenever nobody has said otherwise (#2416), and
-        // an operator who *has* said otherwise is obeyed (#2374). The
-        // non-prompt knobs also arrive via `config.engine` (built from the
-        // worker's tuning); `prompt` has no seat there and reaches the planner
-        // only here, prepended as a system message ahead of
-        // `PLANNER_INSTRUCTIONS` so the JSON-array contract `parse_plan` reads
-        // is never replaced.
-        let plan_overrides = &self.config.role_overrides.plan;
-        let result = match self
-            .metered_raw_call(
-                RawCall {
-                    role: ModelCallRole::Plan,
-                    resolved: &resolved,
-                    messages: prompt.into_messages(),
-                    policy: RetryPolicy::standard(),
-                    overrides: plan_overrides,
-                    timeout: self.config.engine.model_timeout,
-                },
-                spend.budget,
-                spend.total,
-            )
-            .await
-        {
-            Ok(r) => r,
-            // Still before execute: a fallback plan here would only buy the
-            // worker turns the run has no clock left to run.
-            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
-            Err(RawCallError::Provider | RawCallError::Timeout) => return Ok(fallback_plan()),
-        };
-
-        if let Some(steps) = parse_plan(&result.text) {
-            return Ok(steps);
-        }
-
-        // One bounded JSON-repair retry (L-V2), deterministic (no retry-hang).
-        match self
-            .metered_raw_call(
-                RawCall {
-                    role: ModelCallRole::PlanRepair,
-                    resolved: &resolved,
-                    messages: plan_repair_prompt(&result.text).into_messages(),
-                    policy: RetryPolicy::deterministic(),
-                    overrides: plan_overrides,
-                    timeout: self.config.engine.model_timeout,
-                },
-                spend.budget,
-                spend.total,
-            )
-            .await
-        {
-            Ok(repair) => {
-                if let Some(steps) = parse_plan(&repair.text) {
-                    return Ok(steps);
-                }
-            }
-            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
-            Err(RawCallError::Provider | RawCallError::Timeout) => {}
-        }
-
-        // Degrade to a single-step plan rather than failing — a planner that
-        // won't produce a parseable plan must still let the work proceed.
-        Ok(fallback_plan())
-    }
+    // Stage: plan — see `plan_stage.rs` (split out when #2932 added the
+    // path-repair retry; a god file closed to growth cannot host a stage that
+    // keeps growing legitimate retry logic).
 
     // Stage: execute + verify — candidate generation and selection
 

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -2661,7 +2661,7 @@ impl<'a> Pipeline<'a> {
         self.emit(AgentEvent::Stage {
             name: StageKind::Execute,
         });
-        match self
+        let (outcome, _) = self
             .run_engine_turn(
                 engine,
                 &mut state.messages,
@@ -2669,8 +2669,8 @@ impl<'a> Pipeline<'a> {
                 &mut state.signals,
                 crate::flip_halt::for_revision(&state.flip_halt, state.oracle.state()),
             )
-            .await
-        {
+            .await;
+        match outcome {
             TurnOutcome::Completed { text, cost_usd } => {
                 state.final_text = text;
                 *spend.total += cost_usd;

--- a/crates/stella-pipeline/src/pipeline/execute_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/execute_stage.rs
@@ -24,6 +24,12 @@ pub(super) struct TurnTallies {
     opaque: Arc<AtomicU32>,
     verify_confirmations: Arc<AtomicU32>,
     errored_commands: Arc<AtomicU32>,
+    /// Every `ToolStart` this turn dispatched, read-only calls included —
+    /// unlike `mutating`, which excludes them on purpose (#2933). Not folded
+    /// into `ChangeSignals`: that struct is the candidate's running total,
+    /// and this is read once per turn, by the plan-step walk alone, to tell
+    /// a turn that acted from one that only answered.
+    tool_calls: Arc<AtomicU32>,
 }
 
 impl TurnTallies {
@@ -34,6 +40,11 @@ impl TurnTallies {
         signals.opaque_actions += self.opaque.load(Ordering::Relaxed);
         signals.verify_done_confirmations += self.verify_confirmations.load(Ordering::Relaxed);
         signals.errored_commands += self.errored_commands.load(Ordering::Relaxed);
+    }
+
+    /// How many tool calls this one turn dispatched, mutating or not.
+    pub(super) fn tool_call_count(&self) -> u32 {
+        self.tool_calls.load(Ordering::Relaxed)
     }
 }
 
@@ -97,6 +108,7 @@ impl<'a> Pipeline<'a> {
                     state.flip_halt.clone(),
                 )
                 .await
+                .0
             {
                 TurnOutcome::Completed { text, cost_usd } => {
                     state.final_text = text;
@@ -171,7 +183,7 @@ impl<'a> Pipeline<'a> {
                     total,
                     &step.description,
                 )));
-            match self
+            let (outcome, tool_calls) = self
                 .run_engine_turn(
                     engine,
                     &mut state.messages,
@@ -179,8 +191,8 @@ impl<'a> Pipeline<'a> {
                     &mut state.signals,
                     state.flip_halt.clone(),
                 )
-                .await
-            {
+                .await;
+            match outcome {
                 TurnOutcome::Completed { text, cost_usd } => {
                     *spend.total += cost_usd;
                     mark(i, TaskStatus::Completed);
@@ -194,6 +206,7 @@ impl<'a> Pipeline<'a> {
                     // `UNVERIFIABLE` and refutes nothing (#2104).
                     let closed_out = plan_steps::goal_declared_complete(&text);
                     state.final_text = text;
+                    let remaining = i + 1 < steps.len();
                     if closed_out {
                         // #1702's early close-out: the remaining steps are not
                         // abandoned, they are covered. Saying so on the rail is
@@ -204,6 +217,49 @@ impl<'a> Pipeline<'a> {
                         // gave before this.
                         for (j, _) in steps.iter().enumerate().skip(i + 1) {
                             mark(j, TaskStatus::Completed);
+                        }
+                        break;
+                    }
+                    // #2933: a turn that dispatched no tool call at all
+                    // answered rather than worked, and `step_prompt` already
+                    // tells the worker to do exactly that when a step is
+                    // already covered — which measured true for the whole
+                    // remaining plan far more often than not. Walking the
+                    // rest one step per turn just repeats the same no-op
+                    // answer at one full model call each; ask once instead,
+                    // then stop regardless of what it finds.
+                    if tool_calls == 0 && remaining {
+                        state.messages.push(CompletionMessage::user(
+                            plan_steps::outstanding_work_prompt(&steps[i + 1..]),
+                        ));
+                        let (follow_up, _) = self
+                            .run_engine_turn(
+                                engine,
+                                &mut state.messages,
+                                spend.budget,
+                                &mut state.signals,
+                                state.flip_halt.clone(),
+                            )
+                            .await;
+                        match follow_up {
+                            TurnOutcome::Completed { text, cost_usd } => {
+                                *spend.total += cost_usd;
+                                state.final_text = text;
+                                for (j, _) in steps.iter().enumerate().skip(i + 1) {
+                                    mark(j, TaskStatus::Completed);
+                                }
+                            }
+                            TurnOutcome::Aborted {
+                                reason,
+                                kind,
+                                cost_usd,
+                            } => {
+                                *spend.total += cost_usd;
+                                for (j, _) in steps.iter().enumerate().skip(i + 1) {
+                                    mark(j, TaskStatus::Cancelled);
+                                }
+                                return Err(TurnAbort { reason, kind });
+                            }
                         }
                         break;
                     }
@@ -239,6 +295,11 @@ impl<'a> Pipeline<'a> {
     /// `mutating_actions` answers "was anything even asked to change", which
     /// nothing can defeat, because it is counted off the calls this pipeline
     /// dispatched rather than off any look at the world.
+    /// Returns the turn's outcome alongside its own tool-call count — see
+    /// [`TurnTallies::tool_call_count`] — so a caller that needs to tell an
+    /// acting turn from a purely narrated one (#2933) does not have to infer
+    /// it from `ChangeSignals`, which is the candidate's running total, not
+    /// this one turn's.
     pub(super) async fn run_engine_turn(
         &self,
         engine: &Engine<'_>,
@@ -246,7 +307,7 @@ impl<'a> Pipeline<'a> {
         budget: &mut BudgetGuard,
         signals: &mut ChangeSignals,
         flip_halt: Option<Arc<FlipHalt>>,
-    ) -> TurnOutcome {
+    ) -> (TurnOutcome, u32) {
         // Every execute turn gets a halt now (#2661): armed with the tracked
         // command when `run_candidate` observed a failing baseline, otherwise
         // watching only for a confirmed `verify_done` — the deterministic
@@ -259,8 +320,9 @@ impl<'a> Pipeline<'a> {
         let outcome = halted
             .run_turn_with_sender(messages, budget, &filtered)
             .await;
+        let tool_calls = tallies.tool_call_count();
         tallies.fold_into(signals);
-        outcome
+        (outcome, tool_calls)
     }
 
     /// Drive a checkpoint-restored turn to its end under the same event
@@ -318,6 +380,8 @@ impl<'a> Pipeline<'a> {
         // oracle.
         let seen_command_errors = Arc::new(AtomicU32::new(0));
         let command_errors = seen_command_errors.clone();
+        let seen_tool_calls = Arc::new(AtomicU32::new(0));
+        let tool_calls = seen_tool_calls.clone();
         // The `verify_done` calls in flight, so their results can be scored
         // (#2129). Correlated by `call_id` for the same reason the command
         // map below is — a step dispatches calls concurrently.
@@ -363,6 +427,11 @@ impl<'a> Pipeline<'a> {
                     consumer.send(event)
                 }
                 AgentEvent::ToolStart { call } => {
+                    // Unconditional, unlike `mutating` below: #2933's replay
+                    // guard needs "did this turn act at all", not "did it
+                    // mutate", to tell a worker that made a read-only lookup
+                    // from one that only narrated in prose.
+                    tool_calls.fetch_add(1, Ordering::Relaxed);
                     // Counted at dispatch, not at result: a call that errored
                     // or timed out still means the turn *tried* to act, and
                     // the no-op rung is about the attempt. Only a name the
@@ -470,6 +539,7 @@ impl<'a> Pipeline<'a> {
                 opaque: seen_opaque,
                 verify_confirmations: seen_verify,
                 errored_commands: seen_command_errors,
+                tool_calls: seen_tool_calls,
             },
         )
     }

--- a/crates/stella-pipeline/src/pipeline/plan_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/plan_stage.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The plan stage: one planner call, a bounded JSON-repair retry (L-V2), and
+//! (#2932) a second bounded retry for a plan that parsed cleanly but named
+//! an absolute filesystem path — see [`Pipeline::resolve_plan_paths`] in
+//! `plan_steps.rs` for that half. Split out of `pipeline.rs` (a god file
+//! closed to growth) so the second retry had somewhere to land that was not
+//! a baseline exception.
+
+use super::*;
+
+impl<'a> Pipeline<'a> {
+    /// `revision` is the reviewer's note from a rejected scope card, or `None`
+    /// for a turn's first plan. `spend` bundles budget + total as downstream
+    /// does: #1778's `research` param took the pair one over clippy's cap.
+    pub(super) async fn plan_stage(
+        &self,
+        goal: &str,
+        recall: &[RecalledFrame],
+        research: &[ResearchFinding],
+        repo_structure: &str,
+        revision: Option<&str>,
+        spend: &mut Spend<'_>,
+    ) -> Result<Vec<PlanStep>, PipelineStageAbort> {
+        self.emit(AgentEvent::Stage {
+            name: StageKind::Plan,
+        });
+        let fallback_plan = || vec![PlanStep::new(goal)];
+
+        let resolved = match self.assigned(ModelCallRole::Plan) {
+            Assigned::To(r) => r,
+            Assigned::Withheld | Assigned::Unresolvable => return Ok(fallback_plan()),
+        };
+        if let Some(fb) = &resolved.fallback {
+            self.emit_fallback(fb);
+        }
+
+        let prompt = build_planner_prompt(goal, recall, research, repo_structure, revision);
+        // The planner's own row, which the caller resolves as `agents.plan`
+        // over `agents.worker` field by field — so plan still rides the
+        // worker's settings whenever nobody has said otherwise (#2416), and
+        // an operator who *has* said otherwise is obeyed (#2374). The
+        // non-prompt knobs also arrive via `config.engine` (built from the
+        // worker's tuning); `prompt` has no seat there and reaches the planner
+        // only here, prepended as a system message ahead of
+        // `PLANNER_INSTRUCTIONS` so the JSON-array contract `parse_plan` reads
+        // is never replaced.
+        let plan_overrides = &self.config.role_overrides.plan;
+        let result = match self
+            .metered_raw_call(
+                RawCall {
+                    role: ModelCallRole::Plan,
+                    resolved: &resolved,
+                    messages: prompt.into_messages(),
+                    policy: RetryPolicy::standard(),
+                    overrides: plan_overrides,
+                    timeout: self.config.engine.model_timeout,
+                },
+                spend.budget,
+                spend.total,
+            )
+            .await
+        {
+            Ok(r) => r,
+            // Still before execute: a fallback plan here would only buy the
+            // worker turns the run has no clock left to run.
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
+            Err(RawCallError::Provider | RawCallError::Timeout) => return Ok(fallback_plan()),
+        };
+
+        if let Some(steps) = parse_plan(&result.text) {
+            return self
+                .resolve_plan_paths(steps, &resolved, plan_overrides, spend)
+                .await;
+        }
+
+        // One bounded JSON-repair retry (L-V2), deterministic (no retry-hang).
+        match self
+            .metered_raw_call(
+                RawCall {
+                    role: ModelCallRole::PlanRepair,
+                    resolved: &resolved,
+                    messages: plan_repair_prompt(&result.text).into_messages(),
+                    policy: RetryPolicy::deterministic(),
+                    overrides: plan_overrides,
+                    timeout: self.config.engine.model_timeout,
+                },
+                spend.budget,
+                spend.total,
+            )
+            .await
+        {
+            Ok(repair) => {
+                if let Some(steps) = parse_plan(&repair.text) {
+                    return self
+                        .resolve_plan_paths(steps, &resolved, plan_overrides, spend)
+                        .await;
+                }
+            }
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => return Err(abort),
+            Err(RawCallError::Provider | RawCallError::Timeout) => {}
+        }
+
+        // Degrade to a single-step plan rather than failing — a planner that
+        // won't produce a parseable plan must still let the work proceed.
+        Ok(fallback_plan())
+    }
+}

--- a/crates/stella-pipeline/src/pipeline/plan_steps.rs
+++ b/crates/stella-pipeline/src/pipeline/plan_steps.rs
@@ -18,6 +18,10 @@
 //! - [`goal_declared_complete`] is the close-out channel the prompt offers: a
 //!   reply that opens or closes with an affirmative [`PLAN_COMPLETE_MARKER`]
 //!   line ends the step loop.
+//! - [`outstanding_work_prompt`] is #2933's narrower close-out: a step
+//!   answered with no tool calls at all almost always means the rest are
+//!   covered too, and the walk asks about all of them in one further turn
+//!   instead of one per remaining step.
 //!
 //! **The close-out is screened here, not downstream, because the backstop this
 //! module originally leaned on does not always exist.** The first version
@@ -29,6 +33,8 @@
 //! negated echo of the marker skipped nine of ten steps for reward 0.0
 //! (#2104). Most of Terminal-Bench is that shape, so the screen is the
 //! backstop.
+
+use crate::plan::PlanStep;
 
 /// The line a worker opens with to declare the whole goal finished and end
 /// the step loop. Matched at line start (after leading whitespace) so prose
@@ -52,6 +58,33 @@ pub(super) fn step_prompt(index: usize, total: usize, description: &str) -> Stri
         index + 1,
         total,
         description,
+    )
+}
+
+/// The one consolidated follow-up sent instead of walking the rest of the
+/// plan one step per turn (#2933).
+///
+/// [`step_prompt`] already instructs a worker that finished a step in an
+/// earlier turn to answer in one line with no tool calls — the correct
+/// behavior for *that* step. The loop's fault was upstream of the prompt: a
+/// worker that closed out step 1 with no tool calls almost always covered
+/// the whole goal there too, and the loop re-asked every remaining step
+/// individually anyway, paying one full model call per step for a reply
+/// that was `Already done` every time (measured: 52 such calls in one
+/// 20-trial arm, 0 in the arm with no plan stage). This prompt asks about
+/// every remaining step at once, so the loop pays for at most one more
+/// call instead of one per step.
+pub(super) fn outstanding_work_prompt(remaining: &[PlanStep]) -> String {
+    let mut listed = String::new();
+    for (i, step) in remaining.iter().enumerate() {
+        listed.push_str(&format!("{}. {}\n", i + 1, step.description));
+    }
+    format!(
+        "The previous step needed no tool calls, which usually means the remaining plan steps \
+         below are already covered too. This is the last check before the walk ends: if every \
+         one of them is genuinely already done, say so in one line and make no tool calls. If \
+         any of them are not actually done, do that work now — there will be no further \
+         per-step turn to catch it.\n\n{listed}"
     )
 }
 

--- a/crates/stella-pipeline/src/pipeline/plan_steps.rs
+++ b/crates/stella-pipeline/src/pipeline/plan_steps.rs
@@ -34,7 +34,48 @@
 //! (#2104). Most of Terminal-Bench is that shape, so the screen is the
 //! backstop.
 
-use crate::plan::PlanStep;
+use super::*;
+use crate::plan::{names_an_absolute_path, parse_plan, plan_path_repair_prompt};
+
+impl<'a> Pipeline<'a> {
+    /// One bounded repair retry (L-V2) for a plan that parsed cleanly but
+    /// named an absolute filesystem path — a blind planner cannot know a
+    /// path it never saw is real, and #2932 measured 32% of plan steps in
+    /// one benchmark run naming `/app`, most refused outright by the
+    /// candidate sandbox. Degrades to the original plan on any repair
+    /// failure: a plan naming a path the worker has to correct is still
+    /// better than no plan.
+    pub(super) async fn resolve_plan_paths(
+        &self,
+        steps: Vec<PlanStep>,
+        resolved: &ResolvedRole<'a>,
+        overrides: &RoleCallOverrides,
+        spend: &mut Spend<'_>,
+    ) -> Result<Vec<PlanStep>, PipelineStageAbort> {
+        if !steps.iter().any(|s| names_an_absolute_path(&s.description)) {
+            return Ok(steps);
+        }
+        match self
+            .metered_raw_call(
+                RawCall {
+                    role: ModelCallRole::PlanRepair,
+                    resolved,
+                    messages: plan_path_repair_prompt(&steps).into_messages(),
+                    policy: RetryPolicy::deterministic(),
+                    overrides,
+                    timeout: self.config.engine.model_timeout,
+                },
+                spend.budget,
+                spend.total,
+            )
+            .await
+        {
+            Ok(repair) => Ok(parse_plan(&repair.text).unwrap_or(steps)),
+            Err(RawCallError::Budget(abort) | RawCallError::Deadline(abort)) => Err(abort),
+            Err(RawCallError::Provider | RawCallError::Timeout) => Ok(steps),
+        }
+    }
+}
 
 /// The line a worker opens with to declare the whole goal finished and end
 /// the step loop. Matched at line start (after leading whitespace) so prose

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -96,9 +96,14 @@ fn management_bounds(role: ModelCallRole) -> (Option<u32>, Option<ReasoningEffor
         // ceiling: pinned-low effort is not only cheaper, it keeps the call
         // inside the ceiling so the fast route actually gets taken.
         ModelCallRole::Triage => (Some(512), Some(ReasoningEffort::Low)),
-        // A small ordered-JSON plan. Output is bounded; effort is inherited —
-        // plan quality rides the session's own reasoning posture.
-        ModelCallRole::Plan | ModelCallRole::PlanRepair => (Some(4096), None),
+        // A small ordered-JSON plan. Effort is pinned low, not inherited
+        // (#2869): a high-effort session let a reasoning model spend its
+        // entire 8k-token headroom thinking and answer with nothing, twice —
+        // the starvation retry re-sends through this same closure, so an
+        // inherited high effort loses the identical bet at a 3.4x larger
+        // cap. Plan's output contract is three to eight short strings; that
+        // does not need session-level deliberation to produce.
+        ModelCallRole::Plan | ModelCallRole::PlanRepair => (Some(4096), Some(ReasoningEffort::Low)),
         // "PASS or FAIL, then one line" / "at most 6 lines" by their own
         // prompts. Effort inherited: both are judgment calls on evidence.
         ModelCallRole::Verdict | ModelCallRole::DistressGuidance => (Some(1024), None),
@@ -466,6 +471,23 @@ mod tests {
             role_output_cap(ModelCallRole::Triage, &pinned, Some(64_000)),
             Some(512)
         );
+    }
+
+    /// #2869 witness: Plan and PlanRepair pin low effort instead of
+    /// inheriting the session's, so a high-effort session cannot drive a
+    /// reasoning model to spend the entire cap thinking and answer with
+    /// nothing. Fails on the old code, where both roles inherited (`None`)
+    /// and a `high`-effort session reached the wire unbounded.
+    #[test]
+    fn plan_roles_pin_low_effort_rather_than_inherit() {
+        for role in [ModelCallRole::Plan, ModelCallRole::PlanRepair] {
+            assert_eq!(
+                management_bounds(role).1,
+                Some(ReasoningEffort::Low),
+                "{role:?} must pin low effort so an inherited high-effort session \
+                 cannot spend the whole output cap on reasoning"
+            );
+        }
     }
 
     /// An uncapped role inherits the engine base, exactly as before.

--- a/crates/stella-pipeline/src/pipeline/tests/best_of_n.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/best_of_n.rs
@@ -823,10 +823,18 @@ async fn workspace_creation_seeds_the_plan_and_only_a_lone_candidate_may_report(
 /// model round trip per step would be both slower and less reliable.
 #[tokio::test]
 async fn a_plan_walk_moves_the_candidates_board_step_by_step() {
+    // Step 1 dispatches a real tool call (then a plain-text reply closing
+    // that turn's own inner tool loop) so it does not trip #2933's
+    // zero-tool-call consolidation — this test is about the ordinary
+    // per-step InProgress/Completed pairing, which #2933's collapsed path
+    // deliberately does not use (see `a_no_tool_call_step_ends_the_walk_
+    // with_one_consolidated_check` in `plan_walk.rs` for that path). Step 2
+    // is the last step, so it has nothing left to consolidate either way.
     let provider = ScriptedProvider::new(vec![
         text_result("CLASS: multi"),
         text_result(r#"["read the layout","fold the rail"]"#),
-        text_result("step 1 done"),
+        writing_tool_result("step 1 done"),
+        text_result("step 1 confirmed"),
         text_result("step 2 done"),
     ]);
     let log = Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/crates/stella-pipeline/src/pipeline/tests/plan_shaping.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/plan_shaping.rs
@@ -274,3 +274,69 @@ async fn the_conversational_path_does_not_carry_the_worker_prompt() {
         );
     }
 }
+
+/// #2932 witness: a plan that parses cleanly but names an absolute path
+/// spends one bounded repair call restating it declaratively, and the
+/// repaired plan — not the original path-naming one — is what the worker
+/// sees. Fails on `main`, where a step naming `/app/pyknotid` reaches the
+/// worker verbatim with no repair call in between.
+#[tokio::test]
+async fn a_plan_step_naming_an_absolute_path_is_repaired_before_the_worker_sees_it() {
+    let provider = plan_call_with(
+        RoleCallOverrides::default(),
+        text_result(r#"["Clone the repository into /app/pyknotid"]"#),
+        vec![text_result(r#"["Clone the pyknotid repository"]"#)],
+    )
+    .await;
+
+    let repair = call(&provider, 2);
+    let roles: Vec<_> = repair.iter().map(|(role, _)| *role).collect();
+    assert_eq!(
+        roles,
+        vec![
+            stella_protocol::MessageRole::System,
+            stella_protocol::MessageRole::User,
+        ],
+        "the path-repair call carries the same split shape as the plan call; got {repair:#?}"
+    );
+    assert!(
+        repair[0].1.contains("no tool access")
+            && repair[0].1.contains("absolute filesystem path"),
+        "the repair instructions must explain why the path may be wrong: {}",
+        repair[0].1
+    );
+    assert!(
+        repair[1].1.contains("/app/pyknotid"),
+        "the repair payload must echo the flagged step: {}",
+        repair[1].1
+    );
+
+    let worker_step = call(&provider, 3);
+    let worker_text: String = worker_step.iter().map(|(_, t)| t.as_str()).collect();
+    assert!(
+        !worker_text.contains("/app/pyknotid"),
+        "the worker must see the repaired step, not the original path-naming one: {worker_text}"
+    );
+    assert!(
+        worker_text.contains("Clone the pyknotid repository"),
+        "the worker must see the repaired step's text: {worker_text}"
+    );
+}
+
+/// The other direction: a plan with no absolute path spends no extra call —
+/// the repair retry is conditional, not a tax on every plan.
+#[tokio::test]
+async fn a_plan_with_no_absolute_path_skips_the_repair_call() {
+    let provider = plan_call_with(
+        RoleCallOverrides::default(),
+        text_result(r#"["Install and start nginx"]"#),
+        Vec::new(),
+    )
+    .await;
+    assert_eq!(
+        provider.prompts().len(),
+        3,
+        "triage, plan, and the one step turn — no path-repair call: {:?}",
+        provider.prompts()
+    );
+}

--- a/crates/stella-pipeline/src/pipeline/tests/plan_shaping.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/plan_shaping.rs
@@ -300,8 +300,7 @@ async fn a_plan_step_naming_an_absolute_path_is_repaired_before_the_worker_sees_
         "the path-repair call carries the same split shape as the plan call; got {repair:#?}"
     );
     assert!(
-        repair[0].1.contains("no tool access")
-            && repair[0].1.contains("absolute filesystem path"),
+        repair[0].1.contains("no tool access") && repair[0].1.contains("absolute filesystem path"),
         "the repair instructions must explain why the path may be wrong: {}",
         repair[0].1
     );

--- a/crates/stella-pipeline/src/pipeline/tests/plan_walk.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/plan_walk.rs
@@ -8,6 +8,12 @@
 //! loop ends when the worker takes it. These scenarios pin both directions:
 //! the close-out skips the redundant walk, and a worker that never declares
 //! completion keeps the full walk exactly as before.
+//!
+//! #2933 adds a second, narrower close-out below (`a_no_tool_call_step_ends_
+//! the_walk_with_one_consolidated_check`): a step whose turn makes literally
+//! no tool call — `step_prompt` already tells the worker to answer exactly
+//! that way when a step is already covered — collapses the rest of the walk
+//! into one consolidated check instead of one turn per remaining step.
 
 use super::*;
 
@@ -16,11 +22,14 @@ use super::*;
 /// baseline, green candidate, green confirmation) and never spends a model
 /// call the assertion would have to account for.
 macro_rules! plan_walk_scenario {
-    ($provider:expr) => {{
+    ($provider:expr) => {
+        plan_walk_scenario!($provider, EmptyTools)
+    };
+    ($provider:expr, $tools:expr) => {{
         let provider = $provider;
         let resolver = OneProvider(&provider);
         let runner = ScriptedRunner::new(vec![false, true, true], "@@ -1 +1 @@\n-old\n+new");
-        let tools = EmptyTools;
+        let tools = $tools;
         let recall = NoContextRecall;
         let repo = NoRepoStructure;
         let repo_status = NoRepoStatus;
@@ -112,38 +121,88 @@ async fn a_declared_complete_goal_ends_the_step_walk() {
     );
 }
 
-/// The other direction: a worker that never takes the close-out channel gets
-/// the full walk, one turn per step, exactly as before — the early exit is
-/// the worker's declaration, never this loop's guess.
+/// The other direction: a worker that never takes the close-out channel AND
+/// keeps dispatching tool calls every step gets the full walk, one turn per
+/// step, exactly as before — the early exit is the worker's own declaration
+/// or (#2933) a turn that acted on nothing, never a guess about a worker that
+/// is visibly still working.
 #[tokio::test]
 async fn an_undeclared_goal_still_walks_every_step() {
-    let (outcome, _events, prompts) = plan_walk_scenario!(ScriptedProvider::new(vec![
-        text_result("multi"),
-        eight_step_plan(),
-        text_result("did step 1"),
-        text_result("did step 2"),
-        text_result("did step 3"),
-        text_result("did step 4"),
-        text_result("did step 5"),
-        text_result("did step 6"),
-        text_result("did step 7"),
-        text_result("did step 8"),
-    ]));
+    // Each step's turn is two model calls: the tool dispatch, then a
+    // plain-text reply that closes the turn's own inner tool loop (the
+    // engine keeps calling the model within a turn until one comes back with
+    // no more tool calls) — so a real acting turn never trips #2933's
+    // zero-tool-call trigger.
+    let mut script = vec![text_result("multi"), eight_step_plan()];
+    for n in 1..=8 {
+        script.push(writing_tool_result(&format!("did step {n}")));
+        script.push(text_result(&format!("step {n} complete")));
+    }
+    let (outcome, _events, prompts) =
+        plan_walk_scenario!(ScriptedProvider::new(script), OneWritingTool);
 
     assert_eq!(outcome.status, PipelineStatus::Completed);
     assert_eq!(
         prompts.len(),
-        10,
-        "triage, plan, and all 8 step turns — no step is skipped on a guess"
+        18,
+        "triage, plan, and two model calls per step (tool dispatch + close) \
+         across all 8 steps — no step is skipped while the worker keeps \
+         acting: {prompts:?}"
     );
     assert!(
-        prompts[9].contains("Step 8/8: s8"),
-        "the last step turn carries the last step: {}",
-        prompts[9]
+        prompts.last().unwrap().contains("Step 8/8: s8"),
+        "the last step's turn carries the last step: {}",
+        prompts.last().unwrap()
     );
     assert!(
         prompts[2].contains(plan_steps::PLAN_COMPLETE_MARKER),
         "every step prompt offers the close-out channel: {}",
         prompts[2]
+    );
+}
+
+/// #2933 witness: a step turn that dispatches literally no tool call is
+/// answering, not working — `step_prompt` already instructs the worker to
+/// reply that way when a step is already covered, and one such reply usually
+/// means the rest of the plan is covered too. The walk must not replay the
+/// remaining steps one per turn; it asks once, then stops.
+///
+/// Fails on `main`, where the loop keeps feeding steps 3–8 one at a time
+/// (10 total prompts) no matter how many of them come back with zero tool
+/// calls.
+#[tokio::test]
+async fn a_no_tool_call_step_ends_the_walk_with_one_consolidated_check() {
+    let (outcome, _events, prompts) = plan_walk_scenario!(
+        ScriptedProvider::new(vec![
+            text_result("multi"),
+            eight_step_plan(),
+            // Step 1 does the real work: a tool dispatch, then the close of
+            // that turn's own inner loop.
+            writing_tool_result("did step 1"),
+            text_result("step 1 complete"),
+            // Step 2 answers with no tool call at all: #2933's trigger.
+            text_result("Step 2 was already done"),
+            // The one consolidated follow-up covering steps 3-8.
+            text_result("Everything else was already covered too."),
+        ]),
+        OneWritingTool
+    );
+
+    assert_eq!(outcome.status, PipelineStatus::Completed);
+    assert_eq!(
+        prompts.len(),
+        6,
+        "triage, plan, step 1's dispatch + close, step 2, and ONE \
+         consolidated follow-up — not one further turn per remaining step: \
+         {prompts:?}"
+    );
+    assert!(
+        prompts[5].contains("s3") && prompts[5].contains("s8"),
+        "the consolidated follow-up must name every remaining step: {}",
+        prompts[5]
+    );
+    assert_eq!(
+        outcome.final_text, "Everything else was already covered too.",
+        "the consolidated follow-up's reply is the run's final text"
     );
 }

--- a/crates/stella-pipeline/src/pipeline/tests/research.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/research.rs
@@ -232,7 +232,18 @@ async fn the_research_row_reaches_the_childrens_requests_and_not_the_workers() {
         "every research child must carry the pinned effort, got {research:?}"
     );
 
-    let worker = provider.efforts_for("## Plan (JSON array of step strings)");
+    // "## Plan (JSON array of step strings)" is the planner's OWN prompt
+    // heading (`build_planner_prompt`), not anything a worker turn's request
+    // carries — matching on it selected the plan call, not the worker, which
+    // this test's old assertion could not tell apart because both used to
+    // inherit the same engine effort. #2869 pins Plan's own effort low
+    // unconditionally, so the needle has to name the worker's actual step
+    // prompt to keep testing what this test is titled for.
+    let worker = provider.efforts_for("Step 1/1: update retry.rs");
+    assert!(
+        !worker.is_empty(),
+        "the worker's step turn must have been called"
+    );
     assert!(
         worker
             .iter()

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -66,6 +66,30 @@ async fn runner_availability(tests: &dyn TestRunner) -> Vec<String> {
 /// empty authoring reply.
 const WITNESS_MAX_OUTPUT_TOKENS: u32 = 16_384;
 
+/// Per-turn step ceiling for the witness author/repair engine (#2559, the
+/// wall-clock half of #2149's token bound above).
+///
+/// The author's own system prompt asks for "read the exemplar, write the
+/// file, reply" — a handful of tool calls, not a work session, the same
+/// characterization the research stage's own step ceiling documents for the
+/// goal verifier. Left uncapped, the author inherits the WORKER's
+/// `max_steps` (200 by default) via [`Pipeline::engine_config_for`], which is
+/// how one observed run spent 10 model calls and 20 tool calls (`glob`,
+/// `read_file` only — the closed vocabulary has no `grep`) rediscovering this
+/// repository's own test conventions, then authored nothing. On breach the
+/// turn aborts with a step-cap reason, which the existing match arm below
+/// already treats as `WitnessAbort::unauthorable` — the executed change
+/// stands unproven and the run still reaches a verdict; nothing new to wire.
+const WITNESS_AUTHOR_MAX_STEPS: usize = 8;
+
+/// Lower `config.max_steps` to at most [`WITNESS_AUTHOR_MAX_STEPS`], leaving
+/// a stricter operator value untouched — the step-count sibling of
+/// [`bound_witness_output_tokens`], same min-not-raise contract.
+fn bound_witness_steps(mut config: EngineConfig) -> EngineConfig {
+    config.max_steps = config.max_steps.min(WITNESS_AUTHOR_MAX_STEPS);
+    config
+}
+
 /// Lower `config.max_output_tokens` to at most [`WITNESS_MAX_OUTPUT_TOKENS`],
 /// leaving a stricter operator value untouched. Pure so the min-not-raise
 /// contract is testable without a pipeline.
@@ -328,10 +352,10 @@ impl<'a> Pipeline<'a> {
         // The output ceiling (#2141) is applied *after* role shaping so it
         // caps whatever the verifier overrides resolved to — an override can
         // lower the bound but never raise it back above the witness ceiling.
-        bound_witness_output_tokens(apply_role_shaping(
+        bound_witness_steps(bound_witness_output_tokens(apply_role_shaping(
             self.engine_config_for(surface),
             &self.config.role_overrides.verifier,
-        ))
+        )))
     }
 
     pub(super) fn engine_config_for(&self, surface: CandidateSurface<'_>) -> EngineConfig {
@@ -1090,5 +1114,30 @@ mod tests {
             ..EngineConfig::default()
         });
         assert_eq!(from_stricter.max_output_tokens, Some(2_048));
+    }
+
+    /// #2559 witness: the author/repair engine's step ceiling lowers the
+    /// worker's `max_steps` (200 by default) to [`WITNESS_AUTHOR_MAX_STEPS`],
+    /// and never raises a stricter operator value. Fails on `main`, where
+    /// `witness_engine_config` never touches `max_steps` at all, so the
+    /// author inherits the worker's 200-step ceiling and can spend it
+    /// rediscovering the repository's own test conventions before authoring
+    /// anything.
+    #[test]
+    fn the_witness_step_ceiling_only_ever_lowers() {
+        let from_worker = bound_witness_steps(EngineConfig {
+            max_steps: 200,
+            ..EngineConfig::default()
+        });
+        assert_eq!(from_worker.max_steps, WITNESS_AUTHOR_MAX_STEPS);
+
+        let from_stricter = bound_witness_steps(EngineConfig {
+            max_steps: 3,
+            ..EngineConfig::default()
+        });
+        assert_eq!(
+            from_stricter.max_steps, 3,
+            "a stricter operator value must stand — the bound is a ceiling, not a floor"
+        );
     }
 }

--- a/crates/stella-pipeline/src/pipeline/witness_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/witness_stage.rs
@@ -490,6 +490,7 @@ impl<'a> Pipeline<'a> {
                 None,
             )
             .await
+            .0
         {
             TurnOutcome::Completed { text, cost_usd } => {
                 *spend.total += cost_usd;
@@ -626,13 +627,16 @@ impl<'a> Pipeline<'a> {
                          the executed change stands unproven"
                     )));
                 }
-                Ok(TurnOutcome::Completed { text, cost_usd }) => {
+                Ok((TurnOutcome::Completed { text, cost_usd }, _)) => {
                     *spend.total += cost_usd;
                     text
                 }
-                Ok(TurnOutcome::Aborted {
-                    reason, cost_usd, ..
-                }) => {
+                Ok((
+                    TurnOutcome::Aborted {
+                        reason, cost_usd, ..
+                    },
+                    _,
+                )) => {
                     *spend.total += cost_usd;
                     // Degradable for the same #1789 reason as the author
                     // turn's budget arm above.

--- a/crates/stella-pipeline/src/plan.rs
+++ b/crates/stella-pipeline/src/plan.rs
@@ -220,7 +220,12 @@ fn balanced_span(text: &str, open: char, close: char) -> Option<&str> {
 const PLANNER_INSTRUCTIONS: &str = "You are the planner for a coding agent. Produce a short ordered plan of \
      concrete steps to accomplish the goal. Respond with a JSON array of \
      step strings, e.g. [\"step one\", \"step two\"]. Keep it minimal — the \
-     fewest steps that fully accomplish the goal.";
+     fewest steps that fully accomplish the goal. You have no tool access and \
+     cannot see the real repository: state each step as an OUTCOME (what \
+     should be true when it is done), never as a literal absolute path or a \
+     specific shell command — a path or command you have not verified exists \
+     may be wrong, and the worker that carries out the step can see the tree \
+     and choose one correctly.";
 
 /// Assemble the planner's split context (L-E6): goal + recalled frames +
 /// repo-structure summary, and an instruction to emit a JSON array of steps.
@@ -340,6 +345,57 @@ pub fn plan_repair_prompt(previous_response: &str) -> ManagementPrompt {
     ManagementPrompt {
         instructions: PLAN_REPAIR_INSTRUCTIONS,
         payload: format!("Previous response:\n{echoed}\n\nJSON array:"),
+    }
+}
+
+/// Whether `step` names an absolute filesystem path — something a blind
+/// planner (no tool access, no view of the tree) cannot actually know is
+/// real. Measured: 32% of plan steps across a benchmark run named `/app`,
+/// half of which the candidate sandbox refuses outright as written, and the
+/// rest are copied straight from the goal text with no guarantee the build
+/// system or layout they imply matches the real repository (#2932:
+/// `python setup.py sdist` shipped no wheel because the plan prescribed it
+/// sight-unseen, while the same worker chose correctly with no plan at all).
+///
+/// Matched word-by-word, not by scanning for a bare `/` anywhere in the
+/// text: a URL (`https://example.com/api`) is one word that starts with a
+/// scheme name, never with `/`, so it is never mistaken for a path, and a
+/// word like `and/or` or `3/4` does not start with `/` either. Surrounding
+/// punctuation a model commonly wraps a path in — backticks, quotes,
+/// parens, a trailing comma or period — is stripped before the check.
+pub fn names_an_absolute_path(step: &str) -> bool {
+    step.split_whitespace().any(|word| {
+        let trimmed = word
+            .trim_start_matches(['(', '`', '"', '\'', '['])
+            .trim_end_matches([')', '`', '"', '\'', ']', ',', '.', ';', ':']);
+        trimmed.len() > 1 && trimmed.starts_with('/') && !trimmed[1..].starts_with('/')
+    })
+}
+
+/// The repair call's fixed instruction block for a plan that parsed cleanly
+/// but named an absolute path (#2932) — distinct from
+/// [`PLAN_REPAIR_INSTRUCTIONS`], which is for a response that failed to
+/// parse at all.
+const PLAN_PATH_REPAIR_INSTRUCTIONS: &str = "Your plan named one or more absolute filesystem paths, but you have no \
+     tool access and cannot see the real repository layout — those paths were \
+     guessed from the goal text and may be wrong. Re-emit the SAME plan as a \
+     strict JSON array of step strings, restating any step that named an \
+     absolute path or a shell command as an OUTCOME instead (what should be \
+     true when the step is done) — never a literal path or command you have \
+     not verified exists.";
+
+/// A short re-prompt asking the planner to restate any step that named an
+/// absolute path declaratively — the pipeline's other bounded repair retry
+/// (L-V2), alongside [`plan_repair_prompt`]'s unparseable-response one.
+pub fn plan_path_repair_prompt(steps: &[PlanStep]) -> ManagementPrompt {
+    let mut payload = String::from("## Previous plan\n");
+    for (i, step) in steps.iter().enumerate() {
+        payload.push_str(&format!("{}. {}\n", i + 1, step.description));
+    }
+    payload.push_str("\n## Plan (JSON array of step strings)\n");
+    ManagementPrompt {
+        instructions: PLAN_PATH_REPAIR_INSTRUCTIONS,
+        payload,
     }
 }
 
@@ -562,5 +618,49 @@ mod tests {
             p.chars().count() < PLAN_REPAIR_ECHO_CHARS + 500,
             "the prompt must be bounded by the echo ceiling, not the response size"
         );
+    }
+
+    /// #2932 witness: the exact `pypi-server` plan step that shipped no wheel
+    /// because a blind planner prescribed `python setup.py sdist` against a
+    /// tree it never saw — real absolute paths in various positions and
+    /// wrappers must all be caught.
+    #[test]
+    fn an_absolute_path_step_is_flagged() {
+        for step in [
+            "Start pypiserver on port 8080 with `pypi-server -p 8080 /app/dist`",
+            "Clone the repository into /app/pyknotid",
+            "Write the summary to /app/summary.csv",
+            "Verify (/app/ssl/server.crt) exists",
+            "Read '/app/config.json' for settings",
+        ] {
+            assert!(names_an_absolute_path(step), "should flag: {step}");
+        }
+    }
+
+    /// The false-positive side: prose that merely contains a `/` must not be
+    /// flagged, or the repair retry would fire on nearly every plan.
+    #[test]
+    fn ordinary_prose_with_a_slash_is_not_flagged() {
+        for step in [
+            "Install the package with pip and/or conda",
+            "Split the ratio 3/4 across both shards",
+            "Fetch https://example.com/api/v1 for the schema",
+            "Configure read/write access for the service account",
+            "Run tests in the ci/cd pipeline",
+        ] {
+            assert!(!names_an_absolute_path(step), "should not flag: {step}");
+        }
+    }
+
+    #[test]
+    fn path_repair_prompt_lists_every_step_and_asks_for_json() {
+        let steps = vec![
+            PlanStep::new("Clone the repository into /app/pyknotid"),
+            PlanStep::new("Install build dependencies"),
+        ];
+        let p = plan_path_repair_prompt(&steps).rendered();
+        assert!(p.contains("/app/pyknotid"));
+        assert!(p.contains("Install build dependencies"));
+        assert!(p.contains("JSON array of step strings"));
     }
 }

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -261,6 +261,69 @@ fn graph_advisory(command: &str, root: &Path, confinement: &ShellConfinement) ->
     None
 }
 
+/// A bare `sleep` blocking the whole trial budget goes undetected today:
+/// loop detection sees polls (`read_output`) between the sleeps so the
+/// interleaved-repeat rung reads the window as progressing, and the budget
+/// guard is spend-based, so idling costs $0. #2022's first step is honest
+/// visibility, not a refusal — a static text-shape check on the command, not
+/// a measured elapsed time, so it stays deterministic for the loop detector
+/// (never embed a timing here; see `stella-tool-timings-must-not-ride-tooloutput`).
+///
+/// Only a *bare* sleep is worth naming: `sleep 2 && curl` retry backoffs are
+/// ordinary and must stay unflagged, so this requires every segment of the
+/// command to be `sleep N` or an inert no-op (`echo`, `printf`, `true`) —
+/// anything else (a real command sharing the line) disqualifies the whole
+/// command, matching the observed pathological shape (`sleep 300; echo
+/// done`) rather than a compound one that happens to contain a sleep.
+const SLEEP_ADVISORY_THRESHOLD_SECS: u64 = 30;
+
+/// The accumulated seconds a *bare* sleep command blocks for, or `None` if
+/// any segment does real work beyond sleeping and a harmless no-op.
+fn bare_sleep_seconds(command: &str) -> Option<u64> {
+    let words = shell_words(command);
+    let mut segments: Vec<&[String]> = Vec::new();
+    let mut start = 0;
+    for (i, w) in words.iter().enumerate() {
+        if matches!(w.as_str(), ";" | "&" | "&&" | "|" | "||") {
+            segments.push(&words[start..i]);
+            start = i + 1;
+        }
+    }
+    segments.push(&words[start..]);
+
+    let mut total_secs = 0u64;
+    let mut saw_sleep = false;
+    for segment in &segments {
+        match segment {
+            [] => {}
+            [cmd, arg] if cmd == "sleep" => {
+                let secs = arg.parse::<f64>().ok()?;
+                total_secs += secs.round() as u64;
+                saw_sleep = true;
+            }
+            [cmd, ..] if matches!(cmd.as_str(), "echo" | "printf" | "true") => {}
+            _ => return None,
+        }
+    }
+    saw_sleep.then_some(total_secs)
+}
+
+/// A footer naming a bare `sleep` that crossed the advisory threshold, and
+/// the instrument (`read_output`/`wait_for`) that returns as soon as there is
+/// something to see instead of blocking the whole interval.
+fn sleep_advisory(command: &str) -> Option<String> {
+    let secs = bare_sleep_seconds(command)?;
+    if secs < SLEEP_ADVISORY_THRESHOLD_SECS {
+        return None;
+    }
+    Some(format!(
+        "\n\nnote: this call blocked for {secs}s inside a bare `sleep` with no other work in \
+         it. If you are waiting on a background process, poll with `read_output`/`wait_for` \
+         instead — they return as soon as there is something to see, so a short poll costs less \
+         of the trial's budget than sleeping through the whole interval."
+    ))
+}
+
 pub struct Bash {
     scratch: Option<std::path::PathBuf>,
     confinement: ShellConfinement,
@@ -451,6 +514,9 @@ impl Tool for Bash {
         // cut: a cross-root `cd` warning or a symbol-shaped-grep graph_query
         // nudge, when an index exists.
         if let Some(note) = graph_advisory(command, root, &self.confinement) {
+            combined.push_str(&note);
+        }
+        if let Some(note) = sleep_advisory(command) {
             combined.push_str(&note);
         }
 
@@ -821,6 +887,53 @@ mod tests {
         assert!(!bash_grep_is_symbol_shaped(r#"grep -rn "TODO:" ."#));
         assert!(!bash_grep_is_symbol_shaped("ls -la && cargo build"));
         assert!(!bash_grep_is_symbol_shaped("cat foo.rs"));
+    }
+
+    /// #2022 witness: the exact observed pathological shape
+    /// (`sleep 300; echo done`, `sleep 120` alone) is caught and its
+    /// accumulated seconds are named, so the advisory can fire on it.
+    #[test]
+    fn bare_sleep_is_detected_and_summed() {
+        assert_eq!(bare_sleep_seconds("sleep 300; echo done"), Some(300));
+        assert_eq!(bare_sleep_seconds("sleep 120"), Some(120));
+        assert_eq!(bare_sleep_seconds("sleep 60"), Some(60));
+        // Multiple bare sleeps in one call accumulate.
+        assert_eq!(
+            bare_sleep_seconds("sleep 30 && sleep 30"),
+            Some(60),
+            "accumulated sleep across the whole call, not just the last segment"
+        );
+        assert_eq!(
+            bare_sleep_seconds("sleep 2.5"),
+            Some(3),
+            "rounds to the nearest second"
+        );
+    }
+
+    /// The legitimate case must stay unflagged: a sleep inside a retry
+    /// backoff, or any command sharing the line with real work, is not the
+    /// pathological shape — only a command whose ENTIRE body is sleep-plus-
+    /// no-op is.
+    #[test]
+    fn a_sleep_beside_real_work_is_not_flagged() {
+        assert_eq!(
+            bare_sleep_seconds("sleep 2 && curl -s http://localhost:8080"),
+            None
+        );
+        assert_eq!(bare_sleep_seconds("sleep 5; tail -f build.log"), None);
+        assert_eq!(bare_sleep_seconds("read_output --wait 2"), None);
+        assert_eq!(bare_sleep_seconds("echo waiting; sleep 5; ls"), None);
+    }
+
+    #[test]
+    fn the_sleep_advisory_only_fires_past_the_threshold() {
+        assert!(
+            sleep_advisory("sleep 5").is_none(),
+            "under threshold, no nudge"
+        );
+        let note = sleep_advisory("sleep 300; echo done").expect("over threshold");
+        assert!(note.contains("300s"));
+        assert!(note.contains("read_output"));
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/bash/confine.rs
+++ b/crates/stella-tools/src/bash/confine.rs
@@ -195,9 +195,10 @@ impl std::fmt::Display for Refusal {
                 }
                 write!(
                     f,
-                    " Naming the graded tree at all — even inside a script body, an `echo`, or \
-                     a comment — trips this, so rewrite the path rather than quoting it \
-                     differently. Nothing else outside this workspace is restricted: system \
+                    " This is about where the write lands, not about naming the path — a plain \
+                     read (`cat`, `ls`, `grep`, …) of the graded tree is fine; rewrite the \
+                     command so the write itself lands here instead. Nothing else outside this \
+                     workspace is restricted: system \
                      paths such as /etc, /usr and /var are still writable."
                 )
             }
@@ -330,6 +331,15 @@ impl ShellConfinement {
         let reported = self.graded_root().unwrap_or(Path::new("/"));
         for graded in &self.graded_roots {
             if let Some(literal) = graded_literal(command, graded, session_root) {
+                // A mention that is provably a read — `cat /app/x`, `ls
+                // /app/documents` — cannot corrupt the tree the run is
+                // judged against; only a write can (#2928). Naming it in a
+                // segment this scan cannot classify (a general-purpose
+                // interpreter, an unlisted command) still refuses, same as
+                // today.
+                if only_reads_graded_tree(command, graded) {
+                    continue;
+                }
                 let substitute = Path::new(&literal)
                     .strip_prefix(graded)
                     .ok()
@@ -409,6 +419,94 @@ fn graded_literal(command: &str, graded_root: &Path, session_root: &Path) -> Opt
         from = end;
     }
     None
+}
+
+/// Bash leaders whose text shape is provably read-only: the command inspects
+/// a path and produces output, it does not accept a target to write. An
+/// allowlist rather than a denylist of write commands on purpose — a
+/// general-purpose interpreter (`python3`, `bash`, `eval`, …) or any leader
+/// not named here defaults to the existing refusal, because the text audit
+/// cannot see what an interpreter does with the path once it has it (#2928).
+const READ_ONLY_LEADERS: &[&str] = &[
+    "ls",
+    "cat",
+    "find",
+    "grep",
+    "egrep",
+    "fgrep",
+    "rg",
+    "ripgrep",
+    "ag",
+    "stat",
+    "file",
+    "head",
+    "tail",
+    "wc",
+    "diff",
+    "du",
+    "tree",
+    "readlink",
+    "realpath",
+    "test",
+    "pwd",
+    "basename",
+    "dirname",
+    "less",
+    "more",
+    "nl",
+    "od",
+    "xxd",
+    "hexdump",
+    "sha1sum",
+    "sha256sum",
+    "sha512sum",
+    "md5sum",
+    "echo",
+    "printf",
+    "type",
+    "which",
+    "env",
+];
+
+/// Whether every mention of `graded_root` in `command` sits inside a segment
+/// this scan can prove is read-only — a pipeline stage led by a
+/// [`READ_ONLY_LEADERS`] command with no output redirection (#2928: `ls
+/// /app/documents` cannot corrupt the graded tree; refusing it taught the
+/// worker nothing and cost a wasted retry).
+///
+/// Segmented on the same operators [`ShellConfinement::audit`]'s relative-climb
+/// scan bounds a word list on (`;`, `&`, `&&`, `|`, `||`) — a text audit, not a
+/// shell parser, so a leader that is itself the *value* of a flag
+/// (`find . -exec cp {} /app \;`) is judged by whatever word starts its own
+/// segment, which is the conservative direction: it still refuses.
+fn only_reads_graded_tree(command: &str, graded_root: &Path) -> bool {
+    let Some(needle) = graded_root.to_str() else {
+        return false;
+    };
+    let mut mentioned = false;
+    let mut all_safe = true;
+    let mut segment: Vec<String> = Vec::new();
+    let classify = |segment: &[String], mentioned: &mut bool, all_safe: &mut bool| {
+        if !segment.iter().any(|w| w.contains(needle)) {
+            return;
+        }
+        *mentioned = true;
+        let leader = segment.iter().find(|w| !w.starts_with('-'));
+        let redirects = segment.iter().any(|w| w == ">" || w == ">>");
+        if redirects || !leader.is_some_and(|l| READ_ONLY_LEADERS.contains(&l.as_str())) {
+            *all_safe = false;
+        }
+    };
+    for word in super::shell_words(command) {
+        if matches!(word.as_str(), ";" | "&" | "&&" | "|" | "||") {
+            classify(&segment, &mut mentioned, &mut all_safe);
+            segment.clear();
+            continue;
+        }
+        segment.push(word);
+    }
+    classify(&segment, &mut mentioned, &mut all_safe);
+    mentioned && all_safe
 }
 
 /// The object-destroying git subcommand the command runs, if any.
@@ -546,6 +644,54 @@ mod tests {
                 "{command}: {refusal:?}"
             );
         }
+    }
+
+    /// #2928 witness: a plain read of the graded tree cannot corrupt it, so
+    /// it must not be refused. Fails on the old code, which refused any
+    /// mention of the graded tree regardless of what the command did with it.
+    #[test]
+    fn a_read_only_command_naming_the_graded_tree_is_permitted() {
+        let (confined, root) = candidate();
+        for command in [
+            "ls -la /app/documents/",
+            "cat /app/check_cert.py",
+            "grep -rn TODO /app",
+            "find /app -name '*.py'",
+            "stat /app/ssl/server.crt",
+            "echo /app/ssl/server.crt",
+        ] {
+            assert!(confined.audit(command, &root).is_ok(), "{command}");
+        }
+    }
+
+    /// The read/write split is per mention, not per command: a command that
+    /// both reads and writes the graded tree in the same breath still
+    /// refuses, and a read that shares a pipeline with an unrelated write
+    /// elsewhere in the graded tree is not laundered by the read half.
+    #[test]
+    fn a_write_alongside_a_read_of_the_graded_tree_still_refuses() {
+        let (confined, root) = candidate();
+        for command in [
+            "cat /app/config.txt > /app/backup.txt",
+            "ls /app && rm -rf /app/pyknotid",
+            "cat /app/x; cp y /app/y",
+        ] {
+            let refusal = confined.audit(command, &root).expect_err(command);
+            assert!(matches!(refusal, Refusal::GradedTree { .. }), "{command}");
+        }
+    }
+
+    /// A general-purpose interpreter is not on the read-only allowlist, so a
+    /// mention inside its command line still refuses even though `python3`
+    /// itself is not one of the known write commands — the text audit cannot
+    /// see what the interpreter does with the path.
+    #[test]
+    fn an_unclassifiable_leader_still_refuses() {
+        let (confined, root) = candidate();
+        let refusal = confined
+            .audit("python3 -c \"print(open('/app/x').read())\"", &root)
+            .expect_err("unclassifiable leader");
+        assert!(matches!(refusal, Refusal::GradedTree { .. }));
     }
 
     /// The legitimate case the posture is built around: a task that installs

--- a/crates/stella-tools/src/bash/confine.rs
+++ b/crates/stella-tools/src/bash/confine.rs
@@ -479,6 +479,20 @@ const READ_ONLY_LEADERS: &[&str] = &[
 /// shell parser, so a leader that is itself the *value* of a flag
 /// (`find . -exec cp {} /app \;`) is judged by whatever word starts its own
 /// segment, which is the conservative direction: it still refuses.
+/// Whether `word` is an output redirection operator — standalone (`>`, `>>`)
+/// or attached to its target, since [`shell_words`](super::shell_words) does
+/// not split `>`/`<` and so leaves `>/app/f`, `>>/app/f`, `2>/app/f`,
+/// `&>/app/f` as a single word. Any of these writes to whatever follows, so a
+/// read-only leader (`echo`, `cat`, `printf`, …) cannot launder them: an
+/// attached redirect into the graded tree must still refuse, exactly as the
+/// spaced form does (#2928).
+fn is_output_redirect(word: &str) -> bool {
+    // Strip a leading fd/`&` prefix (`2>`, `1>>`, `&>`, `>&`) so the attached
+    // and spaced forms collapse to a `>`-led remainder.
+    let rest = word.trim_start_matches(|c: char| c.is_ascii_digit() || c == '&');
+    rest.starts_with('>')
+}
+
 fn only_reads_graded_tree(command: &str, graded_root: &Path) -> bool {
     let Some(needle) = graded_root.to_str() else {
         return false;
@@ -492,7 +506,7 @@ fn only_reads_graded_tree(command: &str, graded_root: &Path) -> bool {
         }
         *mentioned = true;
         let leader = segment.iter().find(|w| !w.starts_with('-'));
-        let redirects = segment.iter().any(|w| w == ">" || w == ">>");
+        let redirects = segment.iter().any(|w| is_output_redirect(w));
         if redirects || !leader.is_some_and(|l| READ_ONLY_LEADERS.contains(&l.as_str())) {
             *all_safe = false;
         }
@@ -673,6 +687,12 @@ mod tests {
         let (confined, root) = candidate();
         for command in [
             "cat /app/config.txt > /app/backup.txt",
+            // Attached redirects (no space before the target) must refuse too:
+            // `shell_words` leaves `>/app/f` as one word, so a read-only leader
+            // cannot launder the write.
+            "echo pwned >/app/graded_file",
+            "cat /app/a >>/app/b",
+            "printf x >/app/out",
             "ls /app && rm -rf /app/pyknotid",
             "cat /app/x; cp y /app/y",
         ] {


### PR DESCRIPTION
## Summary

Six Tier C bench-waste findings — wall-clock/budget burned on non-work rather than scored-wrong outcomes. Four are fully fixed; two land their safest, well-scoped slice with the rest explicitly left open (one needs a new port method, one needs a maintainer's policy sign-off).

- **#2869** — `Plan`/`PlanRepair` pin `ReasoningEffort::Low` instead of inheriting the session's effort. A high-effort session could drive a reasoning model to spend its entire 8k-token headroom thinking and answer with nothing — twice, since the starvation retry re-sends through the same closure at 3.4x the cap.
- **#2928** — The candidate sandbox's bash guard (`stella-tools/src/bash/confine.rs`) now distinguishes a *read* of the graded tree (`ls`, `cat`, `grep`, …) from a *write*. Only a write-shaped mention still refuses — a plain read cannot corrupt the tree the run is judged against. Verified by inspection that `write_file`/`edit_file` already allow `/app` inside `content`/`new_string` (no code change needed there).
- **#2933** — The plan-step walk no longer replays every remaining step one turn at a time once the worker starts answering with zero tool calls. `step_prompt` already tells a worker that a step is already covered to answer in one line with no tool calls; the walk now asks once, in a single consolidated follow-up, instead of paying a full model call per remaining step.
- **#2932** — The planner's instructions now ask for outcomes, never literal paths or commands (a blind planner cannot know a real path or build system is correct). A bounded repair retry restates any step that still names an absolute path before the worker ever sees it. `plan_stage` moves out of `pipeline.rs` (closed to growth) into its own `plan_stage.rs`, matching every other stage's existing pattern.
- **#2559** (`Refs`, not closed) — Bounds the witness author/repair engine's step ceiling to 8, mirroring the research stage's own bound. The other two halves — a deterministic test-convention brief, and threading the changed-path list — need a new repo-listing port method and an explicit maintainer policy decision respectively (the issue says so itself), so they stay open.
- **#2022** (`Refs`, not closed) — A bash command whose entire body is a bare `sleep` (optionally plus a harmless echo) past 30s accumulated now gets a static advisory footer naming `read_output`/`wait_for`. The issue is explicit that visibility should land and be judged before the guidance-rung or hard-clamp options, so those stay open.

## Test plan

- [x] `cargo test --workspace` — 133/133 test-result groups green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `scripts/check-file-size.sh` — OK (pipeline.rs stayed at/under its 2951-line baseline via the plan_stage.rs extraction)
- [x] `scripts/check-left-behind.sh`, `scripts/check-invariants.sh` — OK
- [x] Full local `make gate` ran green before push (self-driving-test: 60/60 checks passed)
- [x] Every behavior change carries a witness test that fails on `main` and passes with the change (see individual commits)

Closes #2869
Closes #2928
Closes #2933
Closes #2932
Refs #2559
Refs #2022

## Summary by Sourcery

Address several Tier C bench-waste issues by tightening planning behavior, shell confinement, execution walk-offs, witness authoring limits, and idle bash usage visibility.

Bug Fixes:
- Allow read-only bash commands that reference the graded tree to run while continuing to forbid writes.
- Detect bare long-duration `sleep` bash commands and attach guidance about using non-blocking polling tools instead.
- Ensure the plan-step walk stops early when steps produce no tool calls by issuing a single consolidated follow-up for remaining work.
- Prevent planners from emitting absolute filesystem paths by detecting and repairing such steps before workers see them.
- Constrain witness author/repair turns with a step-count ceiling to avoid long, unproductive tool-call sessions.
- Pin plan and plan-repair model calls to low reasoning effort to avoid expensive, non-productive planning retries.

Enhancements:
- Clarify bash confinement refusal messaging around graded-tree access semantics.
- Expose per-turn tool-call counts from engine runs to distinguish acting turns from purely narrative ones in execution.
- Refactor the plan stage into its own module, keeping pipeline core slimmer and enabling additional repair logic.
- Strengthen planner instructions to focus on outcome-oriented steps rather than commands or paths.
- Add targeted tests around plan shaping, plan walking, bash confinement behavior, sleep advisory messaging, witness step ceilings, and management bounds.

Tests:
- Extend and add witness tests to cover graded-tree read commands, sleep advisories, plan-walk consolidation behavior, path-detection and repair prompts, witness step ceilings, and reasoning-effort bounds for management roles.