### PR TITLE
fix(stella-pipeline): pin triage's sampling temperature to zero

### DIFF
--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -126,6 +126,35 @@ fn management_bounds(role: ModelCallRole) -> (Option<u32>, Option<ReasoningEffor
     }
 }
 
+/// The pinned sampling temperature for one management role, applied between
+/// the caller's explicit override (which always wins) and the engine's
+/// worker-tier base — the same precedence [`role_output_cap`] and
+/// [`management_bounds`]'s effort arm already give their fields.
+///
+/// Triage is the only role pinned today, and to zero specifically (#2932
+/// evidence 3): its `CLASS` line gates whether `plan`/`scope`/the verifier run
+/// at all, so the same goal text disagreeing with itself across trials on
+/// sampling entropy alone reshapes the whole stage graph nondeterministically
+/// — measured as `CLASS: multi` on one trial of a task and `CLASS: single` on
+/// another, identical goal. Unlike [`RetryPolicy::deterministic`], which only
+/// names the fast-fail retry posture, nothing upstream of this call pinned the
+/// *sampling* — `engine.temperature` is the worker's creative-writing default,
+/// wrong for a role whose entire output is a three-line classification token.
+/// `research`'s child turns already pin the same value for the identical
+/// reason (`research_stage`'s `SubAgentSpec.temperature`); this closes the one
+/// raw-call role that evidence showed drifting.
+///
+/// Every other role is left `None` (falls through to the override/engine
+/// chain unchanged): plan, verdict and guidance are judgment calls where some
+/// sampling variance is an accepted cost, not a structural defect, and
+/// widening this pin is a separate decision per role.
+fn management_temperature(role: ModelCallRole) -> Option<f32> {
+    match role {
+        ModelCallRole::Triage => Some(0.0),
+        _ => None,
+    }
+}
+
 /// The wire cap for one management call: the caller's explicit override
 /// (which always wins, unchanged), else the role's visible-output contract
 /// plus [`with_reasoning_headroom`]'s thinking room, else the engine base.
@@ -209,7 +238,10 @@ impl<'a> Pipeline<'a> {
         let request = |messages, max_output_tokens| CompletionRequest {
             messages,
             max_output_tokens,
-            temperature: overrides.temperature.or(engine.temperature),
+            temperature: overrides
+                .temperature
+                .or_else(|| management_temperature(role))
+                .or(engine.temperature),
             effort: overrides
                 .effort
                 .or(management_bounds(role).1)

--- a/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
+++ b/crates/stella-pipeline/src/pipeline/tests/management_accounting.rs
@@ -300,12 +300,20 @@ async fn a_late_plan_is_abandoned_and_falls_back_to_the_single_step_plan() {
     );
 }
 
+/// One request's `(max_output_tokens, effort, temperature)`, as observed by
+/// [`BoundsProvider`].
+type ObservedBounds = (
+    Option<u32>,
+    Option<stella_protocol::ReasoningEffort>,
+    Option<f32>,
+);
+
 /// Serves one scripted result per call while recording the request-shaping
 /// fields that reached it, so a test can assert the *allowance* a management
 /// call was dispatched with — `ScriptedProvider` records prompts, not bounds.
 struct BoundsProvider {
     script: TokioMutex<VecDeque<CompletionResult>>,
-    bounds: std::sync::Mutex<Vec<(Option<u32>, Option<stella_protocol::ReasoningEffort>)>>,
+    bounds: std::sync::Mutex<Vec<ObservedBounds>>,
 }
 
 impl BoundsProvider {
@@ -316,8 +324,8 @@ impl BoundsProvider {
         }
     }
 
-    /// Each request's `(max_output_tokens, effort)`, in call order.
-    fn bounds(&self) -> Vec<(Option<u32>, Option<stella_protocol::ReasoningEffort>)> {
+    /// Each request's observed bounds, in call order.
+    fn bounds(&self) -> Vec<ObservedBounds> {
         self.bounds.lock().unwrap().clone()
     }
 }
@@ -335,7 +343,7 @@ impl Provider for BoundsProvider {
         self.bounds
             .lock()
             .unwrap()
-            .push((req.max_output_tokens, req.effort));
+            .push((req.max_output_tokens, req.effort, req.temperature));
         let mut q = self.script.lock().await;
         q.pop_front()
             .ok_or_else(|| ProviderError::Terminal("bounds provider exhausted".into()))
@@ -401,10 +409,162 @@ async fn triage_dispatches_with_pinned_management_bounds() {
 
     assert_eq!(
         provider.bounds(),
-        vec![(Some(4608), Some(stella_protocol::ReasoningEffort::Low))],
+        vec![(
+            Some(4608),
+            Some(stella_protocol::ReasoningEffort::Low),
+            Some(0.0)
+        )],
         "the triage dispatch must carry the pinned management bounds — its \
-         512-token output contract plus reasoning headroom — and neither fall \
-         through to the worker-tier allowance nor starve a reasoning model"
+         512-token output contract plus reasoning headroom, and a pinned zero \
+         temperature — and neither fall through to the worker-tier allowance \
+         nor starve a reasoning model"
+    );
+}
+
+/// #2932 evidence 3: triage's `CLASS` line gates whether `plan` runs at all,
+/// so classifying the SAME goal text differently across trials reshapes the
+/// whole stage graph on nothing but sampling entropy. Nothing upstream of
+/// this call pinned the *sampling* temperature for it — `RetryPolicy::
+/// deterministic()` only names the fast-fail retry posture, and an unset
+/// `engine.temperature` left the provider's own (non-zero) default in force.
+/// This is the witness: it fails on the pre-fix chokepoint, where triage's
+/// request carries no temperature at all and silently inherits whatever the
+/// worker-tier engine config happens to be set to.
+#[tokio::test]
+async fn triage_dispatches_with_a_pinned_zero_temperature() {
+    let provider = BoundsProvider::new(vec![text_result("single")]);
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    // A worker-tier temperature the pin must NOT inherit — proves the pin is
+    // a role decision, not an artifact of the engine base happening to be
+    // unset in the test fixture.
+    let engine = stella_core::EngineConfig {
+        temperature: Some(0.7),
+        ..stella_core::EngineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            engine,
+            ..PipelineConfig::default()
+        },
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None);
+    let mut total = 0.0;
+
+    pipeline
+        .triage("fix the failing parser test", &mut budget, &mut total)
+        .await
+        .expect("a served triage call must classify");
+
+    let bounds = provider.bounds();
+    assert_eq!(
+        bounds.len(),
+        1,
+        "exactly one triage call must have been dispatched"
+    );
+    assert_eq!(
+        bounds[0].2,
+        Some(0.0),
+        "triage must pin temperature to zero regardless of the worker-tier \
+         engine default, so the same goal text classifies the same way every \
+         trial instead of the CLASS line disagreeing with itself on sampling \
+         entropy alone"
+    );
+}
+
+/// An explicit `agents.triage.temperature` override must still win over the
+/// role's zero pin — the pin is a default between the caller's explicit
+/// intent and the engine base, never a ceiling on operator configuration
+/// (the same contract [`explicit_triage_overrides_win_over_the_role_bounds`]
+/// already holds for the output-token and effort bounds).
+#[tokio::test]
+async fn explicit_triage_temperature_override_wins_over_the_pin() {
+    let provider = BoundsProvider::new(vec![text_result("single")]);
+    let resolver = AnyProvider(&provider);
+    let runner = ScriptedRunner::new(vec![], "");
+    let tools = EmptyTools;
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AutoApproveGate;
+    let sleeper = NoopSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            touches: &NoFileTouches,
+            diagnostics: &runner,
+            tests: &runner,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        PipelineConfig {
+            role_overrides: PipelineRoleOverrides {
+                triage: RoleCallOverrides {
+                    temperature: Some(0.6),
+                    ..RoleCallOverrides::default()
+                },
+                ..PipelineRoleOverrides::default()
+            },
+            ..PipelineConfig::default()
+        },
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None);
+    let mut total = 0.0;
+
+    pipeline
+        .triage("fix the failing parser test", &mut budget, &mut total)
+        .await
+        .expect("a served triage call must classify");
+
+    assert_eq!(
+        provider.bounds()[0].2,
+        Some(0.6),
+        "an explicit triage temperature override must not be shadowed by the \
+         role's zero pin"
     );
 }
 
@@ -468,7 +628,12 @@ async fn explicit_triage_overrides_win_over_the_role_bounds() {
 
     assert_eq!(
         provider.bounds(),
-        vec![(Some(9000), Some(stella_protocol::ReasoningEffort::High))],
-        "explicit role overrides must not be shadowed by the role bounds"
+        vec![(
+            Some(9000),
+            Some(stella_protocol::ReasoningEffort::High),
+            Some(0.0)
+        )],
+        "explicit role overrides must not be shadowed by the role bounds; the \
+         temperature pin still applies since this override left it unset"
     );
 }


### PR DESCRIPTION
## Summary

- #2932 evidence 3 measured triage classifying the SAME goal text differently across trials (`CLASS: multi` on one trial, `CLASS: single` on another) — this reshapes the whole stage graph (plan/scope/verifier) on sampling entropy alone, injected by the cheapest model in the roster.
- PR #2975, which closed #2932, pinned triage's output-token cap and reasoning effort but never touched sampling temperature: the raw triage request fell through to `engine.temperature` (the worker-tier default), so a flaky or unset engine temperature left triage's classification genuinely nondeterministic.
- Pins `Triage`'s temperature to `0.0` at the same chokepoint that already pins its bounds (`management_temperature` beside `management_bounds` in `raw_usage.rs`), resolved with the same precedence every other role override gets: explicit `agents.triage.temperature` always wins, then the pin, then the engine base. Mirrors the precedent already set for `research`'s child turns (`SubAgentSpec.temperature: Some(0.0)`).

## Test plan

- [x] New witness test `triage_dispatches_with_a_pinned_zero_temperature`: constructs an engine config with `temperature: Some(0.7)` and asserts the dispatched request still carries `Some(0.0)`. Confirmed it **fails** on the pre-fix code (`left: Some(0.7)`) and **passes** with the fix (`git stash` verified).
- [x] New test `explicit_triage_temperature_override_wins_over_the_pin` — an operator-set `agents.triage.temperature` still wins over the pin.
- [x] Updated the two pre-existing `BoundsProvider`-based tests (`triage_dispatches_with_pinned_management_bounds`, `explicit_triage_overrides_win_over_the_role_bounds`) for the widened `(max_output_tokens, effort, temperature)` tuple.
- [x] `make gate CARGO_SCOPE="-p stella-pipeline"` — fmt, clippy, guards, rustdoc, full `stella-pipeline` test suite (743+ tests) all green.

Closes #2932

## Summary by Sourcery

Pin triage management calls to a deterministic zero sampling temperature while preserving explicit role overrides, and extend bounds tracking to include temperature.

Bug Fixes:
- Ensure triage classifications are deterministic across trials by pinning their sampling temperature to zero instead of inheriting worker-tier engine defaults.

Enhancements:
- Extend management bounds accounting to track and assert temperature alongside output tokens and reasoning effort.

Tests:
- Add tests verifying triage dispatches with a pinned zero temperature regardless of engine configuration and that explicit triage temperature overrides take precedence over the pin.
- Update existing bounds-related tests to cover the extended tuple including temperature.