### PR TITLE
feat(stella-cli): teach the bare worker when the working-tree delta is the answer

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -226,6 +226,10 @@ macro_rules! injection_defense {
     };
 }
 
+/// The default interactive persona. Its Rules block opens with the
+/// delta-orientation rule (#2984), whose measurement, discriminator shape, and
+/// per-clause pin live with the test in `parity.rs` —
+/// `the_default_persona_reads_the_delta_only_when_the_task_claims_one`.
 pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"You are Stella, a fast terminal coding agent. You help the user with software engineering tasks by reading files, writing code, running commands, and searching the codebase.
 
@@ -266,6 +270,7 @@ pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"
 
 Rules:
+- When the task text itself claims something was DONE to this repository — introduced, planted, broke, leaked, removed, changed, regressed — read that delta before you go looking for it, and read the WORKING TREE first: `git status` and `git diff` (then `git diff --staged`), falling back to `git log -p` only once you have seen the working tree is clean. A change made to your workspace need never have been committed, so a history-first probe (`git diff HEAD~5`, `git log`) can return nothing while the answer sits unstaged in front of you. One diff names the exact lines someone touched; the grep sweep that finds those same lines is a dozen calls, each testing one guess. The trigger is that past-tense claim and nothing else: a task to BUILD, ADD or IMPLEMENT something, or one reporting a symptom without asserting a recent change, has no delta to read — there git returns nothing and the probe is a call spent on nothing, so skip it and orient from the task's own subject.
 - For "where is X defined", "who calls/references X", or "what depends on this file" questions, reach for graph_query FIRST when it is available — it is precise and cheap. Fall back to grep/glob only when the graph can't answer (free-text search, a symbol the index doesn't carry, or no index yet).
 - Always read a file before editing it — never edit blind.
 - Make minimal, surgical edits. Use edit_file, not write_file, for changes to existing files.

--- a/crates/stella-cli/src/agent/prompt/parity.rs
+++ b/crates/stella-cli/src/agent/prompt/parity.rs
@@ -456,6 +456,73 @@ fn both_prompts_bind_the_model_to_skills() {
     }
 }
 
+/// The delta-orientation rule (#2984), pinned clause by clause so a trim
+/// cannot leave the half that makes it safe behind.
+///
+/// Measured on TB2.1 `fix-code-vulnerability`, where the bug is planted as an
+/// *uncommitted* working-tree change: Claude Code opened with `git diff
+/// bottle.py` at call 1 in both trials and finished in 7 calls; Stella reached
+/// the same diff at call 18, 34, 40 and 41 across four trials and took 23-63.
+/// Its one early git probe was `git diff HEAD~5` — committed history, which
+/// structurally cannot see an uncommitted change — and it then spent dozens of
+/// calls grepping for the bug by name.
+///
+/// The rule is written as a **discriminator, not a recipe**, because the
+/// advantage being copied is selectivity rather than a first move: Claude Code
+/// probes git in only 6 of 20 trials (0.3 git operations per trial on non-git
+/// tasks, against Stella's 3.8). An unconditional "check the diff first" would
+/// add a wasted call to the 14 tasks where git is irrelevant, which is why the
+/// trigger is a property of the task text alone — a past-tense claim that
+/// something was done to this repository — evaluable before any call is spent.
+///
+/// This is deliberately **not** a shared contract: it steers a first move, and
+/// the pipeline persona already prescribes its own first move (the ORIENT →
+/// REPRODUCE → LOCALIZE methodology), so embedding it there would put two
+/// rules in the same slot. `SHARED_CONTRACTS` therefore does not list it and
+/// `every_shared_contract_is_invoked_by_every_static_prompt` does not cover it
+/// — hence this pin.
+///
+/// The two clauses are load-bearing in opposite directions and each fails on
+/// its own. Without the working-tree-first clause the rule reproduces the exact
+/// measured defect: Stella's one early git probe was `git diff HEAD~5`, which
+/// reads committed history and cannot see an uncommitted change. Without the
+/// negative clause it becomes "always check the diff first", which would add a
+/// wasted call to the 14 of 20 trials where Claude Code — the arm being copied
+/// — touches git not at all.
+///
+/// Lives here rather than beside its siblings in `prompt.rs`'s test module for
+/// the same reason `both_prompts_bind_the_model_to_skills` does: that file sits
+/// within a few lines of the 1500-line ratchet, and #2237 makes this module the
+/// home for prompt-content pins.
+#[test]
+fn the_default_persona_reads_the_delta_only_when_the_task_claims_one() {
+    for claim in [
+        // The trigger, stated as a property of the task text alone — the only
+        // kind of rule the model can evaluate before spending a call.
+        "claims something was DONE to this repository",
+        // Working tree before history: the measured failure was a
+        // history-first probe against an uncommitted change.
+        "read the WORKING TREE first",
+        "need never have been committed",
+        // The negative half — what stops a discriminator becoming a recipe.
+        "a task to BUILD, ADD or IMPLEMENT something",
+        "the probe is a call spent on nothing",
+    ] {
+        assert!(
+            SYSTEM_PROMPT.contains(claim),
+            "the default persona must keep the delta-orientation claim {claim:?} — \
+             without it the rule is either blind to uncommitted changes or fires on \
+             every task (#2984)"
+        );
+    }
+    assert!(
+        !PIPELINE_SYSTEM_PROMPT.contains("read the WORKING TREE first"),
+        "the delta-orientation rule is scoped to the default persona: the pipeline \
+         persona prescribes its own first move (ORIENT/REPRODUCE/LOCALIZE), and two \
+         rules competing for the same slot is the drift this scoping avoids (#2984)"
+    );
+}
+
 /// Every way this check could come up empty, driven on hand-built sources.
 ///
 /// The tests above all iterate sets the scan produced; if the scan silently

--- a/docs/prompts/worker.md
+++ b/docs/prompts/worker.md
@@ -154,6 +154,7 @@ Rules:
 
 ```text
 Rules:
+- When the task text itself claims something was DONE to this repository — introduced, planted, broke, leaked, removed, changed, regressed — read that delta before you go looking for it, and read the WORKING TREE first: `git status` and `git diff` (then `git diff --staged`), falling back to `git log -p` only once you have seen the working tree is clean. A change made to your workspace need never have been committed, so a history-first probe (`git diff HEAD~5`, `git log`) can return nothing while the answer sits unstaged in front of you. One diff names the exact lines someone touched; the grep sweep that finds those same lines is a dozen calls, each testing one guess. The trigger is that past-tense claim and nothing else: a task to BUILD, ADD or IMPLEMENT something, or one reporting a symptom without asserting a recent change, has no delta to read — there git returns nothing and the probe is a call spent on nothing, so skip it and orient from the task's own subject.
 - For "where is X defined", "who calls/references X", or "what depends on this file" questions, reach for graph_query FIRST when it is available — it is precise and cheap. Fall back to grep/glob only when the graph can't answer (free-text search, a symbol the index doesn't carry, or no index yet).
 - Always read a file before editing it — never edit blind.
 - Make minimal, surgical edits. Use edit_file, not write_file, for changes to existing files.


### PR DESCRIPTION
## What & why

On a task of the form "someone changed this repo, find and fix what they broke",
Claude Code reads the working-tree diff as its **first tool call** and is done in
7. Stella reaches the same diff at call 18, 34, 40 or 41. Same model, same task,
same day — measured over a 60-trial head-to-head on Terminal-Bench 2.1
(claude-sonnet-5, Anthropic direct, same model both arms), detailed in #2984.

`fix-code-vulnerability` plants its bug as an **uncommitted working-tree change**.
Stella's one early git probe was `git diff HEAD~5` — committed history, which
*structurally cannot see* an uncommitted change — after which it spent dozens of
calls grepping for the bug by name.

This adds one rule to the Rules block of the default `stella` persona
(`SYSTEM_PROMPT`). Nothing else in the prompt changes.

Closes #2984

### The discriminator, and why it is not "always run git diff first"

Claude Code's advantage here is **selectivity, not a recipe**: it probes git in
only 6 of 20 trials and never touches git in 14 of 20 — 0.3 git operations per
trial on non-git tasks, against Stella's 3.8. An unconditional "check the diff
first" would make Stella *worse*, adding a wasted call to every task where git is
irrelevant.

So the trigger is a property of **the task text alone**, evaluable before any call
is spent: *does the task itself claim something was done to this repository?*

> - When the task text itself claims something was DONE to this repository —
>   introduced, planted, broke, leaked, removed, changed, regressed — read that
>   delta before you go looking for it, and read the WORKING TREE first:
>   `git status` and `git diff` (then `git diff --staged`), falling back to
>   `git log -p` only once you have seen the working tree is clean. A change made
>   to your workspace need never have been committed, so a history-first probe
>   (`git diff HEAD~5`, `git log`) can return nothing while the answer sits
>   unstaged in front of you. One diff names the exact lines someone touched; the
>   grep sweep that finds those same lines is a dozen calls, each testing one
>   guess. The trigger is that past-tense claim and nothing else: a task to BUILD,
>   ADD or IMPLEMENT something, or one reporting a symptom without asserting a
>   recent change, has no delta to read — there git returns nothing and the probe
>   is a call spent on nothing, so skip it and orient from the task's own subject.

Three clauses, each doing one job:

1. **The trigger** — a past-tense claim of a change *to this repository*. Not "the
   repo is unfamiliar", not "the task mentions a bug"; the task text has to assert
   that someone did something.
2. **Working tree before history** — the clause that fixes the measured `HEAD~5`
   failure directly, with the reason stated so the model can generalise it.
3. **The negative** — build/add/implement, or a symptom with no asserted change,
   is named as having *no delta*, and the probe there is called a wasted call. The
   negative is what keeps a discriminator from decaying into a recipe.

### Default persona only

The pipeline persona prescribes its own first move (ORIENT → REPRODUCE →
LOCALIZE), so this is deliberately **not** a shared `macro_rules!` contract — two
rules competing for the same slot is exactly the drift the shared-contract
machinery exists to prevent. The pin asserts its *absence* from
`PIPELINE_SYSTEM_PROMPT` as well as its presence in `SYSTEM_PROMPT`, so the
scoping is enforced rather than conventional.

### Relationship to the prior prompt experiment

`prompt/decisive-worker` (`2bc74b13`) rewrote this same block with a three-call
orientation budget and re-reading framed as a defect. Measured: tool calls
32.5 → 27.1, wall −18%, **cost flat and one solve lost**, with the reduction
coming almost entirely out of verification apparatus rather than task work
(#2983). That is the control for what a prompt change to this block moves, and it
is why this PR does not try to trim looking again: it changes *which* probe comes
first, not how many are allowed.

## The witness

- [x] No witness needed — because **this is a pure prompt change**. There is no
      behaviour in the binary to flip fail→pass; the text either reaches the model
      or it does not, and a test asserting "the string is in the string" would be a
      restatement, not evidence. This repo accepts that rather than inventing a
      weak witness.

**How it was verified instead:**

- `cargo test -p stella-cli --bins prompt` — 71 passed, 0 failed.
- `cargo test -p stella-cli --bins agent::prompt` — 26 passed, including every
  `prompt/parity.rs` scan test and
  `agent::tests::assemble_system_prompt_bakes_a_byte_stable_orientation_map`.
- **Goldens: none changed.** The working tree was clean after a full `make gate`,
  so no snapshot was regenerated — nothing under `tests/snapshots/` or
  `crates/stella-pipeline/tests/fixtures/golden/` embeds the persona text.
  `cache_correctness` ran inside `make test` and passed unchanged. The only place
  in the tree that carries a second copy of this Rules block is
  `docs/prompts/worker.md`, which quotes it verbatim; that quote is updated in
  this PR, and the diff there is the same one line.
- A clause-by-clause pin was added
  (`the_default_persona_reads_the_delta_only_when_the_task_claims_one`) so a later
  trim cannot silently drop the working-tree-first clause (leaving the rule blind
  to uncommitted changes, the exact measured defect) or the negative clause
  (leaving it firing on every task).

**Byte stability (invariant 7 / L-E8) is intact:** the rule is a literal inside
the existing `concat!`, so `SYSTEM_PROMPT` remains a compile-time constant.
`prompt/parity.rs`'s scan enforces this — a prompt rewritten as a runtime
composition fails `NoStaticPromptsParsed`.

### The behavioural claim is UNVERIFIED

Nothing here shows the rule reduces calls. It is a hypothesis with a measured
motivation, and it is unverified until a bench arm runs it. **The comparison that
would settle it:** the same 10 Terminal-Bench 2.1 tasks, 2 attempts per task,
claude-sonnet-5 on Anthropic direct, against the measured baseline of **32.5 calls
/ \$0.787 per trial / 18-of-20 solved**. Per #2984's own definition of done, the
metric to report is **calls-to-first-correct-localisation on
`fix-code-vulnerability` and `sanitize-git-repo`**, not solve rate — a 2-trial arm
cannot resolve this, and a 10-task mean would hide that two tasks carry 60% of the
excess. If the rule adds calls on the seven near-parity tasks, that is the number
to report.

## The gate

`make gate` ran in full and passed, **exit 0** — 27 gate steps, redirected to a
file and read (not piped through `tail`).

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed — `docs/prompts/worker.md`
- [x] `Closes #2984` appears both here and as a commit trailer

`check-file-size: OK — nothing went over by this change. Judged against 5398bbe96.`

## Nothing left behind

- [x] Filed: **#2985** — `prompt.rs` is now 1486 lines against the 1500-line
      ceiling. This PR already had to route its provenance prose into
      `prompt/parity.rs` to stay under the line, which is the constraint shaping
      where prose lands rather than where logic lands. #2985 is the handoff for
      splitting the persona literals into `prompt/contracts.rs`, including the two
      traps discovered here (textual `macro_rules!` scope, and `parity.rs`'s
      `include_str!` scan of `prompt.rs`'s own source).

Not touched, by instruction: `grep.rs` — the alternation false-negative bug is
#2982, fixed in parallel. Some of the grep-heavy behaviour in these traces was the
tool lying rather than the agent flailing, so the residual gap attributable to
prompting is smaller than the raw call counts suggest.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

The rule is long for a bullet. That is deliberate — the negative clause is what
makes it a discriminator rather than a recipe, and the *reason* working-tree
precedes history is what lets the model generalise past the one command shape it
names. Trimming either back to a terse imperative recreates the failure it was
written from. Both are pinned by the test for that reason.

The alternative rejected: making this a shared `macro_rules!` contract embedded in
both personas. The pipeline persona's numbered methodology already owns the
first-move slot, and a second first-move rule beside it is ambiguous rather than
additive.

## Summary by Sourcery

Update the default Stella interactive persona to prioritize inspecting git working-tree changes when tasks explicitly describe recent modifications to the repository, while keeping this behavior scoped to the default persona only.

Enhancements:
- Add a delta-orientation rule to the default SYSTEM_PROMPT so Stella checks working-tree diffs first when the task text claims something was done to the repository, avoiding unnecessary git probes on unrelated tasks.
- Introduce a test pin that asserts the presence and scoping of the delta-orientation rule in SYSTEM_PROMPT and its absence from PIPELINE_SYSTEM_PROMPT to preserve prompt byte-stability and persona separation.

Documentation:
- Update worker persona documentation to include the new delta-orientation rule in the Rules block, matching the default SYSTEM_PROMPT behavior.