### PR TITLE
fix(stella-cli): adoption delivers the modes a patch cannot encode, and stops reading the oracle's own writes as tampering

### DIFF
--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -22,8 +22,11 @@
 //! and only back to the value recorded before that candidate existed.
 //! Final verification first seals
 //! the shadow in a private commit. Adoption requires the shadow to remain
-//! byte-identical to that seal, diffs the immutable baseline against that
-//! exact verified commit, and applies the result in one `git apply`. The
+//! byte-identical to that seal *except* where the verification run itself is
+//! the observed author of the difference ([`oracle_writes`], #2877), diffs the
+//! immutable baseline against that exact verified commit, applies the result
+//! in one `git apply`, and then replays the permission bits that patch could
+//! not encode ([`modes`], #2935). The
 //! worker cannot race verification with adoption, and a real tree that no
 //! longer matches what the candidate started from fails the whole adoption
 //! loudly instead of half-applying — naming which of the two divergences it
@@ -125,10 +128,13 @@ use crate::agent::{
 
 mod adopt;
 mod escape;
+mod modes;
+mod oracle_writes;
 mod ref_escape;
 mod snapshot_gaps;
 mod task_events;
 mod witness_tools;
+use oracle_writes::{ObservedTestRunner, OracleWrites};
 use witness_tools::WitnessToolExecutor;
 
 /// The commit identity for snapshot plumbing commits (which exist only
@@ -488,6 +494,10 @@ impl GitCandidateWorkspaces {
                 // (#1719) — see `task_events`'s module doc.
                 let (tools, task_board) = task_events::tap(tools, board, self.events.clone());
                 let omitted = snapshot_gaps::omitted_ignored_paths(&toplevel, &root_rel).await;
+                // Shared between the workspace's drift check and the test
+                // runner that fills it — the runner is the only thing that
+                // knows *when* the verification run happened (#2877).
+                let oracle_writes = Arc::new(OracleWrites::default());
                 Ok(GitCandidateWorkspace {
                     toplevel,
                     dir: dir.clone(),
@@ -499,9 +509,14 @@ impl GitCandidateWorkspaces {
                     tools,
                     witness_tools,
                     diagnostics: GitDiagnosticRunner::new(ws_root.clone()),
-                    tests: TypedTestRunner {
-                        root: ws_root.clone(),
-                    },
+                    tests: ObservedTestRunner::new(
+                        TypedTestRunner {
+                            root: ws_root.clone(),
+                        },
+                        dir.clone(),
+                        oracle_writes.clone(),
+                    ),
+                    oracle_writes,
                     repo_status: SnapshotRepoStatus {
                         inner: GitRepoStatus {
                             root: ws_root.clone(),
@@ -778,7 +793,13 @@ pub(crate) struct GitCandidateWorkspace {
     /// Constructed before dispatch and incapable of general mutation or egress.
     witness_tools: WitnessToolExecutor,
     diagnostics: GitDiagnosticRunner,
-    tests: TypedTestRunner,
+    /// The candidate's test runner, bracketed so the paths a verification run
+    /// writes are attributed to that run rather than read as the worker
+    /// tampering with a verified tree (#2877) — see [`oracle_writes`].
+    tests: ObservedTestRunner,
+    /// What those brackets recorded, shared with [`Self::tests`]. Consulted
+    /// by [`Self::sealed_unchanged_inner`]; cleared by every seal.
+    oracle_writes: Arc<OracleWrites>,
     repo_status: SnapshotRepoStatus,
     /// This candidate's private task board plus its announce latch — the
     /// pipeline drives it through [`CandidateWorkspace::seed_task_board`]
@@ -857,6 +878,11 @@ impl GitCandidateWorkspace {
         // `WorkspaceError` into a second panic. Same convention as
         // `main::test_env::lock` and the deck's session-id mutex.
         *self.sealed.lock().unwrap_or_else(|p| p.into_inner()) = Some(sealed);
+        // The `add -A` above swept every previously-attributed path into this
+        // commit, so those attributions can no longer excuse anything except a
+        // mutation made *after* this seal — which is exactly what the drift
+        // check exists to catch (#2877).
+        self.oracle_writes.forget();
         Ok(())
     }
 
@@ -878,6 +904,13 @@ impl GitCandidateWorkspace {
         // adoption already excludes by pathspec cannot make the sealed tree
         // disagree with the tree that was verified, and the oracle runs in
         // this worktree immediately before this check.
+        //
+        // The second subtraction, of paths the verification run was *observed*
+        // writing, is argued in [`oracle_writes`]: a fixed scratch list can
+        // only ever name the artifact types someone already lost work to, and
+        // `.gcda` was the next one (#2877). Everything not attributed to an
+        // observed run remains fatal, so the check still refuses a worker that
+        // moved a verified tree.
         let status = git(
             &self.dir,
             &[
@@ -890,7 +923,11 @@ impl GitCandidateWorkspace {
         )
         .await
         .map_err(fail)?;
-        Ok(head.trim() == sealed && adopt::drifted_paths(&status).is_empty())
+        let unattributed = adopt::drifted_paths(&status)
+            .into_iter()
+            .filter(|path| !self.oracle_writes.wrote(path))
+            .count();
+        Ok(head.trim() == sealed && unattributed == 0)
     }
 
     /// The commit [`Self::adopt_inner`] and [`Self::escaped_paths_inner`]

--- a/crates/stella-cli/src/candidate_ws/adopt.rs
+++ b/crates/stella-cli/src/candidate_ws/adopt.rs
@@ -24,7 +24,7 @@ use stella_pipeline::ports::{AdoptedChange, WorkspaceError};
 use stella_pipeline::scratch::{TOOL_SCRATCH_DIRS, is_tool_scratch};
 use stella_protocol::FileChangeKind;
 
-use super::{GitCandidateWorkspace, SHADOW_SEQ, git, git_stdout_to_file};
+use super::{GitCandidateWorkspace, SHADOW_SEQ, git, git_stdout_to_file, modes};
 
 impl GitCandidateWorkspace {
     /// Winner-only adoption: diff the immutable baseline→verified seal and
@@ -168,12 +168,32 @@ impl GitCandidateWorkspace {
                 ));
             }
         };
+        // Asked BEFORE the apply, because afterwards every one of them exists
+        // and the question is unanswerable — see [`super::modes`] for why only
+        // directories adoption itself creates are the candidate's to set.
+        let created_dirs = modes::directories_adoption_will_create(&self.toplevel, &changes);
         let apply = SystemGitCli
             .run(&self.toplevel, &["apply", "--whitespace=nowarn", patch_str])
             .await;
         let _ = tokio::fs::remove_file(&patch_file).await;
         match apply {
             Ok(out) if out.success => {
+                // The half of the delivery the patch could not carry (#2935):
+                // a `chmod 600` private key, a `chmod 700` directory holding
+                // it. Read from the candidate worktree the drift check has
+                // just certified byte-identical to `sealed`, applied here and
+                // recorded nowhere — see [`super::modes`].
+                //
+                // The returned residue — paths whose mode could not be read
+                // or set — is named and dropped rather than silently
+                // discarded: adoption has no event to carry it on yet (#2927
+                // adds one), and wiring it there is #2990.
+                let _unreplayable_modes = modes::replay_unrepresentable_modes(
+                    &self.dir,
+                    &self.toplevel,
+                    &changes,
+                    &created_dirs,
+                );
                 *self.delivered.lock().unwrap_or_else(|p| p.into_inner()) = Some(sealed);
                 Ok(changes)
             }
@@ -278,10 +298,15 @@ pub(super) fn blob_id(probe: Result<String, String>) -> Option<String> {
 /// is `git diff baseline sealed`, computed from two immutable commit objects
 /// and *already* excluding these paths by pathspec. A mutation confined to
 /// them therefore cannot change one byte of what adoption delivers, so it
-/// cannot make the sealed tree disagree with the tree that was verified. A
-/// build artifact outside the list (a `.gcda`, an object file) still trips the
-/// check — that residue is #2877, and it needs a decision about what adoption
-/// carries, not a longer list here.
+/// cannot make the sealed tree disagree with the tree that was verified.
+///
+/// A build artifact outside that list — a `.gcda`, an object file — is still
+/// drift *here*, deliberately: this is a parser over a status listing and it
+/// knows nothing about who wrote a path. The second subtraction, of paths the
+/// verification run was observed writing, belongs to the caller that holds
+/// that observation ([`super::GitCandidateWorkspace::sealed_unchanged_inner`],
+/// via [`super::oracle_writes`]) — which is how #2877's `.gcda` case is
+/// answered without this list ever growing a suffix.
 ///
 /// Records are `XY <space> path\0`. `--no-renames` is what makes that shape
 /// total: a rename record would carry two NUL-separated paths and shift every
@@ -880,8 +905,8 @@ deleted file mode 100644
 
     /// The check still has to fire on a real one. A source file rewritten
     /// after verification is drift, and so — deliberately — is a build
-    /// artifact outside the scratch list: whether adoption should carry a
-    /// `.gcda` is a decision this parser must not make silently (#2877).
+    /// artifact outside the scratch list: *this parser* cannot know who wrote
+    /// a `.gcda`, and the caller that can is the one that excuses it (#2877).
     #[test]
     fn a_real_mutation_after_the_seal_is_still_drift() {
         assert_eq!(

--- a/crates/stella-cli/src/candidate_ws/modes.rs
+++ b/crates/stella-cli/src/candidate_ws/modes.rs
@@ -1,0 +1,278 @@
+//! The half of a candidate's work a git patch cannot carry: permission bits.
+//!
+//! Adoption delivers by `git apply` of a `git diff --binary --no-renames`
+//! patch, and that is the right mechanism — it is atomic, it verifies every
+//! preimage before writing a byte, and it gets deletions and binary files
+//! right (#2927 cleared it of both suspicions). What it is *not* is a
+//! description of a tree. Git records exactly two file modes, `100644` and
+//! `100755`, and no directory modes at all. So a candidate that does the job
+//! correctly — `chmod 600` on a generated private key, `chmod 700` on the
+//! directory holding it — has that half of its work silently dropped between
+//! the worktree where it was verified and the tree that is graded (#2935,
+//! observed on `openssl-selfsigned-cert`).
+//!
+//! # Why a replay rather than a manifest
+//!
+//! The obvious fix — record every path's `st_mode` at seal time and apply the
+//! recording after `git apply` — creates a second description of the tree that
+//! can disagree with the tree, and the disagreement would be undetectable: a
+//! stale manifest `chmod`s a delivered file to a mode the candidate no longer
+//! holds, and nothing in the run can tell that from the truth.
+//!
+//! So nothing is recorded. The modes are read from the candidate worktree at
+//! the moment of delivery and applied immediately, in the same call, from the
+//! same tree the patch was built against — which the drift check
+//! (`sealed_unchanged_inner`) has just certified byte-identical to the sealed
+//! commit. There is one description of the tree, and it is the tree.
+//!
+//! # What is replayed, and what deliberately is not
+//!
+//! Only modes git **cannot** express: [`is_git_representable`] passes `0644`
+//! and `0755` straight through to the patch, which already carries the
+//! executable bit correctly. The asymmetry is deliberate and it is the whole
+//! safety argument. A tracked file enters the candidate through
+//! `git worktree add`, so its mode there is git's normalization (`0644`) and
+//! not the mode the user's own file carries. Forcing the candidate's mode onto
+//! every delivered path would therefore *destroy* a `0600` the user set on a
+//! file the candidate merely edited the contents of. Adding what git cannot
+//! say can only ever be information the patch lost; removing what git cannot
+//! say would be information the patch never had. The residue — a candidate
+//! that deliberately relaxes a `0600` back to `0644` — is unrepresentable in
+//! either direction and is tracked in #2988.
+//!
+//! Directory modes are replayed only for directories **adoption itself
+//! created**, computed before the patch is applied. A directory the real tree
+//! already had is the user's, not the candidate's, and its mode is not the
+//! candidate's to change.
+
+use std::path::Path;
+
+use stella_pipeline::ports::AdoptedChange;
+use stella_protocol::FileChangeKind;
+
+/// The permission bits a git patch can express: `100644` and `100755`.
+///
+/// Anything else — `0600`, `0640`, `0700`, a setgid bit — is lost between the
+/// candidate worktree and the graded tree unless it is replayed.
+pub(crate) fn is_git_representable(mode: u32) -> bool {
+    matches!(mode & 0o7777, 0o644 | 0o755)
+}
+
+/// Repository-relative directories that applying this patch will have to
+/// create, deepest first — the ancestors of every delivered path that the real
+/// tree does not have yet.
+///
+/// Must be called **before** `git apply`: afterwards every one of them exists
+/// and the question can no longer be asked. Deepest first so a caller
+/// `chmod`ping them in order never has to write through a directory it has
+/// already tightened.
+pub(crate) fn directories_adoption_will_create(
+    real_toplevel: &Path,
+    changes: &[AdoptedChange],
+) -> Vec<String> {
+    let mut absent: Vec<String> = Vec::new();
+    for change in changes {
+        if change.kind == FileChangeKind::Deleted {
+            continue;
+        }
+        let mut prefix = String::new();
+        let mut components = change.path.split('/').peekable();
+        while let Some(component) = components.next() {
+            // The last component is the file itself, never a directory.
+            if components.peek().is_none() {
+                break;
+            }
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            if real_toplevel.join(&prefix).exists() || absent.contains(&prefix) {
+                continue;
+            }
+            absent.push(prefix.clone());
+        }
+    }
+    // Deepest first: `a/b/c` before `a/b` before `a`.
+    absent.sort_by_key(|path| std::cmp::Reverse(path.matches('/').count()));
+    absent
+}
+
+/// Give every delivered path the candidate's own permission bits, for the
+/// modes a patch could not carry. Returns the repository-relative paths whose
+/// mode could not be read or set, in sorted order.
+///
+/// Best-effort by construction, and that is a decision rather than an
+/// omission: `git apply` has already written the bytes atomically and they
+/// cannot be un-written, so a failure here is a partially-faithful delivery,
+/// never an absent one. Returning `Err` would make the caller report an
+/// adoption that did not happen — the one thing that is certainly false.
+/// Surfacing this residue on the adoption event is #2990.
+///
+/// `created_dirs` comes from [`directories_adoption_will_create`], evaluated
+/// before the apply.
+#[cfg(unix)]
+pub(crate) fn replay_unrepresentable_modes(
+    candidate_toplevel: &Path,
+    real_toplevel: &Path,
+    changes: &[AdoptedChange],
+    created_dirs: &[String],
+) -> Vec<String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut unfaithful: Vec<String> = Vec::new();
+    let mut replay = |rel: &str, representable_only: bool| {
+        let source = candidate_toplevel.join(rel);
+        // `symlink_metadata`: a symlink's own mode is meaningless (`0777` on
+        // every Unix that has them) and git records it as `120000` — following
+        // the link would read the target's mode and stamp it on the link.
+        let Ok(meta) = std::fs::symlink_metadata(&source) else {
+            unfaithful.push(rel.to_string());
+            return;
+        };
+        if meta.file_type().is_symlink() {
+            return;
+        }
+        let mode = meta.permissions().mode() & 0o7777;
+        if representable_only && is_git_representable(mode) {
+            return;
+        }
+        let target = real_toplevel.join(rel);
+        if !target.exists() {
+            return;
+        }
+        if std::fs::set_permissions(&target, std::fs::Permissions::from_mode(mode)).is_err() {
+            unfaithful.push(rel.to_string());
+        }
+    };
+
+    for change in changes {
+        if change.kind == FileChangeKind::Deleted {
+            continue;
+        }
+        replay(&change.path, true);
+    }
+    // Files before directories, and `created_dirs` deepest-first: a directory
+    // the candidate tightened to `0500` must not be tightened before the files
+    // inside it have been written and chmod'ed.
+    for dir in created_dirs {
+        replay(dir, false);
+    }
+    unfaithful.sort();
+    unfaithful.dedup();
+    unfaithful
+}
+
+/// Windows has no Unix permission bits, so there is nothing a patch failed to
+/// carry and nothing to replay.
+#[cfg(not(unix))]
+pub(crate) fn replay_unrepresentable_modes(
+    _candidate_toplevel: &Path,
+    _real_toplevel: &Path,
+    _changes: &[AdoptedChange],
+    _created_dirs: &[String],
+) -> Vec<String> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(path: &str, kind: FileChangeKind) -> AdoptedChange {
+        AdoptedChange {
+            path: path.to_string(),
+            kind,
+            added: 0,
+            removed: 0,
+            diff: None,
+        }
+    }
+
+    #[test]
+    fn only_the_two_modes_a_patch_encodes_are_representable() {
+        assert!(is_git_representable(0o644));
+        assert!(is_git_representable(0o755));
+        assert!(!is_git_representable(0o600), "the openssl key mode (#2935)");
+        assert!(!is_git_representable(0o700));
+        assert!(!is_git_representable(0o640));
+        assert!(
+            !is_git_representable(0o2755),
+            "a setgid bit is not the executable bit"
+        );
+    }
+
+    #[test]
+    fn absent_ancestors_are_reported_deepest_first_and_once() {
+        let root = std::env::temp_dir().join(format!(
+            "stella_modes_dirs_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(root.join("existing")).unwrap();
+        let changes = vec![
+            change("existing/a.txt", FileChangeKind::Created),
+            change("ssl/deep/server.key", FileChangeKind::Created),
+            change("ssl/server.crt", FileChangeKind::Created),
+            change("top.txt", FileChangeKind::Created),
+        ];
+        assert_eq!(
+            directories_adoption_will_create(&root, &changes),
+            vec!["ssl/deep".to_string(), "ssl".to_string()],
+            "an existing directory is the user's; a file at the root has no ancestor"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_deletion_creates_no_directories() {
+        let root = std::env::temp_dir().join(format!(
+            "stella_modes_del_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let changes = vec![change("gone/x.txt", FileChangeKind::Deleted)];
+        assert!(directories_adoption_will_create(&root, &changes).is_empty());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The safety half of the asymmetry, at the unit level: a candidate whose
+    /// file carries a mode git *can* express is left to the patch, so a `0600`
+    /// the user set on a file the candidate only edited is never clobbered.
+    #[cfg(unix)]
+    #[test]
+    fn a_representable_mode_is_left_to_the_patch() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!(
+            "stella_modes_keep_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        let (candidate, real) = (base.join("candidate"), base.join("real"));
+        std::fs::create_dir_all(&candidate).unwrap();
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::write(candidate.join("edited.txt"), "new\n").unwrap();
+        std::fs::set_permissions(
+            candidate.join("edited.txt"),
+            PermissionsExt::from_mode(0o644),
+        )
+        .unwrap();
+        std::fs::write(real.join("edited.txt"), "new\n").unwrap();
+        std::fs::set_permissions(real.join("edited.txt"), PermissionsExt::from_mode(0o600))
+            .unwrap();
+
+        let changes = vec![change("edited.txt", FileChangeKind::Modified)];
+        assert!(replay_unrepresentable_modes(&candidate, &real, &changes, &[]).is_empty());
+        assert_eq!(
+            std::fs::metadata(real.join("edited.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o600,
+            "the user's own tightening survives an ordinary content edit"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+}

--- a/crates/stella-cli/src/candidate_ws/oracle_writes.rs
+++ b/crates/stella-cli/src/candidate_ws/oracle_writes.rs
@@ -1,0 +1,177 @@
+//! Who wrote the file — the discriminator the post-seal drift check was
+//! missing (#2877).
+//!
+//! `sealed_unchanged_inner` runs *after* the flip oracle has executed the test
+//! command inside this very worktree, and it reads any difference from the
+//! seal as the worker tampering with a verified tree. On a gcov-instrumented
+//! task the binary rewrites `*.gcda` on every run, so the check answered
+//! `false` about the oracle's own side effects and the pipeline discarded the
+//! whole candidate — a 194,561-line change a grader independently scored 2 of
+//! 3 passing. #2876 repaired the `__pycache__`-shaped instance of this by
+//! subtracting a fixed list of scratch directories, and said in as many words
+//! that the list was not the answer: the next task brings the next artifact
+//! type, and `.gcda` was already it.
+//!
+//! # Why an observation and not a longer list
+//!
+//! An extension blocklist answers "does this path *look* like something a test
+//! run produces". The question that actually decides the case is "did the
+//! verification run write this path", and it is answerable exactly, for any
+//! artifact type that exists or ever will, by looking while the run happens.
+//!
+//! [`ObservedTestRunner`] brackets every `run_test` with a `git status` of the
+//! candidate worktree and records the paths that appear between the two reads.
+//! Those, and only those, are the verification run's own leavings; anything
+//! else that moved after the seal is unattributed and stays fatal, which is
+//! what keeps the check a check. Cost is two `git status` invocations per
+//! oracle run — unmeasurable beside running a test suite.
+//!
+//! The attribution is deliberately conservative in the one place it is not
+//! exact. A path that had *already* drifted before the run and was rewritten
+//! by it appears in both reads, so it is not attributed and the candidate
+//! still fails. Being wrong toward refusing an adoption is the direction that
+//! loses work rather than trust, and it is the direction the seal check exists
+//! to be wrong in.
+//!
+//! # What this does not claim
+//!
+//! It does not claim the oracle's writes are harmless. A test command that
+//! rewrites a source file is attributed here exactly like a `.gcda`, and the
+//! candidate proceeds. What makes that survivable is a fact about the
+//! deliverable rather than about this module: adoption applies
+//! `git diff <anchor> <sealed>`, computed from two immutable commit objects,
+//! so the bytes delivered are the bytes that were verified no matter what the
+//! worktree does afterwards. The drift check is a statement about the
+//! *claim* — whether the flip was measured against the tree that is being
+//! delivered — which is why #2881's rule applies: a post-completion check may
+//! downgrade a claim, never discard a deliverable. Reporting an attributed
+//! source rewrite as a claim degradation, rather than silently, is #2990.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use stella_pipeline::ports::{CmdOutcome, TestInvocation, TestRunner};
+
+use crate::agent::TypedTestRunner;
+
+/// The paths this candidate's own verification runs wrote, accumulated across
+/// every oracle run since the last seal.
+///
+/// Cleared by [`Self::forget`] on every seal: the seal commits the tree, so a
+/// path attributed under the previous seal is part of the new one and can only
+/// serve to excuse a *later* mutation at the same path.
+#[derive(Default)]
+pub(super) struct OracleWrites(Mutex<BTreeSet<String>>);
+
+impl OracleWrites {
+    /// Whether the verification run wrote this repository-relative path.
+    pub(super) fn wrote(&self, path: &str) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .contains(path)
+    }
+
+    /// Drop every attribution — called from the seal, whose commit makes them
+    /// all moot.
+    pub(super) fn forget(&self) {
+        self.0.lock().unwrap_or_else(|p| p.into_inner()).clear();
+    }
+
+    fn record(&self, paths: impl IntoIterator<Item = String>) {
+        let mut set = self.0.lock().unwrap_or_else(|p| p.into_inner());
+        set.extend(paths);
+    }
+}
+
+/// The candidate's [`TestRunner`], bracketed so the worktree paths a test run
+/// moves are attributed to the run rather than to the worker.
+pub(super) struct ObservedTestRunner {
+    inner: TypedTestRunner,
+    /// The shadow worktree's toplevel — the tree the status reads describe,
+    /// which is not necessarily the runner's root (the session workspace may
+    /// be a subdirectory) and must not be, since adoption is repo-wide.
+    toplevel: PathBuf,
+    written: std::sync::Arc<OracleWrites>,
+}
+
+impl ObservedTestRunner {
+    pub(super) fn new(
+        inner: TypedTestRunner,
+        toplevel: PathBuf,
+        written: std::sync::Arc<OracleWrites>,
+    ) -> Self {
+        Self {
+            inner,
+            toplevel,
+            written,
+        }
+    }
+}
+
+#[async_trait]
+impl TestRunner for ObservedTestRunner {
+    async fn run_test(&self, invocation: &TestInvocation) -> CmdOutcome {
+        let before = moved_paths(&self.toplevel).await;
+        let outcome = self.inner.run_test(invocation).await;
+        let after = moved_paths(&self.toplevel).await;
+        self.written.record(after.difference(&before).cloned());
+        outcome
+    }
+
+    async fn runner_available(&self, probe: &TestInvocation) -> bool {
+        // A `--version` probe is not an oracle run and writes nothing worth
+        // attributing; bracketing it would buy two `git status` calls per
+        // availability question and excuse nothing.
+        self.inner.runner_available(probe).await
+    }
+}
+
+/// Every path `git status` currently reports as moved in `toplevel`, or an
+/// empty set when the status cannot be read.
+///
+/// An unreadable status degrades toward attributing *nothing*, which leaves
+/// the drift check exactly as strict as it was before this module existed —
+/// the safe direction for a probe whose whole job is to excuse a difference.
+async fn moved_paths(toplevel: &Path) -> BTreeSet<String> {
+    let status = super::git(
+        toplevel,
+        &[
+            "status",
+            "--porcelain",
+            "--no-renames",
+            "-z",
+            "--untracked-files=all",
+        ],
+    )
+    .await;
+    status
+        .map(|raw| super::adopt::drifted_paths(&raw).into_iter().collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_seal_forgets_every_attribution() {
+        let writes = OracleWrites::default();
+        writes.record(["build/x.gcda".to_string()]);
+        assert!(writes.wrote("build/x.gcda"));
+        writes.forget();
+        assert!(
+            !writes.wrote("build/x.gcda"),
+            "the new seal contains it; excusing a later mutation there would be a hole"
+        );
+    }
+
+    #[test]
+    fn only_recorded_paths_are_attributed() {
+        let writes = OracleWrites::default();
+        writes.record(["build/x.gcda".to_string()]);
+        assert!(!writes.wrote("src/lib.rs"));
+    }
+}

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -977,3 +977,141 @@ async fn a_candidates_shell_cannot_move_stellas_witness_baseline_ref() {
         "Stella's own ref was writable from a candidate: {output:?}"
     );
 }
+
+/// #2935 — the delivery is a git patch, and a git patch encodes exactly two
+/// file modes and no directory modes at all. A task whose deliverable is a
+/// `chmod 600` private key inside a `chmod 700` directory (the
+/// `openssl-selfsigned-cert` shape) therefore had that half of its work
+/// dropped between the worktree where it was verified and the tree that is
+/// graded.
+///
+/// Two-sided on purpose: the unrepresentable modes must arrive, and the
+/// representable one must still be the patch's business — the replay adds only
+/// what git could not say (see [`super::modes`]).
+#[cfg(unix)]
+#[tokio::test]
+async fn a_mode_no_patch_can_encode_survives_adoption() {
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    let root = scaffold("modes");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+
+    // Exactly what the observed trial did: `mkdir -p ssl && chmod 700 ssl`,
+    // then `openssl genrsa -out server.key && chmod 600 server.key`.
+    let ssl = ws.dir().join("ssl");
+    std::fs::create_dir_all(&ssl).unwrap();
+    std::fs::write(ssl.join("server.key"), "PRIVATE KEY\n").unwrap();
+    std::fs::set_permissions(ssl.join("server.key"), PermissionsExt::from_mode(0o600)).unwrap();
+    std::fs::write(ssl.join("server.crt"), "CERTIFICATE\n").unwrap();
+    std::fs::set_permissions(ssl.join("server.crt"), PermissionsExt::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&ssl, PermissionsExt::from_mode(0o700)).unwrap();
+
+    ws.seal().await.expect("the candidate seals");
+    let adopted = ws.adopt(&[]).await.expect("the work is delivered");
+    let paths: Vec<&str> = adopted.iter().map(|c| c.path.as_str()).collect();
+    assert_eq!(paths, vec!["ssl/server.crt", "ssl/server.key"]);
+
+    assert_eq!(
+        mode_of(&root.join("ssl/server.key")),
+        0o600,
+        "a private key delivered world-readable fails its grader however correct it is"
+    );
+    assert_eq!(
+        mode_of(&root.join("ssl")),
+        0o700,
+        "git tracks no directory modes at all, so nothing but a replay can carry this"
+    );
+    assert_eq!(
+        mode_of(&root.join("ssl/server.crt")),
+        0o644,
+        "a mode the patch CAN encode stays the patch's business"
+    );
+
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// #2877 — the third case the scratch subtraction (#2876) deliberately did not
+/// cover: a build artifact the verification run itself rewrote. A
+/// gcov-instrumented binary rewrites `*.gcda` on every run, and the drift
+/// check read the oracle's own side effect as the worker tampering with a
+/// verified tree, discarding a change a grader scored 2 of 3 passing.
+///
+/// The discriminator is who wrote the file, observed rather than guessed from
+/// its extension — so both halves are asserted here on one tree and one seal:
+/// a path the verification run was seen writing does not discard the work, and
+/// a path nothing was seen writing still does.
+#[tokio::test]
+async fn a_build_artifact_the_verification_run_wrote_does_not_discard_the_work() {
+    let root = scaffold("sealed-gcda");
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        RegistryOptions::default(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = port.create_workspace().await.unwrap();
+    std::fs::write(ws.dir().join("verified.txt"), "verified bytes\n").unwrap();
+
+    ws.seal()
+        .await
+        .expect("candidate state seals before verification");
+
+    // The flip oracle, running the test command in this very worktree. The
+    // instrumented binary rewrites its coverage data as a side effect — no
+    // extension list names this; the bracketing does.
+    let outcome = ws
+        .tests()
+        .run_test(&stella_pipeline::ports::TestInvocation {
+            program: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "mkdir -p build && printf 'coverage' > build/sqlite3-shell.gcda".to_string(),
+            ],
+        })
+        .await;
+    assert!(outcome.passed(), "the fixture oracle run must succeed");
+    assert!(ws.dir().join("build/sqlite3-shell.gcda").exists());
+
+    assert!(
+        ws.sealed_is_unchanged().await.unwrap(),
+        "the oracle's own coverage data is not a tampering signal"
+    );
+    let adopted = ws.adopt(&[]).await.expect("the work is delivered");
+    assert_eq!(
+        adopted.iter().map(|c| c.path.as_str()).collect::<Vec<_>>(),
+        vec!["verified.txt"],
+        "the sealed bytes are delivered; the post-seal artifact is not in the seal"
+    );
+    assert_eq!(read(&root.join("verified.txt")), "verified bytes\n");
+
+    // The other half, on the same tree: a mutation nothing was observed making
+    // is still fatal. A fix that let all drift through would have removed the
+    // protection rather than repaired it.
+    std::fs::write(
+        ws.dir().join("verified.txt"),
+        "mutated after verification\n",
+    )
+    .unwrap();
+    assert!(
+        !ws.sealed_is_unchanged().await.unwrap(),
+        "an unattributed post-seal mutation must still refuse the adoption"
+    );
+
+    ws.remove().await;
+    assert_no_candidate_worktrees(&root);
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/crates/stella-pipeline/src/scratch.rs
+++ b/crates/stella-pipeline/src/scratch.rs
@@ -28,9 +28,14 @@
 //! `build`) are deliberately absent: producing one of those is frequently the
 //! whole job, and the same reasoning keeps them out of
 //! `stella_tools::shell_touch::SKIP_DIRS`. Coverage data (`.gcda`) is likewise
-//! absent — it is a *file suffix* rather than a directory, and whether a gcov
-//! task's coverage data is scratch or deliverable is a judgement this list
-//! cannot make (#2877 tracks it).
+//! absent, and stays absent: whether a gcov task's coverage data is scratch or
+//! deliverable is a judgement no list of names can make. The seal check now
+//! answers the question this list was being asked to approximate — *did the
+//! verification run write this path* — by observing the run rather than by
+//! recognizing the filename (`stella_cli::candidate_ws::oracle_writes`,
+//! #2877). This list survives it because adoption's pathspecs still need a
+//! set of names to exclude from the *delivered patch*, which is a different
+//! question with a different answer.
 
 /// Directory names that hold tool scratch, matched at **any depth**.
 ///


### PR DESCRIPTION
Two defects with one root: candidate adoption's fidelity model assumed a `git diff` patch captures everything that matters about a tree. It captures neither a file's permission bits nor the question of who wrote a file.

Closes #2935
Closes #2877

## #2935 — modes a patch cannot encode

A git patch records exactly two file modes (`100644`, `100755`) and no directory modes at all. A candidate that does the job correctly — `chmod 600` on a generated private key, `chmod 700` on the directory holding it — had that half of its work dropped between the worktree where it was verified and the tree that is graded. Reproduced locally exactly as the issue asked: the witness below shows `0644` (420) delivered where `0600` (384) was verified.

**Decision: replay, not a manifest.** Recording every path's `st_mode` at seal time and applying the recording after `git apply` creates a second description of the tree that can disagree with the tree, and the disagreement is undetectable — a stale manifest `chmod`s a delivered file to a mode the candidate no longer holds and nothing in the run can tell that from the truth. So nothing is recorded: `crates/stella-cli/src/candidate_ws/modes.rs` reads the modes from the candidate worktree at the moment of delivery and applies them immediately, in the same call, from the same tree the patch was built against — which the drift check has just certified byte-identical to the sealed commit. There is one description of the tree, and it is the tree. Adoption stays a patch, so the deletion and binary handling `--binary --no-renames` gets right (cleared in #2927) is untouched.

**The replay is asymmetric, and that is the whole safety argument.** It applies only modes git *cannot* express. A tracked file enters the candidate through `git worktree add`, so its mode there is git's normalization (`0644`) and not the mode the user's own file carries; forcing the candidate's mode onto every delivered path would *destroy* a `0600` the user set on a file the candidate merely edited the contents of. Adding what git cannot say can only ever restore information the patch lost. Directory modes are replayed only for directories adoption itself creates, computed before the apply — a directory the real tree already had is the user's.

## #2877 — the oracle's own writes read as tampering

`sealed_unchanged_inner` runs after the flip oracle executed the test command *inside this very worktree*, and read any difference from the seal as the worker tampering. A gcov-instrumented binary rewrites `*.gcda` on every run, so the check answered `false` about its own side effect and the pipeline discarded the whole candidate.

**Decision: observe who wrote the file, do not grow the blocklist.** #2876 repaired the `__pycache__` instance with a fixed scratch list and said in as many words that the list was not the answer — the next task brings the next artifact type, and `.gcda` was already it. An extension list answers "does this path *look* like something a test run produces"; the question that decides the case is "did the verification run write this path", and it is answerable exactly, for any artifact type that exists or ever will, by looking while the run happens. `crates/stella-cli/src/candidate_ws/oracle_writes.rs` brackets every `run_test` with a `git status` of the candidate worktree and records the paths that appear between the two reads. Cost: two `git status` calls per oracle run, beside running a test suite.

**The protection is not removed.** Only observed writes are excused; everything else that moved after the seal is unattributed and still fatal. The attribution is conservative in its one inexact place — a path that had *already* drifted before a run and was rewritten by it appears in both reads, so it is not attributed and the candidate still fails. Attributions are cleared on every seal, since the seal's `add -A` sweeps them into the commit and a stale one could only ever excuse a *later* mutation at the same path.

This is #2881's principle applied where it belongs rather than dropped: adoption applies `git diff <anchor> <sealed>` over two immutable commit objects, so the delivered bytes are the verified bytes whatever the worktree does afterwards. The drift check is a statement about the *claim*, and an oracle-attributed rewrite of a source file (as opposed to a `.gcda`) is a claim to downgrade rather than a deliverable to discard — reporting that downgrade is #2990, because there is no channel here yet and inventing one silently would be worse.

`stella_pipeline::scratch::TOOL_SCRATCH_DIRS` survives unchanged: adoption's pathspecs still need a set of names to exclude from the delivered *patch*, which is a different question with a different answer. Its doc no longer promises `.gcda` a decision it now has.

## Witnesses

Both verified artisanally — source changes removed from the tree, tests kept, suite run, red observed, changes restored, green observed.

| Witness | Fails on `main` with |
|---|---|
| `a_mode_no_patch_can_encode_survives_adoption` | `left: 420, right: 384` — "a private key delivered world-readable fails its grader however correct it is" |
| `a_build_artifact_the_verification_run_wrote_does_not_discard_the_work` | "the oracle's own coverage data is not a tampering signal" |

The second asserts both sides on one tree and one seal: a `build/*.gcda` the verification run was observed writing does not discard the work and the adoption lands, then an unattributed mutation of `verified.txt` still refuses. `post_verification_worktree_drift_is_rejected_and_never_adopted` and `scratch_the_verification_run_wrote_does_not_discard_the_work` are unchanged and still pass.

Plus unit coverage in the two new modules: what a patch can encode, which ancestor directories adoption will create (deepest first, existing ones left alone), that a representable mode is left to the patch when the real tree holds a tighter one, and that a seal forgets every attribution.

## Gate

`make gate` passes in full (exit 0, output read from a file — not piped). No baseline was raised; `check-file-size` reports nothing went over by this change, and both new modules are well under.

## Issues filed

- #2988 — adoption still cannot deliver a mode *relaxation*: `0600` → `0644` is invisible to both git and the replay, and distinguishing "the candidate chose `0644`" from "git checked it out as `0644`" needs an observation of the real tree's mode at snapshot time.
- #2990 — `replay_unrepresentable_modes`' residue is bound and dropped (`_unreplayable_modes`), and an oracle-attributed source rewrite proceeds silently. Both want the adoption event #2927 adds.
- #2991 — only the test runner is bracketed; the lint, coverage and mutation probes also run in the sealed worktree and write `target/`, which is deliberately not scratch, so they discard a candidate through the same door.

## Notes for review

- No test was deleted.
- `crates/stella-pipeline/src/pipeline.rs` is untouched — the whole fix lives behind the existing `CandidateWorkspace` port.
- Exemplar for the bracketing shape: `tokio`'s instrumented-wrapper idiom (a decorator implementing the same trait, holding an `Arc` of the shared observation), which is also how `PolicyToolSet` and `CustomToolSet` already layer this crate's tool stack.

## Summary by Sourcery

Ensure candidate adoption preserves file permission modes that git patches cannot represent and distinguishes oracle-generated artifacts from worker tampering during post-seal drift checks.

New Features:
- Replay unrepresentable permission modes from the candidate worktree during adoption so delivered trees retain secure file and directory permissions.
- Track and attribute files written by the test oracle during verification runs to avoid treating its own build artifacts as tampering.

Enhancements:
- Introduce a bracketed test runner that observes git status before and after verification runs and feeds observed writes into the drift check.
- Limit mode replay to non-git-representable modes and to directories created by adoption, keeping user-set permissions on existing files intact.

Tests:
- Add integration tests validating that unrepresentable permission modes survive adoption and that oracle-written build artifacts no longer cause candidates to be discarded.
- Add unit tests covering git-representable mode detection, directory creation planning for adoption, and lifecycle of oracle write attributions.