### PR TITLE
fix(stella-tools): tell a broken witness from failing code, and bound a rejection loop

### DIFF
--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -94,8 +94,10 @@
 //! why the measurement was needed (#2486) and why it cannot ride the tool's
 //! own output.
 
+mod cap;
 mod creation;
 mod defeater;
+mod instrument;
 mod memo;
 mod phases;
 
@@ -315,48 +317,6 @@ async fn resolve_witness_baseline(
     }
 }
 
-/// Output signatures proving the previous-code run died while *loading* the
-/// test or its imports — no behavioural assertion ever executed, so the
-/// failure is not evidence of a flip (#2067). The live false positive: a
-/// compiled `.so` present in the working tree but absent from a fresh shadow
-/// checkout fails `import` on the old side and fakes a confirmation.
-///
-/// Deliberately narrow, and deliberately NOT the compile-error family:
-/// a witness that fails to *build* on the old code (rustc `error[E…]`) is
-/// the canonical missing-API witness shape and stays credited with the
-/// existing weaker-evidence warning (#1790). The import/loader family is
-/// different: the author can always convert module absence into an
-/// assertion (`try: import x … except ImportError: ok = False`), so refusal
-/// is actionable, while crediting it lets a stale artifact decide the
-/// verdict. `SyntaxError` and "No such file or directory" are also absent —
-/// both can BE the witnessed behaviour (a fix-the-parse-error task; a shell
-/// witness asserting a file the change creates).
-///
-/// A match here is a *candidate* refusal, not the verdict: on a creation
-/// task the module that would not load can be the deliverable itself, absent
-/// at the baseline by construction. [`creation::confirm`] decides that from
-/// git — never from the text this function reads, which cannot tell the two
-/// apart (#2668).
-fn import_failure_signature(output: &str) -> Option<&'static str> {
-    const SIGNATURES: &[(&str, &str)] = &[
-        ("modulenotfounderror", "a Python `ModuleNotFoundError`"),
-        ("no module named", "a missing Python module"),
-        ("importerror", "a Python `ImportError`"),
-        (
-            "error while loading shared libraries",
-            "a missing shared library",
-        ),
-        ("cannot find module", "a missing Node module"),
-        ("error collecting", "a pytest collection error"),
-        ("errors during collection", "a pytest collection error"),
-    ];
-    let lower = output.to_ascii_lowercase();
-    SIGNATURES
-        .iter()
-        .find(|(needle, _)| lower.contains(needle))
-        .map(|(_, label)| *label)
-}
-
 /// Best-effort removal of the shadow worktree — both the registration and
 /// the directory.
 async fn cleanup_shadow(root: &std::path::Path, shadow: &std::path::Path) {
@@ -552,6 +512,9 @@ impl Tool for VerifyDone {
             Err(message) => (ToolOutput::Error { message }, Verdict::Error),
         };
         phases.verdict = verdict;
+        // The turn's rejection run (#2863), folded in at the one exit every
+        // verdict passes through — so no future arm can forget to count.
+        self.memo.record_verdict(verdict);
         // Last, so it spans everything above it including the teardown.
         phases.total = call.stop();
         if let Some(dx) = &self.diagnostics {
@@ -577,6 +540,12 @@ impl VerifyDone {
         root: &std::path::Path,
         phases: &mut Phases,
     ) -> Result<(ToolOutput, Verdict), String> {
+        // Before the argument is even read: this turn may already have bought
+        // this answer twice, and the saving is only real if the refused call
+        // resolves no baseline and checks out no shadow (#2863).
+        if let Some(class) = self.memo.gate_closed() {
+            return Err(cap::refusal(class));
+        }
         let setup = Phase::start();
         let test_cmd = crate::input::required_str(input, "test_cmd").map_err(|e| e.to_string())?;
         // Before anything expensive, and refused rather than rewritten (#2871).
@@ -724,6 +693,17 @@ impl VerifyDone {
         phases.working_tree_run = half_one.stop();
         let (new_exit, new_output) = new_run?;
         if new_exit != 0 {
+            // Did it run and fail, or never run? Only the first is evidence
+            // about the code; answering both with `NOT DONE` sent an agent
+            // after its own harness for fifteen consecutive calls (#2872).
+            if let Some(broken) = instrument::working_tree_failure(new_exit, &new_output) {
+                return Ok((
+                    ToolOutput::Error {
+                        message: instrument::refusal(broken, test_cmd, new_exit, tail(&new_output)),
+                    },
+                    Verdict::InstrumentBroken,
+                ));
+            }
             return Ok((
                 ToolOutput::Error {
                     message: format!(
@@ -813,7 +793,7 @@ impl VerifyDone {
         // deliverable, absent at baseline by construction — mechanically
         // distinguished from a stale artifact by asking git whether the named
         // file is new relative to the baseline, never by trusting a claim.
-        if let Some(label) = import_failure_signature(&old_output) {
+        if let Some(label) = instrument::import_failure_signature(&old_output) {
             let flip = creation::ImportFlip {
                 label,
                 test_cmd,
@@ -1214,28 +1194,6 @@ mod tests {
             other => panic!("an import failure must not confirm a witness, got {other:?}"),
         }
         std::fs::remove_dir_all(&root).ok();
-    }
-
-    /// The import/loader vocabulary is deliberately narrow: behavioural
-    /// failures — assertions, files a shell witness checks for, and the Rust
-    /// missing-API compile shape (#1790) — stay credited.
-    #[test]
-    fn import_failure_signatures_are_narrow() {
-        assert!(import_failure_signature("ModuleNotFoundError: No module named 'x'").is_some());
-        assert!(import_failure_signature("ImportError: undefined symbol: foo").is_some());
-        assert!(
-            import_failure_signature("./app: error while loading shared libraries: libz.so.1")
-                .is_some()
-        );
-        assert!(import_failure_signature("Error: Cannot find module 'left-pad'").is_some());
-        assert!(import_failure_signature("assertion failed: `(left == right)`").is_none());
-        assert!(
-            import_failure_signature("cat: /etc/nginx/ssl/cert.pem: No such file or directory")
-                .is_none()
-        );
-        assert!(
-            import_failure_signature("error[E0425]: cannot find function `retry_delays`").is_none()
-        );
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/verify/cap.rs
+++ b/crates/stella-tools/src/verify/cap.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The bound on how many times one turn may re-derive the same rejection.
+//!
+//! # What this costs when it is missing
+//!
+//! `verify_done`'s expensive half is a fresh shadow checkout and a cold build,
+//! and nothing stopped a turn from buying it again for an answer it already
+//! held. Measured 2026-08-10: `kv-store-grpc__RpPZcUD` spent 430 of 911s and
+//! 20 of 52 steps in the gate loop for five `VACUOUS` verdicts;
+//! `pypi-server__HRUntZQ` spent 665 of 921s and 65 of 89 steps for twelve
+//! (#2863). Across the 2026-08-11 panel the verification apparatus was 24-36%
+//! of every tool call Stella made, on a benchmark Claude Code solves 20/20
+//! while spending none.
+//!
+//! # What the cap is a cap ON, and why not the other two
+//!
+//! **Consecutive rejections of the same [`Verdict`] class, inside one turn.**
+//! Not total calls and not spend, and the difference is the whole design:
+//!
+//! - A cap on **total calls** punishes a progressing repair loop exactly as
+//!   hard as a stuck one. A turn that goes `NOT DONE` → fix → `VACUOUS` →
+//!   restage → `WITNESS CONFIRMED` is three calls doing three different
+//!   things, and a call budget cannot tell it from three identical ones. A cap
+//!   that fires on a loop that is converging is worse than no cap: it takes
+//!   away a proof the turn was about to earn.
+//! - A cap on **spend** cannot live here at all. A `Tool` is handed an input
+//!   and a root; it holds no budget, no turn clock, and no session. Wall-clock
+//!   share of budget — #2668's other half — belongs to the driver that owns
+//!   the budget, and is tracked separately rather than approximated here from
+//!   numbers this crate would have to invent.
+//! - **Same-class consecutive** is the signal that no progress is being made:
+//!   the class *is* what the last edit was supposed to change. Any change of
+//!   class resets the run, so a turn that is genuinely converging is never
+//!   capped, however many calls it takes; a turn that is not converging stops
+//!   after the second identical answer.
+//!
+//! [`Verdict::Confirmed`] clears the run outright — the gate opened, and
+//! whatever comes after is a new question. [`Verdict::Error`] is deliberately
+//! **neutral**: it counts for nothing and clears nothing. Those are the input
+//! refusals and the workspace refusals, which never build a shadow and so are
+//! not the cost this bounds — and the closure notice below is itself one of
+//! them, so counting it would let the gate re-arm by refusing.
+//!
+//! # A bounded loop must still fail honestly
+//!
+//! The closure is a refusal, never a pass. [`refusal`] returns a message the
+//! caller hands back as `ToolOutput::Error`, and its text says the change is
+//! **UNPROVEN** and must be reported as unwitnessed. Nothing here can produce
+//! a `WITNESS CONFIRMED`, and no verdict is manufactured to end the loop —
+//! that would trade a wall-clock defect for a correctness one, and #2915
+//! settled that an unprovable claim ends nothing.
+//!
+//! # Where the state lives
+//!
+//! In [`ShadowMemo`](super::ShadowMemo), the turn-scoped seam the registry
+//! already brackets (`begin_workspace_probe` arms, `settle_workspace_probe`
+//! clears). The tool itself holds no turn state — and the tally must not ride
+//! the `ToolOutput` text either, because `stella-core`'s loop detector keys on
+//! it and a counter in the verdict would blind both of its rungs for the one
+//! tool a stuck agent calls repeatedly (see [`phases`](super::phases)).
+//!
+//! Like the memo, the tally is inert until a host brackets a turn: an unarmed
+//! [`ShadowMemo`](super::ShadowMemo) never closes the gate, so a standalone
+//! `VerifyDone` behaves exactly as it did before this existed.
+
+use super::phases::Verdict;
+
+/// How many consecutive rejections of one class a turn may buy before the
+/// gate closes. Two, per #2668 — so the *third* call that would answer the
+/// same way is refused before it builds a shadow worktree.
+///
+/// Two rather than one because the first re-derivation is legitimate: the
+/// agent edits the tree between calls, and one repeat is how it learns the
+/// edit did not move the verdict. The second repeat teaches nothing the first
+/// did not.
+pub(super) const CONSECUTIVE_LIMIT: u32 = 2;
+
+/// One turn's run of same-class rejections.
+///
+/// A plain value with pure transitions, so the policy is testable without a
+/// registry, a repository, or a clock — the engine-logic discipline, applied
+/// to the one piece of `verify_done` that is a decision rather than an
+/// observation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct Tally {
+    /// The class currently repeating, and how many times it has been seen in
+    /// a row. `None` when nothing is repeating — the start of a turn, or
+    /// after a confirmation.
+    run: Option<(Verdict, u32)>,
+}
+
+impl Tally {
+    /// Fold one call's verdict in.
+    #[must_use]
+    pub(super) fn record(self, verdict: Verdict) -> Self {
+        match verdict {
+            // The gate opened. Whatever the turn asks next is a new question.
+            Verdict::Confirmed => Self::default(),
+            // Neutral — see the module docs.
+            Verdict::Error => self,
+            rejection => Self {
+                run: Some(match self.run {
+                    Some((class, seen)) if class == rejection => (class, seen.saturating_add(1)),
+                    _ => (rejection, 1),
+                }),
+            },
+        }
+    }
+
+    /// The class that closed the gate, or `None` while the turn may still
+    /// call. Asked *before* a call, which is what makes the saving real: the
+    /// refused call never resolves a baseline, never checks out a shadow, and
+    /// never builds.
+    pub(super) fn closed(self) -> Option<Verdict> {
+        self.run
+            .filter(|(_, seen)| *seen >= CONSECUTIVE_LIMIT)
+            .map(|(class, _)| class)
+    }
+}
+
+/// What the repeating verdict was, in the words the agent saw — so the notice
+/// names the answer it is declining to re-derive rather than a wire tag.
+const fn class_name(class: Verdict) -> &'static str {
+    match class {
+        Verdict::Confirmed => "WITNESS CONFIRMED",
+        Verdict::Vacuous => "VACUOUS TEST",
+        Verdict::NotDone => "NOT DONE",
+        Verdict::InconclusiveBuildError => "WITNESS_INCONCLUSIVE_BUILD_ERROR",
+        Verdict::InstrumentBroken => "WITNESS UNRUNNABLE",
+        Verdict::Error => "a refusal",
+    }
+}
+
+/// The closure notice. Deterministic in its inputs — one class in, one string
+/// out, no counts that move call to call — so the loop detector keeps working
+/// on it.
+pub(super) fn refusal(class: Verdict) -> String {
+    format!(
+        "VERIFICATION GATE CLOSED — this turn has already had `{}` back from verify_done \
+         {CONSECUTIVE_LIMIT} times in a row, so this call was refused before it built a shadow \
+         worktree. A third identical answer costs a full checkout and a cold build and buys \
+         nothing: the verdict is not moving, and re-deriving it is where a stuck turn spends \
+         its budget.\n\
+         This is NOT a pass, and it is NOT permission to claim the work is verified. The change \
+         is UNPROVEN by a witness test. Report it as unwitnessed — say plainly what you \
+         changed, that no witness test proves it, and what you tried — and stop calling \
+         verify_done for the rest of this turn. Do not weaken the test to get past this, and do \
+         not delete or edit working code in response to it.",
+        class_name(class)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::{Value, json};
+    use stella_protocol::tool::ToolOutput;
+
+    use super::*;
+    use crate::registry::Tool;
+    use crate::verify::tests::scaffold;
+    use crate::verify::{ShadowMemo, ShadowMemoHandle, VerifyDone};
+
+    #[test]
+    fn a_run_of_one_class_closes_the_gate_at_the_limit() {
+        let mut tally = Tally::default();
+        assert_eq!(tally.closed(), None);
+        tally = tally.record(Verdict::Vacuous);
+        assert_eq!(tally.closed(), None, "one rejection is not a loop");
+        tally = tally.record(Verdict::Vacuous);
+        assert_eq!(tally.closed(), Some(Verdict::Vacuous));
+    }
+
+    /// The property the whole design rests on: a turn that is getting
+    /// somewhere is never capped. Each new class restarts the run, so a repair
+    /// loop that keeps changing the answer can call as often as it needs to.
+    #[test]
+    fn a_progressing_loop_is_never_capped() {
+        let mut tally = Tally::default();
+        for verdict in [
+            Verdict::NotDone,
+            Verdict::Vacuous,
+            Verdict::NotDone,
+            Verdict::InconclusiveBuildError,
+            Verdict::InstrumentBroken,
+            Verdict::Vacuous,
+        ] {
+            tally = tally.record(verdict);
+            assert_eq!(
+                tally.closed(),
+                None,
+                "capped a converging turn at {verdict:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_confirmation_clears_the_run_and_a_refusal_is_neutral() {
+        let stuck = Tally::default()
+            .record(Verdict::Vacuous)
+            .record(Verdict::Vacuous);
+        assert_eq!(stuck.closed(), Some(Verdict::Vacuous));
+        assert_eq!(
+            stuck.record(Verdict::Confirmed).closed(),
+            None,
+            "the gate opened; the next question is a new one"
+        );
+        assert_eq!(
+            Tally::default()
+                .record(Verdict::Vacuous)
+                .record(Verdict::Error)
+                .record(Verdict::Vacuous)
+                .closed(),
+            Some(Verdict::Vacuous),
+            "a refusal between two identical rejections is not progress"
+        );
+    }
+
+    fn vacuous_input() -> Value {
+        json!({
+            "test_cmd": "bash witness.sh",
+            "test_files": ["witness.sh"],
+            "timeout_secs": 60
+        })
+    }
+
+    /// How many shadow builds have happened: the witness script appends a line
+    /// on every run inside a linked worktree (where `.git` is a file, not a
+    /// directory), which is exactly the shadow. The same counter `memo.rs`
+    /// uses, for the same reason — the saving has to be observed, not assumed.
+    fn shadow_runs(marker: &std::path::Path) -> usize {
+        std::fs::read_to_string(marker)
+            .map(|text| text.lines().count())
+            .unwrap_or(0)
+    }
+
+    /// #2863 witness.
+    ///
+    /// Fails on `main`, where a turn can re-enter `verify_done` on the same
+    /// rejection class without bound and pay for a shadow checkout every time.
+    ///
+    /// Two assertions, and both matter: the third call does not build a
+    /// shadow, and it reports the change as UNPROVEN rather than manufacturing
+    /// the pass the bound could have been made to produce (#2915).
+    #[tokio::test]
+    async fn the_third_same_class_rejection_builds_no_shadow_and_reports_unproven() {
+        let root = scaffold("cap_vacuous").await;
+        let marker = root.join("shadow-runs.txt");
+        // Vacuous by construction: true on the baseline and on the working
+        // tree, so every call answers the same way however the agent edits.
+        std::fs::write(
+            root.join("witness.sh"),
+            format!(
+                "if [ ! -d .git ]; then printf 'r\\n' >> '{}'; fi\ngrep -q 'behavior' impl.txt\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+
+        let memo: ShadowMemoHandle = Arc::new(ShadowMemo::default());
+        memo.arm();
+        let tool = VerifyDone::new(memo, None);
+
+        for call in 1..=2 {
+            let out = tool.execute(&vacuous_input(), &root).await;
+            let message = match &out {
+                ToolOutput::Error { message } => message.clone(),
+                other => panic!("call {call} should be VACUOUS, got {other:?}"),
+            };
+            assert!(message.contains("VACUOUS"), "call {call}: {message}");
+        }
+        // The memo (#2208) serves an identical repeat, so only the first call
+        // built. Either way the count must not move again below.
+        let built = shadow_runs(&marker);
+        assert!(built >= 1, "the first call must build a shadow");
+
+        let out = tool.execute(&vacuous_input(), &root).await;
+        let message = match &out {
+            ToolOutput::Error { message } => message.clone(),
+            other => panic!("the capped call must be a refusal, not a pass: {other:?}"),
+        };
+        assert!(
+            message.contains("VERIFICATION GATE CLOSED"),
+            "the third same-class call was not capped: {message}"
+        );
+        assert!(
+            message.contains("UNPROVEN"),
+            "a bounded loop must still fail honestly: {message}"
+        );
+        assert!(
+            !message.contains("WITNESS CONFIRMED"),
+            "the cap must never manufacture a pass: {message}"
+        );
+        assert_eq!(
+            shadow_runs(&marker),
+            built,
+            "the capped call built a shadow worktree anyway"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The tool is inert outside a bracketed turn — the memo's own contract,
+    /// and the reason every pre-existing test that builds a bare `VerifyDone`
+    /// still sees exactly the behaviour it always did.
+    #[tokio::test]
+    async fn an_unbracketed_host_is_never_capped() {
+        let root = scaffold("cap_unarmed").await;
+        std::fs::write(root.join("witness.sh"), "grep -q 'behavior' impl.txt\n").unwrap();
+        let tool = VerifyDone::default();
+
+        for call in 1..=3 {
+            let out = tool.execute(&vacuous_input(), &root).await;
+            match &out {
+                ToolOutput::Error { message } => assert!(
+                    message.contains("VACUOUS"),
+                    "call {call} was capped without a turn bracket: {message}"
+                ),
+                other => panic!("call {call}: {other:?}"),
+            }
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/stella-tools/src/verify/creation.rs
+++ b/crates/stella-tools/src/verify/creation.rs
@@ -1,6 +1,6 @@
 //! The creation-task exception to the import/loader refusal (#2668).
 //!
-//! [`super::import_failure_signature`] states the general rule: a
+//! [`super::instrument::import_failure_signature`] states the general rule: a
 //! previous-code run that dies while *loading* the test — an import, not an
 //! assertion — is not evidence of a flip, because a build artifact present in
 //! the working tree and absent from the fresh shadow checkout produces the
@@ -241,7 +241,7 @@ async fn added_since_baseline(root: &Path, baseline_sha: &str) -> Vec<String> {
 /// A struct rather than six positional parameters because four of them are
 /// strings, which is the shape that silently swaps at a call site.
 pub(super) struct ImportFlip<'a> {
-    /// What [`super::import_failure_signature`] recognised, for the prose.
+    /// What [`super::instrument::import_failure_signature`] recognised, for the prose.
     pub label: &'a str,
     pub test_cmd: &'a str,
     pub baseline: &'a super::WitnessBaseline,

--- a/crates/stella-tools/src/verify/instrument.rs
+++ b/crates/stella-tools/src/verify/instrument.rs
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Whether the witness command **ran at all** — the question that separates a
+//! fact about the test from a fact about the code.
+//!
+//! # The failure this module exists to end
+//!
+//! `verify_done` had one channel for both answers. A witness whose command
+//! could not execute — a malformed argv, a missing interpreter, a shell that
+//! could not parse it — exits non-zero exactly like a witness whose assertion
+//! failed, so the working-tree half answered `NOT DONE — the witness test
+//! fails on your NEW code. Fix the implementation (or the test) and retry.`
+//! That sentence is an accusation against code the run never reached, and it
+//! is advice that cannot terminate: no edit to the implementation can make a
+//! command run that the shell never parsed.
+//!
+//! On a 2026-08-11 Terminal-Bench trial an agent spent **fifteen consecutive
+//! `verify_done` calls** chasing an argv bug in a witness it had authored
+//! itself — `fatal: ambiguous argument 'AKIA1234567890123456': unknown
+//! revision or path not in the working tree`, git refusing to run the search
+//! at all — and read every one of them as evidence about its change. It then
+//! contaminated the control branch trying to make the accusation go away. 38
+//! of that trial's 82 tool calls were spent after the task was already done,
+//! and it scored 0 (#2872).
+//!
+//! An agent cannot repair what it cannot name. So the tool names it: an exit
+//! that arrived without the command ever running is reported as a broken
+//! **instrument**, and the message withholds — explicitly — the inference the
+//! old one invited.
+//!
+//! # The discriminator, and why it is this one
+//!
+//! Not "did it fail twice": every armed witness is red on the baseline by
+//! construction, so failing on both trees discriminates nothing (the reasoning
+//! `stella-pipeline`'s `WitnessUnsatisfiable` doc comment puts on the record).
+//! The discriminator here is **whether the command ran** — an exit the shell
+//! itself produced instead of running the program ([`Instrument::NotFound`],
+//! [`Instrument::NotExecutable`]), an exit from a parser that never reached
+//! the first statement ([`Instrument::ShellSyntax`]), or a program that
+//! refused its own arguments and did no work ([`Instrument::Argv`]). None of
+//! those is an assertion about anything.
+//!
+//! # Why only the working-tree half
+//!
+//! `verify_done` runs the baseline half only once the working-tree half has
+//! passed, so any breakage that is a property of the *command* or of the
+//! staged witness text is caught on the first run — the shadow sees the same
+//! command and the same bytes. What can still fail at the baseline alone is
+//! tree-dependent: a program that does not exist there yet, which on a
+//! creation task is the deliverable itself and the whole proof.
+//! [`creation::confirm`](super::creation::confirm) already decides that one
+//! from git rather than from text, and widening this classifier over the
+//! baseline would take those verdicts away from it.
+//!
+//! The case this module therefore does not cover is the pipeline's: an
+//! author-written witness whose baseline run is its *first* run, where a
+//! shell that could not parse it reads as "the test fails on the old code"
+//! and arms the flip oracle. That screen belongs in
+//! `stella-pipeline`'s witness stage, which has the separate stdout this tool
+//! does not, and is tracked as the second half of #2872.
+//!
+//! # Style
+//!
+//! [`import_failure_signature`] lives here for the same reason and is the
+//! shape the rest of the module copies: a deliberately narrow vocabulary in
+//! which every entry is justified by why an author can always act on it, and
+//! every exclusion is named. Every string below is a pure function of the
+//! call's inputs and observations — no timings, no counters — because
+//! `ToolOutput` is what `stella-core`'s loop detector keys on (see
+//! [`phases`](super::phases)).
+
+/// Output signatures proving the previous-code run died while *loading* the
+/// test or its imports — no behavioural assertion ever executed, so the
+/// failure is not evidence of a flip (#2067). The live false positive: a
+/// compiled `.so` present in the working tree but absent from a fresh shadow
+/// checkout fails `import` on the old side and fakes a confirmation.
+///
+/// Deliberately narrow, and deliberately NOT the compile-error family:
+/// a witness that fails to *build* on the old code (rustc `error[E…]`) is
+/// the canonical missing-API witness shape and stays credited with the
+/// existing weaker-evidence warning (#1790). The import/loader family is
+/// different: the author can always convert module absence into an
+/// assertion (`try: import x … except ImportError: ok = False`), so refusal
+/// is actionable, while crediting it lets a stale artifact decide the
+/// verdict. `SyntaxError` and "No such file or directory" are also absent —
+/// both can BE the witnessed behaviour (a fix-the-parse-error task; a shell
+/// witness asserting a file the change creates).
+///
+/// A match here is a *candidate* refusal, not the verdict: on a creation
+/// task the module that would not load can be the deliverable itself, absent
+/// at the baseline by construction. [`creation::confirm`](super::creation::confirm)
+/// decides that from git — never from the text this function reads, which
+/// cannot tell the two apart (#2668).
+pub(super) fn import_failure_signature(output: &str) -> Option<&'static str> {
+    const SIGNATURES: &[(&str, &str)] = &[
+        ("modulenotfounderror", "a Python `ModuleNotFoundError`"),
+        ("no module named", "a missing Python module"),
+        ("importerror", "a Python `ImportError`"),
+        (
+            "error while loading shared libraries",
+            "a missing shared library",
+        ),
+        ("cannot find module", "a missing Node module"),
+        ("error collecting", "a pytest collection error"),
+        ("errors during collection", "a pytest collection error"),
+    ];
+    let lower = output.to_ascii_lowercase();
+    SIGNATURES
+        .iter()
+        .find(|(needle, _)| lower.contains(needle))
+        .map(|(_, label)| *label)
+}
+
+/// A witness command that did not run. Each variant is one way an exit code
+/// can arrive with nothing having been asserted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Instrument {
+    /// Exit 127: the shell looked the command up and found nothing. Read as a
+    /// code and not as a message because POSIX reserves the code for exactly
+    /// this, while the wording differs per shell and per locale.
+    NotFound,
+    /// Exit 126: the file was found and could not be executed — a missing
+    /// exec bit, or a `#!` line naming an interpreter that is not installed.
+    NotExecutable,
+    /// The shell could not parse the command or the script, so no statement
+    /// in it ever ran.
+    ShellSyntax,
+    /// The program refused its own arguments and did no work — git's
+    /// revision-versus-path ambiguity, the shape that cost fifteen calls.
+    Argv,
+}
+
+impl Instrument {
+    /// What the call observed, as a clause completing "the witness command
+    /// did not run: …".
+    pub(super) const fn observed(self) -> &'static str {
+        match self {
+            Self::NotFound => "the shell could not find the command (exit 127)",
+            Self::NotExecutable => {
+                "the command was found but could not be executed — a missing exec bit, or a \
+                 `#!` interpreter that is not installed (exit 126)"
+            }
+            Self::ShellSyntax => {
+                "the shell could not parse it, so no statement in it ever ran (syntax error)"
+            }
+            Self::Argv => {
+                "the program rejected its own arguments and performed no work (git could not \
+                 tell a revision from a path — the missing `--` separator)"
+            }
+        }
+    }
+
+    /// The repair, stated as one action on the *command*. Advice that can
+    /// terminate; in particular, never "strengthen the test".
+    pub(super) const fn repair(self) -> &'static str {
+        match self {
+            Self::NotFound => {
+                "install the tool, or call it by a path that exists in this workspace"
+            }
+            Self::NotExecutable => {
+                "run it through its interpreter explicitly (`bash x.sh`, `python3 x.py`), or \
+                 `chmod +x` it"
+            }
+            Self::ShellSyntax => {
+                "fix the quoting or the shell dialect — a `#!/bin/sh` script may not use bash \
+                 arrays, and `bash x.sh` runs the same file under a parser that accepts them"
+            }
+            Self::Argv => {
+                "separate revisions from paths with `--` (`git grep -e PATTERN --`), or use a \
+                 tool that takes no revision argument at all (`grep -r PATTERN .`)"
+            }
+        }
+    }
+}
+
+/// Shell parse-error signatures. Narrow by construction: each is text a
+/// *parser* emits about text it refused, never text a program emits about a
+/// value it compared.
+///
+/// Python's `SyntaxError` is absent for the reason
+/// [`import_failure_signature`] excludes it — a fix-the-parse-error task
+/// witnesses one, and a classifier must not swallow a task's whole subject.
+/// The three below name a *shell* parser, which the witness command always
+/// passes through and a task's subject essentially never is.
+const SYNTAX_SIGNATURES: &[&str] = &[
+    // bash
+    "syntax error near unexpected token",
+    // bash, an unterminated construct
+    "unexpected end of file",
+    // dash / ash: `Syntax error: "(" unexpected`
+    "syntax error:",
+];
+
+/// git's revision-versus-path fatal, which is a usage error and not a result.
+/// Both halves are required: `ambiguous argument` alone also appears in advice
+/// text printed alongside runs that did the work.
+const ARGV_SIGNATURES: &[(&str, &str)] = &[(
+    "fatal: ambiguous argument",
+    "unknown revision or path not in the working tree",
+)];
+
+/// Classify the working-tree half's failure: did the witness command run and
+/// fail, or never run?
+///
+/// `None` means it ran — the ordinary case, which keeps its `NOT DONE`
+/// verdict, because a witness that runs and fails on the new code is exactly
+/// the evidence that verdict claims it is.
+pub(super) fn working_tree_failure(exit: i32, output: &str) -> Option<Instrument> {
+    // Codes first: they come from the outer `bash -c` and say what happened to
+    // the command itself, independent of wording a locale could change.
+    match exit {
+        127 => return Some(Instrument::NotFound),
+        126 => return Some(Instrument::NotExecutable),
+        _ => {}
+    }
+    let lower = output.to_ascii_lowercase();
+    if SYNTAX_SIGNATURES
+        .iter()
+        .any(|needle| lower.contains(needle))
+    {
+        return Some(Instrument::ShellSyntax);
+    }
+    if ARGV_SIGNATURES
+        .iter()
+        .any(|(head, tail)| lower.contains(head) && lower.contains(tail))
+    {
+        return Some(Instrument::Argv);
+    }
+    None
+}
+
+/// The refusal: what was observed, what it is not evidence of, and the one
+/// repair. Terminal in the honest direction — the change stays UNPROVEN, and
+/// no path here can produce a confirmation.
+pub(super) fn refusal(broken: Instrument, test_cmd: &str, exit: i32, tail: &str) -> String {
+    format!(
+        "WITNESS UNRUNNABLE — the witness command did not run: {}. This is a fact about the \
+         TEST COMMAND, not about your change: no assertion was reached, so exit {exit} is NOT \
+         evidence that your implementation is wrong, and editing working code in response to \
+         it is how a correct change gets undone.\n\
+         Repair the instrument once — {} — then call verify_done again. If the command cannot \
+         be made to run, report the change as UNPROVEN and stop: repeating it proves nothing, \
+         and no number of retries turns an unrun command into a witness.\n\
+         - command:       `{test_cmd}`\n\
+         - previous code: not attempted — the witness never ran on the new code, so there is \
+         nothing to compare it against\n\
+         --- output tail ---\n{tail}",
+        broken.observed(),
+        broken.repair()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use stella_protocol::tool::ToolOutput;
+
+    use super::*;
+    use crate::registry::Tool;
+    use crate::verify::VerifyDone;
+    use crate::verify::tests::scaffold;
+
+    /// The import/loader vocabulary is deliberately narrow: behavioural
+    /// failures — assertions, files a shell witness checks for, and the Rust
+    /// missing-API compile shape (#1790) — stay credited.
+    ///
+    /// Moved here with [`import_failure_signature`] itself, unchanged.
+    #[test]
+    fn import_failure_signatures_are_narrow() {
+        assert!(import_failure_signature("ModuleNotFoundError: No module named 'x'").is_some());
+        assert!(import_failure_signature("ImportError: undefined symbol: foo").is_some());
+        assert!(
+            import_failure_signature("./app: error while loading shared libraries: libz.so.1")
+                .is_some()
+        );
+        assert!(import_failure_signature("Error: Cannot find module 'left-pad'").is_some());
+        assert!(import_failure_signature("assertion failed: `(left == right)`").is_none());
+        assert!(
+            import_failure_signature("cat: /etc/nginx/ssl/cert.pem: No such file or directory")
+                .is_none()
+        );
+        assert!(
+            import_failure_signature("error[E0425]: cannot find function `retry_delays`").is_none()
+        );
+    }
+
+    /// The exact argv bug from the trace: git refuses to tell a revision from
+    /// a path, searches nothing, and exits non-zero.
+    #[test]
+    fn the_git_argv_fatal_is_an_instrument_failure() {
+        let observed = "fatal: ambiguous argument 'AKIA1234567890123456': unknown revision or \
+                        path not in the working tree.\n";
+        assert_eq!(working_tree_failure(128, observed), Some(Instrument::Argv));
+    }
+
+    /// The half of the vocabulary that must stay narrow: an assertion that ran
+    /// and failed is not an instrument failure, however loud it is. Excusing
+    /// one would be the mirror defect — a broken change reported as a broken
+    /// test.
+    #[test]
+    fn an_assertion_failure_is_not_an_instrument_failure() {
+        for output in [
+            "FAILED tests/test_api.py::test_rate_limit - assert 0 == 1\n1 failed in 0.42s\n",
+            "thread 'main' panicked at src/lib.rs:9:5:\nassertion `left == right` failed\n",
+            "expected 'gcov' in the output, got ''\n",
+            // git ran, searched, and found nothing: exit 1 with no fatal.
+            "",
+        ] {
+            assert_eq!(working_tree_failure(1, output), None, "{output}");
+        }
+    }
+
+    #[test]
+    fn a_missing_command_and_a_missing_exec_bit_are_read_from_the_exit_code() {
+        assert_eq!(
+            working_tree_failure(127, "witness.sh: line 1: pytest: command not found\n"),
+            Some(Instrument::NotFound)
+        );
+        assert_eq!(
+            working_tree_failure(126, "bash: ./witness.sh: Permission denied\n"),
+            Some(Instrument::NotExecutable)
+        );
+    }
+
+    #[test]
+    fn a_shell_that_could_not_parse_the_witness_is_an_instrument_failure() {
+        for output in [
+            "bash: -c: line 1: syntax error near unexpected token `('\n",
+            "witness.sh: 3: Syntax error: \"(\" unexpected\n",
+            "bash: witness.sh: line 9: unexpected end of file\n",
+        ] {
+            assert_eq!(
+                working_tree_failure(2, output),
+                Some(Instrument::ShellSyntax),
+                "{output}"
+            );
+        }
+    }
+
+    /// #2872 witness.
+    ///
+    /// Fails on `main`, where a witness that cannot run returns `NOT DONE —
+    /// the witness test fails on your NEW code. Fix the implementation (or the
+    /// test) and retry.` — an accusation against code the command never
+    /// reached, and the sentence that cost fifteen consecutive calls on the
+    /// 2026-08-11 panel.
+    ///
+    /// The *pair* is the assertion: one witness broken as an instrument and
+    /// one that runs and legitimately fails, same tool and same workspace,
+    /// must not come back as the same kind of answer. Asserting only the first
+    /// half would pass on a tool that called everything a broken instrument.
+    #[tokio::test]
+    async fn a_witness_that_cannot_run_is_not_reported_as_failing_code() {
+        let root = scaffold("instrument_working_tree").await;
+        std::fs::write(root.join("impl.txt"), "new behavior\n").unwrap();
+
+        // Broken as an instrument: git refuses the argv and searches nothing.
+        std::fs::write(
+            root.join("witness.sh"),
+            "git grep -q AKIA1234567890123456 AKIA1234567890123456\n",
+        )
+        .unwrap();
+        let broken = VerifyDone::default()
+            .execute(
+                &json!({
+                    "test_cmd": "bash witness.sh",
+                    "test_files": ["witness.sh"],
+                    "timeout_secs": 60
+                }),
+                &root,
+            )
+            .await;
+        let broken = match &broken {
+            ToolOutput::Error { message } => message.clone(),
+            other => panic!("expected a refusal, got {other:?}"),
+        };
+        assert!(
+            broken.contains("WITNESS UNRUNNABLE"),
+            "an instrument failure must be named as one: {broken}"
+        );
+        assert!(
+            !broken.contains("NOT DONE"),
+            "the tool accused the implementation for a command that never ran: {broken}"
+        );
+        assert!(
+            broken.contains("NOT evidence that your implementation is wrong"),
+            "the refusal must withhold the inference the old message invited: {broken}"
+        );
+        assert!(
+            broken.contains("UNPROVEN"),
+            "a refusal must never read as a pass: {broken}"
+        );
+
+        // Ran, and legitimately failed: the assertion is false on this tree.
+        std::fs::write(
+            root.join("witness.sh"),
+            "grep -q 'behaviour that does not exist' impl.txt\n",
+        )
+        .unwrap();
+        let genuine = VerifyDone::default()
+            .execute(
+                &json!({
+                    "test_cmd": "bash witness.sh",
+                    "test_files": ["witness.sh"],
+                    "timeout_secs": 60
+                }),
+                &root,
+            )
+            .await;
+        let genuine = match &genuine {
+            ToolOutput::Error { message } => message.clone(),
+            other => panic!("expected a refusal, got {other:?}"),
+        };
+        assert!(
+            genuine.contains("NOT DONE"),
+            "a witness that ran and failed is still evidence about the code: {genuine}"
+        );
+        assert!(
+            !genuine.contains("WITNESS UNRUNNABLE"),
+            "a real assertion failure must not be excused as a broken instrument: {genuine}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/stella-tools/src/verify/memo.rs
+++ b/crates/stella-tools/src/verify/memo.rs
@@ -159,6 +159,11 @@ struct State {
     /// would leave every turn after the first without a memo.
     armed: bool,
     entries: HashMap<ShadowKey, ShadowObservation>,
+    /// This turn's run of same-class rejections (#2863). It lives here rather
+    /// than in the tool for the reason the entries do: a `Tool` is handed an
+    /// input and a root and holds no turn state, and this bracket is the only
+    /// turn boundary a `ToolRegistry` is told about.
+    rejections: super::cap::Tally,
 }
 
 impl ShadowMemo {
@@ -168,11 +173,34 @@ impl ShadowMemo {
         let mut state = self.lock();
         state.armed = true;
         state.entries.clear();
+        state.rejections = super::cap::Tally::default();
     }
 
-    /// End the turn: every observation was true of *that* turn only.
+    /// End the turn: every observation was true of *that* turn only, and so
+    /// was the rejection run — a fresh turn is owed a fresh gate.
     pub fn invalidate(&self) {
-        self.lock().entries.clear();
+        let mut state = self.lock();
+        state.entries.clear();
+        state.rejections = super::cap::Tally::default();
+    }
+
+    /// Which rejection class has closed the gate for this turn, if any —
+    /// asked before a call so the refused one pays for no shadow (#2863).
+    ///
+    /// Inert without a bracket, exactly like [`Self::get`]: a host that marks
+    /// no turn boundaries has no turn to bound.
+    pub(super) fn gate_closed(&self) -> Option<super::phases::Verdict> {
+        let state = self.lock();
+        state.armed.then(|| state.rejections.closed()).flatten()
+    }
+
+    /// Fold one call's verdict into this turn's run.
+    pub(super) fn record_verdict(&self, verdict: super::phases::Verdict) {
+        let mut state = self.lock();
+        if !state.armed {
+            return;
+        }
+        state.rejections = state.rejections.record(verdict);
     }
 
     pub(super) fn get(&self, key: &ShadowKey) -> Option<ShadowObservation> {

--- a/crates/stella-tools/src/verify/phases.rs
+++ b/crates/stella-tools/src/verify/phases.rs
@@ -81,6 +81,10 @@ pub(crate) enum Verdict {
     NotDone,
     /// The baseline run died loading the test rather than asserting (#2067).
     InconclusiveBuildError,
+    /// The witness command never ran — a malformed argv, a missing
+    /// interpreter, a shell that could not parse it. A fact about the
+    /// instrument, not about the code (#2872).
+    InstrumentBroken,
     /// A named refusal — bad input, no repo, no resolvable baseline, a
     /// worktree that would not create.
     Error,
@@ -95,6 +99,7 @@ impl Verdict {
             Self::Vacuous => "vacuous",
             Self::NotDone => "not_done",
             Self::InconclusiveBuildError => "inconclusive_build_error",
+            Self::InstrumentBroken => "instrument_broken",
             Self::Error => "error",
         }
     }


### PR DESCRIPTION
## What

`verify_done` reported an **instrument** failure in the same channel as a
verdict about the **work**, so the agent could not tell which it had — and
nothing stopped it paying for the same answer again. Two changes, one root.

### 1. Tell a witness that did not run from code that is wrong (#2872, tool half)

`crates/stella-tools/src/verify/instrument.rs` classifies the working-tree
half's failure by whether the command **ran**: exit 127 / 126, a shell that
could not parse it, or a program that refused its own argv (git's
revision-versus-path fatal). Those return `WITNESS UNRUNNABLE`, which names the
mechanism, gives the one repair, and says in as many words that the exit is
*not* evidence the implementation is wrong. A witness that ran and legitimately
failed keeps its `NOT DONE` verdict, byte for byte.

On the 2026-08-11 Terminal-Bench panel this shape cost **fifteen consecutive
`verify_done` calls** chasing `fatal: ambiguous argument 'AKIA…': unknown
revision or path not in the working tree` in a witness Stella had authored
itself, then a contaminated control branch — 38 of 82 tool calls spent after
the task was already done, on a trial that scored 0.

The vocabulary is deliberately narrow, in `import_failure_signature`'s style,
and every exclusion is named: Python's `SyntaxError` stays out because a
fix-the-parse-error task witnesses one; the baseline half is not classified at
all, because it only runs once the working-tree half has passed, so anything
that is a property of the command or the staged witness text was already caught
— what is left is tree-dependent absence, which is `creation::confirm`'s
(#2668) and would be taken away from it.

### 2. Bound a rejection loop, honestly (#2863 item 1)

`crates/stella-tools/src/verify/cap.rs` bounds **consecutive rejections of the
same verdict class inside one turn**. The argument for that axis over the two
alternatives is in the module docs:

- a cap on **total calls** cannot tell a converging repair loop from a stuck
  one, and a cap that fires on the former takes away a proof the turn was about
  to earn — worse than no cap;
- a cap on **spend** cannot live here: a `Tool` is handed `(input, root)` and
  holds no budget, no turn clock, no session (filed as #3000);
- **same-class consecutive** is the signal that nothing is moving — the class is
  precisely what the last edit was supposed to change. Any change of class
  resets the run, so a converging turn is never capped however long it takes.

The third same-class call is refused **before** it resolves a baseline or checks
out a shadow. It is a refusal, never a pass: the message says the change is
UNPROVEN and must be reported as unwitnessed, so the bound cannot resurrect what
#2915 removed. The tally lives in `ShadowMemo` — the turn-scoped seam the
registry already brackets — and never in the `ToolOutput` text, which
`stella-core`'s loop detector keys on. Inert without a turn bracket, like the
memo.

## Witness tests

| Test | Fails on `main` because |
|---|---|
| `verify::instrument::tests::a_witness_that_cannot_run_is_not_reported_as_failing_code` | `main` answers `NOT DONE — the witness test fails on your NEW code (exit 128). Fix the implementation (or the test) and retry.` for a `git grep` argv bug. The test asserts the **pair**: the broken instrument and a witness that runs and genuinely fails must not come back as the same kind of answer, so it also fails a tool that excuses everything. |
| `verify::cap::tests::the_third_same_class_rejection_builds_no_shadow_and_reports_unproven` | `main` re-derives the same `VACUOUS` forever. Asserts both halves: the third call builds no shadow (counted by a witness script that fires only inside the shadow worktree) and reports UNPROVEN rather than a manufactured pass. |

Both verified artisanally by reverting the production hunk and keeping the test:
each goes red with the exact `main` message quoted above, then green.

## Deleted / moved tests

`import_failure_signatures_are_narrow` **moved verbatim** from `verify.rs` into
`verify/instrument.rs`, together with `import_failure_signature` itself — same
family of question, and `verify.rs` sat one line under the hard 1500-line
ceiling (it is not in `scripts/file-size-baseline.txt`). No test was deleted; no
baseline was raised. `verify.rs` ends 15 lines smaller than it started.

## Not in this PR, and not claimed

The **pipeline** half of #2872 — screening an author-written witness whose
*baseline* run died on a shell parse error, and the `WitnessUnsatisfiable`
routing — is absent, so this PR says `Refs #2872`, not `Closes`. It is not a
design gap: an end-to-end witness needs a test runner double that can carry a
specific `stderr_tail`, and today's `ScriptedRunner` carries booleans and lives
in `pipeline/tests.rs`, which is exactly at its baseline ceiling. Shipping that
screen without a witness would be a declaration nothing proves. Filed as a full
handoff in **#3001**, including the god-file constraint on the second item.

`make gate`: green in full (exit 0), including `file-size`, `god-files`,
`typed-errors`, `doc-warnings`, clippy at `-D warnings`, the workspace test
suite and the self-driving harness.

## Issues filed

- **#3000** — bound the share of wall budget the gate may consume (#2863 item 2 / #2668 item 2), which cannot live in a `Tool`.
- **#3001** — the pipeline half of #2872, with the test-double and god-file blockers written out.

Closes #2863
Refs #2872, #2668, #2871, #2915, #2983

## Summary by Sourcery

Differentiate witness command failures from code failures and introduce a per-turn cap on repeated verification rejections.

Bug Fixes:
- Report non-running witness commands as instrument failures instead of `NOT DONE` verdicts against the new code.
- Prevent unbounded repeated verification of the same rejection class in a single turn by refusing the third identical verdict.

Enhancements:
- Add an `InstrumentBroken` verdict class and dedicated messaging to clarify that certain failures are about the test command, not the implementation.
- Centralize import/loader failure classification into a dedicated `instrument` module with a narrowly defined vocabulary.
- Track per-turn verdict runs in `ShadowMemo` so verification behavior respects turn boundaries while remaining inert for unbracketed hosts.

Tests:
- Add tests ensuring witnesses that cannot run are distinguished from genuinely failing code and still preserve real assertion failures.
- Add tests verifying the rejection cap skips shadow creation on the capped call, reports the change as unproven, and remains inactive without a turn bracket.
- Move and retain coverage for the narrow import failure signature classifier in its new module.