### PR TITLE
feat(arenabench): register nemo-agent, openhands-sdk, pi as launchable agents

### DIFF
--- a/arenabench/arenabench/agents.py
+++ b/arenabench/arenabench/agents.py
@@ -258,6 +258,24 @@ AGENTS: dict[str, AgentSpec] = {
         _builtin("mini-swe-agent", "Mini SWE-Agent", "Minimal SWE-bench scaffold."),
         _builtin("swe-agent", "SWE-Agent", "Princeton's SWE-agent scaffold."),
         _builtin("openhands", "OpenHands", "All-Hands OpenHands."),
+        _builtin(
+            "openhands-sdk",
+            "OpenHands SDK",
+            "Lightweight OpenHands Software Agent SDK, run directly in the "
+            "container without the full OpenHands Docker runtime.",
+        ),
+        _builtin(
+            "pi",
+            "Pi",
+            "Pi Coding Agent, run headless via 'pi --print --mode json'.",
+        ),
+        _builtin(
+            "nemo-agent",
+            "NeMo Agent Toolkit",
+            "NVIDIA's text-I/O agent framework. Only text-based verifiers "
+            "(no filesystem changes) can score it, so it is a poor seat for "
+            "most coding tasks in this dataset.",
+        ),
         _builtin("terminus-2", "Terminus 2", "Harbor's reference terminal agent."),
         _builtin("nop", "No-op", "Does nothing. A free floor for the scoreboard."),
         _builtin("oracle", "Oracle", "Applies the reference solution. A ceiling."),

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -416,6 +416,20 @@ def test_every_registered_agent_declares_how_it_launches(monkeypatch, import_pat
         assert launch_flags(seat), slug
 
 
+def test_the_registry_declares_every_agent_harbor_actually_installs():
+    """Harbor 0.6.1's `AgentFactory._AGENTS` is the ground truth for what
+    `--agent <slug>` can launch; `nemo-agent`, `openhands-sdk`, and `pi` were
+    installed there but absent from this registry, so an operator asking for
+    any of them by slug got `resolve_agent`'s "unknown agent" error despite
+    the CLI being real. `terminus`/`terminus-1` are deliberately excluded:
+    they exist as `AgentName` enum members but no class is registered for
+    them in Harbor's factory, so they are not actually launchable either.
+    """
+    for slug in ("nemo-agent", "openhands-sdk", "pi"):
+        spec = resolve_agent(slug)
+        assert spec.harbor_agent == slug
+
+
 class TestRecorder:
     """The recorder is optional, so its failures must stay cheap and quiet.
 


### PR DESCRIPTION
## Summary
- Harbor 0.6.1's `AgentFactory` (checked directly against the installed `harbor==0.6.1` package's `harbor/agents/factory.py`) actually registers 22 agent classes, three of which (`nemo-agent`, `openhands-sdk`, `pi`) were never declared in ArenaBench's `AGENTS` registry (`arenabench/arenabench/agents.py`), so `resolve_agent()` rejected them as unknown despite the CLI being real and installable.
- Added plain `_builtin(...)` entries for all three, following the same pattern as `opencode`/`openhands` (model-only honours — none of the three has env-var-backed effort/reasoning/base-url plumbing arenabench can actually drive, so nothing beyond `KNOB_MODEL` is claimed).
- `terminus`/`terminus-1` remain unregistered on purpose: they exist as `AgentName` enum values but have no class in Harbor's `_AGENT_MAP`, so they are not actually launchable.

## Context
This started from a much larger Dockerfile listing ~25 agent CLIs. Cross-checking each one against Harbor's actual installed factory found only these three genuine gaps; the rest either already had registry entries or aren't Harbor built-ins at all (filed as #3012 for anyone who wants to build native adapters for those).

## Test plan
- [x] Added `test_the_registry_declares_every_agent_harbor_actually_installs` to `tests/test_arena.py` — verified it fails with `KeyError: unknown agent 'nemo-agent'` on the pre-change registry (`git stash` on `agents.py` alone) and passes with the fix.
- [x] `python3 -m pytest tests/test_arena.py -q` — all pass.
- [x] `python3 -m pytest tests -q` — only pre-existing, unrelated `test_sut.py` failures (missing `tomllib` on the system interpreter for the Stella Harbor adapter), confirmed to fail identically with my change stashed out.

## Summary by Sourcery

Register Harbor-installed agents nemo-agent, openhands-sdk, and pi in the ArenaBench agent registry so they can be launched by slug, and add a test ensuring all Harbor-bundled agents are declared in the registry.

New Features:
- Expose nemo-agent, openhands-sdk, and pi as launchable built-in agents in ArenaBench.

Tests:
- Add a test that verifies every agent installed in Harbor's AgentFactory is present in the ArenaBench agent registry and correctly resolved.