### PR TITLE
fix(stella-tools): give the mount-namespace recipe CAP_SYS_ADMIN it doesn't have

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-cli"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "clap",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "proptest",
  "serde",
@@ -3140,11 +3140,11 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.9.12"
+version = "0.9.13"
 
 [[package]]
 name = "stella-embed"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "stella-engine"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "serde",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3219,11 +3219,11 @@ dependencies = [
 
 [[package]]
 name = "stella-home"
-version = "0.9.12"
+version = "0.9.13"
 
 [[package]]
 name = "stella-mcp"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "libc",
  "rusqlite",
@@ -3310,14 +3310,14 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "stella-serve",
 ]
 
 [[package]]
 name = "stella-pipeline"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "schemars",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "serde",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "base64 0.23.1",
  "libc",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "arboard",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-cli"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "clap",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "proptest",
  "serde",
@@ -3140,11 +3140,11 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.9.11"
+version = "0.9.12"
 
 [[package]]
 name = "stella-embed"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "stella-engine"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "serde",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3219,11 +3219,11 @@ dependencies = [
 
 [[package]]
 name = "stella-home"
-version = "0.9.11"
+version = "0.9.12"
 
 [[package]]
 name = "stella-mcp"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "libc",
  "rusqlite",
@@ -3310,14 +3310,14 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "stella-serve",
 ]
 
 [[package]]
 name = "stella-pipeline"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "schemars",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "serde",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "base64 0.23.1",
  "libc",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "arboard",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.11"
+version = "0.9.12"
 edition = "2024"
 rust-version = "1.90"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.12"
+version = "0.9.13"
 edition = "2024"
 rust-version = "1.90"
 license = "AGPL-3.0-only"

--- a/crates/stella-tools/src/bash/contain.rs
+++ b/crates/stella-tools/src/bash/contain.rs
@@ -19,9 +19,16 @@
 //!   graded subpath. The profile is inherited by every descendant of the
 //!   shell, which is what makes it a boundary rather than a check on the first
 //!   process.
-//! * **Linux** — a private mount namespace (`unshare --mount`) in which each
-//!   graded tree is bind-mounted back over itself read-only. `MS_RDONLY` is
-//!   enforced against root, which the container case needs.
+//! * **Linux** — a private mount namespace (`unshare --user --map-root-user
+//!   --mount`) in which each graded tree is bind-mounted back over itself
+//!   read-only. `MS_RDONLY` is enforced against root, which the container
+//!   case needs. The user-namespace pair is load-bearing, not decoration:
+//!   changing a pre-existing mount's propagation type requires `CAP_SYS_ADMIN`
+//!   in the user namespace that *owns* that mount, and an unprivileged CI
+//!   runner process has no such capability in the initial namespace it was
+//!   born into — `--user --map-root-user` gives it root, and therefore
+//!   `CAP_SYS_ADMIN`, inside a namespace of its own before `--mount` runs
+//!   (#3010).
 //!
 //! Neither is available everywhere, and a facility that is *present* is not
 //! the same as one that *works* — an unprivileged container, a missing
@@ -207,6 +214,8 @@ fn wrap_argv(
         Mechanism::MountNamespace => {
             let script = mount_script(protected, exempt)?;
             let argv = vec![
+                "--user".to_string(),
+                "--map-root-user".to_string(),
                 "--mount".to_string(),
                 "--propagation".to_string(),
                 "private".to_string(),

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.9.12"
-  version "0.9.12"
+  url "https://github.com/macanderson/stella.git", tag: "v0.9.13"
+  version "0.9.13"
   license "AGPL-3.0-only"
   head "https://github.com/macanderson/stella.git", branch: "main"
   depends_on "rust" => :build

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.9.11"
-  version "0.9.11"
+  url "https://github.com/macanderson/stella.git", tag: "v0.9.12"
+  version "0.9.12"
   license "AGPL-3.0-only"
   head "https://github.com/macanderson/stella.git", branch: "main"
   depends_on "rust" => :build


### PR DESCRIPTION
## Summary

Refs #3010, #2931, #2998.

PR #3011's new `containment-posture.yml` supplied the missing evidence #3010 was waiting on: on a real GitHub Actions `ubuntu-latest` runner, `unshare --mount --propagation private` reports `ProbeFailed`, the same permission-denied failure the issue reproduced under Docker — not a Docker-specific artifact.

`unshare --mount --propagation private` needs to change the propagation type of an inherited mount (the root filesystem). That requires `CAP_SYS_ADMIN` in the user namespace that *owns* that mount — and an unprivileged CI runner process has no such capability in the initial namespace it was born into. `--user --map-root-user` creates a fresh user namespace and maps the caller to uid 0 inside it, giving it root — and therefore `CAP_SYS_ADMIN` — in a namespace of its own before `--mount` runs. This is the standard recipe rootless container tools (podman/buildah/bubblewrap) use for the same reason.

- `wrap_argv`'s `MountNamespace` arm now prepends `--user --map-root-user` to the `unshare` invocation.
- Module doc comment updated to state and justify the recipe.
- No change to `mount_script` itself — once inside the new user+mount namespace pair, the process already holds the capability the bind/remount sequence needs.

## Test plan

- [x] `cargo test -p stella-tools --lib bash::contain` — 6/6 pass (pure `wrap_argv`/`mount_script` unit tests, platform-independent).
- [x] `cargo fmt -p stella-tools --check`, `cargo clippy -p stella-tools --all-targets -- -D warnings` — clean.
- [ ] `containment-posture.yml` (non-required, informational) on this PR is the actual verification: if it reports `Enforced(MountNamespace)`, #3010 is resolved; if it still reports `Advisory(ProbeFailed)` (e.g. Ubuntu 24.04 AppArmor's `unprivileged_userns_restrict` blocking unconfined user-namespace creation), the recipe needs more plumbing and this PR should not merge as-is — I don't have a Linux host to verify the kernel behavior directly, so this run is the evidence, not a guess dressed as one.

## Summary by Sourcery

Adjust Linux containment to use a user+mount namespace pair so mount-namespace probing works on unprivileged CI runners.

Enhancements:
- Update mount-namespace invocation to include user namespace creation with mapped root user before establishing the private mount namespace.
- Expand module documentation to explain the dependency on CAP_SYS_ADMIN and reference the related issue.