### PR TITLE
fix(arenabench): merge a cloud fetch's per-arm files into one trial

### DIFF
--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -1113,6 +1113,7 @@ def _cmd_cloud_run(args: Any, executor: CloudExecutor | None = None) -> int:
             run_id, jobs, dest, artifacts=args.artifacts
         )
         print(f"results   : {fetched} file(s) -> {dest}")
+        _merge_and_report(dest)
     return 0 if final.failed == 0 else 1
 
 
@@ -1142,7 +1143,66 @@ def _cmd_cloud_fetch(args: Any, executor: CloudExecutor | None = None) -> int:
         args.run_id, record["jobs"], dest, artifacts=args.artifacts
     )
     print(f"results   : {fetched} file(s) -> {dest}")
+    _merge_and_report(dest)
     return 0
+
+
+def _cmd_cloud_merge(args: Any) -> int:
+    """``arenabench cloud merge <dest...> --out <dir>`` — pair arms fetched separately."""
+    from . import cloud_merge
+
+    bodies: list[dict[str, Any]] = []
+    for raw in args.dest:
+        bodies.extend(cloud_merge.load_fetched_results(Path(raw).expanduser()))
+    if not bodies:
+        print(f"no results.json found under: {', '.join(args.dest)}")
+        return 1
+    try:
+        merged = cloud_merge.merge_trial(bodies)
+    except cloud_merge.MergeError as exc:
+        print(f"error: {exc}")
+        return 2
+    out_dir = Path(args.out).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = cloud_merge.write_merged_trial(out_dir, merged)
+    tasks = len(merged["match"]["tasks"])
+    seats = len(merged["match"]["contestants"])
+    print(f"trial     : {tasks} task(s) x {seats} contestant(s) -> {target}")
+    if merged["incomplete_tasks"]:
+        print(
+            f"            {len(merged['incomplete_tasks'])} task(s) missing at "
+            "least one arm's cell — see trial.json's incomplete_tasks"
+        )
+    return 0
+
+
+def _merge_and_report(dest: Path, out: Callable[[str], None] = print) -> None:
+    """Regroup whatever ``fetch_results`` just wrote into one trial.
+
+    A no-op with a one-line note when nothing fetched (a run still in
+    flight) or when the fetched bodies don't merge (mixed datasets) — a
+    fetch that produced flat per-job files must not fail just because the
+    trial-level view could not be built from them.
+    """
+    from . import cloud_merge
+
+    bodies = cloud_merge.load_fetched_results(dest)
+    if not bodies:
+        return
+    try:
+        merged = cloud_merge.merge_trial(bodies)
+    except cloud_merge.MergeError as exc:
+        out(f"trial     : not merged — {exc}")
+        return
+    cloud_merge.write_merged_trial(dest, merged)
+    tasks = len(merged["match"]["tasks"])
+    seats = len(merged["match"]["contestants"])
+    out(f"trial     : {tasks} task(s) x {seats} contestant(s) -> {dest / 'trial.json'}")
+    if merged["incomplete_tasks"]:
+        out(
+            f"            {len(merged['incomplete_tasks'])} task(s) missing at "
+            "least one arm's cell — see trial.json's incomplete_tasks"
+        )
 
 
 def _cmd_cloud_watch(args: Any, executor: CloudExecutor | None = None) -> int:
@@ -1278,3 +1338,20 @@ def register_cli(subparsers: Any) -> None:
     fetch.add_argument("--out", help="local directory for downloaded results")
     _common_aws_arguments(fetch)
     fetch.set_defaults(func=_cmd_cloud_fetch)
+
+    merge = verbs.add_parser(
+        "merge",
+        help="regroup one or more already-fetched destinations into one trial",
+    )
+    merge.add_argument(
+        "dest",
+        nargs="+",
+        help="a `cloud fetch`/`cloud run` --out directory; pass more than one "
+             "to pair arms that were fetched separately (e.g. two runs "
+             "submitted as independent single-arm matches)",
+    )
+    merge.add_argument(
+        "--out", required=True,
+        help="directory to write the merged trial.json into",
+    )
+    merge.set_defaults(func=_cmd_cloud_merge)

--- a/arenabench/arenabench/cloud_merge.py
+++ b/arenabench/arenabench/cloud_merge.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Merge fetched cloud results into one trial (#2100 offline half).
+
+A cloud match is submitted and scored one Batch job per (task, contestant) —
+correct, because container isolation needs it — but nothing regrouped the
+fetched output: :func:`arenabench.cloud.CloudExecutor.fetch_results` wrote one
+``results.json`` per job, so a two-arm, 89-task run landed locally as 178
+disconnected single-cell files with no trial-level view at all. This module is
+the regrouping step, run automatically by ``cloud fetch``/``cloud run`` on
+whatever one call fetched, and separately by ``cloud merge`` across two or
+more already-fetched destinations for a match whose arms were submitted as
+independent runs (a real workflow: an arm re-run after a credential rotation,
+or two arms deliberately launched hours apart).
+
+Same honesty rule as :mod:`.cloud_watch`: every number in the merged trial is
+copied or summed from a real per-task ``results.json`` a finished job wrote.
+Nothing is inferred, and a task only one arm has is reported, never silently
+dropped or padded with a fabricated cell for the other arm.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "MergeError",
+    "load_fetched_results",
+    "merge_trial",
+    "write_merged_trial",
+]
+
+
+class MergeError(ValueError):
+    """A fetched results.json set cannot be merged into one trial."""
+
+
+def load_fetched_results(dest: Path) -> list[dict[str, Any]]:
+    """Every ``results.json`` :func:`fetch_results` wrote under ``dest``.
+
+    One file per ``<job-label>/results.json``, sorted by label so a merge is
+    reproducible across re-runs of the same fetch.
+    """
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(dest.glob("*/results.json"))
+    ]
+
+
+def _totals(cells: list[dict[str, Any]]) -> dict[str, Any]:
+    """One contestant's aggregate across the real per-task cells it has.
+
+    Every field is a sum or count over values a finished trial already wrote
+    to its own ``results.json`` — combined here, never invented. A task this
+    contestant has no cell for (see ``merge_trial``) is excluded from ``n``
+    entirely rather than counted as a loss, which is what would happen if a
+    missing cell were padded with a zero-reward placeholder.
+    """
+    judged = [c for c in cells if c.get("reward") is not None]
+    passed = sum(1 for c in judged if (c.get("reward") or 0) >= 1.0)
+
+    def total(key: str) -> float:
+        return sum((c.get(key) or 0) for c in cells)
+
+    return {
+        "trials": len(cells),
+        "infrastructure": sum(1 for c in cells if c.get("infrastructure")),
+        "running": sum(1 for c in cells if c.get("status") == "running"),
+        "done": sum(1 for c in cells if c.get("status") == "done"),
+        "judged": len(judged),
+        "passed": passed,
+        "solve_rate": (passed / len(judged) * 100.0) if judged else 0.0,
+        "clock_time": total("clock_time"),
+        "tokens_in": total("tokens_in"),
+        "tokens_out": total("tokens_out"),
+        "cache_read": total("cache_read"),
+        "cache_write": total("cache_write"),
+        "total_cost": total("total_cost"),
+        "priced_cost": total("priced_cost"),
+    }
+
+
+def merge_trial(bodies: list[dict[str, Any]]) -> dict[str, Any]:
+    """Regroup N single-task ``results.json`` bodies into one trial.
+
+    Each ``body`` is exactly what a finished cloud job wrote: one task in
+    ``match.tasks`` and one contestant in ``match.contestants``/``rows[0].cells``.
+    Raises :class:`MergeError` on an empty input or on bodies that do not
+    share one dataset — merging across datasets would silently average two
+    different benchmarks into one number.
+
+    Returns a dict shaped like a native multi-task, multi-contestant match
+    snapshot (``match.tasks``, ``match.contestants`` with recomputed
+    ``totals``, and one ``rows`` entry per task carrying whichever
+    contestants actually have a cell for it). ``incomplete_tasks`` lists any
+    task at least one contestant is missing, so a caller can surface the gap
+    instead of it being invisible in an all-arms-present-looking grid.
+    """
+    if not bodies:
+        raise MergeError("no results.json bodies to merge")
+
+    datasets = {body["match"]["dataset"] for body in bodies}
+    if len(datasets) > 1:
+        raise MergeError(f"refusing to merge across datasets: {sorted(datasets)}")
+
+    # task -> contestant_id -> cell
+    grid: dict[str, dict[str, dict[str, Any]]] = {}
+    contestants: dict[str, dict[str, Any]] = {}
+    for body in bodies:
+        match = body["match"]
+        tasks = match["tasks"]
+        contestant = match["contestants"][0]
+        cid = contestant["id"]
+        if len(tasks) != 1:
+            raise MergeError(
+                f"expected one task per fetched job, got {tasks} for {cid}"
+            )
+        task = tasks[0]
+        cell = body["rows"][0]["cells"][cid]
+        grid.setdefault(task, {})
+        if cid in grid[task]:
+            raise MergeError(f"duplicate ({task}, {cid}) — two jobs scored the same cell")
+        grid[task][cid] = cell
+        contestants.setdefault(cid, contestant)
+
+    contestant_ids = sorted(contestants)
+    tasks_sorted = sorted(grid)
+    incomplete_tasks = {
+        task: sorted(set(contestant_ids) - set(cells))
+        for task, cells in grid.items()
+        if set(cells) != set(contestant_ids)
+    }
+
+    merged_contestants = []
+    for cid in contestant_ids:
+        cells = [grid[task][cid] for task in tasks_sorted if cid in grid[task]]
+        merged_contestants.append({**contestants[cid], "totals": _totals(cells)})
+
+    rows = [
+        {"task": task, "cells": dict(grid[task])} for task in tasks_sorted
+    ]
+
+    any_body = bodies[0]
+    return {
+        "match": {
+            "id": any_body["match"].get("id", ""),
+            "name": any_body["match"].get("name", ""),
+            "dataset": any_body["match"]["dataset"],
+            "tasks": tasks_sorted,
+            "contestants": merged_contestants,
+        },
+        "dataset": any_body.get("dataset"),
+        "status": "finished",
+        "rows": rows,
+        "contestants": merged_contestants,
+        "incomplete_tasks": incomplete_tasks,
+    }
+
+
+def write_merged_trial(dest: Path, merged: dict[str, Any]) -> Path:
+    """Write ``merged`` to ``dest/trial.json`` and return the path."""
+    target = dest / "trial.json"
+    target.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+    return target

--- a/arenabench/arenabench/cloud_merge.py
+++ b/arenabench/arenabench/cloud_merge.py
@@ -64,6 +64,24 @@ def _totals(cells: list[dict[str, Any]]) -> dict[str, Any]:
     def total(key: str) -> float:
         return sum((c.get(key) or 0) for c in cells)
 
+    # `priced_cost` follows the #2132 null-poisoning rule, not a plain sum: a
+    # cell whose model could not be priced carries `priced_cost: None` (with
+    # `usage_measured: True`), and summing that as `0` would silently drop its
+    # spend, reporting a merged seat cheaper than reality with nothing marking
+    # it a subset. Report `None` — "unknown, never smaller" — whenever a
+    # measured cell was left unpriced, matching `telemetry.aggregate` and
+    # `series._seat_outcomes`. A cell that measured no usage at all does not
+    # poison (it has no tokens to be short by); `None` too when no cell had a
+    # priced model, so the column reads empty rather than as a free run.
+    if any(c.get("priced_cost") is None and c.get("usage_measured") for c in cells):
+        priced_cost: float | None = None
+    elif any(c.get("priced_cost") is not None for c in cells):
+        priced_cost = sum(
+            c["priced_cost"] for c in cells if c.get("priced_cost") is not None
+        )
+    else:
+        priced_cost = None
+
     return {
         "trials": len(cells),
         "infrastructure": sum(1 for c in cells if c.get("infrastructure")),
@@ -78,7 +96,7 @@ def _totals(cells: list[dict[str, Any]]) -> dict[str, Any]:
         "cache_read": total("cache_read"),
         "cache_write": total("cache_write"),
         "total_cost": total("total_cost"),
-        "priced_cost": total("priced_cost"),
+        "priced_cost": priced_cost,
     }
 
 

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -33,6 +33,8 @@ from arenabench.cloud import (
     MEASURE_QUEUE,
     CloudError,
     CloudExecutor,
+    _cmd_cloud_fetch,
+    _cmd_cloud_merge,
     _cmd_cloud_run,
     is_moving_ref,
     job_name,
@@ -923,6 +925,123 @@ class TestFetchResults:
         assert any("001-cc-task-a" in note for note in notes), (
             "a missing results.json must be said out loud, not skipped silently"
         )
+
+
+def _single_task_result(task: str, contestant_id: str, reward: float) -> bytes:
+    body = {
+        "match": {
+            "id": f"{contestant_id}-{task}",
+            "name": "smoke",
+            "dataset": "terminal-bench-2.1",
+            "tasks": [task],
+            "contestants": [{"id": contestant_id, "name": contestant_id}],
+        },
+        "dataset": {"key": "terminal-bench-2.1"},
+        "rows": [
+            {
+                "task": task,
+                "cells": {
+                    contestant_id: {
+                        "task": task,
+                        "status": "done",
+                        "reward": reward,
+                        "resolved": reward >= 1.0,
+                        "infrastructure": False,
+                        "tokens_in": 10,
+                        "tokens_out": 10,
+                        "clock_time": 1.0,
+                        "total_cost": 0.01,
+                        "priced_cost": 0.01,
+                        "cache_read": 0,
+                        "cache_write": 0,
+                    }
+                },
+            }
+        ],
+    }
+    return json.dumps(body).encode()
+
+
+class TestFetchMergesIntoOneTrial:
+    """The offline half of the importer bug: a fetch that used to leave N
+    disconnected single-task files now also writes one trial.json spanning
+    every task both arms ran — proven by driving the real CLI verb, not just
+    the pure merge function underneath it.
+    """
+
+    def test_cloud_fetch_writes_a_merged_trial_alongside_the_flat_files(
+        self, tmp_path
+    ) -> None:
+        s3 = FakeS3(
+            {
+                "runs/r1/job-stella/results.json": _single_task_result(
+                    "task-a", "stella", 1.0
+                ),
+                "runs/r1/job-cc/results.json": _single_task_result(
+                    "task-a", "claude-code", 0.0
+                ),
+            }
+        )
+        dynamo = FakeDynamo([{"Items": []}])
+        jobs = [
+            {"id": "job-stella", "label": "000-stella-task-a"},
+            {"id": "job-cc", "label": "001-cc-task-a"},
+        ]
+        executor = _executor(s3=s3, dynamodb=dynamo)
+        executor.load_jobs = lambda run_id: {"jobs": jobs}  # type: ignore[method-assign]
+
+        args = argparse.Namespace(
+            run_id="r1", artifacts=False, out=str(tmp_path), region=None, bucket=None
+        )
+        rc = _cmd_cloud_fetch(args, executor=executor)
+
+        assert rc == 0
+        trial = json.loads((tmp_path / "trial.json").read_text())
+        assert trial["match"]["tasks"] == ["task-a"]
+        assert {c["id"] for c in trial["match"]["contestants"]} == {
+            "stella",
+            "claude-code",
+        }
+        # The bug this fixes: previously only the two flat per-job files
+        # existed, with no view spanning both arms of task-a.
+        assert (tmp_path / "000-stella-task-a" / "results.json").exists()
+        assert (tmp_path / "001-cc-task-a" / "results.json").exists()
+
+
+class TestCloudMerge:
+    """`arenabench cloud merge` — pairing arms that were fetched separately."""
+
+    def test_merges_two_already_fetched_destinations(self, tmp_path) -> None:
+        arm_a = tmp_path / "run-a"
+        arm_b = tmp_path / "run-b"
+        out = tmp_path / "merged"
+        (arm_a / "000-stella-task-a").mkdir(parents=True)
+        (arm_a / "000-stella-task-a" / "results.json").write_bytes(
+            _single_task_result("task-a", "stella", 1.0)
+        )
+        (arm_b / "000-cc-task-a").mkdir(parents=True)
+        (arm_b / "000-cc-task-a" / "results.json").write_bytes(
+            _single_task_result("task-a", "claude-code", 0.0)
+        )
+
+        args = argparse.Namespace(dest=[str(arm_a), str(arm_b)], out=str(out))
+        rc = _cmd_cloud_merge(args)
+
+        assert rc == 0
+        trial = json.loads((out / "trial.json").read_text())
+        assert trial["match"]["tasks"] == ["task-a"]
+        assert {c["id"] for c in trial["match"]["contestants"]} == {
+            "stella",
+            "claude-code",
+        }
+
+    def test_no_results_anywhere_is_reported_not_a_silent_no_op(
+        self, tmp_path, capsys
+    ) -> None:
+        args = argparse.Namespace(dest=[str(tmp_path)], out=str(tmp_path / "out"))
+        rc = _cmd_cloud_merge(args)
+        assert rc == 1
+        assert "no results.json found" in capsys.readouterr().out
 
 
 # --------------------------------------------------------------------------

--- a/arenabench/tests/test_cloud_merge.py
+++ b/arenabench/tests/test_cloud_merge.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Regrouping fetched single-task results.json bodies into one trial."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from arenabench.cloud_merge import (
+    MergeError,
+    load_fetched_results,
+    merge_trial,
+    write_merged_trial,
+)
+
+
+def _body(
+    task: str,
+    contestant_id: str,
+    *,
+    reward: float | None,
+    dataset: str = "terminal-bench-2.1",
+    tokens_in: int = 100,
+) -> dict:
+    return {
+        "match": {
+            "id": f"{contestant_id}-{task}",
+            "name": "smoke",
+            "dataset": dataset,
+            "tasks": [task],
+            "contestants": [{"id": contestant_id, "name": contestant_id}],
+        },
+        "dataset": {"key": dataset},
+        "rows": [
+            {
+                "task": task,
+                "cells": {
+                    contestant_id: {
+                        "task": task,
+                        "status": "done",
+                        "reward": reward,
+                        "resolved": None if reward is None else reward >= 1.0,
+                        "infrastructure": False,
+                        "tokens_in": tokens_in,
+                        "tokens_out": tokens_in,
+                        "clock_time": 10.0,
+                        "total_cost": 0.01,
+                        "priced_cost": 0.02,
+                        "cache_read": 0,
+                        "cache_write": 0,
+                    }
+                },
+            }
+        ],
+    }
+
+
+def test_merges_two_arms_across_every_task_into_one_trial() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=1.0),
+        _body("task-b", "stella", reward=0.0),
+        _body("task-a", "claude-code", reward=0.0),
+        _body("task-b", "claude-code", reward=1.0),
+    ]
+    merged = merge_trial(bodies)
+    assert merged["match"]["tasks"] == ["task-a", "task-b"]
+    assert {c["id"] for c in merged["match"]["contestants"]} == {"stella", "claude-code"}
+    assert len(merged["rows"]) == 2
+    assert set(merged["rows"][0]["cells"]) == {"stella", "claude-code"}
+    assert merged["incomplete_tasks"] == {}
+
+
+def test_this_is_the_bug_being_fixed_flat_files_have_no_trial_view() -> None:
+    """The witness: before this module existed, N fetched results.json files
+    were the whole story — nothing combined a run's two arms into one trial
+    spanning every task. This asserts the fix actually produces that view.
+    """
+    bodies = [
+        _body(f"task-{i}", arm, reward=float(i % 2))
+        for i in range(5)
+        for arm in ("a", "b")
+    ]
+    merged = merge_trial(bodies)
+    assert len(merged["match"]["tasks"]) == 5
+    assert len(merged["match"]["contestants"]) == 2
+    # One row per task, not one row per (task, arm) — the defect this fixes.
+    assert len(merged["rows"]) == 5
+
+
+def test_totals_sum_real_recorded_values_not_invented_ones() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=1.0, tokens_in=100),
+        _body("task-b", "stella", reward=0.0, tokens_in=200),
+    ]
+    merged = merge_trial(bodies)
+    totals = merged["match"]["contestants"][0]["totals"]
+    assert totals["trials"] == 2
+    assert totals["judged"] == 2
+    assert totals["passed"] == 1
+    assert totals["solve_rate"] == 50.0
+    assert totals["tokens_in"] == 300
+
+
+def test_a_task_missing_one_arms_cell_is_reported_not_hidden_or_faked() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=1.0),
+        _body("task-a", "claude-code", reward=1.0),
+        _body("task-b", "stella", reward=1.0),  # claude-code never ran task-b
+    ]
+    merged = merge_trial(bodies)
+    assert merged["incomplete_tasks"] == {"task-b": ["claude-code"]}
+    # claude-code's totals only count the one task it actually has.
+    cc_totals = next(
+        c["totals"] for c in merged["match"]["contestants"] if c["id"] == "claude-code"
+    )
+    assert cc_totals["trials"] == 1
+
+
+def test_an_unjudged_trial_is_excluded_from_solve_rate_not_scored_zero() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=None),
+        _body("task-b", "stella", reward=1.0),
+    ]
+    merged = merge_trial(bodies)
+    totals = merged["match"]["contestants"][0]["totals"]
+    assert totals["trials"] == 2
+    assert totals["judged"] == 1
+    assert totals["passed"] == 1
+    assert totals["solve_rate"] == 100.0
+
+
+def test_refuses_to_merge_across_datasets() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=1.0, dataset="terminal-bench-2.1"),
+        _body("task-a", "claude-code", reward=1.0, dataset="terminal-bench-1.0"),
+    ]
+    with pytest.raises(MergeError, match="dataset"):
+        merge_trial(bodies)
+
+
+def test_refuses_two_jobs_scoring_the_same_cell() -> None:
+    bodies = [
+        _body("task-a", "stella", reward=1.0),
+        _body("task-a", "stella", reward=0.0),
+    ]
+    with pytest.raises(MergeError, match="duplicate"):
+        merge_trial(bodies)
+
+
+def test_empty_input_is_a_merge_error_not_a_crash() -> None:
+    with pytest.raises(MergeError):
+        merge_trial([])
+
+
+def test_load_fetched_results_reads_every_label_dir(tmp_path) -> None:
+    (tmp_path / "000-stella-task-a").mkdir()
+    (tmp_path / "000-stella-task-a" / "results.json").write_text(
+        json.dumps(_body("task-a", "stella", reward=1.0))
+    )
+    (tmp_path / "001-cc-task-a").mkdir()
+    (tmp_path / "001-cc-task-a" / "results.json").write_text(
+        json.dumps(_body("task-a", "claude-code", reward=0.0))
+    )
+    bodies = load_fetched_results(tmp_path)
+    assert len(bodies) == 2
+
+
+def test_write_merged_trial_round_trips(tmp_path) -> None:
+    bodies = [_body("task-a", "stella", reward=1.0)]
+    merged = merge_trial(bodies)
+    target = write_merged_trial(tmp_path, merged)
+    assert target == tmp_path / "trial.json"
+    assert json.loads(target.read_text())["match"]["tasks"] == ["task-a"]


### PR DESCRIPTION
## Summary
- `cloud fetch`/`cloud run` fetched one `results.json` per (task, contestant) Batch job — correct for container isolation — but nothing regrouped them, so a two-arm run landed locally as N×arms disconnected single-cell files with no trial-level view ("1 match per arm per task").
- Adds `arenabench/arenabench/cloud_merge.py`: a pure `merge_trial()` that regroups fetched `results.json` bodies into one match spanning every task, recomputing each contestant's totals from its own real per-task cells. Nothing is invented — a task only one arm has is reported in `incomplete_tasks`, never padded with a fake cell.
- Wires the merge into `cloud fetch`/`cloud run` automatically, and adds `cloud merge <dest...> --out <dir>` for arms fetched as separate runs (e.g. two independently-launched or re-dispatched runs).
- Kept as its own module (not grown into `cloud.py`) per the repo's file-size ratchet, matching the existing `cloud_watch.py`/`series.py` split pattern.

Local data was also fixed directly: `~/.arenabench/matches/f89-pipeline-vs-bareloop-89/` now holds one merged `trial.json` (+ `scoreboard.html`, + the 178 raw per-task source files) for the f89p3 (pipeline) vs f89b2 (bare-loop) 89-task run, re-fetched from S3 since the locally-fetched artifacts were missing every `results.json`.

Related to #2100 (teaching the live `:8900` arena to read the cloud substrate directly) but narrower — this fixes the offline fetch/import path only, not `restore_from_disk`.

## Test plan
- [x] `uv run pytest tests/test_cloud_merge.py tests/test_cloud.py -q` — all pass, including new CLI-level witness tests driving `_cmd_cloud_fetch`/`_cmd_cloud_merge` end-to-end
- [x] `uv run pytest -q` (full suite) — no new failures; the 5 pre-existing `test_sut.py` failures (missing Harbor adapter venv) reproduce identically on `main`
- [x] `uv run --with ruff --no-project ruff check .` (matches CI) — clean on every file this PR touches

## Summary by Sourcery

Regroup fetched per-job cloud results into a single trial-level view and expose it via the CLI.

New Features:
- Introduce a cloud_merge module that builds a merged trial.json from fetched single-task results.json files.
- Automatically produce a merged trial.json after cloud fetch and cloud run operations.
- Add an arenabench cloud merge CLI verb to combine results from multiple previously fetched destinations into one trial.

Enhancements:
- Report incomplete tasks and per-contestant totals in merged trial outputs without fabricating cells.

Tests:
- Add unit tests for the cloud_merge module covering merging behavior, error cases, and I/O helpers.
- Add CLI-level tests to verify cloud fetch writes a merged trial alongside per-job flat files and that cloud merge behaves correctly, including failures when no results are found.