### PR TITLE
fix(stella-graph): an embedding window is sized in readable files, not rows (#3016)

### DIFF
--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -130,6 +130,10 @@ async fn warm_semantic_index(
 /// that silently ranks a subset of the repository is worse than one that says
 /// which subset it ranked. The leftovers are not lost — the lazy per-query
 /// pass picks them up.
+///
+/// Unless they cannot be read, which is a different sentence and gets one: no
+/// later pass will pick those up, so "they embed on demand" would be a promise
+/// this code cannot keep (#3016).
 fn format_warm_outcome(
     outcome: &stella_tools::graph::semantic::WarmOutcome,
     model: &str,
@@ -139,10 +143,21 @@ fn format_warm_outcome(
         WarmOutcome::Warmed {
             embedded,
             remaining: 0,
+            ..
         } => format!("✓ semantic index: {embedded} files embedded by {model}"),
         WarmOutcome::Warmed {
             embedded,
             remaining,
+            unreadable,
+        } if *unreadable > 0 => format!(
+            "! semantic index: {embedded} files embedded by {model} — {remaining} left \
+             unembedded, {unreadable} of them because their content could not be read (the \
+             next `stella init` drops files that have moved or vanished)"
+        ),
+        WarmOutcome::Warmed {
+            embedded,
+            remaining,
+            ..
         } => format!(
             "✓ semantic index: {embedded} files embedded by {model} — {remaining} left \
              unembedded (they embed on demand as semantic searches reach them)"

--- a/crates/stella-cli/src/agent/graph/tests.rs
+++ b/crates/stella-cli/src/agent/graph/tests.rs
@@ -223,9 +223,37 @@ fn a_capped_pass_names_what_it_left_unembedded() {
         &stella_tools::graph::semantic::WarmOutcome::Warmed {
             embedded: 2_000,
             remaining: 3_231,
+            unreadable: 0,
         },
         "voyage-code-3",
     );
     assert!(rendered.contains("2000 files embedded"), "{rendered}");
     assert!(rendered.contains("3231 left unembedded"), "{rendered}");
+    assert!(
+        rendered.contains("embed on demand"),
+        "the cap's leftovers are picked up by the lazy pass: {rendered}"
+    );
+}
+
+/// #3016: a file the pass could not read is a different leftover from one the
+/// cap deferred — no later pass picks it up — so it may not be reported in the
+/// sentence that promises it will be.
+#[test]
+fn an_unreadable_file_is_named_as_a_problem_not_as_the_cap() {
+    let rendered = format_warm_outcome(
+        &stella_tools::graph::semantic::WarmOutcome::Warmed {
+            embedded: 68,
+            remaining: 32,
+            unreadable: 32,
+        },
+        "voyage-code-3",
+    );
+    assert!(rendered.starts_with('!'), "{rendered}");
+    assert!(rendered.contains("68 files embedded"), "{rendered}");
+    assert!(rendered.contains("32 left unembedded"), "{rendered}");
+    assert!(rendered.contains("could not be read"), "{rendered}");
+    assert!(
+        !rendered.contains("embed on demand"),
+        "an unreadable file will not embed on demand — do not promise it: {rendered}"
+    );
 }

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -370,8 +370,13 @@ impl CodeGraph {
         store::all_files(&self.inner.read_guard())
     }
 
-    /// Indexed files with no current vector under `fingerprint`, rendered and
-    /// ready to embed, capped at `limit`.
+    /// Up to `limit` indexed files with no current vector under `fingerprint`,
+    /// rendered and ready to embed, plus how many unreadable files the scan
+    /// stepped over to find them.
+    ///
+    /// An empty [`PendingScan::files`] means the pending set is exhausted, not
+    /// merely that this window happened to land on unreadable rows — which is
+    /// what lets a caller loop on it until it comes back empty.
     ///
     /// The embedding itself is deliberately **not** here: producing a vector
     /// is I/O against a model, and this crate holds no transport and no key.
@@ -384,7 +389,7 @@ impl CodeGraph {
         &self,
         fingerprint: &str,
         limit: usize,
-    ) -> Result<Vec<vectors::PendingEmbed>, GraphError> {
+    ) -> Result<vectors::PendingScan, GraphError> {
         vectors::pending(
             &self.inner.read_guard(),
             &self.inner.root,

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -374,9 +374,9 @@ impl CodeGraph {
     /// rendered and ready to embed, plus how many unreadable files the scan
     /// stepped over to find them.
     ///
-    /// An empty [`PendingScan::files`] means the pending set is exhausted, not
-    /// merely that this window happened to land on unreadable rows — which is
-    /// what lets a caller loop on it until it comes back empty.
+    /// An empty [`files`] means the pending set is exhausted, not merely that
+    /// this window happened to land on unreadable rows — which is what lets a
+    /// caller loop on it until it comes back empty.
     ///
     /// The embedding itself is deliberately **not** here: producing a vector
     /// is I/O against a model, and this crate holds no transport and no key.
@@ -385,6 +385,7 @@ impl CodeGraph {
     /// out of the indexer (invariant 1).
     ///
     /// [`store_file_vectors`]: CodeGraph::store_file_vectors
+    /// [`files`]: vectors::PendingScan::files
     pub fn files_pending_embedding(
         &self,
         fingerprint: &str,

--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -80,7 +80,7 @@ pub use lang::Language;
 pub use storage::{StorageExtract, StorageExtractor, StorageSnapshot};
 pub use store::IndexStats;
 pub use symbol::{CallSite, Symbol, SymbolKind};
-pub use vectors::{FileVector, MAX_FILES_PER_PASS, PendingEmbed, render_file_text};
+pub use vectors::{FileVector, MAX_FILES_PER_PASS, PendingEmbed, PendingScan, render_file_text};
 #[doc(hidden)]
 pub use watch::WatchInjector;
 

--- a/crates/stella-graph/src/vectors.rs
+++ b/crates/stella-graph/src/vectors.rs
@@ -80,6 +80,24 @@ pub struct PendingEmbed {
     pub text: String,
 }
 
+/// What one [`pending`] scan found: the files it can offer, and how many it
+/// had to step over to fill the window.
+///
+/// The count is not decoration. It is the only place anything knows that a
+/// file the index holds could not be turned into text, and a caller that
+/// reports "N files left unembedded" without it states the cap as the reason
+/// when the reason was a file it could not read (#3016).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PendingScan {
+    /// Files ready to embed, ordered by path, at most `limit` of them.
+    pub files: Vec<PendingEmbed>,
+    /// Indexed files stepped over because their content could not be read —
+    /// deleted since the index pass, unreadable by this process, or not UTF-8.
+    /// Counted over the rows this scan actually walked, so a scan that stopped
+    /// at `limit` reports what it saw on the way, not a repository total.
+    pub unreadable: usize,
+}
+
 /// A vector ready to be written back, as produced by an [`stella_embed::Embedder`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct FileVector {
@@ -129,8 +147,8 @@ pub fn render_file_text(rel_path: &str, symbol_names: &[String], content: &str) 
     out
 }
 
-/// Files with no usable vector under `fingerprint`, rendered and ready to
-/// embed, capped at `limit`.
+/// Up to `limit` files with no usable vector under `fingerprint`, rendered and
+/// ready to embed.
 ///
 /// "No usable vector" is either no row at all or a row whose `content_sha256`
 /// no longer matches the file's — the same `(content, fingerprint)` skip the
@@ -138,44 +156,68 @@ pub fn render_file_text(rel_path: &str, symbol_names: &[String], content: &str) 
 /// deterministic and a second pass resumes rather than re-rolling the dice.
 ///
 /// A file the index knows about but that has since vanished from disk is
-/// skipped, not an error: the next `index_all` prunes its row.
+/// skipped, not an error: the next `index_all` prunes its row. The window
+/// **fills past those skips** rather than spending itself on them, walking a
+/// path cursor until it has `limit` embeddable files or the pending set runs
+/// out. Truncating in SQL and filtering afterwards is what it used to do, and
+/// a run of unreadable files ahead of the readable ones then returned nothing
+/// while thousands still pended — which the eager `stella init` pass read as
+/// "done" and stopped on (#3016). The cursor keeps that fix inside the one
+/// function both passes share; the path ordering, and so the resume, is
+/// unchanged.
 pub fn pending(
     conn: &Connection,
     root: &Path,
     fingerprint: &str,
     limit: usize,
-) -> Result<Vec<PendingEmbed>, GraphError> {
+) -> Result<PendingScan, GraphError> {
     let mut stmt = conn.prepare(
         "SELECT f.path, f.content_sha256 \
          FROM code_graph_files f \
          LEFT JOIN code_graph_vectors v \
            ON v.file_id = f.id AND v.fingerprint = ?1 \
-         WHERE v.file_id IS NULL OR v.content_sha256 <> f.content_sha256 \
+         WHERE (v.file_id IS NULL OR v.content_sha256 <> f.content_sha256) \
+           AND f.path > ?2 \
          ORDER BY f.path \
-         LIMIT ?2",
+         LIMIT ?3",
     )?;
-    let rows: Vec<(String, String)> = stmt
-        .query_map(params![fingerprint, limit as i64], |row| {
-            Ok((row.get(0)?, row.get(1)?))
-        })?
-        .collect::<Result<_, _>>()?;
 
-    let mut pending = Vec::with_capacity(rows.len());
-    for (path, content_sha256) in rows {
-        let Ok(content) = std::fs::read_to_string(root.join(&path)) else {
-            continue;
+    let mut scan = PendingScan::default();
+    // The empty string sorts before every non-empty path under SQLite's BINARY
+    // collation — the same ordering `ORDER BY f.path` uses — so the first round
+    // starts at the beginning of the pending set.
+    let mut cursor = String::new();
+    while scan.files.len() < limit {
+        let want = limit - scan.files.len();
+        let rows: Vec<(String, String)> = stmt
+            .query_map(params![fingerprint, cursor, want as i64], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+        // No rows past the cursor: the pending set is exhausted, and whatever
+        // is still unembedded is what this scan stepped over.
+        let Some((last, _)) = rows.last() else {
+            break;
         };
-        let names: Vec<String> = store::symbols_in_file(conn, &path)?
-            .into_iter()
-            .map(|def| def.name)
-            .collect();
-        pending.push(PendingEmbed {
-            path: path.clone(),
-            content_sha256,
-            text: render_file_text(&path, &names, &content),
-        });
+        cursor = last.clone();
+
+        for (path, content_sha256) in rows {
+            let Ok(content) = std::fs::read_to_string(root.join(&path)) else {
+                scan.unreadable += 1;
+                continue;
+            };
+            let names: Vec<String> = store::symbols_in_file(conn, &path)?
+                .into_iter()
+                .map(|def| def.name)
+                .collect();
+            scan.files.push(PendingEmbed {
+                path: path.clone(),
+                content_sha256,
+                text: render_file_text(&path, &names, &content),
+            });
+        }
     }
-    Ok(pending)
+    Ok(scan)
 }
 
 /// Write vectors back under `fingerprint`, replacing whatever was there.

--- a/crates/stella-graph/src/vectors/tests.rs
+++ b/crates/stella-graph/src/vectors/tests.rs
@@ -64,7 +64,7 @@ fn every_indexed_file_is_pending_until_it_is_embedded() {
         indexed_workspace(&[("a.rs", "fn alpha() {}\n"), ("b.rs", "fn beta() {}\n")]);
     let root = ws.path().canonicalize().expect("canonicalize");
 
-    let first = pending(&conn, &root, FP, 10).expect("pending");
+    let first = pending(&conn, &root, FP, 10).expect("pending").files;
     assert_eq!(
         first.iter().map(|p| p.path.as_str()).collect::<Vec<_>>(),
         vec!["a.rs", "b.rs"],
@@ -85,7 +85,10 @@ fn every_indexed_file_is_pending_until_it_is_embedded() {
         .collect();
     assert_eq!(store_vectors(&mut conn, FP, &rows).expect("store"), 2);
     assert!(
-        pending(&conn, &root, FP, 10).expect("pending").is_empty(),
+        pending(&conn, &root, FP, 10)
+            .expect("pending")
+            .files
+            .is_empty(),
         "an embedded file is not embedded twice"
     );
     assert_eq!(count(&conn, FP).expect("count"), 2);
@@ -98,6 +101,7 @@ fn changing_a_file_makes_it_pending_again_without_touching_the_other() {
     let root = ws.path().canonicalize().expect("canonicalize");
     let rows: Vec<FileVector> = pending(&conn, &root, FP, 10)
         .expect("pending")
+        .files
         .iter()
         .map(|p| FileVector {
             path: p.path.clone(),
@@ -110,7 +114,7 @@ fn changing_a_file_makes_it_pending_again_without_touching_the_other() {
     fs::write(ws.path().join("a.rs"), "fn alpha_renamed() {}\n").expect("write");
     store::index_tree(&mut conn, &root, &Grammars::load().expect("grammars")).expect("reindex");
 
-    let stale = pending(&conn, &root, FP, 10).expect("pending");
+    let stale = pending(&conn, &root, FP, 10).expect("pending").files;
     assert_eq!(
         stale.iter().map(|p| p.path.as_str()).collect::<Vec<_>>(),
         vec!["a.rs"],
@@ -127,7 +131,7 @@ fn a_different_fingerprint_re_embeds_rather_than_mixing_vector_spaces() {
     let root = ws.path().canonicalize().expect("canonicalize");
     let rows = vec![FileVector {
         path: "a.rs".into(),
-        content_sha256: pending(&conn, &root, FP, 10).expect("pending")[0]
+        content_sha256: pending(&conn, &root, FP, 10).expect("pending").files[0]
             .content_sha256
             .clone(),
         vector: vec![1.0, 0.0, 0.0, 0.0],
@@ -148,13 +152,114 @@ fn a_different_fingerprint_re_embeds_rather_than_mixing_vector_spaces() {
         "the other embedder's ranking must not see this vector"
     );
     assert_eq!(
-        pending(&conn, &root, OTHER_FP, 10).expect("pending").len(),
+        pending(&conn, &root, OTHER_FP, 10)
+            .expect("pending")
+            .files
+            .len(),
         1,
         "the file is pending again under the new fingerprint"
     );
     // ...and the original fingerprint still answers, so the re-embed is
     // incremental rather than a wipe.
     assert_eq!(count(&conn, FP).expect("count"), 1);
+}
+
+/// #3016: the window is `limit` *embeddable* files, not `limit` rows that are
+/// then filtered. Truncating in SQL and skipping afterwards meant a run of
+/// unreadable files at the head of the path order returned nothing at all —
+/// which the eager `stella init` loop reads as "no work left" and stops on,
+/// leaving every readable file behind it unembedded.
+#[test]
+fn a_run_of_unreadable_files_does_not_consume_the_window() {
+    let (ws, conn) = indexed_workspace(&[
+        ("a.rs", "fn a() {}\n"),
+        ("b.rs", "fn b() {}\n"),
+        ("c.rs", "fn c() {}\n"),
+        ("d.rs", "fn d() {}\n"),
+    ]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+    // Deleted from disk but still indexed — exactly what the graph holds
+    // between a file being removed and the next `index_all` pruning its row.
+    // They sort ahead of every readable file, so they are what the old SQL
+    // `LIMIT` spent itself on.
+    fs::remove_file(ws.path().join("a.rs")).expect("remove");
+    fs::remove_file(ws.path().join("b.rs")).expect("remove");
+
+    let scan = pending(&conn, &root, FP, 2).expect("pending");
+    assert_eq!(
+        scan.files
+            .iter()
+            .map(|p| p.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["c.rs", "d.rs"],
+        "the scan fills past the unreadable rows instead of truncating on them"
+    );
+    assert_eq!(
+        scan.unreadable, 2,
+        "and says how many it stepped over, so a caller reporting leftovers \
+         can name the reason instead of blaming the cap"
+    );
+}
+
+/// The step-over keeps the path ordering, so the resume contract below still
+/// holds when unreadable files are interleaved with readable ones.
+#[test]
+fn stepping_over_an_unreadable_file_keeps_the_pass_ordered_by_path() {
+    let (ws, mut conn) = indexed_workspace(&[
+        ("a.rs", "fn a() {}\n"),
+        ("b.rs", "fn b() {}\n"),
+        ("c.rs", "fn c() {}\n"),
+        ("d.rs", "fn d() {}\n"),
+    ]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+    fs::remove_file(ws.path().join("b.rs")).expect("remove");
+
+    let first = pending(&conn, &root, FP, 2).expect("pending");
+    assert_eq!(
+        first
+            .files
+            .iter()
+            .map(|p| p.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a.rs", "c.rs"]
+    );
+    let rows: Vec<FileVector> = first
+        .files
+        .iter()
+        .map(|p| FileVector {
+            path: p.path.clone(),
+            content_sha256: p.content_sha256.clone(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+        })
+        .collect();
+    store_vectors(&mut conn, FP, &rows).expect("store");
+
+    let second = pending(&conn, &root, FP, 2).expect("pending");
+    assert_eq!(
+        second
+            .files
+            .iter()
+            .map(|p| p.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["d.rs"],
+        "the second pass resumes rather than re-offering what it already saw"
+    );
+    assert_eq!(second.unreadable, 1, "and still steps over the deleted row");
+}
+
+/// A pending set that is *entirely* unreadable comes back with no files —
+/// which is the signal the eager loop stops on, and now the honest one: the
+/// scan reached the end of the set rather than giving up inside it.
+#[test]
+fn an_entirely_unreadable_pending_set_reports_no_files_and_the_count() {
+    let (ws, conn) = indexed_workspace(&[("a.rs", "fn a() {}\n"), ("b.rs", "fn b() {}\n")]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+    fs::remove_file(ws.path().join("a.rs")).expect("remove");
+    fs::remove_file(ws.path().join("b.rs")).expect("remove");
+
+    let scan = pending(&conn, &root, FP, 200).expect("pending");
+    assert!(scan.files.is_empty());
+    assert_eq!(scan.unreadable, 2);
 }
 
 #[test]
@@ -166,7 +271,7 @@ fn a_capped_pass_resumes_where_it_stopped() {
     ]);
     let root = ws.path().canonicalize().expect("canonicalize");
 
-    let first = pending(&conn, &root, FP, 2).expect("pending");
+    let first = pending(&conn, &root, FP, 2).expect("pending").files;
     assert_eq!(
         first.iter().map(|p| p.path.as_str()).collect::<Vec<_>>(),
         vec!["a.rs", "b.rs"]
@@ -181,7 +286,7 @@ fn a_capped_pass_resumes_where_it_stopped() {
         .collect();
     store_vectors(&mut conn, FP, &rows).expect("store");
 
-    let second = pending(&conn, &root, FP, 2).expect("pending");
+    let second = pending(&conn, &root, FP, 2).expect("pending").files;
     assert_eq!(
         second.iter().map(|p| p.path.as_str()).collect::<Vec<_>>(),
         vec!["c.rs"]
@@ -206,6 +311,7 @@ fn ranking_is_ordered_by_similarity_and_bounded_by_the_floor() {
     let root = ws.path().canonicalize().expect("canonicalize");
     let hashes: Vec<(String, String)> = pending(&conn, &root, FP, 10)
         .expect("pending")
+        .files
         .into_iter()
         .map(|p| (p.path, p.content_sha256))
         .collect();
@@ -243,6 +349,7 @@ fn pruning_a_file_takes_its_vector_with_it() {
     let root = ws.path().canonicalize().expect("canonicalize");
     let rows: Vec<FileVector> = pending(&conn, &root, FP, 10)
         .expect("pending")
+        .files
         .iter()
         .map(|p| FileVector {
             path: p.path.clone(),

--- a/crates/stella-graph/tests/semantic_recall.rs
+++ b/crates/stella-graph/tests/semantic_recall.rs
@@ -163,7 +163,8 @@ async fn embed_all(graph: &CodeGraph, embedder: &dyn Embedder) -> String {
     let fingerprint = embedder.fingerprint().id();
     let pending = graph
         .files_pending_embedding(&fingerprint, MAX_FILES_PER_PASS)
-        .expect("pending");
+        .expect("pending")
+        .files;
     assert!(!pending.is_empty(), "the fixture must have indexed");
 
     let texts: Vec<String> = pending.iter().map(|p| p.text.clone()).collect();

--- a/crates/stella-tools/src/graph/semantic.rs
+++ b/crates/stella-tools/src/graph/semantic.rs
@@ -300,13 +300,18 @@ pub const MAX_FILES_PER_EAGER_PASS: usize = 2_000;
 /// a caller branches on.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WarmOutcome {
-    /// The pass ran. `remaining` is what the cap (or an unreadable file) left
-    /// for the lazy path to pick up on the first semantic query.
+    /// The pass ran. `remaining` is what the cap left for the lazy path to
+    /// pick up on the first semantic query.
     Warmed {
         /// Files embedded by this pass.
         embedded: usize,
         /// Indexed files still carrying no vector under this fingerprint.
         remaining: usize,
+        /// How many of those the pass could not read from disk. Separated from
+        /// `remaining` because the two want different sentences: the cap's
+        /// leftovers embed themselves on the next query, and an unreadable
+        /// file never will (#3016).
+        unreadable: usize,
     },
     /// The pass stopped early. `reason` is prose meant to be shown verbatim;
     /// whatever was embedded before the failure is committed and counted.
@@ -363,10 +368,11 @@ async fn warm_opened(
 ) -> WarmOutcome {
     let fingerprint = embedder.fingerprint().id();
     let mut embedded = 0usize;
+    let mut unreadable = 0usize;
     while embedded < limit {
         let want = BATCH.min(limit - embedded);
-        let pending = match graph.files_pending_embedding(&fingerprint, want) {
-            Ok(pending) => pending,
+        let scan = match graph.files_pending_embedding(&fingerprint, want) {
+            Ok(scan) => scan,
             Err(error) => {
                 return WarmOutcome::Failed {
                     embedded,
@@ -374,17 +380,21 @@ async fn warm_opened(
                 };
             }
         };
-        // Empty means done — or that every remaining candidate vanished from
-        // disk between the index pass and now, which `pending` skips. Either
-        // way there is nothing this pass can embed, and `remaining` below
-        // reports the gap rather than spinning on it.
-        if pending.is_empty() {
+        // Overwritten, never summed: each round rescans the pending set from
+        // the start, so an unreadable file is stepped over again every round
+        // and adding the counts would multiply it by the round count. The last
+        // round's figure is the one that walked furthest.
+        unreadable = unreadable.max(scan.unreadable);
+        // No files means the pending set is exhausted — a window landing on
+        // unreadable rows keeps filling past them, so this is genuinely done
+        // rather than a scan that gave up early (#3016).
+        if scan.files.is_empty() {
             break;
         }
-        if let Err(reason) = embed_batch(graph, embedder, &fingerprint, &pending).await {
+        if let Err(reason) = embed_batch(graph, embedder, &fingerprint, &scan.files).await {
             return WarmOutcome::Failed { embedded, reason };
         }
-        embedded += pending.len();
+        embedded += scan.files.len();
     }
 
     let total = graph.file_count().unwrap_or(0);
@@ -392,6 +402,7 @@ async fn warm_opened(
     WarmOutcome::Warmed {
         embedded,
         remaining: total.saturating_sub(stored),
+        unreadable,
     }
 }
 
@@ -401,14 +412,14 @@ async fn catch_up_embeddings(
     embedder: &dyn Embedder,
     fingerprint: &str,
 ) -> Result<(), String> {
-    let pending = graph
+    let scan = graph
         .files_pending_embedding(fingerprint, stella_graph::MAX_FILES_PER_PASS)
         .map_err(|error| format!("cannot read the code graph: {error}"))?;
-    if pending.is_empty() {
+    if scan.files.is_empty() {
         return Ok(());
     }
 
-    for chunk in pending.chunks(BATCH) {
+    for chunk in scan.files.chunks(BATCH) {
         embed_batch(graph, embedder, fingerprint, chunk).await?;
     }
     Ok(())

--- a/crates/stella-tools/src/graph/semantic/tests.rs
+++ b/crates/stella-tools/src/graph/semantic/tests.rs
@@ -152,7 +152,8 @@ async fn an_eager_pass_embeds_the_corpus_and_no_query() {
         outcome,
         WarmOutcome::Warmed {
             embedded: FIXTURE.len(),
-            remaining: 0
+            remaining: 0,
+            unreadable: 0
         }
     );
 
@@ -173,7 +174,8 @@ async fn an_eager_pass_embeds_the_corpus_and_no_query() {
         again,
         WarmOutcome::Warmed {
             embedded: 0,
-            remaining: 0
+            remaining: 0,
+            unreadable: 0
         }
     );
 }
@@ -192,8 +194,35 @@ async fn a_pass_that_hits_its_cap_reports_what_it_left() {
         outcome,
         WarmOutcome::Warmed {
             embedded: 1,
-            remaining: FIXTURE.len() - 1
+            remaining: FIXTURE.len() - 1,
+            unreadable: 0
         }
+    );
+}
+
+/// #3016: an unreadable file at the head of the path order must not end the
+/// pass. The window is sized in embeddable files, so the readable ones behind
+/// it are still offered — and the leftover is reported as what it is rather
+/// than as the cap's doing.
+#[tokio::test]
+async fn an_unreadable_file_does_not_stop_the_eager_pass_at_the_readable_ones() {
+    let ws = workspace();
+    let root = ws.path().canonicalize().expect("canonicalize");
+    index_as_init_does(&root);
+    // Indexed, then gone — `src/scrub.rs` sorts ahead of `src/wire.rs`, so it
+    // is what a window of one lands on first.
+    std::fs::remove_file(root.join("src/scrub.rs")).expect("remove");
+    let server = concept_server().await;
+
+    let outcome = warm_file_vectors(&root, &embedder(&server), 1).await;
+    assert_eq!(
+        outcome,
+        WarmOutcome::Warmed {
+            embedded: 1,
+            remaining: 1,
+            unreadable: 1
+        },
+        "the readable file behind the deleted one must still be embedded"
     );
 }
 


### PR DESCRIPTION
## What & why

`vectors::pending` applied its `LIMIT` **in SQL** and *then* dropped the rows
whose content it could not read from disk. The skip itself is right — a file the
index knows about that has since vanished is pruned by the next `index_all`, not
an error — but choosing the window before the predicate that decides membership
means a run of unreadable files at the head of the path order consumes the whole
window and the function returns nothing.

#3014's eager `stella init` pass loops `pending(BATCH)` until it comes back
empty, so it read that as "done" and stopped with every readable file behind the
bad prefix unembedded. Measured on the repro, one deleted file ahead of one
readable one: `Warmed { embedded: 0, remaining: 2 }`. The lazy per-query pass
has the same property over its single window.

**The fix** (the issue's first option, argued): `pending` walks a path cursor,
filling to `limit` *embeddable* files rather than truncating on the first
window. It stays inside the one function both passes share — `vectors.rs`'s
header states there is exactly one way a file becomes embeddable text — so the
lazy path is fixed by the same change rather than by a second cursor at a second
call site, which is what the issue's option 2 would have needed. The `ORDER BY
f.path` and therefore the resume contract are unchanged.

**And it stops swallowing the reason.** `pending` returns
`PendingScan { files, unreadable }`, carrying the count out of the only place
that knows a file could not be read. The CLI's `N left unembedded` otherwise
states the cap as the reason for a leftover the cap did not cause, and an
unreadable file — unlike a deferred one — will never "embed on demand as
semantic searches reach them". That line now says which of the two it is, and
says it with `!` rather than `✓`.

Closes #3016

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four, each checked the artisanal way by restoring the truncate-then-filter
ordering under the new struct and re-running:

| Test | Crate | On the old ordering |
|---|---|---|
| `a_run_of_unreadable_files_does_not_consume_the_window` | `stella-graph` | `left: []`, `right: ["c.rs", "d.rs"]` |
| `stepping_over_an_unreadable_file_keeps_the_pass_ordered_by_path` | `stella-graph` | `left: ["a.rs"]`, `right: ["a.rs", "c.rs"]` |
| `an_unreadable_file_does_not_stop_the_eager_pass_at_the_readable_ones` | `stella-tools` | `Warmed { embedded: 0, remaining: 2, .. }` vs `embedded: 1, remaining: 1` |
| `an_unreadable_file_is_named_as_a_problem_not_as_the_cap` | `stella-cli` | the `unreadable` arm does not exist |

The third reproduces the issue's own observation (`embedded: 0`) end to end
through the eager pass, not just at the scan.

`an_entirely_unreadable_pending_set_reports_no_files_and_the_count` is a
contract test rather than a witness: it passes either way, and pins the
"empty means exhausted" signal the eager loop's `break` depends on.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed (`pending`, `files_pending_embedding`,
      `WarmOutcome::Warmed` and `format_warm_outcome` doc comments)
- [x] `Closes #3016` appears both here and as a commit trailer

`make gate` green locally (all steps, including `self-driving-test`).

## Nothing left behind

- [x] Filed: #3021 — the lazy per-query pass now gets the correct *files* from
      the shared scan, but its answer footer still discards `scan.unreadable`
      and still invites a re-run that cannot close the gap. Deliberately out of
      scope here: it is a rendering change to model-facing text, and this PR is
      the scan fix.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**Two things worth a second look:**

1. **The cursor's collation.** `AND f.path > ?2` relies on SQLite's default
   BINARY collation being the same ordering `ORDER BY f.path` uses, and on `''`
   sorting before every non-empty path. Both hold for the `TEXT` column here,
   and the ordering assertion is what
   `stepping_over_an_unreadable_file_keeps_the_pass_ordered_by_path` pins.

2. **`unreadable` is overwritten, not summed, across the eager loop's rounds.**
   Each round rescans the pending set from the start, so an unreadable file is
   stepped over again every round and summing would multiply it by the round
   count. Taking the maximum gives the exact total when the loop exits on an
   exhausted scan, and a lower bound when it exits at the cap — where the cap is
   the honest headline anyway. The field doc says so rather than implying a
   repository total.

**Round-trip cost:** worst case the scan issues one extra query per `limit`
rows walked, and each round advances the cursor by at least one row, so it is
bounded by the pending-row count and cannot spin.

**Rejected:** having the eager loop advance its own cursor (the issue's second
option). It fixes one of the two callers, leaves `pending`'s "capped at `limit`"
contract still misleading for the other, and puts a second copy of the
skip discipline outside the function whose header claims to be the only one.

## Summary by Sourcery

Adjust pending embedding scans to size their window by embeddable files instead of raw rows and surface unreadable-file counts to callers so eager and CLI paths can distinguish true exhaustion from unreadable leftovers.

New Features:
- Expose a PendingScan struct from stella-graph that returns both embeddable files and a count of unreadable indexed files encountered during a pending scan.

Bug Fixes:
- Ensure pending embedding scans skip over unreadable files while continuing to fill the window, so deleted or unreadable files at the head of the path order no longer cause eager embedding passes to stop with readable files unembedded.
- Update eager and catch-up embedding flows to consume PendingScan and correctly interpret an empty files set as exhaustion of the pending set rather than a window landing entirely on unreadable rows.
- Fix CLI warm outcome rendering so unreadable files are reported explicitly as a problem instead of being conflated with cap-deferred files that will embed on demand.

Enhancements:
- Refine WarmOutcome to track unreadable-file counts separately from remaining pending files, enabling more accurate status reporting.
- Extend tests across stella-graph, stella-tools, and stella-cli to cover windowing over unreadable files, cursor ordering and resume behavior, eager pass behavior with unreadable files, and CLI messaging for unreadable leftovers.

Documentation:
- Update documentation and comments for pending, files_pending_embedding, WarmOutcome::Warmed, format_warm_outcome, and related APIs to describe the new windowing and unreadable-file reporting semantics.