### PR TITLE
feat(stella-cli): batch independent tool calls, and route file work off the shell

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -38,7 +38,11 @@ use super::*;
 
 /// The cross-tool steering shared by both static prompts — what the generated
 /// schemas cannot say. No trailing newline: each prompt continues with its own
-/// blank line and section header.
+/// blank line and section header. The last two bullets — batching independent
+/// calls, and routing file work off the shell — carry their measurement and
+/// their clause-by-clause pins in `prompt/parity.rs`, which is where
+/// prompt-content provenance lives while this file sits against the 1500-line
+/// ratchet (#2985).
 macro_rules! tool_steering {
     () => {
         r#"Your tool schemas are the reference for what each tool does and what it takes. What they cannot tell you, because each describes one tool in isolation:
@@ -46,7 +50,9 @@ macro_rules! tool_steering {
 - Read a definition by name with read_symbol; guessing read_file offsets after a graph_query is the round-trip it exists to remove.
 - A change touching several files is ONE apply_edits call, not a chain of edit_file calls.
 - A tool you cannot see is not available in this session rather than nonexistent. The shell ships registered and a workspace withholds it with "tools": {"bash": "off"}; issue tracking, web, and media tools register only once their backend is configured (`stella connect github|linear`, an API key, or `gh auth`; ci_status needs the gh CLI). Reach for tool_search before concluding a capability is missing.
-- The user watches your plan on screen the whole time you work, so keeping it current is not bookkeeping — it is the only report they get while a long turn runs. When a plan was approved, its steps are ALREADY on the board with the same numbers the user approved: call task_list first to read them, then mark exactly one step started before you work on it and completed the moment it is done. Never re-create a step that is already there. On work that reached no approval gate, create the steps yourself before starting, one per concrete deliverable. A step you abandon is cancelled, not left open — a step still showing started at the end of a turn is a false report."#
+- The user watches your plan on screen the whole time you work, so keeping it current is not bookkeeping — it is the only report they get while a long turn runs. When a plan was approved, its steps are ALREADY on the board with the same numbers the user approved: call task_list first to read them, then mark exactly one step started before you work on it and completed the moment it is done. Never re-create a step that is already there. On work that reached no approval gate, create the steps yourself before starting, one per concrete deliverable. A step you abandon is cancelled, not left open — a step still showing started at the end of a turn is a false report.
+- Independent tool calls belong in ONE response. The test is dependency: if no call needs another's result — three reads of files you already named, a grep and an unrelated glob, reading a file while listing a directory — issue them together in the same response. Each extra response re-sends the entire conversation so far to the model, so three independent reads issued one per response pay for that transcript three times and issued together pay once. Issue calls sequentially only where one genuinely consumes a previous result: read a file before editing it, locate a symbol before reading it, run the test after the edit. Never batch an edit with the read it depends on.
+- Reading, editing, and creating files, finding files by name, and searching file contents each have a dedicated tool — use it rather than the shell. Two reasons, both real: a dedicated tool names the file it touches, so the engine records that change exactly, while a `sed -i` or a heredoc inside bash names nothing and forces the change to be reconstructed by fingerprinting the whole workspace either side of the call — a scan that costs real time and can come up short; and the dedicated call is cheaper per call than shelling out. This is routing, not a ban — the shell is the right tool for what genuinely needs one: running builds and tests, process and service control, git operations, package managers, and anything with no tool equivalent."#
     };
 }
 

--- a/crates/stella-cli/src/agent/prompt/parity.rs
+++ b/crates/stella-cli/src/agent/prompt/parity.rs
@@ -413,6 +413,124 @@ fn every_engine_marker_is_taught_verbatim_by_every_static_prompt() {
     }
 }
 
+/// Witness for the batching gap: Stella essentially never issued two tool
+/// calls in one response, and neither prompt said it could.
+///
+/// Measured by censusing `tool_start` against `step_usage` (one completed model
+/// call) in the bench event logs of four arms: post1 600 tool calls over 595
+/// model calls (1.01 per turn, 519 of 595 turns carrying exactly one), s5b2
+/// 649/659, dec1 543/578, f89b2 2812/2707. Essentially every tool call bought
+/// its own round trip. That is the direct cost lever, because a turn re-reads
+/// the whole cached conversation prefix — measured growth on one real trial was
+/// 16.7k tokens at turn 0 to 46.6k by turn 55 — so three independent reads
+/// issued separately pay for that transcript three times and issued together
+/// pay once. `rg -ic parallel` over this file's subject returned 0 before this
+/// bullet: the capability was never mentioned at all.
+///
+/// The dependency test is the half that makes the rule safe, and it is pinned
+/// separately for that reason. Without it the instruction reads as "batch your
+/// calls" and produces an agent issuing an edit alongside the read of the file
+/// it has not seen yet — which is why the negative clauses ("Never batch an
+/// edit with the read it depends on", "read a file before editing it") are
+/// asserted here rather than left to survive a future trim on their own.
+///
+/// Lives here rather than beside its siblings in `prompt.rs`'s test module for
+/// the same reason `both_prompts_bind_the_model_to_skills` does: that file sits
+/// within a few lines of the 1500-line ratchet (#2985), and #2237 makes this
+/// module the home for prompt-content pins.
+#[test]
+fn both_prompts_batch_independent_tool_calls() {
+    let shared = tool_steering!();
+    for claim in [
+        // The rule itself.
+        "Independent tool calls belong in ONE response",
+        // Why it pays — the cached prefix is re-sent per response, so the
+        // saving is per avoided round trip, not per avoided tool call.
+        "re-sends the entire conversation so far to the model",
+        // The dependency test, which is what makes batching safe rather than
+        // merely aggressive.
+        "The test is dependency",
+        "issue them together in the same response",
+        // The negative half: a dependent call is still sequential, and the
+        // read-before-edit case is named explicitly because it is the one a
+        // blunt batching rule breaks first.
+        "only where one genuinely consumes a previous result",
+        "read a file before editing it",
+        "Never batch an edit with the read it depends on",
+    ] {
+        assert!(
+            shared.contains(claim),
+            "the shared literal must keep the batching claim {claim:?} — \
+             dropping the dependency half leaves a blunt rule that batches an \
+             edit with the read it depends on"
+        );
+    }
+    for (label, prompt) in STATIC_PROMPTS {
+        assert!(
+            prompt.contains(shared),
+            "{label} does not embed the shared tool-steering block verbatim"
+        );
+    }
+}
+
+/// Witness for the shell-routing gap: Stella reached for `bash` when it held a
+/// purpose-built tool, and neither prompt said not to.
+///
+/// Measured in bench run post1: 425 of 600 tool calls were `bash`. In one trial
+/// the worker made 8 shell `grep` invocations *on top of* 6 calls to its own
+/// `grep` tool, in the same session against the same file. `rg -ic "dedicated
+/// tool"` over both prompts returned 0.
+///
+/// Both stated reasons are pinned because they are different claims. The first
+/// is about the record: a shell command declares no path, so
+/// `stella_tools::shell_touch::WorkspaceProbe` has to fingerprint the workspace
+/// either side of every opaque call and attribute the difference — a walk whose
+/// bounds are recorded as saturation rather than guessed at, which is why it
+/// can come up short (deletions are dropped outright once either walk
+/// saturated). A dedicated tool declares its path and needs none of that. The
+/// prompt says "can come up short", deliberately not "invisible": shell
+/// mutations ARE attributed here, just reconstructed rather than declared.
+/// The second reason is the per-call cost, and it is the weaker of the two.
+///
+/// The reservation clause is pinned for the same reason the dependency test
+/// above is: shell is the right answer for a large share of real work on this
+/// benchmark, and an instruction that reads as "never use bash" fights the task
+/// and gets ignored wholesale. A trim that keeps the routing and drops the
+/// reservation would turn this into exactly that rule.
+#[test]
+fn both_prompts_route_file_work_to_the_dedicated_tool() {
+    let shared = tool_steering!();
+    for claim in [
+        // The routing itself, enumerated so a schema-level "use the right
+        // tool" cannot stand in for it.
+        "Reading, editing, and creating files, finding files by name, and \
+         searching file contents each have a dedicated tool",
+        "use it rather than the shell",
+        // Reason one: the record. A shell edit declares no path, so the
+        // change has to be reconstructed by a bounded workspace scan.
+        "names the file it touches",
+        "fingerprinting the whole workspace either side of the call",
+        // Reason two, and deliberately the weaker of the two.
+        "cheaper per call than shelling out",
+        // The negative half — this is routing, never a ban.
+        "This is routing, not a ban",
+        "running builds and tests, process and service control, git operations",
+    ] {
+        assert!(
+            shared.contains(claim),
+            "the shared literal must keep the shell-routing claim {claim:?} — \
+             dropping the reservation clause turns routing into a blanket ban \
+             on a tool that is the right answer for much of the work"
+        );
+    }
+    for (label, prompt) in STATIC_PROMPTS {
+        assert!(
+            prompt.contains(shared),
+            "{label} does not embed the shared tool-steering block verbatim"
+        );
+    }
+}
+
 /// Witness for the skill-use gap (#2724): neither persona said the word
 /// "skill", so the only skill text the model ever saw was the volatile recall
 /// block's section header — a label with no contract. Each clause pinned

--- a/docs/prompts/worker.md
+++ b/docs/prompts/worker.md
@@ -94,6 +94,8 @@ Your tool schemas are the reference for what each tool does and what it takes. W
 - A change touching several files is ONE apply_edits call, not a chain of edit_file calls.
 - A tool you cannot see is not available in this session rather than nonexistent. The shell ships registered and a workspace withholds it with "tools": {"bash": "off"}; issue tracking, web, and media tools register only once their backend is configured (`stella connect github|linear`, an API key, or `gh auth`; ci_status needs the gh CLI). Reach for tool_search before concluding a capability is missing.
 - The user watches your plan on screen the whole time you work, so keeping it current is not bookkeeping — it is the only report they get while a long turn runs. When a plan was approved, its steps are ALREADY on the board with the same numbers the user approved: call task_list first to read them, then mark exactly one step started before you work on it and completed the moment it is done. Never re-create a step that is already there. On work that reached no approval gate, create the steps yourself before starting, one per concrete deliverable. A step you abandon is cancelled, not left open — a step still showing started at the end of a turn is a false report.
+- Independent tool calls belong in ONE response. The test is dependency: if no call needs another's result — three reads of files you already named, a grep and an unrelated glob, reading a file while listing a directory — issue them together in the same response. Each extra response re-sends the entire conversation so far to the model, so three independent reads issued one per response pay for that transcript three times and issued together pay once. Issue calls sequentially only where one genuinely consumes a previous result: read a file before editing it, locate a symbol before reading it, run the test after the edit. Never batch an edit with the read it depends on.
+- Reading, editing, and creating files, finding files by name, and searching file contents each have a dedicated tool — use it rather than the shell. Two reasons, both real: a dedicated tool names the file it touches, so the engine records that change exactly, while a `sed -i` or a heredoc inside bash names nothing and forces the change to be reconstructed by fingerprinting the whole workspace either side of the call — a scan that costs real time and can come up short; and the dedicated call is cheaper per call than shelling out. This is routing, not a ban — the shell is the right tool for what genuinely needs one: running builds and tests, process and service control, git operations, package managers, and anything with no tool equivalent.
 ```
 
 This block *replaced* a hand-maintained per-tool catalogue that cost ~1,240
@@ -101,6 +103,21 @@ tokens restating what the generated schemas already carry — a default session
 of ~46 tools paid for every description twice on every call (#639). What
 remains is the residue: steering the schemas structurally cannot express.
 Anything a tool's own description already says belongs there, not here.
+
+The last two bullets close measured gaps rather than stating a preference.
+Batching: censusing `tool_start` against `step_usage` across four bench arms
+put tool calls per completed model call at 1.01 (post1), 0.98 (s5b2), 0.94
+(dec1) and 1.04 (f89b2) — essentially every tool call bought its own round
+trip, each of which re-reads the whole cached prefix (16.7k tokens at turn 0
+growing to 46.6k by turn 55 on one measured trial). Shell routing: 425 of
+post1's 600 tool calls were `bash`, and one trial made 8 shell `grep`
+invocations on top of 6 calls to the `grep` tool against the same file. Both
+bullets' qualifier halves — the dependency test, and "routing, not a ban" —
+are pinned clause by clause in `prompt/parity.rs`
+(`both_prompts_batch_independent_tool_calls`,
+`both_prompts_route_file_work_to_the_dedicated_tool`) so a later trim cannot
+leave the blunt rule behind. The behavioural effect is unverified until a
+bench arm runs it.
 
 ### `scope_discipline!`
 


### PR DESCRIPTION
## What & why

Two measured gaps in what Stella tells the model about its own tools. Both land
as bullets in the shared `tool_steering!` literal in
`crates/stella-cli/src/agent/prompt.rs`, which `SYSTEM_PROMPT` and
`PIPELINE_SYSTEM_PROMPT` both embed verbatim — so both reach the bare-persona
bench arms *and* `stella run`.

**Gap 1 — Stella never issues parallel tool calls.** Censusing `tool_start`
against `step_usage` (one completed model call) in the bench event logs:

| arm | model calls | tool calls | tools/turn | turns with exactly 1 tool call |
|---|---|---|---|---|
| post1 | 595 | 600 | 1.01 | 519 of 595 |
| s5b2 | 659 | 649 | 0.98 | 592 |
| dec1 | 578 | 543 | 0.94 | 530 |
| f89b2 | 2707 | 2812 | 1.04 | 2396 |

Essentially every tool call bought its own round trip, and a round trip
re-reads the whole cached conversation prefix — measured growth on one real
trial was 16.7k tokens at turn 0 to 46.6k by turn 55. Neither prompt mentioned
parallel or concurrent calls at all (`rg -ic parallel` returned 0).

**Gap 2 — Stella reaches for `bash` when it holds a dedicated tool.** 425 of
post1's 600 tool calls were `bash`; in one trial the worker made 8 shell `grep`
invocations *on top of* 6 calls to its own `grep` tool, in the same session
against the same file. Neither prompt said to prefer the dedicated tool
(`rg -ic "dedicated tool"` returned 0).

### The exact text added

```text
- Independent tool calls belong in ONE response. The test is dependency: if no call needs another's result — three reads of files you already named, a grep and an unrelated glob, reading a file while listing a directory — issue them together in the same response. Each extra response re-sends the entire conversation so far to the model, so three independent reads issued one per response pay for that transcript three times and issued together pay once. Issue calls sequentially only where one genuinely consumes a previous result: read a file before editing it, locate a symbol before reading it, run the test after the edit. Never batch an edit with the read it depends on.
- Reading, editing, and creating files, finding files by name, and searching file contents each have a dedicated tool — use it rather than the shell. Two reasons, both real: a dedicated tool names the file it touches, so the engine records that change exactly, while a `sed -i` or a heredoc inside bash names nothing and forces the change to be reconstructed by fingerprinting the whole workspace either side of the call — a scan that costs real time and can come up short; and the dedicated call is cheaper per call than shelling out. This is routing, not a ban — the shell is the right tool for what genuinely needs one: running builds and tests, process and service control, git operations, package managers, and anything with no tool equivalent.
```

### One correction to the brief I was given

The brief said a shell edit "produces no `file_change`, which is why `bash`
edits are invisible to the trace". That is not true of this tree.
`crates/stella-tools/src/shell_touch.rs` exists precisely to attribute opaque
shell mutations: `WorkspaceProbe::capture_with` fingerprints the workspace
either side of every opaque call and `diff` attributes the difference. Shell
edits are therefore *reconstructed*, not invisible. The prompt text says "can
come up short" instead — which is accurate and still motivating, because the
probe is a bounded walk that records saturation and drops deletions outright
when either side saturated. I would rather ship the true reason than the
stronger one.

### Why bullets in an existing contract, not two new contracts

Two reasons. It is exactly what `tool_steering!` is for — the module comment
says the block is "the steering the schemas structurally cannot express… a
schema describes one tool in isolation, so it can say what `apply_edits` does
but not that it beats a chain of `edit_file` calls," and both new bullets are
statements about tools relative to each other. And `prompt.rs` is at its
1500-line ceiling (#2985): a new contract costs ~15 lines (declaration plus two
invocation sites) and there were 14 available. The file goes 1486 → 1492. **No
baseline was raised and no baseline entry was added.**

Refs #2985

## The witness

- [x] No witness needed — because a prompt change has no natural behavioural
      witness, and this repo says so explicitly rather than inventing a weak one.

What *is* tested is the text, pinned clause by clause in
`crates/stella-cli/src/agent/prompt/parity.rs` — the established home for
prompt-content pins (#2237) and the file the ceiling pushes this into:

- `both_prompts_batch_independent_tool_calls`
- `both_prompts_route_file_work_to_the_dedicated_tool`

Each asserts across **both** prompts and pins the **negative halves**
separately, because those are what keep the rules safe: the dependency test and
"Never batch an edit with the read it depends on" for the first; "This is
routing, not a ban" and the reserved-for-the-shell list for the second. Without
them you get an agent batching an edit with the read of a file it has not seen,
and a blanket anti-bash rule that fights the benchmark and gets ignored
wholesale.

Demonstrated load-bearing, not asserted: deleting *only* the two qualifier
clauses from the literal turns both new tests red and leaves every other prompt
test green — `10 passed; 2 failed`. Reverted immediately.

**The behavioural claim is unverified until a bench arm runs it.** The settling
comparison is the same 10 tasks, 2 attempts, claude-sonnet-5 via OpenRouter,
against post1's measured baseline of 30.0 tool calls / 1.01 tools per turn /
16-of-20 solved. The metric that would show gap 1 working is **tools per turn
rising above 1.0**, not tool-call count falling. **No cost reduction is
claimed** — three prompt experiments this week looked strong at partial samples
and finished flat or worse.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Full `make gate` run, output to a file and read (never piped through
      `tail`, which masks the exit code) — `check-file-size: OK … nothing went
      over by this change`
- [x] Docs updated: `docs/prompts/worker.md` quotes this literal verbatim and
      now carries both bullets plus their measurement

No goldens moved. The prompt-cache golden fixtures (`make cache-correctness`)
record where cache breakpoints fell, not prompt bytes, and are green.

## Nothing left behind

- [x] Filed: #3029 — `docs/prompts/worker.md` documents 4 of the 9 shared
      prompt contracts and nothing checks it. Found while updating that doc's
      `tool_steering!` quote: the doc is five contracts behind (`skill_use!`,
      `faithful_reporting!`, `complexity_discipline!`, `action_care!`,
      `injection_defense!` are all missing) and its assembly summary still says
      "five shared blocks". Deliberately out of scope here — the fix wants a
      guard, not another manual pass.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] Invariant 7 (L-E8) intact: the literals stay `macro_rules!` compile-time
      constants inside `concat!`, so the byte-stable cached prefix is exactly
      what it was, one block longer

## Anything reviewers should know?

The prompt grew by three sentences of instruction on a prefix that is already
long, and prefix length is itself the cost the batching rule is trying to
reduce. That is the trade this PR makes and it is worth naming: the bullets are
paid for on every call, and only earn it back if turns actually start carrying
more than one tool call. The bench arm named above is what settles it.

## Summary by Sourcery

Extend the shared tool-steering prompt to encourage batching independent tool calls in a single model response and to route file-related work through dedicated file tools instead of the shell, with corresponding prompt parity tests and documentation updates.

Enhancements:
- Add clause-by-clause parity tests ensuring both static prompts include the new batching and shell-routing guidance in the shared tool-steering literal.
- Document the new tool usage guidance and its measured motivation in the worker prompt docs, including notes on test pins and expected behavioural effects.