### PR TITLE
fix(arenabench): a default cloud fetch gets its cross-arm view back

### DIFF
--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -1128,6 +1128,15 @@ def _assemble_fetched(dest: Path) -> None:
     command. A failure here never fails the fetch: the artifacts are on disk,
     which is the part that cost money, and `arenabench assemble <dir>` retries
     the free part.
+
+    Assembly needs ``match.toml``, which only a ``--artifacts`` fetch brings
+    down — so on the default path it *always* declines, and declining alone
+    would leave the plain fetch with no view spanning the arms at all. That is
+    the regression #3018 fixed and this restores: when assembly cannot run,
+    :func:`_merge_and_report` still folds the per-job ``results.json`` bodies
+    into one ``trial.json``. The order is the point — the assembled match is a
+    restoration of the submitted spec and strictly better, and the merge is
+    what a fetch that never downloaded the spec can honestly build instead.
     """
     from .assemble import AssembleError, assemble_run
 
@@ -1135,6 +1144,7 @@ def _assemble_fetched(dest: Path) -> None:
         assembly = assemble_run(dest)
     except AssembleError as exc:
         print(f"assembled : not yet — {exc}")
+        _merge_and_report(dest)
         return
     print(
         f"assembled : {assembly.trials} trial(s) into one match "

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -1007,6 +1007,57 @@ class TestFetchMergesIntoOneTrial:
         assert (tmp_path / "000-stella-task-a" / "results.json").exists()
         assert (tmp_path / "001-cc-task-a" / "results.json").exists()
 
+    def test_an_assembled_run_is_not_also_merged(self, tmp_path, monkeypatch) -> None:
+        """The ordering half: the merge is the fallback, never a second write.
+
+        A default fetch downloads only each job's ``results.json``, so
+        ``match.toml`` is absent and assembly declines — which is why the
+        merge above still has to run. When the spec *is* on disk the assembled
+        match is the restoration of the submitted one and strictly better, so
+        the merge must not also fire and leave a rival ``trial.json`` beside
+        it claiming to describe the same run.
+        """
+        import arenabench.assemble as assemble_mod
+
+        assembled = assemble_mod.Assembly(
+            match_id="r1",
+            match_dir=tmp_path / "assembled" / "r1",
+            tasks=("task-a",),
+            linked={"stella": 1, "claude-code": 1},
+        )
+        monkeypatch.setattr(
+            assemble_mod, "assemble_run", lambda run_dir, **kw: assembled
+        )
+
+        s3 = FakeS3(
+            {
+                "runs/r1/job-stella/results.json": _single_task_result(
+                    "task-a", "stella", 1.0
+                ),
+                "runs/r1/job-cc/results.json": _single_task_result(
+                    "task-a", "claude-code", 0.0
+                ),
+            }
+        )
+        executor = _executor(s3=s3, dynamodb=FakeDynamo([{"Items": []}]))
+        executor.load_jobs = lambda run_id: {  # type: ignore[method-assign]
+            "jobs": [
+                {"id": "job-stella", "label": "000-stella-task-a"},
+                {"id": "job-cc", "label": "001-cc-task-a"},
+            ]
+        }
+
+        args = argparse.Namespace(
+            run_id="r1", artifacts=True, out=str(tmp_path), region=None, bucket=None
+        )
+        rc = _cmd_cloud_fetch(args, executor=executor)
+
+        assert rc == 0
+        assert not (tmp_path / "trial.json").exists(), (
+            "an assembled run must not also be merged — two files describing "
+            "one run is the ambiguity assembly exists to remove"
+        )
+
 
 class TestCloudMerge:
     """`arenabench cloud merge` — pairing arms that were fetched separately."""


### PR DESCRIPTION
`main` is red, and has been since #3026 merged. Every open PR's
`harbor_adapter + analyzer pytest` job fails on a test neither that PR nor any
other one touched — #3044 is how I found it.

## What broke

#3026 pointed the tail of `_cmd_cloud_fetch` at `_assemble_fetched` and left
`_merge_and_report` — the whole of #3018 — with **zero callers**. The orphaned
function is the tell: a deliberate retirement deletes it.

Assembly reads `runs/<id>/match.toml`, and `CloudExecutor.fetch_results`
downloads that only under `--artifacts` (the default pulls each job's
`results.json` and nothing else, because the full artifact tree is gigabytes).
So the default fetch **could never assemble**. It printed

```
assembled : not yet — …/match.toml does not exist — the whole-match spec is what
makes assembly a restoration rather than a guess.
```

on every invocation and produced no view spanning the arms at all — exactly the
N-disconnected-single-task-files state #3018 was filed to fix.

## The fix

`_assemble_fetched` degrades to `_merge_and_report` instead of returning. The
order carries the argument: the assembled match is a restoration of the
submitted spec and stays the better outcome whenever the spec is on disk; the
merge is what a fetch that never downloaded the spec can honestly build from the
bodies it does have.

The alternatives were worse. Deleting the failing test discards a capability
operators still use, and making `--artifacts` mandatory bills gigabytes for a
scoreboard.

## Evidence

**Witness** — `TestFetchMergesIntoOneTrial::test_cloud_fetch_writes_a_merged_trial_alongside_the_flat_files`,
added by #3018:

- on `main` (44f62e8e0, unmodified): `FileNotFoundError: …/trial.json` — this is
  the failure CI reports on every open PR;
- with this change: passes.

Verified the artisanal way, by stashing **only** `cloud.py` and re-running, so
the pass is attributable to the source change and not to the new test.

**Guard, not a witness** — `test_an_assembled_run_is_not_also_merged` is new and
**passes on `main` too**; it is named here rather than presented as proof. It
pins the ordering so the red cannot be cleared later by calling the merge
unconditionally, which would satisfy the witness above while leaving a rival
`trial.json` beside an assembled match — two files claiming to describe one run.

`arenabench` pytest is green locally except for `test_sut.py` / `test_replay_docker.py`,
which need Docker and a buildable adapter this machine does not have; CI's log for
the same job named exactly one failure, the one fixed here.

## Deliberately not in this PR

`arenabench/pyproject.toml` configures `[tool.ruff]` and carries `ruff` as a dev
dependency, but no workflow runs it — `.github/workflows/bench.yml` has no lint
step. Two stale `RUF100` findings in `cloud.py` predate this change and are
untouched by it. Filed separately rather than folded in.

## Summary by Sourcery

Ensure cloud fetch produces a merged cross-arm trial when assembly cannot run, while preserving assembly as the preferred path when match specs are available.

Bug Fixes:
- Restore default cloud fetch behavior to produce a unified trial view from per-job results when match.toml is not present.

Enhancements:
- Add a test to enforce that an assembled run is not also merged, keeping a single authoritative trial description per run.

Tests:
- Extend cloud fetch tests to cover the assembly-vs-merge ordering and guarantee no duplicate trial.json is written when assembly succeeds.