### PR TITLE
docs: publish the diagnostics plane and --upstream-pin's real home

### DIFF
--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -347,6 +347,39 @@ have an Anthropic session, with no part of this routed through the gateway.
   still works if you pin it — it is simply no longer the default.
 </Callout>
 
+#### Pinning the upstream
+
+A gateway is a router, not a vendor: OpenRouter picks the upstream that actually serves a
+request per **app identity**, and it is free to choose a different one between two calls to
+the same slug — a probe carrying stella's own attribution once asked for
+`anthropic/claude-sonnet-5` and was served by `provider: Amazon Bedrock`. That is invisible
+in the ordinary case — you asked for a model family, and you got it — but it means the
+model *provider* behind an OpenRouter-routed run is not something a bare `--model` pins.
+
+`--upstream-pin <vendor>` (env `STELLA_UPSTREAM_PIN`, repeatable or comma-separated) fixes
+it: the request carries `provider: {order: [...], allow_fallbacks: false}`, so OpenRouter
+either serves it from the named vendor, in the order given, or the call fails rather than
+silently routing elsewhere.
+
+```bash
+stella run "…" --model openrouter/anthropic/claude-fable-5 \
+  --upstream-pin z-ai --upstream-pin anthropic
+```
+
+Reach for it whenever two runs need to be the *same experiment* — a before/after
+comparison, a head-to-head against another agent, anything where "which vendor actually
+answered" is part of what you are claiming stayed fixed. See the
+[terminal-bench head-to-head guide](/docs/guides/terminal-bench-head-to-head#pin-the-upstream-when-either-arm-goes-through-a-gateway)
+for the case that motivated it. Inert on every provider that is not a gateway — a direct
+`anthropic/…` or `openai/…` session has no routing step to pin.
+
+<Callout type="info">
+`--upstream-pin` is a flag, not a `settings.json` field, on purpose: a benchmark harness
+runs with settings isolation (`STELLA_NO_SETTINGS`), so a settings-defined pin would never
+reach a measured trial. An argument is the only authority that survives that isolation —
+the same reason `--base-url` is one.
+</Callout>
+
 #### Selecting models
 
 ```bash

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -10,6 +10,7 @@ Answer "is my local state sound?" before you go looking for a bug that isn't you
 ```bash
 stella doctor                                    # diagnose, change nothing
 stella doctor --repair                           # also quarantine a corrupt store
+stella doctor --last-failure                     # print the newest crash dump
 ```
 
 ## What it does
@@ -69,6 +70,11 @@ Diagnosis never writes. The check opens the database immutably — no locks, no 
     Act on a store SQLite judged corrupt: move it aside to a timestamped name — renamed,
     **never** deleted — and copy out whatever is still readable. A healthy store and an
     inconclusive check are both left untouched.
+  </OptionCard>
+  <OptionCard name="--last-failure">
+    Print the newest [crash dump](/docs/diagnostics#the-crash-file) —
+    `.stella/private/crash-*.jsonl` — and nothing else; no checks run. Content-free by
+    construction, so it's safe to attach to a bug report as printed. Errors if none exists.
   </OptionCard>
 </CardGrid>
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -188,6 +188,11 @@ Every one of them is registered with every subcommand, so **either position pars
     Required with `--model local/<model>` to point at a local OpenAI-compatible server; an
     optional proxy override for any other provider. Env `STELLA_BASE_URL`.
   </OptionCard>
+  <OptionCard name="--upstream-pin <vendor>" defaultValue="gateway's own choice">
+    Pin a **gateway** to these upstreams, in order, and refuse any fallback. Repeatable or
+    comma-separated. Inert on a direct endpoint. Env `STELLA_UPSTREAM_PIN`. See
+    [below](#--upstream-pin-holding-the-vendor-fixed).
+  </OptionCard>
   <OptionCard name="--budget <usd>" defaultValue="none (observed)">
     Hard USD spend cap for the whole run or session. Must be positive and finite. Env
     `STELLA_BUDGET`.
@@ -205,11 +210,66 @@ Every one of them is registered with every subcommand, so **either position pars
     Freeze all deck animation to a static frame, for CI and asciinema-style recordings.
     Env `STELLA_NO_ANIM` / `NO_COLOR`.
   </OptionCard>
+  <OptionCard name="-v / --verbose" defaultValue="warn">
+    Diagnostics: `-v` info, `-vv` debug, `-vvv` trace. See
+    [below](#diagnostics--v---log-level---log-file).
+  </OptionCard>
+  <OptionCard name="--log-level <spec>" defaultValue="warn">
+    Per-crate diagnostic filter — `warn,stella_store=debug`. Env `STELLA_LOG`; the flag
+    wins over both it and `-v`.
+  </OptionCard>
+  <OptionCard name="--log-file <path>" defaultValue="none">
+    Write diagnostics as JSONL to a file, created `0600`, defaulting to `info`. An
+    unwritable path is reported and the run continues.
+  </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
 Prefer an environment variable or `credentials.toml` for anything long-lived. A key passed with `--api-key` is visible in your shell history and in `ps` output.
 </Callout>
+
+### `--upstream-pin`: holding the vendor fixed
+
+Only a **gateway** routes to somebody else's silicon, so this applies to OpenRouter — where
+it sets `provider.order` and `allow_fallbacks: false` — and is inert on a direct endpoint.
+
+```bash
+stella run "…" --model openrouter/anthropic/claude-fable-5 \
+  --upstream-pin z-ai --upstream-pin anthropic
+```
+
+Reach for it when **two runs must be comparable**. A gateway otherwise picks per app
+identity and may serve the same model slug from a different vendor between runs, which
+silently varies the thing a head-to-head claims to hold fixed. It is a flag rather than
+settings-only because a measured trial runs with settings isolation
+(`STELLA_NO_SETTINGS`), where an argument is the only authority that reaches it — the same
+reason `--base-url` is one. See [API providers](/docs/api-providers#pinning-the-upstream)
+for the gateway-routing background, and the
+[head-to-head guide](/docs/guides/terminal-bench-head-to-head#pin-the-upstream-when-either-arm-goes-through-a-gateway)
+for why a benchmark needs this.
+
+### Diagnostics: `-v`, `--log-level`, `--log-file`
+
+The diagnostic plane is the stream that explains *why* stella behaved the way it did — as
+distinct from what the agent did (the [event stream](/docs/event-stream-compatibility)) and
+what it cost (the [receipts](/docs/telemetry)). Records carry a stable code and typed
+fields, and **never** prompts, paths, or model output. [Diagnostics](/docs/diagnostics) is
+the full reference; the short version:
+
+```bash
+stella run "…" -vv                                   # debug everywhere
+stella run "…" --log-level 'warn,stella_model=trace' # quiet except where you are looking
+stella run "…" --log-file ./run.jsonl                # JSONL to a file, created 0600
+```
+
+A target is a Rust module path, so library crates are `stella_store`, `stella_model`, …
+and the binary's own records are under `stella` (hyphens are accepted too). Longest match
+wins; an unrecognised clause is reported and skipped, never fatal. Levels are `off`,
+`error`, `warn`, `info`, `debug`, `trace`.
+
+For a crash you did not anticipate you need no flag at all: stella writes
+`.stella/private/crash-*.jsonl` on a panic or a failed run, and
+[`stella doctor --last-failure`](/docs/commands/doctor) prints the newest.
 
 ### `--output-format` (a flag of `run` and `fleet`, not a global)
 

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -226,6 +226,7 @@ stella inspect 42 --step 0 --diff --only system --format json |
 - **Executions from before the receipts plane landed.** They have no receipt rows and are omitted from the index rather than listed as empty.
 - **The literal wire bytes.** Receipts are taken before the provider adapter runs, and adapters transform the system block on the way out — Anthropic keeps only the last system message and inserts cache breakpoints, OpenAI and Gemini join system messages with `\n\n`. A receipt is the canonical pre-adapter view of the call.
 - **Tool JSON schemas.** The manifest records the messages, not the tool definitions sent alongside them.
+- **Which vendor served a gateway-routed call.** `step_receipt.provider` is the provider you configured — `openrouter` for every OpenRouter call, whichever vendor actually answered. That upstream is recorded, just not by this command — see [Telemetry → who actually served a gateway-routed call](/docs/telemetry#who-actually-served-a-gateway-routed-call).
 
 <Callout type="info">
 Receipts never leave your machine. The content-free export boundary (`stella-store`'s egress guard) strips prompts, paths, and tool payloads from anything replicated off-box, and is enforced by a compile-time column allowlist plus a sentinel-poisoning test. See [Telemetry](/docs/telemetry).

--- a/website/content/docs/diagnostics.mdx
+++ b/website/content/docs/diagnostics.mdx
@@ -1,0 +1,202 @@
+---
+title: Diagnostics
+description: The fourth plane — why stella behaved the way it did, as distinct from what it did and what it cost. -v, --log-level, --log-file, the crash file, and the privacy contract that makes a log safe to attach to a bug report.
+---
+
+Every mature CLI can say "run it again with `-v` and attach the log." Until this
+plane existed, stella could not — for a coding agent that is a sharper gap than
+usual, because runs are nondeterministic and expensive, so "reproduce it with
+verbose on" is frequently not a request you can fulfil. This page is the plane
+that fixes that: what it is, how to turn it on, what it promises never to
+contain, and the one artifact it writes without being asked.
+
+## Three questions, three planes
+
+stella already answers two other questions about a run, and diagnostics is
+deliberately not a second copy of either:
+
+| Plane | Question it answers | Where it lives |
+| --- | --- | --- |
+| **Event stream** | *What did the agent do?* | [`--output-format stream-json`](/docs/scripting), the session journal |
+| **Telemetry** | *What did it cost, and can I prove it?* | [receipts and the local store](/docs/telemetry) |
+| **Diagnostics** | *Why did it behave this way?* | `-v`, `--log-level`, `--log-file`, this page |
+
+A diagnostic record *references* an event by its sequence number rather than
+restating it — so if you want to know what the agent did, read the event
+stream, and if you want to know why it did it, cross-reference the diagnostic
+record at the same point in the timeline.
+
+## Turning it on
+
+```bash
+stella run "…" -vv                                    # debug everywhere
+stella run "…" --log-level 'warn,stella_model=trace'   # quiet except where you're looking
+stella run "…" --log-file ./run.jsonl                  # JSONL to a file, created 0600
+```
+
+<CardGrid size="md">
+  <OptionCard name="-v / -vv / -vvv" defaultValue="warn">
+    Global flag. One `v` is `info`, two is `debug`, three is `trace`. Applies to
+    stderr; a `--log-file` is unaffected and floors at `info` regardless (see
+    below).
+  </OptionCard>
+  <OptionCard name="--log-level <spec>" defaultValue="none">
+    The full filter grammar — see below. Wins over both `-v` and `STELLA_LOG`,
+    because a flag you just typed must never be silently outranked by a
+    variable you exported once.
+  </OptionCard>
+  <OptionCard name="--log-file <path>" defaultValue="none">
+    Write diagnostics as JSONL to a file, created `0600`. Defaults to `info`
+    even when stderr is at `warn` — a file nobody reads until something breaks
+    may as well be able to explain it. An unwritable path is reported on
+    stderr and the run continues; a diagnostic request is never allowed to
+    take a run hostage.
+  </OptionCard>
+  <OptionCard name="STELLA_LOG" defaultValue="warn">
+    Environment form of `--log-level`, same grammar. `STELLA_SERVE_LOG` is
+    checked as a fallback when `STELLA_LOG` is unset — the variable
+    [`stella-serve`](/docs/agent-engine-paths) shipped first, kept working
+    rather than retired.
+  </OptionCard>
+</CardGrid>
+
+Resolution order, most specific first: **`--log-level`**, then **`-v`/`-vv`/`-vvv`**,
+then **`STELLA_LOG`** (or `STELLA_SERVE_LOG`), then the default, `warn`.
+`--log-level` deliberately does not also read from the environment — with it,
+`STELLA_LOG=warn stella -vv run "…"` would silently ignore the `-vv` you just
+typed, because a flag parser cannot tell an env-sourced value from a typed one.
+
+### The filter grammar
+
+```text
+warn                                    # global default
+warn,stella_store=debug                 # quiet, except one crate at debug
+off,stella=trace,stella_model=trace     # silent except two targets
+```
+
+A comma-separated spec. A bare level sets the default; `target=level`
+overrides it for that module subtree, **longest match wins** — so
+`warn,stella_store=debug,stella_model=trace` is quiet everywhere except the two
+places you're looking. Levels are `off`, `error`, `warn`, `info`, `debug`,
+`trace`.
+
+A target is a Rust module path: library crates are `stella_store`,
+`stella_model`, `stella_diag`, and so on, while the binary's own records are
+under `stella` — not `stella_cli`, which is only the package name, not the
+compiled target. Hyphens are accepted too (`stella-store=debug`).
+
+An unrecognised clause is **skipped and reported**, never fatal — a typo in a
+log knob must not take a process down. The report lands as a `warn` record of
+its own (`diag.filter.bad_clause`) once there is somewhere to write it.
+
+## The privacy contract
+
+Records carry a stable `code` and typed fields, and **never** prompts, paths,
+model output, or full identifiers. That is a much stronger claim than "we try
+not to log secrets," and it is worth stating precisely because it decides
+whether you can hand a log to a stranger:
+
+**It is enforced by the type system, not by review.** A diagnostic field value
+is not `String`, not `Path`, and not anything with a blanket `Display` impl —
+it is a closed type constructible only from things that structurally cannot
+carry runtime content: integers, `bool`, `Duration`, `&'static str`, a closed
+`log_enum!` vocabulary, an 8-character `ShortId` (never a whole identifier),
+and `PathClass` (a path's *shape* — `inside_workspace`, four levels deep, a
+`.rs` file — never its bytes). Writing this does not compile:
+
+```rust
+diag!(warn, "tools.write.denied", path = user_path);   // ← String; will not build
+```
+
+`tracing` or a hand-rolled logger would happily print that with `%user_path`.
+Here it is a type error, checked once at compile time instead of on every call
+site forever. There is a single, deliberate escape hatch (`Redacted`, gated
+behind a written justification that ships in the diff), and a single way
+around the type system entirely (`Box::leak`ing a `String` into `&'static
+str`) — which is why it is on the workspace's `clippy.toml` disallowed-methods
+list. The claim is not "impossible," it is *"impossible by accident, and loud
+on purpose."* See [`crates/stella-diag`](https://github.com/macanderson/stella/tree/main/crates/stella-diag)
+for the full mechanism.
+
+## The crash file
+
+Every record at every level, filter notwithstanding, also lands in a bounded
+in-memory ring (2,000 records or 1 MiB, whichever binds first). On a panic —
+or any non-zero exit from `main` — that ring is written to disk:
+
+```text
+.stella/private/crash-<timestamp>.jsonl
+```
+
+`0700` directory, `0600` file — the same permissions the receipts plane
+already uses. Print the newest one:
+
+```bash
+stella doctor --last-failure
+```
+
+Because content cannot enter a record, this file is content-free **by
+construction**. That is what turns "please attach your log" from a request
+that needs a privacy review into one a stranger on the internet can act on
+immediately, and it is the sentence stella could not say before this plane
+existed. You need no flag set in advance for this — it works at the default
+`warn`, because the ring captures every level regardless of what the filter
+sends to a visible sink.
+
+<Callout type="info">
+The filter governs **sinks**, never **emission**. Raising `-vv` changes what
+you see on stderr or in `--log-file`; it does not change what the crash ring
+holds, so a crash dump is complete however quiet the run looked.
+</Callout>
+
+## Reading the codes
+
+A record's `code` is stable, versioned, public surface — the same idea as
+`rustc`'s `E0308`: you can alert on it, link to it in a runbook, and it
+outlives whatever the message text says this release. A curated set worth
+knowing while chasing a specific symptom:
+
+| Code | Level | What it means |
+| --- | --- | --- |
+| `cli.boot` | info | The process came up with diagnostics wired. The first record of every run — a log that doesn't start with this was produced some other way. |
+| `agent.loop.detected` | warn | The loop detector matched a repeating action pattern. If `aborted` is true, this is why the run ended. |
+| `agent.budget.denied` | error | A step was refused because spend hit the configured cap — the engine working as configured, not a fault. |
+| `agent.model.retry` | warn | A model call failed and is being retried. A cluster against one provider is usually rate limiting or an outage. |
+| `agent.model.retries_exhausted` | error | Every retry failed and the turn could not proceed — almost always upstream availability or auth. |
+| `agent.provider.fallback` | warn | The configured provider failed and the engine fell back to another. Answers "which model actually served this turn." |
+| `agent.tool.result` | debug / warn | A tool finished. Emitted at `warn` only on failure, so a default `stderr` filter shows failures and only failures. |
+| `agent.turn.parked` / `agent.turn.woken` | info | The turn parked to wait on something external. A run that looks hung right after `parked` is doing exactly what the record says. |
+| `agent.unknown` | warn | An event variant this build doesn't recognise crossed the stream — almost always version skew between producer and consumer. |
+| `diag.log_file.unavailable` | warn | `--log-file` was requested but couldn't be opened. The run continues without it; this record on stderr says why. |
+| `diag.panic` | error | The process panicked. Carries the panic's file/line/column in stella's own source — never the panic message, which routinely interpolates runtime content. |
+
+This is a subset, hand-picked for the symptoms in
+[When something isn't working](/docs/guides/troubleshooting). The complete,
+generated list — every code the tree emits, its level, its emit site, and its
+full field set — is
+[`docs/reference/diagnostics.md`](https://github.com/macanderson/stella/blob/main/docs/reference/diagnostics.md)
+in the repository. It is regenerated from the emit sites themselves, so it can
+never drift the way a second hand-maintained copy would; this page's table is
+transcribed from it by hand, which is a gap of its own —
+[#3045](https://github.com/macanderson/stella/issues/3045) tracks generating
+this page's table from the same source instead.
+
+## Next
+
+<CardGrid size="sm">
+  <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
+    Symptom-first checks — config, keys, hooks, cost — most of which need no
+    diagnostic flag at all.
+  </SpecCard>
+  <SpecCard title="stella doctor" href="/docs/commands/doctor">
+    Local-state checks, and what `--last-failure` prints.
+  </SpecCard>
+  <SpecCard title="Telemetry" href="/docs/telemetry">
+    What it cost, and the receipts that prove it — the plane diagnostics
+    deliberately doesn't duplicate.
+  </SpecCard>
+  <SpecCard title="Event stream compatibility" href="/docs/event-stream-compatibility">
+    What the agent did — the other plane diagnostics references but never
+    restates.
+  </SpecCard>
+</CardGrid>

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -163,6 +163,35 @@ Hitting `api.anthropic.com` directly on a single model gives one backend, no
 routing lottery, and Claude Code on its home API where thinking engages
 natively.
 
+### Pin the upstream when either arm goes through a gateway
+
+Sometimes routing directly at the provider is not an option — a gateway may be
+the only surface with the model or the credential you need. If either arm goes
+through OpenRouter (or any other gateway), the routing lottery in the section
+above is not merely a confound to avoid by routing around it; it is a variable
+you can pin instead: **`--upstream-pin <vendor>`** fixes stella's arm to a
+named upstream, in order, and refuses fallback rather than letting the gateway
+silently pick per app identity.
+
+```bash
+stella run "…" --model openrouter/anthropic/claude-fable-5 \
+  --upstream-pin anthropic
+```
+
+This is the flag's actual reason to exist: a run's `--model` names a model
+family, not a vendor, and two arms that both say "Claude" through a gateway
+have not shown they were served by the same silicon unless the pin — or a
+direct endpoint — says so. Pass `--upstream-pin` on the launch command
+directly, never through `settings.json`. The Harbor trial launches stella with
+**`STELLA_NO_SETTINGS=1`** — filesystem isolation so a task repository cannot
+plant configuration a trial would trust — and a settings-defined pin would
+therefore never reach the process being measured. A command-line argument is
+the only authority that survives that isolation, which is the same reason
+`--base-url` is passed as a flag here rather than configured.
+
+See [API providers → pinning the upstream](/docs/api-providers#pinning-the-upstream)
+for why this exists and what it does on the wire.
+
 ### Give each arm its own key
 
 Two keys on the same account, one per arm:

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -17,6 +17,7 @@
     "accessibility",
     "self-improvement",
     "telemetry",
+    "diagnostics",
     "principles",
     "---Configure---",
     "configuration",

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -204,6 +204,17 @@ editing the command line:
     Equivalent to `--budget`. Hard USD cap for the whole run. Unset means
     spend is metered but never blocked.
   </OptionCard>
+  <OptionCard name="STELLA_UPSTREAM_PIN">
+    Equivalent to `--upstream-pin`. Pins a gateway to named upstreams and
+    refuses fallback — set it when two runs have to be comparable. See
+    [Diagnostics and comparability](/docs/api-providers#pinning-the-upstream).
+  </OptionCard>
+  <OptionCard name="STELLA_LOG" defaultValue="warn">
+    Equivalent to `--log-level`. Per-crate diagnostic filter, e.g.
+    `warn,stella_model=trace`. Resolution is most-specific-first: `--log-level`,
+    then `-v`/`-vv`/`-vvv`, then this, then `warn` — so a typed `-vv` is never
+    silently overridden by an exported value. See [Diagnostics](/docs/diagnostics).
+  </OptionCard>
   <OptionCard name="STELLA_PLAIN">
     Set to `1` for the plain line-based REPL instead of the Command Deck. Rarely
     needed in CI — the deck already steps aside when stdout is not a terminal.

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -185,6 +185,32 @@ sqlite3 -json .stella/private/store.db \
   | jq -r '.[] | "step \(.step).\(.call_seq)\t\(.call_role)\t\(.estimated_input_tokens)/\(.effective_budget_tokens)"'
 ```
 
+### Who actually served a gateway-routed call
+
+`step_receipt.provider` (and the `telemetry` table's own provider column) name the provider
+you **configured** — for an OpenRouter run, that is always the string `openrouter`, the
+gateway, never the vendor it routed to. [Pinning the upstream](/docs/api-providers#pinning-the-upstream)
+stops the gateway from routing inconsistently between calls, but *auditing* which vendor
+served a past call is a different question, and the two receipt tables above cannot answer
+it — they were not extended with a column for it.
+
+The answer is recorded, just not in a queryable column yet. The `events` table stores every
+execution's raw event stream verbatim, and a `step_usage` event carries `upstream_provider`
+whenever a pinned gateway call named one:
+
+```bash
+sqlite3 -json .stella/private/store.db \
+  "SELECT payload FROM events WHERE execution_id = 42 AND event_type = 'step_usage'" \
+  | jq -r '.[].payload | fromjson | select(.upstream_provider) | "\(.provider) → \(.upstream_provider)"'
+```
+
+`upstream_provider` is `null` on a direct endpoint (where `provider` is already the honest
+answer) and on any call that predates the field. Neither [`stella inspect`](/docs/commands/inspect)
+nor [`stella stats`](/docs/commands/stats) surfaces it today — reading it means querying
+`events` directly, as above. [#3054](https://github.com/macanderson/stella/issues/3054)
+tracks giving `step_receipt` its own column so a future `stella inspect` can show it
+without the raw query.
+
 ## Oxagen Enterprise managed export
 
 Managed mode exists for cross-seat operational visibility, capacity planning, and


### PR DESCRIPTION
## Summary

Closes #3043, closes #3042 — both docs-only, both surfaced by the freshness
audit as flags/subsystems with an `OptionCard` mention in `commands/index.mdx`
but no real home where the people who need them are reading.

**#3043 — the diagnostic plane had no page at all.** Adds
`website/content/docs/diagnostics.mdx`: the three-planes framing (event
stream / telemetry / diagnostics), the filter grammar, the privacy contract
and its compile-time enforcement mechanism (`stella-diag`'s closed `Loggable`
vocabulary), the crash file (`.stella/private/crash-*.jsonl`,
`stella doctor --last-failure` — itself undocumented until this PR), and a
curated subset of the generated diagnostic codes reference. The full,
generated table stays `docs/reference/diagnostics.md`; generating this page's
table from the same source is filed as #3045 rather than silently
hand-transcribed forever.

**#3042 — `--upstream-pin` only had a flag card.** Gives it a real home in
three places: `api-providers/index.mdx` (what gateway upstream selection is,
and how the pin works on the wire), the terminal-bench head-to-head guide
(why `STELLA_NO_SETTINGS` makes this a flag rather than a settings key), and
`telemetry/index.mdx` for the other half of #2786 — recording who served the
call.

That last one surfaced a real finding: `upstream_provider` is durable
(`AgentEvent::StepUsage`, serialized verbatim into the `events` table), but
neither `step_receipt` nor `stella inspect` carries it — both only ever
recorded the gateway id. I documented the surface that actually exists today
(a raw SQL/jq query against `events`) rather than one that doesn't, and filed
#3054 to give it a real column so `stella inspect` can answer it directly.

## Verification

- Every flag claim was checked against `stella --help` / `stella doctor --help`
  built at this commit, not transcribed from the issues — output pasted below.
- `make doc-links`, `make command-docs`, `make brand-case` all pass.
- `rg -rln 'log-level|log-file|STELLA_LOG' website/content/docs/` now hits
  `diagnostics.mdx`, `commands/index.mdx`, `commands/doctor.mdx`, `scripting.mdx`.
- `rg -rln 'upstream.pin|upstream_pin|STELLA_UPSTREAM_PIN' website/content/docs/`
  now hits `commands/index.mdx`, `api-providers/index.mdx`,
  `guides/terminal-bench-head-to-head.mdx`, `telemetry/index.mdx`,
  `scripting.mdx`.

```
$ ./target/debug/stella doctor --help | grep -A2 last-failure
      --last-failure
          Print the newest crash dump instead of running the checks: .stella/private/crash-*.jsonl,
          written automatically when a run panics or exits non-zero. ...
```

No Rust files changed; this is a docs-only PR (`website/content/docs/**`),
so `ci.yml`'s Rust jobs don't apply — `docs-guards.yml` is the relevant gate.

## Filed while doing this

- #3045 — generate this page's diagnostic-codes table from the same
  emit-site scan `docs/reference/diagnostics.md` already uses, instead of a
  hand-transcribed subset.
- #3054 — give `step_receipt` (or equivalent) a real `upstream_provider`
  column so `stella inspect`/`stella stats` can answer "who served this call"
  without a raw query.

## Test plan

- [x] `make doc-links`
- [x] `make command-docs`
- [x] `make brand-case`
- [x] Every `--flag`/env-var claim checked against `stella --help` and
      `stella doctor --help` built at this commit
- [x] Manually verified every new internal anchor link's slug against the
      site's actual heading-to-anchor convention (cross-checked against
      `commands/daemon.mdx`'s existing `--detach` anchor)

## Summary by Sourcery

Document the diagnostics plane and upstream pin behavior, giving them full reference pages and integrating them into related docs.

Documentation:
- Add a dedicated Diagnostics page explaining the diagnostics plane, logging flags and environment variables, privacy guarantees, crash file behavior, and key diagnostic codes.
- Expand command and scripting documentation to cover -v, --log-level, --log-file, STELLA_LOG, and STELLA_UPSTREAM_PIN, including usage examples and cross-links.
- Document --upstream-pin semantics for gateway-based API providers, its benchmarking motivation, and how to use it in terminal-bench head-to-head guides.
- Clarify telemetry documentation around gateway-routed calls by explaining where upstream provider information is stored and how to query it from events.
- Update doctor and inspect command docs to describe crash dump retrieval via --last-failure and limitations around identifying gateway vendors from receipts.