### PR TITLE
feat(bench): catch the credential void the gate was actually asked for

### DIFF
--- a/bench/trace_triage/banned.py
+++ b/bench/trace_triage/banned.py
@@ -206,15 +206,39 @@ LEDGER: dict[str, Disposition] = {
                 "`step_usage` fires only on a completed step, so a trial with "
                 "reasoning deltas and none of them never got one model call back. "
                 "The trial measured the harness, and scoring its zero as a task loss "
-                "is the flattering-artifact error inverted. This is the shape an "
-                "expired credential takes: it is decidable on trial one, because the "
-                "next trial uses the same credential."
+                "is the flattering-artifact error inverted. Note this row is the "
+                "narrower of the pair: it requires reasoning, so the credential case "
+                "belongs to `graded-void-trial` and not here."
             ),
         ),
         trip=FIRST_TRIAL,
         evidence=(
             "silent on both real runs mirrored with agent artifacts — 20 of 20 trials "
             "completed at least one model call in each of s5b2 and post1."
+        ),
+    ),
+    "graded-void-trial": Banned(
+        warrant=Warrant(
+            kind=MEASUREMENT_INVARIANT,
+            citation="",
+            note=(
+                "a trial that completed zero model calls measured nothing, and its "
+                "reward is a fact about the credentials, the gateway or the harness "
+                "rather than about the agent. This is the shape an expired credential "
+                "takes — twenty dead trials, every one scored as a task loss — and it "
+                "is decidable on trial one, because the next trial uses the same "
+                "credential against the same gateway."
+            ),
+        ),
+        trip=FIRST_TRIAL,
+        evidence=(
+            "silent on all three real runs mirrored with agent artifacts (s5b2, "
+            "post1, dec1) — 60 of 60 trials completed at least one model call. The "
+            "firing half is fixture-only: no mirrored run here captured a credential "
+            "failure. Added after checking that `void-model-call` does NOT cover this "
+            "case — that detector requires `reasoning` deltas, and a request rejected "
+            "on authentication streams nothing, so a zero-event trial left the gate "
+            "silent until this row existed."
         ),
     ),
     "agent-timeout": Banned(

--- a/bench/trace_triage/detectors.py
+++ b/bench/trace_triage/detectors.py
@@ -1143,3 +1143,91 @@ def _grep_ere_false_negative(run: Run) -> list[Finding]:
             ],
         )
     ]
+
+
+# --------------------------------------------------------------------------
+# 12. A trial that measured nothing, and was graded anyway
+# --------------------------------------------------------------------------
+
+
+@detector(
+    code="graded-void-trial",
+    title="a trial completed zero model calls and its zero was still scored",
+    site="",
+    search_terms=("no step_usage graded zero", "credential failure scored as a task loss"),
+)
+def _graded_void_trial(run: Run) -> list[Finding]:
+    """Zero `step_usage` in the whole trial, with a reward recorded.
+
+    The general form of `void-model-call`, and the one that catches the case
+    that detector cannot see. `void-model-call` requires `reasoning` deltas —
+    it is the trial that *thought* and never got a call back. A credential that
+    has expired produces no reasoning at all: the request is rejected before
+    anything streams, so the trial emits nothing and the older detector stays
+    silent on it. That is the shape that produced twenty dead trials in one run
+    and scored every one of them as a task loss.
+
+    Keyed on the absence of completed model calls rather than on an
+    authentication string, deliberately. Scanning tool output for `401` is a
+    false-positive machine: across the three runs mirrored here, every single
+    `401` occurrence is task content — a `bottle` test fixture, an `objdump`
+    listing — and not one is a credential failure. The absence of a completed
+    call is the thing that makes the trial unmeasurable, whatever caused it.
+
+    Requires a recorded reward, because that is what makes it a *measurement*
+    defect rather than an infrastructure note: a void trial nobody graded costs
+    nothing, and a void trial graded 0 is a zero in a solve rate that measures
+    the harness.
+    """
+    occurrences = []
+    for trial in run.trials:
+        if trial.reward is None or trial.of_type("step_usage"):
+            continue
+        occurrences.append(
+            Occurrence(
+                trial_uuid=trial.trial_uuid,
+                task_id=trial.task_id,
+                s3_key=trial.s3_key(),
+                location=f"0 completed model calls, graded {trial.reward}",
+                excerpt=(
+                    f"step_usage       : 0   <- no model call ever completed\n"
+                    f"reasoning deltas : {len(trial.of_type('reasoning'))}\n"
+                    f"tool_start       : {len(trial.of_type('tool_start'))}\n"
+                    f"events in trial  : {len(trial.events)}\n"
+                    f"reward recorded  : {trial.reward}\n"
+                    f"harbor exception : {', '.join(trial.exception_types) or 'none recorded'}"
+                ),
+            )
+        )
+    if not occurrences:
+        return []
+    return [
+        Finding(
+            detector="graded-void-trial",
+            site="",
+            variant_source="zero completed model calls on a trial that carries a reward",
+            title="a trial completed zero model calls and its zero was still scored",
+            summary=(
+                "These trials never completed a single model call and were graded "
+                "anyway. `step_usage` is emitted only when a step completes, so the "
+                "agent was never measured — the reward is a fact about the harness, "
+                "the credentials or the gateway, and averaging it into a solve rate "
+                "reports an infrastructure failure as the agent failing."
+            ),
+            occurrences=occurrences,
+            denominator=len(run.trials),
+            search_terms=(
+                "no step_usage graded zero",
+                "credential failure scored as a task loss",
+            ),
+            caveats=[
+                "States that no call *completed*, never why. An expired credential, a "
+                "gateway refusing the request and a trial killed before its first "
+                "response are indistinguishable here; all three are voids, and the "
+                "cause is not decided by this signal alone.",
+                "Overlaps `void-model-call` on a trial that streamed reasoning and was "
+                "graded. That is two true observations of one trial, not double "
+                "counting: this one is about the grade, the other about the thinking.",
+            ],
+        )
+    ]

--- a/bench/trace_triage/tests/test_banned.py
+++ b/bench/trace_triage/tests/test_banned.py
@@ -351,6 +351,77 @@ def test_a_trial_that_completed_no_model_call_stops_the_run(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# graded-void-trial — the credential shape void-model-call cannot see
+# --------------------------------------------------------------------------
+
+
+def _void_trials(count, events=()):
+    return [
+        {"task": f"alpha{i}__AAA", "reward": 0, "events": list(events)}
+        for i in range(count)
+    ]
+
+
+def test_a_graded_trial_with_no_events_at_all_stops_the_run(tmp_path):
+    """The expired-credential shape: the request is refused before anything streams.
+
+    This is the case the whole gate was asked for — twenty dead trials, every
+    one scored as a task loss — and it is the case `void-model-call` misses,
+    because that detector requires `reasoning` deltas and there are none.
+    """
+    write_run(
+        tmp_path,
+        _void_trials(3),
+        declared_worker="anthropic/claude-sonnet-5",
+        declared_roles={},
+    )
+    verdict = _verdict(tmp_path)
+    assert "graded-void-trial" in verdict.codes
+    tripped = next(t for t in verdict.tripped if t.code == "graded-void-trial")
+    assert tripped.trip == FIRST_TRIAL
+    assert "0 completed model calls" in tripped.excerpt or "step_usage       : 0" in tripped.excerpt
+
+
+def test_void_model_call_alone_would_have_missed_it(tmp_path):
+    """Pins *why* the second row exists, so nobody merges the two detectors.
+
+    If this ever starts firing, `void-model-call` has been widened and the
+    `graded-void-trial` row's rationale needs rewriting rather than quietly
+    becoming redundant.
+    """
+    write_run(
+        tmp_path,
+        _void_trials(1),
+        declared_worker="anthropic/claude-sonnet-5",
+        declared_roles={},
+    )
+    fired = {f.detector for f in detectors.run_all(load_run(tmp_path, "testrun"))}
+    assert "void-model-call" not in fired
+    assert "graded-void-trial" in fired
+
+
+def test_a_void_trial_nobody_graded_is_not_a_measurement_defect(tmp_path):
+    """No reward means no number was reported, so nothing was mismeasured."""
+    write_run(
+        tmp_path,
+        [{"task": "alpha__AAA", "reward": None, "events": []}],
+        declared_worker="anthropic/claude-sonnet-5",
+        declared_roles={},
+    )
+    assert "graded-void-trial" not in _verdict(tmp_path).codes
+
+
+def test_a_trial_that_completed_a_call_is_clear(tmp_path):
+    write_run(
+        tmp_path,
+        [_healthy_trial("alpha__AAA")],
+        declared_worker="anthropic/claude-sonnet-5",
+        declared_roles={},
+    )
+    assert "graded-void-trial" not in _verdict(tmp_path).codes
+
+
+# --------------------------------------------------------------------------
 # agent-timeout — the row that proves the rate rule is needed
 # --------------------------------------------------------------------------
 

--- a/bench/trace_triage/tests/test_dedup.py
+++ b/bench/trace_triage/tests/test_dedup.py
@@ -63,12 +63,31 @@ class FakeGitHub:
 def _witness_failure_events(reason: str = REASON) -> list:
     """One witness failure, and nothing else a detector would also fire on.
 
-    The trailing verdict and post-verdict `file_change` are load-bearing: a
-    trial with neither would additionally trip `no-post-verdict-file-change`,
-    and these tests are about the de-duplication decision, not about how many
-    shapes one trial can carry.
+    Three of these four events are load-bearing for that "nothing else", and
+    each was added after a detector fired on the fixture rather than on the
+    defect it describes:
+
+    * the trailing `verdict` and post-verdict `file_change` — without them the
+      trial also trips `no-post-verdict-file-change`;
+    * the leading `step_usage` — without it the trial has completed zero model
+      calls, and a graded trial that never reached the model trips
+      `graded-void-trial`. It also makes the fixture agree with the wire, which
+      is the standing rule in `fixtures.py`: a trial cannot emit a `proof` and a
+      `verdict` without a model call having completed first, so a fixture with a
+      proof and no `step_usage` was describing a trace that cannot exist.
+
+    Its model is the unqualified tail of `write_run`'s default declared worker,
+    which is how the telemetry spells it, so the census detector stays quiet.
     """
     return [
+        {
+            "ts": 1,
+            "type": "step_usage",
+            "step": 0,
+            "role": "worker",
+            "model": "z-ai/glm-5.2",
+            "complete": True,
+        },
         proof("witness_unavailable", reason=reason),
         {"ts": 8, "type": "verdict", "passed": False, "evidence": {}},
         {"ts": 9, "type": "file_change", "path": "out", "kind": "created"},


### PR DESCRIPTION
Follow-up to #3044. The gate shipped without catching the case that motivated
it, and checking my own ledger note is what found that.

## What was wrong

The `void-model-call` row's note claimed it covered an expired credential:

> This is the shape an expired credential takes: it is decidable on trial one,
> because the next trial uses the same credential.

That is false, and the detector's own predicate says so — it requires
`reasoning` deltas present with zero `step_usage`. It is the trial that
*thought* and never got a call back. A credential that has expired streams
nothing: the request is refused before the first byte, so the trial emits zero
events and `reasoning > 0` is never satisfied.

Verified rather than reasoned about — a three-trial fixture with empty event
files and a graded reward of 0, which is the on-disk shape of the incident:

```
trials loaded          : 3
reasoning in t0        : 0
step_usage in t0       : 0
verdict.banned         : False ()
```

So the run that produced twenty dead trials and scored every one as a task loss
would have sailed straight past the gate built to stop it.

## The fix

`graded-void-trial` — zero completed `step_usage` in the trial, with a reward
recorded. The general form of `void-model-call`, which stays as the narrower
sibling (the two overlap on a graded trial that streamed reasoning; that is two
true observations of one trial, and both say so in their caveats).

**Keyed on the absence of a completed call, never on an authentication string.**
Scanning tool output for `401` is a false-positive machine: across the three
mirrored runs, every single `401` occurrence is task content — a `bottle` test
fixture, an `objdump` listing — and not one is a credential failure. The absence
of a completed call is what makes the trial unmeasurable, whatever caused it.

**Requires a recorded reward**, because that is what makes it a *measurement*
defect rather than an infrastructure note: a void trial nobody graded costs
nothing; a void trial graded 0 is a zero in a solve rate that measures the
harness.

## Evidence

- **Silent on all 60 trials** of `s5b2`, `post1` and `dec1` — every trial in
  every run mirrored with agent artifacts completed at least one model call.
- **Fires on the fixture** reproducing the incident shape (above).
- The firing half is fixture-only, and the ledger's `evidence` string says so:
  no mirrored run here captured a credential failure.
- `banned.py` over the three real runs is unchanged by this PR — `post1` clear,
  `s5b2` and `dec1` still exit 9 on `grep-ere-false-negative` alone.

## Tests

Four new in `bench/trace_triage/tests/test_banned.py`, both halves as usual:

- `test_a_graded_trial_with_no_events_at_all_stops_the_run` — the incident shape.
- `test_void_model_call_alone_would_have_missed_it` — pins **why** the second
  row exists, so nobody merges the two detectors without rewriting the
  rationale.
- `test_a_void_trial_nobody_graded_is_not_a_measurement_defect` — no reward
  means no number was reported, so nothing was mismeasured.
- `test_a_trial_that_completed_a_call_is_clear` — the silence half.

Witnessed failing before the detector existed: the first two, via the fixture
above returning `banned=False`.

## One fixture correction

`test_dedup.py::_witness_failure_events` gained the `step_usage` it always
implied. That function's docstring already existed to keep the fixture from
tripping detectors other than the one under test, and this is the same
maintenance — but it is also a faithfulness fix, and that is the better reason:
a trial cannot emit a `proof` and a `verdict` without a model call having
completed first, so the fixture was describing a trace that cannot exist.
`fixtures.py` states the standing rule — "a fixture that disagrees with the wire
tests the fixture".

Its model is the unqualified tail of `write_run`'s default declared worker,
which is how the telemetry spells it, so the census detector stays quiet.

## Gate

`make gate` passed in full on the parent branch (exit 0, redirected to a file,
not piped). This PR changes Python under `bench/` only — no crate, no Rust —
and `python3 -m pytest -q bench/trace_triage/tests` is 90 passed.

Refs #3044, #3053

## Summary by Sourcery

Add a detector for graded trials that completed zero model calls and integrate it into the banned gate, clarifying its relationship to the existing void-model-call detector and updating fixtures to avoid spurious detections.

New Features:
- Introduce the graded-void-trial detector to flag graded trials with no completed model calls as measurement defects.

Enhancements:
- Document graded-void-trial in the banned gate with warrant and evidence notes, and adjust the void-model-call note to describe its narrower scope.
- Update the witness failure fixture to include a completed step_usage event so it faithfully reflects a valid trace and remains isolated from unrelated detectors.

Tests:
- Add targeted tests covering graded-void-trial behaviour, including credential-like void trials, ungraded void trials, and trials that completed model calls.