### PR TITLE
fix(arenabench): the live scoreboard reads results where the runner writes them

### DIFF
--- a/arenabench/arenabench/cloud_watch.py
+++ b/arenabench/arenabench/cloud_watch.py
@@ -252,20 +252,27 @@ class CloudScoreboard:
             pass
         results: dict[str, Any] = {}
         for job in jobs:
-            body = self._results(job["label"])
+            body = self._results(job["id"])
             if body is not None:
                 results[job["label"]] = body
         return assemble(self.run_id, jobs, states, results, details)
 
-    def _results(self, label: str) -> Any:
+    def _results(self, job_id: str) -> Any:
         """One trial's ``results.json``, or ``None`` while it does not exist.
 
         Absence is the normal state for most of a run and must not raise: a
         watcher that dies on the first unwritten result would only ever work
         on a finished run, which is the one case it is not needed for.
+
+        Addressed by **job id**, because that is what the runner writes under
+        (``entrypoint.sh``'s ``JOB_ID``, the Batch job's UUID). The label names
+        the trial's directory on *disk* once fetched, never its object in S3 —
+        the split :meth:`CloudExecutor.fetch_results` already makes. Asking for
+        the label here returns a key nothing writes, and the ``except`` below
+        reports that as "not finished yet" for the life of the run.
         """
         s3 = self.executor._client("s3")  # noqa: SLF001 - same package
-        key = f"runs/{self.run_id}/{label}/results.json"
+        key = f"runs/{self.run_id}/{job_id}/results.json"
         try:
             body = s3.get_object(Bucket=self.executor.bucket(), Key=key)
             return json.loads(body["Body"].read())

--- a/arenabench/tests/test_cloud_watch.py
+++ b/arenabench/tests/test_cloud_watch.py
@@ -4,7 +4,18 @@
 
 from __future__ import annotations
 
-from arenabench.cloud_watch import Cell, assemble, cell_for, render_html, reward_of
+import io
+import json
+from typing import Any
+
+from arenabench.cloud_watch import (
+    Cell,
+    CloudScoreboard,
+    assemble,
+    cell_for,
+    render_html,
+    reward_of,
+)
 
 
 def _results(reward: float | None, *, finished: bool = True) -> dict:
@@ -118,3 +129,77 @@ def test_render_is_self_contained_and_escapes_its_inputs() -> None:
 def test_a_cell_with_no_reward_never_prints_a_number() -> None:
     assert Cell(state="queued").text == "QUEUED"
     assert Cell(state="won", reward=1.0).text == "✓ 1.0"
+
+
+class _FakeS3:
+    """An S3 holding exactly the keys the runner writes, and nothing else.
+
+    ``get_object`` raising on an unknown key is the fidelity that matters: the
+    scoreboard treats any exception as "not written yet", so a fake that
+    returned an empty body for a missing key would hide the bug this proves.
+    """
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.asked: list[str] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict:  # noqa: N803 - boto3 spelling
+        self.asked.append(Key)
+        if Key not in self.objects:
+            raise KeyError(Key)
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+
+class _FakeExecutor:
+    def __init__(self, s3: _FakeS3, jobs: list[dict], states: dict[str, str]) -> None:
+        self.s3 = s3
+        self.jobs = jobs
+        self.states = states
+
+    def load_jobs(self, run_id: str) -> dict:
+        return {"jobs": self.jobs}
+
+    def job_states(self, ids: Any) -> dict[str, str]:
+        return self.states
+
+    def run_rows(self, run_id: str) -> list[dict]:
+        return []
+
+    def bucket(self) -> str:
+        return "arenabench-artifacts-test"
+
+    def _client(self, name: str) -> _FakeS3:
+        return self.s3
+
+
+def test_the_scoreboard_finds_a_result_written_under_the_job_id() -> None:
+    """The live watch path must address S3 by job id, not by trial label.
+
+    ``entrypoint.sh`` writes ``runs/<run>/$JOB_ID/results.json`` where
+    ``JOB_ID`` is the Batch job's UUID; the label only ever names the trial's
+    directory on disk after a fetch. Reading by label asks for a key nothing
+    writes, and the miss is swallowed as "still running" — so a whole run
+    renders empty and never says why.
+
+    The fixture's ids and labels are deliberately different strings. Make them
+    equal and this test passes against the bug.
+    """
+    jobs = _jobs()
+    s3 = _FakeS3(
+        {
+            "runs/contest-1/j0/results.json": json.dumps(_results(1.0)).encode(),
+            "runs/contest-1/j1/results.json": json.dumps(_results(0.0)).encode(),
+        }
+    )
+    board = CloudScoreboard(
+        _FakeExecutor(s3, jobs, {j["id"]: "SUCCEEDED" for j in jobs}),
+        "contest-1",
+    ).fetch()
+
+    assert board.cells[("fix-git", "claude-code")].reward == 1.0
+    assert board.cells[("fix-git", "stella")].reward == 0.0
+    assert board.settled() == 2
+
+    # And it asked for the keys that exist, rather than finding them by luck.
+    assert "runs/contest-1/j0/results.json" in s3.asked
+    assert not [k for k in s3.asked if "cc-fix-git" in k]


### PR DESCRIPTION
## The bug

`CloudScoreboard._results` built its S3 key from the trial **label**. The runner
writes `runs/<run>/$JOB_ID/results.json`, where `JOB_ID` is the Batch job's UUID
(`arenabench/infra/runner/entrypoint.sh:24,241`).

So the watch path asked for a key nothing ever writes, and the `except` below it
reports a miss as "not finished yet" — correct handling for a trial that has
genuinely not finished, and indistinguishable from this. A watched run rendered
every trial as pending for its whole duration, then finished still empty.

Post-run `cloud fetch` was unaffected, which is why it survived: the numbers
always arrived eventually, by the other path.

## The fix

The correct split already existed one file over, in `CloudExecutor.fetch_results`
(`cloud.py:994`):

```python
key = f"runs/{run_id}/{job['id']}/results.json"   # id addresses the object in S3
target = dest / job["label"] / "results.json"     # label names the dir on disk
```

This applies that same split to the watch path. The parameter is renamed
`label` -> `job_id` so a call site cannot silently regress to the old meaning,
and the docstring now states which name addresses S3 and why.

`assemble` is unchanged — it is keyed by label, correctly, and the existing
tests cover that.

## Witness

`test_the_scoreboard_finds_a_result_written_under_the_job_id`.

Its fixture ids (`j0`, `j1`) and labels (`000-cc-fix-git`, ...) are deliberately
different strings; make them equal and the test passes against the bug, which is
noted in the docstring so a later edit cannot quietly defeat it. The fake S3
raises on an unknown key rather than returning an empty body, because the
scoreboard treats any exception as "not written yet" and a lenient fake would
hide exactly this.

Verified by flipping the single line back and re-running. It fails with the
production symptom itself:

```
AssertionError: assert None == 1.0
 +  where None = Cell(state='unknown', reward=None, detail='SUCCEEDED, no results').reward
```

A job that succeeded and did write results, reading back as no results.

## Test state

`uv run pytest tests/test_cloud_watch.py` — 12 passed.

The full `tests/` run has 5 failures, all in `tests/test_sut.py`, all
`AdapterUnavailableError: /usr/bin/python3 cannot build a...` — a local
environment fact. `test_sut.py` imports `runner`, `sut`, `adapter`, `model`,
`provenance` and `registry`; none of them reaches `cloud_watch`, so this
two-file diff cannot be their cause.

Closes #3067

## Summary by Sourcery

Ensure the live CloudScoreboard reads trial results from the S3 keys written by the runner, indexed by job id rather than trial label.

Bug Fixes:
- Fix scoreboard result lookup so the watch path fetches results.json objects by Batch job id, preventing completed trials from appearing permanently pending.

Tests:
- Add a focused CloudScoreboard watch-path test with strict fake S3 and executor fixtures to verify results are found under job ids and not mislabeled as unfinished.