### PR TITLE
fix(stella-cli,stella-model): read the shared human-presence derivation at the daemon console and credential prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,7 +497,7 @@ empty and is meant to stay empty.
 
 ## Workspace layout — where a change goes
 
-Twenty-two crates, every one under the `crates/` directory (`crates/stella-core`,
+Twenty-three crates, every one under the `crates/` directory (`crates/stella-core`,
 `crates/stella-cli`, …; the two bench members stay under `bench/`). The
 one-sentence rule of thumb below routes you to the right one; **each crate's
 own `README.md`** (linked from the table) then covers its boundary, layout,
@@ -515,6 +515,7 @@ the files you must plan around (see below).
 | Change REPL rendering / panels / keybindings | [`stella-tui`](crates/stella-tui/README.md) | Pure-fold ratatui REPL — the Command Deck, the default interactive shell on a TTY. |
 | Touch shared types crossing a crate boundary | [`stella-protocol`](crates/stella-protocol/README.md) | **Zero logic, zero I/O — types only.** |
 | Resolve where `~/.stella` is — home dir, stella home, the user-tier data dir | [`stella-home`](crates/stella-home/README.md) | **A leaf with NO dependencies at all**, which is what lets `stella-store`, `stella-observatory`, `stella-cli`, `stella-model` and `stella-tools` all share it (the observatory must not link the store). Every resolver has a pure `resolve_*` half that reads no environment. |
+| Decide whether a human is present to see/answer a mid-run prompt | [`stella-tty`](crates/stella-tty/README.md) | **A leaf with NO dependencies at all** (#3036) — one pure `human_can_answer(interactive_output, stdin_is_terminal, prompt_is_visible)`, which is what lets `stella-cli`'s `ask_user`/approval prompts and `stella-model`'s credential prompt share one derivation without `stella-model` depending on `stella-cli` (invariant 1). |
 | Emit a diagnostic — a record explaining *why* the program did something | [`stella-diag`](crates/stella-diag/README.md) | **A leaf: `serde` only, so anything may depend on it.** Field values cannot hold a `String`, a `Path`, or model output — that is a compile error, not a review question. Design: [`docs/spec/diagnostics.md`](docs/spec/diagnostics.md). |
 | Compute a line-oriented unified diff (`@@` hunks, git's exact shape) | [`stella-diff`](crates/stella-diff/README.md) | **A leaf with NO dependencies at all** (#1511) — pure functions over borrowed strings, which is what lets [`stella-observatory`](crates/stella-observatory/README.md) and [`stella-cli`](crates/stella-cli/README.md) share one differ without costing the observatory its isolation. |
 | Turn text into a vector, or compare two vectors honestly | [`stella-embed`](crates/stella-embed/README.md) | **A leaf with NO workspace-crate dependencies** — the `Embedder` seam, the fingerprint every stored vector is stamped with, the `SimilarityPosture` a backend must declare, and a pure deterministic ranker. Shared by [`stella-context`](crates/stella-context/README.md) (retrieval) and [`stella-graph`](crates/stella-graph/README.md) (semantic code search) so neither has to depend on the other. |
@@ -587,7 +588,7 @@ a plan needs and the part that rarely changes:
 | `stella-tools` | `src/registry.rs` |
 | `stella-tui` | `src/deck_ui.rs`, `src/views/engine.rs`, `src/views/session.rs`, `src/deck_render.rs` |
 
-The other fifteen crates carry no god files — keep it that way. Each crate's
+The other sixteen crates carry no god files — keep it that way. Each crate's
 README repeats its own list under "God files — do not add lines", so the
 constraint is in view wherever planning starts.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "stella-runtime",
  "stella-store",
  "stella-tools",
+ "stella-tty",
  "stella-tui",
  "tempfile",
  "tokio",
@@ -3282,6 +3283,7 @@ dependencies = [
  "sha2 0.11.0",
  "stella-home",
  "stella-protocol",
+ "stella-tty",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -3433,6 +3435,10 @@ dependencies = [
  "toml",
  "wiremock",
 ]
+
+[[package]]
+name = "stella-tty"
+version = "0.9.16"
 
 [[package]]
 name = "stella-tui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/stella-diff",
   "crates/stella-embed",
   "crates/stella-home",
+  "crates/stella-tty",
   "crates/stella-protocol",
   "crates/stella-core",
   "crates/stella-model",

--- a/crates/stella-cli/Cargo.toml
+++ b/crates/stella-cli/Cargo.toml
@@ -31,6 +31,10 @@ stella-diag = { path = "../stella-diag" }
 # `paths` seam (#1139). Depended on directly so the CLI's resolved paths cannot
 # drift from the crates that own the files they name.
 stella-home = { path = "../stella-home" }
+# The single "is a human present to answer?" derivation (#3036), shared with
+# stella-model's credential prompt without either crate depending on the
+# other.
+stella-tty = { path = "../stella-tty" }
 stella-protocol = { path = "../stella-protocol" }
 contextgraph-types.workspace = true
 contextgraph-host.workspace = true

--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -688,7 +688,10 @@ impl Supervised {
     /// see [`stella_store::supervised::STDOUT_LOG`].
     pub(crate) async fn follow(&mut self) -> Result<Option<u8>, String> {
         use std::io::IsTerminal;
-        let interactive = std::io::stdin().is_terminal();
+        let interactive = approval::console_is_interactive(
+            std::io::stdin().is_terminal(),
+            std::io::stderr().is_terminal(),
+        );
         let mut approval_noted = false;
         loop {
             let moved = self.pump()?;
@@ -1360,7 +1363,10 @@ fn attach(registry: &SessionRegistry, id: Option<&str>) -> Result<(), String> {
     let record = resolve(registry, id)?;
     let sidecar = registry.sidecar_dir(&record.id);
     let mut console = console::Follower::open(&sidecar)?;
-    let interactive = std::io::stdin().is_terminal();
+    let interactive = approval::console_is_interactive(
+        std::io::stdin().is_terminal(),
+        std::io::stderr().is_terminal(),
+    );
     let mut approval_noted = false;
     eprintln!(
         "{} {} — {}",

--- a/crates/stella-cli/src/daemon/approval.rs
+++ b/crates/stella-cli/src/daemon/approval.rs
@@ -286,6 +286,26 @@ impl ApprovalGate for OneShotApprovalGate {
     }
 }
 
+/// Whether this attached/following terminal can answer a parked scope
+/// review. Pure over already-observed booleans (rather than calling
+/// `IsTerminal` itself) so the exact condition is directly unit-testable —
+/// the same shape as `crate::agent::engine::approval_capability_for`
+/// (private to that module, so not linkable from here).
+///
+/// Reads [`stella_tty::human_can_answer`] with the **stderr** handle in the
+/// "where does the prompt render" slot, not stdout: this module's doc above
+/// is explicit that the scope-review prompt is stderr-only by design (stdout
+/// is the run's own byte-verbatim relay, and a prompt folded into it would
+/// corrupt a machine-format caller reading that stream), so a stdout check
+/// would both miss the real hazard here — a redirected stderr with a
+/// terminal stdin, `stella daemon attach 2>out.log` — and gate on a stream
+/// this prompt never touches (#3036). There is no machine `--output-format`
+/// for `attach`/`follow` themselves — they always render text — so
+/// `interactive_output` is unconditionally `true`.
+pub(crate) fn console_is_interactive(stdin_is_terminal: bool, stderr_is_terminal: bool) -> bool {
+    stella_tty::human_can_answer(true, stdin_is_terminal, stderr_is_terminal)
+}
+
 /// The attached-terminal side: answer a parked scope review, if one is
 /// pending and this terminal can.
 ///
@@ -619,6 +639,30 @@ mod tests {
             settings.approval_wait(),
             Some(std::time::Duration::from_secs(90))
         );
+    }
+
+    /// The #3036 witness: a redirected stderr must decline to answer even
+    /// with a live keyboard on stdin — the disagreeing configuration
+    /// `stdin().is_terminal()` alone could not see, because the daemon
+    /// console's prompt renders on stderr, not stdin. On `main` before this
+    /// fix, `console_is_interactive` did not exist and both call sites
+    /// derived `interactive` from stdin alone, so a `stella daemon attach
+    /// 2>out.log` from a real terminal would print its scope-review prompt
+    /// into a file nobody reads and then block reading stdin for an answer
+    /// nobody knows to give.
+    #[test]
+    fn a_redirected_stderr_cannot_answer_even_with_a_live_stdin() {
+        assert!(
+            !console_is_interactive(true, false),
+            "a human at the keyboard is not enough if the prompt itself is invisible"
+        );
+    }
+
+    /// The happy path, named explicitly so the witness above is read as a
+    /// missing condition rather than an always-false predicate.
+    #[test]
+    fn a_full_terminal_can_answer() {
+        assert!(console_is_interactive(true, true));
     }
 
     /// A piped attach notes the parked run once and answers nothing.

--- a/crates/stella-cli/src/interactive.rs
+++ b/crates/stella-cli/src/interactive.rs
@@ -123,12 +123,19 @@ impl AskUserIo for HeadlessAskUserIo {
 /// (the pipeline's approval port). Deriving it separately is what let the
 /// rules/approvals layer believe a human could be asked while `ask_user` had
 /// already resolved to an io that only returns an error.
+///
+/// A thin wrapper over [`stella_tty::human_can_answer`] — every consumer in
+/// this crate prints its prompt on stdout, so `stdout_is_terminal` is the
+/// right name for the third input here, but the underlying predicate is
+/// shared with `stella-model`'s credential prompt and the daemon console's
+/// stderr-rendered scope review too (#3036), neither of which could depend on
+/// this crate to read it.
 pub fn human_can_answer(
     interactive_output: bool,
     stdin_is_terminal: bool,
     stdout_is_terminal: bool,
 ) -> bool {
-    interactive_output && stdin_is_terminal && stdout_is_terminal
+    stella_tty::human_can_answer(interactive_output, stdin_is_terminal, stdout_is_terminal)
 }
 
 /// [`human_can_answer`] against this process's real stdio handles.

--- a/crates/stella-model/Cargo.toml
+++ b/crates/stella-model/Cargo.toml
@@ -14,6 +14,11 @@ stella-protocol = { path = "../stella-protocol" }
 # moves with `STELLA_HOME` like every other user-tier file (#2178). A leaf with
 # an empty `[dependencies]` block, which is what makes it depend-able here.
 stella-home = { path = "../stella-home" }
+# The single "is a human present to answer?" derivation (#3036) — the
+# credential prompt's interactive gate reads it rather than re-deriving the
+# fact from only stdin, which `stella-cli`'s ask_user tool and approvals
+# already learned is not enough on its own.
+stella-tty = { path = "../stella-tty" }
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/stella-model/src/credential.rs
+++ b/crates/stella-model/src/credential.rs
@@ -136,6 +136,32 @@ impl ApiKey {
         }
     }
 
+    /// Whether this invocation can host the interactive credential prompt.
+    /// Pure over already-observed booleans (rather than calling `IsTerminal`
+    /// itself) so the exact condition is directly unit-testable — the same
+    /// shape `stella-cli`'s `agent::engine::approval_capability_for` and
+    /// `daemon::approval::console_is_interactive` use.
+    ///
+    /// The single "is a human present?" derivation (#3036), shared with
+    /// `stella-cli`'s `ask_user` tool and approvals without this crate
+    /// depending on that one (invariant 1). `interactive` here already plays
+    /// [`stella_tty::human_can_answer`]'s `interactive_output` role — the
+    /// caller's "would I even attempt a prompt" decision (`stella-cli` clears
+    /// it for a machine `--output-format`) — so this only adds the check that
+    /// was missing: a redirected stdout must decline exactly as a redirected
+    /// stdin does, not just print a prompt nobody reads before blocking on an
+    /// answer nobody can give. `stdout_is_terminal` is a proxy for whether
+    /// `rpassword`'s prompt is actually visible rather than an exact match —
+    /// it writes to `/dev/tty` directly on Unix, not stdout — tracked
+    /// separately as #3052 rather than folded into this fix.
+    fn can_prompt_interactively(
+        interactive: bool,
+        stdin_is_terminal: bool,
+        stdout_is_terminal: bool,
+    ) -> bool {
+        stella_tty::human_can_answer(interactive, stdin_is_terminal, stdout_is_terminal)
+    }
+
     /// The full resolution chain: CLI flag -> env
     /// var -> `credentials_file` -> interactive prompt. `provider_id` keys
     /// both the credentials-file lookup and, on a successful interactive
@@ -172,7 +198,11 @@ impl ApiKey {
             return Ok((Self(value.to_string()), CredentialSource::ConfigFile));
         }
 
-        if interactive && std::io::stdin().is_terminal() {
+        if Self::can_prompt_interactively(
+            interactive,
+            std::io::stdin().is_terminal(),
+            std::io::stdout().is_terminal(),
+        ) {
             // A successful prompt returns immediately. A failure — most
             // commonly because stdin reports as a terminal (`is_terminal()`
             // == true) yet is not genuinely readable (the libtest pty,
@@ -810,6 +840,28 @@ mod tests {
         let debug = format!("{key:?}");
         assert!(!debug.contains("sk-super-secret-value"));
         assert!(debug.contains("redacted"));
+    }
+
+    /// The #3036 witness: a redirected stdout must decline the prompt even
+    /// with a live keyboard on stdin — the disagreeing configuration a
+    /// stdin-only check could not see. On `main` before this fix,
+    /// `ApiKey::resolve`'s interactive gate was `interactive &&
+    /// stdin_is_terminal` alone, so a `stella config > out.txt` from a real
+    /// terminal would have `rpassword` write its "enter it now" prompt where
+    /// nobody could read it and then block on an answer nobody knew to give.
+    #[test]
+    fn a_redirected_stdout_declines_the_prompt_even_with_a_live_stdin() {
+        assert!(
+            !ApiKey::can_prompt_interactively(true, true, false),
+            "a human at the keyboard is not enough if the prompt itself is invisible"
+        );
+    }
+
+    /// The happy path, named explicitly so the witness above reads as a
+    /// missing condition rather than an always-false predicate.
+    #[test]
+    fn a_full_terminal_can_host_the_prompt() {
+        assert!(ApiKey::can_prompt_interactively(true, true, true));
     }
 
     #[test]

--- a/crates/stella-tty/Cargo.toml
+++ b/crates/stella-tty/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stella-tty"
+description = "Whether a human is present to see and answer a prompt this process might print, mid-run — one pure derivation shared by stella-cli's ask_user/approval prompts and stella-model's credential prompt, neither of which may depend on the other."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+# Deliberately empty: the stella-home shape (#1139). stella-model needs this
+# predicate but must never depend on stella-cli (invariant 1 — the CLI is the
+# binary, the model crate is a library below it), and stella-home's own
+# README draws its boundary at "what path is the stella home" and names
+# exactly this dependency-direction shape as when a new leaf is warranted
+# rather than folded in (#3036). A crate that pulls in nothing costs neither
+# side any isolation.
+[dependencies]

--- a/crates/stella-tty/README.md
+++ b/crates/stella-tty/README.md
@@ -1,0 +1,61 @@
+# stella-tty
+
+Whether a human is present to see and answer a prompt this process might
+print, mid-run. One pure function:
+
+```rust
+stella_tty::human_can_answer(interactive_output, stdin_is_terminal, prompt_is_visible);
+```
+
+`true` only when the run would render interactive text at all, stdin is a
+real terminal (so an answer can come back), and the stream the prompt is
+actually printed on is a real terminal too (so the question was seen). All
+three are independently required — see the function's doc comment for what
+each one means and who supplies it.
+
+## Boundary — does this change belong here?
+
+This crate owns one decision: whether a human is present to answer. If a
+planned change adds a new stream a prompt might render on, or a new reason a
+run cannot host one, it belongs here, expressed as another `bool` input to
+the same pure function — never as this crate reading `std::io` itself (see
+the crate doc for why: each consumer's three booleans come from a genuinely
+different place, and purity is what keeps the condition unit-testable without
+faking a terminal).
+
+Everything else is out. This crate has **no dependencies and must keep
+none** — the `stella-home` shape (#1139): a leaf that pulls in nothing costs
+neither `stella-cli` nor `stella-model` any isolation by depending on it.
+Deciding *what to do* once a human is or isn't present (offer a tool, print a
+prompt, fail closed) is the consumer's job, not this crate's.
+
+## Why it is a crate and not a module in `stella-home`
+
+`stella-home` already answers "where is `~/.stella`" for both `stella-cli`
+and `stella-model`, and its own README states the rule for when a new leaf is
+justified rather than folded into it: functionality that needs a dependency
+direction the current graph forbids. That is exactly this shape (#3036) —
+`stella-model`'s credential prompt needs the same derivation `stella-cli`'s
+`ask_user` tool uses, but `stella-model` must never depend on `stella-cli`
+(invariant 1) — and `stella-home`'s own boundary section is explicit that "what
+path is the stella home" is the only decision it owns; a human-presence fact
+is a different question answered for a different reason, so bolting it on
+would violate that boundary rather than honour the same shape.
+
+## God files — do not add lines
+
+This crate has no god files: no file exceeds the gate's 1500-line ratchet
+(`scripts/check-file-size.sh`), and none may appear — a new file crossing
+1500 lines fails the gate outright, and `scripts/file-size-baseline.txt`
+accepts no new entries. When a file here approaches the limit, split it before
+it crosses.
+
+## Consumers
+
+- `stella-cli`: `crates/stella-cli/src/interactive.rs::human_can_answer` is a
+  thin wrapper (same public path, same doc, same signature — nothing else in
+  the crate needed to change) so every existing call site and doc-link keeps
+  working. `daemon/approval.rs` calls this crate directly for the daemon
+  console's stderr-rendered prompt.
+- `stella-model`: `crates/stella-model/src/credential.rs`'s interactive
+  credential prompt.

--- a/crates/stella-tty/src/lib.rs
+++ b/crates/stella-tty/src/lib.rs
@@ -1,0 +1,88 @@
+//! **Whether a human is present to see and answer a prompt this process
+//! might print, mid-run.** The single pure derivation of that fact, so two
+//! call sites can never disagree about whether somebody is there to ask.
+//!
+//! # Why this is its own crate
+//!
+//! This predicate has two consumers on opposite sides of a dependency
+//! direction invariant 1 (`AGENTS.md`) forbids: `stella-cli`'s own
+//! `ask_user` tool and scope-review approvals, and `stella-model`'s
+//! interactive credential prompt (`credential.rs`) — which must never depend
+//! on `stella-cli`, the binary above it (#3036). `stella-home` is the
+//! obvious-looking home (both crates already depend on it), but its own
+//! README draws the boundary explicitly: "this crate owns one decision: what
+//! path a process should treat as the stella home... everything else is
+//! out." A human-presence fact is not a path. `stella-home`'s README also
+//! names the rule this crate satisfies: a new leaf is warranted when
+//! functionality needs a dependency direction the current graph forbids —
+//! exactly this shape, and the same one `stella-diff` and `stella-embed`
+//! were split out for (#1139, #1511).
+//!
+//! # The three inputs, and why they stay three separate booleans
+//!
+//! Asking costs a human two capabilities, and both are needed: they must SEE
+//! the prompt and they must be able to ANSWER it. So a run has a human
+//! exactly when:
+//!
+//! - `interactive_output` — this run would render interactive text at all.
+//!   `false` for a machine output format (`--output-format json`) or an
+//!   invocation that has otherwise forbidden prompting, regardless of what
+//!   the terminal looks like.
+//! - `stdin_is_terminal` — the human can answer. A piped or redirected stdin
+//!   can accept bytes but never a keystroke meant for this question.
+//! - `prompt_is_visible` — the human can see the question in the first
+//!   place, on whichever stream this caller's prompt actually renders on.
+//!   `stella-cli`'s `ask_user` tool and its approval responder print via
+//!   `println!`, so their callers pass `stdout().is_terminal()`. The daemon
+//!   console's scope-review prompt is deliberately stderr-only — stdout there
+//!   is the run's own byte-verbatim relay, and folding a prompt into it would
+//!   corrupt a machine-format caller reading that stream — so its callers
+//!   pass `stderr().is_terminal()` instead. `stella-model`'s credential
+//!   prompt goes through `rpassword`, whose default configuration writes to
+//!   `/dev/tty` directly on Unix rather than stdout; checking
+//!   `stdout().is_terminal()` there is a proxy for that, not an exact match
+//!   (tracked as its own gap, not fixed here: #3052).
+//!
+//! Deliberately pure over already-observed booleans rather than reading
+//! `std::io` itself: each consumer's three inputs come from a genuinely
+//! different place (a supervised child's stdin is a parked file with no real
+//! terminal to query; a JSON-format run's `interactive_output` is `false`
+//! independent of any terminal at all), so computing them here would either
+//! narrow this crate to one caller's shape or grow an API this crate has no
+//! business owning. Purity is also what makes the condition directly
+//! unit-testable without faking a terminal.
+pub fn human_can_answer(
+    interactive_output: bool,
+    stdin_is_terminal: bool,
+    prompt_is_visible: bool,
+) -> bool {
+    interactive_output && stdin_is_terminal && prompt_is_visible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The full truth table: every one of the three inputs is load-bearing on
+    /// its own, so a caller cannot drop one and still get the right answer by
+    /// accident.
+    #[test]
+    fn all_three_conditions_are_independently_required() {
+        assert!(
+            human_can_answer(true, true, true),
+            "every condition met has a human"
+        );
+        assert!(
+            !human_can_answer(false, true, true),
+            "a machine output format has nobody to ask, whatever the terminal looks like"
+        );
+        assert!(
+            !human_can_answer(true, false, true),
+            "a piped stdin cannot answer even if the prompt is visible"
+        );
+        assert!(
+            !human_can_answer(true, true, false),
+            "a prompt nobody can see must not be sent, even with a live stdin"
+        );
+    }
+}


### PR DESCRIPTION
## What & why

#3036 named two call sites that still answered "is a human present to
answer?" from their own local, stdin-only check instead of #3035's shared
`human_can_answer(interactive_output, stdin_is_terminal, prompt_is_visible)`
(#3035 merged as `83ce884` while this PR was in flight; this is rebased onto
current `main`).

### The two sites, resolved

- **`daemon.rs`'s `Supervised::follow` and `attach`** both derived
  `interactive` from `stdin` alone. The daemon console's scope-review prompt
  is **stderr-only by design** (`daemon/approval.rs`'s own module doc: stdout
  is the run's byte-verbatim relay, and folding a prompt into it would
  corrupt a machine-format caller) — so a redirected stderr with a live
  stdin took the interactive branch, printed the prompt where nobody could
  read it, and then blocked on an answer nobody knew to give. Both call
  sites now read a new `daemon::approval::console_is_interactive(stdin,
  stderr)`.
- **`credential.rs`'s `ApiKey::resolve`** checked stdin only, same hole for a
  redirected stdout. `stella-model` cannot depend on `stella-cli` to read
  `human_can_answer` (invariant 1), so the predicate moves to a new leaf
  crate, **`stella-tty`** — justified by `stella-home`'s own README, which
  names exactly this shape (a dependency direction the graph forbids) as
  when a new leaf is warranted rather than folded into an existing crate.
  `stella-cli`'s `interactive::human_can_answer` becomes a thin wrapper over
  it, so every existing call site and doc-link is untouched.

Both fixes extract a small pure predicate (`console_is_interactive`,
`ApiKey::can_prompt_interactively`) rather than inlining the `IsTerminal`
calls, matching the shape `agent/engine.rs::approval_capability_for` already
uses in this codebase — pure over already-observed booleans, so the exact
condition is directly unit-testable without faking a terminal.

### A note on `rpassword`

While fixing the credential prompt I found that `rpassword`'s default prompt
renders on `/dev/tty` directly on Unix, not stdout — so the stdout check
added here is a documented proxy, not an exact match, for that one call
site. That's a real design decision (probe `/dev/tty` directly vs.
reconfigure `rpassword` to use stdout, trading away its redirected-stdin
robustness), so it's out of scope for this "reuse the shared derivation" fix
and filed separately as #3052.

Closes #3036

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four new tests, each exercising the **disagreeing configuration** (a live
stdin, an invisible prompt) rather than the happy TTY path:

- `daemon::approval::tests::a_redirected_stderr_cannot_answer_even_with_a_live_stdin`
- `daemon::approval::tests::a_full_terminal_can_answer`
- `credential::tests::a_redirected_stdout_declines_the_prompt_even_with_a_live_stdin`
- `credential::tests::a_full_terminal_can_host_the_prompt`

Plus `stella-tty`'s own truth-table test on `human_can_answer`. The existing
`credential_prompt_degrade.rs` regression guard (documents that
`stdin().is_terminal()` reports oddly under the `cargo test` harness) still
passes unchanged — verified both branches of the new stdout check still
resolve to the same `NotFound` outcome that test asserts.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tty -p stella-model -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-tty -p stella-model --lib` + `cargo test -p stella-cli --bin stella` (binary-only crate) — 397 + 1 + 1765 passed
- [x] `cargo check --workspace --all-targets` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tty -p stella-model -p stella-cli --no-deps --document-private-items` — clean
- [x] `make guards-fast` — all green (see note below on `god-files`)
- [x] `scripts/check-wire-schema.sh`, `scripts/check-typed-errors.py` — both green
- [x] Docs updated: new crate's own README, `AGENTS.md`'s workspace-routing table + crate count (22→23) + god-file-crate count (15→16 clean crates)
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #N` appears both above and as a commit trailer

**Pre-existing `main` failure, not from this PR:** `make god-files` currently
fails on a clean `main` — `crates/stella-cli/src/agent/prompt.rs` was grown
past 1500 lines and baselined by an unrelated merged PR without updating
AGENTS.md's god-file table / `stella-cli/README.md` in the same PR. Verified
via a throwaway detached worktree of `origin/main` with zero local changes.
I did not touch that file, its README, or the baseline, and did not fix it
here per AGENTS.md's own rule against folding an unrelated ratchet fix into
this PR. Filed as #3072.

## Nothing left behind

- [x] Filed: #3052 (rpassword's `/dev/tty` prompt-visibility gap), #3072
      (pre-existing `check-god-files` failure on `main`, unrelated to this
      change)

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] New dependency: `stella-tty`, a leaf crate with an empty `[dependencies]`
      block (justified above and in the crate's own README)
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary wire types

## Anything reviewers should know?

- `stella-tty` is new workspace surface (root `Cargo.toml` members,
  `AGENTS.md`'s table). I weighed reusing `stella-home` (already a dependency
  of both `stella-cli` and `stella-model`, zero new dependency edges) against
  a new leaf, and went with a new leaf because `stella-home`'s own README
  draws its boundary explicitly ("this crate owns one decision: what path...
  everything else is out") and separately states the exact rule this
  satisfies for warranting a new crate instead.
- #3072 (the pre-existing `god-files` failure on `main`) will likely show
  this PR's CI as red on that one check through no fault of this diff — see
  the gate note above.

## Summary by Sourcery

Introduce a shared human-presence predicate and use it to correctly gate interactive prompts in the CLI daemon console and credential resolution.

New Features:
- Add the stella-tty leaf crate providing a pure human_can_answer(interactive_output, stdin_is_terminal, prompt_is_visible) predicate shared across workspace crates.

Bug Fixes:
- Ensure the daemon console only treats sessions as interactive when both stdin and the stderr-rendered scope-review prompt are attached to a terminal, avoiding invisible, blocking prompts.
- Ensure API key credential prompting in stella-model respects both stdin and stdout terminal state so a redirected stdout declines the prompt instead of blocking on unseen input.

Enhancements:
- Refactor interactive gating in stella-cli and stella-model to call shared pure predicates (console_is_interactive and ApiKey::can_prompt_interactively) rather than rederiving terminal checks inline.

Build:
- Register stella-tty as a workspace member and dependency of stella-cli and stella-model in Cargo.toml.

Documentation:
- Document the new stella-tty crate, its boundary, and consumers, and update AGENTS.md with the additional crate and god-file counts.

Tests:
- Add targeted tests in stella-cli and stella-model covering disagreeing configurations where stdin is live but the prompt stream is redirected, plus a truth-table test for stella-tty::human_can_answer.