### PR TITLE
feat(stella-tools): one `search` tool, because six ways to find code is a selection problem

### DIFF
--- a/crates/stella-cli/src/discovery.rs
+++ b/crates/stella-cli/src/discovery.rs
@@ -24,7 +24,10 @@
 //!
 //! With `STELLA_LEAN_TOOLS=1` (or a comma-separated custom core list) the
 //! session advertises only a small core toolset plus the three discovery
-//! tools; everything else stays hidden until a `tool_search` surfaces it —
+//! tools; `STELLA_LEAN_TOOLS=only:a,b,c` advertises exactly `a,b,c` and
+//! nothing else, which is the form a fixed-size bench arm needs (see
+//! [`LEAN_TOOLS_ENV`]). Everything else stays hidden until a `tool_search`
+//! surfaces it —
 //! matched tools are *activated* and advertised from the next model call.
 //! Execution is deliberately permissive: a hidden tool called by name still
 //! runs (the model may know it from history), so lean mode can never
@@ -52,9 +55,27 @@ pub const SKILL_SEARCH: &str = "skill_search";
 pub const MCP_SEARCH: &str = "mcp_search";
 
 /// The env switch for lean frontloading: `1`/`true` for the default core
-/// set, a comma-separated list for a custom core, unset/`0`/`false` for the
-/// full catalog (today's behavior).
+/// set, a comma-separated list for a custom core, `only:a,b,c` for a **closed**
+/// set, unset/`0`/`false` for the full catalog (today's behavior).
+///
+/// The `only:` form exists because the other three cannot express a tool set
+/// of a stated size. Lean mode always adds the three discovery tools on top
+/// of the core, which is right for a session — they are what makes hiding the
+/// long tail safe — and wrong for an experiment: an arm specified as five
+/// tools that ships eight is not the arm anyone reasoned about, and
+/// `tool_search` sitting beside a `search` tool additionally competes with
+/// the thing under test for the model's attention. `only:` takes the list
+/// literally and adds nothing. It borrows its `verb:` shape from
+/// `tool_search`'s own `select:` query grammar rather than inventing a second
+/// env var.
+///
+/// Execution stays permissive in every form (see [`DiscoveryToolSet::execute`]):
+/// a tool that is not advertised still runs when called by name, so a closed
+/// set can never deadlock a turn.
 pub const LEAN_TOOLS_ENV: &str = "STELLA_LEAN_TOOLS";
+
+/// The [`LEAN_TOOLS_ENV`] prefix selecting a closed set.
+const ONLY_PREFIX: &str = "only:";
 
 /// The default lean core: the tools an agent needs to make *any* progress
 /// (file CRUD, exec, search, the definition of done, and asking the user).
@@ -115,13 +136,27 @@ pub fn new_activation() -> ActivatedTools {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeanConfig {
     pub core: HashSet<String>,
+    /// Whether the three discovery tools ride on top of [`Self::core`].
+    ///
+    /// True for every form of [`LEAN_TOOLS_ENV`] except `only:` — see that
+    /// constant's docs for why a closed set had to become expressible.
+    pub discovery: bool,
 }
 
 impl LeanConfig {
-    /// The default core set (see [`DEFAULT_CORE_TOOLS`]).
+    /// The default core set (see [`DEFAULT_CORE_TOOLS`]), plus discovery.
     pub fn default_core() -> Self {
         Self {
             core: DEFAULT_CORE_TOOLS.iter().map(|s| s.to_string()).collect(),
+            discovery: true,
+        }
+    }
+
+    /// Exactly these tools and nothing else — no discovery layer.
+    pub fn closed(names: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            core: names.into_iter().collect(),
+            discovery: false,
         }
     }
 }
@@ -136,14 +171,20 @@ pub(crate) fn lean_from_env() -> Option<LeanConfig> {
     if trimmed == "1" || trimmed.eq_ignore_ascii_case("true") {
         return Some(LeanConfig::default_core());
     }
-    Some(LeanConfig {
-        core: trimmed
-            .split(',')
+    let names = |list: &str| {
+        list.split(',')
             .map(str::trim)
-            .filter(|s| !s.is_empty())
+            .filter(|name| !name.is_empty())
             .map(str::to_string)
-            .collect(),
-    })
+            .collect::<Vec<_>>()
+    };
+    match trimmed.strip_prefix(ONLY_PREFIX) {
+        Some(list) => Some(LeanConfig::closed(names(list))),
+        None => Some(LeanConfig {
+            core: names(trimmed).into_iter().collect(),
+            discovery: true,
+        }),
+    }
 }
 
 /// The MCP-registry lookup port — injectable so unit tests never hit the
@@ -794,11 +835,16 @@ impl<'a> DiscoveryToolSet<'a> {
 impl ToolExecutor for DiscoveryToolSet<'_> {
     fn schemas(&self) -> Vec<ToolSchema> {
         let mut schemas = self.inner.schemas();
+        // No lean config at all means the full catalog, which has always
+        // carried the discovery tools; only a `only:` set withholds them.
+        let advertise_discovery = self.lean.as_ref().is_none_or(|lean| lean.discovery);
         if let Some(lean) = &self.lean {
             let activated = self.activated.read().unwrap_or_else(|p| p.into_inner());
             schemas.retain(|s| lean.core.contains(&s.name) || activated.contains(&s.name));
         }
-        schemas.extend(self.discovery_schemas());
+        if advertise_discovery {
+            schemas.extend(self.discovery_schemas());
+        }
         // A live skill's allowed-tools grant narrows the whole advertised
         // surface, this layer's own tools included (#2682).
         self.invoke.filter_schemas(&mut schemas);
@@ -1113,6 +1159,7 @@ mod tests {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
+                discovery: true,
             }));
 
         let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
@@ -1160,6 +1207,7 @@ mod tests {
             .with_registry_search(Box::new(StubRegistry))
             .with_lean(Some(LeanConfig {
                 core: HashSet::new(),
+                discovery: true,
             }));
         match set.execute("screenshot", &Value::Null).await {
             ToolOutput::Ok { content } => assert_eq!(content, "inner ran screenshot"),
@@ -1173,6 +1221,7 @@ mod tests {
         let activation = new_activation();
         let lean = Some(LeanConfig {
             core: HashSet::new(),
+            discovery: true,
         });
         {
             let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
@@ -1328,15 +1377,16 @@ mod tests {
     #[test]
     fn lean_env_parsing_covers_all_forms() {
         let _lock = crate::test_env::lock();
-        let cases: &[(&str, Option<usize>)] = &[
-            ("0", None),
-            ("false", None),
-            ("", None),
-            ("1", Some(DEFAULT_CORE_TOOLS.len())),
-            ("true", Some(DEFAULT_CORE_TOOLS.len())),
-            ("read_file, bash", Some(2)),
+        let cases: &[(&str, Option<usize>, bool)] = &[
+            ("0", None, false),
+            ("false", None, false),
+            ("", None, false),
+            ("1", Some(DEFAULT_CORE_TOOLS.len()), true),
+            ("true", Some(DEFAULT_CORE_TOOLS.len()), true),
+            ("read_file, bash", Some(2), true),
+            ("only:read_file, bash", Some(2), false),
         ];
-        for (value, expected_core_len) in cases {
+        for (value, expected_core_len, expected_discovery) in cases {
             unsafe { std::env::set_var(LEAN_TOOLS_ENV, value) };
             let lean = lean_from_env();
             assert_eq!(
@@ -1344,8 +1394,62 @@ mod tests {
                 *expected_core_len,
                 "for env value {value:?}"
             );
+            if let Some(lean) = &lean {
+                assert_eq!(
+                    lean.discovery, *expected_discovery,
+                    "for env value {value:?}"
+                );
+            }
         }
         unsafe { std::env::remove_var(LEAN_TOOLS_ENV) };
         assert_eq!(lean_from_env(), None);
+    }
+
+    /// The witness for `only:` — a bench arm specified as N tools must
+    /// advertise exactly N schemas.
+    ///
+    /// The plain-list form silently adds three discovery tools on top, which
+    /// is right for a session and wrong for an experiment: an arm reasoned
+    /// about as five tools that ships eight measures something nobody
+    /// designed, and `tool_search` beside a `search` tool competes with the
+    /// thing under test. Both halves are asserted here so the difference
+    /// between the two forms cannot quietly disappear.
+    #[tokio::test]
+    async fn an_only_set_advertises_exactly_its_members_and_a_plain_list_does_not() {
+        let inner = FakeInner;
+        let arm = ["read_file", "bash"];
+
+        let closed = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+            .with_registry_search(Box::new(StubRegistry))
+            .with_lean(Some(LeanConfig::closed(
+                arm.iter().map(|name| name.to_string()),
+            )));
+        let mut names: Vec<String> = closed.schemas().into_iter().map(|s| s.name).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["bash".to_string(), "read_file".to_string()],
+            "an `only:` set must advertise exactly its members — no discovery layer"
+        );
+
+        // The contrast, so this test fails if the two forms ever converge.
+        let open = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+            .with_registry_search(Box::new(StubRegistry))
+            .with_lean(Some(LeanConfig {
+                core: arm.iter().map(|name| name.to_string()).collect(),
+                discovery: true,
+            }));
+        let open_names: Vec<String> = open.schemas().into_iter().map(|s| s.name).collect();
+        assert!(
+            open_names.contains(&TOOL_SEARCH.to_string()),
+            "the plain-list form must keep the discovery layer: {open_names:?}"
+        );
+
+        // Withholding a schema is not withholding the capability: execution
+        // stays permissive, so a closed set can never deadlock a turn.
+        match closed.execute("screenshot", &Value::Null).await {
+            ToolOutput::Ok { content } => assert_eq!(content, "inner ran screenshot"),
+            other => panic!("a closed set must still execute hidden tools, got {other:?}"),
+        }
     }
 }

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod retry;
 pub mod router;
 pub mod rules;
 pub mod scoreboard;
+pub mod search;
 pub mod self_driving;
 pub mod self_tuning;
 pub mod skills;

--- a/crates/stella-core/src/search.rs
+++ b/crates/stella-core/src/search.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The depth ladder and the context budget behind the `search` tool — the
+//! decision half, with no I/O in it (invariant 2).
+//!
+//! # What this module decides
+//!
+//! `search` ranks files by meaning and then spends a fixed context allowance
+//! saying more about the ones that ranked highest. Two questions have to be
+//! answered before any file is read, and both are pure arithmetic over owned
+//! data:
+//!
+//! - **How much do we want to know about one hit?** That is [`Depth`], a
+//!   1..=10 dial the *maintainer* sets and the model never sees. 1 is the
+//!   path; 10 is every bloody detail. Each level strictly adds
+//!   ([`facets_at`]), which is what makes a sweep between two settings
+//!   interpretable: any behaviour change between depth *n* and depth *n+1*
+//!   came from the facets *n+1* added and from nothing else.
+//! - **How much can we actually afford?** That is [`allocate`], which spends
+//!   a character budget across ranked hits and reports what it could not
+//!   afford. Depth is intent; the budget is the hard stop.
+//!
+//! # Why the budget decides, and not an inferred intent
+//!
+//! The tempting design is to read the query ("what calls X?") and enrich
+//! accordingly. It is the wrong one here: `search` deliberately has no mode
+//! parameter, so a wrong intent inference is **unrecoverable** — the model has
+//! no flag with which to correct it and must fall back to the tools `search`
+//! exists to replace. A budget cannot be wrong in that way. It degrades: the
+//! top hit keeps its detail, the tail loses depth first, and the answer says
+//! so.
+//!
+//! # Why the tail decays geometrically
+//!
+//! [`allocate`] halves the requested depth at each rank. Rank 0 is the answer
+//! often enough to earn the full allowance; by rank 3 the hit is a pointer the
+//! model may never follow, and paying body-excerpt prices for it is how a
+//! one-call search becomes as expensive as the six calls it replaced.
+
+/// How much to say about a single search hit: 1 = just the path,
+/// 10 = every detail the code graph and the file can produce.
+///
+/// Owned by configuration, never by the model. A knob the model must learn to
+/// use well will not be used well — that is the measured lesson of
+/// `gather_context`, which offered exactly this power through parameters and
+/// was called zero times in 408 trials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Depth(u8);
+
+impl Depth {
+    /// Just the path.
+    pub const MIN: Depth = Depth(1);
+    /// Every facet the ladder knows about.
+    pub const MAX: Depth = Depth(10);
+    /// Enough structure to skip the follow-up read on an easy hit, cheap
+    /// enough that a ten-hit answer is still a pointer rather than a paste.
+    pub const DEFAULT: Depth = Depth(4);
+
+    /// Clamp `level` into 1..=10. Total by construction: a depth read from
+    /// configuration is runtime data, and there is no level at which
+    /// refusing to search is the better answer.
+    #[must_use]
+    pub const fn new(level: u8) -> Depth {
+        if level < Depth::MIN.0 {
+            Depth::MIN
+        } else if level > Depth::MAX.0 {
+            Depth::MAX
+        } else {
+            Depth(level)
+        }
+    }
+
+    /// The clamped level, 1..=10.
+    #[must_use]
+    pub const fn level(self) -> u8 {
+        self.0
+    }
+
+    /// One rung down, saturating at [`Depth::MIN`].
+    #[must_use]
+    pub const fn shallower(self) -> Depth {
+        Depth::new(self.0.saturating_sub(1))
+    }
+}
+
+impl Default for Depth {
+    fn default() -> Self {
+        Depth::DEFAULT
+    }
+}
+
+/// One kind of detail the renderer can add to a hit.
+///
+/// The order is the ladder, and the ladder is ordered by **rendered cost**,
+/// cheapest first. That ordering is the reason the budget can degrade a hit
+/// gracefully: dropping a rung always removes the most expensive thing still
+/// present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Facet {
+    /// The file path. Always present — a hit with no path is not a hit.
+    Path,
+    /// The names of the symbols the file defines.
+    SymbolNames,
+    /// Each symbol's kind and definition line.
+    SymbolKinds,
+    /// What the file imports.
+    Imports,
+    /// What imports the file.
+    Importers,
+    /// The declaration line of the file's leading symbols.
+    Signature,
+    /// The doc comment immediately above those declarations.
+    DocComment,
+    /// What calls those symbols.
+    Callers,
+    /// What those symbols call.
+    Callees,
+    /// The source body of the leading symbol.
+    Body,
+}
+
+impl Facet {
+    /// Every facet, in ladder order.
+    pub const ALL: [Facet; 10] = [
+        Facet::Path,
+        Facet::SymbolNames,
+        Facet::SymbolKinds,
+        Facet::Imports,
+        Facet::Importers,
+        Facet::Signature,
+        Facet::DocComment,
+        Facet::Callers,
+        Facet::Callees,
+        Facet::Body,
+    ];
+
+    /// The lowest depth at which this facet is rendered.
+    #[must_use]
+    pub const fn min_depth(self) -> Depth {
+        match self {
+            Facet::Path => Depth(1),
+            Facet::SymbolNames => Depth(2),
+            Facet::SymbolKinds => Depth(3),
+            Facet::Imports => Depth(4),
+            Facet::Importers => Depth(5),
+            Facet::Signature => Depth(6),
+            Facet::DocComment => Depth(7),
+            Facet::Callers => Depth(8),
+            Facet::Callees => Depth(9),
+            Facet::Body => Depth(10),
+        }
+    }
+
+    /// What this facet is estimated to cost in rendered characters.
+    ///
+    /// Estimates, deliberately: the budget's job is to stop an answer running
+    /// away, and an estimate that is uniformly a little wrong still orders
+    /// the ladder correctly. Measuring the true cost would require rendering
+    /// first, which is the I/O this module is not allowed to do — and would
+    /// make the allocation depend on the workspace, so two runs at the same
+    /// depth would no longer be comparable.
+    #[must_use]
+    pub const fn estimated_cost(self) -> usize {
+        match self {
+            Facet::Path => 60,
+            Facet::SymbolNames => 140,
+            Facet::SymbolKinds => 160,
+            Facet::Imports => 200,
+            Facet::Importers => 200,
+            Facet::Signature => 140,
+            Facet::DocComment => 320,
+            Facet::Callers => 400,
+            Facet::Callees => 400,
+            Facet::Body => 1_600,
+        }
+    }
+
+    /// Whether this facet is rendered at `depth`.
+    #[must_use]
+    pub const fn rendered_at(self, depth: Depth) -> bool {
+        self.min_depth().0 <= depth.0
+    }
+}
+
+/// The facets rendered at `depth`, in ladder order.
+///
+/// Monotone **by construction**: membership is `facet.min_depth() <= depth`,
+/// so `facets_at(n)` is a prefix of `facets_at(n + 1)` and no level can ever
+/// take a facet away from the level below it. That is a structural property,
+/// not a convention someone has to remember — which matters because a
+/// non-monotone rung would make a depth sweep uninterpretable.
+#[must_use]
+pub fn facets_at(depth: Depth) -> Vec<Facet> {
+    Facet::ALL
+        .into_iter()
+        .filter(|facet| facet.rendered_at(depth))
+        .collect()
+}
+
+/// The estimated rendered cost of one hit at `depth`, in characters.
+#[must_use]
+pub fn hit_cost(depth: Depth) -> usize {
+    Facet::ALL
+        .iter()
+        .filter(|facet| facet.rendered_at(depth))
+        .map(|facet| facet.estimated_cost())
+        .sum()
+}
+
+/// The depth rank `rank` asks for when the top hit is granted `top`.
+///
+/// Halves per rank: rank 0 gets `top`, rank 1 half of it, and so on to the
+/// floor. See the module docs for why the tail decays rather than sharing
+/// equally.
+#[must_use]
+pub fn requested_depth(top: Depth, rank: usize) -> Depth {
+    let shift = u32::try_from(rank).unwrap_or(u32::MAX);
+    Depth::new(top.level().checked_shr(shift).unwrap_or(0))
+}
+
+/// A budget spent across ranked hits.
+///
+/// Total by construction and never a `Result`: every input has an answer,
+/// including a budget too small for a single path, which allocates nothing
+/// and omits everything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Allocation {
+    /// The depth granted to each hit, in rank order. Shorter than the hit
+    /// count exactly when the budget ran out.
+    pub granted: Vec<Depth>,
+    /// Hits the budget could not afford at any depth. **Must be stated in
+    /// the rendered answer**: an agent that cannot tell a complete answer
+    /// from a truncated one will stop looking, which is the failure mode this
+    /// field exists to prevent.
+    pub omitted: usize,
+    /// Estimated characters the granted depths will spend.
+    pub spent: usize,
+}
+
+impl Allocation {
+    /// Whether anything was dropped for want of budget.
+    #[must_use]
+    pub fn truncated(&self) -> bool {
+        self.omitted > 0
+    }
+}
+
+/// Spend `budget` characters across `hits` ranked results, granting the top
+/// hit at most `top` depth.
+///
+/// Greedy in rank order, which is the only order that respects the ranking:
+/// a hit is reduced to fit, and reduced again, down to [`Depth::MIN`]; only a
+/// budget that cannot afford a bare path stops the walk, and everything from
+/// there on is omitted rather than silently rendered thin.
+#[must_use]
+pub fn allocate(hits: usize, top: Depth, budget: usize) -> Allocation {
+    let mut granted = Vec::with_capacity(hits);
+    let mut spent = 0usize;
+
+    for rank in 0..hits {
+        let mut depth = requested_depth(top, rank);
+        loop {
+            if spent + hit_cost(depth) <= budget {
+                spent += hit_cost(depth);
+                granted.push(depth);
+                break;
+            }
+            if depth == Depth::MIN {
+                return Allocation {
+                    omitted: hits - granted.len(),
+                    granted,
+                    spent,
+                };
+            }
+            depth = depth.shallower();
+        }
+    }
+
+    Allocation {
+        granted,
+        omitted: 0,
+        spent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn depth_clamps_into_the_ladder() {
+        assert_eq!(Depth::new(0), Depth::MIN);
+        assert_eq!(Depth::new(200), Depth::MAX);
+        assert_eq!(Depth::new(7).level(), 7);
+    }
+
+    #[test]
+    fn the_shallowest_depth_is_the_path_alone() {
+        assert_eq!(facets_at(Depth::MIN), vec![Facet::Path]);
+        assert_eq!(facets_at(Depth::MAX).len(), Facet::ALL.len());
+    }
+
+    #[test]
+    fn a_budget_too_small_for_one_path_omits_everything() {
+        let allocation = allocate(5, Depth::MAX, 0);
+        assert!(allocation.granted.is_empty());
+        assert_eq!(allocation.omitted, 5);
+        assert!(allocation.truncated());
+    }
+
+    #[test]
+    fn the_top_hit_can_be_deep_while_the_tail_is_shallow() {
+        let allocation = allocate(6, Depth::new(8), usize::MAX);
+        assert_eq!(allocation.granted[0], Depth::new(8));
+        assert_eq!(allocation.granted[1], Depth::new(4));
+        assert_eq!(allocation.granted[2], Depth::new(2));
+        assert_eq!(allocation.granted[3], Depth::MIN);
+        assert!(!allocation.truncated());
+    }
+
+    proptest! {
+        /// The property the whole ladder rests on: level n + 1 strictly adds.
+        #[test]
+        fn each_depth_is_a_superset_of_the_one_below(level in 1u8..10) {
+            let lower = facets_at(Depth::new(level));
+            let higher = facets_at(Depth::new(level + 1));
+            prop_assert!(higher.len() > lower.len(), "level {level} added nothing");
+            for facet in &lower {
+                prop_assert!(higher.contains(facet), "level {level} lost {facet:?}");
+            }
+        }
+
+        #[test]
+        fn cost_never_falls_as_depth_rises(level in 1u8..10) {
+            prop_assert!(hit_cost(Depth::new(level + 1)) > hit_cost(Depth::new(level)));
+        }
+
+        #[test]
+        fn allocation_never_overspends(
+            hits in 0usize..24,
+            top in 1u8..=10,
+            budget in 0usize..40_000,
+        ) {
+            let allocation = allocate(hits, Depth::new(top), budget);
+            prop_assert!(allocation.spent <= budget);
+            prop_assert_eq!(allocation.granted.len() + allocation.omitted, hits);
+            let recomputed: usize = allocation.granted.iter().copied().map(hit_cost).sum();
+            prop_assert_eq!(recomputed, allocation.spent);
+        }
+
+        #[test]
+        fn no_hit_is_granted_more_than_it_asked_for(
+            hits in 0usize..24,
+            top in 1u8..=10,
+            budget in 0usize..40_000,
+        ) {
+            let allocation = allocate(hits, Depth::new(top), budget);
+            for (rank, granted) in allocation.granted.iter().enumerate() {
+                prop_assert!(*granted <= requested_depth(Depth::new(top), rank));
+            }
+        }
+
+        /// Invariant 7 reaches here: the same configuration must produce the
+        /// same plan, or two runs of the same query are not comparable.
+        #[test]
+        fn allocation_is_deterministic(
+            hits in 0usize..24,
+            top in 1u8..=10,
+            budget in 0usize..40_000,
+        ) {
+            prop_assert_eq!(
+                allocate(hits, Depth::new(top), budget),
+                allocate(hits, Depth::new(top), budget)
+            );
+        }
+    }
+}

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -58,6 +58,7 @@ pub mod schema_gate;
 pub mod scratch;
 pub mod screenshot;
 pub mod scripts;
+pub mod search;
 pub mod shell_touch;
 pub mod skill_grant;
 pub mod staleness;

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -523,6 +523,13 @@ impl ToolRegistry {
         // background session build still runs; this just removes the race and
         // the chicken-and-egg gate.
         entries.push(Arc::new(crate::overview::ProjectOverview));
+        // The fused retrieval tool (#3032). Registered beside the five it
+        // subsumes rather than instead of them: the experiment is about what
+        // the schema menu SENDS, and deleting a working tool to run it would
+        // confound the measurement with a capability loss. Its depth dial is
+        // read from configuration once, here, so the advertised schema is
+        // byte-identical across settings (invariant 7).
+        entries.push(Arc::new(crate::search::Search::from_env()));
         entries.push(Arc::new(crate::graph::CodeGraphQuery));
         entries.push(Arc::new(crate::graph::semantic::SemanticCodeSearch));
         entries.push(Arc::new(crate::read_symbol::ReadSymbol::new(

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `search` — the one way to find code.
+//!
+//! # The measurement that produced this
+//!
+//! Stella advertises 72 tool schemas per request — 11,797 tokens, 71% of the
+//! opening context — against Claude Code's 25 (#3032). Six of those schemas
+//! are ways to find code, and across 408 bench trials and 15,304 model calls
+//! the model's usage of them was not a distribution, it was a collapse:
+//!
+//! ```text
+//! bash                 10,835 calls   first reached at call  2.2
+//! grep                    120         first reached at call  2.3
+//! glob                     83         first reached at call 33.1
+//! project_overview         33         first reached at call  8.1
+//! read_symbol              23         first reached at call  8.0
+//! graph_query               3         first reached at call  9.7
+//! gather_context            0
+//! semantic_code_search      0
+//! ```
+//!
+//! `gather_context` is the decisive row. Its description already promised
+//! exactly what this module does — "one deterministic context sweep (grep
+//! patterns + file globs + code-graph symbol lookups + bounded excerpts) in a
+//! single call… Prefer this over issuing several separate
+//! grep/glob/graph_query/read_file calls" — and it was called **zero** times.
+//! The concept did not fail. The name and the shape did: a tool whose value
+//! depends on the model assembling four parameter lists correctly is a tool
+//! the model must first believe in, and it never did.
+//!
+//! Six ways to find code is a selection problem. One way is not.
+//!
+//! # Why there is no mode parameter
+//!
+//! `search(query, mode="regex"|"semantic"|"symbol")` would satisfy invariant
+//! 9's letter and break its purpose: a parameter that *selects* an operation
+//! is three tools wearing one schema, and it would reproduce the same
+//! selection problem one level down, where it is harder to see. **We choose
+//! the strategy, not the model.** That is the point — it is what lets the
+//! implementation outlive grep, glob and the graph, and it is what makes the
+//! code graph and the embedding index *unconditionally exercised*: today
+//! `graph_query` has 3 calls in 408 trials, so we cannot tell whether it is
+//! bad or merely unchosen. Behind a dispatcher, every search produces
+//! evidence about both.
+//!
+//! # What one call does
+//!
+//! 1. **Rank.** Always semantically when an embedder resolves — the query is
+//!    embedded and the indexed files ranked against it, reusing the vector
+//!    table `stella init` already fills (#3014). See [`dispatch`] for the
+//!    ladder of strategies and what each one costs.
+//! 2. **Enrich, budget-driven.** The ranked hits are then spent against a
+//!    fixed character allowance, adding structure from the code graph:
+//!    symbols, kinds, imports, importers, signatures, docs, callers, callees,
+//!    a body excerpt. Which facets appear is decided by
+//!    [`stella_core::search`] from *what was found and what is affordable* —
+//!    never from an inferred intent, because a wrong intent inference is
+//!    unrecoverable in a tool with no mode flag to correct it.
+//! 3. **Say what happened.** Which strategies ran, and whether the budget
+//!    truncated the answer. An agent that cannot tell a complete answer from
+//!    a truncated one stops looking.
+//!
+//! # The bar is "not assemblable in bash", not "better than grep"
+//!
+//! The same census shows Stella running grep *through the shell* while a
+//! native `grep` tool sits in the menu — 8 shell greps on top of 6 native
+//! `grep` calls in one trial, same session, same file. It did not forget the
+//! tool. It chose the shell for the identical operation, because bash is the
+//! only tool where the model can **compose a verb that does not exist**: 8.9
+//! command segments per call, median 6, one call routinely listing a
+//! directory, grepping three patterns, listing the tests and labelling each
+//! section with an `echo`. Every other tool is a fixed verb somebody else
+//! chose. That is why a better fixed verb keeps losing.
+//!
+//! A fixed shape is therefore not automatically safe from the shell. **If
+//! this tool returned a list of `file:line` matches it would lose anyway**,
+//! because the model can shape that output with a pipe and cannot shape ours.
+//! So the answer is deliberately weighted toward what no pipeline of shell
+//! commands produces:
+//!
+//! - it **leads with the ranking and why each hit ranked** — a meaning score
+//!   is not expressible in grep at all;
+//! - it carries **graph structure** (signature, callers, callees, importers)
+//!   as first-class content, not as an appendix to a match list;
+//! - it is **not formatted like `grep -n`**, because that shape invites the
+//!   comparison this tool loses.
+//!
+//! Composability-beating comes second, though, and one number keeps that
+//! honest: `apply_edits` is the *more* expressive structured tool and loses
+//! 42 calls to `edit_file`'s 372 — while failing 33% of the time against
+//! `edit_file`'s 5.9%. Expressiveness does not win if the tool is
+//! unreliable. Every strategy below is total, every failure degrades to the
+//! next rung with its reason quoted, and the answer always states what it
+//! did — correct and predictable first.
+//!
+//! The metric that decides whether this worked is **not** `search`'s call
+//! count. It is the count of `bash` calls whose command text is itself a
+//! search (`grep`/`rg`/`find` inside a shell invocation). If that does not
+//! fall, the fused-tool thesis is wrong in a specific and useful way.
+//!
+//! # Nothing is replaced
+//!
+//! `grep`, `glob`, `graph_query`, `read_symbol`, `project_overview` and
+//! `gather_context` all keep working exactly as they did. The experiment
+//! (#3032) is about what is *sent* in the schema menu, not about what exists.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_core::search::{Allocation, Depth, allocate};
+use stella_embed::{Embedder, Resolution, SimilarityPosture};
+use stella_graph::CodeGraph;
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+use crate::registry::Tool;
+
+pub(crate) mod enrich;
+pub(crate) mod scan;
+
+#[cfg(test)]
+mod tests;
+
+/// Files ranked back to the model. Enough to choose from, few enough that the
+/// answer stays a pointer rather than a paste.
+const MAX_HITS: usize = 10;
+
+/// Files embedded per backend request — one request stays inside every
+/// documented body limit while still amortising the round trip.
+const EMBED_BATCH: usize = 32;
+
+/// The depth dial, read from configuration at construction.
+///
+/// **Not a tool argument, deliberately.** Everything measured says a knob the
+/// model must learn to use well will not be used well; `gather_context` is
+/// the proof. Keeping it out of the input schema also keeps the schema
+/// byte-identical across depth settings, so a depth sweep costs no prompt
+/// cache (invariant 7).
+pub const DEPTH_ENV: &str = "STELLA_SEARCH_DEPTH";
+
+/// The context allowance one answer may spend, in characters.
+pub const BUDGET_ENV: &str = "STELLA_SEARCH_BUDGET";
+
+/// Roughly 2,250 tokens at four characters each: large enough that the top
+/// hit can carry a body excerpt, small enough that a search is still cheaper
+/// than the read it saves.
+const DEFAULT_BUDGET_CHARS: usize = 9_000;
+
+/// How the ranked hits were produced. Reported in every answer, because a
+/// name match wearing a semantic answer's clothes is worse than no answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Strategy {
+    /// The query and the files were embedded and compared by meaning.
+    Semantic,
+    /// The code graph's paths and symbol names were matched by term.
+    GraphNames,
+    /// The workspace was walked and files matched by path and content term —
+    /// the only strategy that needs no index at all.
+    FileScan,
+}
+
+impl Strategy {
+    /// The word that appears in the answer's `via:` line.
+    const fn label(self) -> &'static str {
+        match self {
+            Strategy::Semantic => "semantic (embedding rank over the code-graph index)",
+            Strategy::GraphNames => "names (path + symbol-name terms over the code-graph index)",
+            Strategy::FileScan => "scan (path + content terms over the working tree, no index)",
+        }
+    }
+}
+
+/// One ranked file on its way to the renderer.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Hit {
+    /// Workspace-relative, forward-slash.
+    pub(crate) path: String,
+    /// **Why this file ranked**, as a phrase — not a score column.
+    ///
+    /// A bare number invites the reader to compare it against the next
+    /// strategy's number, and the three strategies do not share a scale. It
+    /// is also the one part of the answer a shell pipeline cannot produce, so
+    /// it is stated in words and shown first (see the module docs).
+    pub(crate) why: String,
+}
+
+/// Everything one search decided, before it is rendered.
+#[derive(Debug, Clone)]
+pub(crate) struct Answer {
+    pub(crate) hits: Vec<Hit>,
+    /// In the order they ran. More than one means an earlier one came back
+    /// empty or unavailable and the next was tried.
+    pub(crate) strategies: Vec<Strategy>,
+    /// Why the semantic strategy did not run, or ran degraded — shown
+    /// verbatim, never summarised away.
+    pub(crate) note: Option<String>,
+}
+
+/// The depth and budget one `search` instance runs at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchConfig {
+    /// How much to say about the top hit; the tail decays from here.
+    pub depth: Depth,
+    /// The hard stop, in characters.
+    pub budget: usize,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            depth: Depth::DEFAULT,
+            budget: DEFAULT_BUDGET_CHARS,
+        }
+    }
+}
+
+impl SearchConfig {
+    /// Read the dial from the environment, falling back to the defaults.
+    ///
+    /// Resolved **once, at registration** rather than per call: a schema and
+    /// an answer shape that could change mid-session would make two calls in
+    /// one transcript incomparable, and would put a nondeterministic value
+    /// upstream of the prompt (invariant 7).
+    #[must_use]
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        Self {
+            depth: std::env::var(DEPTH_ENV)
+                .ok()
+                .and_then(|raw| raw.trim().parse::<u8>().ok())
+                .map_or(default.depth, Depth::new),
+            budget: std::env::var(BUDGET_ENV)
+                .ok()
+                .and_then(|raw| raw.trim().parse::<usize>().ok())
+                .filter(|budget| *budget > 0)
+                .unwrap_or(default.budget),
+        }
+    }
+}
+
+/// The one way to find code.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Search {
+    config: SearchConfig,
+}
+
+impl Search {
+    /// A `search` running at an explicit depth and budget.
+    #[must_use]
+    pub fn with_config(config: SearchConfig) -> Self {
+        Self { config }
+    }
+
+    /// A `search` running at the configured depth ([`SearchConfig::from_env`]).
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::with_config(SearchConfig::from_env())
+    }
+}
+
+#[async_trait]
+impl Tool for Search {
+    /// The description is the entire user interface: the model calls this
+    /// tool or does not, on these words alone, and `gather_context` proves
+    /// what a bad one costs — a strictly better capability, called zero times
+    /// in 408 trials.
+    ///
+    /// So it is written for the **moment of need** rather than for the
+    /// mechanism, and it corrects the name: `search` reads as "lexical
+    /// match", and a model that believes that will keep grepping for the
+    /// spellings it can guess. The worked argument shapes are load-bearing
+    /// for the same reason — they show that a sentence and a symbol name are
+    /// both valid input, which no amount of prose asserts as convincingly.
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "search".into(),
+            description: "Find code. This is the ONLY search you need: describe what you are \
+                          looking for, in whatever form you have it, and get back the files \
+                          that answer it with their symbols, callers, imports and source \
+                          already attached — so one call usually replaces a run of \
+                          grep/glob/read_file round trips.\n\
+                          \n\
+                          It matches by MEANING, not just by text, so the words you use do not \
+                          have to appear anywhere in the code. Ask it the question you actually \
+                          have:\n\
+                          - `search(\"where are request headers sanitized before logging\")` — \
+                          finds the file even if it is called `hkey.rs` and says `scrub`\n\
+                          - `search(\"what calls resolve_provider\")` — a symbol name works \
+                          just as well as a sentence\n\
+                          - `search(\"the retry/backoff policy for failed HTTP requests\")` — \
+                          describe behaviour when you cannot name it\n\
+                          - `search(\"CredentialStore\")` — a bare type name finds its \
+                          definition and its neighbourhood\n\
+                          \n\
+                          Reach for it the moment you are about to guess a spelling. An agent \
+                          grepping `redact|scrub|sanitize|mask` in turn is describing something \
+                          semantically to an index that only matches substrings; the spelling \
+                          you did not think of is the one grep silently misses, and this call \
+                          replaces that whole run. Use `read_file` afterwards when you need \
+                          more of a file than the answer carried, and `bash` with `grep -n` \
+                          when you need every occurrence of one exact literal string. The \
+                          answer always states which strategies ran and whether it was \
+                          truncated."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "What you are looking for — a question, a description \
+                                        of the behaviour, or a symbol/file name. Plain words \
+                                        work; you do not need to guess how the code spells it."
+                    }
+                },
+                "required": ["query"]
+            }),
+            read_only: true,
+            // Embedding is a network write-through: the pass stores vectors
+            // in codegraph.db on the way to answering, and the graph open may
+            // bootstrap the index besides. A read that writes (#923).
+            speculation_safe: false,
+        }
+    }
+
+    async fn execute(&self, input: &Value, root: &Path) -> ToolOutput {
+        let query = input
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim();
+        if query.is_empty() {
+            return ToolOutput::Error {
+                message: "`query` is required: what you are looking for, as a question, a \
+                          description of the behaviour, or a symbol name — e.g. \"where request \
+                          headers are sanitized\" or \"CredentialStore\""
+                    .into(),
+            };
+        }
+        search(root, query, self.config).await
+    }
+}
+
+/// One `search` end to end.
+///
+/// `open_or_build` runs a full `index_all` catch-up pass, which its contract
+/// says an async caller must wrap in `spawn_blocking`. The handle is then held
+/// across the embedding awaits — the remaining graph calls are single SQLite
+/// reads against a local file, so paying a thread hop for each would cost more
+/// than it saves. This is `semantic_code_search`'s discipline, deliberately
+/// unchanged (`crate::graph::semantic`).
+pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
+    let owned_root = root.to_path_buf();
+    let opened = tokio::task::spawn_blocking(move || crate::graph::open_or_build(&owned_root)).await;
+    let (graph, index_warning) = match opened {
+        Ok(Ok(opened)) => (Some(opened.graph), opened.index_warning),
+        // A graph that will not open is a degradation, not a turn ending: the
+        // file scan needs no index and is exactly the strategy for a
+        // workspace the indexer cannot serve.
+        Ok(Err(message)) => (None, Some(message)),
+        Err(_) => {
+            return ToolOutput::Error {
+                message: "the search was cancelled".into(),
+            };
+        }
+    };
+
+    let embedder = match stella_embed::from_env() {
+        Resolution::Configured(embedder) => Ok(embedder as Box<dyn Embedder>),
+        Resolution::Unconfigured => Err(None),
+        // A half-configured backend is neither "off" nor "working". Saying so
+        // is why resolution has three outcomes: a typo in a model name must
+        // not read as a deliberate lexical setup.
+        Resolution::Incomplete(reason) => {
+            Err(Some(format!("semantic search is misconfigured: {reason}")))
+        }
+    };
+
+    let answer = match (graph.as_ref(), embedder) {
+        (graph, Ok(embedder)) => dispatch(graph, root, query, Some(embedder.as_ref())).await,
+        (graph, Err(note)) => {
+            let mut answer = dispatch(graph, root, query, None).await;
+            if let Some(note) = note {
+                answer.note = Some(note);
+            }
+            answer
+        }
+    };
+
+    let output = render(graph.as_ref(), root, query, &answer, config);
+    if let Some(graph) = graph {
+        graph.shutdown();
+    }
+    crate::graph::with_index_warning(output, index_warning)
+}
+
+/// Choose and run the ranking strategies, in cost order, stopping at the
+/// first that produces hits.
+///
+/// The ladder, and why it is a ladder rather than a fusion:
+///
+/// - **Semantic** first whenever an embedder resolves, so the vector index is
+///   exercised on every search rather than only when a model happens to pick
+///   the semantic tool (#2995). A backend that fails mid-flight degrades to
+///   the next rung with the failure quoted, never a lost turn.
+/// - **Graph names** next: it searches *symbol* names, which a path glob
+///   cannot, so it is genuinely better than nothing — and it is honest about
+///   being a name match.
+/// - **File scan** last, and it is not an edge case. `stella init` is
+///   best-effort by design and a workspace with no tree-sitter grammar for
+///   its language is the normal case on Terminal-Bench, where the graph is
+///   empty and both rungs above return nothing at all.
+///
+/// Fusing them instead would mix three incomparable scales into one ordering
+/// and make the answer's `via:` line a lie.
+pub(crate) async fn dispatch(
+    graph: Option<&CodeGraph>,
+    root: &Path,
+    query: &str,
+    embedder: Option<&dyn Embedder>,
+) -> Answer {
+    let mut strategies = Vec::new();
+    let mut note = None;
+
+    if let (Some(graph), Some(embedder)) = (graph, embedder) {
+        strategies.push(Strategy::Semantic);
+        match semantic_hits(graph, embedder, query).await {
+            Ok(hits) if !hits.is_empty() => {
+                return Answer {
+                    hits,
+                    strategies,
+                    note,
+                };
+            }
+            Ok(_) => {}
+            Err(reason) => note = Some(reason),
+        }
+    }
+
+    if let Some(graph) = graph {
+        strategies.push(Strategy::GraphNames);
+        let hits = enrich::name_hits(graph, query, MAX_HITS);
+        if !hits.is_empty() {
+            return Answer {
+                hits,
+                strategies,
+                note,
+            };
+        }
+    }
+
+    strategies.push(Strategy::FileScan);
+    Answer {
+        hits: scan::scan_hits(root, query, MAX_HITS),
+        strategies,
+        note,
+    }
+}
+
+/// Embed what is pending, embed the query, rank. `Err` carries a reason
+/// already phrased for the answer's note.
+async fn semantic_hits(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    query: &str,
+) -> Result<Vec<Hit>, String> {
+    let fingerprint = embedder.fingerprint().id();
+    catch_up_embeddings(graph, embedder, &fingerprint).await?;
+
+    let query_vector = match embedder.embed(&[query.to_string()]).await {
+        Ok(mut vectors) if !vectors.is_empty() => vectors.remove(0).vector,
+        Ok(_) => return Err("the embedder returned no vector for the query".into()),
+        Err(error) => return Err(format!("the embedder failed: {error}")),
+    };
+
+    // Only a `Semantic` backend has earned a floor. Under `Surface` the score
+    // orders and never admits, so nothing is filtered out on its say-so.
+    let floor = match embedder.similarity_posture() {
+        SimilarityPosture::Semantic { admission_floor } => admission_floor,
+        SimilarityPosture::Surface => f32::NEG_INFINITY,
+    };
+
+    graph
+        .rank_files_by_vector(&fingerprint, &query_vector, floor, MAX_HITS)
+        .map(|ranked| {
+            ranked
+                .into_iter()
+                .map(|scored| Hit {
+                    path: scored.key,
+                    why: format!("ranked by MEANING against your query (cosine {:.3})", scored.score),
+                })
+                .collect()
+        })
+        .map_err(|error| format!("the vector index could not be read: {error}"))
+}
+
+/// Embed every indexed file still pending under `fingerprint`, up to the
+/// per-pass cap. Shares `stella-graph`'s pending-scan cursor with
+/// `semantic_code_search`, so the two tools warm one index rather than two.
+async fn catch_up_embeddings(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    fingerprint: &str,
+) -> Result<(), String> {
+    let scan = graph
+        .files_pending_embedding(fingerprint, stella_graph::MAX_FILES_PER_PASS)
+        .map_err(|error| format!("the code graph could not be read: {error}"))?;
+    for chunk in scan.files.chunks(EMBED_BATCH) {
+        let texts: Vec<String> = chunk.iter().map(|pending| pending.text.clone()).collect();
+        let embeddings = embedder
+            .embed(&texts)
+            .await
+            .map_err(|error| format!("the embedder failed: {error}"))?;
+        let rows: Vec<stella_graph::FileVector> = chunk
+            .iter()
+            .zip(embeddings)
+            .map(|(pending, embedding)| stella_graph::FileVector {
+                path: pending.path.clone(),
+                content_sha256: pending.content_sha256.clone(),
+                vector: embedding.vector,
+            })
+            .collect();
+        graph
+            .store_file_vectors(fingerprint, &rows)
+            // Not recoverable by continuing: the next batch would be written
+            // into the same broken store and the pass would report success
+            // having stored nothing.
+            .map_err(|error| format!("the vector index could not be written: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Render an answer against the allocation the budget allows.
+///
+/// The two lines that are never optional are the `via:` line and the
+/// truncation line — the first because an agent must be able to tell a
+/// meaning match from a name match, the second because an agent that cannot
+/// tell a complete answer from a truncated one stops looking.
+pub(crate) fn render(
+    graph: Option<&CodeGraph>,
+    root: &Path,
+    query: &str,
+    answer: &Answer,
+    config: SearchConfig,
+) -> ToolOutput {
+    let allocation: Allocation = allocate(answer.hits.len(), config.depth, config.budget);
+
+    let mut content = String::new();
+    if let Some(note) = &answer.note {
+        content.push_str(&format!("({note})\n"));
+    }
+    content.push_str(&format!(
+        "search `{query}` — {} result(s) at depth {}",
+        allocation.granted.len(),
+        config.depth.level()
+    ));
+    content.push_str("\nvia: ");
+    content.push_str(
+        &answer
+            .strategies
+            .iter()
+            .map(|strategy| strategy.label())
+            .collect::<Vec<_>>()
+            .join(" -> "),
+    );
+
+    if answer.hits.is_empty() {
+        content.push_str("\nno file matched. Widen the description, or use `bash` with `grep -n` for an exact literal.");
+        return ToolOutput::Ok { content };
+    }
+
+    for (hit, depth) in answer.hits.iter().zip(&allocation.granted) {
+        content.push('\n');
+        content.push_str(&enrich::render_hit(graph, root, hit, *depth));
+    }
+
+    if allocation.truncated() {
+        content.push_str(&format!(
+            "\nTRUNCATED: {} further result(s) were dropped to stay inside the context budget \
+             ({} of {} characters spent). They exist — narrow the query to see them.",
+            allocation.omitted,
+            allocation.spent,
+            config.budget
+        ));
+    }
+
+    ToolOutput::Ok { content }
+}

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -352,7 +352,8 @@ impl Tool for Search {
 /// unchanged (`crate::graph::semantic`).
 pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
     let owned_root = root.to_path_buf();
-    let opened = tokio::task::spawn_blocking(move || crate::graph::open_or_build(&owned_root)).await;
+    let opened =
+        tokio::task::spawn_blocking(move || crate::graph::open_or_build(&owned_root)).await;
     let (graph, index_warning) = match opened {
         Ok(Ok(opened)) => (Some(opened.graph), opened.index_warning),
         // A graph that will not open is a degradation, not a turn ending: the
@@ -488,7 +489,10 @@ async fn semantic_hits(
                 .into_iter()
                 .map(|scored| Hit {
                     path: scored.key,
-                    why: format!("ranked by MEANING against your query (cosine {:.3})", scored.score),
+                    why: format!(
+                        "ranked by MEANING against your query (cosine {:.3})",
+                        scored.score
+                    ),
                 })
                 .collect()
         })
@@ -579,9 +583,7 @@ pub(crate) fn render(
         content.push_str(&format!(
             "\nTRUNCATED: {} further result(s) were dropped to stay inside the context budget \
              ({} of {} characters spent). They exist — narrow the query to see them.",
-            allocation.omitted,
-            allocation.spent,
-            config.budget
+            allocation.omitted, allocation.spent, config.budget
         ));
     }
 

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -49,8 +49,8 @@
 //!
 //! 1. **Rank.** Always semantically when an embedder resolves — the query is
 //!    embedded and the indexed files ranked against it, reusing the vector
-//!    table `stella init` already fills (#3014). See [`dispatch`] for the
-//!    ladder of strategies and what each one costs.
+//!    table `stella init` already fills (#3014). The `dispatch` function
+//!    below documents the ladder of strategies and what each one costs.
 //! 2. **Enrich, budget-driven.** The ranked hits are then spent against a
 //!    fixed character allowance, adding structure from the code graph:
 //!    symbols, kinds, imports, importers, signatures, docs, callers, callees,

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -73,57 +73,63 @@ pub(crate) fn render_hit(
     let source = std::fs::read_to_string(root.join(&hit.path)).ok();
 
     for facet in facets {
-        let line = match facet {
-            // Written above: it is the block's header, not a labelled line.
-            Facet::Path => None,
-            Facet::SymbolNames => list_line(
-                "symbols",
-                neighborhood
-                    .symbols
-                    .iter()
-                    .take(MAX_SYMBOLS)
-                    .map(|symbol| symbol.name.clone()),
-            ),
-            Facet::SymbolKinds => list_line(
-                "kinds",
-                neighborhood.symbols.iter().take(MAX_SYMBOLS).map(|symbol| {
-                    format!("{} {}:{}", symbol.kind, symbol.name, symbol.start_line)
-                }),
-            ),
-            Facet::Imports => list_line(
-                "imports",
-                neighborhood.imports.iter().take(MAX_EDGES).cloned(),
-            ),
-            Facet::Importers => list_line(
-                "imported by",
-                neighborhood.importers.iter().take(MAX_EDGES).cloned(),
-            ),
-            Facet::Signature => list_line(
-                "signature",
-                leading
-                    .iter()
-                    .filter_map(|symbol| declaration_line(source.as_deref(), symbol)),
-            ),
-            Facet::DocComment => list_line(
-                "doc",
-                leading
-                    .iter()
-                    .filter_map(|symbol| doc_comment(source.as_deref(), symbol)),
-            ),
-            Facet::Callers => list_line(
-                "callers",
-                leading.iter().flat_map(|symbol| {
-                    frame_titles(graph.callers(&symbol.name).unwrap_or_default())
-                }),
-            ),
-            Facet::Callees => list_line(
-                "callees",
-                leading.iter().flat_map(|symbol| {
-                    frame_titles(graph.callees(&symbol.name).unwrap_or_default())
-                }),
-            ),
-            Facet::Body => body_block(graph, source.as_deref(), &hit.path, leading.first().copied()),
-        };
+        let line =
+            match facet {
+                // Written above: it is the block's header, not a labelled line.
+                Facet::Path => None,
+                Facet::SymbolNames => list_line(
+                    "symbols",
+                    neighborhood
+                        .symbols
+                        .iter()
+                        .take(MAX_SYMBOLS)
+                        .map(|symbol| symbol.name.clone()),
+                ),
+                Facet::SymbolKinds => list_line(
+                    "kinds",
+                    neighborhood.symbols.iter().take(MAX_SYMBOLS).map(|symbol| {
+                        format!("{} {}:{}", symbol.kind, symbol.name, symbol.start_line)
+                    }),
+                ),
+                Facet::Imports => list_line(
+                    "imports",
+                    neighborhood.imports.iter().take(MAX_EDGES).cloned(),
+                ),
+                Facet::Importers => list_line(
+                    "imported by",
+                    neighborhood.importers.iter().take(MAX_EDGES).cloned(),
+                ),
+                Facet::Signature => list_line(
+                    "signature",
+                    leading
+                        .iter()
+                        .filter_map(|symbol| declaration_line(source.as_deref(), symbol)),
+                ),
+                Facet::DocComment => list_line(
+                    "doc",
+                    leading
+                        .iter()
+                        .filter_map(|symbol| doc_comment(source.as_deref(), symbol)),
+                ),
+                Facet::Callers => list_line(
+                    "callers",
+                    leading.iter().flat_map(|symbol| {
+                        frame_titles(graph.callers(&symbol.name).unwrap_or_default())
+                    }),
+                ),
+                Facet::Callees => list_line(
+                    "callees",
+                    leading.iter().flat_map(|symbol| {
+                        frame_titles(graph.callees(&symbol.name).unwrap_or_default())
+                    }),
+                ),
+                Facet::Body => body_block(
+                    graph,
+                    source.as_deref(),
+                    &hit.path,
+                    leading.first().copied(),
+                ),
+            };
         if let Some(line) = line {
             block.push('\n');
             block.push_str(&line);
@@ -221,11 +227,9 @@ fn body_block(
         .into_iter()
         .find(|span| span.path == path)?;
     let start = usize::try_from(span.start_line).ok()?.max(1);
-    let end = usize::try_from(span.end_line).ok()?.min(
-        start
-            .saturating_add(MAX_BODY_LINES)
-            .saturating_sub(1),
-    );
+    let end = usize::try_from(span.end_line)
+        .ok()?
+        .min(start.saturating_add(MAX_BODY_LINES).saturating_sub(1));
     let quoted: Vec<String> = (start..=end)
         .filter_map(|number| {
             line_at(source, u32::try_from(number).ok()?)

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -239,7 +239,7 @@ fn body_block(
     if quoted.is_empty() {
         return None;
     }
-    let elided = u32::try_from(end).map_or(false, |end| end < span.end_line);
+    let elided = u32::try_from(end).is_ok_and(|end| end < span.end_line);
     let mut block = format!("    body of `{}` ({path}:{start}-{end}):", symbol.name);
     for line in quoted {
         block.push('\n');

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Turning a ranked path into the block the model reads — and the graph-name
+//! strategy that ranks when no embedder does.
+//!
+//! # Why each facet is its own labelled line
+//!
+//! [`stella_core::search`] guarantees the facet *set* at depth `n + 1` is a
+//! superset of the set at depth `n`. This module makes the same true of the
+//! rendered *text*: every facet writes its own `label: …` line and no facet
+//! rewrites another's, so the block at depth `n + 1` contains every line of
+//! the block at depth `n` verbatim. That turns monotonicity from a convention
+//! into something a test can check by line containment, which is what a depth
+//! sweep needs to be interpretable — a rung that quietly reformatted a lower
+//! rung's line would make two settings incomparable without failing anything.
+//!
+//! It costs a little redundancy (`symbols:` names them, `kinds:` types them)
+//! and buys a checkable property. That trade is deliberate.
+//!
+//! # Why this is not a match list
+//!
+//! Signature, callers, callees and importers are the content here, and the
+//! path is a header rather than the payload. A block of `file:line` matches
+//! would be assemblable with `grep -n | head`, and a tool the shell can
+//! reproduce loses to the shell (see the module docs of the parent).
+
+use std::path::Path;
+
+use stella_core::search::{Depth, Facet, facets_at};
+use stella_graph::{CodeGraph, NeighborhoodSymbol};
+
+use super::Hit;
+
+/// Symbols named per hit. Past this the list stops being a summary.
+const MAX_SYMBOLS: usize = 8;
+/// Symbols carrying a signature, doc, callers or callees. Those facets cost
+/// a graph query and a file read apiece, so they cover the leading few.
+const MAX_DETAILED_SYMBOLS: usize = 3;
+/// Import/importer/caller/callee edges listed per hit.
+const MAX_EDGES: usize = 6;
+/// Source lines of the leading symbol quoted at [`Facet::Body`].
+const MAX_BODY_LINES: usize = 40;
+
+/// Render one hit at `depth`.
+///
+/// Total: a missing graph, an unreadable file and a path the index does not
+/// know all degrade to fewer lines, never to an error. A search that failed
+/// to enrich a hit still found the hit, and losing the whole answer over a
+/// detail line would be the worst possible trade.
+pub(crate) fn render_hit(
+    graph: Option<&CodeGraph>,
+    root: &Path,
+    hit: &Hit,
+    depth: Depth,
+) -> String {
+    let facets = facets_at(depth);
+    // `Facet::Path` is the header and is present at every depth by
+    // construction, so it is written unconditionally rather than looked up.
+    let mut block = format!("{}\n    why: {}", hit.path, hit.why);
+
+    let Some(graph) = graph else {
+        return block;
+    };
+    let Ok(neighborhood) = graph.file_neighborhood(Path::new(&hit.path)) else {
+        return block;
+    };
+    let leading: Vec<&NeighborhoodSymbol> = neighborhood
+        .symbols
+        .iter()
+        .take(MAX_DETAILED_SYMBOLS)
+        .collect();
+    let source = std::fs::read_to_string(root.join(&hit.path)).ok();
+
+    for facet in facets {
+        let line = match facet {
+            // Written above: it is the block's header, not a labelled line.
+            Facet::Path => None,
+            Facet::SymbolNames => list_line(
+                "symbols",
+                neighborhood
+                    .symbols
+                    .iter()
+                    .take(MAX_SYMBOLS)
+                    .map(|symbol| symbol.name.clone()),
+            ),
+            Facet::SymbolKinds => list_line(
+                "kinds",
+                neighborhood.symbols.iter().take(MAX_SYMBOLS).map(|symbol| {
+                    format!("{} {}:{}", symbol.kind, symbol.name, symbol.start_line)
+                }),
+            ),
+            Facet::Imports => list_line(
+                "imports",
+                neighborhood.imports.iter().take(MAX_EDGES).cloned(),
+            ),
+            Facet::Importers => list_line(
+                "imported by",
+                neighborhood.importers.iter().take(MAX_EDGES).cloned(),
+            ),
+            Facet::Signature => list_line(
+                "signature",
+                leading
+                    .iter()
+                    .filter_map(|symbol| declaration_line(source.as_deref(), symbol)),
+            ),
+            Facet::DocComment => list_line(
+                "doc",
+                leading
+                    .iter()
+                    .filter_map(|symbol| doc_comment(source.as_deref(), symbol)),
+            ),
+            Facet::Callers => list_line(
+                "callers",
+                leading.iter().flat_map(|symbol| {
+                    frame_titles(graph.callers(&symbol.name).unwrap_or_default())
+                }),
+            ),
+            Facet::Callees => list_line(
+                "callees",
+                leading.iter().flat_map(|symbol| {
+                    frame_titles(graph.callees(&symbol.name).unwrap_or_default())
+                }),
+            ),
+            Facet::Body => body_block(graph, source.as_deref(), &hit.path, leading.first().copied()),
+        };
+        if let Some(line) = line {
+            block.push('\n');
+            block.push_str(&line);
+        }
+    }
+    block
+}
+
+/// `    label: a, b, c` — or nothing at all when there is nothing to say.
+///
+/// An empty facet writes no line rather than `label: (none)`: a rung that
+/// always emits keeps the monotonicity property either way, and silence costs
+/// the budget nothing.
+fn list_line(label: &str, items: impl Iterator<Item = String>) -> Option<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for item in items {
+        let item = item.trim().to_string();
+        if !item.is_empty() && !seen.contains(&item) {
+            seen.push(item);
+        }
+        if seen.len() >= MAX_EDGES.max(MAX_SYMBOLS) {
+            break;
+        }
+    }
+    (!seen.is_empty()).then(|| format!("    {label}: {}", seen.join(", ")))
+}
+
+/// The frames' human labels — `name (path:line)`, already rendered by
+/// `stella-graph` for citation (L-C4), so this never re-derives a citation.
+fn frame_titles(frames: Vec<stella_graph::ContextFrame>) -> Vec<String> {
+    frames
+        .into_iter()
+        .take(MAX_EDGES)
+        .map(|frame| frame.title)
+        .collect()
+}
+
+/// The symbol's declaration line, as written in the file.
+fn declaration_line(source: Option<&str>, symbol: &NeighborhoodSymbol) -> Option<String> {
+    let line = line_at(source?, symbol.start_line)?;
+    Some(line.trim().to_string())
+}
+
+/// The comment block immediately above the declaration, joined to one line.
+///
+/// Walks upward from the declaration over `///`, `//!`, `//`, `#` and `*`
+/// openers, which covers every language the indexer parses without a
+/// per-language table — a doc comment recognised loosely is a doc comment
+/// recognised, and the cost of a false positive here is one quoted line.
+fn doc_comment(source: Option<&str>, symbol: &NeighborhoodSymbol) -> Option<String> {
+    let lines: Vec<&str> = source?.lines().collect();
+    // `start_line` is 1-based, so the declaration sits at index
+    // `start_line - 1` and the line above it at `start_line - 2`.
+    let mut index = usize::try_from(symbol.start_line).ok()?.checked_sub(2)?;
+    let mut collected: Vec<&str> = Vec::new();
+    loop {
+        let candidate = lines.get(index)?.trim();
+        let is_comment = candidate.starts_with("///")
+            || candidate.starts_with("//!")
+            || candidate.starts_with("//")
+            || candidate.starts_with('#')
+            || candidate.starts_with('*')
+            || candidate.starts_with("/*");
+        if !is_comment {
+            break;
+        }
+        collected.push(candidate.trim_start_matches(['/', '!', '#', '*', ' ']));
+        let Some(next) = index.checked_sub(1) else {
+            break;
+        };
+        index = next;
+    }
+    collected.reverse();
+    let joined = collected.join(" ");
+    let joined = joined.trim();
+    (!joined.is_empty()).then(|| joined.to_string())
+}
+
+/// The leading symbol's source span, quoted and line-numbered.
+///
+/// The span comes from the code graph (`definition_spans`), never from a
+/// guessed offset — the same resolution `read_symbol` uses, so a body here
+/// and a body there are the same bytes.
+fn body_block(
+    graph: &CodeGraph,
+    source: Option<&str>,
+    path: &str,
+    symbol: Option<&NeighborhoodSymbol>,
+) -> Option<String> {
+    let symbol = symbol?;
+    let source = source?;
+    let span = graph
+        .definition_spans(&symbol.name)
+        .ok()?
+        .into_iter()
+        .find(|span| span.path == path)?;
+    let start = usize::try_from(span.start_line).ok()?.max(1);
+    let end = usize::try_from(span.end_line).ok()?.min(
+        start
+            .saturating_add(MAX_BODY_LINES)
+            .saturating_sub(1),
+    );
+    let quoted: Vec<String> = (start..=end)
+        .filter_map(|number| {
+            line_at(source, u32::try_from(number).ok()?)
+                .map(|text| format!("    {number:>5} | {text}"))
+        })
+        .collect();
+    if quoted.is_empty() {
+        return None;
+    }
+    let elided = u32::try_from(end).map_or(false, |end| end < span.end_line);
+    let mut block = format!("    body of `{}` ({path}:{start}-{end}):", symbol.name);
+    for line in quoted {
+        block.push('\n');
+        block.push_str(&line);
+    }
+    if elided {
+        block.push_str(&format!(
+            "\n    … {} further line(s); read the rest with `read_symbol`",
+            span.end_line - u32::try_from(end).unwrap_or(span.end_line)
+        ));
+    }
+    Some(block)
+}
+
+/// The 1-based `number`th line of `source`.
+fn line_at(source: &str, number: u32) -> Option<&str> {
+    let index = usize::try_from(number).ok()?.checked_sub(1)?;
+    source.lines().nth(index)
+}
+
+/// Rank indexed files by how many query terms appear in their path or their
+/// symbol names — the strategy for a workspace with an index but no embedder.
+///
+/// This is what a path glob cannot do: it searches *symbol* names. It is
+/// still a name match, and every answer carrying it says so.
+/// Deterministic: score descending, then path ascending.
+pub(crate) fn name_hits(graph: &CodeGraph, query: &str, limit: usize) -> Vec<Hit> {
+    let terms = terms_of(query);
+    if terms.is_empty() {
+        return Vec::new();
+    }
+    let Ok(files) = graph.all_files() else {
+        return Vec::new();
+    };
+
+    let mut scored: Vec<(usize, String)> = files
+        .into_iter()
+        .filter_map(|path| {
+            let symbols = graph
+                .file_neighborhood(Path::new(&path))
+                .map(|neighborhood| {
+                    neighborhood
+                        .symbols
+                        .iter()
+                        .map(|symbol| symbol.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_default();
+            let haystack = format!("{path} {symbols}").to_lowercase();
+            let hits = terms.iter().filter(|term| haystack.contains(*term)).count();
+            (hits > 0).then_some((hits, path))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    scored.truncate(limit);
+
+    scored
+        .into_iter()
+        .map(|(hits, path)| Hit {
+            why: format!(
+                "matched {hits} of {} query term(s) in its path or symbol NAMES (not by meaning)",
+                terms.len()
+            ),
+            path,
+        })
+        .collect()
+}
+
+/// English function words that carry no signal in a path or a symbol name.
+///
+/// A length floor alone cannot do this job: `the`, `and` and `for` are three
+/// characters and pure noise, while `api`, `sql`, `url` and `log` are three
+/// characters and exactly what someone is searching for. So the floor stays
+/// at three and the handful of words that would otherwise match half the tree
+/// are named. Deliberately short — this is a noise filter, not a linguistics
+/// project, and every word added is a word a caller can no longer search for.
+///
+/// Kept identical to `crate::graph::semantic`'s list on purpose: the two
+/// tools must agree on what a term is, or the same query scores differently
+/// depending on which one the model reached for.
+const STOPWORDS: &[&str] = &[
+    "the", "and", "for", "are", "was", "were", "that", "this", "with", "from", "into", "when",
+    "where", "what", "which", "does", "how", "its", "not", "but", "all", "any", "can", "has",
+    "have", "before", "after", "them", "then", "than",
+];
+
+/// Words worth matching on: lowercase, alphanumeric, at least three
+/// characters, and not a [`STOPWORDS`] entry.
+pub(crate) fn terms_of(query: &str) -> Vec<String> {
+    let mut terms: Vec<String> = query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|word| word.chars().count() >= 3)
+        .map(str::to_lowercase)
+        .filter(|word| !STOPWORDS.contains(&word.as_str()))
+        .collect();
+    terms.sort();
+    terms.dedup();
+    terms
+}

--- a/crates/stella-tools/src/search/scan.rs
+++ b/crates/stella-tools/src/search/scan.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The strategy that needs no index at all: walk the working tree and rank
+//! files by how many query terms appear in their path and their contents.
+//!
+//! # This is not an edge case
+//!
+//! `stella init` is best-effort by design, and a workspace whose language has
+//! no tree-sitter grammar in `stella-graph` produces an empty index — which
+//! is the *normal* case on Terminal-Bench, where the task tree is frequently
+//! a handful of shell scripts, config and a language nobody indexed. Without
+//! this rung, `search` would answer "nothing found" on exactly the workspaces
+//! the bench measures, and the fused-tool experiment would fail for a reason
+//! that has nothing to do with fusion.
+//!
+//! # Why it still is not a match list
+//!
+//! It ranks *files*, and it says how many terms and where they matched. It
+//! deliberately does not emit `path:line: text` rows: that output shape is
+//! what `grep -n` already produces, and a tool that produces it competes with
+//! the shell on the shell's ground (see the parent module's docs). The path
+//! is a pointer; the follow-up is `read_file`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::Hit;
+
+/// Files opened in one scan. A bound, not a tuning knob: the walk is
+/// synchronous and an agent is waiting on it, and a repository large enough
+/// to exceed this has an index worth building instead.
+const MAX_FILES_SCANNED: usize = 4_000;
+
+/// Bytes read from each file. Enough to cover the imports, the type
+/// declarations and the head of a typical module.
+const MAX_BYTES_PER_FILE: usize = 64 * 1024;
+
+/// Directories never descended into. Every entry is either machine-generated
+/// or another tool's private state; a term matched inside one of them points
+/// at nothing the agent can edit.
+const SKIPPED_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    ".stella",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "vendor",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".next",
+    ".cargo",
+];
+
+/// A term found in a path is worth this many found in contents.
+///
+/// A file *named* for the thing is a stronger signal than a file that
+/// mentions it: `retry.rs` is about retries; a file that says "retry" twice
+/// in a comment is not. Three is judgement, not measurement — it is enough to
+/// float a well-named file over an incidental mention without letting a lucky
+/// path beat a file that is genuinely dense in the term.
+const PATH_TERM_WEIGHT: usize = 3;
+
+/// Rank files under `root` against `query`, best first.
+///
+/// Deterministic: score descending, then path ascending, and the walk itself
+/// sorts each directory's entries — a filesystem's readdir order is not
+/// stable across machines, and two runs of one query must rank identically
+/// (invariant 7).
+pub(crate) fn scan_hits(root: &Path, query: &str, limit: usize) -> Vec<Hit> {
+    let terms = super::enrich::terms_of(query);
+    if terms.is_empty() {
+        return Vec::new();
+    }
+
+    let mut scored: Vec<(usize, usize, usize, String)> = Vec::new();
+    let mut budget = MAX_FILES_SCANNED;
+    for file in walk(root, &mut budget) {
+        let Ok(relative) = file.strip_prefix(root) else {
+            continue;
+        };
+        let path = relative.to_string_lossy().replace('\\', "/");
+        let lowered_path = path.to_lowercase();
+        let in_path = terms
+            .iter()
+            .filter(|term| lowered_path.contains(*term))
+            .count();
+
+        let contents = read_head(&file).unwrap_or_default().to_lowercase();
+        let in_body = terms.iter().filter(|term| contents.contains(*term)).count();
+
+        let score = in_path * PATH_TERM_WEIGHT + in_body;
+        if score > 0 {
+            scored.push((score, in_path, in_body, path));
+        }
+    }
+
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.3.cmp(&b.3)));
+    scored.truncate(limit);
+    scored
+        .into_iter()
+        .map(|(_, in_path, in_body, path)| Hit {
+            why: format!(
+                "matched {in_path} query term(s) in its PATH and {in_body} in its contents, out \
+                 of {} (no index was available, so this is a term match, not a meaning match)",
+                terms.len()
+            ),
+            path,
+        })
+        .collect()
+}
+
+/// Every regular file under `root`, sorted, skipping [`SKIPPED_DIRS`] and
+/// dotted entries, stopping once `budget` files have been yielded.
+///
+/// Iterative rather than recursive: a symlink loop or a pathological tree
+/// must cost a bounded walk, never the process's stack.
+fn walk(root: &Path, budget: &mut usize) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut queue = vec![root.to_path_buf()];
+    while let Some(directory) = queue.pop() {
+        if *budget == 0 {
+            break;
+        }
+        let Ok(entries) = fs::read_dir(&directory) else {
+            continue;
+        };
+        let mut children: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
+        children.sort();
+        for child in children {
+            if *budget == 0 {
+                break;
+            }
+            let Some(name) = child.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            // `symlink_metadata`, not `metadata`: a symlink pointing at a
+            // parent directory would otherwise make this walk unbounded, and
+            // a symlink out of the workspace would read files the tool has no
+            // business reading.
+            let Ok(metadata) = fs::symlink_metadata(&child) else {
+                continue;
+            };
+            if metadata.is_dir() {
+                if !name.starts_with('.') && !SKIPPED_DIRS.contains(&name) {
+                    queue.push(child);
+                }
+            } else if metadata.is_file() && !name.starts_with('.') {
+                *budget -= 1;
+                found.push(child);
+            }
+        }
+    }
+    found
+}
+
+/// The first [`MAX_BYTES_PER_FILE`] of `path` as text, or `None` when it is
+/// binary or unreadable.
+fn read_head(path: &Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    let head = &bytes[..bytes.len().min(MAX_BYTES_PER_FILE)];
+    // A NUL byte in the head is the same binary sniff `grep` uses. Cheaper
+    // than a UTF-8 validation over a large blob and it fails in the right
+    // direction: a text file with a stray NUL is skipped, never mis-decoded.
+    if head.contains(&0) {
+        return None;
+    }
+    Some(String::from_utf8_lossy(head).into_owned())
+}

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for `search`, in the crate so they exercise the shipped internals
+//! rather than a re-implementation — the discipline `crate::graph::semantic`
+//! already follows.
+//!
+//! The witness is [`one_search_call_answers_what_today_takes_several_tools`].
+//! Everything else covers a way the tool can be wrong quietly: a fallback
+//! that does not say it fell back, a depth rung that takes something away,
+//! and a truncation nobody is told about.
+
+use std::fs;
+use std::path::Path;
+
+use async_trait::async_trait;
+use stella_core::search::{Depth, allocate, facets_at};
+use stella_embed::{EmbedError, Embedder, EmbedderFingerprint, Embedding, SimilarityPosture};
+use stella_graph::CodeGraph;
+use stella_protocol::tool::ToolOutput;
+
+use super::{Hit, Search, SearchConfig, Strategy, dispatch, render};
+use crate::registry::Tool;
+
+/// The question the witness asks. Every word of it is checked against the
+/// answer's path and body before the search runs — see the witness itself.
+const QUESTION: &str = "removing sensitive credentials before they reach the log";
+
+/// The fixture: three files, one of which is the answer, and whose name and
+/// body share no word with [`QUESTION`].
+const FIXTURE: &[(&str, &str)] = &[
+    (
+        "src/hkey.rs",
+        "//! Keeps confidential material out of emitted diagnostics.\n\
+         pub struct Scrubber;\n\
+         pub fn scrub_record(record: &mut Record) {\n\
+         record.password.clear();\n\
+         record.secret_token.clear();\n\
+         }\n",
+    ),
+    (
+        "src/wire.rs",
+        "//! HTTP request plumbing.\n\
+         pub struct Socket;\n\
+         pub fn send_request(socket: &Socket) -> Response {\n\
+         socket.write_header();\n\
+         socket.flush()\n\
+         }\n",
+    ),
+    (
+        "src/tally.rs",
+        "//! Matrix arithmetic.\n\
+         pub struct Matrix;\n\
+         pub fn multiply(a: &Matrix, b: &Matrix) -> Matrix {\n\
+         a.rows().sum(b)\n\
+         }\n",
+    ),
+];
+
+/// The four concepts the fixture separates on.
+const LEXICON: &[(&str, usize)] = &[
+    ("secret", 0),
+    ("password", 0),
+    ("credential", 0),
+    ("confidential", 0),
+    ("sensitive", 0),
+    ("scrub", 0),
+    ("redact", 0),
+    ("log", 1),
+    ("diagnostic", 1),
+    ("emit", 1),
+    ("http", 2),
+    ("request", 2),
+    ("socket", 2),
+    ("header", 2),
+    ("wire", 2),
+    ("matrix", 3),
+    ("multiply", 3),
+    ("arithmetic", 3),
+    ("sum", 3),
+    ("row", 3),
+];
+
+const DIMS: usize = 4;
+
+/// A deterministic, offline embedder that is genuinely *semantic*: different
+/// surface words map to the same dimension, which is the whole property under
+/// test. Deliberately not `HashEmbedder` — a hashing projection would make
+/// the fixture surface-solvable and the witness would prove nothing.
+///
+/// Same shape as `stella-graph`'s `semantic_recall.rs::ConceptEmbedder`, so
+/// the two suites agree on what "semantic" means here.
+#[derive(Debug)]
+struct ConceptEmbedder;
+
+impl ConceptEmbedder {
+    fn project(text: &str) -> Vec<f32> {
+        let mut accumulator = vec![0.0f32; DIMS];
+        for word in text
+            .to_lowercase()
+            .split(|c: char| !c.is_alphabetic())
+            .filter(|word| !word.is_empty())
+        {
+            for (term, dimension) in LEXICON {
+                if word.contains(term) {
+                    accumulator[*dimension] += 1.0;
+                }
+            }
+        }
+        stella_embed::l2_normalize(&mut accumulator);
+        accumulator
+    }
+}
+
+#[async_trait]
+impl Embedder for ConceptEmbedder {
+    fn fingerprint(&self) -> EmbedderFingerprint {
+        EmbedderFingerprint {
+            model_id: "concept-lexicon".into(),
+            revision: "1".into(),
+            dims: DIMS,
+            normalization: "l2".into(),
+        }
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedError> {
+        if texts.is_empty() {
+            return Err(EmbedError::EmptyInput);
+        }
+        let fingerprint = self.fingerprint().id();
+        Ok(texts
+            .iter()
+            .map(|text| Embedding {
+                fingerprint: fingerprint.clone(),
+                vector: Self::project(text),
+            })
+            .collect())
+    }
+
+    fn similarity_posture(&self) -> SimilarityPosture {
+        SimilarityPosture::Semantic {
+            admission_floor: 0.2,
+        }
+    }
+}
+
+/// Write the fixture and index it. Returns the canonical root and an open
+/// graph; the caller shuts the graph down.
+fn indexed_fixture(workspace: &Path) -> (std::path::PathBuf, CodeGraph) {
+    for (path, body) in FIXTURE {
+        let file = workspace.join(path);
+        fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+        fs::write(&file, body).expect("write");
+    }
+    let root = workspace.canonicalize().expect("canonicalize");
+    let graph = CodeGraph::open(&root, &root.join("codegraph.db")).expect("open");
+    graph.index_all().expect("index");
+    (root, graph)
+}
+
+fn content_of(output: &ToolOutput) -> String {
+    match output {
+        ToolOutput::Ok { content } => content.clone(),
+        ToolOutput::Error { message } => panic!("expected an answer, got an error: {message}"),
+    }
+}
+
+/// **The witness.**
+///
+/// It proves the claim the whole change rests on, in the only way that
+/// distinguishes it from its opposite: one `search` call returns the file
+/// that answers a plain-English question *whose words appear nowhere in that
+/// file's name or body* — and returns it already carrying the structure that
+/// today costs a `graph_query` and a `read_symbol` on top of the grep that
+/// would have failed anyway.
+///
+/// The fixture's own premise is asserted first. A fixture that drifts into
+/// being grep-solvable would let this test pass while proving nothing, so
+/// every word of the question is checked against both the answer's path and
+/// its body, and the test fails loudly rather than vacuously.
+#[tokio::test]
+async fn one_search_call_answers_what_today_takes_several_tools() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+
+    // The premise that makes this test worth anything: no lexical route
+    // exists from the question to the answer. If either assertion fires, the
+    // fixture has become solvable by grep and the test below proves nothing.
+    let answer_path = "src/hkey.rs";
+    let body = fs::read_to_string(root.join(answer_path))
+        .expect("read")
+        .to_lowercase();
+    for word in QUESTION.split_whitespace() {
+        assert!(
+            !answer_path.contains(word),
+            "the question word `{word}` appears in the answer's path — the fixture would be \
+             solvable by a filename match and proves nothing"
+        );
+        assert!(
+            !body.contains(word),
+            "the question word `{word}` appears in the answer's body — grep would find it and \
+             this test proves nothing"
+        );
+    }
+
+    let answer = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
+    assert_eq!(
+        answer.strategies,
+        vec![Strategy::Semantic],
+        "the semantic strategy must be the one that answered; note={:?}",
+        answer.note
+    );
+    assert_eq!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some(answer_path),
+        "expected the redaction file first; got {:?}",
+        answer.hits
+    );
+
+    // Depth 8 buys symbols, kinds, imports, importers, signature, doc and
+    // callers — the graph structure that a grep cannot express and that the
+    // model would otherwise pay separate calls for.
+    let output = render(
+        Some(&graph),
+        &root,
+        QUESTION,
+        &answer,
+        SearchConfig {
+            depth: Depth::new(8),
+            budget: 200_000,
+        },
+    );
+    let content = content_of(&output);
+    assert!(content.contains(answer_path), "no answer path in: {content}");
+    assert!(
+        content.contains("scrub_record"),
+        "the hit did not carry its symbols — a second tool call would still be needed: {content}"
+    );
+    assert!(
+        content.contains("signature:"),
+        "the hit did not carry a signature: {content}"
+    );
+    assert!(
+        content.contains("ranked by MEANING"),
+        "the answer did not say why the file ranked: {content}"
+    );
+
+    // Deterministic: the identical query renders identically, which is what
+    // invariant 7 needs from output that reaches the prompt.
+    let again = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
+    assert_eq!(answer.hits, again.hits);
+
+    graph.shutdown();
+}
+
+/// With no embedder the answer must still be useful, and must say which
+/// strategy produced it — a name match wearing a meaning match's clothes is
+/// worse than no answer.
+#[tokio::test]
+async fn without_an_embedder_the_answer_is_useful_and_says_it_is_a_name_match() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+
+    let answer = dispatch(Some(&graph), &root, "scrub_record", None).await;
+    assert_eq!(answer.strategies, vec![Strategy::GraphNames]);
+    assert_eq!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some("src/hkey.rs"),
+        "the name strategy must still find a symbol by name: {:?}",
+        answer.hits
+    );
+
+    let content = content_of(&render(
+        Some(&graph),
+        &root,
+        "scrub_record",
+        &answer,
+        SearchConfig::default(),
+    ));
+    assert!(
+        content.contains("symbol NAMES (not by meaning)"),
+        "the answer did not label itself a name match: {content}"
+    );
+    assert!(
+        content.contains("via: names"),
+        "the answer did not name the strategy that ran: {content}"
+    );
+
+    graph.shutdown();
+}
+
+/// A workspace the indexer cannot serve — no tree-sitter grammar, so an empty
+/// graph — is the normal case on Terminal-Bench. It must still answer, and
+/// still say what it did.
+#[tokio::test]
+async fn with_no_index_at_all_the_file_scan_answers_and_labels_itself() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        workspace.path().join("deploy.conf"),
+        "# rotate the credential bundle nightly\nrotation = nightly\n",
+    )
+    .expect("write");
+    let root = workspace.path().canonicalize().expect("canonicalize");
+
+    let answer = dispatch(None, &root, "credential rotation", None).await;
+    assert_eq!(answer.strategies, vec![Strategy::FileScan]);
+    assert_eq!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some("deploy.conf"),
+        "the scan found nothing in an unindexable workspace: {:?}",
+        answer.hits
+    );
+
+    let content = content_of(&render(
+        None,
+        &root,
+        "credential rotation",
+        &answer,
+        SearchConfig::default(),
+    ));
+    assert!(
+        content.contains("no index was available"),
+        "the scan answer did not label itself: {content}"
+    );
+    assert!(
+        content.contains("via: scan"),
+        "the scan answer did not name its strategy: {content}"
+    );
+}
+
+/// Depth monotonicity, on the rendered text rather than only on the facet
+/// set: every line the shallower block emitted must survive into the deeper
+/// one. A rung that reformatted a lower rung's line would make a depth sweep
+/// uninterpretable without failing anything else.
+#[tokio::test]
+async fn each_depth_renders_a_superset_of_the_one_below() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+    let answer = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
+
+    let block_at = |level: u8| {
+        content_of(&render(
+            Some(&graph),
+            &root,
+            QUESTION,
+            &answer,
+            SearchConfig {
+                depth: Depth::new(level),
+                budget: 200_000,
+            },
+        ))
+    };
+
+    for level in 1..Depth::MAX.level() {
+        let shallow = block_at(level);
+        let deep = block_at(level + 1);
+        for line in shallow.lines() {
+            assert!(
+                deep.contains(line),
+                "depth {} lost the line `{line}` that depth {level} rendered",
+                level + 1
+            );
+        }
+        assert!(
+            deep.len() >= shallow.len(),
+            "depth {} rendered less than depth {level}",
+            level + 1
+        );
+    }
+
+    graph.shutdown();
+}
+
+/// A budget too small for every hit must say so. An agent that cannot tell a
+/// complete answer from a truncated one stops looking, which is the exact
+/// failure this line prevents.
+#[test]
+fn a_truncated_answer_says_it_was_truncated() {
+    let hits: Vec<Hit> = (0..6)
+        .map(|index| Hit {
+            path: format!("src/file{index}.rs"),
+            why: "ranked by MEANING against your query (cosine 0.900)".into(),
+        })
+        .collect();
+    let answer = super::Answer {
+        hits,
+        strategies: vec![Strategy::Semantic],
+        note: None,
+    };
+
+    let content = content_of(&render(
+        None,
+        Path::new("/nonexistent"),
+        "anything",
+        &answer,
+        SearchConfig {
+            depth: Depth::MIN,
+            budget: 130,
+        },
+    ));
+    assert!(
+        content.contains("TRUNCATED"),
+        "a truncated answer did not say so: {content}"
+    );
+    assert!(
+        content.contains("further result(s) were dropped"),
+        "the truncation line did not say what was dropped: {content}"
+    );
+
+    // The complement: given room, the same answer must NOT claim truncation.
+    let roomy = content_of(&render(
+        None,
+        Path::new("/nonexistent"),
+        "anything",
+        &answer,
+        SearchConfig {
+            depth: Depth::MIN,
+            budget: 100_000,
+        },
+    ));
+    assert!(
+        !roomy.contains("TRUNCATED"),
+        "an untruncated answer claimed truncation: {roomy}"
+    );
+}
+
+/// The schema is the whole user interface, so its promises are pinned:
+/// one required argument, no mode selector (invariant 9), and a description
+/// that corrects the lexical reading of the name.
+#[test]
+fn the_schema_offers_one_query_and_no_mode_selector() {
+    let schema = Search::default().schema();
+    assert_eq!(schema.name, "search");
+    assert!(schema.read_only);
+    assert!(!schema.speculation_safe, "the graph open writes (#923)");
+
+    let properties = schema.input_schema["properties"]
+        .as_object()
+        .expect("an object schema");
+    assert_eq!(
+        properties.keys().collect::<Vec<_>>(),
+        vec!["query"],
+        "a second parameter is a mode selector waiting to happen (invariant 9)"
+    );
+    assert_eq!(schema.input_schema["required"][0], "query");
+
+    let description = &schema.description;
+    assert!(
+        description.contains("MEANING"),
+        "the description must correct the lexical reading of the name `search`"
+    );
+    assert!(
+        description.contains("search(\""),
+        "the description must show worked argument shapes"
+    );
+    for shape in ["where are request headers", "CredentialStore"] {
+        assert!(
+            description.contains(shape),
+            "the description lost the `{shape}` example — it must show BOTH a described \
+             behaviour and a named symbol"
+        );
+    }
+}
+
+/// The dial is configuration, never a tool argument, and the advertised
+/// schema must not move when it changes — tool schemas ride at position 0 of
+/// the cached prefix (invariant 7).
+#[test]
+fn the_depth_dial_never_reaches_the_advertised_schema() {
+    let shallow = Search::with_config(SearchConfig {
+        depth: Depth::MIN,
+        budget: 1_000,
+    })
+    .schema();
+    let deep = Search::with_config(SearchConfig {
+        depth: Depth::MAX,
+        budget: 900_000,
+    })
+    .schema();
+    assert_eq!(
+        serde_json::to_string(&shallow).expect("serialize"),
+        serde_json::to_string(&deep).expect("serialize"),
+        "the depth setting changed the advertised schema, so a sweep would cost the prompt cache"
+    );
+}
+
+/// The allocator and the renderer must agree about how many hits were shown;
+/// they are separately written and a drift between them would silently drop
+/// results with no truncation line.
+#[test]
+fn the_rendered_hit_count_matches_the_allocation() {
+    let hits: Vec<Hit> = (0..7)
+        .map(|index| Hit {
+            path: format!("src/file{index}.rs"),
+            why: "matched 1 query term(s)".into(),
+        })
+        .collect();
+    let answer = super::Answer {
+        hits: hits.clone(),
+        strategies: vec![Strategy::FileScan],
+        note: None,
+    };
+    let config = SearchConfig {
+        depth: Depth::new(3),
+        budget: 900,
+    };
+    let allocation = allocate(hits.len(), config.depth, config.budget);
+    let content = content_of(&render(
+        None,
+        Path::new("/nonexistent"),
+        "anything",
+        &answer,
+        config,
+    ));
+
+    let shown = hits
+        .iter()
+        .filter(|hit| content.contains(&hit.path))
+        .count();
+    assert_eq!(shown, allocation.granted.len());
+    assert_eq!(allocation.omitted, hits.len() - shown);
+    assert!(facets_at(config.depth).len() >= 3);
+}

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -26,9 +26,34 @@ use crate::registry::Tool;
 /// answer's path and body before the search runs — see the witness itself.
 const QUESTION: &str = "removing sensitive credentials before they reach the log";
 
-/// The fixture: three files, one of which is the answer, and whose name and
+/// The file the question is about. Its name and body share no word with
+/// [`QUESTION`] — asserted by the witness before it searches.
+const ANSWER: &str = "src/hkey.rs";
+
+/// The file a *lexical* method answers with instead.
+///
+/// It is stuffed with the question's own surface words (`removing`, `before`,
+/// `they reach`, `the`) while being about queue arithmetic, so any strategy
+/// that matches text rather than meaning ranks it first. Without this decoy
+/// the fixture is only three files wide and a surface embedder can land on
+/// the right one by luck — which it did, in a run of this suite, while the
+/// witness reported success. A witness that passes for the wrong reason is
+/// worse than no witness, and this file is what makes the assertion
+/// load-bearing. `a_surface_embedder_cannot_answer_the_same_question` pins it.
+const DECOY: &str = "src/reaching.rs";
+
+/// The fixture: four files, one of which is the answer, and whose name and
 /// body share no word with [`QUESTION`].
 const FIXTURE: &[(&str, &str)] = &[
+    (
+        DECOY,
+        "//! Removing an element before they reach the end of the queue.\n\
+         pub struct Queue;\n\
+         pub fn removing_before_they_reach_the_end(queue: &mut Queue) {\n\
+         queue.reach_the_end();\n\
+         queue.removing_before();\n\
+         }\n",
+    ),
     (
         "src/hkey.rs",
         "//! Keeps confidential material out of emitted diagnostics.\n\
@@ -186,7 +211,7 @@ async fn one_search_call_answers_what_today_takes_several_tools() {
     // The premise that makes this test worth anything: no lexical route
     // exists from the question to the answer. If either assertion fires, the
     // fixture has become solvable by grep and the test below proves nothing.
-    let answer_path = "src/hkey.rs";
+    let answer_path = ANSWER;
     let body = fs::read_to_string(root.join(answer_path))
         .expect("read")
         .to_lowercase();
@@ -249,6 +274,40 @@ async fn one_search_call_answers_what_today_takes_several_tools() {
     // invariant 7 needs from output that reaches the prompt.
     let again = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
     assert_eq!(answer.hits, again.hits);
+
+    graph.shutdown();
+}
+
+/// The control that makes the witness above mean something.
+///
+/// A *surface* backend — one that compares text shape rather than meaning —
+/// must NOT reach the answer, or the witness is measuring a coincidence. This
+/// test exists because an earlier version of the fixture was small enough
+/// that `HashEmbedder` landed on the right file by luck and the witness went
+/// green anyway. It is the same control `stella-graph`'s
+/// `semantic_recall.rs::the_lexical_embedder_cannot_answer_the_same_question`
+/// runs, pointed at this tool's dispatch, and it fails the moment the fixture
+/// drifts back into being surface-solvable.
+#[tokio::test]
+async fn a_surface_embedder_cannot_answer_the_same_question() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+
+    let surface = stella_embed::HashEmbedder::default();
+    assert_eq!(
+        surface.similarity_posture(),
+        SimilarityPosture::Surface,
+        "this control is only meaningful against a backend that declares itself surface-only"
+    );
+
+    let answer = dispatch(Some(&graph), &root, QUESTION, Some(&surface)).await;
+    assert_eq!(answer.strategies, vec![Strategy::Semantic]);
+    assert_ne!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some(ANSWER),
+        "a surface embedder reached the answer, so the witness proves nothing about MEANING — \
+         the fixture has become surface-solvable and needs a stronger decoy than {DECOY}"
+    );
 
     graph.shutdown();
 }
@@ -338,8 +397,12 @@ async fn each_depth_renders_a_superset_of_the_one_below() {
     let (root, graph) = indexed_fixture(workspace.path());
     let answer = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
 
+    // The hit blocks only. The two header lines are deliberately excluded:
+    // they *report* the depth ("… at depth 3"), so they are expected to
+    // differ between rungs, and asserting over them would test the report
+    // rather than the ladder.
     let block_at = |level: u8| {
-        content_of(&render(
+        let content = content_of(&render(
             Some(&graph),
             &root,
             QUESTION,
@@ -348,13 +411,20 @@ async fn each_depth_renders_a_superset_of_the_one_below() {
                 depth: Depth::new(level),
                 budget: 200_000,
             },
-        ))
+        ));
+        content
+            .lines()
+            .skip_while(|line| !line.starts_with("via: "))
+            .skip(1)
+            .map(str::to_string)
+            .collect::<Vec<_>>()
     };
 
     for level in 1..Depth::MAX.level() {
         let shallow = block_at(level);
         let deep = block_at(level + 1);
-        for line in shallow.lines() {
+        assert!(!shallow.is_empty(), "depth {level} rendered no hit block");
+        for line in &shallow {
             assert!(
                 deep.contains(line),
                 "depth {} lost the line `{line}` that depth {level} rendered",
@@ -363,7 +433,7 @@ async fn each_depth_renders_a_superset_of_the_one_below() {
         }
         assert!(
             deep.len() >= shallow.len(),
-            "depth {} rendered less than depth {level}",
+            "depth {} rendered fewer lines than depth {level}",
             level + 1
         );
     }

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -256,7 +256,10 @@ async fn one_search_call_answers_what_today_takes_several_tools() {
         },
     );
     let content = content_of(&output);
-    assert!(content.contains(answer_path), "no answer path in: {content}");
+    assert!(
+        content.contains(answer_path),
+        "no answer path in: {content}"
+    );
     assert!(
         content.contains("scrub_record"),
         "the hit did not carry its symbols — a second tool call would still be needed: {content}"

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -59,6 +59,9 @@ These 58 tools register in every session — no configuration, no prerequisites.
 #### Search
 
 <CardGrid size="md">
+  <ToolCard name="search" access="read">
+    One way to find code, whatever form the question takes: a description of behaviour, a question, or a symbol name. Ranks by meaning rather than substring, then spends a fixed context budget attaching structure to the top hits — symbols, imports, importers, signatures, docs, callers, callees, a body excerpt — so one call usually replaces a run of grep/glob/read_file round trips. How much detail each hit carries is the `STELLA_SEARCH_DEPTH` dial (1–10, default 4), owned by configuration and never by the model; `STELLA_SEARCH_BUDGET` is the hard stop in characters. Degrades to symbol-name matching without an embedder and to an index-free file scan without a code graph, and every answer states which strategies ran and whether it was truncated.
+  </ToolCard>
   <ToolCard name="grep" access="read">
     Search file contents with a regex (ripgrep-backed when available); once the code-graph index exists, matches carry a code-map footer.
   </ToolCard>
@@ -273,7 +276,7 @@ These 58 tools register in every session — no configuration, no prerequisites.
 <Callout type="info">
 `verify_done` and `screenshot` are **mutating** in the permission model (`read_only: false`) even though `verify_done` never edits your working tree and `screenshot` only writes into `.stella/`. `web_download` is mutating for the same reason — it writes a file.
 
-The read-only partition is exactly: `read_file`, `read_symbol`, `grep`, `glob`, `graph_query`, `semantic_code_search`, `project_overview`, `gather_context`, `explorations`, `diagnostics`, `list_scripts`, `get_state`, `list_state`, `get_environment`, `probe_capability`, `repo_status`, `repo_diff`, `repo_history`, `repo_recover`, `ci_status`, `task_list`, and (when present) `search_issues`, `get_issue`, `list_labels`, `list_members`, `web_fetch`, `web_extract_assets`, `web_search` — plus `search_skills`, `recall_context`, `tool_search`, `skill_search`, and `mcp_search` at the session layer.
+The read-only partition is exactly: `read_file`, `read_symbol`, `search`, `grep`, `glob`, `graph_query`, `semantic_code_search`, `project_overview`, `gather_context`, `explorations`, `diagnostics`, `list_scripts`, `get_state`, `list_state`, `get_environment`, `probe_capability`, `repo_status`, `repo_diff`, `repo_history`, `repo_recover`, `ci_status`, `task_list`, and (when present) `search_issues`, `get_issue`, `list_labels`, `list_members`, `web_fetch`, `web_extract_assets`, `web_search` — plus `search_skills`, `recall_context`, `tool_search`, `skill_search`, and `mcp_search` at the session layer.
 </Callout>
 
 ### Conditionally registered
@@ -470,14 +473,22 @@ The remaining three session tools are read-only **discovery** tools layered over
 Set `STELLA_LEAN_TOOLS=1` to advertise only a lean core toolset plus the discovery tools; everything else stays out of the prompt until a `tool_search` surfaces it.
 
 ```bash
-# Trim the prompt to the core eleven plus the discovery tools.
+# Trim the prompt to the default core plus the discovery tools.
 STELLA_LEAN_TOOLS=1 stella run "wire up the new webhook handler"
 
 # Or choose your own core — a comma-separated list replaces the default.
+# The discovery tools still ride along on top of it.
 STELLA_LEAN_TOOLS=read_file,grep,glob,bash stella run "audit the config loader"
+
+# Or close the set: `only:` advertises exactly these and nothing else,
+# discovery tools included. This is the form a fixed-size experiment needs.
+STELLA_LEAN_TOOLS=only:search,read_file,edit_file,write_file,bash \
+  stella run "audit the config loader"
 ```
 
-The default core is exactly eleven tools: `read_file`, `write_file`, `edit_file`, `grep`, `glob`, `gather_context`, `build_project`, `run_tests`, `verify_done`, `bash`, and `ask_user`. Note what is *not* in it — `delete_file` and `apply_edits` are absent, so lean mode is read/write/edit rather than full file CRUD.
+The default core is exactly thirteen tools: `read_file`, `write_file`, `edit_file`, `bash`, `grep`, `glob`, `graph_query`, `read_symbol`, `gather_context`, `verify_done`, `build_project`, `run_tests`, and `ask_user`. Note what is *not* in it — `delete_file` and `apply_edits` are absent, so lean mode is read/write/edit rather than full file CRUD.
+
+`graph_query` and `read_symbol` are core rather than searchable on purpose: a model that does not know the code graph exists has no reason to search for it, so hiding the structural retrieval tools behind `tool_search` pins every lean session to grep.
 
 Matched tools are *activated* — advertised for the rest of the session. A hidden tool called by name still executes, so lean mode trims prompt weight without ever gating a capability.
 


### PR DESCRIPTION
## One `search` tool, because six ways to find code is a selection problem

Stella sends **72 tool schemas** per request — 11,797 tokens, 71% of the opening context — against Claude Code's 25 (#3032). Six of them are ways to find code. Across 408 bench trials and 15,304 model calls the usage was not a distribution, it was a collapse:

```
bash                 10,835 calls   first reached at call  2.2
grep                    120         first reached at call  2.3
glob                     83         first reached at call 33.1
project_overview         33         first reached at call  8.1
read_symbol              23         first reached at call  8.0
graph_query               3         first reached at call  9.7
gather_context            0
semantic_code_search      0
```

`gather_context` is the decisive row. Its description already promised this design — *"one deterministic context sweep (grep patterns + file globs + code-graph symbol lookups + bounded excerpts) in a single call… Prefer this over issuing several separate grep/glob/graph_query/read_file calls"* — and it was called **zero** times. The concept did not fail; the name and the shape did.

## The design

`search(query)` — one operation, **no mode selector**. `mode="regex"|"semantic"|"symbol"` would satisfy invariant 9's letter and break its purpose: it is three tools wearing one schema, and it reproduces the selection problem one level down where it is harder to see. **We choose the strategy, not the model.**

- **Always ranks semantically** when an embedder resolves, reusing the `code_graph_vectors` table `stella init` already fills (#3014) and the `stella-embed` seam (#3003). No second embedding path, no second vector table. This is also what makes the vector index *unconditionally exercised*: with 3 `graph_query` calls in 408 trials we cannot tell whether it is bad or merely unchosen (#2995).
- **Enriches budget-driven, not intent-driven.** A wrong intent inference is unrecoverable in a tool with no mode flag to correct it; a budget degrades — the top hit keeps its detail, the tail loses depth first, and the answer says so.
- **Depth is a 1..=10 dial owned by configuration** (`STELLA_SEARCH_DEPTH`), never by the model. Monotone by construction, per-hit within one allowance (rank 0 gets the full depth, each rank halves), and absent from the advertised schema so a sweep costs no prompt cache (invariant 7).
- **Honest fallback.** Semantic → graph-name matching → an index-free file scan. Every answer states which strategies ran. The scan is not an edge case: `stella init` is best-effort and an unindexable workspace is the normal case on Terminal-Bench.
- **Nothing is deleted.** All six existing tools keep working. The experiment is about what the schema menu *sends*.

### Architecture

The decision half — the depth ladder and the budget arithmetic — is pure and lives in `stella-core::search` (invariant 2), property-tested for monotonicity, never-overspending, and determinism. Embedding calls and file reads stay in `stella-tools` (invariant 1). New logic landed in sibling modules; `registry.rs` grew six lines of comment and one registration.

Exemplar followed: `crate::graph::semantic` (the open → query → `shutdown()` inside one `spawn_blocking` discipline, and the embedder-as-parameter seam so tests exercise the shipped path with no test-only branch).

### The bar is "not assemblable in bash", not "better than grep"

The same census shows Stella running grep *through the shell* while a native `grep` tool sits in the menu — 8 shell greps on top of 6 native `grep` calls in one trial, same session, same file. bash wins because it composes (8.9 command segments per call, median 6). So a fixed shape is not automatically safe from the shell: **a list of `file:line` matches would lose anyway**, because the model can shape that with a pipe and cannot shape ours. The answer therefore leads with the ranking and *why* each hit ranked, carries graph structure as first-class content, and is deliberately not formatted like `grep -n`.

Correctness comes first, though: `apply_edits` is the more expressive structured tool and loses 42 calls to `edit_file`'s 372 while failing 33% of the time against 5.9%. Every strategy here is total and every failure degrades with its reason quoted.

## Witness test

`stella_tools::search::tests::one_search_call_answers_what_today_takes_several_tools` — one `search` call returns the file answering a plain-English question whose words appear nowhere in that file's name or body, already carrying the structure that today costs a `graph_query` and a `read_symbol` on top of the grep that would have failed anyway. The fixture's own premise is asserted first: every question word is checked against the answer's path and body.

**The first version of this witness was wrong and passed anyway.** With only three fixture files, `HashEmbedder` — a *surface* backend — landed on the answer by luck and the witness went green. Evidence consistent with both answers is not evidence. Fixed by adding `src/reaching.rs`, a decoy stuffed with the question's surface words while being about queue arithmetic, and by `a_surface_embedder_cannot_answer_the_same_question`, a permanent control that fails the moment the fixture drifts back into being surface-solvable (the same control shape as `stella-graph`'s `semantic_recall.rs`).

Fail side verified artisanally, both halves:
- semantic ranking removed → `assertion failed: the semantic strategy must be the one that answered`
- graph enrichment removed → `the hit did not carry its symbols — a second tool call would still be needed`

Also covered: the no-embedder fallback and its labelling, the no-index file scan and its labelling, depth monotonicity asserted on rendered **line containment** (not just the facet set), truncation being stated, and that the depth dial never reaches the advertised schema.

## The five-tool arm

`STELLA_LEAN_TOOLS=only:search,read_file,edit_file,write_file,bash`.

The `only:` form is new and necessary: lean mode always appended the three discovery tools, so an arm specified as five tools shipped **eight** — and `tool_search` beside a `search` tool competes with the thing under test. Every existing form of the variable is unchanged. Witness: `an_only_set_advertises_exactly_its_members_and_a_plain_list_does_not`.

**This arm has no `verify_done`, so the witness contract does not run — it measures raw completion, not verified completion.** That is intended and is stated wherever the arm is described.

Still needed before the arm can run, filed as issues: the bench adapter refuses `STELLA_LEAN_TOOLS` as an unregistered ambient knob and must register + forward it, and it must enter the posture digest or two arms differing only in tool set are indistinguishable.

## Deleted tests

None.

## Gate

`make gate` run in full, output redirected to a file and read (not piped through `tail`). The first run **failed** on a rustdoc private-intra-doc-link, which is fixed here.

Refs #3032
Refs #3033
Refs #2995

## Summary by Sourcery

Introduce a unified `search` tool for code discovery and integrate it into the tool registry, configuration, and documentation, while preserving existing search-related tools.

New Features:
- Add a new `search` tool that performs semantic, graph-based, and fallback file-scan code search in a single call with budget-driven enrichment.
- Expose configuration for search depth and context budget via environment variables to control how much structure each result carries.
- Support a closed lean toolset via `STELLA_LEAN_TOOLS=only:...` so experiments can advertise an exact set of tools without implicit discovery tools.

Enhancements:
- Refine lean tool configuration to track whether discovery tools are included and adjust advertised schemas accordingly.
- Update agent tools documentation to describe the new `search` tool, its configuration, and its inclusion in the read-only and default core tool partitions.

Tests:
- Add an extensive test suite for the `search` tool covering semantic ranking, fallbacks, depth monotonicity, truncation labelling, configuration effects, and lean-tool advertising behavior.