### PR TITLE
fix(stella-tools): declare `search` in the catalog, and unred main

### DIFF
--- a/crates/stella-tools/src/catalog.rs
+++ b/crates/stella-tools/src/catalog.rs
@@ -137,7 +137,11 @@ catalog! {
     "edit_file"           => (false, false, Always, "file"),
     "apply_edits"         => (false, false, Always, "file"),
     "delete_file"         => (false, false, Always, "file"),
-    // Search
+    // Search. The fused entry point (#3063) ranks semantically and enriches
+    // from the code graph, so it shares `graph_query`'s "read that writes"
+    // posture — `open_or_build` may bring codegraph.db up to date on the way
+    // to answering, which is never safe to speculate.
+    "search"              => (true, false, Always, "search"),
     "grep"                => (true, true, Always, "search"),
     "glob"                => (true, true, Always, "search"),
     // The read that writes: graph queries bootstrap/catch up codegraph.db.


### PR DESCRIPTION
## main is red

`origin/main` at `ec6bc0900` fails four `stella-tools` registry tests. #3076
registered the fused `search` tool (`registry.rs`, `Search::from_env()`) without
adding its row to `catalog::CATALOG`:

```
`search` registers but is not declared in catalog::CATALOG
```

- `registry_advertises_exactly_the_catalog_tool_set`
- `read_only_flags_partition_the_registry_correctly`
- `every_registry_tool_is_reserved_against_custom_shadowing`
- `issue_tools_absent_without_a_configured_backend`

## Control

Verified pre-existing rather than inherited, on a clean checkout of
`origin/main`:

```
$ git rev-parse --short HEAD
ec6bc0900
$ cargo test -p stella-tools --lib registry::tests::registry_advertises_exactly_the_catalog_tool_set
test result: FAILED. 0 passed; 1 failed
```

## The fix

One row, sharing `graph_query`'s posture for the same reason — read-only for
the workspace, never speculation-safe, because `open_or_build` may bring
`codegraph.db` up to date on the way to answering.

Deliberately nothing else: this is a red-`main` fix and every extra line in it
delays the unred.

## Why the row matters beyond the red

The catalog is the one place a built-in is declared and everything else is
derived from it. Undeclared, `search` is also missing from `RESERVED_NAMES` (a
customer's manifest tool could shadow it), from the read-only partition the
engine parallelizes on, from the per-tool policy surface, and from the
generated `docs/tools/` pages in #3080.

## Verification

`cargo test -p stella-tools --lib registry::` — **120 passed, 0 failed.**

No witness test authored: the four tests that fail on `main` and pass here are
the witness, and they were written before this change rather than for it.

Closes #3084

## Summary by Sourcery

Bug Fixes:
- Add the missing catalog entry for the `search` tool so registry tests pass and the built-in is consistently recognized as a reserved, read-only tool.