### PR TITLE
fix(stella-cli): shorten stella --help's session flags to one line each

### DIFF
--- a/crates/stella-cli/src/cli/help.rs
+++ b/crates/stella-cli/src/cli/help.rs
@@ -17,6 +17,19 @@
 //! is not assigned one. A command that somehow reaches a release unassigned
 //! still lists — under `Other` — because a help page that silently omits a
 //! command is worse than an ugly one.
+//!
+//! Reordering the index ahead of the flags fixed the *first* screen; it did
+//! not fix the *last* one. Several session flags carry a multi-paragraph
+//! `long_help` (the rationale `--tools` or `--upstream-pin` deserves), and
+//! `--help` used to print every one of them in full — enough text that on a
+//! real terminal the index, printed first, had scrolled off the top by the
+//! time the command finished and the cursor came to rest, so reaching it
+//! meant scrolling back up past the whole flag list. `-h` never had this
+//! problem: clap only ever prints the short `help` line there.
+//! `shorten_root_session_flags` gives `--help` the same one-line-per-flag
+//! budget at the root. The paragraph is not deleted, only relocated to where
+//! a reader who typed `stella <command> --help` is already looking for
+//! depth.
 
 use std::collections::BTreeSet;
 
@@ -118,7 +131,8 @@ fn root_template(cmd: &clap::Command) -> String {
 {{options}}
 
 Run `stella help <command>` for a command's full description.
-Session flags work on either side of it: `stella run … --budget 5`.",
+Session flags work on either side of it: `stella run … --budget 5`.
+Flags are one line here; `stella <command> --help` explains each in full.",
         on = header.render(),
         off = header.render_reset(),
     )
@@ -135,11 +149,48 @@ pub(crate) fn command() -> clap::Command {
     // and the propagated globals, so the index below reads the same tree a
     // user's terminal will.
     cmd.build();
+    // Must run after `build()`, not before: propagation of `global = true`
+    // args into every subcommand (`Command::_propagate_global_args`) already
+    // happened above, as a deep clone per subcommand. Shortening the root's
+    // own copy now touches only what the root page renders — `stella run
+    // --help` and friends keep their subcommand-local clone, long_help intact.
+    cmd = shorten_root_session_flags(cmd);
     let index = render_index(&cmd);
     let template = root_template(&cmd);
     cmd.help_template(template)
         .after_help(index.clone())
         .after_long_help(index)
+}
+
+/// Drop every session flag's `long_help` from the root command's own copy, so
+/// `--help` falls back to the same one-line `help` summary `-h` already used
+/// (clap's long-help renderer tries `long_help` first, then `help` — see
+/// `clap_builder::output::help_template`). Scoped by `is_global_set()` rather
+/// than a hardcoded flag list: every session flag is `global = true` by
+/// `every_root_flag_is_global` (src/tests.rs), so a new flag inherits this
+/// automatically instead of silently reopening the wall of text.
+///
+/// `Command::mut_args` (plural), not `mut_arg`: `build()` above has already
+/// populated clap's internal keymap, which caches each flag's *position* in
+/// the arg vector for fast lookup during parsing. `mut_arg` (singular)
+/// implements one flag by removing it and pushing it back at the *end* of
+/// the vector, which shifts every later flag's position without refreshing
+/// the keymap's cached indices — so after 17 of those, `--help` itself
+/// silently resolved to the wrong `Arg`, and the process fell through to the
+/// default chat REPL instead of printing help and exiting. `mut_args`
+/// rewrites every element via `drain().map(f).extend()`, which preserves
+/// vector order exactly, so the keymap's positions stay valid. No test in
+/// this file's suite would have caught the corrupt-keymap version — they all
+/// inspect the built `Command` tree, never run real parsing — so this was
+/// only found by running `stella --help` end to end.
+fn shorten_root_session_flags(cmd: clap::Command) -> clap::Command {
+    cmd.mut_args(|a| {
+        if a.is_global_set() {
+            a.long_help(None::<&str>)
+        } else {
+            a
+        }
+    })
 }
 
 /// Render the grouped command list.

--- a/crates/stella-cli/src/cli/help/tests.rs
+++ b/crates/stella-cli/src/cli/help/tests.rs
@@ -141,6 +141,140 @@ fn the_long_help_opens_with_the_product_not_the_source() {
     );
 }
 
+/// clap word-wraps rendered help at the terminal width, so a raw stored
+/// `long_help` paragraph (one unbroken line per source paragraph) never
+/// appears as a contiguous substring of rendered output — comparing the two
+/// verbatim would make a test pass whether or not the paragraph is actually
+/// there, for the wrong reason. Collapse whitespace on both sides before
+/// comparing so wrapping differences wash out and the comparison is honest.
+fn normalize_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The index printing first (`the_first_screen_shows_the_commands_people_type`)
+/// only fixes the *first* screen. `--help` used to also print every session
+/// flag's full `long_help` paragraph, which pushed total output so far past
+/// terminal height that the (correctly-first) index had scrolled off the top
+/// by the time the command finished — "I have to scroll up for days" to see
+/// it. Assert the general property directly against the source tree, so a
+/// *future* flag's paragraph is covered automatically rather than only the
+/// ones named here.
+#[test]
+fn root_help_does_not_print_a_session_flags_paragraph() {
+    let rendered = normalize_ws(&long_help());
+
+    let mut source = <crate::cli::Cli as clap::CommandFactory>::command();
+    source.build();
+
+    let mut checked = 0;
+    for arg in source.get_arguments().filter(|a| a.is_global_set()) {
+        let Some(paragraph) = arg.get_long_help().map(|h| h.to_string()) else {
+            continue; // this flag never had a long form to begin with
+        };
+        checked += 1;
+        let paragraph = normalize_ws(&paragraph);
+        assert!(
+            !rendered.contains(&paragraph),
+            "`--{}`'s full long_help still renders on the root `stella --help` page; it \
+             should fall back to the one-line summary there, and `stella <command> --help` \
+             is where the paragraph belongs (see `shorten_root_session_flags`).",
+            arg.get_id()
+        );
+    }
+    assert!(
+        checked > 0,
+        "expected at least one session flag with a long_help to exercise this test"
+    );
+}
+
+/// The paragraph above is relocated, not deleted: every subcommand still
+/// carries the full `long_help` for the session flags it inherited, because
+/// `shorten_root_session_flags` runs on the root command's own copy only,
+/// after `build()` has already cloned the pre-shortened text into each
+/// subcommand. Compared at the `Arg` level, not the rendered page, so this
+/// is exact rather than at the mercy of word-wrap.
+#[test]
+fn subcommand_help_still_carries_the_full_session_flag_long_help() {
+    let cmd = command();
+    let run = cmd.find_subcommand("run").expect("`run` exists");
+    let tools = run
+        .get_arguments()
+        .find(|a| a.get_id().as_str() == "tools")
+        .expect("`run` inherited the global --tools flag");
+
+    let mut source = <crate::cli::Cli as clap::CommandFactory>::command();
+    source.build();
+    let expected = source
+        .get_arguments()
+        .find(|a| a.get_id().as_str() == "tools")
+        .and_then(|a| a.get_long_help())
+        .map(|h| h.to_string())
+        .expect("--tools carries a long_help in the source tree");
+
+    assert_eq!(
+        tools.get_long_help().map(|h| h.to_string()),
+        Some(expected),
+        "`stella run`'s inherited --tools flag lost its long_help — the root page's \
+         shortened summary must still be backed by the full explanation somewhere reachable"
+    );
+}
+
+/// Every test above inspects the *built* `Command` tree — `get_arguments()`,
+/// `render_help()` — never real parsing. `shorten_root_session_flags` once
+/// broke real parsing while every one of those still passed: it mutated the
+/// arg list in a way that shifted element positions after clap's keymap (a
+/// position-indexed lookup cache) had already been built, so `--help` itself
+/// silently resolved to the wrong `Arg` and the process fell through to the
+/// default chat REPL instead of printing help and exiting — only caught by
+/// running `stella --help` end to end. This test parses for real, so a
+/// regression here fails in `cargo test`, not just in someone's terminal.
+#[test]
+fn help_flag_still_triggers_claps_help_action() {
+    let err = command()
+        .try_get_matches_from(["stella", "--help"])
+        .expect_err("--help must short-circuit to clap's help action, not reach the app");
+    assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+}
+
+/// The general form of the test above: a spread of session flags, old and
+/// new alike, each still resolves to its *own* value — proof the arg list's
+/// positions were not shuffled — and the subcommand after them still
+/// resolves too.
+#[test]
+fn session_flags_still_parse_to_their_own_values() {
+    let matches = command()
+        .try_get_matches_from([
+            "stella",
+            "--model",
+            "zai/glm-5.2",
+            "--budget",
+            "5",
+            "--plan-mode",
+            "chat",
+        ])
+        .expect("a full spread of session flags plus a subcommand is valid input");
+
+    assert_eq!(
+        matches.get_one::<String>("model").map(String::as_str),
+        Some("zai/glm-5.2"),
+        "--model's value landed on a different flag's slot"
+    );
+    assert_eq!(
+        matches.get_one::<f64>("budget").copied(),
+        Some(5.0),
+        "--budget's value landed on a different flag's slot"
+    );
+    assert!(
+        matches.get_flag("plan_mode"),
+        "--plan-mode did not set its own boolean slot"
+    );
+    assert_eq!(
+        matches.subcommand_name(),
+        Some("chat"),
+        "the subcommand did not resolve correctly alongside session flags"
+    );
+}
+
 /// The reported bug, stated as a property: with thirty-odd commands no help
 /// page fits a 24-line terminal, so the thing that matters is not total
 /// length but *what is above the fold*. It used to be the tail of the global


### PR DESCRIPTION
## Summary

`stella --help` printed every session flag's full multi-paragraph `long_help` below the (already correctly-ordered) grouped command index, so on a real terminal the index scrolled off the top by the time the command finished printing — reaching it meant scrolling back up past the whole flag list ("I have to scroll up for days just to see the main subcommands"). `-h` never had this problem, since clap only ever prints the short `help` summary there.

- `shorten_root_session_flags` (new, in `cli/help.rs`) clears `long_help` on every `global = true` session flag in the **root command's own post-`build()` copy only**, so `--help` falls back to the same one-line summary `-h` already used.
- The full paragraph is **relocated, not deleted**: every subcommand's own page (`stella run --help`, `stella chat --help`, …) still carries it in full, since `Command::_propagate_global_args` already deep-cloned each global arg into every subcommand before the shortening runs.
- Footer gained one line pointing at where the depth went: `` Flags are one line here; `stella <command> --help` explains each in full. ``

## Bug caught along the way

The first implementation used `Command::mut_arg` per flag (17 calls), which removes an arg and re-pushes it at the *end* of the internal arg vector. clap's keymap — a position-indexed lookup cache used during real parsing — is built once during `build()` and is **not** refreshed by `mut_arg`. After 17 remove+push cycles, `--help` itself resolved to the wrong `Arg` at parse time: `stella --help` silently matched as `--foreground=true` and fell through to launching the chat REPL instead of printing help and exiting.

None of the existing help tests caught this — they all inspect the *built* `Command` tree (`get_arguments()`, `render_help()`) and never call real parsing. Fixed with `Command::mut_args` (plural), which mutates in place via `drain().map(f).extend()` and preserves vector order, so the keymap's cached positions stay valid.

Two new tests parse for real (`try_get_matches_from`) instead of only inspecting the tree, so this exact regression fails `cargo test` again if reintroduced:
- `help_flag_still_triggers_claps_help_action`
- `session_flags_still_parse_to_their_own_values`

Verified both fail against the `mut_arg` version and pass against the `mut_args` fix (confirmed by temporarily reintroducing the bug and re-running the suite).

## Test plan

- [x] `cargo test -p stella-cli --bin stella cli::help` — 15/15 pass
- [x] `cargo test -p stella-cli --bin stella` (full suite) — 1772/1773 pass; the one failure (`tool_docs::tool_docs_match_the_declarations`) is pre-existing on `main`, unrelated to this change (confirmed via `git stash`), and tracked separately as #3090
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p stella-cli -- --check` — clean
- [x] Manual: `stella --help`, `stella -h`, and `stella run --help` all render correctly; `--help` exits 0 with the shortened root page, `stella run --help` still shows `--tools`' full paragraph
- [x] Witness check: reverted `help.rs` via `git stash` and confirmed the new tests fail on `main`'s current behavior, pass with the fix

## Summary by Sourcery

Shorten root `stella --help` output so session flags show only one-line summaries while preserving full explanations on subcommand help pages, and add safeguards to ensure help and session flags still parse correctly after this change.

New Features:
- Introduce `shorten_root_session_flags` to trim long help text for global session flags on the root command only, keeping subcommand-level long help intact.

Enhancements:
- Update the root help footer to explain that flags are summarized on the main help page and documented in full on subcommand help pages.

Tests:
- Add tests to verify root help no longer renders full session flag paragraphs, that subcommands retain full long help for inherited session flags, that `--help` still triggers clap's help action, and that session flags continue to parse to their own values without position corruption.