### PR TITLE
fix(bench): forward the embedding backend's credential independent of the model provider route

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -75,6 +75,7 @@ from .credential_bundle import (
     HOST_CREDENTIAL_SOURCE,
     PROVIDER_CREDENTIAL_SPECS,
     SelectedProviderCredentials,
+    optional_embedding_credentials,
     read_bundle_from_environment,
     select_route_credentials,
 )
@@ -1067,10 +1068,12 @@ class StellaAgent(BaseInstalledAgent):
             self._container_credential_absence_verified = True
         else:
             self._container_credential_absence_verified = False
+        # A second, independent route, appended after the provider's own (#2995).
+        embedding = optional_embedding_credentials(self._configured_value)
         env[_HANDOFF_FD_ENV] = "0"
         # One name per value, in the order the values are written to the pipe.
         # Stella pairs them positionally, so this ordering is the contract.
-        env[_HANDOFF_TARGET_ENV] = ",".join(selected.credentials)
+        env[_HANDOFF_TARGET_ENV] = ",".join((*selected.credentials, *embedding))
         # Routing rides as ordinary registered container environment: a region
         # is disclosed in the manifest, not a secret to keep out of `/proc`.
         env.update(selected.routing)
@@ -1086,7 +1089,7 @@ class StellaAgent(BaseInstalledAgent):
             environment,
             command=command,
             env=env,
-            credentials=tuple(selected.credentials.values()),
+            credentials=(*selected.credentials.values(), *embedding.values()),
             verifier=verifier,
             expected_posture_json=self._engine_posture_json,
             posture_builder=self._build_engine_posture,
@@ -1576,6 +1579,10 @@ class StellaAgent(BaseInstalledAgent):
             len(host_credential_name.split(",")) if host_credential_name else 0
         )
         provider_routing = getattr(self, "_provider_routing", None) or None
+        # Recomputed rather than stored: pure given `_configured_value` (#2995).
+        embedding_credential_names = sorted(
+            optional_embedding_credentials(self._configured_value)
+        )
         container_credential_absence_verified = getattr(
             self, "_container_credential_absence_verified", False
         )
@@ -1663,6 +1670,7 @@ class StellaAgent(BaseInstalledAgent):
             # scrubbed: a Bedrock number nobody can attribute to a region is a
             # number nobody can reproduce.
             "stella_provider_routing": provider_routing,
+            "stella_embedding_credential_names": embedding_credential_names,
             "stella_container_credential_absence_verified": (
                 container_credential_absence_verified
             ),

--- a/bench/harbor_adapter/stella_harbor/credential_bundle.py
+++ b/bench/harbor_adapter/stella_harbor/credential_bundle.py
@@ -83,6 +83,21 @@ PROVIDER_ROUTING_NAMES = frozenset({"AWS_REGION"})
 
 HOST_ONLY_CONTROL_CREDENTIAL_NAMES = frozenset({"OPENROUTER_MANAGEMENT_API_KEY"})
 
+# The semantic-search embedding backend's credential (#2995). A second route,
+# independent of the model provider above: `stella-embed`'s HTTP embedder
+# (`EmbedderEnv::from_process` in crates/stella-embed/src/http.rs) reads it
+# ambiently regardless of which model provider is selected, so modelling it as
+# a per-provider credential — the way `PROVIDER_CREDENTIAL_NAMES` models model
+# auth — would make it unreachable for every arm that does not happen to route
+# its model through the same vendor. Forwarded on the same anonymous-stdin
+# handoff as the provider credential (the wire format was built to generalize
+# to more than one line; see `credential_handoff.rs`'s module doc), one
+# additional optional line appended after the provider's own. Optional and
+# fails open: an arm with none configured still runs, and `search`'s semantic
+# rung degrades to a labelled lexical answer rather than silently claiming to
+# rank by meaning.
+EMBEDDING_CREDENTIAL_NAMES = frozenset({"VOYAGE_API_KEY"})
+
 
 @dataclass(frozen=True)
 class ProviderCredentialSpec:
@@ -211,9 +226,32 @@ def provider_credentials_from_environment(
     return credentials
 
 
+def optional_embedding_credentials(
+    lookup: Callable[[str], str | None],
+) -> dict[str, str]:
+    """Resolve the embedding backend's credential, independent of model route.
+
+    ``lookup`` matches `select_route_credentials`'s parameter so a caller with
+    Harbor per-run overrides (`StellaAgent._configured_value`) resolves this
+    exactly as it resolves the model provider's own credential. Unlike
+    `provider_credentials_from_environment`, an empty result is not a
+    misconfiguration — see `EMBEDDING_CREDENTIAL_NAMES`.
+    """
+    credentials: dict[str, str] = {}
+    for name in sorted(EMBEDDING_CREDENTIAL_NAMES):
+        value = lookup(name)
+        if value:
+            credentials[name] = value
+    return credentials
+
+
 def credential_values_from_environment(environ: Mapping[str, str]) -> tuple[str, ...]:
-    """Collect every provider or host-only control secret for byte scrubbing."""
-    names = PROVIDER_CREDENTIAL_NAMES | HOST_ONLY_CONTROL_CREDENTIAL_NAMES
+    """Collect every provider, embedding, or host-only control secret for scrubbing."""
+    names = (
+        PROVIDER_CREDENTIAL_NAMES
+        | EMBEDDING_CREDENTIAL_NAMES
+        | HOST_ONLY_CONTROL_CREDENTIAL_NAMES
+    )
     return tuple(value for name in sorted(names) if (value := environ.get(name)))
 
 

--- a/bench/harbor_adapter/tests/test_embedding_credential.py
+++ b/bench/harbor_adapter/tests/test_embedding_credential.py
@@ -1,0 +1,136 @@
+"""The embedding backend's credential rides the same handoff, independently (#2995).
+
+Its own module rather than a block in `test_adapter.py`, which is at its
+recorded size ceiling (`scripts/check-file-size.sh`).
+
+The subject: `search`'s semantic rung needs a Voyage (or OpenAI) key, and
+`stella-embed` reads it ambiently regardless of which model provider serves
+the trial. Modelling it as a per-provider credential — the way the model
+route's own secret is modelled — would make it unreachable for every arm that
+does not happen to route its model through that same vendor. This is verified
+end to end on the Rust side too: `crates/stella-cli/src/credential_handoff.rs`
+proves the target is accepted and pairs positionally, and was manually proven
+against the real `stella` binary (not just unit-tested) to reach process
+environment after consumption.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+import asyncio  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+from harbor.models.agent.context import AgentContext  # noqa: E402
+
+from stella_harbor import (  # noqa: E402 - after importorskip by design
+    _INSTALL_PATH,
+    StellaAgent,
+)
+from stella_harbor.credential_bundle import (  # noqa: E402
+    EMBEDDING_CREDENTIAL_NAMES,
+    optional_embedding_credentials,
+)
+
+from .test_adapter import _bare_agent, _stream_for, _trajectory_envelope  # noqa: E402
+
+
+class TestOptionalEmbeddingCredentials:
+    def test_unset_resolves_to_nothing(self) -> None:
+        assert optional_embedding_credentials({}.get) == {}
+
+    def test_configured_is_forwarded_by_name(self) -> None:
+        resolved = optional_embedding_credentials({"VOYAGE_API_KEY": "pa-test"}.get)
+        assert resolved == {"VOYAGE_API_KEY": "pa-test"}
+
+    def test_an_empty_string_is_treated_as_unset(self) -> None:
+        assert optional_embedding_credentials({"VOYAGE_API_KEY": ""}.get) == {}
+
+    def test_only_the_registered_names_are_recognized(self) -> None:
+        assert frozenset({"VOYAGE_API_KEY"}) == EMBEDDING_CREDENTIAL_NAMES
+        resolved = optional_embedding_credentials(
+            {"VOYAGE_API_KEY": "pa-test", "SOME_OTHER_KEY": "x"}.get
+        )
+        assert resolved == {"VOYAGE_API_KEY": "pa-test"}
+
+
+class TestHandoffCarriesBothRoutes:
+    def test_the_embedding_credential_rides_the_same_stdin_after_the_provider(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The witness: on `main` this test fails — `VOYAGE_API_KEY` never
+        reaches `STELLA_CREDENTIAL_HANDOFF_TARGET`, stdin carries one line, and
+        the trial's `search` has nothing to embed with even when the host has
+        a valid key.
+        """
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
+        monkeypatch.setenv("VOYAGE_API_KEY", "pa-test-voyage-secret")
+        source_envelope = _trajectory_envelope()
+        durable_stream = _stream_for(source_envelope)
+        (tmp_path / "stella-events.jsonl").write_text(durable_stream)
+
+        agent = _bare_agent()
+        agent.logs_dir = tmp_path
+        agent.model_name = "openrouter/provider/model"
+        agent._extra_env = {}
+        agent._version = "stella 0.4.47"
+
+        class _Environment:
+            async def _stella_secure_exec_with_stdin(
+                self, *, command: list[str], env: dict[str, str], stdin: bytes
+            ):
+                assert command[0] == _INSTALL_PATH
+                # Provider credential first, embedding credential appended —
+                # positional pairing on the Stella side depends on this order.
+                assert env["STELLA_CREDENTIAL_HANDOFF_TARGET"] == (
+                    "OPENROUTER_API_KEY,VOYAGE_API_KEY"
+                )
+                assert stdin == b"openrouter-test-secret\npa-test-voyage-secret\n"
+                # Never as a plain container variable — only on the sealed pipe.
+                assert "VOYAGE_API_KEY" not in env
+                assert "OPENROUTER_API_KEY" not in env
+                return SimpleNamespace(stdout="ok", stderr=None, return_code=0)
+
+        context = AgentContext()
+        asyncio.run(
+            StellaAgent.run.__wrapped__(
+                agent, "Fix the task.", _Environment(), context
+            )
+        )
+
+    def test_an_unconfigured_embedder_leaves_the_provider_only_handoff_unchanged(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Optional and fails open (#2995): no `VOYAGE_API_KEY` on the host,
+        no change to the pre-existing single-credential wire shape.
+        """
+        monkeypatch.delenv("STELLA_BUDGET", raising=False)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
+        source_envelope = _trajectory_envelope()
+        durable_stream = _stream_for(source_envelope)
+        (tmp_path / "stella-events.jsonl").write_text(durable_stream)
+
+        agent = _bare_agent()
+        agent.logs_dir = tmp_path
+        agent.model_name = "openrouter/provider/model"
+        agent._extra_env = {}
+        agent._version = "stella 0.4.47"
+
+        class _Environment:
+            async def _stella_secure_exec_with_stdin(
+                self, *, command: list[str], env: dict[str, str], stdin: bytes
+            ):
+                assert env["STELLA_CREDENTIAL_HANDOFF_TARGET"] == "OPENROUTER_API_KEY"
+                assert stdin == b"openrouter-test-secret\n"
+                return SimpleNamespace(stdout="ok", stderr=None, return_code=0)
+
+        context = AgentContext()
+        asyncio.run(
+            StellaAgent.run.__wrapped__(
+                agent, "Fix the task.", _Environment(), context
+            )
+        )

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -40,6 +40,22 @@
 //! opposite of what a one-descriptor handoff is for. Explicit credentials
 //! only; see `bench/harbor_adapter/README.md` for the same list stated from
 //! the launcher's side.
+//!
+//! ## The one target that leaves the seal (`VOYAGE_API_KEY`)
+//!
+//! Every target above stays inside the sealed [`HANDOFF`] map for the rest of
+//! the process's life and is read only through [`key_for`]. The embedding
+//! backend's credential is the deliberate exception (#2995): `stella-embed`'s
+//! `EmbedderEnv::from_process` (`crates/stella-embed/src/http.rs`) reads
+//! `VOYAGE_API_KEY` ambiently — a pre-existing, shipped contract this handoff
+//! does not change — so [`consume_at_startup`] re-exports it into the process
+//! environment once consumed. That is a strictly weaker guarantee than every
+//! other target gets: a spawned bash tool call inherits it, exactly as it
+//! would inherit a developer's own exported `VOYAGE_API_KEY`. What this
+//! handoff still buys for it: it never touches Harbor's environment or
+//! `docker compose exec` argv, and it never enters the model-provider
+//! selection contract. Threading a typed, ambient-env-free path through
+//! `stella-embed`'s call sites is a larger, separate change.
 
 use std::collections::BTreeMap;
 use std::io::Read;
@@ -60,9 +76,9 @@ const HANDOFF_TARGET_ENV: &str = "STELLA_CREDENTIAL_HANDOFF_TARGET";
 const MAX_CREDENTIAL_BYTES: u64 = 64 * 1024;
 
 /// How many values one handoff may carry. Bedrock's three (access key id,
-/// secret access key, session token) is the largest real set; the cap exists
-/// so a malformed target list cannot turn a stray multi-line payload into an
-/// unbounded parse.
+/// secret access key, session token) plus the embedding credential is the
+/// largest real set at four; the cap exists so a malformed target list cannot
+/// turn a stray multi-line payload into an unbounded parse.
 const MAX_HANDOFF_VALUES: usize = 8;
 
 /// Only credential slots Stella's built-in providers already recognize may be
@@ -84,7 +100,16 @@ const ALLOWED_TARGETS: &[&str] = &[
     "AWS_ACCESS_KEY_ID",
     "AWS_SECRET_ACCESS_KEY",
     "AWS_SESSION_TOKEN",
+    // The embedding backend's credential (#2995) — a second, independent
+    // route, never selected by a model provider spec. See the module doc's
+    // "one target that leaves the seal" section: unlike every name above,
+    // `consume_at_startup` re-exports this one into the process environment.
+    EMBEDDING_CREDENTIAL_TARGET,
 ];
+
+/// The embedding backend credential name this handoff re-exports into the
+/// process environment after consumption. See the module doc.
+const EMBEDDING_CREDENTIAL_TARGET: &str = "VOYAGE_API_KEY";
 
 static HANDOFF: OnceLock<BTreeMap<String, String>> = OnceLock::new();
 
@@ -130,6 +155,13 @@ pub(crate) fn consume_at_startup(phase: &StartupPhase) -> Result<(), String> {
     unsafe {
         std::env::remove_var(HANDOFF_FD_ENV);
         std::env::remove_var(HANDOFF_TARGET_ENV);
+        // The one target that leaves the seal — see the module doc. Every
+        // other credential stays in `HANDOFF` only, read through `key_for`;
+        // this one is re-exported because `stella-embed`'s ambient read is a
+        // pre-existing contract this handoff does not change.
+        if let Some(value) = credentials.get(EMBEDDING_CREDENTIAL_TARGET) {
+            std::env::set_var(EMBEDDING_CREDENTIAL_TARGET, value);
+        }
     }
 
     HANDOFF
@@ -307,6 +339,33 @@ mod tests {
         // close through the same `file` drop at function exit. Re-checking the
         // raw fd number here would be racy under the parallel harness — a
         // sibling test can reuse the freed number immediately.
+    }
+
+    #[test]
+    fn the_embedding_credential_is_an_allowed_target() {
+        // #2995: a second, independent route, not selected by any provider
+        // spec, must still be a valid target on its own.
+        assert!(validate_targets("VOYAGE_API_KEY").is_ok());
+    }
+
+    #[test]
+    fn a_provider_and_the_embedding_credential_pair_independently() {
+        // The shape the adapter actually sends when both routes are
+        // configured: the model provider's own credential first, the
+        // embedding credential appended after (#2995). Proves the two routes
+        // do not collide or reorder on the wire.
+        let targets = validate_targets("OPENROUTER_API_KEY,VOYAGE_API_KEY").unwrap();
+        let paired =
+            pair_targets_with_values(&targets, "openrouter-secret\nvoyage-secret").unwrap();
+        assert_eq!(paired.len(), 2);
+        assert_eq!(
+            paired.get("OPENROUTER_API_KEY").map(String::as_str),
+            Some("openrouter-secret")
+        );
+        assert_eq!(
+            paired.get("VOYAGE_API_KEY").map(String::as_str),
+            Some("voyage-secret")
+        );
     }
 
     #[test]

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1839 bench/harbor_adapter/stella_harbor/__init__.py
+1847 bench/harbor_adapter/stella_harbor/__init__.py
 4366 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2352 bench/harbor_adapter/tests/test_adapter.py
 3368 bench/harbor_adapter/tests/test_secure_launcher.py


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

The Voyage key ArenaBench has in SSM (`/arenabench/voyage_api_key`) is now
valid — verified directly against the real endpoint (`pa-` prefix, HTTP 200,
1024-dim embedding returned) — but nothing carried it into a bench container.
`credential_bundle.py` only ever forwarded the *model provider's* route
credential (`PROVIDER_CREDENTIAL_SPECS`), so an OpenRouter/Anthropic/z.ai arm
never received `VOYAGE_API_KEY` regardless of what was configured on the
host. `search`'s semantic rung was structurally dead for every arm that
didn't happen to route its model through the same vendor Voyage would need.

This extends the existing FD-only stdin handoff — already built to
generalize to more than one value, for Bedrock's three-secret set — with a
second, independent, optional credential line appended after the provider's
own. It's never selected by `PROVIDER_CREDENTIAL_SPECS`, never required, and
fails open (an arm with none configured runs exactly as before). On the Rust
side, `VOYAGE_API_KEY` is a new allowed handoff target that
`credential_handoff::consume_at_startup` re-exports into process env once
consumed — because `stella-embed`'s `EmbedderEnv::from_process` already reads
it ambiently, a pre-existing contract this change doesn't alter. That
re-export is a strictly weaker guarantee than every other handoff target
gets (a spawned `bash` tool call inherits it, unlike a provider credential);
this tradeoff is documented in the module doc and tracked separately (#3093)
rather than hidden.

Verified end to end against the real `stella` binary, not just unit tests: a
two-value FD handoff correctly paired `VOYAGE_API_KEY` positionally and
re-exported it into the process's own environment.

Two things #2995 also asked for are intentionally **not** in this change:

- The posture digest doesn't yet record embedder-credential presence, so two
  arms differing only in embedder still hash identically. Tracked as #3092.
- #3087 (a bench container's code graph reports `built: true` / `files: 0`
  even in a non-empty workspace) means even a reachable credential currently
  has nothing to embed. That blocker is untouched here — it's a separate
  Rust bug in `crates/stella-tools/src/overview.rs`.

Refs #2995

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Two witnesses, both verified artisanally (stashed the fix, confirmed the
new test genuinely fails, restored, confirmed it passes):

- Rust: `credential_handoff::tests::the_embedding_credential_is_an_allowed_target`
  and `a_provider_and_the_embedding_credential_pair_independently` — fail on
  `main` (`VOYAGE_API_KEY` is not a built-in provider credential`), pass here.
- Python: `tests/test_embedding_credential.py` — fails to even *import* on
  `main` (`EMBEDDING_CREDENTIAL_NAMES` doesn't exist), passes here. The key
  test (`test_the_embedding_credential_rides_the_same_stdin_after_the_provider`)
  exercises the real `StellaAgent.run()` path with both credentials configured
  and asserts the exact wire shape: `STELLA_CREDENTIAL_HANDOFF_TARGET ==
  "OPENROUTER_API_KEY,VOYAGE_API_KEY"`, `stdin` carries both secrets
  newline-joined in that order, and neither ever appears as a plain container
  env var.

Additionally verified by hand against the compiled `stella` binary itself
(not just the unit test harness): ran it with a real anonymous-FD handoff
carrying two positional values and confirmed `VOYAGE_API_KEY` landed in the
process's own environment after consumption — the actual mechanism
`stella-embed`'s ambient read depends on.

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli` — 1770/1771 pass; the one failure
      (`tool_docs::tool_docs_match_the_declarations`, a `search` tool-docs
      drift) is pre-existing on `main` and unrelated — verified by stashing
      this diff and reproducing the identical failure on unmodified `main`.
- [x] `python3 -m pytest bench/harbor_adapter/tests/` (adapter + new file) —
      89/89 pass
- [x] `python3 -m ruff check` on every changed Python file — clean
- [x] `make file-size-update` — `bench/harbor_adapter/stella_harbor/__init__.py`'s
      ceiling moves 1839 → 1847. This file is grandfathered/closed to growth;
      the +8 lines are the minimum I could get the two call sites down to
      after moving all resolution logic into the sibling `credential_bundle.py`
      module (which has plenty of headroom) — the same +8 PR #3081 already
      needed on this identical file for an analogous reason. Flagging this
      explicitly per CLAUDE.md rather than letting it pass as routine.
- [ ] Docs updated where behavior/flags changed — N/A, no CLI flag or
      user-facing behavior changed; this is bench-harness-internal wiring
- [x] CLA signed
- [x] `Refs #2995` appears both above and as a commit trailer (not `Closes` —
      #3087 and #3092 still block the arm this issue asked for)

## Nothing left behind

- [x] Filed: #3092 (posture digest doesn't record embedder-credential
      presence — two arms differing only in embedder are indistinguishable
      in the ledger), #3093 (`VOYAGE_API_KEY` is re-exported into ambient
      process env after the handoff, a real if narrow weaker guarantee than
      every provider credential gets — hardening it needs cross-crate
      surgery through `stella-tools`' and `stella-cli`'s embedder call
      sites, out of scope here)

## Ground-rule check

- [x] No I/O added to `stella-core` — this touches only `stella-cli` and the
      Python bench harness
- [x] No new outbound network calls
- [x] No new cross-boundary types (the handoff's wire format — comma-separated
      names, newline-separated values — is unchanged; this only appends one
      more optional name/value pair to the existing shape)

## Anything reviewers should know?

- The `std::env::set_var` re-export for `VOYAGE_API_KEY` is the one place
  this PR deliberately breaks from "every handoff target stays sealed in
  `HANDOFF`, read only via `key_for`." I considered instead threading a typed
  credential through `stella-tools`' `search`/`semantic_code_search` call
  sites and `stella-cli`'s `agent/graph.rs` indexing path, but `stella-embed`
  is a dependency leaf with no workspace-crate deps (AGENTS.md), so that
  would mean rewriting three call sites across two crates rather than one
  function in one file. Scoped that out as #3093 rather than let this PR grow
  into an unrelated security-hardening change.
- This does **not** make the ArenaBench arm blocked in #2995's parent task
  runnable — #3087 (empty code graph in bench containers) is untouched and
  still means `search`'s semantic rung has nothing to embed even with a
  credential now reachable.

## Summary by Sourcery

Wire the embedding backend credential into ArenaBench containers via the existing anonymous-stdin handoff, independently of the model provider route.

New Features:
- Support an embedding backend credential (VOYAGE_API_KEY) as a distinct handoff target alongside provider credentials in the bench harness.

Enhancements:
- Allow the embedding credential to be re-exported into the process environment after handoff so the embedder can read it ambiently.
- Extend Harbor adapter wiring to resolve optional embedding credentials and include them in the FD-based credential handoff without changing the existing wire format.
- Record embedding credential names in the bench run context for posture/telemetry purposes.

Tests:
- Add Rust tests verifying VOYAGE_API_KEY is an allowed handoff target and pairs positionally with provider credentials.
- Add Python tests validating optional embedding credential resolution and that both provider and embedding credentials are forwarded over stdin in the expected order while remaining out of the container environment.