### PR TITLE
feat(search): rank chunks, index markdown, and let relevance decide the answer's size

### DIFF
--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -128,7 +128,7 @@ from .turn_budget import (
 from .turn_budget import (
     resolve_turn_budget as _resolve_turn_budget,
 )
-from . import upstream_pin
+from . import code_graph, upstream_pin
 
 try:
     # Harbor renders prompt templates onto the ``instruction`` argument of a
@@ -829,6 +829,10 @@ class StellaAgent(BaseInstalledAgent):
     _assurance_tiers_json: str
     _assurance_tiers_sha256: str
     _workspace_git_baseline: dict[str, str]
+    #: What ``stella init`` built, per :mod:`code_graph`. Declared, because an
+    #: attribute that exists only when one stdout line matched is one no
+    #: reader trusts — which is how it went unread entirely (#3087).
+    _code_graph_summary: dict[str, str]
 
     def __init__(self, *args: Any, agent_timeout_sec: Any = None, **kwargs: Any):
         """Accept Harbor's per-trial agent deadline, and keep it off the base.
@@ -991,12 +995,9 @@ class StellaAgent(BaseInstalledAgent):
             )
         except Exception as exc:  # noqa: BLE001 - discovery aid, never fatal
             print(f"stella-adapter: code graph unavailable: {exc}", file=sys.stderr)
+            self._code_graph_summary = code_graph.unavailable(exc)
             return
-        summary = getattr(result, "stdout", None) or ""
-        for line in summary.splitlines():
-            if "code graph:" in line:
-                self._code_graph_summary = line.strip()
-                break
+        self._code_graph_summary = code_graph.from_stdout(getattr(result, "stdout", None))
 
     @with_prompt_template
     async def run(
@@ -1623,6 +1624,8 @@ class StellaAgent(BaseInstalledAgent):
         workspace_git_baseline = getattr(
             self, "_workspace_git_baseline", {"state": "not_attempted"}
         )
+        # Same discipline, same reason (:mod:`code_graph`, #3087).
+        graph_state = getattr(self, "_code_graph_summary", code_graph.NOT_ATTEMPTED)
 
         extra: dict[str, Any] = {
             "stella_status": metrics.get("status"),
@@ -1684,6 +1687,8 @@ class StellaAgent(BaseInstalledAgent):
             "stella_witness_authored_state": witness_authored_state,
             "stella_self_verdict_state": self_verdict_state,
             "stella_workspace_git_baseline": workspace_git_baseline,
+            # What `stella init` built in this container, per #3087.
+            "stella_code_graph": graph_state,
             # The contamination marker (:mod:`lineage`) — present iff seeded.
             "stella_lineage": disclosed_lineage(getattr(self, "_lineage", None)),
         }
@@ -1744,6 +1749,7 @@ class StellaAgent(BaseInstalledAgent):
                 verifier_model=verifier_model,
                 witness_authored_state=witness_authored_state,
                 workspace_git_baseline=workspace_git_baseline,
+                code_graph=graph_state,
             )
             self._write_log(
                 _TRAJECTORY_NAME,

--- a/bench/harbor_adapter/stella_harbor/atif.py
+++ b/bench/harbor_adapter/stella_harbor/atif.py
@@ -481,6 +481,7 @@ def envelope_to_trajectory(
     verifier_model: str | None = None,
     witness_authored_state: str | None = None,
     workspace_git_baseline: dict[str, str] | None = None,
+    code_graph: dict[str, str] | None = None,
 ) -> Trajectory:
     """Build and validate an ATIF-v1.7 trajectory from a Stella envelope."""
     events = envelope.get("events")
@@ -660,6 +661,12 @@ def envelope_to_trajectory(
     agent_extra["workspace_git_baseline"] = dict(
         workspace_git_baseline or {"state": "not_attempted"}
     )
+    # Unconditional for the same reason. `_build_code_graph` has always
+    # computed this line and nothing has ever read it, so every container's
+    # answer to "was this workspace actually indexed" was produced and dropped
+    # — the one question a trial reporting `files: 0` against a non-empty
+    # checkout needs answered (#3087).
+    agent_extra["code_graph"] = dict(code_graph or {"state": "not_attempted"})
 
     return Trajectory(
         schema_version="ATIF-v1.7",

--- a/bench/harbor_adapter/stella_harbor/code_graph.py
+++ b/bench/harbor_adapter/stella_harbor/code_graph.py
@@ -1,0 +1,68 @@
+"""What ``stella init`` built in the container, as a state a trial can record.
+
+``_build_code_graph`` runs ``stella init`` before the first turn and parses a
+``code graph:`` line out of its stdout. That line was assigned to an instance
+attribute and **read nowhere** — one write, zero reads, no class-level
+declaration — so every container computed the answer and dropped it.
+
+The cost of dropping it is #3087. A real trial reported ``files: 0,
+symbols: 0, imports: 0`` from inside an ``/app`` workspace that git had a
+committed, non-empty baseline for, and the recorded evidence could not say
+which of four things had happened:
+
+* the step never ran (an outer timeout, an adapter that predates it);
+* it ran and raised;
+* it ran, exited cleanly, and printed nothing about a code graph;
+* it ran and honestly reported an empty graph.
+
+All four left the same trace, which was none — so a ``files: 0`` reading was
+consistent with every one of them. Evidence that cannot distinguish a claim
+from its opposite is not evidence, and no amount of reasoning about the
+container recovers what was never recorded.
+
+This module is the classification, kept out of ``__init__.py`` because that
+file is grandfathered at its file-size ceiling and closed to growth. It is
+the shape :mod:`upstream_pin` and :mod:`tool_set` already use: a small
+pure module beside the adapter, so the adapter keeps one line per concern.
+"""
+
+from __future__ import annotations
+
+#: The step did not run at all. A real state, and deliberately spelled the
+#: same way :func:`run_git_baseline`'s absence is, so a reader learns one
+#: convention rather than two.
+NOT_ATTEMPTED: dict[str, str] = {"state": "not_attempted"}
+
+#: The substring ``stella init`` prints its index summary on.
+_SUMMARY_MARKER = "code graph:"
+
+
+def from_stdout(stdout: str | None) -> dict[str, str]:
+    """Classify what ``stella init`` said about the graph it built.
+
+    ``no_summary_line`` is the state that earns this function: an init that
+    ran, exited cleanly and printed nothing about a code graph is not the
+    same event as an init that reported an empty one, and the two were
+    previously indistinguishable because only the second was ever recorded.
+    The line count rides along because it is the cheapest thing that
+    separates "produced no output at all" from "produced output we did not
+    recognise" without shipping the container's stdout into trial metadata.
+    """
+    text = stdout or ""
+    for line in text.splitlines():
+        if _SUMMARY_MARKER in line:
+            return {"state": "reported", "summary": line.strip()}
+    return {
+        "state": "no_summary_line",
+        "detail": (
+            f"`stella init` exited without a '{_SUMMARY_MARKER}' line "
+            f"({len(text.splitlines())} line(s) of stdout)"
+        ),
+    }
+
+
+def unavailable(error: BaseException) -> dict[str, str]:
+    """The step raised. Best-effort by construction, so never fatal — but a
+    failure that is not recorded is a failure that gets attributed to
+    whatever is measured next."""
+    return {"state": "unavailable", "detail": str(error)}

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -113,6 +113,7 @@ _FIXED_PROTOCOL_PATH = "bench/terminal-bench-2.1-protocol.md"
 _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/__init__.py",
     "bench/harbor_adapter/stella_harbor/atif.py",
+    "bench/harbor_adapter/stella_harbor/code_graph.py",
     "bench/harbor_adapter/stella_harbor/credential_bundle.py",
     "bench/harbor_adapter/stella_harbor/exit_cause.py",
     "bench/harbor_adapter/stella_harbor/exit_status.py",

--- a/bench/harbor_adapter/tests/test_code_graph_disclosure.py
+++ b/bench/harbor_adapter/tests/test_code_graph_disclosure.py
@@ -1,0 +1,97 @@
+"""What ``stella init`` built in the container is disclosed, or said not to be.
+
+``_build_code_graph`` has always parsed a ``code graph:`` line out of
+``stella init``'s stdout into ``self._code_graph_summary``, and **nothing has
+ever read it** — one write, zero reads, and no class-level declaration, so it
+existed only on instances where that exact line happened to match. Every
+container computed the one fact #3087 needs and threw it away.
+
+That is why a trial reporting ``files: 0, symbols: 0, imports: 0`` against an
+``/app`` workspace with a committed, non-empty baseline could not be
+diagnosed from the recorded evidence: "init never ran", "init failed", "init
+ran and printed nothing", and "init ran and found nothing" all left the same
+trace, which is none.
+
+In its own file because ``test_adapter.py`` is grandfathered at its
+file-size ceiling and closed to growth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from stella_harbor.atif import envelope_to_trajectory  # noqa: E402
+
+_ENVELOPE = {
+    "status": "completed",
+    "model": "provider/model",
+    "events": [{"type": "text", "text": "done"}],
+}
+
+
+def _agent_extra(**kwargs: object) -> dict:
+    trajectory = envelope_to_trajectory(
+        _ENVELOPE,
+        instruction="do the thing",
+        session_id="s1",
+        agent_version="0.0.0-test",
+        default_model="provider/model",
+        return_code=0,
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return trajectory.to_json_dict()["agent"]["extra"]
+
+
+def test_a_trajectory_always_says_what_the_code_graph_step_did() -> None:
+    """Unconditional, like ``workspace_git_baseline`` beside it.
+
+    An omitted key reads as "this adapter is too old to say"; a present key
+    saying ``not_attempted`` is an answer. The difference is the whole point
+    — a reviewer must not have to infer an in-container action from a
+    missing field.
+    """
+    extra = _agent_extra()
+    assert extra["code_graph"] == {"state": "not_attempted"}
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        # init ran and reported — the only case the old code could produce,
+        # and even then it produced it into a field nobody read.
+        {"state": "reported", "summary": "code graph: files 12, symbols 340"},
+        # init raised. Distinct from an empty graph, and the distinction is
+        # exactly what #3087 could not make.
+        {"state": "unavailable", "detail": "exec failed: no such container"},
+        # init ran, exited cleanly, and said nothing about a code graph.
+        {"state": "no_summary_line", "detail": "`stella init` exited without a line"},
+    ],
+)
+def test_every_code_graph_state_reaches_the_trajectory_intact(state: dict) -> None:
+    assert _agent_extra(code_graph=state)["code_graph"] == state
+
+
+def test_the_four_outcomes_are_all_distinguishable_from_each_other() -> None:
+    """The property the defect turned on.
+
+    Four things can happen to the code-graph step and they need four
+    different traces. Before this, all four produced no trace at all, so a
+    ``files: 0`` reading was consistent with every one of them — evidence
+    that cannot distinguish a claim from its opposite is not evidence.
+    """
+    outcomes = [
+        _agent_extra()["code_graph"],
+        _agent_extra(code_graph={"state": "unavailable", "detail": "boom"})["code_graph"],
+        _agent_extra(code_graph={"state": "no_summary_line", "detail": "quiet"})[
+            "code_graph"
+        ],
+        _agent_extra(code_graph={"state": "reported", "summary": "code graph: files 0"})[
+            "code_graph"
+        ],
+    ]
+    rendered = [repr(sorted(outcome.items())) for outcome in outcomes]
+    assert len(set(rendered)) == len(outcomes), (
+        f"two outcomes of the code-graph step are indistinguishable: {rendered}"
+    )

--- a/crates/stella-embed/src/rank.rs
+++ b/crates/stella-embed/src/rank.rs
@@ -92,8 +92,223 @@ pub fn top_k(query: &[f32], candidates: &[Candidate<'_>], floor: f32, limit: usi
     scored
 }
 
+/// How much larger than the average gap a gap must be to count as the edge of
+/// relevance rather than ordinary spacing.
+///
+/// Provisional, and **scale-free by construction**, which is the whole reason
+/// it is defensible without a per-model measurement: it compares gaps in a
+/// ranking against other gaps in the same ranking, so it carries no assumption
+/// about where a given embedder's cosines sit. An absolute cutoff does — and
+/// `DEFAULT_ADMISSION_FLOOR` is the cautionary case, sitting at 0.25 while
+/// `voyage-code-3` scores unrelated files at 0.604, dropping nothing.
+pub const DEFAULT_RELEVANCE_GAP_RATIO: f32 = 2.5;
+
+/// The smallest drop in cosine that may be called a boundary at all.
+///
+/// **This exists because the ratio alone is not enough, and the number that
+/// proves it is the one #3089 measured.** On that real ten-result ranking
+/// (0.656 down to 0.604) the widest gap is 0.015 — which is *2.6x the mean
+/// gap*, comfortably past [`DEFAULT_RELEVANCE_GAP_RATIO`], and would have cut
+/// the list to a single confident result. The correct answer was not in the
+/// list at all. A ratio is scale-free about the *level* of a score and says
+/// nothing about its *resolution*: 0.015 is both 2.6x the mean and 1.5% of a
+/// cosine, and the second reading is the true one.
+///
+/// So a boundary must be two independent things at once — wide relative to
+/// the ranking's other gaps, and wide enough absolutely that it is not
+/// measurement noise. This constant is the second test.
+///
+/// Provisional like [`DEFAULT_RELEVANCE_GAP_RATIO`], but far less fragile than
+/// an absolute *floor*: gaps between scores are much more comparable across
+/// models than the scores themselves, which is exactly why
+/// `DEFAULT_ADMISSION_FLOOR` sits at 0.25 while a real backend scores
+/// unrelated files at 0.604. It still wants measuring per model.
+pub const DEFAULT_MIN_BOUNDARY_GAP: f32 = 0.05;
+
+/// How many of a ranked list are relevant — the answer to "where does this
+/// result set stop being about the query".
+///
+/// # Why a count is the wrong way to shape an answer
+///
+/// A fixed `limit` is wrong in both directions at once. A query whose answer
+/// genuinely spans forty chunks is truncated at ten and the caller cannot tell;
+/// a query with two real hits returns ten and the eight passengers read as
+/// findings. Neither failure is visible in the output, which is what makes it
+/// worse than a wrong answer.
+///
+/// # The mechanism
+///
+/// `scored` is assumed sorted descending — [`top_k`]'s output. The largest
+/// **drop** between adjacent scores is the candidate boundary, and it is
+/// accepted only when it passes **both** tests: at least `gap_ratio` times the
+/// mean gap across the list, *and* at least `min_gap` in absolute cosine.
+///
+/// Both, because either alone is wrong in a way that has already been
+/// observed. Without the ratio, an evenly-spaced ranking gets cut at whichever
+/// gap rounding made widest. Without `min_gap`, the ranking #3089 measured —
+/// ten results spanning 0.05 — cuts to a single confident answer on a gap of
+/// 0.015, and the correct answer was not in that list at all
+/// ([`DEFAULT_MIN_BOUNDARY_GAP`] carries the full argument).
+///
+/// When no gap passes both, the honest report is that this ranking does not
+/// resolve: the whole list is returned, and something downstream — a context
+/// budget — has to be the one to say it could not show all of it.
+///
+/// Never returns zero for a non-empty list: admission is the absolute floor's
+/// job ([`crate::SimilarityPosture`]), and this function's job is only to find
+/// the edge *within* what was already admitted. Returning zero here would
+/// silently overrule a floor that had already said yes.
+///
+/// Pure and total: no I/O, no clock, no panic on `NaN`, empty or single-item
+/// input.
+#[must_use]
+pub fn relevant_prefix(scored: &[Scored], gap_ratio: f32, min_gap: f32) -> usize {
+    if scored.len() <= 1 {
+        return scored.len();
+    }
+    let gaps: Vec<f32> = scored
+        .windows(2)
+        .map(|pair| (pair[0].score - pair[1].score).max(0.0))
+        .collect();
+    let total: f32 = gaps.iter().sum();
+    // Every score identical: no boundary exists anywhere, and dividing by a
+    // zero mean below would produce one out of a rounding artefact.
+    if total <= 0.0 {
+        return scored.len();
+    }
+    let mean = total / gaps.len() as f32;
+
+    let (index, widest) = gaps
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(Ordering::Equal))
+        .map(|(index, gap)| (index, *gap))
+        .unwrap_or((0, 0.0));
+
+    if widest >= mean * gap_ratio && widest >= min_gap {
+        index + 1
+    } else {
+        scored.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn scores(values: &[f32]) -> Vec<Scored> {
+        values
+            .iter()
+            .enumerate()
+            .map(|(index, score)| Scored {
+                key: format!("k{index}"),
+                score: *score,
+            })
+            .collect()
+    }
+
+    /// The shape the whole function exists for: three real hits, then a cliff,
+    /// then noise. The cut lands at the cliff regardless of how much noise
+    /// follows it.
+    #[test]
+    fn a_cliff_between_relevant_and_irrelevant_is_where_the_cut_lands() {
+        let ranked = scores(&[0.91, 0.88, 0.86, 0.42, 0.41, 0.40, 0.39]);
+        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 3);
+    }
+
+    /// A smoothly-decaying ranking has no boundary in it. Inventing one would
+    /// be an arbitrary cut wearing a threshold's authority, so the whole list
+    /// is returned and the budget is left to say what it could not show.
+    #[test]
+    fn a_smooth_decay_has_no_boundary_and_is_not_cut() {
+        let ranked = scores(&[0.90, 0.85, 0.80, 0.75, 0.70, 0.65]);
+        assert_eq!(
+            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            ranked.len()
+        );
+    }
+
+    /// The exact distribution #3089 measured — ten results spanning 0.05.
+    /// Nothing in it separates, and the honest answer is that this ranking
+    /// does not resolve, not that the top three are the answer.
+    #[test]
+    fn the_file_level_ranking_that_motivated_this_does_not_resolve() {
+        let ranked = scores(&[
+            0.656, 0.641, 0.636, 0.628, 0.621, 0.615, 0.612, 0.607, 0.606, 0.604,
+        ]);
+        assert_eq!(
+            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            ranked.len(),
+            "a tie dressed as a ranking must not be cut into a confident answer"
+        );
+    }
+
+    #[test]
+    fn one_hit_and_no_hits_are_both_answered_without_a_gap_to_measure() {
+        assert_eq!(relevant_prefix(&[], DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 0);
+        assert_eq!(relevant_prefix(&scores(&[0.9]), DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+    }
+
+    #[test]
+    fn an_exact_tie_across_the_whole_list_is_never_cut() {
+        let ranked = scores(&[0.5, 0.5, 0.5, 0.5]);
+        assert_eq!(
+            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            ranked.len()
+        );
+    }
+
+    /// A single dominant hit is the other end of the same shape, and the one
+    /// most easily got wrong: the cut must keep it rather than reading "one
+    /// item" as "no boundary".
+    #[test]
+    fn one_dominant_hit_cuts_to_one() {
+        let ranked = scores(&[0.95, 0.31, 0.30, 0.29, 0.28]);
+        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+    }
+
+    proptest! {
+        /// Never zero, never past the end. A zero would silently overrule the
+        /// admission floor, which has already said these are relevant.
+        #[test]
+        fn the_cut_is_always_a_non_empty_prefix(
+            mut values in proptest::collection::vec(0.0f32..1.0, 1..40),
+            ratio in 0.1f32..8.0,
+        ) {
+            values.sort_by(|a, b| b.partial_cmp(a).unwrap());
+            let ranked = scores(&values);
+            let cut = relevant_prefix(&ranked, ratio, DEFAULT_MIN_BOUNDARY_GAP);
+            prop_assert!(cut >= 1);
+            prop_assert!(cut <= ranked.len());
+        }
+
+        /// Appending more noise below an existing cliff can never move the cut
+        /// deeper — the answer to "what is relevant" must not grow because
+        /// irrelevant things were added.
+        #[test]
+        fn extra_noise_below_the_cliff_never_widens_the_answer(
+            tail_len in 1usize..20,
+        ) {
+            let head = vec![0.95f32, 0.93, 0.92];
+            let base: Vec<f32> = head.iter().copied().chain([0.20]).collect();
+            let longer: Vec<f32> = head
+                .iter()
+                .copied()
+                .chain((0..=tail_len).map(|i| 0.20 - i as f32 * 0.001))
+                .collect();
+            let short_cut = relevant_prefix(&scores(&base), DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP);
+            let long_cut = relevant_prefix(&scores(&longer), DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP);
+            prop_assert!(
+                long_cut <= short_cut,
+                "cut widened from {short_cut} to {long_cut} when only noise was added"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod top_k_tests {
     use super::*;
     use proptest::prelude::*;
 

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -434,6 +434,75 @@ impl CodeGraph {
         vectors::count(&self.inner.read_guard(), fingerprint)
     }
 
+    /// Files whose **chunks** — symbols, markdown sections — are not fully
+    /// embedded under `fingerprint`, rendered and hashed ready to embed
+    /// (#3089).
+    ///
+    /// The embedding itself is deliberately not here, for the reason
+    /// [`files_pending_embedding`] gives: producing a vector is I/O against a
+    /// model, and this crate holds no transport and no key.
+    ///
+    /// [`files_pending_embedding`]: CodeGraph::files_pending_embedding
+    pub fn chunks_pending_embedding(
+        &self,
+        fingerprint: &str,
+        limit: usize,
+    ) -> Result<vectors::chunks::PendingChunkScan, GraphError> {
+        vectors::chunks::pending_chunks(
+            &self.inner.read_guard(),
+            &self.inner.root,
+            fingerprint,
+            limit,
+        )
+    }
+
+    /// Persist one file's chunk vectors and sweep the chunks it no longer has.
+    ///
+    /// **One file per call**, because the sweep keys on `file_sha256`: writing
+    /// half a file's chunks and then the other half would have the second call
+    /// delete the first call's rows.
+    pub fn store_chunk_vectors(
+        &self,
+        fingerprint: &str,
+        path: &str,
+        file_sha256: &str,
+        chunks: &[vectors::chunks::ChunkVector],
+    ) -> Result<usize, GraphError> {
+        vectors::chunks::store_chunk_vectors(
+            &mut self.inner.write_guard(),
+            fingerprint,
+            path,
+            file_sha256,
+            chunks,
+        )
+    }
+
+    /// Rank indexed chunks against a query vector, best first.
+    ///
+    /// Same contract as [`rank_files_by_vector`] — `floor` drops candidates
+    /// below it, and only vectors stamped with `fingerprint` are considered —
+    /// over a corpus roughly twenty times larger and correspondingly sharper.
+    ///
+    /// [`rank_files_by_vector`]: CodeGraph::rank_files_by_vector
+    pub fn rank_chunks_by_vector(
+        &self,
+        fingerprint: &str,
+        query: &[f32],
+        floor: f32,
+        limit: usize,
+    ) -> Result<Vec<vectors::chunks::ScoredChunk>, GraphError> {
+        vectors::chunks::rank_chunks(&self.inner.read_guard(), fingerprint, query, floor, limit)
+    }
+
+    /// How many chunks carry a vector under `fingerprint`. With
+    /// [`symbol_count`] this is the chunk-level answer to "how much of this
+    /// workspace can a semantic query see".
+    ///
+    /// [`symbol_count`]: CodeGraph::symbol_count
+    pub fn embedded_chunk_count(&self, fingerprint: &str) -> Result<usize, GraphError> {
+        vectors::chunks::chunk_count(&self.inner.read_guard(), fingerprint)
+    }
+
     /// The structured neighborhood of `file` — its symbols and import edges
     /// in both directions — for UI consumers (the deck's Graph tab). The
     /// frame methods above render prose for the model; this keeps the shape.

--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -24,6 +24,10 @@ pub enum Language {
     Java,
     C,
     Php,
+    /// Prose, split on its heading hierarchy by [`crate::markdown`] rather
+    /// than by a grammar — the one language here whose parser is this crate's
+    /// own, and so the one that is present in every build.
+    Markdown,
 }
 
 impl Language {
@@ -57,6 +61,7 @@ impl Language {
             "c" | "h" => Language::C,
             "php" => Language::Php,
             "sql" => Language::Sql,
+            "md" | "markdown" => Language::Markdown,
             _ => return None,
         };
         lang.is_compiled_in().then_some(lang)
@@ -74,7 +79,7 @@ impl Language {
     }
 
     /// Every language the enum knows, compiled in or not.
-    pub const ALL: [Language; 10] = [
+    pub const ALL: [Language; 11] = [
         Language::Rust,
         Language::Python,
         Language::JavaScript,
@@ -85,11 +90,27 @@ impl Language {
         Language::Java,
         Language::C,
         Language::Php,
+        Language::Markdown,
     ];
 
-    /// Whether this build carries this language's grammar.
+    /// Whether this build can parse this language.
+    ///
+    /// For every grammar-backed language that is "did this build compile the
+    /// grammar in" (#1268). [`Language::Markdown`] is parsed by
+    /// [`crate::markdown`], a line scan in this crate with no feature gate and
+    /// nothing to link, so it is always available — which is why this is not
+    /// simply `ts_language().is_some()`.
     pub fn is_compiled_in(self) -> bool {
-        self.ts_language().is_some()
+        match self {
+            Language::Markdown => true,
+            _ => self.ts_language().is_some(),
+        }
+    }
+
+    /// Whether this language is parsed by a tree-sitter grammar rather than
+    /// by this crate's own reader. Only [`Language::Markdown`] answers `false`.
+    pub(crate) fn is_grammar_backed(self) -> bool {
+        !matches!(self, Language::Markdown)
     }
 
     /// Stable lowercase tag stored in `code_graph_files.language` and used in
@@ -106,6 +127,7 @@ impl Language {
             Language::Java => "java",
             Language::C => "c",
             Language::Php => "php",
+            Language::Markdown => "markdown",
         }
     }
 
@@ -142,6 +164,8 @@ impl Language {
             // and the PHP-only grammar cannot parse those at all.
             #[cfg(feature = "lang-php")]
             Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+            // Markdown has no grammar by design, not by trimming — see
+            // [`Language::is_compiled_in`].
             #[allow(unreachable_patterns)]
             _ => return None,
         })
@@ -159,6 +183,7 @@ impl Language {
             Language::Java => queries::JAVA_SYMBOLS,
             Language::C => queries::C_SYMBOLS,
             Language::Php => queries::PHP_SYMBOLS,
+            Language::Markdown => NO_QUERY,
         }
     }
 
@@ -174,6 +199,7 @@ impl Language {
             Language::Java => queries::JAVA_IMPORTS,
             Language::C => queries::C_IMPORTS,
             Language::Php => queries::PHP_IMPORTS,
+            Language::Markdown => NO_QUERY,
         }
     }
 
@@ -189,9 +215,18 @@ impl Language {
             Language::Java => queries::JAVA_CALLS,
             Language::C => queries::C_CALLS,
             Language::Php => queries::PHP_CALLS,
+            Language::Markdown => NO_QUERY,
         }
     }
 }
+
+/// The query source for a language that has no grammar to run one against.
+///
+/// Unreachable in practice — `LangPack::load` returns before it asks a
+/// grammarless language for a query, and `parse_file` answers markdown before
+/// it looks for a pack — but a total match needs an arm, and an empty query is
+/// the honest value rather than a panic on a path no input can reach.
+const NO_QUERY: &str = "";
 
 #[cfg(test)]
 mod tests {
@@ -241,8 +276,23 @@ mod tests {
             Language::from_path(Path::new("migrations/001.sql")),
             Some(Language::Sql)
         );
-        assert_eq!(Language::from_path(Path::new("README.md")), None);
+        assert_eq!(
+            Language::from_path(Path::new("README.md")),
+            Some(Language::Markdown),
+            "165 markdown files in this workspace were invisible to every \
+             search the agent had until they became indexable (#3089)"
+        );
         assert_eq!(Language::from_path(Path::new("noext")), None);
+    }
+
+    /// Markdown carries no grammar and is still always indexable — the one
+    /// language whose reader ships with this crate rather than with a
+    /// `lang-*` feature.
+    #[test]
+    fn markdown_is_indexable_in_every_build() {
+        assert!(Language::Markdown.is_compiled_in());
+        assert!(!Language::Markdown.is_grammar_backed());
+        assert_eq!(Language::Markdown.ts_language(), None);
     }
 
     /// The `default` feature set must reproduce the language coverage that
@@ -278,7 +328,7 @@ mod tests {
     /// reads to the agent as "this file declares nothing".
     #[test]
     fn detection_never_names_a_language_this_build_cannot_parse() {
-        for lang in Language::ALL {
+        for lang in Language::ALL.iter().copied().filter(|l| l.is_grammar_backed()) {
             assert_eq!(
                 lang.is_compiled_in(),
                 lang.ts_language().is_some(),
@@ -287,7 +337,7 @@ mod tests {
             );
         }
         for probe in [
-            "a.rs", "a.py", "a.go", "a.java", "a.c", "a.php", "a.sql", "a.tsx",
+            "a.rs", "a.py", "a.go", "a.java", "a.c", "a.php", "a.sql", "a.tsx", "a.md",
         ] {
             if let Some(lang) = Language::from_path(Path::new(probe)) {
                 assert!(

--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -61,6 +61,7 @@ mod graph;
 mod import;
 mod lang;
 pub mod manifest;
+mod markdown;
 mod parse;
 mod queries;
 mod rust_resolve;

--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -81,6 +81,10 @@ pub use lang::Language;
 pub use storage::{StorageExtract, StorageExtractor, StorageSnapshot};
 pub use store::IndexStats;
 pub use symbol::{CallSite, Symbol, SymbolKind};
+pub use vectors::chunks::{
+    ChunkVector, MAX_FILES_PER_CHUNK_PASS, PendingChunk, PendingChunkFile, PendingChunkScan,
+    ScoredChunk, render_chunk_text,
+};
 pub use vectors::{FileVector, MAX_FILES_PER_PASS, PendingEmbed, PendingScan, render_file_text};
 #[doc(hidden)]
 pub use watch::WatchInjector;

--- a/crates/stella-graph/src/markdown.rs
+++ b/crates/stella-graph/src/markdown.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Markdown's heading hierarchy, as the sections the semantic index ranks.
+//!
+//! # Why markdown is indexed at all
+//!
+//! It was not, and the omission was invisible: `code_graph_files` held zero
+//! rows whose path ended `.md`, so 165 markdown files in this workspace —
+//! `AGENTS.md`, `CLAUDE.md`, every crate README, all of `docs/spec/` — could
+//! not be reached by any search the agent had. The invariants that govern
+//! this repository were unsearchable *by the agent that has to obey them*.
+//!
+//! A question like "why must a new `AgentEvent` variant declare what consumes
+//! it" has no answer in the code at all. It is answered by one section of one
+//! markdown file, and until that section is a row in the index the honest
+//! answer to the query is silence.
+//!
+//! # Why a line scan and not a tree-sitter grammar
+//!
+//! Every other language in this crate arrives through a native grammar
+//! ([`crate::lang`]), and markdown deliberately does not. The index needs one
+//! fact from a markdown file — where each ATX heading starts, and which
+//! headings enclose it — and that is a line scan with a fence flag. A grammar
+//! would add a build dependency and a syntax tree to recover a fact that is
+//! already lexically obvious at the start of a line.
+//!
+//! The failure direction matters too: a scan that misses a heading yields one
+//! coarser section, never a wrong one, and never an error. That is the same
+//! best-effort contract every other per-file failure mode here has (`L-L1`).
+//!
+//! # Why a section, not a file and not a heading
+//!
+//! A section's body runs from its heading to the **next heading of any
+//! level** — not to the end of its own subtree. A subtree-scoped section
+//! would make `# AGENTS.md`'s body the entire document, which is the
+//! whole-file dilution [`crate::vectors`] exists to escape; a heading with no
+//! body would embed a title with no content to disambiguate it. Sibling-
+//! scoped sections give every heading exactly the prose written under it.
+//!
+//! Content *before* the first heading is deliberately not a section. The
+//! file-level vector already carries it (`render_file_text` leads with the
+//! head of the file), and inventing a `(preamble)` symbol would put a name in
+//! `code_graph_symbols.name` that names nothing a reader could cite.
+
+use crate::symbol::{Symbol, SymbolKind};
+
+/// The deepest heading markdown defines. A run of seven or more `#` is not a
+/// heading at all, which is why this is a bound and not a clamp.
+const MAX_HEADING_LEVEL: usize = 6;
+
+/// The shortest run of backticks or tildes that opens a fenced code block.
+const MIN_FENCE: usize = 3;
+
+/// How many leading spaces a construct may carry and still be recognised.
+/// Four spaces starts an indented code block instead, so this is CommonMark's
+/// bound rather than a tolerance we chose.
+const MAX_INDENT: usize = 3;
+
+/// The separator between the levels of a section's breadcrumb.
+///
+/// A non-ASCII separator on purpose: it cannot occur in a heading by accident
+/// the way `/` or `>` can, so splitting a breadcrumb back into its levels is
+/// unambiguous, and a reader seeing
+/// `Architecture › 8. Provider feature parity` knows immediately that it is a
+/// path through a document rather than part of one heading.
+pub(crate) const BREADCRUMB_SEPARATOR: &str = " › ";
+
+/// Every ATX-headed section of `source`, in document order, as symbols the
+/// index stores exactly like any other.
+///
+/// The `name` is the section's **breadcrumb** — the enclosing headings joined
+/// by [`BREADCRUMB_SEPARATOR`], without the file path, matching every other
+/// symbol name in this crate (the path is `code_graph_files.path`, and a
+/// citation composes the two). Lines are 1-based and inclusive, the same
+/// convention `Symbol` carries everywhere else.
+///
+/// Pure: no I/O, no clock, no environment. Setext headings (`===`/`---`
+/// underlines) are **not** recognised — `---` is also a thematic break and
+/// also YAML frontmatter's delimiter, and guessing between them wrong would
+/// invent sections rather than miss them (#TBD-setext).
+pub(crate) fn sections(source: &str) -> Vec<Symbol> {
+    let mut out: Vec<Symbol> = Vec::new();
+    // One entry per open heading level, so the breadcrumb of the next heading
+    // is a prefix of this stack. Index 0 is level 1.
+    let mut stack: Vec<String> = Vec::new();
+    let mut fence: Option<(u8, usize)> = None;
+    let mut total_lines: u32 = 0;
+
+    for (index, line) in source.lines().enumerate() {
+        let line_no = index as u32 + 1;
+        total_lines = line_no;
+
+        // Fence state first: a `#` inside a code block is a shell comment or
+        // a Rust attribute, not a heading, and a document that opens a fence
+        // and never closes it must not resume finding headings.
+        match fence {
+            Some((ch, open_len)) => {
+                if closes_fence(line, ch, open_len) {
+                    fence = None;
+                }
+                continue;
+            }
+            None => {
+                if let Some(marker) = fence_marker(line) {
+                    fence = Some(marker);
+                    continue;
+                }
+            }
+        }
+
+        let Some((level, text)) = atx_heading(line) else {
+            continue;
+        };
+
+        // Close the previous section at the line above this heading. A
+        // heading immediately following another leaves the earlier one with
+        // an empty body, which is correct: it had none.
+        if let Some(previous) = out.last_mut() {
+            previous.end_line = line_no.saturating_sub(1).max(previous.start_line);
+        }
+
+        // A jump from level 2 to level 4 opens level 4 under whatever level 2
+        // was open — the document's own nesting, not a repaired one.
+        stack.truncate(level.saturating_sub(1));
+        while stack.len() < level.saturating_sub(1) {
+            stack.push(String::new());
+        }
+        stack.push(text.to_string());
+
+        out.push(Symbol {
+            name: stack
+                .iter()
+                .filter(|level| !level.is_empty())
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(BREADCRUMB_SEPARATOR),
+            kind: SymbolKind::Section,
+            start_line: line_no,
+            end_line: line_no,
+        });
+    }
+
+    if let Some(last) = out.last_mut() {
+        last.end_line = total_lines.max(last.start_line);
+    }
+    // A heading with no text (`##` alone) opens a level and names nothing.
+    // It is dropped *here*, after the spans are closed, so the section above
+    // it still ends where the nameless heading began — filtering earlier
+    // would silently extend the previous section over it.
+    out.retain(|section| !section.name.is_empty());
+    out
+}
+
+/// The heading level and text of an ATX heading line, or `None`.
+///
+/// Requires whitespace (or end of line) after the `#` run, which is what
+/// separates `# Title` from `#hashtag`, and strips the optional closing run
+/// so `## Title ##` and `## Title` produce the same breadcrumb.
+fn atx_heading(line: &str) -> Option<(usize, &str)> {
+    let rest = after_indent(line)?;
+    let hashes = rest.bytes().take_while(|byte| *byte == b'#').count();
+    if hashes == 0 || hashes > MAX_HEADING_LEVEL {
+        return None;
+    }
+    let after = &rest[hashes..];
+    if !after.is_empty() && !after.starts_with([' ', '\t']) {
+        return None;
+    }
+    let text = after.trim().trim_end_matches('#').trim();
+    // `##` alone is a heading with no text; it opens a level but names
+    // nothing, and an empty breadcrumb level is dropped when the name is
+    // joined.
+    Some((hashes, text))
+}
+
+/// The fence character and length if `line` opens a fenced code block.
+fn fence_marker(line: &str) -> Option<(u8, usize)> {
+    let rest = after_indent(line)?;
+    let ch = *rest.as_bytes().first()?;
+    if ch != b'`' && ch != b'~' {
+        return None;
+    }
+    let len = rest.bytes().take_while(|byte| *byte == ch).count();
+    (len >= MIN_FENCE).then_some((ch, len))
+}
+
+/// Whether `line` closes a fence opened with `ch` repeated `open_len` times.
+///
+/// A closing fence must use the same character, be at least as long, and
+/// carry nothing but whitespace after the run — otherwise the ```` ```rust ````
+/// opening an inner block would close the outer one.
+fn closes_fence(line: &str, ch: u8, open_len: usize) -> bool {
+    let Some(rest) = after_indent(line) else {
+        return false;
+    };
+    let len = rest.bytes().take_while(|byte| *byte == ch).count();
+    len >= open_len && rest[len..].trim().is_empty()
+}
+
+/// The line's content past its leading spaces, or `None` when there are more
+/// than [`MAX_INDENT`] of them — four spaces opens an indented code block,
+/// inside which neither a heading nor a fence is recognised.
+fn after_indent(line: &str) -> Option<&str> {
+    let spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+    (spaces <= MAX_INDENT).then(|| &line[spaces..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(source: &str) -> Vec<String> {
+        sections(source)
+            .into_iter()
+            .map(|symbol| symbol.name)
+            .collect()
+    }
+
+    #[test]
+    fn a_heading_path_becomes_a_breadcrumb() {
+        let source = "# Top\nbody\n## Middle\nmore\n### Leaf\nleaf body\n";
+        assert_eq!(
+            names(source),
+            vec!["Top", "Top › Middle", "Top › Middle › Leaf"]
+        );
+    }
+
+    /// The property the whole module exists for: a section's span is its own
+    /// prose, not its subtree's, so a top heading is not the whole file.
+    #[test]
+    fn a_section_ends_at_the_next_heading_of_any_level() {
+        let source = "# Top\nline two\nline three\n## Middle\nline five\n";
+        let found = sections(source);
+        assert_eq!((found[0].start_line, found[0].end_line), (1, 3));
+        assert_eq!((found[1].start_line, found[1].end_line), (4, 5));
+    }
+
+    #[test]
+    fn a_hash_inside_a_fenced_block_is_not_a_heading() {
+        let source = "# Real\n```sh\n# not a heading\n```\n## Also real\n";
+        assert_eq!(names(source), vec!["Real", "Real › Also real"]);
+    }
+
+    /// A short fence inside a longer one is content, not a close — otherwise
+    /// the headings after it would be read out of a code block.
+    #[test]
+    fn a_shorter_inner_fence_does_not_close_a_longer_one() {
+        let source = "# Real\n````\n```\n# hidden\n```\n````\n## Visible\n";
+        assert_eq!(names(source), vec!["Real", "Real › Visible"]);
+    }
+
+    #[test]
+    fn an_unclosed_fence_swallows_the_rest_of_the_document() {
+        let source = "# Real\n```\n# hidden\n## also hidden\n";
+        assert_eq!(names(source), vec!["Real"]);
+    }
+
+    #[test]
+    fn a_closing_hash_run_is_not_part_of_the_name() {
+        assert_eq!(names("## Title ##\n"), vec!["Title"]);
+    }
+
+    #[test]
+    fn a_hash_with_no_space_is_not_a_heading() {
+        assert_eq!(names("#hashtag\ntext\n"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn seven_hashes_are_not_a_heading() {
+        assert_eq!(names("####### deep\n"), Vec::<String>::new());
+    }
+
+    /// Four spaces is an indented code block in CommonMark, so what looks
+    /// like a heading inside one is not one.
+    #[test]
+    fn an_indented_code_block_hides_a_heading() {
+        assert_eq!(names("# Real\n\n    # indented\n"), vec!["Real"]);
+    }
+
+    #[test]
+    fn a_skipped_level_nests_under_what_is_actually_open() {
+        assert_eq!(
+            names("## Two\n#### Four\n"),
+            vec!["Two", "Two › Four"],
+            "the empty level 3 contributes no breadcrumb segment"
+        );
+    }
+
+    #[test]
+    fn content_before_the_first_heading_is_not_a_section() {
+        let found = sections("---\nid: doc\n---\n\nintro prose\n\n# First\nbody\n");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].start_line, 7);
+    }
+
+    #[test]
+    fn a_document_with_no_headings_has_no_sections() {
+        assert_eq!(sections("just prose\nand more\n"), Vec::new());
+    }
+
+    /// Every section must carry a usable span — `start <= end`, inside the
+    /// document — or an excerpt read against it would panic or read nothing.
+    #[test]
+    fn every_span_is_orderable_and_inside_the_document() {
+        let source = "# A\n\n## B\n\n```\n# C\n```\n\n### D\nlast\n";
+        let lines = source.lines().count() as u32;
+        for section in sections(source) {
+            assert!(
+                section.start_line <= section.end_line,
+                "{section:?} has an inverted span"
+            );
+            assert!(section.end_line <= lines, "{section:?} runs past the file");
+        }
+    }
+}

--- a/crates/stella-graph/src/parse.rs
+++ b/crates/stella-graph/src/parse.rs
@@ -115,6 +115,9 @@ impl Grammars {
             Language::Java => self.java.as_ref(),
             Language::C => self.c.as_ref(),
             Language::Php => self.php.as_ref(),
+            // Markdown is read by `crate::markdown`, not by a grammar, and
+            // `parse_file` answers it before it reaches here.
+            Language::Markdown => None,
         }
     }
 }
@@ -150,6 +153,19 @@ pub(crate) fn parse_sql_tree(grammars: &Grammars, source: &str) -> Option<tree_s
 /// Parse one file's `source`. `None` = un-armable grammar or wholly
 /// unparseable input → the caller records a skip and continues.
 pub(crate) fn parse_file(grammars: &Grammars, lang: Language, source: &str) -> Option<Parsed> {
+    // Markdown ahead of the grammar lookup, because it has none: its sections
+    // come from a line scan in this crate ([`crate::markdown`]), which is why
+    // it is the one language present in every build. A document with no
+    // headings yields no symbols and is still a successful parse — it is a
+    // file the index knows about, with a file-level vector, exactly like a
+    // source file that declares nothing.
+    if lang == Language::Markdown {
+        return Some(Parsed {
+            symbols: crate::markdown::sections(source),
+            imports: Vec::new(),
+            calls: Vec::new(),
+        });
+    }
     let pack = grammars.pack(lang)?;
     let mut parser = Parser::new();
     if parser.set_language(&pack.language).is_err() {
@@ -177,6 +193,10 @@ pub(crate) fn parse_file(grammars: &Grammars, lang: Language, source: &str) -> O
             extract_ts_imports(&pack.imports, root, src)
         }
         Language::Sql => Vec::new(), // SQL has no imports
+        // Unreachable: markdown returned above, before the pack lookup. A
+        // link between documents IS an import edge and would be worth
+        // extracting, but it is a separate change (#TBD-md-links).
+        Language::Markdown => Vec::new(),
         Language::Go => extract_go_imports(&pack.imports, root, src),
         Language::Java => extract_java_imports(&pack.imports, root, src),
         Language::C => extract_c_imports(&pack.imports, root, src),

--- a/crates/stella-graph/src/store.rs
+++ b/crates/stella-graph/src/store.rs
@@ -80,6 +80,7 @@ const SCHEMA_TABLES: &[&str] = &[
     "code_graph_calls",
     "code_graph_storage_objects",
     "code_graph_vectors",
+    "code_graph_chunk_vectors",
 ];
 
 /// DDL for the code graph's tables. `IF NOT EXISTS` throughout so opening an
@@ -180,6 +181,57 @@ CREATE TABLE IF NOT EXISTS code_graph_vectors (
 -- Both reads scan one fingerprint's whole vector set: the rank pass, and the
 -- pending pass that finds what still needs embedding.
 CREATE INDEX IF NOT EXISTS code_graph_vectors_fp ON code_graph_vectors(fingerprint);
+-- Semantic vectors for the pieces a file is made of (#3089). One vector per
+-- FILE answers "what is this module about" and nothing sharper: averaging a
+-- 900-line multi-topic file into one 1024-dimension vector produced a measured
+-- 0.05 score spread across ten results — a tie dressed as a ranking — and left
+-- the actual answer out of the top ten entirely.
+--
+-- A "chunk" is a symbol, a markdown section, or anything else with a name, a
+-- kind and a line span. They share one table because they share one vector
+-- space: the same embedder under the same `fingerprint`, so a doc section's
+-- score and a function's score are genuinely comparable, and `kind` is what
+-- later lets an answer be grouped by role rather than truncated down one list.
+--
+-- **Keyed on the chunk's own content hash, not on `code_graph_symbols.id`.**
+-- That is a deliberate departure from #3089's proposed schema, and the reason
+-- is three lines up in this file: `index_one` replaces a changed file's
+-- symbols with `DELETE FROM code_graph_symbols WHERE file_id = ?` followed by
+-- fresh inserts, so symbol ids are not stable across a re-parse. A
+-- `symbol_id REFERENCES code_graph_symbols(id) ON DELETE CASCADE` table would
+-- therefore lose EVERY vector in a file on ANY edit to that file — destroying
+-- exactly the incremental property #3089's own `content_sha256` requirement
+-- exists to protect, and before that hash ever got a chance to save anything.
+-- Content addressing survives the churn: an untouched function in an edited
+-- file renders to the same bytes, so its vector is re-stamped rather than
+-- re-bought.
+--
+-- `file_sha256` is the hash of the file the chunk was last seen in, which is
+-- what makes "is this file fully embedded" a pure SQL question — a count
+-- comparison against `code_graph_symbols` — instead of a re-read of every file
+-- in the workspace on every query. It is also the sweep key: after a file's
+-- chunks are written, rows still carrying an older `file_sha256` are the
+-- chunks that no longer exist, and they are deleted.
+--
+-- A rowid table, for the reason `code_graph_vectors` above is one.
+CREATE TABLE IF NOT EXISTS code_graph_chunk_vectors (
+    file_id      INTEGER NOT NULL REFERENCES code_graph_files(id) ON DELETE CASCADE,
+    chunk_sha256 TEXT NOT NULL,
+    fingerprint  TEXT NOT NULL,
+    file_sha256  TEXT NOT NULL,
+    name         TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    start_line   INTEGER NOT NULL,
+    end_line     INTEGER NOT NULL,
+    dims         INTEGER NOT NULL,
+    vector       BLOB NOT NULL,
+    embedded_at  INTEGER NOT NULL,
+    PRIMARY KEY (file_id, chunk_sha256, fingerprint)
+);
+-- The rank pass scans one fingerprint's whole set, exactly as the file-vector
+-- pass does.
+CREATE INDEX IF NOT EXISTS code_graph_chunk_vectors_fp
+    ON code_graph_chunk_vectors(fingerprint);
 "#;
 
 /// Largest source file this index will read, in bytes.

--- a/crates/stella-graph/src/symbol.rs
+++ b/crates/stella-graph/src/symbol.rs
@@ -20,6 +20,14 @@ pub enum SymbolKind {
     Column,
     SchemaEnum,
     View,
+    /// One heading's section of a markdown document ([`crate::markdown`]).
+    ///
+    /// Not a declaration, and deliberately in this enum anyway: a section has
+    /// a name, a kind and a line span, which is the entire contract the index,
+    /// the vector pass and the citation layer ask of a symbol. A parallel
+    /// "document chunk" type would duplicate all three tables to express the
+    /// same four fields.
+    Section,
 }
 impl SymbolKind {
     /// Map a query kind-capture name (see [`crate::queries`]) to a kind.
@@ -54,6 +62,7 @@ impl SymbolKind {
             SymbolKind::Column => "column",
             SymbolKind::SchemaEnum => "schema_enum",
             SymbolKind::View => "view",
+            SymbolKind::Section => "section",
         }
     }
 
@@ -70,6 +79,10 @@ impl SymbolKind {
             "column" => SymbolKind::Column,
             "schema_enum" => SymbolKind::SchemaEnum,
             "view" => SymbolKind::View,
+            // Markdown sections have no tree-sitter capture to arrive from,
+            // so `from_capture` above deliberately does not know this tag —
+            // only the store round-trip does.
+            "section" => SymbolKind::Section,
             // "function" and any unknown/forward-compat tag read back as a
             // plain function — the least-surprising, never-panicking default.
             _ => SymbolKind::Function,
@@ -91,6 +104,7 @@ impl SymbolKind {
             SymbolKind::Column => "column",
             SymbolKind::SchemaEnum => "enum",
             SymbolKind::View => "view",
+            SymbolKind::Section => "section",
         }
     }
 

--- a/crates/stella-graph/src/vectors.rs
+++ b/crates/stella-graph/src/vectors.rs
@@ -33,10 +33,14 @@
 //!   what a later pass would index degrades ranking silently, with no error to
 //!   catch it, so there is exactly one function and its output is what the
 //!   stored `content_sha256` refers to.
-//! - **Files are the ranking unit.** Symbols and edges come in afterwards
-//!   through the traversal that already exists (`neighbors`, `definitions`).
-//!   Ranking symbols directly would multiply the corpus by twenty for an
-//!   answer the caller then has to re-aggregate to a file anyway.
+//! - **A file is one ranking unit, and no longer the only one.** This module
+//!   held that ranking symbols directly "would multiply the corpus by twenty
+//!   for an answer the caller then has to re-aggregate to a file anyway".
+//!   Measurement refuted it: one vector per file returned a **0.05 score
+//!   spread across ten results** on a real query, with the answer absent
+//!   entirely (#3089). Multiplying the corpus by twenty is exactly what buys
+//!   the resolution, and [`chunks`] does it. A file vector still answers
+//!   "what is this module about", which no symbol can, so both rungs stay.
 //! - **The fingerprint is the invalidation.** A vector is keyed
 //!   `(file_id, fingerprint)` and carries the content hash it was computed
 //!   from, so changing the embedder or the file content makes the old vector
@@ -350,6 +354,8 @@ fn decode(bytes: &[u8]) -> Vec<f32> {
         .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
         .collect()
 }
+
+pub mod chunks;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Chunk vectors: the pieces a file is made of, embedded one at a time.
+//!
+//! # The measurement
+//!
+//! [`super`] embeds one vector per **file**. Asked *"where is the prompt cache
+//! engaged on outbound requests"* against this workspace, that index returned
+//! ten files scoring 0.656 down to 0.604 — a **0.05 spread across ten
+//! results**, which is a tie wearing a ranking's clothes — and the file that
+//! actually engages the cache was not among them. Its *test file* was, at rank
+//! ten.
+//!
+//! Neither half of that is a tuning problem. Averaging a 900-line multi-topic
+//! file into one 1024-dimension vector destroys the distinctions a query is
+//! asking about; `render_file_text` already concedes it by truncating at
+//! `MAX_CONTENT_CHARS` because "a whole large file dilutes its own vector
+//! besides". This module embeds the parts instead: **27,150 symbols against
+//! 1,431 files**, a 19x sharper index over text the indexer has already read.
+//!
+//! A sharper index is also what makes a *relevance threshold* possible at all.
+//! A cutoff over scores spanning 0.05 admits everything or nothing; there is
+//! no line to draw until the vectors spread.
+//!
+//! # A chunk is not a symbol
+//!
+//! It is anything with a file, a name, a kind and a line span — a function, a
+//! markdown section (this crate's `markdown` module), and later a table
+//! definition. They share one table because they share one **vector space**:
+//! the same embedder under the same fingerprint, so a doc section's score and
+//! a function's score are genuinely comparable rather than two scales glued
+//! together. That is the difference between this and the strategy ladder in
+//! `search`, where fusing scores would make the answer's `via:` line a lie.
+//!
+//! # Why the key is a content hash
+//!
+//! `store::index_one` replaces a changed file's symbols wholesale — one
+//! `DELETE ... WHERE file_id = ?` and fresh inserts — so `code_graph_symbols.id`
+//! is not stable across a re-parse. Keying a vector on it (with the
+//! `ON DELETE CASCADE` such a key implies) would discard every vector in a
+//! file whenever any line of that file changed. Hashing the chunk's own
+//! rendered text instead means an untouched function in an edited file is
+//! **re-stamped, not re-bought**, which is the whole point of an incremental
+//! pass. See the DDL comment in `store.rs` for the full argument.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use rusqlite::{Connection, Transaction, params};
+use stella_embed::rank::{Candidate, Scored};
+
+use crate::error::GraphError;
+use crate::store;
+
+/// How many *files* one pass will chunk-embed. Files rather than chunks
+/// because a file's chunks are written as one unit: the sweep that deletes
+/// vanished chunks keys on the file hash, so a file split across two passes
+/// would have its first half swept away by its second.
+pub const MAX_FILES_PER_CHUNK_PASS: usize = 64;
+
+/// How much of a chunk's body reaches the embedder.
+///
+/// Smaller than the whole-file cap on purpose: a chunk is already
+/// the unit of meaning, so the cap is a guard against one pathological
+/// generated function rather than the summarisation device it has to be for a
+/// whole file. Roughly 1,000 tokens — past any hand-written function.
+const MAX_CHUNK_CHARS: usize = 4_000;
+
+/// One chunk that needs attention on this pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingChunk {
+    /// The chunk's name — a symbol name, or a markdown section's breadcrumb.
+    pub name: String,
+    /// [`crate::SymbolKind::tag`], carried as text so the vector table does
+    /// not have to know this crate's enum.
+    pub kind: String,
+    /// 1-based, inclusive, as everywhere else in this crate.
+    pub start_line: u32,
+    pub end_line: u32,
+    /// sha256 of [`render_chunk_text`]'s output — the vector's identity.
+    pub chunk_sha256: String,
+    /// The text to embed, or `None` when a vector for this exact
+    /// `(file, chunk_sha256, fingerprint)` already exists and the row only
+    /// needs re-stamping with the file's current hash. **`None` is the
+    /// incremental win**: it is a chunk that survived an edit to its file.
+    pub text: Option<String>,
+}
+
+/// One file's chunks, all of them, as a single unit of work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingChunkFile {
+    /// Workspace-relative, forward-slash path.
+    pub path: String,
+    /// The file's current content hash — what the stored rows get stamped
+    /// with, and what the sweep compares against.
+    pub file_sha256: String,
+    /// Every chunk the file currently has, in `start_line` order. Chunks
+    /// whose `text` is `None` need no embedding.
+    pub chunks: Vec<PendingChunk>,
+}
+
+impl PendingChunkFile {
+    /// How many of this file's chunks actually need an embedder round trip.
+    #[must_use]
+    pub fn to_embed(&self) -> usize {
+        self.chunks.iter().filter(|c| c.text.is_some()).count()
+    }
+}
+
+/// What one [`pending_chunks`] scan found.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PendingChunkScan {
+    /// Files with work to do, ordered by path, at most `limit` of them.
+    pub files: Vec<PendingChunkFile>,
+    /// Indexed files stepped over because their content could not be read.
+    /// Counted over the rows this scan walked, matching
+    /// [`super::PendingScan::unreadable`]'s contract exactly (#3016).
+    pub unreadable: usize,
+}
+
+/// A chunk on its way back to storage.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChunkVector {
+    pub chunk_sha256: String,
+    pub name: String,
+    pub kind: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    /// `None` re-stamps the existing row rather than replacing its vector —
+    /// the caller passes `None` back for every [`PendingChunk`] that arrived
+    /// with `text: None`.
+    pub vector: Option<Vec<f32>>,
+}
+
+/// One ranked chunk, with everything needed to cite it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoredChunk {
+    pub path: String,
+    pub name: String,
+    pub kind: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    /// Cosine similarity against the query, in `[-1.0, 1.0]`.
+    pub score: f32,
+}
+
+/// Turn one chunk into the text an embedder sees.
+///
+/// Path and name first, for the reason [`super::render_file_text`] leads with
+/// the path: a model reading
+/// `crates/stella-model/src/anthropic.rs :: apply_cache_control (function)`
+/// has most of what it needs before a line of body. Deliberately plain — no
+/// headings a tokenizer spends budget on.
+///
+/// Pure: no I/O, no clock, no environment. The same inputs render the same
+/// bytes forever, which is what makes the hash of this output a valid identity
+/// for the vector computed from it.
+#[must_use]
+pub fn render_chunk_text(rel_path: &str, name: &str, kind: &str, body: &str) -> String {
+    let mut out = String::with_capacity(MAX_CHUNK_CHARS + 128);
+    out.push_str(rel_path);
+    out.push_str(" :: ");
+    out.push_str(name);
+    out.push_str(" (");
+    out.push_str(kind);
+    out.push_str(")\n\n");
+    // `char_indices` rather than a byte slice: truncating a UTF-8 sequence
+    // would make the render depend on where the cut landed.
+    match body.char_indices().nth(MAX_CHUNK_CHARS) {
+        Some((byte, _)) => out.push_str(&body[..byte]),
+        None => out.push_str(body),
+    }
+    out
+}
+
+/// The 1-based, inclusive line range `start..=end` of `content`.
+///
+/// Total: a span running past the end of the file yields what there is, and an
+/// inverted span yields the empty string. A stale span cannot be an error here
+/// — the index and the file on disk are read at different instants by
+/// construction.
+#[must_use]
+pub fn line_span(content: &str, start_line: u32, end_line: u32) -> String {
+    if start_line == 0 || end_line < start_line {
+        return String::new();
+    }
+    content
+        .lines()
+        .skip(start_line as usize - 1)
+        .take((end_line - start_line) as usize + 1)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Up to `limit` files whose chunks are not fully embedded under
+/// `fingerprint`, with each chunk rendered and hashed.
+///
+/// "Not fully embedded" is a pure count comparison — how many symbols the file
+/// has against how many chunk vectors it carries stamped with the file's
+/// *current* hash. That is what keeps a scan over an up-to-date workspace from
+/// re-reading every file on disk to discover there is nothing to do.
+///
+/// Ordered by path and resumed through a path cursor, filling **past**
+/// unreadable files rather than spending the window on them — the same
+/// discipline [`super::pending`] uses, and for the same reason (#3016).
+pub fn pending_chunks(
+    conn: &Connection,
+    root: &Path,
+    fingerprint: &str,
+    limit: usize,
+) -> Result<PendingChunkScan, GraphError> {
+    let mut stmt = conn.prepare(
+        "SELECT f.id, f.path, f.content_sha256 \
+         FROM code_graph_files f \
+         WHERE f.path > ?2 \
+           AND (SELECT COUNT(*) FROM code_graph_symbols s WHERE s.file_id = f.id) > \
+               (SELECT COUNT(*) FROM code_graph_chunk_vectors v \
+                WHERE v.file_id = f.id AND v.fingerprint = ?1 \
+                  AND v.file_sha256 = f.content_sha256) \
+         ORDER BY f.path \
+         LIMIT ?3",
+    )?;
+
+    let mut scan = PendingChunkScan::default();
+    // The empty string sorts before every non-empty path under SQLite's
+    // BINARY collation, so the first round starts at the beginning.
+    let mut cursor = String::new();
+    while scan.files.len() < limit {
+        let want = limit - scan.files.len();
+        let rows: Vec<(i64, String, String)> = stmt
+            .query_map(params![fingerprint, cursor, want as i64], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })?
+            .collect::<Result<_, _>>()?;
+        let Some((_, last, _)) = rows.last() else {
+            break;
+        };
+        cursor = last.clone();
+
+        for (file_id, path, file_sha256) in rows {
+            let Ok(content) = std::fs::read_to_string(root.join(&path)) else {
+                scan.unreadable += 1;
+                continue;
+            };
+            let already = embedded_hashes(conn, file_id, fingerprint)?;
+            let chunks: Vec<PendingChunk> = store::symbols_in_file(conn, &path)?
+                .into_iter()
+                .map(|def| {
+                    let kind = def.kind.tag().to_string();
+                    let body = line_span(&content, def.start_line, def.end_line);
+                    let text = render_chunk_text(&path, &def.name, &kind, &body);
+                    let chunk_sha256 = store::sha256_hex(text.as_bytes());
+                    let needed = !already.contains(&chunk_sha256);
+                    PendingChunk {
+                        name: def.name,
+                        kind,
+                        start_line: def.start_line,
+                        end_line: def.end_line,
+                        chunk_sha256,
+                        text: needed.then_some(text),
+                    }
+                })
+                .collect();
+            if chunks.is_empty() {
+                continue;
+            }
+            scan.files.push(PendingChunkFile {
+                path,
+                file_sha256,
+                chunks,
+            });
+        }
+    }
+    Ok(scan)
+}
+
+/// Every chunk hash already stored for `file_id` under `fingerprint`.
+fn embedded_hashes(
+    conn: &Connection,
+    file_id: i64,
+    fingerprint: &str,
+) -> Result<HashSet<String>, GraphError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT chunk_sha256 FROM code_graph_chunk_vectors \
+         WHERE file_id = ?1 AND fingerprint = ?2",
+    )?;
+    let rows = stmt.query_map(params![file_id, fingerprint], |row| row.get::<_, String>(0))?;
+    Ok(rows.collect::<Result<_, _>>()?)
+}
+
+/// Write one file's chunks under `fingerprint`, then sweep what no longer
+/// exists. Returns how many rows were written or re-stamped.
+///
+/// **One file per call, one transaction, and the sweep is why.** After the
+/// upserts, every row for this `(file, fingerprint)` still carrying an older
+/// `file_sha256` is a chunk the file no longer has — a deleted function, a
+/// renamed heading — and is removed. Splitting a file across two calls would
+/// let the first half's rows be swept by the second, which is exactly why
+/// [`pending_chunks`] caps on files rather than on chunks.
+///
+/// A path the index has since dropped is skipped rather than resurrected,
+/// matching [`super::store_vectors`].
+pub fn store_chunk_vectors(
+    conn: &mut Connection,
+    fingerprint: &str,
+    path: &str,
+    file_sha256: &str,
+    chunks: &[ChunkVector],
+) -> Result<usize, GraphError> {
+    let tx = conn.transaction()?;
+    let written = write_chunks(&tx, fingerprint, path, file_sha256, chunks)?;
+    tx.commit()?;
+    Ok(written)
+}
+
+fn write_chunks(
+    tx: &Transaction<'_>,
+    fingerprint: &str,
+    path: &str,
+    file_sha256: &str,
+    chunks: &[ChunkVector],
+) -> Result<usize, GraphError> {
+    let file_id: Option<i64> = tx
+        .prepare_cached("SELECT id FROM code_graph_files WHERE path = ?1")?
+        .query_row(params![path], |row| row.get(0))
+        .ok();
+    let Some(file_id) = file_id else {
+        return Ok(0);
+    };
+
+    let now = store::now_unix();
+    let mut written = 0usize;
+    {
+        let mut insert = tx.prepare_cached(
+            "INSERT INTO code_graph_chunk_vectors\
+               (file_id, chunk_sha256, fingerprint, file_sha256, name, kind, \
+                start_line, end_line, dims, vector, embedded_at) \
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
+             ON CONFLICT(file_id, chunk_sha256, fingerprint) DO UPDATE SET \
+               file_sha256 = excluded.file_sha256, \
+               name        = excluded.name, \
+               kind        = excluded.kind, \
+               start_line  = excluded.start_line, \
+               end_line    = excluded.end_line",
+        )?;
+        // Re-stamping a surviving chunk: the row keeps its vector and takes
+        // the new file hash and line span. The span is the half that moves —
+        // an edit above a function shifts it without changing a byte of it.
+        let mut restamp = tx.prepare_cached(
+            "UPDATE code_graph_chunk_vectors \
+             SET file_sha256 = ?4, name = ?5, kind = ?6, start_line = ?7, end_line = ?8 \
+             WHERE file_id = ?1 AND chunk_sha256 = ?2 AND fingerprint = ?3",
+        )?;
+
+        for chunk in chunks {
+            let touched = match &chunk.vector {
+                Some(vector) => insert.execute(params![
+                    file_id,
+                    chunk.chunk_sha256,
+                    fingerprint,
+                    file_sha256,
+                    chunk.name,
+                    chunk.kind,
+                    chunk.start_line,
+                    chunk.end_line,
+                    vector.len() as i64,
+                    super::encode(vector),
+                    now,
+                ])?,
+                None => restamp.execute(params![
+                    file_id,
+                    chunk.chunk_sha256,
+                    fingerprint,
+                    file_sha256,
+                    chunk.name,
+                    chunk.kind,
+                    chunk.start_line,
+                    chunk.end_line,
+                ])?,
+            };
+            written += touched;
+        }
+    }
+
+    tx.execute(
+        "DELETE FROM code_graph_chunk_vectors \
+         WHERE file_id = ?1 AND fingerprint = ?2 AND file_sha256 <> ?3",
+        params![file_id, fingerprint, file_sha256],
+    )?;
+    Ok(written)
+}
+
+/// Rank every stored chunk under `fingerprint` against `query`.
+///
+/// The ranking itself is [`stella_embed::rank::top_k`] — pure, total and
+/// property-tested there — so this function only gets the vectors out of
+/// SQLite and hands them over, the invariant-2 split [`super::rank`] already
+/// makes.
+///
+/// Candidates are keyed `path#line#name` rather than by rowid: the key is
+/// `top_k`'s tie-break, so it has to be both unique per chunk and *stable
+/// across rebuilds of the database*, which a rowid is not.
+pub fn rank_chunks(
+    conn: &Connection,
+    fingerprint: &str,
+    query: &[f32],
+    floor: f32,
+    limit: usize,
+) -> Result<Vec<ScoredChunk>, GraphError> {
+    let mut stmt = conn.prepare(
+        "SELECT f.path, v.name, v.kind, v.start_line, v.end_line, v.vector \
+         FROM code_graph_chunk_vectors v \
+         JOIN code_graph_files f ON f.id = v.file_id \
+         WHERE v.fingerprint = ?1 \
+         ORDER BY f.path, v.start_line, v.name",
+    )?;
+    let rows: Vec<(ScoredChunk, Vec<f32>)> = stmt
+        .query_map(params![fingerprint], |row| {
+            let blob: Vec<u8> = row.get(5)?;
+            Ok((
+                ScoredChunk {
+                    path: row.get(0)?,
+                    name: row.get(1)?,
+                    kind: row.get(2)?,
+                    start_line: row.get(3)?,
+                    end_line: row.get(4)?,
+                    score: 0.0,
+                },
+                super::decode(&blob),
+            ))
+        })?
+        .collect::<Result<_, _>>()?;
+
+    let keys: Vec<String> = rows.iter().map(|(chunk, _)| candidate_key(chunk)).collect();
+    let candidates: Vec<Candidate<'_>> = keys
+        .iter()
+        .zip(&rows)
+        .map(|(key, (_, vector))| Candidate {
+            key: key.as_str(),
+            vector: vector.as_slice(),
+        })
+        .collect();
+
+    let scored: Vec<Scored> = stella_embed::rank::top_k(query, &candidates, floor, limit);
+    let by_key: std::collections::HashMap<&str, &ScoredChunk> = keys
+        .iter()
+        .zip(&rows)
+        .map(|(key, (chunk, _))| (key.as_str(), chunk))
+        .collect();
+
+    Ok(scored
+        .into_iter()
+        .filter_map(|hit| {
+            by_key.get(hit.key.as_str()).map(|chunk| ScoredChunk {
+                score: hit.score,
+                ..(*chunk).clone()
+            })
+        })
+        .collect())
+}
+
+/// The rank key for one chunk: unique within a database, and stable across
+/// rebuilds of it. Zero-padded so the ordering the key imposes on a tie is the
+/// document order a reader expects rather than a lexical one.
+fn candidate_key(chunk: &ScoredChunk) -> String {
+    format!(
+        "{}#{:08}#{}",
+        chunk.path, chunk.start_line, chunk.name
+    )
+}
+
+/// How many chunks carry a vector under `fingerprint`.
+pub fn chunk_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphError> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM code_graph_chunk_vectors WHERE fingerprint = ?1",
+        params![fingerprint],
+        |row| row.get(0),
+    )?;
+    Ok(count.max(0) as usize)
+}

--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -559,17 +559,73 @@ fn open_graph(root: &Path) -> Option<crate::graph::OpenedGraph> {
     crate::graph::open_or_build(root).ok()
 }
 
+/// Report the index's size, distinguishing "empty" from "could not be
+/// counted".
+///
+/// Every count here used to be `.unwrap_or(0)` beside a flat `"built": true`,
+/// so a workspace whose graph existed but whose counts all failed rendered
+/// **identically** to one that was indexed and genuinely held nothing:
+/// `built: true, files: 0, symbols: 0, imports: 0`. A real bench trial
+/// reported exactly that shape against an `/app` workspace with a committed,
+/// non-empty baseline, and the reading was unfalsifiable from the output
+/// alone — which is the whole defect in #3087, independent of its cause.
+///
+/// A failed count is now `null` with the error named, and `built` says which
+/// of the three states this is rather than asserting the cheerful one.
 fn index_section(graph: &stella_graph::CodeGraph, index_warning: Option<&str>) -> Value {
+    index_json(
+        graph.file_count().map_err(|e| e.to_string()),
+        graph.symbol_count().map_err(|e| e.to_string()),
+        graph.import_count().map_err(|e| e.to_string()),
+        index_warning,
+    )
+}
+
+/// The decision half of [`index_section`], with no database in it.
+///
+/// Split out so the case that matters — a count that *failed* — is reachable
+/// from a test at all. Reproducing it through `CodeGraph` would mean
+/// corrupting a SQLite file mid-flight, which is why the old shape went
+/// unchallenged: nothing could exhibit it.
+fn index_json(
+    files: Result<usize, String>,
+    symbols: Result<usize, String>,
+    imports: Result<usize, String>,
+    index_warning: Option<&str>,
+) -> Value {
+    // Each count reports its own truth — a count that succeeded is a fact and
+    // nulling it would discard one — while a single failure is enough to
+    // retract `built` and name the error. That pairing is what makes the
+    // section unambiguous: a number is real, a `null` is unknown, and
+    // `built: false` says not to read the section as a description of the
+    // workspace.
+    let count_error = files
+        .as_ref()
+        .err()
+        .or(symbols.as_ref().err())
+        .or(imports.as_ref().err())
+        .cloned();
+
     let mut section = json!({
-        "built": true,
-        "files": graph.file_count().unwrap_or(0),
-        "symbols": graph.symbol_count().unwrap_or(0),
-        "imports": graph.import_count().unwrap_or(0),
+        // `true` is now a claim about having *read* the index, not merely
+        // about having opened it.
+        "built": count_error.is_none(),
+        "files": files.ok(),
+        "symbols": symbols.ok(),
+        "imports": imports.ok(),
         // The index is a point-in-time build, so anything written since is
         // invisible here. Saying so is what keeps a stale answer from being
         // mistaken for a current one.
         "freshness": "caught up to the working tree when this call ran",
     });
+    if let Some(error) = count_error {
+        let map = section.as_object_mut().expect("object literal");
+        map.insert(
+            "freshness".into(),
+            json!("UNKNOWN — the index opened but could not be counted"),
+        );
+        map.insert("count_error".into(), json!(error));
+    }
     // A failed catch-up pass makes the freshness claim above a lie, so it is
     // reported here — in the object the model reads — rather than printed over
     // the TUI frame (#643).
@@ -725,6 +781,69 @@ fn language_of(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The defect #3087 was reported through: a graph that opens but cannot be
+    /// counted must not render identically to one that is genuinely empty.
+    ///
+    /// Before this, every count was `.unwrap_or(0)` beside a literal
+    /// `"built": true`, so both cases produced
+    /// `built: true, files: 0, symbols: 0, imports: 0` and no reader could
+    /// tell them apart — which is exactly what a real bench trial reported
+    /// against an `/app` workspace that git had a non-empty baseline for.
+    #[test]
+    fn a_countable_and_an_uncountable_index_do_not_render_identically() {
+        let empty = index_json(Ok(0), Ok(0), Ok(0), None);
+        let broken = index_json(
+            Err("no such table: code_graph_files".into()),
+            Ok(0),
+            Ok(0),
+            None,
+        );
+        assert_ne!(
+            empty, broken,
+            "an unreadable index and an empty one must be distinguishable"
+        );
+
+        assert_eq!(empty["built"], serde_json::json!(true));
+        assert_eq!(empty["files"], serde_json::json!(0));
+
+        assert_eq!(
+            broken["built"],
+            serde_json::json!(false),
+            "`built` claims the index was READ, not merely opened"
+        );
+        assert!(
+            broken["files"].is_null(),
+            "a count that failed is null, never a confident zero"
+        );
+        assert_eq!(
+            broken["count_error"],
+            serde_json::json!("no such table: code_graph_files"),
+            "the reason is named, not summarised away"
+        );
+    }
+
+    /// A partial failure reports exactly what it knows: the counts that
+    /// succeeded stay (they are facts, and discarding them would lose real
+    /// information), the one that failed is `null`, and `built: false` plus
+    /// the named error is what stops the section being read as a description
+    /// of the workspace.
+    #[test]
+    fn a_partial_failure_keeps_the_facts_and_retracts_the_claim() {
+        let broken = index_json(Ok(12), Err("disk I/O error".into()), Ok(7), None);
+        assert_eq!(broken["files"], serde_json::json!(12));
+        assert_eq!(broken["imports"], serde_json::json!(7));
+        assert!(
+            broken["symbols"].is_null(),
+            "only the count that failed is unknown"
+        );
+        assert_eq!(
+            broken["built"],
+            serde_json::json!(false),
+            "one failure is still enough to retract the claim that the index was read"
+        );
+        assert_eq!(broken["count_error"], serde_json::json!("disk I/O error"));
+    }
 
     /// A truly empty workspace (no source at all) still answers, with an
     /// index that built but found nothing — never an error that would send

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -123,9 +123,26 @@ pub(crate) mod scan;
 #[cfg(test)]
 mod tests;
 
-/// Files ranked back to the model. Enough to choose from, few enough that the
-/// answer stays a pointer rather than a paste.
-const MAX_HITS: usize = 10;
+/// The most hits any one strategy will consider, as a **memory and latency
+/// guard — not as the shape of the answer**.
+///
+/// What is relevant is decided by [`stella_embed::rank::relevant_prefix`] plus
+/// the admission floor, and how much of it fits is decided by the budget. A
+/// count decides neither, because a count is wrong in both directions at once:
+/// a query whose answer genuinely spans forty chunks was truncated at ten with
+/// no way for the caller to tell it had been, and a query with two real hits
+/// returned ten, where the eight passengers read as findings.
+///
+/// It stays as a ceiling only because ranking is a full scan over every stored
+/// vector, and a pathological query against a monorepo should not materialise
+/// a hundred thousand scored rows to then throw nearly all of them away.
+/// Reaching it is reported, never silent.
+const RANK_CEILING: usize = 200;
+
+/// The most hits the two index-free strategies return. They have no score to
+/// threshold on — a name match either matched or did not — so a count is the
+/// only bound available to them, and the honest one.
+const MAX_NAME_HITS: usize = 10;
 
 /// Files embedded per backend request — one request stays inside every
 /// documented body limit while still amortising the round trip.
@@ -441,7 +458,7 @@ pub(crate) async fn dispatch(
 
     if let Some(graph) = graph {
         strategies.push(Strategy::GraphNames);
-        let hits = enrich::name_hits(graph, query, MAX_HITS);
+        let hits = enrich::name_hits(graph, query, MAX_NAME_HITS);
         if !hits.is_empty() {
             return Answer {
                 hits,
@@ -453,7 +470,7 @@ pub(crate) async fn dispatch(
 
     strategies.push(Strategy::FileScan);
     Answer {
-        hits: scan::scan_hits(root, query, MAX_HITS),
+        hits: scan::scan_hits(root, query, MAX_NAME_HITS),
         strategies,
         note,
     }
@@ -461,6 +478,14 @@ pub(crate) async fn dispatch(
 
 /// Embed what is pending, embed the query, rank. `Err` carries a reason
 /// already phrased for the answer's note.
+///
+/// **Chunks first, files as the fallback.** A chunk vector names the symbol or
+/// the documentation section that matched, which is both a sharper ranking and
+/// a citation; a file vector answers "what is this module about", which no
+/// chunk can, and is what a workspace whose chunk pass has not run yet still
+/// has. A file whose chunks matched is reported once, at its best chunk's
+/// score, with that chunk named — so the answer keeps the shape callers
+/// already read while the score finally means something specific.
 async fn semantic_hits(
     graph: &CodeGraph,
     embedder: &dyn Embedder,
@@ -468,6 +493,7 @@ async fn semantic_hits(
 ) -> Result<Vec<Hit>, String> {
     let fingerprint = embedder.fingerprint().id();
     catch_up_embeddings(graph, embedder, &fingerprint).await?;
+    catch_up_chunk_embeddings(graph, embedder, &fingerprint).await?;
 
     let query_vector = match embedder.embed(&[query.to_string()]).await {
         Ok(mut vectors) if !vectors.is_empty() => vectors.remove(0).vector,
@@ -482,21 +508,74 @@ async fn semantic_hits(
         SimilarityPosture::Surface => f32::NEG_INFINITY,
     };
 
+    let chunks = graph
+        .rank_chunks_by_vector(&fingerprint, &query_vector, floor, RANK_CEILING)
+        .map_err(|error| format!("the chunk index could not be read: {error}"))?;
+    if !chunks.is_empty() {
+        return Ok(group_chunks_by_file(&chunks));
+    }
+
     graph
-        .rank_files_by_vector(&fingerprint, &query_vector, floor, MAX_HITS)
+        .rank_files_by_vector(&fingerprint, &query_vector, floor, RANK_CEILING)
         .map(|ranked| {
+            let cut = stella_embed::rank::relevant_prefix(
+                &ranked,
+                stella_embed::rank::DEFAULT_RELEVANCE_GAP_RATIO,
+                stella_embed::rank::DEFAULT_MIN_BOUNDARY_GAP,
+            );
             ranked
                 .into_iter()
+                .take(cut)
                 .map(|scored| Hit {
                     path: scored.key,
                     why: format!(
-                        "ranked by MEANING against your query (cosine {:.3})",
+                        "ranked by MEANING against your query, over the whole file \
+                         (cosine {:.3})",
                         scored.score
                     ),
                 })
                 .collect()
         })
         .map_err(|error| format!("the vector index could not be read: {error}"))
+}
+
+/// Collapse a chunk ranking to one hit per file, best chunk first.
+///
+/// The relevance cut is applied to the **chunk** ranking rather than to the
+/// grouped one, because the boundary is a property of the scores and grouping
+/// discards scores. Cutting after the grouping would measure gaps between
+/// per-file maxima, which is a different and much sparser distribution than
+/// the one the boundary was defined over.
+fn group_chunks_by_file(chunks: &[stella_graph::ScoredChunk]) -> Vec<Hit> {
+    let cut = stella_embed::rank::relevant_prefix(
+        &chunks
+            .iter()
+            .map(|chunk| stella_embed::rank::Scored {
+                key: format!("{}#{}#{}", chunk.path, chunk.start_line, chunk.name),
+                score: chunk.score,
+            })
+            .collect::<Vec<_>>(),
+        stella_embed::rank::DEFAULT_RELEVANCE_GAP_RATIO,
+        stella_embed::rank::DEFAULT_MIN_BOUNDARY_GAP,
+    );
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut hits: Vec<Hit> = Vec::new();
+    for chunk in chunks.iter().take(cut) {
+        if seen.iter().any(|path| path == &chunk.path) {
+            continue;
+        }
+        seen.push(chunk.path.clone());
+        hits.push(Hit {
+            path: chunk.path.clone(),
+            why: format!(
+                "ranked by MEANING against your query — best match is `{}` ({}) at line {} \
+                 (cosine {:.3})",
+                chunk.name, chunk.kind, chunk.start_line, chunk.score
+            ),
+        });
+    }
+    hits
 }
 
 /// Embed every indexed file still pending under `fingerprint`, up to the
@@ -531,6 +610,70 @@ async fn catch_up_embeddings(
             // into the same broken store and the pass would report success
             // having stored nothing.
             .map_err(|error| format!("the vector index could not be written: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Embed every indexed chunk still pending under `fingerprint`, up to the
+/// per-pass cap.
+///
+/// **One file per store call**, because the store's sweep — the thing that
+/// removes a deleted function's vector — keys on the file's content hash, so
+/// writing half a file's chunks and then the other half would have the second
+/// write delete the first's rows.
+///
+/// A chunk whose rendered text is unchanged arrives with no `text` and costs
+/// no request: it is re-stamped with the file's new hash and keeps its vector.
+/// That is what makes editing one function in a 60-symbol file cost one
+/// embedding rather than sixty.
+async fn catch_up_chunk_embeddings(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    fingerprint: &str,
+) -> Result<(), String> {
+    let scan = graph
+        .chunks_pending_embedding(fingerprint, stella_graph::MAX_FILES_PER_CHUNK_PASS)
+        .map_err(|error| format!("the code graph could not be read: {error}"))?;
+
+    for file in &scan.files {
+        let mut vectors: Vec<Option<Vec<f32>>> = vec![None; file.chunks.len()];
+        let needed: Vec<(usize, &str)> = file
+            .chunks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, chunk)| chunk.text.as_deref().map(|text| (index, text)))
+            .collect();
+
+        for batch in needed.chunks(EMBED_BATCH) {
+            let texts: Vec<String> = batch.iter().map(|(_, text)| (*text).to_string()).collect();
+            let embeddings = embedder
+                .embed(&texts)
+                .await
+                .map_err(|error| format!("the embedder failed: {error}"))?;
+            for ((index, _), embedding) in batch.iter().zip(embeddings) {
+                vectors[*index] = Some(embedding.vector);
+            }
+        }
+
+        let rows: Vec<stella_graph::ChunkVector> = file
+            .chunks
+            .iter()
+            .zip(vectors)
+            .map(|(chunk, vector)| stella_graph::ChunkVector {
+                chunk_sha256: chunk.chunk_sha256.clone(),
+                name: chunk.name.clone(),
+                kind: chunk.kind.clone(),
+                start_line: chunk.start_line,
+                end_line: chunk.end_line,
+                vector,
+            })
+            .collect();
+        graph
+            .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
+            // Not recoverable by continuing: the next file would be written
+            // into the same broken store and the pass would report success
+            // having stored nothing.
+            .map_err(|error| format!("the chunk index could not be written: {error}"))?;
     }
     Ok(())
 }

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,8 +7,8 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1839 bench/harbor_adapter/stella_harbor/__init__.py
-4366 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1845 bench/harbor_adapter/stella_harbor/__init__.py
+4367 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2352 bench/harbor_adapter/tests/test_adapter.py
 3368 bench/harbor_adapter/tests/test_secure_launcher.py
 8298 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
Makes `search` precise enough to be worth choosing over `bash | grep`, and makes two measurement surfaces stop lying about what they know.

Closes #3087. Refs #3089, #3063.

## The measurement this starts from

One query against the real index — *"where is the prompt cache engaged on outbound requests"*:

```
 1 crates/stella-protocol/src/cache.rs              0.656
 ...
10 crates/stella-model/src/anthropic/tests/cache_breakpoints.rs  0.604
```

Two defects at once. The answer (`crates/stella-model/src/anthropic.rs`) is **absent** — only its test file appears, at rank 10. And the spread is **0.05 across ten results**, which is a tie wearing a ranking's clothes.

Neither is a tuning problem. One vector per file averages a 900-line multi-topic file into 1024 dimensions; `render_file_text` already conceded the point by truncating at 6,000 chars.

## What changed

**Markdown is indexed** (`stella-graph`). 165 markdown files — `AGENTS.md`, `CLAUDE.md`, every crate README, all of `docs/spec/` — had zero rows in `code_graph_files`. The invariants governing this repository were unsearchable *by the agent that has to obey them*. `Language::Markdown`'s parser is a line scan in this crate rather than a tree-sitter grammar: the index needs one fact per document (where each ATX heading starts, which headings enclose it), and a missed heading yields a coarser section, never a wrong one. A section spans to the **next heading of any level**, not to the end of its subtree — subtree scoping would make the top heading's body the whole document, which is the dilution we are escaping.

**Chunk vectors** (`code_graph_chunk_vectors`). A chunk is anything with a file, a name, a kind and a line span. One table, because they share one **vector space** — same embedder, same fingerprint — so a doc section's score and a function's score are genuinely comparable. `kind` is what later lets an answer be grouped by role instead of truncated down one list.

**`search` ranks chunks** and reports one hit per file at its best chunk's score, naming that chunk. The score means something specific and the hit carries a citation. File vectors remain the fallback: they answer "what is this module about", which no chunk can.

**`MAX_HITS` is gone as a shaping device.** A fixed count is wrong in both directions at once — it truncates a forty-chunk answer invisibly, and pads a two-hit answer with eight passengers that read as findings.

**#3087**, both halves — see the commit for the full argument.

## Deliberate departure from #3089's proposed schema

#3089 specifies `code_graph_symbol_vectors(symbol_id REFERENCES code_graph_symbols(id) ON DELETE CASCADE)`. **That schema cannot work here**, and the reason is in `store.rs::index_one`: a changed file's symbols are replaced wholesale (`DELETE ... WHERE file_id = ?` then fresh inserts), so symbol ids are not stable across a re-parse. The cascade would discard **every** vector in a file on **any** edit to that file — destroying precisely the incremental property #3089's own `content_sha256` requirement exists to protect, before that hash could save anything.

So the row is content-addressed on the chunk's own rendered text, with `file_sha256` carried alongside to make "is this file fully embedded" a pure SQL count comparison and to key the sweep that removes vanished chunks.

## Witnesses

- `markdown::tests` — 14, including span/fence/breadcrumb properties.
- `rank::tests::the_file_level_ranking_that_motivated_this_does_not_resolve` — the real measured distribution must **not** be cut into a confident answer. **This test failed first**, see below.
- `overview::tests::a_countable_and_an_uncountable_index_do_not_render_identically`.
- `tests/test_code_graph_disclosure.py` — 5; fails on `main` with `TypeError` (the kwarg does not exist).

### A test that changed the design

`relevant_prefix` was first written as a pure relative-gap rule. On the real ranking it cut to **one** result and declared `cache.rs` the answer — the widest gap (0.015) is 2.6x the mean gap. The correct answer was not in that list at all. A ratio is scale-free about a score's *level* and says nothing about its *resolution*. A boundary now has to be **both** wide relative to the ranking's other gaps **and** wide in absolute cosine.

## What is NOT claimed

- **The threshold constants are provisional and labelled so in the source** (#3096). They are not measured separations. So is the pre-existing `DEFAULT_ADMISSION_FLOOR = 0.25`, which is *inert* — `voyage-code-3` scores unrelated files at 0.604, so it drops nothing. Calibration needs a run against the real index: **#3096**, not done here.
- **The three #3089 retrieval witnesses are not in this PR.** They require an embedding key and a populated index; unit tests cannot assert them. **#3097**.
- **`stella init` does not eagerly fill the chunk table.** `search` tops it up incrementally, so the feature works from the first call, but the first call pays for it. **#3098**.

## Gate

`cargo test -p stella-graph -p stella-embed -p stella-tools` green; harbor adapter 684 passed / 2 skipped; `check-file-size.sh` green after a justified +6/+1 baseline move (everything reducible went into a new `code_graph.py` sibling module instead).

## Merge note — the baseline diff is mostly not mine

#3081 and #3094 both landed while this was in flight; `main` is merged in and the conflicts are resolved. The baseline moves `1847 → 1861` for `__init__.py`, and **only 6 of those 14 lines belong to this PR**. The other 8 arrived on `main` via #3094, which grew the file and did not update the baseline — `main`'s copy is 1855 against a recorded ceiling of 1847. Filed as **#3101**; regenerating here was the only way to be green, since the baseline is a single shared cell.

## Follow-ups filed

| | |
|---|---|
| #3096 | calibrate the three relevance constants — all provisional, and `DEFAULT_ADMISSION_FLOOR` is inert |
| #3097 | the three #3089 retrieval witnesses (need a key + a populated index) |
| #3098 | `stella init` should fill the chunk table eagerly, as it already does for file vectors |
| #3100 | #3081 deleted the only test that a closed tool set still executes a withheld tool |
| #3101 | `main`'s file-size drift from #3094 |
| #3102 | `stella init` UX — real progress in the transcript, and three costs nobody asked for |
| #3103 | markdown link edges and setext headings |

The design proposal for the labelled-section / role-grouped dossier shape is on **#3063**.

No test was deleted in this PR.
