### PR TITLE
chore(gate): retighten the file-size baseline to the tree it now judges

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -8,8 +8,8 @@
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
 1503 arenabench/arenabench/runner.py
-1847 bench/harbor_adapter/stella_harbor/__init__.py
-4380 bench/harbor_adapter/stella_harbor/secure_launcher.py
+1862 bench/harbor_adapter/stella_harbor/__init__.py
+4381 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2356 bench/harbor_adapter/tests/test_adapter.py
 3368 bench/harbor_adapter/tests/test_secure_launcher.py
 8298 bench/terminal_bench_analysis/tb21_analysis.py


### PR DESCRIPTION
Two grandfathered bench files drifted past their recorded ceilings without the baseline being regenerated in the same PR:

- `bench/harbor_adapter/stella_harbor/__init__.py` — 1862 lines against a ceiling of 1847
- `bench/harbor_adapter/stella_harbor/secure_launcher.py` — 4381 against 4380

They grew across #3081 / #3094 / #3095. Because the guard judges a change against its base rather than the whole tree (#2004), this was never fatal — `check-file-size.sh` reported it as inherited drift and passed. But every branch cut from main inherits the drift report until someone regenerates.

This is the `regenerate` remedy the script itself prescribes, run via `make file-size-update`, and landed **on its own from a fresh main** — the baseline is one shared cell that two concurrent PRs cannot both write, which is the failure mode that reddened main three times before.

**No structural slack is bought.** Both files stay in the grandfather list and stay closed to growth; the honest fix is still to split them.

### Verification
- Before: `./scripts/check-file-size.sh` reports both files as drift.
- After: `check-file-size: OK — 1430 Rust/Python/shell files, 28 grandfathered over 1500 lines, and nothing went over by this change.`

### Witness test
None — this is a generated-baseline change with no behavior change. `scripts/check-file-size.sh` is itself the check, and its before/after output is above.

### Deleted tests
None.

## Summary by Sourcery

Regenerate the file-size baseline so the size guard reflects the current main tree without introducing structural changes.

Bug Fixes:
- Resolve inherited drift in the file-size check for grandfathered harbor adapter bench files by updating their recorded ceilings.

Chores:
- Refresh scripts/file-size-baseline.txt via the prescribed make target to keep file-size enforcement aligned with the current codebase.