### PR TITLE
fix(stella-graph): gate is_grammar_backed behind #[cfg(test)]

### DIFF
--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -109,6 +109,11 @@ impl Language {
 
     /// Whether this language is parsed by a tree-sitter grammar rather than
     /// by this crate's own reader. Only [`Language::Markdown`] answers `false`.
+    ///
+    /// Test-only: production code has no reason to distinguish "compiled in"
+    /// from "conceptually grammar-backed" ([`Language::is_compiled_in`]
+    /// already answers the question anything else would ask).
+    #[cfg(test)]
     pub(crate) fn is_grammar_backed(self) -> bool {
         !matches!(self, Language::Markdown)
     }


### PR DESCRIPTION
## Summary
- `Language::is_grammar_backed` (added in #3095 alongside Markdown support) is only called from two test assertions; a normal (non-test) build flagged it as dead code.
- Gated it with `#[cfg(test)]` rather than silencing with `#[allow(dead_code)]`, since it genuinely has no production caller today — `is_compiled_in` already answers the question any production code would ask.

## Test plan
- [x] `cargo build -p stella-graph` — clean, no warnings
- [x] `cargo clippy -p stella-graph --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-graph --lib lang::` — 4/4 pass, including the two tests exercising `is_grammar_backed`

## Summary by Sourcery

Enhancements:
- Clarify documentation for `Language::is_grammar_backed` to note it is a test-only helper with no production callers.