### PR TITLE
fix(stella-graph,stella-tools): main is red — a stale test fixture, an unformatted file, and two placeholder issue ids

### DIFF
--- a/crates/stella-embed/src/rank.rs
+++ b/crates/stella-embed/src/rank.rs
@@ -214,7 +214,14 @@ mod tests {
     #[test]
     fn a_cliff_between_relevant_and_irrelevant_is_where_the_cut_lands() {
         let ranked = scores(&[0.91, 0.88, 0.86, 0.42, 0.41, 0.40, 0.39]);
-        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 3);
+        assert_eq!(
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            3
+        );
     }
 
     /// A smoothly-decaying ranking has no boundary in it. Inventing one would
@@ -224,7 +231,11 @@ mod tests {
     fn a_smooth_decay_has_no_boundary_and_is_not_cut() {
         let ranked = scores(&[0.90, 0.85, 0.80, 0.75, 0.70, 0.65]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len()
         );
     }
@@ -238,7 +249,11 @@ mod tests {
             0.656, 0.641, 0.636, 0.628, 0.621, 0.615, 0.612, 0.607, 0.606, 0.604,
         ]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len(),
             "a tie dressed as a ranking must not be cut into a confident answer"
         );
@@ -246,15 +261,29 @@ mod tests {
 
     #[test]
     fn one_hit_and_no_hits_are_both_answered_without_a_gap_to_measure() {
-        assert_eq!(relevant_prefix(&[], DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 0);
-        assert_eq!(relevant_prefix(&scores(&[0.9]), DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+        assert_eq!(
+            relevant_prefix(&[], DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            0
+        );
+        assert_eq!(
+            relevant_prefix(
+                &scores(&[0.9]),
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            1
+        );
     }
 
     #[test]
     fn an_exact_tie_across_the_whole_list_is_never_cut() {
         let ranked = scores(&[0.5, 0.5, 0.5, 0.5]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len()
         );
     }
@@ -265,7 +294,14 @@ mod tests {
     #[test]
     fn one_dominant_hit_cuts_to_one() {
         let ranked = scores(&[0.95, 0.31, 0.30, 0.29, 0.28]);
-        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+        assert_eq!(
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            1
+        );
     }
 
     proptest! {

--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -328,7 +328,11 @@ mod tests {
     /// reads to the agent as "this file declares nothing".
     #[test]
     fn detection_never_names_a_language_this_build_cannot_parse() {
-        for lang in Language::ALL.iter().copied().filter(|l| l.is_grammar_backed()) {
+        for lang in Language::ALL
+            .iter()
+            .copied()
+            .filter(|l| l.is_grammar_backed())
+        {
             assert_eq!(
                 lang.is_compiled_in(),
                 lang.ts_language().is_some(),

--- a/crates/stella-graph/src/markdown.rs
+++ b/crates/stella-graph/src/markdown.rs
@@ -78,7 +78,7 @@ pub(crate) const BREADCRUMB_SEPARATOR: &str = " › ";
 /// Pure: no I/O, no clock, no environment. Setext headings (`===`/`---`
 /// underlines) are **not** recognised — `---` is also a thematic break and
 /// also YAML frontmatter's delimiter, and guessing between them wrong would
-/// invent sections rather than miss them (#TBD-setext).
+/// invent sections rather than miss them (#3103).
 pub(crate) fn sections(source: &str) -> Vec<Symbol> {
     let mut out: Vec<Symbol> = Vec::new();
     // One entry per open heading level, so the breadcrumb of the next heading

--- a/crates/stella-graph/src/parse.rs
+++ b/crates/stella-graph/src/parse.rs
@@ -195,7 +195,7 @@ pub(crate) fn parse_file(grammars: &Grammars, lang: Language, source: &str) -> O
         Language::Sql => Vec::new(), // SQL has no imports
         // Unreachable: markdown returned above, before the pack lookup. A
         // link between documents IS an import edge and would be worth
-        // extracting, but it is a separate change (#TBD-md-links).
+        // extracting, but it is a separate change (#3103).
         Language::Markdown => Vec::new(),
         Language::Go => extract_go_imports(&pack.imports, root, src),
         Language::Java => extract_java_imports(&pack.imports, root, src),

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -464,10 +464,7 @@ pub fn rank_chunks(
 /// rebuilds of it. Zero-padded so the ordering the key imposes on a tie is the
 /// document order a reader expects rather than a lexical one.
 fn candidate_key(chunk: &ScoredChunk) -> String {
-    format!(
-        "{}#{:08}#{}",
-        chunk.path, chunk.start_line, chunk.name
-    )
+    format!("{}#{:08}#{}", chunk.path, chunk.start_line, chunk.name)
 }
 
 /// How many chunks carry a vector under `fingerprint`.

--- a/crates/stella-tools/src/graph.rs
+++ b/crates/stella-tools/src/graph.rs
@@ -987,6 +987,13 @@ mod tests {
         )
         .expect("write source");
         std::fs::write(root.join("packages/core/README.md"), "# core\n").expect("write doc");
+        // A file type nothing in this workspace indexes, for the tests that
+        // need one. It used to be the README, and markdown became an indexed
+        // language (#3089) — so the fixture, not the property, was what went
+        // stale. `.cfg` has no `Language` arm and no storage adapter claims
+        // it, which is what makes it a *permanent* non-answer rather than a
+        // stale index.
+        std::fs::write(root.join("packages/core/app.cfg"), "key = value\n").expect("write cfg");
         // The sibling checkout: real source, real files, and permanently
         // outside the indexed root.
         std::fs::create_dir_all(outer.path().join("sibling/src")).expect("mkdir");
@@ -1129,7 +1136,7 @@ mod tests {
     fn an_unindexed_file_type_is_named_rather_than_sent_to_stella_init() {
         let outer = monorepo_workspace();
         let root = outer.path().join("api");
-        let content = ok_content(run_query(&root, "neighbors", "packages/core/README.md"));
+        let content = ok_content(run_query(&root, "neighbors", "packages/core/app.cfg"));
         assert!(content.contains(NOT_INDEXED_MARKER), "{content}");
         assert!(!content.contains("index may be stale"), "{content}");
         assert_eq!(classify_answer(&content), GraphAnswer::NotIndexed);
@@ -1149,10 +1156,12 @@ mod tests {
             ("definitions", "core_util", GraphAnswer::Resolved),
             // Out of root: a sibling checkout.
             ("imports", "../sibling/src/lib.rs", GraphAnswer::OutOfRoot),
-            // Not indexed: a markdown file that really is in the workspace.
+            // Not indexed: a file that really is in the workspace and that
+            // no language or storage adapter claims. Markdown used to serve
+            // here and is an indexed language since #3089.
             (
                 "neighbors",
-                "packages/core/README.md",
+                "packages/core/app.cfg",
                 GraphAnswer::NotIndexed,
             ),
             // Unresolved, ambiguous spelling.


### PR DESCRIPTION
`main` is red. Three defects, all introduced by #3095, all mine.

## 1. Two `graph_query` tests fail on `main`

```
graph::tests::an_unindexed_file_type_is_named_rather_than_sent_to_stella_init ... FAILED
graph::tests::every_answer_branch_classifies_the_way_the_report_reads_it ... FAILED
```

Both used `packages/core/README.md` as their example of *a file type the code graph does not index*. #3089 made markdown an indexed language, so the README now resolves and both tests correctly stop seeing `NotIndexed`.

**The fixture went stale; the property did not.** What they assert is still exactly right and still worth asserting — a permanent non-answer must be *named* as one rather than sent back to `stella init`, because re-indexing can never fix it. So the fixture becomes `packages/core/app.cfg`: no `Language` arm claims `.cfg` and no storage adapter does either, which makes it a permanent non-answer for a structural reason rather than by omission. Picking another currently-unindexed *source* language would have re-armed the same trap for whoever adds that grammar next.

## 2. `cargo fmt --check` fails on `crates/stella-embed/src/rank.rs`

rustfmt had never run over the new test bodies. The formatting fix existed only in a commit that did not make it into the merge.

## 3. Two markers name issues that do not exist

`markdown.rs` and `parse.rs` carried `#TBD-setext` and `#TBD-md-links`. Both now name **#3103**, which tracks link-edge extraction and setext headings.

Worth noting for the guard's sake: `check-left-behind` does **not** catch this shape. Its patterns are `TODO`/`FIXME`/`XXX`/`HACK`, so a placeholder issue id in a doc comment is a marker with no handoff that no guard can see. That is a gap in the guard, not in this fix — filed separately if it recurs.

## Verification

```
cargo test -p stella-embed --lib     36 passed
cargo test -p stella-graph  --lib    148 passed
cargo test -p stella-tools  --lib    957 passed
cargo clippy -p stella-graph -p stella-tools --all-targets   clean
cargo fmt --all --check              clean
./scripts/check-left-behind.sh       OK
```

Each of the two tests was confirmed failing on `5d37de245` before the change and passing after — an artisanal witness in the intended direction.

## Relationship to #3104

#3104 fixes a *different* symptom of the same PR: a dead-code warning on `Language::is_grammar_backed` in a non-test build. It does not touch these three. The two can land in either order; they do not overlap.

No test was deleted in this PR.

Refs #3095, #3103.

## Summary by Sourcery

Fix failing graph query tests due to a stale unindexed-file fixture, restore rustfmt-clean state, and retag markdown/parse TODO markers to the correct tracking issue.

Bug Fixes:
- Update graph query tests to use a truly unindexed file type so NotIndexed answers are correctly exercised.
- Reformat stella-embed ranking tests to satisfy cargo fmt and keep the crate rustfmt-clean.
- Retarget markdown section and import-link placeholder comments from generic TBD markers to the concrete tracking issue #3103.

Enhancements:
- Clarify test fixture setup in the graph tools tests with commentary about permanently unindexed file types.