### PR TITLE
fix(stella-graph,stella-embed): main is red — markdown became source, and one test still says it is not

### DIFF
--- a/crates/stella-embed/src/rank.rs
+++ b/crates/stella-embed/src/rank.rs
@@ -214,7 +214,14 @@ mod tests {
     #[test]
     fn a_cliff_between_relevant_and_irrelevant_is_where_the_cut_lands() {
         let ranked = scores(&[0.91, 0.88, 0.86, 0.42, 0.41, 0.40, 0.39]);
-        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 3);
+        assert_eq!(
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            3
+        );
     }
 
     /// A smoothly-decaying ranking has no boundary in it. Inventing one would
@@ -224,7 +231,11 @@ mod tests {
     fn a_smooth_decay_has_no_boundary_and_is_not_cut() {
         let ranked = scores(&[0.90, 0.85, 0.80, 0.75, 0.70, 0.65]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len()
         );
     }
@@ -238,7 +249,11 @@ mod tests {
             0.656, 0.641, 0.636, 0.628, 0.621, 0.615, 0.612, 0.607, 0.606, 0.604,
         ]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len(),
             "a tie dressed as a ranking must not be cut into a confident answer"
         );
@@ -246,15 +261,29 @@ mod tests {
 
     #[test]
     fn one_hit_and_no_hits_are_both_answered_without_a_gap_to_measure() {
-        assert_eq!(relevant_prefix(&[], DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 0);
-        assert_eq!(relevant_prefix(&scores(&[0.9]), DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+        assert_eq!(
+            relevant_prefix(&[], DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            0
+        );
+        assert_eq!(
+            relevant_prefix(
+                &scores(&[0.9]),
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            1
+        );
     }
 
     #[test]
     fn an_exact_tie_across_the_whole_list_is_never_cut() {
         let ranked = scores(&[0.5, 0.5, 0.5, 0.5]);
         assert_eq!(
-            relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP),
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
             ranked.len()
         );
     }
@@ -265,7 +294,14 @@ mod tests {
     #[test]
     fn one_dominant_hit_cuts_to_one() {
         let ranked = scores(&[0.95, 0.31, 0.30, 0.29, 0.28]);
-        assert_eq!(relevant_prefix(&ranked, DEFAULT_RELEVANCE_GAP_RATIO, DEFAULT_MIN_BOUNDARY_GAP), 1);
+        assert_eq!(
+            relevant_prefix(
+                &ranked,
+                DEFAULT_RELEVANCE_GAP_RATIO,
+                DEFAULT_MIN_BOUNDARY_GAP
+            ),
+            1
+        );
     }
 
     proptest! {

--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -328,7 +328,11 @@ mod tests {
     /// reads to the agent as "this file declares nothing".
     #[test]
     fn detection_never_names_a_language_this_build_cannot_parse() {
-        for lang in Language::ALL.iter().copied().filter(|l| l.is_grammar_backed()) {
+        for lang in Language::ALL
+            .iter()
+            .copied()
+            .filter(|l| l.is_grammar_backed())
+        {
             assert_eq!(
                 lang.is_compiled_in(),
                 lang.ts_language().is_some(),

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -464,10 +464,7 @@ pub fn rank_chunks(
 /// rebuilds of it. Zero-padded so the ordering the key imposes on a tie is the
 /// document order a reader expects rather than a lexical one.
 fn candidate_key(chunk: &ScoredChunk) -> String {
-    format!(
-        "{}#{:08}#{}",
-        chunk.path, chunk.start_line, chunk.name
-    )
+    format!("{}#{:08}#{}", chunk.path, chunk.start_line, chunk.name)
 }
 
 /// How many chunks carry a vector under `fingerprint`.

--- a/crates/stella-graph/tests/live_index.rs
+++ b/crates/stella-graph/tests/live_index.rs
@@ -295,9 +295,11 @@ async fn irrelevant_paths_are_filtered_at_injection() {
 
     // Same filter as the real notify callback: non-source extensions,
     // ignored directories, and paths outside the workspace root never enter
-    // the pipeline.
-    let readme = fx.write("README.md", "# not source\n");
-    assert!(!fx.injector.inject(&readme));
+    // the pipeline. `.md` is deliberately NOT the example any more — markdown
+    // became a source extension in #3095, and its relevance is asserted
+    // positively by `markdown_is_a_source_extension_at_injection` below.
+    let asset = fx.write("logo.png", "not source\n");
+    assert!(!fx.injector.inject(&asset));
 
     fs::create_dir_all(fx.abs("node_modules")).unwrap();
     let vendored = fx.write("node_modules/dep.js", "export const x = 1;\n");
@@ -308,6 +310,27 @@ async fn irrelevant_paths_are_filtered_at_injection() {
 
     assert_eq!(fx.injector.batches_applied(), 0, "nothing was enqueued");
     assert_eq!(fx.graph.file_count().unwrap(), 1);
+
+    fx.graph.shutdown();
+}
+
+/// Markdown is source to this crate (#3095): `AGENTS.md`, `CLAUDE.md` and
+/// every crate README are documents the agent has to be able to search. Live
+/// indexing has to agree with `Language::from_path`, so this asserts the flip
+/// end to end — through the filter *and* into an applied batch — rather than
+/// leaving it to be inferred from an absent negative assertion.
+#[tokio::test(start_paused = true)]
+async fn markdown_is_a_source_extension_at_injection() {
+    let mut fx = Live::build(&[("a.rs", "pub fn alpha() {}\n")]);
+    assert_eq!(fx.graph.file_count().unwrap(), 1);
+
+    let readme = fx.write("README.md", "# Heading\n\nprose\n");
+    assert!(fx.injector.inject(&readme), "markdown must pass the filter");
+
+    let (seq, stats) = fx.injector.applied_past(0).await.unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(stats.files_parsed, 1);
+    assert_eq!(fx.graph.file_count().unwrap(), 2, "markdown was indexed");
 
     fx.graph.shutdown();
 }


### PR DESCRIPTION
`main` is red at `b33acc07f`. Two independent failures, both introduced by #3095 (`136d5f808`), both invisible to that PR because its own CI was green against a base that predated them.

## 1. A test whose premise expired

`live_index.rs::irrelevant_paths_are_filtered_at_injection` used `README.md` as its example of a non-source extension:

```
thread 'irrelevant_paths_are_filtered_at_injection' panicked at
crates/stella-graph/tests/live_index.rs:300:5:
assertion failed: !fx.injector.inject(&readme)
```

`is_watch_relevant` (`crates/stella-graph/src/watch.rs:70`) defers to `Language::from_path`, and #3095 added `"md" | "markdown" => Language::Markdown` — deliberately, so `AGENTS.md`, `CLAUDE.md` and every crate README are searchable by the agent that has to obey them. **The behaviour is correct; the test's premise is what expired.**

Two changes:

- The negative example becomes `logo.png` — non-source on any reading, and not something a future language addition will quietly reclassify.
- The flip is now asserted **positively** by a new test rather than inferred from an absent negative. `markdown_is_a_source_extension_at_injection` drives a `.md` write through the filter *and* into an applied batch (`files_parsed == 1`, `file_count == 2`), so live indexing disagreeing with `Language::from_path` fails loudly in either direction. That is the assertion whose absence let this drift land.

## 2. Three unformatted files

`crates/stella-embed/src/rank.rs`, `crates/stella-graph/src/lang.rs` and `crates/stella-graph/src/vectors/chunks.rs` landed without `cargo fmt`, so `format-check` was red independently of the test. Fixed by `cargo fmt --all`; the diff is confined to those three files.

## Witness test

Already observed on CI, not just claimed: run [31654301632](https://github.com/macanderson/stella/actions/runs/31654301632) is `main` at `b33acc07f` — this branch's base without this change — and it fails on `irrelevant_paths_are_filtered_at_injection`. This branch passes it.

Locally:

```
cargo test -p stella-embed -p stella-graph    # all green, 9 tests in live_index (was 8)
cargo fmt --all -- --check                    # clean
cargo clippy -p stella-graph --all-targets -- -D warnings   # clean
```

## Deleted tests

None. One test's body changed (`irrelevant_paths_are_filtered_at_injection` — same name, same job); one test added.

## Summary by Sourcery

Align live indexing behaviour with markdown being treated as source and fix formatting issues that were breaking main.

New Features:
- Add an end-to-end live indexing test asserting that markdown files pass the filter and are indexed as source documents.

Bug Fixes:
- Update the live indexing filter test to use a clearly non-source asset instead of README.md, restoring its original intent now that markdown is treated as source.

Tests:
- Strengthen live indexing coverage by adding a dedicated markdown injection test and adjusting the existing irrelevant-paths test premise.
- Reformat rank, language detection, and chunk key code to satisfy `cargo fmt` and keep format-check green.