### PR TITLE
fix(stella-tools): the not-indexed miss told the agent markdown was unindexed

### DIFF
--- a/crates/stella-tools/src/graph.rs
+++ b/crates/stella-tools/src/graph.rs
@@ -44,7 +44,7 @@ const MAX_PATH_CANDIDATES: usize = 5;
 /// The language families the index recognizes, named in the not-indexed miss
 /// so the agent learns the boundary once instead of re-probing it.
 const INDEXED_LANGUAGES: &str =
-    "rust, python, javascript, typescript, tsx, go, java, c, php, sql, prisma";
+    "rust, python, javascript, typescript, tsx, go, java, c, php, sql, markdown, prisma";
 
 // ---------------------------------------------------------------------------
 // Answer classification (#896)
@@ -552,9 +552,11 @@ fn out_of_root_answer(root: &Path, target: &str) -> Option<String> {
 }
 
 /// Distinguish "the code graph does not index this kind of file" from "indexed,
-/// no edges". A `.md`/`.toml`/`.yaml` target is a permanent non-answer; sending
+/// no edges". A `.cfg`/`.toml`/`.yaml` target is a permanent non-answer; sending
 /// the agent to `stella init` for it is the miss that teaches the tool is
-/// unreliable.
+/// unreliable. `.md` was such a target until markdown became an indexed
+/// language — the boundary is read from [`stella_graph::Language::from_path`]
+/// rather than restated here, so it moves whenever the indexer's does.
 fn unindexed_language_answer(root: &Path, target: &str) -> Option<String> {
     let full = crate::resolve_within_root(root, target)?;
     if !full.is_file() {
@@ -1140,6 +1142,39 @@ mod tests {
         assert!(content.contains(NOT_INDEXED_MARKER), "{content}");
         assert!(!content.contains("index may be stale"), "{content}");
         assert_eq!(classify_answer(&content), GraphAnswer::NotIndexed);
+    }
+
+    /// The other side of that boundary, asserted rather than assumed: markdown
+    /// is indexed, so a `.md` target must NOT come back as a permanent
+    /// non-answer. `unindexed_language_answer` reads the boundary from
+    /// `Language::from_path`, and this is what fails if the two disagree —
+    /// the fixture change alone leaves that direction uncovered.
+    #[test]
+    fn an_indexed_markdown_file_is_not_reported_as_an_unindexed_file_type() {
+        let outer = monorepo_workspace();
+        let root = outer.path().join("api");
+        let content = ok_content(run_query(&root, "neighbors", "packages/core/README.md"));
+        assert!(
+            !content.contains(NOT_INDEXED_MARKER),
+            "markdown is an indexed language: {content}"
+        );
+        assert_ne!(classify_answer(&content), GraphAnswer::NotIndexed);
+    }
+
+    /// The not-indexed miss prints `INDEXED_LANGUAGES` so the agent learns the
+    /// boundary once instead of re-probing it — which only helps if the list is
+    /// the real one. It is hand-written and had already fallen a language
+    /// behind, telling the agent that `AGENTS.md`, `CLAUDE.md` and every crate
+    /// README were outside the index while the tool was in fact resolving them.
+    #[test]
+    fn the_named_language_list_matches_what_the_indexer_accepts() {
+        for lang in stella_graph::Language::compiled_in() {
+            assert!(
+                INDEXED_LANGUAGES.contains(lang.tag()),
+                "`{}` is indexed but absent from INDEXED_LANGUAGES: {INDEXED_LANGUAGES}",
+                lang.tag()
+            );
+        }
     }
 
     /// The metric and the prose share one set of literals — this walks every


### PR DESCRIPTION
#3106 and #3107 repaired the tests that broke when markdown became an indexed language. **Neither touched the defect underneath them**, because changing the fixture made the assertions pass without it.

## The defect

`INDEXED_LANGUAGES` (`crates/stella-tools/src/graph.rs:46`) is a hand-written list printed inside the not-indexed miss — its own doc comment says it exists "so the agent learns the boundary once instead of re-probing it":

```
`app.cfg` is not a file type the code graph indexes
(rust, python, javascript, typescript, tsx, go, java, c, php, sql, prisma)
— read it with read_file or search it with grep; re-indexing will not add it.
```

It omitted `markdown`. So every not-indexed miss named a boundary that excluded `AGENTS.md`, `CLAUDE.md` and every crate README — the documents carrying the invariants the agent has to obey — while `unindexed_language_answer` was in fact resolving them. **The tool taught the agent to stop looking in exactly the place it had just been given access to.**

The production predicate was never wrong: it defers to `Language::from_path`. Only the prose the agent reads was, which is the half nothing checked.

## The fix

- `markdown` added to `INDEXED_LANGUAGES`.
- `unindexed_language_answer`'s doc comment named `.md` as a permanent non-answer; corrected, and it now points at `Language::from_path` as the boundary rather than restating one.

## Witness test

`the_named_language_list_matches_what_the_indexer_accepts` walks `Language::compiled_in()` and asserts each tag appears in the list, so the next language cannot land half-announced. Verified by reverting the one-word fix:

```
$ sed -i "" "s/php, sql, markdown, prisma/php, sql, prisma/" crates/stella-tools/src/graph.rs
$ cargo test -p stella-tools the_named_language_list
thread ...the_named_language_list_matches_what_the_indexer_accepts panicked at
crates/stella-tools/src/graph.rs:1172:13:
`markdown` is indexed but absent from INDEXED_LANGUAGES:
rust, python, javascript, typescript, tsx, go, java, c, php, sql, prisma
test result: FAILED. 0 passed; 1 failed
```

Restored: `23 passed; 0 failed`.

A second test, `an_indexed_markdown_file_is_not_reported_as_an_unindexed_file_type`, covers the direction the fixture change left uncovered — the fixtures now prove a `.cfg` **is** a non-answer, but nothing proved a `.md` is **not** one.

## Deleted tests

None. Two added.

## Summary by Sourcery

Align stella-tools’ user-facing description of indexed languages with the actual indexer by adding markdown to the named boundary and guarding it with tests.

Bug Fixes:
- Ensure markdown files are correctly treated as indexed rather than permanently unindexed in not-indexed answers.

Enhancements:
- Clarify unindexed-language documentation to defer to Language::from_path for the index boundary instead of restating it.

Tests:
- Add a test confirming indexed markdown files are not reported as unindexed file types.
- Add a test ensuring the hand-written INDEXED_LANGUAGES list matches the languages accepted by the indexer.