### PR TITLE
docs(stella-graph): public docs must not link the private markdown module

### DIFF
--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -24,9 +24,10 @@ pub enum Language {
     Java,
     C,
     Php,
-    /// Prose, split on its heading hierarchy by [`crate::markdown`] rather
-    /// than by a grammar — the one language here whose parser is this crate's
-    /// own, and so the one that is present in every build.
+    /// Prose, split on its heading hierarchy by this crate's private
+    /// `markdown` module rather than by a grammar — the one language here
+    /// whose parser is this crate's own, and so the one that is present in
+    /// every build.
     Markdown,
 }
 
@@ -96,10 +97,10 @@ impl Language {
     /// Whether this build can parse this language.
     ///
     /// For every grammar-backed language that is "did this build compile the
-    /// grammar in" (#1268). [`Language::Markdown`] is parsed by
-    /// [`crate::markdown`], a line scan in this crate with no feature gate and
-    /// nothing to link, so it is always available — which is why this is not
-    /// simply `ts_language().is_some()`.
+    /// grammar in" (#1268). [`Language::Markdown`] is parsed by this crate's
+    /// private `markdown` module, a line scan with no feature gate and nothing
+    /// to link, so it is always available — which is why this is not simply
+    /// `ts_language().is_some()`.
     pub fn is_compiled_in(self) -> bool {
         match self {
             Language::Markdown => true,

--- a/crates/stella-graph/src/symbol.rs
+++ b/crates/stella-graph/src/symbol.rs
@@ -20,7 +20,8 @@ pub enum SymbolKind {
     Column,
     SchemaEnum,
     View,
-    /// One heading's section of a markdown document ([`crate::markdown`]).
+    /// One heading's section of a markdown document, produced by this crate's
+    /// private `markdown` module.
     ///
     /// Not a declaration, and deliberately in this enum anyway: a section has
     /// a name, a kind and a line span, which is the entire contract the index,


### PR DESCRIPTION
The `doc-warnings` gate step is red on `main`, so `cargo doc -D warnings` fails **every** PR regardless of its diff — this is what #3104 was failing on, not its own change.

```
error: public documentation for `Section` links to private item `crate::markdown`
  --> crates/stella-graph/src/symbol.rs:23:57
note: this link resolves only because you passed `--document-private-items`,
      but will break without
error: could not document `stella-graph`
```

## Cause

#3095 added the markdown reader as a **private** module (`crates/stella-graph/src/lib.rs:64` — `mod markdown;`) and linked it from three **public** items:

- `Language::Markdown` (`lang.rs:27`)
- `Language::is_compiled_in` (`lang.rs:100`)
- `SymbolKind::Section` (`symbol.rs:23`)

The link resolves only under the gate's own `--document-private-items`, and breaks in the docs a user actually reads — which is exactly what rustdoc's note says.

## Fix

The links are demoted to code spans naming it as this crate's private `markdown` module. Widening `mod markdown` to `pub` would trade a real, permanent API commitment for a formatting problem, so that option is deliberately not taken. The sentence a maintainer needs — *markdown is parsed here rather than by a grammar* — is unchanged; only the hyperlink goes.

## Verification

The gate step itself, before and after:

```
$ make doc-warnings          # on main
error: could not document `stella-graph`      → exit 101

$ make doc-warnings          # this branch
MAKE-EXIT=0
```

The one message left in that output is the `is_grammar_backed` dead-code warning, which **#3104 fixes** and which does not fail this step (`RUSTDOCFLAGS` denies rustdoc lints, not the accompanying check pass).

## Witness test

None, and none is possible in the test suite: the assertion here *is* a gate step, and its before/after exit codes are above. This is the same category as a `fmt` or `clippy` repair.

## Deleted tests

None.

## Summary by Sourcery

Documentation:
- Update documentation for Language::Markdown, Language::is_compiled_in, and SymbolKind::Section to describe the internal markdown module without exposing it as a linked public API.