### PR TITLE
feat(arenabench): transcript deck parity — tool-class colour, tool-name filter, uncapped full-transcript fetch

### DIFF
--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -20,7 +20,16 @@ Two live channels, both Server-Sent Events over a threading HTTP server:
 ``/api/matches/<id>/transcript/<contestant>/<task>``
     One trial's transcript, streamed as it is written. Incremental: the reader
     keeps a byte offset, so a client that connects to a match already an hour
-    deep gets the backlog once and then only deltas.
+    deep gets the backlog once and then only deltas. Every tool call/result
+    body on this channel is character-capped (:data:`.transcript.TOOL_RESULT_BUDGET`,
+    :data:`.transcript.TOOL_INPUT_BUDGET`) so a long-running match stays cheap
+    to stream — a compromise the plain request below does not have to make.
+
+``/api/matches/<id>/transcript-full/<contestant>/<task>``
+    The same trial's transcript, read once from byte zero with both caps
+    disabled — the "load full transcript" button's endpoint. Not a stream: a
+    finished trial's file does not grow while this reads it, so one JSON
+    response is the whole answer.
 
 **The trust boundary is the loopback interface, and it is enforced rather than
 recommended.** ``POST /api/matches`` starts subprocesses with the operator's
@@ -656,6 +665,38 @@ class ArenaServer:
                 last_beat = time.time()
                 yield "ping", {"t": last_beat}
 
+    def full_transcript(self, match_id: str, contestant_id: str, task: str) -> dict:
+        """One trial's transcript, read fresh from byte zero with no caps.
+
+        The live SSE channel (:meth:`stream_transcript`) caps a tool call's
+        argument and a tool result's body at
+        :data:`~.transcript.TOOL_INPUT_BUDGET` /
+        :data:`~.transcript.TOOL_RESULT_BUDGET` characters, middle-elided —
+        the wire-cost compromise a channel that has to stay cheap over a
+        match running for hours has to make. That cap is unrecoverable from
+        the client side: the elided bytes were never sent, so no amount of
+        client-side "show more" can produce them. This is the other half of
+        that trade — a plain, uncapped read of the same file, for a reader who
+        has decided one specific trial is worth the extra bytes.
+
+        A fresh :class:`~.transcript.TranscriptReader` with both budgets set to
+        ``0`` (:func:`~.toolout.cap_middle` treats a non-positive budget as
+        "no cap"), reading the file's entire current contents in one call —
+        the caller is a plain request-response route, not a stream, so there
+        is no cursor to keep between calls.
+        """
+        match = self.runner.matches.get(match_id)
+        if match is None:
+            raise KeyError(match_id)
+        path = match.events_path(contestant_id, task)
+        if path is None or not path.exists():
+            return {"entries": []}
+        reader = TranscriptReader(tool_result_budget=0, tool_input_budget=0)
+        # No trial's transcript approaches a million lines; the limit exists
+        # so `read` has one to check rather than because this one is expected
+        # to bind.
+        return {"entries": reader.read(path, limit=1_000_000)}
+
     def video(self, match_id: str, contestant_id: str, task: str) -> Path | None:
         match = self.runner.matches.get(match_id)
         if match is None:
@@ -1026,6 +1067,8 @@ def _handler_factory(
                     self._sse(
                         lambda: arena.stream_transcript(match_id, contestant, task)
                     )
+                case ["matches", match_id, "transcript-full", contestant, task]:
+                    self._json(arena.full_transcript(match_id, contestant, task))
                 case ["matches", match_id, "template.toml"]:
                     self._toml(arena.template_for(match_id), f"{match_id}.toml")
                 case ["matches", match_id, "video", contestant, task]:

--- a/arenabench/arenabench/toolclass.py
+++ b/arenabench/arenabench/toolclass.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""What KIND of thing a tool call was, and the categorical class that says so.
+
+A port of ``crates/stella-tui/src/tool_class.rs``: six visual classes (read /
+write / run / verify / repo / delegate), the same ``(read_only, group)`` table
+``stella-tools::catalog`` carries, and the same group -> class switch. Two
+readers of the same wire event must agree on what class it belongs to — a
+transcript rendered by the arena and the same trial replayed in the Command
+Deck are describing the same run, and a tool that shows as a "write" in one
+and a "run" in the other is a rendering bug, not a difference of opinion.
+
+``_CATALOG`` is copied, not derived: Python has no route to the Rust crate
+this data actually lives in. It was generated from the `catalog!` table in
+``crates/stella-tools/src/catalog.rs`` with::
+
+    rg -o '"\\w+"\\s*=>\\s*\\((true|false), (true|false), \\w+, "\\w+"\\)' \\
+        crates/stella-tools/src/catalog.rs
+
+``tests/test_toolclass.py`` pins the deck's own classification examples
+(``crates/stella-tui/src/tool_class.rs``'s ``each_family_lands_in_its_own_class``
+and ``a_read_and_a_write_of_the_same_family_are_different_classes``) against
+this port, so a name the Rust catalog reclassifies and this table does not
+follow shows up as a red test rather than a silent drift.
+"""
+
+from __future__ import annotations
+
+__all__ = ["CLASSES", "classify", "class_label"]
+
+#: `(read_only, group)` per dispatch name — copied verbatim from the
+#: `catalog!` table in `crates/stella-tools/src/catalog.rs`. `speculation_safe`
+#: and `availability` are that table's other two columns; neither one bears on
+#: which of the six visual classes a call renders as, so only the two that do
+#: are carried over.
+_CATALOG: dict[str, tuple[bool, str]] = {
+    "read_file": (True, "file"),
+    "read_symbol": (True, "file"),
+    "write_file": (False, "file"),
+    "edit_file": (False, "file"),
+    "apply_edits": (False, "file"),
+    "delete_file": (False, "file"),
+    "search": (True, "search"),
+    "grep": (True, "search"),
+    "glob": (True, "search"),
+    "graph_query": (True, "search"),
+    "semantic_code_search": (True, "search"),
+    "project_overview": (True, "context"),
+    "gather_context": (True, "context"),
+    "explorations": (True, "context"),
+    "save_exploration": (False, "context"),
+    "save_memory": (False, "context"),
+    "cite_memory": (False, "context"),
+    "verify_done": (False, "build"),
+    "build_project": (False, "build"),
+    "run_tests": (False, "build"),
+    "diagnostics": (True, "build"),
+    "run_lint": (False, "build"),
+    "format_code": (False, "build"),
+    "probe_capability": (True, "environment"),
+    "list_scripts": (True, "scripts"),
+    "run_script": (False, "scripts"),
+    "start_process": (False, "process"),
+    "read_output": (False, "process"),
+    "clear_output": (False, "process"),
+    "send_stdin": (False, "process"),
+    "restart_process": (False, "process"),
+    "stop_process": (False, "process"),
+    "repo_status": (True, "repo"),
+    "repo_diff": (True, "repo"),
+    "repo_history": (True, "repo"),
+    "repo_recover": (True, "repo"),
+    "repo_commit": (False, "repo"),
+    "repo_push": (False, "repo"),
+    "repo_pull": (False, "repo"),
+    "repo_rollback": (False, "repo"),
+    "ci_status": (True, "ci"),
+    "screenshot": (False, "ci"),
+    "generate_svg": (False, "media"),
+    "task_create": (False, "task"),
+    "task_list": (True, "task"),
+    "task_start": (False, "task"),
+    "task_complete": (False, "task"),
+    "task_cancel": (False, "task"),
+    "task_assign": (False, "task"),
+    "task": (False, "task"),
+    "bash": (False, "bash"),
+    "save_state": (False, "scratch"),
+    "get_state": (True, "scratch"),
+    "list_state": (True, "scratch"),
+    "delete_state": (False, "scratch"),
+    "get_environment": (True, "environment"),
+    "web_fetch": (True, "web"),
+    "web_extract_assets": (True, "web"),
+    "web_download": (False, "web"),
+    "web_search": (True, "web"),
+    "generate_image": (False, "media"),
+    "generate_video": (False, "media"),
+    "poll_video": (False, "media"),
+    "create_issue": (False, "issue"),
+    "update_issue": (False, "issue"),
+    "close_issue": (False, "issue"),
+    "search_issues": (True, "issue"),
+    "get_issue": (True, "issue"),
+    "list_labels": (True, "issue"),
+    "list_members": (True, "issue"),
+    "start_work_on_issue": (False, "issue"),
+    "ask_user": (False, "session"),
+    "search_skills": (True, "session"),
+    "install_skill": (False, "session"),
+    "tool_search": (True, "session"),
+    "skill_search": (True, "session"),
+    "invoke_skill": (False, "session"),
+    "mcp_search": (True, "session"),
+    "recall_context": (True, "context"),
+}
+
+#: Groups that hold both a read and a write, split on the catalog's own
+#: `read_only` bit — `ToolClass::classify`'s first match arm.
+_SPLIT_GROUPS = frozenset({"file", "context", "scratch"})
+
+#: Every other group's class, fixed regardless of `read_only`.
+_GROUP_CLASS: dict[str, str] = {
+    "search": "inspect",
+    "environment": "inspect",
+    "web": "inspect",
+    "media": "mutate",
+    "bash": "execute",
+    "process": "execute",
+    "scripts": "execute",
+    "build": "verify",
+    "ci": "verify",
+    "repo": "repo",
+    "issue": "repo",
+    "task": "delegate",
+    "session": "delegate",
+}
+
+#: The six visual classes, in the deck's legend order.
+CLASSES: tuple[str, ...] = ("inspect", "mutate", "execute", "verify", "repo", "delegate")
+
+#: One-word label per class — matches `ToolClass::label()`.
+_LABELS: dict[str, str] = {
+    "inspect": "read",
+    "mutate": "write",
+    "execute": "run",
+    "verify": "verify",
+    "repo": "repo",
+    "delegate": "delegate",
+}
+
+
+def classify(name: str) -> str:
+    """Classify one dispatch name into `inspect | mutate | execute | verify |
+    repo | delegate`.
+
+    An unrecognized name — an MCP server's tool (`mcp__<server>__<tool>`), or
+    a customer's own manifest tool — falls back to the catalog's `_ if
+    read_only` arm: unknown names are never in `_CATALOG`, so `read_only`
+    there is always `False` and the fallback is always `execute`, the class
+    that promises the least about what a call nobody here recognizes actually
+    did. That matches the Rust default arm exactly, which is reached the same
+    way for the same names — `an_unknown_tool_promises_the_least` in
+    `tool_class.rs` is the same assertion against the same two example names.
+    """
+    entry = _CATALOG.get(name)
+    if entry is not None:
+        read_only, group = entry
+    else:
+        read_only, group = False, ("mcp" if name.startswith("mcp__") else "custom")
+
+    if group in _SPLIT_GROUPS:
+        return "inspect" if read_only else "mutate"
+    cls = _GROUP_CLASS.get(group)
+    if cls is not None:
+        return cls
+    return "inspect" if read_only else "execute"
+
+
+def class_label(cls: str) -> str:
+    """The one-word legend label for a class key `classify` returned."""
+    return _LABELS.get(cls, cls)

--- a/arenabench/arenabench/transcript.py
+++ b/arenabench/arenabench/transcript.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from .proof import flip_outcome
+from .toolclass import class_label, classify
 from .toolout import (
     cap_middle,
     decode_tool_output,
@@ -414,7 +415,20 @@ class TranscriptReader:
     appends.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        tool_result_budget: int = TOOL_RESULT_BUDGET,
+        tool_input_budget: int = TOOL_INPUT_BUDGET,
+    ) -> None:
+        #: `cap_middle` treats a non-positive budget as "no cap" — so a caller
+        #: reading a *finished* trial for the "load full transcript" button
+        #: (`ArenaServer.full_transcript`) passes `0` here instead of the SSE
+        #: endpoint's generous-but-still-finite defaults, and gets every byte
+        #: the trial actually wrote rather than the wire-cost compromise a live
+        #: stream has to make.
+        self._tool_result_budget = tool_result_budget
+        self._tool_input_budget = tool_input_budget
         self._states: dict[Path, TranscriptState] = {}
         #: Accumulated bodies for open streaming entries, keyed by
         #: ``(path, seq)``. Per-instance: a class-level dict would be shared by
@@ -593,6 +607,14 @@ class TranscriptReader:
             # the whole object rides as `meta.raw` for the expanded view, so
             # nothing is lost by summarizing here.
             arguments = call.get("input", call.get("arguments"))
+            # The call's CLASS (`crate::tool_class` in the deck, ported at
+            # `arenabench.toolclass`) — a read, a write, a shell, a test, a
+            # push, a hand-off. The page paints the name in this class's hue
+            # rather than the arena's flat accent, the same categorical
+            # colour the deck uses and for the same reason: the class is the
+            # first question a reader asks of any row, and it should answer
+            # from the margin before a single name is read.
+            cls = classify(name)
             return [
                 entry(
                     seq,
@@ -601,11 +623,13 @@ class TranscriptReader:
                     format_tool_input(name, arguments),
                     call_id=call_id,
                     state="running",
+                    tool_class=cls,
+                    tool_class_label=class_label(cls),
                     raw=cap_middle(
                         json.dumps(arguments, indent=2, ensure_ascii=False)
                         if isinstance(arguments, (dict, list))
                         else "",
-                        TOOL_INPUT_BUDGET,
+                        self._tool_input_budget,
                     ),
                 )
             ]
@@ -617,12 +641,14 @@ class TranscriptReader:
             # every failed call rendered as a success, in the success colour,
             # with the failure message presented as ordinary output.
             decoded = decode_tool_output(event.get("output", event.get("result")))
-            body = cap_middle(strip_ansi(decoded.text), TOOL_RESULT_BUDGET)
+            body = cap_middle(strip_ansi(decoded.text), self._tool_result_budget)
+            name = state.tool_names.get(call_id, "tool")
+            cls = classify(name)
             return [
                 entry(
                     self._next_seq(state),
                     "tool_result",
-                    state.tool_names.get(call_id, "tool"),
+                    name,
                     body,
                     call_id=call_id,
                     error=not decoded.ok,
@@ -630,6 +656,8 @@ class TranscriptReader:
                     duration_ms=event.get("duration_ms"),
                     speculated=bool(event.get("speculated")),
                     lines=body.count("\n") + 1 if body else 0,
+                    tool_class=cls,
+                    tool_class_label=class_label(cls),
                 )
             ]
 

--- a/arenabench/tests/test_toolclass.py
+++ b/arenabench/tests/test_toolclass.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""`arenabench.toolclass` against the Command Deck's own classification rules.
+
+Every example here is copied from `crates/stella-tui/src/tool_class.rs`'s own
+test module — `each_family_lands_in_its_own_class`,
+`a_read_and_a_write_of_the_same_family_are_different_classes`, and
+`an_unknown_tool_promises_the_least` — so a transcript rendered by the arena
+and the same trial replayed in the deck are pinned to agree, name for name.
+A future edit to either side's table that drops one of these names into a
+different class is exactly the defect this file exists to catch.
+"""
+
+from __future__ import annotations
+
+from arenabench.toolclass import classify, class_label
+
+
+class TestEachFamilyLandsInItsOwnClass:
+    """Mirrors `tool_class.rs::each_family_lands_in_its_own_class`."""
+
+    def test_examples(self) -> None:
+        for name, expected in [
+            ("grep", "inspect"),
+            ("glob", "inspect"),
+            ("project_overview", "inspect"),
+            ("graph_query", "inspect"),
+            ("web_fetch", "inspect"),
+            ("write_file", "mutate"),
+            ("save_memory", "mutate"),
+            ("bash", "execute"),
+            ("run_script", "execute"),
+            ("start_process", "execute"),
+            ("verify_done", "verify"),
+            ("run_tests", "verify"),
+            ("diagnostics", "verify"),
+            ("ci_status", "verify"),
+            ("repo_push", "repo"),
+            ("repo_status", "repo"),
+            ("create_issue", "repo"),
+            ("task", "delegate"),
+            ("task_complete", "delegate"),
+            ("invoke_skill", "delegate"),
+        ]:
+            assert classify(name) == expected, name
+
+
+class TestReadWriteSplitWithinAFamily:
+    """Mirrors `a_read_and_a_write_of_the_same_family_are_different_classes` —
+    the one distinction the catalog's `group` column cannot draw on its own."""
+
+    def test_examples(self) -> None:
+        for read, write in [
+            ("read_file", "write_file"),
+            ("read_file", "edit_file"),
+            ("read_file", "apply_edits"),
+            ("read_file", "delete_file"),
+            ("explorations", "save_exploration"),
+            ("get_state", "save_state"),
+            ("list_state", "delete_state"),
+        ]:
+            assert classify(read) == "inspect", read
+            assert classify(write) == "mutate", write
+
+
+class TestUnknownToolsPromiseTheLeast:
+    """Mirrors `an_unknown_tool_promises_the_least`: a name nobody here has
+    heard of never defaults to the read colour, since that would paint an MCP
+    server's mutating call as if it were safe to ignore."""
+
+    def test_examples(self) -> None:
+        assert classify("mcp__github__create_pull_request") == "execute"
+        assert classify("some_customer_manifest_tool") == "execute"
+
+
+class TestClassLabels:
+    def test_every_class_has_a_one_word_label(self) -> None:
+        assert class_label("inspect") == "read"
+        assert class_label("mutate") == "write"
+        assert class_label("execute") == "run"
+        assert class_label("verify") == "verify"
+        assert class_label("repo") == "repo"
+        assert class_label("delegate") == "delegate"

--- a/arenabench/tests/test_toolout.py
+++ b/arenabench/tests/test_toolout.py
@@ -241,6 +241,83 @@ class TestTranscriptToolRows:
         assert meta["speculated"] is True
         assert meta["lines"] == 3
 
+    def test_a_call_and_its_result_both_carry_the_tool_class(self, tmp_path: Path):
+        """The page paints a tool's name by its CLASS (read/write/run/verify/
+        repo/delegate — `arenabench.toolclass`, ported from the deck's
+        `tool_class.rs`), not the arena's flat accent. Both the call row and
+        the result row need it: the result row can be scrolled to with its
+        call folded out of view by the kind filters, and it must still say
+        what kind of thing produced it without the reader scrolling back up."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "write_file", {"path": "a.rs", "content": "x"}),
+            ok_result("c1", "wrote 1 line"),
+        ])
+        call, result = TranscriptReader().read(path)
+        assert call["meta"]["tool_class"] == "mutate"
+        assert call["meta"]["tool_class_label"] == "write"
+        assert result["meta"]["tool_class"] == "mutate"
+        assert result["meta"]["tool_class_label"] == "write"
+
+    def test_a_results_tool_class_is_recovered_from_its_call(self, tmp_path: Path):
+        """`tool_result` carries only `call_id` on the wire — the same
+        correlation problem the row's *name* already has, solved the same
+        way: through the `tool_start` that opened the call, not by guessing
+        from the result's own shape."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [
+            start("c1", "repo_push", {}),
+            ok_result("c1", "pushed"),
+        ])
+        result = TranscriptReader().read(path)[-1]
+        assert result["meta"]["tool_class"] == "repo"
+
+    def test_an_orphan_result_with_no_recorded_call_still_classifies(
+        self, tmp_path: Path
+    ):
+        """A reader joining mid-stream has no `tool_start` to correlate, so
+        the name falls back to the generic `"tool"` label — which is not in
+        the catalog, and so classifies the same way any unrecognized name
+        does rather than raising."""
+        path = tmp_path / "e.jsonl"
+        write_events(path, [ok_result("orphan", "x")])
+        result = TranscriptReader().read(path)[-1]
+        assert result["meta"]["tool_class"] == "execute"
+
+
+class TestFullTranscriptDisablesTheCap:
+    """`ArenaServer.full_transcript`'s "load full transcript" reader passes
+    budget `0` for both caps — the knob `TestTranscriptToolRows` above never
+    touches, and the one place a defect here would hide, since every other
+    test in this file reads through the SSE channel's generous-but-finite
+    defaults."""
+
+    def test_a_budget_of_zero_returns_the_whole_body_uncapped(self, tmp_path: Path):
+        path = tmp_path / "e.jsonl"
+        long_output = "line\n" * 5000  # ~25,000 chars, well past both caps
+        write_events(path, [
+            start("c1", "bash", {"cmd": "yes line | head -5000"}),
+            ok_result("c1", long_output),
+        ])
+        reader = TranscriptReader(tool_result_budget=0, tool_input_budget=0)
+        result = reader.read(path)[-1]
+        assert result["body"] == long_output
+        assert "truncated" not in result["body"]
+
+    def test_the_default_reader_still_caps_the_same_body(self, tmp_path: Path):
+        """The control: the same payload through the ordinary (SSE-facing)
+        reader still elides, so the difference above is the budget argument
+        and not something else about the fixture."""
+        path = tmp_path / "e.jsonl"
+        long_output = "line\n" * 5000
+        write_events(path, [
+            start("c1", "bash", {"cmd": "yes line | head -5000"}),
+            ok_result("c1", long_output),
+        ])
+        result = TranscriptReader().read(path)[-1]
+        assert result["body"] != long_output
+        assert "truncated" in result["body"]
+
 
 class TestRecorderCopyStaysHonest:
     """`recorder/render.py` ships into a Docker image whose build context is

--- a/arenabench/tests/test_transcript_full.py
+++ b/arenabench/tests/test_transcript_full.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""``GET /api/matches/<id>/transcript-full/<contestant>/<task>`` — the "load
+full transcript" button's route.
+
+The live SSE channel (``/transcript/...``) caps a tool call/result body so a
+match running for hours stays cheap to stream over; that cap is
+unrecoverable client-side, since the elided bytes were never sent. This route
+is the other half: a plain request that reads the same file from byte zero
+with both caps disabled. Modelled on ``tests/test_file_api.py``'s pattern — a
+real socket through ``_handler_factory``, not just the server method — because
+that is where a route that forgets to disable the cap would actually be
+caught.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from arenabench.server import ArenaServer, _handler_factory, allowed_hosts
+
+
+class _FakeMatch:
+    """Just enough `Match` for the transcript routes: one trial's events file."""
+
+    def __init__(self, events: Path) -> None:
+        self._events = events
+
+    def events_path(self, contestant_id: str, task: str) -> Path | None:
+        if contestant_id == "seat" and task == "demo":
+            return self._events
+        return None
+
+
+@pytest.fixture
+def served(tmp_path: Path):
+    events = tmp_path / "trial" / "agent" / "stella-events.jsonl"
+    events.parent.mkdir(parents=True)
+
+    arena = ArenaServer(tmp_path / "ws")
+    arena.runner.matches["m1"] = _FakeMatch(events)  # type: ignore[assignment]
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    port = httpd.server_address[1]
+    httpd.RequestHandlerClass = _handler_factory(arena, allowed_hosts("127.0.0.1", port))
+    httpd.daemon_threads = True
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, events
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+
+def _get(port: int, path: str) -> tuple[int, bytes]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", path, headers={"Host": f"127.0.0.1:{port}"})
+        res = conn.getresponse()
+        return res.status, res.read()
+    finally:
+        conn.close()
+
+
+def test_the_full_transcript_route_returns_every_entry_uncapped(served):
+    port, events = served
+    long_output = "line\n" * 5000
+    events.write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {"type": "tool_start", "call": {"call_id": "c1", "name": "bash", "input": {"cmd": "x"}}},
+                {
+                    "type": "tool_result",
+                    "call_id": "c1",
+                    "output": {"ok": {"content": long_output}},
+                    "duration_ms": 5,
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    status, body = _get(port, "/api/matches/m1/transcript-full/seat/demo")
+    assert status == 200
+    payload = json.loads(body)
+    entries = payload["entries"]
+    assert len(entries) == 2
+    result = entries[-1]
+    assert result["body"] == long_output
+    assert "truncated" not in result["body"]
+    assert result["meta"]["tool_class"] == "execute"
+
+
+def test_an_unknown_trial_returns_an_empty_transcript_not_an_error(served):
+    port, _events = served
+    status, body = _get(port, "/api/matches/m1/transcript-full/seat/nope")
+    assert status == 200
+    assert json.loads(body) == {"entries": []}

--- a/arenabench/ui/app/globals.css
+++ b/arenabench/ui/app/globals.css
@@ -102,6 +102,28 @@
   --acc-rose:   #8f8f8f;
   --acc-citron: #c4c4c4;
 
+  /* Tool-class hues — the transcript reader's one deliberate exception to the
+     lightness-only rule above. A tool call's CLASS (read/write/run/verify/
+     repo/delegate — `arenabench.toolclass`, mirrored client-side in
+     `lib/tool-class.ts`) is DATA in exactly the sense a seat colour is: the
+     job of the transcript page is telling calls of one kind from another at a
+     glance, across a scroll of hundreds of rows, and a lightness ramp cannot
+     do that — six steps of grey read as one grey with noise. So this is the
+     one place on the page real hue is spent, and it borrows rather than
+     invents: these are the Command Deck's own six categorical values
+     (`crates/stella-tui/src/tool_class.rs` / `theme.rs`'s `LIGHT_REMAP`),
+     already load-bearing on the same question there, so a reader who has
+     learned "teal reads, rose writes" in the deck does not relearn it here.
+     Never used as a fill or a decoration — always as text colour on a tool's
+     own name, which is unique per row, so identity is never hue-alone even
+     where two classes sit close in lightness. */
+  --tool-inspect:  #0f766e; /* read — teal */
+  --tool-mutate:   #a6185c; /* write — rose */
+  --tool-execute:  #6d28d9; /* run — violet */
+  --tool-verify:   #16744f; /* verify — green */
+  --tool-repo:     #4d6b12; /* repo — citron/olive */
+  --tool-delegate: #8b2ba8; /* delegate — orchid */
+
   /* Seat colours arrive as data (each contestant carries a hex) and stay —
      a seat IS data, and it is the one place on the page where distinguishing
      two things by hue is the job. As fills they work on both schemes; as
@@ -133,6 +155,16 @@
   --acc-rose:   #6e6e6e;
   --acc-citron: #4a4a4a;
 
+  /* The deck's dark-side categorical values (`palette::DATA_1..6` on Ink) —
+     see the `:root` block above for why the transcript reader carries these
+     at all. */
+  --tool-inspect:  #2fd3c6; /* read — teal */
+  --tool-mutate:   #e4408f; /* write — rose */
+  --tool-execute:  #8f70e8; /* run — violet */
+  --tool-verify:   #4ade80; /* verify — green */
+  --tool-repo:     #a3d14b; /* repo — citron */
+  --tool-delegate: #d46fe8; /* delegate — orchid */
+
   --seat-fg: var(--seat, #ededed);
 }
 
@@ -153,6 +185,13 @@
   --color-acc-violet: var(--acc-violet);
   --color-acc-rose: var(--acc-rose);
   --color-acc-citron: var(--acc-citron);
+
+  --color-tool-inspect: var(--tool-inspect);
+  --color-tool-mutate: var(--tool-mutate);
+  --color-tool-execute: var(--tool-execute);
+  --color-tool-verify: var(--tool-verify);
+  --color-tool-repo: var(--tool-repo);
+  --color-tool-delegate: var(--tool-delegate);
 
   /* What sits on a fill. Two tokens because they are two different jobs that
      shared the name `ink` and diverged the moment the accent stopped being a

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -5,6 +5,12 @@ import { api } from "@/lib/api";
 import type { Cell, Snapshot, TranscriptEntry } from "@/lib/types";
 import { fmtClock, fmtDuration, fmtMoney, fmtTokens } from "@/lib/format";
 import { cn, seatStyle } from "@/lib/utils";
+import {
+  TOOL_CLASSES,
+  TOOL_CLASS_LABEL,
+  TOOL_CLASS_TEXT,
+  toolClassOf,
+} from "@/lib/tool-class";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ProofPanel } from "@/components/arena/proof-panel";
@@ -24,17 +30,33 @@ import { ProofPanel } from "@/components/arena/proof-panel";
  * - **Reasoning is quiet.** Dim, italic, collapsed to a short preview with
  *   its line count in the header; the least load-bearing text on screen
  *   never outshouts the response.
- * - **The label is coloured, the value is read.** Tool names take the
- *   accent; bodies stay plain. A colour earns its place by being rare.
+ * - **The label is coloured, the value is read.** A tool's name takes its
+ *   CLASS's hue — read/write/run/verify/repo/delegate
+ *   (`crates/stella-tui/src/tool_class.rs`, mirrored server-side by
+ *   `arenabench.toolclass` and surfaced as `meta.tool_class`) — never the
+ *   brand accent; bodies stay plain. A colour earns its place by being rare,
+ *   and here it answers the first question a reader asks of any row before a
+ *   single name is read: was that a look, a change, a shell, a test, a push,
+ *   a hand-off?
+ * - **A collapsed result shows the line that matters, not the first one.**
+ *   `salient_line` (ported below) anchors the preview at the first line
+ *   carrying an error/warning/failure marker rather than line 1 — a build's
+ *   first line is `Checking foo v0.1.0`, and the line a reader came for is
+ *   twenty lines down. A success shows one line from there; a failure shows
+ *   six (`crates/stella-tui/src/render/row.rs::{salient_line,FAIL_PREVIEW}`).
  * - **The rails are the deck's**: `●` opens a call, `⎿` its result, `✗` a
  *   failed one — a distinct glyph *and* column, so a failure is findable by
  *   margin-scan alone (`crates/stella-tui/src/render/row.rs::Rail`).
  *
- * One deliberate departure: the deck renders a call and its result as one
+ * Two deliberate departures. The deck renders a call and its result as one
  * tight block that nothing can split, so the result row need not repeat the
  * tool's name. Here the kind filters can hide every call row, which would
  * leave a column of results naming nothing — so a result row carries its
- * tool's name, subordinate to the call's.
+ * tool's name (and its class colour), subordinate to the call's. And every
+ * body on the wire here is character-capped for the live stream's sake
+ * (`arenabench.transcript.TOOL_RESULT_BUDGET`) in a way the deck, reading a
+ * session in memory, never has to be — the "load full transcript" button
+ * fetches the same trial uncapped for the one reader who needs every byte.
  *
  * Playback matches the drawer it replaced: a finished trial replays paced by
  * each entry's own elapsed stamp, a live one streams. Search and filters are
@@ -173,8 +195,70 @@ function usageLine(entry: TranscriptEntry): string {
   );
 }
 
-const RESULT_PREVIEW_LINES = 12;
 const THINKING_PREVIEW_LINES = 5;
+
+/** Collapsed-result line budgets, matching the deck's `row.rs` exactly: a
+ * successful call shows one line from the salient point, a failed one shows
+ * six — enough for a compiler error with its location and caret line, or the
+ * top of a panic backtrace. */
+const OK_PREVIEW_LINES = 1;
+const FAIL_PREVIEW_LINES = 6;
+
+/** Split on `\n` the way Rust's `str::lines()` does: no trailing empty
+ * element for text ending in a newline. Every result body downstream of
+ * `salientLine` goes through this rather than a bare `.split("\n")`, so an
+ * index computed on one agrees with a slice taken from the other. */
+function splitLines(text: string): string[] {
+  const lines = text.split("\n");
+  if (text.endsWith("\n")) lines.pop();
+  return lines;
+}
+
+/** Markers that make a line of tool output worth anchoring a collapsed
+ * preview on, ported verbatim from `crates/stella-tui/src/render/row.rs::SALIENT`. */
+const SALIENT_MARKERS = [
+  "error",
+  "warning",
+  "failed",
+  "failure",
+  "panic",
+  "assert",
+  "fatal",
+  "exception",
+];
+
+/**
+ * The line index a collapsed result should start its preview from.
+ *
+ * A direct port of `row.rs::salient_line`: showing line 1 is the obvious
+ * choice and the wrong one — a build's first line is `Checking foo v0.1.0`
+ * while the line that matters is twenty lines down — so this finds the first
+ * line carrying a failure marker (`error:`, `warning:`, `panic: …`, matched
+ * case-insensitively at the start of the trimmed line or as `marker:` within
+ * its first 12 characters, so a log line that merely *mentions* an error
+ * later on does not hijack the row) and falls back to the first non-blank
+ * line when nothing stands out.
+ */
+function salientLine(text: string): number {
+  const lines = splitLines(text);
+  let firstNonBlank = 0;
+  let seenNonBlank = false;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].replace(/^\s+/, "");
+    if (!seenNonBlank && trimmed !== "") {
+      firstNonBlank = i;
+      seenNonBlank = true;
+    }
+    const lower = trimmed.toLowerCase();
+    const hit = SALIENT_MARKERS.some((marker) => {
+      if (lower.startsWith(marker)) return true;
+      const at = lower.indexOf(`${marker}:`);
+      return at !== -1 && at <= 12;
+    });
+    if (hit) return i;
+  }
+  return firstNonBlank;
+}
 
 /** Frames shown before the fold, matching the deck's `RECALL_PREVIEW`. */
 const RECALL_PREVIEW_FRAMES = 3;
@@ -446,11 +530,26 @@ function Entry({
     const meta = (entry.meta || {}) as Record<string, unknown>;
     const raw = typeof meta.raw === "string" ? meta.raw : "";
     const expandable = Boolean(raw) && raw !== "{}";
+    // The name's colour is the call's CLASS — read/write/run/verify/repo/
+    // delegate — never the arena's flat `--accent`: the class answers "what
+    // kind of thing was that" from the margin before a single name is read.
+    // The `●` glyph itself stays neutral: arenabench carries no brand/identity
+    // hue at all (the arena scores stella as one seat among several, so its
+    // gold does not belong in chrome every seat is judged under), so unlike
+    // the deck's `Rail::Call` — which paints the glyph `ACCENT_DEEP` — the
+    // rail here is undyed and the class colour is spent on the one place a
+    // reader actually scans: the tool's own name.
+    const cls = toolClassOf(meta);
     return (
       <div>
         <div className="flex items-baseline gap-2">
           <span className="select-none text-dim">●</span>
-          <span className="min-w-[8.5rem] shrink-0 font-semibold text-accent">
+          <span
+            className={cn(
+              "min-w-[8.5rem] shrink-0 font-semibold",
+              TOOL_CLASS_TEXT[cls],
+            )}
+          >
             <Highlight text={entry.title ?? "tool"} query={query} />
           </span>
           {body && (
@@ -481,21 +580,33 @@ function Entry({
   if (entry.kind === "tool_result") {
     // `⎿ name · 141ms · 12 lines`, then the body — the deck's result rail,
     // subordinate to the call above it. A failure takes `✗` and its own
-    // colour so it is findable by margin-scan alone.
+    // colour so it is findable by margin-scan alone, overriding the class
+    // colour below: an outcome always outranks a category, the same
+    // precedence the deck gives a stage rule over its own hue.
     //
     // The name is on the row rather than left implicit in the call above,
     // which is where this page departs from the deck on purpose: the deck
     // renders a call and its result as one tight block that cannot be split,
     // while here the kind filters can hide every call row and leave a column
-    // of results naming nothing.
+    // of results naming nothing. It carries the same class colour as its
+    // call for the same reason — a reader who has filtered down to "results"
+    // alone should not lose which kind of call produced each one.
     const meta = (entry.meta || {}) as Record<string, unknown>;
     const isError = Boolean(meta.error);
-    const lines = body ? body.split("\n") : [];
-    const folded = !resultOpen && lines.length > RESULT_PREVIEW_LINES;
-    const shown = resultOpen ? lines : lines.slice(0, RESULT_PREVIEW_LINES);
+    const cls = toolClassOf(meta);
+    const lines = body ? splitLines(body) : [];
+    const total = lines.length;
+    // The collapsed window anchors on the SALIENT line, not line 1 — see
+    // `salientLine`'s doc comment — and its size is the deck's own budget: a
+    // success shows a single line, a failure shows six.
+    const budget = isError ? FAIL_PREVIEW_LINES : OK_PREVIEW_LINES;
+    const anchor = total > 0 ? salientLine(body ?? "") : 0;
+    const collapsedShown = lines.slice(anchor, anchor + budget);
+    const shown = resultOpen ? lines : collapsedShown;
+    const hidden = resultOpen ? 0 : total - collapsedShown.length;
     const metrics = [
       meta.duration_ms != null ? fmtDuration(meta.duration_ms) : null,
-      lines.length > 1 ? `${lines.length} lines` : null,
+      total > 1 ? `${total} lines` : null,
       // ⚡ marks a speculated result: its duration overlapped the model's own
       // streaming instead of following it, so the number is not latency the
       // run actually spent waiting.
@@ -510,7 +621,9 @@ function Entry({
           <span className={cn("select-none", isError ? "text-bad" : "text-dim")}>
             {isError ? "✗" : "⎿"}
           </span>
-          <span className={cn("font-medium", isError ? "text-bad" : "text-dim")}>
+          <span
+            className={cn("font-medium", isError ? "text-bad" : TOOL_CLASS_TEXT[cls])}
+          >
             <Highlight text={entry.title ?? "tool"} query={query} />
           </span>
           {metrics.length > 0 && (
@@ -527,16 +640,24 @@ function Entry({
             <Highlight text={shown.join("\n")} query={query} />
           </pre>
         )}
-        {folded && (
+        {/* The deck only earns this row for a failure — a successful result
+            already states its size in the metric column above. A mouse-driven
+            page has no ctrl+o, though, so a folded SUCCESS still gets a quiet
+            way to see the rest; it just does not compete for attention the
+            way the failure's does. */}
+        {!resultOpen && hidden > 0 && (
           <button
             type="button"
             onClick={toggleResult}
-            className="ml-5 cursor-pointer text-[10.5px] text-dim hover:text-muted"
+            className={cn(
+              "ml-5 cursor-pointer text-[10.5px] hover:text-muted",
+              isError ? "text-dim" : "text-dim/70",
+            )}
           >
-            ⋯ {lines.length - RESULT_PREVIEW_LINES} more lines
+            ⋯ {hidden} more {hidden === 1 ? "line" : "lines"}
           </button>
         )}
-        {resultOpen && lines.length > RESULT_PREVIEW_LINES && (
+        {resultOpen && total > budget && (
           <button
             type="button"
             onClick={toggleResult}
@@ -714,12 +835,69 @@ function TranscriptView({
   }, [task, seatId]);
 
   const live = snapshot?.status === "running";
-  const { entries, waiting, ended } = useTranscript(matchId, seatId, task);
+  const { entries: streamedEntries, waiting, ended } = useTranscript(matchId, seatId, task);
+
+  // -- the full, uncapped transcript, fetched on demand --------------------
+  // The SSE channel above character-caps a tool call/result body
+  // (`arenabench.transcript.TOOL_RESULT_BUDGET`/`TOOL_INPUT_BUDGET`) so a
+  // match running for hours stays cheap to stream. That cap is
+  // unrecoverable client-side — the elided bytes were never sent — so a
+  // reader who has decided this one trial is worth the extra bytes gets a
+  // plain request-response fetch of the same file from byte zero with both
+  // caps disabled, wholesale replacing the capped array rather than
+  // patching it (every field but the body is identical either way).
+  const [fullEntries, setFullEntries] = React.useState<TranscriptEntry[] | null>(null);
+  const [loadingFull, setLoadingFull] = React.useState(false);
+  const [fullError, setFullError] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    setFullEntries(null);
+    setFullError(null);
+  }, [matchId, seatId, task]);
+  const loadFullTranscript = React.useCallback(async () => {
+    setLoadingFull(true);
+    setFullError(null);
+    try {
+      const payload = await api<{ entries: TranscriptEntry[] }>(
+        `/api/matches/${encodeURIComponent(matchId)}/transcript-full/` +
+          `${encodeURIComponent(seatId)}/${encodeURIComponent(task)}`,
+      );
+      setFullEntries(payload.entries);
+    } catch (err) {
+      setFullError(String(err));
+    } finally {
+      setLoadingFull(false);
+    }
+  }, [matchId, seatId, task]);
+  const entries = fullEntries ?? streamedEntries;
 
   // -- reading tools ------------------------------------------------------
   const [enabled, setEnabled] = React.useState<Record<string, boolean>>(() =>
     Object.fromEntries(GROUPS.map((group) => [group.key, true])),
   );
+  // Tools explicitly excluded by name — empty means no filter is active.
+  // Unlike `enabled` (whole kind-groups, seeded once), this has to grow with
+  // the transcript: a trial's tool names are not known until entries arrive.
+  const [disabledTools, setDisabledTools] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const toolIndex = React.useMemo(() => {
+    const classByName = new Map<string, ReturnType<typeof toolClassOf>>();
+    for (const entry of entries) {
+      if (entry.kind === "tool" && entry.title && !classByName.has(entry.title)) {
+        classByName.set(entry.title, toolClassOf(entry.meta));
+      }
+    }
+    const names = [...classByName.keys()].sort((a, b) => a.localeCompare(b));
+    return { names, classByName };
+  }, [entries]);
+  const toggleTool = React.useCallback((name: string) => {
+    setDisabledTools((state) => {
+      const next = new Set(state);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
   const [query, setQuery] = React.useState("");
   const searching = query.trim().length > 0;
 
@@ -743,6 +921,16 @@ function TranscriptView({
     return entries.filter((entry) => {
       const group = groupOf(entry.kind);
       if (group !== null && !enabled[group]) return false;
+      // A call and its result are both named by the tool's own name — the
+      // one identifier both kinds share — so one filter set hides both
+      // halves of a call the reader asked not to see.
+      if (
+        (entry.kind === "tool" || entry.kind === "tool_result") &&
+        entry.title &&
+        disabledTools.has(entry.title)
+      ) {
+        return false;
+      }
       if (!needle) return true;
       return (
         (entry.body ?? "").toLowerCase().includes(needle) ||
@@ -750,7 +938,7 @@ function TranscriptView({
         (entry.kind === "usage" && usageLine(entry).toLowerCase().includes(needle))
       );
     });
-  }, [entries, enabled, query]);
+  }, [entries, enabled, disabledTools, query]);
 
   // -- playback (paced replay for a finished trial) -----------------------
   const [playing, setPlaying] = React.useState(true);
@@ -901,6 +1089,23 @@ function TranscriptView({
           ))}
         </div>
         <div className="ml-auto flex items-center gap-2">
+          {/* Every tool call/result body on the streamed channel is
+              character-capped for the live feed's sake; this fetches the same
+              trial from byte zero with the cap disabled. Bytes elided on the
+              wire cannot be recovered by any amount of client-side "show
+              more", so this is the only way back to the whole payload. */}
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loadingFull || fullEntries !== null}
+            onClick={loadFullTranscript}
+          >
+            {fullEntries !== null
+              ? "full transcript loaded ✓"
+              : loadingFull
+                ? "loading full transcript…"
+                : "load full transcript"}
+          </Button>
           <Button
             variant="ghost"
             size="sm"
@@ -948,6 +1153,62 @@ function TranscriptView({
           ) : null}
         </div>
       </div>
+
+      {fullError && (
+        <div className="border-b border-line py-1.5 font-mono text-[11px] text-bad">
+          full transcript failed to load: {fullError}
+        </div>
+      )}
+
+      {/* Filter by tool name, and the class legend that explains the colour
+          each name is painted in. One row: the chips are the working filter,
+          the legend on the right is the key a first-time reader needs to
+          learn it. Only rendered once the trial has produced at least one
+          tool call — an empty filter row above an empty transcript answers
+          a question nobody asked yet. */}
+      {toolIndex.names.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-b border-line py-2">
+          <div className="flex flex-wrap items-center gap-1">
+            {toolIndex.names.map((name) => {
+              const cls = toolIndex.classByName.get(name) ?? "execute";
+              const off = disabledTools.has(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => toggleTool(name)}
+                  aria-pressed={!off}
+                  className={cn(
+                    "cursor-pointer px-2 py-1 font-mono text-[11px]",
+                    off
+                      ? "text-dim line-through hover:bg-panel"
+                      : ["bg-current/10", TOOL_CLASS_TEXT[cls]],
+                  )}
+                >
+                  {name}
+                </button>
+              );
+            })}
+            {disabledTools.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setDisabledTools(new Set())}
+                className="cursor-pointer px-2 py-1 font-mono text-[11px] text-dim underline hover:text-muted"
+              >
+                reset
+              </button>
+            )}
+          </div>
+          <div className="ml-auto flex flex-wrap items-center gap-x-2.5 gap-y-1 font-mono text-[10px] text-dim">
+            {TOOL_CLASSES.map((cls) => (
+              <span key={cls} className="flex items-center gap-1">
+                <span className={TOOL_CLASS_TEXT[cls]}>●</span>
+                {TOOL_CLASS_LABEL[cls]}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* The proof rail, above the transcript it summarises. A verdict says
           whether the trial passed; only this says what claims that. */}

--- a/arenabench/ui/lib/tool-class.ts
+++ b/arenabench/ui/lib/tool-class.ts
@@ -1,0 +1,54 @@
+/**
+ * A tool call's visual class — the six categories the Command Deck paints a
+ * tool NAME by (`crates/stella-tui/src/tool_class.rs`): read, write, run,
+ * verify, repo, delegate.
+ *
+ * The classification itself happens server-side (`arenabench.toolclass`,
+ * itself a port of the same Rust module) and rides on `tool`/`tool_result`
+ * entries as `meta.tool_class` / `meta.tool_class_label` — this module only
+ * maps the six class keys to the Tailwind colour token defined in
+ * `app/globals.css` (`--tool-*`), so the legend can list every class even
+ * when the loaded transcript only exercises a few of them.
+ */
+
+export const TOOL_CLASSES = [
+  "inspect",
+  "mutate",
+  "execute",
+  "verify",
+  "repo",
+  "delegate",
+] as const;
+
+export type ToolClassKey = (typeof TOOL_CLASSES)[number];
+
+/** One-word legend label — matches `ToolClass::label()` / `class_label()`. */
+export const TOOL_CLASS_LABEL: Record<ToolClassKey, string> = {
+  inspect: "read",
+  mutate: "write",
+  execute: "run",
+  verify: "verify",
+  repo: "repo",
+  delegate: "delegate",
+};
+
+/** The Tailwind text-colour utility for a class, from `--tool-*` in globals.css. */
+export const TOOL_CLASS_TEXT: Record<ToolClassKey, string> = {
+  inspect: "text-tool-inspect",
+  mutate: "text-tool-mutate",
+  execute: "text-tool-execute",
+  verify: "text-tool-verify",
+  repo: "text-tool-repo",
+  delegate: "text-tool-delegate",
+};
+
+/** Read a `tool_class` out of an entry's `meta`, tolerating older transcripts
+ * that predate the field (a "load full transcript" fetch against an already
+ * open trial, a saved recording) — those fall back to the deck's own
+ * unrecognized-tool default, `execute`, rather than rendering unstyled. */
+export function toolClassOf(meta: Record<string, unknown> | undefined): ToolClassKey {
+  const cls = meta?.tool_class;
+  return typeof cls === "string" && (TOOL_CLASSES as readonly string[]).includes(cls)
+    ? (cls as ToolClassKey)
+    : "execute";
+}


### PR DESCRIPTION
## Summary

- Ports the Command Deck's tool-class colouring (`crates/stella-tui/src/tool_class.rs`
  — six categorical classes: read/write/run/verify/repo/delegate) to the arena's
  `/transcript` page as `arenabench.toolclass`, and threads `meta.tool_class` /
  `meta.tool_class_label` through both `tool` and `tool_result` entries. A tool's
  name now takes its class's colour instead of the arena's flat `--accent`,
  matching how the deck answers "what kind of thing was that" from the margin.
  This is a deliberate, narrow exception to arenabench's monochrome-chrome rule
  (`ui/app/globals.css`'s doc comment) — the same "colour carries data" carve-out
  the file already grants seat identity, applied to a tool call's class.
- Adds `GET /api/matches/<id>/transcript-full/<contestant>/<task>` — the "load
  full transcript" button's endpoint. The live SSE channel character-caps a
  tool call/result body (`TOOL_RESULT_BUDGET`/`TOOL_INPUT_BUDGET`) so a
  match running for hours stays cheap to stream; those elided bytes are
  unrecoverable client-side. The new endpoint reads the same trial's events
  file from byte zero with both caps disabled.
- Brings the collapsed tool-result preview to the deck's own `salient_line` +
  1-line(success)/6-line(failure) budget (`crates/stella-tui/src/render/row.rs`)
  instead of a flat first-12-lines cut, so a collapsed row anchors on the
  error/warning line rather than a build's uninformative first line.
- Adds a tool-name filter (chips, coloured by class) alongside the existing
  kind-group filters, plus a small always-visible class legend.

## Left out of scope, filed as issues

- #3110 — a mutating tool's diff still doesn't render inline in the arena
  transcript, unlike the deck (protocol work, not a rendering change).
- #3111 — the MP4 recorder (`recorder/render.py`) has no equivalent tool-class
  colouring; it's a separate surface with its own acknowledged-copy discipline.

## Test plan

- [x] `pytest tests/test_toolclass.py tests/test_toolout.py tests/test_transcript_recall.py tests/test_transcript_full.py -q` — 66 passed
- [x] `pytest tests/ -q` (full suite) — only pre-existing, unrelated `test_sut.py` failures (missing Harbor adapter venv in this environment; reproduced identically against unmodified `main`)
- [x] `npm run typecheck` — clean
- [x] `npx next build` — compiles and statically prerenders `/transcript`

## Summary by Sourcery

Introduce tool-class-aware coloring and filtering to the arena transcript page and provide an uncapped full-transcript endpoint that aligns arena transcript behavior with the Command Deck.

New Features:
- Color tool names in the arena transcript by their server-provided tool class rather than a global accent, matching Command Deck categories.
- Add a client-side tool-name filter with class-colored chips and a visible class legend for transcript entries.
- Expose a new GET /api/matches/<id>/transcript-full/<contestant>/<task> endpoint to retrieve a trial’s full uncapped transcript in one response.

Enhancements:
- Align collapsed tool-result previews with the Command Deck’s salient-line based budgets so previews center on error or warning lines instead of the first line.
- Extend TranscriptReader to support configurable caps for tool input and result bodies, enabling both capped streaming and uncapped full reads.
- Add tool-class metadata to both tool call and tool result entries so arena and Deck share a consistent classification of tools.

Tests:
- Add tests validating tool-class classification parity with the Command Deck’s rules and labels.
- Add tests ensuring tool call and result entries carry consistent tool-class metadata and that orphan results still classify safely.
- Add tests and route-level integration checks confirming the full-transcript endpoint returns uncapped bodies while the streaming reader remains capped.