### PR TITLE
docs(website): add a clickable Command Deck explorer to Agent Modes

### DIFF
--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -71,9 +71,23 @@ engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
 
 ## Interactive: the Command Deck
 
-Running `stella` with no subcommand opens the **Command Deck** — a tabbed
-terminal UI over the same engine. Type to send a prompt; slash commands open
-tabs and overlays:
+Running `stella` with no subcommand opens the **Command Deck** — not a
+generic TUI in the `htop`/`vim` sense, but stella's own tabbed workspace over
+the same engine that drives every other mode on this page. One surface, nine
+tabs, and every tab is a live view over the same session: what a sub-agent is
+doing right now, the code graph, the files this turn touched, your MCP
+servers. Type to send a prompt; slash commands open tabs and overlays.
+
+Click a tab below to see what's actually in it. This isn't an embedded
+terminal or a recording — each pane is trimmed straight from the deck's own
+golden render tests (`crates/stella-tui/tests/snapshots/deck/`), the fixtures
+that gate every pull request touching the TUI, so what you're clicking
+through is the deck's real output, not a redrawn approximation of it.
+
+<CommandDeckExplorer />
+
+The full slash-command set — including `/inspect` and `/context` — is on
+[`stella chat`](/docs/commands/chat); here's what each tab opens:
 
 <CardGrid size="sm">
   <OptionCard name="/help">Show help.</OptionCard>
@@ -96,9 +110,6 @@ tabs and overlays:
   </OptionCard>
   <OptionCard name="/clear">Reset the conversation.</OptionCard>
 </CardGrid>
-
-The full deck command set — including `/inspect` and `/context` — is on
-[`stella chat`](/docs/commands/chat).
 
 **⏎** inserts a line break; **⌘⏎ / ⌃⏎** submits. Prompts queue while a turn
 runs — you never wait for the agent to finish before typing the next thing

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -775,6 +775,77 @@ html[data-home-nav="hidden"] #nd-nav {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+ * Command Deck explorer — a clickable reproduction of the deck's tab strip.
+ * Same ink-terminal treatment as `.term` above; the tab strip is the only
+ * new chrome. There is no timer and nothing animates on its own — a click
+ * swaps the pane instantly — so there is no reduced-motion case to design
+ * around.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.dke {
+  font-family: var(--font-mono);
+  border: 1px solid #232327;
+  border-radius: 0.5rem;
+  background: var(--stella-ink);
+  color: var(--stella-paper);
+  overflow: hidden;
+  box-shadow: var(--stella-shadow-card);
+  margin: 1.5rem 0;
+}
+
+.dke-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+  padding: 0.6rem 0.6rem 0;
+  border-bottom: 1px solid #232327;
+}
+
+.dke-tab {
+  font-family: inherit;
+  font-size: var(--stella-type-xs);
+  letter-spacing: 0.08em;
+  color: #9b9890; /* muted on ink, regardless of page theme */
+  background: none;
+  border: none;
+  border-radius: 0.35rem 0.35rem 0 0;
+  padding: 0.4rem 0.65rem;
+  cursor: pointer;
+}
+
+.dke-tab:hover {
+  color: var(--stella-paper);
+}
+
+.dke-tab[data-active="true"] {
+  background: #1e1806;
+  color: var(--stella-gold);
+}
+
+.dke-tab:focus-visible {
+  outline: 2px solid var(--stella-gold);
+  outline-offset: -2px;
+}
+
+.dke-pane {
+  padding: 0.9rem 1rem 1.1rem;
+}
+
+.dke-blurb {
+  margin: 0 0 0.75rem;
+  font-size: var(--stella-type-sm);
+  color: #9b9890;
+}
+
+.dke-lines {
+  margin: 0;
+  font-size: var(--stella-type-sm);
+  line-height: 1.7;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
  * Install block — the one-liner you copy.
  *
  * A real surface, not a sticker: hovering lifts it on a spring (Motion-

--- a/website/src/components/command-deck-explorer.tsx
+++ b/website/src/components/command-deck-explorer.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+/**
+ * A clickable reproduction of the Command Deck's own tab strip.
+ *
+ * This is not an embedded terminal and it is not a screen recording — it is
+ * nine static panes, one per real deck tab, and clicking a tab swaps which
+ * one is showing. Each pane's content is trimmed straight out of
+ * `crates/stella-tui/tests/snapshots/deck/tab_*.txt`, the golden renders that
+ * `make gate` checks on every PR touching the TUI, so what is on screen here
+ * is the deck's own output rather than a redrawn mock of it.
+ *
+ * Deliberately not a repeat of the old animated command-deck (see
+ * `command-deck.tsx`'s doc comment for why that one was cut): there is no
+ * timer, nothing plays on a loop, and nothing moves without a click — so
+ * there is no `prefers-reduced-motion` case to design around.
+ */
+
+import { useRef, useState } from "react";
+
+interface DeckTabSpec {
+  key: string;
+  label: string;
+  blurb: string;
+  lines: string[];
+}
+
+const TABS: DeckTabSpec[] = [
+  {
+    key: "session",
+    label: "SESSION",
+    blurb:
+      "The transcript for the turn in flight — prompts, the live plan, and each stage as it runs.",
+    lines: [
+      "? lead  ·  needs input                                     0:00:00",
+      "└─ ◆ sub:auth  needs input · model glm-5.2 · spend $0.01",
+      "     ⚒ grep trigger → wire automations triggers API",
+      "└─ ◆ sub:ci    running    · model glm-5.2-air · spend $0.00",
+      "     ⚒ no tool calls yet → watch CI + open PR",
+      "",
+      "  Planning the automations cluster: list, editor, triggers, workflows.",
+      "☰  plan  4/7 · Wire the triggers API",
+      "── WITNESS ──",
+      "── EXECUTE ──",
+      "● read_file  apps/app/automations/page.tsx      ⎿ 312 lines · 42ms",
+    ],
+  },
+  {
+    key: "agents",
+    label: "AGENTS",
+    blurb:
+      "Every execution — lead and sub-agents — with live cost, context %, and cache warmth. Paired with your installed agents.",
+    lines: [
+      "EXECUTIONS │ INSTALLED AGENTS",
+      "Agent        Goal                          Status        Cost    $/hr",
+      "  lead       web-app-2.0 · phase           needs input   $0.04   $0.45",
+      "  sub:auth   wire automations triggers     needs input   $0.01   $0.13",
+      "▶ sub:ci      watch CI + open PR            running       $0.00   $0.05",
+    ],
+  },
+  {
+    key: "traces",
+    label: "TRACES",
+    blurb:
+      "One scrollable, filterable timeline of every agent's tool calls, verdicts, and spend, interleaved by time.",
+    lines: [
+      "traces · all · 33 events · following",
+      "00:00 lead      [stage] witness",
+      "00:00 lead      [verdict] witness authored: automations/triggers.test.ts",
+      "00:00 lead      [verdict] oracle: fail on base",
+      "00:00 lead      [tool] read_file() → ok in 42ms",
+      "00:00 lead      [file] modified automations/page.tsx +4/-1",
+      "00:00 lead      [verdict] oracle: pass on new",
+      "00:00 sub:auth  [stage] wire the automations triggers API",
+      "00:00 sub:ci    [vcs] pr open",
+    ],
+  },
+  {
+    key: "graph",
+    label: "GRAPH",
+    blurb:
+      "The tree-sitter code graph — pick a symbol, see its file, its relations, and its neighborhood. Answered offline, no key needed.",
+    lines: [
+      "nodes · 6 · /files",
+      "ƒ run_turn   ◆ Engine   ◆ Router   ◆ AgentEvent   ◆ Ledger   ▤ driver.rs",
+      "",
+      "Engine — struct · stella-core/src/engine.rs:48",
+      "relations · 3",
+      "called by ← run_turn",
+      "uses      → Router",
+      "writes    → Ledger",
+    ],
+  },
+  {
+    key: "files",
+    label: "FILES",
+    blurb: "Every file this session touched, by agent, with lines added and removed.",
+    lines: [
+      "Files · 2",
+      "File                                     Agent      Op   +    -",
+      "apps/app/automations/page.tsx            lead       U    +4   -1",
+      "apps/api/routes/v1/automations.ts        sub:auth   C    +3   -0",
+      "2 files  +7  -1  0 reads",
+    ],
+  },
+  {
+    key: "skills",
+    label: "SKILLS",
+    blurb:
+      "Installed skills you can toggle on or off, plus a live search of the skills registry — install without leaving the deck.",
+    lines: [
+      "Installed — 4 (user + project)",
+      "[x] release-checklist v3  (project·workspace)  Cut a release…",
+      "[x] rust-review v2/4      (user·user)          Review Rust diffs…",
+      "[ ] sql-tuning v1         (user·installed)     Read a query plan…",
+      "[x] bench-rig-access v1   (project·auto)       Reach the bench rig…",
+      "",
+      "Registry search — find: _   (⏎ to search)",
+    ],
+  },
+  {
+    key: "mcp",
+    label: "MCP",
+    blurb:
+      "Configured MCP servers — connection state, tool counts, auth — enable, disable, or authenticate without leaving the deck.",
+    lines: [
+      "MCP — 3 configured / 2 connected",
+      "● Stripe   http   live      ⚿ oauth ✓  · 21 tools · 14×",
+      "● fs       stdio  live      · 4 tools",
+      "○ Linear   http   disabled  ⚿ oauth: o to log in · 0 tools",
+    ],
+  },
+  {
+    key: "issues",
+    label: "ISSUES",
+    blurb:
+      "Your connected GitHub or Linear tracker, with instant search and the ability to start work on an issue.",
+    lines: [
+      "ISSUES — 3 listed",
+      "#874 [open]    Command-deck render golden tests · enhancement",
+      "#826 [open]    run_deck event-loop pty harness · enhancement",
+      "#689 [closed]  Surface per-server MCP tool truncation · bug",
+    ],
+  },
+  {
+    key: "settings",
+    label: "SETTINGS",
+    blurb: "The home of all config — agents, tools, models, credentials — including the engine-config editor.",
+    lines: [
+      "AGENTS │ TOOLS",
+      "GLOBAL   default   worker   verifier   triage   research   plan",
+      "",
+      "waiting for the engine config snapshot — r to reload",
+      "e edit agents config",
+    ],
+  },
+];
+
+export function CommandDeckExplorer() {
+  const [activeKey, setActiveKey] = useState(TABS[0].key);
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const active = TABS.find((tab) => tab.key === activeKey) ?? TABS[0];
+
+  function focusTab(index: number) {
+    const wrapped = TABS[(index + TABS.length) % TABS.length];
+    setActiveKey(wrapped.key);
+    tabRefs.current[wrapped.key]?.focus();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusTab(index + 1);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusTab(index - 1);
+    }
+  }
+
+  return (
+    <div className="dke">
+      <div className="dke-tabs" role="tablist" aria-label="Command Deck tabs">
+        {TABS.map((tab, index) => (
+          <button
+            key={tab.key}
+            ref={(el) => {
+              tabRefs.current[tab.key] = el;
+            }}
+            type="button"
+            role="tab"
+            id={`dke-tab-${tab.key}`}
+            aria-selected={tab.key === activeKey}
+            aria-controls={`dke-panel-${tab.key}`}
+            tabIndex={tab.key === activeKey ? 0 : -1}
+            className="dke-tab"
+            data-active={tab.key === activeKey}
+            onClick={() => setActiveKey(tab.key)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div
+        className="dke-pane"
+        role="tabpanel"
+        id={`dke-panel-${active.key}`}
+        aria-labelledby={`dke-tab-${active.key}`}
+      >
+        <p className="dke-blurb">{active.blurb}</p>
+        <pre className="dke-lines">{active.lines.join("\n")}</pre>
+      </div>
+    </div>
+  );
+}

--- a/website/src/mdx-components.tsx
+++ b/website/src/mdx-components.tsx
@@ -4,6 +4,7 @@ import type { MDXComponents } from "mdx/types";
 import type { ComponentProps } from "react";
 
 import { Badge, CardGrid, OptionCard, SpecCard, ToolCard } from "@/components/cards";
+import { CommandDeckExplorer } from "@/components/command-deck-explorer";
 import { DocsCodeBlock } from "@/components/docs-code-block";
 import {
   BudgetGuardDiagram,
@@ -79,6 +80,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BudgetGuardDiagram,
     CostChainDiagram,
     ClaimLockDiagram,
+    CommandDeckExplorer,
     // Cards — the mobile-first replacement for reference tables
     CardGrid,
     SpecCard,


### PR DESCRIPTION
## What & why

The "Interactive: the Command Deck" section on the docs site (`/docs/agent-modes`) explained the deck only in prose — a `CardGrid` of slash commands. A reader who knows what a TUI is still doesn't know what "the deck" *is*: a specific 9-tab workspace, not a generic terminal UI.

Adds `<CommandDeckExplorer />`, a small clickable tab strip mirroring the deck's own 9 real tabs (SESSION, AGENTS, TRACES, GRAPH, FILES, SKILLS, MCP, ISSUES, SETTINGS). Clicking a tab swaps in that tab's content.

Was given a marketing mock (`stella-site-mock.html`) as a starting reference — a 6-satellite "product tour" with scripted, timer-driven terminal playback per feature (memories, context PRs, best-of-N, goal mode, fleet, witness protocol). Fact-checked its claims against the actual source before shipping anything (per this repo's CLAUDE.md evidence rule) and found several inaccuracies: the deck tab list was missing 2 of 9 real tabs, a verification rank was misnamed (`JudgePass` → real name `VerifierPass`, and that rank is dead code today), "mutation check 3/3 killed" isn't a score the tool actually reports, and "memories quietly retire" contradicts the real mechanic (retirement is an explicit human action, never automatic).

Given those findings, scoped this down from a full port of the 6-feature marketing tour to a focused, verifiable demo of the Command Deck itself — its real 9 tabs, each pane trimmed directly from `crates/stella-tui/tests/snapshots/deck/tab_*.txt` (the golden renders `make gate` already checks on every TUI PR), rather than reconstructed or invented transcript text. No timers, no autoplay — a click swaps the pane instantly, so there's no loop to make unreadable and no `prefers-reduced-motion` case to design around (the failure mode the *previous* animated command-deck component was deliberately cut for — see `command-deck.tsx`'s doc comment).

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is a docs-site content + presentational-component change with no engine/CLI behavior. Verified instead by: `pnpm typecheck` and `pnpm build` (the site's own CI job) both pass, and the rendered static HTML output was inspected to confirm all 9 tabs and their content actually render.

## The gate

- [ ] `cargo fmt --check` — N/A, no Rust changed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo test --workspace` — N/A, no Rust changed
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments) — this PR *is* the doc update
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [ ] `Closes #N` appears both above and as a commit trailer — N/A, no tracking issue for this change

Ran the repo's docs-relevant gate scripts directly since this branch touches no crate: `check-brand-case.sh`, `check-doc-links.py`, `check-command-docs.sh`, `check-no-scratch.sh`, `check-left-behind.sh` — all pass.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

(The mock's inaccuracies described above were corrected in what shipped here rather than filed as issues, since they were never claims this repo made — they lived only in an external, un-committed marketing mock, not in tracked docs or code.)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below — no new dependencies; no engine code touched
- [x] No new outbound network calls (stella never phones home) — purely static, server-rendered-by-default content; the one client component (`command-deck-explorer.tsx`) is local click-state only, no network calls
- N/A New cross-boundary types round-trip through serde (test included) — no cross-boundary types involved

## Anything reviewers should know?

- New client component: `website/src/components/command-deck-explorer.tsx` (`"use client"` — necessary since the whole point is click-driven tab switching; it ships no timers and no scripted animation, unlike the deck's earlier, since-removed autoplay component).
- New CSS block in `website/src/app/global.css` under a `.dke-*` prefix, styled to match the existing `.term` (ink terminal) treatment used elsewhere on the site for visual consistency.
- Registered `CommandDeckExplorer` in `website/src/mdx-components.tsx` so it's usable directly in MDX without a per-page import, following the same pattern as the existing diagram/card components.
- Scope call: intentionally did **not** port the mock's full 6-feature "product tour" (memories / context PRs / best-of-N / goal mode / fleet / witness protocol) — those are separate subsystems with their own existing docs pages, and porting all six would mean maintaining six more hand-authored scripted transcripts alongside this one evidence-backed deck-tab demo. Happy to revisit if a broader product-tour section is wanted elsewhere (e.g. the homepage).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DPnNhxmdYq5gt185uPTqPv)_

## Summary by Sourcery

Introduce an interactive Command Deck explorer in the Agent Modes docs that visually mirrors the deck’s nine tabs using evidence-backed snapshot content.

Enhancements:
- Add a reusable CommandDeckExplorer client component and associated styles, and register it in the MDX components map for use across the docs site.

Documentation:
- Clarify the Command Deck description and add a clickable tab explorer showing real snapshot-based output for each deck tab in the Agent Modes documentation.