### PR TITLE
fix(stella-embed): a proptest's `vec!` fails clippy, so main cannot compile its tests

### DIFF
--- a/crates/stella-embed/src/rank.rs
+++ b/crates/stella-embed/src/rank.rs
@@ -326,7 +326,7 @@ mod tests {
         fn extra_noise_below_the_cliff_never_widens_the_answer(
             tail_len in 1usize..20,
         ) {
-            let head = vec![0.95f32, 0.93, 0.92];
+            let head = [0.95f32, 0.93, 0.92];
             let base: Vec<f32> = head.iter().copied().chain([0.20]).collect();
             let longer: Vec<f32> = head
                 .iter()


### PR DESCRIPTION
`main` is red on the `lint` gate step:

```
error: useless use of `vec!`
   --> crates/stella-embed/src/rank.rs:329:24
    |
329 |             let head = vec![0.95f32, 0.93, 0.92];
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly
    = note: `-D clippy::useless-vec` implied by `-D warnings`
error: could not compile `stella-embed` (lib test)
```

The binding is only ever borrowed (`head.iter().copied()` twice), so the heap allocation buys nothing and an array is the identical code. Fixed by using the array, not by `#[allow]` — the lint is right here.

## Why this surfaced only now

This is the **fifth** gate step #3095 landed red, and the first four hid it: a CI job stops at its first failing step, so each repair exposed the next one underneath.

| # | Step | Failure | Fixed by |
|---|---|---|---|
| 1 | `test` | `live_index.rs` — README stopped being unindexed | #3106 / #3107 |
| 2 | `format-check` | 3 files landed unformatted | #3106 / #3107 |
| 3 | `test` | `graph.rs` — same stale fixture | #3106 |
| 4 | `doc-warnings` | public docs linked private `crate::markdown` | #3112 |
| 5 | `lint` | this | this PR |

Separately, `INDEXED_LANGUAGES` omitted `markdown` — a defect the fixture repairs in 1/3 papered over rather than caused (#3109).

## Verification

```
$ make lint
cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile
LINT-EXIT=0
```

## Witness test

None possible in the suite — the assertion *is* the `lint` gate step, whose before/after is above. Same category as a `fmt` repair.

## Deleted tests

None.

## Summary by Sourcery

Bug Fixes:
- Fix clippy lint `useless-vec` in stella-embed rank tests to allow the lint gate to pass again.