### PR TITLE
fix(stella-tools): search was ranking over 14% of the workspace and not saying so

### DIFF
--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -444,14 +444,19 @@ pub(crate) async fn dispatch(
     if let (Some(graph), Some(embedder)) = (graph, embedder) {
         strategies.push(Strategy::Semantic);
         match semantic_hits(graph, embedder, query).await {
-            Ok(hits) if !hits.is_empty() => {
+            Ok((hits, coverage)) if !hits.is_empty() => {
                 return Answer {
                     hits,
                     strategies,
-                    note,
+                    // Coverage rides even on a successful answer: it is
+                    // exactly the successful-looking partial answer that
+                    // needs the caveat.
+                    note: coverage,
                 };
             }
-            Ok(_) => {}
+            // An empty semantic answer over a partial index is the most
+            // misleading outcome of all — "nothing matched" reads as absence.
+            Ok((_, coverage)) => note = coverage,
             Err(reason) => note = Some(reason),
         }
     }
@@ -479,18 +484,30 @@ pub(crate) async fn dispatch(
 /// Embed what is pending, embed the query, rank. `Err` carries a reason
 /// already phrased for the answer's note.
 ///
-/// **Chunks first, files as the fallback.** A chunk vector names the symbol or
-/// the documentation section that matched, which is both a sharper ranking and
-/// a citation; a file vector answers "what is this module about", which no
-/// chunk can, and is what a workspace whose chunk pass has not run yet still
-/// has. A file whose chunks matched is reported once, at its best chunk's
-/// score, with that chunk named — so the answer keeps the shape callers
-/// already read while the score finally means something specific.
+/// **Both rungs, merged — not chunks-then-files.** Ranking chunks and
+/// returning early whenever they produced anything let a *partially filled*
+/// chunk index shadow a better-covered file index, and the failure was total
+/// rather than marginal: the chunk pass fills in `ORDER BY path` at
+/// `MAX_FILES_PER_CHUNK_PASS` files a call, so on this workspace it held
+/// 4,011 of 29,334 chunks, every one under `arenabench/` or `bench/`, with the
+/// frontier sitting alphabetically short of `crates/`. Every Rust file was
+/// invisible to the sharp rung while the file rung already covered 69% of the
+/// tree — so a query about `crates/` got a confident answer assembled entirely
+/// from the bench harness.
+///
+/// Merging is legitimate here and *only* here: chunk and file vectors are
+/// written by the same embedder under the same `fingerprint`, so they are one
+/// vector space and their cosines are directly comparable. That is not true
+/// across the strategy ladder, which is why `dispatch` still refuses to fuse.
+///
+/// A file reached by both rungs is reported once, preferring its chunk hit —
+/// same score meaning, plus the symbol or section that matched, which is a
+/// citation a file vector cannot produce.
 async fn semantic_hits(
     graph: &CodeGraph,
     embedder: &dyn Embedder,
     query: &str,
-) -> Result<Vec<Hit>, String> {
+) -> Result<(Vec<Hit>, Option<String>), String> {
     let fingerprint = embedder.fingerprint().id();
     catch_up_embeddings(graph, embedder, &fingerprint).await?;
     catch_up_chunk_embeddings(graph, embedder, &fingerprint).await?;
@@ -511,72 +528,122 @@ async fn semantic_hits(
     let chunks = graph
         .rank_chunks_by_vector(&fingerprint, &query_vector, floor, RANK_CEILING)
         .map_err(|error| format!("the chunk index could not be read: {error}"))?;
-    if !chunks.is_empty() {
-        return Ok(group_chunks_by_file(&chunks));
-    }
-
-    graph
+    let files = graph
         .rank_files_by_vector(&fingerprint, &query_vector, floor, RANK_CEILING)
-        .map(|ranked| {
-            let cut = stella_embed::rank::relevant_prefix(
-                &ranked,
-                stella_embed::rank::DEFAULT_RELEVANCE_GAP_RATIO,
-                stella_embed::rank::DEFAULT_MIN_BOUNDARY_GAP,
-            );
-            ranked
-                .into_iter()
-                .take(cut)
-                .map(|scored| Hit {
-                    path: scored.key,
-                    why: format!(
-                        "ranked by MEANING against your query, over the whole file \
-                         (cosine {:.3})",
-                        scored.score
-                    ),
-                })
-                .collect()
-        })
-        .map_err(|error| format!("the vector index could not be read: {error}"))
+        .map_err(|error| format!("the vector index could not be read: {error}"))?;
+
+    Ok((
+        merge_rungs(&chunks, &files),
+        coverage_note(graph, &fingerprint),
+    ))
 }
 
-/// Collapse a chunk ranking to one hit per file, best chunk first.
+/// One ordering over both rungs, best first, one hit per file.
 ///
-/// The relevance cut is applied to the **chunk** ranking rather than to the
-/// grouped one, because the boundary is a property of the scores and grouping
-/// discards scores. Cutting after the grouping would measure gaps between
-/// per-file maxima, which is a different and much sparser distribution than
-/// the one the boundary was defined over.
-fn group_chunks_by_file(chunks: &[stella_graph::ScoredChunk]) -> Vec<Hit> {
+/// See [`semantic_hits`] for why merging is sound: one embedder, one
+/// fingerprint, one vector space.
+fn merge_rungs(
+    chunks: &[stella_graph::ScoredChunk],
+    files: &[stella_embed::rank::Scored],
+) -> Vec<Hit> {
+    let mut scored: Vec<(f32, String, String)> = chunks
+        .iter()
+        .map(|chunk| {
+            (
+                chunk.score,
+                chunk.path.clone(),
+                format!(
+                    "ranked by MEANING against your query — best match is `{}` ({}) at line {} \
+                     (cosine {:.3})",
+                    chunk.name, chunk.kind, chunk.start_line, chunk.score
+                ),
+            )
+        })
+        .chain(files.iter().map(|file| {
+            (
+                file.score,
+                file.key.clone(),
+                format!(
+                    "ranked by MEANING against your query, over the whole file (cosine {:.3})",
+                    file.score
+                ),
+            )
+        }))
+        .collect();
+    // Descending by score, then by path, so the ordering is total and the
+    // answer is byte-stable across runs (invariant 7).
+    scored.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.1.cmp(&b.1))
+    });
+
+    // The cut is taken over the merged SCORES, before collapsing to files:
+    // the boundary is a property of the score distribution, and collapsing
+    // discards scores. The synthetic key keeps `relevant_prefix`'s input
+    // unique without reordering it.
+    let ordered: Vec<stella_embed::rank::Scored> = scored
+        .iter()
+        .enumerate()
+        .map(|(index, (score, path, _))| stella_embed::rank::Scored {
+            key: format!("{index:06}#{path}"),
+            score: *score,
+        })
+        .collect();
     let cut = stella_embed::rank::relevant_prefix(
-        &chunks
-            .iter()
-            .map(|chunk| stella_embed::rank::Scored {
-                key: format!("{}#{}#{}", chunk.path, chunk.start_line, chunk.name),
-                score: chunk.score,
-            })
-            .collect::<Vec<_>>(),
+        &ordered,
         stella_embed::rank::DEFAULT_RELEVANCE_GAP_RATIO,
         stella_embed::rank::DEFAULT_MIN_BOUNDARY_GAP,
     );
 
     let mut seen: Vec<String> = Vec::new();
-    let mut hits: Vec<Hit> = Vec::new();
-    for chunk in chunks.iter().take(cut) {
-        if seen.iter().any(|path| path == &chunk.path) {
+    let mut hits = Vec::new();
+    for (_, path, why) in scored.into_iter().take(cut) {
+        if seen.iter().any(|p| p == &path) {
             continue;
         }
-        seen.push(chunk.path.clone());
-        hits.push(Hit {
-            path: chunk.path.clone(),
-            why: format!(
-                "ranked by MEANING against your query — best match is `{}` ({}) at line {} \
-                 (cosine {:.3})",
-                chunk.name, chunk.kind, chunk.start_line, chunk.score
-            ),
-        });
+        seen.push(path.clone());
+        hits.push(Hit { path, why });
     }
     hits
 }
+
+/// How much of the workspace this ranking could actually see, when that is
+/// less than all of it.
+///
+/// **An incomplete index reported as a complete one is worse than an empty
+/// one**, and this tool had no way to say so: it printed `via: semantic` over
+/// a ranking drawn from 14% of the workspace — every one of those chunks in
+/// the same two directories — with nothing in the answer to suggest the other
+/// 86% had never been looked at. The argument the module already makes about
+/// budget truncation, that an agent which cannot tell a complete answer from a
+/// partial one stops looking, applies to coverage exactly as it does to
+/// length. Coverage was the half that was silent.
+///
+/// The "not a random sample" sentence is the load-bearing one. Embedding fills
+/// in path order, so a partial index is not a uniform thinning of the tree; it
+/// is a prefix of it, and a caller who assumes otherwise will read a miss as
+/// evidence of absence.
+///
+/// `None` when both rungs are complete, so a healthy workspace pays no tokens
+/// for the disclosure.
+fn coverage_note(graph: &CodeGraph, fingerprint: &str) -> Option<String> {
+    let symbols = graph.symbol_count().ok()?;
+    let chunks = graph.embedded_chunk_count(fingerprint).ok()?;
+    let total_files = graph.file_count().ok()?;
+    let files = graph.embedded_file_count(fingerprint).ok()?;
+    if chunks >= symbols && files >= total_files {
+        return None;
+    }
+    Some(format!(
+        "PARTIAL INDEX — this ranking saw {chunks} of {symbols} symbols/sections and {files} \
+         of {total_files} files. Embedding fills in path order a batch per call, so the \
+         remainder is NOT a random sample: it is the tail of the tree alphabetically. Run \
+         `stella init` to finish it; until then treat a miss as inconclusive and use `bash` \
+         with `grep -n` for anything exact."
+    ))
+}
+
 
 /// Embed every indexed file still pending under `fingerprint`, up to the
 /// per-pass cap. Shares `stella-graph`'s pending-scan cursor with

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -644,7 +644,6 @@ fn coverage_note(graph: &CodeGraph, fingerprint: &str) -> Option<String> {
     ))
 }
 
-
 /// Embed every indexed file still pending under `fingerprint`, up to the
 /// per-pass cap. Shares `stella-graph`'s pending-scan cursor with
 /// `semantic_code_search`, so the two tools warm one index rather than two.

--- a/crates/stella-tools/tests/search_recall.rs
+++ b/crates/stella-tools/tests/search_recall.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Does `search` actually find the answer? (#3097)
+//!
+//! Every other test of this tool uses a hashing embedder, which declares
+//! [`SimilarityPosture::Surface`] — its scores order candidates and certify
+//! nothing. That is precisely the property under test here, so those tests
+//! cannot answer the only question that matters: **given a real embedding
+//! backend and a real workspace, does the tool return the file that answers
+//! the query?**
+//!
+//! This harness runs against a live backend and a real index, so it is gated
+//! on `STELLA_SEARCH_RECALL=1` **and** a configured embedder. Without both it
+//! prints why it did not run and passes — a skip that silently reads as a pass
+//! is the failure shape #3011 already paid for, so the reason is always
+//! printed.
+//!
+//! ```sh
+//! set -a; . ~/.env.global.local; set +a
+//! STELLA_SEARCH_RECALL=1 STELLA_SEARCH_WORKSPACE=/path/to/stella \
+//!   cargo test -p stella-tools --test search_recall -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use stella_tools::registry::Tool;
+
+/// One labelled query: what to ask, and what a correct answer contains.
+struct Probe {
+    /// The query, exactly as a model would phrase it.
+    query: &'static str,
+    /// A workspace-relative path that MUST appear in the ranked answer.
+    expect: &'static str,
+    /// How near the top it must appear. **Presence is not the bar** — #3089
+    /// asks for the top 3, and an answer buried at rank 36 of 139 is one the
+    /// model will never read. Asserting only presence is how a harness
+    /// reports success over a result nobody could use.
+    within: usize,
+    /// Why this probe exists — printed with the result, so a failure reads as
+    /// a finding rather than as a red line.
+    why: &'static str,
+}
+
+/// The three #3089 names, which test three different things.
+const PROBES: &[Probe] = &[
+    Probe {
+        query: "where is the prompt cache engaged on outbound requests",
+        expect: "crates/stella-model/src/anthropic.rs",
+        within: 3,
+        why: "the measured regression: file-level vectors put the answer \
+              nowhere in the top 10 and spread only 0.05 across all of them",
+    },
+    Probe {
+        query: "the function that decides whether a ranked list stops being relevant",
+        expect: "crates/stella-embed/src/rank.rs",
+        within: 5,
+        why: "an answer that is exactly one function — does chunk granularity \
+              resolve to a symbol rather than to its file?",
+    },
+    Probe {
+        query: "why must a new AgentEvent variant declare what consumes it",
+        expect: "AGENTS.md",
+        within: 5,
+        why: "an answer that is PROSE, not code — unanswerable from the code \
+              index at all, so a pass cannot be an accident of it",
+    },
+];
+
+fn workspace() -> PathBuf {
+    std::env::var("STELLA_SEARCH_WORKSPACE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+#[tokio::test]
+async fn search_returns_the_file_that_answers_the_query() {
+    if std::env::var("STELLA_SEARCH_RECALL").as_deref() != Ok("1") {
+        println!("SKIPPED: set STELLA_SEARCH_RECALL=1 to run (needs a live embedder)");
+        return;
+    }
+    let root = workspace();
+    println!("workspace: {}", root.display());
+
+    let mut failures = Vec::new();
+    for probe in PROBES {
+        // Through the `Tool` trait, which is the path the agent itself takes
+        // — so a schema or dispatch defect shows up here rather than being
+        // stepped around by calling the inner function.
+        let tool = stella_tools::search::Search::from_env();
+        let output = tool
+            .execute(&serde_json::json!({ "query": probe.query }), &root)
+            .await;
+        let content = match output {
+            stella_protocol::tool::ToolOutput::Ok { content } => content,
+            stella_protocol::tool::ToolOutput::Error { message } => {
+                failures.push(format!("`{}` errored: {message}", probe.query));
+                continue;
+            }
+        };
+
+        println!("\n=== query: {}\n=== why:   {}", probe.query, probe.why);
+        println!("{content}");
+
+        // Rank, not presence. The hit lines are the ones that start at
+        // column 0 and look like a path; the renderer indents everything else.
+        let ranked: Vec<&str> = content
+            .lines()
+            .filter(|line| {
+                !line.starts_with(char::is_whitespace)
+                    && (line.contains(".rs") || line.contains(".md") || line.contains(".py"))
+                    && !line.starts_with("search `")
+            })
+            .collect();
+        match ranked.iter().position(|line| line.trim() == probe.expect) {
+            Some(index) if index < probe.within => {
+                println!("PASS: `{}` at rank {}", probe.expect, index + 1);
+            }
+            Some(index) => failures.push(format!(
+                "`{}` returned `{}` at rank {} of {} — the bar is top {}\n  ({})",
+                probe.query,
+                probe.expect,
+                index + 1,
+                ranked.len(),
+                probe.within,
+                probe.why
+            )),
+            None => failures.push(format!(
+                "`{}` did not return `{}` at all (in {} results)\n  ({})",
+                probe.query,
+                probe.expect,
+                ranked.len(),
+                probe.why
+            )),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "search failed to answer {} of {} probes:\n{}",
+        failures.len(),
+        PROBES.len(),
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
You were right that search doesn't work well. This is what testing it against the real workspace and a live Voyage backend actually showed, and the part of it I can fix here.

## Measured, not inferred

```
chunk vectors   4,011 of 29,334 symbols — every one under arenabench/ or bench/
frontier        bench/loop-bench/src/compare/tests.rs — alphabetically short of crates/
file vectors    1,112 of 1,605, and those DO cover crates/
anthropic.rs    0 chunks embedded
```

`pending_chunks` fills in `ORDER BY f.path`, `MAX_FILES_PER_CHUNK_PASS` (64) files per call. `arenabench/` < `bench/` < `crates/`, so **the entire Rust codebase had never been chunk-embedded and would not be for dozens more calls.**

## The regression this PR fixes

`semantic_hits` returned early on any non-empty chunk result. So a **14%-covered index shadowed a 69%-covered one**: every query about `crates/` got a confident answer assembled entirely from the bench harness. #3095 made search *worse* for the Rust tree than it was before.

Both rungs are now ranked and **merged into one ordering**. That is sound here and nowhere else: chunk and file vectors are written by the same embedder under the same `fingerprint`, so they are one vector space and their cosines are directly comparable. `dispatch` still refuses to fuse across the strategy ladder, where they are not.

## The more important half: the answer now states its own coverage

```
(PARTIAL INDEX — this ranking saw 11,776 of 29,334 symbols/sections and 1,605 of
 1,605 files. Embedding fills in path order a batch per call, so the remainder is
 NOT a random sample: it is the tail of the tree alphabetically. Run `stella init`
 to finish it; until then treat a miss as inconclusive and use `bash` with
 `grep -n` for anything exact.)
```

The tool printed `via: semantic` over a ranking drawn from 14% of the workspace with nothing to suggest the other 86% had never been looked at. The module already argues that an agent which cannot tell a complete answer from a truncated one stops looking — that argument applies to **coverage** exactly as it does to length, and coverage was the half that was silent. Emitted only when a rung is incomplete, so a healthy workspace pays no tokens for it.

## The harness (#3097), asserting rank rather than presence

An earlier draft asserted only that the expected path *appeared*. It passed while `anthropic.rs` sat at **rank 38 of 139** — an answer no model will read. Asserting presence is how a harness reports success over a result nobody can use. It now asserts #3089's actual bar.

## Current honest state — the harness still fails, deliberately

| Probe | Result |
|---|---|
| one function → `crates/stella-embed/src/rank.rs` | **PASS at rank 3** |
| prompt cache → `crates/stella-model/src/anthropic.rs` | rank 38 of 138 — bar is top 3 |
| prose → `AGENTS.md` invariant 10 | **not returned at all** in 136 results |

Read together these are one finding, and it is not "the ranking is bad":

- **Where chunks are embedded, it works.** `stella-embed` is alphabetically inside the filled region and lands at rank 3.
- **Where they are not, it does not.** `stella-model` is past the frontier, so `anthropic.rs` matches only through its diluted whole-file vector — the exact mechanism #3089 was filed about. **Filling the index is the fix, not tuning the ranker** — that is #3098, and it is now the critical path, not a nicety.
- **`AGENTS.md` regressed from present to absent as chunk coverage grew.** Code chunks crowded out the doc section that answers the question. One flat ranked list cannot hold a dossier: this is direct evidence for the **role-grouped, per-role budget** proposed on #3063, and it is the first measurement supporting it.

I am leaving the harness red rather than relaxing it to green. It is measuring the truth.

## Scope

Exactly two files: `crates/stella-tools/src/search.rs` and the new `crates/stella-tools/tests/search_recall.rs`. The red-`main` fixes this branch also carried (the two `graph_query` fixtures, `cargo fmt`, the placeholder issue ids) merged separately as **#3106** and are **not** in this PR.

No test was deleted in this PR.

Refs #3089, #3097, #3098, #3063.
