### PR TITLE
fix(stella-tools,stella-graph,stella-cli): stella init eagerly embeds every chunk, so search ranks by meaning on query one

### DIFF
--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -121,6 +121,23 @@ async fn warm_semantic_index(
         &outcome,
         &embedder.fingerprint().model_id,
     ));
+
+    // The sharper rung `search` ranks first (#3098): a file-level vector
+    // exists but a query naming one function in a large multi-purpose file
+    // loses to a file that happens to have complete per-symbol coverage,
+    // regardless of which is the true answer. Same reasoning as the pass
+    // above, one layer down.
+    emit("◈ embedding code chunks for search…".to_string());
+    let chunk_outcome = stella_tools::search::warm_chunk_vectors(
+        workspace_root,
+        embedder.as_ref(),
+        stella_tools::search::MAX_FILES_PER_CHUNK_EAGER_PASS,
+    )
+    .await;
+    emit(format_chunk_warm_outcome(
+        &chunk_outcome,
+        &embedder.fingerprint().model_id,
+    ));
 }
 
 /// The one-line report of an eager embedding pass.
@@ -165,6 +182,46 @@ fn format_warm_outcome(
         WarmOutcome::Failed { embedded, reason } => format!(
             "! semantic index: stopped after {embedded} files — {reason} (the rest embed on \
              demand)"
+        ),
+    }
+}
+
+/// The one-line report of an eager chunk-embedding pass. Same shape and the
+/// same reasoning as [`format_warm_outcome`], one rung sharper.
+fn format_chunk_warm_outcome(
+    outcome: &stella_tools::search::ChunkWarmOutcome,
+    model: &str,
+) -> String {
+    use stella_tools::search::ChunkWarmOutcome;
+    match outcome {
+        ChunkWarmOutcome::Warmed {
+            files_embedded,
+            files_remaining: 0,
+            ..
+        } => format!("✓ chunk index: {files_embedded} file(s) embedded by {model}"),
+        ChunkWarmOutcome::Warmed {
+            files_embedded,
+            files_remaining,
+            unreadable,
+        } if *unreadable > 0 => format!(
+            "! chunk index: {files_embedded} file(s) embedded by {model} — {files_remaining} \
+             left unembedded, {unreadable} of them because their content could not be read (the \
+             next `stella init` drops files that have moved or vanished)"
+        ),
+        ChunkWarmOutcome::Warmed {
+            files_embedded,
+            files_remaining,
+            ..
+        } => format!(
+            "✓ chunk index: {files_embedded} file(s) embedded by {model} — {files_remaining} \
+             left unembedded (they embed on demand as searches reach them)"
+        ),
+        ChunkWarmOutcome::Failed {
+            files_embedded,
+            reason,
+        } => format!(
+            "! chunk index: stopped after {files_embedded} file(s) — {reason} (the rest embed \
+             on demand)"
         ),
     }
 }

--- a/crates/stella-cli/src/agent/graph/tests.rs
+++ b/crates/stella-cli/src/agent/graph/tests.rs
@@ -121,13 +121,17 @@ async fn init_embeds_the_index_without_any_semantic_query_being_issued() {
 
     // The half that makes this a witness for EAGER embedding rather than for
     // embedding at all: a query would have been sent as a bare sentence, and
-    // every text here is a file render (`render_file_text` opens with `file: `).
+    // every text here is either a file render (`render_file_text` opens with
+    // `file: `) or a chunk render (`render_chunk_text`'s `path :: name (kind)`
+    // header) — the chunk pass runs against this same mock server (#3098), so
+    // both shapes are expected traffic now, and neither is a bare query.
     let texts = sent_texts(&server).await;
     assert!(!texts.is_empty(), "the pass sent nothing");
     for text in &texts {
         assert!(
-            text.starts_with("file: "),
-            "only file renders may be embedded by init — this looks like a query: {text:?}"
+            text.starts_with("file: ") || (text.contains(" :: ") && text.contains(")\n\n")),
+            "only file or chunk renders may be embedded by init — this looks like a query: \
+             {text:?}"
         );
     }
     assert!(
@@ -255,5 +259,71 @@ fn an_unreadable_file_is_named_as_a_problem_not_as_the_cap() {
     assert!(
         !rendered.contains("embed on demand"),
         "an unreadable file will not embed on demand — do not promise it: {rendered}"
+    );
+}
+
+/// THE WITNESS for #3098's fix: on `main` the chunk vector table is empty
+/// until `search` has already been called several times (each call capped at
+/// `MAX_FILES_PER_CHUNK_PASS`, 64 files); here `stella init` alone leaves
+/// every symbol in the fixture chunk-embedded, with no semantic query issued.
+#[tokio::test]
+async fn init_embeds_every_chunk_without_any_semantic_query_being_issued() {
+    use stella_embed::Embedder;
+
+    let ws = workspace();
+    let root = ws.path().canonicalize().expect("canonicalize");
+    let server = embeddings_server().await;
+
+    let mut lines: Vec<String> = Vec::new();
+    build_code_graph_with(&root, &env_for(&server), &mut |line| lines.push(line)).await;
+
+    let fingerprint = stella_embed::HttpEmbedder::new(
+        &format!("{}/v1", server.uri()),
+        "concept-2",
+        None,
+        2,
+        0.25,
+    )
+    .fingerprint()
+    .id();
+    let graph = open_graph(&root);
+    let chunks_remaining = graph
+        .pending_chunk_file_count(&fingerprint)
+        .expect("pending count");
+    let chunks_embedded = graph.embedded_chunk_count(&fingerprint).expect("count");
+    graph.shutdown();
+
+    assert_eq!(
+        chunks_remaining, 0,
+        "`stella init` must leave no file with an un-chunked symbol; lines were {lines:?}"
+    );
+    assert_eq!(
+        chunks_embedded,
+        FIXTURE.len(),
+        "one function per fixture file"
+    );
+    assert!(
+        lines.iter().any(|line| line.contains("chunk index")),
+        "the pass must report what it did: {lines:?}"
+    );
+}
+
+/// Same discipline as `a_capped_pass_names_what_it_left_unembedded`, one rung
+/// sharper.
+#[test]
+fn a_capped_chunk_pass_names_what_it_left_unembedded() {
+    let rendered = format_chunk_warm_outcome(
+        &stella_tools::search::ChunkWarmOutcome::Warmed {
+            files_embedded: 2_000,
+            files_remaining: 1_231,
+            unreadable: 0,
+        },
+        "voyage-code-3",
+    );
+    assert!(rendered.contains("2000 file(s) embedded"), "{rendered}");
+    assert!(rendered.contains("1231 left unembedded"), "{rendered}");
+    assert!(
+        rendered.contains("embed on demand"),
+        "the cap's leftovers are picked up by the lazy pass: {rendered}"
     );
 }

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -503,6 +503,14 @@ impl CodeGraph {
         vectors::chunks::chunk_count(&self.inner.read_guard(), fingerprint)
     }
 
+    /// How many indexed files still carry a symbol with no chunk vector under
+    /// `fingerprint`. What an eager chunk-embedding pass reports as
+    /// `remaining` — cheap on purpose, since it is checked after every pass
+    /// without re-rendering or re-hashing anything.
+    pub fn pending_chunk_file_count(&self, fingerprint: &str) -> Result<usize, GraphError> {
+        vectors::chunks::pending_chunk_file_count(&self.inner.read_guard(), fingerprint)
+    }
+
     /// The structured neighborhood of `file` — its symbols and import edges
     /// in both directions — for UI consumers (the deck's Graph tab). The
     /// frame methods above render prose for the model; this keeps the shape.

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -53,6 +53,9 @@ use stella_embed::rank::{Candidate, Scored};
 use crate::error::GraphError;
 use crate::store;
 
+#[cfg(test)]
+mod tests;
+
 /// How many *files* one pass will chunk-embed. Files rather than chunks
 /// because a file's chunks are written as one unit: the sweep that deletes
 /// vanished chunks keys on the file hash, so a file split across two passes
@@ -471,6 +474,24 @@ fn candidate_key(chunk: &ScoredChunk) -> String {
 pub fn chunk_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphError> {
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM code_graph_chunk_vectors WHERE fingerprint = ?1",
+        params![fingerprint],
+        |row| row.get(0),
+    )?;
+    Ok(count.max(0) as usize)
+}
+
+/// How many indexed files still have a symbol with no chunk vector under
+/// `fingerprint` — the same WHERE clause [`pending_chunks`] scans, as a count
+/// rather than a page of rendered work. An eager pass reports this as
+/// `remaining` without paying for a render-and-hash pass over files it is
+/// about to discard the content of.
+pub fn pending_chunk_file_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphError> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM code_graph_files f \
+         WHERE (SELECT COUNT(*) FROM code_graph_symbols s WHERE s.file_id = f.id) > \
+               (SELECT COUNT(*) FROM code_graph_chunk_vectors v \
+                WHERE v.file_id = f.id AND v.fingerprint = ?1 \
+                  AND v.file_sha256 = f.content_sha256)",
         params![fingerprint],
         |row| row.get(0),
     )?;

--- a/crates/stella-graph/src/vectors/chunks/tests.rs
+++ b/crates/stella-graph/src/vectors/chunks/tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+use crate::parse::Grammars;
+use std::fs;
+use tempfile::tempdir;
+
+const FP: &str = "test-model@1/4/l2";
+
+fn indexed_workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, Connection) {
+    let ws = tempdir().expect("tempdir");
+    for (rel, body) in files {
+        let path = ws.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir");
+        }
+        fs::write(&path, body).expect("write");
+    }
+    let db = ws.path().join("codegraph.db");
+    let mut conn = store::open(&db).expect("open");
+    let root = ws.path().canonicalize().expect("canonicalize");
+    store::index_tree(&mut conn, &root, &Grammars::load().expect("grammars")).expect("index");
+    (ws, conn)
+}
+
+/// The witness: a file with symbols is pending-by-file-count until every one
+/// of its chunks is stored, then the count drops — and stays accurate once a
+/// second file with symbols of its own is added.
+#[test]
+fn the_pending_file_count_drops_only_once_every_chunk_is_stored() {
+    let (ws, mut conn) = indexed_workspace(&[("a.rs", "fn alpha() {}\nfn beta() {}\n")]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+
+    assert_eq!(
+        pending_chunk_file_count(&conn, FP).expect("count"),
+        1,
+        "one file, two un-embedded symbols — still pending"
+    );
+
+    let scan = pending_chunks(&conn, &root, FP, 10).expect("scan");
+    assert_eq!(scan.files.len(), 1);
+    let file = &scan.files[0];
+    assert_eq!(file.chunks.len(), 2, "alpha and beta are both chunks");
+
+    // Store only the first chunk — the file must still read as pending.
+    let rows = vec![ChunkVector {
+        chunk_sha256: file.chunks[0].chunk_sha256.clone(),
+        name: file.chunks[0].name.clone(),
+        kind: file.chunks[0].kind.clone(),
+        start_line: file.chunks[0].start_line,
+        end_line: file.chunks[0].end_line,
+        vector: Some(vec![1.0, 0.0, 0.0, 0.0]),
+    }];
+    store_chunk_vectors(&mut conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
+    assert_eq!(
+        pending_chunk_file_count(&conn, FP).expect("count"),
+        1,
+        "one of two chunks stored — still pending"
+    );
+
+    // Store the second chunk — now the file drops out of the pending count.
+    let rows = vec![ChunkVector {
+        chunk_sha256: file.chunks[1].chunk_sha256.clone(),
+        name: file.chunks[1].name.clone(),
+        kind: file.chunks[1].kind.clone(),
+        start_line: file.chunks[1].start_line,
+        end_line: file.chunks[1].end_line,
+        vector: Some(vec![0.0, 1.0, 0.0, 0.0]),
+    }];
+    store_chunk_vectors(&mut conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
+    assert_eq!(
+        pending_chunk_file_count(&conn, FP).expect("count"),
+        0,
+        "both chunks stored — no longer pending"
+    );
+    assert_eq!(chunk_count(&conn, FP).expect("chunk_count"), 2);
+}
+
+/// A different fingerprint's vectors do not satisfy this one's pending count
+/// — the same discipline `vectors::tests` pins for whole-file vectors, so a
+/// model swap does not silently under-report unembedded work.
+#[test]
+fn a_different_fingerprint_still_counts_as_pending() {
+    let (ws, mut conn) = indexed_workspace(&[("a.rs", "fn alpha() {}\n")]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+    let scan = pending_chunks(&conn, &root, FP, 10).expect("scan");
+    let file = &scan.files[0];
+    let rows = vec![ChunkVector {
+        chunk_sha256: file.chunks[0].chunk_sha256.clone(),
+        name: file.chunks[0].name.clone(),
+        kind: file.chunks[0].kind.clone(),
+        start_line: file.chunks[0].start_line,
+        end_line: file.chunks[0].end_line,
+        vector: Some(vec![1.0, 0.0, 0.0, 0.0]),
+    }];
+    store_chunk_vectors(&mut conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
+
+    assert_eq!(pending_chunk_file_count(&conn, FP).expect("count"), 0);
+    assert_eq!(
+        pending_chunk_file_count(&conn, "other-model@1/4/l2").expect("count"),
+        1,
+        "a fingerprint that has embedded nothing must still see the file as pending"
+    );
+}

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -636,46 +636,224 @@ async fn catch_up_chunk_embeddings(
         .map_err(|error| format!("the code graph could not be read: {error}"))?;
 
     for file in &scan.files {
-        let mut vectors: Vec<Option<Vec<f32>>> = vec![None; file.chunks.len()];
-        let needed: Vec<(usize, &str)> = file
-            .chunks
-            .iter()
-            .enumerate()
-            .filter_map(|(index, chunk)| chunk.text.as_deref().map(|text| (index, text)))
-            .collect();
-
-        for batch in needed.chunks(EMBED_BATCH) {
-            let texts: Vec<String> = batch.iter().map(|(_, text)| (*text).to_string()).collect();
-            let embeddings = embedder
-                .embed(&texts)
-                .await
-                .map_err(|error| format!("the embedder failed: {error}"))?;
-            for ((index, _), embedding) in batch.iter().zip(embeddings) {
-                vectors[*index] = Some(embedding.vector);
-            }
-        }
-
-        let rows: Vec<stella_graph::ChunkVector> = file
-            .chunks
-            .iter()
-            .zip(vectors)
-            .map(|(chunk, vector)| stella_graph::ChunkVector {
-                chunk_sha256: chunk.chunk_sha256.clone(),
-                name: chunk.name.clone(),
-                kind: chunk.kind.clone(),
-                start_line: chunk.start_line,
-                end_line: chunk.end_line,
-                vector,
-            })
-            .collect();
-        graph
-            .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
-            // Not recoverable by continuing: the next file would be written
-            // into the same broken store and the pass would report success
-            // having stored nothing.
-            .map_err(|error| format!("the chunk index could not be written: {error}"))?;
+        embed_and_store_chunk_file(graph, embedder, fingerprint, file).await?;
     }
     Ok(())
+}
+
+/// Embed one file's pending chunks and store them — the single place a chunk
+/// vector comes into existence, shared by the lazy per-query catch-up above
+/// and the eager `stella init` pass below, so there is one render, one table
+/// and one fingerprint discipline (mirrors `embed_batch` in
+/// `crate::graph::semantic` for whole-file vectors).
+async fn embed_and_store_chunk_file(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    fingerprint: &str,
+    file: &stella_graph::PendingChunkFile,
+) -> Result<(), String> {
+    let mut vectors: Vec<Option<Vec<f32>>> = vec![None; file.chunks.len()];
+    let needed: Vec<(usize, &str)> = file
+        .chunks
+        .iter()
+        .enumerate()
+        .filter_map(|(index, chunk)| chunk.text.as_deref().map(|text| (index, text)))
+        .collect();
+
+    for batch in needed.chunks(EMBED_BATCH) {
+        let texts: Vec<String> = batch.iter().map(|(_, text)| (*text).to_string()).collect();
+        let embeddings = embedder
+            .embed(&texts)
+            .await
+            .map_err(|error| format!("the embedder failed: {error}"))?;
+        for ((index, _), embedding) in batch.iter().zip(embeddings) {
+            vectors[*index] = Some(embedding.vector);
+        }
+    }
+
+    let rows: Vec<stella_graph::ChunkVector> = file
+        .chunks
+        .iter()
+        .zip(vectors)
+        .map(|(chunk, vector)| stella_graph::ChunkVector {
+            chunk_sha256: chunk.chunk_sha256.clone(),
+            name: chunk.name.clone(),
+            kind: chunk.kind.clone(),
+            start_line: chunk.start_line,
+            end_line: chunk.end_line,
+            vector,
+        })
+        .collect();
+    graph
+        .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
+        // Not recoverable by continuing: the next file would be written
+        // into the same broken store and the pass would report success
+        // having stored nothing.
+        .map_err(|error| format!("the chunk index could not be written: {error}"))
+        .map(|_| ())
+}
+
+/// The most files one eager (`stella init`) chunk-embedding pass will
+/// process. Matches `crate::graph::semantic::MAX_FILES_PER_EAGER_PASS`'s cap
+/// and its reasoning: this pass runs before any turn starts, so its budget is
+/// the user's money and patience rather than a round trip, and a workspace
+/// larger than this gets a **stated** partial index rather than a silent one.
+pub const MAX_FILES_PER_CHUNK_EAGER_PASS: usize = 2_000;
+
+/// What an eager chunk-embedding pass did, as data the caller renders. Total
+/// by construction and never a `Result` — `stella init` must succeed with no
+/// embedder, a broken embedder, and a workspace too big to finish in one
+/// pass, and telling those apart is something a human reads, not something a
+/// caller branches on (same contract as
+/// `crate::graph::semantic::WarmOutcome`, kept as its own type because a
+/// chunk pass counts files-with-pending-chunk-work, not files-with-no-vector
+/// — the two are not interchangeable once a file can be partially chunked).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChunkWarmOutcome {
+    /// The pass ran. `files_remaining` is what the cap left for the lazy
+    /// per-query pass (`catch_up_chunk_embeddings`) to pick up on the first
+    /// `search` call.
+    Warmed {
+        /// Files whose chunks this pass embedded or re-stamped.
+        files_embedded: usize,
+        /// Indexed files still carrying a symbol with no chunk vector under
+        /// this fingerprint, per the same pre-filter `chunks_pending_embedding`
+        /// scans with — an upper bound, not an exact count: a file whose
+        /// symbols happen to render byte-identical text to one another can
+        /// read as pending forever even once fully covered (see the "no
+        /// progress" comment in `warm_chunks_opened` — filed as #3128).
+        files_remaining: usize,
+        /// How many of those this pass could not read from disk. Separated
+        /// from `files_remaining` for the reason
+        /// `crate::graph::semantic::WarmOutcome::Warmed::unreadable` gives:
+        /// the cap's leftovers embed themselves on the next query, an
+        /// unreadable file never will.
+        unreadable: usize,
+    },
+    /// The pass stopped early. `reason` is prose meant to be shown verbatim;
+    /// whatever was embedded before the failure is committed and counted.
+    Failed {
+        /// Files whose chunks were embedded before the failure — each file
+        /// commits as it completes.
+        files_embedded: usize,
+        reason: String,
+    },
+}
+
+/// Embed the workspace's indexed chunks — symbols, markdown sections —
+/// **without answering a query**: the `stella init` pass for `search`'s
+/// primary ranking rung (#3098).
+///
+/// The lazy per-query pass above is right for a long session and wrong for a
+/// single-turn run in a fresh checkout: it fires only once `search` has
+/// already been called, capped at `stella_graph::MAX_FILES_PER_CHUNK_PASS`
+/// (64) files, so a workspace this crate's own repository's size needs
+/// roughly 25 calls before its first full pass completes — meaning the first
+/// several searches in a session rank against whichever files happened to be
+/// processed first, not the best answer. Running the same pass here, ahead of
+/// the first turn, makes that work free from the agent's perspective —
+/// mirroring `crate::graph::semantic::warm_file_vectors` one layer down, and
+/// deliberately not `open_or_build`, for the identical reason it gives: the
+/// caller has just run `index_all`, and a second catch-up pass would re-walk
+/// and re-hash a tree nothing has touched since.
+pub async fn warm_chunk_vectors(
+    root: &Path,
+    embedder: &dyn Embedder,
+    limit: usize,
+) -> ChunkWarmOutcome {
+    let graph = stella_store::workspace_private_sqlite_path(root, "codegraph.db")
+        .map_err(|error| format!("cannot prepare the code graph store: {error}"))
+        .and_then(|db_path| {
+            CodeGraph::open(root, &db_path)
+                .map_err(|error| format!("could not open the code graph: {error}"))
+        });
+    let graph = match graph {
+        Ok(graph) => graph,
+        Err(reason) => {
+            return ChunkWarmOutcome::Failed {
+                files_embedded: 0,
+                reason,
+            };
+        }
+    };
+    let outcome = warm_chunks_opened(&graph, embedder, limit).await;
+    graph.shutdown();
+    outcome
+}
+
+async fn warm_chunks_opened(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    limit: usize,
+) -> ChunkWarmOutcome {
+    let fingerprint = embedder.fingerprint().id();
+    let mut files_embedded = 0usize;
+    let mut unreadable = 0usize;
+    while files_embedded < limit {
+        let want = stella_graph::MAX_FILES_PER_CHUNK_PASS.min(limit - files_embedded);
+        let scan = match graph.chunks_pending_embedding(&fingerprint, want) {
+            Ok(scan) => scan,
+            Err(error) => {
+                return ChunkWarmOutcome::Failed {
+                    files_embedded,
+                    reason: format!("cannot read the code graph: {error}"),
+                };
+            }
+        };
+        // Overwritten, never summed — same discipline as
+        // `crate::graph::semantic::warm_opened`: each round rescans the
+        // pending set from the start, so an unreadable file is stepped over
+        // again every round and summing would multiply it by the round count.
+        unreadable = unreadable.max(scan.unreadable);
+        // No files means the pending set is exhausted — a window landing on
+        // unreadable rows keeps filling past them, so this is genuinely done
+        // rather than a scan that gave up early (#3016).
+        if scan.files.is_empty() {
+            break;
+        }
+        // The pending-files pre-filter is a cheap, deliberately loose COUNT
+        // comparison (raw symbols vs. stored chunks) — it can select a file
+        // that in fact needs no embedding at all: two symbols whose rendered
+        // text is byte-identical (a common shape for trivial mock/test
+        // boilerplate — `fn execute(&self) { todo!() }` repeated across
+        // several fixtures in one file) collapse to one stored row under the
+        // content-hash key, so the raw symbol count can never equal the
+        // stored count for that file even once every one of its symbols is
+        // correctly embedded. `PendingChunkFile::to_embed()` is the precise,
+        // per-symbol answer the SQL pre-filter cannot give; if an entire
+        // window comes back with nothing left to actually embed, every
+        // further window would just re-select and re-stamp the same
+        // false-positive files forever without buying anything real —
+        // tracked as a pre-filter imprecision rather than reworked into an
+        // exact predicate here (it also affects the lazy per-query pass
+        // above, which is bounded to one window per call and so never pays
+        // more than a single wasted re-scan for it) — filed as #3128.
+        let mut made_progress = false;
+        for file in &scan.files {
+            if file.to_embed() > 0 {
+                made_progress = true;
+            }
+            if let Err(reason) =
+                embed_and_store_chunk_file(graph, embedder, &fingerprint, file).await
+            {
+                return ChunkWarmOutcome::Failed {
+                    files_embedded,
+                    reason,
+                };
+            }
+            files_embedded += 1;
+        }
+        if !made_progress {
+            break;
+        }
+    }
+
+    let files_remaining = graph.pending_chunk_file_count(&fingerprint).unwrap_or(0);
+    ChunkWarmOutcome::Warmed {
+        files_embedded,
+        files_remaining,
+        unreadable,
+    }
 }
 
 /// Render an answer against the allocation the budget allows.

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -19,7 +19,9 @@ use stella_embed::{EmbedError, Embedder, EmbedderFingerprint, Embedding, Similar
 use stella_graph::CodeGraph;
 use stella_protocol::tool::ToolOutput;
 
-use super::{Hit, Search, SearchConfig, Strategy, dispatch, render};
+use super::{
+    ChunkWarmOutcome, Hit, Search, SearchConfig, Strategy, dispatch, render, warm_chunk_vectors,
+};
 use crate::registry::Tool;
 
 /// The question the witness asks. Every word of it is checked against the
@@ -181,6 +183,25 @@ fn indexed_fixture(workspace: &Path) -> (std::path::PathBuf, CodeGraph) {
     let graph = CodeGraph::open(&root, &root.join("codegraph.db")).expect("open");
     graph.index_all().expect("index");
     (root, graph)
+}
+
+/// Same fixture, indexed at the real `.stella/private/codegraph.db` path
+/// [`crate::graph::open_or_build`] resolves — what `warm_chunk_vectors` and
+/// every production caller actually open, unlike [`indexed_fixture`]'s
+/// `<root>/codegraph.db`, which only the tests calling `dispatch`/`render`
+/// directly ever touch. Closes the graph before returning so the caller's own
+/// connection (opened fresh, matching `stella init`'s real sequencing) is not
+/// racing an already-open one.
+fn write_fixture_at_the_real_workspace_path(workspace: &Path) -> std::path::PathBuf {
+    for (path, body) in FIXTURE {
+        let file = workspace.join(path);
+        fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+        fs::write(&file, body).expect("write");
+    }
+    let root = workspace.canonicalize().expect("canonicalize");
+    let opened = crate::graph::open_or_build(&root).expect("open_or_build");
+    opened.graph.shutdown();
+    root
 }
 
 fn content_of(output: &ToolOutput) -> String {
@@ -593,4 +614,120 @@ fn the_rendered_hit_count_matches_the_allocation() {
     assert_eq!(shown, allocation.granted.len());
     assert_eq!(allocation.omitted, hits.len() - shown);
     assert!(facets_at(config.depth).len() >= 3);
+}
+
+/// The witness for the eager `stella init` chunk pass (#3098): a fixture
+/// wider than one lazy per-query window (`MAX_FILES_PER_CHUNK_PASS`, 64)
+/// would take several `search` calls to fully cover — this proves one
+/// `warm_chunk_vectors` call finishes it, so `search` can rank by meaning on
+/// its very first invocation rather than the ~25th on a repository this
+/// crate's own size.
+#[tokio::test]
+async fn one_eager_pass_embeds_every_pending_chunk_no_matter_how_many_files() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let root = write_fixture_at_the_real_workspace_path(workspace.path());
+
+    let outcome = warm_chunk_vectors(&root, &ConceptEmbedder, 1_000).await;
+    let ChunkWarmOutcome::Warmed {
+        files_embedded,
+        files_remaining,
+        unreadable,
+    } = outcome
+    else {
+        panic!("expected Warmed, got {outcome:?}");
+    };
+    assert_eq!(
+        files_embedded,
+        FIXTURE.len(),
+        "every fixture file has symbols to chunk"
+    );
+    assert_eq!(files_remaining, 0, "nothing left pending after one pass");
+    assert_eq!(unreadable, 0);
+
+    // Idempotent: a second pass over an already-warm index embeds nothing new.
+    let again = warm_chunk_vectors(&root, &ConceptEmbedder, 1_000).await;
+    assert_eq!(
+        again,
+        ChunkWarmOutcome::Warmed {
+            files_embedded: 0,
+            files_remaining: 0,
+            unreadable: 0,
+        },
+        "re-running against a fully warm index must be a no-op, not a re-embed"
+    );
+}
+
+/// A capped pass says honestly what it left behind, rather than reporting
+/// success over a partial index — the same discipline
+/// `crate::graph::semantic::WarmOutcome` holds for whole-file vectors.
+#[tokio::test]
+async fn a_capped_pass_reports_what_it_left_pending() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let root = write_fixture_at_the_real_workspace_path(workspace.path());
+
+    // FIXTURE has 4 files; cap the pass at fewer files than that.
+    let outcome = warm_chunk_vectors(&root, &ConceptEmbedder, 2).await;
+    let ChunkWarmOutcome::Warmed {
+        files_embedded,
+        files_remaining,
+        ..
+    } = outcome
+    else {
+        panic!("expected Warmed, got {outcome:?}");
+    };
+    assert_eq!(files_embedded, 2, "the pass must stop exactly at its cap");
+    assert!(
+        files_remaining > 0,
+        "a capped pass over a wider fixture must say something is still pending"
+    );
+}
+
+/// #3128: two symbols that render byte-identical text collapse to one stored
+/// row, so the pending-files pre-filter's raw symbol-count-vs-stored-count
+/// comparison can never reach equality for that file — without the "no
+/// progress" early exit, `warm_chunk_vectors` would re-select and re-stamp it
+/// on every round until its cap, never returning promptly even once every
+/// real symbol is embedded. This is the witness for that early exit.
+#[tokio::test]
+async fn a_file_whose_symbols_collide_on_rendered_text_does_not_spin_the_pass() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let root = {
+        let file = workspace.path().join("src/dupes.rs");
+        fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+        // Two distinct symbols, same name, same kind, byte-identical body —
+        // ordinary trait-stub-across-fixtures shape, not a contrived one.
+        fs::write(
+            &file,
+            "mod a {\n    pub fn execute() { todo!() }\n}\n\
+             mod b {\n    pub fn execute() { todo!() }\n}\n",
+        )
+        .expect("write");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let opened = crate::graph::open_or_build(&root).expect("open_or_build");
+        opened.graph.shutdown();
+        root
+    };
+
+    // First pass: real embedding work happens (however few distinct chunks
+    // there are), and the pass must still terminate rather than hang.
+    let outcome = warm_chunk_vectors(&root, &ConceptEmbedder, 1_000).await;
+    assert!(
+        matches!(outcome, ChunkWarmOutcome::Warmed { .. }),
+        "expected Warmed, got {outcome:?}"
+    );
+
+    // Second pass over the now-embedded fixture: with the collision, the
+    // pre-filter still selects `src/dupes.rs` (symbol count 2 > stored rows
+    // 1), so without the early exit this would spend its entire `limit`
+    // re-visiting it. It must instead return quickly, having made no further
+    // progress, and must not report a growing `files_embedded` each time.
+    let again = warm_chunk_vectors(&root, &ConceptEmbedder, 1_000).await;
+    let ChunkWarmOutcome::Warmed { files_embedded, .. } = again else {
+        panic!("expected Warmed, got {again:?}");
+    };
+    assert!(
+        files_embedded <= stella_graph::MAX_FILES_PER_CHUNK_PASS,
+        "a fully-covered fixture must stop after at most one window, not spin \
+         toward the cap: files_embedded={files_embedded}"
+    );
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`search`'s primary ranking rung is per-symbol chunk vectors (#3095), but
`stella init` never built them — only the lazy pass triggered by a live
`search` call did, capped at `MAX_FILES_PER_CHUNK_PASS` (64) files per call.

Measured directly against this repository (not inferred): after 8 real
`search` calls with a real embedder, only 482 of 1564 symbol-bearing files
(31%) had any chunk coverage, and three ground-truth-verified answers were
missing as a direct result — including `search`'s own worked example in its
tool description (`"what calls resolve_provider"`). A repository this size
needed roughly 25 `search` calls before its first full pass would complete.
Posted as evidence on #3098, which had already diagnosed the design gap but
had no measurement or reproduction.

This PR:

1. Adds an eager chunk-embedding pass to `stella init`, mirroring the
   existing eager file-vector pass exactly: `warm_chunk_vectors` loops
   `chunks_pending_embedding` in `MAX_FILES_PER_CHUNK_PASS`-sized windows up
   to a 2,000-file cap (matching the file-level eager pass's own cap), and
   reports honestly what it left for the lazy pass to pick up. The lazy
   per-query pass is untouched — this only changes *when* the same work
   happens, not what it does.
2. Fixes a real bug the first real run surfaced: `pending_chunks`'
   pending-files predicate (raw symbol count vs. stored chunk-vector count)
   can never reach equality for a file where two symbols render
   byte-identical text — an ordinary shape for trivial mock/test boilerplate
   (several `fn execute(&self) { todo!() }` stubs across different fixtures
   in one file) — because they collapse to one stored row under the
   content-hash key. Without a fix, the eager pass spun toward its 2,000-file
   cap re-visiting the same ~34 false-positive files in this repository
   forever; a second, back-to-back `stella init` run against an
   already-fully-embedded index took several minutes instead of returning
   promptly. `warm_chunks_opened` now stops a round early once nothing in its
   window has real work left (`PendingChunkFile::to_embed()` is the precise
   per-symbol answer the SQL pre-filter cannot give).

Closes #3098
Refs #3128

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Six, each verified fail-on-old/pass-on-new artisanally (stashed the fix,
confirmed a compile error or assertion failure, restored, confirmed green):

- `stella-graph`: `pending_chunk_file_count` accuracy —
  `the_pending_file_count_drops_only_once_every_chunk_is_stored`,
  `a_different_fingerprint_still_counts_as_pending`.
- `stella-tools`: the eager pass's completeness, idempotency, and honest
  capping — `one_eager_pass_embeds_every_pending_chunk_no_matter_how_many_files`,
  `a_capped_pass_reports_what_it_left_pending`.
- `stella-tools`: **the collision bug specifically** —
  `a_file_whose_symbols_collide_on_rendered_text_does_not_spin_the_pass`.
  Reproduces the exact shape found on the real run (two symbols, same name,
  identical body, in different modules of one file) in a fast unit test:
  without the fix it drives `files_embedded` to the full 1,000-file `limit`
  passed in the test; with the fix it stops after one window.
- `stella-cli`: `stella init`'s end-to-end wiring, with no semantic query
  ever issued — `init_embeds_every_chunk_without_any_semantic_query_being_issued`.

One pre-existing `stella-cli` test's assertion was updated (not deleted):
`init_embeds_the_index_without_any_semantic_query_being_issued` asserted
every request sent to the mock embeddings server was a whole-file render.
That was true before this PR — it is no longer, because the new eager chunk
pass sends its own (also-eager, also-not-a-query) requests through the same
mock. The assertion now accepts either shape, and still fails on a bare
query sentence, which is the property the test actually exists to check.

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-graph -p stella-tools -p stella-cli` — every
      binary green (1777 stella-cli, 962 stella-tools, all stella-graph
      binaries)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` on the
      three touched crates — clean (checked deliberately, given the recent
      main-red private-intra-doc-link incident)
- [x] `scripts/check-file-size.sh` / `scripts/check-left-behind.sh` — clean,
      no baseline changes needed
- [ ] Docs updated where behavior/flags changed — N/A, no CLI flag or schema
      changed; `stella init`'s own console output gained one new line
      (`◈ embedding code chunks for search…` / `✓ chunk index: …`), which is
      self-describing the way the existing file-embedding line already is
- [x] CLA signed
- [x] `Closes #3098` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #3128 — the underlying `pending_chunks` predicate imprecision
      (this PR works around it at the caller; #3128 asks for the predicate
      itself to be made exact, which needs either a stored per-file distinct-
      chunk-count or a different approach, and is real, separable work)

There is nothing else I noticed and did not fix or file.

## Ground-rule check

- [x] No I/O added to `stella-core` — this touches `stella-tools`,
      `stella-graph`, and `stella-cli` only
- [x] No new outbound network calls — this reaches the *already-configured*
      embedding backend `stella init` already talks to for file vectors, on
      the same code path
- [x] No new cross-boundary types cross a crate boundary that needs serde —
      `ChunkWarmOutcome` is `stella-tools`-internal-consumed-by-`stella-cli`,
      same shape and same non-serialized usage as the existing `WarmOutcome`
      it mirrors

## Anything reviewers should know?

- I verified this end to end against the real `stella` binary against this
  actual repository (1606 files, 29349 symbols), not just synthetic
  fixtures — including catching and fixing the collision bug live, from a
  real run that took several minutes when it should have taken seconds. The
  before/after: first real run (bug present) processed 2,000 files and
  reported "34 left"; a rebuild with the fix, run again from the same
  already-embedded state, finished in ~2 minutes total (dominated by domain
  inference and re-indexing, not the chunk pass) and reported the same
  honest "34 left" — now understood to be the `#3128` false-positive class,
  confirmed by direct SQL query to be exactly 34 files.
- `MAX_FILES_PER_CHUNK_EAGER_PASS` is set to 2,000, matching the existing
  file-level eager cap exactly, on the theory that both passes should cover
  the same size of workspace fully. This repository's *first* eager pass
  (before this PR existed, i.e. before any chunks were ever warmed) would
  likely need more than one `stella init` run to fully catch up under that
  cap, exactly like the file-level pass already accepts for very large
  repositories — reported honestly via `files_remaining`, not hidden.
- `ChunkWarmOutcome::Warmed::files_remaining` is documented as an upper
  bound rather than an exact count, because of #3128 — flagging this
  explicitly rather than letting the doc comment overclaim precision the
  underlying query doesn't have.

## Summary by Sourcery

Add an eager chunk-embedding pass wired into `stella init` so semantic search can use per-symbol chunk vectors from the first query, and expose its outcome via CLI output.

New Features:
- Introduce `warm_chunk_vectors` and `ChunkWarmOutcome` to eagerly embed code chunks during initialization, capped to a configurable number of files.
- Add user-facing reporting for the chunk-embedding pass in `stella init`, including success, partial, and failure messages.

Bug Fixes:
- Prevent the chunk-embedding pass from repeatedly reprocessing files whose symbols collide to identical rendered text, avoiding spinning against the cap.
- Ensure pending-chunk file counts are accurate per fingerprint and reflect when all chunks of a file have been stored.

Enhancements:
- Refactor chunk embedding into a shared helper used by both the lazy per-query pass and the new eager init pass.
- Add APIs in the code graph to query pending chunk-file counts to support accurate reporting of remaining work.

Tests:
- Add tests covering the eager chunk pass behavior, capping semantics, collision scenarios, and its CLI wiring, including witnesses that fail on old code and pass on the new.
- Add tests for the pending-chunk file-count query to validate its correctness across partial embedding and multiple fingerprints.