### PR TITLE
feat(stella-cli): carry the search ranking as data in stella search --format json

### DIFF
--- a/crates/stella-cli/src/contextgraph.rs
+++ b/crates/stella-cli/src/contextgraph.rs
@@ -57,7 +57,6 @@ use stella_context::{
 use stella_protocol::{ContextProviderUsage, ContextUsage};
 
 use crate::domains::Domains;
-use crate::query_format::{QueryFormat, Versioned};
 use crate::settings::{ContextProviderSettings, ExternalContextProvider, ProviderEndpoint};
 
 mod suppression;
@@ -950,67 +949,6 @@ fn now_rfc3339() -> String {
         .map(|d| d.as_secs() as i64)
         .unwrap_or_default();
     stella_context::format_rfc3339(secs)
-}
-
-/// One `stella search` answer, machine-readable — the `--format json`
-/// envelope. `content` carries the exact text a human (or the agent) would
-/// read; `error` is `None` on success. Both are always present so a script
-/// parsing this need not branch on which key exists.
-#[derive(Debug, Clone, serde::Serialize)]
-struct SearchAnswer {
-    query: String,
-    ok: bool,
-    content: String,
-    error: Option<String>,
-}
-
-/// `stella search <query>` — the human door to the same `search` tool the
-/// agent calls, run through the real [`stella_tools::registry::Tool`]
-/// interface rather than a reimplementation, so a CLI run and an agent's
-/// call exercise identical code and `--format json` is a faithful fixture
-/// for testing the ranking against real queries.
-pub async fn run_search(query: &str, format: QueryFormat) -> Result<(), String> {
-    use stella_tools::registry::Tool;
-
-    let root =
-        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
-    let input = serde_json::json!({ "query": query });
-    let output = stella_tools::search::Search::from_env()
-        .execute(&input, &root)
-        .await;
-
-    let (ok, content, error) = match output {
-        stella_protocol::tool::ToolOutput::Ok { content } => (true, content, None),
-        stella_protocol::tool::ToolOutput::Error { message } => {
-            (false, String::new(), Some(message))
-        }
-    };
-
-    match format {
-        QueryFormat::Text => {
-            if let Some(message) = &error {
-                return Err(message.clone());
-            }
-            println!("{content}");
-        }
-        QueryFormat::Json => {
-            let answer = SearchAnswer {
-                query: query.to_string(),
-                ok,
-                content,
-                error: error.clone(),
-            };
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&Versioned::new(answer))
-                    .map_err(|e| format!("serialize: {e}"))?
-            );
-            if let Some(message) = error {
-                return Err(message);
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/contextgraph/tests.rs
+++ b/crates/stella-cli/src/contextgraph/tests.rs
@@ -1341,28 +1341,3 @@ mod query_domain_scope_derivation {
         assert_eq!(scope, vocabulary, "the scope IS the vocabulary");
     }
 }
-
-/// `stella search` (#3098's follow-up ask): the CLI door onto the same
-/// `search` tool the agent calls, replacing the old `stella graph <op>
-/// <target>` surface. `Search::execute` rejects an empty query before
-/// touching the graph or an embedder, so this needs no fixture — and it
-/// pins that both `--format text` and `--format json` report the same
-/// underlying failure rather than the JSON path swallowing it.
-#[tokio::test]
-async fn run_search_reports_the_missing_query_error_in_both_formats() {
-    let text_err = run_search("", QueryFormat::Text)
-        .await
-        .expect_err("an empty query must fail");
-    assert!(
-        text_err.contains("`query` is required"),
-        "text error: {text_err}"
-    );
-
-    let json_err = run_search("", QueryFormat::Json)
-        .await
-        .expect_err("an empty query must fail under --format json too");
-    assert_eq!(
-        json_err, text_err,
-        "both formats surface the same underlying failure"
-    );
-}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -97,6 +97,7 @@ mod resume_frame;
 mod rules;
 mod runtime;
 mod scripts_cmd;
+mod search_cmd;
 mod session_persist;
 mod settings;
 mod settings_check;
@@ -716,11 +717,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             // Ranks semantically when an embedder is configured (a network
             // write-through into codegraph.db); otherwise reads the local
             // index only.
-            return signals::block_on_interruptible(
-                rt()?,
-                contextgraph::run_search(query, *format),
-            )
-            .map_err(failure::CliFailure::from);
+            return signals::block_on_interruptible(rt()?, search_cmd::run_search(query, *format))
+                .map_err(failure::CliFailure::from);
         }
         Some(Command::Scripts { cmd }) => {
             // Static manifest parsing plus a local subprocess — works with

--- a/crates/stella-cli/src/search_cmd.rs
+++ b/crates/stella-cli/src/search_cmd.rs
@@ -1,0 +1,199 @@
+//! `stella search` — the human door to the same `search` tool the agent
+//! calls, replacing the retired `stella graph <op> <target>` surface.
+//!
+//! The command runs [`stella_tools::search::report`], the exact mechanism the
+//! agent's tool wraps — not a reimplementation — so a CLI invocation and an
+//! in-turn call exercise identical dispatch, ranking, and rendering. What
+//! differs is only what survives the call: the agent's door gets the rendered
+//! prose (the module docs there argue why the model must not get a
+//! pipeline-shapeable match list), while `--format json` also carries the
+//! decided answer — `hits` in rank order, the strategy ladder that ran, the
+//! degradation note — so a script probing ranking quality asserts on data
+//! instead of regexing prose.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::query_format::{QueryFormat, Versioned};
+
+/// One `stella search` answer, machine-readable — the `--format json`
+/// envelope. `content` carries the exact text the agent would read; `error`
+/// is `None` on success. Every field is always present so a script parsing
+/// this need not branch on which key exists. Field order is a courtesy, not
+/// the contract (consumers read by key): append new fields, don't reorder.
+#[derive(Debug, Clone, Serialize)]
+struct SearchAnswer {
+    query: String,
+    ok: bool,
+    /// The strategies that ran, in order, as the `via:` line prints them.
+    strategies: Vec<String>,
+    /// Why the semantic rung did not run or ran degraded, verbatim.
+    note: Option<String>,
+    /// The ranked hits, best first — the assertable half of the answer.
+    hits: Vec<SearchAnswerHit>,
+    content: String,
+    error: Option<String>,
+}
+
+/// One ranked hit of the JSON envelope, in rank order.
+#[derive(Debug, Clone, Serialize)]
+struct SearchAnswerHit {
+    path: String,
+    why: String,
+}
+
+/// Entry point for `stella search <query>`.
+pub async fn run_search(query: &str, format: QueryFormat) -> Result<(), String> {
+    let root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    let answer = search_answer_in(&root, query).await;
+    render(answer, format)
+}
+
+/// The search for a workspace — [`run_search`] minus the cwd resolution and
+/// the printing, so tests can drive it against a temp root (the
+/// `memory_cmd::list_rows` discipline: no process-global cwd mutation).
+async fn search_answer_in(root: &Path, query: &str) -> SearchAnswer {
+    let report =
+        stella_tools::search::report(root, query, stella_tools::search::SearchConfig::from_env())
+            .await;
+
+    let (ok, content, error) = match report.rendered {
+        stella_protocol::tool::ToolOutput::Ok { content } => (true, content, None),
+        stella_protocol::tool::ToolOutput::Error { message } => {
+            (false, String::new(), Some(message))
+        }
+    };
+    SearchAnswer {
+        query: query.trim().to_string(),
+        ok,
+        strategies: report.strategies.iter().map(ToString::to_string).collect(),
+        note: report.note,
+        hits: report
+            .hits
+            .into_iter()
+            .map(|hit| SearchAnswerHit {
+                path: hit.path,
+                why: hit.why,
+            })
+            .collect(),
+        content,
+        error,
+    }
+}
+
+/// Print one answer in the requested format. Fails with the search's own
+/// error after printing — under `--format json` the envelope still reaches
+/// stdout (`ok: false`, `error` set), and the non-zero exit is the signal a
+/// script checks without parsing the body.
+fn render(answer: SearchAnswer, format: QueryFormat) -> Result<(), String> {
+    match format {
+        QueryFormat::Text => {
+            if let Some(message) = answer.error {
+                return Err(message);
+            }
+            println!("{}", answer.content);
+        }
+        QueryFormat::Json => {
+            let error = answer.error.clone();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Versioned::new(answer))
+                    .map_err(|e| format!("serialize: {e}"))?
+            );
+            if let Some(message) = error {
+                return Err(message);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The blank-query refusal, through the same [`stella_tools::search::report`]
+    /// path the agent's tool takes — one validation, two doors (#3098's
+    /// follow-up ask). Environment-free: the refusal short-circuits before
+    /// the graph is opened or an embedder is resolved, so this asserts the
+    /// real plumbing without touching the network.
+    #[tokio::test]
+    async fn a_blank_query_is_refused_before_anything_is_opened() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let answer = search_answer_in(dir.path(), "   ").await;
+        assert!(!answer.ok);
+        let error = answer.error.as_deref().expect("a refusal message");
+        assert!(error.contains("`query` is required"), "{error}");
+        assert!(answer.hits.is_empty());
+        assert!(answer.strategies.is_empty());
+        assert!(
+            !dir.path().join(".stella").exists(),
+            "a refused query must not create workspace state as a side effect"
+        );
+    }
+
+    /// Both formats surface the same underlying failure — the JSON path must
+    /// never swallow it into a zero exit.
+    #[test]
+    fn render_fails_with_the_answers_own_error_in_both_formats() {
+        let failed = |format| {
+            render(
+                SearchAnswer {
+                    query: "q".into(),
+                    ok: false,
+                    strategies: Vec::new(),
+                    note: None,
+                    hits: Vec::new(),
+                    content: String::new(),
+                    error: Some("it broke".into()),
+                },
+                format,
+            )
+        };
+        assert_eq!(failed(QueryFormat::Text).unwrap_err(), "it broke");
+        assert_eq!(failed(QueryFormat::Json).unwrap_err(), "it broke");
+    }
+
+    /// The envelope's shape is the contract a test script writes against:
+    /// `hits` in rank order with `path`/`why`, the strategy labels, and the
+    /// version leading the object.
+    #[test]
+    fn the_json_envelope_carries_ranked_hits_as_data() {
+        let answer = SearchAnswer {
+            query: "where is the budget guard".into(),
+            ok: true,
+            strategies: vec!["semantic (embedding rank over the code-graph index)".into()],
+            note: None,
+            hits: vec![
+                SearchAnswerHit {
+                    path: "crates/stella-cli/src/agent/budget.rs".into(),
+                    why: "ranked by MEANING (cosine 0.631)".into(),
+                },
+                SearchAnswerHit {
+                    path: "crates/stella-core/src/goal.rs".into(),
+                    why: "ranked by MEANING (cosine 0.454)".into(),
+                },
+            ],
+            content: "rendered".into(),
+            error: None,
+        };
+        let value: serde_json::Value =
+            serde_json::to_value(Versioned::new(answer)).expect("serializes");
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["ok"], true);
+        assert_eq!(
+            value["hits"][0]["path"], "crates/stella-cli/src/agent/budget.rs",
+            "hit order is rank order"
+        );
+        assert_eq!(value["hits"][1]["path"], "crates/stella-core/src/goal.rs");
+        assert!(value["hits"][0]["why"].as_str().unwrap().contains("cosine"));
+        assert!(
+            value["strategies"][0]
+                .as_str()
+                .unwrap()
+                .starts_with("semantic"),
+        );
+    }
+}

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -345,21 +345,95 @@ impl Tool for Search {
         let query = input
             .get("query")
             .and_then(Value::as_str)
-            .unwrap_or_default()
-            .trim();
-        if query.is_empty() {
-            return ToolOutput::Error {
-                message: "`query` is required: what you are looking for, as a question, a \
-                          description of the behaviour, or a symbol name — e.g. \"where request \
-                          headers are sanitized\" or \"CredentialStore\""
-                    .into(),
-            };
-        }
+            .unwrap_or_default();
+        // Validation (the blank-query refusal included) lives in [`report`],
+        // so this door and the CLI's `stella search` cannot drift apart.
         search(root, query, self.config).await
     }
 }
 
-/// One `search` end to end.
+/// The refusal both doors return for a blank query. One string, one place:
+/// the tool's `execute` and the CLI's `stella search` reach it through the
+/// same [`report`] path, so the wording cannot fork between them.
+const QUERY_REQUIRED: &str = "`query` is required: what you are looking for, as a question, a \
+                              description of the behaviour, or a symbol name — e.g. \"where \
+                              request headers are sanitized\" or \"CredentialStore\"";
+
+/// One ranked hit, as data — the crate-private `Hit` with its fields public,
+/// for consumers outside this crate ([`SearchReport`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchHit {
+    /// Workspace-relative, forward-slash.
+    pub path: String,
+    /// Why this file ranked, as a phrase — see `Hit::why` for why it is
+    /// words rather than a score column.
+    pub why: String,
+}
+
+/// One search, as data plus the rendered answer — the seam the CLI's
+/// `stella search --format json` consumes.
+///
+/// The agent's door deliberately gets **only** [`Self::rendered`]: the module
+/// docs argue at length that a structured match list invites the model to
+/// reshape it in a shell pipeline and lose the ranking's meaning. A test
+/// script is the opposite consumer — it must assert on hit *order* without
+/// parsing prose — so the decided answer rides beside the rendered one
+/// instead of being thrown away at render time. Same dispatch, same render,
+/// one mechanism; only what survives the call differs.
+#[derive(Debug, Clone)]
+pub struct SearchReport {
+    /// The ranked hits, best first — empty when the search failed.
+    pub hits: Vec<SearchHit>,
+    /// The strategies that ran, in order, as the labels the answer's `via:`
+    /// line prints. More than one means an earlier rung came back empty.
+    pub strategies: Vec<&'static str>,
+    /// Why the semantic strategy did not run, or ran degraded — verbatim.
+    pub note: Option<String>,
+    /// Exactly what the agent's door would have returned.
+    pub rendered: ToolOutput,
+}
+
+impl SearchReport {
+    /// The structured half of an [`Answer`], paired with its rendering.
+    fn of(answer: &Answer, rendered: ToolOutput) -> Self {
+        Self {
+            hits: answer
+                .hits
+                .iter()
+                .map(|hit| SearchHit {
+                    path: hit.path.clone(),
+                    why: hit.why.clone(),
+                })
+                .collect(),
+            strategies: answer.strategies.iter().map(|s| s.label()).collect(),
+            note: answer.note.clone(),
+            rendered,
+        }
+    }
+
+    /// A search that never reached dispatch: no hits, no strategies, just
+    /// the error the caller must surface.
+    fn failed(message: &str) -> Self {
+        Self {
+            hits: Vec::new(),
+            strategies: Vec::new(),
+            note: None,
+            rendered: ToolOutput::Error {
+                message: message.into(),
+            },
+        }
+    }
+}
+
+/// One `search` end to end, rendered — the agent's door.
+pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
+    report(root, query, config).await.rendered
+}
+
+/// One `search` end to end, as a [`SearchReport`] — the CLI's door
+/// (`stella search --format json`), and the single mechanism the tool's own
+/// `search` wraps, so a scripted test and an agent call exercise identical
+/// code.
 ///
 /// `open_or_build` runs a full `index_all` catch-up pass, which its contract
 /// says an async caller must wrap in `spawn_blocking`. The handle is then held
@@ -367,7 +441,12 @@ impl Tool for Search {
 /// reads against a local file, so paying a thread hop for each would cost more
 /// than it saves. This is `semantic_code_search`'s discipline, deliberately
 /// unchanged (`crate::graph::semantic`).
-pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
+pub async fn report(root: &Path, query: &str, config: SearchConfig) -> SearchReport {
+    let query = query.trim();
+    if query.is_empty() {
+        return SearchReport::failed(QUERY_REQUIRED);
+    }
+
     let owned_root = root.to_path_buf();
     let opened =
         tokio::task::spawn_blocking(move || crate::graph::open_or_build(&owned_root)).await;
@@ -378,9 +457,7 @@ pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> To
         // workspace the indexer cannot serve.
         Ok(Err(message)) => (None, Some(message)),
         Err(_) => {
-            return ToolOutput::Error {
-                message: "the search was cancelled".into(),
-            };
+            return SearchReport::failed("the search was cancelled");
         }
     };
 
@@ -410,7 +487,10 @@ pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> To
     if let Some(graph) = graph {
         graph.shutdown();
     }
-    crate::graph::with_index_warning(output, index_warning)
+    SearchReport::of(
+        &answer,
+        crate::graph::with_index_warning(output, index_warning),
+    )
 }
 
 /// Choose and run the ranking strategies, in cost order, stopping at the

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -731,3 +731,60 @@ async fn a_file_whose_symbols_collide_on_rendered_text_does_not_spin_the_pass() 
          toward the cap: files_embedded={files_embedded}"
     );
 }
+
+/// The blank-query refusal lives in `report` — one validation both doors
+/// share — and the agent's door still surfaces it. This pins the refusal
+/// from the `execute` side so moving the check cannot silently lose it.
+#[tokio::test]
+async fn a_blank_query_is_refused_through_the_tool_door() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    let output = Search::default()
+        .execute(&serde_json::json!({"query": "   "}), workspace.path())
+        .await;
+    let ToolOutput::Error { message } = output else {
+        panic!("a blank query must be an error, got: {output:?}");
+    };
+    assert!(message.contains("`query` is required"), "{message}");
+    assert!(
+        !workspace.path().join(".stella").exists(),
+        "a refused query must not create workspace state as a side effect"
+    );
+}
+
+/// `SearchReport` is the CLI's `--format json` contract: the decided answer
+/// as data beside the rendering. Hit order is rank order, strategies carry
+/// the exact labels the `via:` line prints, and the note survives verbatim.
+#[test]
+fn the_report_preserves_rank_order_and_strategy_labels() {
+    let answer = super::Answer {
+        hits: vec![
+            Hit {
+                path: "src/first.rs".into(),
+                why: "the top hit".into(),
+            },
+            Hit {
+                path: "src/second.rs".into(),
+                why: "the runner-up".into(),
+            },
+        ],
+        strategies: vec![Strategy::Semantic, Strategy::GraphNames],
+        note: Some("degraded: the backend hiccuped".into()),
+    };
+    let rendered = ToolOutput::Ok {
+        content: "the rendered answer".into(),
+    };
+    let report = super::SearchReport::of(&answer, rendered.clone());
+
+    let paths: Vec<&str> = report.hits.iter().map(|hit| hit.path.as_str()).collect();
+    assert_eq!(paths, ["src/first.rs", "src/second.rs"]);
+    assert_eq!(report.hits[0].why, "the top hit");
+    assert_eq!(
+        report.strategies,
+        [Strategy::Semantic.label(), Strategy::GraphNames.label()]
+    );
+    assert_eq!(
+        report.note.as_deref(),
+        Some("degraded: the backend hiccuped")
+    );
+    assert_eq!(report.rendered, rendered);
+}

--- a/website/content/docs/commands/search.mdx
+++ b/website/content/docs/commands/search.mdx
@@ -52,7 +52,7 @@ stella search "what calls resolve_provider"
 
 ## `--format json`
 
-For scripted testing — feeding real queries through the exact ranking the agent uses and reading the answer back structurally:
+For scripted testing — feeding real queries through the exact ranking the agent uses and reading the answer back as data:
 
 ```bash
 stella search "the retry/backoff policy for failed HTTP requests" --format json
@@ -63,9 +63,20 @@ stella search "the retry/backoff policy for failed HTTP requests" --format json
   "schema_version": 1,
   "query": "the retry/backoff policy for failed HTTP requests",
   "ok": true,
-  "content": "search `...` — N result(s) at depth 4\nvia: semantic\n...",
-  "error": null
+  "strategies": ["semantic (embedding rank over the code-graph index)"],
+  "note": null,
+  "hits": [
+    {
+      "path": "crates/stella-core/src/retry.rs",
+      "why": "ranked by MEANING against your query — best match is `RetryPolicy` (struct) at line 12 (cosine 0.612)"
+    }
+  ],
+  "content": "search `...` — N result(s) at depth 4\nvia: semantic\n..."
 }
 ```
 
-`content` is the exact text the agent would read; `error` is `null` on success and the failure message otherwise. The command exits non-zero on failure even under `--format json`, so a script can check the exit code without parsing the body — but the JSON envelope on stdout stays valid either way.
+The parts a test script asserts on ride as data, not prose: `hits` is the ranking in rank order (each with the `why` phrase the agent reads), `strategies` lists which rungs of the ladder actually ran — more than one entry means an earlier rung came back empty — and `note` carries the degradation reason verbatim when the semantic rung was skipped or failed. `content` is still the exact rendered text the agent would receive, and `error` is `null` on success.
+
+The command exits non-zero on failure even under `--format json`, so a script can check the exit code without parsing the body — the JSON envelope on stdout stays valid either way, with `ok: false` and `error` set.
+
+Two environment dials tune the rendering, the same ones the agent's registration reads: `STELLA_SEARCH_DEPTH` (how much is said about the top hit) and `STELLA_SEARCH_BUDGET` (the answer's character allowance). They shape `content` only — the `hits` ranking is unaffected.


### PR DESCRIPTION
## Summary

Review pass over the `stella search` door #3126 shipped, fixing three defects found in it:

1. **The JSON envelope's answer was one opaque text blob.** A script probing ranking quality had to regex rendered prose to learn hit order, when the structured `Answer` (hits, strategies, note) was computed and then thrown away at render time. `stella_tools::search` now exposes `report()` — a public `SearchReport` seam carrying the decided answer beside the rendering — and the agent-door `search()` becomes a thin wrapper over it, so the two doors stay one mechanism. The `--format json` envelope gains `hits` (rank order, `path` + `why`), `strategies` (the `via:`-line labels, in the order the rungs ran), and `note` (the degradation reason, verbatim).
2. **Wrong housing.** `run_search` sat in `contextgraph.rs` (the CGP host module) only because the retired `run_graph` lived there. Moved to a new `search_cmd.rs`, matching the one-command-one-module idiom (`memory_cmd`, `scripts_cmd`, `storage_cmd`, …).
3. **No cwd-free test seam.** The command resolved `current_dir()` inline, so no test could drive a temp workspace without process-global cwd mutation. Split into `search_answer_in(root, query)` (data) and `render` (I/O) — the `memory_cmd::list_rows` discipline.

The blank-query validation moves from `Search::execute` into `report()` so the tool door and the CLI door share exactly one refusal. That refusal previously had **no test at all**; it is now pinned from the execute side (stella-tools) and the CLI side (search_cmd), including that a refused query creates no `.stella/` state as a side effect.

Rebased onto main after #3125 landed — the conflict was both branches appending tests to `search/tests.rs` tail; resolved by keeping both sets (the chunk-warm witnesses and the report-seam tests).

Exemplar for the seam shape: `memory_cmd.rs`'s data/render split and the `query_format` versioned envelope (#1568).

No test was deleted in this PR.

## Test plan

- [x] `cargo test -p stella-tools --lib search` on the rebased tree — 25 passed (main's 3 chunk-warm tests + the 2 new seam tests + the 20 existing)
- [x] `cargo build -p stella-tools` clean on the rebased tree
- [x] New tests: `a_blank_query_is_refused_through_the_tool_door`, `the_report_preserves_rank_order_and_strategy_labels` (stella-tools); `a_blank_query_is_refused_before_anything_is_opened`, `render_fails_with_the_answers_own_error_in_both_formats`, `the_json_envelope_carries_ranked_hits_as_data` (stella-cli)
- [x] Manual smoke test pre-rebase: `stella search "CredentialStore" --format json` returns `hits`/`strategies`/`note` as data alongside `content`
- [ ] CI runs the full workspace gate (fmt/clippy/rustdoc/full test suite pending there; local full-gate pass was skipped to get the PR up)

Refs #3126, #1568.

## Summary by Sourcery

Expose a structured search report from stella-tools and wire stella-cli’s `stella search` to consume it, enriching the JSON output while keeping agent and CLI behavior aligned.

New Features:
- Add `SearchReport` and `SearchHit` data structures in stella-tools to expose ranked hits, strategies, and degradation notes alongside the rendered search answer.
- Extend `stella search --format json` to return a machine-readable envelope that includes ranking hits (`path`/`why`), strategy labels, and semantic degradation notes in addition to the rendered content.

Bug Fixes:
- Ensure blank search queries are uniformly rejected via shared validation in `report`, preventing divergence between the tool and CLI doors and avoiding unintended workspace state creation.
- Guarantee that search cancellation and other failures are surfaced consistently in both text and JSON formats, with non-zero exits and error messages preserved.

Enhancements:
- Refactor the stella search CLI command into a dedicated `search_cmd` module, separating cwd resolution and rendering from the core search logic for better testability and alignment with other commands.
- Introduce `search_answer_in` and `render` seams to enable cwd-independent testing of `stella search` and clarify the JSON envelope contract.
- Adjust documentation for `stella search --format json` to describe the new data-bearing envelope and environment tuning knobs for rendering depth and budget.

Tests:
- Add tool-side tests to pin blank-query refusal behavior and verify that `SearchReport` preserves rank order, strategy labels, notes, and rendered output.
- Add CLI-side tests to ensure blank queries are refused without touching workspace state, that both formats propagate the same failure, and that the JSON envelope carries ranked hits and strategies as data.