### PR TITLE
perf(stella-cli): persist telemetry off the reactor on both event drains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ running at all.
 
 The hook derives `CARGO_SCOPE` from the pushed diff via
 `scripts/impacted-crates.sh`, so a change confined to one crate compiles and
-tests that crate and its dependents rather than all 22 members (#1135). It
+tests that crate and its dependents rather than all 23 members (#1135). It
 widens to the whole workspace for a push to `main`, a tag, a diff touching a
 workspace-root manifest / `Cargo.lock` / a build script / the gate machinery,
 and for anything it cannot narrow with confidence. Two escape hatches sit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ for the server-side checks.
 
 The hook scopes the three compile tiers — clippy, rustdoc, test — to the crates
 your diff can actually reach, so a change confined to one crate no longer pays
-for all 22 members (#1135). It falls back to the whole workspace for a push to
+for all 23 members (#1135). It falls back to the whole workspace for a push to
 `main`, a tag, a diff touching a workspace-root manifest / `Cargo.lock` / a
 build script / the gate machinery, and for anything it cannot narrow with
 confidence. See what it would choose with `make impacted`. Under time pressure,

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -46,6 +46,9 @@ pub(crate) fn spawn_renderer(
 ) -> tokio::task::JoinHandle<RendererOutcome> {
     tokio::spawn(async move {
         let mut tool_names: HashMap<String, String> = HashMap::new();
+        // Shared with every blocking persistence hop below, so the provider id
+        // is not re-allocated once per persisted event.
+        let provider_id: Arc<str> = provider_id.into();
         let mut outcome = RendererOutcome {
             events: Vec::new(),
             persistence_complete: true,
@@ -79,10 +82,51 @@ pub(crate) fn spawn_renderer(
                 event
             };
             let preview = matches!(event, AgentEvent::TextDelta { .. });
-            if let Some((store, id)) = &execution
+            let event = if let Some((store, id)) = &execution
                 && !preview
             {
-                let persisted = persist_event_detailed(store, *id, seq, &event, &provider_id);
+                // `record_event` is a synchronous `rusqlite` write and this is a
+                // Tokio worker thread. At the default durability the write costs
+                // 37 microseconds (`stella_store::migrations::Durability`), which
+                // inline would be unremarkable — but `busy_timeout` is five
+                // seconds, and that pragma exists precisely because a second
+                // same-workspace session contending for the write lock is an
+                // expected condition rather than an exotic one. Run inline, the
+                // worst case is therefore a five-second stalled reactor rather
+                // than one slow write, and `paranoid` durability turns the
+                // ordinary case into 4 ms an event as well. Both belong on the
+                // blocking pool.
+                //
+                // The event moves in and back out rather than being cloned: it is
+                // still needed for rendering below, and a `ToolResult` payload is
+                // exactly the event least worth copying.
+                //
+                // The feeding channel stays unbounded on purpose. `EventSender`
+                // is synchronous by construction (invariant #2 keeps
+                // `stella-core` I/O-free), so a bounded channel could only
+                // `try_send` — dropping telemetry — or block the engine thread,
+                // which is strictly worse than the stall this hop removes.
+                let store = Arc::clone(store);
+                let id = *id;
+                let provider_id = Arc::clone(&provider_id);
+                let joined = tokio::task::spawn_blocking(move || {
+                    let persisted = persist_event_detailed(&store, id, seq, &event, &provider_id);
+                    (event, persisted)
+                })
+                .await;
+                let (event, persisted) = match joined {
+                    Ok(pair) => pair,
+                    // The blocking pool only fails here if `persist_event_detailed`
+                    // panicked or the runtime is shutting down. The event went with
+                    // the task either way, so the turn loses one rendered line —
+                    // what it must not lose is the admission that persistence is no
+                    // longer complete.
+                    Err(_) => {
+                        outcome.persistence_complete = false;
+                        seq += 1;
+                        continue;
+                    }
+                };
                 if !persisted.is_complete() {
                     outcome.persistence_complete = false;
                     // This path used to print "store write failed" for BOTH
@@ -100,7 +144,10 @@ pub(crate) fn spawn_renderer(
                     }
                 }
                 seq += 1;
-            }
+                event
+            } else {
+                event
+            };
             match format {
                 // One line per event — the stable machine interface.
                 // Serialization of a protocol enum never fails; if it somehow
@@ -1191,5 +1238,75 @@ mod stream_tests {
             recon.digest_mismatches
         );
         assert_eq!(recon.messages, original);
+    }
+}
+
+#[cfg(test)]
+mod reactor_tests {
+    /// The two async drains that write telemetry to SQLite, named by the
+    /// function whose body must show the blocking hop.
+    const DRAIN_SITES: [(&str, &str); 2] = [
+        ("src/agent/persistence.rs", "pub(crate) fn spawn_renderer("),
+        (
+            "src/command_deck/forwarder.rs",
+            "pub(crate) fn spawn_forwarder(",
+        ),
+    ];
+
+    /// Every SQLite write on an event drain must run on the blocking pool.
+    ///
+    /// `Store::record_event` is a synchronous `rusqlite` write, and both drains
+    /// are `tokio::spawn`ed tasks — so an inline call blocks a Tokio worker for
+    /// as long as the write takes. That is 37 microseconds at the default
+    /// durability, 4 ms under `STELLA_STORE_DURABILITY=paranoid`, and up to the
+    /// full five-second `busy_timeout` whenever a second same-workspace session
+    /// holds the write lock. The pragma exists because that contention is
+    /// expected, which is what makes the worst case reachable rather than
+    /// theoretical.
+    ///
+    /// This is a source-grep guard for the same reason `resume_frame.rs`'s
+    /// `every_pipeline_construction_declares_its_resume_frame` is one: what can
+    /// regress here is *wiring*, not logic. Observing "this ran on the blocking
+    /// pool" at runtime needs either a wall-clock race or a seam injected into
+    /// `persist_event_detailed` purely to be observed, and the first is flaky
+    /// while the second is test-shaped production code. The lexical check has
+    /// neither problem and fails the moment a call site moves back inline.
+    #[test]
+    fn every_event_drain_persists_off_the_reactor() {
+        let crate_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        for (relative, signature) in DRAIN_SITES {
+            let path = crate_root.join(relative);
+            let source = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let start = source
+                .find(signature)
+                .unwrap_or_else(|| panic!("{relative}: `{signature}` not found"));
+            let body = &source[start..];
+
+            // The first call after the signature is the drain's own; later ones
+            // in the same file belong to tests.
+            let call = body
+                .find("persist_event_detailed(")
+                .unwrap_or_else(|| panic!("{relative}: no persistence call after `{signature}`"));
+            let hop = body[..call].rfind("spawn_blocking(").unwrap_or_else(|| {
+                panic!(
+                    "{relative}: the SQLite write in `{signature}` is inline on a Tokio worker \
+                     thread — a contended write stalls the reactor for up to the five-second \
+                     busy_timeout. Move it onto `tokio::task::spawn_blocking`."
+                )
+            });
+            assert!(
+                !body[hop..call].contains(".await"),
+                "{relative}: `spawn_blocking` closes before the persistence call, so the write \
+                 is still running on the reactor"
+            );
+            assert!(
+                body[call..]
+                    .get(..600)
+                    .is_some_and(|w| w.contains(".await")),
+                "{relative}: the blocking hop is never awaited — detaching it would let events \
+                 persist out of `seq` order"
+            );
+        }
     }
 }

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -72,6 +72,9 @@ pub(crate) fn spawn_forwarder(
         let mut usage_warned = false;
         let mut store_warned = false;
         let mut persistence_complete = true;
+        // Shared with every blocking persistence hop below, so the provider id
+        // is not re-allocated once per persisted event.
+        let provider_id: Arc<str> = scope.provider_id.as_str().into();
         // The deck's half of the diagnostic timeline. The renderer covers the
         // one-shot and pipeline paths; every deck lane and sub-session worker
         // arrives here instead, and a bridge on only one of the two would make
@@ -93,9 +96,36 @@ pub(crate) fn spawn_forwarder(
                 let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
                 guard.seed_from_plan(&proposal.steps);
             }
-            if let Some((store, id)) = &execution {
-                let outcome =
-                    agent::persist_event_detailed(store, *id, seq, &event, &scope.provider_id);
+            let event = if let Some((store, id)) = &execution {
+                // Off the reactor for the same reason the one-shot renderer's
+                // hop exists — see `agent::persistence::spawn_renderer`, which
+                // carries the measured numbers. This lane matters at least as
+                // much: the deck is the default interactive shell on a TTY, so
+                // a five-second `busy_timeout` stall here is a five-second
+                // unresponsive UI.
+                //
+                // The event moves in and back out rather than being cloned; it
+                // is still owed to `cache_insight_for` and the deck below.
+                let store = Arc::clone(store);
+                let id = *id;
+                let provider_id = Arc::clone(&provider_id);
+                let joined = tokio::task::spawn_blocking(move || {
+                    let outcome =
+                        agent::persist_event_detailed(&store, id, seq, &event, &provider_id);
+                    (event, outcome)
+                })
+                .await;
+                let (event, outcome) = match joined {
+                    Ok(pair) => pair,
+                    // The event went with the panicking or shutting-down task,
+                    // so this lane loses one rendered event; what it must not
+                    // lose is the admission that persistence is incomplete.
+                    Err(_) => {
+                        persistence_complete = false;
+                        seq += 1;
+                        continue;
+                    }
+                };
                 if !outcome.is_complete() {
                     persistence_complete = false;
                     // One warning per condition per turn, each naming what
@@ -128,7 +158,10 @@ pub(crate) fn spawn_forwarder(
                     }
                 }
                 seq += 1;
-            }
+                event
+            } else {
+                event
+            };
             // Derived BEFORE the event is moved into the send below, but
             // emitted AFTER it: the insight annotates the usage the event
             // carries, so the deck must fold the event first or the annotation


### PR DESCRIPTION
## What & why

`Store::record_event` is a synchronous `rusqlite` write, and both of Stella's
event drains called it inline inside a `tokio::spawn`ed task, so the write ran
on a Tokio worker thread:

- `crates/stella-cli/src/agent/persistence.rs` — `spawn_renderer`, the one-shot
  and pipeline paths.
- `crates/stella-cli/src/command_deck/forwarder.rs` — `spawn_forwarder`, every
  deck lane and sub-session worker.

The store's own **measured** table (`stella_store::migrations::Durability`)
makes the ordinary cost concrete, and it is not the reason to move:

| level | ms/event |
|---|---|
| `normal` | 0.022 |
| `full` (default) | 0.037 |
| `paranoid` | 3.99 |

The reason is `busy_timeout`, which is **5000 ms** — and the pragma exists
precisely because a second same-workspace session contending for the write lock
is an expected condition. The comment at `stella-store/src/lib.rs:673` says so:
without the timeout "a second same-workspace session gets an immediate
`SQLITE_BUSY` and its best-effort telemetry writes vanish silently". So the
worst case is a **five-second stalled reactor**, reachable by design rather than
by accident. On the deck lane that is also five seconds of unresponsive UI,
since the Command Deck is the default interactive shell on a TTY.

`TextDelta` was already excluded from persistence, so the highest-frequency
event never hit the DB — this is a latent stall, not a live hot-path
regression. It is fixed here because the failure mode is silent and the fix is
contained.

### What changed

Both call sites hop through `tokio::task::spawn_blocking`. The event moves into
the closure and back out rather than being cloned — it is still owed to the
renderer below and to `cache_insight_for` on the deck side, and a `ToolResult`
payload is exactly the event least worth copying. The hop is awaited, so `seq`
ordering is unchanged. A `JoinError` (blocking task panicked, or runtime
shutting down) costs that lane one rendered event and is recorded as incomplete
persistence rather than passing silently. `provider_id` becomes an `Arc<str>`
once per task so it is not re-allocated per event.

**The feeding channels stay unbounded, deliberately.** `EventSender::send` is
synchronous by construction (invariant #2 keeps `stella-core` I/O-free), so a
bounded channel could only `try_send` — dropping telemetry — or block the engine
thread, which is strictly worse than the stall this removes. That reasoning is
recorded in the code so the next reader does not re-litigate it.

Also corrects the workspace member count in AGENTS.md and CONTRIBUTING.md from
22 to 23 (21 crates + 2 bench members).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`every_event_drain_persists_off_the_reactor`
(`crates/stella-cli/src/agent/persistence.rs`) asserts that each drain's
persistence call sits inside an open, awaited `spawn_blocking` hop.

Verified artisanally: with the two production hunks reverted and the test
retained, it fails naming the inline write —

```
crates/stella-cli/src/agent/persistence.rs: the SQLite write in
`pub(crate) fn spawn_renderer(` is inline on a Tokio worker thread — a
contended write stalls the reactor for up to the five-second busy_timeout.
Move it onto `tokio::task::spawn_blocking`.
```

— and passes with them restored.

It is a source-grep guard for the same reason
`resume_frame.rs`'s `every_pipeline_construction_declares_its_resume_frame` is
one: what regresses here is **wiring**, not logic. Observing "this ran on the
blocking pool" at runtime needs either a wall-clock race (flaky) or a seam
injected into `persist_event_detailed` purely to be observed (test-shaped
production code). The lexical check has neither problem and fails the moment a
call site moves back inline.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace`
- [x] All toolchain-free guards (`invariants`, `doc-links`, `command-docs`,
      `brand-case`, `file-size`, `god-files`, `gate-parity`, `left-behind`,
      `role-names`, `stat-portability`, `module-reachability`) — green
- [x] Docs updated where behavior changed
- [ ] `shellcheck` not run — not installed in this environment; this diff
      touches no shell scripts

**One flake to disclose.** The first `cargo test --workspace` run failed on
`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`. It
passed on the two subsequent runs of this branch, passes on `main` under
`--workspace`, and passes 3/3 in isolation. The test documents this exact
sensitivity itself — "Under full-suite load, with ~1400 tests and several
sibling cases spawning their own children, that window is exactly what widens
(#1721)" — and touches neither changed path. Reported rather than buried
because a green-on-retry is still a red someone should see.

## Nothing left behind

- [x] Filed: #3135, #3136

Both are unwired-code findings from the same audit pass, written as fresh-agent
handoffs:

- **#3135** — `crates/stella-protocol/src/context_event.rs` ships 524 lines of
  lifecycle-event wire contract that nothing constructs or reads, with no
  tracking issue. `check-left-behind` cannot catch it: the module carries no
  bare `TODO`, because its prose is careful enough to read as a decision.
- **#3136** — `Node::valid_from` is documented "always `None` today", with no
  tracking issue.

Neither is fixed here: both are design calls (wire an emitter vs. record the
deferral; wire the field vs. drop it from the public projection), not cleanups.

Two further findings from the audit are facts rather than defects and are not
filed: the 1500-line ratchet carries 33,305 lines of grandfathered amnesty
across 30 files (already visible and gate-enforced in
`scripts/file-size-baseline.txt`), and 37 `#[allow(clippy::too_many_arguments)]`
cluster in `stella-cli`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**Two audit findings I reported and then disproved**, recorded here so the
review does not chase them:

1. *"`stella-parity` / `stella-serve` / `stella-engine` are 25,410 unreachable
   lines."* Wrong. `cargo test --workspace` is a `make gate` step, and
   workspace membership is exactly how a test-assertion crate is wired —
   `stella-parity`'s 8 assertions run and pass. Inferred from zero reverse-deps
   without running the tests.
2. *"77 `Result<_, String>` signatures in library crates violate invariant #5."*
   Wrong for the 61 that dominate the count. The `ToolExecutor` port states
   "tool failures are model-visible data, not engine failures", and
   `ToolOutput::Error.message` is "phrased so the model can act on it" —
   `stella-tools` passes those strings through verbatim
   (`issues.rs:244`, `:267`). `String` is the mandated domain type there, not a
   violation. The remainder are operator-facing diagnostics where a typed enum
   would carry the same string as its only payload.

The rejected alternative for the fix itself: cloning the event into the
blocking closure. Simpler to read, but it copies `ToolResult` payloads on every
persisted event, and the move-in/move-out costs only the `JoinError` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWURXuucxhbjQ5vhFtPb5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWURXuucxhbjQ5vhFtPb5n)_

## Summary by Sourcery

Ensure telemetry persistence from both CLI event drains runs on the blocking pool to avoid stalling the Tokio reactor while preserving event ordering and failure reporting.

Enhancements:
- Move renderer event persistence in agent persistence path to `spawn_blocking`, sharing provider identifiers across events and treating blocking-task failures as incomplete persistence.
- Move Command Deck forwarder event persistence to `spawn_blocking`, keeping the interactive UI responsive under SQLite busy timeouts and marking incomplete persistence on blocking-task failure.
- Add a source-grep test that asserts both event drains wrap their SQLite persistence calls in an awaited `spawn_blocking` hop to guard wiring regressions.

Documentation:
- Update AGENTS.md and CONTRIBUTING.md to reflect the workspace now has 23 members instead of 22.