### PR TITLE
fix(stella-graph,stella-tools): a fully indexed workspace can finally say so

### DIFF
--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -196,13 +196,46 @@ pub fn line_span(content: &str, start_line: u32, end_line: u32) -> String {
         .join("\n")
 }
 
+/// The one predicate for "this file still needs a chunk pass", shared by
+/// [`pending_chunks`] and [`pending_chunk_file_count`] so the page of work and
+/// the count of it can never disagree. `?1` is the fingerprint.
+///
+/// **It is a coverage marker, not a count comparison** (#3128). The obvious
+/// spelling — raw symbol count against stored chunk-vector rows — is wrong in
+/// one direction and permanently so: rows are keyed
+/// `(file_id, chunk_sha256, fingerprint)`, and `chunk_sha256` hashes the
+/// *rendered* chunk, so two different symbols whose rendered text is
+/// byte-identical collapse to one row. Two trait accessors that both read
+/// `&self.id`, or two `fn execute() { todo!() }` stubs across fixtures in one
+/// test file, are enough. The symbol count then exceeds the row count forever,
+/// and the file is re-selected on every pass no matter how correctly and how
+/// often it has been embedded.
+///
+/// Asking instead whether the file carries **any** chunk vector stamped with
+/// its current content hash is exact here, because a chunk pass is per-file
+/// atomic: `embed_and_store_chunk_file` gathers every vector the file needs
+/// before it writes any of them, and re-stamps `file_sha256` on the rows it
+/// skipped. So a file is either untouched at this content hash or completely
+/// covered at it — there is no partial state for the marker to misread. Edited
+/// files still re-enter: their new `content_sha256` matches no stored row.
+///
+/// The `EXISTS` on symbols is load-bearing rather than tidiness. Without it a
+/// file with no symbols at all — an empty source file, a markdown document with
+/// no headings — matches "carries no chunk vector" trivially and would be
+/// selected on every pass forever, which is the very bug this predicate exists
+/// to remove, merely relocated.
+const NEEDS_CHUNK_PASS: &str = "EXISTS (SELECT 1 FROM code_graph_symbols s WHERE s.file_id = f.id) \
+     AND NOT EXISTS (SELECT 1 FROM code_graph_chunk_vectors v \
+                     WHERE v.file_id = f.id AND v.fingerprint = ?1 \
+                       AND v.file_sha256 = f.content_sha256)";
+
 /// Up to `limit` files whose chunks are not fully embedded under
 /// `fingerprint`, with each chunk rendered and hashed.
 ///
-/// "Not fully embedded" is a pure count comparison — how many symbols the file
-/// has against how many chunk vectors it carries stamped with the file's
-/// *current* hash. That is what keeps a scan over an up-to-date workspace from
-/// re-reading every file on disk to discover there is nothing to do.
+/// "Not fully embedded" is [`NEEDS_CHUNK_PASS`] — a coverage marker read
+/// straight from the index, which is what keeps a scan over an up-to-date
+/// workspace from re-reading every file on disk to discover there is nothing
+/// to do.
 ///
 /// Ordered by path and resumed through a path cursor, filling **past**
 /// unreadable files rather than spending the window on them — the same
@@ -213,17 +246,13 @@ pub fn pending_chunks(
     fingerprint: &str,
     limit: usize,
 ) -> Result<PendingChunkScan, GraphError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare(&format!(
         "SELECT f.id, f.path, f.content_sha256 \
          FROM code_graph_files f \
-         WHERE f.path > ?2 \
-           AND (SELECT COUNT(*) FROM code_graph_symbols s WHERE s.file_id = f.id) > \
-               (SELECT COUNT(*) FROM code_graph_chunk_vectors v \
-                WHERE v.file_id = f.id AND v.fingerprint = ?1 \
-                  AND v.file_sha256 = f.content_sha256) \
+         WHERE f.path > ?2 AND {NEEDS_CHUNK_PASS} \
          ORDER BY f.path \
-         LIMIT ?3",
-    )?;
+         LIMIT ?3"
+    ))?;
 
     let mut scan = PendingChunkScan::default();
     // The empty string sorts before every non-empty path under SQLite's
@@ -480,18 +509,18 @@ pub fn chunk_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphE
     Ok(count.max(0) as usize)
 }
 
-/// How many indexed files still have a symbol with no chunk vector under
-/// `fingerprint` — the same WHERE clause [`pending_chunks`] scans, as a count
+/// How many indexed files still need a chunk pass under `fingerprint` — the
+/// same [`NEEDS_CHUNK_PASS`] predicate [`pending_chunks`] scans, as a count
 /// rather than a page of rendered work. An eager pass reports this as
 /// `remaining` without paying for a render-and-hash pass over files it is
 /// about to discard the content of.
+///
+/// Because the predicate is exact, **zero here means done**: a caller may treat
+/// it as the completeness oracle it reads like, which
+/// `stella_tools::search::coverage_note` does (#3124).
 pub fn pending_chunk_file_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphError> {
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM code_graph_files f \
-         WHERE (SELECT COUNT(*) FROM code_graph_symbols s WHERE s.file_id = f.id) > \
-               (SELECT COUNT(*) FROM code_graph_chunk_vectors v \
-                WHERE v.file_id = f.id AND v.fingerprint = ?1 \
-                  AND v.file_sha256 = f.content_sha256)",
+        &format!("SELECT COUNT(*) FROM code_graph_files f WHERE {NEEDS_CHUNK_PASS}"),
         params![fingerprint],
         |row| row.get(0),
     )?;

--- a/crates/stella-graph/src/vectors/chunks/tests.rs
+++ b/crates/stella-graph/src/vectors/chunks/tests.rs
@@ -21,11 +21,46 @@ fn indexed_workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, Connection) 
     (ws, conn)
 }
 
-/// The witness: a file with symbols is pending-by-file-count until every one
-/// of its chunks is stored, then the count drops — and stays accurate once a
-/// second file with symbols of its own is added.
+/// Store every chunk a scan handed back for one file, as
+/// [`store_chunk_vectors`]'s contract requires — one file per call, the whole
+/// set — and give each a distinguishable vector.
+fn store_whole_file(conn: &mut Connection, file: &PendingChunkFile) {
+    let rows: Vec<ChunkVector> = file
+        .chunks
+        .iter()
+        .enumerate()
+        .map(|(index, chunk)| ChunkVector {
+            chunk_sha256: chunk.chunk_sha256.clone(),
+            name: chunk.name.clone(),
+            kind: chunk.kind.clone(),
+            start_line: chunk.start_line,
+            end_line: chunk.end_line,
+            vector: Some(vec![index as f32, 1.0, 0.0, 0.0]),
+        })
+        .collect();
+    store_chunk_vectors(conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
+}
+
+/// The witness: a file with symbols is pending until its chunks are stored,
+/// stops being pending once they are, and **becomes pending again when its
+/// content changes**.
+///
+/// The last leg is the one that keeps [`NEEDS_CHUNK_PASS`] honest. The
+/// predicate is a coverage marker — "does this file carry any chunk vector
+/// stamped with its *current* hash" — so the content-change leg is what proves
+/// the marker is keyed to content and not merely to existence, which is the
+/// only way it could go stale silently.
+///
+/// It used to store one of two chunks and assert the file was still pending.
+/// That state is unreachable: [`store_chunk_vectors`] documents "one file per
+/// call, one transaction", the single production caller
+/// (`stella_tools::search::embed_and_store_chunk_file`) always passes the
+/// file's complete row set, and splitting a file across two calls is precisely
+/// what that doc says the sweep would corrupt. Pinning the count's behaviour in
+/// a state the writer forbids pinned the old predicate's arithmetic rather than
+/// the contract (#3128).
 #[test]
-fn the_pending_file_count_drops_only_once_every_chunk_is_stored() {
+fn the_pending_file_count_tracks_whole_file_coverage() {
     let (ws, mut conn) = indexed_workspace(&[("a.rs", "fn alpha() {}\nfn beta() {}\n")]);
     let root = ws.path().canonicalize().expect("canonicalize");
 
@@ -37,41 +72,77 @@ fn the_pending_file_count_drops_only_once_every_chunk_is_stored() {
 
     let scan = pending_chunks(&conn, &root, FP, 10).expect("scan");
     assert_eq!(scan.files.len(), 1);
-    let file = &scan.files[0];
-    assert_eq!(file.chunks.len(), 2, "alpha and beta are both chunks");
-
-    // Store only the first chunk — the file must still read as pending.
-    let rows = vec![ChunkVector {
-        chunk_sha256: file.chunks[0].chunk_sha256.clone(),
-        name: file.chunks[0].name.clone(),
-        kind: file.chunks[0].kind.clone(),
-        start_line: file.chunks[0].start_line,
-        end_line: file.chunks[0].end_line,
-        vector: Some(vec![1.0, 0.0, 0.0, 0.0]),
-    }];
-    store_chunk_vectors(&mut conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
     assert_eq!(
-        pending_chunk_file_count(&conn, FP).expect("count"),
-        1,
-        "one of two chunks stored — still pending"
+        scan.files[0].chunks.len(),
+        2,
+        "alpha and beta are both chunks"
     );
+    store_whole_file(&mut conn, &scan.files[0]);
 
-    // Store the second chunk — now the file drops out of the pending count.
-    let rows = vec![ChunkVector {
-        chunk_sha256: file.chunks[1].chunk_sha256.clone(),
-        name: file.chunks[1].name.clone(),
-        kind: file.chunks[1].kind.clone(),
-        start_line: file.chunks[1].start_line,
-        end_line: file.chunks[1].end_line,
-        vector: Some(vec![0.0, 1.0, 0.0, 0.0]),
-    }];
-    store_chunk_vectors(&mut conn, FP, &file.path, &file.file_sha256, &rows).expect("store");
     assert_eq!(
         pending_chunk_file_count(&conn, FP).expect("count"),
         0,
-        "both chunks stored — no longer pending"
+        "the file's chunks are stored — no longer pending"
     );
     assert_eq!(chunk_count(&conn, FP).expect("chunk_count"), 2);
+    assert!(
+        pending_chunks(&conn, &root, FP, 10)
+            .expect("scan")
+            .files
+            .is_empty(),
+        "the page of work must agree with the count"
+    );
+
+    // Edit the file: its content hash moves, so the stored vectors no longer
+    // describe it and it must re-enter the pending set.
+    fs::write(
+        ws.path().join("a.rs"),
+        "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n",
+    )
+    .expect("rewrite");
+    store::index_tree(&mut conn, &root, &Grammars::load().expect("grammars")).expect("reindex");
+    assert_eq!(
+        pending_chunk_file_count(&conn, FP).expect("count"),
+        1,
+        "an edited file is not covered by vectors stamped with its old content hash"
+    );
+}
+
+/// The graph-level witness for #3128: two symbols whose rendered text is
+/// byte-identical store one row for two symbols, and the file must still leave
+/// the pending set once it has been embedded.
+///
+/// Before the coverage marker this was unreachable — the raw symbol count
+/// exceeded the stored row count forever, so the file was re-selected on every
+/// pass no matter how many times it had been correctly processed, and every
+/// consumer of "how much is left" reported a number that could never reach
+/// zero (#3124).
+#[test]
+fn a_file_whose_symbols_render_identical_text_still_finishes() {
+    let (ws, mut conn) = indexed_workspace(&[(
+        "dupes.rs",
+        "mod a {\n    pub fn id() -> u8 { 0 }\n}\nmod b {\n    pub fn id() -> u8 { 0 }\n}\n",
+    )]);
+    let root = ws.path().canonicalize().expect("canonicalize");
+
+    let scan = pending_chunks(&conn, &root, FP, 10).expect("scan");
+    assert_eq!(scan.files.len(), 1);
+    let symbols = scan.files[0].chunks.len();
+    store_whole_file(&mut conn, &scan.files[0]);
+
+    // The premise: the collision really happened, so this is not a file that
+    // would have finished under the old count comparison anyway.
+    let stored = chunk_count(&conn, FP).expect("chunk_count");
+    assert!(
+        stored < symbols,
+        "fixture no longer collides ({stored} rows for {symbols} symbols) — the old predicate \
+         would have been satisfied and this witness proves nothing"
+    );
+    assert_eq!(
+        pending_chunk_file_count(&conn, FP).expect("count"),
+        0,
+        "a fully embedded file must leave the pending set even when its symbols collide"
+    );
 }
 
 /// A different fingerprint's vectors do not satisfy this one's pending count

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -707,20 +707,35 @@ fn merge_rungs(
 ///
 /// `None` when both rungs are complete, so a healthy workspace pays no tokens
 /// for the disclosure.
+///
+/// **And a complete workspace must be able to reach `None`** (#3124). This
+/// asked `embedded_chunk_count >= symbol_count` until chunk coverage was
+/// measured on a corpus small enough to finish: chunk rows are keyed on the
+/// hash of the rendered chunk, so two byte-identical bodies in one file store
+/// one row for two symbols and that comparison is unsatisfiable forever. A
+/// 158-file workspace froze at 1,810 of 1,814 across thirty passes and warned
+/// on every search — and the warning's own advice is "use `bash` with `grep -n`
+/// for anything exact", which is precisely the call this module exists to stop
+/// the model making. A disclosure nobody can ever clear is not a disclosure; it
+/// is noise with a suggestion attached.
+///
+/// Both halves are now like-for-like counts of **files**:
+/// `pending_chunk_file_count` is exact by construction (see
+/// `stella_graph`'s `NEEDS_CHUNK_PASS`), and whole-file vectors are one row per
+/// file, so neither side can dedup out from under the other.
 fn coverage_note(graph: &CodeGraph, fingerprint: &str) -> Option<String> {
-    let symbols = graph.symbol_count().ok()?;
-    let chunks = graph.embedded_chunk_count(fingerprint).ok()?;
     let total_files = graph.file_count().ok()?;
     let files = graph.embedded_file_count(fingerprint).ok()?;
-    if chunks >= symbols && files >= total_files {
+    let chunks_pending = graph.pending_chunk_file_count(fingerprint).ok()?;
+    if chunks_pending == 0 && files >= total_files {
         return None;
     }
     Some(format!(
-        "PARTIAL INDEX — this ranking saw {chunks} of {symbols} symbols/sections and {files} \
-         of {total_files} files. Embedding fills in path order a batch per call, so the \
-         remainder is NOT a random sample: it is the tail of the tree alphabetically. Run \
-         `stella init` to finish it; until then treat a miss as inconclusive and use `bash` \
-         with `grep -n` for anything exact."
+        "PARTIAL INDEX — this ranking saw {files} of {total_files} files, and {chunks_pending} \
+         indexed file(s) still have symbols with no vector. Embedding fills in path order a \
+         batch per call, so the remainder is NOT a random sample: it is the tail of the tree \
+         alphabetically. Run `stella init` to finish it; until then treat a miss as \
+         inconclusive and use `bash` with `grep -n` for anything exact."
     ))
 }
 
@@ -957,23 +972,18 @@ async fn warm_chunks_opened(
         if scan.files.is_empty() {
             break;
         }
-        // The pending-files pre-filter is a cheap, deliberately loose COUNT
-        // comparison (raw symbols vs. stored chunks) — it can select a file
-        // that in fact needs no embedding at all: two symbols whose rendered
-        // text is byte-identical (a common shape for trivial mock/test
-        // boilerplate — `fn execute(&self) { todo!() }` repeated across
-        // several fixtures in one file) collapse to one stored row under the
-        // content-hash key, so the raw symbol count can never equal the
-        // stored count for that file even once every one of its symbols is
-        // correctly embedded. `PendingChunkFile::to_embed()` is the precise,
-        // per-symbol answer the SQL pre-filter cannot give; if an entire
-        // window comes back with nothing left to actually embed, every
-        // further window would just re-select and re-stamp the same
-        // false-positive files forever without buying anything real —
-        // tracked as a pre-filter imprecision rather than reworked into an
-        // exact predicate here (it also affects the lazy per-query pass
-        // above, which is bounded to one window per call and so never pays
-        // more than a single wasted re-scan for it) — filed as #3128.
+        // The pre-filter is exact since #3128: it reads a per-file coverage
+        // marker rather than comparing a raw symbol count against stored rows,
+        // so a file whose symbols render byte-identical text is no longer
+        // selected forever after being fully embedded.
+        //
+        // This guard stays anyway, and is not redundant belt-and-braces. It
+        // asserts the loop's own termination condition — a window that embeds
+        // nothing cannot be made progress by another window — which holds
+        // whatever the pre-filter's precision happens to be. Deleting it would
+        // make the loop's boundedness depend on a SQL predicate in another
+        // crate being right, which is exactly the coupling that produced
+        // #3128. `PendingChunkFile::to_embed()` is the per-symbol truth.
         let mut made_progress = false;
         for file in &scan.files {
             if file.to_embed() > 0 {

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -732,6 +732,90 @@ async fn a_file_whose_symbols_collide_on_rendered_text_does_not_spin_the_pass() 
     );
 }
 
+/// **The witness for #3124.** A workspace with nothing left to embed must stop
+/// describing itself as partial.
+///
+/// It is the same collision as #3128, read by a different consumer: the note
+/// compared `embedded_chunk_count` against `symbol_count`, and chunk rows are
+/// keyed on the hash of the rendered chunk, so the two byte-identical bodies
+/// below store one row for two symbols and that comparison can never hold
+/// again. Measured on a 158-file workspace, coverage froze at 1,810 of 1,814
+/// and every search carried the warning — whose own advice is to go back to
+/// `grep`, the call this module exists to remove.
+///
+/// The premise is asserted first, so this cannot pass vacuously: if the fixture
+/// ever stops colliding, the old comparison would have succeeded too and the
+/// test would be proving nothing.
+#[tokio::test]
+async fn a_fully_embedded_workspace_stops_calling_itself_partial() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let file = workspace.path().join("src/accessors.rs");
+    fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+    // Two distinct symbols, byte-identical rendered text — the ordinary
+    // trait-accessor shape, not a contrived one.
+    fs::write(
+        &file,
+        "mod a {\n    pub fn id() -> u8 { 0 }\n}\n\
+         mod b {\n    pub fn id() -> u8 { 0 }\n}\n",
+    )
+    .expect("write");
+    let root = workspace.path().canonicalize().expect("canonicalize");
+    crate::graph::open_or_build(&root)
+        .expect("open_or_build")
+        .graph
+        .shutdown();
+
+    let fingerprint = ConceptEmbedder.fingerprint().id();
+    let warmed = warm_chunk_vectors(&root, &ConceptEmbedder, 1_000).await;
+    assert!(
+        matches!(warmed, ChunkWarmOutcome::Warmed { .. }),
+        "expected Warmed, got {warmed:?}"
+    );
+
+    let opened = crate::graph::open_or_build(&root).expect("open_or_build");
+    super::catch_up_embeddings(&opened.graph, &ConceptEmbedder, &fingerprint)
+        .await
+        .expect("whole-file vectors");
+
+    // The premise: the collision really happened, so the count comparison this
+    // note used to make is unsatisfiable for this workspace.
+    let symbols = opened.graph.symbol_count().expect("symbol_count");
+    let chunks = opened
+        .graph
+        .embedded_chunk_count(&fingerprint)
+        .expect("embedded_chunk_count");
+    assert!(
+        chunks < symbols,
+        "fixture no longer collides ({chunks} chunk rows for {symbols} symbols) — the old \
+         `chunks >= symbols` test would have passed and this witness proves nothing"
+    );
+
+    let note = super::coverage_note(&opened.graph, &fingerprint);
+    opened.graph.shutdown();
+    assert!(
+        note.is_none(),
+        "a workspace with nothing left to embed still calls itself partial: {note:?}"
+    );
+}
+
+/// The other half of the same contract: a workspace that genuinely has work
+/// left must still say so. Without this, #3124 could be "fixed" by never
+/// warning at all, which loses the disclosure #3117 added.
+#[tokio::test]
+async fn a_workspace_with_work_left_still_says_it_is_partial() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let root = write_fixture_at_the_real_workspace_path(workspace.path());
+
+    // Indexed, nothing embedded at all — the state right after `stella init`
+    // on a build with no embedder configured.
+    let opened = crate::graph::open_or_build(&root).expect("open_or_build");
+    let note = super::coverage_note(&opened.graph, &ConceptEmbedder.fingerprint().id());
+    opened.graph.shutdown();
+
+    let note = note.expect("an unembedded workspace must disclose that it is partial");
+    assert!(note.contains("PARTIAL INDEX"), "{note}");
+}
+
 /// The blank-query refusal lives in `report` — one validation both doors
 /// share — and the agent's door still surfaces it. This pins the refusal
 /// from the `execute` side so moving the check cannot silently lose it.


### PR DESCRIPTION
## What

`search` told the agent its index was partial — and to go back to `grep` — on a
workspace with nothing left to embed.

Measured on a 158-file corpus with a live Voyage backend: coverage froze at
**1,810 of 1,814** and stayed there for thirty passes, with every search
carrying

> PARTIAL INDEX — … until then treat a miss as inconclusive and **use `bash`
> with `grep -n` for anything exact.**

which is precisely the call `search`'s module docs name as the metric the tool
exists to move. A disclosure nobody can ever clear is not a disclosure.

## Why

One predicate, in three places. Chunk rows are keyed
`(file_id, chunk_sha256, fingerprint)` and `chunk_sha256` hashes the *rendered*
chunk, so two symbols whose text is byte-identical store **one row for two
symbols**. Comparing a raw symbol count against stored rows is then unsatisfiable
forever for that file.

Proved, not inferred: `contextgraph-host/src/host.rs` is short by exactly 2 and
holds exactly 2 byte-identical pairs — `fn id(&self) -> &str { &self.id }` at
lines 858 and 1400, `fn capabilities` at 864 and 1407. Two trait accessors in
test modules poison the count for the whole tree.

This is the root cause #3128 already described for `pending_chunks`; #3124 is
the same comparison read by a different consumer.

## How

A coverage marker replaces the count comparison: *does this file carry any chunk
vector stamped with its current content hash?*

That is exact here because a chunk pass is **per-file atomic** —
`embed_and_store_chunk_file` gathers every vector before it writes any, and
`store_chunk_vectors` already documents "one file per call, one transaction"
because its sweep depends on it. Edited files still re-enter: their new content
hash matches no stored row.

The `EXISTS` on symbols is load-bearing, not tidiness. Without it every
symbol-less file — an empty source file, a heading-less markdown document —
matches "carries no chunk vector" trivially, and the same bug reappears one step
over.

`coverage_note` now compares **files to files** on both halves, so neither side
can dedup out from under the other.

## Witnesses

Both fail before and pass after, and each asserts its premise first — if the
fixture ever stops colliding, the old predicate would have been satisfied too
and the test would prove nothing.

- `a_fully_embedded_workspace_stops_calling_itself_partial` (stella-tools).
  With the old comparison it warns *while its own numbers read* "1 of 1 files,
  and 0 indexed file(s) still have symbols with no vector" — confirmed by
  temporarily restoring the old condition.
- `a_file_whose_symbols_render_identical_text_still_finishes` (stella-graph).

## Test changed — named per the deleted-test guard

`the_pending_file_count_drops_only_once_every_chunk_is_stored` stored one of two
chunks and asserted the file was still pending. That state is **unreachable**:
`store_chunk_vectors` forbids splitting a file across calls, and the single
production caller always passes the complete set. It pinned the old predicate's
arithmetic rather than the contract.

Replaced by `the_pending_file_count_tracks_whole_file_coverage`, which keeps
every reachable leg and adds the one that actually keeps the marker honest: **an
edited file becomes pending again**.

## Not done

The no-progress guard in `warm_chunks_opened` stays. It is not redundant
belt-and-braces — it asserts the loop's own termination condition, which must
not depend on a SQL predicate in another crate being right. That coupling is
what produced #3128 in the first place. Its stale comment is rewritten.

## Verification

- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo fmt --all --check` — green
- Trial-merged with #3125's branch: clean, and the merged tree's tests pass

Closes #3124
Closes #3128
Refs #3097

## Summary by Sourcery

Ensure chunk embedding coverage is measured exactly so fully embedded workspaces no longer report a partial index, while preserving disclosure when embedding is incomplete.

Bug Fixes:
- Fix chunk coverage so files with byte-identical symbol bodies are not re-selected forever and can leave the pending set once embedded.
- Fix search coverage reporting so completely embedded workspaces stop warning about a partial index and workspaces with remaining work still disclose it.

Enhancements:
- Introduce a shared SQL coverage predicate for pending chunk passes that treats zero pending files as a correctness oracle for workspace completeness.
- Align coverage_note to use file-based counts and the new pending-file predicate, ensuring consistent reporting between tools and the graph.

Tests:
- Replace the pending-chunk-file-count test with one that tracks whole-file coverage and re-pending on content changes.
- Add graph-level and search-level witnesses that assert collisions on rendered text and verify correct termination and disclosure behaviour in those scenarios.