### PR TITLE
fix(stella-tools): an exact symbol name is answered by the graph, not by rank

### DIFF
--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -169,6 +169,9 @@ const DEFAULT_BUDGET_CHARS: usize = 9_000;
 /// name match wearing a semantic answer's clothes is worse than no answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Strategy {
+    /// The query named an indexed symbol exactly, and the graph knows where it
+    /// is defined. Not a ranking — a lookup that either hit or did not.
+    ExactSymbol,
     /// The query and the files were embedded and compared by meaning.
     Semantic,
     /// The code graph's paths and symbol names were matched by term.
@@ -182,6 +185,7 @@ impl Strategy {
     /// The word that appears in the answer's `via:` line.
     const fn label(self) -> &'static str {
         match self {
+            Strategy::ExactSymbol => "exact symbol name (code-graph definition sites)",
             Strategy::Semantic => "semantic (embedding rank over the code-graph index)",
             Strategy::GraphNames => "names (path + symbol-name terms over the code-graph index)",
             Strategy::FileScan => "scan (path + content terms over the working tree, no index)",
@@ -498,7 +502,9 @@ pub async fn report(root: &Path, query: &str, config: SearchConfig) -> SearchRep
 ///
 /// The ladder, and why it is a ladder rather than a fusion:
 ///
-/// - **Semantic** first whenever an embedder resolves, so the vector index is
+/// - **Exact symbol** first, and it is not a ranking at all — it is the graph
+///   answering "where is this defined" with a fact. It leads whenever it hits.
+/// - **Semantic** next whenever an embedder resolves, so the vector index is
 ///   exercised on every search rather than only when a model happens to pick
 ///   the semantic tool (#2995). A backend that fails mid-flight degrades to
 ///   the next rung with the failure quoted, never a lost turn.
@@ -510,8 +516,25 @@ pub async fn report(root: &Path, query: &str, config: SearchConfig) -> SearchRep
 ///   its language is the normal case on Terminal-Bench, where the graph is
 ///   empty and both rungs above return nothing at all.
 ///
-/// Fusing them instead would mix three incomparable scales into one ordering
-/// and make the answer's `via:` line a lie.
+/// Fusing them instead would mix incomparable scales into one ordering and
+/// make the answer's `via:` line a lie.
+///
+/// # Why the top rung is a stack rather than a stop
+///
+/// Every rung below the first was unreachable in practice (#3125). "Stop at
+/// the first that produces hits" plus an admission floor that rejects nothing —
+/// measured: the lowest cosine anywhere in a 158-file corpus was 0.418 against
+/// a floor of 0.25, so 158 of 158 files were admitted — means semantic never
+/// returns empty and nothing after it ever runs. `via: semantic` on 9 of 9
+/// probes. The floor itself is #2993; this is the structural consequence, and
+/// it bites hardest exactly where ranking is weakest, on a bare symbol name.
+///
+/// So the exact rung **prepends** rather than replacing: its hits are
+/// certainties and lead, the semantic ranking follows for context with its
+/// duplicates removed, and `via:` names both. Concatenating is not the fusion
+/// the paragraph above forbids — no score from one rung is ever compared
+/// against a score from another, and each hit still says in its own `why:`
+/// which kind of answer it is.
 pub(crate) async fn dispatch(
     graph: Option<&CodeGraph>,
     root: &Path,
@@ -521,12 +544,19 @@ pub(crate) async fn dispatch(
     let mut strategies = Vec::new();
     let mut note = None;
 
+    let exact = graph.map_or_else(Vec::new, |graph| {
+        enrich::exact_symbol_hits(graph, query, MAX_NAME_HITS)
+    });
+    if !exact.is_empty() {
+        strategies.push(Strategy::ExactSymbol);
+    }
+
     if let (Some(graph), Some(embedder)) = (graph, embedder) {
         strategies.push(Strategy::Semantic);
         match semantic_hits(graph, embedder, query).await {
             Ok((hits, coverage)) if !hits.is_empty() => {
                 return Answer {
-                    hits,
+                    hits: lead_with(exact, hits),
                     strategies,
                     // Coverage rides even on a successful answer: it is
                     // exactly the successful-looking partial answer that
@@ -539,6 +569,18 @@ pub(crate) async fn dispatch(
             Ok((_, coverage)) => note = coverage,
             Err(reason) => note = Some(reason),
         }
+    }
+
+    // A definition site is a complete answer on its own, so it is returned
+    // before the term-matching rungs rather than after them — reaching a name
+    // match having already found the definition would rank the certainty below
+    // the guesses.
+    if !exact.is_empty() {
+        return Answer {
+            hits: exact,
+            strategies,
+            note,
+        };
     }
 
     if let Some(graph) = graph {
@@ -559,6 +601,24 @@ pub(crate) async fn dispatch(
         strategies,
         note,
     }
+}
+
+/// Put the certainties first and let the ranking follow, minus anything the
+/// certainties already named.
+///
+/// Order within each group is preserved, and no score from one group is ever
+/// weighed against a score from the other — the concatenation is the whole
+/// operation. A file reached by both is reported once, as the exact hit,
+/// because "this is where it is defined" is strictly more information than
+/// "this scored 0.61".
+fn lead_with(exact: Vec<Hit>, ranked: Vec<Hit>) -> Vec<Hit> {
+    if exact.is_empty() {
+        return ranked;
+    }
+    let led: std::collections::HashSet<String> = exact.iter().map(|hit| hit.path.clone()).collect();
+    let mut hits = exact;
+    hits.extend(ranked.into_iter().filter(|hit| !led.contains(&hit.path)));
+    hits
 }
 
 /// Embed what is pending, embed the query, rank. `Err` carries a reason

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -260,6 +260,58 @@ fn line_at(source: &str, number: u32) -> Option<&str> {
     source.lines().nth(index)
 }
 
+/// The files that define a symbol the query names **exactly** — a lookup, not
+/// a ranking (#3125).
+///
+/// Ranking is the wrong instrument for this question and measurably so: asked
+/// for `ContextFrame`, a name with exactly one definition in its repository,
+/// embedding rank returned that definition at **rank 5 of 139** because a
+/// symbol name is a handful of tokens against whole files of prose. The graph
+/// already holds the answer as a fact.
+///
+/// Consulting it introduces no mode parameter and so does not reopen invariant
+/// 9: nothing about the *call* changes, and nothing is inferred about intent.
+/// Whether the query names an indexed symbol is a property of the index, which
+/// this module is entitled to read — the same standing on which it decides to
+/// rank semantically at all.
+///
+/// A sentence is not a symbol, so a multi-word query is refused before the
+/// query runs rather than after it returns nothing. That is the common case,
+/// and it keeps this free for every search that is a question.
+pub(crate) fn exact_symbol_hits(graph: &CodeGraph, query: &str, limit: usize) -> Vec<Hit> {
+    let name = query.trim();
+    if name.is_empty() || name.split_whitespace().count() != 1 {
+        return Vec::new();
+    }
+    let Ok(spans) = graph.definition_spans(name) else {
+        return Vec::new();
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut hits = Vec::new();
+    for span in spans {
+        // `definition_spans` is already `WHERE s.name = ?`, so this only guards
+        // the contract rather than filtering: an inexact hit here would be a
+        // ranking wearing a certainty's label, which is the one thing this
+        // strategy must never do.
+        if span.name != name || !seen.insert(span.path.clone()) {
+            continue;
+        }
+        hits.push(Hit {
+            why: format!(
+                "EXACT name match — `{}` ({}) is DEFINED here at line {}. This is a code-graph \
+                 fact, not a similarity score.",
+                span.name, span.kind, span.start_line
+            ),
+            path: span.path,
+        });
+        if hits.len() >= limit {
+            break;
+        }
+    }
+    hits
+}
+
 /// Rank indexed files by how many query terms appear in their path or their
 /// symbol names — the strategy for a workspace with an index but no embedder.
 ///

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -339,12 +339,19 @@ async fn a_surface_embedder_cannot_answer_the_same_question() {
 /// With no embedder the answer must still be useful, and must say which
 /// strategy produced it — a name match wearing a meaning match's clothes is
 /// worse than no answer.
+///
+/// The query is a *term*, not a symbol name: `scrub` appears inside
+/// `scrub_record` and `Scrubber` but names neither, so it reaches the
+/// term-matching rung rather than the exact one (#3125). An exact name takes
+/// the shorter route now, which is
+/// [`an_exact_name_without_an_embedder_is_still_a_certainty`]'s subject — this
+/// test is about the rung that guesses.
 #[tokio::test]
 async fn without_an_embedder_the_answer_is_useful_and_says_it_is_a_name_match() {
     let workspace = tempfile::tempdir().expect("tempdir");
     let (root, graph) = indexed_fixture(workspace.path());
 
-    let answer = dispatch(Some(&graph), &root, "scrub_record", None).await;
+    let answer = dispatch(Some(&graph), &root, "scrub", None).await;
     assert_eq!(answer.strategies, vec![Strategy::GraphNames]);
     assert_eq!(
         answer.hits.first().map(|hit| hit.path.as_str()),
@@ -356,7 +363,7 @@ async fn without_an_embedder_the_answer_is_useful_and_says_it_is_a_name_match() 
     let content = content_of(&render(
         Some(&graph),
         &root,
-        "scrub_record",
+        "scrub",
         &answer,
         SearchConfig::default(),
     ));
@@ -787,4 +794,135 @@ fn the_report_preserves_rank_order_and_strategy_labels() {
         Some("degraded: the backend hiccuped")
     );
     assert_eq!(report.rendered, rendered);
+}
+
+/// **The witness for #3125.** A query that exactly names an indexed symbol
+/// returns that symbol's defining file first, even when embedding rank puts
+/// something else on top.
+///
+/// The fixture is built so semantic ranking is *wrong on purpose* and provably
+/// so: the decoy's chunk contains only dimension-2 words, so it projects onto
+/// the query's own direction and scores 1.0, while the definition's chunk
+/// carries a dimension-3 word from its body and scores lower. On `main` the
+/// ladder returns at the semantic rung and the decoy is rank 1.
+///
+/// Measured cause: asked for `ContextFrame` — one definition in its repository
+/// — the semantic-only ladder returned it at rank 5 of 139, because the graph's
+/// exact-name rung is unreachable whenever semantic returns anything, and an
+/// admission floor of 0.25 against a corpus whose lowest cosine is 0.418 means
+/// it always does.
+#[tokio::test]
+async fn an_exact_symbol_name_beats_the_ranking_that_would_bury_it() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    for (path, body) in [
+        // The definition. Its body pulls it toward another dimension, so it
+        // cannot win the ranking on its own.
+        (
+            "src/holder.rs",
+            "pub fn socket_registry_of(matrix: &Matrix) -> u8 {\n\
+             matrix.rows().sum();\n\
+             0\n\
+             }\n",
+        ),
+        // The decoy: nothing but dimension-2 words, so it scores 1.0 against
+        // this query and outranks the definition every time.
+        (
+            "src/wirehub.rs",
+            "//! socket header request http wire\n\
+             pub fn send_socket_header_request() {\n\
+             socket_header_request_wire();\n\
+             }\n",
+        ),
+    ] {
+        let file = workspace.path().join(path);
+        fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+        fs::write(&file, body).expect("write");
+    }
+    let root = workspace.path().canonicalize().expect("canonicalize");
+    let graph = CodeGraph::open(&root, &root.join("codegraph.db")).expect("open");
+    graph.index_all().expect("index");
+
+    // The premise: the ranking really does prefer the decoy. Without this the
+    // test could pass on `main` by luck and prove nothing.
+    let (ranking, _) = super::semantic_hits(&graph, &ConceptEmbedder, "socket_registry_of")
+        .await
+        .expect("the fixture must rank");
+    assert_eq!(
+        ranking.first().map(|hit| hit.path.as_str()),
+        Some("src/wirehub.rs"),
+        "the decoy must outrank the definition semantically, or this witness proves nothing: {ranking:?}"
+    );
+
+    let answer = dispatch(
+        Some(&graph),
+        &root,
+        "socket_registry_of",
+        Some(&ConceptEmbedder),
+    )
+    .await;
+    graph.shutdown();
+
+    assert_eq!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some("src/holder.rs"),
+        "the defining file must lead: {:?}",
+        answer.hits
+    );
+    assert_eq!(
+        answer.strategies,
+        vec![Strategy::ExactSymbol, Strategy::Semantic],
+        "`via:` must name both rungs, never silently skip one"
+    );
+    assert!(
+        answer.hits[0].why.contains("EXACT"),
+        "the leading hit must say it is a fact rather than a score: {:?}",
+        answer.hits[0]
+    );
+    assert!(
+        answer
+            .hits
+            .iter()
+            .filter(|h| h.path == "src/holder.rs")
+            .count()
+            == 1,
+        "a file reached by both rungs must be reported once: {:?}",
+        answer.hits
+    );
+}
+
+/// The exact rung needs no embedder: it reads the graph, not a vector index.
+/// On a workspace with no embedding backend — the common case on
+/// Terminal-Bench — a symbol name should still be answered with a fact rather
+/// than with a term-overlap guess.
+#[tokio::test]
+async fn an_exact_name_without_an_embedder_is_still_a_certainty() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+
+    let answer = dispatch(Some(&graph), &root, "scrub_record", None).await;
+    graph.shutdown();
+    assert_eq!(answer.strategies, vec![Strategy::ExactSymbol]);
+    assert_eq!(
+        answer.hits.first().map(|hit| hit.path.as_str()),
+        Some("src/hkey.rs"),
+        "{:?}",
+        answer.hits
+    );
+}
+
+/// A question is not a symbol, so the exact rung must stay out of the way —
+/// otherwise every sentence-shaped search pays a graph lookup that can only
+/// ever miss, and `via:` starts naming a strategy that did nothing.
+#[tokio::test]
+async fn a_sentence_never_reaches_the_exact_symbol_rung() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let (root, graph) = indexed_fixture(workspace.path());
+
+    let answer = dispatch(Some(&graph), &root, QUESTION, Some(&ConceptEmbedder)).await;
+    graph.shutdown();
+    assert_eq!(
+        answer.strategies,
+        vec![Strategy::Semantic],
+        "a multi-word question must not engage the exact-symbol rung"
+    );
 }


### PR DESCRIPTION
## What

`dispatch` is a ladder that stops at the first rung producing hits — and the
first rung produced hits **every single time**, so nothing below it ever ran.

Measured over nine queries on a fully indexed 158-file corpus: `via: semantic`
on **9 of 9**, with 8 of those returning all 158 files.

## Why the ladder cannot advance

The admission floor is `0.25`. The **lowest cosine anywhere in that corpus** was
`0.418`. So the floor rejects nothing, `semantic_hits` cannot return an empty
list, and the rungs beneath it are unreachable whenever an embedder resolves.
The floor itself is #2993; this PR is the structural consequence, and it is
worth fixing independently — a floor tuned to reject 90% of a corpus would still
admit *something* for nearly every query.

It bites hardest exactly where ranking is weakest. Asked for `ContextFrame` — a
name with one definition in its repository — the ladder returned that definition
at **rank 5 of 139**, because a symbol name is a handful of tokens competing
against whole files of prose, while the code graph has held the answer as a fact
the whole time.

## How

The exact rung leads when it hits: the graph's definition sites first
(`definition_spans`, already `WHERE s.name = ?`), the semantic ranking after with
its duplicates removed, and `via:` naming both.

**This is not the fusion the module forbids.** No score from one rung is ever
compared against a score from another — the operation is concatenation — and
each hit still says in its own `why:` which kind of answer it is:

```
contextgraph-types/src/frame.rs
    why: EXACT name match — `ContextFrame` (struct) is DEFINED here at line 241.
         This is a code-graph fact, not a similarity score.
```

**Nor does it reopen invariant 9.** Whether the query names an indexed symbol is
a property of the *index*, not a mode the caller selected; the call shape is
unchanged and nothing about intent is inferred. A multi-word query is refused
before the lookup runs, so every search that is a question pays nothing — pinned
by `a_sentence_never_reaches_the_exact_symbol_rung`.

## Witness

`an_exact_symbol_name_beats_the_ranking_that_would_bury_it` fails hard without
the change. With the exact rung disabled, the fixture's decoy leads at cosine
**1.000** and the definition is **not returned at all** — it scored below the
floor for its own name:

```
left:  Some("src/wirehub.rs")
right: Some("src/holder.rs")
```

It asserts its premise first: the decoy must genuinely outrank the definition
semantically, or the test proves nothing.

## Test changed — named per the deleted-test guard

No test was deleted. `without_an_embedder_the_answer_is_useful_and_says_it_is_a_name_match`
asked for `scrub_record`, which *is* an exact symbol name and now takes the
shorter route. Its subject is the rung that **guesses**, so its query became the
term `scrub` — which appears inside `scrub_record` and `Scrubber` and names
neither — and the exact-name-without-an-embedder case got its own test
(`an_exact_name_without_an_embedder_is_still_a_certainty`) rather than being
folded into it. The graph-names rung keeps its coverage.

## Merge note

The new tests are appended at the **end** of `search/tests.rs` rather than at
the natural anchor, specifically so this does not collide with #3152, which adds
tests to the same file. Trial-merged locally: clean, and the merged tree's tests
pass (19 search + 17 vector).

## Verification

- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo fmt --all --check` — green

Closes #3125
Refs #2993
Refs #3097

## Summary by Sourcery

Prioritize exact symbol definition hits from the code graph ahead of semantic ranking in search results, ensuring symbol-name queries return factual definition locations first while keeping multi-word questions on semantic search only.

New Features:
- Introduce an ExactSymbol search strategy that surfaces code-graph definition sites for exact symbol-name queries.
- Add support for combining exact symbol hits with semantic ranking results while de-duplicating overlapping files in the final answer.

Bug Fixes:
- Fix search behavior where semantic ranking with a permissive admission floor prevented lower rungs from ever running, causing exact symbol definitions to be buried or missing.

Enhancements:
- Document the search ladder to clarify the role of the new exact-symbol rung, its non-fused ordering, and why certainties lead over ranked guesses.
- Refine strategy labels and `via:` reporting so answers clearly distinguish exact symbol facts from semantic and term-based guesses.

Tests:
- Update the no-embedder search test to use a term query instead of an exact symbol name, preserving coverage of the term-matching rung.
- Add tests that prove exact symbol queries beat misleading semantic rankings, work without an embedder, and that sentence-shaped queries never engage the exact-symbol rung.