### PR TITLE
fix(stella-store): an abandoned tool call is no longer a tool error

### DIFF
--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -645,7 +645,7 @@ impl Observatory {
         // the whole history was unbounded, and calls old enough to age out of
         // the window no longer describe how the tools behave today anyway.
         let sql = format!(
-            "SELECT name, ok, duration_ms, bytes_out FROM tool_calls
+            "SELECT name, state, duration_ms, bytes_out FROM tool_calls
              ORDER BY rowid DESC LIMIT {TOOL_CALL_SCAN_WINDOW}"
         );
         let mut stmt = match conn.prepare(&sql) {
@@ -656,7 +656,7 @@ impl Observatory {
         let scanned = stmt.query_map([], |r| {
             Ok((
                 r.get::<_, String>(0)?,
-                r.get::<_, i64>(1)? != 0,
+                r.get::<_, String>(1)?,
                 r.get::<_, i64>(2)?,
                 r.get::<_, i64>(3)?,
             ))
@@ -664,11 +664,17 @@ impl Observatory {
         let mut by_name: std::collections::BTreeMap<String, ToolAgg> =
             std::collections::BTreeMap::new();
         for call in scanned {
-            let (name, ok, duration_ms, bytes_out) = call?;
+            let (name, state, duration_ms, bytes_out) = call?;
             let entry = by_name.entry(name).or_default();
             entry.calls += 1;
-            if !ok {
-                entry.errors += 1;
+            // An abandoned call is a fact about its turn, not the tool: it
+            // must not count against the tool's error rate (#3146). A store
+            // not yet migrated to v24 still spells abandonment 'error'; its
+            // rates stay conservatively inflated until its next CLI open.
+            match state.as_str() {
+                "error" => entry.errors += 1,
+                "abandoned" => entry.abandoned += 1,
+                _ => {}
             }
             entry.durations.push(duration_ms);
             entry.bytes_out += bytes_out;
@@ -701,6 +707,7 @@ impl Observatory {
                     "name": name,
                     "calls": agg.calls,
                     "errors": agg.errors,
+                    "abandoned": agg.abandoned,
                     "p50_ms": p50,
                     "p90_ms": p90,
                     "p99_ms": p99,
@@ -890,7 +897,7 @@ impl Observatory {
         }
         for row in collect_rows(
             &conn,
-            "SELECT coalesce(date(ts), ''), count(*), count(*) FILTER (WHERE ok = 0)
+            "SELECT coalesce(date(ts), ''), count(*), count(*) FILTER (WHERE state = 'error')
              FROM tool_calls GROUP BY 1",
             |r| {
                 Ok(json!({
@@ -1218,6 +1225,10 @@ fn rules_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
 struct ToolAgg {
     calls: i64,
     errors: i64,
+    /// Calls whose turn ended before they returned — counted apart from
+    /// `errors` because abandonment is a fact about the turn, not the tool
+    /// (#3146).
+    abandoned: i64,
     /// Every call's duration, sorted in place when the p50/max are taken.
     durations: Vec<i64>,
     bytes_out: i64,

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -98,6 +98,8 @@ fn seeded_workspace() -> TempDir {
                args_digest TEXT NOT NULL DEFAULT '',
                reason TEXT NOT NULL DEFAULT '',
                ok INTEGER NOT NULL DEFAULT 1,
+               state TEXT NOT NULL DEFAULT 'ok'
+                 CHECK(state IN ('running', 'ok', 'error', 'abandoned')),
                error TEXT NOT NULL DEFAULT '',
                bytes_out INTEGER NOT NULL DEFAULT 0,
                duration_ms INTEGER NOT NULL DEFAULT 0,
@@ -123,11 +125,11 @@ fn seeded_workspace() -> TempDir {
                (2, 1, CURRENT_TIMESTAMP, 'local', 'llama',
                 2000, 0, 100, 0, 2000, 0, 0.0, 900, 1, 1);
              INSERT INTO tool_calls
-               (execution_id, seq, name, ok, error, bytes_out, duration_ms)
+               (execution_id, seq, name, ok, state, error, bytes_out, duration_ms)
              VALUES
-               (1, 1, 'read_file', 1, '', 2048, 12),
-               (1, 2, 'edit_file', 1, '', 64, 3),
-               (2, 1, 'bash', 0, 'exit 1', 0, 40);
+               (1, 1, 'read_file', 1, 'ok', '', 2048, 12),
+               (1, 2, 'edit_file', 1, 'ok', '', 64, 3),
+               (2, 1, 'bash', 0, 'error', 'exit 1', 0, 40);
              INSERT INTO files_touched VALUES
                (1, 'src/lib.rs', 'RU', 4, 1, '[]');
              CREATE TABLE execution_reflection (
@@ -722,8 +724,8 @@ fn activity_buckets_unparseable_timestamps_instead_of_failing() {
                 retries, tool_calls)
              VALUES (3, 1, 'sometime', 'zai', 'glm-5.2', 7, 0, 9, 0, 0, 0, 0.5, 11, 0, 1);
              INSERT INTO tool_calls
-               (execution_id, seq, name, ok, error, bytes_out, duration_ms, ts)
-             VALUES (3, 1, 'bash', 0, 'boom', 0, 4, 'sometime');",
+               (execution_id, seq, name, ok, state, error, bytes_out, duration_ms, ts)
+             VALUES (3, 1, 'bash', 0, 'error', 'boom', 0, 4, 'sometime');",
     )
     .unwrap();
     let response = respond(ws.path(), "/api/activity");

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -1386,3 +1386,79 @@ fn a_context_db_older_than_v8_degrades_to_empty_ledger_sections() {
         assert_eq!(v[key], serde_json::json!([]), "{key} must be empty: {v}");
     }
 }
+
+/// An interrupted turn's in-flight call must not count against its tool.
+///
+/// The sweep settles a still-`running` call as `'abandoned'` (v24), and the
+/// leaderboard reports it in its own column: before #3146 it landed in
+/// `errors`, so every ctrl-C or SIGKILL charged an "error" to whatever tool
+/// happened to be in flight — usually the slowest, most-watched ones.
+#[test]
+fn an_abandoned_call_is_not_a_tool_error_on_the_leaderboard() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let store = Store::open(dir.path()).expect("store");
+    let id = store
+        .begin_execution("run", "interrupted mid-tool", "anthropic", "opus")
+        .expect("begin");
+    store
+        .record_event(
+            id,
+            0,
+            &AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: "c1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({ "command": "false" }),
+                },
+            },
+        )
+        .expect("start c1");
+    store
+        .record_event(
+            id,
+            1,
+            &AgentEvent::ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::Error {
+                    message: "exit status 1".into(),
+                },
+                duration_ms: 3,
+                speculated: false,
+            },
+        )
+        .expect("c1 fails for real");
+    store
+        .record_event(
+            id,
+            2,
+            &AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: "c2".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({ "command": "sleep 60" }),
+                },
+            },
+        )
+        .expect("start c2");
+    // The owner is gone: the sweep settles c2 as abandoned, not errored.
+    store.mark_execution_interrupted(id).expect("sweep");
+
+    let tools: serde_json::Value =
+        serde_json::from_slice(&respond(dir.path(), "/api/tools").body).expect("json");
+    let bash = tools
+        .as_array()
+        .expect("array")
+        .iter()
+        .find(|t| t["name"] == "bash")
+        .cloned()
+        .expect("bash row");
+    assert_eq!(bash["calls"], 2, "both calls count: {bash}");
+    assert_eq!(
+        bash["errors"], 1,
+        "only the real failure is an error (#3146): {bash}"
+    );
+    assert_eq!(
+        bash["abandoned"], 1,
+        "the abandonment is visible, apart from the error count: {bash}"
+    );
+}

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -350,11 +350,15 @@ pub(crate) const MCP_USAGE_DDL: &str = "CREATE TABLE IF NOT EXISTS mcp_usage (
 /// survives as the idempotent *repair* path, not as the only writer.
 ///
 /// `state` is the lifecycle the live write needs and the end-of-turn fold
-/// could not express: `'running'` (announced, no result yet), `'ok'`, or
-/// `'error'`. It is strictly richer than `ok`, which is kept in lockstep
+/// could not express: `'running'` (announced, no result yet), `'ok'`,
+/// `'error'`, or `'abandoned'` (v24 — never returned because its turn ended
+/// first). It is strictly richer than `ok`, which is kept in lockstep
 /// (`ok = 1` iff `state = 'ok'`) so every pre-v18 reader keeps working.
 /// Without it an in-flight call is indistinguishable from a failed one with
 /// an empty error message, and a dashboard cannot honestly draw either.
+/// `'abandoned'` is split from `'error'` (#3146) because every error-rate
+/// reader groups on this column, and an interrupt charging an "error" to
+/// whatever tool was in flight made those rates dishonest.
 ///
 /// `ts` is now the moment the call was **announced** rather than the moment
 /// the turn ended, so per-day rollups bucket a call on the day it ran.
@@ -372,25 +376,33 @@ pub(crate) const MCP_USAGE_DDL: &str = "CREATE TABLE IF NOT EXISTS mcp_usage (
 /// and a total unique index would fail to build on any file holding two of
 /// them, which fails the migration and takes the workspace's whole store with
 /// it. The invariant is only meaningful for real ids anyway.
-pub(crate) const TOOL_CALLS_DDL: &str = "CREATE TABLE IF NOT EXISTS tool_calls (
+pub(crate) fn tool_calls_ddl(table: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {table} (
        execution_id INTEGER NOT NULL,
        seq INTEGER NOT NULL,
        call_id TEXT NOT NULL DEFAULT '',
        name TEXT NOT NULL,
        surface TEXT NOT NULL DEFAULT 'native',
-       args_json TEXT NOT NULL DEFAULT '{}',
+       args_json TEXT NOT NULL DEFAULT '{{}}',
        args_digest TEXT NOT NULL DEFAULT '',
        reason TEXT NOT NULL DEFAULT '',
        ok INTEGER NOT NULL DEFAULT 1,
        state TEXT NOT NULL DEFAULT 'ok'
-         CHECK(state IN ('running', 'ok', 'error')),
+         CHECK(state IN ('running', 'ok', 'error', 'abandoned')),
        error TEXT NOT NULL DEFAULT '',
        bytes_out INTEGER NOT NULL DEFAULT 0,
        duration_ms INTEGER NOT NULL DEFAULT 0,
        ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
        UNIQUE (execution_id, seq)
-     );
-     CREATE INDEX IF NOT EXISTS tool_calls_by_name
+     );"
+    )
+}
+
+/// The `tool_calls` indexes, separate from the table shape so the §7 rebuild
+/// path can recreate them *after* renaming the copy into place — an index
+/// created on the staging name would not survive the rename.
+pub(crate) const TOOL_CALLS_INDEXES: &str = "CREATE INDEX IF NOT EXISTS tool_calls_by_name
        ON tool_calls(name, execution_id);
      CREATE INDEX IF NOT EXISTS tool_calls_by_state
        ON tool_calls(state, execution_id, seq);

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -1258,7 +1258,7 @@ impl Store {
         let tool_histogram = {
             let mut stmt = conn.prepare(
                 "SELECT name, surface, COUNT(*), \
-                        SUM(CASE WHEN ok = 0 THEN 1 ELSE 0 END) \
+                        SUM(CASE WHEN state = 'error' THEN 1 ELSE 0 END) \
                  FROM tool_calls WHERE execution_id = ?1 GROUP BY name, surface",
             )?;
             let rows = stmt.query_map(params![execution_id], |r| {

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -14,11 +14,12 @@ use crate::ddl::{
     AGENT_USES_DDL, CONTEXT_BLOCKS_DDL, EXECUTION_REFLECTION_DDL, EXECUTIONS_DDL, FORGOTTEN_DDL,
     FOUNDRY_TOOLS_DDL, MCP_USAGE_DDL, MEMORY_CITATIONS_DDL, PULL_REQUESTS_DDL, REFLECTIONS_DDL,
     RULES_TABLE, SESSION_TURN_DIFFS_DDL, SKILL_USAGE_DDL, STEP_MANIFEST_DDL, STEP_RECEIPT_DDL,
-    TABLES, TASKS_DDL, TELEMETRY_INDEX, TOOL_CALLS_DDL, UNCHANGED_TABLES, events_ddl,
-    files_touched_ddl, telemetry_ddl,
+    TABLES, TASKS_DDL, TELEMETRY_INDEX, TOOL_CALLS_INDEXES, UNCHANGED_TABLES, events_ddl,
+    files_touched_ddl, telemetry_ddl, tool_calls_ddl,
 };
 use crate::{Result, StoreError};
 
+mod abandoned_state;
 mod token_unit;
 
 use token_unit::migrate_v18_to_v19;
@@ -33,7 +34,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 23] = [
+pub(crate) const MIGRATIONS: [Migration; 24] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -143,6 +144,12 @@ pub(crate) const MIGRATIONS: [Migration; 23] = [
     // no backfill to do — the fact was only ever printed to stderr before, so
     // it does not exist anywhere to recover.
     migrate_v22_to_v23,
+    // v23 → v24: `tool_calls.state` gains `'abandoned'` — a call whose turn
+    // ended before it returned stops masquerading as a tool error (#3146). A
+    // §7 rebuild (the CHECK constraint cannot be altered in place, and fresh
+    // v18..=v23 files carry one that would reject the new value), with the
+    // copy doubling as the backfill from the stable abandonment sentinel.
+    abandoned_state::migrate_v23_to_v24,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -173,7 +180,9 @@ pub(crate) const MIGRATIONS: [Migration; 23] = [
     //
     //   v22 → v23: CLAIMED above by the reflection parse-failure record.
     //
-    // Nothing is reserved now: take v23 → v24 and add your own line here.
+    //   v23 → v24: CLAIMED above by the abandoned-call state (#3146).
+    //
+    // Nothing is reserved now: take v24 → v25 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];
@@ -199,7 +208,8 @@ pub(crate) fn create_latest_schema(tx: &rusqlite::Transaction<'_>) -> Result<()>
     tx.execute_batch(AGENT_USES_DDL)?;
     tx.execute_batch(SKILL_USAGE_DDL)?;
     tx.execute_batch(MCP_USAGE_DDL)?;
-    tx.execute_batch(TOOL_CALLS_DDL)?;
+    tx.execute_batch(&tool_calls_ddl("tool_calls"))?;
+    tx.execute_batch(TOOL_CALLS_INDEXES)?;
     tx.execute_batch(EXECUTION_REFLECTION_DDL)?;
     tx.execute_batch(REFLECTIONS_DDL)?;
     tx.execute_batch(TASKS_DDL)?;
@@ -508,7 +518,8 @@ fn migrate_v22_to_v23(tx: &rusqlite::Transaction<'_>) -> Result<()> {
 /// v6 → v7: the additive data-plane tables — `tool_calls`,
 /// `execution_reflection`, and `reflections`. No existing table changes shape.
 fn migrate_v6_to_v7(tx: &rusqlite::Transaction<'_>) -> Result<()> {
-    tx.execute_batch(TOOL_CALLS_DDL)?;
+    tx.execute_batch(&tool_calls_ddl("tool_calls"))?;
+    tx.execute_batch(TOOL_CALLS_INDEXES)?;
     tx.execute_batch(EXECUTION_REFLECTION_DDL)?;
     tx.execute_batch(REFLECTIONS_DDL)?;
     Ok(())

--- a/crates/stella-store/src/migrations/abandoned_state.rs
+++ b/crates/stella-store/src/migrations/abandoned_state.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v23 → v24: `tool_calls.state` gains `'abandoned'` (#3146).
+//!
+//! Before this step a call whose turn ended first was stored as
+//! `state = 'error'`, distinguishable from a real failure only by its
+//! `error` prose — the crate-private [`ABANDONED`] sentinel. Every
+//! error-rate reader groups on `state`, and none of them can (or should)
+//! match that string: the Observatory reads this file directly without
+//! linking this crate, so the sentinel is structurally out of its reach.
+//! The result was that a SIGKILL or a ctrl-C charged an "error" to
+//! whatever tool happened to be in flight, inflating exactly the per-tool
+//! rates a reliability ceiling reads.
+//!
+//! # Why a §7 rebuild rather than nothing
+//!
+//! Two table populations exist, and *neither* admits the new value. A file
+//! migrated from pre-v18 grew `state` via `ALTER TABLE ADD COLUMN`, which
+//! carried no CHECK constraint — but a file created fresh at v18..=v23 has
+//! `CHECK(state IN ('running', 'ok', 'error'))` baked into its table SQL,
+//! and the first `'abandoned'` write would abort with a constraint
+//! violation. SQLite cannot alter a CHECK in place, so the table is
+//! rebuilt through the canonical DDL (which now includes `'abandoned'`),
+//! normalizing both populations to one shape.
+//!
+//! The copy doubles as the backfill: a row whose `state = 'error'` carries
+//! the exact sentinel prose is rewritten to `'abandoned'`. The sentinel
+//! has been byte-stable since v18 (two writers were required to agree on
+//! it), which is what makes the historic split recoverable at all.
+
+use crate::Result;
+use crate::ddl::{TOOL_CALLS_INDEXES, tool_calls_ddl};
+use crate::tool_calls::ABANDONED;
+
+pub(super) fn migrate_v23_to_v24(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    tx.execute_batch(&tool_calls_ddl("tool_calls_v24"))?;
+    tx.execute(
+        "INSERT INTO tool_calls_v24 \
+           (execution_id, seq, call_id, name, surface, args_json, args_digest, \
+            reason, ok, state, error, bytes_out, duration_ms, ts) \
+         SELECT execution_id, seq, call_id, name, surface, args_json, args_digest, \
+                reason, ok, \
+                CASE WHEN state = 'error' AND error = ?1 THEN 'abandoned' \
+                     ELSE state END, \
+                error, bytes_out, duration_ms, ts \
+         FROM tool_calls",
+        rusqlite::params![ABANDONED],
+    )?;
+    // Dropping the old table drops its indexes with it; they are recreated
+    // against the renamed copy, which is why they live apart from the shape.
+    tx.execute_batch(
+        "DROP TABLE tool_calls;
+         ALTER TABLE tool_calls_v24 RENAME TO tool_calls;",
+    )?;
+    tx.execute_batch(TOOL_CALLS_INDEXES)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, params};
+
+    use super::super::apply_migration;
+    use crate::tool_calls::ABANDONED;
+
+    /// The v23 shape a fresh v18..=v23 file carries: the three-state CHECK
+    /// that would reject the first `'abandoned'` write.
+    const V23_TOOL_CALLS: &str = "CREATE TABLE tool_calls (
+           execution_id INTEGER NOT NULL,
+           seq INTEGER NOT NULL,
+           call_id TEXT NOT NULL DEFAULT '',
+           name TEXT NOT NULL,
+           surface TEXT NOT NULL DEFAULT 'native',
+           args_json TEXT NOT NULL DEFAULT '{}',
+           args_digest TEXT NOT NULL DEFAULT '',
+           reason TEXT NOT NULL DEFAULT '',
+           ok INTEGER NOT NULL DEFAULT 1,
+           state TEXT NOT NULL DEFAULT 'ok'
+             CHECK(state IN ('running', 'ok', 'error')),
+           error TEXT NOT NULL DEFAULT '',
+           bytes_out INTEGER NOT NULL DEFAULT 0,
+           duration_ms INTEGER NOT NULL DEFAULT 0,
+           ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+           UNIQUE (execution_id, seq)
+         );";
+
+    /// The rebuild admits the new state AND rewrites history: a legacy row
+    /// spelling abandonment as `'error'` + the sentinel becomes
+    /// `'abandoned'`, while a genuine error keeps its state. Fails on the
+    /// old code twice over — the migration did not exist, and the v23 CHECK
+    /// rejects `'abandoned'` outright.
+    #[test]
+    fn v24_backfills_the_sentinel_and_admits_the_new_state() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(V23_TOOL_CALLS).expect("v23 shape");
+        conn.execute(
+            "INSERT INTO tool_calls (execution_id, seq, name, ok, state, error) \
+             VALUES (1, 0, 'bash', 0, 'error', ?1), \
+                    (1, 1, 'bash', 0, 'error', 'boom'), \
+                    (1, 2, 'grep', 1, 'ok', '')",
+            params![ABANDONED],
+        )
+        .expect("legacy rows");
+        conn.pragma_update(None, "user_version", 23).expect("stamp");
+
+        apply_migration(&mut conn, super::migrate_v23_to_v24, 24).expect("migrate");
+
+        let states: Vec<String> = conn
+            .prepare("SELECT state FROM tool_calls WHERE execution_id = 1 ORDER BY seq")
+            .expect("prepare")
+            .query_map([], |r| r.get(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("rows");
+        assert_eq!(states, ["abandoned", "error", "ok"]);
+
+        conn.execute(
+            "INSERT INTO tool_calls (execution_id, seq, name, ok, state, error) \
+             VALUES (2, 0, 'bash', 0, 'abandoned', ?1)",
+            params![ABANDONED],
+        )
+        .expect("the rebuilt CHECK admits 'abandoned'");
+    }
+}

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -1106,9 +1106,9 @@ fn skill_usage_records_per_execution_version_rows() {
     // `enabled` flag adoption never sets. Additive. v21 adds
     // `session_turn_diffs` (#1870): the precomputed per-turn workspace diff.
     // Additive. v22 adds `executions.journal_era` (#1981). v23 adds nullable
-    // `execution_reflection.parse_error` (#2175): the unreadable excerpt a
-    // starved learning loop leaves behind.
-    assert_eq!(SCHEMA_VERSION, 23);
+    // `execution_reflection.parse_error` (#2175). v24 splits `'abandoned'`
+    // from `'error'` in `tool_calls.state` (#3146), backfilled by rebuild.
+    assert_eq!(SCHEMA_VERSION, 24);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")

--- a/crates/stella-store/src/tool_calls.rs
+++ b/crates/stella-store/src/tool_calls.rs
@@ -62,8 +62,17 @@ pub enum ToolCallState {
     Running,
     /// Returned successfully.
     Ok,
-    /// Returned an error, or was abandoned when its turn ended.
+    /// Returned an error.
     Error,
+    /// Never returned — its turn ended (or its process died) first.
+    ///
+    /// Distinct from [`Self::Error`] because the two answer different
+    /// questions: an error is a fact about the *tool*, an abandonment is a
+    /// fact about the *turn*. Folding them together (which is what this
+    /// projection did before v24) charged an "error" to whatever tool
+    /// happened to be in flight at every interrupt, inflating exactly the
+    /// per-tool error rates a reliability ceiling reads (#3146).
+    Abandoned,
 }
 
 impl ToolCallState {
@@ -74,6 +83,7 @@ impl ToolCallState {
             Self::Running => "running",
             Self::Ok => "ok",
             Self::Error => "error",
+            Self::Abandoned => "abandoned",
         }
     }
 
@@ -87,6 +97,7 @@ impl ToolCallState {
         match value {
             "running" => Self::Running,
             "ok" => Self::Ok,
+            "abandoned" => Self::Abandoned,
             _ => Self::Error,
         }
     }
@@ -446,7 +457,7 @@ impl Store {
             let digest = fnv_hex(args_json);
             let (state, error, bytes_out, duration_ms) = match results.get(call_id) {
                 Some((state, error, bytes, dur)) => (*state, error.clone(), *bytes, *dur),
-                None => (ToolCallState::Error, ABANDONED.to_string(), 0, 0),
+                None => (ToolCallState::Abandoned, ABANDONED.to_string(), 0, 0),
             };
             rows.push(ToolCallRow {
                 call_id: call_id.clone(),
@@ -532,7 +543,7 @@ impl Store {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
         tx.execute(
-            "UPDATE tool_calls SET state = 'error', ok = 0, error = ?2 \
+            "UPDATE tool_calls SET state = 'abandoned', ok = 0, error = ?2 \
              WHERE execution_id = ?1 AND state = 'running'",
             params![execution_id, ABANDONED],
         )?;

--- a/crates/stella-store/src/tool_calls/tests.rs
+++ b/crates/stella-store/src/tool_calls/tests.rs
@@ -162,7 +162,10 @@ fn an_interrupted_execution_recovers_every_call_from_the_log() {
     assert_eq!(repaired, 1);
     let recovered = rows(&store, id);
     assert_eq!(recovered.len(), 3, "every call comes back: {recovered:?}");
-    assert_eq!(recovered[2].2, "error");
+    assert_eq!(
+        recovered[2].2, "abandoned",
+        "a call that never returned is abandoned, not a tool error (#3146)"
+    );
     assert_eq!(
         recovered[2].3, ABANDONED,
         "the call that never returned is honest about why"
@@ -206,7 +209,10 @@ fn marking_interrupted_settles_running_calls_and_dates_from_the_log() {
     store.mark_execution_interrupted(id).unwrap();
 
     let settled = rows(&store, id);
-    assert_eq!(settled[0].2, "error");
+    assert_eq!(
+        settled[0].2, "abandoned",
+        "the interrupt sweep settles to abandoned, never to error (#3146)"
+    );
     assert_eq!(settled[0].3, ABANDONED);
     let (finished, outcome): (Option<String>, Option<String>) = store
         .lock()
@@ -521,4 +527,36 @@ fn tool_call_counts_group_every_call_by_name() {
         "busiest first: {counts:?}"
     );
     assert!(counts.contains(&("graph_query".to_string(), 1)));
+}
+
+/// A finished turn can still hold calls that never returned (the turn-end
+/// fold settles them). The usage rollup's per-tool histogram must charge the
+/// tool for its real failures and NOT for the turn's abandonments — before
+/// #3146 both counted as `errors`, so every interrupt inflated exactly the
+/// per-tool error rate a reliability ceiling reads.
+#[test]
+fn rollup_bucket_counts_errors_but_not_abandonment() {
+    let (store, id) = fixture();
+    store.record_event(id, 0, &start("c1", "bash")).unwrap();
+    store
+        .record_event(id, 1, &err_result("c1", "boom"))
+        .unwrap();
+    store.record_event(id, 2, &start("c2", "bash")).unwrap();
+    store.materialize_tool_calls(id).unwrap();
+    store.finish_execution(id, "completed", 0.0).unwrap();
+
+    let rollup = store
+        .execution_rollup(id, std::path::Path::new("/tmp/workspace"))
+        .unwrap()
+        .expect("a finished, accounted execution rolls up");
+    let bucket = rollup
+        .tool_histogram
+        .iter()
+        .find(|b| b.tool == "bash")
+        .expect("bash bucket");
+    assert_eq!(
+        (bucket.calls, bucket.errors),
+        (2, 1),
+        "abandonment is a fact about the turn, not the tool (#3146)"
+    );
 }


### PR DESCRIPTION
## What

`tool_calls.state` gains `'abandoned'` (schema v24), and every error-rate reader stops counting abandonment as failure.

Before this change a call whose turn ended first (ctrl-C, SIGKILL, clean turn end with an in-flight call) was stored as `state = 'error'`, distinguishable from a real failure only by the crate-private `ABANDONED` sentinel prose. The Observatory leaderboard (`/api/tools`), the per-day activity series, and the cross-project usage rollup (`ToolBucket` → `tool_usage_rollup.errors`) all counted it as a tool error — so every interrupt charged an "error" to whatever tool happened to be running, usually the slowest, most-watched ones (`bash`, `verify_done`). Any per-tool reliability ceiling was unenforceable on those numbers.

## How

- `ToolCallState::Abandoned` (`crates/stella-store/src/tool_calls.rs`): the interrupt sweep (`mark_execution_interrupted`) and the turn-end repair fold (`materialize_tool_calls`) settle a still-`running` call to `'abandoned'` instead of `'error'`. The `ok` column stays in lockstep (`ok = 1` iff `state = 'ok'`).
- **Migration v23 → v24** (`crates/stella-store/src/migrations/abandoned_state.rs`, a submodule following the `token_unit` precedent): a table rebuild, because *neither* historic population admits the new value — pre-v18 files grew `state` via `ALTER TABLE ADD COLUMN` (no CHECK), while files created fresh at v18..=v23 carry `CHECK(state IN ('running','ok','error'))` which would reject the first `'abandoned'` write, and SQLite cannot alter a CHECK in place. The copy doubles as the backfill: `state='error' AND error=<sentinel>` rows become `'abandoned'`. Exemplar: the v12→v13 `step_manifest` rebuild; the DDL is name-parameterized following `events_ddl`.
- `ToolBucket` histogram (`crates/stella-store/src/lib.rs`): counts `state = 'error'` only, so abandonment stops leaking into `tool_usage_rollup.errors` permanently and cross-project.
- Observatory (`crates/stella-observatory/src/db.rs`): the leaderboard scans `state` instead of `ok`, reports `abandoned` as its own column, and the per-day `tool_errors` filter moves to `state = 'error'`. A store not yet migrated (not opened by a new CLI) still spells abandonment `'error'`; its rates stay conservatively inflated until its next open — noted in a comment at the fold.

## Witnesses (each fails on `main`)

- `migrations::abandoned_state::tests::v24_backfills_the_sentinel_and_admits_the_new_state` — fails twice over on main: the migration does not exist, and the v23 CHECK rejects `'abandoned'`.
- `tool_calls::tests::rollup_bucket_counts_errors_but_not_abandonment` — on main the bucket reports `errors = 2` for one real failure plus one abandonment.
- `tool_calls::tests::an_interrupted_execution_recovers_every_call_from_the_log` and `marking_interrupted_settles_running_calls_and_dates_from_the_log` — existing tests, expectations flipped from `"error"` to `"abandoned"`.
- `schema_conformance::an_abandoned_call_is_not_a_tool_error_on_the_leaderboard` (stella-observatory) — on main `errors = 2` and no `abandoned` key.

The observatory unit fixture (`src/tests.rs`) gained the `state` column its hand-written `tool_calls` shape was missing — the routes now read it.

## Verification

`cargo test -p stella-store` (333 passed), `cargo test -p stella-observatory` (all suites green), `cargo clippy -p stella-store -p stella-observatory --all-targets -- -D warnings` clean, `cargo check -p stella-cli` clean, `scripts/check-file-size.sh` OK (god files stella-store/src/{tests,lib}.rs held at net-zero growth).

Part of the tool-certification epic #3150; unblocks the honest denominator for #3147.

Closes #3146

## Summary by Sourcery

Separate abandoned tool calls from real errors and update storage, migration, and observatory reporting so interrupts no longer count against per-tool error rates.

Bug Fixes:
- Stop counting interrupted, never-returned tool calls as errors in per-tool histograms, rollups, and observatory leaderboards.

Enhancements:
- Extend tool call state model with an explicit 'abandoned' state and expose abandonment as its own metric in observatory APIs.
- Add a schema v23→v24 migration that rebuilds the tool_calls table to admit the new state and backfills legacy abandoned calls from the sentinel error text.
- Refactor tool_calls table DDL to be parameterized and split indexes from table creation to support rebuilds and fresh schema creation.

Tests:
- Add and update tests to validate the new 'abandoned' state behavior across store rollups, interruption handling, schema migration, and observatory leaderboard reporting.