### PR TITLE
fix(stella-tools): validate tool input against the advertised schema at dispatch

### DIFF
--- a/crates/stella-protocol/src/tool.rs
+++ b/crates/stella-protocol/src/tool.rs
@@ -52,8 +52,13 @@ pub struct ToolCall {
     /// Which tool to run — matches the [`ToolSchema::name`] it was chosen
     /// from.
     pub name: String,
-    /// The arguments, as the model produced them. Runtime data: validate
-    /// against [`ToolSchema::input_schema`] rather than trusting the shape.
+    /// The arguments, as the model produced them. Runtime data: never trust
+    /// the shape. `stella-tools` validates this against
+    /// [`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,
+    /// #3144) — required fields, declared types, enums, item types, and
+    /// `additionalProperties: false` where a schema advertises it — and
+    /// refuses a contradicting call before the tool runs. Tools still read
+    /// fields defensively: a direct caller may bypass the registry.
     pub input: serde_json::Value,
 }
 

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -396,12 +396,18 @@ impl Tool for Bash {
         let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
         // trace: true prefixes `set -x` so every executed line echoes to
         // stderr — an execution trace a verifier can demand as evidence.
+        // A wrong-typed `trace` is refused, never silently read as false:
+        // the caller believes it armed the trace (#3144).
+        let trace = match crate::input::optional_bool(input, "trace") {
+            Ok(trace) => trace.unwrap_or(false),
+            Err(err) => {
+                return ToolOutput::Error {
+                    message: err.to_string(),
+                };
+            }
+        };
         let traced;
-        let command = if input
-            .get("trace")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
+        let command = if trace {
             traced = format!("set -x\n{command}");
             traced.as_str()
         } else {
@@ -559,6 +565,28 @@ mod tests {
             ToolOutput::Ok { content } => assert!(content.contains("hello_stella")),
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
+    }
+
+    /// The #3144 witness: a wrong-typed `trace` is refused, never silently
+    /// read as `false`. On main, `{"trace": "yes"}` ran the command untraced
+    /// — the caller believed it armed the trace it asked for as evidence.
+    #[tokio::test]
+    async fn a_mistyped_trace_is_refused_not_silently_untraced() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = Bash::new(None)
+            .execute(
+                &serde_json::json!({"command": "echo hi > probe.txt", "trace": "yes"}),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("a mistyped trace must be an error, got: {out:?}");
+        };
+        assert_eq!(message, "field `trace` must be a boolean, got string");
+        assert!(
+            !dir.path().join("probe.txt").exists(),
+            "the command must not run on refused input"
+        );
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/exploration.rs
+++ b/crates/stella-tools/src/exploration.rs
@@ -66,7 +66,10 @@ pub const LEDGER_FILES_KEY: &str = "_session_read_files";
 /// fabricated evidence. `files_touched` is the registry ledger's
 /// `(path, op-letters)` rows; only rows recording a read (`R`) count.
 /// Returns `None` when the input is already correct as-is.
-pub(crate) fn ledger_augmented(files_touched: Vec<(String, String)>, input: &Value) -> Option<Value> {
+pub(crate) fn ledger_augmented(
+    files_touched: Vec<(String, String)>,
+    input: &Value,
+) -> Option<Value> {
     let Value::Object(map) = input else {
         return None;
     };
@@ -77,10 +80,7 @@ pub(crate) fn ledger_augmented(files_touched: Vec<(String, String)>, input: &Val
         .collect();
     if !read_paths.is_empty() {
         let mut map = map.clone();
-        map.insert(
-            LEDGER_FILES_KEY.to_string(),
-            serde_json::json!(read_paths),
-        );
+        map.insert(LEDGER_FILES_KEY.to_string(), serde_json::json!(read_paths));
         Some(Value::Object(map))
     } else if map.contains_key(LEDGER_FILES_KEY) {
         let mut map = map.clone();

--- a/crates/stella-tools/src/exploration.rs
+++ b/crates/stella-tools/src/exploration.rs
@@ -58,6 +58,39 @@ const MAX_MANIFEST_FILES: usize = 200;
 /// advertised in the tool schema — the model never authors it.
 pub const LEDGER_FILES_KEY: &str = "_session_read_files";
 
+/// The registry's dispatch-time augmentation for `save_exploration` (spec
+/// §3d): the staleness manifest is built from the ledger's actual evidence,
+/// passed through the internal [`LEDGER_FILES_KEY`]. The model never authors
+/// that field; a value it did author is replaced — and when the session
+/// recorded no reads, removed, so it cannot flow into the manifest as
+/// fabricated evidence. `files_touched` is the registry ledger's
+/// `(path, op-letters)` rows; only rows recording a read (`R`) count.
+/// Returns `None` when the input is already correct as-is.
+pub(crate) fn ledger_augmented(files_touched: Vec<(String, String)>, input: &Value) -> Option<Value> {
+    let Value::Object(map) = input else {
+        return None;
+    };
+    let read_paths: Vec<String> = files_touched
+        .into_iter()
+        .filter(|(_, letters)| letters.contains('R'))
+        .map(|(path, _)| path)
+        .collect();
+    if !read_paths.is_empty() {
+        let mut map = map.clone();
+        map.insert(
+            LEDGER_FILES_KEY.to_string(),
+            serde_json::json!(read_paths),
+        );
+        Some(Value::Object(map))
+    } else if map.contains_key(LEDGER_FILES_KEY) {
+        let mut map = map.clone();
+        map.remove(LEDGER_FILES_KEY);
+        Some(Value::Object(map))
+    } else {
+        None
+    }
+}
+
 /// Lifecycle of a record: a draft is an in-flight claim with partial notes;
 /// complete is a finished map.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/stella-tools/src/input.rs
+++ b/crates/stella-tools/src/input.rs
@@ -46,8 +46,9 @@ use serde_json::Value;
 
 /// The JSON type name of `value`, for an error a model can act on. These are
 /// the JSON spelling (`number`, `boolean`) rather than Rust's, because the
-/// caller wrote JSON.
-fn type_name(value: &Value) -> &'static str {
+/// caller wrote JSON. `pub(crate)` for the dispatch-time schema validator
+/// (`crate::registry::validate`), which names types in the same vocabulary.
+pub(crate) fn type_name(value: &Value) -> &'static str {
     match value {
         Value::Null => "null",
         Value::Bool(_) => "boolean",
@@ -60,8 +61,9 @@ fn type_name(value: &Value) -> &'static str {
 
 /// `null` is treated as absence, not as a wrong type: every JSON encoder in
 /// the wild emits `null` for "no value", and failing a call over the
-/// difference would be pedantry the caller cannot act on.
-fn present<'a>(input: &'a Value, field: &str) -> Option<&'a Value> {
+/// difference would be pedantry the caller cannot act on. `pub(crate)` so
+/// the dispatch-time schema validator applies the same convention.
+pub(crate) fn present<'a>(input: &'a Value, field: &str) -> Option<&'a Value> {
     match input.get(field) {
         None | Some(Value::Null) => None,
         Some(v) => Some(v),
@@ -96,21 +98,51 @@ pub enum InputError {
         /// The field that was mistyped.
         field: String,
         /// What the reader wanted, phrased for the message ("a string").
-        want: &'static str,
+        /// A `String` rather than `&'static str` so the dispatch validator
+        /// can phrase a schema's `"type": [..]` alternatives ("a string or
+        /// an integer") — the readers above still pass fixed phrases.
+        want: String,
         /// The JSON type that actually arrived.
         got: &'static str,
     },
 
-    /// One element of an array field was not a string. Carries the index,
-    /// because "one of these is wrong" is not something a caller can act on.
-    #[error("field `{field}`[{index}] must be a string, got {got}")]
+    /// One element of an array field did not carry the type the schema
+    /// declares for its items. Carries the index, because "one of these is
+    /// wrong" is not something a caller can act on.
+    #[error("field `{field}`[{index}] must be {want}, got {got}")]
     WrongElementType {
         /// The array field being read.
         field: String,
         /// The offending element's position.
         index: usize,
+        /// What the items were declared as, phrased for the message.
+        want: String,
         /// The JSON type that actually arrived.
         got: &'static str,
+    },
+
+    /// The field's value is not one of the schema's declared `enum` members.
+    #[error("field `{field}` must be one of {allowed}, got {got}")]
+    NotOneOf {
+        /// The field carrying the out-of-set value.
+        field: String,
+        /// The `enum` members, rendered as JSON and comma-joined in the
+        /// schema's declared order — pre-joined so `Display` stays a plain
+        /// format and the ordering decision lives with the constructor.
+        allowed: String,
+        /// The value that arrived, rendered as JSON (length-capped).
+        got: String,
+    },
+
+    /// The tool declares `additionalProperties: false` and the call carried
+    /// a key its schema does not name.
+    #[error("unknown field `{field}` — this tool accepts only: {allowed}")]
+    UnknownField {
+        /// The first unrecognized key, in lexicographic order.
+        field: String,
+        /// The schema's declared property names, backtick-quoted, sorted,
+        /// and comma-joined.
+        allowed: String,
     },
 }
 
@@ -123,7 +155,7 @@ fn missing(field: &str) -> InputError {
 fn wrong_type(field: &str, want: &'static str, got: &Value) -> InputError {
     InputError::WrongType {
         field: field.to_string(),
-        want,
+        want: want.to_string(),
         got: type_name(got),
     }
 }
@@ -196,6 +228,7 @@ pub fn optional_str_array<'a>(
         let text = item.as_str().ok_or_else(|| InputError::WrongElementType {
             field: field.to_string(),
             index: i,
+            want: "a string".to_string(),
             got: type_name(item),
         })?;
         out.push(text);
@@ -237,9 +270,9 @@ mod tests {
             mistyped,
             InputError::WrongType {
                 ref field,
-                want: "a string",
+                ref want,
                 got: "number",
-            } if field == "pattern"
+            } if field == "pattern" && want == "a string"
         ));
     }
 

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -282,7 +282,9 @@ impl Tool for ReadFile {
         // MAX_LINES is a ceiling, not just the default: the flood protection
         // the module header promises must hold for explicit limits too.
         let limit = match crate::input::optional_u64(input, "limit") {
-            Ok(limit) => limit.map(|n| (n as usize).min(MAX_LINES)).unwrap_or(MAX_LINES),
+            Ok(limit) => limit
+                .map(|n| (n as usize).min(MAX_LINES))
+                .unwrap_or(MAX_LINES),
             Err(err) => {
                 return ToolOutput::Error {
                     message: err.to_string(),

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -268,17 +268,27 @@ impl Tool for ReadFile {
             }
         };
 
-        let offset = input
-            .get("offset")
-            .and_then(|v| v.as_u64())
-            .map(|n| n as usize);
+        // A wrong-typed `offset`/`limit` is refused, never silently
+        // defaulted — `and_then(as_u64)` read `"limit": "200"` as the
+        // default window without a word (#3144). Absent still defaults.
+        let offset = match crate::input::optional_u64(input, "offset") {
+            Ok(offset) => offset.map(|n| n as usize),
+            Err(err) => {
+                return ToolOutput::Error {
+                    message: err.to_string(),
+                };
+            }
+        };
         // MAX_LINES is a ceiling, not just the default: the flood protection
         // the module header promises must hold for explicit limits too.
-        let limit = input
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|n| (n as usize).min(MAX_LINES))
-            .unwrap_or(MAX_LINES);
+        let limit = match crate::input::optional_u64(input, "limit") {
+            Ok(limit) => limit.map(|n| (n as usize).min(MAX_LINES)).unwrap_or(MAX_LINES),
+            Err(err) => {
+                return ToolOutput::Error {
+                    message: err.to_string(),
+                };
+            }
+        };
 
         let handle = match crate::rootfd::RootHandle::open(root) {
             Ok(handle) => std::sync::Arc::new(handle),
@@ -527,6 +537,50 @@ mod tests {
             ToolOutput::Error { message } => panic!("expected ok, got: {message}"),
         }
         let _ = tokio::fs::remove_file(&full).await;
+    }
+
+    /// The #3144 witness: a wrong-typed `offset`/`limit` is refused, never
+    /// silently defaulted. On main, `{"limit": "200"}` vanished into the
+    /// default window — no refusal, no note, wrong-sized read.
+    #[tokio::test]
+    async fn a_mistyped_offset_or_limit_is_refused_not_defaulted() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "a\nb\nc\n").unwrap();
+        let tool = ReadFile::default();
+
+        let out = tool
+            .execute(
+                &serde_json::json!({"path": "f.txt", "limit": "200"}),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("a mistyped limit must be an error, got: {out:?}");
+        };
+        assert_eq!(
+            message,
+            "field `limit` must be a non-negative integer, got string"
+        );
+
+        let out = tool
+            .execute(
+                &serde_json::json!({"path": "f.txt", "offset": true}),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("a mistyped offset must be an error, got: {out:?}");
+        };
+        assert_eq!(
+            message,
+            "field `offset` must be a non-negative integer, got boolean"
+        );
+
+        // Absent still defaults — the fix refuses wrong types, not absence.
+        let out = tool
+            .execute(&serde_json::json!({"path": "f.txt"}), dir.path())
+            .await;
+        assert!(!out.is_error(), "{out:?}");
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -25,6 +25,7 @@ mod executor;
 mod options;
 mod process_tools;
 mod turn_probe;
+mod validate;
 
 pub use options::RegistryOptions;
 
@@ -852,40 +853,10 @@ impl ToolRegistry {
         }
         let input: &Value = modified_input.as_ref().unwrap_or(input);
 
-        // A save_exploration's staleness manifest is built from the map's
-        // actual evidence: pass the session's read paths from the file-touch
-        // ledger through the internal input key (spec §3d). The model never
-        // authors this field; a value it did author is replaced — and when
-        // the session recorded no reads, removed, or it would flow into the
-        // manifest as fabricated evidence.
-        let mut ledger_augmented: Option<Value> = None;
-        if name == "save_exploration"
-            && let Value::Object(map) = input
-        {
-            let read_paths: Vec<String> = self
-                .files_touched()
-                .into_iter()
-                .filter(|(_, letters)| letters.contains('R'))
-                .map(|(path, _)| path)
-                .collect();
-            if !read_paths.is_empty() {
-                let mut map = map.clone();
-                map.insert(
-                    crate::exploration::LEDGER_FILES_KEY.to_string(),
-                    serde_json::json!(read_paths),
-                );
-                ledger_augmented = Some(Value::Object(map));
-            } else if map.contains_key(crate::exploration::LEDGER_FILES_KEY) {
-                let mut map = map.clone();
-                map.remove(crate::exploration::LEDGER_FILES_KEY);
-                ledger_augmented = Some(Value::Object(map));
-            }
-        }
-        let input: &Value = ledger_augmented.as_ref().unwrap_or(input);
-
-        // Resolve the tool now rather than at dispatch below: the command
-        // fence asks IT for the line it would run. Clone the `Arc` out so
-        // the overlay's read lock is released before any `.await`.
+        // Resolve the tool now rather than at dispatch below: the input gate
+        // directly below needs its advertised schema, and the command fence
+        // asks IT for the line it would run. Clone the `Arc` out so the
+        // overlay's read lock is released before any `.await`.
         let tool = self.tools.get(name).cloned().or_else(|| {
             self.late_tools
                 .read()
@@ -893,6 +864,21 @@ impl ToolRegistry {
                 .get(name)
                 .cloned()
         });
+
+        // Dispatch-time input validation (#3144): a call whose input
+        // contradicts the tool's advertised `input_schema` is refused here,
+        // before anything downstream runs — see `registry/validate.rs`.
+        if let Some(deny) = validate::refusal(tool.as_deref(), input) {
+            return deny;
+        }
+
+        // A save_exploration's staleness manifest is built from the ledger's
+        // actual evidence, threaded through an internal input key (spec §3d)
+        // — see [`crate::exploration::ledger_augmented`].
+        let ledger_augmented = (name == "save_exploration")
+            .then(|| crate::exploration::ledger_augmented(self.files_touched(), input))
+            .flatten();
+        let input: &Value = ledger_augmented.as_ref().unwrap_or(input);
 
         // `run_script` threads its gate resolution into execution through an
         // internal input key, so the line the `command.started` chain

--- a/crates/stella-tools/src/registry/validate.rs
+++ b/crates/stella-tools/src/registry/validate.rs
@@ -171,7 +171,8 @@ fn check(schema: &Value, input: &Value) -> Option<InputError> {
             .collect();
         unknown.sort();
         if let Some(field) = unknown.first() {
-            let mut allowed: Vec<&String> = properties.into_iter().flatten().map(|(k, _)| k).collect();
+            let mut allowed: Vec<&String> =
+                properties.into_iter().flatten().map(|(k, _)| k).collect();
             allowed.sort();
             let allowed = allowed
                 .iter()

--- a/crates/stella-tools/src/registry/validate.rs
+++ b/crates/stella-tools/src/registry/validate.rs
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Dispatch-time validation of a tool call's input against the tool's
+//! advertised `input_schema` (#3144).
+//!
+//! [`ToolCall::input`]'s doc comment has always promised "validate against
+//! `ToolSchema::input_schema` rather than trusting the shape" — this module
+//! is the one seam that performs it, in `ToolRegistry::execute`, before the
+//! tool runs. Without it a mistyped argument was misreported as a missing
+//! one (`{"query": 42}` → "query is required") or silently defaulted
+//! (`"trace": "yes"` → traced nothing), so the model retried against a
+//! refusal naming the wrong defect.
+//!
+//! # The enforced subset
+//!
+//! The catalog's schemas use a small JSON-Schema subset, and this checker
+//! deliberately implements exactly that subset rather than pulling in a
+//! `jsonschema` dependency:
+//!
+//! - **`required`** — every listed field must be present. The refusal is
+//!   [`InputError::Missing`], byte-identical to the wording every tool has
+//!   always used.
+//! - **`properties.*.type`** — a present field must carry a declared type.
+//!   Both spellings are honored: a single string (`"type": "string"`) and an
+//!   array of alternatives (`"type": ["string", "null"]` — any listed type
+//!   passes). An absent `type` checks nothing. `"integer"` rejects a number
+//!   with a fractional part; an integer against `"number"` passes. A type
+//!   word outside the known seven checks nothing (fail-open: an exotic
+//!   schema must not brick its tool).
+//! - **`properties.*.enum`** — a present field must equal one member.
+//! - **`properties.*.items.type`** — each element of a present array must
+//!   carry the declared item type ([`InputError::WrongElementType`], which
+//!   names the index).
+//! - **`additionalProperties: false`** — unknown keys are rejected, but
+//!   **only** for schemas that advertise this (the `task` tool,
+//!   foundry-authored tools, custom manifests that opt in).
+//!
+//! # Unknown keys are otherwise ignored — deliberately (#3144)
+//!
+//! For every schema that does not declare `additionalProperties: false`,
+//! unknown keys pass exactly as they always have. Models pass stray extra
+//! keys constantly, and a new refusal class for them would fail calls that
+//! previously succeeded — a solve-rate regression bought for pedantry. The
+//! conservative decision, made in #3144: enforce strictness only where the
+//! tool already advertises it.
+//!
+//! # `null` reads as absence
+//!
+//! [`crate::input`]'s `present` treats an explicit `null` as an absent
+//! field, because every JSON encoder in the wild emits `null` for "no
+//! value", and every tool reads its input through that convention. This
+//! validator applies the same rule rather than inventing a stricter one the
+//! tools would then contradict: a required field sent as `null` is refused
+//! as [`InputError::Missing`] — unless its declared `type` lists `"null"`,
+//! in which case it is a legitimate value — and an optional field sent as
+//! `null` is skipped, exactly as the tool itself will skip it.
+//!
+//! # MCP and custom tools
+//!
+//! MCP-supplied tools (`mcp__`-prefixed) and custom script tools pass
+//! through the same seam and are validated against whatever schema they
+//! advertise. A schema with no `properties`/`required` (common for external
+//! servers) naturally checks nothing — the validator enforces only what a
+//! schema declares, so a permissive tool stays permissive.
+//!
+//! # Determinism
+//!
+//! Refusal text is model-visible and must be byte-deterministic (the loop
+//! detector compares outputs; see `tests/search_determinism.rs`). One call
+//! yields at most one refusal, chosen in a fixed order: `required` fields in
+//! schema order, then per-property checks in the property map's iteration
+//! order (stable for a given build), then unknown keys sorted
+//! lexicographically. No timings, no unstable map orders.
+//!
+//! [`ToolCall::input`]: stella_protocol::tool::ToolCall
+
+use serde_json::Value;
+use stella_protocol::tool::ToolOutput;
+
+use super::Tool;
+use crate::input::{InputError, present, type_name};
+
+/// The dispatch gate: `Some(refusal)` when `input` contradicts the tool's
+/// advertised schema, `None` to proceed (including for an unknown tool —
+/// the unknown-name arm downstream owns that refusal).
+pub(super) fn refusal(tool: Option<&dyn Tool>, input: &Value) -> Option<ToolOutput> {
+    let schema = tool?.schema();
+    check(&schema.input_schema, input).map(|err| ToolOutput::Error {
+        message: err.to_string(),
+    })
+}
+
+/// Validate `input` against `schema` over the enforced subset. Returns the
+/// first violation in the module doc's fixed order, or `None` when the input
+/// is acceptable (or the schema declares nothing checkable).
+fn check(schema: &Value, input: &Value) -> Option<InputError> {
+    let properties = schema.get("properties").and_then(Value::as_object);
+
+    // `required`, in the schema's declared order.
+    for field in schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+    {
+        if present(input, field).is_none() {
+            // An explicit `null` normally reads as absence, but a type that
+            // lists "null" declares it a legitimate value.
+            let null_allowed = matches!(input.get(field), Some(Value::Null))
+                && properties
+                    .and_then(|props| props.get(field))
+                    .and_then(|prop| prop.get("type"))
+                    .is_some_and(type_lists_null);
+            if !null_allowed {
+                return Some(InputError::Missing {
+                    field: field.to_string(),
+                });
+            }
+        }
+    }
+
+    // Per-property checks, in the property map's iteration order.
+    for (field, prop) in properties.into_iter().flatten() {
+        let Some(value) = present(input, field) else {
+            continue;
+        };
+        if let Some(declared) = prop.get("type")
+            && !type_allows(declared, value)
+        {
+            return Some(InputError::WrongType {
+                field: field.clone(),
+                want: want_phrase(declared),
+                got: type_name(value),
+            });
+        }
+        if let Some(members) = prop.get("enum").and_then(Value::as_array)
+            && !members.contains(value)
+        {
+            return Some(InputError::NotOneOf {
+                field: field.clone(),
+                allowed: join_rendered(members),
+                got: render_capped(value),
+            });
+        }
+        if let (Some(elements), Some(item_type)) = (
+            value.as_array(),
+            prop.get("items").and_then(|items| items.get("type")),
+        ) {
+            for (index, element) in elements.iter().enumerate() {
+                if !type_allows(item_type, element) {
+                    return Some(InputError::WrongElementType {
+                        field: field.clone(),
+                        index,
+                        want: want_phrase(item_type),
+                        got: type_name(element),
+                    });
+                }
+            }
+        }
+    }
+
+    // Unknown keys, only where the schema advertises strictness.
+    if schema.get("additionalProperties") == Some(&Value::Bool(false))
+        && let Some(map) = input.as_object()
+    {
+        let mut unknown: Vec<&String> = map
+            .keys()
+            .filter(|key| !properties.is_some_and(|props| props.contains_key(*key)))
+            .collect();
+        unknown.sort();
+        if let Some(field) = unknown.first() {
+            let mut allowed: Vec<&String> = properties.into_iter().flatten().map(|(k, _)| k).collect();
+            allowed.sort();
+            let allowed = allowed
+                .iter()
+                .map(|key| format!("`{key}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Some(InputError::UnknownField {
+                field: (*field).clone(),
+                allowed,
+            });
+        }
+    }
+
+    None
+}
+
+/// Whether a `"type"` declaration (string or array of strings) admits
+/// `value`. A malformed declaration or an unknown type word admits
+/// everything — the validator fails open outside the enforced subset.
+fn type_allows(declared: &Value, value: &Value) -> bool {
+    match declared {
+        Value::String(word) => word_allows(word, value),
+        Value::Array(words) => words.iter().any(|word| type_allows(word, value)),
+        _ => true,
+    }
+}
+
+/// One JSON-Schema type word against one value. `"integer"` is the number
+/// with no fractional part; an integer passes `"number"` but a float does
+/// not pass `"integer"`. An unknown word admits everything.
+fn word_allows(word: &str, value: &Value) -> bool {
+    match word {
+        "string" => value.is_string(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+/// Whether a `"type"` declaration lists `"null"`.
+fn type_lists_null(declared: &Value) -> bool {
+    match declared {
+        Value::String(word) => word == "null",
+        Value::Array(words) => words.iter().any(type_lists_null),
+        _ => false,
+    }
+}
+
+/// The "must be …" phrase for a `"type"` declaration, matching the fixed
+/// phrases [`crate::input`]'s readers use ("a string", "an integer") so the
+/// two vocabularies cannot drift. Alternatives join with " or "; `"null"`
+/// alternatives are elided from the phrase (a present, non-null value is
+/// being described).
+fn want_phrase(declared: &Value) -> String {
+    fn word_phrase(word: &str) -> Option<&'static str> {
+        Some(match word {
+            "string" => "a string",
+            "integer" => "an integer",
+            "number" => "a number",
+            "boolean" => "a boolean",
+            "array" => "an array",
+            "object" => "an object",
+            "null" => return None,
+            _ => return None,
+        })
+    }
+    let phrases: Vec<&'static str> = match declared {
+        Value::String(word) => word_phrase(word).into_iter().collect(),
+        Value::Array(words) => words
+            .iter()
+            .filter_map(Value::as_str)
+            .filter_map(word_phrase)
+            .collect(),
+        _ => Vec::new(),
+    };
+    if phrases.is_empty() {
+        // Unreachable when `type_allows` refused: a declaration made only of
+        // unknown words (or only "null") admits everything. Kept total.
+        "the declared type".to_string()
+    } else {
+        phrases.join(" or ")
+    }
+}
+
+/// `enum` members rendered as JSON in declared order, comma-joined.
+fn join_rendered(members: &[Value]) -> String {
+    members
+        .iter()
+        .map(render_capped)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// A value rendered as compact JSON, capped so a pathological input cannot
+/// balloon the refusal. The cap is a fixed constant, so the text stays
+/// byte-deterministic for a given input.
+fn render_capped(value: &Value) -> String {
+    const CAP: usize = 120;
+    let rendered = value.to_string();
+    if rendered.len() <= CAP {
+        return rendered;
+    }
+    let mut end = CAP;
+    while !rendered.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &rendered[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ToolRegistry;
+    use super::*;
+
+    fn registry() -> (tempfile::TempDir, ToolRegistry) {
+        let root = tempfile::tempdir().unwrap();
+        let reg = ToolRegistry::with_issue_backend(root.path().to_path_buf(), None);
+        (root, reg)
+    }
+
+    fn error_message(output: &ToolOutput) -> &str {
+        match output {
+            ToolOutput::Error { message } => message,
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    /// The seam witness (#3144): a schema-declared type mismatch is refused
+    /// at dispatch with the `WrongType` wording, and the tool never runs —
+    /// on main, `trace: "yes"` silently defaulted to false and the shell
+    /// command executed anyway.
+    #[tokio::test]
+    async fn a_mistyped_field_is_refused_at_dispatch_and_the_tool_does_not_run() {
+        let (root, reg) = registry();
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({
+                    "command": "echo hi > seam_probe.txt",
+                    "trace": "yes"
+                }),
+            )
+            .await;
+        assert_eq!(
+            error_message(&out),
+            "field `trace` must be a boolean, got string"
+        );
+        assert!(
+            !root.path().join("seam_probe.txt").exists(),
+            "the tool must not run on refused input — the shell wrote a file"
+        );
+    }
+
+    /// A present-but-mistyped required field is a type mismatch, never
+    /// "missing" — the misreport the whole issue is about.
+    #[tokio::test]
+    async fn a_mistyped_required_field_is_not_reported_as_missing() {
+        let (_root, reg) = registry();
+        let out = reg
+            .execute("read_file", &serde_json::json!({ "path": 42 }))
+            .await;
+        assert_eq!(
+            error_message(&out),
+            "field `path` must be a string, got number"
+        );
+    }
+
+    /// An absent required field keeps the exact wording every tool has
+    /// always used, so the seam is invisible where behavior was correct.
+    #[tokio::test]
+    async fn an_absent_required_field_keeps_the_original_wording() {
+        let (_root, reg) = registry();
+        let out = reg.execute("read_file", &serde_json::json!({})).await;
+        assert_eq!(error_message(&out), "missing required field `path`");
+    }
+
+    /// `"type": "integer"` rejects a fractional number; the refusal names
+    /// the field, the expectation, and what arrived.
+    #[tokio::test]
+    async fn a_fractional_number_fails_an_integer_declaration() {
+        let (_root, reg) = registry();
+        let out = reg
+            .execute(
+                "read_file",
+                &serde_json::json!({ "path": "a.txt", "offset": 2.5 }),
+            )
+            .await;
+        assert_eq!(
+            error_message(&out),
+            "field `offset` must be an integer, got number"
+        );
+    }
+
+    /// `additionalProperties: false` — advertised by the `task` tool — now
+    /// rejects unknown keys with a deterministic, sorted refusal. On main
+    /// the key was silently ignored and the sub-agent spawned anyway.
+    #[tokio::test]
+    async fn an_unknown_key_is_rejected_only_where_the_schema_forbids_it() {
+        let (_root, reg) = registry();
+        let out = reg
+            .execute(
+                "task",
+                &serde_json::json!({
+                    "description": "probe",
+                    "prompt": "p",
+                    "zubagent": 1,
+                    "agent": "x"
+                }),
+            )
+            .await;
+        assert_eq!(
+            error_message(&out),
+            "unknown field `agent` — this tool accepts only: `description`, `prompt`"
+        );
+    }
+
+    /// A tool without `additionalProperties: false` keeps ignoring unknown
+    /// keys — the documented conservative decision (#3144).
+    #[tokio::test]
+    async fn an_unknown_key_passes_where_the_schema_is_open() {
+        let (_root, reg) = registry();
+        let out = reg
+            .execute(
+                "bash",
+                &serde_json::json!({ "command": "echo ok", "stray_key": 1 }),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+    }
+
+    /// Direct subset checks the catalog cannot exercise: type alternatives,
+    /// null-as-absence, enum membership, item types, absent declarations.
+    #[test]
+    fn the_subset_checker_honors_type_arrays_null_and_enums() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "mode": { "type": "string", "enum": ["fast", "full"] },
+                "count": { "type": ["integer", "null"] },
+                "files": { "type": "array", "items": { "type": "string" } },
+                "anything": {}
+            },
+            "required": ["mode"]
+        });
+
+        // Absent type declaration: no check.
+        assert_eq!(
+            check(&schema, &serde_json::json!({"mode": "fast", "anything": 5})),
+            None
+        );
+        // A type array admits any listed type; a present integer passes.
+        assert_eq!(
+            check(&schema, &serde_json::json!({"mode": "full", "count": 3})),
+            None
+        );
+        // An optional field sent as null reads as absent — no refusal.
+        assert_eq!(
+            check(&schema, &serde_json::json!({"mode": "fast", "count": null})),
+            None
+        );
+        // An integer satisfies "number", but 2.5 does not satisfy "integer".
+        let err = check(&schema, &serde_json::json!({"mode": "fast", "count": 2.5})).unwrap();
+        assert_eq!(
+            err.to_string(),
+            "field `count` must be an integer, got number"
+        );
+        // Enum membership, with the members in declared order.
+        let err = check(&schema, &serde_json::json!({"mode": "slow"})).unwrap();
+        assert_eq!(
+            err.to_string(),
+            "field `mode` must be one of \"fast\", \"full\", got \"slow\""
+        );
+        // A wrong-typed enum field is a type mismatch, not an enum miss.
+        let err = check(&schema, &serde_json::json!({"mode": 7})).unwrap();
+        assert_eq!(err.to_string(), "field `mode` must be a string, got number");
+        // items.type names the offending index.
+        let err = check(
+            &schema,
+            &serde_json::json!({"mode": "fast", "files": ["a", 2]}),
+        )
+        .unwrap();
+        assert_eq!(
+            err.to_string(),
+            "field `files`[1] must be a string, got number"
+        );
+    }
+
+    /// A required field whose type lists "null" accepts an explicit null;
+    /// one whose type does not is refused as missing (the `crate::input`
+    /// convention: null reads as absence).
+    #[test]
+    fn required_null_follows_the_declared_type() {
+        let strict = serde_json::json!({
+            "properties": { "q": { "type": "string" } },
+            "required": ["q"]
+        });
+        assert_eq!(
+            check(&strict, &serde_json::json!({"q": null}))
+                .unwrap()
+                .to_string(),
+            "missing required field `q`"
+        );
+        let nullable = serde_json::json!({
+            "properties": { "q": { "type": ["string", "null"] } },
+            "required": ["q"]
+        });
+        assert_eq!(check(&nullable, &serde_json::json!({"q": null})), None);
+    }
+
+    /// A schema with no `properties`/`required` — the common shape for an
+    /// external MCP server — checks nothing, so permissive tools stay
+    /// permissive through the same seam.
+    #[test]
+    fn a_bare_schema_checks_nothing() {
+        let bare = serde_json::json!({ "type": "object" });
+        assert_eq!(check(&bare, &serde_json::json!({"whatever": 1})), None);
+        assert_eq!(check(&bare, &serde_json::json!(null)), None);
+    }
+
+    /// The refusal must be byte-deterministic: same input, same bytes, and
+    /// oversized values are capped rather than echoed whole.
+    #[test]
+    fn refusals_are_deterministic_and_capped() {
+        let schema = serde_json::json!({
+            "properties": { "mode": { "type": "string", "enum": ["a"] } }
+        });
+        let huge = serde_json::json!({ "mode": "x".repeat(500) });
+        let first = check(&schema, &huge).unwrap().to_string();
+        let second = check(&schema, &huge).unwrap().to_string();
+        assert_eq!(first, second);
+        assert!(first.len() < 300, "capped, not echoed whole: {first}");
+        assert!(first.ends_with('…'));
+    }
+}

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -342,10 +342,17 @@ impl Tool for Search {
     }
 
     async fn execute(&self, input: &Value, root: &Path) -> ToolOutput {
-        let query = input
-            .get("query")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
+        // A mistyped `query` must be refused as the type mismatch it is —
+        // collapsing it into the blank-query refusal below told the model
+        // the field was missing when it was present (#3144).
+        let query = match crate::input::optional_str(input, "query") {
+            Ok(query) => query.unwrap_or_default(),
+            Err(err) => {
+                return ToolOutput::Error {
+                    message: err.to_string(),
+                };
+            }
+        };
         // Validation (the blank-query refusal included) lives in [`report`],
         // so this door and the CLI's `stella search` cannot drift apart.
         search(root, query, self.config).await

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -751,6 +751,26 @@ async fn a_blank_query_is_refused_through_the_tool_door() {
     );
 }
 
+/// The #3144 witness: a mistyped `query` is a type mismatch, not a missing
+/// field. On main, `{"query": 42}` fell through `as_str().unwrap_or_default()`
+/// into the blank-query refusal — the model was told the field it sent was
+/// missing, and retried against the wrong defect.
+#[tokio::test]
+async fn a_mistyped_query_is_refused_as_a_type_mismatch_not_as_missing() {
+    let workspace = tempfile::TempDir::new().unwrap();
+    let output = Search::default()
+        .execute(&serde_json::json!({"query": 42}), workspace.path())
+        .await;
+    let ToolOutput::Error { message } = output else {
+        panic!("a mistyped query must be an error, got: {output:?}");
+    };
+    assert_eq!(message, "field `query` must be a string, got number");
+    assert!(
+        !message.contains("required"),
+        "a present-but-mistyped field is not missing: {message}"
+    );
+}
+
 /// `SearchReport` is the CLI's `--format json` contract: the decided answer
 /// as data beside the rendering. Hit order is rank order, strategies carry
 /// the exact labels the `via:` line prints, and the note survives verbatim.

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -552,14 +552,13 @@ impl VerifyDone {
         if let Some(refusal) = defeater::cwd_refusal(test_cmd) {
             return Err(refusal);
         }
-        let test_files: Vec<String> = input
-            .get("test_files")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect()
-            })
+        // A mistyped `test_files` (a bare string, or an array carrying a
+        // non-string element) must be refused as the type problem it is —
+        // silently emptying it via `filter_map(as_str)` reported the field
+        // as missing when it was present (#3144).
+        let test_files: Vec<String> = crate::input::optional_str_array(input, "test_files")
+            .map_err(|err| err.to_string())?
+            .map(|files| files.into_iter().map(str::to_string).collect())
             .unwrap_or_default();
         if test_files.is_empty() {
             return Err(
@@ -904,6 +903,39 @@ mod tests {
             String::from_utf8_lossy(&out.stderr)
         );
         String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    /// The #3144 witness: a mistyped `test_files` names the type problem.
+    /// On main a bare string (or an array of non-strings) was silently
+    /// emptied by `filter_map(as_str)` and refused as "missing required
+    /// field `test_files`" — present, mistyped, and misreported.
+    #[tokio::test]
+    async fn a_mistyped_test_files_is_refused_as_the_type_problem_it_is() {
+        let root = tempfile::tempdir().unwrap();
+        let out = VerifyDone::default()
+            .execute(
+                &serde_json::json!({ "test_cmd": "bash w.sh", "test_files": "w.sh" }),
+                root.path(),
+            )
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("expected a refusal, got {out:?}");
+        };
+        assert_eq!(
+            message,
+            "field `test_files` must be an array of strings, got string"
+        );
+
+        let out = VerifyDone::default()
+            .execute(
+                &serde_json::json!({ "test_cmd": "bash w.sh", "test_files": [1, "w.sh"] }),
+                root.path(),
+            )
+            .await;
+        let ToolOutput::Error { message } = out else {
+            panic!("expected a refusal, got {out:?}");
+        };
+        assert_eq!(message, "field `test_files`[0] must be a string, got number");
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/verify.rs
+++ b/crates/stella-tools/src/verify.rs
@@ -935,7 +935,10 @@ mod tests {
         let ToolOutput::Error { message } = out else {
             panic!("expected a refusal, got {out:?}");
         };
-        assert_eq!(message, "field `test_files`[0] must be a string, got number");
+        assert_eq!(
+            message,
+            "field `test_files`[0] must be a string, got number"
+        );
     }
 
     #[tokio::test]

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1167,8 +1167,13 @@ export interface ToolCall {
    */
   call_id: string;
   /**
-   * The arguments, as the model produced them. Runtime data: validate
-   * against [`ToolSchema::input_schema`] rather than trusting the shape.
+   * The arguments, as the model produced them. Runtime data: never trust
+   * the shape. `stella-tools` validates this against
+   * [`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,
+   * #3144) — required fields, declared types, enums, item types, and
+   * `additionalProperties: false` where a schema advertises it — and
+   * refuses a contradicting call before the tool runs. Tools still read
+   * fields defensively: a direct caller may bypass the registry.
    */
   input: unknown;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1740,7 +1740,7 @@
           "type": "string"
         },
         "input": {
-          "description": "The arguments, as the model produced them. Runtime data: validate\nagainst [`ToolSchema::input_schema`] rather than trusting the shape."
+          "description": "The arguments, as the model produced them. Runtime data: never trust\nthe shape. `stella-tools` validates this against\n[`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,\n#3144) — required fields, declared types, enums, item types, and\n`additionalProperties: false` where a schema advertises it — and\nrefuses a contradicting call before the tool runs. Tools still read\nfields defensively: a direct caller may bypass the registry."
         },
         "name": {
           "description": "Which tool to run — matches the [`ToolSchema::name`] it was chosen\nfrom.",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -1991,8 +1991,13 @@ export interface ToolCall {
    */
   call_id: string;
   /**
-   * The arguments, as the model produced them. Runtime data: validate
-   * against [`ToolSchema::input_schema`] rather than trusting the shape.
+   * The arguments, as the model produced them. Runtime data: never trust
+   * the shape. `stella-tools` validates this against
+   * [`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,
+   * #3144) — required fields, declared types, enums, item types, and
+   * `additionalProperties: false` where a schema advertises it — and
+   * refuses a contradicting call before the tool runs. Tools still read
+   * fields defensively: a direct caller may bypass the registry.
    */
   input: unknown;
   /**
@@ -2505,8 +2510,13 @@ export interface ToolCall {
    */
   call_id: string;
   /**
-   * The arguments, as the model produced them. Runtime data: validate
-   * against [`ToolSchema::input_schema`] rather than trusting the shape.
+   * The arguments, as the model produced them. Runtime data: never trust
+   * the shape. `stella-tools` validates this against
+   * [`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,
+   * #3144) — required fields, declared types, enums, item types, and
+   * `additionalProperties: false` where a schema advertises it — and
+   * refuses a contradicting call before the tool runs. Tools still read
+   * fields defensively: a direct caller may bypass the registry.
    */
   input: unknown;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -3447,7 +3447,7 @@
           "type": "string"
         },
         "input": {
-          "description": "The arguments, as the model produced them. Runtime data: validate\nagainst [`ToolSchema::input_schema`] rather than trusting the shape."
+          "description": "The arguments, as the model produced them. Runtime data: never trust\nthe shape. `stella-tools` validates this against\n[`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,\n#3144) — required fields, declared types, enums, item types, and\n`additionalProperties: false` where a schema advertises it — and\nrefuses a contradicting call before the tool runs. Tools still read\nfields defensively: a direct caller may bypass the registry."
         },
         "name": {
           "description": "Which tool to run — matches the [`ToolSchema::name`] it was chosen\nfrom.",

--- a/docs/wire/serveinbound.schema.json
+++ b/docs/wire/serveinbound.schema.json
@@ -640,7 +640,7 @@
               "type": "string"
             },
             "input": {
-              "description": "The arguments, as the model produced them. Runtime data: validate\nagainst [`ToolSchema::input_schema`] rather than trusting the shape."
+              "description": "The arguments, as the model produced them. Runtime data: never trust\nthe shape. `stella-tools` validates this against\n[`ToolSchema::input_schema`] at dispatch (`registry/validate.rs`,\n#3144) — required fields, declared types, enums, item types, and\n`additionalProperties: false` where a schema advertises it — and\nrefuses a contradicting call before the tool runs. Tools still read\nfields defensively: a direct caller may bypass the registry."
             },
             "name": {
               "description": "Which tool to run — matches the [`ToolSchema::name`] it was chosen\nfrom.",


### PR DESCRIPTION
## What & why

No code validated a tool call's input against the advertised `input_schema`, so a mistyped argument was misreported as a missing one (`{"query": 42}` → "query is required") or silently defaulted (`"trace": "yes"` → traced nothing) — the model then retried against a refusal naming the wrong defect.

This PR adds one validation seam at dispatch — `ToolRegistry::execute` — in a new sibling module `crates/stella-tools/src/registry/validate.rs`, which checks the model-supplied input against the tool's advertised schema before the tool runs:

- `required` fields present → refusal with the existing `InputError::Missing` wording, byte-identical to what every tool already said;
- declared `type` per property honoured (single word and `["string","null"]` array spellings; `integer` rejects fractional numbers; an integer passes `number`) → `InputError::WrongType`, naming field + expected + got, never misreported as missing;
- `enum` membership and `items.type` per element (index named);
- **unknown keys: documented-ignore**, except for schemas that already advertise `additionalProperties: false` (the `task` tool, foundry-authored tools, opted-in custom manifests), which now get them rejected deterministically. Rationale in the module doc: models pass stray keys constantly, and a new refusal class would fail calls that previously succeeded.

It is a small internal checker over exactly the JSON-Schema subset the catalog uses — no `jsonschema` dependency. MCP (`mcp__`) and custom script tools pass through the same seam; a schema with no `properties`/`required` naturally checks nothing. Refusal text is byte-deterministic (fixed check order, sorted unknown keys, capped value rendering) for loop-detector comparability.

The four witnessed per-tool defects are also fixed at the tool level (belt and braces for direct callers that bypass the registry): `search` query, `verify_done` test_files, `read_file` offset/limit, `bash` trace. `InputError` gained the vocabulary the seam needs (`want` became `String` for type-alternative phrasing, `WrongElementType` carries `want`, new `NotOneOf` and `UnknownField` variants) — `Display` output for existing variants is unchanged byte-for-byte. The `ToolCall::input` doc comment in `stella-protocol` now describes what actually happens.

**Exemplar followed:** the `driver/settlement.rs` split pattern — `registry.rs` is a grandfathered god file closed to growth, so the validator is a sibling module and the wiring in `registry.rs` is minimal. To keep `registry.rs` under its ceiling (now 1737 of 1751), the inline `save_exploration` ledger-augmentation block moved to `crate::exploration::ledger_augmented`, beside the `LEDGER_FILES_KEY` it writes. The validator's error vocabulary follows `input.rs` (#1267) rather than inventing a parallel one.

Closes #3144

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Five witnesses, one per defect plus the seam:

1. `registry::validate::tests::a_mistyped_field_is_refused_at_dispatch_and_the_tool_does_not_run` — **run-verified**: with the dispatch gate disabled and the old `trace` read restored, the test fails with `expected a refusal, got Ok { content: "\n[exit code: 0]" }` — the shell ran the command and wrote the probe file.
2. `read::tests::a_mistyped_offset_or_limit_is_refused_not_defaulted` — **run-verified**: with the old `and_then(as_u64)` reads restored, fails with `a mistyped limit must be an error, got: Ok { … 3/3 lines shown … }` — the mistyped limit silently read the default window.
3. `search::tests::a_mistyped_query_is_refused_as_a_type_mismatch_not_as_missing` — fails on main by the diff: `as_str().unwrap_or_default()` collapses `{"query": 42}` into the blank-query "required" refusal the test forbids.
4. `verify::tests::a_mistyped_test_files_is_refused_as_the_type_problem_it_is` — fails on main by the diff: `filter_map(as_str)` empties a mistyped array/string and returns "missing required field `test_files`", not the asserted type message.
5. `bash::tests::a_mistyped_trace_is_refused_not_silently_untraced` — fails on main by the diff (same silent-default shape as 2; the seam variant of it was run-verified in 1).

Plus direct subset-checker tests in `validate.rs` (type arrays, required-null vs nullable types, enums, item indices, bare MCP-shaped schemas, determinism/capping) and a pin that unknown keys still pass where the schema is open.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings` (clean)
- [x] `cargo test -p stella-tools` (1029 passed, 0 failed) and `cargo test -p stella-cli` (all green, including the `tool_docs` gate — no schema prose changed, so no `docs/tools/` regeneration needed)
- [x] Docs updated where behavior changed (`ToolCall::input` doc comment; validator module doc records the unknown-keys decision)
- [x] CLA signed
- [x] `Closes #3144` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

Two deliberate deviations from the issue's letter, both toward the codebase's existing conventions:

- **`null` handling.** The issue asked for "null against any type is a mismatch unless the schema allows it". `input.rs`'s `present` deliberately reads `null` as absence ("every JSON encoder in the wild emits null for no value"), and every tool reads input through that convention — a stricter validator would refuse what the tool itself accepts. So: a required field sent as `null` is refused as `Missing` (unless its type lists `"null"`), and an optional `null` is skipped, exactly as the tool will skip it.
- **`search` uses `optional_str`, not `required_str`.** The blank-query refusal is one string shared by the tool door and `stella search` (the `report` seam); keeping absence on that path preserves the shared wording, while the mistyped case now gets the `WrongType` refusal the issue requires. The dispatch seam reports absence as `Missing` anyway for registry callers.

Validation runs after the `tool.call.requested` hook chain (a `modify` decision must be validated, not the original input) and before the internal-key augmentations (`save_exploration`'s ledger key, `run_script`'s gate threading), so engine-authored internal keys are never judged against the model-facing schema.

## Summary by Sourcery

Validate tool call inputs against their advertised schemas at dispatch and align individual tools and docs with the new error vocabulary.

Bug Fixes:
- Prevent mistyped tool arguments from being misreported as missing or silently defaulted for search, read_file, verify_done, and bash tools.

Enhancements:
- Introduce a dispatch-time JSON-schema subset validator for tool inputs, including required fields, type checks, enums, item types, and optional strict handling of unknown keys.
- Extend input error variants to describe type mismatches, bad array element types, enum violations, and unknown fields while keeping existing messages stable.
- Factor save_exploration ledger augmentation into a dedicated helper to keep the registry module small and composable.

Documentation:
- Update ToolCall::input documentation to describe dispatch-time schema validation behavior.

Tests:
- Add witness and validator tests covering dispatch gating, per-tool mistyped inputs, schema subset semantics, unknown key handling, and deterministic, capped error messages.