### PR TITLE
feat(stella-cli): stella usage report --tools, the per-tool reliability surface

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -35,6 +35,11 @@ pub enum UsageCmd {
         /// Only rows replicated under this org id
         #[arg(long)]
         org: Option<String>,
+
+        /// Per-tool reliability instead: cross-project calls, errors, and
+        /// error rate per (tool, surface), from the hub's rollup
+        #[arg(long)]
+        tools: bool,
     },
     /// Replicate this workspace's telemetry into the hub (cursor-based;
     /// safe to re-run). --all heals every project the hub knows about
@@ -129,8 +134,30 @@ pub fn run_usage(cmd: Option<UsageCmd>) -> Result<(), String> {
     match cmd.unwrap_or(UsageCmd::Report {
         format: StatsFormat::Text,
         org: None,
+        tools: false,
     }) {
-        UsageCmd::Report { format, org } => report(format, org.as_deref()),
+        UsageCmd::Report {
+            format,
+            org,
+            tools: false,
+        } => report(format, org.as_deref()),
+        UsageCmd::Report {
+            format,
+            org,
+            tools: true,
+        } => {
+            // The rollup is keyed (project, tool, surface, day) and carries
+            // no org column, so an org filter here would be silently
+            // unhonored — refused instead (#3147).
+            if org.is_some() {
+                return Err(
+                    "--tools cannot filter by --org: the tool rollup is project-keyed, \
+                     not org-keyed"
+                        .into(),
+                );
+            }
+            tool_report(format)
+        }
         UsageCmd::Sync { all } => sync(all),
         UsageCmd::Prune {
             older_than,
@@ -247,6 +274,98 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
             println!(
                 "{:<14} {:<10} {:<28} {:>8} {:>12} {:>12} {:>12} {:>12} {:>10.4} {:>9}",
                 "TOTAL", "", "", totals.0, totals.1, totals.2, totals.3, totals.4, totals.5, ""
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `stella usage report --tools` — the scriptable per-tool reliability
+/// surface (#3147): cross-project calls, errors, and the derived error rate
+/// per (tool, surface), read from `tool_usage_rollup`, whose `errors` column
+/// previously had no reader anywhere.
+///
+/// The rate divides exact hub counts; rows synced by pre-v24 stores counted
+/// abandoned calls as errors (#3146), so historic rates read conservatively
+/// high until those buckets age out.
+fn tool_report(format: StatsFormat) -> Result<(), String> {
+    let hub = open_hub()?;
+    let rows = hub
+        .tool_report()
+        .map_err(|e| format!("cannot read the usage hub: {e}"))?;
+    let rate = |calls: i64, errors: i64| {
+        if calls > 0 {
+            errors as f64 / calls as f64
+        } else {
+            0.0
+        }
+    };
+    match format {
+        StatsFormat::Json => {
+            let objects: Vec<serde_json::Value> = rows
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "tool": r.tool,
+                        "surface": r.surface,
+                        "calls": r.calls,
+                        "errors": r.errors,
+                        "error_rate": rate(r.calls, r.errors),
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Rows::new(&objects)).map_err(|e| e.to_string())?
+            );
+        }
+        StatsFormat::Csv => {
+            println!("tool,surface,calls,errors,error_rate");
+            for r in &rows {
+                // Tool names are model- and MCP-supplied text: same RFC-4180
+                // escape as every other text column on this surface.
+                println!(
+                    "{},{},{},{},{:.4}",
+                    crate::stats::csv_escape(&r.tool),
+                    crate::stats::csv_escape(&r.surface),
+                    r.calls,
+                    r.errors,
+                    rate(r.calls, r.errors),
+                );
+            }
+        }
+        StatsFormat::Text => {
+            if rows.is_empty() {
+                println!(
+                    "usage hub has no tool rollup yet — run `stella usage sync` in a \
+                     workspace (or finish a turn) to replicate telemetry"
+                );
+                return Ok(());
+            }
+            println!(
+                "{:<28} {:<8} {:>8} {:>8} {:>8}",
+                "TOOL", "SURFACE", "CALLS", "ERRORS", "ERR-RATE"
+            );
+            let mut totals = (0i64, 0i64);
+            for r in &rows {
+                println!(
+                    "{:<28} {:<8} {:>8} {:>8} {:>7.2}%",
+                    r.tool,
+                    r.surface,
+                    r.calls,
+                    r.errors,
+                    100.0 * rate(r.calls, r.errors),
+                );
+                totals.0 += r.calls;
+                totals.1 += r.errors;
+            }
+            println!(
+                "{:<28} {:<8} {:>8} {:>8} {:>7.2}%",
+                "TOTAL",
+                "",
+                totals.0,
+                totals.1,
+                100.0 * rate(totals.0, totals.1),
             );
         }
     }

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -495,10 +495,10 @@ fn producer_materializes_tool_calls_reflection_and_rolls_up_to_usage() {
     assert_eq!(usage.execution_count(&pid).unwrap(), 1);
     assert_eq!(
         usage
-            .tool_totals()
+            .tool_report()
             .unwrap()
             .iter()
-            .map(|(_, c)| *c)
+            .map(|r| r.calls)
             .sum::<i64>(),
         2,
         "grep + read_file folded into the cross-project histogram"

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -341,22 +341,6 @@ impl UsageStore {
             .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))?)
     }
 
-    /// Cross-project per-tool call totals, most-used first — the histogram a
-    /// dashboard/recommender reads to spot "grep a lot, graph_query never".
-    pub fn tool_totals(&self) -> Result<Vec<(String, i64)>> {
-        let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT tool, SUM(calls) AS c FROM tool_usage_rollup \
-             GROUP BY tool ORDER BY c DESC, tool ASC",
-        )?;
-        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
-    }
-
     /// Count of rolled-up executions for a project.
     pub fn execution_count(&self, project_id: &str) -> Result<i64> {
         Ok(self.lock().query_row(
@@ -1150,6 +1134,10 @@ pub struct QuarantinedRow {
 
 // The registration-time scope backfill (#406), in its own module.
 mod backfill;
+
+mod tool_report;
+
+pub use tool_report::ToolReportRow;
 // Drain observability: last-attempt record + cursor/backlog readers (#464).
 pub mod drain_state;
 // Project re-key: merge a forked path-derived identity into the stable one (#408).
@@ -1210,8 +1198,16 @@ mod tests {
             .unwrap();
         assert_eq!(usage.project_count().unwrap(), 1);
         assert_eq!(usage.execution_count("proj_a").unwrap(), 1);
-        let totals = usage.tool_totals().unwrap();
-        assert_eq!(totals[0], ("grep".to_string(), 2));
+        let totals = usage.tool_report().unwrap();
+        assert_eq!(
+            (totals[0].tool.as_str(), totals[0].calls, totals[0].errors),
+            ("grep", 2, 0)
+        );
+        assert_eq!(
+            (totals[1].tool.as_str(), totals[1].calls, totals[1].errors),
+            ("read_file", 1, 1),
+            "the error count survives the sync into the hub (#3147)"
+        );
     }
 
     #[test]
@@ -1229,7 +1225,9 @@ mod tests {
         usage.sync_execution(&r).unwrap();
         usage.sync_execution(&r).unwrap(); // re-sync must not double-count
         assert_eq!(usage.execution_count("proj_a").unwrap(), 1);
-        assert_eq!(usage.tool_totals().unwrap(), vec![("grep".to_string(), 2)]);
+        let totals = usage.tool_report().unwrap();
+        assert_eq!((totals[0].tool.as_str(), totals[0].calls), ("grep", 2));
+        assert_eq!(totals.len(), 1);
     }
 
     #[test]
@@ -1250,7 +1248,9 @@ mod tests {
         a.execution_id = 1;
         usage.sync_execution(&a).unwrap();
         assert_eq!(usage.project_count().unwrap(), 2);
-        assert_eq!(usage.tool_totals().unwrap(), vec![("grep".to_string(), 6)]);
+        let totals = usage.tool_report().unwrap();
+        assert_eq!((totals[0].tool.as_str(), totals[0].calls), ("grep", 6));
+        assert_eq!(totals.len(), 1);
     }
 
     fn scope(org: Option<&str>, workspace: Option<&str>) -> crate::identity::TelemetryScope {

--- a/crates/stella-store/src/usage/tool_report.rs
+++ b/crates/stella-store/src/usage/tool_report.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The cross-project per-tool reliability report (#3147).
+//!
+//! `tool_usage_rollup` has been written on every synced turn since the hub
+//! existed — per `(project, tool, surface, day)` call and error counts — but
+//! its `errors` column had no reader at all: the one consumer summed `calls`
+//! and dropped the rest. That made a per-tool reliability ceiling ("no
+//! shipped tool errors more than N% of the time") unenforceable in any
+//! script, CI job, or bench postmortem: the only surface showing tool errors
+//! was the Observatory's browser dashboard, loopback-only and windowed.
+//!
+//! This module is the hub-side half of that surface: one reader returning
+//! the unwindowed cross-project totals, consumed by `stella usage report
+//! --tools`. Rates are left to the caller — the hub hands out exact
+//! numerators and denominators, not derived percentages.
+//!
+//! Honesty caveat, named rather than silent: rows written by pre-v24 stores
+//! counted *abandoned* calls (turn ended mid-flight) as errors, and those
+//! historic buckets are already merged beyond splitting. Writers at v24+
+//! exclude abandonment (#3146), so the report converges on the true defect
+//! rate going forward.
+
+use super::{Result, UsageStore};
+
+/// One tool's cross-project totals, straight off `tool_usage_rollup`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolReportRow {
+    /// Tool name as the projection recorded it (raw, including `mcp__`
+    /// namespacing — the hub never renames).
+    pub tool: String,
+    /// `"native"` | `"mcp"` — the surfaces the store-side producer derives.
+    pub surface: String,
+    /// Total calls across every project and day the hub has seen.
+    pub calls: i64,
+    /// Total errored calls (`state = 'error'` at the producer; see the
+    /// module doc for the pre-v24 caveat).
+    pub errors: i64,
+}
+
+impl UsageStore {
+    /// Cross-project per-tool call and error totals, most-used first.
+    ///
+    /// Supersedes the calls-only `tool_totals` histogram, which read the
+    /// same table and discarded the `errors` column — the exact number a
+    /// reliability ceiling needs (#3147).
+    pub fn tool_report(&self) -> Result<Vec<ToolReportRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT tool, surface, SUM(calls) AS c, SUM(errors) \
+             FROM tool_usage_rollup \
+             GROUP BY tool, surface ORDER BY c DESC, tool ASC, surface ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ToolReportRow {
+                tool: row.get(0)?,
+                surface: row.get(1)?,
+                calls: row.get(2)?,
+                errors: row.get(3)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::super::UsageStore;
+
+    /// The witness for #3147: the `errors` column actually reaches a reader.
+    /// On the old code this fails at compile time — no reader existed, and
+    /// the one adjacent histogram summed `calls` alone.
+    #[test]
+    fn the_report_reads_the_errors_column_not_just_calls() {
+        let usage = UsageStore::in_memory().unwrap();
+        usage
+            .lock()
+            .execute_batch(
+                "INSERT INTO tool_usage_rollup (project_id, tool, surface, day, calls, errors)
+                 VALUES ('p1', 'bash', 'native', '2026-08-11', 10, 2),
+                        ('p2', 'bash', 'native', '2026-08-12', 5, 1),
+                        ('p1', 'read_file', 'native', '2026-08-12', 3, 0)",
+            )
+            .unwrap();
+
+        let report = usage.tool_report().unwrap();
+        assert_eq!(report.len(), 2);
+        assert_eq!(
+            (report[0].tool.as_str(), report[0].calls, report[0].errors),
+            ("bash", 15, 3),
+            "cross-project, cross-day sums with the error numerator intact"
+        );
+        assert_eq!(
+            (report[1].tool.as_str(), report[1].errors),
+            ("read_file", 0)
+        );
+        // Distinct surfaces stay distinct rows: an MCP tool's reliability is
+        // not folded into a native tool that happens to share a name.
+        usage
+            .lock()
+            .execute(
+                "INSERT INTO tool_usage_rollup (project_id, tool, surface, day, calls, errors)
+                 VALUES ('p1', 'bash', 'mcp', '2026-08-12', 1, 1)",
+                params![],
+            )
+            .unwrap();
+        assert_eq!(usage.tool_report().unwrap().len(), 3);
+    }
+}

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -9,7 +9,7 @@ description: Report, replicate, and prune the cross-project telemetry hub at ~/.
 
 ```bash
 stella usage
-stella usage report [--format <text|json|csv>] [--org <id>]
+stella usage report [--format <text|json|csv>] [--org <id>] [--tools]
 stella usage sync [--all]
 stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
 ```
@@ -62,12 +62,20 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
     Only rows replicated under this org id. Rows written before you registered carry no
     org and are excluded by any `--org` filter.
   </OptionCard>
+  <OptionCard name="--tools">
+    Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
+    derived error rate per `(tool, surface)`, read from the hub's tool rollup. This is the
+    scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
+    leaderboard draws, unwindowed and pipeable. Cannot combine with `--org` (the rollup is
+    project-keyed, and a silently unhonored filter would misreport).
+  </OptionCard>
 </CardGrid>
 
 ```bash
 stella usage
 stella usage report --format json
 stella usage report --org acme --format csv > acme-spend.csv
+stella usage report --tools --format json | jq '.rows[] | select(.error_rate > 0.03)'
 ```
 
 Representative table output (illustrative):


### PR DESCRIPTION
## What

`stella usage report --tools` — the scriptable per-tool reliability surface: cross-project calls, errors, and derived error rate per `(tool, surface)`, in text, JSON (versioned query envelope), and CSV.

## Why

`tool_usage_rollup(project_id, tool, surface, day, calls, errors)` has been upserted on every synced turn since the hub existed (`crates/stella-store/src/usage.rs`), but its `errors` column was **write-only**: the sole adjacent reader (`tool_totals()`) summed `calls` and had zero production callers. The only surface showing per-tool errors at all was the Observatory browser dashboard — loopback-only and windowed to the newest 10,000 calls. A tool-reliability ceiling ("no shipped tool errors more than 3% of the time", epic #3150) had nothing a script, CI job, or bench postmortem could read.

## How

- New hub reader `UsageStore::tool_report()` in `crates/stella-store/src/usage/tool_report.rs` (the `backfill`/`rekey` submodule pattern — `usage.rs` is a grandfathered god file and shrinks by 12 lines here). Returns exact numerators and denominators; rates are derived at the CLI.
- The dead `tool_totals()` is **removed** — the issue's definition-of-done offered "becomes the implementation or is removed", and it becomes the implementation's predecessor: its three test call sites now assert through `tool_report()`, including that the error count survives the sync path into the hub.
- `stella usage report --tools` renders the report; `--tools` with `--org` is **refused** rather than silently unhonored (the rollup is project-keyed and carries no org column) — the #3051 discipline: a caller must be able to tell.
- `website/content/docs/commands/usage.mdx` documents the flag, including the 3%-ceiling jq one-liner; `check-command-docs.sh` green.

Flag-vs-tool note (invariant #9): `--tools` *scopes* the report to a different grouping of the same hub; it selects no new operation.

## Honesty caveat (named, not silent)

Rows synced by pre-v24 stores counted abandoned calls as errors; those historic buckets are merged beyond splitting. Writers at v24+ exclude abandonment (#3146, PR #3157), so the report converges on the true defect rate going forward. Stated in the module doc and the renderer doc.

## Witnesses

- `usage::tool_report::tests::the_report_reads_the_errors_column_not_just_calls` — on main this fails at compile time (no reader existed); asserts cross-project/cross-day summing, the error numerator, and that surfaces stay distinct rows.
- `usage` tests `sync_records_project_execution_and_tool_histogram` (strengthened: asserts `read_file (calls 1, errors 1)` reaches the report through the real sync path), `re_syncing_the_same_execution_is_idempotent`, `two_projects_aggregate_independently_but_share_tool_totals` — expectations migrated from the removed tuple shape.

## Verification

`cargo test -p stella-store` (332 passed), `cargo test -p stella-cli usage` green, `cargo clippy -p stella-cli --all-targets -- -D warnings` clean, `scripts/check-command-docs.sh` OK.

Part of epic #3150; reads honestly once #3157 (v24 abandoned split) lands.

Closes #3147

## Summary by Sourcery

Introduce a per-tool reliability usage report in stella, exposing cross-project call and error totals from the hub and wiring it into the CLI.

New Features:
- Add a `--tools` flag to `stella usage report` to show per-tool reliability metrics with calls, errors, and derived error rates in text, JSON, and CSV formats.
- Provide a new `UsageStore::tool_report` reader that returns cross-project per-tool call and error totals from `tool_usage_rollup`.

Enhancements:
- Enforce that `--tools` cannot be combined with `--org` to avoid silently misreporting org-scoped data.
- Update usage command documentation to describe the `--tools` flag and include an example for enforcing an error-rate ceiling.

Documentation:
- Extend the `stella usage` command docs with the `--tools` flag description, its reliability use case, and example jq filtering for tools exceeding an error-rate ceiling.

Tests:
- Add dedicated tests for the new `tool_report` reader to ensure error counts are surfaced correctly and per-surface rows remain distinct.
- Adjust existing usage store tests to validate behavior via `tool_report` instead of the removed `tool_totals`, including idempotent sync and cross-project aggregation behavior.

Chores:
- Remove the obsolete `tool_totals` histogram in favor of the more complete `tool_report` API and re-export its row type from the usage module.