### PR TITLE
test(stella-cli): pin create_witness_test as the declared out-of-catalog exemption

### DIFF
--- a/crates/stella-cli/src/candidate_ws/witness_tools.rs
+++ b/crates/stella-cli/src/candidate_ws/witness_tools.rs
@@ -1052,4 +1052,54 @@ mod tests {
             .count();
         assert_eq!(created, 1, "the replaced artifact must not survive");
     }
+
+    /// #3148: `create_witness_test` is the one tool mounted outside
+    /// `stella_tools::catalog` — a **declared** exemption, pinned from both
+    /// sides, where before this test it was a silence.
+    ///
+    /// It is deliberately not a catalog row: it exists only inside the
+    /// candidate-workspace mount, must never be model-visible in an ordinary
+    /// session, and its artifact's lifecycle is the witness stage's, not the
+    /// registry's. The catalog pins (`registry_advertises_exactly_the_catalog
+    /// _tool_set`) cannot see it because it never enters a `ToolRegistry` —
+    /// so nothing would have noticed a *second* bespoke tool accumulating
+    /// out here either. Now:
+    ///
+    /// - a new out-of-catalog name on this surface fails here until it is
+    ///   cataloged or added to `EXEMPT` with its own issue;
+    /// - `create_witness_test` joining the catalog fails here too, so the
+    ///   exemption is retired instead of going stale.
+    #[tokio::test]
+    async fn the_out_of_catalog_surface_is_exactly_the_declared_exemption() {
+        const EXEMPT: &[&str] = &["create_witness_test"];
+
+        let root = tempfile::tempdir().unwrap();
+        let registry: Arc<dyn ToolExecutor> = Arc::new(
+            ToolRegistry::new_detected(root.path().to_path_buf(), RegistryOptions::default()).await,
+        );
+        let tools = WitnessToolExecutor::new(root.path().to_path_buf(), root.path(), registry);
+
+        let advertised: Vec<String> = tools
+            .schemas()
+            .into_iter()
+            .map(|schema| schema.name)
+            .collect();
+        let out_of_catalog: Vec<&str> = advertised
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !stella_tools::catalog::ALL_NAMES.contains(name))
+            .collect();
+        assert_eq!(
+            out_of_catalog, EXEMPT,
+            "every tool this executor advertises beyond the declared \
+             exemption must be a catalog row (#3148)"
+        );
+        for name in EXEMPT {
+            assert!(
+                !stella_tools::catalog::ALL_NAMES.contains(name),
+                "{name} joined the catalog — retire its exemption here \
+                 and give it the standard docs/policy surface (#3148)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What

Pins `create_witness_test` — the one live tool mounted outside `stella_tools::catalog` — as a **declared, machine-checked exemption** instead of a silence (option 2 of the issue).

## Why

`crates/stella-cli/src/candidate_ws/witness_tools.rs` mounts `create_witness_test` via the bespoke `WitnessToolExecutor` for candidate/witness workspaces. Because it never enters a `ToolRegistry`, every registry-side pin (`registry_advertises_exactly_the_catalog_tool_set`, the tool-docs gate, the `tools.<name>` policy switches, arenabench's toolclass port) is structurally blind to it — and equally blind to any *second* bespoke tool that might accumulate out there. The tool stays deliberately uncataloged: it must never be model-visible in an ordinary session, and its artifact's lifecycle belongs to the witness stage, not the registry.

## How

One test, `the_out_of_catalog_surface_is_exactly_the_declared_exemption`, pinning both directions:

- the executor's advertised surface minus catalog rows must equal exactly `["create_witness_test"]` — a new bespoke tool fails until it is cataloged or exempted with its own issue;
- `create_witness_test` must remain absent from `catalog::ALL_NAMES` — if it ever joins the catalog, the test fails so the exemption is retired rather than left stale.

## Witness

Verified by construction in both directions: appending a second schema to `WitnessToolExecutor::schemas()` fails the first assertion; adding `create_witness_test` to the catalog fails the second. The test is the declaration the issue asked for — on `main` neither the pin nor any statement of the exemption exists.

## Verification

`cargo test -p stella-cli witness_tools` — 14 passed. No production code changed.

Part of epic #3150.

Closes #3148

## Summary by Sourcery

Tests:
- Add a witness-tools test that asserts `create_witness_test` is the only out-of-catalog tool and remains absent from the catalog, keeping the exemption accurate.