### PR TITLE
fix(stella-graph): main is red — public docs cannot link a private const

### DIFF
--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -232,7 +232,7 @@ const NEEDS_CHUNK_PASS: &str = "EXISTS (SELECT 1 FROM code_graph_symbols s WHERE
 /// Up to `limit` files whose chunks are not fully embedded under
 /// `fingerprint`, with each chunk rendered and hashed.
 ///
-/// "Not fully embedded" is [`NEEDS_CHUNK_PASS`] — a coverage marker read
+/// "Not fully embedded" is `NEEDS_CHUNK_PASS` — a coverage marker read
 /// straight from the index, which is what keeps a scan over an up-to-date
 /// workspace from re-reading every file on disk to discover there is nothing
 /// to do.
@@ -510,7 +510,7 @@ pub fn chunk_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphE
 }
 
 /// How many indexed files still need a chunk pass under `fingerprint` — the
-/// same [`NEEDS_CHUNK_PASS`] predicate [`pending_chunks`] scans, as a count
+/// same `NEEDS_CHUNK_PASS` predicate [`pending_chunks`] scans, as a count
 /// rather than a page of rendered work. An eager pass reports this as
 /// `remaining` without paying for a render-and-hash pass over files it is
 /// about to discard the content of.

--- a/crates/stella-graph/src/vectors/chunks/tests.rs
+++ b/crates/stella-graph/src/vectors/chunks/tests.rs
@@ -45,7 +45,7 @@ fn store_whole_file(conn: &mut Connection, file: &PendingChunkFile) {
 /// stops being pending once they are, and **becomes pending again when its
 /// content changes**.
 ///
-/// The last leg is the one that keeps [`NEEDS_CHUNK_PASS`] honest. The
+/// The last leg is the one that keeps `NEEDS_CHUNK_PASS` honest. The
 /// predicate is a coverage marker — "does this file carry any chunk vector
 /// stamped with its *current* hash" — so the content-change leg is what proves
 /// the marker is keyed to content and not merely to existence, which is the


### PR DESCRIPTION
fix(stella-graph): main is red — public docs cannot link a private const

`cargo doc -D warnings --document-private-items` fails on `main`, so the
required `fmt + clippy + test` job is red on both ebe812925 and 8bf525765 and
every open PR inherits it:

    error: public documentation for `pending_chunk_file_count` links to
           private item `NEEDS_CHUNK_PASS`
    note: this link resolves only because you passed --document-private-items,
          but will break without
    note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`

#3152 introduced `NEEDS_CHUNK_PASS` as a deliberately private SQL fragment and
then cited it from the doc comments of two `pub fn`s with an intra-doc link.
Under `--document-private-items` the link resolves locally, which is exactly
why the lint exists: it would break in the published docs, where the private
item does not appear.

The fix is the link, not the visibility. `NEEDS_CHUNK_PASS` is an
implementation detail two functions in this module share; making it `pub` to
satisfy a doc link would put a SQL string fragment in the crate's public API to
win an argument with rustdoc. The three citations become plain code spans, so
they still name the thing a reader greps for and no longer promise a hyperlink
that cannot exist.

My miss: I ran clippy, fmt and the test suite on that change and not
`cargo doc`. `make gate` runs `doc-warnings` before `lint` and `test`, and I
ran the later steps by hand instead of the gate — the precise shape CLAUDE.md's
"one red gate step masks the next" warns about, in the direction where the
masking is self-inflicted.

Verified: `make doc-warnings` exits 0.

Refs #3124

**Priority: main is red**, so every open PR inherits the failure until this lands.

Verified: `make doc-warnings` exits 0 (it is the gate step that fails on main today; CI's required `fmt + clippy + test` job runs it before clippy and test).

## Summary by Sourcery

Bug Fixes:
- Resolve rustdoc failures caused by public documentation linking to the private `NEEDS_CHUNK_PASS` constant.