### PR TITLE
fix(stella-store): the generated .stella/.gitignore must ignore itself

### DIFF
--- a/crates/stella-store/src/private.rs
+++ b/crates/stella-store/src/private.rs
@@ -17,8 +17,19 @@ use crate::{Result, StoreError};
 pub(crate) use crate::durable::sync_directory;
 
 pub const WORKSPACE_PRIVATE_DIR: &str = "private";
+/// The trailing `/.gitignore` line makes the generated ignore ignore *itself*:
+/// in a repository that never chose to track `.stella/`, a bulk `git add -A`
+/// must sweep up nothing Stella scaffolded — an ignored file is skipped by
+/// `add`, so the whole directory stays invisible to git. Without it, the one
+/// file the other lines cannot cover is the ignore file itself, and a
+/// Terminal-Bench verifier failed a solved task because the agent's
+/// `git add -A && git commit` had captured `.stella/.gitignore` into the
+/// graded repository (run `fivetools2`, `sanitize-git-repo`,
+/// `test_no_other_files_changed`). Repositories that deliberately track the
+/// file (this one does) are unaffected: ignore rules never apply to paths
+/// already in the index.
 pub(crate) const WORKSPACE_GENERATED_IGNORE: &[u8] =
-    b"*.db\n*.db-wal\n*.db-shm\nreflections.jsonl\nprivate/\n";
+    b"*.db\n*.db-wal\n*.db-shm\nreflections.jsonl\nprivate/\n/.gitignore\n";
 
 #[cfg(unix)]
 fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {

--- a/crates/stella-store/src/tests/private_state.rs
+++ b/crates/stella-store/src/tests/private_state.rs
@@ -306,3 +306,39 @@ fn generated_ignore_is_created_world_readable_not_owner_only() {
         "the generated ignore must exclude the private dir"
     );
 }
+
+#[test]
+fn bulk_git_add_stages_nothing_stella_scaffolded() {
+    // Witness for the generated ignore's self-ignore line: in a repository
+    // that never chose to track `.stella/`, `git add -A` must sweep up nothing
+    // Stella scaffolded — including the generated `.gitignore` itself, the one
+    // file the other rules cannot cover. A Terminal-Bench verifier failed a
+    // solved `sanitize-git-repo` because the agent's `git add -A && git commit`
+    // captured `.stella/.gitignore` into the graded repository.
+    let root = tempfile::tempdir().unwrap();
+    Store::open(root.path()).expect("open");
+
+    for args in [
+        ["init", "--quiet"].as_slice(),
+        ["config", "user.email", "t@t"].as_slice(),
+        ["config", "user.name", "t"].as_slice(),
+        ["add", "-A"].as_slice(),
+    ] {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root.path())
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+    let staged = std::process::Command::new("git")
+        .args(["ls-files", "--cached"])
+        .current_dir(root.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8_lossy(&staged.stdout);
+    assert!(
+        !staged.contains(".stella"),
+        "git add -A must stage nothing under .stella/, staged: {staged}"
+    );
+}


### PR DESCRIPTION
## What

One anchored line — `/.gitignore` — added to `WORKSPACE_GENERATED_IGNORE` (`crates/stella-store/src/private.rs`), making the generated `.stella/.gitignore` self-ignoring.

## Why

On Terminal-Bench run `fivetools2` (SUT `8bf525765b…`, the valid five-tool arm), `sanitize-git-repo` **passed both content tests and failed** `test_no_other_files_changed`: the agent ran `git add -A && git commit` inside the graded repo `/app/dclm`, and `add -A` swept up the untracked `.stella/.gitignore` — the one file the ignore's own rules cannot cover. Every other scaffolded path (`private/`, `*.db`, `reflections.jsonl`) was already covered; the ignore file itself was the single leak. That one file cost the panel its 10/10 (9/10, the sole failure).

Repositories that deliberately track the file — this one does — are unaffected: ignore rules never apply to paths already in the index. The append-to-existing-ignore path is untouched, so a user's customized `.stella/.gitignore` is never rewritten.

## Witness

`bulk_git_add_stages_nothing_stella_scaffolded` (`crates/stella-store/src/tests/private_state.rs`; in the sibling module because `src/tests.rs` is a god file closed to growth): fresh dir → `Store::open` → `git init` + `git add -A` → asserts nothing under `.stella/` staged.

- **Fails on old code** with `staged: .stella/.gitignore` — the bench failure, byte for byte (verified by reverting the constant and running it).
- **Passes with the fix.**

`cargo test -p stella-store`: 332 + 31 pass. Trial evidence: `runs/fivetools2/f9b28a58…/…/sanitize-git-repo__9dvBY7E/verifier/test-stdout.txt` in the arenabench artifacts bucket.

## Summary by Sourcery

Ensure the generated .stella/.gitignore file ignores itself so bulk git adds do not stage Stella-scaffolded files in repos that do not track .stella/.

Bug Fixes:
- Prevent .stella/.gitignore from being accidentally staged by git add -A in repositories that do not track the .stella/ directory.

Enhancements:
- Document the behavior and rationale of the generated .stella/.gitignore contents in the workspace ignore definition.

Tests:
- Add a test that verifies git add -A stages no files under .stella/ in a freshly initialized repository using the generated ignore file.