### PR TITLE
docs(stella-graph): public docs must not link the private NEEDS_CHUNK_PASS — unbreak main

### DIFF
--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -232,7 +232,7 @@ const NEEDS_CHUNK_PASS: &str = "EXISTS (SELECT 1 FROM code_graph_symbols s WHERE
 /// Up to `limit` files whose chunks are not fully embedded under
 /// `fingerprint`, with each chunk rendered and hashed.
 ///
-/// "Not fully embedded" is [`NEEDS_CHUNK_PASS`] — a coverage marker read
+/// "Not fully embedded" is `NEEDS_CHUNK_PASS` — a coverage marker read
 /// straight from the index, which is what keeps a scan over an up-to-date
 /// workspace from re-reading every file on disk to discover there is nothing
 /// to do.
@@ -510,7 +510,7 @@ pub fn chunk_count(conn: &Connection, fingerprint: &str) -> Result<usize, GraphE
 }
 
 /// How many indexed files still need a chunk pass under `fingerprint` — the
-/// same [`NEEDS_CHUNK_PASS`] predicate [`pending_chunks`] scans, as a count
+/// same `NEEDS_CHUNK_PASS` predicate [`pending_chunks`] scans, as a count
 /// rather than a page of rendered work. An eager pass reports this as
 /// `remaining` without paying for a render-and-hash pass over files it is
 /// about to discard the content of.


### PR DESCRIPTION
main is red: the required `fmt + clippy + test` job fails at `cargo doc -D warnings` with

> public documentation for `pending_chunks` links to private item `NEEDS_CHUNK_PASS`
> public documentation for `pending_chunk_file_count` links to private item `NEEDS_CHUNK_PASS`

introduced by #3152's doc comments in `crates/stella-graph/src/vectors/chunks.rs`. Every open PR inherits the red (it failed #3164's run: https://github.com/macanderson/stella/actions/runs/31670350937/job/94353536768).

De-links the two references to plain code spans — the same fix shape #3112 applied when public docs linked the private markdown module. No behavior change; doc-only.

Verified: `RUSTDOCFLAGS='-D warnings' cargo doc -p stella-graph --no-deps` red before, green after. Doc-only change, so no witness test applies.

## Summary by Sourcery

Documentation:
- Update stella-graph vector chunk documentation to reference the NEEDS_CHUNK_PASS marker as plain code text instead of a rustdoc link to a private item.