### PR TITLE
fix(stella-cli): usage report --tools collided with the session-wide --tools global — rename to --by-tool

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -37,9 +37,10 @@ pub enum UsageCmd {
         org: Option<String>,
 
         /// Per-tool reliability instead: cross-project calls, errors, and
-        /// error rate per (tool, surface), from the hub's rollup
+        /// error rate per (tool, surface), from the hub's rollup. (Named
+        /// --by-tool because --tools is the session-wide tool-switch global)
         #[arg(long)]
-        tools: bool,
+        by_tool: bool,
     },
     /// Replicate this workspace's telemetry into the hub (cursor-based;
     /// safe to re-run). --all heals every project the hub knows about
@@ -134,24 +135,24 @@ pub fn run_usage(cmd: Option<UsageCmd>) -> Result<(), String> {
     match cmd.unwrap_or(UsageCmd::Report {
         format: StatsFormat::Text,
         org: None,
-        tools: false,
+        by_tool: false,
     }) {
         UsageCmd::Report {
             format,
             org,
-            tools: false,
+            by_tool: false,
         } => report(format, org.as_deref()),
         UsageCmd::Report {
             format,
             org,
-            tools: true,
+            by_tool: true,
         } => {
             // The rollup is keyed (project, tool, surface, day) and carries
             // no org column, so an org filter here would be silently
             // unhonored — refused instead (#3147).
             if org.is_some() {
                 return Err(
-                    "--tools cannot filter by --org: the tool rollup is project-keyed, \
+                    "--by-tool cannot filter by --org: the tool rollup is project-keyed, \
                      not org-keyed"
                         .into(),
                 );
@@ -280,7 +281,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-/// `stella usage report --tools` — the scriptable per-tool reliability
+/// `stella usage report --by-tool` — the scriptable per-tool reliability
 /// surface (#3147): cross-project calls, errors, and the derived error rate
 /// per (tool, surface), read from `tool_usage_rollup`, whose `errors` column
 /// previously had no reader anywhere.

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -9,7 +9,7 @@ description: Report, replicate, and prune the cross-project telemetry hub at ~/.
 
 ```bash
 stella usage
-stella usage report [--format <text|json|csv>] [--org <id>] [--tools]
+stella usage report [--format <text|json|csv>] [--org <id>] [--by-tool]
 stella usage sync [--all]
 stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
 ```
@@ -62,11 +62,11 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
     Only rows replicated under this org id. Rows written before you registered carry no
     org and are excluded by any `--org` filter.
   </OptionCard>
-  <OptionCard name="--tools">
+  <OptionCard name="--by-tool">
     Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
     derived error rate per `(tool, surface)`, read from the hub's tool rollup. This is the
     scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
-    leaderboard draws, unwindowed and pipeable. Cannot combine with `--org` (the rollup is
+    leaderboard draws, unwindowed and pipeable. Named `--by-tool` because `--tools` is the session-wide tool-switch global. Cannot combine with `--org` (the rollup is
     project-keyed, and a silently unhonored filter would misreport).
   </OptionCard>
 </CardGrid>
@@ -75,7 +75,7 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
 stella usage
 stella usage report --format json
 stella usage report --org acme --format csv > acme-spend.csv
-stella usage report --tools --format json | jq '.rows[] | select(.error_rate > 0.03)'
+stella usage report --by-tool --format json | jq '.rows[] | select(.error_rate > 0.03)'
 ```
 
 Representative table output (illustrative):


### PR DESCRIPTION
## What — unbreak main

`stella usage report --tools` (merged in #3159) reuses the name of the **session-wide global** `--tools '<SPEC>'` (the tool-switch flag, `crates/stella-cli/src/cli.rs`), which the `no_subcommand_flag_reuses_a_global_name` guard test rejects. Renamed to `--by-tool`; refusal message and `website/content/docs/commands/usage.mdx` follow. No behavior change.

## Why it reached main

The guard's failure was **masked** on #3159's own CI: the `fmt + clippy + test` job was already failing at the earlier `cargo doc -D warnings` step on the inherited `stella-graph` doc-links red (fixed since by #3166), so the test step's own failure never showed as the headline. The one-red-gate-step-masks-the-next trap, exactly as documented — #3159 merged while the job was red for the "known" reason, and the collision surfaced on the first branch to run full CI against the repaired base (#3169's log names this test).

Main is currently red on `cargo test -p stella-cli` because of this; every open PR inherits it.

## Verification

`cargo test -p stella-cli no_subcommand_flag_reuses_a_global_name` — passes (fails on main: the collision is live there); `cargo test -p stella-cli usage` — 20 passed; `scripts/check-command-docs.sh` OK; fmt clean.

Refs #3147, #3159

## Summary by Sourcery

Rename the stella usage report CLI flag from --tools to --by-tool to avoid collision with the session-wide tool-switch global, updating messages and docs accordingly.

Bug Fixes:
- Resolve the naming collision between the usage report --tools flag and the global --tools tool-switch flag.

Documentation:
- Update usage command documentation and examples to use the new --by-tool flag and clarify its relationship to the global --tools option.