### PR TITLE
fix(stella-cli): usage report's per-tool flag is --by-tool — unbreak main flag collision

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -37,9 +37,12 @@ pub enum UsageCmd {
         org: Option<String>,
 
         /// Per-tool reliability instead: cross-project calls, errors, and
-        /// error rate per (tool, surface), from the hub's rollup
+        /// error rate per (tool, surface), from the hub's rollup.
+        /// (`--by-tool`, not `--tools`: that name is the session-wide
+        /// tool-toggle global, and clap propagates globals into every
+        /// subcommand, so the two would collide at match time.)
         #[arg(long)]
-        tools: bool,
+        by_tool: bool,
     },
     /// Replicate this workspace's telemetry into the hub (cursor-based;
     /// safe to re-run). --all heals every project the hub knows about
@@ -134,24 +137,24 @@ pub fn run_usage(cmd: Option<UsageCmd>) -> Result<(), String> {
     match cmd.unwrap_or(UsageCmd::Report {
         format: StatsFormat::Text,
         org: None,
-        tools: false,
+        by_tool: false,
     }) {
         UsageCmd::Report {
             format,
             org,
-            tools: false,
+            by_tool: false,
         } => report(format, org.as_deref()),
         UsageCmd::Report {
             format,
             org,
-            tools: true,
+            by_tool: true,
         } => {
             // The rollup is keyed (project, tool, surface, day) and carries
             // no org column, so an org filter here would be silently
             // unhonored — refused instead (#3147).
             if org.is_some() {
                 return Err(
-                    "--tools cannot filter by --org: the tool rollup is project-keyed, \
+                    "--by-tool cannot filter by --org: the tool rollup is project-keyed, \
                      not org-keyed"
                         .into(),
                 );
@@ -280,7 +283,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-/// `stella usage report --tools` — the scriptable per-tool reliability
+/// `stella usage report --by-tool` — the scriptable per-tool reliability
 /// surface (#3147): cross-project calls, errors, and the derived error rate
 /// per (tool, surface), read from `tool_usage_rollup`, whose `errors` column
 /// previously had no reader anywhere.

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -9,7 +9,7 @@ description: Report, replicate, and prune the cross-project telemetry hub at ~/.
 
 ```bash
 stella usage
-stella usage report [--format <text|json|csv>] [--org <id>] [--tools]
+stella usage report [--format <text|json|csv>] [--org <id>] [--by-tool]
 stella usage sync [--all]
 stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
 ```
@@ -62,7 +62,7 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
     Only rows replicated under this org id. Rows written before you registered carry no
     org and are excluded by any `--org` filter.
   </OptionCard>
-  <OptionCard name="--tools">
+  <OptionCard name="--by-tool">
     Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
     derived error rate per `(tool, surface)`, read from the hub's tool rollup. This is the
     scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
@@ -75,7 +75,7 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
 stella usage
 stella usage report --format json
 stella usage report --org acme --format csv > acme-spend.csv
-stella usage report --tools --format json | jq '.rows[] | select(.error_rate > 0.03)'
+stella usage report --by-tool --format json | jq '.rows[] | select(.error_rate > 0.03)'
 ```
 
 Representative table output (illustrative):


### PR DESCRIPTION
main is red: `tests::no_subcommand_flag_reuses_a_global_name` fails because #3159's `stella usage report --tools` (bool) collides with the session-wide tool-toggle global `--tools <SPEC>` (`cli.rs:288`) — clap propagates globals into every subcommand, so the two collide at match time. Each PR was green alone; the composition never ran `cargo test` together until both had merged (parallel-merge red, third instance this week).

Renames the day-old subcommand flag rather than the wider global surface: `stella usage report --by-tool`. Error message and `website/content/docs/commands/usage.mdx` updated in the same change; the doc comment on the field now names the collision so the next reader doesn't re-introduce it.

Witness: `tests::no_subcommand_flag_reuses_a_global_name` — red on main, green with this rename. `cargo test -p stella-cli` usage subset green; clippy clean.

## Summary by Sourcery

Rename the per-tool usage report flag to avoid collision with the global --tools toggle and keep the CLI behavior consistent.

Bug Fixes:
- Resolve a flag name collision between the usage report subcommand and the session-wide tool-toggle global, restoring passing tests.

Documentation:
- Update CLI usage documentation and examples to reference the new --by-tool flag and clarify its semantics.