### PR TITLE
fix(stella-cli): rename usage report --tools to --by-tool

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -37,9 +37,10 @@ pub enum UsageCmd {
         org: Option<String>,
 
         /// Per-tool reliability instead: cross-project calls, errors, and
-        /// error rate per (tool, surface), from the hub's rollup
+        /// error rate per (tool, surface), from the hub's rollup.
+        /// (`--tools` is reserved by the session-wide tool-policy global.)
         #[arg(long)]
-        tools: bool,
+        by_tool: bool,
     },
     /// Replicate this workspace's telemetry into the hub (cursor-based;
     /// safe to re-run). --all heals every project the hub knows about
@@ -134,24 +135,24 @@ pub fn run_usage(cmd: Option<UsageCmd>) -> Result<(), String> {
     match cmd.unwrap_or(UsageCmd::Report {
         format: StatsFormat::Text,
         org: None,
-        tools: false,
+        by_tool: false,
     }) {
         UsageCmd::Report {
             format,
             org,
-            tools: false,
+            by_tool: false,
         } => report(format, org.as_deref()),
         UsageCmd::Report {
             format,
             org,
-            tools: true,
+            by_tool: true,
         } => {
             // The rollup is keyed (project, tool, surface, day) and carries
             // no org column, so an org filter here would be silently
             // unhonored — refused instead (#3147).
             if org.is_some() {
                 return Err(
-                    "--tools cannot filter by --org: the tool rollup is project-keyed, \
+                    "--by-tool cannot filter by --org: the tool rollup is project-keyed, \
                      not org-keyed"
                         .into(),
                 );
@@ -280,7 +281,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-/// `stella usage report --tools` — the scriptable per-tool reliability
+/// `stella usage report --by-tool` — the scriptable per-tool reliability
 /// surface (#3147): cross-project calls, errors, and the derived error rate
 /// per (tool, surface), read from `tool_usage_rollup`, whose `errors` column
 /// previously had no reader anywhere.

--- a/crates/stella-store/src/usage/tool_report.rs
+++ b/crates/stella-store/src/usage/tool_report.rs
@@ -13,7 +13,7 @@
 //!
 //! This module is the hub-side half of that surface: one reader returning
 //! the unwindowed cross-project totals, consumed by `stella usage report
-//! --tools`. Rates are left to the caller — the hub hands out exact
+//! --by-tool`. Rates are left to the caller — the hub hands out exact
 //! numerators and denominators, not derived percentages.
 //!
 //! Honesty caveat, named rather than silent: rows written by pre-v24 stores

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -9,7 +9,7 @@ description: Report, replicate, and prune the cross-project telemetry hub at ~/.
 
 ```bash
 stella usage
-stella usage report [--format <text|json|csv>] [--org <id>] [--tools]
+stella usage report [--format <text|json|csv>] [--org <id>] [--by-tool]
 stella usage sync [--all]
 stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
 ```
@@ -62,12 +62,13 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
     Only rows replicated under this org id. Rows written before you registered carry no
     org and are excluded by any `--org` filter.
   </OptionCard>
-  <OptionCard name="--tools">
+  <OptionCard name="--by-tool">
     Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
     derived error rate per `(tool, surface)`, read from the hub's tool rollup. This is the
     scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
     leaderboard draws, unwindowed and pipeable. Cannot combine with `--org` (the rollup is
-    project-keyed, and a silently unhonored filter would misreport).
+    project-keyed, and a silently unhonored filter would misreport). Named `--by-tool`
+    because `--tools` is the session-wide [tool-policy global](/docs/commands#--tools-narrowing-for-one-run).
   </OptionCard>
 </CardGrid>
 
@@ -75,7 +76,7 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
 stella usage
 stella usage report --format json
 stella usage report --org acme --format csv > acme-spend.csv
-stella usage report --tools --format json | jq '.rows[] | select(.error_rate > 0.03)'
+stella usage report --by-tool --format json | jq '.rows[] | select(.error_rate > 0.03)'
 ```
 
 Representative table output (illustrative):


### PR DESCRIPTION
## What

Renames `stella usage report --tools` (#3159) to `--by-tool`.

## Why

`main` is red: the flag collides with the session-wide `--tools` global (the per-invocation tool-policy scope, #1263), and the guard test `no_subcommand_flag_reuses_a_global_name` fails in the required `fmt + clippy + test` job — first red run was #3159's own merge commit (`67a657248`, ci.yml run 31672876237), and every PR since inherits it (#3169 among them). The collision is also a real clap hazard, not just a style rule: the global's `Option<String>` value slot against the local `bool` misbinds at match-downcast time (the guard's doc records the `connect linear --api-key` precedent).

Landed on its own from a fresh `main` per the red-main rule, not folded into an unrelated PR.

## Witness

`cargo test -p stella-cli --bin stella tests::no_subcommand_flag_reuses_a_global_name` — **fails on `main`** (see the CI run above and every run since), **passes on this branch**. The witness is pre-existing (#261); this PR makes it true again, so no new test is added.

## Scope

- `crates/stella-cli/src/usage_cmd.rs` — declaration, match arms, the `--org` refusal wording, doc comment
- `crates/stella-store/src/usage/tool_report.rs` — module doc
- `website/content/docs/commands/usage.mdx` — synopsis, OptionCard (now names why `--tools` is reserved), example

Checked: `cargo test -p stella-cli` green, `cargo clippy -p stella-cli -p stella-store --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `make command-docs` OK.

## Deleted tests

None.

Closes #3180

## Summary by Sourcery

Rename the `stella usage report` per-tool reliability flag to avoid collision with the global `--tools` option and update its behavior accordingly.

Bug Fixes:
- Resolve the flag name collision between `stella usage report --tools` and the session-wide `--tools` global to restore test and CLI robustness.

Enhancements:
- Rename the report flag from `--tools` to `--by-tool` across CLI handling and hub-side usage reporting surfaces.
- Clarify help text and error messaging for the per-tool usage report, including the incompatibility with `--org` filtering.

Documentation:
- Update CLI usage documentation and examples to use `--by-tool` and explain that `--tools` is reserved for the session-wide tool-policy global.