### PR TITLE
fix(stella-graph): index C++ source under the C grammar so search can rank it

### DIFF
--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -64,7 +64,7 @@ impl Language {
             // `.cpp` gets when it maps to no language at all (search then has
             // nothing to rank and falls to a lexical scan). This extends the
             // header-under-C precedent to C++ source; a dedicated
-            // `tree-sitter-cpp` grammar is the sharper fix (#3182).
+            // `tree-sitter-cpp` grammar is the sharper fix (#3184).
             "c" | "h" | "cpp" | "cc" | "cxx" | "c++" | "hpp" | "hh" | "hxx" => Language::C,
             "php" => Language::Php,
             "sql" => Language::Sql,
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(Language::from_path(Path::new("noext")), None);
     }
 
-    /// C++ source and headers index under the C grammar (#3182). Before this
+    /// C++ source and headers index under the C grammar (#3184). Before this
     /// they mapped to `None` — a `.cpp` file declared nothing to the graph, so
     /// `search` had no symbols to rank over a C++ codebase (`build-pov-ray`,
     /// `sqlite`'s amalgamation) and fell to a lexical scan.

--- a/crates/stella-graph/src/lang.rs
+++ b/crates/stella-graph/src/lang.rs
@@ -56,10 +56,16 @@ impl Language {
             "tsx" => Language::Tsx,
             "go" => Language::Go,
             "java" => Language::Java,
-            // Headers index as C. A C++ project's `.h` still yields useful
-            // struct/function symbols under the C grammar, and misreading a
-            // header beats skipping every declaration in the tree.
-            "c" | "h" => Language::C,
+            // C and C++ both index under the C grammar. A C++ file still
+            // yields its free functions, structs, and many declarations under
+            // it — tree-sitter is error-tolerant, so the class/template/
+            // namespace syntax it cannot parse degrades to error nodes around
+            // the symbols it can, and partial symbols beat the zero a
+            // `.cpp` gets when it maps to no language at all (search then has
+            // nothing to rank and falls to a lexical scan). This extends the
+            // header-under-C precedent to C++ source; a dedicated
+            // `tree-sitter-cpp` grammar is the sharper fix (#3182).
+            "c" | "h" | "cpp" | "cc" | "cxx" | "c++" | "hpp" | "hh" | "hxx" => Language::C,
             "php" => Language::Php,
             "sql" => Language::Sql,
             "md" | "markdown" => Language::Markdown,
@@ -289,6 +295,24 @@ mod tests {
              search the agent had until they became indexable (#3089)"
         );
         assert_eq!(Language::from_path(Path::new("noext")), None);
+    }
+
+    /// C++ source and headers index under the C grammar (#3182). Before this
+    /// they mapped to `None` — a `.cpp` file declared nothing to the graph, so
+    /// `search` had no symbols to rank over a C++ codebase (`build-pov-ray`,
+    /// `sqlite`'s amalgamation) and fell to a lexical scan.
+    #[cfg(feature = "lang-c")]
+    #[test]
+    fn cpp_source_and_headers_index_under_the_c_grammar() {
+        for probe in [
+            "ray.cpp", "scene.cc", "mesh.cxx", "vec.c++", "vec.hpp", "vec.hh", "vec.hxx",
+        ] {
+            assert_eq!(
+                Language::from_path(Path::new(probe)),
+                Some(Language::C),
+                "`{probe}` must index (as C) so search has C++ symbols to rank"
+            );
+        }
     }
 
     /// Markdown carries no grammar and is still always indexable — the one


### PR DESCRIPTION
## What

`.cpp`/`.cc`/`.cxx`/`.c++`/`.hpp`/`.hh`/`.hxx` now map to `Language::C` in `from_path`, so C++ files are symbol-indexed by the code graph. Before, they mapped to `None` — zero symbols — so `search`'s semantic tier had nothing to rank over a C++ codebase and fell to a lexical scan.

## Why (measured, not argued)

Investigating why the five-tool bench arm's `search` looked disabled, I built the binary and reproduced on a fresh workspace (no `stella init`):

- **Python/Rust/C**: `search` embeds and ranks by meaning on the first call (e.g. "where are HTTP headers scrubbed" → `sanitize_request_headers`, cosine 0.814). The on-demand path works.
- **C++ (`.cpp`)**: `search "function that finds where a ray hits a sphere"` returned **0 symbols** from `ray.cpp` and mis-ranked a weaker Rust match — `sphere_intersect` was invisible.
- **After this fix**: same query returns `ray.cpp::sphere_intersect` (function) + `Vec3` (struct), **cosine 0.836, ranked #1**.

So C++ was the concrete gap behind `build-pov-ray`, `sqlite`'s amalgamation, and other C++ tasks where search could not help.

## Approach

Extends the existing header-under-C precedent (`.h` already indexes as C, "misreading a header beats skipping every declaration") to C++ source, with **no new dependency**. tree-sitter is error-tolerant: a C++ file yields its free functions/structs/declarations under the C grammar; the class/template/namespace syntax it cannot parse degrades to error nodes around the symbols it can. A dedicated `tree-sitter-cpp` grammar is the sharper fix, filed as #3182.

## Witness

`cpp_source_and_headers_index_under_the_c_grammar` — fails on the old `.cpp → None` mapping, passes now. `cargo test -p stella-graph`: 152 pass; clippy clean.

Refs #3172.

## Summary by Sourcery

Index C++ source and header files under the C grammar so their symbols are available to the code graph and semantic search.

Bug Fixes:
- Ensure C++ files with common source and header extensions are mapped to a language instead of None so search can rank symbols in C++ codebases.

Tests:
- Add a regression test verifying that typical C++ source and header extensions resolve to Language::C for indexing.