### PR TITLE
docs: record the unwired-surface deferrals of #3135 and #3136 in-module

### DIFF
--- a/crates/stella-context/src/store/node.rs
+++ b/crates/stella-context/src/store/node.rs
@@ -229,6 +229,7 @@ pub struct NodeRow {
     /// column's NULL for every row. It is kept because the column exists and a
     /// point-in-time node reader would populate it — not because anything
     /// currently sets it. Read it as "not yet wired", never as "unknown".
+    /// Wiring it — or removing it from this projection — is tracked in #3136.
     pub valid_from: Option<String>,
     /// Transaction time the row was **first** written (RFC-3339). `upsert_node`
     /// updates content in place without touching it, so it is a creation time,

--- a/crates/stella-protocol/src/context_event.rs
+++ b/crates/stella-protocol/src/context_event.rs
@@ -17,13 +17,14 @@
 //! (as strings), never the `stella-core` record structs: `stella-core` depends on
 //! `stella-protocol`, so importing core types here would be a dependency cycle.
 //!
-//! **Status: schema landed, channel not yet wired.** Nothing in this workspace
-//! constructs or reads a [`LifecycleEventEnvelope`] today — the types and their
-//! golden JCS vectors exist so the wire shape (and therefore the `record_hash`
-//! preimages built from it) is pinned before the first emitter lands. Treat the
-//! bodies below as a published contract regardless: the golden vectors are the
-//! thing that makes a later rename a test failure rather than a silent hash
-//! change across replays.
+//! **Status: schema landed, channel not yet wired — the wiring is tracked in
+//! #3135.** Nothing in this workspace constructs or reads a
+//! [`LifecycleEventEnvelope`] today — the types and their golden JCS vectors
+//! exist so the wire shape (and therefore the `record_hash` preimages built
+//! from it) is pinned before the first emitter lands. Treat the bodies below
+//! as a published contract regardless: the golden vectors are the thing that
+//! makes a later rename a test failure rather than a silent hash change across
+//! replays.
 //!
 //! ## Forward compatibility
 //!


### PR DESCRIPTION
## What & why

The two unwired-surface findings from the adversarial audit (#3135, #3136) both
say the same thing: deliberately-deferred wiring whose deferral is only
discoverable by reading the whole file, because the code names no tracking
issue. This PR records both deferrals where a reader lands first:

- `crates/stella-protocol/src/context_event.rs` — the module doc's
  **Status** paragraph now cites #3135 as the tracker for wiring the first
  `LifecycleEventEnvelope` emitter. Module doc only, per the constraint in
  #3135: type doc comments export into `docs/wire/`, module docs do not
  (`wire-schema` verified unchanged, see below).
- `crates/stella-context/src/store/node.rs` — the `Node::valid_from` doc
  comment now cites #3136 as the tracker for the wire-or-remove decision.

Refs #3135
Refs #3136

**Deliberately `Refs`, not `Closes`.** #3135's own reasoning treats a closed
issue as no longer covering the wiring (it cites the closed #469 as exactly
that gap), so closing it on this citation would recreate the finding one audit
later. Both issues stay open as the trackers for their design calls — wiring
the first emitter (#3135) and wiring-or-removing `valid_from` (#3136) — which
their bodies both mark as maintainer decisions, not cleanups. If the intent of
#3135's "either of these closes it" was that the citation alone closes it,
closing manually after merge is one click.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: doc-comment-only
      change; no behavior, no types, no wire bytes. `wire-schema` passing with
      no diff is the proof that nothing exported moved.

## The gate

- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol -p stella-context --no-deps`
- [x] `make wire-schema` — generated artifacts unchanged
- [x] `cargo test -p stella-protocol` — all green, including the
      `context_event` golden JCS vectors
- Clippy and the full workspace suite are left to CI: doc comments are inert to
  both, and the four checks above cover every way this diff could bite.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR. The two open
      design decisions are already tracked — they are #3135 and #3136
      themselves, which this PR deliberately leaves open.

## Anything reviewers should know?

The #3135 status sentence was reflowed to fit the citation, so the diff there
is 8 lines replacing 7 — the prose content is unchanged apart from the added
tracking reference.

## Summary by Sourcery

Document the intentional deferral of wiring for lifecycle event envelopes and the `valid_from` field by referencing their tracking issues in module and API docs.

Documentation:
- Update `stella-protocol` context event module docs to reference issue #3135 as the tracker for wiring the first `LifecycleEventEnvelope` emitter.
- Extend `Node::valid_from` field documentation in `stella-context` to reference issue #3136 as the tracker for its wire-or-remove decision.