### PR TITLE
fix(stella-tools): edit_file success output carries the edit's identity

### DIFF
--- a/crates/stella-tools/src/apply_edits.rs
+++ b/crates/stella-tools/src/apply_edits.rs
@@ -65,9 +65,14 @@ struct ParsedEdit {
 
 /// One edit's validate-phase outcome, rendered into the per-edit report.
 enum EditVerdict {
-    /// Resolves cleanly; `occurrences` will be replaced.
+    /// Resolves cleanly; `occurrences` will be replaced, the first at byte
+    /// `offset` of the content this edit saw. The offset rides into the
+    /// report so distinct batches render distinct output — the stagnation
+    /// detector keys on byte-identical tool output, and occurrence counts
+    /// alone collide across different edits (#3176).
     Ok {
         occurrences: usize,
+        offset: usize,
     },
     Failed {
         reason: String,
@@ -314,8 +319,11 @@ impl Tool for ApplyEdits {
                     Some((old, new)) => (old.as_str(), new.as_str()),
                     None => (edit.old_string.as_str(), edit.new_string.as_str()),
                 };
+                // `find` returning `None` is exactly the zero-match case;
+                // the offset it returns otherwise stamps the report (#3176).
+                let first_match = simulated.find(old_string);
                 let count = simulated.matches(old_string).count();
-                if count == 0 {
+                let Some(offset) = first_match else {
                     // A prior edit in this batch consuming the match is a
                     // composition mistake, not drift — say which it is.
                     let attribution = if original.contains(&edit.old_string) {
@@ -342,7 +350,7 @@ impl Tool for ApplyEdits {
                     break 'verdict EditVerdict::Failed {
                         reason: format!("old_string not found in `{}`{attribution}", edit.path),
                     };
-                }
+                };
                 if count > 1 && !edit.replace_all {
                     break 'verdict EditVerdict::Failed {
                         reason: format!(
@@ -357,7 +365,10 @@ impl Tool for ApplyEdits {
                 } else {
                     simulated.replacen(old_string, new_string, 1)
                 };
-                EditVerdict::Ok { occurrences: count }
+                EditVerdict::Ok {
+                    occurrences: count,
+                    offset,
+                }
             };
             if matches!(verdict, EditVerdict::Failed { .. }) {
                 failures += 1;
@@ -370,8 +381,11 @@ impl Tool for ApplyEdits {
                 .iter()
                 .enumerate()
                 .map(|(i, v)| match v {
-                    EditVerdict::Ok { occurrences } => format!(
-                        "  edit {i} ({}): ok — {occurrences} occurrence(s)",
+                    EditVerdict::Ok {
+                        occurrences,
+                        offset,
+                    } => format!(
+                        "  edit {i} ({}): ok — {occurrences} occurrence(s) at byte {offset}",
                         edits[i].path
                     ),
                     EditVerdict::Failed { reason } => format!("  edit {i}: FAILED — {reason}"),
@@ -464,9 +478,26 @@ impl Tool for ApplyEdits {
             self.ledger.record_known(root, path, simulated);
         }
 
+        // Each touched file's final digest joins the per-edit offsets as the
+        // batch's identity stamp (#3176): the stagnation detector keys on
+        // byte-identical tool output, and without these two distinct batches
+        // with matching occurrence counts rendered the same bytes —
+        // `edit_file`'s constant success string killed a correct run that
+        // way. Deterministic by construction: content hashes, never timings.
+        let digests: String = order
+            .iter()
+            .map(|key| {
+                let (path, _, simulated) = &files[key];
+                format!(
+                    "\n  {path}: file sha256/8 {}",
+                    crate::staleness::sha256_8(simulated.as_bytes())
+                )
+            })
+            .collect();
+
         ToolOutput::Ok {
             content: format!(
-                "applied {} edits across {} file(s):\n{}",
+                "applied {} edits across {} file(s):\n{}{digests}",
                 edits.len(),
                 files.len(),
                 report(&verdicts)
@@ -553,6 +584,49 @@ mod tests {
             std::fs::read_to_string(dir.path().join("b.rs")).unwrap(),
             "fn b() { one }\n"
         );
+    }
+
+    /// The #3176 witness, batch flavor: two DIFFERENT batches against one
+    /// file, each with the same shape (one edit, one occurrence), must not
+    /// render byte-identical success output — the stagnation detector keys
+    /// on repeated identical tool output, and occurrence counts alone
+    /// collide across distinct edits.
+    #[tokio::test]
+    async fn distinct_batches_produce_distinct_success_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("input.tex"), "very big and very large\n").unwrap();
+        let apply = ApplyEdits::default();
+
+        let first = apply
+            .execute(
+                &serde_json::json!({ "edits": [edit("input.tex", "big", "huge")] }),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Ok { content: first } = first else {
+            panic!("expected ok, got: {first:?}");
+        };
+        let second = apply
+            .execute(
+                &serde_json::json!({ "edits": [edit("input.tex", "large", "vast")] }),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Ok { content: second } = second else {
+            panic!("expected ok, got: {second:?}");
+        };
+
+        assert_ne!(
+            first, second,
+            "two different batches must not render byte-identical output"
+        );
+        for output in [&first, &second] {
+            assert!(output.contains("at byte "), "offset missing: {output}");
+            assert!(
+                output.contains("file sha256/8 "),
+                "digest missing: {output}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -11,6 +11,14 @@
 //! embeds the changed content, a legitimate recovery never produces
 //! byte-identical outputs, so the loop detector (which requires identical
 //! outputs to flag a loop) keeps treating it as progress.
+//!
+//! The success path holds itself to the same contract (#3176): every success
+//! string carries the match's byte offset and a short digest of the resulting
+//! file, so N distinct edits to one file produce N distinct outputs. A
+//! constant `replaced 1 occurrence(s) in {path}` once made seven different,
+//! correct edits look byte-identical to that detector, which killed the run
+//! as stagnant mid-solve. Both stamps are deterministic — identity, never a
+//! timing.
 
 use std::sync::Arc;
 
@@ -224,8 +232,10 @@ impl Tool for EditFile {
             None => (old_string, new_string),
         };
 
-        let count = content.matches(old_string).count();
-        if count == 0 {
+        // The first match's byte offset is half of the success output's
+        // identity stamp (#3176); `find` returning `None` is exactly the
+        // zero-match case the attribution below explains.
+        let Some(offset) = content.find(old_string) else {
             // Attribute the miss (#331): compare current bytes against what
             // the model last saw. Three distinguishable causes, three
             // different recoveries — a generic not-found forces the model to
@@ -260,7 +270,8 @@ impl Tool for EditFile {
                          this session; read it first and copy old_string byte-exact"
                 )),
             };
-        }
+        };
+        let count = content.matches(old_string).count();
         if count > 1 && !replace_all {
             return ToolOutput::error(format!(
                 "old_string appears {count} times in `{path}` — set replace_all=true or provide a more specific string"
@@ -286,8 +297,18 @@ impl Tool for EditFile {
                 // its own edit is never later misattributed as drift.
                 self.ledger.record_known(root, path, &new_content);
                 let replaced = if replace_all { count } else { 1 };
+                // The offset and digest are the edit's identity (#3176): the
+                // stagnation detector keys on byte-identical tool output, so
+                // a constant success string made N distinct edits to one file
+                // indistinguishable from a stuck loop. Both stamps are
+                // deterministic — never a timestamp, which broke the detector
+                // in the opposite direction once.
+                let digest = crate::staleness::sha256_8(new_content.as_bytes());
                 ToolOutput::Ok {
-                    content: format!("replaced {replaced} occurrence(s) in {path}"),
+                    content: format!(
+                        "replaced {replaced} occurrence(s) in {path} at byte {offset} \
+                         (file sha256/8 {digest})"
+                    ),
                 }
             }
             Err(e) => ToolOutput::error(format!("failed to write `{path}`: {e}")),
@@ -320,6 +341,53 @@ mod tests {
         let after = tokio::fs::read_to_string(&full).await.unwrap();
         assert_eq!(after, "fn main() { new }");
         let _ = tokio::fs::remove_file(&full).await;
+    }
+
+    /// The #3176 witness: the stagnation detector keys on byte-identical
+    /// tool output, and the old constant success string made every edit to
+    /// one file render the same bytes — seven distinct, correct edits were
+    /// killed as a stuck loop mid-solve. Two DIFFERENT edits back-to-back
+    /// must produce two different success outputs.
+    #[tokio::test]
+    async fn distinct_edits_produce_distinct_success_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("input.tex"), "very big and very large\n").unwrap();
+        let edit = EditFile::default();
+
+        let first = edit
+            .execute(
+                &serde_json::json!({"path": "input.tex", "old_string": "big", "new_string": "huge"}),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Ok { content: first } = first else {
+            panic!("expected ok, got: {first:?}");
+        };
+        let second = edit
+            .execute(
+                &serde_json::json!({"path": "input.tex", "old_string": "large", "new_string": "vast"}),
+                dir.path(),
+            )
+            .await;
+        let ToolOutput::Ok { content: second } = second else {
+            panic!("expected ok, got: {second:?}");
+        };
+
+        assert_ne!(
+            first, second,
+            "two different edits must not render byte-identical output — \
+             the stagnation detector keys on repeated identical tool output"
+        );
+        // The identity is stamped, not incidental: offset and digest are
+        // both present, so the guarantee survives edits that happen to
+        // share one of the two.
+        for output in [&first, &second] {
+            assert!(output.contains("at byte "), "offset missing: {output}");
+            assert!(
+                output.contains("file sha256/8 "),
+                "digest missing: {output}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/staleness.rs
+++ b/crates/stella-tools/src/staleness.rs
@@ -37,6 +37,19 @@ pub fn hex_sha256(bytes: &[u8]) -> String {
     out
 }
 
+/// First 8 hex chars of [`hex_sha256`] — the short content identity a
+/// mutating tool stamps into its success output so distinct effects render
+/// distinct bytes. The engine's stagnation detector keys on byte-identical
+/// tool output; a constant success string made seven different edits look
+/// like a stuck loop and killed a correct in-progress solve (#3176). Eight
+/// chars is plenty: the digest only has to separate the handful of outputs a
+/// detector window compares, not resist collision attacks.
+pub(crate) fn sha256_8(bytes: &[u8]) -> String {
+    let mut hex = hex_sha256(bytes);
+    hex.truncate(8);
+    hex
+}
+
 /// Hash every extant path into a manifest, silently skipping paths that do
 /// not exist or cannot be read (they were never evidence). Order and dedup
 /// come from the `BTreeMap`.


### PR DESCRIPTION
## Defect

The engine's stagnation detector deliberately keys on repeated byte-identical tool **output** (that design is settled; a prior incident pinned that tool outputs must not carry timings). `edit_file` returned the constant string `replaced N occurrence(s) in {path}` regardless of what changed, so on Terminal-Bench `overfull-hbox` seven different, correct edits to one file rendered seven byte-identical outputs and the run was killed as stagnant mid-solve — a competent run converted into an `agent_error` loss.

## Fix (issue's fix 1 — output identity, detector untouched)

`crates/stella-tools/src/edit.rs` — the success output now stamps the edit's deterministic identity:

```
replaced 1 occurrence(s) in {path} at byte {offset} (file sha256/8 {digest})
```

where `offset` is the byte offset of the first match and `digest` is the first 8 hex chars of a sha256 of the resulting file content. No new dependency: `sha2` is already a workspace dep used by `stella-tools` (`crates/stella-tools/src/staleness.rs::hex_sha256`); the new `staleness::sha256_8` helper truncates it. Both stamps are content-derived and fully deterministic — no timestamps, no randomness — so byte-stable outputs are preserved and identical *re-runs of the same effect* still render identical bytes.

`crates/stella-tools/src/apply_edits.rs` had the same constant-string shape: two distinct batches with matching occurrence counts rendered identical output. Its per-edit report lines now carry `at byte {offset}` and the applied summary appends one `{path}: file sha256/8 {digest}` line per touched file.

The stagnation detector (`crates/stella-core/src/driver/loop_escalation.rs`) is deliberately **unchanged**.

## Witness — two-sided check performed

`edit::tests::distinct_edits_produce_distinct_success_outputs` and `apply_edits::tests::distinct_batches_produce_distinct_success_outputs`: two DIFFERENT edits/batches back-to-back against one temp file, asserting the two success outputs differ (and that both identity stamps are present).

I verified both sides the artisanal way: with the fix committed, I temporarily reverted only the format strings in the working tree to the old constant shape, ran the tests, and watched both fail — old side printed byte-identical pairs:

- `left: "replaced 1 occurrence(s) in input.tex"` == `right: "replaced 1 occurrence(s) in input.tex"`
- `left: "applied 1 edits across 1 file(s):\n  edit 0 (input.tex): ok — 1 occurrence(s)"` == right, identical

Then restored the committed fix (`git checkout --`) and re-ran: both tests pass. With the fix, the outputs carry distinct `at byte {offset} (file sha256/8 {digest})` stamps.

## Gates

- `cargo fmt -p stella-tools` — applied
- `cargo test -p stella-tools` — green (lib + integration + doc tests)
- `cargo clippy -p stella-tools --all-targets -- -D warnings` — green
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tools --no-deps --document-private-items` — green
- `make tool-docs` — green (the `ToolSchema` is unchanged; `docs/tools/edit_file.toml`'s example block is an observed historical capture, not derived from the format string)
- No lines added to any god file (`src/registry.rs` untouched)

Existing `contains`-style assertions on these outputs (`replaced 1`, `applied 2 edits across 1 file(s)`, `edit 0 (a.rs): ok` in `hunk_review.rs` and the tools' own tests) are prefix-stable and still pass.

## Residue

The issue's fix 2 (detector-side: exempt calls whose *arguments* differ from output-keyed stagnation) is deliberately not taken here — the detector's output-keying is settled design and out of scope for this PR; noted for the maintainer in case a detector-side follow-up is still wanted as defense-in-depth for third-party/MCP tools whose outputs this PR cannot stamp.

Closes #3176

## Summary by Sourcery

Stamp deterministic content identity into edit_file and apply_edits success outputs to avoid stagnation detector collisions on byte-identical tool output.

New Features:
- Include byte offset and short SHA-256-derived digest of resulting file content in edit_file success messages.
- Include byte offsets per edit and short SHA-256-derived digests per touched file in apply_edits success reports.

Enhancements:
- Introduce a shared helper for truncated SHA-256 digests used by stella-tools success outputs.

Tests:
- Add tests ensuring distinct edits and edit batches against the same file produce distinct success outputs carrying offset and digest stamps.