### PR TITLE
test(stella-cli): a closed tool set still executes a withheld tool — restore #3081's deleted witness

### DIFF
--- a/crates/stella-cli/src/discovery.rs
+++ b/crates/stella-cli/src/discovery.rs
@@ -1428,6 +1428,41 @@ mod tests {
         assert_eq!(lean_from_env(), None);
     }
 
+    /// The witness for `only:` (#3100, restoring the test #3081 deleted): a
+    /// closed set advertises exactly its members — no discovery layer — while
+    /// the plain-list form keeps `tool_search`, and, the load-bearing half,
+    /// execution stays permissive: withholding a schema is a prompt-budget
+    /// measure, never a capability gate, so a closed set cannot wedge a turn
+    /// on a tool the model knows from history but cannot see.
+    #[tokio::test]
+    async fn an_only_set_advertises_exactly_its_members_but_still_executes_a_withheld_tool() {
+        let inner = FakeInner;
+        let arm = || ["read_file", "bash"].map(String::from);
+        let closed =
+            full_set(&inner, std::env::temp_dir()).with_lean(Some(LeanConfig::closed(arm())));
+        let mut names: Vec<String> = closed.schemas().into_iter().map(|s| s.name).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            ["bash", "read_file"],
+            "an `only:` set must advertise exactly its members — `screenshot` stays hidden"
+        );
+        // The contrast, so the two forms can never quietly converge.
+        let open = full_set(&inner, std::env::temp_dir()).with_lean(Some(LeanConfig {
+            core: arm().into_iter().collect(),
+            discovery: true,
+        }));
+        let open_names: Vec<String> = open.schemas().into_iter().map(|s| s.name).collect();
+        assert!(
+            open_names.contains(&TOOL_SEARCH.to_string()),
+            "the plain-list form must keep the discovery layer: {open_names:?}"
+        );
+        match closed.execute("screenshot", &Value::Null).await {
+            ToolOutput::Ok { content } => assert_eq!(content, "inner ran screenshot"),
+            other => panic!("a closed set must still execute a withheld tool, got {other:?}"),
+        }
+    }
+
     /// The lean core may not withhold a tool the static prompt *commands*.
     ///
     /// Not "every tool the prompt names" — the prompts mention plenty that


### PR DESCRIPTION
Closes #3100

## What this restores

PR #3081 (merged as `4b06db35c`) deleted **`an_only_set_advertises_exactly_its_members_and_a_plain_list_does_not`** from `crates/stella-cli/src/discovery.rs` (last present at `b32b9be1c`), replacing it with `the_lean_core_offers_every_tool_the_prompt_commands` — a different property. Three assertions died with it, and the load-bearing one was that **a closed `only:` set still `execute`s a withheld tool called by name**: withholding a schema is a prompt-budget measure, never a capability gate, so a lean bench arm can never wedge a turn on a tool the model knows but cannot see. After the merge, nothing tested that.

This PR restores the property as a new test written against today's code, beside the kept replacement (which stays untouched):

**`an_only_set_advertises_exactly_its_members_but_still_executes_a_withheld_tool`** (`#[tokio::test]`, since `execute` is async) asserts all three halves of the original:

1. a `LeanConfig::closed` set advertises **exactly** its members (`["bash", "read_file"]` — exact equality, so `screenshot` and the discovery trio are proven absent from the menu);
2. the plain-list form keeps `tool_search`, so the two forms cannot quietly converge;
3. `closed.execute("screenshot", …)` — a tool absent from the advertised set — still runs and returns the inner executor's output, not an unknown-tool error.

The pairing of (1) and (3) — hidden from the menu, still executable — is the whole property.

## Non-vacuity check

The restored test is the witness of the gap, and I verified it can actually fail: I temporarily made `DiscoveryToolSet::execute`'s fall-through arm withhold dispatch for a closed set (return an unknown-tool error when `!lean.discovery && !lean.core.contains(name)` — exactly the regression #3100 fears), ran the test, and it failed on the permissive-execution assertion:

```text
a closed set must still execute a withheld tool, got Error { message: "unknown tool screenshot", class: None }
```

Then restored the branch; the committed diff touches only the test module (35 added lines, zero production changes).

## Gates

- `cargo fmt -p stella-cli -- --check`, `cargo clippy -p stella-cli --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps`, `cargo test -p stella-cli` — all green (exit codes checked directly, not through a pipe).
- `scripts/check-file-size.sh` green: `discovery.rs` is not grandfathered and now sits at **1499/1500 lines**. No baseline entry added or moved. The next addition to this file forces a `discovery/tests.rs` split — filed as #3189 rather than folded in here.

No tests are deleted by this PR.

## Summary by Sourcery

Tests:
- Add an async test verifying that a closed `only:` tool set advertises only its configured members while still allowing execution of withheld tools such as `screenshot`.