### PR TITLE
fix(stella-tools): a panicked spawn_blocking names the panic instead of reporting cancelled

### DIFF
--- a/crates/stella-tools/src/blocking.rs
+++ b/crates/stella-tools/src/blocking.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Rendering a blocking-worker [`JoinError`] into the message a tool reports.
+//!
+//! Every tool that hops work to the blocking pool awaits a
+//! [`tokio::task::spawn_blocking`] handle, and the [`JoinError`] that await
+//! can produce has exactly two causes: the closure **panicked**, or the task
+//! was **cancelled** (a runtime tearing down). The two demand opposite
+//! debugging — a panic is a crash in our own indexer or scanner, a
+//! cancellation is an operational fact about the process — and reporting a
+//! panic as "cancelled" sends whoever reads the message (the model, a human
+//! on the transcript, a bench census) after a shutdown race instead of the
+//! bug (#3141). So every such site funnels through [`worker_failure`], and
+//! each cause keeps its own words.
+
+use tokio::task::JoinError;
+
+/// The one rendering of a blocking-worker failure, shared by every
+/// `spawn_blocking` site in the crate so the siblings stay in lockstep.
+///
+/// `what` is the operation as a noun phrase — "the search", "diagnostics
+/// detection" — chosen so the cancelled arm reproduces the exact wording
+/// each call site reported before this helper existed. A panic is named as
+/// one, carrying its payload when the payload is a string: the
+/// `&'static str`-then-`String` downcast pair is the same one tokio's own
+/// `JoinError: Display` uses, because those are the two types `panic!`
+/// produces.
+pub(crate) fn worker_failure(what: &str, error: JoinError) -> String {
+    if error.is_panic() {
+        let payload = error.into_panic();
+        let message = payload
+            .downcast_ref::<&'static str>()
+            .copied()
+            .map(str::to_owned)
+            .or_else(|| payload.downcast_ref::<String>().cloned());
+        match message {
+            Some(message) => format!("{what} panicked: {message}"),
+            None => format!("{what} panicked"),
+        }
+    } else {
+        format!("{what} was cancelled")
+    }
+}
+
+/// [`worker_failure`] applied to a `spawn_blocking` result whose closure
+/// already returns `Result<T, String>` — flattens the join layer so the
+/// call site stays a single expression.
+pub(crate) fn flatten<T>(
+    what: &str,
+    joined: Result<Result<T, String>, JoinError>,
+) -> Result<T, String> {
+    joined.unwrap_or_else(|error| Err(worker_failure(what, error)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The witness for #3141: a panicked blocking closure must be reported
+    /// as a panic — payload and all — never as a cancellation.
+    #[tokio::test]
+    async fn a_panicked_worker_names_the_panic_not_a_cancellation() {
+        let error = tokio::task::spawn_blocking(|| panic!("boom in the indexer"))
+            .await
+            .expect_err("the closure panicked");
+        assert!(error.is_panic());
+        let message = worker_failure("the search", error);
+        assert!(message.contains("panicked"), "panic unnamed: {message}");
+        assert!(
+            message.contains("boom in the indexer"),
+            "payload lost: {message}"
+        );
+        assert!(
+            !message.contains("cancelled"),
+            "a panic is not a cancellation: {message}"
+        );
+    }
+
+    /// A formatted panic carries a `String` payload — the other downcast arm.
+    #[tokio::test]
+    async fn a_string_panic_payload_survives_into_the_message() {
+        let error = tokio::task::spawn_blocking(|| panic!("row {} poisoned", 7))
+            .await
+            .expect_err("the closure panicked");
+        let message = worker_failure("the code-graph query", error);
+        assert_eq!(message, "the code-graph query panicked: row 7 poisoned");
+    }
+
+    /// A real cancellation keeps the wording every call site had before.
+    #[tokio::test]
+    async fn a_cancelled_task_keeps_the_cancelled_wording() {
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+        let error = handle.await.expect_err("the task was aborted");
+        assert!(error.is_cancelled());
+        assert_eq!(
+            worker_failure("the search", error),
+            "the search was cancelled"
+        );
+    }
+
+    /// `flatten` routes a join failure through the same rendering and leaves
+    /// the closure's own `Err` untouched.
+    #[tokio::test]
+    async fn flatten_renders_the_join_layer_and_preserves_the_inner_error() {
+        let joined: Result<Result<(), String>, _> =
+            tokio::task::spawn_blocking(|| panic!("manifest walk crashed")).await;
+        assert_eq!(
+            flatten("diagnostics detection", joined),
+            Err("diagnostics detection panicked: manifest walk crashed".into())
+        );
+
+        let inner: Result<Result<(), String>, tokio::task::JoinError> =
+            Ok(Err("no toolchain resolves here".into()));
+        assert_eq!(
+            flatten("diagnostics detection", inner),
+            Err("no toolchain resolves here".into())
+        );
+    }
+}

--- a/crates/stella-tools/src/diagnostics.rs
+++ b/crates/stella-tools/src/diagnostics.rs
@@ -560,9 +560,8 @@ impl Tool for Diagnostics {
         let plan = {
             // Manifest reads on the blocking pool, like `ScriptIndex::detect`.
             let root = root.to_path_buf();
-            tokio::task::spawn_blocking(move || resolve_plan(&root))
-                .await
-                .unwrap_or_else(|_| Err("diagnostics detection was cancelled".into()))
+            let joined = tokio::task::spawn_blocking(move || resolve_plan(&root)).await;
+            crate::blocking::flatten("diagnostics detection", joined)
         };
         let plan = match plan {
             Ok(plan) => plan,

--- a/crates/stella-tools/src/gather.rs
+++ b/crates/stella-tools/src/gather.rs
@@ -566,7 +566,7 @@ async fn gather(
     let graph_results = {
         let graph_root = root.to_path_buf();
         let symbols = inputs.symbols.clone();
-        let cancelled = inputs.symbols.clone();
+        let failed = inputs.symbols.clone();
         async move {
             if !graph_on {
                 return (
@@ -576,11 +576,9 @@ async fn gather(
             }
             tokio::task::spawn_blocking(move || graph_sweep(&graph_root, symbols))
                 .await
-                .unwrap_or_else(|_| {
-                    (
-                        symbol_failures(cancelled, "the code-graph sweep was cancelled".into()),
-                        None,
-                    )
+                .unwrap_or_else(|error| {
+                    let failure = crate::blocking::worker_failure("the code-graph sweep", error);
+                    (symbol_failures(failed, failure), None)
                 })
         }
     };

--- a/crates/stella-tools/src/graph.rs
+++ b/crates/stella-tools/src/graph.rs
@@ -188,7 +188,12 @@ impl Tool for CodeGraphQuery {
         let target = target.to_string();
         tokio::task::spawn_blocking(move || run_query(&root, &op, &target))
             .await
-            .unwrap_or_else(|_| ToolOutput::error("the code-graph query was cancelled"))
+            .unwrap_or_else(|error| {
+                ToolOutput::error(crate::blocking::worker_failure(
+                    "the code-graph query",
+                    error,
+                ))
+            })
     }
 }
 

--- a/crates/stella-tools/src/graph/semantic.rs
+++ b/crates/stella-tools/src/graph/semantic.rs
@@ -162,8 +162,11 @@ pub(crate) async fn semantic_query(root: &Path, query: &str) -> ToolOutput {
         Ok(Err(message)) => {
             return ToolOutput::error(message);
         }
-        Err(_) => {
-            return ToolOutput::error("the code-graph query was cancelled");
+        Err(join_error) => {
+            return ToolOutput::error(crate::blocking::worker_failure(
+                "the code-graph query",
+                join_error,
+            ));
         }
     };
 

--- a/crates/stella-tools/src/impact.rs
+++ b/crates/stella-tools/src/impact.rs
@@ -358,11 +358,13 @@ pub(crate) async fn select_impacted(root: &Path) -> ImpactSelection {
     .await;
     // A cancelled/panicked blocking task is one more way selection can fail,
     // and it degrades exactly like the others: the full suite, never an
-    // error and never a silent narrowing.
-    selection.unwrap_or_else(|_| ImpactSelection::FullSuite {
-        note: "impact selection unavailable (the code-graph pass was cancelled) — ran the \
-               full suite"
-            .into(),
+    // error and never a silent narrowing — with the note naming which of
+    // the two it was (#3141).
+    selection.unwrap_or_else(|error| ImpactSelection::FullSuite {
+        note: format!(
+            "impact selection unavailable ({}) — ran the full suite",
+            crate::blocking::worker_failure("the code-graph pass", error)
+        ),
     })
 }
 

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -13,6 +13,7 @@ pub mod agent_use;
 pub mod apply_edits;
 pub mod authored_diff;
 pub mod bash;
+pub(crate) mod blocking;
 pub mod capability;
 pub mod catalog;
 pub mod ci;

--- a/crates/stella-tools/src/overview.rs
+++ b/crates/stella-tools/src/overview.rs
@@ -78,8 +78,11 @@ impl Tool for ProjectOverview {
         };
         let overview = match overview {
             Ok(overview) => overview,
-            Err(_) => {
-                return ToolOutput::error("the project overview was cancelled");
+            Err(join_error) => {
+                return ToolOutput::error(crate::blocking::worker_failure(
+                    "the project overview",
+                    join_error,
+                ));
             }
         };
         ToolOutput::Ok {

--- a/crates/stella-tools/src/read_symbol.rs
+++ b/crates/stella-tools/src/read_symbol.rs
@@ -94,7 +94,7 @@ impl Tool for ReadSymbol {
         let looked_up = {
             let root = root.to_path_buf();
             let name = name.to_string();
-            tokio::task::spawn_blocking(move || {
+            let joined = tokio::task::spawn_blocking(move || {
                 let crate::graph::OpenedGraph {
                     graph,
                     index_warning,
@@ -105,8 +105,8 @@ impl Tool for ReadSymbol {
                     .map(|spans| (spans, index_warning))
                     .map_err(|e| format!("code-graph lookup failed: {e}"))
             })
-            .await
-            .unwrap_or_else(|_| Err("the code-graph symbol lookup was cancelled".into()))
+            .await;
+            crate::blocking::flatten("the code-graph symbol lookup", joined)
         };
         let (spans, index_warning) = match looked_up {
             Ok(found) => found,

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -1039,11 +1039,11 @@ impl ToolRegistry {
                 if snapshot.is_none() {
                     let persisted = {
                         let root = self.root.clone();
-                        tokio::task::spawn_blocking(move || {
+                        let joined = tokio::task::spawn_blocking(move || {
                             crate::graph::load_storage_snapshot(&root)
                         })
-                        .await
-                        .unwrap_or_else(|_| Err("the storage map load was cancelled".into()))
+                        .await;
+                        crate::blocking::flatten("the storage map load", joined)
                     };
                     snapshot = match persisted {
                         Ok(persisted) => Some(self.merge_storage_overlay(persisted)),

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -488,8 +488,11 @@ pub(crate) async fn report_with(
         // file scan needs no index and is exactly the strategy for a
         // workspace the indexer cannot serve.
         Ok(Err(message)) => (None, Some(message)),
-        Err(_) => {
-            return SearchReport::failed("the search was cancelled");
+        Err(join_error) => {
+            return SearchReport::failed(&crate::blocking::worker_failure(
+                "the search",
+                join_error,
+            ));
         }
     };
 


### PR DESCRIPTION
## What & why

A `JoinError` from an awaited `tokio::task::spawn_blocking` handle has exactly two causes — the closure **panicked**, or the task was **cancelled** — and nine call sites in `stella-tools` mapped both to a "was cancelled" message. A panicked search/graph worker therefore read as an operational shutdown race instead of a crash in the indexer, to the model, in the transcript, and in every bench census.

This PR adds one crate-private module, `crates/stella-tools/src/blocking.rs`, and funnels every such site through it:

- `worker_failure(what, err)` — on `is_panic()`, `{what} panicked: {payload}` (payload extracted via `into_panic()` + the `&'static str`-then-`String` downcast pair, the same one tokio's own `JoinError: Display` uses — tokio is the exemplar here); otherwise the exact `{what} was cancelled` wording each site had before, byte-for-byte.
- `flatten(what, joined)` — `worker_failure` applied to the sites whose closures already return `Result<_, String>`, so the call stays one expression.

Call sites fixed (all nine renderings of a `JoinError` in the crate that said "cancelled"):

| File | Site |
|---|---|
| `src/search.rs` | `report_with`'s `Err(_)` arm (the issue's first site) |
| `src/graph/semantic.rs` | `semantic_query`'s `Err(_)` arm (the issue's second site) |
| `src/graph.rs` | `graph_query`'s `unwrap_or_else` |
| `src/read_symbol.rs` | the symbol-lookup `unwrap_or_else` |
| `src/overview.rs` | `project_overview`'s `Err(_)` arm |
| `src/gather.rs` | the code-graph sweep (also renames the now-mislabelled `cancelled` binding to `failed`) |
| `src/diagnostics.rs` | `execute`'s `resolve_plan` hop |
| `src/impact.rs` | the full-suite stand-down note now names which of the two it was |
| `src/registry.rs` | the storage-map load — **net-zero lines in the god file** (3+/3-) |

The remaining `spawn_blocking` sites in the crate were audited and left alone on purpose: `durable_write.rs`, `rootfd.rs`, `delete.rs`, `read.rs`, `gather.rs`/`exploration.rs` pack writes all render the `JoinError`'s `Display`, which already says "panicked" for a panic; `scripts.rs`, `issues.rs`/`issue_backend.rs`, and `diagnostics.rs::snapshot`/`command_for_gate` swallow the error as deliberate degrade-open probes — that silent-panic gap is filed as #3191, not fixed here, because the right surfacing (keep degrading open, add a diagnostic) is a design call.

Closes #3141

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`blocking::tests` builds a real panicked `JoinError` (`spawn_blocking(|| panic!("boom in the indexer")).await.unwrap_err()`) and a real cancelled one (aborted task), and asserts the panic message survives and "cancelled" does not appear. Verified two-sided, both ways:

- **Old rendering** (the helper temporarily given main's unconditional `{what} was cancelled` body, which is literally what every old arm did to a `JoinError`): 3 of 4 tests **fail** — `a_panicked_worker_names_the_panic_not_a_cancellation` printed `panic unnamed: the search was cancelled`, and the eq assertions printed `left: "the code-graph query was cancelled" / right: "the code-graph query panicked: row 7 poisoned"`. The cancellation test passes on both sides, as it must — that wording is preserved.
- **New rendering**: all 4 pass; the panic case renders `the search panicked: boom in the indexer`.
- On `main` itself the test file cannot compile (the helper is new); the old behavior lives in the inline `Err(_) =>` arms quoted above, e.g. `src/search.rs:491-493`.

## The gate

- [x] `cargo fmt -p stella-tools -- --check`
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings`
- [x] `cargo test -p stella-tools` (1000 lib tests + all integration suites, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tools --no-deps --document-private-items`
- [x] Docs: doc comments on the new module and both helpers; no user-facing flags changed
- [x] `Closes #3141` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #3191 — the sibling defect class: best-effort probes (`scripts.rs`, `issues.rs`, `issue_backend.rs`, `diagnostics.rs::snapshot`) swallow a panicked worker with no signal at all; needs a surfacing design that keeps them degrade-open.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`worker_failure`/`flatten` are `pub(crate)` and return `String` deliberately: every caller feeds `ToolOutput::error`/`SearchReport::failed`, none branches on the value, and invariant #5's typed-errors rule covers `pub` library signatures a caller must branch on — internal helpers are explicitly out of its scope. No existing test pinned the old "was cancelled" strings (verified by `rg`), and no other crate carries the misreport shape.

## Summary by Sourcery

Clarify reporting of blocking worker failures so panics are distinguished from cancellations across stella-tools.

Bug Fixes:
- Ensure panicked spawn_blocking tasks are reported as panics with preserved payloads instead of being mislabelled as cancellations in tool outputs and impact selection notes.

Enhancements:
- Introduce a crate-private blocking helper module that centralizes JoinError-to-message rendering and reuse it across search, graph queries, symbol lookup, diagnostics, impact selection, and registry storage loading.

Tests:
- Add targeted tests verifying panic vs cancellation messaging and the behavior of the new blocking helpers, including flattening join results without altering existing error semantics.