### PR TITLE
fix(arenabench): render a mutating tool's diff inline in the transcript

### DIFF
--- a/arenabench/arenabench/transcript.py
+++ b/arenabench/arenabench/transcript.py
@@ -48,6 +48,36 @@ TOOL_RESULT_BUDGET = 8000
 #: label as ``meta.raw`` for the page's expanded view.
 TOOL_INPUT_BUDGET = 4000
 
+#: The file-*mutating* built-ins — the only calls whose result entry carries an
+#: inline diff (reads must not). A port of ``is_file_mutation`` in
+#: ``crates/stella-tui/src/model/summarize.rs``, which itself must stay in
+#: lockstep with the ``FileChange`` emitter that owns the list.
+_FILE_MUTATIONS = frozenset({"write_file", "edit_file", "apply_edits", "delete_file"})
+
+
+def _tool_input_path(arguments: Any) -> str | None:
+    """The workspace-relative path a file tool targets — the join key between
+    a tool result and the ``file_change`` diff its call produced.
+
+    A port of ``tool_input_path`` (beside ``is_file_mutation``, above): every
+    built-in file tool takes its path under the ``path`` key, and the engine
+    emits ``file_change`` for that same path. ``apply_edits`` carries its
+    paths in a batch rather than at the top level; the first edit's path
+    stands in, so a single-file batch still renders an inline diff under its
+    result row.
+    """
+    if not isinstance(arguments, dict):
+        return None
+    path = arguments.get("path")
+    if isinstance(path, str):
+        return path
+    edits = arguments.get("edits")
+    if isinstance(edits, list) and edits and isinstance(edits[0], dict):
+        first = edits[0].get("path")
+        if isinstance(first, str):
+            return first
+    return None
+
 
 def _proof_line(step: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
     """One ``proof`` step as a transcript line: title, body, metadata.
@@ -392,6 +422,23 @@ class TranscriptState:
     #: (``crates/stella-tui/src/model.rs``) and this reader never did, which is
     #: why every result in every arena transcript read "result".
     tool_names: dict[str, str] = field(default_factory=dict)
+    #: ``call_id`` -> ``(path, change_seq when the call opened)`` for a
+    #: *mutating* file tool (:data:`_FILE_MUTATIONS`). The path is the join
+    #: key to the ``file_change`` the call will emit; the mark is what makes
+    #: the join honest: only a mutation recorded *after* the call opened may
+    #: ride its result, so a no-op edit — which emits no ``file_change`` —
+    #: cannot inherit the path's previous diff. The deck keeps the same
+    #: discipline with ``FileState::changes`` as its freshness tag
+    #: (``crates/stella-tui/src/render/entry.rs``).
+    tool_paths: dict[str, tuple[str, int]] = field(default_factory=dict)
+    #: Mutations folded so far — the clock :attr:`tool_paths` marks are read
+    #: against.
+    change_seq: int = 0
+    #: path -> the latest mutation recorded for it: ``{diff, added, removed,
+    #: at}``. ``diff`` is ``None`` for a mutation that carried none — recorded
+    #: anyway, so it *supersedes* an older diff rather than exposing it to the
+    #: next result on the same path.
+    file_diffs: dict[str, dict[str, Any]] = field(default_factory=dict)
     #: The last fragment-built text entry not yet superseded by its
     #: consolidated ``text`` event. Outlives ``open_entries`` on purpose:
     #: ``step_usage`` routinely closes the run *before* the consolidated
@@ -607,6 +654,14 @@ class TranscriptReader:
             # the whole object rides as `meta.raw` for the expanded view, so
             # nothing is lost by summarizing here.
             arguments = call.get("input", call.get("arguments"))
+            # A mutating file tool's target, kept so the *result* entry can
+            # carry the diff of the change this very call made — the same
+            # correlate-through-state move `tool_names` makes for the name,
+            # keyed the same way.
+            if call_id and name in _FILE_MUTATIONS:
+                path = _tool_input_path(arguments)
+                if path is not None:
+                    state.tool_paths[call_id] = (path, state.change_seq)
             # The call's CLASS (`crate::tool_class` in the deck, ported at
             # `arenabench.toolclass`) — a read, a write, a shell, a test, a
             # push, a hand-off. The page paints the name in this class's hue
@@ -644,6 +699,34 @@ class TranscriptReader:
             body = cap_middle(strip_ansi(decoded.text), self._tool_result_budget)
             name = state.tool_names.get(call_id, "tool")
             cls = classify(name)
+            # The mutation's diff, correlated onto the result the same way the
+            # name is: through state recorded at `tool_start`. The
+            # `file_change` event precedes its `tool_result` on the wire
+            # (`ToolRegistry::record_touch` emits mid-execution), so by the
+            # time this result folds, the path's latest recorded mutation is
+            # this very call's — and the `at > seen` mark guards the one case
+            # where it is not: a call that emitted no `file_change` must not
+            # inherit an older call's diff. Gated to successful calls, like
+            # the deck (`crates/stella-tui/src/model.rs`): a failed call
+            # produced no `FileChange`, and rendering the path's previous diff
+            # under its ✗ would attribute a change the call never made.
+            #
+            # The diff is carried whole, never `cap_middle`d: a mid-hunk
+            # elision garbles the render, and the emitter already bounds it
+            # (`crates/stella-tools/src/file_touch.rs::changed_region_diff`
+            # caps each side of the changed region).
+            mutation: dict[str, Any] = {}
+            marked = state.tool_paths.get(call_id)
+            if decoded.ok and marked is not None:
+                path, seen = marked
+                change = state.file_diffs.get(path)
+                if change is not None and change["at"] > seen and change["diff"]:
+                    mutation = {
+                        "diff": change["diff"],
+                        "diff_path": path,
+                        "diff_added": change["added"],
+                        "diff_removed": change["removed"],
+                    }
             return [
                 entry(
                     self._next_seq(state),
@@ -658,6 +741,7 @@ class TranscriptReader:
                     lines=body.count("\n") + 1 if body else 0,
                     tool_class=cls,
                     tool_class_label=class_label(cls),
+                    **mutation,
                 )
             ]
 
@@ -753,6 +837,30 @@ class TranscriptReader:
                     cost_usd=event.get("cost_usd"),
                 )
             ]
+
+        if kind == "file_change":
+            # Not (only) a row: the correlation state the *result* entry needs
+            # to render this mutation's diff inline (see the `tool_result`
+            # arm). `added`/`removed` are the emitter's own counts and are
+            # carried rather than recounted from the diff — the diff is a
+            # bounded, deliberately coarse rendering of the changed region,
+            # and re-deriving the delta from it is the exact disagreement the
+            # event's contract warns against
+            # (`crates/stella-protocol/src/event.rs::FileChange`). A mutation
+            # with no diff is recorded too, so it supersedes the path's
+            # previous diff instead of leaving it to be misattributed. Reads
+            # carry `0/0` and no diff, and record nothing.
+            path = event.get("path")
+            diff = event.get("diff")
+            if isinstance(path, str) and path and str(event.get("kind") or "") != "read":
+                state.change_seq += 1
+                state.file_diffs[path] = {
+                    "diff": diff if isinstance(diff, str) and diff else None,
+                    "added": event.get("added") or 0,
+                    "removed": event.get("removed") or 0,
+                    "at": state.change_seq,
+                }
+            # ...and then the compact row below, unchanged.
 
         if kind in ("file_change", "commit", "task_update", "loop_detected"):
             return [

--- a/arenabench/tests/test_transcript_diff.py
+++ b/arenabench/tests/test_transcript_diff.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""A mutating tool call's diff rides its ``tool_result`` entry (#3110).
+
+The Command Deck renders a mutation's diff inline under the result row —
+``crates/stella-tui/src/render/entry.rs``, the ``ToolResult`` arm — by
+correlating the ``file_change`` the call emitted back to the call through
+state its fold recorded at ``tool_start``. Until this existed,
+:class:`~arenabench.transcript.TranscriptReader` made no such join: a
+``file_change`` was its own compact-JSON row, never associated with the
+``tool_result`` that produced it, so the arena transcript could not show what
+an ``edit_file`` actually changed.
+
+The wire facts these tests lean on (``crates/stella-protocol/src/event.rs``):
+a ``file_change`` carries ``{path, kind, added, removed, diff}``; the counts
+are the emitter's own measurement and the authority over the diff, which is a
+bounded rendering of the changed region; reads carry ``0/0`` and no diff; and
+the event precedes its ``tool_result`` in the stream, because
+``ToolRegistry::record_touch`` emits it during the tool's execution.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from arenabench.transcript import TOOL_RESULT_BUDGET, TranscriptReader
+
+DIFF = "@@ -1,2 +1,3 @@\n-old\n+new\n+more\n context\n"
+
+
+def write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+
+
+def call(name: str, call_id: str = "c1", **arguments) -> dict:
+    return {
+        "type": "tool_start",
+        "call": {"call_id": call_id, "name": name, "input": arguments},
+    }
+
+
+def change(
+    path: str = "src/lib.rs",
+    diff: str | None = DIFF,
+    added: int = 2,
+    removed: int = 1,
+    kind: str = "modified",
+) -> dict:
+    return {
+        "type": "file_change",
+        "path": path,
+        "kind": kind,
+        "added": added,
+        "removed": removed,
+        "diff": diff,
+    }
+
+
+def result(call_id: str = "c1", ok: bool = True, text: str = "done") -> dict:
+    output = {"ok": {"content": text}} if ok else {"error": {"message": text}}
+    return {"type": "tool_result", "call_id": call_id, "output": output, "duration_ms": 12}
+
+
+def results_of(entries: list[dict]) -> list[dict]:
+    return [e for e in entries if e["kind"] == "tool_result"]
+
+
+class TestAMutationsDiffRidesItsResult:
+    def test_an_edit_files_result_carries_its_diff(self, tmp_path: Path):
+        """The witness. Before the join existed, a `tool_result` entry's meta
+        never held a `diff` at all — the deck-parity gap of #3110."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("edit_file", path="src/lib.rs"),
+                change(),
+                result(text="Applied edit to src/lib.rs"),
+            ],
+        )
+        (entry,) = results_of(TranscriptReader().read(path))
+        assert entry["meta"]["diff"] == DIFF
+        assert entry["meta"]["diff_path"] == "src/lib.rs"
+
+    def test_the_counts_are_the_emitters_not_a_recount(self, tmp_path: Path):
+        """`added`/`removed` come from the event's own fields — the measured
+        delta — never from counting `+`/`-` lines in the bounded diff, which
+        is the re-derivation the wire contract forbids."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("write_file", path="a.txt"),
+                # A coarse diff showing fewer lines than the change really had.
+                change(path="a.txt", diff="@@ -1,1 +1,1 @@\n+tail\n", added=40, removed=0),
+                result(),
+            ],
+        )
+        (entry,) = results_of(TranscriptReader().read(path))
+        assert entry["meta"]["diff_added"] == 40
+        assert entry["meta"]["diff_removed"] == 0
+
+    def test_a_read_only_calls_result_carries_none(self, tmp_path: Path):
+        """The other half of the witness: a read's `file_change` carries no
+        diff and must not put one on the result row."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("read_file", path="src/lib.rs"),
+                change(diff=None, added=0, removed=0, kind="read"),
+                result(text="1: fn main() {}"),
+            ],
+        )
+        (entry,) = results_of(TranscriptReader().read(path))
+        assert "diff" not in entry["meta"]
+
+    def test_a_failed_mutations_result_carries_none(self, tmp_path: Path):
+        """A failed call produced no `file_change` (the registry only records
+        touches on success). Rendering the path's previous diff under its ✗
+        would attribute a change the call never made — the deck's own gate."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("edit_file", path="src/lib.rs"),
+                change(),
+                result(text="Applied edit to src/lib.rs"),
+                call("edit_file", call_id="c2", path="src/lib.rs"),
+                result(call_id="c2", ok=False, text="old_string not found"),
+            ],
+        )
+        first, second = results_of(TranscriptReader().read(path))
+        assert first["meta"]["diff"] == DIFF
+        assert "diff" not in second["meta"]
+
+    def test_apply_edits_correlates_through_its_batch(self, tmp_path: Path):
+        """`apply_edits` names its paths inside `edits`, not at the top level;
+        the first edit's path is the join key, as in the deck's
+        `tool_input_path`."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("apply_edits", edits=[{"path": "b.rs", "old": "x", "new": "y"}]),
+                change(path="b.rs"),
+                result(),
+            ],
+        )
+        (entry,) = results_of(TranscriptReader().read(path))
+        assert entry["meta"]["diff"] == DIFF
+        assert entry["meta"]["diff_path"] == "b.rs"
+
+    def test_a_non_file_tool_stays_bare(self, tmp_path: Path):
+        """`bash` mutates through redirects and heredocs and emits no
+        `file_change` at all; nothing must be invented for it — and a stray
+        recorded diff for some other path must not leak onto it."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("edit_file", path="src/lib.rs"),
+                change(),
+                result(),
+                call("bash", call_id="c2", cmd="make test"),
+                result(call_id="c2", text="ok"),
+            ],
+        )
+        _, bash = results_of(TranscriptReader().read(path))
+        assert "diff" not in bash["meta"]
+
+
+class TestTheJoinIsHonest:
+    def test_a_diffless_mutation_does_not_inherit_the_previous_diff(
+        self, tmp_path: Path
+    ):
+        """The freshness mark. A second edit of the same path whose
+        `file_change` carried no diff supersedes the recorded one — its result
+        must not resurrect the *first* call's diff, which is exactly the
+        misattribution the deck's `FileState::changes` seq guards against."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("edit_file", path="src/lib.rs"),
+                change(),
+                result(),
+                call("edit_file", call_id="c2", path="src/lib.rs"),
+                change(diff=None, added=1, removed=1),
+                result(call_id="c2"),
+            ],
+        )
+        first, second = results_of(TranscriptReader().read(path))
+        assert first["meta"]["diff"] == DIFF
+        assert "diff" not in second["meta"]
+
+    def test_a_call_that_emitted_nothing_does_not_reach_back(self, tmp_path: Path):
+        """A mutation call whose execution recorded no `file_change` at all (a
+        no-op write) sees only mutations recorded *after* it opened — the
+        path's older diff is out of reach by construction."""
+        path = tmp_path / "e.jsonl"
+        write_events(
+            path,
+            [
+                call("write_file", path="a.txt"),
+                change(path="a.txt", diff="@@ -0,0 +1,1 @@\n+hi\n", added=1, removed=0),
+                result(),
+                call("write_file", call_id="c2", path="a.txt"),
+                result(call_id="c2"),
+            ],
+        )
+        first, second = results_of(TranscriptReader().read(path))
+        assert first["meta"]["diff_added"] == 1
+        assert "diff" not in second["meta"]
+
+    def test_interleaved_paths_do_not_cross(self, tmp_path: Path):
+        """Two mutations of different files each find their own diff, keyed by
+        the path recorded at their `tool_start`."""
+        path = tmp_path / "e.jsonl"
+        a_diff = "@@ -1,1 +1,1 @@\n-a\n+A\n"
+        b_diff = "@@ -1,1 +1,1 @@\n-b\n+B\n"
+        write_events(
+            path,
+            [
+                call("edit_file", call_id="ca", path="a.rs"),
+                change(path="a.rs", diff=a_diff, added=1, removed=1),
+                result(call_id="ca"),
+                call("edit_file", call_id="cb", path="b.rs"),
+                change(path="b.rs", diff=b_diff, added=1, removed=1),
+                result(call_id="cb"),
+            ],
+        )
+        first, second = results_of(TranscriptReader().read(path))
+        assert first["meta"]["diff"] == a_diff and first["meta"]["diff_path"] == "a.rs"
+        assert second["meta"]["diff"] == b_diff and second["meta"]["diff_path"] == "b.rs"
+
+    def test_the_diff_is_never_capped(self, tmp_path: Path):
+        """The result *body* is middle-elided for the SSE channel's sake; the
+        diff must not be — a mid-hunk elision garbles the render, and the
+        emitter already bounds the diff at the source
+        (`file_touch.rs::changed_region_diff` caps each side)."""
+        path = tmp_path / "e.jsonl"
+        big = "@@ -1,1 +1,999 @@\n" + "".join(f"+line {i}\n" for i in range(999))
+        assert len(big) > TOOL_RESULT_BUDGET
+        write_events(
+            path,
+            [
+                call("write_file", path="big.txt"),
+                change(path="big.txt", diff=big, added=999, removed=0),
+                result(text="Wrote 999 lines to big.txt"),
+            ],
+        )
+        (entry,) = results_of(TranscriptReader().read(path))
+        assert entry["meta"]["diff"] == big

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -47,6 +47,14 @@ import { ProofPanel } from "@/components/arena/proof-panel";
  * - **The rails are the deck's**: `●` opens a call, `⎿` its result, `✗` a
  *   failed one — a distinct glyph *and* column, so a failure is findable by
  *   margin-scan alone (`crates/stella-tui/src/render/row.rs::Rail`).
+ * - **A mutation's diff rides its result row.** A successful `write_file`/
+ *   `edit_file`/`apply_edits`/`delete_file` result carries the `file_change`
+ *   diff its call produced (`meta.diff`, correlated server-side by
+ *   `arenabench.transcript`), rendered GitHub-PR style under the row with
+ *   the emitter's own `+N −M` in the metric column — at most
+ *   `INLINE_DIFF_CAP` lines until disclosed, the fold the deck gives the
+ *   same diff (`crates/stella-tui/src/render/entry.rs`, the `ToolResult`
+ *   arm).
  *
  * Two deliberate departures. The deck renders a call and its result as one
  * tight block that nothing can split, so the result row need not repeat the
@@ -259,6 +267,138 @@ function salientLine(text: string): number {
   }
   return firstNonBlank;
 }
+
+/** Collapsed inline-diff line budget, matching the deck's
+ * `crates/stella-tui/src/render.rs::INLINE_DIFF_CAP` exactly. */
+const INLINE_DIFF_CAP = 20;
+
+type DiffTone = "add" | "remove" | "hunk" | "meta" | "context";
+
+type DiffRow = {
+  /** The raw diff line, `+`/`-` marker included. */
+  text: string;
+  tone: DiffTone;
+  /** The PR-style gutter number — added and context lines numbered on the
+   * new side, removed lines on the old side — or `null` for hunk headers,
+   * file metadata, and lines outside any hunk. */
+  no: number | null;
+};
+
+/** Diff metadata rather than source content (`crates/stella-tui/src/diff.rs::is_meta`). */
+function isDiffMeta(line: string): boolean {
+  return (
+    line.startsWith("+++ ") ||
+    line.startsWith("--- ") ||
+    line.startsWith("diff ") ||
+    line.startsWith("index ")
+  );
+}
+
+/**
+ * One `DiffRow` per diff line, with the gutter tracked from the
+ * `@@ -a,b +c,d @@` hunk headers the way a PR view numbers them — a port of
+ * `crates/stella-tui/src/diff.rs::body_lines`' numbering walk. Tones do not
+ * depend on hunk state (the event path can emit a headerless pseudo-diff of
+ * bare `+`/`-` lines); only the numbers do, so malformed input degrades to
+ * unnumbered coloured text, never a crash. Deliberately *not* ported: the
+ * deck's syntax colouring and intra-line word emphasis, which lean on its
+ * terminal theme machinery.
+ */
+function parseDiff(diff: string): DiffRow[] {
+  let oldNo: number | null = null;
+  let newNo: number | null = null;
+  return splitLines(diff).map((text): DiffRow => {
+    if (text.startsWith("@@")) {
+      const m = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(text);
+      oldNo = m ? parseInt(m[1], 10) : null;
+      newNo = m ? parseInt(m[2], 10) : null;
+      return { text, tone: "hunk", no: null };
+    }
+    if (isDiffMeta(text)) return { text, tone: "meta", no: null };
+    const head = text.charAt(0);
+    if (head === "+") {
+      const no = newNo;
+      if (newNo !== null) newNo += 1;
+      return { text, tone: "add", no };
+    }
+    if (head === "-") {
+      const no = oldNo;
+      if (oldNo !== null) oldNo += 1;
+      return { text, tone: "remove", no };
+    }
+    if (head === " ") {
+      const no = newNo;
+      if (oldNo !== null) oldNo += 1;
+      if (newNo !== null) newNo += 1;
+      return { text, tone: "context", no };
+    }
+    // An elision marker (`… (25 more lines)`) or anything else the emitter
+    // interleaves: rendered plain and unnumbered.
+    return { text, tone: "context", no: null };
+  });
+}
+
+/**
+ * Which diff lines a cap-limited render keeps — the deck's hunk-aware cap
+ * (`crates/stella-tui/src/diff.rs::select_lines`). Whole hunks are emitted
+ * while they fit and the rest dropped, rather than slicing at line `cap`: a
+ * flat cut lands wherever it lands — routinely between a `-` line and the
+ * `+` line replacing it — leaving a change that reads as a pure deletion.
+ * Only when the first hunk alone overruns the budget does this fall back to
+ * a window: the `@@` header (the line that says *where* in the file this
+ * is), then the body from two context lines above the first real change.
+ */
+function selectDiffLines(raw: string[], cap: number): boolean[] {
+  const n = raw.length;
+  if (n <= cap) return raw.map(() => true);
+  const keep = raw.map(() => false);
+  const bounds: number[] = [];
+  raw.forEach((line, i) => {
+    if (line.startsWith("@@")) bounds.push(i);
+  });
+  if ((bounds[0] ?? 1) !== 0) bounds.unshift(0);
+  bounds.push(n);
+
+  let used = 0;
+  for (let w = 0; w + 1 < bounds.length; w++) {
+    const [start, end] = [bounds[w], bounds[w + 1]];
+    if (used + (end - start) > cap) break;
+    keep.fill(true, start, end);
+    used += end - start;
+  }
+  if (used > 0) return keep;
+
+  const end = bounds[1];
+  let firstChange = 0;
+  for (let i = 0; i < end; i++) {
+    if ((raw[i].startsWith("+") || raw[i].startsWith("-")) && !isDiffMeta(raw[i])) {
+      firstChange = i;
+      break;
+    }
+  }
+  const header = raw.slice(0, end).findIndex((line) => line.startsWith("@@"));
+  let budget = cap;
+  if (header !== -1) {
+    keep[header] = true;
+    budget -= 1;
+  }
+  const start = Math.max(firstChange - 2, header === -1 ? 0 : header + 1);
+  for (let i = start; i < end && budget > 0; i++) {
+    if (!keep[i]) {
+      keep[i] = true;
+      budget -= 1;
+    }
+  }
+  return keep;
+}
+
+const DIFF_TONE_TEXT: Record<DiffTone, string> = {
+  add: "text-ok",
+  remove: "text-bad",
+  hunk: "text-dim",
+  meta: "text-dim",
+  context: "text-muted",
+};
 
 /** Frames shown before the fold, matching the deck's `RECALL_PREVIEW`. */
 const RECALL_PREVIEW_FRAMES = 3;
@@ -596,17 +736,47 @@ function Entry({
     const cls = toolClassOf(meta);
     const lines = body ? splitLines(body) : [];
     const total = lines.length;
+    // The mutation's diff, inline under the result — correlated server-side
+    // (`arenabench.transcript`, the `tool_result` arm) and rendered in the
+    // deck's grammar (`crates/stella-tui/src/render/entry.rs`): the metric
+    // column states the emitter's own `+N −M` instead of a line count, the
+    // collapsed row suppresses the output preview (a prose "Applied edit to
+    // …" would restate the call row above it and the diff under it in the
+    // same breath), and the diff shows at most `INLINE_DIFF_CAP` lines until
+    // disclosed. Only a successful mutation carries one, so `isError` never
+    // coincides with a diff.
+    const diffText = typeof meta.diff === "string" ? meta.diff : "";
+    const hasDiff = diffText.length > 0;
+    const diffAll = hasDiff ? parseDiff(diffText) : [];
+    const diffKeep = resultOpen
+      ? diffAll.map(() => true)
+      : selectDiffLines(
+          diffAll.map((row) => row.text),
+          INLINE_DIFF_CAP,
+        );
+    // A lone hunk header is dropped (`diff.rs::body_lines_inline`): inline
+    // under a call row it restates what the gutter beside it already says,
+    // and a two-line change should not cost three rows. With several hunks
+    // the headers stay — there they are the boundary between two disjoint
+    // regions of the file.
+    const multiHunk = diffAll.filter((row) => row.tone === "hunk").length > 1;
+    const diffShown = diffAll.filter(
+      (row, i) => diffKeep[i] && (multiHunk || row.tone !== "hunk"),
+    );
+    const diffHidden = diffKeep.filter((kept) => !kept).length;
     // The collapsed window anchors on the SALIENT line, not line 1 — see
     // `salientLine`'s doc comment — and its size is the deck's own budget: a
     // success shows a single line, a failure shows six.
     const budget = isError ? FAIL_PREVIEW_LINES : OK_PREVIEW_LINES;
     const anchor = total > 0 ? salientLine(body ?? "") : 0;
-    const collapsedShown = lines.slice(anchor, anchor + budget);
+    const collapsedShown = hasDiff ? [] : lines.slice(anchor, anchor + budget);
     const shown = resultOpen ? lines : collapsedShown;
     const hidden = resultOpen ? 0 : total - collapsedShown.length;
     const metrics = [
       meta.duration_ms != null ? fmtDuration(meta.duration_ms) : null,
-      total > 1 ? `${total} lines` : null,
+      // A diff states its own size in `+N −M` — the honest unit for an edit;
+      // "12 lines" would describe the tool's chatter, not the change.
+      total > 1 && !hasDiff ? `${total} lines` : null,
       // ⚡ marks a speculated result: its duration overlapped the model's own
       // streaming instead of following it, so the number is not latency the
       // run actually spent waiting.
@@ -614,6 +784,16 @@ function Entry({
       // The protocol grew a `ToolOutput` arm this page predates. Say so
       // rather than presenting the JSON fallback as if it were output.
       meta.unrecognized ? "unrecognized output shape" : null,
+    ].filter(Boolean);
+    const foldParts = [
+      diffHidden > 0
+        ? `${diffHidden} more diff ${diffHidden === 1 ? "line" : "lines"}`
+        : null,
+      hidden > 0
+        ? hasDiff
+          ? `${hidden} output ${hidden === 1 ? "line" : "lines"}`
+          : `${hidden} more ${hidden === 1 ? "line" : "lines"}`
+        : null,
     ].filter(Boolean);
     return (
       <div>
@@ -626,6 +806,16 @@ function Entry({
           >
             <Highlight text={entry.title ?? "tool"} query={query} />
           </span>
+          {/* The deck's `+N −M`, first in the metric column, from the counts
+              the emitter measured (`meta.diff_added`/`diff_removed`) — never
+              a recount of the rendered hunk, which is a bounded view of the
+              changed region and reports a smaller number. */}
+          {hasDiff && (
+            <span className="text-[10.5px] tabular-nums">
+              <span className="text-ok">+{Number(meta.diff_added ?? 0)}</span>{" "}
+              <span className="text-bad">−{Number(meta.diff_removed ?? 0)}</span>
+            </span>
+          )}
           {metrics.length > 0 && (
             <span className="text-[10.5px] text-dim">· {metrics.join(" · ")}</span>
           )}
@@ -640,12 +830,40 @@ function Entry({
             <Highlight text={shown.join("\n")} query={query} />
           </pre>
         )}
+        {diffShown.length > 0 && (
+          <div className="ml-5 overflow-x-auto text-[11px]">
+            {diffShown.map((row, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "flex",
+                  row.tone === "add" && "bg-ok/10",
+                  row.tone === "remove" && "bg-bad/10",
+                )}
+              >
+                <span className="w-[34px] flex-none select-none pr-1.5 text-right text-[10px] tabular-nums text-dim/70">
+                  {row.no ?? ""}
+                </span>
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 whitespace-pre-wrap break-words",
+                    DIFF_TONE_TEXT[row.tone],
+                  )}
+                >
+                  <Highlight text={row.text} query={query} />
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
         {/* The deck only earns this row for a failure — a successful result
             already states its size in the metric column above. A mouse-driven
             page has no ctrl+o, though, so a folded SUCCESS still gets a quiet
             way to see the rest; it just does not compete for attention the
-            way the failure's does. */}
-        {!resultOpen && hidden > 0 && (
+            way the failure's does. With a diff, the fold names both of the
+            things it hides: the diff's overflow and the output the collapsed
+            row suppressed entirely. */}
+        {!resultOpen && foldParts.length > 0 && (
           <button
             type="button"
             onClick={toggleResult}
@@ -654,10 +872,10 @@ function Entry({
               isError ? "text-dim" : "text-dim/70",
             )}
           >
-            ⋯ {hidden} more {hidden === 1 ? "line" : "lines"}
+            ⋯ {foldParts.join(" · ")}
           </button>
         )}
-        {resultOpen && total > budget && (
+        {resultOpen && (total > budget || hasDiff) && (
           <button
             type="button"
             onClick={toggleResult}
@@ -932,9 +1150,14 @@ function TranscriptView({
         return false;
       }
       if (!needle) return true;
+      // A result's inline diff is part of what the entry shows, so the
+      // search that promises "every entry" must read it too — it lives in
+      // `meta`, not `body`, precisely so the body cap can never garble it.
+      const diff = entry.meta?.diff;
       return (
         (entry.body ?? "").toLowerCase().includes(needle) ||
         (entry.title ?? "").toLowerCase().includes(needle) ||
+        (typeof diff === "string" && diff.toLowerCase().includes(needle)) ||
         (entry.kind === "usage" && usageLine(entry).toLowerCase().includes(needle))
       );
     });


### PR DESCRIPTION
## What & why

The Command Deck renders a mutating tool call's diff inline under the result
row (`crates/stella-tui/src/render/entry.rs`, the `ToolResult` arm). The
arena's `/transcript` page had no equivalent — a `file_change` event was its
own compact-JSON row, never associated with the `tool_result` that produced
it — the one divergence the #3113 deck-parity pass left open, because closing
it means correlating events, not just re-rendering one.

**No wire change was needed.** The correlation the issue anticipated already
exists in the stream's ordering: `ToolRegistry::record_touch` emits
`FileChange` during the tool's execution, so the event precedes its
`tool_result` — the same fact the deck's fold leans on. This PR makes the
arena reader perform the same join the deck performs, entirely inside
`arenabench`:

- **`arenabench/arenabench/transcript.py`** — `tool_start` records the path a
  mutating file tool targets (`write_file`/`edit_file`/`apply_edits`/
  `delete_file`, a port of the deck's `is_file_mutation` +
  `tool_input_path`, `apply_edits` joining through its first edit's path);
  each mutating `file_change` records the path's latest diff with the
  emitter's own `added`/`removed` counts; a **successful** `tool_result`
  joins the two — the same correlate-through-state move the reader already
  makes for the tool's *name* via `state.tool_names` — and carries
  `meta.diff` / `diff_path` / `diff_added` / `diff_removed`. A recency mark
  keeps the join honest (the deck's `FileState::changes` freshness tag,
  translated to a stream): a call that emitted no `file_change` cannot
  inherit an older call's diff, and a failed call never carries one. The
  diff is carried whole, never `cap_middle`d — a mid-hunk elision garbles
  the render, and the emitter already bounds it
  (`file_touch.rs::changed_region_diff` caps each side).
- **`arenabench/ui/components/arena/transcript-page.tsx`** — the
  `tool_result` arm renders the diff GitHub-PR style under the row. Ports
  from the deck, named in the code: the emitter's `+N −M` first in the
  metric column (replacing the line count — the honest unit for an edit);
  the collapsed row suppressing the output preview; the PR-style
  line-number gutter tracked from `@@` headers (`diff.rs::body_lines`); a
  lone hunk header dropped (`body_lines_inline`); and the hunk-aware
  `INLINE_DIFF_CAP = 20` fold (`select_lines` — whole hunks while they fit,
  else a window centred on the first change), behind the page's existing
  disclosure buttons. The transcript search now reads `meta.diff` too, so
  "search across every entry" stays true. Deliberately not ported: the
  deck's syntax colouring and intra-line word emphasis (terminal theme
  machinery), said so in the module comment.

Closes #3110

## The render, in words

Collapsed (an `edit_file` that changed 2/1 lines):

```
0:12  ⎿ edit_file  +2 −1 · 12ms
           1  -old          ← red, bg-bad/10, old-side gutter number
           1  +new          ← green, bg-ok/10, new-side number
           2  +more
           3   context      ← muted, numbered on the new side
```

A diff past 20 lines folds hunk-aware and the quiet button names both things
it hides: `⋯ 14 more diff lines · 1 output line`. Expanded shows the full
output body, the full diff, and `⏶ collapse`. Failures are untouched: only a
successful mutation carries a diff, so `✗` rows render exactly as before.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`arenabench/tests/test_transcript_diff.py` — checked the artisanal way
(`git stash` the reader, run, pop): on `main`'s `transcript.py` the
diff-carrying tests fail with `KeyError: 'diff'`; with this change all 10
pass. Both halves of the issue's contract are pinned: a
`write_file`/`edit_file`/`apply_edits` result carries its diff; a read-only
call's, a failed call's, and a `bash` call's do not. The join's honesty is
its own test class (a diffless second mutation must not resurrect the first
call's diff; interleaved paths must not cross; the diff is never capped).

The React half has no component-test infra in `ui/` (scripts are
`dev`/`build`/`typecheck` only; adding a test framework is a new dependency
this PR does not smuggle in), so it is verified by typecheck + build and the
manual path below.

## The gate

- [x] Python: `cd arenabench && uv run --with pytest --no-project pytest -q`
      (CI's exact invocation, `bench.yml`) — passes except `tests/test_sut.py`,
      which fails identically without this diff for a host fact:
      `/usr/bin/python3 … ModuleNotFoundError: No module named 'tomllib'`
      (pre-3.11 system interpreter; the failure names the interpreter, and
      this diff touches no adapter code). Excluding it:
      `pytest -q --ignore=tests/test_sut.py` → all pass.
- [x] `uvx ruff check arenabench/transcript.py tests/test_transcript_diff.py` — clean
- [x] UI: `npm ci && npm run typecheck && npm run build` in `arenabench/ui/`
      (build regenerates the static export into `arenabench/arenabench/web/`)
- [x] `Closes #3110` in this description **and** as a commit trailer
- Rust gate untouched: no `crates/**` change; `ci.yml`'s required job does not
  trigger on `arenabench/**` — `bench.yml`'s arenabench pytest step is the
  gate for this diff, and it is green locally.

## Manual verification path

1. `cd arenabench/ui && npm ci && npm run build` (writes `arenabench/arenabench/web/`).
2. Drop a fixture stream where a match keeps its trials —
   `<workspace>/matches/<id>/trials/<seat>/<task>/agent/stella-events.jsonl` —
   with the three-event shape `tests/test_transcript_diff.py` uses
   (`tool_start` edit_file → `file_change` with a `diff` → `tool_result` ok),
   or open any real Stella trial: every `edit_file`/`write_file` in a real
   run emits the triple.
3. `arenabench serve`, open `/transcript?match=…&task=…&seat=…`: the result
   row reads `⎿ edit_file  +N −M · <duration>` with the coloured, numbered
   diff under it; the `tools`/`results` filters, search (diff text is
   searchable), and "load full transcript" all keep working — the full fetch
   carries the same meta.

## Nothing left behind

- #3200 — the `file_change` row still dumps its compact JSON (escaped diff
  included) directly above the result row that now renders the same diff;
  deciding that row's future shape is a presentation call with an
  information-loss edge (an uncorrelated mutation's diff has nowhere else to
  live today), filed as a handoff rather than smuggled in here.

## Summary by Sourcery

Correlate mutating file tool results with their corresponding file change events so arena transcripts can display inline diffs for edits, matching Command Deck behavior.

New Features:
- Render GitHub-style inline diffs under successful mutating file tool result rows on the arena transcript page, including +N/−M change metrics and hunk-aware folding.
- Enable transcript search to match against inline diff text in addition to entry titles and bodies.

Enhancements:
- Extend the arena transcript reader to track file mutation paths and latest diffs, attaching uncapped diff metadata to successful write/edit/apply_edits/delete_file results while preserving correctness for non-mutating, failed, and read-only calls.

Tests:
- Add dedicated transcript reader tests that exercise diff correlation, path handling, mutation freshness, and uncapped diff propagation across various tool and file_change event sequences.