### PR TITLE
feat(stella-tools): search caches gathered per-file context, invalidated by content identity

### DIFF
--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -107,6 +107,7 @@
 //! (#3032) is about what is *sent* in the schema menu, not about what exists.
 
 use std::path::Path;
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -117,8 +118,11 @@ use stella_protocol::tool::{ToolOutput, ToolSchema};
 
 use crate::registry::Tool;
 
+pub(crate) mod cache;
 pub(crate) mod enrich;
 pub(crate) mod scan;
+
+use cache::GatherCache;
 
 #[cfg(test)]
 mod tests;
@@ -273,22 +277,44 @@ impl SearchConfig {
 }
 
 /// The one way to find code.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Default)]
 pub struct Search {
     config: SearchConfig,
+    /// The session's gathered-context cache (#3163). It lives on the tool
+    /// instance because the registry holds one `Search` for the whole
+    /// session, which is exactly the lifetime the cache wants — and a
+    /// `Mutex` because `execute` takes `&self`; the lock is only ever held
+    /// across the synchronous render, never an await.
+    cache: Mutex<GatherCache>,
 }
 
 impl Search {
     /// A `search` running at an explicit depth and budget.
     #[must_use]
     pub fn with_config(config: SearchConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            cache: Mutex::new(GatherCache::default()),
+        }
     }
 
     /// A `search` running at the configured depth ([`SearchConfig::from_env`]).
     #[must_use]
     pub fn from_env() -> Self {
         Self::with_config(SearchConfig::from_env())
+    }
+
+    /// One search through this instance's session cache — the exact
+    /// mechanism `execute` runs, split out so a test can drive the same
+    /// instance twice with a pinned [`Resolution`] instead of reading the
+    /// process environment under a parallel suite.
+    pub(crate) async fn report_cached(
+        &self,
+        root: &Path,
+        query: &str,
+        resolution: Resolution,
+    ) -> SearchReport {
+        report_with(root, query, self.config, resolution, &self.cache).await
     }
 }
 
@@ -366,15 +392,18 @@ impl Tool for Search {
                 return ToolOutput::from(err);
             }
         };
-        // Validation (the blank-query refusal included) lives in [`report`],
-        // so this door and the CLI's `stella search` cannot drift apart.
-        search(root, query, self.config).await
+        // Validation (the blank-query refusal included) lives in
+        // [`report_with`], so this door and the CLI's `stella search` cannot
+        // drift apart.
+        self.report_cached(root, query, stella_embed::from_env())
+            .await
+            .rendered
     }
 }
 
 /// The refusal both doors return for a blank query. One string, one place:
 /// the tool's `execute` and the CLI's `stella search` reach it through the
-/// same [`report`] path, so the wording cannot fork between them.
+/// same [`report_with`] path, so the wording cannot fork between them.
 const QUERY_REQUIRED: &str = "`query` is required: what you are looking for, as a question, a \
                               description of the behaviour, or a symbol name — e.g. \"where \
                               request headers are sanitized\" or \"CredentialStore\"";
@@ -443,15 +472,13 @@ impl SearchReport {
     }
 }
 
-/// One `search` end to end, rendered — the agent's door.
-pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
-    report(root, query, config).await.rendered
-}
-
 /// One `search` end to end, as a [`SearchReport`] — the CLI's door
-/// (`stella search --format json`), and the single mechanism the tool's own
-/// `search` wraps, so a scripted test and an agent call exercise identical
-/// code.
+/// (`stella search --format json`), and the same mechanism the tool's
+/// `execute` wraps through `Search::report_cached`, so a scripted test and
+/// an agent call exercise identical code. The one difference is deliberate:
+/// this door gathers into a cache that dies with the call, because the CLI
+/// process runs one search and exits — session-lifetime reuse belongs to the
+/// tool instance that has a session.
 ///
 /// `open_or_build` runs a full `index_all` catch-up pass, which its contract
 /// says an async caller must wrap in `spawn_blocking`. The handle is then held
@@ -460,19 +487,28 @@ pub(crate) async fn search(root: &Path, query: &str, config: SearchConfig) -> To
 /// than it saves. This is `semantic_code_search`'s discipline, deliberately
 /// unchanged (`crate::graph::semantic`).
 pub async fn report(root: &Path, query: &str, config: SearchConfig) -> SearchReport {
-    report_with(root, query, config, stella_embed::from_env()).await
+    report_with(
+        root,
+        query,
+        config,
+        stella_embed::from_env(),
+        &Mutex::new(GatherCache::default()),
+    )
+    .await
 }
 
 /// [`report`], with the embedder's resolution passed in rather than read from
 /// the process environment — the pure half of the `resolve`/`from_env` split
 /// `stella_embed` itself uses, and the seam that lets a test drive the
 /// misconfigured-embedder path without mutating the environment under a
-/// parallel suite.
+/// parallel suite — and with the gathered-context cache the rendering may
+/// serve repeat hits from (#3163).
 pub(crate) async fn report_with(
     root: &Path,
     query: &str,
     config: SearchConfig,
     resolution: Resolution,
+    cache: &Mutex<GatherCache>,
 ) -> SearchReport {
     let query = query.trim();
     if query.is_empty() {
@@ -516,7 +552,16 @@ pub(crate) async fn report_with(
         }
     };
 
-    let output = render(graph.as_ref(), root, query, &answer, config);
+    let output = {
+        // Poisoning here means a peer search panicked mid-render. Every cache
+        // mutation is a single `Vec` operation, so the state a panic leaves
+        // is still coherent — recovering it beats losing the session's cache
+        // (the discipline `crate::process` already applies to its table).
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        render(graph.as_ref(), root, query, &answer, config, &mut cache)
+    };
     if let Some(graph) = graph {
         graph.shutdown();
     }
@@ -1190,6 +1235,7 @@ pub(crate) fn render(
     query: &str,
     answer: &Answer,
     config: SearchConfig,
+    cache: &mut GatherCache,
 ) -> ToolOutput {
     let allocation: Allocation = allocate(answer.hits.len(), config.depth, config.budget);
 
@@ -1219,7 +1265,7 @@ pub(crate) fn render(
 
     for (hit, depth) in answer.hits.iter().zip(&allocation.granted) {
         content.push('\n');
-        content.push_str(&enrich::render_hit(graph, root, hit, *depth));
+        content.push_str(&enrich::render_hit(graph, root, hit, *depth, cache));
     }
 
     if allocation.truncated() {

--- a/crates/stella-tools/src/search/cache.rs
+++ b/crates/stella-tools/src/search/cache.rs
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The per-file gathered-context cache behind `search`'s enrichment (#3163).
+//!
+//! # What is cached, and against what identity
+//!
+//! Rendering one hit gathers the file's [`FileNeighborhood`] — symbols,
+//! kinds, imports, importers — from the code graph before any facet is
+//! written. Within a session the same files rank again and again, and each
+//! re-gather re-runs the same SQLite reads to reproduce an answer nothing has
+//! invalidated. This cache keeps that bundle keyed by
+//! **(path, content identity)**, where the identity is a SHA-256 over the
+//! file's bytes as read for rendering.
+//!
+//! The bytes themselves are the invalidation authority, deliberately, rather
+//! than the git blob sha #3163 opens with: a content hash needs no
+//! subprocess, works in a workspace that is not a git checkout at all, and
+//! makes the dirty-file case the issue calls out disappear instead of needing
+//! a bypass — an uncommitted edit simply *is* different bytes, so it can
+//! never be served an entry gathered from the old ones. The renderer already
+//! reads the file on every call (the source feeds the signature, doc and body
+//! facets), so the identity costs one hash over bytes that are in hand, and
+//! the source-derived facets are always rendered from the fresh read — only
+//! the graph lookups are skipped on a hit.
+//!
+//! A file whose bytes cannot be read as UTF-8 has no identity here and
+//! bypasses the cache entirely: it is gathered fresh every time, which is the
+//! conservative direction.
+//!
+//! # The precision boundary
+//!
+//! Symbols, kinds and import *specifiers* are functions of the file's own
+//! bytes, so the key invalidates them exactly. Two facts in the bundle are
+//! drawn from the rest of the tree: the `importers` list, and the resolution
+//! of an import specifier to a path. Those can go one index generation stale
+//! while the file itself is unchanged — file B gaining an import of A does
+//! not change A's bytes, so A's cached entry keeps its old importers until A
+//! changes or the entry is evicted. The per-symbol facets (callers, callees,
+//! body spans) are **not** cached and stay live for this reason. Tightening
+//! the cross-file half — e.g. keying entries additionally by an index
+//! generation stamp — is #3196.
+//!
+//! # The bound
+//!
+//! [`MAX_ENTRIES`] entries, least-recently-used out first. A `Vec` scanned
+//! linearly is the right structure at this size: 256 entries is a few pages
+//! of pointers, a lookup touches at most one screen of memory, and the
+//! workspace already carries no LRU crate to reach for.
+
+use sha2::{Digest, Sha256};
+use stella_graph::FileNeighborhood;
+
+/// The most files whose gathered context one session retains. Past this the
+/// least-recently-used entry is evicted; see the module docs for why the
+/// bound is a small constant rather than a knob.
+pub(crate) const MAX_ENTRIES: usize = 256;
+
+/// One cached gather: the neighborhood as the graph answered it, pinned to
+/// the bytes the file had when it was gathered.
+#[derive(Debug)]
+struct GatherEntry {
+    /// Workspace-relative, forward-slash — `Hit::path`'s spelling.
+    path: String,
+    /// SHA-256 of the file's bytes at gather time ([`content_identity`]).
+    identity: [u8; 32],
+    neighborhood: FileNeighborhood,
+}
+
+/// The session-lifetime cache, owned by the `Search` tool instance. Recency
+/// order: the last entry is the most recently used.
+#[derive(Debug, Default)]
+pub(crate) struct GatherCache {
+    entries: Vec<GatherEntry>,
+    /// How many times a neighborhood was gathered from the graph — the
+    /// witness counter for #3163: unchanged across a repeat search that was
+    /// served from cache, incremented again once the file's bytes change.
+    #[cfg(test)]
+    pub(super) gathered: usize,
+}
+
+impl GatherCache {
+    /// The cached neighborhood for `path`, if one exists **and** its identity
+    /// still matches. An entry whose identity does not match is removed on
+    /// the spot — the file changed, and a stale bundle must not survive to
+    /// be served by a later buggy caller.
+    pub(crate) fn lookup(&mut self, path: &str, identity: &[u8; 32]) -> Option<FileNeighborhood> {
+        let position = self.entries.iter().position(|entry| entry.path == path)?;
+        if self.entries[position].identity != *identity {
+            self.entries.remove(position);
+            return None;
+        }
+        // Move to the back: most recently used, last to be evicted.
+        let entry = self.entries.remove(position);
+        let neighborhood = entry.neighborhood.clone();
+        self.entries.push(entry);
+        Some(neighborhood)
+    }
+
+    /// Retain `neighborhood` for `path` under `identity`, evicting the
+    /// least-recently-used entry once the bound is reached.
+    pub(crate) fn store(
+        &mut self,
+        path: String,
+        identity: [u8; 32],
+        neighborhood: FileNeighborhood,
+    ) {
+        if let Some(position) = self.entries.iter().position(|entry| entry.path == path) {
+            self.entries.remove(position);
+        }
+        self.entries.push(GatherEntry {
+            path,
+            identity,
+            neighborhood,
+        });
+        if self.entries.len() > MAX_ENTRIES {
+            self.entries.remove(0);
+        }
+    }
+}
+
+/// The content identity a cache entry is keyed by: SHA-256 over the file's
+/// bytes as read for rendering. See the module docs for why this — and not
+/// the git blob sha — is the invalidation authority.
+pub(crate) fn content_identity(source: &str) -> [u8; 32] {
+    Sha256::digest(source.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use stella_core::search::Depth;
+    use stella_embed::Resolution;
+    use stella_graph::CodeGraph;
+    use stella_protocol::tool::ToolOutput;
+
+    use super::super::{Hit, Search, SearchConfig, enrich};
+    use super::{GatherCache, MAX_ENTRIES, content_identity};
+
+    /// Two files, one call edge between them, indexed the way the direct
+    /// `dispatch`/`render` tests index (`<root>/codegraph.db`).
+    fn indexed_workspace(workspace: &Path) -> (std::path::PathBuf, CodeGraph) {
+        write_sources(workspace);
+        let root = workspace.canonicalize().expect("canonicalize");
+        let graph = CodeGraph::open(&root, &root.join("codegraph.db")).expect("open");
+        graph.index_all().expect("index");
+        (root, graph)
+    }
+
+    fn write_sources(workspace: &Path) {
+        let src = workspace.join("src");
+        fs::create_dir_all(&src).expect("mkdir");
+        fs::write(src.join("callee.rs"), "pub fn cached_target() {}\n").expect("write");
+        fs::write(
+            src.join("caller.rs"),
+            "pub fn calling_site() {\n    cached_target();\n}\n",
+        )
+        .expect("write");
+    }
+
+    fn neighborhood_named(file: &str) -> stella_graph::FileNeighborhood {
+        stella_graph::FileNeighborhood {
+            file: file.into(),
+            ..Default::default()
+        }
+    }
+
+    /// **The #3163 witness, cache half.** The second render of an unchanged
+    /// file must not re-gather from the graph — and must render
+    /// byte-identically to the miss that populated the cache, which is the
+    /// fidelity contract the issue states.
+    #[test]
+    fn a_repeat_render_of_an_unchanged_file_is_served_from_cache_byte_identically() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let (root, graph) = indexed_workspace(workspace.path());
+        let hit = Hit {
+            path: "src/callee.rs".into(),
+            why: "fixture".into(),
+            focus: None,
+        };
+        let mut cache = GatherCache::default();
+
+        let first = enrich::render_hit(Some(&graph), &root, &hit, Depth::new(8), &mut cache);
+        assert!(
+            first.contains("symbols: cached_target"),
+            "the fixture must actually enrich, or this test proves nothing: {first}"
+        );
+        assert_eq!(cache.gathered, 1, "the first render gathers from the graph");
+
+        let second = enrich::render_hit(Some(&graph), &root, &hit, Depth::new(8), &mut cache);
+        assert_eq!(
+            first, second,
+            "a cache hit must render byte-identically to the miss that populated it"
+        );
+        assert_eq!(
+            cache.gathered, 1,
+            "the second render of an unchanged file must be served from cache, not re-gathered"
+        );
+
+        graph.shutdown();
+    }
+
+    /// **The #3163 witness, invalidation half.** Changing the file's bytes
+    /// must invalidate its entry: the next render re-gathers and shows the
+    /// new content, never the cached snapshot of the old bytes.
+    #[test]
+    fn a_mutated_file_is_regathered_never_served_stale() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let (root, graph) = indexed_workspace(workspace.path());
+        let hit = Hit {
+            path: "src/callee.rs".into(),
+            why: "fixture".into(),
+            focus: None,
+        };
+        let mut cache = GatherCache::default();
+        let stale = enrich::render_hit(Some(&graph), &root, &hit, Depth::new(8), &mut cache);
+        assert!(!stale.contains("appended_later"));
+        assert_eq!(cache.gathered, 1);
+
+        fs::write(
+            root.join("src/callee.rs"),
+            "pub fn cached_target() {}\npub fn appended_later() {}\n",
+        )
+        .expect("write");
+        // What every real call does before rendering: `open_or_build`'s
+        // catch-up pass, so the graph reflects the new bytes.
+        graph.index_all().expect("re-index");
+
+        let fresh = enrich::render_hit(Some(&graph), &root, &hit, Depth::new(8), &mut cache);
+        assert!(
+            fresh.contains("appended_later"),
+            "the changed file was served from a stale cache entry: {fresh}"
+        );
+        assert_eq!(
+            cache.gathered, 2,
+            "the changed file must be re-gathered, not served from cache"
+        );
+
+        graph.shutdown();
+    }
+
+    /// The tool holds one cache for its whole session: a repeat `search`
+    /// through the same instance is answered without re-gathering, and the
+    /// two answers are byte-identical end to end.
+    #[tokio::test]
+    async fn one_tool_instance_serves_repeat_searches_from_its_session_cache() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        write_sources(workspace.path());
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let tool = Search::with_config(SearchConfig::default());
+
+        let first = tool
+            .report_cached(&root, "cached_target", Resolution::Unconfigured)
+            .await;
+        assert_eq!(
+            first.hits.first().map(|hit| hit.path.as_str()),
+            Some("src/callee.rs"),
+            "the exact rung must find the fixture symbol: {:?}",
+            first.hits
+        );
+        let gathered = tool.cache.lock().expect("lock").gathered;
+        assert!(gathered > 0, "the first search must gather");
+
+        let second = tool
+            .report_cached(&root, "cached_target", Resolution::Unconfigured)
+            .await;
+        assert_eq!(
+            rendered(&first.rendered),
+            rendered(&second.rendered),
+            "the cached answer must be byte-identical to the one that populated it"
+        );
+        assert_eq!(
+            tool.cache.lock().expect("lock").gathered,
+            gathered,
+            "the repeat search through the same tool instance re-gathered"
+        );
+    }
+
+    fn rendered(output: &ToolOutput) -> &str {
+        match output {
+            ToolOutput::Ok { content } => content,
+            ToolOutput::Error { message, .. } => panic!("expected an answer, got: {message}"),
+        }
+    }
+
+    /// A path whose bytes changed is removed on lookup, and the removal is
+    /// final — a later lookup under the *old* identity must not resurrect it.
+    #[test]
+    fn a_changed_identity_removes_the_entry_instead_of_serving_it() {
+        let mut cache = GatherCache::default();
+        cache.store("a.rs".into(), [1; 32], neighborhood_named("a.rs"));
+        assert!(cache.lookup("a.rs", &[2; 32]).is_none());
+        assert!(
+            cache.lookup("a.rs", &[1; 32]).is_none(),
+            "the stale entry must be flushed, not kept for a caller with older bytes"
+        );
+    }
+
+    /// The bound holds, and eviction is least-recently-used: a full cache
+    /// drops the entry nothing has touched, never the one just served.
+    #[test]
+    fn the_bound_evicts_the_least_recently_used_entry() {
+        let mut cache = GatherCache::default();
+        for index in 0..MAX_ENTRIES {
+            let path = format!("file{index}.rs");
+            cache.store(path.clone(), [7; 32], neighborhood_named(&path));
+        }
+        // Touch the oldest entry so the *second*-oldest becomes the victim.
+        assert!(cache.lookup("file0.rs", &[7; 32]).is_some());
+
+        cache.store(
+            "overflow.rs".into(),
+            [7; 32],
+            neighborhood_named("overflow.rs"),
+        );
+        assert!(cache.entries.len() <= MAX_ENTRIES, "the bound must hold");
+        assert!(
+            cache.lookup("file1.rs", &[7; 32]).is_none(),
+            "the least-recently-used entry is the one evicted"
+        );
+        assert!(
+            cache.lookup("file0.rs", &[7; 32]).is_some(),
+            "a just-served entry must survive the eviction"
+        );
+        assert!(cache.lookup("overflow.rs", &[7; 32]).is_some());
+    }
+
+    /// Storing a path twice replaces the entry rather than duplicating it.
+    #[test]
+    fn restoring_a_path_replaces_its_entry() {
+        let mut cache = GatherCache::default();
+        cache.store("a.rs".into(), [1; 32], neighborhood_named("a.rs"));
+        cache.store("a.rs".into(), [2; 32], neighborhood_named("a.rs"));
+        assert_eq!(cache.entries.len(), 1);
+        assert!(cache.lookup("a.rs", &[1; 32]).is_none());
+        // The [1; 32] miss above flushed the entry — by design; re-store and
+        // confirm the newest identity is the one that serves.
+        cache.store("a.rs".into(), [2; 32], neighborhood_named("a.rs"));
+        assert!(cache.lookup("a.rs", &[2; 32]).is_some());
+    }
+
+    /// The identity is over bytes, so any byte matters — including a
+    /// trailing newline a diff viewer would hide.
+    #[test]
+    fn the_identity_distinguishes_any_byte_change() {
+        assert_ne!(
+            content_identity("pub fn a() {}"),
+            content_identity("pub fn a() {}\n")
+        );
+        assert_eq!(content_identity("same"), content_identity("same"));
+    }
+}

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -28,9 +28,10 @@
 use std::path::Path;
 
 use stella_core::search::{Depth, Facet, facets_at};
-use stella_graph::{CodeGraph, NeighborhoodSymbol};
+use stella_graph::{CodeGraph, FileNeighborhood, NeighborhoodSymbol};
 
 use super::Hit;
+use super::cache::{self, GatherCache};
 
 /// Symbols named per hit. Past this the list stops being a summary.
 const MAX_SYMBOLS: usize = 8;
@@ -48,11 +49,17 @@ const MAX_BODY_LINES: usize = 40;
 /// know all degrade to fewer lines, never to an error. A search that failed
 /// to enrich a hit still found the hit, and losing the whole answer over a
 /// detail line would be the worst possible trade.
+///
+/// The neighborhood comes through `cache` ([`gathered_neighborhood`]); the
+/// source is read fresh on every call, both because it is the cache's
+/// invalidation identity and because the facets derived from it must describe
+/// the bytes on disk now, not the bytes at gather time.
 pub(crate) fn render_hit(
     graph: Option<&CodeGraph>,
     root: &Path,
     hit: &Hit,
     depth: Depth,
+    cache: &mut GatherCache,
 ) -> String {
     let facets = facets_at(depth);
     // `Facet::Path` is the header and is present at every depth by
@@ -62,7 +69,9 @@ pub(crate) fn render_hit(
     let Some(graph) = graph else {
         return block;
     };
-    let Ok(neighborhood) = graph.file_neighborhood(Path::new(&hit.path)) else {
+    let source = std::fs::read_to_string(root.join(&hit.path)).ok();
+    let Some(neighborhood) = gathered_neighborhood(cache, graph, &hit.path, source.as_deref())
+    else {
         return block;
     };
     // The matched symbol leads the detailed facets when the ranking named
@@ -84,7 +93,6 @@ pub(crate) fn render_hit(
         )
         .take(MAX_DETAILED_SYMBOLS)
         .collect();
-    let source = std::fs::read_to_string(root.join(&hit.path)).ok();
 
     for facet in facets {
         let line =
@@ -162,6 +170,37 @@ pub(crate) fn render_hit(
         }
     }
     block
+}
+
+/// The file's neighborhood, from the session cache when the file's bytes
+/// still match the entry, and from the graph otherwise (#3163).
+///
+/// `source` doubles as the cache key: `None` (an unreadable or non-UTF-8
+/// file) has no identity to validate against, so it bypasses the cache in
+/// both directions — gathered fresh, never stored. A graph the query fails
+/// against degrades to `None` exactly as the un-cached gather did, and is
+/// likewise never stored.
+fn gathered_neighborhood(
+    cache: &mut GatherCache,
+    graph: &CodeGraph,
+    path: &str,
+    source: Option<&str>,
+) -> Option<FileNeighborhood> {
+    let identity = source.map(cache::content_identity);
+    if let Some(identity) = &identity
+        && let Some(neighborhood) = cache.lookup(path, identity)
+    {
+        return Some(neighborhood);
+    }
+    let neighborhood = graph.file_neighborhood(Path::new(path)).ok()?;
+    #[cfg(test)]
+    {
+        cache.gathered += 1;
+    }
+    if let Some(identity) = identity {
+        cache.store(path.to_string(), identity, neighborhood.clone());
+    }
+    Some(neighborhood)
 }
 
 /// `    label: a, b, c` — or nothing at all when there is nothing to say.

--- a/crates/stella-tools/src/search/tests.rs
+++ b/crates/stella-tools/src/search/tests.rs
@@ -19,6 +19,7 @@ use stella_embed::{EmbedError, Embedder, EmbedderFingerprint, Embedding, Similar
 use stella_graph::CodeGraph;
 use stella_protocol::tool::ToolOutput;
 
+use super::cache::GatherCache;
 use super::{
     ChunkWarmOutcome, Hit, Search, SearchConfig, Strategy, dispatch, render, warm_chunk_vectors,
 };
@@ -275,6 +276,7 @@ async fn one_search_call_answers_what_today_takes_several_tools() {
             depth: Depth::new(8),
             budget: 200_000,
         },
+        &mut GatherCache::default(),
     );
     let content = content_of(&output);
     assert!(
@@ -368,6 +370,7 @@ async fn without_an_embedder_the_answer_is_useful_and_says_it_is_a_name_match() 
         "scrub",
         &answer,
         SearchConfig::default(),
+        &mut GatherCache::default(),
     ));
     assert!(
         content.contains("symbol NAMES (not by meaning)"),
@@ -409,6 +412,7 @@ async fn with_no_index_at_all_the_file_scan_answers_and_labels_itself() {
         "credential rotation",
         &answer,
         SearchConfig::default(),
+        &mut GatherCache::default(),
     ));
     assert!(
         content.contains("no index was available"),
@@ -444,6 +448,7 @@ async fn each_depth_renders_a_superset_of_the_one_below() {
                 depth: Depth::new(level),
                 budget: 200_000,
             },
+            &mut GatherCache::default(),
         ));
         content
             .lines()
@@ -492,6 +497,7 @@ async fn the_default_answer_carries_the_body_without_a_follow_up_read() {
         QUESTION,
         &answer,
         SearchConfig::default(),
+        &mut GatherCache::default(),
     ));
     assert!(
         content.contains("signature:"),
@@ -613,6 +619,7 @@ async fn a_misconfigured_embedder_note_joins_the_cut_list_note_instead_of_replac
         "widget",
         SearchConfig::default(),
         stella_embed::Resolution::Incomplete("STELLA_EMBED_MODEL is unset".into()),
+        &std::sync::Mutex::new(GatherCache::default()),
     )
     .await;
 
@@ -817,6 +824,7 @@ async fn the_matched_symbol_leads_the_detailed_facets() {
         "sensitive credentials",
         &answer,
         SearchConfig::default(),
+        &mut GatherCache::default(),
     ));
     assert!(
         content.contains("body of `scrub_credentials`"),
@@ -857,6 +865,7 @@ async fn caller_entries_carry_their_site_not_a_placeholder() {
             focus: None,
         },
         Depth::new(8),
+        &mut GatherCache::default(),
     );
     assert!(
         block.contains("callers:"),
@@ -901,6 +910,7 @@ fn a_truncated_answer_says_it_was_truncated() {
             depth: Depth::MIN,
             budget: 130,
         },
+        &mut GatherCache::default(),
     ));
     assert!(
         content.contains("TRUNCATED"),
@@ -921,6 +931,7 @@ fn a_truncated_answer_says_it_was_truncated() {
             depth: Depth::MIN,
             budget: 100_000,
         },
+        &mut GatherCache::default(),
     ));
     assert!(
         !roomy.contains("TRUNCATED"),
@@ -1016,6 +1027,7 @@ fn the_rendered_hit_count_matches_the_allocation() {
         "anything",
         &answer,
         config,
+        &mut GatherCache::default(),
     ));
 
     let shown = hits


### PR DESCRIPTION
## What & why

Implements the smallest coherent slice of #3163: `search`'s enrichment gathers each hit's `FileNeighborhood` (symbols, kinds, imports, importers) from the code graph on every call, even when nothing about the file changed since the previous search in the same session. The `Search` tool now owns a **session-lifetime, in-process cache** of that gathered bundle:

- **Key**: `(path, sha256 of the file's bytes)` — `crates/stella-tools/src/search/cache.rs`.
- **Bound**: 256 entries, least-recently-used out first (move-to-front `Vec`; the workspace carries no LRU crate and this stays dependency-free — no new deps).
- **Seam**: one function, `gathered_neighborhood` in `crates/stella-tools/src/search/enrich.rs`; the cache lives on the `Search` struct because the registry holds one instance per session (`registry.rs:533`), threaded through `report_with` and locked only across the synchronous render.

**The identity choice, justified**: a content hash of the file bytes rather than the issue's git last-change sha — it needs no subprocess per lookup, is correct in a workspace that is not a git checkout, and dissolves the issue's dirty-file problem instead of special-casing it: an uncommitted edit *is* a different identity, so a dirty file can never be served an entry gathered from other bytes. The renderer already reads the file every call for the signature/doc/body facets, so the identity hashes bytes already in hand and those facets always render from the fresh read — a hit skips only the graph lookups.

**Where this diverges from the issue's fuller proposal, deliberately** (the issue lists these as open design questions; this PR takes the per-file-granularity branch it names as "composes and invalidates precisely"):
- No cross-session persistence, no `.stella/private/` store, no domain grouping via `domains.toml`, no warm pre-gather — that half is filed as a handoff in #3198.
- Per-file identity keys are exact for every fact that is a function of the file's own bytes; the two cross-file facets in the bundle (`importers`, import-path resolution) can go one index generation stale while the file itself is unchanged. The per-symbol facets (callers, callees, body spans) are deliberately **not** cached and stay live for this reason. The boundary is documented in the module docs and tracked as #3196.
- "A dirty file is never served from cache" is met more strongly than written: it is served, correctly, keyed to its dirty bytes.
- No disclosure line on cached answers: a hit renders **byte-identically** to the miss that populated it (asserted in tests), so within this slice fidelity is never affected — the issue's own condition for disclosure.

Exemplars: the `Mutex`-poisoning recovery follows `crate::process`'s table discipline; the env-free test seam extends the existing `report_with` split; the test-only gather counter is a `#[cfg(test)]` hook, matching the crate's `block_index_writes` test-seam precedent.

Closes #3163

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two-sided, in `crates/stella-tools/src/search/cache.rs::tests`:

1. **Cache half** — `a_repeat_render_of_an_unchanged_file_is_served_from_cache_byte_identically`: two renders of the same hit through one cache; the second performs zero graph gathers (counter pinned) and the outputs are byte-equal. `one_tool_instance_serves_repeat_searches_from_its_session_cache` proves the same end-to-end through the tool's own door, twice on one instance.
2. **Invalidation half** — `a_mutated_file_is_regathered_never_served_stale`: the file's bytes change between renders (graph re-indexed, as every real call does); the second render re-gathers and shows the new symbol.

Checked the artisanal way: with `GatherCache::lookup` neutered to always miss, the cache-half witnesses fail (and the invalidation test still passes, as it must for a trivially-fresh cache); restored, all pass. On `main` the tests do not exist and the seam does not compile.

## The gate

- [x] `cargo fmt --check` (crate-clean)
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings`
- [x] `cargo test -p stella-tools` — 1003 lib tests + integration suites green
- [x] rustdoc `-D warnings` on the crate
- [x] Docs updated where behavior changed (module docs in `cache.rs`, `search.rs`, `enrich.rs`; no flag or schema changes — the advertised tool schema is byte-identical)
- [x] CLA signed
- [x] `Closes #3163` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #3196 (cross-file facet staleness under per-file identity keys, with the generation-stamp design sketch and the constraint that the live session watcher defeats a flush-on-own-pass scheme), #3198 (the domain-grouped, cross-session, git-authority half of #3163, as a handoff)

Also noticed but out of scope, covered inside #3196/#3198's seam notes: the `GraphNames` ranking rung sweeps `file_neighborhood` across every indexed file per query — a larger gather cost than the render-phase one this PR caches, but it belongs to ranking, not per-hit context, and restructuring ranking was explicitly out of scope.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (`sha2` was already a dependency of this crate)
- [x] No new outbound network calls

## Anything reviewers should know?

`Search` lost `Clone, Copy` (it now owns a `Mutex<GatherCache>`); the registry's `Arc<Search>` and both constructors are unchanged in shape. The free `search()` wrapper folded into `Search::report_cached` so the tool door and the CLI door still share one validation path (`QUERY_REQUIRED` cannot fork). `stella search` (one process, one query) gathers into a per-call cache — behavior unchanged there by design.

Refs #3154, #3162.

## Summary by Sourcery

Introduce a session-lifetime, per-file content-identity cache for search enrichment to avoid redundant graph neighborhood gathers while preserving answer fidelity and correct behavior for modified files.

New Features:
- Add a gathered-context cache owned by the Search tool instance, keyed by file path and SHA-256 of file contents, with an LRU bound.
- Expose a report_cached path on Search so agent calls and tests reuse the same session cache behavior.

Enhancements:
- Refactor search rendering to thread the cache through report/report_with/render and enrich::render_hit, using file contents as the cache invalidation identity.
- Document the cache behavior, precision boundary, and CLI vs tool-session lifetimes in module and function docs.
- Adjust Search to hold a Mutex-protected cache and drop Clone/Copy semantics accordingly.

Tests:
- Add cache-focused tests that verify repeat renders of unchanged files are served from cache byte-identically and that mutated files are re-gathered and never served stale.
- Add tests that exercise LRU eviction behavior, identity correctness, and session-level cache reuse across multiple searches on the same tool instance.