### PR TITLE
fix(stella-cli): --tools '*:off,…' advertises exactly the requested set

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -386,7 +386,7 @@ async fn run_pipeline_one_shot(
         let permitted = PolicyToolSet::new(&interactive, session_tool_policy(cfg));
         // Outermost: the discovery layer (tool_search/skill_search/mcp_search)
         // must see the complete advertised catalog below it.
-        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&permitted, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed);
 
         let ws_ports = workspace_ports(
@@ -1991,7 +1991,7 @@ async fn run_turn(
         let permitted = PolicyToolSet::new(&interactive, session_tool_policy(cfg));
         // Outermost discovery layer; the session-scoped `activated` handle
         // keeps lean-mode activations across the per-turn stack rebuild.
-        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&permitted, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed)
             .with_activation(activated.clone());
         let hook_runner = ShellHookRunner;

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -588,7 +588,7 @@ pub(crate) async fn run_goal_turn(
             .with_ask_user(tty_ask_io(human_is_present(true)))
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
         let permitted = PolicyToolSet::new(&interactive, session_tool_policy(cfg));
-        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&permitted, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed);
         // Inline skill invocations (#2682) ride the engine's steering seam:
         // arm the queue and publish it as this turn's steering, so an
@@ -804,7 +804,7 @@ async fn run_goal_pipeline_turn(
             .with_ask_user(tty_ask_io(human_is_present(true)))
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
         let permitted = PolicyToolSet::new(&interactive, session_tool_policy(cfg));
-        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&permitted, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed)
             .with_sub_agent_dispatcher(sub_agents);
         // Inline skill invocations (#2682): armed here because the ports

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -218,7 +218,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
             .with_ask_user(tty_ask_io(human_is_present(true)))
             .with_skill_registry(SkillRegistry::from_env(cfg.workspace_root.clone()));
         let permitted = PolicyToolSet::new(&interactive, session_tool_policy(cfg));
-        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&permitted, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed);
         let hook_runner = ShellHookRunner;
         match restored {

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -4231,7 +4231,7 @@ async fn run_lead_turn(
         // Discovery layer above the policy filter (it must see the full
         // *permitted* catalog), below the taps (searches are read-only; taps
         // watch writes).
-        let tools = crate::discovery::DiscoveryToolSet::new(&gated, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&gated, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed)
             .with_activation(activated.clone());
         let tapped = TaskTap {

--- a/crates/stella-cli/src/command_deck/pipeline_turn.rs
+++ b/crates/stella-cli/src/command_deck/pipeline_turn.rs
@@ -105,7 +105,7 @@ pub(super) async fn run_lead_pipeline_turn(
             hunk_io,
             cfg.workspace_root.clone(),
         );
-        let tools = crate::discovery::DiscoveryToolSet::new(&gated, cfg.workspace_root.clone())
+        let tools = crate::discovery::DiscoveryToolSet::for_session(&gated, cfg)
             .with_project_prompts_allowed(cfg.authority.project_prompts_allowed)
             .with_activation(activated.clone());
         let tapped = TaskTap {

--- a/crates/stella-cli/src/discovery.rs
+++ b/crates/stella-cli/src/discovery.rs
@@ -39,6 +39,16 @@
 //! OUTERMOST (wrapping `InteractiveToolSet`), because only the outermost
 //! layer sees the complete advertised catalog. The MCP registry lookup goes
 //! through the [`McpRegistrySearch`] port so tests never touch the network.
+//!
+//! Being outermost has a price: the operator's `PolicyToolSet` sits *below*
+//! this layer, so the four tools this layer itself mounts (`tool_search`,
+//! `skill_search`, `mcp_search`, `invoke_skill`) never pass through that
+//! filter. This layer therefore re-applies the same [`ToolPolicy`] to its own
+//! additions — withheld from [`ToolExecutor::schemas`] and refused by
+//! [`ToolExecutor::execute`], the policy's two-sided shape — which is what
+//! keeps `--tools "*:off,…"` honest on the wire (#3120). Lean *hiding* stays
+//! permissive on execute; that is a prompt-budget measure, not a gate, and
+//! the two must not be confused.
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
@@ -49,6 +59,7 @@ use serde_json::Value;
 use stella_core::discovery::{Candidate, DiscoveryQuery, parse_query, rank};
 use stella_core::ports::ToolExecutor;
 use stella_protocol::{ToolOutput, ToolSchema};
+use stella_tools::policy::ToolPolicy;
 
 pub const TOOL_SEARCH: &str = "tool_search";
 pub const SKILL_SEARCH: &str = "skill_search";
@@ -229,6 +240,11 @@ pub struct DiscoveryToolSet<'a> {
     lean: Option<LeanConfig>,
     activated: ActivatedTools,
     include_workspace_skills: bool,
+    /// The operator's tool switches, re-applied to this layer's own four
+    /// tools: everything below is already filtered by `PolicyToolSet`, but
+    /// discovery's additions are advertised and executed *above* it, which
+    /// is how they used to escape `--tools "*:off,…"` entirely (#3120).
+    policy: ToolPolicy,
     /// The `invoke_skill` session tool (#2682) — mounted here because this
     /// is the layer that already owns `skill_search`, and an invocation's
     /// allowed-tools grant must scope the same complete surface discovery
@@ -237,10 +253,34 @@ pub struct DiscoveryToolSet<'a> {
 }
 
 impl<'a> DiscoveryToolSet<'a> {
-    /// Wrap `inner` with the discovery tools. Lean mode comes from
+    /// Wrap `inner` with the discovery tools for a real session: the layer's
+    /// own additions are filtered and gated by the session's operator policy
+    /// — the same one the `PolicyToolSet` below enforces — so a `--tools` or
+    /// settings deny reaches them too (#3120). Lean mode comes from
     /// [`LEAN_TOOLS_ENV`]; activation state is fresh — callers with a session
     /// loop should pass a persistent handle via [`Self::with_activation`].
+    pub fn for_session(inner: &'a dyn ToolExecutor, cfg: &crate::config::Config) -> Self {
+        Self::with_parts(
+            inner,
+            cfg.workspace_root.clone(),
+            crate::agent::session_tool_policy(cfg),
+        )
+    }
+
+    /// Wrap `inner` with the discovery tools and an allow-all policy. Test
+    /// scaffolding only: every production stack has a `Config` and goes
+    /// through [`Self::for_session`], which is what keeps the operator policy
+    /// attached to this layer's own additions (#3120).
+    #[cfg(test)]
     pub fn new(inner: &'a dyn ToolExecutor, workspace_root: PathBuf) -> Self {
+        Self::with_parts(inner, workspace_root, ToolPolicy::allow_all())
+    }
+
+    fn with_parts(
+        inner: &'a dyn ToolExecutor,
+        workspace_root: PathBuf,
+        policy: ToolPolicy,
+    ) -> Self {
         Self {
             inner,
             registry: Box::new(HttpMcpRegistrySearch {
@@ -251,6 +291,7 @@ impl<'a> DiscoveryToolSet<'a> {
             lean: lean_from_env(),
             activated: new_activation(),
             include_workspace_skills: false,
+            policy,
         }
     }
 
@@ -306,6 +347,13 @@ impl<'a> DiscoveryToolSet<'a> {
     #[cfg(test)]
     pub fn with_lean(mut self, lean: Option<LeanConfig>) -> Self {
         self.lean = lean;
+        self
+    }
+
+    /// Override the operator policy (tests build stacks without a `Config`).
+    #[cfg(test)]
+    pub fn with_policy(mut self, policy: ToolPolicy) -> Self {
+        self.policy = policy;
         self
     }
 
@@ -759,7 +807,14 @@ impl ToolExecutor for DiscoveryToolSet<'_> {
             schemas.retain(|s| lean.core.contains(&s.name) || activated.contains(&s.name));
         }
         if advertise_discovery {
-            schemas.extend(self.discovery_schemas());
+            // The operator's switches, re-applied to this layer's own
+            // additions: everything below is already policy-filtered, but
+            // these four ride above the `PolicyToolSet` (#3120).
+            schemas.extend(
+                self.discovery_schemas()
+                    .into_iter()
+                    .filter(|schema| self.policy.allows(&schema.name)),
+            );
         }
         // A live skill's allowed-tools grant narrows the whole advertised
         // surface, this layer's own tools included (#2682).
@@ -774,6 +829,18 @@ impl ToolExecutor for DiscoveryToolSet<'_> {
         // so the effective surface is structurally grant ∩ operator.
         if let Some(refusal) = self.invoke.grant_refusal(name) {
             return refusal;
+        }
+        // The four names this layer owns never reach the `PolicyToolSet`
+        // below, so the operator's gate is applied here — with the same
+        // wording, so a policy-denied tool is indistinguishable from one
+        // that was never built (#3120). Only policy gates: lean hiding stays
+        // permissive on execute, by design.
+        if matches!(
+            name,
+            TOOL_SEARCH | SKILL_SEARCH | MCP_SEARCH | crate::invoke_skill::INVOKE_SKILL
+        ) && !self.policy.allows(name)
+        {
+            return ToolOutput::error(format!("unknown tool: {name}"));
         }
         match name {
             TOOL_SEARCH => self.execute_tool_search(input).await,
@@ -978,487 +1045,4 @@ pub(crate) fn declared_discovery_schemas() -> Vec<ToolSchema> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A fake session stack: a few natives plus two MCP servers' tools.
-    struct FakeInner;
-
-    fn schema(name: &str, description: &str, read_only: bool) -> ToolSchema {
-        ToolSchema {
-            name: name.into(),
-            description: description.into(),
-            input_schema: serde_json::json!({"type": "object"}),
-            read_only,
-            // Irrelevant to these discovery tests - the searches never speculate.
-            speculation_safe: false,
-        }
-    }
-
-    #[async_trait]
-    impl ToolExecutor for FakeInner {
-        fn schemas(&self) -> Vec<ToolSchema> {
-            vec![
-                schema("read_file", "Read a file with line numbers", true),
-                schema("bash", "Run a shell command", false),
-                schema("screenshot", "Capture a screenshot", true),
-                schema(
-                    "search_issues",
-                    "Search the configured issue tracker by keywords",
-                    true,
-                ),
-                schema(
-                    "mcp__github__list_commits",
-                    "List commits on a GitHub branch",
-                    true,
-                ),
-                schema(
-                    "mcp__linear__list_issues",
-                    "List Linear issues in the workspace",
-                    true,
-                ),
-            ]
-        }
-        async fn execute(&self, name: &str, _input: &Value) -> ToolOutput {
-            ToolOutput::Ok {
-                content: format!("inner ran {name}"),
-            }
-        }
-    }
-
-    /// A scripted registry: returns a fixed page, records nothing.
-    struct StubRegistry;
-
-    #[async_trait]
-    impl McpRegistrySearch for StubRegistry {
-        async fn search(
-            &self,
-            _query: &str,
-            _limit: u32,
-        ) -> Result<stella_mcp::RegistryPage, String> {
-            Ok(stella_mcp::RegistryPage {
-                entries: vec![stella_mcp::RegistryEntry {
-                    server: stella_mcp::RegistryServer {
-                        name: "io.github.acme/postgres-mcp".into(),
-                        description: Some("Query Postgres databases over MCP".into()),
-                        title: None,
-                        version: Some("1.2.0".into()),
-                        repository: None,
-                        packages: Vec::new(),
-                        remotes: Vec::new(),
-                    },
-                    status: Some("active".into()),
-                    is_latest: Some(true),
-                    updated_at: None,
-                }],
-                next_cursor: None,
-                count: Some(1),
-            })
-        }
-    }
-
-    fn full_set(inner: &FakeInner, root: PathBuf) -> DiscoveryToolSet<'_> {
-        DiscoveryToolSet::new(inner, root)
-            .with_lean(None)
-            .with_registry_search(Box::new(StubRegistry))
-    }
-
-    fn content(out: ToolOutput) -> String {
-        match out {
-            ToolOutput::Ok { content } => content,
-            ToolOutput::Error { message, .. } => panic!("expected Ok, got error: {message}"),
-        }
-    }
-
-    /// The mount is where `ToolExecutor::active_skill_slugs` stops being the
-    /// empty default (#2685): a span begun on the shared tracking handle must
-    /// surface to the engine through the port, and end structurally with its
-    /// guard — this is the wiring that lets a live skill body survive an
-    /// overflow-summarization splice.
-    #[test]
-    fn a_live_invocation_span_surfaces_through_the_executor_port() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        assert!(set.active_skill_slugs().is_empty(), "nothing live yet");
-        let span = set.active_skill_invocations().begin("release-notes");
-        assert_eq!(
-            set.active_skill_slugs(),
-            vec!["release-notes".to_string()],
-            "the engine-facing port must see the live invocation"
-        );
-        drop(span);
-        assert!(
-            set.active_skill_slugs().is_empty(),
-            "teardown is structural — the dropped guard ends the span"
-        );
-    }
-
-    #[tokio::test]
-    async fn schemas_add_the_discovery_trio_on_top_of_inner() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
-        for expected in [TOOL_SEARCH, SKILL_SEARCH, MCP_SEARCH, "bash", "read_file"] {
-            assert!(names.contains(&expected.to_string()), "missing {expected}");
-        }
-        // All three are read-only, so the goal verifier's ReadOnlyTools keeps them.
-        for s in set.schemas() {
-            if [TOOL_SEARCH, SKILL_SEARCH, MCP_SEARCH].contains(&s.name.as_str()) {
-                assert!(s.read_only, "{} must be read-only", s.name);
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn non_discovery_tools_fall_through_to_inner() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        match set.execute("bash", &Value::Null).await {
-            ToolOutput::Ok { content } => assert_eq!(content, "inner ran bash"),
-            other => panic!("expected fallthrough, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn tool_search_ranks_and_labels_mcp_tools() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        let out = content(
-            set.execute(
-                TOOL_SEARCH,
-                &serde_json::json!({"query": "+github commits"}),
-            )
-            .await,
-        );
-        let first_hit = out.lines().nth(1).expect("a first hit line");
-        assert!(
-            first_hit.contains("mcp__github__list_commits") && first_hit.contains("(MCP: github)"),
-            "got: {out}"
-        );
-        assert!(
-            !out.contains("mcp__linear__"),
-            "+github must exclude linear tools: {out}"
-        );
-    }
-
-    #[tokio::test]
-    async fn tool_search_select_form_reports_unknown_names() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        let out = content(
-            set.execute(
-                TOOL_SEARCH,
-                &serde_json::json!({"query": "select:bash,no_such_tool"}),
-            )
-            .await,
-        );
-        assert!(out.contains("1. bash"), "got: {out}");
-        assert!(out.contains("not found: no_such_tool"), "got: {out}");
-    }
-
-    #[tokio::test]
-    async fn tool_search_requires_a_query() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        assert!(
-            set.execute(TOOL_SEARCH, &serde_json::json!({}))
-                .await
-                .is_error()
-        );
-        assert!(
-            set.execute(TOOL_SEARCH, &serde_json::json!({"query": "  "}))
-                .await
-                .is_error()
-        );
-    }
-
-    #[tokio::test]
-    async fn lean_mode_advertises_only_core_plus_discovery_until_a_search_activates() {
-        let inner = FakeInner;
-        let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
-            .with_registry_search(Box::new(StubRegistry))
-            .with_lean(Some(LeanConfig {
-                core: ["read_file", "bash"]
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-                discovery: true,
-            }));
-
-        let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
-        assert!(names.contains(&"read_file".to_string()));
-        assert!(names.contains(&TOOL_SEARCH.to_string()));
-        assert!(
-            !names.iter().any(|n| n.starts_with("mcp__")),
-            "lean mode must hide non-core tools: {names:?}"
-        );
-
-        // A search for the hidden tool activates it…
-        let _ = set
-            .execute(TOOL_SEARCH, &serde_json::json!({"query": "github commits"}))
-            .await;
-        let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
-        assert!(
-            names.contains(&"mcp__github__list_commits".to_string()),
-            "a searched tool must be advertised afterwards: {names:?}"
-        );
-    }
-
-    /// #896: lean mode used to advertise three text-search tools and hide both
-    /// structural ones behind `tool_search`. A model that does not know the
-    /// code graph exists has no reason to search for it, so the discovery step
-    /// never fires and lean sessions are pinned to grep by construction.
-    #[test]
-    fn the_lean_core_advertises_the_structural_retrieval_tools() {
-        let core = LeanConfig::default_core().core;
-        for name in ["graph_query", "read_symbol"] {
-            assert!(
-                core.contains(name),
-                "{name} must be advertised without a tool_search first: {core:?}"
-            );
-        }
-        // Still a *lean* core — the text tools it competes with stay, and the
-        // long tail stays behind discovery.
-        assert!(core.contains("grep") && core.contains("glob"));
-        assert!(!core.contains("screenshot"));
-    }
-
-    #[tokio::test]
-    async fn lean_mode_still_executes_hidden_tools_by_name() {
-        let inner = FakeInner;
-        let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
-            .with_registry_search(Box::new(StubRegistry))
-            .with_lean(Some(LeanConfig {
-                core: HashSet::new(),
-                discovery: true,
-            }));
-        match set.execute("screenshot", &Value::Null).await {
-            ToolOutput::Ok { content } => assert_eq!(content, "inner ran screenshot"),
-            other => panic!("hidden tools must still execute, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn lean_activation_survives_a_tool_stack_rebuild_via_the_shared_handle() {
-        let inner = FakeInner;
-        let activation = new_activation();
-        let lean = Some(LeanConfig {
-            core: HashSet::new(),
-            discovery: true,
-        });
-        {
-            let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
-                .with_registry_search(Box::new(StubRegistry))
-                .with_lean(lean.clone())
-                .with_activation(activation.clone());
-            let _ = set
-                .execute(TOOL_SEARCH, &serde_json::json!({"query": "github commits"}))
-                .await;
-        }
-        // A NEW per-turn stack with the same session handle still advertises
-        // the activated tool.
-        let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
-            .with_registry_search(Box::new(StubRegistry))
-            .with_lean(lean)
-            .with_activation(activation);
-        let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
-        assert!(names.contains(&"mcp__github__list_commits".to_string()));
-    }
-
-    /// Write a skill in the ecosystem layout under the given root.
-    fn write_skill(root: &std::path::Path, slug: &str, description: &str, body: &str) {
-        let dir = root.join(".stella/skills").join(slug);
-        std::fs::create_dir_all(&dir).expect("skill dir");
-        std::fs::write(
-            dir.join("SKILL.md"),
-            format!("---\nname: {slug}\ndescription: {description}\n---\n{body}\n"),
-        )
-        .expect("skill file");
-    }
-
-    /// Run one skill_search against a workspace with HOME redirected to an
-    /// empty tempdir, so the developer's real user-global skills can't leak
-    /// into assertions. Sync on purpose: the env lock must be held across
-    /// the whole mutation window, and holding a `MutexGuard` across an
-    /// `.await` trips `clippy::await_holding_lock` — so the async execute
-    /// runs on a local runtime inside the sync scope instead.
-    fn skill_search_with_isolated_home(ws: &std::path::Path, input: Value) -> String {
-        let _lock = crate::test_env::lock();
-        let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
-        let home = tempfile::tempdir().expect("home");
-        unsafe { std::env::set_var("HOME", home.path()) };
-
-        let inner = FakeInner;
-        let set = full_set(&inner, ws.to_path_buf()).with_project_prompts_allowed(true);
-        let out = tokio::runtime::Runtime::new()
-            .expect("runtime")
-            .block_on(set.execute(SKILL_SEARCH, &input));
-
-        content(out)
-    }
-
-    #[test]
-    fn skill_search_finds_installed_skills_and_returns_the_body_on_request() {
-        let ws = tempfile::tempdir().expect("ws");
-        write_skill(
-            ws.path(),
-            "sql-formatting",
-            "How this repo formats SQL migrations",
-            "Always uppercase keywords.",
-        );
-        write_skill(
-            ws.path(),
-            "release-notes",
-            "Writing release notes for the changelog",
-            "Lead with user impact.",
-        );
-
-        let out = skill_search_with_isolated_home(
-            ws.path(),
-            serde_json::json!({"query": "sql migrations", "include_body": true}),
-        );
-
-        let first_hit = out.lines().nth(1).expect("a first hit line");
-        assert!(first_hit.contains("sql-formatting"), "got: {out}");
-        assert!(
-            out.contains("Always uppercase keywords."),
-            "include_body must return the top match's instructions: {out}"
-        );
-    }
-
-    #[test]
-    fn skill_search_with_no_match_points_at_the_public_registry() {
-        let ws = tempfile::tempdir().expect("ws");
-        let out =
-            skill_search_with_isolated_home(ws.path(), serde_json::json!({"query": "kubernetes"}));
-        assert!(out.contains("search_skills"), "got: {out}");
-    }
-
-    #[tokio::test]
-    async fn mcp_search_workspace_scope_merges_config_and_connected_servers() {
-        let ws = tempfile::tempdir().expect("ws");
-        std::fs::create_dir_all(ws.path().join(".stella")).expect("dir");
-        std::fs::write(
-            ws.path().join(".stella/mcp.toml"),
-            "[servers.linear]\ntransport = \"http\"\nurl = \"https://mcp.linear.app/mcp\"\n\
-             [servers.offline]\ntransport = \"stdio\"\ncmd = \"npx\"\n",
-        )
-        .expect("mcp.toml");
-
-        let inner = FakeInner;
-        let set = full_set(&inner, ws.path().to_path_buf());
-        let out = content(
-            set.execute(MCP_SEARCH, &serde_json::json!({"query": "linear issues"}))
-                .await,
-        );
-        assert!(out.contains("linear"), "got: {out}");
-        assert!(
-            out.contains("mcp__linear__list_issues"),
-            "the server's matching tools must be listed: {out}"
-        );
-        // `github` is connected but absent from mcp.toml — still findable.
-        let out = content(
-            set.execute(MCP_SEARCH, &serde_json::json!({"query": "github commits"}))
-                .await,
-        );
-        assert!(out.contains("github"), "got: {out}");
-    }
-
-    #[tokio::test]
-    async fn mcp_search_registry_scope_lists_installable_servers() {
-        let ws = tempfile::tempdir().expect("ws");
-        let inner = FakeInner;
-        let set = full_set(&inner, ws.path().to_path_buf());
-        let out = content(
-            set.execute(
-                MCP_SEARCH,
-                &serde_json::json!({"query": "postgres", "scope": "registry"}),
-            )
-            .await,
-        );
-        assert!(out.contains("io.github.acme/postgres-mcp"), "got: {out}");
-        assert!(
-            out.contains("stella mcp install io.github.acme/postgres-mcp"),
-            "an install hint must be present: {out}"
-        );
-    }
-
-    #[tokio::test]
-    async fn mcp_search_rejects_an_unknown_scope() {
-        let inner = FakeInner;
-        let set = full_set(&inner, std::env::temp_dir());
-        assert!(
-            set.execute(
-                MCP_SEARCH,
-                &serde_json::json!({"query": "x", "scope": "everywhere"})
-            )
-            .await
-            .is_error()
-        );
-    }
-
-    #[test]
-    fn lean_env_parsing_covers_all_forms() {
-        let _lock = crate::test_env::lock();
-        let cases: &[(&str, Option<usize>, bool)] = &[
-            ("0", None, false),
-            ("false", None, false),
-            ("", None, false),
-            ("1", Some(DEFAULT_CORE_TOOLS.len()), true),
-            ("true", Some(DEFAULT_CORE_TOOLS.len()), true),
-            ("read_file, bash", Some(2), true),
-            ("only:read_file, bash", Some(2), false),
-        ];
-        for (value, expected_core_len, expected_discovery) in cases {
-            unsafe { std::env::set_var(LEAN_TOOLS_ENV, value) };
-            let lean = lean_from_env();
-            assert_eq!(
-                lean.as_ref().map(|l| l.core.len()),
-                *expected_core_len,
-                "for env value {value:?}"
-            );
-            if let Some(lean) = &lean {
-                assert_eq!(
-                    lean.discovery, *expected_discovery,
-                    "for env value {value:?}"
-                );
-            }
-        }
-        unsafe { std::env::remove_var(LEAN_TOOLS_ENV) };
-        assert_eq!(lean_from_env(), None);
-    }
-
-    /// The lean core may not withhold a tool the static prompt *commands*.
-    ///
-    /// Not "every tool the prompt names" — the prompts mention plenty that
-    /// lean mode deliberately hides behind `tool_search`, and asserting that
-    /// would be asserting #3033's unbuilt design. The narrow, true property is
-    /// about the imperative: the prompt opens by naming its five tools, so a
-    /// lean core missing any of them ships instructions the session cannot
-    /// obey. `search` joined the core with the five-tool prompt (#3079's
-    /// lean-core half: the prompt now advertises it first, so a core without
-    /// it would be the exact mismatch this test exists to prevent).
-    ///
-    /// Anti-vacuity is the first assertion: the mandate is read out of
-    /// `prompt.rs` at compile time, so deleting the sentence fails this test
-    /// rather than silently satisfying it.
-    #[test]
-    fn the_lean_core_offers_every_tool_the_prompt_commands() {
-        const PROMPT_SOURCE: &str = include_str!("agent/prompt.rs");
-        const MANDATE: &str = "Your tools are search, read_file, edit_file, write_file, and bash.";
-        assert!(
-            PROMPT_SOURCE.contains(MANDATE),
-            "the prompt no longer carries {MANDATE:?} — re-derive this test \
-             from whatever replaced it rather than deleting it"
-        );
-        let core = LeanConfig::default_core().core;
-        for tool in ["search", "read_file", "edit_file", "write_file", "bash"] {
-            assert!(
-                core.contains(tool),
-                "the prompt names {tool} in its tool mandate and the lean \
-                 core does not advertise it — a session whose instructions \
-                 name a tool it cannot see"
-            );
-        }
-    }
-}
+mod tests;

--- a/crates/stella-cli/src/discovery/tests.rs
+++ b/crates/stella-cli/src/discovery/tests.rs
@@ -1,0 +1,479 @@
+use super::*;
+
+/// A fake session stack: a few natives plus two MCP servers' tools.
+struct FakeInner;
+
+fn schema(name: &str, description: &str, read_only: bool) -> ToolSchema {
+    ToolSchema {
+        name: name.into(),
+        description: description.into(),
+        input_schema: serde_json::json!({"type": "object"}),
+        read_only,
+        // Irrelevant to these discovery tests - the searches never speculate.
+        speculation_safe: false,
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for FakeInner {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![
+            schema("read_file", "Read a file with line numbers", true),
+            schema("bash", "Run a shell command", false),
+            schema("screenshot", "Capture a screenshot", true),
+            schema(
+                "search_issues",
+                "Search the configured issue tracker by keywords",
+                true,
+            ),
+            schema(
+                "mcp__github__list_commits",
+                "List commits on a GitHub branch",
+                true,
+            ),
+            schema(
+                "mcp__linear__list_issues",
+                "List Linear issues in the workspace",
+                true,
+            ),
+        ]
+    }
+    async fn execute(&self, name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: format!("inner ran {name}"),
+        }
+    }
+}
+
+/// A scripted registry: returns a fixed page, records nothing.
+struct StubRegistry;
+
+#[async_trait]
+impl McpRegistrySearch for StubRegistry {
+    async fn search(&self, _query: &str, _limit: u32) -> Result<stella_mcp::RegistryPage, String> {
+        Ok(stella_mcp::RegistryPage {
+            entries: vec![stella_mcp::RegistryEntry {
+                server: stella_mcp::RegistryServer {
+                    name: "io.github.acme/postgres-mcp".into(),
+                    description: Some("Query Postgres databases over MCP".into()),
+                    title: None,
+                    version: Some("1.2.0".into()),
+                    repository: None,
+                    packages: Vec::new(),
+                    remotes: Vec::new(),
+                },
+                status: Some("active".into()),
+                is_latest: Some(true),
+                updated_at: None,
+            }],
+            next_cursor: None,
+            count: Some(1),
+        })
+    }
+}
+
+fn full_set(inner: &FakeInner, root: PathBuf) -> DiscoveryToolSet<'_> {
+    DiscoveryToolSet::new(inner, root)
+        .with_lean(None)
+        .with_registry_search(Box::new(StubRegistry))
+}
+
+fn content(out: ToolOutput) -> String {
+    match out {
+        ToolOutput::Ok { content } => content,
+        ToolOutput::Error { message, .. } => panic!("expected Ok, got error: {message}"),
+    }
+}
+
+/// The mount is where `ToolExecutor::active_skill_slugs` stops being the
+/// empty default (#2685): a span begun on the shared tracking handle must
+/// surface to the engine through the port, and end structurally with its
+/// guard — this is the wiring that lets a live skill body survive an
+/// overflow-summarization splice.
+#[test]
+fn a_live_invocation_span_surfaces_through_the_executor_port() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    assert!(set.active_skill_slugs().is_empty(), "nothing live yet");
+    let span = set.active_skill_invocations().begin("release-notes");
+    assert_eq!(
+        set.active_skill_slugs(),
+        vec!["release-notes".to_string()],
+        "the engine-facing port must see the live invocation"
+    );
+    drop(span);
+    assert!(
+        set.active_skill_slugs().is_empty(),
+        "teardown is structural — the dropped guard ends the span"
+    );
+}
+
+#[tokio::test]
+async fn schemas_add_the_discovery_trio_on_top_of_inner() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
+    for expected in [TOOL_SEARCH, SKILL_SEARCH, MCP_SEARCH, "bash", "read_file"] {
+        assert!(names.contains(&expected.to_string()), "missing {expected}");
+    }
+    // All three are read-only, so the goal verifier's ReadOnlyTools keeps them.
+    for s in set.schemas() {
+        if [TOOL_SEARCH, SKILL_SEARCH, MCP_SEARCH].contains(&s.name.as_str()) {
+            assert!(s.read_only, "{} must be read-only", s.name);
+        }
+    }
+}
+
+#[tokio::test]
+async fn non_discovery_tools_fall_through_to_inner() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    match set.execute("bash", &Value::Null).await {
+        ToolOutput::Ok { content } => assert_eq!(content, "inner ran bash"),
+        other => panic!("expected fallthrough, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn tool_search_ranks_and_labels_mcp_tools() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    let out = content(
+        set.execute(
+            TOOL_SEARCH,
+            &serde_json::json!({"query": "+github commits"}),
+        )
+        .await,
+    );
+    let first_hit = out.lines().nth(1).expect("a first hit line");
+    assert!(
+        first_hit.contains("mcp__github__list_commits") && first_hit.contains("(MCP: github)"),
+        "got: {out}"
+    );
+    assert!(
+        !out.contains("mcp__linear__"),
+        "+github must exclude linear tools: {out}"
+    );
+}
+
+#[tokio::test]
+async fn tool_search_select_form_reports_unknown_names() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    let out = content(
+        set.execute(
+            TOOL_SEARCH,
+            &serde_json::json!({"query": "select:bash,no_such_tool"}),
+        )
+        .await,
+    );
+    assert!(out.contains("1. bash"), "got: {out}");
+    assert!(out.contains("not found: no_such_tool"), "got: {out}");
+}
+
+#[tokio::test]
+async fn tool_search_requires_a_query() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    assert!(
+        set.execute(TOOL_SEARCH, &serde_json::json!({}))
+            .await
+            .is_error()
+    );
+    assert!(
+        set.execute(TOOL_SEARCH, &serde_json::json!({"query": "  "}))
+            .await
+            .is_error()
+    );
+}
+
+#[tokio::test]
+async fn lean_mode_advertises_only_core_plus_discovery_until_a_search_activates() {
+    let inner = FakeInner;
+    let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+        .with_registry_search(Box::new(StubRegistry))
+        .with_lean(Some(LeanConfig {
+            core: ["read_file", "bash"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            discovery: true,
+        }));
+
+    let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
+    assert!(names.contains(&"read_file".to_string()));
+    assert!(names.contains(&TOOL_SEARCH.to_string()));
+    assert!(
+        !names.iter().any(|n| n.starts_with("mcp__")),
+        "lean mode must hide non-core tools: {names:?}"
+    );
+
+    // A search for the hidden tool activates it…
+    let _ = set
+        .execute(TOOL_SEARCH, &serde_json::json!({"query": "github commits"}))
+        .await;
+    let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
+    assert!(
+        names.contains(&"mcp__github__list_commits".to_string()),
+        "a searched tool must be advertised afterwards: {names:?}"
+    );
+}
+
+/// #896: lean mode used to advertise three text-search tools and hide both
+/// structural ones behind `tool_search`. A model that does not know the
+/// code graph exists has no reason to search for it, so the discovery step
+/// never fires and lean sessions are pinned to grep by construction.
+#[test]
+fn the_lean_core_advertises_the_structural_retrieval_tools() {
+    let core = LeanConfig::default_core().core;
+    for name in ["graph_query", "read_symbol"] {
+        assert!(
+            core.contains(name),
+            "{name} must be advertised without a tool_search first: {core:?}"
+        );
+    }
+    // Still a *lean* core — the text tools it competes with stay, and the
+    // long tail stays behind discovery.
+    assert!(core.contains("grep") && core.contains("glob"));
+    assert!(!core.contains("screenshot"));
+}
+
+#[tokio::test]
+async fn lean_mode_still_executes_hidden_tools_by_name() {
+    let inner = FakeInner;
+    let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+        .with_registry_search(Box::new(StubRegistry))
+        .with_lean(Some(LeanConfig {
+            core: HashSet::new(),
+            discovery: true,
+        }));
+    match set.execute("screenshot", &Value::Null).await {
+        ToolOutput::Ok { content } => assert_eq!(content, "inner ran screenshot"),
+        other => panic!("hidden tools must still execute, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn lean_activation_survives_a_tool_stack_rebuild_via_the_shared_handle() {
+    let inner = FakeInner;
+    let activation = new_activation();
+    let lean = Some(LeanConfig {
+        core: HashSet::new(),
+        discovery: true,
+    });
+    {
+        let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+            .with_registry_search(Box::new(StubRegistry))
+            .with_lean(lean.clone())
+            .with_activation(activation.clone());
+        let _ = set
+            .execute(TOOL_SEARCH, &serde_json::json!({"query": "github commits"}))
+            .await;
+    }
+    // A NEW per-turn stack with the same session handle still advertises
+    // the activated tool.
+    let set = DiscoveryToolSet::new(&inner, std::env::temp_dir())
+        .with_registry_search(Box::new(StubRegistry))
+        .with_lean(lean)
+        .with_activation(activation);
+    let names: Vec<String> = set.schemas().into_iter().map(|s| s.name).collect();
+    assert!(names.contains(&"mcp__github__list_commits".to_string()));
+}
+
+/// Write a skill in the ecosystem layout under the given root.
+fn write_skill(root: &std::path::Path, slug: &str, description: &str, body: &str) {
+    let dir = root.join(".stella/skills").join(slug);
+    std::fs::create_dir_all(&dir).expect("skill dir");
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {slug}\ndescription: {description}\n---\n{body}\n"),
+    )
+    .expect("skill file");
+}
+
+/// Run one skill_search against a workspace with HOME redirected to an
+/// empty tempdir, so the developer's real user-global skills can't leak
+/// into assertions. Sync on purpose: the env lock must be held across
+/// the whole mutation window, and holding a `MutexGuard` across an
+/// `.await` trips `clippy::await_holding_lock` — so the async execute
+/// runs on a local runtime inside the sync scope instead.
+fn skill_search_with_isolated_home(ws: &std::path::Path, input: Value) -> String {
+    let _lock = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["HOME"]);
+    let home = tempfile::tempdir().expect("home");
+    unsafe { std::env::set_var("HOME", home.path()) };
+
+    let inner = FakeInner;
+    let set = full_set(&inner, ws.to_path_buf()).with_project_prompts_allowed(true);
+    let out = tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(set.execute(SKILL_SEARCH, &input));
+
+    content(out)
+}
+
+#[test]
+fn skill_search_finds_installed_skills_and_returns_the_body_on_request() {
+    let ws = tempfile::tempdir().expect("ws");
+    write_skill(
+        ws.path(),
+        "sql-formatting",
+        "How this repo formats SQL migrations",
+        "Always uppercase keywords.",
+    );
+    write_skill(
+        ws.path(),
+        "release-notes",
+        "Writing release notes for the changelog",
+        "Lead with user impact.",
+    );
+
+    let out = skill_search_with_isolated_home(
+        ws.path(),
+        serde_json::json!({"query": "sql migrations", "include_body": true}),
+    );
+
+    let first_hit = out.lines().nth(1).expect("a first hit line");
+    assert!(first_hit.contains("sql-formatting"), "got: {out}");
+    assert!(
+        out.contains("Always uppercase keywords."),
+        "include_body must return the top match's instructions: {out}"
+    );
+}
+
+#[test]
+fn skill_search_with_no_match_points_at_the_public_registry() {
+    let ws = tempfile::tempdir().expect("ws");
+    let out =
+        skill_search_with_isolated_home(ws.path(), serde_json::json!({"query": "kubernetes"}));
+    assert!(out.contains("search_skills"), "got: {out}");
+}
+
+#[tokio::test]
+async fn mcp_search_workspace_scope_merges_config_and_connected_servers() {
+    let ws = tempfile::tempdir().expect("ws");
+    std::fs::create_dir_all(ws.path().join(".stella")).expect("dir");
+    std::fs::write(
+        ws.path().join(".stella/mcp.toml"),
+        "[servers.linear]\ntransport = \"http\"\nurl = \"https://mcp.linear.app/mcp\"\n\
+         [servers.offline]\ntransport = \"stdio\"\ncmd = \"npx\"\n",
+    )
+    .expect("mcp.toml");
+
+    let inner = FakeInner;
+    let set = full_set(&inner, ws.path().to_path_buf());
+    let out = content(
+        set.execute(MCP_SEARCH, &serde_json::json!({"query": "linear issues"}))
+            .await,
+    );
+    assert!(out.contains("linear"), "got: {out}");
+    assert!(
+        out.contains("mcp__linear__list_issues"),
+        "the server's matching tools must be listed: {out}"
+    );
+    // `github` is connected but absent from mcp.toml — still findable.
+    let out = content(
+        set.execute(MCP_SEARCH, &serde_json::json!({"query": "github commits"}))
+            .await,
+    );
+    assert!(out.contains("github"), "got: {out}");
+}
+
+#[tokio::test]
+async fn mcp_search_registry_scope_lists_installable_servers() {
+    let ws = tempfile::tempdir().expect("ws");
+    let inner = FakeInner;
+    let set = full_set(&inner, ws.path().to_path_buf());
+    let out = content(
+        set.execute(
+            MCP_SEARCH,
+            &serde_json::json!({"query": "postgres", "scope": "registry"}),
+        )
+        .await,
+    );
+    assert!(out.contains("io.github.acme/postgres-mcp"), "got: {out}");
+    assert!(
+        out.contains("stella mcp install io.github.acme/postgres-mcp"),
+        "an install hint must be present: {out}"
+    );
+}
+
+#[tokio::test]
+async fn mcp_search_rejects_an_unknown_scope() {
+    let inner = FakeInner;
+    let set = full_set(&inner, std::env::temp_dir());
+    assert!(
+        set.execute(
+            MCP_SEARCH,
+            &serde_json::json!({"query": "x", "scope": "everywhere"})
+        )
+        .await
+        .is_error()
+    );
+}
+
+#[test]
+fn lean_env_parsing_covers_all_forms() {
+    let _lock = crate::test_env::lock();
+    let cases: &[(&str, Option<usize>, bool)] = &[
+        ("0", None, false),
+        ("false", None, false),
+        ("", None, false),
+        ("1", Some(DEFAULT_CORE_TOOLS.len()), true),
+        ("true", Some(DEFAULT_CORE_TOOLS.len()), true),
+        ("read_file, bash", Some(2), true),
+        ("only:read_file, bash", Some(2), false),
+    ];
+    for (value, expected_core_len, expected_discovery) in cases {
+        unsafe { std::env::set_var(LEAN_TOOLS_ENV, value) };
+        let lean = lean_from_env();
+        assert_eq!(
+            lean.as_ref().map(|l| l.core.len()),
+            *expected_core_len,
+            "for env value {value:?}"
+        );
+        if let Some(lean) = &lean {
+            assert_eq!(
+                lean.discovery, *expected_discovery,
+                "for env value {value:?}"
+            );
+        }
+    }
+    unsafe { std::env::remove_var(LEAN_TOOLS_ENV) };
+    assert_eq!(lean_from_env(), None);
+}
+
+/// The lean core may not withhold a tool the static prompt *commands*.
+///
+/// Not "every tool the prompt names" — the prompts mention plenty that
+/// lean mode deliberately hides behind `tool_search`, and asserting that
+/// would be asserting #3033's unbuilt design. The narrow, true property is
+/// about the imperative: the prompt opens by naming its five tools, so a
+/// lean core missing any of them ships instructions the session cannot
+/// obey. `search` joined the core with the five-tool prompt (#3079's
+/// lean-core half: the prompt now advertises it first, so a core without
+/// it would be the exact mismatch this test exists to prevent).
+///
+/// Anti-vacuity is the first assertion: the mandate is read out of
+/// `prompt.rs` at compile time, so deleting the sentence fails this test
+/// rather than silently satisfying it.
+#[test]
+fn the_lean_core_offers_every_tool_the_prompt_commands() {
+    // Relative to this file (`src/discovery/tests.rs`), so one `..` up.
+    const PROMPT_SOURCE: &str = include_str!("../agent/prompt.rs");
+    const MANDATE: &str = "Your tools are search, read_file, edit_file, write_file, and bash.";
+    assert!(
+        PROMPT_SOURCE.contains(MANDATE),
+        "the prompt no longer carries {MANDATE:?} — re-derive this test \
+         from whatever replaced it rather than deleting it"
+    );
+    let core = LeanConfig::default_core().core;
+    for tool in ["search", "read_file", "edit_file", "write_file", "bash"] {
+        assert!(
+            core.contains(tool),
+            "the prompt names {tool} in its tool mandate and the lean \
+             core does not advertise it — a session whose instructions \
+             name a tool it cannot see"
+        );
+    }
+}

--- a/crates/stella-cli/src/invoke_skill.rs
+++ b/crates/stella-cli/src/invoke_skill.rs
@@ -779,7 +779,7 @@ mod tests {
         write_skill(
             ws.path(),
             "deep-audit",
-            "context: fork\nallowed-tools: read_file, search\neffort: high\n",
+            "context: fork\nallowed-tools: read_file, retrieval\neffort: high\n",
             "SECRET-PROCEDURE: audit $ARGUMENTS thoroughly.",
         );
         let tools = InvokeSkillTools::new(ws.path().to_path_buf());
@@ -811,8 +811,10 @@ mod tests {
         assert!(charter.contains("audit src/lib.rs thoroughly"), "{charter}");
         assert_eq!(spec.effort, Some(stella_protocol::ReasoningEffort::High));
         assert!(!spec.write_access, "forked skills never get write access");
-        // `read_file` granted by name; `search` is a catalog group — it
+        // `read_file` granted by name; `retrieval` is a catalog group — it
         // resolves to whichever of its tools the surface advertises (grep).
+        // (`search` would grant only the tool of that name since #3120: a
+        // tool name never doubles as its family's key.)
         assert_eq!(
             spec.allowed_tools,
             Some(vec!["read_file".to_string(), "grep".to_string()])

--- a/crates/stella-cli/src/tool_policy.rs
+++ b/crates/stella-cli/src/tool_policy.rs
@@ -320,4 +320,141 @@ mod tests {
         );
         assert_eq!(names(&set), vec!["read_file".to_string()]);
     }
+
+    // -----------------------------------------------------------------------
+    // #3120 witnesses: the assembled session surface, not the policy
+    // arithmetic. That issue shipped precisely because the policy's own unit
+    // tests were green while the layers above and beside it leaked — so these
+    // build the real stack the way every session driver does and census what
+    // it advertises, which is the exact `tools` array the provider serializes.
+    // -----------------------------------------------------------------------
+
+    /// The real session chain — native registry, customs, interactive, the
+    /// policy filter, discovery on top — with the discovery layer carrying
+    /// the same policy `for_session` gives it, and lean pinned explicitly so
+    /// an ambient `STELLA_LEAN_TOOLS` cannot wobble the census.
+    async fn wire_surface(
+        root: &std::path::Path,
+        policy: ToolPolicy,
+        lean: Option<crate::discovery::LeanConfig>,
+        call: Option<(&str, Value)>,
+    ) -> (Vec<ToolSchema>, Option<ToolOutput>) {
+        let registry = stella_tools::ToolRegistry::with_backends_and_options(
+            root.to_path_buf(),
+            None,
+            None,
+            Default::default(),
+        );
+        let customs =
+            stella_tools::custom::CustomToolSet::new(&registry, vec![], root.to_path_buf());
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let interactive = crate::interactive::InteractiveToolSet::new(&customs, event_tx);
+        let permitted = PolicyToolSet::new(&interactive, policy.clone());
+        let tools = crate::discovery::DiscoveryToolSet::new(&permitted, root.to_path_buf())
+            .with_policy(policy)
+            .with_lean(lean);
+        let schemas = tools.schemas();
+        let output = match call {
+            Some((name, input)) => Some(tools.execute(name, &input).await),
+            None => None,
+        };
+        (schemas, output)
+    }
+
+    /// **The #3120 witness.** `--tools
+    /// "*:off,search:on,read_file:on,edit_file:on,write_file:on,bash:on"`
+    /// puts exactly the five requested names on the wire. The old stack
+    /// advertised thirteen, through two independent defects asserted here by
+    /// name: the catalog group then called `search` made `search:on` resolve
+    /// as a family switch for grep/glob/graph_query/semantic_code_search, and
+    /// the discovery layer appended its four tools above the policy filter.
+    #[tokio::test]
+    async fn a_tools_spec_advertises_exactly_the_requested_set() {
+        let root = tempfile::tempdir().unwrap();
+        let spec = "*:off,search:on,read_file:on,edit_file:on,write_file:on,bash:on";
+        let mut policy = ToolPolicy::allow_all();
+        policy.narrow_with(&ToolPolicy::parse_spec(spec).unwrap());
+
+        let (schemas, _) = wire_surface(root.path(), policy, None, None).await;
+        let mut advertised: Vec<String> = schemas.into_iter().map(|s| s.name).collect();
+
+        // Each family explicitly, so a partial regression names itself.
+        for leak in ["grep", "glob", "graph_query", "semantic_code_search"] {
+            assert!(
+                !advertised.contains(&leak.to_string()),
+                "`{leak}` leaked through the `search` group key: {advertised:?}"
+            );
+        }
+        for leak in ["tool_search", "skill_search", "mcp_search", "invoke_skill"] {
+            assert!(
+                !advertised.contains(&leak.to_string()),
+                "`{leak}` was re-added above the policy filter: {advertised:?}"
+            );
+        }
+        advertised.sort_unstable();
+        assert_eq!(
+            advertised,
+            ["bash", "edit_file", "read_file", "search", "write_file"].map(String::from),
+            "five requested, exactly five on the wire"
+        );
+    }
+
+    /// The issue's closing demand: `--tools X` and `STELLA_LEAN_TOOLS=only:X`
+    /// are one intent and must be one wire result — byte-identical `tools`
+    /// arrays. The lean arm uses [`crate::discovery::LeanConfig::closed`],
+    /// the parsed form of `only:` pinned by
+    /// `lean_env_parsing_covers_all_forms`.
+    #[tokio::test]
+    async fn a_tools_spec_and_a_closed_lean_set_are_byte_identical_on_the_wire() {
+        let root = tempfile::tempdir().unwrap();
+        let five = ["search", "read_file", "edit_file", "write_file", "bash"];
+
+        let mut policy = ToolPolicy::allow_all();
+        let spec = "*:off,search:on,read_file:on,edit_file:on,write_file:on,bash:on";
+        policy.narrow_with(&ToolPolicy::parse_spec(spec).unwrap());
+        let (via_policy, _) = wire_surface(root.path(), policy, None, None).await;
+
+        let lean = crate::discovery::LeanConfig::closed(five.map(String::from));
+        let (via_lean, _) =
+            wire_surface(root.path(), ToolPolicy::allow_all(), Some(lean), None).await;
+
+        assert_eq!(
+            serde_json::to_string(&via_policy).unwrap(),
+            serde_json::to_string(&via_lean).unwrap(),
+            "two mechanisms, one intent, one wire result"
+        );
+    }
+
+    /// The discovery layer's four tools never reach `PolicyToolSet`, so the
+    /// operator's two-sided contract — withheld from `schemas` AND refused by
+    /// `execute`, in the unknown-tool wording — has to hold at that layer
+    /// too. Exact-name deny: the rest of the layer stays advertised.
+    #[tokio::test]
+    async fn a_policy_denied_discovery_tool_is_hidden_and_refused() {
+        let root = tempfile::tempdir().unwrap();
+
+        // Anti-vacuity: with no switches at all, the tool is advertised.
+        let (schemas, _) = wire_surface(root.path(), ToolPolicy::allow_all(), None, None).await;
+        assert!(schemas.iter().any(|s| s.name == "tool_search"));
+
+        let policy = ToolPolicy::from_switches([("tool_search".into(), false)]);
+        let (schemas, output) = wire_surface(
+            root.path(),
+            policy,
+            None,
+            Some(("tool_search", serde_json::json!({"query": "anything"}))),
+        )
+        .await;
+        assert!(
+            schemas.iter().all(|s| s.name != "tool_search"),
+            "a denied discovery tool must be withheld"
+        );
+        match output.expect("a call was made") {
+            ToolOutput::Error { message, .. } => assert!(
+                message.contains("unknown tool"),
+                "a denied tool must not announce itself: {message}"
+            ),
+            other => panic!("a denied discovery tool must be refused, got {other:?}"),
+        }
+    }
 }

--- a/crates/stella-tools/src/catalog.rs
+++ b/crates/stella-tools/src/catalog.rs
@@ -137,20 +137,27 @@ catalog! {
     "edit_file"           => (false, false, Always, "file"),
     "apply_edits"         => (false, false, Always, "file"),
     "delete_file"         => (false, false, Always, "file"),
-    // Search
+    // Search. The family is grouped as `retrieval`, not `search`, because a
+    // policy key must be unambiguous: this group used to share its name with
+    // the `search` tool below, which made `--tools "*:off,search:on"` resolve
+    // `search` as a *group* switch and re-enable all four siblings the
+    // wildcard had just turned off (#3120). A group may only carry a tool's
+    // name when it holds exactly that tool — pinned by
+    // `a_group_key_never_doubles_as_another_tools_switch` below.
+    //
     // The fused entry point (#3076), registered beside the four it subsumes
     // rather than instead of them. Not speculation-safe, and for the union of
     // its parts' reasons: a query can reach the graph and the embedding pass,
     // so it inherits the "read that writes" posture from the strictest branch
     // it can take, never the cheapest.
-    "search"              => (true, false, Always, "search"),
-    "grep"                => (true, true, Always, "search"),
-    "glob"                => (true, true, Always, "search"),
+    "search"              => (true, false, Always, "retrieval"),
+    "grep"                => (true, true, Always, "retrieval"),
+    "glob"                => (true, true, Always, "retrieval"),
     // The read that writes: graph queries bootstrap/catch up codegraph.db.
-    "graph_query"         => (true, false, Always, "search"),
+    "graph_query"         => (true, false, Always, "retrieval"),
     // Same store, same "read that writes" posture, and one more write besides:
     // the pass stores the vectors it embeds on the way to answering.
-    "semantic_code_search" => (true, false, Always, "search"),
+    "semantic_code_search" => (true, false, Always, "retrieval"),
     // Context & memory. The overview and gather ride the same graph
     // substrate as graph_query; explorations is pure file reads.
     "project_overview"    => (true, false, Always, "context"),
@@ -458,6 +465,35 @@ mod tests {
             "every read-only row claims speculation_safe — the two flags \
              must be able to diverge (#923)"
         );
+    }
+
+    /// A policy switch key resolves exact-name-first, then by group
+    /// (`ToolPolicy::allows`), so a group that shares its name with a tool
+    /// while holding *other* tools makes one key address two surfaces: #3120
+    /// measured `--tools "*:off,search:on"` re-enabling grep, glob,
+    /// graph_query and semantic_code_search through the then-`search` group.
+    /// A single-member group named after its only tool (`bash`) is harmless —
+    /// both readings resolve identically.
+    ///
+    /// `task` is the one declared exemption: the delegation tool `task` still
+    /// shares its name with the task-board group, and untangling that is a
+    /// vocabulary decision tracked in #3192, not a silence.
+    #[test]
+    fn a_group_key_never_doubles_as_another_tools_switch() {
+        for entry in CATALOG {
+            if entry.group == "task" {
+                continue; // declared gap: #3192
+            }
+            if get(entry.group).is_some() {
+                assert_eq!(
+                    names_in_group(entry.group),
+                    vec![entry.group],
+                    "group `{}` shares its name with a tool but holds other tools — \
+                     one policy key would address both surfaces (#3120)",
+                    entry.group
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/stella-tools/src/policy.rs
+++ b/crates/stella-tools/src/policy.rs
@@ -246,6 +246,32 @@ mod narrowing_tests {
         assert!(!effective.allows("bash"), "a grant must never transfer");
     }
 
+    /// #3120's first family: `search:on` used to resolve as a *group* switch
+    /// too (the group then shared the tool's name), so the read-only idiom
+    /// re-enabled grep, glob, graph_query and semantic_code_search alongside
+    /// the one tool it named. A tool name now addresses exactly that tool;
+    /// the family stays addressable under its own key, `retrieval`.
+    #[test]
+    fn enabling_the_search_tool_does_not_enable_its_family() {
+        let mut effective = ToolPolicy::allow_all();
+        effective.narrow_with(&ToolPolicy::parse_spec("*:off,search:on").unwrap());
+
+        assert!(effective.allows("search"));
+        for sibling in ["grep", "glob", "graph_query", "semantic_code_search"] {
+            assert!(
+                !effective.allows(sibling),
+                "`search:on` names one tool and must not re-enable `{sibling}`"
+            );
+        }
+
+        // The family switch still exists — under the group's own name.
+        let family = ToolPolicy::parse_spec("*:off,retrieval:on").unwrap();
+        for name in catalog::names_in_group("retrieval") {
+            assert!(family.allows(name), "`retrieval:on` must cover `{name}`");
+        }
+        assert!(!family.allows("read_file"));
+    }
+
     /// A narrowing scope must not disturb tools neither side mentions.
     #[test]
     fn tools_no_scope_mentions_are_untouched() {

--- a/crates/stella-tools/src/skill_grant.rs
+++ b/crates/stella-tools/src/skill_grant.rs
@@ -177,13 +177,28 @@ mod tests {
     /// selects its family, and everything unnamed is off.
     #[test]
     fn a_grant_is_the_read_only_idiom_over_the_named_tools() {
-        let grant = grant_policy(&["read_file".to_string(), "search".to_string()]);
+        let grant = grant_policy(&["read_file".to_string(), "retrieval".to_string()]);
         assert!(grant.allows("read_file"));
         assert!(grant.allows("grep"), "group entries cover their family");
         assert!(grant.allows("glob"));
         assert!(!grant.allows("bash"));
         assert!(!grant.allows("write_file"));
         assert!(!grant.allows("mcp__github__create_issue"));
+    }
+
+    /// #3120: a granted *tool* name selects that tool alone — `search` no
+    /// longer doubles as its family's group key, so a skill that asks for the
+    /// fused entry point does not silently receive grep and glob too.
+    #[test]
+    fn a_granted_tool_name_does_not_expand_to_its_family() {
+        let grant = grant_policy(&["search".to_string()]);
+        assert!(grant.allows("search"));
+        for sibling in ["grep", "glob", "graph_query", "semantic_code_search"] {
+            assert!(
+                !grant.allows(sibling),
+                "`search` must not grant `{sibling}`"
+            );
+        }
     }
 
     /// An empty grant list denies everything — `allowed-tools` with names is

--- a/crates/stella-tui/src/tool_class.rs
+++ b/crates/stella-tui/src/tool_class.rs
@@ -139,7 +139,7 @@ pub fn classify(name: &str) -> ToolClass {
                 ToolClass::Mutate
             }
         }
-        "search" | "environment" | "web" => ToolClass::Inspect,
+        "retrieval" | "environment" | "web" => ToolClass::Inspect,
         "media" => ToolClass::Mutate,
         "bash" | "process" | "scripts" => ToolClass::Execute,
         "build" | "ci" => ToolClass::Verify,
@@ -229,7 +229,7 @@ mod tests {
                 "file"
                     | "context"
                     | "scratch"
-                    | "search"
+                    | "retrieval"
                     | "environment"
                     | "web"
                     | "media"

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -43,9 +43,9 @@ Two fields are stated absences rather than values, because inventing them would 
 | [`get_environment`](get_environment.toml) | environment | always | yes | yes | yes |
 | [`get_issue`](get_issue.toml) | issue | requires-issue-backend | yes | no | none observed |
 | [`get_state`](get_state.toml) | scratch | always | yes | yes | none observed |
-| [`glob`](glob.toml) | search | always | yes | yes | yes |
-| [`graph_query`](graph_query.toml) | search | always | yes | no | none observed |
-| [`grep`](grep.toml) | search | always | yes | yes | none observed |
+| [`glob`](glob.toml) | retrieval | always | yes | yes | yes |
+| [`graph_query`](graph_query.toml) | retrieval | always | yes | no | none observed |
+| [`grep`](grep.toml) | retrieval | always | yes | yes | none observed |
 | [`install_skill`](install_skill.toml) | session | cli-session-layer | no | no | none observed |
 | [`invoke_skill`](invoke_skill.toml) | session | cli-session-layer | no | no | none observed |
 | [`list_labels`](list_labels.toml) | issue | requires-issue-backend | yes | no | none observed |
@@ -76,10 +76,10 @@ Two fields are stated absences rather than values, because inventing them would 
 | [`save_memory`](save_memory.toml) | context | always | no | no | yes |
 | [`save_state`](save_state.toml) | scratch | always | no | no | none observed |
 | [`screenshot`](screenshot.toml) | ci | always | no | no | yes |
-| [`search`](search.toml) | search | always | yes | no | none observed |
+| [`search`](search.toml) | retrieval | always | yes | no | none observed |
 | [`search_issues`](search_issues.toml) | issue | requires-issue-backend | yes | no | none observed |
 | [`search_skills`](search_skills.toml) | session | cli-session-layer | yes | no | none observed |
-| [`semantic_code_search`](semantic_code_search.toml) | search | always | yes | no | none observed |
+| [`semantic_code_search`](semantic_code_search.toml) | retrieval | always | yes | no | none observed |
 | [`send_stdin`](send_stdin.toml) | process | always | no | no | none observed |
 | [`skill_search`](skill_search.toml) | session | cli-session-layer | yes | yes | none observed |
 | [`start_process`](start_process.toml) | process | always | no | no | yes |

--- a/docs/tools/glob.toml
+++ b/docs/tools/glob.toml
@@ -11,7 +11,7 @@
 #   risk_level                             nothing declares it (see below)
 
 name = "glob"
-category = "search"
+category = "retrieval"
 availability = "always"
 read_only = true
 available_for_speculation = true

--- a/docs/tools/graph_query.toml
+++ b/docs/tools/graph_query.toml
@@ -11,7 +11,7 @@
 #   risk_level                             nothing declares it (see below)
 
 name = "graph_query"
-category = "search"
+category = "retrieval"
 availability = "always"
 read_only = true
 available_for_speculation = false

--- a/docs/tools/grep.toml
+++ b/docs/tools/grep.toml
@@ -11,7 +11,7 @@
 #   risk_level                             nothing declares it (see below)
 
 name = "grep"
-category = "search"
+category = "retrieval"
 availability = "always"
 read_only = true
 available_for_speculation = true

--- a/docs/tools/search.toml
+++ b/docs/tools/search.toml
@@ -11,7 +11,7 @@
 #   risk_level                             nothing declares it (see below)
 
 name = "search"
-category = "search"
+category = "retrieval"
 availability = "always"
 read_only = true
 available_for_speculation = false

--- a/docs/tools/semantic_code_search.toml
+++ b/docs/tools/semantic_code_search.toml
@@ -11,7 +11,7 @@
 #   risk_level                             nothing declares it (see below)
 
 name = "semantic_code_search"
-category = "search"
+category = "retrieval"
 availability = "always"
 read_only = true
 available_for_speculation = false

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -340,7 +340,7 @@ Every tool ships **on**, `bash` and the web family included. The one way to turn
 }
 ```
 
-A key is a **tool name**, a **group name** (the family headings above — `file`, `search`, `process`, `repo`, `web`, `bash`, `task`, …, plus `mcp` and `custom` for tools the built-in catalog has never heard of), or `"*"` for everything. Most specific wins: name beats group beats `"*"`, and anything unmentioned is on.
+A key is a **tool name**, a **group name** (the family headings above — `file`, `retrieval` (the Search family; deliberately not keyed `search`, so that key addresses the `search` tool alone), `process`, `repo`, `web`, `bash`, `task`, …, plus `mcp` and `custom` for tools the built-in catalog has never heard of), or `"*"` for everything. Most specific wins: name beats group beats `"*"`, and anything unmentioned is on.
 
 Two recipes that fall out of that rule:
 

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -383,10 +383,12 @@ A key is one of three things, and the most specific one wins:
 
 1. an exact **tool name** — `repo_push`, `mcp__github__create_issue`, your own
    `deploy_to_staging`;
-2. a **group** — the families in [Built-in tools](/docs/agent-tools): `file`, `search`,
-   `context`, `build`, `scripts`, `process`, `bash`, `web`, `repo`, `ci`, `media`,
-   `task`, `issue`, `session`, plus `mcp` and `custom` for anything the built-in catalog
-   has never heard of;
+2. a **group** — the families in [Built-in tools](/docs/agent-tools): `file`,
+   `retrieval` (the Search family: `search`, `grep`, `glob`, `graph_query`,
+   `semantic_code_search` — deliberately not keyed `search`, so that key addresses the
+   `search` tool alone), `context`, `build`, `scripts`, `process`, `bash`, `web`,
+   `repo`, `ci`, `media`, `task`, `issue`, `session`, `environment`, `scratch`, plus
+   `mcp` and `custom` for anything the built-in catalog has never heard of;
 3. `"*"`, every tool.
 
 Anything unmentioned is on. So `{"*": "off", "read_file": "on"}` is a read-only agent in


### PR DESCRIPTION
## What & why

`stella run --tools "*:off,search:on,read_file:on,edit_file:on,write_file:on,bash:on"` put **13** tools on the wire when **5** were requested (measured via a recording proxy in the issue). The 8 leaks split into two families with two independent causes, both fixed here.

Closes #3120

### Family 1 — `grep`, `glob`, `graph_query`, `semantic_code_search`: a group named after a tool

The catalog group holding the search family was itself named `search` — the same name as the fused `search` tool (#3076). `ToolPolicy::allows` resolves a switch key exact-name-first, then by group (`crates/stella-tools/src/policy.rs`), so the single key `search:on` meant two things at once: the tool (intended) *and* the whole group (not intended). Under `*:off`, the group reading re-enabled all four siblings. The policy arithmetic was correct — the issue's guess that "the defect is in what reaches the filter, not the filter's arithmetic" was half right: the defect was in the *vocabulary* the filter resolves.

**Fix:** the family is grouped as **`retrieval`** (`crates/stella-tools/src/catalog.rs`). `search:on`/`search:off` now address exactly the `search` tool; `retrieval:on`/`retrieval:off` address the family. A new catalog invariant test (`a_group_key_never_doubles_as_another_tools_switch`) pins that a group may only share a tool's name when it holds exactly that tool (single-member `bash` stays legal). Consumers chased in the same PR: `stella-tui/src/tool_class.rs`, the skill-grant tests, `docs/tools/` regenerated via `make tool-docs-update`, and the group lists in `website/content/docs/configuration/settings.mdx` and `website/content/docs/agent-tools/index.mdx`.

### Family 2 — `tool_search`, `skill_search`, `mcp_search`, `invoke_skill`: appended above the policy filter

`DiscoveryToolSet` is deliberately the OUTERMOST decorator (it must see the complete advertised catalog), which puts it *above* `PolicyToolSet` — so `schemas()` appended its four session tools after the policy filter had run, and `execute()` answered them without consulting the policy. `*:off` never reached them. (Same hole for settings: `"tools": {"session": "off"}` could not withhold them either.)

**Fix:** the discovery layer now carries the session's `ToolPolicy` and applies it to its own four additions on **both sides** — withheld from `schemas()` and refused by `execute()` in the same `unknown tool: …` wording `PolicyToolSet` uses (`crates/stella-cli/src/discovery.rs`). The production constructor is `DiscoveryToolSet::for_session(inner, cfg)`, deriving the policy from the same `session_tool_policy(cfg)` every driver hands `PolicyToolSet`; the policy-free `new` is `#[cfg(test)]`, so a production call site that omits the policy is a compile error, not a review question (the same make-the-safe-path-the-only-compiling-path shape `cargo` uses for its builder seams). All seven driver call sites switched (agent, goal ×2, resume, deck, pipeline turn).

Per #3100: **lean-mode hiding stays permissive on execute — unchanged.** That permissiveness is a prompt-budget measure, not a gate. What gates here is only the operator policy, which `crates/stella-cli/src/tool_policy.rs`'s module docs always documented as two-sided.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_tools_spec_advertises_exactly_the_requested_set` (`crates/stella-cli/src/tool_policy.rs`) builds the **real** session stack — native registry → customs → interactive → `PolicyToolSet` → `DiscoveryToolSet` — folds the issue's exact spec the way `main.rs` does (`narrow_with`), and censuses the advertised schemas, i.e. the exact `tools` array the provider serializes. It asserts both leak families explicitly by name, then equality with the five.

**Old side** (origin/main `e91f0ef29`; the same assertion run through main's own `stack_names_and_execute` harness in a detached scratch worktree, since the new-API witness cannot compile there):

```
assertion `left == right` failed
  left: ["bash", "edit_file", "glob", "graph_query", "grep", "invoke_skill", "mcp_search", "read_file", "search", "semantic_code_search", "skill_search", "tool_search", "write_file"]
 right: ["bash", "edit_file", "read_file", "search", "write_file"]
```

13 names — the issue's proxy capture, name-for-name. The family-1 half alone also fails on main at the unit level: `` `search:on` re-enabled `grep` ``.

**New side** (this branch): passes with exactly `["bash", "edit_file", "read_file", "search", "write_file"]`.

Two further witnesses, per the issue's definition of done:

- `a_tools_spec_and_a_closed_lean_set_are_byte_identical_on_the_wire` — `--tools X` and `STELLA_LEAN_TOOLS=only:X` (via `LeanConfig::closed`, the parsed form pinned by `lean_env_parsing_covers_all_forms`) serialize to byte-identical `tools` arrays. One intent, one wire result.
- `a_policy_denied_discovery_tool_is_hidden_and_refused` — the two-sided gate at the discovery layer, with an anti-vacuity control (allow-all advertises `tool_search`).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-tools -p stella-tui --all-targets -- -D warnings`
- [x] `cargo test`: stella-tools 999 ✓, stella-cli 1788 unit + all integration targets ✓, stella-tui 866 ✓, stella-runtime/serve/fleet ✓; `rustdoc -D warnings` clean on all three changed crates; `make guards-fast`, `check-file-size`, `check-god-files`, `check-tool-docs`, `check-invariants` ✓
- [x] Docs updated where behavior changed (settings.mdx, agent-tools/index.mdx, docs/tools regenerated)
- [x] CLA signed
- [x] `Closes #3120` appears both above and as a commit trailer

## Behavior change, named honestly

A pre-existing `settings.json` entry `"tools": {"search": "off"}` used to disable the tool *and* (via the group reading) grep/glob/graph_query/semantic_code_search; it now disables only the `search` tool, and the family key is `retrieval:off`. The old meaning was only reachable since #3076 introduced the collision (weeks), and no shipped doc ever used `search` as a group key — but a config relying on the group reading widens on upgrade and must switch to `retrieval`. Same for skill `allowed-tools: search` grants (now the tool alone). The docs now say this explicitly.

## Nothing left behind

- **#3192 (filed by this PR):** the `task` key has the identical collision — the delegation tool `task` shares its name with the six-tool task-board group, so `--tools "*:off,task:on"` still advertises 7 tools. It is the one declared, issue-cited exemption in the new catalog invariant test; untangling it is a settings-vocabulary decision left to a maintainer (both directions silently change what existing `"task"` entries mean).
- **No test deleted:** `crates/stella-cli/src/discovery.rs`'s inline test module moved verbatim to `crates/stella-cli/src/discovery/tests.rs` (file-size headroom — discovery.rs sat 35 lines under the 1500 ratchet before this change). One `include_str!` path adjusted for the new location; every `#[test]` survives, which `check-deleted-tests` will confirm on this PR.

## Summary by Sourcery

Ensure stella-cli tool policies apply consistently so a tools spec or lean configuration advertises exactly the requested tools, with discovery-layer additions no longer bypassing policy and the search family keyed unambiguously.

Bug Fixes:
- Prevent discovery-layer tools (tool_search, skill_search, mcp_search, invoke_skill) from leaking past operator tool policy in both schemas and execute paths.
- Correct tool policy resolution so the search tool no longer implicitly enables its whole search family under specs like "*:off,search:on".

Enhancements:
- Introduce a dedicated `retrieval` group for search-related tools and enforce a catalog invariant that group keys cannot ambiguously overlap other tool names (except the declared task case).
- Wire DiscoveryToolSet through a session-aware constructor that always carries the current ToolPolicy, making the safe, policy-attached path the default in all drivers.
- Add integration-style tests that build the full session tool stack and assert the on-the-wire tool set for policy specs, lean configurations, and discovery tools denied by policy.

Documentation:
- Update built-in tool catalogs and configuration docs to reflect the new `retrieval` group and clarify how search-related keys and skill grants behave.

Tests:
- Move discovery-layer tests into a dedicated module file and expand coverage around lean core behavior, prompt-tool consistency, and discovery tool policy gating.