### PR TITLE
feat(arenabench): Experiments product Phase 1 — durable experiment store, seed Fable 5 document, report

### DIFF
--- a/arenabench/arenabench/experiments.py
+++ b/arenabench/arenabench/experiments.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The experiments store: durable, database-backed experiment documents.
+
+Phase 1 of the Experiments product, and deliberately the smallest durable
+shape that is honest about what it is: one SQLite database at
+``arenabench_home() / "experiments.db"`` holding one table,
+``experiment_results``, with a single non-null JSON document column named
+``results``. No normalization yet — an experiment document is stored whole,
+exactly as assembled from the ground-truth artifacts it cites, so the
+schema cannot silently drop a field the document carries. Normalizing into
+typed tables is a later, separate decision made against real documents
+rather than ahead of them.
+
+Everything here is generic product surface: an "experiment" is any JSON
+document a caller assembles (hypothesis, comparability keys, trials,
+metrics). Agent names, models, and datasets are data *inside* documents,
+never concepts this module knows about.
+
+Storage conventions follow the two stores that already exist in this
+repository:
+
+- ``bench/telemetry_store/ingest.py`` — stdlib :mod:`sqlite3`, an
+  all-``IF NOT EXISTS`` schema applied on every connect, additive-only
+  idempotent migration. Copied here so the two stores age the same way.
+- The column is declared ``JSONB`` (valid DDL on both SQLite and
+  PostgreSQL). SQLite stores what it is given: on a linked SQLite new
+  enough to have the JSONB functions (>= 3.45) writes go through
+  ``jsonb()`` and are stored in the compact binary encoding; on an older
+  SQLite the same document is stored as JSON text. Reads normalize through
+  ``json()`` wherever it exists, so a database file written by either
+  encoding round-trips on any host — the portability concern
+  ``bench/telemetry_store/schema.sql`` documents, answered by
+  feature-detection instead of by refusing the binary encoding.
+
+WAL journaling is enabled because ArenaBench is multi-process by design
+(``arenabench serve`` and ``arenabench run`` share one workspace), and the
+documents are serialized with sorted keys so identical documents produce
+identical bytes — the same byte-stability discipline the SUT applies to
+its prompts.
+
+Its own module rather than more length on ``server.py``, per the
+repository's file-size ratchet rule: separable new code becomes a module.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .sut import arenabench_home
+
+__all__ = [
+    "connect",
+    "experiments_db_path",
+    "load_results",
+    "store_results",
+]
+
+#: The whole schema, applied on every connect. ``IF NOT EXISTS`` makes it
+#: idempotent; there is deliberately no version table — additive changes
+#: follow ``bench/telemetry_store/ingest.py::migrate`` when they arrive.
+#:
+#: One column, by design (see the module doc): the document is the record.
+#: Identity, timestamps, and comparability keys live *inside* ``results``
+#: and are queryable with ``json_extract`` — promoting them to columns is
+#: the normalization step this phase explicitly defers.
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS experiment_results (
+    results JSONB NOT NULL
+);
+"""
+
+#: The JSONB function family arrived in SQLite 3.45.0. Older linked
+#: SQLites still read and write this store — as JSON text.
+_JSONB_MIN_VERSION = (3, 45, 0)
+
+
+def experiments_db_path() -> Path:
+    """Where the experiments database lives, honouring ``ARENABENCH_HOME``."""
+    return arenabench_home() / "experiments.db"
+
+
+def _jsonb_available() -> bool:
+    """Whether the linked SQLite has the ``jsonb()`` function family."""
+    return sqlite3.sqlite_version_info >= _JSONB_MIN_VERSION
+
+
+def connect(db_path: Path | None = None) -> sqlite3.Connection:
+    """Open (creating if absent) the experiments database.
+
+    Applies the schema on every call, so callers never see a database
+    missing its table. WAL because the server and a concurrent run are
+    separate processes sharing one workspace.
+    """
+    path = experiments_db_path() if db_path is None else db_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+def store_results(document: Mapping[str, Any], db_path: Path | None = None) -> None:
+    """Persist one experiment document into ``experiment_results``.
+
+    The document must be a JSON-serializable mapping — an experiment is a
+    document, not a bare scalar. Serialization uses sorted keys so the
+    same document always produces the same stored bytes.
+    """
+    if not isinstance(document, Mapping):
+        raise TypeError(
+            f"an experiment document is a JSON object, got {type(document).__name__}"
+        )
+    text = json.dumps(document, ensure_ascii=False, sort_keys=True)
+    sql = (
+        "INSERT INTO experiment_results (results) VALUES (jsonb(?))"
+        if _jsonb_available()
+        else "INSERT INTO experiment_results (results) VALUES (?)"
+    )
+    conn = connect(db_path)
+    try:
+        with conn:
+            conn.execute(sql, (text,))
+    finally:
+        conn.close()
+
+
+def load_results(db_path: Path | None = None) -> list[dict[str, Any]]:
+    """Every stored experiment document, in insertion order.
+
+    Reads normalize through ``json()`` when the linked SQLite has it, so
+    rows written in either encoding (binary JSONB or JSON text) come back
+    as the same Python mapping.
+    """
+    select = (
+        "SELECT json(results) FROM experiment_results"
+        if _jsonb_available()
+        else "SELECT results FROM experiment_results"
+    )
+    conn = connect(db_path)
+    try:
+        return [json.loads(row[0]) for row in conn.execute(select)]
+    finally:
+        conn.close()

--- a/arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py
+++ b/arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""Assemble the seed experiment document: Stella vs Claude Code on Fable 5.
+
+This is the calculation artifact for one experiment — the seed data the
+generic experiments store (``arenabench.experiments``) holds, not product
+surface. It reads ground-truth artifacts only (each trial's
+``result.json``, ``verifier/reward.txt``, and each arm's *own* journal —
+``agent/claude-code.txt`` / ``agent/stella-events.jsonl``), never a
+dashboard, summary file, or assembly projection, and emits one canonical
+JSON document with every raw value, formula, denominator, and source
+recorded. Committing this script is what preserves the calculation
+version: rerunning it against the same artifacts reproduces the same
+document.
+
+Outcome vocabulary is the experiment's preregistered taxonomy
+(verified_solve, verified_failure, solved_then_timeout,
+timeout_before_solve, invalid_infrastructure, provider_failure,
+budget_rejected, aborted, pending, unverified), with the classification
+rules and their precedence written into the document itself. Provider
+failures are detected from structured fields (Claude Code's terminal
+``api_error_status``; Stella's parsed ``error`` events) plus strict
+phrase needles — a bare "402" once matched timestamps, which is why
+``score-match.py`` insists on phrases.
+
+Usage: python3 arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py
+           [--store] [--out FILE]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from arenabench import pricing
+from arenabench.experiments import store_results
+from arenabench.sut import arenabench_home
+from arenabench.telemetry import INFRASTRUCTURE_FAILURES
+
+CALCULATION_VERSION = "exp-fable5-cc-vs-stella-tb21/1"
+EXPERIMENT_ID = "stella-vs-claude-code-fable5-tb21"
+
+#: Strict phrase needles (never bare numbers) for provider rejections in
+#: Stella's stream. Loose needles matched timestamps and task content.
+STELLA_PROVIDER_NEEDLES = (
+    "HTTP 402",
+    "payment required",
+    "out of credits",
+    "HTTP 401",
+)
+
+#: Quota-throttle needles for the Claude Code journal.
+CC_THROTTLE_NEEDLES = ('"api_error_status":429', "session limit", "rate limit")
+
+SOLVE_CLASSES = ("verified_solve", "solved_then_timeout")
+LOSS_CLASSES = ("verified_failure", "timeout_before_solve")
+VALID_CLASSES = SOLVE_CLASSES + LOSS_CLASSES
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _reward(result: dict[str, Any], trial_dir: Path) -> float | None:
+    """The external verifier's reward, cross-checked against reward.txt."""
+    nested = (result.get("verifier_result") or {}).get("rewards") or {}
+    recorded = nested.get("reward", (result.get("verifier_result") or {}).get("reward"))
+    txt = trial_dir / "verifier" / "reward.txt"
+    if txt.exists():
+        try:
+            file_reward = float(txt.read_text().strip())
+        except ValueError:
+            file_reward = None
+        if file_reward is not None:
+            return file_reward
+    return float(recorded) if recorded is not None else None
+
+
+def _cc_journal(trial_dir: Path) -> dict[str, Any]:
+    """Facts from Claude Code's own stream-json journal."""
+    path = trial_dir / "agent" / "claude-code.txt"
+    facts: dict[str, Any] = {"present": path.exists(), "path": str(path)}
+    if not path.exists():
+        return facts
+    text = path.read_text(encoding="utf-8", errors="replace")
+    facts["throttle_needle_hits"] = sum(text.count(n) for n in CC_THROTTLE_NEEDLES)
+    terminal = None
+    for line in reversed(text.splitlines()):
+        if '"type":"result"' in line:
+            with contextlib.suppress(json.JSONDecodeError):
+                terminal = json.loads(line)
+            break
+    if terminal is not None:
+        usage = terminal.get("usage") or {}
+        facts["terminal"] = {
+            "is_error": terminal.get("is_error"),
+            "api_error_status": terminal.get("api_error_status"),
+            "terminal_reason": terminal.get("terminal_reason"),
+            "result_text": str(terminal.get("result", ""))[:200],
+            "num_turns": terminal.get("num_turns"),
+            "total_cost_usd": terminal.get("total_cost_usd"),
+            "duration_ms": terminal.get("duration_ms"),
+            "duration_api_ms": terminal.get("duration_api_ms"),
+            "input_tokens": usage.get("input_tokens"),
+            "cache_read_input_tokens": usage.get("cache_read_input_tokens"),
+            "cache_creation_input_tokens": usage.get("cache_creation_input_tokens"),
+            "output_tokens": usage.get("output_tokens"),
+        }
+    return facts
+
+
+def _stella_journal(trial_dir: Path) -> dict[str, Any]:
+    """Facts from Stella's own event stream."""
+    path = trial_dir / "agent" / "stella-events.jsonl"
+    facts: dict[str, Any] = {"present": path.exists(), "path": str(path)}
+    if not path.exists():
+        return facts
+    usage_by_model: dict[str, dict[str, int | float]] = {}
+    error_messages: list[str] = []
+    terminal_type = None
+    tool_calls = 0
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        etype = event.get("type")
+        terminal_type = etype or terminal_type
+        if etype == "error":
+            error_messages.append(str(event.get("message", ""))[:300])
+        elif etype == "tool_start":
+            tool_calls += 1
+        elif etype == "step_usage":
+            model = str(event.get("model", "?"))
+            slot = usage_by_model.setdefault(
+                model,
+                {
+                    "calls": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cached_input_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "cost_usd": 0.0,
+                    "duration_ms": 0,
+                },
+            )
+            slot["calls"] += 1
+            for key in (
+                "input_tokens",
+                "output_tokens",
+                "cached_input_tokens",
+                "cache_write_tokens",
+                "cost_usd",
+                "duration_ms",
+            ):
+                slot[key] += event.get(key) or 0
+    provider_hits = [
+        m for m in error_messages if any(n in m for n in STELLA_PROVIDER_NEEDLES)
+    ]
+    if not provider_hits:
+        # A reaped stream can lose its terminal error event (#2131); fall
+        # back to a raw strict-phrase scan and say the evidence came from it.
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        if any(n in raw for n in STELLA_PROVIDER_NEEDLES[:3]):
+            provider_hits = ["<needle found outside a parsed error event>"]
+    facts.update(
+        {
+            "terminal_event_type": terminal_type,
+            "error_messages": error_messages[:3],
+            "provider_rejection_evidence": provider_hits[:2],
+            "tool_calls": tool_calls,
+            "usage_by_model": usage_by_model,
+        }
+    )
+    return facts
+
+
+def classify(
+    *,
+    reward: float | None,
+    exception_type: str | None,
+    exception_message: str,
+    cc: dict[str, Any],
+    stella: dict[str, Any],
+    ran: bool,
+) -> tuple[str, list[str]]:
+    """Mission taxonomy, precedence top-down. Returns (label, evidence)."""
+    if not ran:
+        return "pending", ["no trial artifacts: the task was never attempted"]
+    if exception_type == "CancelledError":
+        return "aborted", [f"exception_info: {exception_type}"]
+    if exception_type == "DeliberateStopError":
+        if "budget" in exception_message.lower():
+            return "budget_rejected", [f"DeliberateStopError: {exception_message[:160]}"]
+        return "aborted", [f"DeliberateStopError: {exception_message[:160]}"]
+    terminal = cc.get("terminal") or {}
+    if terminal.get("is_error") and terminal.get("api_error_status") in (401, 402, 429):
+        return "provider_failure", [
+            f"claude-code.txt terminal: api_error_status={terminal['api_error_status']}"
+            f" result={terminal.get('result_text', '')!r}"
+        ]
+    if stella.get("provider_rejection_evidence"):
+        return "provider_failure", [
+            f"stella-events.jsonl error: {m}"
+            for m in stella["provider_rejection_evidence"]
+        ]
+    if (
+        exception_type == "AgentTimeoutError"
+        and cc.get("present")
+        and cc.get("throttle_needle_hits", 0) > 0
+    ):
+        # Judgment call, recorded as such: a run throttled by quota that then
+        # timed out measures the quota, not the agent (fable5-cc-repair.toml
+        # states the same rule for these exact trials).
+        return "provider_failure", [
+            "AgentTimeoutError with "
+            f"{cc['throttle_needle_hits']} quota-throttle needle hits in the "
+            "agent's own journal (classified as quota, not capability — inference)"
+        ]
+    if exception_type in INFRASTRUCTURE_FAILURES:
+        return "invalid_infrastructure", [f"exception_info: {exception_type}"]
+    if reward is not None and reward >= 1.0:
+        if exception_type == "AgentTimeoutError":
+            return "solved_then_timeout", [
+                f"reward {reward} with AgentTimeoutError — solved, then ran out"
+            ]
+        return "verified_solve", [f"external verifier reward {reward}"]
+    if exception_type == "AgentTimeoutError":
+        return "timeout_before_solve", ["AgentTimeoutError with reward < 1"]
+    if reward is None:
+        return "unverified", ["no verifier reward was recorded"]
+    return "verified_failure", [
+        f"external verifier reward {reward}"
+        + (f"; exception {exception_type}" if exception_type else "")
+    ]
+
+
+def read_trial(trial_dir: Path, arm: str) -> dict[str, Any] | None:
+    result = _read_json(trial_dir / "result.json")
+    if result is None:
+        return None
+    exc = result.get("exception_info") or {}
+    exception_type = exc.get("exception_type")
+    exception_message = str(exc.get("exception_message", ""))
+    reward = _reward(result, trial_dir)
+    cc = _cc_journal(trial_dir) if arm == "claude-code" else {}
+    stella = _stella_journal(trial_dir) if arm == "stella" else {}
+    label, evidence = classify(
+        reward=reward,
+        exception_type=exception_type,
+        exception_message=exception_message,
+        cc=cc,
+        stella=stella,
+        ran=True,
+    )
+    envelope = result.get("agent_result") or {}
+    metadata = envelope.get("metadata") or {}
+    # Harbor's task_name is org-qualified ("terminal-bench/fix-git"); match
+    # specs carry the bare name. The bare name is the join key everywhere.
+    task_name = str(result.get("task_name") or "").rsplit("/", 1)[-1]
+    trial: dict[str, Any] = {
+        "task": task_name,
+        "trial": result.get("trial_name"),
+        "arm": arm,
+        "outcome": label,
+        "outcome_evidence": evidence,
+        "reward": reward,
+        "exception_type": exception_type,
+        "started_at": result.get("started_at"),
+        "finished_at": result.get("finished_at"),
+        "raw": {
+            "envelope_tokens_in": envelope.get("n_input_tokens"),
+            "envelope_tokens_cached": envelope.get("n_cache_tokens"),
+            "envelope_tokens_out": envelope.get("n_output_tokens"),
+            "envelope_cost_usd": envelope.get("cost_usd"),
+            "stella_status": metadata.get("stella_status"),
+        },
+        "sources": {"result_json": str(trial_dir / "result.json")},
+    }
+    if arm == "claude-code" and cc.get("terminal"):
+        t = cc["terminal"]
+        tokens_in = sum(
+            t.get(k) or 0
+            for k in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens")
+        )
+        trial["measured"] = {
+            "basis": "agent_own_journal (claude-code.txt terminal result)",
+            "cost_usd": t.get("total_cost_usd"),
+            "tokens_in_total": tokens_in,
+            "tokens_cache_read": t.get("cache_read_input_tokens"),
+            "tokens_cache_write": t.get("cache_creation_input_tokens"),
+            "tokens_out": t.get("output_tokens"),
+            "wall_ms": t.get("duration_ms"),
+            "model_ms": t.get("duration_api_ms"),
+            "turns": t.get("num_turns"),
+        }
+        trial["sources"]["journal"] = cc["path"]
+    if arm == "stella" and stella.get("usage_by_model"):
+        by_model = stella["usage_by_model"]
+        trial["measured"] = {
+            "basis": "agent_own_journal (stella-events.jsonl step_usage sum)",
+            "cost_usd": round(sum(m["cost_usd"] for m in by_model.values()), 6),
+            "tokens_in_total": sum(m["input_tokens"] for m in by_model.values()),
+            "tokens_cache_read": sum(m["cached_input_tokens"] for m in by_model.values()),
+            "tokens_cache_write": sum(m["cache_write_tokens"] for m in by_model.values()),
+            "tokens_out": sum(m["output_tokens"] for m in by_model.values()),
+            "model_ms": sum(m["duration_ms"] for m in by_model.values()),
+            "tool_calls": stella.get("tool_calls"),
+            "by_model": by_model,
+        }
+        trial["sources"]["journal"] = stella["path"]
+    return trial
+
+
+def reprice_trial(
+    trial: dict[str, Any], route_api: str, model: str = "claude-fable-5"
+) -> tuple[float | None, str]:
+    """List-price the trial from its own token counts; None when unpriceable."""
+    measured = trial.get("measured")
+    if not measured:
+        return None, "no usage measured"
+    by_model = measured.get("by_model")
+    if by_model:
+        total = 0.0
+        for model, usage in by_model.items():
+            price = pricing.price_on_route(route_api, model)
+            if price is None:
+                return None, f"unpriced model {model} (missing beats wrong)"
+            total += (
+                pricing.trial_cost(
+                    price,
+                    tokens_in=int(usage["input_tokens"]),
+                    tokens_out=int(usage["output_tokens"]),
+                    cache_read=int(usage["cached_input_tokens"]),
+                    cache_write=int(usage["cache_write_tokens"]),
+                )
+                or 0.0
+            )
+        return round(total, 6), "priced per-model on the seat's recorded route"
+    price = pricing.price_on_route(route_api, model)
+    cost = pricing.trial_cost(
+        price,
+        tokens_in=int(measured.get("tokens_in_total") or 0),
+        tokens_out=int(measured.get("tokens_out") or 0),
+        cache_read=int(measured.get("tokens_cache_read") or 0),
+        cache_write=int(measured.get("tokens_cache_write") or 0),
+    )
+    return (round(cost, 6) if cost is not None else None), (
+        "priced on the seat's recorded route" if cost is not None else "unpriced"
+    )
+
+
+def aggregate(trials: list[dict[str, Any]]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    for t in trials:
+        counts[t["outcome"]] = counts.get(t["outcome"], 0) + 1
+    valid = [t for t in trials if t["outcome"] in VALID_CLASSES]
+    solves = [t for t in trials if t["outcome"] in SOLVE_CLASSES]
+    excluded = [t for t in trials if t["outcome"] not in VALID_CLASSES]
+    # A trial without a terminal usage record (a timed-out agent's journal
+    # has no result line) is UNMEASURED, not zero. Totals over trials that
+    # did measure are therefore lower bounds, and say so.
+    unmeasured = sum(
+        1 for t in valid if (t.get("measured") or {}).get("cost_usd") is None
+    )
+    measured_valid = sum(
+        (t.get("measured") or {}).get("cost_usd") or 0.0 for t in valid
+    )
+    measured_excluded = sum(
+        (t.get("measured") or {}).get("cost_usd") or 0.0 for t in excluded
+    )
+    repriced_values = [t.get("repriced_cost_usd") for t in valid]
+    repriced_total = (
+        None
+        if any(v is None for v in repriced_values)
+        else round(sum(repriced_values), 6)
+    )
+    return {
+        "attempted_trials": len(trials),
+        "outcome_counts": counts,
+        "valid_attempts": len(valid),
+        "verified_solves": len(solves),
+        "solve_rate": (
+            round(len(solves) / len(valid), 4) if valid else None
+        ),
+        "valid_trials_with_unmeasured_usage": unmeasured,
+        "measured_cost_usd_valid_trials": round(measured_valid, 6),
+        "measured_cost_is_lower_bound": unmeasured > 0,
+        "measured_cost_usd_excluded_trials": round(measured_excluded, 6),
+        "repriced_cost_usd_valid_trials": repriced_total,
+        "cost_per_verified_solve_measured_usd": (
+            round(measured_valid / len(solves), 6) if solves else None
+        ),
+        "cost_per_verified_solve_repriced_usd": (
+            round(repriced_total / len(solves), 6)
+            if solves and repriced_total is not None
+            else None
+        ),
+    }
+
+
+def read_arm(
+    job_dir: Path, arm: str, route_api: str, expected_tasks: list[str] | None = None
+) -> dict[str, Any]:
+    trials: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for trial_dir in sorted(job_dir.glob("*__*")):
+        if not trial_dir.is_dir():
+            continue
+        trial = read_trial(trial_dir, arm)
+        if trial is None:
+            continue
+        cost, note = reprice_trial(trial, route_api)
+        trial["repriced_cost_usd"] = cost
+        trial["repriced_note"] = note
+        trials.append(trial)
+        seen.add(str(trial["task"]))
+    for task in expected_tasks or []:
+        if task not in seen:
+            trials.append(
+                {
+                    "task": task,
+                    "arm": arm,
+                    "outcome": "pending",
+                    "outcome_evidence": [
+                        "listed in the match spec but no trial artifacts exist"
+                    ],
+                    "reward": None,
+                }
+            )
+    return {"trials": trials, "aggregates": aggregate(trials)}
+
+
+def read_assembly_run(match_dir: Path, model: str) -> dict[str, Any]:
+    """Classify every cell of an assembled (cloud-fanned) match.
+
+    ``assembly.json`` cells carry no outcome — status is derived from each
+    cell's own artifacts, which is the point: one classifier over ground
+    truth, where today three consumers disagree.
+    """
+    assembly = _read_json(match_dir / "assembly.json") or {}
+    per_arm: dict[str, list[dict[str, Any]]] = {}
+    unreadable = 0
+    for cell in assembly.get("cells", []):
+        artifacts = (match_dir / cell.get("artifacts", "")).resolve()
+        arm = "claude-code" if "claude-code" in str(cell.get("seat")) else "stella"
+        trial = read_trial(artifacts, arm)
+        if trial is None:
+            unreadable += 1
+            continue
+        route = "anthropic" if arm == "claude-code" else "openrouter"
+        cost, note = reprice_trial(trial, route, model=model)
+        trial["repriced_cost_usd"] = cost
+        trial["repriced_note"] = note
+        per_arm.setdefault(arm, []).append(trial)
+    return {
+        "unreadable_cells": unreadable,
+        "arms": {
+            arm: {"trials": trials, "aggregates": aggregate(trials)}
+            for arm, trials in sorted(per_arm.items())
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", action="store_true", help="persist into experiments.db")
+    parser.add_argument("--out", type=Path, help="also write the document to this file")
+    args = parser.parse_args()
+
+    home = arenabench_home()
+    matches = home / "matches"
+
+    h2h = matches / "dd52a57a6f49" / "jobs"
+    cc_h2h = read_arm(
+        h2h / "dd52a57a6f49-claude-code-fable-5", "claude-code", "anthropic"
+    )
+    stella_h2h = read_arm(
+        h2h / "dd52a57a6f49-stella-fable-5-pipeline", "stella", "openrouter"
+    )
+
+    cc_panel = read_arm(
+        matches / "41c7e447666a" / "jobs" / "41c7e447666a-claude-code-fable-5",
+        "claude-code",
+        "anthropic",
+    )
+    spec_96b5 = _read_json(matches / "96b5d7b9710c" / "spec.json") or {}
+    stella_panel = read_arm(
+        matches
+        / "96b5d7b9710c"
+        / "jobs"
+        / "96b5d7b9710c-stella-fable-5-full-pipeline-xhigh",
+        "stella",
+        "openrouter",
+        expected_tasks=spec_96b5.get("tasks") or [],
+    )
+
+    paired = []
+    stella_by_task = {t["task"]: t for t in stella_h2h["trials"]}
+    for t in cc_h2h["trials"]:
+        partner = stella_by_task.get(t["task"])
+        if partner is None:
+            continue
+        both_valid = (
+            t["outcome"] in VALID_CLASSES and partner["outcome"] in VALID_CLASSES
+        )
+        paired.append(
+            {
+                "task": t["task"],
+                "claude_code": t["outcome"],
+                "stella": partner["outcome"],
+                "matched_usable": both_valid,
+            }
+        )
+
+    document = {
+        "schema": "arenabench-experiment-document/1",
+        "calculation_version": CALCULATION_VERSION,
+        "experiment": {
+            "id": EXPERIMENT_ID,
+            "title": (
+                "Can Stella reliably outperform Claude Code on Fable 5 across >= 4 "
+                "independent matched Terminal-Bench 2.1 repetitions, at materially "
+                "lower cost per verified solve?"
+            ),
+            "status": "hypothesis_untested_evidence_incomplete",
+            "verdict": (
+                "No claim is made in either direction. Zero matched repetitions "
+                "exist against a requirement of four; the single head-to-head has "
+                "4 of 6 comparator trials invalidated by provider quota."
+            ),
+        },
+        "subject_resolution": {
+            "supplied_label": "Fable 5",
+            "resolved_model_id": "claude-fable-5",
+            "arms": {
+                "claude-code": {
+                    "route": "anthropic/claude-fable-5",
+                    "provider": "Anthropic first-party (no base_url)",
+                    "auth": "Claude subscription OAuth (CLAUDE_CODE_OAUTH_TOKEN)",
+                    "source": "matches/dd52a57a6f49/jobs/*/config.json:model_name",
+                },
+                "stella": {
+                    "route": "openrouter/anthropic/claude-fable-5",
+                    "provider": "OpenRouter (metered credits)",
+                    "source": "matches/dd52a57a6f49/jobs/*/config.json:model_name",
+                },
+            },
+        },
+        "taxonomy": {
+            "classes": [
+                "verified_solve",
+                "verified_failure",
+                "solved_then_timeout",
+                "timeout_before_solve",
+                "invalid_infrastructure",
+                "provider_failure",
+                "budget_rejected",
+                "aborted",
+                "pending",
+                "unverified",
+            ],
+            "precedence": (
+                "pending > aborted/budget_rejected > provider_failure > "
+                "invalid_infrastructure > solved_then_timeout/verified_solve > "
+                "timeout_before_solve > unverified > verified_failure"
+            ),
+            "never_a_loss": [
+                "aborted",
+                "invalid_infrastructure",
+                "provider_failure",
+                "budget_rejected",
+                "pending",
+                "unverified",
+            ],
+        },
+        "formulas": {
+            "valid_attempts": "count(outcome in {verified_solve, verified_failure, "
+            "solved_then_timeout, timeout_before_solve})",
+            "verified_solves": "count(outcome in {verified_solve, solved_then_timeout})",
+            "solve_rate": "verified_solves / valid_attempts",
+            "cost_per_verified_solve": "sum(cost over valid trials) / verified_solves",
+            "measured_cost": "each arm's own journal (CC terminal total_cost_usd; "
+            "Stella sum of step_usage.cost_usd); pricing bases differ across arms "
+            "and are never compared without the label",
+            "repriced_cost": "arenabench.pricing.trial_cost over the trial's own "
+            "token counts at one list-price table (claude-fable-5: 10/50 in/out, "
+            "cache read 1.0, write 12.5 per Mtok); unpriced => null, never a guess",
+            "units": {"cost": "USD", "tokens": "tokens", "durations": "ms"},
+        },
+        "runs": [
+            {
+                "match_id": "dd52a57a6f49",
+                "role": "the only head-to-head",
+                "executed": "2026-08-04/05",
+                "tasks": 6,
+                "comparability_key": {
+                    "dataset": "terminal-bench-2.1 (staged path)",
+                    "dataset_digest": {
+                        "value": None,
+                        "status": "unrecorded (provenance.json dataset_digest is "
+                        "empty; source: backfilled, measured: false)",
+                    },
+                    "attempts_per_task": 1,
+                    "seed": {"value": None, "status": "no seed concept in harness"},
+                    "harbor_version": {
+                        "value": "0.6.1",
+                        "status": "inference — run-fable5.sh hard-asserts 0.6.1; "
+                        "provenance.json records null",
+                    },
+                    "effort": "medium (both arms)",
+                    "reasoning": True,
+                    "budget_usd": None,
+                    "max_tokens": None,
+                    "timeout_multiplier": 1.0,
+                    "agent_setup_timeout_multiplier": 4.0,
+                    "environment": "docker, DOCKER_DEFAULT_PLATFORM=linux/amd64, "
+                    "local macOS host",
+                    "runner_image_digest": {
+                        "value": None,
+                        "status": "unrecorded — no image-digest field exists in any "
+                        "provenance schema generation",
+                    },
+                    "sut_git_sha": {
+                        "value": None,
+                        "status": "unrecorded in the match; ~/.arenabench/sut/"
+                        "sut_commit.txt is mutable state and cannot date this run",
+                    },
+                    "claude_code_version": {"value": None, "status": "unrecorded"},
+                    "stella_roles": {
+                        "verifier": "moonshotai/kimi-k3 (high)",
+                        "triage": "anthropic/claude-haiku-4.5 (low)",
+                    },
+                },
+                "arms": {"claude-code": cc_h2h, "stella": stella_h2h},
+                "paired_cells": paired,
+            },
+            {
+                "match_id": "41c7e447666a",
+                "role": "unpaired Claude Code 8-task baseline (xhigh)",
+                "executed": "2026-08-05",
+                "comparability_key": {
+                    "effort": "xhigh",
+                    "concurrency": 2,
+                    "agent_setup_timeout_multiplier": 6.0,
+                    "not_comparable_to": [
+                        "dd52a57a6f49 (effort medium)",
+                        "96b5d7b9710c (3 days apart, concurrency 1, co-tenant load, "
+                        "aborted)",
+                    ],
+                },
+                "arms": {"claude-code": cc_panel},
+            },
+            {
+                "match_id": "96b5d7b9710c",
+                "role": "unpaired Stella 8-task run (xhigh) — operator-aborted",
+                "executed": "2026-08-08",
+                "comparability_key": {
+                    "effort": "xhigh",
+                    "concurrency": 1,
+                    "budget_usd": 5.0,
+                    "sut_git_sha": "7edec3b2333e0a8649bb1fcc7190ad97242d9e3e",
+                    "dataset_digest": "sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0"
+                    "ea7c4186773687d177ad3a0699a",
+                    "harbor_version": "0.6.1 (measured provenance)",
+                },
+                "arms": {"stella": stella_panel},
+            },
+            {
+                "match_id": "VOID-ambient-key-095a17dda694",
+                "role": "voided by the operator before scoring",
+                "excluded_because": "launched accidentally with the ambient "
+                "ANTHROPIC_API_KEY instead of the subscription OAuth token; both "
+                "in-flight trials cancelled ~2min in, no scored result (VOID.md)",
+                "arms": {},
+            },
+        ],
+        "replications": {
+            "required_matched_repetitions": 4,
+            "completed_matched_repetitions": 0,
+            "definition": "one full run of one task set with both arms producing "
+            "valid (non-excluded) trials under one comparability key",
+            "nearest_evidence": "dd52a57a6f49 with 2 of 6 paired cells usable",
+        },
+        "related_runs": [
+            {
+                "match_id": "h2h891-full",
+                "subject": "claude-sonnet-5 (NOT the experiment's model)",
+                "why_here": "the improvement-history context: the five-tool bare "
+                "loop campaign this experiment inherits its harness and fixes "
+                "from; classified under this document's single taxonomy where "
+                "the existing consumers (score-match.py, metrics-match.py, "
+                "arenabench telemetry) disagree three ways about the 402-dead "
+                "trials",
+                "not_comparable_because": "different model (sonnet-5), different "
+                "tool set (five-tool bare loop), different SUT builds across "
+                "slices (208 distinct provenance records per assembly warning)",
+                **read_assembly_run(matches / "h2h891-full", "claude-sonnet-5"),
+            }
+        ],
+    }
+
+    if args.out:
+        args.out.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"wrote {args.out}")
+    if args.store:
+        store_results(document)
+        print(f"stored into {home / 'experiments.db'}")
+    if not args.out and not args.store:
+        json.dump(document, sys.stdout, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/arenabench/tests/test_experiments.py
+++ b/arenabench/tests/test_experiments.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The experiments store: schema shape, round-trips, and encoding tolerance."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from arenabench import experiments
+
+
+def test_home_resolution_honours_arenabench_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARENABENCH_HOME", str(tmp_path / "home"))
+    assert experiments.experiments_db_path() == tmp_path / "home" / "experiments.db"
+
+
+def test_schema_is_one_non_null_results_column(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    conn = experiments.connect(db)
+    try:
+        info = list(conn.execute("PRAGMA table_info(experiment_results)"))
+    finally:
+        conn.close()
+    assert [(row[1], row[2], row[3]) for row in info] == [("results", "JSONB", 1)]
+
+
+def test_store_and_load_round_trip(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    document = {
+        "experiment": {"id": "exp-001", "hypothesis": "arm A beats arm B"},
+        "trials": [{"task": "t1", "outcome": "verified_solve"}],
+    }
+    experiments.store_results(document, db)
+    assert experiments.load_results(db) == [document]
+
+
+def test_documents_come_back_in_insertion_order(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    first = {"experiment": {"id": "exp-001"}}
+    second = {"experiment": {"id": "exp-002"}}
+    experiments.store_results(first, db)
+    experiments.store_results(second, db)
+    assert experiments.load_results(db) == [first, second]
+
+
+def test_non_mapping_document_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="JSON object"):
+        experiments.store_results(["not", "a", "document"], tmp_path / "experiments.db")  # type: ignore[arg-type]
+
+
+def test_null_results_are_impossible(tmp_path: Path) -> None:
+    conn = experiments.connect(tmp_path / "experiments.db")
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("INSERT INTO experiment_results (results) VALUES (NULL)")
+    finally:
+        conn.close()
+
+
+def test_reads_tolerate_text_rows(tmp_path: Path) -> None:
+    """A row stored as JSON text (an older linked SQLite) still loads.
+
+    The store feature-detects ``jsonb()``, so one database file can hold a
+    mix of encodings across hosts; the read path must not care.
+    """
+    db = tmp_path / "experiments.db"
+    document = {"experiment": {"id": "exp-legacy"}}
+    conn = experiments.connect(db)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO experiment_results (results) VALUES (?)",
+                (json.dumps(document, sort_keys=True),),
+            )
+    finally:
+        conn.close()
+    assert experiments.load_results(db) == [document]
+
+
+@pytest.mark.skipif(
+    sqlite3.sqlite_version_info < (3, 45, 0),
+    reason="linked SQLite predates the jsonb() function family",
+)
+def test_writes_use_binary_jsonb_where_available(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    experiments.store_results({"experiment": {"id": "exp-bin"}}, db)
+    conn = experiments.connect(db)
+    try:
+        (storage_class,) = conn.execute(
+            "SELECT typeof(results) FROM experiment_results"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert storage_class == "blob"

--- a/bench/evidence/fable5-experiment-20260813/REPORT.md
+++ b/bench/evidence/fable5-experiment-20260813/REPORT.md
@@ -1,0 +1,267 @@
+# Experiment report: Stella vs Claude Code on Fable 5 (Terminal-Bench 2.1)
+
+- **Experiment id:** `stella-vs-claude-code-fable5-tb21`
+- **Status:** hypothesis untested — evidence incomplete
+- **Date:** 2026-08-13
+- **Canonical data:** the experiment document in `~/.arenabench/experiments.db`
+  (table `experiment_results`), assembled by
+  `arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py`
+  (calculation version `exp-fable5-cc-vs-stella-tb21/1`), which reads only
+  ground-truth trial artifacts: each trial's `result.json`,
+  `verifier/reward.txt`, and each arm's own journal
+  (`agent/claude-code.txt` / `agent/stella-events.jsonl`). Nothing in this
+  report comes from a dashboard, screenshot, or stale summary; every number
+  below is reproducible by re-running that script.
+
+## 1. The hypothesis, stated as a hypothesis
+
+> Stella can reliably outperform Claude Code running Fable 5 across at least
+> four independent, matched Terminal-Bench 2.1 repetitions while achieving
+> materially lower cost per verified solve.
+
+**No claim is made in either direction.** The completed evidence cannot
+support superiority, parity, or cost advantage:
+
+- **Matched repetitions completed: 0 of the 4 required.**
+- The single head-to-head that exists (`dd52a57a6f49`, 6 tasks, one attempt
+  each) lost 4 of its 6 Claude Code trials to provider quota, leaving **2
+  usable paired cells** — and those two lean *toward* Claude Code (CC 2/2,
+  Stella 1/2), the opposite of the raw per-arm headline (CC 2/6, Stella 3/6).
+  Two paired cells resolve nothing; both readings are noise.
+- The two 8-task runs are unpaired across time, effort-matched to each other
+  but not to the head-to-head, and one of them was operator-aborted.
+
+## 2. Subject resolution: what "Fable 5" is
+
+The supplied label resolves to model id **`claude-fable-5`**, served two ways
+(source: `matches/dd52a57a6f49/jobs/*/config.json` `model_name`, and the match
+specs in `arenabench/matches/`):
+
+| Arm | Route | Provider | Auth / billing |
+|---|---|---|---|
+| Claude Code | `anthropic/claude-fable-5` | Anthropic first-party (no `base_url`) | Claude subscription OAuth (`CLAUDE_CODE_OAUTH_TOKEN`), unmetered |
+| Stella | `openrouter/anthropic/claude-fable-5` | OpenRouter | Metered credits (`OPENROUTER_API_KEY`) |
+
+Effort was `medium` on both arms in the head-to-head and `xhigh` in both
+8-task runs — the two campaigns are not comparable to each other. Stella's
+pipeline arm also carries two role models (`moonshotai/kimi-k3` verifier at
+high, `anthropic/claude-haiku-4.5` triage at low); their tokens are included
+in Stella's cost. No model substitution occurred anywhere in the recorded
+runs. The exact provider serving OpenRouter's `anthropic/*` route is not
+pinned or recorded (#2419) — a known comparability caveat.
+
+## 3. Outcome taxonomy and evidence rules
+
+Every trial is classified into exactly one of: `verified_solve`,
+`verified_failure`, `solved_then_timeout`, `timeout_before_solve`,
+`invalid_infrastructure`, `provider_failure`, `budget_rejected`, `aborted`,
+`pending`, `unverified`. Classification uses structured fields (exception
+class, Claude Code's terminal `api_error_status`, Stella's parsed `error`
+events) plus strict phrase needles — never bare numbers, which have matched
+timestamps before. **Provider failures, budget rejections, aborts, pending
+and infrastructure voids are never counted as agent losses.** A trial that
+solved and then timed out counts as a solve with its timeout disclosed
+(`solved_then_timeout`). Full rules, precedence, and per-trial evidence
+strings are in the stored document.
+
+Solve rate = verified solves ÷ valid attempts, where valid attempts =
+`verified_solve + verified_failure + solved_then_timeout +
+timeout_before_solve`. Cost per verified solve = cost over valid trials ÷
+verified solves. Costs are reported on two labeled bases and never mixed:
+
+- **measured** — each arm's own journal (CC: terminal `total_cost_usd`,
+  computed by CC itself against a subscription that bills nothing per token;
+  Stella: sum of `step_usage.cost_usd` as charged by OpenRouter). The two
+  arms' measured numbers are **not subtractable from each other**.
+- **repriced** — one list-price table applied to both arms' own token counts
+  (`arenabench/pricing.py`; `claude-fable-5`: $10/$50 per Mtok in/out, cache
+  read $1.00, write $12.50; unpriced or unmeasured ⇒ null, never a guess).
+  Timed-out CC trials leave no terminal usage record, so their usage is
+  **unmeasured, not zero**; affected totals are labeled lower bounds.
+
+## 4. What the completed evidence shows
+
+### 4.1 `dd52a57a6f49` — the only head-to-head (2026-08-04/05, effort medium, 6 tasks, 1 attempt)
+
+| Task | Claude Code | Stella | Paired cell usable? |
+|---|---|---|---|
+| regex-log | verified_solve | verified_solve | yes |
+| large-scale-text-editing | verified_solve | verified_failure | yes |
+| fix-git | provider_failure (429 before turn 1) | timeout_before_solve | no |
+| nginx-request-logging | provider_failure (429 before turn 1) | verified_solve | no |
+| openssl-selfsigned-cert | provider_failure (429 before turn 1) | verified_solve | no |
+| sqlite-with-gcov | provider_failure (throttled: 8 rate-limit events, then timeout) | verified_failure | no |
+
+The four CC provider failures are the Claude subscription's five-hour limit
+(`api_error_status: 429`, "You've hit your session limit"), confirmed in CC's
+own journal per trial. They measure the quota, not the agent.
+
+| Aggregate | Claude Code | Stella |
+|---|---|---|
+| Valid attempts | 2 | 6 |
+| Verified solves | 2 | 3 |
+| Solve rate (valid basis) | 2/2 | 3/6 |
+| Measured cost, valid trials | $0.95 *(subscription-computed)* | $6.32 *(OpenRouter-metered)* |
+| Measured spend on excluded trials | $0.47 | $0 |
+| Repriced cost, valid trials (one table) | $0.83 | $6.32 |
+| Cost per verified solve (repriced) | $0.41 | $2.11 |
+
+The per-solve cost gap is real in the recorded data but rests on n=2 vs n=6
+valid trials of different tasks — **not a like-for-like comparison**, and
+Stella's number includes its verifier/triage role tokens. Explanation status
+for the gap: **unknown** (confounded by task mix, arm asymmetry, and
+denominator).
+
+### 4.2 The unpaired 8-task panel (effort xhigh — not comparable to 4.1)
+
+- **`41c7e447666a` (Claude Code, 2026-08-05, complete):** 5/8 verified
+  solves (4 clean + 1 `solved_then_timeout`: cobol-modernization), 2
+  `timeout_before_solve` (path-tracing, qemu-alpine-ssh), 1
+  `verified_failure` (extract-elf). Measured cost $4.35 (lower bound — 3
+  timed-out trials left no usage record). Repriced total: null (missing
+  beats wrong).
+- **`96b5d7b9710c` (Stella, 2026-08-08, operator-aborted):** 0 solves in 3
+  valid attempts (extract-elf, pypi-server failures; cobol timeout), 1
+  `budget_rejected` (path-tracing — a $5 `budget_usd` cap was set, violating
+  the no-caps bench rule), 1 `aborted` (kv-store-grpc cancelled), 3
+  `pending` (never ran). $10.58 spent in total.
+
+These two runs differ in date (3 days), concurrency (2 vs 1),
+setup-timeout multiplier, co-tenant load (the Stella host was sharing with
+an Opus 5 run per the spec's own notes), and completion state. **They do not
+constitute a comparison**, and 96b5d7b9710c is not a usable arm at all.
+
+- **`VOID-ambient-key-095a17dda694`:** operator-voided (wrong credential);
+  excluded by its own record, counted nowhere.
+
+### 4.3 Comparability-key audit
+
+No run in the runtime carries a complete comparability key (now #3214):
+the head-to-head's provenance is `source: backfilled, measured: false` with
+an empty dataset digest, null harness version, and no SUT/agent identity —
+harbor 0.6.1 is recoverable only from a launcher assertion (labeled
+inference), and the Stella SUT commit for it is **unknown** (the pointer file
+is mutable state that cannot date the run). No provenance generation records
+a runner-image digest at all. The strongest record (`96b5d7b9710c`) has
+dataset digest `sha256:7d7bdc1c…`, harbor 0.6.1, SUT
+`7edec3b2333e0a8649bb1fcc7190ad97242d9e3e` — the aborted run, ironically.
+
+## 5. Related context (labeled, not evidence for this hypothesis)
+
+`h2h891-full` — Claude Code vs Stella *five-tool bare loop* on
+**claude-sonnet-5**, full 89-task panel (2026-08-11/13). Different model,
+different tool posture, mixed SUT builds across slices — **not comparable to
+the Fable 5 experiment**; included because it is the improvement-history
+context and the largest run in the runtime. Classified under this
+experiment's single taxonomy (210 assembly cells, all readable):
+
+| Aggregate | Claude Code | Stella (five-tool bare loop) |
+|---|---|---|
+| Attempted cells | 88 | 122 |
+| Provider failures (excluded, never losses) | 0 | 50 (credit-exhaustion 402s; one 401) |
+| Budget-rejected / aborted | 0 | 1 |
+| Valid attempts | 88 | 71 |
+| Verified solves | 72 | 60 |
+| Solve rate (valid basis) | 81.8% | 84.5% |
+| Measured cost, valid trials | $82.22 *(subscription-computed)* | $31.59 *(OpenRouter-metered)* |
+| Wasted spend on dead trials | $0 | $42.04 |
+| Repriced cost, valid trials (one table, $3/$15) | $67.05 | $47.38 |
+| Cost per verified solve (repriced) | $0.93 | $0.79 |
+
+Two readings of the same artifacts and why they differ: the raw grid
+(72/88 vs 61/88) shows an 11-task CC lead that is **entirely the dead arm** —
+50 Stella trials died unfunded and score as losses in the canonical
+telemetry today (#3209, confirmed independently by this derivation).
+On the valid basis Stella edges ahead on rate and repriced per-solve cost.
+Explanation status: the *402-contamination* mechanism is **confirmed**
+(per-trial terminal events); the *residual Stella edge* is **plausible but
+unconfirmed** (single run, no repetition, mixed SUT builds across slices).
+
+## 6. Replication plan — what it takes to actually test the hypothesis
+
+**Census: 0 matched repetitions exist. Required: ≥ 4.** Definition: one full
+run of one task set with both arms producing valid trials under one
+comparability key.
+
+The instrument already exists: `arenabench/matches/fable5-cc-vs-stella-10task.toml`
+(10-task stratified panel — 1 easy / 6 medium / 3 hard, mirrors the dataset's
+difficulty mix, 6 tasks carry over from the head-to-head for
+cross-cycle comparability; both arms pinned to effort `medium`). It was
+designed and never executed. Protocol per repetition (r = 1..4):
+
+1. **Preflight the Claude Code credential** (until #3216 lands, run the
+   pattern from `~/.arenabench/run-fable5-repair.sh`): one 4-token request;
+   any 429/401 ⇒ do not launch. Verify OpenRouter balance ≥ $30.
+2. **Pin the apparatus once, before repetition 1**: SUT = latest `main` at
+   that moment (record sha + binary sha256), dataset
+   `terminal-bench/terminal-bench-2-1@sha256:7d7bdc1c…`, harbor 0.6.1 —
+   identical for all four repetitions. No budget caps, no token caps.
+3. Launch `arenabench run matches/fable5-cc-vs-stella-10task.toml`,
+   probe within 5 minutes that both arms are producing real turns.
+4. Classify with the experiment's classifier; a repetition is valid only if
+   ≥ 8 of 10 paired cells survive (both arms valid). A failed repetition is
+   an operational abort — named, re-run, never averaged in.
+5. Store each repetition's document in `experiments.db`; no peeking rule:
+   the decision reads all four repetitions together, once.
+
+**Pre-registered decision rule (proposed — needs Mac's sign-off before
+launch):** "reliably outperform" = Stella's valid-basis verified-solve rate
+strictly higher in ≥ 3 of 4 repetitions *and* higher pooled; "materially
+lower cost" = pooled repriced cost per verified solve ≥ 20% lower on the
+one-table basis. Anything else: report the numbers, make no claim.
+
+**Estimated spend** (basis: dd52a57a6f49 measured per-task costs scaled to
+10 tasks × 4 repetitions): Stella arm ≈ $42 metered; CC arm $0 marginal on
+subscription (or ≈ $22 metered if #3216's preflight forces an API key).
+Wall clock ≈ 1–1.5 h per repetition at concurrency 3. **Launching is a
+spend decision and, per the standing bench protocol, needs settings
+confirmed with Mac first — nothing has been launched.**
+
+## 7. Regression-correction plan
+
+Stage 1 — **measurement plane** (fix before spending on repetitions,
+otherwise the new data inherits the old distortions):
+
+| Issue | Defect | State |
+|---|---|---|
+| #3209 | Mid-run provider 402 scores as an agent loss (34 of 50 dead trials had spend and count as losses in canonical telemetry; 3 solved-then-402 trials lose their pass in `score-match.py`) | open, pre-existing; independently confirmed here |
+| #3216 | No quota preflight for subscription-OAuth seats — 4 of 6 head-to-head CC trials measured the quota | **filed by this experiment** |
+| #3214 | No complete comparability key anywhere; no image-digest field in provenance; backfilled-era records unidentifiable | **filed by this experiment** |
+| #3208 | Cloud submit accepts phantom task ids (task "89" shrank the 89-panel to 88) | open, pre-existing |
+| #3215 | Experiments store unwired (server route / UI / normalization decision) | **filed by this experiment**, Refs #2889 |
+
+Copy-paste fix prompt for stage 1:
+
+> Work the ArenaBench measurement-plane fixes in this order: #3209 (classify
+> terminal provider-payment/auth failures as infrastructure voids, keep a
+> 402'd trial's earned pass, surface an unfunded-trials count), #3216
+> (launch-time quota preflight for subscription-OAuth seats, fail closed
+> with the reset time), #3214 (record runner-image identity and complete the
+> comparability key in provenance), #3208 (reject task ids not in the
+> dataset at submit time). Each fix needs a witness test that fails on
+> current main. Evidence and repro paths are in each issue and in the
+> experiment document `stella-vs-claude-code-fable5-tb21` in
+> `~/.arenabench/experiments.db` (`arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py --out /tmp/doc.json` to inspect).
+
+Stage 2 — **engine regressions**: no engine regression is *confirmed* by the
+Fable 5 evidence (the failed tasks lack matched historical baselines on an
+identified SUT — the apparatus gap in #3214 is precisely why). Candidates
+worth carrying into the repetitions, per the diagnosis workflow in
+`docs/tools/2 - Diagnost regressions task.md`: Stella's
+`large-scale-text-editing` loss where CC solved it (verifier: 2/8 pytest
+cases passed), and the `fix-git` timeout (task family with a long fix
+history). After the four repetitions, any task that regresses against its
+own history gets a transcript-level comparison and an
+"Engine Regressions Correction:"-prefixed issue with the full spec —
+**none is filed now because none is evidenced now.**
+
+## 8. Where everything lives
+
+- **Database:** `~/.arenabench/experiments.db`, table `experiment_results`
+  (single non-null JSONB `results` column), one stored document.
+- **Store module:** `arenabench/arenabench/experiments.py` (+
+  `arenabench/tests/test_experiments.py`, 8 tests).
+- **Document builder:** `arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py`.
+- **This report:** `bench/evidence/fable5-experiment-20260813/REPORT.md`.
+- Issues filed by this experiment: #3214, #3215, #3216; confirmation
+  comment on #3209.


### PR DESCRIPTION
## What this is

Phase 1 of turning ArenaBench results into a durable, database-backed Experiments product, plus the first canonical experiment document and its report.

- **`arenabench/arenabench/experiments.py`** — the experiments store: `~/.arenabench/experiments.db`, one table `experiment_results` with a single non-null JSONB column `results`, deliberately unnormalized (normalization is #3215's decision, made against real documents). Stdlib `sqlite3` only, so `dependencies = []` stays true; writes feature-detect `jsonb()` (SQLite ≥ 3.45) and fall back to JSON text; reads normalize through `json()` so a DB file round-trips across hosts on either encoding. Exemplar followed: `bench/telemetry_store/ingest.py`'s connect/migrate idiom, plus WAL for ArenaBench's multi-process workspace.
- **`arenabench/scripts/exp-fable5-cc-vs-stella-tb21.py`** — the seed document's calculation artifact: reads ground-truth trial artifacts only (result.json, verifier/reward.txt, each arm's own journal), classifies every trial into the preregistered outcome taxonomy with recorded evidence, prices measured and repriced cost separately (unmeasured usage is a lower bound, never zero), and stores the document.
- **`bench/evidence/fable5-experiment-20260813/REPORT.md`** — the report. Headline: **the hypothesis (Stella beats CC-on-Fable-5 across ≥4 matched TB2.1 repetitions at materially lower cost per verified solve) is untested** — 0 matched repetitions exist; the one head-to-head has 4/6 comparator trials quota-invalidated; no run carries a complete comparability key. No superiority or cost claim is made.

## Witness

`arenabench/tests/test_experiments.py` (8 tests) fails on main (module absent) and passes here: schema shape (exactly one non-null `results` column), round-trip, insertion order, NULL impossibility, text-row tolerance, binary-JSONB storage where available. Verified: `python3 -m pytest tests/test_experiments.py -q` → 8 passed; ruff clean on the three new Python files.

Full local `pytest -q` in `arenabench/` has pre-existing environment-dependent failures in `test_sut.py` (`AdapterUnavailableError: /usr/bin/python3 cannot build a venv`) untouched by this add-only change.

## Issues

Filed from the experiment's findings: #3214 (comparability key / image digest gap), #3215 (wire the store into server+UI — the unwired-code handoff for this PR), #3216 (subscription quota preflight). Independent confirmation comment added to #3209. Refs #2889 (experiment-plane umbrella), #3208.

No new dependencies.

## Summary by Sourcery

Introduce a durable experiments store and seed it with the first canonical Fable 5 experiment document and report.

New Features:
- Add a SQLite-backed experiments store module that persists JSON experiment documents in a single experiment_results table.
- Add a script that assembles the canonical Stella vs Claude Code on Fable 5 experiment document from ground-truth trial artifacts and optionally stores or outputs it.
- Add a user-facing experiment report documenting the Fable 5 hypothesis, current evidence, comparability audit, and replication plan.

Enhancements:
- Add tests covering experiments store path resolution, schema shape, round-tripping, insertion order, encoding tolerance, and JSONB usage.