### PR TITLE
feat(arenabench): serve stored experiments — GET /api/experiments and /api/experiments/<id>

### DIFF
--- a/arenabench/arenabench/experiments.py
+++ b/arenabench/arenabench/experiments.py
@@ -55,7 +55,9 @@ from .sut import arenabench_home
 
 __all__ = [
     "connect",
+    "experiment_document",
     "experiments_db_path",
+    "experiments_payload",
     "load_results",
     "store_results",
 ]
@@ -135,15 +137,60 @@ def load_results(db_path: Path | None = None) -> list[dict[str, Any]]:
 
     Reads normalize through ``json()`` when the linked SQLite has it, so
     rows written in either encoding (binary JSONB or JSON text) come back
-    as the same Python mapping.
+    as the same Python mapping. A workspace that never stored an
+    experiment gets an empty list — looking must not create a database.
     """
+    path = experiments_db_path() if db_path is None else db_path
+    if not path.exists():
+        return []
     select = (
         "SELECT json(results) FROM experiment_results"
         if _jsonb_available()
         else "SELECT results FROM experiment_results"
     )
-    conn = connect(db_path)
+    conn = connect(path)
     try:
         return [json.loads(row[0]) for row in conn.execute(select)]
     finally:
         conn.close()
+
+
+def experiments_payload(db_path: Path | None = None) -> dict[str, Any]:
+    """Every stored document summarized for a listing surface (#3215).
+
+    One row per document: the document's own ``experiment`` header plus
+    the calculation version, which is what a gallery needs to name a card.
+    The full document stays behind :func:`experiment_document` — a listing
+    that shipped whole documents would grow with every trial they record.
+    """
+    summaries = []
+    for document in load_results(db_path):
+        experiment = document.get("experiment")
+        header = experiment if isinstance(experiment, Mapping) else {}
+        summaries.append(
+            {
+                "id": header.get("id"),
+                "title": header.get("title"),
+                "status": header.get("status"),
+                "schema": document.get("schema"),
+                "calculation_version": document.get("calculation_version"),
+            }
+        )
+    return {"experiments": summaries}
+
+
+def experiment_document(
+    experiment_id: str, db_path: Path | None = None
+) -> dict[str, Any] | None:
+    """The full stored document whose experiment id matches, or ``None``.
+
+    When one id was stored more than once, the *latest* row wins: a re-run
+    of a calculation supersedes its predecessor, and rows are read in
+    insertion order.
+    """
+    found = None
+    for document in load_results(db_path):
+        experiment = document.get("experiment")
+        if isinstance(experiment, Mapping) and experiment.get("id") == experiment_id:
+            found = document
+    return found

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -81,6 +81,7 @@ from .credentials import (
     missing_required_credentials,
     resolve_launch_credentials,
 )
+from .experiments import experiment_document, experiments_payload
 from .model import (
     EFFORTS,
     RESPONSIBILITIES,
@@ -501,6 +502,22 @@ class ArenaServer:
         grouping is enforced rather than assumed.
         """
         return series_payload(list(self.runner.matches.values()))
+
+    def experiments(self) -> Any:
+        """Stored experiment documents, summarized for the gallery (#3215).
+
+        Reads the experiments store only — a workspace that never stored an
+        experiment gets an empty listing, and the read never creates the
+        database. Match discovery stays independent of this store by design.
+        """
+        return experiments_payload()
+
+    def experiment(self, experiment_id: str) -> Any:
+        """One full experiment document by its id (#3215)."""
+        document = experiment_document(experiment_id)
+        if document is None:
+            raise KeyError(experiment_id)
+        return document
 
     #: Shortest gap between disk sweeps driven by a request. The listing is
     #: polled by every open browser tab, and the sweep stats every match
@@ -1057,6 +1074,10 @@ def _handler_factory(
                     self._json(arena.sut_build(build_id))
                 case ["series"]:
                     self._json(arena.series())
+                case ["experiments"]:
+                    self._json(arena.experiments())
+                case ["experiments", experiment_id]:
+                    self._json(arena.experiment(experiment_id))
                 case ["matches"]:
                     self._json(arena.list_matches())
                 case ["matches", match_id]:

--- a/arenabench/tests/test_experiments.py
+++ b/arenabench/tests/test_experiments.py
@@ -83,6 +83,52 @@ def test_reads_tolerate_text_rows(tmp_path: Path) -> None:
     assert experiments.load_results(db) == [document]
 
 
+def test_loading_a_missing_database_returns_empty_and_creates_nothing(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "experiments.db"
+    assert experiments.load_results(db) == []
+    assert not db.exists()
+
+
+def test_payload_summarizes_each_document(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    experiments.store_results(
+        {
+            "schema": "arenabench-experiment-document/1",
+            "calculation_version": "calc/1",
+            "experiment": {"id": "exp-001", "title": "A vs B", "status": "open"},
+            "trials": [{"task": "t1"}],
+        },
+        db,
+    )
+    assert experiments.experiments_payload(db) == {
+        "experiments": [
+            {
+                "id": "exp-001",
+                "title": "A vs B",
+                "status": "open",
+                "schema": "arenabench-experiment-document/1",
+                "calculation_version": "calc/1",
+            }
+        ]
+    }
+
+
+def test_document_lookup_finds_by_id_and_latest_wins(tmp_path: Path) -> None:
+    db = tmp_path / "experiments.db"
+    experiments.store_results(
+        {"experiment": {"id": "exp-001"}, "calculation_version": "calc/1"}, db
+    )
+    experiments.store_results(
+        {"experiment": {"id": "exp-001"}, "calculation_version": "calc/2"}, db
+    )
+    document = experiments.experiment_document("exp-001", db)
+    assert document is not None
+    assert document["calculation_version"] == "calc/2"
+    assert experiments.experiment_document("exp-missing", db) is None
+
+
 @pytest.mark.skipif(
     sqlite3.sqlite_version_info < (3, 45, 0),
     reason="linked SQLite predates the jsonb() function family",


### PR DESCRIPTION
## What this is

The read half of #3215, on top of the merged Phase 1 store (#3220): the server now serves stored experiment documents.

- `GET /api/experiments` — gallery listing: each document's own `experiment` header (id, title, status) plus schema and calculation version. Whole documents deliberately stay out of the listing — they grow with every trial they record.
- `GET /api/experiments/<id>` — the full document; unknown id → 404 via the existing `KeyError` convention.

Follows the `/api/series` shape exactly: thin handlers on `ArenaServer`, one `case` arm each in `_route_api_get`. Two properties held deliberately:

- **Reading never creates the database** — `load_results` now returns `[]` for a missing file instead of connecting (a GET must not write), and match discovery (`restore_from_disk`) remains fully independent of the store.
- **Latest row wins on duplicate ids** — a re-run of a calculation supersedes its predecessor, in insertion order.

## Witness

Three new tests in `arenabench/tests/test_experiments.py` fail on main (functions absent) and pass here: missing-DB read creates nothing, payload summarization, latest-wins lookup + miss → `None`. `python3 -m pytest tests/test_experiments.py -q` → 11 passed; ruff clean on all three touched files. Live smoke against the real `~/.arenabench/experiments.db` returns the stored `stella-vs-claude-code-fable5-tb21` document.

## Scope

Refs #3215 — deliberately not `Closes`: the UI view and the normalization decision remain there.

No new dependencies.

## Summary by Sourcery

Expose stored experiment documents via new GET /api/experiments and /api/experiments/<id> endpoints backed by the experiments store.

New Features:
- Add experiments_payload helper to summarize stored experiment documents for listing surfaces.
- Add experiment_document lookup helper to retrieve the full stored experiment document by id.
- Expose summarized experiments listing and single experiment retrieval on ArenaServer via new experiments and experiment methods, wired into the API router.

Bug Fixes:
- Ensure load_results returns an empty list and does not create a database when the experiments store file is missing.

Tests:
- Add tests covering missing-database reads, experiment listing payload summarization, and latest-wins experiment document lookup semantics.