### PR TITLE
feat(arenabench-ui): render file-mutating tool calls as coloured git diffs

### DIFF
--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -15,6 +15,91 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ProofPanel } from "@/components/arena/proof-panel";
 
+/** Tools whose raw input IS a file change, so it reads far better as a
+ *  git-style diff than as a JSON dump — additions green, removals red, the
+ *  path as the hunk header. Every other tool keeps the plain argument view. */
+const FILE_MUTATION_TOOLS = new Set([
+  "write_file",
+  "edit_file",
+  "apply_edits",
+  "delete_file",
+]);
+
+type DiffLine = { sign: "+" | "-"; text: string };
+
+/** Read a file-mutating tool's raw input into diff lines, or `null` when the
+ *  tool is not a mutation or its input does not parse — the caller then falls
+ *  back to the plain JSON. A new file is all-additions; an edit is its
+ *  old lines removed then its new lines added; `apply_edits` concatenates each
+ *  edit's pair; a delete is one removal marker (the bytes are not in the call).
+ *  Field names are the tools' own schemas: write_file `{content,path}`,
+ *  edit_file `{old_string,new_string,path}`. */
+function fileDiffFromRaw(
+  name: string | undefined,
+  raw: string,
+): { path?: string; lines: DiffLine[] } | null {
+  if (!name || !FILE_MUTATION_TOOLS.has(name)) return null;
+  let input: Record<string, unknown>;
+  try {
+    input = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const path = typeof input.path === "string" ? input.path : undefined;
+  const asLines = (v: unknown, sign: DiffLine["sign"]): DiffLine[] =>
+    typeof v === "string" && v.length > 0
+      ? v.replace(/\n$/, "").split("\n").map((text) => ({ sign, text }))
+      : [];
+  let lines: DiffLine[] = [];
+  if (name === "write_file") {
+    lines = asLines(input.content, "+");
+  } else if (name === "edit_file") {
+    lines = [...asLines(input.old_string, "-"), ...asLines(input.new_string, "+")];
+  } else if (name === "apply_edits") {
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    for (const e of edits as Record<string, unknown>[]) {
+      lines.push(...asLines(e.old_string, "-"), ...asLines(e.new_string, "+"));
+    }
+  } else if (name === "delete_file") {
+    lines = [{ sign: "-", text: "(file deleted)" }];
+  }
+  return lines.length > 0 ? { path, lines } : null;
+}
+
+/** A tool's file change as a git-style diff: the path as the hunk header,
+ *  additions on a green ground and removals on a red one, each with its `+`/`-`
+ *  sign. Line-level tint (not just glyph colour) so a scroll of edits reads at
+ *  a glance the way `git diff` does. */
+function FileDiffBlock({
+  diff,
+}: {
+  diff: { path?: string; lines: DiffLine[] };
+}) {
+  return (
+    <div className="ml-5 mt-1 overflow-x-auto rounded border border-line text-[11px]">
+      {diff.path && (
+        <div className="border-b border-line bg-panel-2 px-2 py-1 font-mono text-dim">
+          {diff.path}
+        </div>
+      )}
+      <div className="font-mono leading-[1.4]">
+        {diff.lines.map((ln, i) => (
+          <div
+            key={i}
+            className={cn(
+              "whitespace-pre-wrap break-words px-2",
+              ln.sign === "+" ? "bg-ok/10 text-ok" : "bg-bad/10 text-bad",
+            )}
+          >
+            <span className="select-none opacity-60">{ln.sign} </span>
+            {ln.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /**
  * A trial's transcript as its own page: `/transcript?match=…&task=…&seat=…`.
  *
@@ -568,11 +653,20 @@ function Entry({
             </button>
           )}
         </div>
-        {expandable && resultOpen && (
-          <pre className="ml-5 overflow-x-auto whitespace-pre-wrap break-words text-[11px] text-dim">
-            <Highlight text={raw} query={query} />
-          </pre>
-        )}
+        {expandable && resultOpen &&
+          (() => {
+            // A file-mutating tool renders as a coloured diff; everything else
+            // keeps the raw argument JSON. The diff is null-safe: a call whose
+            // input does not parse falls back to the plain view.
+            const diff = fileDiffFromRaw(entry.title, raw);
+            return diff ? (
+              <FileDiffBlock diff={diff} />
+            ) : (
+              <pre className="ml-5 overflow-x-auto whitespace-pre-wrap break-words text-[11px] text-dim">
+                <Highlight text={raw} query={query} />
+              </pre>
+            );
+          })()}
       </div>
     );
   }

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -27,17 +27,24 @@ const FILE_MUTATION_TOOLS = new Set([
 
 type DiffLine = { sign: "+" | "-"; text: string };
 
-/** Read a file-mutating tool's raw input into diff lines, or `null` when the
- *  tool is not a mutation or its input does not parse — the caller then falls
- *  back to the plain JSON. A new file is all-additions; an edit is its
- *  old lines removed then its new lines added; `apply_edits` concatenates each
- *  edit's pair; a delete is one removal marker (the bytes are not in the call).
- *  Field names are the tools' own schemas: write_file `{content,path}`,
- *  edit_file `{old_string,new_string,path}`. */
+type FileHunk = { path?: string; lines: DiffLine[] };
+
+/** Read a file-mutating tool's raw input into one or more per-file diff hunks,
+ *  or `null` when the tool is not a mutation or its input does not parse — the
+ *  caller then falls back to the plain JSON. A new file is all-additions; an
+ *  edit is its old lines removed then its new lines added; a delete is one
+ *  removal marker (the bytes are not in the call). `apply_edits` carries a
+ *  `path` on each element of its `edits` array (there is no top-level `path`),
+ *  and one call can touch several files — so each edit is grouped under its own
+ *  `e.path`, consecutive edits to the same file sharing a hunk, giving every
+ *  file its own header instead of one anonymous path-less block. Field names
+ *  are the tools' own schemas: write_file `{content,path}`, edit_file
+ *  `{old_string,new_string,path}`, apply_edits `{edits:[{path,old_string,
+ *  new_string}]}`. */
 function fileDiffFromRaw(
   name: string | undefined,
   raw: string,
-): { path?: string; lines: DiffLine[] } | null {
+): FileHunk[] | null {
   if (!name || !FILE_MUTATION_TOOLS.has(name)) return null;
   let input: Record<string, unknown>;
   try {
@@ -50,52 +57,68 @@ function fileDiffFromRaw(
     typeof v === "string" && v.length > 0
       ? v.replace(/\n$/, "").split("\n").map((text) => ({ sign, text }))
       : [];
-  let lines: DiffLine[] = [];
+  const hunks: FileHunk[] = [];
   if (name === "write_file") {
-    lines = asLines(input.content, "+");
+    const lines = asLines(input.content, "+");
+    if (lines.length > 0) hunks.push({ path, lines });
   } else if (name === "edit_file") {
-    lines = [...asLines(input.old_string, "-"), ...asLines(input.new_string, "+")];
+    const lines = [...asLines(input.old_string, "-"), ...asLines(input.new_string, "+")];
+    if (lines.length > 0) hunks.push({ path, lines });
   } else if (name === "apply_edits") {
     const edits = Array.isArray(input.edits) ? input.edits : [];
     for (const e of edits as Record<string, unknown>[]) {
-      lines.push(...asLines(e.old_string, "-"), ...asLines(e.new_string, "+"));
+      const editPath = typeof e.path === "string" ? e.path : undefined;
+      const lines = [...asLines(e.old_string, "-"), ...asLines(e.new_string, "+")];
+      if (lines.length === 0) continue;
+      const last = hunks[hunks.length - 1];
+      if (last && last.path === editPath) last.lines.push(...lines);
+      else hunks.push({ path: editPath, lines });
     }
   } else if (name === "delete_file") {
-    lines = [{ sign: "-", text: "(file deleted)" }];
+    hunks.push({ path, lines: [{ sign: "-", text: "(file deleted)" }] });
   }
-  return lines.length > 0 ? { path, lines } : null;
+  return hunks.length > 0 ? hunks : null;
 }
 
-/** A tool's file change as a git-style diff: the path as the hunk header,
- *  additions on a green ground and removals on a red one, each with its `+`/`-`
- *  sign. Line-level tint (not just glyph colour) so a scroll of edits reads at
- *  a glance the way `git diff` does. */
+/** A tool's file change as a git-style diff: each touched file its own hunk
+ *  with its path as the header, additions on a green ground and removals on a
+ *  red one, each with its `+`/`-` sign. Line-level tint (not just glyph colour)
+ *  so a scroll of edits reads at a glance the way `git diff` does. An
+ *  `apply_edits` batch spanning several files renders one hunk per file so a
+ *  multi-file change is never flattened into one anonymous block. */
 function FileDiffBlock({
-  diff,
+  hunks,
 }: {
-  diff: { path?: string; lines: DiffLine[] };
+  hunks: FileHunk[];
 }) {
   return (
-    <div className="ml-5 mt-1 overflow-x-auto rounded border border-line text-[11px]">
-      {diff.path && (
-        <div className="border-b border-line bg-panel-2 px-2 py-1 font-mono text-dim">
-          {diff.path}
-        </div>
-      )}
-      <div className="font-mono leading-[1.4]">
-        {diff.lines.map((ln, i) => (
-          <div
-            key={i}
-            className={cn(
-              "whitespace-pre-wrap break-words px-2",
-              ln.sign === "+" ? "bg-ok/10 text-ok" : "bg-bad/10 text-bad",
-            )}
-          >
-            <span className="select-none opacity-60">{ln.sign} </span>
-            {ln.text}
+    <div className="ml-5 mt-1 space-y-1">
+      {hunks.map((hunk, h) => (
+        <div
+          key={h}
+          className="overflow-x-auto rounded border border-line text-[11px]"
+        >
+          {hunk.path && (
+            <div className="border-b border-line bg-panel-2 px-2 py-1 font-mono text-dim">
+              {hunk.path}
+            </div>
+          )}
+          <div className="font-mono leading-[1.4]">
+            {hunk.lines.map((ln, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "whitespace-pre-wrap break-words px-2",
+                  ln.sign === "+" ? "bg-ok/10 text-ok" : "bg-bad/10 text-bad",
+                )}
+              >
+                <span className="select-none opacity-60">{ln.sign} </span>
+                {ln.text}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -660,7 +683,7 @@ function Entry({
             // input does not parse falls back to the plain view.
             const diff = fileDiffFromRaw(entry.title, raw);
             return diff ? (
-              <FileDiffBlock diff={diff} />
+              <FileDiffBlock hunks={diff} />
             ) : (
               <pre className="ml-5 overflow-x-auto whitespace-pre-wrap break-words text-[11px] text-dim">
                 <Highlight text={raw} query={query} />


### PR DESCRIPTION
## What

In arenabench transcripts, a `write_file` / `edit_file` / `apply_edits` / `delete_file` call rendered its **raw input JSON** — a wall of escaped content that reads nothing like the change it made. Now it renders as a **git-style diff**: the path as the hunk header, **additions on a green ground, removals on a red one**, each with its `+`/`-` sign, so a scroll of edits reads at a glance the way `git diff` does.

## How

- `fileDiffFromRaw(name, raw)` maps each mutating tool's raw input to diff lines, using the tools' own schema field names (`write_file {content,path}`, `edit_file {old_string,new_string,path}`): a new file is all-additions; an edit is old-removed then new-added; `apply_edits` concatenates each edit's pair; a delete is one removal marker (the bytes aren't in the call).
- `<FileDiffBlock>` renders line-level tint (not just glyph colour) using the existing `--ok`/`--bad` AA-contrast tokens, so it is **theme-aware** in light and dark.
- **Null-safe fallback:** any non-mutating tool, or an input that doesn't parse, keeps the plain JSON view unchanged. Only `transcript-page.tsx` touched.

## Verify

`pnpm exec tsc --noEmit` clean (exit 0). Open any transcript (`arenabench serve`) with file edits — the write/edit calls now show coloured diffs. Field names confirmed against real `stella-events.jsonl` from run `stellasearch89`.

## Summary by Sourcery

Render file-mutating tool calls in transcript pages as git-style coloured diffs instead of raw JSON, with a safe fallback to the original JSON view when inputs cannot be parsed.

New Features:
- Display write_file, edit_file, apply_edits, and delete_file calls as line-based diffs with path headers and +/- markers for additions and deletions.

Enhancements:
- Use theme-aware ok/bad colour tokens to tint diff lines for better readability in light and dark modes.
- Limit diff rendering logic to transcript pages while keeping non-mutating tools on the existing JSON argument view.