### PR TITLE
fix(stella-pipeline): a recalled memory ships its sentence once, not twice

### DIFF
--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -559,13 +559,20 @@ pub fn render_context_section(frames: &[RecalledFrame]) -> Option<String> {
     let mut lines: Vec<String> = Vec::new();
     let mut citable = false;
     for f in frames {
-        let label = &f.citation_label;
+        // Only a label that says something the content does not earns its
+        // bytes: memory (and episode) nodes mint theirs FROM the content, so
+        // rendering both shipped the same sentence twice into a recall budget
+        // the packer had already spent on the content alone (#2476).
+        let body = match f.distinct_label() {
+            Some(label) => format!("{label} — {}", f.content.trim()),
+            None => f.content.trim().to_string(),
+        };
         match (f.kind.as_str(), &f.id) {
             // A memory with an id: citable, and the id is what the model
             // hands back to `cite_memory`.
             ("memory", Some(id)) => {
                 citable = true;
-                lines.push(format!("- [{id}] {label} — {}", f.content.trim()));
+                lines.push(format!("- [{id}] {body}"));
             }
             // A memory WITHOUT an id still has content worth recalling, and
             // the recall budget has already been spent fetching it.
@@ -579,8 +586,8 @@ pub fn render_context_section(frames: &[RecalledFrame]) -> Option<String> {
             // contract even though the only production projection happens to
             // always set `Some`. Render it as grounding — it cannot be cited,
             // so it must not claim to be.
-            ("memory", None) => lines.push(format!("- {label} — {}", f.content.trim())),
-            _ => lines.push(format!("- {label} — {}", f.content.trim())),
+            ("memory", None) => lines.push(format!("- {body}")),
+            _ => lines.push(format!("- {body}")),
         }
     }
     if lines.is_empty() {

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -274,8 +274,11 @@ fn recall_section_renders_a_content_minted_label_once() {
         1,
         "a >80-char memory keeps its full content exactly once: {section}"
     );
+    // The minted label itself (`…` included) must not render — checked by the
+    // label string, not by the `…` char alone, which the citation ask's own
+    // `[nod_…]` wording legitimately carries.
     assert!(
-        !section.contains('…'),
+        !section.contains(&minted),
         "the minted label's truncated copy must not render at all: {section}"
     );
 }

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -229,6 +229,57 @@ fn recall_section_tags_memory_frames_with_ids_and_asks_for_citations() {
     );
 }
 
+/// #2476's witness: memory labels are minted FROM the content
+/// (`stella-context`'s `truncate_label` — the content verbatim at ≤80 chars,
+/// its first 79 chars plus `…` above), so every rendered memory frame carried
+/// its own sentence twice, on every turn that recalled anything, inside a
+/// budget the packer had already spent on the content alone. The renderer now
+/// ships the content once; the `[nod_…]` id stays as the citation handle.
+/// `recall_section_tags_memory_frames_with_ids_and_asks_for_citations` is the
+/// control: its hand-chosen label differs from the content and still renders.
+#[test]
+fn recall_section_renders_a_content_minted_label_once() {
+    // ≤80 chars: the mint copies the content verbatim, so label == content.
+    let lesson = "the spend ledger is append-only, and a resize never rewrites a row";
+    let short = frame(
+        "nod_aaa",
+        contextgraph_types::FrameKind::Memory,
+        lesson,
+        lesson,
+    );
+    // >80 chars: the mint keeps the first 79 chars plus `…`.
+    let long_content = format!("{} and the tail only the content carries", "y".repeat(80));
+    let minted: String = {
+        let head: String = long_content.chars().take(79).collect();
+        format!("{head}…")
+    };
+    let long = frame(
+        "nod_bbb",
+        contextgraph_types::FrameKind::Memory,
+        &minted,
+        &long_content,
+    );
+    let section = render_context_section(&[short, long]).unwrap();
+    assert!(
+        section.contains(&format!("- [nod_aaa] {lesson}")),
+        "the id stays the citation handle and the content ships once: {section}"
+    );
+    assert_eq!(
+        section.matches(lesson).count(),
+        1,
+        "an ≤80-char memory must not print its sentence twice: {section}"
+    );
+    assert_eq!(
+        section.matches(&long_content).count(),
+        1,
+        "a >80-char memory keeps its full content exactly once: {section}"
+    );
+    assert!(
+        !section.contains('…'),
+        "the minted label's truncated copy must not render at all: {section}"
+    );
+}
+
 #[test]
 fn recall_section_without_memories_never_asks_for_citations() {
     let frames = vec![frame(

--- a/crates/stella-pipeline/src/pipeline/user_message.rs
+++ b/crates/stella-pipeline/src/pipeline/user_message.rs
@@ -96,9 +96,16 @@ pub(super) fn assemble_user_message(
             // materialized memory ALSO carries its stable id, because that is
             // the handle `cite_memory` ties feedback to — see the citation ask
             // below for why its absence was not a cosmetic omission.
-            s.push_str("- [");
-            s.push_str(&f.citation_label);
-            s.push_str("] (");
+            // Memory-minted labels ARE the content (its head, `…`-marked when
+            // truncated), so only a label that adds information renders —
+            // otherwise the same sentence shipped twice per frame (#2476).
+            s.push_str("- ");
+            if let Some(label) = f.distinct_label() {
+                s.push('[');
+                s.push_str(label);
+                s.push_str("] ");
+            }
+            s.push('(');
             s.push_str(&f.source);
             s.push(')');
             if let Some(id) = citable_id(f) {
@@ -277,6 +284,34 @@ mod tests {
         assert!(
             msg.find("cite_memory").unwrap() < msg.find("## Task").unwrap(),
             "the ask belongs to the recall block, not to the task: {msg}"
+        );
+    }
+
+    /// #2476's witness for this surface: a label the memory mint copied from
+    /// the content renders once, not twice. `a_recalled_memory_reaches_the_worker_citable`
+    /// above is the control — its hand-chosen label ("prompt caching") differs
+    /// from the content and still leads the line.
+    #[test]
+    fn a_content_minted_label_renders_its_sentence_once() {
+        const NOD: &str = "nod_0123456789abcdef01234567";
+        let lesson = "Anthropic's prompt cache is explicit opt-in.";
+        let msg = assemble_user_message(
+            "fix the cache posture",
+            &[RecalledFrame {
+                citation_label: lesson.into(),
+                ..memory_frame(Some(NOD))
+            }],
+            &[],
+            VerificationContract::None,
+        );
+        assert_eq!(
+            msg.matches(lesson).count(),
+            1,
+            "a content-minted label must not re-ship the content: {msg}"
+        );
+        assert!(
+            msg.contains(NOD),
+            "the citation handle survives the collapsed label: {msg}"
         );
     }
 

--- a/crates/stella-pipeline/src/plan.rs
+++ b/crates/stella-pipeline/src/plan.rs
@@ -286,9 +286,15 @@ pub fn build_planner_prompt(
         prompt.push_str("## Recalled context\n");
         for frame in recall {
             // Cite by human label (L-C4); include the content as grounding.
-            prompt.push_str("- [");
-            prompt.push_str(&frame.citation_label);
-            prompt.push_str("] (");
+            // A memory-minted label duplicates the content it was cut from,
+            // so it renders only when it adds information (#2476).
+            prompt.push_str("- ");
+            if let Some(label) = frame.distinct_label() {
+                prompt.push('[');
+                prompt.push_str(label);
+                prompt.push_str("] ");
+            }
+            prompt.push('(');
             prompt.push_str(&frame.source);
             prompt.push_str(")\n");
             if !frame.content.trim().is_empty() {
@@ -553,6 +559,22 @@ mod tests {
         assert!(prompt.contains("run_turn drives steps"));
         assert!(prompt.contains("stella-core/src/budget.rs"));
         assert!(prompt.contains("JSON array"));
+    }
+
+    /// #2476's witness for this surface: a label the memory mint copied from
+    /// the content renders once, not twice — the distinct-label frame in
+    /// `planner_prompt_includes_goal_recall_and_structure_but_not_transcript`
+    /// is the control.
+    #[test]
+    fn planner_prompt_renders_a_content_minted_label_once() {
+        let lesson = "run_turn drives steps";
+        let recall = vec![frame(lesson, lesson)];
+        let prompt = build_planner_prompt("goal", &recall, &[], "", None).rendered();
+        assert_eq!(
+            prompt.matches(lesson).count(),
+            1,
+            "a content-minted label must not re-ship the content: {prompt}"
+        );
     }
 
     #[test]

--- a/crates/stella-pipeline/src/ports.rs
+++ b/crates/stella-pipeline/src/ports.rs
@@ -94,6 +94,46 @@ pub struct RecalledFrame {
     pub content_digest: Option<String>,
 }
 
+impl RecalledFrame {
+    /// The citation label, when it says something [`Self::content`] does not.
+    ///
+    /// Memory and episode nodes mint their label FROM their content
+    /// (`stella-context`'s `writeback.rs::truncate_label`: the content
+    /// verbatim at ≤80 chars, its first 79 chars plus `…` above that), so for
+    /// them the label is the content — or its head — repeated. Every surface
+    /// that rendered `label` beside `content` therefore shipped the same
+    /// sentence twice into a rationed recall budget, on every turn that
+    /// recalled anything, and the budget packer never saw it: frames are
+    /// packed by `content` alone, so the block silently exceeded the budget
+    /// it was packed to (#2476).
+    ///
+    /// `None` for exactly the two shapes `truncate_label` produces and
+    /// nothing else — a label equal to the content, or a `…`-terminated
+    /// prefix of it. An author-chosen label that merely resembles the
+    /// content's opening words stays distinct: this predicate models the
+    /// mint, not a similarity heuristic, so it can never swallow a label a
+    /// human picked (L-C4 keeps its guarantee that every frame is citable —
+    /// the collapsed cases are those where the content IS the citation text).
+    #[must_use]
+    pub fn distinct_label(&self) -> Option<&str> {
+        let label = self.citation_label.trim();
+        if label.is_empty() {
+            return None;
+        }
+        let content = self.content.trim();
+        if label == content {
+            return None;
+        }
+        if let Some(stem) = label.strip_suffix('…')
+            && !stem.is_empty()
+            && content.starts_with(stem)
+        {
+            return None;
+        }
+        Some(label)
+    }
+}
+
 /// The one sentence that asks a model to cite the injected context it used —
 /// the `cite_memory` affordance, in the words every surface says it in.
 ///
@@ -1223,6 +1263,53 @@ mod tests {
             AlwaysAbortGate.review(&proposal).await,
             ScopeDecision::Abort
         );
+    }
+
+    /// #2476's predicate: a label is dropped for exactly the two shapes the
+    /// memory mint (`truncate_label`) produces, and nothing else.
+    #[test]
+    fn a_label_minted_from_the_content_is_not_distinct() {
+        let frame = |label: &str, content: &str| RecalledFrame {
+            citation_label: label.into(),
+            content: content.into(),
+            ..recalled("workspace-memory", "nod_x", None)
+        };
+        // ≤80 chars: the mint copies the content verbatim.
+        let short = frame("prefer rg over grep", "prefer rg over grep");
+        assert_eq!(short.distinct_label(), None);
+        // >80 chars: the mint keeps the first 79 chars plus `…`.
+        let long_content = "a".repeat(120);
+        let minted: String = format!("{}…", "a".repeat(79));
+        let long = frame(&minted, &long_content);
+        assert_eq!(long.distinct_label(), None);
+        // Whitespace differences do not defeat the match — both sides render
+        // trimmed, so they compare trimmed.
+        let padded = frame("  prefer rg over grep  ", "prefer rg over grep\n");
+        assert_eq!(padded.distinct_label(), None);
+        // An empty label was never citable text at all.
+        assert_eq!(frame("", "some content").distinct_label(), None);
+    }
+
+    #[test]
+    fn an_author_chosen_label_stays_distinct() {
+        let frame = |label: &str, content: &str| RecalledFrame {
+            citation_label: label.into(),
+            content: content.into(),
+            ..recalled("code-graph", "nod_y", None)
+        };
+        // A path label over a code excerpt — the ordinary code-graph shape.
+        let hit = frame("src/lib.rs", "fn main() {}");
+        assert_eq!(hit.distinct_label(), Some("src/lib.rs"));
+        // A hand-picked label that happens to open the content is NOT the
+        // mint's shape (no `…`), so it is the author's choice and it stays.
+        let prefix = frame("prefer rg", "prefer rg over grep here");
+        assert_eq!(prefix.distinct_label(), Some("prefer rg"));
+        // `…`-terminated, but over different text: distinct.
+        let elsewhere = frame("retry policy…", "the backoff doubles per attempt");
+        assert_eq!(elsewhere.distinct_label(), Some("retry policy…"));
+        // A frame with no content cannot cover any label.
+        let bare = frame("an episode title", "");
+        assert_eq!(bare.distinct_label(), Some("an episode title"));
     }
 
     fn recalled(provider: &str, id: &str, digest: Option<&str>) -> RecalledFrame {

--- a/crates/stella-pipeline/src/witness.rs
+++ b/crates/stella-pipeline/src/witness.rs
@@ -915,9 +915,14 @@ pub fn witness_prompt(
     if !recall.is_empty() {
         s.push_str("\n## Recalled context\n");
         for f in recall {
-            s.push_str("- [");
-            s.push_str(&f.citation_label);
-            s.push_str("] ");
+            // A memory-minted label duplicates the content it was cut from,
+            // so it renders only when it adds information (#2476).
+            s.push_str("- ");
+            if let Some(label) = f.distinct_label() {
+                s.push('[');
+                s.push_str(label);
+                s.push_str("] ");
+            }
             s.push_str(f.content.trim());
             s.push('\n');
         }

--- a/crates/stella-pipeline/src/witness/tests.rs
+++ b/crates/stella-pipeline/src/witness/tests.rs
@@ -611,6 +611,32 @@ fn witness_prompt_carries_goal_structure_recall_and_marker() {
     );
 }
 
+/// #2476's witness for this surface: a label the memory mint copied from the
+/// content renders once, not twice — the frame above (distinct label) is the
+/// control that labels which add information still ship.
+#[test]
+fn witness_prompt_renders_a_memory_minted_label_once() {
+    let lesson = "the spend ledger is append-only, and a resize never rewrites a row";
+    let recall = vec![RecalledFrame {
+        citation_label: lesson.to_string(),
+        provider: "workspace-memory".to_string(),
+        source: "memory".to_string(),
+        kind: "memory".to_string(),
+        uri: None,
+        method: None,
+        content: lesson.to_string(),
+        token_cost: 4,
+        id: None,
+        content_digest: None,
+    }];
+    let p = witness_prompt("fix the retry bug", &recall, "", &[], "");
+    assert_eq!(
+        p.matches(lesson).count(),
+        1,
+        "a content-minted label must not re-ship the content: {p}"
+    );
+}
+
 /// The fixed system block carries the whole enforced contract: the
 /// marker line, the one-new-file rule, and the density-screen rule
 /// (#863) — a refusal the author could not have anticipated costs the


### PR DESCRIPTION
## What & why

Every recalled memory shipped its own text **twice** into the prompt, on
every turn that recalled anything. Memory (and episode) nodes mint their
citation label FROM their content (`stella-context`'s
`writeback.rs::truncate_label` — the content verbatim at ≤80 chars, its
first 79 chars plus `…` above), and every render surface printed
`label` beside `content`:

```
- [nod_8af3…] the spend ledger is append-only — the spend ledger is append-only
```

The recall budget is small and rationed (`DEFAULT_RECALL_MAX_TOKENS = 1200`),
and the packer counts each frame's `content` once — the duplication was
introduced by the renderer *after* the pack, so the block silently exceeded
the budget it was packed to.

The fix is one predicate, `RecalledFrame::distinct_label()`
(`crates/stella-pipeline/src/ports.rs`), applied at all four render
surfaces:

- the CLI recall block (`stella-cli/src/memory/recall.rs::render_context_section`)
- the worker's opening user message (`stella-pipeline/src/pipeline/user_message.rs`)
- the planner prompt (`stella-pipeline/src/plan.rs`)
- the witness-author prompt (`stella-pipeline/src/witness.rs`)

The predicate models the mint exactly — label == content, or a
`…`-terminated prefix of it — and nothing else, so an author-chosen label
(a path, a symbol, an episode title that differs) renders exactly as
before; the existing distinct-label tests pass untouched and serve as
controls. This deliberately goes wider than the issue's minimum (which
scoped to the CLI memory arms): episode labels are minted from their
summary the same way (`writeback.rs::as_node` for `Episode`), so the
kind-agnostic predicate covers them at every surface without collapsing
any genuinely distinct label. Exemplar for the shape: the same crate's
`CITE_MEMORY_REQUEST` — one shared definition in `stella-pipeline`, both
crates read it, so four surfaces cannot drift apart again.

Constraint check (issue's "Constraints"): `truncate_label` and the stored
`display_name` are untouched — `stella memory` listings and the Command
Deck still show the label instead of the content. The recall block is the
volatile channel, so invariant 7 (byte-stable prefix) is not in play;
`inject_recall_block`'s exact-string dedup sees new strings once, a
one-time effect the issue already accepted.

Closes #2476

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four, one per surface, each verified the artisanal way (old render code
checked out / temporarily restored, test run, `FAILED` observed, fix
restored, test green):

| Surface | Test |
|---|---|
| CLI recall block | `memory::tests::recall_section_renders_a_content_minted_label_once` (pins both sides of the 80-char boundary) |
| Worker user message | `a_content_minted_label_renders_its_sentence_once` |
| Planner prompt | `planner_prompt_renders_a_content_minted_label_once` |
| Witness prompt | `witness_prompt_renders_a_memory_minted_label_once` |

Plus direct unit tests on the predicate
(`a_label_minted_from_the_content_is_not_distinct`,
`an_author_chosen_label_stays_distinct`) covering the ≤80/>80 shapes, the
author-chosen-prefix case that must NOT collapse, and empty label/content.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-pipeline -p stella-cli --all-targets` — clean; the two touched crates are the impacted set (`stella-cli` is `stella-pipeline`'s only dependent)
- [x] `cargo test -p stella-pipeline` (749 passed) and `cargo test -p stella-cli` (1789 passed), zero failures
- [x] Docs: behavior is doc-commented at the predicate and each render site; no flags or user-facing docs changed
- [x] CLA signed
- [x] `Closes #2476` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #3240 — the `task` tool's children have no model routing
      (session-default worker at inherited effort), found while auditing the
      same token plumbing. The pipeline's research children are role-routed;
      the task-tool population is not.

## Ground-rule check

- [x] No I/O added to `stella-core` (untouched); no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`distinct_label` is prefix-based only when the label ends in `…` (the
mint's truncation marker). A plain label that happens to prefix the
content is treated as author-chosen and still renders — that is the
deliberate line between "models the mint" and "similarity heuristic",
and `an_author_chosen_label_stays_distinct` pins it.

## Summary by Sourcery

Ensure recalled memory and episode labels only render when they add information beyond the content, preventing duplicated sentences in prompts and preserving citation handles.

Bug Fixes:
- Stop recalled memories from shipping their content sentence twice in CLI, worker, planner, and witness prompts when labels are auto-minted from content.

Enhancements:
- Introduce a shared RecalledFrame::distinct_label predicate to centralize label/content handling and keep all render surfaces consistent with the memory label minting rules.

Tests:
- Add targeted tests across CLI, worker user message, planner prompt, and witness prompt to verify content-minted labels render their sentence once while author-chosen labels remain visible.
- Add unit tests for the distinct_label predicate covering minted-label shapes, author-chosen labels, whitespace differences, and empty content/labels.