### PR TITLE
fix(stella-cli): a deck sub-session no longer destroys the lead turn's resume point

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -238,7 +238,7 @@ pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
 /// restores the session record's turn — so a second sink would be a write with
 /// no reader, paid for with a whole-transcript serialization per step
 /// ([`stella_core::Engine::persist_checkpoint`] encodes before the sink sees
-/// anything). Giving a lane its own record is the tracked follow-up (#3231),
+/// anything). Giving a lane its own record is the tracked follow-up (#3233),
 /// and `a_sub_session_carries_no_checkpoint_sink` is the assertion that will
 /// fail when someone does it.
 pub(crate) fn subsession_engine_config_for(cfg: &Config) -> EngineConfig {

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -47,10 +47,26 @@ fn tuned_engine_config(
         // default. Read here rather than at each receipt site so every engine
         // this session builds — default, worker, verifier — agrees on it.
         lifecycle_enabled: crate::memory::session_lifecycle_enabled(&cfg.workspace_root),
-        // Durability, for every role at once. This is the single place an
-        // engine is tuned in this crate, so attaching the sink here covers the
-        // deck's lead turn and its pipeline, sub-agents, sub-sessions and the
-        // fleet without six chances to forget one.
+        // Durability for every role of the SESSION'S OWN turn — the deck's
+        // lead turn and its pipeline, worker and verifier alike. This is the
+        // single place an engine is tuned in this crate, so attaching it here
+        // is what stops a role being left out.
+        //
+        // It covers the roles that run one at a time, and deliberately not the
+        // lanes that run *beside* the lead turn. `SessionDurability` is one
+        // cell keyed on one session record, so a lane that inherits this sink
+        // is a second writer of one resume point, not a second resume point:
+        // its steps overwrite the lead's transcript and its terminal path
+        // `discard`s the lead's point while the lead still needs it. Two doors
+        // reach that hazard and each is closed at its own end — a dispatched
+        // sub-agent by `stella_core::subagent` (which strips the sink it is
+        // handed), and a deck sub-session by `subsession_engine_config_for`
+        // (which the engine crate cannot see, because a sub-session is built
+        // through `Engine::with_sleeper` rather than `run_sub_agent`).
+        //
+        // It does not reach the fleet at all: a fleet worker never binds this
+        // handle, so `sink()` answers `None` for every worker turn and the
+        // whole fan-out runs without step-level durability (#3232).
         //
         // `None` while the session has not bound its durable location — a
         // command with no turn to checkpoint, or a driver that has not yet
@@ -201,6 +217,35 @@ pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
         crate::settings::EngineAgentKind::Default,
         (cfg.provider.id, &cfg.model_id),
     )
+}
+
+/// [`engine_config_for`] for a deck sub-session (`crate::subsession`) — the
+/// session's own tuning, minus the checkpoint sink.
+///
+/// A sub-session is a real engine session dispatched *because* the lead is
+/// mid-turn, so the two run at once. Both are built from the same `Config`, and
+/// [`crate::durability::SessionDurability`] is an `Arc` cell keyed on one
+/// session record — so an inherited sink is not a second resume point, it is the
+/// same one with two writers. `stella_core::subagent` names the damage exactly,
+/// for the same inheritance reached through `run_sub_agent`: every child step
+/// overwrites the parent's resume point with the child's transcript, and the
+/// child's terminal path calls `discard`, retracting the parent's while the
+/// parent still needs it. A deck killed mid-lead-turn then resumes into a
+/// conversation belonging to a different agent, or into nothing.
+///
+/// Stripped rather than re-keyed. A worker lane has no durable identity of its
+/// own today — nothing reads a sub-session's resume point, and `stella resume`
+/// restores the session record's turn — so a second sink would be a write with
+/// no reader, paid for with a whole-transcript serialization per step
+/// ([`stella_core::Engine::persist_checkpoint`] encodes before the sink sees
+/// anything). Giving a lane its own record is the tracked follow-up (#3231),
+/// and `a_sub_session_carries_no_checkpoint_sink` is the assertion that will
+/// fail when someone does it.
+pub(crate) fn subsession_engine_config_for(cfg: &Config) -> EngineConfig {
+    EngineConfig {
+        checkpoint_sink: None,
+        ..engine_config_for(cfg)
+    }
 }
 
 /// [`engine_config_for`], with the prove-it completion gate (#2663) switched

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1451,6 +1451,8 @@ mod usage_completeness;
 
 mod engine_wiring;
 
+mod durability_isolation;
+
 mod code_graph;
 
 /// Issue #644: the machine-readable envelope declares its contract version, and

--- a/crates/stella-cli/src/agent/tests/durability_isolation.rs
+++ b/crates/stella-cli/src/agent/tests/durability_isolation.rs
@@ -70,26 +70,46 @@ fn bound_session(
 /// calls are played by hand, in the order `drive` makes them, against the config
 /// the production seam actually builds.
 ///
-/// Before the fix, `subsession::run_worker` called `engine_config_for`, so the
-/// sub-session's sink WAS the lead's: the `persist` below overwrote the lead's
-/// in-flight transcript with the worker's, and the `discard` then deleted it.
-/// A deck killed while its lead turn was running resumed into a conversation
-/// belonging to a different agent, or into nothing at all.
+/// Both arms are asserted, and that is the point. The first reproduces what
+/// the old wiring did — `subsession::run_worker` called `engine_config_for`, so
+/// the worker's sink WAS the lead's — and the second shows the seam closing it.
+/// Without the first arm this test would pass on a build where the damage is
+/// merely unreachable rather than prevented, and could not say what the fence
+/// below is protecting.
 #[test]
 fn a_sub_sessions_turn_cannot_destroy_the_leads_resume_point() {
-    let (cfg, record, _store, _ws) = bound_session("ses-lead-vs-sub");
-
-    // The lead is mid-turn: `drive` has committed a step and written the
-    // resume point that a crash from here on would be recovered from.
+    // ── Arm 1: the old wiring, played out. ──────────────────────────────
+    let (cfg, record, _store, _ws) = bound_session("ses-inherited-sink");
     let lead = crate::agent::engine_config_for(&cfg)
         .checkpoint_sink
         .expect("the lead session is bound");
     lead.persist(r#"{"version":1,"lane":"lead"}"#);
 
-    // Concurrently — this is the whole reason sub-sessions exist — the deck
-    // dispatches a prompt to a worker session, which runs a full turn and
-    // ends. `drive` persists at every committed step boundary and discards on
-    // every terminal path, so both halves are played.
+    // What the sub-session used to be handed: the lead's own sink, because
+    // `Config` is `Clone` over one `Arc` cell. `drive` persists at every
+    // committed step boundary and discards on every terminal path, so a whole
+    // worker turn is those two calls.
+    let inherited = crate::agent::engine_config_for(&cfg)
+        .checkpoint_sink
+        .expect("bound");
+    inherited.persist(r#"{"version":1,"lane":"sub"}"#);
+    inherited.discard();
+
+    assert!(
+        record.checkpoint().is_none(),
+        "the damage this test exists to prevent did not reproduce — an \
+         inherited sink no longer shares the lead's CHECKPOINT_BLOB, so the \
+         second arm below proves nothing. Re-derive what a sub-session is \
+         actually handed before trusting this file.",
+    );
+
+    // ── Arm 2: the seam. ────────────────────────────────────────────────
+    let (cfg, record, _store, _ws) = bound_session("ses-isolated-sink");
+    let lead = crate::agent::engine_config_for(&cfg)
+        .checkpoint_sink
+        .expect("the lead session is bound");
+    lead.persist(r#"{"version":1,"lane":"lead"}"#);
+
     let sub = crate::agent::subsession_engine_config_for(&cfg).checkpoint_sink;
     if let Some(sub) = &sub {
         sub.persist(r#"{"version":1,"lane":"sub"}"#);

--- a/crates/stella-cli/src/agent/tests/durability_isolation.rs
+++ b/crates/stella-cli/src/agent/tests/durability_isolation.rs
@@ -159,8 +159,8 @@ fn the_lead_session_still_checkpoints_and_still_discards() {
 /// record's own turn — so a second sink would be a write with no reader, and
 /// `Engine::persist_checkpoint` serializes the whole transcript before the sink
 /// ever sees it. Giving a worker lane its own durable identity is the tracked
-/// follow-up, and this assertion is what will fail when someone does it, which
-/// is the right place for that conversation to happen.
+/// follow-up (#3233), and this assertion is what will fail when someone does
+/// it, which is the right place for that conversation to happen.
 #[test]
 fn a_sub_session_carries_no_checkpoint_sink() {
     let (cfg, _record, _store, _ws) = bound_session("ses-sub-none");

--- a/crates/stella-cli/src/agent/tests/durability_isolation.rs
+++ b/crates/stella-cli/src/agent/tests/durability_isolation.rs
@@ -1,0 +1,191 @@
+//! Which concurrently-running lanes may write this session's resume point.
+//!
+//! [`engine_wiring`](super::engine_wiring)'s
+//! `a_bound_session_checkpoints_from_every_role` proves the sink reaches every
+//! role that *should* have it. This module proves the other half, which has no
+//! natural home there because it is the opposite assertion: the lanes that must
+//! NOT have it.
+//!
+//! A [`crate::durability::SessionDurability`] handle is keyed on one session
+//! record, and `Config` is `Clone` over an `Arc` — so every clone of a bound
+//! `Config` yields a sink pointing at the *same* `CHECKPOINT_BLOB`. That is
+//! correct for the session's own turns, which run one at a time, and wrong for
+//! anything that runs *beside* them: two writers of one resume point is one
+//! resume point.
+//!
+//! `stella_core::subagent` already draws this line for dispatched children, in
+//! prose worth restating because it names the damage exactly — inheriting the
+//! parent's sink is "actively destructive in both directions: every child step
+//! would overwrite the parent's resume point with the CHILD's transcript, and
+//! the child reaching a terminal outcome would call `discard` — retracting the
+//! parent's resume point while the parent still needs it."
+//!
+//! A deck sub-session (`crate::subsession`) is that same shape reached by a
+//! different door: a real engine session on its own OS thread, dispatched
+//! *because* the lead is mid-turn, built from a clone of the lead's `Config`.
+//! The engine crate cannot see it — a sub-session is not a sub-agent, it goes
+//! through `Engine::with_sleeper` rather than `run_sub_agent` — so the line has
+//! to be drawn here, at the seam that builds its config.
+
+use super::*;
+
+/// A bound session over two temp dirs, returned with the record so a test can
+/// read the resume point back.
+///
+/// `open_in`, never `open`: the latter reads `STELLA_HOME`, and a test that
+/// touched a process-global would race its siblings — the same trade
+/// `durability.rs`'s own tests make for the same reason.
+fn bound_session(
+    session: &str,
+) -> (
+    Config,
+    stella_store::work_journal::WorkJournal,
+    tempfile::TempDir,
+    tempfile::TempDir,
+) {
+    let store = tempfile::tempdir().unwrap();
+    let ws = tempfile::tempdir().unwrap();
+    let cfg = cfg_for("zai");
+    let record =
+        stella_store::work_journal::WorkJournal::open_in(store.path(), ws.path(), session).unwrap();
+    cfg.durability.bind(
+        record.clone(),
+        std::sync::Arc::new(stella_tools::ToolRegistry::new(
+            ws.path().to_path_buf(),
+            stella_tools::RegistryOptions::default(),
+        )),
+    );
+    (cfg, record, store, ws)
+}
+
+/// **The witness.** A deck sub-session's turn must not be able to destroy the
+/// lead session's resume point.
+///
+/// Driven at the sink seam rather than through a real turn, and that choice is
+/// the honest one to name: reaching `subsession::run_worker` needs a provider, a
+/// tool registry, a spawned OS thread and a current-thread runtime, none of
+/// which change the answer. What decides it is which sink the sub-session's
+/// `EngineConfig` carries, and `Engine::drive` — not this crate — is what turns
+/// that into a `persist` per step and a `discard` at the end. So the two engine
+/// calls are played by hand, in the order `drive` makes them, against the config
+/// the production seam actually builds.
+///
+/// Before the fix, `subsession::run_worker` called `engine_config_for`, so the
+/// sub-session's sink WAS the lead's: the `persist` below overwrote the lead's
+/// in-flight transcript with the worker's, and the `discard` then deleted it.
+/// A deck killed while its lead turn was running resumed into a conversation
+/// belonging to a different agent, or into nothing at all.
+#[test]
+fn a_sub_sessions_turn_cannot_destroy_the_leads_resume_point() {
+    let (cfg, record, _store, _ws) = bound_session("ses-lead-vs-sub");
+
+    // The lead is mid-turn: `drive` has committed a step and written the
+    // resume point that a crash from here on would be recovered from.
+    let lead = crate::agent::engine_config_for(&cfg)
+        .checkpoint_sink
+        .expect("the lead session is bound");
+    lead.persist(r#"{"version":1,"lane":"lead"}"#);
+
+    // Concurrently — this is the whole reason sub-sessions exist — the deck
+    // dispatches a prompt to a worker session, which runs a full turn and
+    // ends. `drive` persists at every committed step boundary and discards on
+    // every terminal path, so both halves are played.
+    let sub = crate::agent::subsession_engine_config_for(&cfg).checkpoint_sink;
+    if let Some(sub) = &sub {
+        sub.persist(r#"{"version":1,"lane":"sub"}"#);
+        sub.discard();
+    }
+
+    assert_eq!(
+        record.checkpoint().as_deref(),
+        Some(r#"{"version":1,"lane":"lead"}"#),
+        "a sub-session's turn ending retracted the LEAD's resume point. The \
+         deck dispatches a sub-session precisely because the lead is mid-turn, \
+         so the two run at once against one `CHECKPOINT_BLOB` — and the loser \
+         is the turn a human is waiting on. `stella-core::subagent` strips the \
+         sink for exactly this reason; a sub-session reaches the same hazard \
+         through `Engine::with_sleeper` instead of `run_sub_agent`, where the \
+         engine crate cannot see it.",
+    );
+}
+
+/// The delta the witness is measured against: the lead's own sink still works.
+/// Without this, stripping the sink from *everything* would pass the test above
+/// while silently ending step-level durability for the session that needs it.
+#[test]
+fn the_lead_session_still_checkpoints_and_still_discards() {
+    let (cfg, record, _store, _ws) = bound_session("ses-lead-alone");
+    let lead = crate::agent::engine_config_for(&cfg)
+        .checkpoint_sink
+        .expect("the lead session is bound");
+
+    lead.persist(r#"{"version":1,"step":3}"#);
+    assert_eq!(
+        record.checkpoint().as_deref(),
+        Some(r#"{"version":1,"step":3}"#),
+    );
+
+    // And the lead's own terminal path still retracts: a checkpoint outliving
+    // its turn invites a resume that replays work the caller saw finish.
+    lead.discard();
+    assert!(record.checkpoint().is_none());
+}
+
+/// A sub-session carries no sink at all, rather than a differently-keyed one.
+///
+/// Stated separately from the witness because it is the *design* decision, not
+/// the damage: a sub-session is not separately resumable today — nothing reads
+/// a worker lane's resume point, and `stella resume` restores the session
+/// record's own turn — so a second sink would be a write with no reader, and
+/// `Engine::persist_checkpoint` serializes the whole transcript before the sink
+/// ever sees it. Giving a worker lane its own durable identity is the tracked
+/// follow-up, and this assertion is what will fail when someone does it, which
+/// is the right place for that conversation to happen.
+#[test]
+fn a_sub_session_carries_no_checkpoint_sink() {
+    let (cfg, _record, _store, _ws) = bound_session("ses-sub-none");
+    assert!(
+        crate::agent::subsession_engine_config_for(&cfg)
+            .checkpoint_sink
+            .is_none(),
+        "a sub-session must carry no sink rather than the lead's",
+    );
+    // Everything else about the config is the session's own tuning — the strip
+    // is one field, not a separate engine shape.
+    let lead = crate::agent::engine_config_for(&cfg);
+    let sub = crate::agent::subsession_engine_config_for(&cfg);
+    assert_eq!(sub.max_steps, lead.max_steps);
+    assert_eq!(sub.compaction_budget_tokens, lead.compaction_budget_tokens);
+    assert_eq!(sub.cwd, lead.cwd);
+}
+
+/// The source fence. `subsession::run_worker` must build its engine through
+/// [`crate::agent::subsession_engine_config_for`] and never through
+/// `engine_config_for`.
+///
+/// A lexical guard for the reason `resume_frame.rs`'s
+/// `every_pipeline_construction_declares_its_resume_frame` is one: what regresses
+/// here is *wiring*, and the regression is invisible at runtime. An inherited
+/// sink and a correct one differ only in which session's blob a write lands in,
+/// which nothing observes until a process dies mid-turn — so the assertions
+/// above pin the behaviour while this pins the call site that reaches it.
+#[test]
+fn the_sub_session_worker_builds_its_engine_through_the_isolating_seam() {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/subsession.rs");
+    let body = std::fs::read_to_string(&src)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", src.display()));
+    // Built rather than written out, so the fence does not match itself.
+    let inherited = format!("agent::engine_config{}(", "_for");
+    assert!(
+        !body.contains(&inherited),
+        "subsession.rs builds its engine through `engine_config_for`, which \
+         attaches the LEAD session's checkpoint sink. A sub-session runs \
+         concurrently with the lead turn, so its steps overwrite — and its \
+         terminal path deletes — the resume point the lead is relying on. Use \
+         `agent::subsession_engine_config_for` instead.",
+    );
+    assert!(
+        body.contains("agent::subsession_engine_config_for("),
+        "subsession.rs no longer builds its engine through the isolating seam",
+    );
+}

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -56,13 +56,30 @@ use stella_store::work_journal::WorkJournal;
 /// A finished session leaves the handle bound, and nothing clears it. That is
 /// safe because the only thing a binding does is answer where the *next* turn
 /// checkpoints, and after a session finishes there is no next turn: the deck
-/// re-binds on a switch, and the one-shot drivers exit. A stale binding cannot
-/// reach a child either — sub-agent and isolated-candidate engines carry no sink
-/// at all (see `Engine::run_sub_agent`), so nothing inherits it downward.
+/// re-binds on a switch, and the one-shot drivers exit.
 ///
-/// An unbind would also cost something real: it would open a window where a
-/// turn still in flight finds `sink()` empty and silently stops checkpointing,
-/// which is the failure this whole module exists to prevent.
+/// # What must NOT inherit a binding
+///
+/// One handle is one session record, so a lane that runs *beside* the session's
+/// own turn and inherits this sink is not a second resume point — it is a second
+/// writer of the one resume point, and it both overwrites the lead's transcript
+/// and `discard`s the lead's point when it ends. There are three such doors and
+/// each is closed at its own end, because no single place can see all three:
+///
+/// - **A dispatched sub-agent** — `Engine::run_sub_agent` strips the sink from
+///   the child config it builds, inside `stella-core`.
+/// - **An isolated candidate** — `Pipeline::engine_config_for` clears it for a
+///   candidate running in a throwaway snapshot, whose transcript names paths
+///   that will not exist.
+/// - **A deck sub-session** — `agent::subsession_engine_config_for`. This one is
+///   invisible to `stella-core`: a sub-session is a full engine session built
+///   through `Engine::with_sleeper`, not a child reached through
+///   `run_sub_agent`, so the engine crate never sees a parent to strip it from.
+///
+/// An unbind would not help with any of them, and would cost something real: it
+/// would open a window where a turn still in flight finds `sink()` empty and
+/// silently stops checkpointing, which is the failure this whole module exists
+/// to prevent.
 #[derive(Clone, Debug, Default)]
 pub struct SessionDurability {
     /// `RwLock` rather than `OnceLock` because a deck session can be switched,

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -751,7 +751,11 @@ async fn run_worker(
         let engine = Engine::with_sleeper(
             &*provider,
             &permitted,
-            agent::engine_config_for(cfg),
+            // Never `engine_config_for`: that attaches the LEAD session's
+            // checkpoint sink, and this worker runs concurrently with the lead
+            // turn against the same `CHECKPOINT_BLOB` — see
+            // `subsession_engine_config_for`.
+            agent::subsession_engine_config_for(cfg),
             &TokioSleeper,
         )
         .with_calibration(&calibration)

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -17,7 +17,7 @@
 4339 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
 2140 crates/stella-cli/src/agent.rs
-1729 crates/stella-cli/src/agent/tests.rs
+1730 crates/stella-cli/src/agent/tests.rs
 4377 crates/stella-cli/src/command_deck.rs
 1891 crates/stella-core/src/bus.rs
 1919 crates/stella-core/src/driver.rs


### PR DESCRIPTION
## What & why

An audit of Stella's state-saving and checkpointing across every form of the agent loop. The engine's step-level machinery is sound; the defect is in **who is allowed to write through it**.

A deck sub-session (`crates/stella-cli/src/subsession.rs`) built its engine through `agent::engine_config_for`, which attaches the session's `checkpoint_sink`. `Config` is `Clone` over one `Arc` cell (`crate::durability::SessionDurability`), so the sub-session and the lead conversation were **two writers of one `CHECKPOINT_BLOB`**:

- every sub-session step overwrote the lead's in-flight transcript with the worker's, and
- the sub-session's terminal path called `discard`, retracting the lead's resume point while the lead still needed it.

A deck killed mid-lead-turn therefore resumed into a conversation belonging to a different agent, or into nothing at all. This is not a race — a sub-session is dispatched *precisely because* the lead is mid-turn, so the overlap is the design.

`stella_core::subagent` already closes this exact door for dispatched children, and names the damage in those words. A sub-session reaches the same hazard through a different door: it is a full engine session built via `Engine::with_sleeper`, not a child reached through `run_sub_agent`, so the engine crate never sees a parent to strip the sink from. The line is therefore drawn at the CLI's config seam — `agent::subsession_engine_config_for`.

Scope note: stripping is the correct fix for the *damage*, and it leaves a sub-session with no step-level durability of its own. That is filed as #3233 rather than silently accepted.

Refs #3232, #3233

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/agent/tests/durability_isolation.rs`, four tests:

- **`a_sub_sessions_turn_cannot_destroy_the_leads_resume_point`** — asserts **both arms**. Arm 1 plays the old wiring (an inherited sink) and asserts the lead's resume point *is* destroyed; arm 2 plays the seam and asserts it survives. Without arm 1 the test would pass on a build where the damage is merely unreachable rather than prevented.
- **`the_lead_session_still_checkpoints_and_still_discards`** — the delta the fix is measured against, so "strip the sink from everything" cannot pass.
- **`a_sub_session_carries_no_checkpoint_sink`** — pins the design decision; this is the assertion that will fail when #3233 lands, which is the right place for that conversation.
- **`the_sub_session_worker_builds_its_engine_through_the_isolating_seam`** — a source fence, for the reason `resume_frame.rs`'s `every_pipeline_construction_declares_its_resume_frame` is one: what regresses here is *wiring*, and an inherited sink differs from a correct one only in which session's blob a write lands in — invisible until a process dies mid-turn.

**Fail→pass verified artisanally**: reverting only the `subsession.rs` call site to `engine_config_for` (leaving the new seam in place) makes the source fence fail with its diagnostic; restoring it passes. Observed, not assumed.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-cli` — 1792 tests in the bin target plus 13 integration binaries, 0 failed, re-run after rebase
- [x] `make guards-fast` — all green (invariants, doc-links, file-size, god-files, gate-parity, left-behind, module-reachability, diagnostic-codes, fmt)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --document-private-items` — clean
- [x] Docs updated: `SessionDurability`'s docs now name all three doors that must not inherit a binding

Scoped to `stella-cli` rather than the workspace: it is a binary crate with no dependents, and nothing outside it changed.

## Nothing left behind

- [x] Filed: **#3232** (fleet workers never bind durability at all — the whole fan-out has no step-level durability), **#3233** (a stripped sub-session now has no step-level durability of its own)

Both are written as handoffs with file paths, repro steps, the constraints already discovered, and a definition of done. Both share one blocker worth stating plainly: **the read side does not exist**. Nothing reads a fleet worker's or a lane's checkpoint, so binding the write side alone would buy a whole-transcript serialization per step with no reader. Neither issue is done until a resume path exists or the cost is explicitly declined.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**The baseline diff is one line, deliberately.** The new tests went in their own module (the god-file rule), and the `mod durability_isolation;` declaration pushed `agent/tests.rs` from 1729 to 1730 — the irreducible module-declaration line AGENTS.md names as the escape hatch. I hand-edited that single entry rather than running `make file-size-update`, which retightens *every* ceiling to its file's current size: here it would have moved **eight unrelated entries**, `agent.rs` by 132 lines. Each of those is a merge-skew landmine for any parallel PR growing toward its recorded ceiling, and absorbing inherited drift into an unrelated PR is what AGENTS.md warns against. This PR raises only the number it actually caused.

**What the audit checked and found sound**, so a reviewer knows the search was not narrow:

- `stella-core/src/step.rs` — `TurnState`/`Checkpoint`, and the fields `from_checkpoint` deliberately does *not* restore
- `driver/drive.rs` — persists at the one boundary where the transcript is guaranteed well-paired, discards on every terminal path
- the four production binders (`presence.rs`, `command_deck.rs` ×2, `resume.rs`) covering `stella run`, `/goal`, the REPL, the deck, and `stella resume`
- `stella-pipeline`'s `FrameProgress` / `PipelineResume`, whose non-restorable cases (isolated candidate worktree, authored witness, lint baseline) are already declared rather than hidden
- `stella-serve`'s `StoreSink`, and the sub-agent and isolated-candidate strips, which are correct and documented

Every other `Engine` construction site in `stella-cli` was checked individually. The CLI's sub-agent dispatcher (`subagent.rs:328`) looks like the same shape but is safe — its engine only calls `run_sub_agent_with_sender`, which strips the sink for the child and never drives a turn of its own. Sub-sessions were the only wrong-inheritance site.

## Summary by Sourcery

Isolate deck sub-session checkpointing from the lead session so that concurrent worker lanes cannot overwrite or discard the lead turn’s resume point.

Bug Fixes:
- Prevent deck sub-sessions from inheriting the lead session’s checkpoint sink, avoiding corruption or loss of the lead resume point when a worker runs or terminates mid-turn.

Enhancements:
- Introduce a dedicated engine config constructor for deck sub-sessions that strips the checkpoint sink while preserving other tuning.
- Clarify durability documentation to enumerate all concurrent lanes that must not inherit the session’s checkpoint binding.
- Add tests and source-level guards ensuring sub-sessions have no checkpoint sink and that their engines are wired through the isolating configuration seam.

Tests:
- Add durability isolation tests that witness the previous destructive behaviour, verify the lead session still checkpoints correctly, assert sub-sessions carry no sink, and enforce that sub-session workers use the isolating engine config constructor.