### PR TITLE
test(arenabench): witness the experiment read routes over HTTP

### DIFF
--- a/arenabench/tests/test_experiments_api.py
+++ b/arenabench/tests/test_experiments_api.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The experiment read routes, against a real socket (#3227).
+
+``test_experiments.py`` witnesses the store's helpers directly, always with
+an explicit database path. That cannot see the wiring the browser actually
+depends on: the ``case`` arms in ``_route_api_get``, the ``KeyError`` -> 404
+conversion an unknown id rides on, and the fact that :class:`ArenaServer`
+calls the helpers with *no* path — so the served code resolves the store
+from ``ARENABENCH_HOME`` on a branch no helper test reaches. Same reasoning
+as :mod:`tests.test_file_api`: a route that forgets to call the helper is
+exactly the bug worth catching, and a unit test of the helper cannot see it.
+
+Every test here runs against a temporary home. The experiments store is
+machine-global rather than per-workspace, so a test that skipped the
+isolation would read the developer's real ``~/.arenabench/experiments.db``
+— documents locally, none on CI — and would be measuring the machine.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from arenabench import experiments
+from arenabench.server import ArenaServer, _handler_factory, allowed_hosts
+
+#: One stored document, with a ``trials`` list the listing must not carry.
+_DOCUMENT = {
+    "schema": "arenabench-experiment-document/1",
+    "calculation_version": "exp-demo/1",
+    "experiment": {"id": "exp-001", "title": "A vs B", "status": "open"},
+    "trials": [{"task": "t1", "outcome": "verified_solve"}],
+}
+
+
+@pytest.fixture
+def served(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A live server whose experiments store is an empty temporary home.
+
+    Yields the port and the home directory, so a test seeds the store by
+    writing to ``home / "experiments.db"`` — the same path the request will
+    resolve — before it makes its request.
+    """
+    home = tmp_path / "home"
+    monkeypatch.setenv("ARENABENCH_HOME", str(home))
+
+    arena = ArenaServer(tmp_path / "ws")
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    port = httpd.server_address[1]
+    httpd.RequestHandlerClass = _handler_factory(arena, allowed_hosts("127.0.0.1", port))
+    httpd.daemon_threads = True
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, home
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+
+def _get(port: int, path: str) -> tuple[int, bytes]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", path, headers={"Host": f"127.0.0.1:{port}"})
+        res = conn.getresponse()
+        return res.status, res.read()
+    finally:
+        conn.close()
+
+
+# -- the listing ------------------------------------------------------------
+
+
+def test_the_listing_summarizes_each_stored_document(served):
+    """Exact equality, because what the listing *omits* is the point.
+
+    A gallery card needs the document's header and nothing else; shipping
+    whole documents would grow the listing with every trial they record.
+    """
+    port, home = served
+    experiments.store_results(_DOCUMENT, home / "experiments.db")
+
+    status, body = _get(port, "/api/experiments")
+
+    assert status == 200
+    assert json.loads(body) == {
+        "experiments": [
+            {
+                "id": "exp-001",
+                "title": "A vs B",
+                "status": "open",
+                "schema": "arenabench-experiment-document/1",
+                "calculation_version": "exp-demo/1",
+            }
+        ]
+    }
+
+
+def test_an_absent_store_is_an_empty_listing_that_creates_nothing(served):
+    """Looking must not write.
+
+    The route is polled by every open browser tab, so a read that created
+    the database would mean merely opening the UI writes to the user's home
+    directory. Witnessed here on the ``ARENABENCH_HOME`` branch the server
+    actually runs, which no helper test reaches.
+    """
+    port, home = served
+
+    status, body = _get(port, "/api/experiments")
+
+    assert status == 200
+    assert json.loads(body) == {"experiments": []}
+    assert not (home / "experiments.db").exists()
+    assert not home.exists()
+
+
+# -- one document -----------------------------------------------------------
+
+
+def test_the_document_route_serves_the_whole_document(served):
+    port, home = served
+    experiments.store_results(_DOCUMENT, home / "experiments.db")
+
+    status, body = _get(port, "/api/experiments/exp-001")
+
+    assert status == 200
+    assert json.loads(body) == _DOCUMENT
+
+
+def test_an_unknown_experiment_is_a_404(served):
+    """The ``KeyError`` :meth:`ArenaServer.experiment` raises reaches the wire.
+
+    Asserted on the body, not the status: deleting the ``case`` arm answers
+    404 too — from the catch-all's ``unknown endpoint`` — so a test that
+    checked only the status would still pass with the route gone, which is
+    the failure mode this module exists to close.
+    """
+    port, home = served
+    experiments.store_results(_DOCUMENT, home / "experiments.db")
+
+    status, body = _get(port, "/api/experiments/exp-missing")
+
+    assert status == 404
+    assert "exp-missing" in json.loads(body)["error"]


### PR DESCRIPTION
## What this is

The test half of the read path #3221 shipped. That PR's three witnesses are all module-level — they call `experiments_payload()` and `experiment_document()` directly, always with an explicit `db_path` — so none of them can see the wiring a browser actually depends on:

- the two `case` arms in `_route_api_get` (`arenabench/arenabench/server.py:1077`, `:1079`);
- the `KeyError` → 404 conversion in `do_GET` (`server.py:998-1000`);
- the **default-path** branch. `ArenaServer.experiments()` and `.experiment()` call both helpers with *no* `db_path`, so the served code resolves the store from `ARENABENCH_HOME` — a branch no helper test reaches.

Four tests against a real socket, following `arenabench/tests/test_file_api.py`, whose docstring already states the principle: *a route that forgets to call the helper is exactly the bug worth catching, and a unit test of the helper cannot see it.*

1. the listing summarizes each stored document — asserted by **exact equality**, because what the listing omits (`trials`) is the point;
2. an absent store is an empty listing that **creates nothing** — #3221's advertised "reading never writes" property, proven on the `ARENABENCH_HOME` branch the server runs rather than the explicit-path branch the helper test uses;
3. the document route serves the **whole** document;
4. an unknown id is a 404.

Test-only. The diff is one added file; no production code changes, and no test is deleted or renamed.

## Two things worth a reviewer's eye

**The 404 test asserts on the body, not the status.** Deleting the `case` arm answers 404 as well — from the catch-all's `unknown endpoint` — so a status-only assertion would have survived the exact mutation it is supposed to fail on. It asserts the error names the missing id, which only the `KeyError` path produces. This was found by running the mutation, not by reading the code.

**Every test isolates `ARENABENCH_HOME`.** The experiments store is machine-global rather than per-workspace, so a route test without isolation reads the developer's real `~/.arenabench/experiments.db` — which holds the seeded `stella-vs-claude-code-fable5-tb21` document locally and nothing on CI. It would have been measuring the machine.

## Witness

A test-only PR's witness is that the tests fail against a mutated source, so each was run against the mutation it exists to catch:

| Mutation to `server.py` | Tests that fail |
|---|---|
| remove `case ["experiments"]` | `test_the_listing_summarizes_each_stored_document`, `test_an_absent_store_is_an_empty_listing_that_creates_nothing` |
| remove `case ["experiments", experiment_id]` | `test_the_document_route_serves_the_whole_document`, `test_an_unknown_experiment_is_a_404` |
| remove `except KeyError` in `do_GET` | `test_an_unknown_experiment_is_a_404` |

Every test is killed by at least one mutation, and none is inert. `server.py` was restored to pristine afterwards — `git diff --name-status origin/main...HEAD` is a single `A`.

Green: the four new tests, and the 43 tests of `test_experiments_api` + `test_experiments` + `test_file_api` + `test_series` run together (they share the store and the served-socket pattern, so cross-test interference was the risk worth checking). `ruff check` and `ruff format --check` clean.

`tests/test_sut.py` has 5 failures on any interpreter lacking `tomllib` (`/usr/bin/python3`) — pre-existing on `main`, identical set with and without this branch, unrelated.

## Scope

No new dependencies; stdlib only, per the ArenaBench charter (`http.client`, as `test_file_api.py` uses).

Closes #3227
Refs #3215, #3221

## Summary by Sourcery

Add socket-level tests for the experiment read HTTP API to validate routing, store resolution, and error handling without changing production code.

Tests:
- Add integration tests that exercise the experiments listing and single-document routes over HTTP using a real server instance and temporary ARENABENCH_HOME.
- Verify the listing returns summarized experiment metadata without trials, and remains empty without creating a store when no database exists.
- Verify the single-document route returns the full experiment document and that unknown experiment IDs produce a 404 with a specific error payload.