### PR TITLE
fix(arenabench): restore the incident count, and make --seat-fg actually resolve

### DIFF
--- a/arenabench/ui/app/globals.css
+++ b/arenabench/ui/app/globals.css
@@ -127,8 +127,45 @@
   /* Seat colours arrive as data (each contestant carries a hex) and stay —
      a seat IS data, and it is the one place on the page where distinguishing
      two things by hue is the job. As fills they work on both schemes; as
-     *text* on paper they need ink mixed in. */
-  --seat-fg: color-mix(in srgb, var(--seat, #0a0a0a) 62%, #0a0a0a);
+     *text* on paper they need ink mixed in.
+
+     The paper fallback, for an element that asks for --seat-fg without
+     carrying a seat. The REAL per-seat value is defined by `.seat` below;
+     this declaration cannot produce one, because a custom property is
+     substituted on the element the declaration applies to — here the root,
+     where --seat does not exist — and descendants inherit the already
+     resolved literal. Setting --seat deeper cannot change it (#3223). */
+  --seat-fg: #0a0a0a;
+}
+
+/* Keyed off the inline --seat that `seatStyle()` writes, rather than off a
+   class the author must remember: the declaration has to live on the SAME
+   element as --seat for the substitution to see it, and there are nine
+   seatStyle() call sites today. A class would be one shared cell every future
+   seat surface has to write, and the one that forgets fails silently — which
+   is precisely how this bug survived unnoticed in the first place. The
+   selector matches exactly the elements the helper produces, and a seat with
+   no colour writes no inline style, so it correctly keeps the paper fallback.
+
+   Split by scheme rather than folded into one color-mix because the schemes
+   want opposite treatments: on paper the hue needs ink mixed in to clear
+   contrast against --panel; on ink it is already legible and is used raw.
+
+   50%, not the 62% this token carried before. That ratio had never actually
+   been rendered — the declaration lived on :root and resolved to the fallback,
+   so nothing ever painted with it — and once it did paint, it failed the
+   4.5:1 AA floor this file holds itself to for three of the four seat hues in
+   use. Measured on --panel (#ffffff), worst case of each ratio:
+
+     62%  rose 5.83  amber 4.29 FAIL  cyan 4.34 FAIL  green 4.14 FAIL
+     55%  rose 6.85  amber 5.16       cyan 5.21       green 4.94
+     50%  rose 7.74  amber 5.92       cyan 6.04       green 5.70
+
+   50% keeps enough saturation for the hue to identify the seat while leaving
+   headroom for an arbitrary seat hex, which is data a user supplies and not a
+   value from this palette. */
+[style*="--seat"] {
+  --seat-fg: color-mix(in srgb, var(--seat, #0a0a0a) 50%, #0a0a0a);
 }
 
 .dark {
@@ -165,6 +202,12 @@
   --tool-repo:     #a3d14b; /* repo — citron */
   --tool-delegate: #d46fe8; /* delegate — orchid */
 
+  --seat-fg: #ededed;
+}
+
+/* The ink-scheme half of the pair above. On this side the seat hue is used
+   raw: the palette's seat colours are chosen to read on --panel already. */
+.dark [style*="--seat"] {
   --seat-fg: var(--seat, #ededed);
 }
 

--- a/arenabench/ui/components/arena/stat-strip.tsx
+++ b/arenabench/ui/components/arena/stat-strip.tsx
@@ -26,6 +26,11 @@ import { Tip } from "@/components/ui/tooltip";
  *
  * A `—` still has to say *why* (#2108): when an arm's cost is unknown the
  * cost card's sub-line names the models with no price row.
+ *
+ * The tasks card carries an `incidents` row for the third rule, which is
+ * about what a rate CANNOT say: a trial that scored the reward and then
+ * raised is invisible in a solve rate, so exceptions are counted beside it and
+ * never folded into it (#2066, #3225).
  */
 
 /** Per-arm figures the wire totals do not reliably carry, summed from the
@@ -40,13 +45,26 @@ interface CellSums {
   attempted: number;
   tools: number;
   steps: number;
+  /** Attempted trials that observed ANY behaviour — a step or a tool call.
+   *
+   *  The denominator behind `tools`, and deliberately NOT `usage_measured`
+   *  (#3224). Behaviour and spend come from the same artifacts but different
+   *  sub-objects: `telemetry.py` counts steps/tools off the trajectory's
+   *  `steps` array and reads tokens off its `final_metrics`, so `final_metrics`
+   *  can be missing while the step array is intact. On match `feebd80ba873`
+   *  the `claude code` arm is exactly that — `usage_measured: false` on all
+   *  three trials, but two of them recorded `steps: 1, tools: 0`, which is a
+   *  real observation of zero tool calls. Gating tools on the usage flag would
+   *  hide those two genuine zeros, so the honest test is whether this seat was
+   *  ever observed doing anything at all. */
+  observed: number;
 }
 
 function useCellSums(snapshot: Snapshot): Record<string, CellSums> {
   return React.useMemo(() => {
     const sums: Record<string, CellSums> = {};
     for (const seat of snapshot.contestants) {
-      sums[seat.id] = { attempted: 0, tools: 0, steps: 0 };
+      sums[seat.id] = { attempted: 0, tools: 0, steps: 0, observed: 0 };
     }
     for (const row of snapshot.rows) {
       for (const seat of snapshot.contestants) {
@@ -54,6 +72,7 @@ function useCellSums(snapshot: Snapshot): Record<string, CellSums> {
         if (!cell) continue;
         const sum = sums[seat.id];
         if (cell.status === "running" || cell.status === "done") sum.attempted += 1;
+        if ((cell.steps || 0) > 0 || (cell.tools || 0) > 0) sum.observed += 1;
         sum.tools += cell.tools || 0;
         sum.steps += cell.steps || 0;
       }
@@ -100,6 +119,93 @@ function avg(numer: number, denom: number): number | null {
   return denom > 0 ? numer / denom : null;
 }
 
+/** One arm's exceptions, split by whether the trial had already solved. */
+interface Incidents {
+  onSolved: number;
+  onFailed: number;
+  timeoutAfterSolve: number;
+  timeoutBeforeSolve: number;
+}
+
+/**
+ * Trials that raised, per arm, counted STRICTLY APART from the solve rate in
+ * both directions (#2066).
+ *
+ * A trial can score the reward and then raise, so folding either number into
+ * the other hides exactly the trials a headline rate flatters — which is why
+ * this is its own row beside `success` rather than a correction applied to it.
+ * An incident on a SOLVED trial means the agent kept burning budget after
+ * succeeding; on a failed trial it is the ordinary kind.
+ *
+ * Timeouts split for the same reason: `solved_then_timeout` (did not stop when
+ * done) and `timeout_before_solve` (ran out of time) mean opposite things, and
+ * a merged count cannot be acted on — the first cost four trials on one
+ * certification panel before the halt was wired (#2661).
+ *
+ * Per arm rather than per match: the old header summed both arms into one
+ * tile, which could not say which agent was the one that would not stop.
+ */
+function useIncidents(snapshot: Snapshot): Record<string, Incidents> {
+  return React.useMemo(() => {
+    const out: Record<string, Incidents> = {};
+    for (const seat of snapshot.contestants) {
+      out[seat.id] = {
+        onSolved: 0,
+        onFailed: 0,
+        timeoutAfterSolve: 0,
+        timeoutBeforeSolve: 0,
+      };
+    }
+    for (const row of snapshot.rows) {
+      for (const seat of snapshot.contestants) {
+        const cell = row.cells[seat.id];
+        if (!cell || cell.status !== "done" || !cell.failure) continue;
+        // The #2076 taxonomy label is authoritative — only the exception the
+        // agent-budget machinery actually raises counts as a timeout. The
+        // substring test survives solely for payloads recorded before the
+        // field existed.
+        const isTimeout =
+          cell.outcome_reason != null
+            ? cell.outcome_reason === "solved_then_timeout" ||
+              cell.outcome_reason === "timeout_before_solve"
+            : /timeout/i.test(cell.failure);
+        const seen = out[seat.id];
+        if (cell.resolved === true) {
+          seen.onSolved += 1;
+          if (isTimeout) seen.timeoutAfterSolve += 1;
+        } else {
+          seen.onFailed += 1;
+          if (isTimeout) seen.timeoutBeforeSolve += 1;
+        }
+      }
+    }
+    return out;
+  }, [snapshot.rows, snapshot.contestants]);
+}
+
+/**
+ * The timeout split, spelled per arm for the tasks card's tooltip.
+ *
+ * It lives in prose rather than in a row because the two numbers are a
+ * breakdown OF the incident count, not a fourth metric — but it cannot be
+ * dropped: "did not stop when done" and "ran out of time before it" mean
+ * opposite things about an agent, and only the first is a halt bug.
+ */
+function incidentTimeoutNote(
+  seats: ContestantSnap[],
+  incidents: Record<string, Incidents>,
+): string {
+  const parts = seats.flatMap((seat) => {
+    const seen = incidents[seat.id];
+    if (!seen || seen.timeoutAfterSolve + seen.timeoutBeforeSolve === 0) return [];
+    return [
+      `${seat.name}: ${seen.timeoutAfterSolve} timed out after the solve, ` +
+        `${seen.timeoutBeforeSolve} before it`,
+    ];
+  });
+  return parts.length > 0 ? `Timeouts — ${parts.join("; ")}.` : "No timeouts recorded.";
+}
+
 /**
  * One card: a label, then a small table — the arms across the top, one row
  * per metric. The first column is the metric's own label, so a card with
@@ -129,14 +235,13 @@ function CompareCard({
       >
         <span />
         {seats.map((seat) => (
-          /* The arm is identified by its COLOUR CHIP, not by tinted text.
-             Five cards across a 1600px page leave each name ~90px, so every
-             name here truncates — and `text-(--seat-fg)` cannot rescue it:
-             that token is declared on `:root`, where `var(--seat, …)` is
-             substituted against a `--seat` that does not exist yet, so every
-             seat inherits the same paper fallback. Measured, not assumed
-             (see the PR). The chip reads `--seat` on the element that sets
-             it, which is the same shape `task-table.tsx`'s legend uses. */
+          /* The chip carries the identity, because five cards across a 1600px
+             page leave each name ~90px and every name here truncates. The
+             tint is the second signal rather than the only one, which is the
+             same shape `task-table.tsx`'s legend uses — and it is now a real
+             per-seat colour: `--seat-fg` used to be declared on `:root`, where
+             it resolved against a `--seat` that does not exist and every seat
+             inherited one paper fallback (#3223). */
           <div
             key={seat.id}
             style={seatStyle(seat.color)}
@@ -144,7 +249,9 @@ function CompareCard({
             className="flex min-w-0 items-center justify-end gap-1.5"
           >
             <span className="size-[7px] flex-none bg-(--seat)" />
-            <span className="truncate font-mono text-[10.5px] text-muted">{seat.name}</span>
+            <span className="truncate font-mono text-[10.5px] text-(--seat-fg)">
+              {seat.name}
+            </span>
           </div>
         ))}
         {rows.map((row) => (
@@ -170,6 +277,7 @@ function CompareCard({
 export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
   const seats = snapshot.contestants;
   const cellSums = useCellSums(snapshot);
+  const incidents = useIncidents(snapshot);
 
   const critical = (snapshot.detections || []).filter((d) => d.severity === "critical").length;
 
@@ -196,19 +304,29 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
           label="tool calls"
           blurb={
             "Every tool invocation the arm made, and the mean per attempted task. " +
-            "Summed from the per-task cells, so a running trial's calls count as they happen."
+            "Summed from the per-task cells, so a running trial's calls count as they happen. " +
+            "`—` means no trial of this arm was ever observed taking a step or calling a " +
+            "tool; a zero here is a trial that genuinely called nothing."
           }
           seats={seats}
           rows={[
             {
               label: "total",
-              values: seats.map((seat) => fmtCount(cellSums[seat.id]?.tools ?? 0)),
+              values: seats.map((seat) => {
+                const sums = cellSums[seat.id];
+                // Zero observed trials means nothing watched this arm work,
+                // so the sum is unknown rather than none (#3224). One
+                // observed trial is enough to make the total a measurement.
+                if (!sums || sums.observed <= 0) return "—";
+                return fmtCount(sums.tools);
+              }),
             },
             {
               label: "avg / task",
               values: seats.map((seat) => {
                 const sums = cellSums[seat.id];
-                const perTask = sums ? avg(sums.tools, sums.attempted) : null;
+                if (!sums || sums.observed <= 0) return "—";
+                const perTask = avg(sums.tools, sums.attempted);
                 return perTask == null ? "—" : perTask.toFixed(1);
               }),
             },
@@ -284,7 +402,12 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
           blurb={
             "Attempted counts every trial that started (running or done). Solved is trials " +
             "the verifier passed. The success rate is over judged trials only — a queued or " +
-            "running trial is not a failure, and an infrastructure void is outside the rate."
+            "running trial is not a failure, and an infrastructure void is outside the rate. " +
+            "Incidents are trials that RAISED, read solved/failed, and are counted apart " +
+            "from the rate in both directions: a trial can score the reward and then raise, " +
+            "and the tick alone hides it. An incident on a solved trial means the agent kept " +
+            "burning budget after succeeding — amber flags exactly that. " +
+            incidentTimeoutNote(seats, incidents)
           }
           seats={seats}
           rows={[
@@ -299,6 +422,21 @@ export function StatStrip({ snapshot }: { snapshot: Snapshot }) {
             {
               label: "success",
               values: seats.map((seat) => fmtPct(seat.totals.solve_rate)),
+            },
+            {
+              // Restored from the tile the five-card rebuild dropped (#3225),
+              // now per arm: the old one summed both arms and so could not say
+              // which agent was the one that would not stop.
+              label: "incidents",
+              values: seats.map((seat) => {
+                const seen = incidents[seat.id];
+                if (!seen) return "—";
+                return (
+                  <span className={seen.onSolved > 0 ? "text-warn" : undefined}>
+                    {seen.onSolved}/{seen.onFailed}
+                  </span>
+                );
+              }),
             },
           ]}
         />


### PR DESCRIPTION
Closes the three residues of #3226. One PR because they are the same file's
honesty contract, and two of them touch the same lines.

## #3225 — incidents are back, per arm

The five-card rebuild dropped the tile counting trials that **raised**, and
nothing else on the arena page carries it. A trial can score the reward and
then raise, so the verdict tick alone hides exactly the trials a headline rate
flatters (#2066).

**Decision: a fourth row of the `tasks` card, read `solved/failed`** — the
five-card shape is unchanged, and it sits beside `success` rather than folded
into it, which is the #2066 rule in both directions.

Per arm, not the old match-level sum, which could not say *which* agent was the
one that would not stop:

| | Claude Code | Stella |
|---|---|---|
| h2h891-full | 1/0 | 2/17 |
| 14d0127b8ca7 (GLM vs Kimi) | 11/9 | 6/8 |

Amber when an arm has an incident on a **solved** trial — budget burnt after
succeeding. The timeout split ("did not stop when done" vs "ran out of time",
opposite facts, only the first a halt bug — #2661) rides in the card tooltip
rather than a fifth row, because it is a breakdown of the incident count
rather than another metric.

## #3223 — `--seat-fg` resolves per seat for the first time

It was declared on `:root` as a substitution over `--seat`. A custom property
is substituted **on the element the declaration applies to** — the root, where
`--seat` does not exist — so descendants inherited one resolved literal and
every seat painted identical paper. Measured, not inferred:

```
before  seatVar #FF6B9D  seatFgVar #ededed
        seatVar #FFB000  seatFgVar #ededed
after   seatVar #FF6B9D  seatFgVar #FF6B9D
        seatVar #FFB000  seatFgVar #FFB000
```

Keyed off the inline `--seat` rather than a `.seat` class: there are nine
`seatStyle()` call sites, and a class is one shared cell every future seat
surface has to remember — the one that forgets fails silently, which is how
this survived unnoticed. `race.tsx` and `task-table.tsx` gain their intended
tint as a result (visible in the screenshots on the winner cells and race
values).

**The mix ratio drops 62% → 50%, and this is the part worth reviewing.** That
ratio had never actually been rendered, and the moment it painted it failed
the 4.5:1 AA floor `globals.css` holds itself to, on three of the four seat
hues in use. Measured on `--panel` (`#ffffff`):

| mix | rose | amber | cyan | green |
|---|---|---|---|---|
| 62% (old) | 5.83 | **4.29** | **4.34** | **4.14** |
| 55% | 6.85 | 5.16 | 5.21 | 4.94 |
| **50% (new)** | **7.74** | **5.92** | **6.04** | **5.70** |

Verified on the real page after the change: 7.63:1 and 5.89:1 on paper,
7.05:1 and 10.31:1 on ink. 50% leaves headroom for an arbitrary seat hex,
which is data a user supplies rather than a value from this palette.

## #3224 — the issue was half wrong, and the fix is narrower

I filed it claiming a zero tool count on an arm with unmeasured usage was a
number nobody observed. **Reading `telemetry.py` refutes half of that**, so the
correction is recorded here rather than shipped silently:

`steps`/`tools` are counted off the trajectory's `steps` array
(`telemetry.py:723-732`); tokens are read off its `final_metrics`
(`:733-748`). Different sub-objects of the same file, so `final_metrics` can be
missing while the step array is intact. On `feebd80ba873` two of the three
cells record `steps: 1, tools: 0` — **genuine observations of zero tool
calls**. Gating tools on `usage_measured`, which is what the issue implied,
would have hidden two real zeros.

The honest test is whether any trial of the arm was observed taking a step or
calling a tool at all; only then is the sum unknown. That arm therefore still
renders `0` tool calls (correct) while its tokens stay `—` (also correct).

## Evidence

Rendered through the built UI against real matches on disk, not a mock:
`h2h891-full` and `14d0127b8ca7` for the incident row, `feebd80ba873` for the
observed-but-unmeasured case, at both themes. Contrast measured with
`getComputedStyle` + WCAG arithmetic rather than eyeballed — the first pass at
this PR eyeballed it and missed the AA failure.

`npm run build` (runs `tsc`) green; `make guards-fast` green.

## Witness

None — `arenabench/ui` has no test runner (`dev` / `build` / `typecheck`
only). Verified by rendering real payloads as above, with the exact match ids
and expected cells named so the check is repeatable. Adding a UI test harness
is a larger change than this and is not smuggled in here.

## Deleted tests

None.

Closes #3223
Closes #3224
Closes #3225

## Summary by Sourcery

Restore per-arm incident reporting in arena stats and fix per-seat foreground colour resolution for seat labels, while tightening the semantics of tool usage reporting.

New Features:
- Add an incidents row to the tasks card showing per-arm counts of exceptions split by solved and failed trials.

Bug Fixes:
- Ensure tool call totals and averages render as unknown when no behaviour was ever observed for an arm instead of incorrectly showing zero.
- Fix the --seat-fg CSS custom property so it resolves per seat based on inline --seat values rather than a global root fallback, restoring intended seat-specific tinting.
- Correct timeout classification for incidents by relying primarily on structured outcome reasons, with a fallback for legacy payloads.

Enhancements:
- Include per-arm timeout breakdown for incidents in the tasks card tooltip to differentiate timeouts after solve from timeouts before solve.
- Adjust the seat foreground color mix ratio to 50% to meet WCAG AA contrast across supported seat hues in both light and dark schemes.
- Use seat foreground colouring for contestant names in the stat strip so the chip and label share the seat identity signal.

Documentation:
- Clarify inline comments and card blurbs about incident counting, timeout semantics, and the meaning of unknown versus zero tool usage.