### PR TITLE
fix(deps): pin nanoid to the patched 3.3.18 in both JS lockfiles

### DIFF
--- a/arenabench/ui/package-lock.json
+++ b/arenabench/ui/package-lock.json
@@ -1147,6 +1147,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
@@ -1965,9 +2031,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/arenabench/ui/package.json
+++ b/arenabench/ui/package.json
@@ -2,7 +2,7 @@
   "name": "arenabench-ui",
   "private": true,
   "version": "0.1.0",
-  "description": "ArenaBench's web client. `npm run build` static-exports it into arenabench/arenabench/web/ — the directory the Python server serves and the wheel ships — so the package never needs Node at runtime. That export is generated and gitignored, not committed: a checkout has to run this build before `arenabench serve` shows any UI change.",
+  "description": "ArenaBench's web client. `npm run build` static-exports it into arenabench/arenabench/web/ \u2014 the directory the Python server serves and the wheel ships \u2014 so the package never needs Node at runtime. That export is generated and gitignored, not committed: a checkout has to run this build before `arenabench serve` shows any UI change.",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev --port 3900",
@@ -27,5 +27,8 @@
     "@types/react-dom": "^19.2.4",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2"
+  },
+  "overrides": {
+    "nanoid": "^3.3.18"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   postcss: '>=8.5.23'
   sharp: '>=0.35.0'
+  nanoid: ^3.3.18
 
 importers:
 
@@ -1705,8 +1706,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3737,7 +3738,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -3797,7 +3798,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -45,3 +45,16 @@ minimumReleaseAgeExclude:
 overrides:
   postcss: ">=8.5.23"
   sharp: ">=0.35.0"
+  # nanoid <3.3.18: a custom alphabet with a non-integer or zero `size` makes
+  # the generator loop indefinitely (GHSA high, patched at 3.3.18). It arrives
+  # transitively through postcss@8.5.23, which both `next` and
+  # `@tailwindcss/postcss` depend on as `nanoid@^3.3.16` — a range that already
+  # admits the patched version, so nothing here needs a dependency bump. The
+  # floor exists because a lockfile resolved before 3.3.18 published stays on
+  # 3.3.17 forever otherwise, which is exactly what happened: Dependabot could
+  # not raise it on its own and its security job failed on every run.
+  #
+  # Caret, not `>=`, unlike its neighbours above: nanoid 4 went ESM-only and
+  # changed its API, and postcss 8 calls the 3.x one. A `>=3.3.18` floor here
+  # resolves to 6.x and breaks the build, so the ceiling is load-bearing.
+  nanoid: "^3.3.18"


### PR DESCRIPTION
## What

Pins `nanoid` to the patched **3.3.18** in both JS projects, clearing two open high-severity Dependabot alerts and un-sticking the `Dependabot Updates` workflow, which has failed on every run.

Closes #3210

## Why it could not fix itself

`nanoid <3.3.18` loops indefinitely when a custom alphabet is given a non-integer or zero `size`. It reaches both projects **only transitively**, via `postcss@8.5.23`:

```
nanoid can't be automatically updated to a non-vulnerable version. The following
top-level dependencies still require a vulnerable nanoid:
  - @tailwindcss/postcss: requires nanoid@^3.3.16 (via postcss@8.5.23)
  - next: requires nanoid@^3.3.16 (via postcss@8.5.23)
```

`^3.3.16` **already admits** 3.3.18, so no dependency bump is needed — but a lockfile resolved before 3.3.18 published stays on 3.3.17 forever. Both were pinned there. Declaring the floor explicitly is what moves it, and it also prevents a future transitive regression.

## The two non-obvious bits

**1. The website override does not go in `package.json`.** pnpm 11 no longer reads the `pnpm` field and ignores it *silently* — the first attempt here wrote `pnpm.overrides`, `pnpm install` printed a WARN, and the lockfile did not move. The live home is `website/pnpm-workspace.yaml`, alongside the existing `postcss`/`sharp` floors.

**2. The website floor is a caret, not `>=`.** Its two neighbours use `>=`, and copying that shape is wrong here: `nanoid@>=3.3.18` resolves to **6.0.1**. nanoid 4 went ESM-only and changed its API while postcss 8 calls the 3.x one, so the unbounded floor breaks the build. Caught before commit; the ceiling is load-bearing and the inline comment says why.

`arenabench/ui` is npm, which does still read `overrides` from `package.json`, so that one is declared there.

## Verification

- `website`: `pnpm install --frozen-lockfile` passes — the exact check `docs.yml` runs, so the override and the lockfile agree.
- `arenabench/ui`: `npm install --package-lock-only` → **found 0 vulnerabilities**.
- Both lockfiles resolve `nanoid` to `3.3.18` (was `3.3.17`).
- `make guards-fast` green (the correct rung — no crate is touched), `cargo fmt --check` clean.

## Witness

No witness test: this is a dependency pin with no behaviour change of our own code. The verifying artifact is the lockfile itself plus `npm audit`'s `0 vulnerabilities`, both shown above. `nanoid` is not a direct dependency of either project — it appears only in `overrides`.

## Deleted tests

None.

## Summary by Sourcery

Pin JavaScript dependencies to a non-vulnerable nanoid version to resolve security alerts and stabilize dependency updates.

Bug Fixes:
- Force nanoid to version 3.3.18 in both JS projects to address the high-severity vulnerability in earlier releases.

Build:
- Add nanoid override constraints to the website pnpm workspace config and arenabench UI npm configuration to ensure consistent resolution in lockfiles.

Chores:
- Regenerate JS lockfiles to reflect the new nanoid version and keep dependency metadata up to date.