### PR TITLE
fix(stella-core): repair main — the tool purge and #3253 composed into a red build

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -30,7 +30,7 @@
 
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionRequest, CompletionResult, MessageRole,
-    ReasoningEffort, ToolCall, ToolOutput,
+    ReasoningEffort,
 };
 
 use super::{Engine, SUMMARY_MARKER_PREFIX, lifecycle};
@@ -43,11 +43,6 @@ use crate::retry::RetryPolicy;
 use crate::starvation::{starved_of_output, starved_retry_cap, with_reasoning_headroom};
 use crate::step::SummarizerHealth;
 use crate::{AccountedCall, AccountedCallError, run_accounted_call};
-
-/// The synthetic `call_id` restoration replays carry — the
-/// `driver::waiting::PARKED_CALL_ID` shape: it never enters the transcript,
-/// so it only needs to be recognizable in hook payloads and diagnostics.
-const RESTORE_CALL_ID: &str = "working-set-restore";
 
 /// The summarizer's **visible-output** contract: the dense bullet summary
 /// `SUMMARIZE_SYSTEM` asks for. What reaches the wire is this plus
@@ -424,6 +419,8 @@ mod tests {
     //! neither the constant nor the behavior); `the_literal_is_the_constant`
     //! pins the spelling.
 
+    use std::sync::Mutex;
+
     use async_trait::async_trait;
     use serde_json::Value;
     use stella_protocol::{
@@ -444,6 +441,21 @@ mod tests {
     #[async_trait]
     impl Sleeper for NoSleep {
         async fn sleep(&self, _duration_ms: u64) {}
+    }
+
+    /// An executor that offers nothing. The starvation witnesses below drive
+    /// the summarizer, never a tool, so the port only has to exist.
+    struct NoTools;
+    #[async_trait]
+    impl ToolExecutor for NoTools {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+            ToolOutput::Ok {
+                content: String::new(),
+            }
+        }
     }
 
     /// Always answers "SUMMARY" — the summarizer path under test is the
@@ -761,10 +773,7 @@ mod tests {
     #[tokio::test]
     async fn a_starved_summarizer_is_retried_with_room_and_never_latches() {
         let provider = StarvingProvider::new(1);
-        let tools = MapTools {
-            files: Arc::new(Mutex::new(HashMap::new())),
-            active: vec![],
-        };
+        let tools = NoTools;
         let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
         let mut messages = vec![
             CompletionMessage::system("sys"),
@@ -815,10 +824,7 @@ mod tests {
     #[tokio::test]
     async fn a_retry_that_starves_again_records_one_failure_and_stops() {
         let provider = StarvingProvider::new(u32::MAX);
-        let tools = MapTools {
-            files: Arc::new(Mutex::new(HashMap::new())),
-            active: vec![],
-        };
+        let tools = NoTools;
         let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
         let mut messages = vec![
             CompletionMessage::system("sys"),


### PR DESCRIPTION
## `main` does not compile

`cargo clippy -D warnings` and `cargo test` both fail on `origin/main` at `868ad77e0`, in `crates/stella-core/src/driver/restore.rs`:

```
error[E0433]: cannot find type `Mutex` in this scope
error[E0422]: cannot find struct, variant or union type `MapTools` in this scope
error: unused imports: `ToolCall` and `ToolOutput`
error: constant `RESTORE_CALL_ID` is never used
```

The required `ci` job has been red since #3253 merged. Everything downstream inherits it — per this repo's own history, a red `main` reds every open PR.

## Neither PR was wrong, and neither was red on its branch

- **#3244** (the 12-tool purge) deleted the working-set re-read that issued a synthetic `read_file` tool call. It took the `MapTools` executor, `RESTORE_CALL_ID`, the `ToolCall`/`ToolOutput` imports, and the test module's `use std::{collections::HashMap, sync::{Arc, Mutex}}` with it.
- **#3253** was cut *before* that landed. It added two starvation witnesses that construct `MapTools`, plus a `StarvingProvider` holding a `Mutex` — and its diff carried the pre-purge import line and the constant back in.

The two edit **different regions** of the same file, so git reported no conflict and the squash took each side verbatim. This is exactly the failure AGENTS.md documents under "A witness that no longer exists cannot fail" — two branches green, the merge textually clean, and neither side containing the other's assumptions.

## The repair

Re-applies the purge's intent. `read_file` no longer exists, so nothing can re-read a file through a tool call:

- **`RESTORE_CALL_ID` and the `ToolCall`/`ToolOutput` imports are removed again.** #3253 resurrected them by accident; `rg` finds no reference to any of the three.
- **The two new witnesses get a local `NoTools`** — an executor that offers nothing — instead of `MapTools`. Both drive the summarizer and never call a tool; they built `Arc<Mutex<HashMap>>::new()` purely to have a port to hand `Engine::with_sleeper`. Restoring a `read_file` executor for a deleted tool would be the wrong repair.
- **The test module keeps only `use std::sync::Mutex`**, which `StarvingProvider::caps` still needs. `Arc` and `HashMap` went with the empty map.

## Verification

- `cargo clippy -p stella-core --all-targets -- -D warnings` → clean, exit 0
- `cargo test -p stella-core` → **1,224 passed, 0 failed**
- Both #3253 witnesses pass unchanged, so the starvation contract they prove is intact:
  - `a_starved_summarizer_is_retried_with_room_and_never_latches ... ok`
  - `a_retry_that_starves_again_records_one_failure_and_stops ... ok`

## Witness

No new witness test. This is a build repair: the witness is that `main` does not compile and this branch does, which `cargo test -p stella-core` demonstrates in both directions. Adding a test asserting "the crate compiles" is what the compiler already is.

Worth noting the masking, since it cost a round here: the `cargo test` compile error hid the two lib-level clippy errors entirely — they only appeared once the test module compiled. Fixing the first error is not evidence that the file is clean.

## Deleted tests

None. No test was removed; two had their unused executor swapped.

Refs #3244, #3253

## Summary by Sourcery

Repair stella-core restore driver tests and protocol imports so main builds clean after recent tool purge and starvation witness additions.

Bug Fixes:
- Remove unused tool-related protocol imports and a stale RESTORE_CALL_ID constant from the restore driver to fix compilation and clippy failures.
- Adjust starvation witness tests to use a no-op tool executor instead of MapTools so they no longer depend on removed tooling while preserving behavior.

Tests:
- Update starvation-related restore driver tests to construct engines with a minimal NoTools executor and retain only the Mutex dependency needed by StarvingProvider.