### PR TITLE
fix(stella-core): unbreak main — restore.rs references a test double #3244 deleted

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -30,7 +30,7 @@
 
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionRequest, CompletionResult, MessageRole,
-    ReasoningEffort, ToolCall, ToolOutput,
+    ReasoningEffort,
 };
 
 use super::{Engine, SUMMARY_MARKER_PREFIX, lifecycle};
@@ -43,11 +43,6 @@ use crate::retry::RetryPolicy;
 use crate::starvation::{starved_of_output, starved_retry_cap, with_reasoning_headroom};
 use crate::step::SummarizerHealth;
 use crate::{AccountedCall, AccountedCallError, run_accounted_call};
-
-/// The synthetic `call_id` restoration replays carry — the
-/// `driver::waiting::PARKED_CALL_ID` shape: it never enters the transcript,
-/// so it only needs to be recognizable in hook payloads and diagnostics.
-const RESTORE_CALL_ID: &str = "working-set-restore";
 
 /// The summarizer's **visible-output** contract: the dense bullet summary
 /// `SUMMARIZE_SYSTEM` asks for. What reaches the wire is this plus
@@ -426,6 +421,7 @@ mod tests {
 
     use async_trait::async_trait;
     use serde_json::Value;
+    use std::sync::Mutex;
     use stella_protocol::{
         CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
         Provider, ProviderError, ToolOutput, ToolSchema,
@@ -761,10 +757,7 @@ mod tests {
     #[tokio::test]
     async fn a_starved_summarizer_is_retried_with_room_and_never_latches() {
         let provider = StarvingProvider::new(1);
-        let tools = MapTools {
-            files: Arc::new(Mutex::new(HashMap::new())),
-            active: vec![],
-        };
+        let tools = SkillTools { active: vec![] };
         let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
         let mut messages = vec![
             CompletionMessage::system("sys"),
@@ -815,10 +808,7 @@ mod tests {
     #[tokio::test]
     async fn a_retry_that_starves_again_records_one_failure_and_stops() {
         let provider = StarvingProvider::new(u32::MAX);
-        let tools = MapTools {
-            files: Arc::new(Mutex::new(HashMap::new())),
-            active: vec![],
-        };
+        let tools = SkillTools { active: vec![] };
         let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
         let mut messages = vec![
             CompletionMessage::system("sys"),


### PR DESCRIPTION
## What

`main` is red: `stella-core` does not compile, failing both `cargo clippy -D warnings` and `cargo test`. This unbreaks it.

Failing run: https://github.com/macanderson/stella/actions/runs/31775648996 (job `fmt + clippy + test`, on `868ad77e0`).

## Why it broke — a merge skew, both PRs green alone

Nothing is wrong with either contributing PR. The break is entirely in how they compose, in one file (`crates/stella-core/src/driver/restore.rs`):

- **#3244** (12-tool purge) changed restoration so it renders skill bodies into a plain user message and replays **no tool call**. It replaced the `MapTools` test executor with the tool-less `SkillTools` ("restoration needs no tools at all"), and deleted the `ToolCall`/`ToolOutput` imports and the `RESTORE_CALL_ID` constant the old replay used, along with the `Arc`/`Mutex`/`HashMap` imports `MapTools` needed.
- **#3253** (overflow-summarizer headroom) added two new witnesses to the same test module that construct `MapTools`.

Neither branch contains the other's lines, so git reported no conflict and merged both. The composed file then fails four ways:

```
error: unused imports: `ToolCall` and `ToolOutput`   crates/stella-core/src/driver/restore.rs:33
error: constant `RESTORE_CALL_ID` is never used      crates/stella-core/src/driver/restore.rs:50
error[E0422]: cannot find struct ... `MapTools`      restore.rs:764, 818
error[E0433]: cannot find type `Arc`/`Mutex`/`HashMap`  restore.rs:684, 692, 765, 819
```

This is the shape `scripts/check-deleted-tests.sh` was written for, one step sideways: the guard compares `#[test]` functions across the two trees, and what went missing here was a *test helper* and its imports, which no guard watches. Filed as a follow-up (see below).

## The fix

Minimal, and it keeps both PRs' intent intact:

- Point #3253's two witnesses at `SkillTools`. They only ever set `active` and never touch `files`, so it is a drop-in.
- Add the `std::sync::Mutex` import `StarvingProvider` needs.
- Finish #3244's removal by deleting the now-genuinely-dead `ToolCall`/`ToolOutput` imports and `RESTORE_CALL_ID`.

I verified the three removed symbols are dead rather than a silently-dropped feature: `restore_working_set` renders from `working_set.skills` and pushes a `CompletionMessage::user`, with no synthetic tool-call replay anywhere on the path. Deleting them completes #3244's change rather than papering over it.

**No production behavior change** — the restore path itself is untouched.

## Witness

Not a behavior change, so no new witness test. The evidence is that the pre-existing suite compiles and passes again, including both of #3253's witnesses, which is what `main` currently cannot do:

```
cargo test -p stella-core --lib driver::restore
running 6 tests ... test result: ok. 6 passed; 0 failed

cargo fmt -p stella-core -- --check      # clean
cargo clippy -p stella-core --all-targets # no errors
```

No tests were deleted or renamed.

## Caveat on scope

I ran the gate for `stella-core` only, not the workspace. `stella-core` failing to compile stopped clippy for every crate that depends on it, so **there may be further breakage masked behind this one** — CI on this PR is the honest check. Flagging rather than claiming a green workspace I did not run.

## Summary by Sourcery

Fix stella-core restore driver tests so the crate compiles again by aligning test tooling with the recent tool-less restore implementation.

Bug Fixes:
- Resolve compilation failures in stella-core restore.rs by removing dead tool-related protocol symbols and constants.
- Update restore driver tests to use SkillTools instead of the removed MapTools helper and add the missing Mutex import for StarvingProvider.