### PR TITLE
fix(stella-core): unbreak main — #3265 and #3271 composed into a duplicate Mutex import and a stranded test double

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -423,7 +423,6 @@ mod tests {
 
     use async_trait::async_trait;
     use serde_json::Value;
-    use std::sync::Mutex;
     use stella_protocol::{
         CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
         Provider, ProviderError, ToolOutput, ToolSchema,

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -443,21 +443,6 @@ mod tests {
         async fn sleep(&self, _duration_ms: u64) {}
     }
 
-    /// An executor that offers nothing. The starvation witnesses below drive
-    /// the summarizer, never a tool, so the port only has to exist.
-    struct NoTools;
-    #[async_trait]
-    impl ToolExecutor for NoTools {
-        fn schemas(&self) -> Vec<ToolSchema> {
-            Vec::new()
-        }
-        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
-            ToolOutput::Ok {
-                content: String::new(),
-            }
-        }
-    }
-
     /// Always answers "SUMMARY" — the summarizer path under test is the
     /// restoration that follows the splice, not the summary itself.
     struct SummaryProvider;


### PR DESCRIPTION
Main is red at the clippy/test step: #3265 (the restore.rs test-double repair) and #3271 (the purge residual sweep) merged textually clean and composed into E0252 — both sides added `use std::sync::Mutex;` to the same test module — plus a `NoTools` double #3265 added that #3271's restaged tests no longer construct. One import stays; the dead double goes.

Verified: `cargo test -p stella-core` and `cargo clippy -p stella-core --all-targets -- -D warnings` green locally on main + this diff.

This is the clean-merge-composition failure class documented in #3267 — third instance this week (#3263 was the second). Refs #3267.

No witness test: this is a compile repair; the compiler is the oracle (the tree fails to build without it).

## Summary by Sourcery

Resolve a compilation failure in stella-core tests by cleaning up conflicting imports and obsolete test scaffolding.

Bug Fixes:
- Remove the redundant Mutex import from the restore.rs test module that caused a duplicate import error.
- Delete the unused NoTools test double from restore.rs tests that was left stranded after prior test changes.