### PR TITLE
fix(stella-core): restore stella-core's test target to compiling

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -419,8 +419,6 @@ mod tests {
     //! neither the constant nor the behavior); `the_literal_is_the_constant`
     //! pins the spelling.
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
     use serde_json::Value;
     use std::sync::Mutex;
@@ -442,21 +440,6 @@ mod tests {
     #[async_trait]
     impl Sleeper for NoSleep {
         async fn sleep(&self, _duration_ms: u64) {}
-    }
-
-    /// An executor that offers nothing. The starvation witnesses below drive
-    /// the summarizer, never a tool, so the port only has to exist.
-    struct NoTools;
-    #[async_trait]
-    impl ToolExecutor for NoTools {
-        fn schemas(&self) -> Vec<ToolSchema> {
-            Vec::new()
-        }
-        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
-            ToolOutput::Ok {
-                content: String::new(),
-            }
-        }
     }
 
     /// Always answers "SUMMARY" — the summarizer path under test is the


### PR DESCRIPTION
`crates/stella-core/src/driver/restore.rs`'s test module does not compile on `main`:

```
error[E0252]: the name `Mutex` is defined multiple times
   --> crates/stella-core/src/driver/restore.rs:426:9
error: struct `NoTools` is never constructed
   --> crates/stella-core/src/driver/restore.rs:447:12
```

So `cargo test -p stella-core` and `cargo clippy -p stella-core --all-targets` — two `make gate` steps — fail on `main`, and every branch cut from it inherits the red before it has changed anything.

## What this does

- Drops the duplicated `use std::sync::Mutex;` (it appears twice, four lines apart).
- Deletes `NoTools` rather than `#[allow]`-ing it. It is superseded, not missing a caller: `SkillTools { active: vec![] }` is the same tool-less executor, and all five tests in the module already use that.

## Evidence

Before, on `main`: both commands above fail as quoted.
After: `cargo clippy -p stella-core --all-targets -- -D warnings` finishes clean, and `cargo test -p stella-core --lib` reports **1216 passed; 0 failed**.

## Witness

None, and deliberately: this is a compile fix for a test module, so the compiler is the witness — the target did not build before and does build now. Nothing about shipped behaviour changes.

## Deleted tests

None. `NoTools` is a test *helper struct*, not a `#[test]`; no test function is removed.

## Summary by Sourcery

Restore stella-core's restore driver test module to compiling by cleaning up redundant and obsolete test-only code.

Bug Fixes:
- Remove a duplicated Mutex import in the restore driver tests that caused a name redefinition compile error.
- Delete the unused NoTools test executor helper superseded by existing SkillTools-based usage to clear dead-code warnings.