### PR TITLE
fix(gate): file-size and left-behind judge the files that exist, not the index

### DIFF
--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -143,6 +143,11 @@ RATCHET_PATHSPECS=('*.rs' '*.py' '*.sh' '.githooks/*')
 # while the guard watched only *.rs. Shell counts (#1563) for the same reason.
 current_sizes() {
   git ls-files -z "${RATCHET_PATHSPECS[@]}" | while IFS= read -r -d '' f; do
+    # A tracked file deleted from the working tree but not yet staged is a
+    # legitimate transient state on a working branch (#3268); judge the files
+    # that exist rather than erroring on the ones that do not. Once the
+    # deletion is staged, ls-files stops listing it and nothing changes.
+    [ -f "$f" ] || continue
     printf '%s %s\n' "$(wc -l <"$f" | tr -d ' ')" "$f"
   done
 }

--- a/scripts/check-left-behind.sh
+++ b/scripts/check-left-behind.sh
@@ -92,7 +92,11 @@ fi
 # markers in prose, and a guard that fails on its own documentation is a guard
 # someone deletes. Nothing else is exempt.
 current_counts() {
+  # The existence filter skips tracked files deleted from the working tree but
+  # not yet staged (#3268) — awk would otherwise die on the missing path
+  # instead of judging the files that exist.
   git ls-files -z '*.rs' '*.py' '*.sh' '.githooks/*' |
+    while IFS= read -r -d '' f; do [ -f "$f" ] && printf '%s\0' "$f"; done |
     xargs -0 awk '
       FILENAME == "scripts/check-left-behind.sh"      { next }
       FILENAME == "scripts/left-behind-baseline.txt"  { next }


### PR DESCRIPTION
A tracked file deleted with plain `rm` (not yet staged) made both guards error — `unbound variable` / awk `can't open file` — instead of producing a verdict. Found live during the tool-purge residual wave, where a session forbidden git mutations had deleted files on disk while they stayed in the index.

Both guards now filter `git ls-files` through a `[ -f ]` existence check, with the constraint documented at the filter site. Commit-time behaviour is unchanged: once a deletion is staged, `ls-files` stops listing it.

**Witness** (fails before, passes after): `rm crates/stella-tty/src/lib.rs && make file-size && make left-behind` — both now report clean verdicts; before, both errored. shellcheck clean on both scripts.

Note: this PR's CI may show red until #3276 (the main unbreak) lands — the failure is main's, not this diff's.

Closes #3268

## Summary by Sourcery

Ensure file size and left-behind guard scripts only process tracked files that still exist in the working tree to avoid errors on transient deletions.

Bug Fixes:
- Prevent check-file-size guard from erroring when tracked files have been removed from the working tree but not yet staged as deletions.
- Prevent check-left-behind guard from failing when encountering tracked files deleted from disk but still present in the index.