### PR TITLE
fix(stella-core): drop the duplicate Mutex import two unbreak PRs both added

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -423,7 +423,6 @@ mod tests {
 
     use async_trait::async_trait;
     use serde_json::Value;
-    use std::sync::Mutex;
     use stella_protocol::{
         CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
         Provider, ProviderError, ToolOutput, ToolSchema,


### PR DESCRIPTION
`main` is red again at `eb427c2da`. One line fixes it.

```
error[E0252]: the name `Mutex` is defined multiple times
   --> crates/stella-core/src/driver/restore.rs:426:9
422 |     use std::sync::Mutex;   <- #3263
426 |     use std::sync::Mutex;   <- #3265
```

## What happened

Two PRs diagnosed the *same* red main independently and shipped the same repair:

- **#3263** `fix(stella-core): repair main — the tool purge and #3253 composed into a red build` (`76ad90621`)
- **#3265** `fix(stella-core): unbreak main — restore.rs references a test double #3244 deleted` (`678f41c27`)

Mine was #3265. I checked for an in-flight fix before starting (`gh pr list` filtered on restore/fix/compile) and found none — #3263 was opened after that check and merged before mine, so by the time #3265 landed the repair was already in. The two edits sit at different lines, so git had no conflict to report and merged both.

The rest of the two repairs converged on byte-identical text — both pointed #3253's starvation witnesses at `SkillTools` and both removed the orphaned `ToolCall`/`ToolOutput`/`RESTORE_CALL_ID` — so this duplicated import is the entire delta.

## The fix

Delete the second import. Keeps the placement #3263 chose, since it landed first.

## Verify

```
cargo test -p stella-core --lib driver::restore   # 6 passed, 0 failed
cargo clippy -p stella-core --all-targets         # clean, no warnings
cargo fmt -p stella-core -- --check               # clean
```

No tests deleted or renamed. No behavior change.

## Note

This is the *second* red main in a row out of the same file, and the two causes are different: #3267 tracks the first (a clean merge deleting a test helper another PR was concurrently using). This one is the duplicate-repair hazard — two agents racing the same breakage — which a merge queue would also have caught, and which is more evidence for option 1 in #3267.

## Summary by Sourcery

Bug Fixes:
- Resolve a compile error in stella-core restore.rs by dropping the extra std::sync::Mutex import in the test module.