### PR TITLE
fix(steering): skill selection scored the repo, not the turn (#3243 D1, D2)

### DIFF
--- a/crates/stella-cli/src/contextgraph.rs
+++ b/crates/stella-cli/src/contextgraph.rs
@@ -115,7 +115,7 @@ struct ScopedStore {
 ///
 /// Sorted and deduplicated so the scope is byte-stable across turns that name
 /// the same files in a different order.
-fn query_domain_scope(domains: &Domains, anchors: &[String]) -> Vec<String> {
+pub(crate) fn query_domain_scope(domains: &Domains, anchors: &[String]) -> Vec<String> {
     let mut selected: Vec<String> = Vec::new();
     for anchor in anchors {
         for name in domains.domains_for_path(anchor) {

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -655,7 +655,7 @@ impl SessionMemory {
         skills::select_skills(
             &self.load_skills(),
             prompt,
-            &self.domains.names(),
+            &self.active_domains(prompt),
             &SelectionConfig::default(),
         )
         .into_iter()

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -163,7 +163,7 @@ impl SessionMemory {
         let selected = skills::select_skills(
             &all_skills,
             prompt,
-            &self.domains.names(),
+            &self.active_domains(prompt),
             &SelectionConfig::default(),
         );
         if !selected.is_empty() {
@@ -227,7 +227,7 @@ impl SessionMemory {
         let selected = skills::select_skills(
             &all_skills,
             prompt,
-            &self.domains.names(),
+            &self.active_domains(prompt),
             &SelectionConfig::default(),
         );
         if !selected.is_empty() {
@@ -238,6 +238,32 @@ impl SessionMemory {
         }
         sections.push(render_today_section(now_unix_secs()));
         (!sections.is_empty()).then(|| format!("{RECALL_MARKER}\n\n{}", sections.join("\n\n")))
+    }
+
+    /// The domains **this turn** is working in, derived from the workspace
+    /// paths its prompt names.
+    ///
+    /// Every `select_skills` call site used to pass `self.domains.names()`,
+    /// which is every domain the repository declares, loaded once at session
+    /// open and constant for the session. Against that list `matched_domains`
+    /// answers "is this skill tagged with a domain this repo has?" — true for
+    /// every domain-tagged skill on every turn — rather than "is this domain
+    /// active right now?". With `domain_boost` at 0.5 against a `min_score` of
+    /// 0.08, and a single domain match satisfying `corroborated`, the effect
+    /// was that any domain-tagged skill was injected on every non-control
+    /// turn regardless of the prompt, ranked by how MANY tags it carried, so a
+    /// 3-tag skill permanently outranked a perfectly-matching 1-tag one and
+    /// the top-k was spent on the most-tagged rather than the most-relevant
+    /// (#3243 D1).
+    ///
+    /// Memory recall already derives per-query scope this way (#2333); skill
+    /// selection was simply never migrated to it. Anchors require the file to
+    /// exist, so a prompt naming no extant path yields an empty scope — the
+    /// honest answer, and the reason the lexical score has to carry its own
+    /// weight (see `mining::coverage`).
+    pub(super) fn active_domains(&self, prompt: &str) -> Vec<String> {
+        let anchors = goal_path_anchors(prompt, &self.workspace_root);
+        crate::contextgraph::query_domain_scope(&self.domains, &anchors)
     }
 
     /// Arm this turn's A/B recall control at the workspace's configured rate

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -22,6 +22,9 @@ mod reflection_mining;
 // Spec §8 (#737): the seam where auto-created skill files meet what is
 // already on disk — its own module, and the reason tests.rs fits the ratchet.
 mod skill_creation;
+// #3243 D1/D2: what selection is allowed to call "relevant to this turn" —
+// per-turn domain scope, and a lexical score that can fire on a real prompt.
+mod steering_selection;
 // #2459: a lesson's `trigger` decides what recall returns. The experiment
 // needs two goals, two crossed lessons and a scripted provider to set up, so it
 // lives beside the other multi-fixture seams rather than inline here.

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -1,0 +1,96 @@
+//! Witnesses for #3243 D1 and D2 — what skill selection is allowed to claim
+//! is "relevant to this turn".
+//!
+//! Its own file rather than more of `memory/tests.rs`, which sits just under
+//! the ratchet `scripts/check-file-size.sh` enforces.
+
+use crate::memory::*;
+
+/// A workspace with one domain covering `crates/stella-model`, one real file
+/// under it to anchor against, and one skill tagged with that domain whose
+/// wording shares nothing with the prompts below.
+fn workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    crate::domains::Domains {
+        version: 1,
+        inferred_by: "heuristic".into(),
+        source_fingerprint: None,
+        domains: vec![crate::domains::Domain {
+            name: "model-adapters".into(),
+            description: "provider adapters".into(),
+            paths: vec!["crates/stella-model".into()],
+        }],
+    }
+    .save(root)
+    .expect("domains.toml writes");
+
+    let anchored = root.join("crates").join("stella-model");
+    std::fs::create_dir_all(&anchored).unwrap();
+    std::fs::write(anchored.join("anthropic.rs"), "// adapter\n").unwrap();
+
+    let skill_dir = root.join(".stella").join("skills").join("adapter-notes");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    // Deliberately zero lexical overlap with either prompt: the ONLY thing
+    // that can select this skill is the domain tag, which is what makes the
+    // two assertions below about domain scope and nothing else.
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: adapter-notes\ndescription: streaming dialect quirks per vendor\n\
+         domains: model-adapters\n---\n\nAlways reuse an existing adapter's shape.\n",
+    )
+    .unwrap();
+
+    dir
+}
+
+/// Workspace skills are behind the project-trust boundary, so a witness about
+/// selecting them has to open the session the way a trusted project does.
+fn session(root: &std::path::Path) -> SessionMemory {
+    SessionMemory::open_with_workspace_skills(root, false, true)
+        .expect("session memory opens in a temp workspace")
+}
+
+/// **Witness (D1).** A skill tagged with a domain this turn is not working in
+/// is not injected.
+///
+/// Fails on base: every `select_skills` call site passed
+/// `self.domains.names()` — every domain the *repository* declares, constant
+/// for the session — so `matched_domains` was non-empty for any domain-tagged
+/// skill on any prompt. One match is worth `domain_boost` 0.5 against a
+/// `min_score` of 0.08 and satisfies `corroborated` on its own, so the skill
+/// below was injected on every non-control turn no matter what was asked.
+#[test]
+fn a_skill_tagged_with_an_inactive_domain_is_not_selected() {
+    let dir = workspace();
+    let memory = session(dir.path());
+
+    let selected = memory.selected_skills("rename the changelog heading");
+
+    assert!(
+        selected.is_empty(),
+        "a prompt that touches no path in the domain must not pull the \
+         domain's skills in: {selected:?}"
+    );
+}
+
+/// **Witness (D1, the other side).** The same skill IS injected once the
+/// prompt names a file inside its domain.
+///
+/// Passes on base too — for the wrong reason, since base injects it for every
+/// prompt. Its job is to prove the fix scoped selection rather than disabling
+/// the domain signal, which an empty-selection assertion alone cannot tell
+/// apart.
+#[test]
+fn the_same_skill_is_selected_once_the_prompt_anchors_in_its_domain() {
+    let dir = workspace();
+    let memory = session(dir.path());
+
+    let selected = memory.selected_skills("fix crates/stella-model/anthropic.rs");
+
+    assert!(
+        selected.iter().any(|(name, _)| name == "adapter-notes"),
+        "a prompt anchored in the domain still selects its skill: {selected:?}"
+    );
+}

--- a/crates/stella-core/src/mining.rs
+++ b/crates/stella-core/src/mining.rs
@@ -46,6 +46,29 @@ pub(crate) fn terms(text: &str) -> Vec<String> {
     out
 }
 
+/// The fraction of `b`'s vocabulary that `a` covers — `|a ∩ b| / |b|`, 0 when
+/// either is empty.
+///
+/// Asymmetric on purpose, and that is the whole point. [`jaccard`] divides by
+/// the UNION, so a long `a` is penalized for every term it holds that `b` does
+/// not: a 15-term skill description scored against a 50-term prompt needs 5
+/// shared terms to clear 0.08, and against a 200-term prompt it needs about
+/// 16. Prompts are long and descriptions are short, so the symmetric measure
+/// answered "are these two texts the same size and about the same thing?" when
+/// the question selection actually asks is "does this prompt cover what this
+/// skill is for?".
+///
+/// Deliberately a second function rather than a change to [`jaccard`]: the
+/// miners' near-duplicate clustering thresholds (`min_similarity`) are tuned
+/// against the symmetric measure, and re-pointing them at this one would
+/// silently re-cluster every observation.
+pub(crate) fn coverage(a: &HashSet<String>, b: &HashSet<String>) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    a.intersection(b).count() as f64 / b.len() as f64
+}
+
 /// Jaccard similarity of two term sets — 0 when either is empty (TS:
 /// `jaccard`).
 pub(crate) fn jaccard(a: &HashSet<String>, b: &HashSet<String>) -> f64 {

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -442,7 +442,13 @@ pub fn select_skills(
             .cloned()
             .collect();
 
-        let lexical = jaccard(&prompt_terms, &skill_terms);
+        // Asymmetric: what fraction of THIS SKILL's vocabulary the prompt
+        // covers. The symmetric Jaccard this used to call divides by the
+        // union, so a long prompt was penalized for every term the skill's
+        // one-line description happens not to contain — which made lexical
+        // selection fire only on prompts about as short as a description, and
+        // effectively never on a real one (#3243 D2).
+        let lexical = coverage(&prompt_terms, &skill_terms);
         let domain_score = matched_domains.len() as f64 * config.domain_boost;
         let recency = if skill.origin == SkillOrigin::AutoCreated {
             config.auto_created_bonus
@@ -909,7 +915,7 @@ pub enum InstallDecision {
 
 // Lexical helpers — shared with the rules miner via `crate::mining`
 
-use crate::mining::{jaccard, terms};
+use crate::mining::{coverage, terms};
 
 /// Union of every domain across a cluster, dedup'd case-insensitively,
 /// first-seen casing preserved, order stable.

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -243,6 +243,50 @@ fn selection_populates_the_why_fields() {
     assert_eq!(selected[0].matched_domains, vec!["sql"]);
 }
 
+/// **Witness (#3243 D2).** An untagged skill whose description the prompt
+/// plainly covers is selected even when the prompt is the length of a real
+/// one.
+///
+/// Fails on base, where the score was symmetric Jaccard. The prompt below
+/// carries ~31 content terms and shares two of the skill's five (`sql`,
+/// `format`), which is what a real goal mentioning a skill's subject looks
+/// like. Jaccard divides by the UNION and so charges the skill for all 29
+/// terms the prompt holds and its description does not: 2/34 ≈ 0.059, under
+/// the 0.08 floor, and it is dropped. Coverage asks the question selection
+/// actually has — what fraction of THIS skill's vocabulary did the prompt
+/// cover — and answers 2/5 = 0.4.
+///
+/// The asymmetry is the entire fix: under Jaccard a skill's score falls as
+/// the *prompt* grows, so the longer someone explains what they want, the
+/// less likely they are to get the skill for it.
+#[test]
+fn a_long_prompt_still_selects_an_untagged_skill_it_names() {
+    let skills = vec![skill(
+        "sql-style",
+        "format sql queries nicely",
+        &[],
+        SkillOrigin::Workspace,
+    )];
+    // No domain tag anywhere, so the lexical score is the only thing that can
+    // select this — which is what makes it a test of the score.
+    let prompt = "I have been staring at this reporting module for a while and \
+                  the thing that keeps bothering me is that nobody can read the \
+                  generated statements, so before we ship the migration please \
+                  clean up every sql fragment you find, keep the format \
+                  consistent across the repository, then run the suite and tell \
+                  me what broke";
+
+    let selected = select_skills(&skills, prompt, &[], &SelectionConfig::default());
+
+    assert_eq!(
+        selected.len(),
+        1,
+        "a goal that names the skill's subject must select it however long \
+         the goal is: {selected:?}"
+    );
+    assert_eq!(selected[0].skill.name, "sql-style");
+}
+
 #[test]
 fn domain_boost_wins_over_a_weak_lexical_match() {
     let skills = vec![


### PR DESCRIPTION
Phase 1 of #3243 — the correctness fixes that need no new architecture. Two defects, D1 and D2, that between them made skill selection effectively binary: **domain-tagged skills were injected on every turn regardless of the prompt, and untagged skills could essentially never be selected on wording at all.**

## D1 — selection scored the repository, not the turn

Every `select_skills` call site passed `self.domains.names()`:

- `crates/stella-cli/src/memory/recall.rs` (×2)
- `crates/stella-cli/src/memory.rs` (`selected_skills`)

That is every domain the *repository* declares, loaded once at session open from `.stella/domains.toml` and constant for the session. Against it, `matched_domains` answers "is this skill tagged with a domain this repo has?" — never "is this domain active this turn?".

The consequences compound, because a domain match is worth `domain_boost` 0.5 against a `min_score` of 0.08 **and** satisfies `corroborated` on its own:

- any domain-tagged skill was injected on every non-control turn, whatever was asked;
- ranking among tagged skills was `tag_count × 0.5`, so a 3-tag skill permanently outranked a perfectly-matching 1-tag one;
- the top-5 cap was spent on the most-tagged skills rather than the most-relevant.

The fix already existed next door: memory recall got per-query domain scoping in #2333 via `query_domain_scope(&domains, &anchors)`. Skill selection was never migrated. This adds `SessionMemory::active_domains(prompt)` — the turn's path anchors, resolved through the taxonomy — and points all three call sites at it.

## D2 — the lexical score fell as the prompt grew

Selection scored prompt-vs-skill with symmetric Jaccard, `|A∩B| / |A∪B|`. Dividing by the union charges a skill for every term the prompt holds that its one-line description does not, so **a skill's score falls as the prompt gets longer**: the more carefully someone explains what they want, the less likely they are to get the skill for it.

Concretely, with the 5-term description `format sql queries nicely` and a 31-term goal sharing two of them: `2/34 ≈ 0.059`, under the 0.08 floor, dropped.

Replaced with `mining::coverage` — `|a ∩ b| / |b|`, the fraction of the *skill's own* vocabulary the prompt covers, which is the question selection actually asks. Same case: `2/5 = 0.4`.

**Deliberately a second function rather than a change to `jaccard`.** The miners' near-duplicate clustering (`already_captured`, `cluster_observations`) compares against tuned `min_similarity` thresholds; re-pointing those at an asymmetric measure would silently re-cluster every observation.

## Witnesses

Each fails on `main` and passes here; I verified the fail half by reverting the specific mechanism and re-running, not by assertion.

| Test | On base |
|---|---|
| `a_skill_tagged_with_an_inactive_domain_is_not_selected` | FAILS — unrelated prompt selects `("adapter-notes", "domains: model-adapters")` |
| `the_same_skill_is_selected_once_the_prompt_anchors_in_its_domain` | passes (for the wrong reason) |
| `a_long_prompt_still_selects_an_untagged_skill_it_names` | FAILS — selects nothing |

The second is load-bearing: without it, an empty-selection assertion could be satisfied by simply disabling the domain signal. Together they prove selection was *scoped*, not switched off.

```
cargo test -p stella-core --lib          # 1217 passed, 0 failed
cargo test -p stella-cli --bin stella memory::   # 271 passed, 0 failed
cargo clippy -p stella-core -p stella-cli --all-targets   # clean
cargo fmt -- --check                     # clean
```

## Two of the epic's Phase 1 items are NOT in this PR, for opposite reasons

**D7 (unbudgeted volatile sections) is stale — there is nothing to fix.** The epic says skills and draft claims enter the volatile block with no character cap. On this tree every section is bounded:

- frames — 1200 tokens
- skills — `SKILLS_SECTION_TOKEN_BUDGET` across the section, `SKILL_BODY_TOKEN_BUDGET` per body, with `SKILLS_SECTION_OMISSION_MARKER` when it truncates (`skills.rs::render_skills_section`)
- records — `RECORD_CHANNEL_BUDGET` = 2000 chars, and it *names the dropped record* rather than dropping silently
- the date line — a single line

and the draft-claims section the epic cites no longer exists in `recall.rs` at all. I'd rather report this than invent a fix for it; worth striking from the epic.

**D4 (the recall→citation receipt loop) is deferred to its own PR.** It is the largest item in Phase 1 — one renderer, one parser, a round-trip property, plus the pipeline marker — and it is the one that unblocks every downstream measurement, so it deserves review on its own rather than riding along with a scoring change.

## Deliberately not fixed: the ASCII-only tokenizer

`mining::terms` treats only ASCII alphanumerics as word characters, so a CJK or accented prompt tokenizes to the empty set and can only ever select via the domain path — which D1 has just correctly narrowed. That is a real gap, and it is **not** a drive-by: the function's own doc says widening it "would change every mined `<slug>-<hash8>` id, so it is a deliberate migration", and `skills/migration_contract.rs` guards that id space. Filed separately rather than edited quietly here.

No tests deleted or renamed.

Refs #3243

## Summary by Sourcery

Fix skill selection relevance by scoping domain-based selection to the current turn and making lexical scoring robust to real-length prompts.

Bug Fixes:
- Scope skill selection domains to the prompt’s active workspace paths instead of all repository domains, so only skills relevant to the current turn’s files are injected.
- Replace symmetric Jaccard similarity with an asymmetric coverage metric for lexical scoring so skills can be selected even when the prompt is much longer than the skill description.

Tests:
- Add integration tests that witness correct domain-scoped skill selection for active vs inactive domains during a session.
- Add a unit test ensuring long, realistic prompts still select untagged skills whose descriptions they cover.