### PR TITLE
fix(stella-tools): save_state success output carries the saved content's identity

### DIFF
--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -177,6 +177,66 @@ async fn state_tools_round_trip_through_registry_dispatch() {
     assert!(out.is_error(), "a deleted key must not read back");
 }
 
+/// Witness for #3297: two `save_state` calls writing *different same-length*
+/// content under one key must render distinct success outputs. The engine's
+/// stagnation detector (`stella-core`'s `loop_detect`, rung 3) kills
+/// consecutive same-tool calls whose outputs are byte-identical — whatever
+/// their arguments — so the old constant-shape `saved {key} (N bytes)`
+/// string let a legitimate checkpoint loop (a fixed-width counter updated
+/// under one key) be killed as stagnant mid-solve. The `sha256/8` suffix is
+/// the content-derived identity that makes the outputs distinct.
+#[tokio::test]
+async fn save_state_outputs_differ_for_different_same_length_content() {
+    let (_root, reg) = bare_registry();
+    let mut outputs = Vec::new();
+    for content in ["counter=1", "counter=2"] {
+        let ToolOutput::Ok { content } = reg
+            .execute(
+                "save_state",
+                &serde_json::json!({"key": "checkpoint", "content": content}),
+            )
+            .await
+        else {
+            panic!("save_state must succeed");
+        };
+        outputs.push(content);
+    }
+    assert!(
+        outputs[0].starts_with("saved checkpoint (9 bytes"),
+        "the `saved {{key}} ({{N}} bytes` prefix is stable — the identity is \
+         appended, never restructured: {:?}",
+        outputs[0]
+    );
+    assert_ne!(
+        outputs[0], outputs[1],
+        "different same-length content under one key must render distinct \
+         outputs, or the stagnation detector kills a legitimate checkpoint \
+         loop as stagnant (#3297)"
+    );
+}
+
+/// The complement that guards the detector's contract: re-saving *identical*
+/// bytes must still render byte-identical output. A loop genuinely stuck
+/// re-saving the same state is exactly what the detector exists to catch,
+/// and only a content-derived suffix — never a timing, never randomness
+/// (#2706) — keeps that catch intact.
+#[tokio::test]
+async fn save_state_output_is_identical_for_identical_content() {
+    let (_root, reg) = bare_registry();
+    let save = serde_json::json!({"key": "checkpoint", "content": "counter=1"});
+    let ToolOutput::Ok { content: first } = reg.execute("save_state", &save).await else {
+        panic!("save_state must succeed");
+    };
+    let ToolOutput::Ok { content: second } = reg.execute("save_state", &save).await else {
+        panic!("save_state must succeed");
+    };
+    assert_eq!(
+        first, second,
+        "re-saving identical bytes must render byte-identical output — the \
+         stagnation detector's catch of a genuinely stuck loop depends on it"
+    );
+}
+
 /// `get_environment` dispatches through the registry and reports the scratch
 /// directory the registry created — the one fact the CLI's prompt block
 /// cannot carry (#3102).

--- a/crates/stella-tools/src/scratch.rs
+++ b/crates/stella-tools/src/scratch.rs
@@ -19,6 +19,14 @@
 //!   named error, which is what makes traversal impossible rather than
 //!   filtered.
 //! - `save_state` refuses content over `MAX_SAVE_BYTES` with a named error.
+//! - `save_state`'s success output embeds the saved content's `sha256/8`, so
+//!   distinct saves render distinct outputs. The engine's stagnation
+//!   detector (`stella-core`'s `loop_detect`) kills consecutive same-tool
+//!   calls whose outputs are byte-identical, and a constant-shape
+//!   `saved {key} (N bytes)` string made a legitimate checkpoint loop —
+//!   different same-length content under one key — indistinguishable from a
+//!   stuck one (#3297). The suffix is content-derived only: a timing or any
+//!   randomness would blind the detector to genuinely stuck loops (#2706).
 //! - `get_state` middle-truncates nothing: it pages (`offset`/`limit`
 //!   in bytes, clamped to a `PAGE_CAP` slice) and names the remainder, so
 //!   a partial read is always visibly partial.
@@ -133,9 +141,19 @@ impl Tool for SaveState {
             }
         };
         match std::fs::write(&path, content) {
-            Ok(()) => ToolOutput::Ok {
-                content: format!("saved {key} ({} bytes)", content.len()),
-            },
+            Ok(()) => {
+                // The digest is the output's content-derived identity: without
+                // it, different same-length saves under one key render
+                // byte-identical outputs and the stagnation detector kills the
+                // loop as stuck (#3297). Deterministic by contract — never a
+                // timing, never randomness (#2706). `sha256/8` = the first 8
+                // hex chars of the sha256; `digest` always returns 64 ASCII
+                // hex chars, so the slice cannot panic.
+                let identity = &crate::foundry_gate::digest(content.as_bytes())[..8];
+                ToolOutput::Ok {
+                    content: format!("saved {key} ({} bytes, sha256/8 {identity})", content.len()),
+                }
+            }
             Err(e) => ToolOutput::error(format!("failed to save {key}: {e}")),
         }
     }


### PR DESCRIPTION
## What & why

`save_state`'s success output was the last constant-shape output on the 12-tool surface (#3297's sweep of the other 11 explains why each is exempt): two saves of **different same-length content under one key** rendered byte-identical `saved {key} ({N} bytes)` outputs, and the stagnation detector (`crates/stella-core/src/loop_detect.rs`, rung 3) deliberately kills consecutive same-tool calls whose outputs are byte-identical — whatever their arguments. A legitimate checkpoint loop (a fixed-width counter or constant-size JSON blob updated under one key) could therefore be killed as stagnant mid-solve — the same hazard class that converted a correct `edit_file` run into an `agent_error` loss on Terminal-Bench (#3176), was fixed for `edit_file`/`apply_edits` by #3187, and re-arose here because the tool purge (#3244) deleted `edit.rs`/`write.rs`/`staleness.rs` and closed #3188 as moot without retiring the class.

The success output now appends the saved content's identity:

```
saved {key} ({N} bytes, sha256/8 {digest})
```

`{digest}` is the first 8 hex chars of the content's sha256, computed via `foundry_gate::digest` — the crate's existing, documented "one hashing primitive" — rather than reintroducing a second Sha256-to-hex helper to replace the deleted `staleness::sha256_8` (no new dependency; `sha2` was already in use). Content-derived only, per the detector's settled output-keying contract: no timings, no randomness (#2706), so a loop genuinely re-saving identical bytes still renders byte-identical output and is still caught. The `saved {key} ({N} bytes` prefix is stable — the identity is appended, never restructured. `ToolSchema` is unchanged.

Closes #3297

Refs #3176, #3187, #3188, #3244, #2706.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Two tests in `crates/stella-tools/src/registry/tests.rs`, beside the existing scratch dispatch tests, checked the two-sided way (format string temporarily reverted to the old constant shape, witness watched failing, fix restored):

- `save_state_outputs_differ_for_different_same_length_content` — **fails on the old format string**, where both saves render byte-identical output:
  - old, `counter=1`: `saved checkpoint (9 bytes)`
  - old, `counter=2`: `saved checkpoint (9 bytes)` (identical — the assertion output was `` left: "saved checkpoint (9 bytes)" / right: "saved checkpoint (9 bytes)" ``)
  - **passes with the fix**, where the outputs are distinct:
  - new, `counter=1`: `saved checkpoint (9 bytes, sha256/8 055ea690)`
  - new, `counter=2`: `saved checkpoint (9 bytes, sha256/8 1424b099)`
- `save_state_output_is_identical_for_identical_content` — re-saving identical bytes still renders byte-identical output (passes on both sides, guarding the detector's catch of genuinely stuck loops).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tools --all-targets -- -D warnings` (no other crate pins the message — swept `rg '"saved |saved \{'` workspace-wide)
- [x] `cargo test -p stella-tools` (222 + 1 integration, all green)
- [x] `make doc-warnings CARGO_SCOPE="-p stella-tools"` (rustdoc `-D warnings`, private items included)
- [x] `make tool-docs` — OK; `docs/tools/save_state.toml` captures no observed example and the schema is unchanged, so no regeneration needed
- [x] Docs updated where behavior changed: the module-doc contract list in `scratch.rs` now states the output-identity contract and why it is content-derived
- [x] CLA signed
- [x] `Closes #3297` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR. (The issue's own sweep of the other 11 tools at `e352cf486` found no further instance of the class, and I re-checked `rg 'content: format!' crates/stella-tools/src` — the remaining constant-shape success string is `delete_state`'s `deleted {key}`, which carries the repeat-delete exemption the issue documents: a second delete of one key errors, so distinct effects cannot repeat silently.)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (reuses `foundry_gate::digest`, already backed by the existing `sha2` dependency)
- [x] No new outbound network calls

## Anything reviewers should know?

Alternative rejected: reintroducing a `staleness.rs`-style `sha256_8` helper (the issue's suggested reference shape). `foundry_gate::digest` already exists in this crate and documents itself as "the workspace's one hashing primitive", so a second Sha256-to-hex function would be duplication; the 8-char truncation happens at the one call site, on a value that is always 64 ASCII hex chars.

## Summary by Sourcery

Ensure save_state success outputs embed content identity to avoid false stagnation detection while keeping identical-content saves byte-identical.

Bug Fixes:
- Prevent the stagnation detector from incorrectly terminating legitimate save_state checkpoint loops by making outputs differ for different same-length content under the same key.

Enhancements:
- Include a truncated sha256-based identity in save_state success messages while preserving a stable prefix and deterministic, content-derived behavior.
- Document the save_state output-identity contract and its rationale in the scratch module docs.

Tests:
- Add regression tests verifying save_state outputs differ for different same-length content and remain identical for identical content.