### PR TITLE
feat(stella-core): the Stop gate becomes a bounded verification loop

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -1172,7 +1172,7 @@ impl<'a> Engine<'a> {
                 state.total_cost_usd,
                 &mut state.messages,
                 &mut state.length_continuations,
-                &mut state.stop_hook_fired,
+                &mut state.stop_hook_consults,
                 continuation_budget,
                 events,
             )

--- a/crates/stella-core/src/driver/completion.rs
+++ b/crates/stella-core/src/driver/completion.rs
@@ -32,8 +32,8 @@ impl<'a> Engine<'a> {
     /// A completion that survives every other gate consults the `Stop`
     /// hooks last ([`Engine::stop_hook_feedback`]): a blocking decision
     /// injects the hook's reason as a marked tail user message and returns
-    /// `None`, holding the turn open for one more round. `stop_fired` is
-    /// the once-per-turn latch (`driver::user_hooks` module docs).
+    /// `None`, holding the turn open for another round. `stop_consults` is
+    /// the bounded consultation counter (`driver::user_hooks` module docs).
     #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
     pub(super) async fn dispatch_completion(
         &self,
@@ -41,7 +41,7 @@ impl<'a> Engine<'a> {
         total_cost_usd: f64,
         messages: &mut Vec<CompletionMessage>,
         length_continuations: &mut u32,
-        stop_fired: &mut bool,
+        stop_consults: &mut u32,
         continuation_budget: Option<ContinuationBudget>,
         events: &EventSender,
     ) -> Option<TurnOutcome> {
@@ -180,7 +180,7 @@ impl<'a> Engine<'a> {
             // history so the hook's feedback answers a recorded turn: a
             // blocking hook holds the turn open with its reason as the
             // model's next observation instead of finishing.
-            if let Some(reason) = self.stop_hook_feedback(&text, stop_fired, events).await {
+            if let Some(reason) = self.stop_hook_feedback(&text, stop_consults, events).await {
                 messages.push(CompletionMessage::user(format!(
                     "{STOP_HOOK_MARKER_PREFIX} — a workspace Stop hook held this turn open; \
                      address it, then finish]\n\n{reason}"

--- a/crates/stella-core/src/driver/tests/user_hooks.rs
+++ b/crates/stella-core/src/driver/tests/user_hooks.rs
@@ -770,19 +770,54 @@ async fn pre_tool_use_payload_carries_the_schemas_read_only_bit() {
 
 // ---- #2684: the Stop gate ---------------------------------------------
 
-/// **Witness (d), #2684.** A `Stop` hook's `deny` holds the completing
-/// turn open exactly once: its reason lands as a tail user message under
-/// the stop-hook marker, the model answers again, and the once-per-turn
-/// latch lets the second completion stand — the death-spiral guard. On the
-/// base commit the `Stop` key is unknown and the turn completes on the
-/// first answer, so this fails there.
+/// Like [`RecordingHookRunner`], but each run pops the next scripted
+/// stdout — the shape a verification hook actually has: deny the first
+/// completion, watch the revision, decide again. The last entry repeats if
+/// the script runs dry, so an over-consulted gate fails an assertion
+/// rather than panicking.
+struct ScriptedHookRunner {
+    stdouts: TokioMutex<Vec<String>>,
+    payloads: Arc<TokioMutex<Vec<String>>>,
+}
+#[async_trait]
+impl HookRunner for ScriptedHookRunner {
+    async fn run(
+        &self,
+        _action: &HookAction,
+        payload_json: &str,
+        _cwd: &str,
+    ) -> Result<HookExecResult, HookExecError> {
+        self.payloads.lock().await.push(payload_json.to_string());
+        let mut stdouts = self.stdouts.lock().await;
+        let stdout = if stdouts.len() > 1 {
+            stdouts.remove(0)
+        } else {
+            stdouts[0].clone()
+        };
+        Ok(HookExecResult {
+            exit_code: 0,
+            stdout,
+            stderr: String::new(),
+        })
+    }
+}
+
+/// **Witness (d), #2684, re-pinned for #3246's bounded loop.** A `Stop`
+/// hook that always denies holds the completing turn open
+/// [`MAX_STOP_CONSULTS`](crate::driver::user_hooks::MAX_STOP_CONSULTS)
+/// times — each reason a marked tail user message, the LAST one announcing
+/// itself as final — and then the next completion stands: the death-spiral
+/// guard, now a counter. On the once-per-turn boolean this fails: the turn
+/// completed on the second answer with a single Stop fire.
 #[tokio::test]
-async fn stop_hook_deny_holds_the_turn_open_once_with_marked_feedback() {
+async fn an_always_denying_stop_hook_is_consulted_to_the_bound_then_the_turn_stands() {
     let provider = ScriptedProvider {
         id: "scripted".into(),
         script: TokioMutex::new(vec![
             Ok(text_result("first answer")),
             Ok(text_result("second answer")),
+            Ok(text_result("third answer")),
+            Ok(text_result("fourth answer")),
         ]),
         calls: Arc::new(AtomicU32::new(0)),
     };
@@ -812,31 +847,49 @@ async fn stop_hook_deny_holds_the_turn_open_once_with_marked_feedback() {
 
     let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
 
-    // The hook held the first completion open; the second stood (latch).
+    // Three held-open rounds, then the fourth completion stands.
     assert_eq!(
         outcome,
         TurnOutcome::Completed {
-            text: "second answer".into(),
-            cost_usd: 0.0002
+            text: "fourth answer".into(),
+            cost_usd: 0.0004
         },
-        "the turn must complete on the SECOND answer — held open once, then latched"
+        "the turn must complete on the FOURTH answer — held open to the bound, then stands"
     );
-    assert_eq!(model_calls.load(Ordering::SeqCst), 2);
-    // The feedback is a marked tail user message between the two answers.
-    let feedback = messages
+    assert_eq!(model_calls.load(Ordering::SeqCst), 4);
+    // Each deny is a marked tail user message; only the last is final-marked.
+    let feedback: Vec<&CompletionMessage> = messages
         .iter()
-        .find(|m| {
+        .filter(|m| {
             m.role == MessageRole::User
                 && m.content
                     .starts_with(crate::driver::user_hooks::STOP_HOOK_MARKER_PREFIX)
         })
-        .expect("the stop-hook feedback message is in history");
-    assert!(
-        feedback.content.contains("the checklist is not done"),
-        "the hook's reason reaches the model: {}",
-        feedback.content
+        .collect();
+    assert_eq!(
+        feedback.len(),
+        3,
+        "one feedback message per held-open round"
     );
-    // The latch: one Stop fire for the whole turn, carrying the final text.
+    assert!(
+        feedback
+            .iter()
+            .all(|m| m.content.contains("the checklist is not done")),
+        "every round carries the hook's reason"
+    );
+    assert!(
+        !feedback[0].content.contains("final verification round")
+            && !feedback[1].content.contains("final verification round"),
+        "rounds with budget left do not claim to be last"
+    );
+    assert!(
+        feedback[2]
+            .content
+            .contains(crate::driver::user_hooks::STOP_FINAL_ROUND_NOTE.trim_start()),
+        "the last permitted round announces itself (#2810): {}",
+        feedback[2].content
+    );
+    // The bound: three Stop fires, each carrying that round's final text.
     let payloads = payloads.lock().await.clone();
     let stop_fires: Vec<&String> = payloads
         .iter()
@@ -844,13 +897,93 @@ async fn stop_hook_deny_holds_the_turn_open_once_with_marked_feedback() {
         .collect();
     assert_eq!(
         stop_fires.len(),
-        1,
-        "the once-per-turn latch must stop a second fire: {payloads:?}"
+        3,
+        "the counter must stop a fourth fire: {payloads:?}"
+    );
+    for (fire, expected) in stop_fires
+        .iter()
+        .zip(["first answer", "second answer", "third answer"])
+    {
+        assert!(
+            fire.contains(&format!("\"finalText\":\"{expected}\"")),
+            "each Stop payload carries the text that round would have completed with: {fire}"
+        );
+    }
+}
+
+/// **The verification loop's own witness (#3246).** A `Stop` hook that
+/// denies the first completion and allows the second is genuinely
+/// consulted BOTH times — the fail→pass observation a verification hook
+/// exists to make. On the once-per-turn boolean this fails: the second
+/// completion was never offered to the hook (one Stop fire, not two).
+#[tokio::test]
+async fn a_deny_then_allow_is_reconsulted_and_the_allowed_completion_stands() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(text_result("first answer")),
+            Ok(text_result("second answer")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let model_calls = provider.calls.clone();
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let payloads = Arc::new(TokioMutex::new(Vec::new()));
+    let runner = ScriptedHookRunner {
+        stdouts: TokioMutex::new(vec![
+            r#"{"action":"deny","reason":"the witness still fails"}"#.into(),
+            r#"{"action":"allow"}"#.into(),
+        ]),
+        payloads: payloads.clone(),
+    };
+    let hooks: Hooks =
+        serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "verify" }] } ] }"#).unwrap();
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+        .with_hooks(&hooks, &runner);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "second answer".into(),
+            cost_usd: 0.0002
+        },
+        "the allowed second completion stands"
+    );
+    assert_eq!(model_calls.load(Ordering::SeqCst), 2);
+    // Two consultations: the deny observed the failure, the allow observed
+    // the fix. The boolean latch never made the second observation.
+    let payloads = payloads.lock().await.clone();
+    let stop_fires: Vec<&String> = payloads
+        .iter()
+        .filter(|p| p.contains("\"event\":\"Stop\""))
+        .collect();
+    assert_eq!(
+        stop_fires.len(),
+        2,
+        "the revised completion must be re-offered to the hook: {payloads:?}"
     );
     assert!(
-        stop_fires[0].contains("\"finalText\":\"first answer\""),
-        "the Stop payload carries the text the turn would have completed with: {}",
-        stop_fires[0]
+        stop_fires[1].contains("\"finalText\":\"second answer\""),
+        "the second consultation judges the revision: {}",
+        stop_fires[1]
+    );
+    // With budget left, no round claimed to be the last.
+    assert!(
+        messages
+            .iter()
+            .all(|m| !m.content.contains("final verification round")),
+        "an under-budget loop never announces a final round"
     );
 }
 

--- a/crates/stella-core/src/driver/user_hooks.rs
+++ b/crates/stella-core/src/driver/user_hooks.rs
@@ -28,24 +28,35 @@
 //!   (OXA-2056). This preserves the legacy contract (non-zero exit
 //!   blocks) while routing it through the one precedence ladder.
 //!
-//! # The Stop gate and its once-per-turn latch
+//! # The Stop gate and its bounded consultation counter
 //!
 //! [`Engine::stop_hook_feedback`] runs when a turn is about to complete
 //! (`driver::completion`). A `deny` decision holds the turn open: the
 //! hook's reason lands as a tail user-role message under
 //! [`STOP_HOOK_MARKER_PREFIX`] (registered in
-//! [`crate::engine_markers::ENGINE_MARKERS`]) and the model gets one more
-//! chance to act on it. The latch — [`crate::step::TurnState`]'s
-//! `stop_hook_fired`, set BEFORE the hooks run — bounds the gate to one
-//! fire per turn. Without it, a hook that always denies chains
-//! completion-attempt → feedback → completion-attempt forever (the
+//! [`crate::engine_markers::ENGINE_MARKERS`]) and the model gets another
+//! chance to act on it. The bound — [`crate::step::TurnState`]'s
+//! `stop_hook_consults` against [`MAX_STOP_CONSULTS`], counted BEFORE the
+//! hooks run — caps how many rounds. Without it, a hook that always denies
+//! chains completion-attempt → feedback → completion-attempt forever (the
 //! compact→error→stop-hook→retry death spiral: every held-open round can
 //! grow the transcript, force compaction, and error its way back to
-//! another completion attempt). One fire per turn caps the spiral at one
-//! extra round. A Stop hook that *fails* (non-zero exit, spawn failure)
-//! never blocks — deliberately the opposite of the PreToolUse posture,
-//! because failing closed HERE means never completing, which is the
-//! spiral, not safety; the failure surfaces as a diagnostic instead.
+//! another completion attempt).
+//!
+//! The bound was a once-per-turn boolean until #3246: fire once, whatever
+//! the decision. That shape structurally forbids the gate's own primary use
+//! case — a verification hook must deny a wrong answer, watch the revision,
+//! and *re-check*, and a fail→pass observation is by definition two
+//! consultations. So the latch became a counter, with two properties the
+//! boolean version already taught: the spiral stays capped (at
+//! [`MAX_STOP_CONSULTS`] held-open rounds now, not one), and the last
+//! permitted round says it is the last ([`STOP_FINAL_ROUND_NOTE`]) — the
+//! #2810 lesson that a bound nobody announces reads as an infinite
+//! allowance from inside the loop. A Stop hook that *fails* (non-zero
+//! exit, spawn failure) never blocks — deliberately the opposite of the
+//! PreToolUse posture, because failing closed HERE means never completing,
+//! which is the spiral, not safety; the failure surfaces as a diagnostic
+//! instead.
 //!
 //! # The PreCompact gate
 //!
@@ -75,6 +86,24 @@ use crate::hooks::{HookEvent, HookPayload, run_hooks};
 /// [`crate::engine_markers::ENGINE_MARKERS`] and classified as steering by
 /// `receipts::user_block_kind` — never attributed to the person.
 pub(crate) const STOP_HOOK_MARKER_PREFIX: &str = "[stop-hook feedback";
+
+/// How many times one turn's `Stop` hooks may be consulted — the bound on
+/// the deny → revise → re-check loop (module docs).
+///
+/// Three, not one, because the gate's primary tenant is verification
+/// (#3246): a verifier needs at least two consultations to observe a
+/// fail→pass flip, and the third admits one more revision round — the
+/// empirically common case of a model landing the fix within three
+/// attempts. Not configurable yet on purpose: a knob here is an invitation
+/// to uncap the spiral, and no caller has demonstrated a need.
+pub(crate) const MAX_STOP_CONSULTS: u32 = 3;
+
+/// Appended to the last permitted round's `deny` reason, so the model and
+/// the transcript both know the next completion stands unchecked. #2810's
+/// lesson, restated for this gate: a bound nobody announces reads as an
+/// infinite allowance from inside the loop.
+pub(crate) const STOP_FINAL_ROUND_NOTE: &str =
+    "\n\n[final verification round — the next completion will stand without another check]";
 
 /// What a `PreCompact` hook run decided about the imminent summarization
 /// round.
@@ -254,20 +283,24 @@ impl<'a> Engine<'a> {
     /// open — the caller (`driver::completion`) injects the marked tail
     /// message and keeps stepping. `None` lets the completion stand.
     ///
-    /// `stop_fired` is the once-per-turn latch (module docs), set BEFORE
-    /// the hooks run so they fire at most once per turn whatever they
-    /// decide.
+    /// `stop_consults` is the turn's bounded consultation counter (module
+    /// docs), spent BEFORE the hooks run so a hook that fails mid-flight
+    /// has still consumed its round. The last permitted `deny` carries
+    /// [`STOP_FINAL_ROUND_NOTE`] so the model knows the next completion
+    /// stands unchecked.
     pub(super) async fn stop_hook_feedback(
         &self,
         final_text: &str,
-        stop_fired: &mut bool,
+        stop_consults: &mut u32,
         events: &EventSender,
     ) -> Option<String> {
         let handle = self.hooks?;
-        if handle.hooks.matchers_for(HookEvent::Stop).is_empty() || *stop_fired {
+        if handle.hooks.matchers_for(HookEvent::Stop).is_empty()
+            || *stop_consults >= MAX_STOP_CONSULTS
+        {
             return None;
         }
-        *stop_fired = true;
+        *stop_consults += 1;
         let run = run_decision_hooks(
             handle.runner,
             Some(handle.hooks),
@@ -277,6 +310,14 @@ impl<'a> Engine<'a> {
         self.surface_hook_diagnostics("Stop", &run.diagnostics, events);
         match run.evaluation {
             Ok(crate::bus::HookDecision::Deny { reason }) => {
+                // The last permitted round announces itself (#2810's lesson):
+                // composed here rather than at the injection site so the
+                // lifecycle event below and the tail message carry one text.
+                let reason = if *stop_consults >= MAX_STOP_CONSULTS {
+                    format!("{reason}{STOP_FINAL_ROUND_NOTE}")
+                } else {
+                    reason
+                };
                 self.emit_lifecycle(
                     bus_names::HOOK_STOP_BLOCKED,
                     || serde_json::json!({ "reason": reason }),

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -352,11 +352,12 @@ pub struct TurnState {
     /// spend; deliberately NOT checkpointed — a resumed turn starts the
     /// allowance over, which only re-permits a bounded amount of work.
     pub(crate) length_continuations: u32,
-    /// Whether this turn's `Stop` hooks have fired — the once-per-turn
-    /// latch that caps the compact→error→stop-hook→retry spiral at one
-    /// held-open round (`driver::user_hooks`, #2684). Not checkpointed,
-    /// like `length_continuations`.
-    pub(crate) stop_hook_fired: bool,
+    /// How many times this turn's `Stop` hooks have been consulted — the
+    /// bounded counter (`driver::user_hooks::MAX_STOP_CONSULTS`) that lets a
+    /// verification hook deny, watch the revision, and re-check, while still
+    /// capping the compact→error→stop-hook→retry spiral (#2684, #3246). Not
+    /// checkpointed, like `length_continuations`.
+    pub(crate) stop_hook_consults: u32,
     /// When this turn began, for deciding whether a length continuation is
     /// affordable against `EngineConfig::turn_budget`.
     ///
@@ -398,7 +399,7 @@ impl TurnState {
             step: 0,
             memos: TurnMemos::new(config.turn_instance, config.lifecycle_enabled),
             length_continuations: 0,
-            stop_hook_fired: false,
+            stop_hook_consults: 0,
             started_at: std::time::Instant::now(),
             last_step: None,
             cancel: CancelToken::new(),
@@ -441,7 +442,7 @@ impl TurnState {
             // Not carried across the checkpoint: the once-per-turn Stop-hook
             // latch re-arms, which only re-permits one more held-open round —
             // the same bounded-allowance reasoning as `length_continuations`.
-            stop_hook_fired: false,
+            stop_hook_consults: 0,
             started_at: std::time::Instant::now(),
             last_step: None,
             cancel: CancelToken::new(),


### PR DESCRIPTION
## What

The `Stop` gate's once-per-turn boolean latch becomes a bounded consultation counter (`MAX_STOP_CONSULTS = 3`), and the last permitted `deny` announces itself (`STOP_FINAL_ROUND_NOTE`).

## Why

The boolean (`stop_hook_fired`, #2684) structurally forbade the gate's primary tenant: a **verification hook** must deny a wrong completion, watch the revision, and re-check — a fail→pass observation is by definition two consultations, and the boolean allowed one. This is #3246's O1 item 1, implemented exactly as that epic's analysis prescribed: "Replace the boolean with a bounded counter (the loop-steer precedent — `MAX_LOOP_STEERS` — is the shape, and #2810 is the live lesson that the *last* iteration must say it is the last one)."

With `verify_done` deleted by the tool purge (#3244) and #3234 closed toward the plugin direction, the Stop deny-loop is the surviving home for a deterministic done-signal on no-test-command turns. This PR is the one engine-side enabler; the oracle itself rides out-of-process as a Stop hook and needs no further engine surface.

## Exemplar

In-repo: `MAX_LOOP_STEERS` (`driver/loop_escalation.rs`) — a bounded, non-configurable counter whose final round is announced. The spiral-cap posture (a failing Stop hook never blocks; increment before running) is preserved from the #2684 design.

## Witnesses (two-sided)

Checked against the control `MAX_STOP_CONSULTS = 1`, which reproduces the retired once-per-turn semantics through the new plumbing:

- `an_always_denying_stop_hook_is_consulted_to_the_bound_then_the_turn_stands` — on the control: `assertion failed: the turn must complete on the FOURTH answer` (it completed on the second, with one Stop fire). With the change: 3 held-open rounds, 3 Stop fires each carrying that round's final text, only the third feedback carries the final-round note.
- `a_deny_then_allow_is_reconsulted_and_the_allowed_completion_stands` — on the control: `left: 1, right: 2` Stop fires (the revised completion was never re-offered). With the change: the deny observes the failure, the allow observes the fix, and the allowed completion stands.

`cargo test -p stella-core --lib`: 1217 passed. `cargo clippy -p stella-core --all-targets -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps` clean, exit codes checked unpiped.

## Renamed test (deliberate — for `check-deleted-tests`)

`stop_hook_deny_holds_the_turn_open_once_with_marked_feedback` → `an_always_denying_stop_hook_is_consulted_to_the_bound_then_the_turn_stands`. The old test pinned the once-latch ("held open once, then latched"), which is precisely the retired behavior; its marked-feedback and payload assertions survive in the successor.

## Why 3

A verifier needs ≥2 consultations to observe a flip; the third admits one more revision round — the empirically common case of a model landing the fix within three attempts (observed repeatedly in Sonnet 5 bench trials). Deliberately not configurable yet: a knob here is an invitation to uncap the spiral, and no caller has demonstrated a need.

Refs #3246, #3234, #2684, #2810

## Summary by Sourcery

Bound the Stop hook verification loop with a multi-consult counter instead of a once-per-turn latch and update tests and docs to exercise and describe the new behavior.

New Features:
- Introduce a bounded Stop hook consultation counter with a deterministic final-round announcement note for the last permitted deny.

Enhancements:
- Replace the Stop hook's once-per-turn boolean latch with a MAX_STOP_CONSULTS counter to support multi-round verification while still capping denial loops.
- Document the Stop gate as a bounded consultation loop and explain the rationale and behavior of the new counter and final-round note.

Tests:
- Extend and rename Stop hook tests to cover multi-round denial up to the consultation bound, final-round signaling, and re-consultation on deny-then-allow scenarios, using a scripted hook runner to simulate verification behavior.