### PR TITLE
fix(stella-core): restore the Mutex import the restore.rs test merge dropped

### DIFF
--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -421,6 +421,7 @@ mod tests {
 
     use async_trait::async_trait;
     use serde_json::Value;
+    use std::sync::Mutex;
     use stella_protocol::{
         CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
         Provider, ProviderError, ToolOutput, ToolSchema,


### PR DESCRIPTION
`main` is red at ef6dc856: `crates/stella-core/src/driver/restore.rs` fails to compile its test target with E0425/E0433, `cannot find type \`Mutex\``.

## Cause

#3277 and #3281 both edited that file. Each was green against its own base, and the two merged with **no textual conflict** — but the surviving import block in the `tests` module carries no `use std::sync::Mutex`, while `StarvingProvider` declares `caps: Mutex<Vec<Option<u32>>>`. The break appeared only in the composition, which is why no PR check caught it.

## Fix

One line: `use std::sync::Mutex;` in the tests module. `std`, not `tokio` — every use site is `self.caps.lock().unwrap()`, a synchronous lock.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p stella-core` — 1224 passed, 0 failed

No witness test: this restores a test target to compiling, so the existing tests in that file are the witness — they cannot run at all on `main` right now and all pass here.

## Summary by Sourcery

Bug Fixes:
- Fix compilation errors in the stella-core restore.rs test module by reintroducing the std::sync::Mutex import used by StarvingProvider.