### PR TITLE
fix: a run that cannot act must say so — four links in one failure chain

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -367,7 +367,7 @@ async fn run_pipeline_one_shot(
             cfg,
             active_rules.clone(),
             mcp.clone(),
-            SessionPlane::new(tx.clone()),
+            SessionPlane::new(tx.clone()).with_sub_agents(registry.sub_agent_dispatcher()),
         )?;
 
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -758,7 +758,8 @@ async fn run_goal_pipeline_turn(
             cfg,
             active_rules.clone(),
             mcp,
-            SessionPlane::new(stella_core::EventSender::new(tx.clone())),
+            SessionPlane::new(stella_core::EventSender::new(tx.clone()))
+                .with_sub_agents(registry.sub_agent_dispatcher()),
         )?;
         let no_recall = NoContextRecall;
         // The workspace memory doubles as the recall port (as on the one-shot

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -257,7 +257,7 @@ pub(crate) const SYSTEM_PROMPT: &str = concat!(
     r#"
 
 Rules:
-- When the task text claims something was DONE to this repository — introduced, planted, broke, leaked, removed, changed — read that delta first: `git status` and `git diff` (then `git diff --staged`), and `git log -p` only once the working tree is clean. A task with no claimed change gets no history probe; orient from the task's own subject.
+- When the task text claims something was DONE to this repository — introduced, planted, broke, leaked, removed, changed — read that delta first, if a tool in your schema list can run a command: `git status` and `git diff` (then `git diff --staged`), and `git log -p` only once the working tree is clean. A task with no claimed change gets no history probe; orient from the task's own subject.
 - After changing behavior, run the relevant test or build and read its output.
 - Before finishing, re-read the task and check every requirement it states.
 - Be concise. End with what changed and the evidence it works.
@@ -468,8 +468,16 @@ fn append_session_environment(
         prompt.push_str(&format!(" ({release})"));
     }
     if let Some(shell) = stella_tools::environment::login_shell() {
+        // Stated as a constant, never as an instruction to write commands.
+        // Nothing here can promise a tool that runs one: the built-in surface
+        // registers none, so command execution arrives only as an MCP or
+        // custom tool — which is exactly what `tool_steering!` tells the model
+        // to check its schema list for. A prompt that says "write commands in
+        // its dialect" contradicts that rule outright, and in a session with
+        // no such tool it advertises a capability that does not exist (#3319).
+        // The dialect is still worth knowing for whichever tool does turn up.
         prompt.push_str(&format!(
-            "\nShell: {shell} — write commands in its dialect rather than guessing"
+            "\nShell dialect (for whichever tool runs one): {shell}"
         ));
     }
     if let Some(worker) = worker {

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -229,7 +229,8 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
                     cfg,
                     active_rules.clone(),
                     mcp.clone(),
-                    crate::agent::SessionPlane::new(events.clone()),
+                    crate::agent::SessionPlane::new(events.clone())
+                        .with_sub_agents(tools_registry.sub_agent_dispatcher()),
                 )?;
                 // The run's ORIGINAL decisions, restored from the frame — a
                 // flag environment that changed across the crash must not

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -437,6 +437,36 @@ fn the_cached_prefix_carries_no_wall_clock_or_per_process_bytes() {
 }
 
 #[test]
+fn the_prefix_never_promises_a_shell_it_cannot_provide() {
+    // The built-in surface registers no command-executing tool, so nothing
+    // here can promise one: execution arrives only as an MCP or custom tool.
+    // The prompt already tells the model to "never assume a capability no
+    // schema names", and an unconditional "write commands in its dialect"
+    // contradicts that to its face. A real session read the shell line,
+    // found no tool that could run one, and had nowhere to go (#3319).
+    let root = tempfile::tempdir().expect("tempdir");
+    let cfg = cfg_for("zai");
+    let rules = crate::rules::ResolvedRules::default();
+    let prompt = build_system_prompt(&cfg, root.path(), &rules);
+
+    assert!(
+        !prompt.contains("write commands in its dialect"),
+        "the environment block must state the shell as a constant, never \
+         instruct the model to write commands for a tool that may not \
+         exist:\n{prompt}"
+    );
+    // The git-delta rule is the same promise in another voice: it names four
+    // commands to run, so it has to be conditioned on being able to run one.
+    if prompt.contains("git status") {
+        assert!(
+            prompt.contains("if a tool in your schema list can run a command"),
+            "the git-delta rule prescribes commands and must say what it \
+             depends on:\n{prompt}"
+        );
+    }
+}
+
+#[test]
 fn benchmark_gate_excludes_hostile_filesystem_steering_and_extensions() {
     let workspace = tempfile::tempdir().expect("workspace");
     let home = tempfile::tempdir().expect("home");

--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -346,6 +346,11 @@ pub(crate) struct SessionPlane {
     /// The turn's event sink, used to bridge each candidate registry's policy
     /// plane into the journal (#441).
     events: Option<stella_core::EventSender>,
+    /// The session's sub-agent runner, so candidates can delegate through it
+    /// (#3318). `None` leaves a candidate's `task` tool reporting sub-agents
+    /// as unavailable — which, with no command-executing built-in, leaves a
+    /// worker there unable to act at all.
+    sub_agents: Option<Arc<dyn stella_core::subagent::SubAgentDispatcher>>,
 }
 
 impl SessionPlane {
@@ -354,7 +359,20 @@ impl SessionPlane {
     pub(crate) fn new(events: stella_core::EventSender) -> Self {
         Self {
             events: Some(events),
+            sub_agents: None,
         }
+    }
+
+    /// Share the session's sub-agent runner with every candidate workspace
+    /// this plane builds. Pass `registry.sub_agent_dispatcher()` straight
+    /// through: `None` is the honest answer when the session itself has no
+    /// dispatcher attached.
+    pub(crate) fn with_sub_agents(
+        mut self,
+        dispatcher: Option<Arc<dyn stella_core::subagent::SubAgentDispatcher>>,
+    ) -> Self {
+        self.sub_agents = dispatcher;
+        self
     }
 }
 
@@ -370,7 +388,7 @@ pub(crate) fn workspace_ports(
     mcp: Option<Arc<stella_mcp::McpToolSet>>,
     session: SessionPlane,
 ) -> Result<WorkspacePorts, String> {
-    let SessionPlane { events } = session;
+    let SessionPlane { events, sub_agents } = session;
     crate::enterprise_telemetry::authorize_execution_surface(
         crate::enterprise_telemetry::ExecutionSurface::WorkspacePorts,
     )?;
@@ -404,6 +422,9 @@ pub(crate) fn workspace_ports(
     }
     if let Some(events) = events {
         candidate_workspaces = candidate_workspaces.with_events(events);
+    }
+    if let Some(dispatcher) = sub_agents {
+        candidate_workspaces = candidate_workspaces.with_sub_agents(dispatcher);
     }
     Ok(WorkspacePorts {
         repo_structure: GitRepoStructure { root: root.clone() },

--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -306,6 +306,10 @@ pub(crate) struct GitCandidateWorkspaces {
     /// rule denials evaluating and blocking exactly as before — they simply
     /// never land as typed `PolicyDecision` events.
     events: Option<stella_core::EventSender>,
+    /// The session's sub-agent runner, shared into every candidate registry.
+    /// `None` leaves the `task` tool reporting sub-agents as unavailable —
+    /// see [`GitCandidateWorkspaces::with_sub_agents`].
+    sub_agents: Option<Arc<dyn stella_core::subagent::SubAgentDispatcher>>,
 }
 
 impl GitCandidateWorkspaces {
@@ -322,7 +326,29 @@ impl GitCandidateWorkspaces {
             active_rules,
             candidate_mcp: None,
             events: None,
+            sub_agents: None,
         }
+    }
+
+    /// Let every candidate delegate through the session's sub-agent runner.
+    ///
+    /// Without this a candidate's `task` tool answers "sub-agents are
+    /// unavailable in this session — do the work directly with your own
+    /// tools", advice a candidate cannot take: the built-in surface has no
+    /// command-executing tool, so a worker there could move the task board
+    /// and nothing else. Since an authored witness forces a candidate even at
+    /// N=1, that state was reached by ordinary single-candidate runs (#3318).
+    ///
+    /// Sharing the session's runner rather than building a candidate-rooted
+    /// one is deliberate and costs the candidate nothing: children run behind
+    /// `ReadOnlyTools`, so a child reads to understand the codebase and the
+    /// snapshot it would otherwise read is a copy of the same tree.
+    pub(crate) fn with_sub_agents(
+        mut self,
+        dispatcher: Arc<dyn stella_core::subagent::SubAgentDispatcher>,
+    ) -> Self {
+        self.sub_agents = Some(dispatcher);
+        self
     }
 
     /// Journal the policy decisions made inside every candidate this port
@@ -402,6 +428,13 @@ impl GitCandidateWorkspaces {
                 // before the `Arc<dyn ToolExecutor>` coercion below erases it.
                 if let Some(events) = &self.events {
                     registry.bridge_policy_plane(events.clone());
+                }
+                // Same late-attachment window as the two above, and for the
+                // same reason: while `registry` is still a concrete
+                // `ToolRegistry`. Without it the candidate's `task` tool is
+                // dead schema (#3318).
+                if let Some(dispatcher) = &self.sub_agents {
+                    registry.attach_sub_agent_dispatcher(dispatcher.clone());
                 }
                 // The candidate's tool surface: the snapshot-rooted registry
                 // plus the session's custom script tools, owned as one value

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -108,6 +108,78 @@ pub(super) fn read(path: &Path) -> String {
     std::fs::read_to_string(path).unwrap()
 }
 
+/// A dispatcher that answers without running anything, so the assertion is
+/// about *reachability* — did the `task` tool find a runner — and not about
+/// what a child would do.
+struct StubDispatcher;
+
+#[async_trait::async_trait]
+impl stella_core::subagent::SubAgentDispatcher for StubDispatcher {
+    async fn dispatch(
+        &self,
+        _spec: stella_core::subagent::SubAgentSpec,
+    ) -> stella_core::subagent::SubAgentOutcome {
+        stella_core::subagent::SubAgentOutcome::Completed(stella_core::subagent::SubAgentReport {
+            summary: "STUB_CHILD_ANSWERED".into(),
+            truncated: false,
+            cost_usd: 0.0,
+            steps: 1,
+            absorbed_messages: 0,
+        })
+    }
+}
+
+/// The witness for #3318.
+///
+/// A candidate registry attached no sub-agent dispatcher, so `task` answered
+/// "sub-agents are unavailable in this session — do the work directly with
+/// your own tools" — advice a candidate cannot take, because the built-in
+/// surface has no command-executing tool. And since an authored witness
+/// forces a candidate even at N=1, ordinary single-candidate runs reached
+/// that state: one spent eleven minutes and $1.52 and did nothing at all.
+///
+/// Both halves are asserted, because only the pair shows the wiring is what
+/// carries the capability rather than something else in the harness.
+#[tokio::test]
+async fn a_candidate_delegates_through_the_session_runner_only_when_it_is_shared() {
+    let root = scaffold("subagents");
+    let call = serde_json::json!({"prompt": "what does this crate do", "description": "probe"});
+
+    let bare = GitCandidateWorkspaces::new(
+        root.clone(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    );
+    let ws = bare.create_workspace().await.unwrap();
+    let out = ws.tools().execute("task", &call).await;
+    let rendered = format!("{out:?}");
+    assert!(
+        rendered.contains("sub-agents are unavailable"),
+        "without a shared runner the candidate cannot delegate — if this stops \
+         being true the positive half below proves nothing: {rendered}"
+    );
+
+    let shared = GitCandidateWorkspaces::new(
+        root.clone(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    )
+    .with_sub_agents(Arc::new(StubDispatcher));
+    let ws = shared.create_workspace().await.unwrap();
+    let out = ws.tools().execute("task", &call).await;
+    let rendered = format!("{out:?}");
+    assert!(
+        !rendered.contains("sub-agents are unavailable"),
+        "a candidate given the session's runner must be able to delegate: {rendered}"
+    );
+    assert!(
+        rendered.contains("STUB_CHILD_ANSWERED"),
+        "the call must reach the shared dispatcher, not merely stop erroring: {rendered}"
+    );
+}
+
 #[tokio::test]
 async fn snapshot_mirrors_dirty_staged_and_untracked_state_without_touching_the_real_tree() {
     let root = scaffold("snap");

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -3957,12 +3957,7 @@ async fn run_lead_turn(
         // The operator's switches, applied over the complete surface — MCP
         // and custom tools included.
         let permitted = agent::PolicyToolSet::new(&customs, agent::session_tool_policy(cfg));
-        let tapped = TaskTap {
-            inner: &permitted,
-            events: tx.clone(),
-            registry,
-            supervisor: Some(sup_tx.clone()),
-        };
+        let tapped = TaskTap::new(&permitted, tx.clone(), registry, Some(sup_tx.clone()));
         let hook_runner = ShellHookRunner;
         let mut engine = Engine::with_sleeper(
             provider,

--- a/crates/stella-cli/src/command_deck/pipeline_turn.rs
+++ b/crates/stella-cli/src/command_deck/pipeline_turn.rs
@@ -109,7 +109,8 @@ pub(super) async fn run_lead_pipeline_turn(
             cfg,
             active_rules.clone(),
             mcp,
-            agent::SessionPlane::new(stella_core::EventSender::new(tx.clone())),
+            agent::SessionPlane::new(stella_core::EventSender::new(tx.clone()))
+                .with_sub_agents(registry.sub_agent_dispatcher()),
         )?;
         let no_recall = NoContextRecall;
         let recall: &dyn ContextRecallPort = match memory {

--- a/crates/stella-cli/src/command_deck/pipeline_turn.rs
+++ b/crates/stella-cli/src/command_deck/pipeline_turn.rs
@@ -86,12 +86,7 @@ pub(super) async fn run_lead_pipeline_turn(
         // The operator's switches, applied over the complete surface — MCP
         // and custom tools included.
         let permitted = agent::PolicyToolSet::new(&customs, agent::session_tool_policy(cfg));
-        let tapped = TaskTap {
-            inner: &permitted,
-            events: tx.clone(),
-            registry,
-            supervisor: Some(sup_tx.clone()),
-        };
+        let tapped = TaskTap::new(&permitted, tx.clone(), registry, Some(sup_tx.clone()));
 
         let model_ref = ModelRef::new(cfg.provider.id, cfg.model_id.clone());
         // Role wiring from `agent_engine_config`: worker/triage/verifier pins +

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -24,6 +24,32 @@ pub(crate) struct TaskTap<'a> {
     pub(crate) supervisor: Option<UnboundedSender<SupervisorMsg>>,
 }
 
+impl<'a> TaskTap<'a> {
+    /// Build the tap and tell the registry whether delegation is real here.
+    ///
+    /// The supervisor is the only thing that turns a queued `task_assign`
+    /// request into a running sub-agent, so it is also the only honest answer
+    /// to "may `task_assign` accept?" — binding the two in one constructor is
+    /// what keeps the next tap from advertising a delegation it cannot
+    /// perform.
+    pub(crate) fn new(
+        inner: &'a dyn ToolExecutor,
+        events: UnboundedSender<AgentEvent>,
+        registry: &'a ToolRegistry,
+        supervisor: Option<UnboundedSender<SupervisorMsg>>,
+    ) -> Self {
+        if supervisor.is_some() {
+            registry.enable_task_delegation();
+        }
+        Self {
+            inner,
+            events,
+            registry,
+            supervisor,
+        }
+    }
+}
+
 #[async_trait]
 impl ToolExecutor for TaskTap<'_> {
     fn schemas(&self) -> Vec<ToolSchema> {

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -421,6 +421,7 @@ mod tests {
 
     use async_trait::async_trait;
     use serde_json::Value;
+    use std::sync::Mutex;
     use stella_protocol::{
         CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage, MessageRole,
         Provider, ProviderError, ToolOutput, ToolSchema,

--- a/crates/stella-pipeline/src/triage.rs
+++ b/crates/stella-pipeline/src/triage.rs
@@ -399,10 +399,52 @@ fn is_bare_greeting(goal: &str) -> bool {
 /// Everything else keeps the existing contract exactly — triage's explicit call
 /// if it made one, otherwise what the class implies.
 pub fn resolve_witness(model_opinion: Option<bool>, class: TaskClass, goal: &str) -> bool {
-    if is_pure_deletion(goal) {
+    if is_pure_deletion(goal) || acts_on_pull_requests(goal) {
         return false;
     }
     model_opinion.unwrap_or_else(|| class.verifies_unconditionally())
+}
+
+/// Whether the goal's end state is a pull request's state on a hosted forge —
+/// `merge all open prs to main`, `close the stale pull requests`.
+///
+/// The second thing allowed to overrule an explicit `WITNESS: yes`, and for
+/// the same reason as [`is_pure_deletion`]: a witness must fail on the old
+/// state and pass on the new, and these change no file in the workspace, so
+/// there is no local before-and-after for one to straddle.
+///
+/// The cost of getting this wrong was not merely a wasted authoring call.
+/// `authored_witness` forces the run into a disposable candidate workspace
+/// even at N=1, and a candidate attaches no sub-agent dispatcher — so asking
+/// for a witness that could not exist also took away the worker's last way to
+/// act. One observed run spent eleven minutes and $1.52 and merged nothing
+/// (#3320, #3318).
+///
+/// Deliberately scoped to the pull-request family rather than to hosted work
+/// in general. The wider rule ("the end state lives outside this workspace")
+/// is guidance in the triage prompt, where a wrong call costs one model's
+/// opinion; here a false positive ships a real code change with no authored
+/// witness, so it is bought with two narrow conditions: the goal names a pull
+/// request *and* a verb that acts on one, and it names no local file-shaped
+/// object — `fix scripts/automerge-nudge.sh so prs land cleanly` is ordinary
+/// code work and keeps its witness.
+fn acts_on_pull_requests(goal: &str) -> bool {
+    let lower = goal.to_ascii_lowercase();
+    if names_a_file_shaped_object(&lower) {
+        return false;
+    }
+    let words: Vec<&str> = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .collect();
+    // Whole words only: `prepare` must never read as `pr`.
+    const PR_VERBS: &[&str] = &["merge", "close", "reopen", "approve", "land"];
+    let acts = words.iter().any(|w| PR_VERBS.contains(w));
+    let names_pr = words.iter().any(|w| *w == "pr" || *w == "prs")
+        || words
+            .windows(2)
+            .any(|w| w[0] == "pull" && w[1].starts_with("request"));
+    acts && names_pr
 }
 
 /// Whether the goal is an unmistakable removal of a named code artifact —
@@ -1078,8 +1120,12 @@ const TRIAGE_INSTRUCTIONS: &str = "Classify the following user message, and deci
      executable could distinguish success from failure. Always say no \
      when the ask is to DELETE something — a witness must fail on the old \
      code and pass on the new, and a removal leaves nothing to write that \
-     against. Prefer `no` on small, self-evident work — ceremony that \
-     proves nothing costs the user time and money.\n\
+     against. Always say no when the end state lives OUTSIDE this \
+     workspace — merging pull requests, deploying, sending mail, changing \
+     a hosted setting. Those change no file here, so there is no local \
+     before-and-after for a witness to straddle. Prefer `no` on small, \
+     self-evident work — ceremony that proves nothing costs the user time \
+     and money.\n\
      VERIFIER is whether a separate model should review the result. It is \
      only consulted when no test settled the outcome, so say no ONLY \
      when a test will already prove the change or the result is \

--- a/crates/stella-pipeline/src/triage/tests.rs
+++ b/crates/stella-pipeline/src/triage/tests.rs
@@ -467,6 +467,61 @@ fn the_deletion_ceiling_does_not_swallow_real_work() {
 }
 
 #[test]
+fn acting_on_pull_requests_never_authors_a_witness() {
+    // The reported failure, verbatim as the first entry: this asked for a
+    // remote state change, got `WITNESS: yes`, and the authored witness then
+    // forced the run into a candidate workspace that could not delegate — so
+    // the worker had no way to act at all (#3320, #3318).
+    for goal in [
+        "merge all open prs to main on github",
+        "merge all open pull requests",
+        "close the stale prs",
+        "approve and merge pr 3312",
+        "land the open pull requests on main",
+    ] {
+        assert!(
+            acts_on_pull_requests(goal),
+            "{goal:?} should be recognized as acting on pull requests"
+        );
+        assert!(
+            !resolve_witness(Some(true), TaskClass::MultiStep, goal),
+            "{goal:?} must not author a witness even when triage asked for one"
+        );
+        assert!(!resolve_witness(None, TaskClass::MultiStep, goal));
+    }
+}
+
+#[test]
+fn the_pull_request_ceiling_does_not_swallow_local_work() {
+    // The half that matters: a false positive here ships a real code change
+    // with no authored witness.
+    for goal in [
+        // Local code that merely mentions pull requests.
+        "fix scripts/automerge-nudge.sh so prs land cleanly",
+        "add a test for the pr template renderer in stella-cli/src/pr.rs",
+        "update .github/workflows/ci.yml to run on pull requests",
+        // A merge that is not a pull request.
+        "merge main into my branch",
+        "merge the two config loaders into one",
+        // Pull requests named without a verb that acts on them.
+        "explain how prs are labelled",
+        "why did that pull request fail ci",
+        // The prefix trap: `prepare` and `preview` must not read as `pr`.
+        "prepare the release notes",
+        "close the preview server cleanly",
+    ] {
+        assert!(
+            !acts_on_pull_requests(goal),
+            "{goal:?} must NOT be treated as acting on pull requests"
+        );
+        assert!(
+            resolve_witness(Some(true), TaskClass::SingleTask, goal),
+            "{goal:?} must honor an explicit WITNESS: yes"
+        );
+    }
+}
+
+#[test]
 fn the_ceiling_leaves_every_other_witness_decision_untouched() {
     // Outside the deletion shape, `resolve_witness` must be exactly the old
     // `wants_witness` contract: triage's call, else the class default.

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -94,6 +94,10 @@ pub struct ToolRegistry {
     /// [`ToolRegistry::take_spawn_requests`] — a drain discipline, so no
     /// request is dispatched twice.
     spawn_queue: crate::tasks::SpawnQueue,
+    /// Whether a host will drain `spawn_queue`. Set by
+    /// [`ToolRegistry::enable_task_delegation`]; `false` here makes
+    /// `task_assign` refuse rather than confirm an undispatched request.
+    spawn_dispatch: crate::tasks::SpawnDispatch,
     /// The sub-agent dispatcher (#922), filled by the host after
     /// construction via [`ToolRegistry::attach_sub_agent_dispatcher`] — it
     /// needs this registry as the child's tool set, so taking it as a
@@ -137,6 +141,7 @@ impl ToolRegistry {
     pub fn new(root: PathBuf) -> Self {
         let task_board: crate::tasks::TaskBoardHandle = Arc::default();
         let spawn_queue: crate::tasks::SpawnQueue = Arc::default();
+        let spawn_dispatch: crate::tasks::SpawnDispatch = Arc::default();
         let sub_agent_dispatcher: crate::subagent::DispatcherSlot = Arc::default();
         let sub_agent_spend: stella_core::subagent::SubAgentSpendLedger = Arc::default();
         let scratch = crate::scratch::ScratchDir::new().map(Arc::new);
@@ -151,6 +156,7 @@ impl ToolRegistry {
             Arc::new(crate::tasks::TaskAssign(
                 task_board.clone(),
                 spawn_queue.clone(),
+                spawn_dispatch.clone(),
             )),
             // Registered unconditionally — see `attach_sub_agent_dispatcher`
             // on why an unattached dispatcher is still the honest shape.
@@ -183,6 +189,7 @@ impl ToolRegistry {
             mcp_usage: Arc::default(),
             task_board,
             spawn_queue,
+            spawn_dispatch,
             sub_agent_dispatcher,
             sub_agent_spend,
             turn_controls: crate::subagent::TurnControlsSlot::default(),
@@ -427,6 +434,20 @@ impl ToolRegistry {
     /// to observe queued spawns without draining them.
     pub fn spawn_queue(&self) -> crate::tasks::SpawnQueue {
         self.spawn_queue.clone()
+    }
+
+    /// Declare that this host drains [`Self::take_spawn_requests`] and spawns
+    /// what it finds, which is what lets `task_assign` accept a delegation.
+    ///
+    /// Late-attached for the same reason the sub-agent dispatcher is: whether
+    /// anything will honor a queued request is a fact about the *host*, not
+    /// about the registry, and it is not known at construction. Registries
+    /// that never call this (a best-of-N candidate workspace, a bare embedding
+    /// host) get a `task_assign` that refuses rather than one that confirms a
+    /// spawn no one performs.
+    pub fn enable_task_delegation(&self) {
+        self.spawn_dispatch
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 
     /// Drain the sub-agent spawn requests `task_assign` queued since the

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -294,6 +294,24 @@ impl ToolRegistry {
             .unwrap_or_else(|p| p.into_inner()) = Some(dispatcher);
     }
 
+    /// The dispatcher this registry runs sub-agents through, if one is
+    /// attached.
+    ///
+    /// For a host building a *second* registry that should delegate through
+    /// the same runner — a best-of-N candidate workspace is the case that
+    /// motivated it. Children run read-only, so sharing the session's runner
+    /// costs the candidate nothing it needed: a research child reads to
+    /// understand the codebase, and the snapshot it would otherwise read is a
+    /// copy of the same tree.
+    pub fn sub_agent_dispatcher(
+        &self,
+    ) -> Option<std::sync::Arc<dyn stella_core::subagent::SubAgentDispatcher>> {
+        self.sub_agent_dispatcher
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
     /// Publish this turn's pause gate and steering tap, until the returned
     /// guard drops.
     ///

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -9,6 +9,7 @@
 //! are `Arc<Mutex<…>>` handles shared between the tool instances and the
 //! [`crate::ToolRegistry`] that exposes/drains them.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -28,6 +29,14 @@ pub type TaskBoardHandle = Arc<Mutex<TaskBoard>>;
 /// driver via [`crate::ToolRegistry::take_spawn_requests`] — the tool only
 /// records intent; the driver owns the actual spawn.
 pub type SpawnQueue = Arc<Mutex<Vec<SpawnRequest>>>;
+
+/// Whether a host is wired to drain [`SpawnQueue`] and actually spawn what
+/// `task_assign` queues. `false` until
+/// [`crate::ToolRegistry::enable_task_delegation`] runs — the same
+/// late-attachment shape as the sub-agent dispatcher slot, and gated for the
+/// same reason: queuing intent nothing will honor is not delegation, and a
+/// tool that confirms it teaches the model it delegated work that never ran.
+pub type SpawnDispatch = Arc<AtomicBool>;
 
 /// Extract a required non-empty string field from model-supplied JSON.
 /// Model input is runtime data: missing or mistyped fields return a tool
@@ -354,7 +363,11 @@ impl Tool for TaskCancel {
 /// `task_assign` — delegate a task: mark it in progress under an owner lane
 /// AND queue a [`SpawnRequest`] for the driver to spawn a dedicated
 /// sub-agent from.
-pub struct TaskAssign(pub TaskBoardHandle, pub SpawnQueue);
+///
+/// Refuses when no host is wired to drain the queue ([`SpawnDispatch`]), and
+/// refuses *before* touching the board: a delegation that will never run must
+/// leave neither a queued request nor a task parked under a phantom owner.
+pub struct TaskAssign(pub TaskBoardHandle, pub SpawnQueue, pub SpawnDispatch);
 
 #[async_trait]
 impl Tool for TaskAssign {
@@ -391,6 +404,18 @@ impl Tool for TaskAssign {
             Err(e) => return e,
         };
         let owner = optional_str(input, "owner").unwrap_or_else(|| format!("sub:{id}"));
+        // Ahead of the board mutation: with nothing draining the queue this
+        // call cannot delegate, and the honest answer is the one `task` already
+        // gives for an unattached dispatcher. Confirming instead is how a
+        // session came to believe six sub-agents were working for it while its
+        // queue grew and nothing ran.
+        if !self.2.load(Ordering::Acquire) {
+            return ToolOutput::error(
+                "delegation is unavailable in this session — nothing will run the \
+                 sub-agent, so the task would sit unstarted; do the work directly \
+                 with your own tools",
+            );
+        }
         // Validate the transition on the board first; only a successful
         // assignment may queue a spawn (a terminal/unknown task must never
         // spawn a worker).
@@ -428,6 +453,18 @@ mod tests {
 
     fn handles() -> (TaskBoardHandle, SpawnQueue) {
         (Arc::default(), Arc::default())
+    }
+
+    /// A host that drains the queue — what every `task_assign` test below
+    /// assumes, and what [`dispatch_off`] is the counterpart to.
+    fn dispatch_on() -> SpawnDispatch {
+        Arc::new(AtomicBool::new(true))
+    }
+
+    /// A host that does not. `SpawnDispatch::default()` is already this, but
+    /// naming it is what makes the refusal tests read as deliberate.
+    fn dispatch_off() -> SpawnDispatch {
+        Arc::new(AtomicBool::new(false))
     }
 
     fn root() -> std::path::PathBuf {
@@ -531,7 +568,7 @@ mod tests {
             Box::new(TaskStart(board.clone())),
             Box::new(TaskComplete(board.clone())),
             Box::new(TaskCancel(board.clone())),
-            Box::new(TaskAssign(board, queue)),
+            Box::new(TaskAssign(board, queue, dispatch_on())),
         ];
         let schemas: Vec<ToolSchema> = tools.iter().map(|t| t.schema()).collect();
         let names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
@@ -695,7 +732,7 @@ mod tests {
         );
         let assigned = content(
             exec(
-                &TaskAssign(board.clone(), queue.clone()),
+                &TaskAssign(board.clone(), queue.clone(), dispatch_on()),
                 serde_json::json!({"id": "1", "briefing": "Port src/parse.rs to the new AST"}),
             )
             .await,
@@ -740,7 +777,7 @@ mod tests {
 
         let ok = content(
             exec(
-                &TaskAssign(board.clone(), queue.clone()),
+                &TaskAssign(board.clone(), queue.clone(), dispatch_on()),
                 serde_json::json!({"id": "1", "briefing": "go", "owner": "worker-7"}),
             )
             .await,
@@ -754,7 +791,7 @@ mod tests {
         // Assigning a cancelled task fails on the board and must not queue.
         let bad = error(
             exec(
-                &TaskAssign(board, queue.clone()),
+                &TaskAssign(board, queue.clone(), dispatch_on()),
                 serde_json::json!({"id": "2", "briefing": "go"}),
             )
             .await,
@@ -785,7 +822,7 @@ mod tests {
         // Assign without a briefing must not touch board or queue.
         let assign = error(
             exec(
-                &TaskAssign(board.clone(), queue.clone()),
+                &TaskAssign(board.clone(), queue.clone(), dispatch_on()),
                 serde_json::json!({"id": "1"}),
             )
             .await,
@@ -799,6 +836,10 @@ mod tests {
     async fn registry_dispatches_task_tools_and_drains_spawn_requests() {
         let dir = tempfile::tempdir().unwrap();
         let reg = crate::ToolRegistry::new(dir.path().to_path_buf());
+        // This test is about the drain, so it plays the host that performs
+        // one. Without this the assignment is refused — see
+        // `task_assign_refuses_when_no_host_will_dispatch`.
+        reg.enable_task_delegation();
 
         let out = reg
             .execute(
@@ -830,5 +871,80 @@ mod tests {
             "a drained spawn request must never be dispatched twice"
         );
         assert!(reg.spawn_queue().lock().unwrap().is_empty());
+    }
+
+    /// The witness for the defect this guard exists to prevent.
+    ///
+    /// A registry no host wired for dispatch — a best-of-N candidate
+    /// workspace is the real one — used to accept `task_assign`, answer "a
+    /// dedicated sub-agent will be spawned for it ... its results will land
+    /// back in this session", and queue a request nothing would ever drain.
+    /// A session took that at its word six times, reported the delegated work
+    /// as done, and merged nothing.
+    ///
+    /// Three things must hold, and the middle one is the one that bites: the
+    /// call fails, the board is left alone (no task parked in_progress under
+    /// a sub-agent that does not exist), and nothing is queued.
+    #[tokio::test]
+    async fn task_assign_refuses_when_no_host_will_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = crate::ToolRegistry::new(dir.path().to_path_buf());
+        // Deliberately NO `enable_task_delegation`.
+
+        let out = reg
+            .execute(
+                "task_create",
+                &serde_json::json!({"subject": "merge the open PRs"}),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+
+        let out = reg
+            .execute(
+                "task_assign",
+                &serde_json::json!({"id": "1", "briefing": "run `gh pr merge`"}),
+            )
+            .await;
+        assert!(
+            out.is_error(),
+            "task_assign must refuse when nothing will spawn the sub-agent, not confirm: {out:?}"
+        );
+
+        let board = reg.task_board();
+        assert_eq!(
+            board.lock().unwrap().items()[0].status,
+            TaskStatus::Pending,
+            "a refused delegation must leave the task claimable, not parked under a \
+             sub-agent that will never run"
+        );
+        assert!(
+            board.lock().unwrap().items()[0].owner.is_none(),
+            "a refused delegation must not name an owner"
+        );
+        assert!(
+            reg.take_spawn_requests().is_empty(),
+            "a refused delegation must queue nothing"
+        );
+    }
+
+    /// The tool-level half: same refusal, and the message points the model at
+    /// the only thing left that can work — doing it itself.
+    #[tokio::test]
+    async fn task_assign_refusal_tells_the_model_to_do_the_work_itself() {
+        let (board, queue) = handles();
+        board.lock().unwrap().create("do a thing", None);
+        let out = TaskAssign(board.clone(), queue.clone(), dispatch_off())
+            .execute(
+                &serde_json::json!({"id": "1", "briefing": "b"}),
+                &root(),
+            )
+            .await;
+        let msg = format!("{out:?}");
+        assert!(out.is_error(), "{msg}");
+        assert!(
+            msg.contains("do the work directly"),
+            "the refusal must say what to do instead: {msg}"
+        );
+        assert!(queue.lock().unwrap().is_empty(), "{msg}");
     }
 }

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -934,10 +934,7 @@ mod tests {
         let (board, queue) = handles();
         board.lock().unwrap().create("do a thing", None);
         let out = TaskAssign(board.clone(), queue.clone(), dispatch_off())
-            .execute(
-                &serde_json::json!({"id": "1", "briefing": "b"}),
-                &root(),
-            )
+            .execute(&serde_json::json!({"id": "1", "briefing": "b"}), &root())
             .await;
         let msg = format!("{out:?}");
         assert!(out.is_error(), "{msg}");


### PR DESCRIPTION
Four fixes from one trace: a `stella run` of "merge all open prs to main on github" spent eleven minutes and $1.52, executed nothing, and merged none of the 15 open PRs — while reporting the work as done.

The chain, and the fix at each link:

## 1. Triage asked for a witness that could not exist

`resolve_witness` gains a second ceiling beside `is_pure_deletion`: a goal whose end state is a pull request's state on a hosted forge changes no file here, so there is no local before-and-after for a witness to straddle.

This is the root trigger, not a cosmetic misclassification. `authored_witness` forces the run into a disposable candidate workspace **even at N=1** (`pipeline.rs:1259`), so asking for an impossible witness is what moved the worker onto a degraded tool surface.

Scoped deliberately to the pull-request family. The wider rule — "the end state lives outside this workspace" — is guidance in the triage prompt, where a wrong call costs one model's opinion; here a false positive would ship a real code change with no authored witness, so it is bought with two narrow conditions and a negative test.

## 2. A candidate workspace could not delegate

The candidate registry never attached a sub-agent dispatcher, so `task` answered "sub-agents are unavailable in this session — do the work directly with your own tools". A candidate cannot take that advice: the built-in surface has no command-executing tool, so a worker there could move the task board and nothing else.

Share the session's runner rather than building a candidate-rooted one. Children run behind `ReadOnlyTools`, so a research child reads to understand the codebase, and the snapshot it would otherwise read is a copy of the same tree. `SessionSubAgents::install` already returned the dispatcher for exactly this — *"a caller that dispatches children outside the native registry can share the same runner."*

## 3. `task_assign` confirmed a delegation nothing would dispatch

It queued a `SpawnRequest` and answered "a dedicated sub-agent will be spawned for it ... its results will land back in this session" whether or not anything drained the queue. Only the Command Deck's `TaskTap` does. The session took that at its word six times.

Gated on a host-declared `SpawnDispatch` flag, late-attached exactly like the dispatcher slot. The check runs **before** the board mutation, so a refused delegation leaves the task claimable rather than parked under an owner that does not exist. `TaskTap::new` binds the flag to the supervisor that performs the spawn, so the next tap cannot advertise a delegation it cannot perform.

## 4. The prompt promised a shell that may not exist

The environment block said "Shell: zsh — write commands in its dialect rather than guessing" unconditionally, and the persona prescribed `git status` / `git diff` / `git log -p`. With no MCP server and no custom script tool, both instruct a capability that does not exist — contradicting the prompt's own rule two screens up: *never assume a capability no schema names.* The model obeyed that rule correctly and then had nowhere to go.

**This one deviates from its issue's stated definition of done, and a reviewer should weigh that.** #3319 proposed plumbing the schema list into `build_system_prompt` and making the lines conditional. Instead the wording is now honest in both worlds: the dialect is stated as the constant the closing sentence already calls it, and the git-delta rule names what it depends on. No plumbing, no new inputs to the byte-stable prefix, and correct whether or not a command tool is present. If the conditional version is wanted anyway, reopen and this can follow.

## Witnesses

Each behavioral fix was checked the artisanal way — guard neutralised in place, test observed failing, guard restored:

| Fix | Test | Failure without the fix |
|---|---|---|
| 1 | `acting_on_pull_requests_never_authors_a_witness` | `"merge all open prs to main on github" must not author a witness even when triage asked for one` |
| 2 | `a_candidate_delegates_through_the_session_runner_only_when_it_is_shared` | `Error { message: "sub-agents are unavailable in this session — …" }` |
| 3 | `task_assign_refuses_when_no_host_will_dispatch` | prints verbatim the false confirmation the real session believed |
| 4 | `the_prefix_never_promises_a_shell_it_cannot_provide` | `must state the shell as a constant, never instruct the model to write commands` |

Fix 2's test asserts **both** halves — bare candidate refuses, shared candidate reaches the stub dispatcher — so the wiring is demonstrably what carries the capability. Fixes 1 and 3 each carry a negative test against false positives; fix 1's is the one that matters, since a false positive there ships a real change with no witness.

The pre-existing `registry_dispatches_task_tools_and_drains_spawn_requests` is corroborating evidence for fix 3: it passed on `main` with no host wired, and now needs an explicit `enable_task_delegation()`.

## Verification

- `cargo test -p stella-cli` — 1731 passed
- `cargo test -p stella-pipeline` — 739 passed
- `cargo test -p stella-tools` — 236 passed
- `cargo clippy -p stella-cli -p stella-tools -p stella-pipeline --all-targets` — clean
- `make guards` — clean

No tests deleted.

## Note on trailers

These commits carry `Refs`, not `Closes`, because the issues were filed after the first commit and amending would need a force-push. The closes below run through GitHub's linked-issue mechanism only — worth a glance at merge that all three actually close.

Closes #3318
Closes #3319
Closes #3320
