### PR TITLE
fix(release): resync Cargo.lock with the 0.9.50 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "stella-plugin"
-version = "0.9.49"
+version = "0.9.50"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
`main` is red at `074124b9c`. The failing step is **Cargo.lock is in sync with the manifests**:

```
cargo metadata --locked --format-version 1 > /dev/null
  || { echo "::error::Cargo.lock is out of sync with the manifests..."; exit 1; }
```

`crates/stella-plugin/Cargo.toml` went to `0.9.50` in the release sync (#3316 / #3323) while `Cargo.lock` still records `0.9.49` for that package, so `--locked` refuses. Because it is a required check, **every PR opened against `main` inherits the failure** until this lands.

## The fix

One line, produced by running `cargo metadata` rather than edited by hand:

```diff
 [[package]]
 name = "stella-plugin"
-version = "0.9.49"
+version = "0.9.50"
```

## Verification

- Before: `cargo metadata --locked` fails on `origin/main` — reproduced locally, same error as CI.
- After: `cargo metadata --locked --format-version 1` exits 0.

No witness test: the CI step *is* the witness, and it fails on `main` and passes here.

## Follow-up

`stella-plugin` is a new crate (#3311's slice landed it). The release-sync automation bumped its manifest but did not refresh the lockfile entry, which will recur for the next crate added. Filed separately so this stays a one-line unblock.

## Summary by Sourcery

Bug Fixes:
- Fix Cargo.lock desynchronization that caused cargo metadata --locked to fail on main due to a stale stella-plugin version entry.