### PR TITLE
fix(docs): drop a hand-written note from the generated docs/tools/ tree

### DIFF
--- a/docs/tools/Review Historical Bench Environment.md
+++ b/docs/tools/Review Historical Bench Environment.md
@@ -1,9 +1,0 @@
-# Review Historical Bench Run Environment
-
-Step 1 - Did init run successfully? Were the API keys for voyage api available and were embeddings generated? How many times did the agent use bash for a tool call that would have genuinely be better served by using the search tool? How many times did they grep, same number for glob, same number for regex search/find list-dir..
-
-Step 2 - Perform Calculations on the Trace Physics: How many tool calls did it take to produce a git diff? Correllate the number of additions vs removals in a write or edit event (i think write is the whole file which could also be an edit so this applies - but basically try and see if agents do more or less context related research before they edit files versus create new files). Calculate the error rates for each tool.
-
-Step 3 - Sanity Check Tool Traces: Confirm the tool call contracts defined in the tool schemas are being honored we should see consistent conformance to the io contracts of tools and you should check a dozen of them (and all the search tool calls until otherwise told) to make sure what the tool produced was actually helpful to accomplish the task.
-
-Step 4 - Synthesize Findings into Actionable Github Issues: Create GH issues for corrections you hypothesize will have an improvement on our benchmark runs that you studied in this task.


### PR DESCRIPTION
`main` is red on `tool_docs::tool_docs_match_the_declarations`:

```
docs/tools/ no longer matches the tool declarations:
  docs/tools/Review Historical Bench Environment.md — not produced by the generator (a retired tool?)
```

## What it actually is

Not a retired tool — **not a tool page at all**. The file is a hand-written four-step prompt for reviewing a historical bench run ("Did init run successfully? … Synthesize findings into actionable GitHub issues"), committed into the generated directory by `9cd35f4f3` ("saving new skills"). `docs/tools/` is generated from the tool declarations, so anything not emitted by the generator fails the check.

## Why it surfaced now

The guard that catches it shipped with #3338 and went red the moment that merged (`48032de2e`). Bisected:

| commit | `tool_docs` |
|---|---|
| `e1e03dae3` (before #3338) | tests do not exist yet |
| `48032de2e` (#3338) | **FAILED** — 2 passed, 1 failed |
| this branch | ok — 3 passed |

Because `fmt + clippy + test` is a required check, every PR opened against `main` inherits the failure until this lands.

## The fix

`make tool-docs-update`. The regeneration's entire diff is the deletion of that one file — no other page moved, which is itself the evidence that the rest of `docs/tools/` is in sync.

The note is not lost: it remains in history at `9cd35f4f3`, and it belongs somewhere hand-written rather than in a generated tree. If it should live on as a prompt, `.stella/skills/` or `docs/playbooks/` is the home — deliberately not decided here, so this stays a one-file unblock.

## Verification

- Before: `cargo test -p stella-cli tool_docs` on `origin/main` — 1 failed.
- After: 3 passed.

No witness test: the guard *is* the witness, and it fails on `main` and passes here.

## Summary by Sourcery

Documentation:
- Delete the non-generated 'Review Historical Bench Environment' document from docs/tools so that the directory only contains generator-produced tool docs.