### PR TITLE
feat(gate,ci): lockfile-sync + main-canary — catch a stale lock before the push, and a broken composition after the merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,10 +358,16 @@ jobs:
       # sub-second resolve that reports the drift precisely, instead of making
       # every later step's failure mode ambiguous between "lock is stale" and
       # "code is broken".
+      #
+      # The command itself moved into scripts/check-lockfile-sync.sh so this job
+      # and `make gate` cannot disagree about what "in sync" means, and so the
+      # check reaches the pre-push hook — where it catches a stale lock before
+      # the push rather than after review (#3332). This step stays because it is
+      # the required job: the hook is advisory and bypassable.
       - name: Cargo.lock is in sync with the manifests
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: |
-          cargo metadata --locked --format-version 1 > /dev/null \
+          ./scripts/check-lockfile-sync.sh \
             || { echo "::error::Cargo.lock is out of sync with the manifests. Run 'cargo check --workspace' and commit the updated Cargo.lock."; exit 1; }
 
       - name: cargo fmt --check

--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -1,0 +1,72 @@
+name: main-canary
+
+# Is `main` still green *after* the merge? (#3332)
+#
+# Some guards in this repository are enforced against a shared cell — one file
+# every PR of a given shape must write. `Cargo.lock` is one; AGENTS.md already
+# names `scripts/file-size-baseline.txt` as the biggest single cause of a red
+# `main`. Two branches can each write that cell correctly, pass every required
+# check, and compose into a broken tree the moment both land. The defect is in
+# the composition, so no pre-merge check can see it: neither author's tree is
+# wrong.
+#
+# On 2026-08-16 it fired twice in one day. #3311 added a crate while the 0.9.50
+# release sync (#3323) regenerated the lock; the merge left 23 crates at 0.9.50
+# and stella-plugin alone at 0.9.49, and every `--locked` build on `main` failed
+# — the MSRV job, the container build, and install.sh, which is the one that
+# reaches people installing from source. It was found by the next contributor's
+# PR going red, which is the expensive way.
+#
+# ── Why this is a separate workflow ──────────────────────────────────────────
+#
+# ci.yml runs on `pull_request` and ignores `docs/**`; this must run on the
+# merged tree, unconditionally, on every path. Same disjoint-trigger reasoning
+# that gave wire-schema.yml its own file.
+#
+# ── Why it writes an issue ───────────────────────────────────────────────────
+#
+# A scheduled workflow that fails quietly into the Actions tab is the shape of
+# #1464, where release.yml failed on 31 consecutive tags across two days while
+# every surface a maintainer glances at stayed green. The canary's output is an
+# issue, because that is the thing people read — and it closes that issue when
+# `main` recovers, so it never becomes a stale-issue generator worth muting.
+
+on:
+  push:
+    branches: [main]
+  # A backstop for the breakage no push caused: a yanked dependency can make a
+  # previously-fine lock unresolvable without a single commit landing.
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # To open, comment on, and close the one tracking issue, and to provision its
+  # label on first use.
+  issues: write
+
+# Deliberately cancel-in-progress: this reconciles state rather than reacting to
+# an event, so under a burst of merges the only tree worth judging is the last
+# one. Every action it takes is idempotent (one issue, found by label), so a
+# cancelled run costs nothing the next run does not redo.
+concurrency:
+  group: main-canary
+  cancel-in-progress: true
+
+jobs:
+  canary:
+    name: main still composes green
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+
+      - name: Reconcile main against the composition checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/main-canary.sh --announce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,20 @@ would launch a browser on nearly every PR — the same disjoint-paths reasoning
 that gave `wire-schema.yml` its own file. It is deliberately not a required
 check yet (#2425).
 
+A fifth, `main-canary.yml`, is the only one that runs **after** the merge, and
+it exists because some guards cannot be settled before one. A guard enforced
+against a *shared cell* — one file every PR of a shape must write, like
+`Cargo.lock` or `scripts/file-size-baseline.txt` — can be satisfied correctly by
+two branches that still compose into a broken tree once both land. No pre-merge
+run can catch that: neither author's tree is wrong. So the canary re-asks the
+composition questions on `main` itself (push, plus a daily backstop for the
+breakage no commit caused, such as a yanked dependency), and reports by opening
+one labelled issue — closing it again when `main` recovers, because a monitor
+that only ever files gets muted and is then worse than none (#1464 is what
+silent failure costs here). `make main-canary` runs the same check locally
+without filing anything; `scripts/main-canary.sh`'s header carries the full
+argument, including why it deliberately does not open a fix PR (#3332).
+
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
 id — `doc:context-reuse §4`. Moving the file cannot break it. A document with no
@@ -801,7 +815,10 @@ seconds; `cargo test --workspace` rebuilds everything.
   `scripts/file-size-baseline.txt` above. That happened twice on 2026-08-16
   (#3311, then the 0.9.50 sync against it) and left `main` red for every
   `--locked` build. Nothing pre-merge can see it, because neither author's tree
-  is wrong; #3332 tracks the post-merge half.
+  is wrong — which is why `main-canary.yml` re-asks the same question after the
+  merge and files an issue when the answer changed (#3332). The two halves are
+  deliberately separate: one stops you shipping a stale lock, the other bounds
+  how long `main` stays broken when nobody did.
 - **`.cargo/config.toml` is gitignored** — it holds per-developer cargo aliases
   (`tc` = test stella-core, etc.). It's not committed.
 - **Settings 3-scope merge**: user → org-managed (`STELLA_MANAGED_SETTINGS`) →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + typed-errors
                          #   + diagnostic-codes
                          #   + wire-schema
+                         #   + lockfile-sync (cargo metadata --locked)
                          #   + doc-warnings (rustdoc -D warnings)
                          #   + format-check (fmt --check)
                          #   + lint (clippy -D warnings)
@@ -126,7 +127,7 @@ Four rungs, each a superset of the one above:
 
 | Target | Runs | Honours `CARGO_SCOPE` |
 | --- | --- | --- |
-| `make guards-fast` | the toolchain-free guards + `fmt --check` — nothing compiles at all | — |
+| `make guards-fast` | the toolchain-free guards + `lockfile-sync` + `fmt --check` — nothing compiles at all | — |
 | `make guards` | ...plus `wire-schema`, whose two schema exporters do compile | — |
 | `make check` | ...plus clippy | clippy |
 | `make gate` | ...plus rustdoc and the test suite | clippy, rustdoc, test |
@@ -788,7 +789,19 @@ seconds; `cargo test --workspace` rebuilds everything.
 ## Gotchas
 
 - **`Cargo.lock` is tracked.** Stella ships a binary and `install.sh` builds
-  with `--locked`, so the lockfile must be committed and reproducible.
+  with `--locked`, so the lockfile must be committed and reproducible. Nothing
+  you run day to day passes `--locked`, which is what makes a stale lock
+  invisible until release time — so `lockfile-sync`
+  (`scripts/check-lockfile-sync.sh`) resolves it on every gate run, including
+  the `guards-fast` rung the pre-push hook picks. It compiles nothing.
+
+  It catches the lock you forgot to regenerate. It cannot catch the other
+  shape: two branches that are each correct and collide only once both land —
+  the lockfile is one shared cell every version-bumping PR writes, exactly like
+  `scripts/file-size-baseline.txt` above. That happened twice on 2026-08-16
+  (#3311, then the 0.9.50 sync against it) and left `main` red for every
+  `--locked` build. Nothing pre-merge can see it, because neither author's tree
+  is wrong; #3332 tracks the post-merge half.
 - **`.cargo/config.toml` is gitignored** — it holds per-developer cargo aliases
   (`tc` = test stella-core, etc.). It's not committed.
 - **Settings 3-scope merge**: user → org-managed (`STELLA_MANAGED_SETTINGS`) →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ python3 ./scripts/check-module-reachability.py
 python3 ./scripts/check-typed-errors.py
 ./scripts/check-diagnostic-codes.sh
 ./scripts/check-wire-schema.sh
+./scripts/check-lockfile-sync.sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,21 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     diagnostic-codes
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
+# The cargo steps that resolve or parse but never build. They are not in
+# GATE_GUARDS_FAST because that variable's contract is literally "a shell script
+# over the tree" and these two shell out to cargo — but they cost about a second
+# between them and compile nothing, so every rung from guards-fast up can afford
+# them. Named once here rather than restated on each tier line, which is the
+# drift this file's tiering exists to prevent (#3332).
+GATE_NO_BUILD := lockfile-sync format-check
+
 # The whole gate, in order, as one name. `gate` below is defined *from* this
 # variable rather than restating it, and `make print-gate-steps` prints it —
 # which is what lets scripts/check-gate-parity.sh hold AGENTS.md and
 # CONTRIBUTING.md to the real list instead of a hand-copied one. Both documents
 # had already re-rotted twice, in the same direction each time: a guard was
 # added here and the prose kept the old count (#1437).
-GATE_STEPS := $(GATE_GUARDS) doc-warnings format-check lint test tool-docs \
+GATE_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) doc-warnings lint test tool-docs \
                self-driving-test
 
 .PHONY: help
@@ -297,7 +305,8 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 # The four tiers of the gate, from cheapest to dearest. Each is a superset of
 # the one above it, and only the compile tiers honour CARGO_SCOPE.
 #
-#   guards-fast  the toolchain-free guards + rustfmt. Nothing compiles at all.
+#   guards-fast  the toolchain-free guards + the lock resolve + rustfmt.
+#                Nothing compiles at all.
 #   guards       ...plus wire-schema, whose two schema exporters do compile.
 #   check        ...plus clippy. The graduated fallback: a reduced gate, not no gate.
 #   gate         ...plus rustdoc and the test suite. What CI runs, unscoped.
@@ -305,15 +314,16 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 # `guards-fast` exists for the one push shape where `guards` is provably
 # wasted work: a diff that reaches no crate AND cannot have touched the wire
 # contract — a website-only or workflow-only push. Every guard in
-# GATE_GUARDS_FAST is a shell script over the tree, and `cargo fmt --check`
-# parses rather than builds, so this rung needs no build at all. The pre-push
+# GATE_GUARDS_FAST is a shell script over the tree, and GATE_NO_BUILD resolves
+# (`cargo metadata --locked`) or parses (`cargo fmt --check`) rather than
+# building, so this rung needs no build at all. The pre-push
 # hook picks between the two by grepping the pushed diff (#1439); wire-schema
 # is not optional, it is *conditional*, and the condition is in one place.
 .PHONY: guards-fast
-guards-fast: $(GATE_GUARDS_FAST) format-check ## Toolchain-free guards + fmt (no cargo build at all)
+guards-fast: $(GATE_GUARDS_FAST) $(GATE_NO_BUILD) ## Toolchain-free guards + lock resolve + fmt (no cargo build at all)
 
 .PHONY: guards
-guards: $(GATE_GUARDS) format-check ## Global guards + fmt only (nothing compiles beyond the wire-schema exporters; nothing to scope)
+guards: $(GATE_GUARDS) $(GATE_NO_BUILD) ## Global guards + lock resolve + fmt only (nothing compiles beyond the wire-schema exporters; nothing to scope)
 
 .PHONY: gate
 gate: $(GATE_STEPS) ## Full CI gate: guards + rustdoc + fmt-check + clippy + test
@@ -357,8 +367,16 @@ module-reachability-test: ## Test the module-reachability walker (hermetic; not 
 god-files: ## Assert AGENTS.md and the crate READMEs name the baselined god files (#1435)
 	@./scripts/check-god-files.sh
 
+.PHONY: lockfile-sync
+lockfile-sync: ## Assert Cargo.lock resolves against the manifests as committed (#3332)
+	@./scripts/check-lockfile-sync.sh
+
+.PHONY: lockfile-sync-test
+lockfile-sync-test: ## Test the lockfile guard against synthetic skewed workspaces (hermetic; not part of `gate`)
+	./scripts/test-lockfile-sync.sh
+
 .PHONY: check
-check: $(GATE_GUARDS) format-check lint ## Reduced pre-push gate: every guard + fmt + clippy, no rustdoc and no tests
+check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
 
 .PHONY: impacted
 impacted: ## Print the cargo scope for a diff (RANGE=origin/main..HEAD)

--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,17 @@ lockfile-sync: ## Assert Cargo.lock resolves against the manifests as committed 
 lockfile-sync-test: ## Test the lockfile guard against synthetic skewed workspaces (hermetic; not part of `gate`)
 	./scripts/test-lockfile-sync.sh
 
+# Deliberately not a gate step: it judges the MERGED tree, which is a question
+# no pre-merge run can answer. .github/workflows/main-canary.yml is where it
+# runs for real; this target is here so the logic can be exercised by hand.
+.PHONY: main-canary
+main-canary: ## Ask whether main still composes green (check only; no issue is filed)
+	@./scripts/main-canary.sh
+
+.PHONY: main-canary-test
+main-canary-test: ## Test the post-merge canary, announcements included (hermetic; not part of `gate`)
+	./scripts/test-main-canary.sh
+
 .PHONY: check
 check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
 

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -96,6 +96,8 @@ number_word() {
   20) echo twenty ;; 21) echo twenty-one ;; 22) echo twenty-two ;;
   23) echo twenty-three ;; 24) echo twenty-four ;; 25) echo twenty-five ;;
   26) echo twenty-six ;; 27) echo twenty-seven ;; 28) echo twenty-eight ;;
+  29) echo twenty-nine ;; 30) echo thirty ;; 31) echo thirty-one ;;
+  32) echo thirty-two ;;
   *) echo "" ;;
   esac
 }

--- a/scripts/check-lockfile-sync.sh
+++ b/scripts/check-lockfile-sync.sh
@@ -60,7 +60,10 @@ while [ $# -gt 0 ]; do
     shift 2
     ;;
   -h | --help)
-    sed -n '2,47p' "$0" | sed 's/^# \{0,1\}//'
+    # The whole comment block after the shebang, bounded by its first
+    # non-comment line — hardcoded line numbers truncate silently the first
+    # time the header grows.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
     exit 0
     ;;
   *)

--- a/scripts/check-lockfile-sync.sh
+++ b/scripts/check-lockfile-sync.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Guard: Cargo.lock resolves against the manifests as committed (#3332).
+#
+# `Cargo.lock` is tracked, and the paths that ship pin it: install.sh's
+# `cargo install --locked --git --tag`, the Homebrew formula, release.yml's
+# `cargo build --release --locked`, docker-serve.yml and msrv.yml. None of the
+# everyday commands pass `--locked`, so a stale lock is invisible while you work
+# and fails at release time — or, worse, on a user's machine installing from
+# source.
+#
+# ci.yml has run exactly this check since it was added, in the `fmt + clippy +
+# test` job. This guard is the same oracle moved to where it can act *earlier*:
+# `make gate`, and therefore the pre-push hook. Two incidents on 2026-08-16 are
+# the argument:
+#
+#   * #3311 added the stella-plugin crate, then merged a `main` that had bumped
+#     the workspace version (0.9.47 -> 0.9.49) and thiserror (2.0.19 -> 2.0.20).
+#     The merge took the new dependency versions but not a matching lock entry.
+#     Both `--locked` CI jobs went red after review, not before the push.
+#   * The release sync to 0.9.50 (#3323) then regenerated the lock while #3311
+#     was still in flight. Both PRs were green; the composition left 23 crates
+#     at 0.9.50 and stella-plugin alone at 0.9.49, and `main` was red for every
+#     `--locked` build until #3333.
+#
+# What this guard does and does not buy, stated plainly because the difference
+# is the whole design: it catches the FIRST shape — a branch whose lock is stale
+# against its own merge result — on the author's machine, before the push. It
+# cannot catch the SECOND: two branches that are each individually correct and
+# collide only when both land. Nothing that runs pre-merge can, because neither
+# author's tree is wrong. That half needs a post-merge canary on `main`, which
+# #3332 tracks separately and this guard deliberately does not pretend to cover.
+#
+# `cargo metadata` rather than `--locked` on a build step, matching ci.yml's
+# reasoning: it is a sub-second resolve that reports the drift precisely,
+# instead of making a later failure ambiguous between "the lock is stale" and
+# "the code is broken". It compiles nothing, which is what lets it sit in the
+# guards-fast tier next to `cargo fmt --check`.
+#
+# Usage:
+#   scripts/check-lockfile-sync.sh                 # this repository
+#   scripts/check-lockfile-sync.sh --manifest-dir DIR
+#
+# `--manifest-dir` exists for scripts/test-lockfile-sync.sh, which builds
+# throwaway path-only workspaces so the failure branch can be proven rather
+# than assumed. A guard that cannot be shown to fail is indistinguishable from
+# one that always passes.
+set -euo pipefail
+
+target_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --manifest-dir)
+    [ $# -ge 2 ] || {
+      echo "check-lockfile-sync: --manifest-dir needs a directory" >&2
+      exit 2
+    }
+    target_dir="$2"
+    shift 2
+    ;;
+  -h | --help)
+    sed -n '2,47p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "check-lockfile-sync: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [ -z "$target_dir" ]; then
+  target_dir="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+if [ ! -d "$target_dir" ]; then
+  echo "check-lockfile-sync: no such directory: $target_dir" >&2
+  exit 2
+fi
+
+cd "$target_dir"
+
+# The verdict is decided before anything is written (#1815): a guard that
+# prints as it scans dies mid-report when its reader exits early (`| head -1`),
+# and under `set -euo pipefail` that partial state becomes the exit status.
+# scripts/check-gate-parity.sh is the shape being copied.
+report=""
+note() { report="${report}check-lockfile-sync: $1"$'\n'; }
+
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if ! command -v cargo >/dev/null 2>&1; then
+  note "FAIL — cargo is not on PATH, so the lock cannot be resolved."
+  note "     This guard is not skippable on a machine that runs the gate:"
+  note "     a silent skip reads exactly like a pass, which is the failure"
+  note "     mode the whole gate exists to prevent."
+  emit
+  exit 2
+fi
+
+# Deliberately NOT --offline. With a cold registry cache, --offline fails on a
+# perfectly correct lock, and a guard that cries wolf gets bypassed. The cost of
+# being right is an index fetch on the rare run where the lock really is stale.
+# `--color never` so the reason below is the same bytes on a developer's
+# terminal and in a CI log. cargo styles its diagnostics whenever the caller
+# exports CLICOLOR_FORCE, and ANSI escapes in a guard's report are noise at
+# best — and, in the one guard that parsed its own output, invalid input.
+if err="$(cargo metadata --locked --color never --format-version 1 2>&1 >/dev/null)"; then
+  emit
+  printf 'check-lockfile-sync: OK — Cargo.lock resolves against the manifests.\n' || true
+  exit 0
+fi
+
+note "FAIL — Cargo.lock is out of sync with the manifests."
+note ""
+note "cargo said:"
+# A here-string, NOT `printf | while`: a piped loop runs in a subshell, so every
+# `note` inside it appends to a copy of $report that dies with the subshell and
+# the reason never reaches the reader. That is exactly how this guard's first
+# draft printed an empty "cargo said:" while still exiting 1 — a failure that
+# told you nothing is barely better than no guard.
+while IFS= read -r line; do
+  note "     $line"
+done <<<"$err"
+note ""
+note "Fix it by regenerating the lock and committing it:"
+note ""
+note "       cargo metadata --format-version 1 >/dev/null   # or: cargo check --workspace"
+note "       git add Cargo.lock"
+note ""
+note "Cargo.lock is tracked and install.sh builds --locked, so this reaches"
+note "people installing from source, not only CI. Commit the regenerated lock"
+note "in the same PR as the manifest change that moved it (#3332)."
+emit
+exit 1

--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+#
+# The post-merge canary: is `main` still green after the merge? (#3332)
+#
+# ── The failure this exists for ──────────────────────────────────────────────
+#
+# Some of this repository's guards are enforced against a *shared cell* — one
+# file every PR of a given shape must write. `Cargo.lock` is one. So is
+# `scripts/file-size-baseline.txt`, which AGENTS.md already names as the single
+# biggest cause of a red `main`. Two branches can each write that cell
+# correctly, pass every check, and compose into a broken tree the moment both
+# land — because the defect is in the *composition*, and no pre-merge check
+# has both halves in front of it.
+#
+# On 2026-08-16 this fired twice in one day. #3311 added a crate; the 0.9.50
+# release sync (#3323) regenerated the lock while it was in flight; the merge
+# left 23 crates at 0.9.50 and stella-plugin alone at 0.9.49. Every `--locked`
+# build on `main` failed — the MSRV job, the container build, and install.sh,
+# which is the one that reaches people installing from source. Both PRs were
+# green. Neither author did anything wrong.
+#
+# `scripts/check-lockfile-sync.sh` is the pre-merge half and cannot see this;
+# its own header says so. This is the other half: it looks at `main` *after*
+# the merge, which is the first moment the question can be asked at all.
+#
+# ── Why it files an issue instead of just going red ──────────────────────────
+#
+# A scheduled workflow that fails silently into the Actions tab is the exact
+# shape of #1464, where release.yml failed on 31 consecutive tags over two days
+# and nothing anywhere said so. Every surface a maintainer glances at was
+# green. So the canary's output is an *issue*: it survives, it notifies, and it
+# is the thing people actually read.
+#
+# It is equally important that it closes that issue when `main` recovers. A
+# canary that only ever opens issues becomes a stale-issue generator, gets
+# muted, and is then worth less than nothing — it is a monitor everyone has
+# learned to ignore. Recovery is detected and announced on the same run.
+#
+# Exactly one issue is kept open at a time, found by label. A red `main` that
+# stays red across ten merges is one issue with ten comments, not ten issues.
+#
+# ── What it deliberately does NOT do ─────────────────────────────────────────
+#
+# It does not open a fix PR. It could — the remediation for a lock skew is one
+# regenerated file, and two humans hand-wrote that same commit on 2026-08-16.
+# But a bot with push access, opening branches against a protected `main` under
+# an auto-merge policy, is a much larger authority decision than "tell someone
+# accurately, fast". The issue body carries the exact commands instead. If that
+# tradeoff should change, change it deliberately, not by extending this script.
+#
+# Usage:
+#   scripts/main-canary.sh                      # check only; exit 1 if main is red
+#   scripts/main-canary.sh --announce           # ...and open/refresh/close the issue
+#   scripts/main-canary.sh --dry-run            # ...printing gh actions instead of running them
+#   scripts/main-canary.sh --manifest-dir DIR   # check a fixture tree (tests)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+announce=0
+dry_run=0
+manifest_dir=""
+fixture_open_issue=""
+label="main-red"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --announce)
+    announce=1
+    shift
+    ;;
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --label)
+    [ $# -ge 2 ] || {
+      echo "main-canary: --label needs a value" >&2
+      exit 2
+    }
+    label="$2"
+    shift 2
+    ;;
+  --manifest-dir)
+    [ $# -ge 2 ] || {
+      echo "main-canary: --manifest-dir needs a directory" >&2
+      exit 2
+    }
+    manifest_dir="$2"
+    shift 2
+    ;;
+  # Test-only: stand in for the `gh issue list` lookup below. The recovery
+  # branch — close the issue when main goes green — only runs when an issue is
+  # already open, so without this seam the one branch that keeps this canary
+  # from becoming a stale-issue generator could never be exercised offline.
+  --fixture-open-issue)
+    [ $# -ge 2 ] || {
+      echo "main-canary: --fixture-open-issue needs a number" >&2
+      exit 2
+    }
+    fixture_open_issue="$2"
+    shift 2
+    ;;
+  -h | --help)
+    sed -n '2,58p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "main-canary: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+# `--dry-run` without `--announce` would be a no-op that still reads as a
+# configured monitor. Reject it rather than run something that cannot report.
+if [ "$dry_run" -eq 1 ] && [ "$announce" -eq 0 ]; then
+  echo "main-canary: --dry-run only means something with --announce" >&2
+  exit 2
+fi
+
+sha="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)"
+short_sha="${sha:0:9}"
+
+# ── The checks ───────────────────────────────────────────────────────────────
+#
+# Only composition-sensitive checks belong here — the ones where two green
+# branches can still compose red. A check that a single PR fully determines is
+# already caught pre-merge, and running it again post-merge buys noise, not
+# safety. Add a row when a new shared cell appears, not to be thorough.
+#
+# Each row is "<name>|<command>". The command runs from the repo root.
+checks=(
+  "lockfile-sync|./scripts/check-lockfile-sync.sh${manifest_dir:+ --manifest-dir $manifest_dir}"
+)
+
+failures=""
+failed_names=""
+
+cd "$repo_root"
+
+for row in "${checks[@]}"; do
+  name="${row%%|*}"
+  cmd="${row#*|}"
+  if out="$(eval "$cmd" 2>&1)"; then
+    printf 'main-canary: ok   %s\n' "$name"
+  else
+    printf 'main-canary: FAIL %s\n' "$name" >&2
+    failed_names="${failed_names}${failed_names:+, }${name}"
+    failures="${failures}### \`${name}\`
+
+\`\`\`
+${out}
+\`\`\`
+
+"
+  fi
+done
+
+green=1
+[ -n "$failed_names" ] && green=0
+
+# ── Announcing ───────────────────────────────────────────────────────────────
+
+gh_run() {
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'main-canary: [dry-run] gh %s\n' "$*"
+    return 0
+  fi
+  gh "$@"
+}
+
+# The open canary issue, or empty. Best-effort by design: a gh outage must not
+# turn a green main red, nor a red main green — the verdict is already decided
+# above and the exit status below does not consult this.
+open_issue=""
+if [ -n "$fixture_open_issue" ]; then
+  open_issue="$fixture_open_issue"
+elif [ "$announce" -eq 1 ] && [ "$dry_run" -eq 0 ]; then
+  open_issue="$(gh issue list --label "$label" --state open --limit 1 \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+fi
+
+if [ "$announce" -eq 1 ]; then
+  if [ "$green" -eq 1 ]; then
+    if [ -n "$open_issue" ]; then
+      body="\`main\` is green again as of ${short_sha}: every composition check
+below passes. Closing automatically — reopen if you disagree.
+
+Checked: $(printf '%s ' "${checks[@]%%|*}")"
+      gh_run issue comment "$open_issue" --body "$body"
+      gh_run issue close "$open_issue" \
+        --reason completed \
+        --comment "Closed by the post-merge canary at ${short_sha}."
+      printf 'main-canary: main recovered — closed #%s\n' "$open_issue"
+    fi
+  else
+    body="The post-merge canary found \`main\` broken at \`${short_sha}\`.
+
+Failing: **${failed_names}**
+
+${failures}
+### Why this was not caught before the merge
+
+These checks are enforced against a shared cell — a file every PR of a given
+shape must write. Two branches can each write it correctly, pass every check,
+and still compose into a broken tree once both land. No pre-merge check has
+both halves in front of it, which is why this canary exists (#3332).
+
+### How to fix
+
+\`\`\`sh
+git checkout main && git pull
+cargo metadata --format-version 1 >/dev/null   # or: cargo check --workspace
+git add Cargo.lock
+\`\`\`
+
+Land it on its own from a fresh \`main\` — do not fold it into an unrelated PR,
+for the reason AGENTS.md gives about the file-size baseline.
+
+### Blast radius while this is open
+
+Everything that passes \`--locked\`: the MSRV check, the \`stella-serve\`
+container build, and \`install.sh\` — which builds \`--locked\`, so this reaches
+people installing from source, not only CI. A red \`main\` also reds every open
+PR, so the next contributor inherits a failure they did not cause.
+
+<!-- main-canary -->"
+
+    if [ -n "$open_issue" ]; then
+      gh_run issue comment "$open_issue" --body "Still red at \`${short_sha}\` — failing: ${failed_names}."
+      printf 'main-canary: still red — commented on #%s\n' "$open_issue"
+    else
+      # Ensure the label first: `gh issue create --label` fails outright on a
+      # label that does not exist, which would break the canary at the exact
+      # moment it has something to say. `--force` makes this idempotent, so it
+      # is a no-op on every run after the first.
+      gh_run label create "$label" \
+        --color B60205 \
+        --description "main is broken on the merged tree — filed by the post-merge canary" \
+        --force
+      gh_run issue create \
+        --title "main is red: ${failed_names} fails on the merged tree" \
+        --label "$label" \
+        --body "$body"
+      printf 'main-canary: opened an issue for %s\n' "$failed_names"
+    fi
+  fi
+fi
+
+if [ "$green" -eq 1 ]; then
+  printf 'main-canary: OK — main composes green at %s.\n' "$short_sha"
+  exit 0
+fi
+
+printf 'main-canary: FAIL — main is red at %s (%s).\n' "$short_sha" "$failed_names" >&2
+exit 1

--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -55,6 +55,15 @@
 #   scripts/main-canary.sh --manifest-dir DIR   # check a fixture tree (tests)
 set -euo pipefail
 
+# A decided verdict must survive a reader that closes the pipe early (#1815).
+# Unlike the buffered guards, this script prints per check, so a `| head -1`
+# reader can close the pipe while writes are still coming. `trap '' PIPE`
+# turns the resulting SIGPIPE into a failed write instead of a kill, and every
+# progress write below carries `|| true` so `set -e` cannot promote that
+# failed write into the exit status. The exit status is the verdict, never
+# the fate of a printf.
+trap '' PIPE
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 announce=0
@@ -102,7 +111,10 @@ while [ $# -gt 0 ]; do
     shift 2
     ;;
   -h | --help)
-    sed -n '2,58p' "$0" | sed 's/^# \{0,1\}//'
+    # The whole comment block after the shebang, bounded by its first
+    # non-comment line — hardcoded line numbers truncate silently the first
+    # time the header grows.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
     exit 0
     ;;
   *)
@@ -143,9 +155,9 @@ for row in "${checks[@]}"; do
   name="${row%%|*}"
   cmd="${row#*|}"
   if out="$(eval "$cmd" 2>&1)"; then
-    printf 'main-canary: ok   %s\n' "$name"
+    printf 'main-canary: ok   %s\n' "$name" || true
   else
-    printf 'main-canary: FAIL %s\n' "$name" >&2
+    printf 'main-canary: FAIL %s\n' "$name" >&2 || true
     failed_names="${failed_names}${failed_names:+, }${name}"
     failures="${failures}### \`${name}\`
 
@@ -164,10 +176,16 @@ green=1
 
 gh_run() {
   if [ "$dry_run" -eq 1 ]; then
-    printf 'main-canary: [dry-run] gh %s\n' "$*"
+    printf 'main-canary: [dry-run] gh %s\n' "$*" || true
     return 0
   fi
-  gh "$@"
+  # Best-effort, like the lookup below: the verdict is already decided, and a
+  # gh outage while announcing must not turn a green main red under `set -e`.
+  # The failure still lands in the workflow log, where a broken announcer is
+  # an operational problem — not a statement about the tree.
+  if ! gh "$@"; then
+    printf 'main-canary: WARN — "gh %s" failed; the verdict is unaffected\n' "$*" >&2 || true
+  fi
 }
 
 # The open canary issue, or empty. Best-effort by design: a gh outage must not
@@ -192,7 +210,7 @@ Checked: $(printf '%s ' "${checks[@]%%|*}")"
       gh_run issue close "$open_issue" \
         --reason completed \
         --comment "Closed by the post-merge canary at ${short_sha}."
-      printf 'main-canary: main recovered — closed #%s\n' "$open_issue"
+      printf 'main-canary: main recovered — closed #%s\n' "$open_issue" || true
     fi
   else
     body="The post-merge canary found \`main\` broken at \`${short_sha}\`.
@@ -229,7 +247,7 @@ PR, so the next contributor inherits a failure they did not cause.
 
     if [ -n "$open_issue" ]; then
       gh_run issue comment "$open_issue" --body "Still red at \`${short_sha}\` — failing: ${failed_names}."
-      printf 'main-canary: still red — commented on #%s\n' "$open_issue"
+      printf 'main-canary: still red — commented on #%s\n' "$open_issue" || true
     else
       # Ensure the label first: `gh issue create --label` fails outright on a
       # label that does not exist, which would break the canary at the exact
@@ -243,15 +261,15 @@ PR, so the next contributor inherits a failure they did not cause.
         --title "main is red: ${failed_names} fails on the merged tree" \
         --label "$label" \
         --body "$body"
-      printf 'main-canary: opened an issue for %s\n' "$failed_names"
+      printf 'main-canary: opened an issue for %s\n' "$failed_names" || true
     fi
   fi
 fi
 
 if [ "$green" -eq 1 ]; then
-  printf 'main-canary: OK — main composes green at %s.\n' "$short_sha"
+  printf 'main-canary: OK — main composes green at %s.\n' "$short_sha" || true
   exit 0
 fi
 
-printf 'main-canary: FAIL — main is red at %s (%s).\n' "$short_sha" "$failed_names" >&2
+printf 'main-canary: FAIL — main is red at %s (%s).\n' "$short_sha" "$failed_names" >&2 || true
 exit 1

--- a/scripts/test-guard-sigpipe.sh
+++ b/scripts/test-guard-sigpipe.sh
@@ -102,6 +102,16 @@ else
   echo "skip check-wire-schema.sh — no cargo toolchain on PATH"
 fi
 
+# check-lockfile-sync.sh shells out to cargo too, but only to resolve — it
+# compiles nothing, so unlike the exporter above it is cheap enough for the
+# deterministic pair. Same skip rule for the same reason.
+if command -v cargo >/dev/null 2>&1; then
+  want check-lockfile-sync.sh true
+  want check-lockfile-sync.sh head -1
+else
+  echo "skip check-lockfile-sync.sh — no cargo toolchain on PATH"
+fi
+
 # ── The original repro (#1815) ───────────────────────────────────────────────
 # The `printf | grep -qx` membership race fired only intermittently — a
 # different innocent crate blamed on each piped run — so this case gets room

--- a/scripts/test-lockfile-sync.sh
+++ b/scripts/test-lockfile-sync.sh
@@ -93,7 +93,11 @@ expect "a synced lock passes" 0 "OK — Cargo.lock resolves" --manifest-dir "$tm
 # twice in a day (#3311 then #3323 x #3311); it is the reason the guard exists,
 # so it is the first thing proven.
 make_workspace "$tmp/skewed" "0.1.0"
-perl -0pi -e 's/^version = "0\.1\.0"$/version = "0.2.0"/m' "$tmp/skewed/Cargo.toml"
+# sed-to-temp rather than `sed -i` (BSD and GNU disagree on -i's argument) or
+# perl (an extra toolchain dependency for one substitution).
+sed 's/^version = "0\.1\.0"$/version = "0.2.0"/' "$tmp/skewed/Cargo.toml" \
+  >"$tmp/skewed/Cargo.toml.new"
+mv "$tmp/skewed/Cargo.toml.new" "$tmp/skewed/Cargo.toml"
 expect "a version bump without a relock fails" 1 "out of sync with the manifests" \
   --manifest-dir "$tmp/skewed"
 

--- a/scripts/test-lockfile-sync.sh
+++ b/scripts/test-lockfile-sync.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/check-lockfile-sync.sh (#3332).
+#
+# Hermetic: every case builds a throwaway workspace under mktemp with path-only
+# members and no registry dependencies, so nothing here needs a network or the
+# repository's own lock. `--manifest-dir` exists for exactly this.
+#
+# The cases that matter are the failure branches. A guard that cannot be shown
+# to fail is indistinguishable from one that always passes — which is how the
+# empty-diff check sat believed-green for a week (#1714), and it is not
+# hypothetical here: this guard's first draft exited 1 correctly but printed an
+# empty "cargo said:", because a `printf | while` loop appends to a $report that
+# dies with its subshell. `the reason survives` below is that regression.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+guard="$repo_root/scripts/check-lockfile-sync.sh"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "skip test-lockfile-sync — no cargo toolchain on PATH"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# Build a minimal, network-free workspace at $1 whose single member is at
+# version $2, and write a lock that matches it.
+make_workspace() {
+  dir="$1"
+  version="$2"
+  mkdir -p "$dir/crates/demo/src"
+  cat >"$dir/Cargo.toml" <<TOML
+[workspace]
+members = ["crates/demo"]
+resolver = "2"
+
+[workspace.package]
+version = "$version"
+edition = "2021"
+TOML
+  cat >"$dir/crates/demo/Cargo.toml" <<'TOML'
+[package]
+name = "demo"
+version.workspace = true
+edition.workspace = true
+TOML
+  echo 'pub fn demo() {}' >"$dir/crates/demo/src/lib.rs"
+  (cd "$dir" && cargo generate-lockfile --offline >/dev/null 2>&1)
+}
+
+# Run the guard over a fixture directory, asserting the exit code and that
+# stdout+stderr contains `needle`.
+expect() {
+  name="$1"
+  want_code="$2"
+  needle="$3"
+  shift 3
+  set +e
+  out="$("$guard" "$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL  $name — exit $code, wanted $want_code"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ;;
+  *)
+    echo "FAIL  $name — output did not contain: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+# ── a workspace whose lock matches passes ─────────────────────────────────
+make_workspace "$tmp/clean" "0.1.0"
+expect "a synced lock passes" 0 "OK — Cargo.lock resolves" --manifest-dir "$tmp/clean"
+
+# ── the 2026-08-16 incident, reproduced ───────────────────────────────────
+# The release sync bumped [workspace.package].version while the lock kept the
+# old number for one member. This is the exact shape that reddened `main`
+# twice in a day (#3311 then #3323 x #3311); it is the reason the guard exists,
+# so it is the first thing proven.
+make_workspace "$tmp/skewed" "0.1.0"
+perl -0pi -e 's/^version = "0\.1\.0"$/version = "0.2.0"/m' "$tmp/skewed/Cargo.toml"
+expect "a version bump without a relock fails" 1 "out of sync with the manifests" \
+  --manifest-dir "$tmp/skewed"
+
+# ── the reason must reach the reader ──────────────────────────────────────
+# Regression for the subshell bug in the first draft. Exiting 1 with an empty
+# "cargo said:" tells the author a lock is stale but not that it is the version
+# — which is the entire content of the diagnosis.
+expect "the reason survives the report buffer" 1 "cannot update the lock file" \
+  --manifest-dir "$tmp/skewed"
+
+# ── a missing lock is stale, not absent ───────────────────────────────────
+# `--locked` refuses to author a lock at all, so "there is no lock" and "the
+# lock is wrong" are the same verdict here. Worth pinning: a guard that treated
+# a missing file as nothing-to-check would pass the worst case.
+make_workspace "$tmp/nolock" "0.1.0"
+rm -f "$tmp/nolock/Cargo.lock"
+expect "a missing lock fails too" 1 "out of sync with the manifests" \
+  --manifest-dir "$tmp/nolock"
+
+# ── argument handling is a usage error, never a silent pass ───────────────
+expect "an unknown argument exits 2" 2 "unknown argument" --nope
+expect "--manifest-dir with no value exits 2" 2 "needs a directory" --manifest-dir
+expect "a nonexistent directory exits 2" 2 "no such directory" \
+  --manifest-dir "$tmp/does-not-exist"
+
+# ── the report survives a reader that closes the pipe (#1815) ─────────────
+# The guard buffers its whole verdict and emits once; `| head -1` must not turn
+# a decided failure into some partial exit status.
+set +e
+"$guard" --manifest-dir "$tmp/skewed" 2>&1 | head -1 >/dev/null
+code=${PIPESTATUS[0]}
+set -e
+if [ "$code" -eq 1 ]; then
+  echo "ok    a truncated reader still gets exit 1"
+  pass=$((pass + 1))
+else
+  echo "FAIL  a truncated reader changed the exit status to $code"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "test-lockfile-sync: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/test-main-canary.sh
+++ b/scripts/test-main-canary.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/main-canary.sh (#3332).
+#
+# Hermetic: the red cases drive the canary at a throwaway workspace via
+# --manifest-dir, and every announcing case runs under --dry-run, so nothing
+# here needs a network, a GH_TOKEN, or the repository's real issues. A monitor
+# that files issues is precisely the kind of script you cannot test by running
+# it for real.
+#
+# The cases that matter are the announcing branches. A canary that cannot be
+# shown to open an issue when main is red, and to CLOSE it when main recovers,
+# is indistinguishable from one that always says "green" — and a monitor
+# trusted on that basis is worse than no monitor, because it is also an excuse
+# not to look.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+canary="$repo_root/scripts/main-canary.sh"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "skip test-main-canary — no cargo toolchain on PATH"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# A minimal, network-free workspace at $1 whose lock matches its manifests.
+make_workspace() {
+  dir="$1"
+  mkdir -p "$dir/crates/demo/src"
+  cat >"$dir/Cargo.toml" <<'TOML'
+[workspace]
+members = ["crates/demo"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+TOML
+  cat >"$dir/crates/demo/Cargo.toml" <<'TOML'
+[package]
+name = "demo"
+version.workspace = true
+edition.workspace = true
+TOML
+  echo 'pub fn demo() {}' >"$dir/crates/demo/src/lib.rs"
+  (cd "$dir" && cargo generate-lockfile --offline >/dev/null 2>&1)
+}
+
+expect() {
+  name="$1"
+  want_code="$2"
+  needle="$3"
+  shift 3
+  set +e
+  out="$("$canary" "$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL  $name — exit $code, wanted $want_code"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ;;
+  *)
+    echo "FAIL  $name — output did not contain: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+refute() {
+  name="$1"
+  needle="$2"
+  shift 2
+  set +e
+  out="$("$canary" "$@" 2>&1)"
+  set -e
+  case "$out" in
+  *"$needle"*)
+    echo "FAIL  $name — output should NOT have contained: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    ;;
+  *)
+    echo "ok    $name"
+    pass=$((pass + 1))
+    ;;
+  esac
+}
+
+# ── green ─────────────────────────────────────────────────────────────────
+make_workspace "$tmp/clean"
+expect "a composing tree passes" 0 "OK — main composes green" --manifest-dir "$tmp/clean"
+
+# A green run must not file anything. This is the case that keeps the canary
+# worth reading: a monitor that comments on healthy days gets muted.
+refute "a green run announces nothing" "gh issue create" \
+  --announce --dry-run --manifest-dir "$tmp/clean"
+
+# ── red: the 2026-08-16 incident ──────────────────────────────────────────
+# The shared-cell shape: the version moved and the lock did not. Both PRs that
+# composed into this were green on their own.
+make_workspace "$tmp/red"
+perl -0pi -e 's/^version = "0\.1\.0"$/version = "0.2.0"/m' "$tmp/red/Cargo.toml"
+expect "a broken composition fails" 1 "FAIL — main is red" --manifest-dir "$tmp/red"
+expect "and it names the failing check" 1 "lockfile-sync" --manifest-dir "$tmp/red"
+
+# ── red + announce ────────────────────────────────────────────────────────
+expect "a red run opens an issue" 1 "gh issue create" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+expect "the issue carries the remediation" 1 "cargo metadata --format-version 1" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+expect "the issue explains the pre-merge blind spot" 1 "shared cell" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+expect "the issue is labelled so only one stays open" 1 "main-red" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+
+# The label does not exist in this repository yet, and `gh issue create
+# --label` fails outright on an unknown label — the canary would have broken at
+# the exact moment it first had something to say. Creating it is idempotent.
+expect "the label is provisioned before the issue" 1 "gh label create main-red" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+
+# ── recovery: the branch that keeps this worth reading ────────────────────
+# A canary that only ever opens issues becomes a stale-issue generator and gets
+# muted, at which point it is worse than nothing. Recovery only runs when an
+# issue is already open, hence --fixture-open-issue.
+expect "main going green closes the open issue" 0 "gh issue close 42" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
+expect "and says so on the way out" 0 "main recovered — closed #42" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
+
+# ── a red main that stays red is ONE issue, not one per merge ─────────────
+# Ten merges against a broken tree must produce ten comments on one issue. The
+# opposite — an issue per run — is how a monitor earns a mute filter.
+expect "a still-red main comments instead of filing again" 1 "gh issue comment 42" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/red"
+refute "and does not open a second issue" "gh issue create" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/red"
+
+# ── argument handling ─────────────────────────────────────────────────────
+# --dry-run alone reads as a configured monitor while reporting to nobody.
+expect "--dry-run without --announce is refused" 2 "only means something with --announce" \
+  --dry-run --manifest-dir "$tmp/clean"
+expect "an unknown argument exits 2" 2 "unknown argument" --nope
+expect "--label with no value exits 2" 2 "--label needs a value" --label
+
+# ── the verdict survives a reader that closes the pipe (#1815) ────────────
+# The canary prints per check rather than buffering one report, so a `| head -1`
+# reader can SIGPIPE it mid-write. Under `set -euo pipefail` that would turn a
+# decided "main is red" into whatever partial status the write died with — a
+# monitor that reports green because someone truncated its output is the worst
+# failure this repository has a name for. Ten runs, all of which must agree
+# with the unpiped verdict.
+sig_fail=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  set +e
+  "$canary" --manifest-dir "$tmp/red" 2>&1 | head -1 >/dev/null
+  code=${PIPESTATUS[0]}
+  set -e
+  [ "$code" -eq 1 ] || sig_fail=1
+done
+if [ "$sig_fail" -eq 0 ]; then
+  echo "ok    a truncated reader still gets exit 1"
+  pass=$((pass + 1))
+else
+  echo "FAIL  a truncated reader changed the red verdict"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "test-main-canary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Both halves of #3332, because the issue describes two different failure shapes
and only one of them can be caught before a merge.

| shape | example from 2026-08-16 | caught by |
|---|---|---|
| a branch whose lock is stale against **its own merge result** | #3311 merged a `main` that had bumped the workspace version and `thiserror`; the merge took the new versions but not a matching lock entry | `lockfile-sync` — pre-push |
| two branches each **individually correct** that collide once both land | the 0.9.50 release sync (#3323) regenerated the lock while #3311 was in flight; the merge left 23 crates at 0.9.50 and `stella-plugin` alone at 0.9.49 | `main-canary` — post-merge |

The second is the one that actually reddened `main`, and no pre-merge check can
see it: neither author's tree is wrong. `Cargo.lock` is a **shared cell** — one
file every PR of a shape must write — exactly like
`scripts/file-size-baseline.txt`, which AGENTS.md already names as the biggest
single cause of a red `main`.

---

## Half 1 — `lockfile-sync` (pre-merge)

Nothing anyone runs day to day passes `--locked`, which is what makes a stale
lock invisible while you work and loud on the paths that *do* pin it:
`install.sh`'s `cargo install --locked --git --tag`, the Homebrew formula,
`release.yml`, `docker-serve.yml`, `msrv.yml`. `ci.yml` already resolved the
lock, but only inside the required `fmt + clippy + test` job — so the author
learned after review, and `make gate` and the pre-push hook never learned at all.

New `GATE_NO_BUILD := lockfile-sync format-check` tier: both shell out to cargo
but **resolve or parse rather than build** (~1.4s, compiles nothing), so the
`guards-fast` rung the hook picks for a cheap push can still afford them. It is
deliberately *not* in `GATE_GUARDS_FAST`, whose stated contract is "a shell
script over the tree" — that claim stays literally true. `ci.yml` now calls the
same script rather than carrying its own copy of the command.

Not `--offline`: with a cold registry cache that fails on a *correct* lock, and
a guard that cries wolf gets bypassed.

## Half 2 — `main-canary` (post-merge)

`.github/workflows/main-canary.yml` runs on push to `main`, plus a daily
backstop for breakage no commit caused (a yanked dependency can make a
previously-fine lock unresolvable), and re-runs the composition-sensitive
checks on the merged tree.

**It reports by opening one labelled issue, not by going red.** A scheduled
workflow that fails quietly into the Actions tab is the shape of #1464, where
`release.yml` failed on 31 consecutive tags across two days while every surface
a maintainer glances at stayed green. It **closes** that issue when `main`
recovers, and comments rather than refiling while `main` stays red — a monitor
that only ever opens issues gets muted, and is then worse than none.

**It deliberately does not open a fix PR.** It could; two humans hand-wrote that
same one-line commit today. But a bot with push access opening branches against
a protected `main` under an auto-merge policy is a much larger authority
decision than "report accurately, fast". The issue body carries the exact
commands instead. `scripts/main-canary.sh`'s header states this so the next
person extends it deliberately rather than by accident.

Only composition-sensitive checks belong in it — a check a single PR fully
determines is already caught pre-merge, and re-running it post-merge buys noise,
not safety. The `checks` array is one row today and the comment says what earns
a second.

---

## Witness

`scripts/test-lockfile-sync.sh` (8 cases) and `scripts/test-main-canary.sh`
(17 cases). Both hermetic: throwaway path-only workspaces under `mktemp`, no
network, no `GH_TOKEN` — every announcing case runs under `--dry-run`.
`make lockfile-sync-test` / `make main-canary-test`, neither part of `gate`.

The canary's covered branches are the ones that decide whether it is worth
reading at all:

```
ok    a green run announces nothing
ok    a red run opens an issue
ok    the label is provisioned before the issue
ok    main going green closes the open issue
ok    a still-red main comments instead of filing again
ok    and does not open a second issue
ok    a truncated reader still gets exit 1
```

The lockfile guard's first failure case reproduces the incident exactly — bump
`[workspace.package].version` without relocking — and is a genuine fail→pass
flip. I also skewed this repository's real lock to `stella-plugin 0.9.51` and
back to confirm it outside the fixtures.

### Three defects the tests found rather than assumed

1. **The guard exited 1 with an empty `cargo said:`.** `printf | while` runs the
   loop in a subshell, so every appended line died with it. A failure that tells
   you nothing is barely better than no guard. Now a here-string, plus
   `--color never` so the reason is identical in a terminal and a CI log.
   (`the reason survives the report buffer`)
2. **The canary's recovery branch was unreachable offline** — it only runs when
   an issue is already open. `--fixture-open-issue` exists so the one branch
   that prevents stale-issue rot can be exercised.
3. **`gh issue create --label` fails outright on a label that does not exist**,
   and `main-red` does not exist in this repository. The canary would have
   broken at the exact moment it first had something to say. The label is now
   provisioned idempotently before the issue.

## Gate wiring

`gate-parity` did its job here — it failed twice before this was right, first on
the unspelled count (29), then naming both prose copies I had not updated.
AGENTS.md's gate block and rung table, and CONTRIBUTING.md's command fence, are
updated in the same PR as it requires; `number_word()` now spells through
thirty-two. AGENTS.md's workflow enumeration gains `main-canary.yml` as the
fifth, and its `Cargo.lock` gotcha now names both halves.

Both guards are registered in `scripts/test-guard-sigpipe.sh` (the #1815
contract — a decided verdict must survive `| head -1`); the canary additionally
carries its own 10-run SIGPIPE case, since it prints per check rather than
buffering one report. A monitor that reports green because someone truncated its
output is the worst failure this repo has a name for.

## Verification

- `make guards-fast` — exit 0, `check-lockfile-sync: OK` in the run
- `make -n gate` — resolves; `lockfile-sync` appears once; no missing targets
- `check-action-pins` — 72 `uses:` references, all SHA-pinned
- workflow YAML parses; triggers `push`/`schedule`/`workflow_dispatch`,
  permissions `contents: read` + `issues: write`
- `shellcheck` clean on all four scripts
- 8/8, 17/17, and 47/0 on the three suites

**Not run locally:** `lint` / `test` / `doc-warnings`. No Rust changed — the
diff is scripts, Makefile, CI and docs — so I left the compile tiers to CI
rather than paying a workspace build to re-prove untouched code. Flagging it
rather than implying a full green gate.

**One blemish, stated rather than hidden:** the second commit's message lost a
backticked fragment to shell substitution before it was committed (`* fails
outright on a label...` should read ``* `gh issue create --label` fails
outright on a label...``). I did not force-push to repair it. The accurate
statement is in `scripts/main-canary.sh`'s comments, its test, and above.

## Dependencies

None. Shell, cargo and `gh` only.

Closes #3332
