### PR TITLE
docs(website): document multimodal input — attachments, Ctrl-V paste, per-provider media matrix

### DIFF
--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -109,7 +109,7 @@ path.
 
 ### Multimodal input
 
-Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment.
+Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment. See [Multimodal input](/docs/multimodal-input) for the `@`-mention rules, what each provider can see, and how unsupported media degrades.
 
 <Callout type="info">
 All [global flags](/docs/commands) apply, in either position — `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session, and `stella chat --model openai/gpt-5.5` does the same thing.

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -6,6 +6,7 @@
     "getting-started",
     "---Do---",
     "guides",
+    "multimodal-input",
     "agent-fleets",
     "scripting",
     "agent-engine-in-your-app",

--- a/website/content/docs/multimodal-input.mdx
+++ b/website/content/docs/multimodal-input.mdx
@@ -1,0 +1,88 @@
+---
+title: Multimodal input
+description: Attach images, PDFs, audio, and video to any prompt — paste a screenshot with Ctrl-V or just mention the file's path. stella sends what your model can see, and tells it what it can't.
+---
+
+Prompts are not text-only. A screenshot of a broken layout, a PDF spec, a
+recording of a bug — any of them can ride into the model alongside your words,
+on every input surface: the interactive deck, `stella run`, and `stella chat`.
+
+## Three ways to attach
+
+**Paste an image — Ctrl-V.** In the deck, **Ctrl-V** reads the system
+clipboard directly. An image (a screenshot, a copied figure) is stored and
+attached to your prompt as a chip in the composer; plain text pastes like any
+other paste, so Ctrl-V is safe as a universal paste key.
+
+Terminals cannot deliver a bitmap through a normal paste — Cmd-V of a
+screenshot arrives as nothing at all, which is why the explicit shortcut
+exists. Pasted images are PNG-encoded into `.stella/attachments/` in your
+workspace so the session transcript has a stable file to replay from; the
+store keeps the most recent hundred pastes and prunes older ones.
+
+**Mention a path.** Name a media file in your prompt and stella attaches the
+file itself as model input:
+
+```bash
+stella run "the header overlaps the nav on mobile — see shots/header.png"
+```
+
+**`@`-mention a file.** `@` is a stronger signal than a bare path: media
+files attach, and text-like files (source, markdown, JSON) are **inlined** as
+text. A bare path-shaped token never inlines a text file — prose mentions
+paths all the time, and inlining every one would bloat context. A mention
+that does not resolve to a real file is left alone as plain text.
+
+```bash
+stella run "implement the retry policy described in @docs/rfc-042.pdf"
+```
+
+## What each kind becomes
+
+| You attach | The model receives |
+| --- | --- |
+| Image (`image/*`) | A native image block — the model sees the pixels |
+| PDF | A native document block |
+| Audio, video | Native media where the provider ingests it (see below) |
+| Text-like file (via `@`) | Its contents, inlined as text |
+| Any other binary | A text note describing what was attached |
+
+There is no stella-side size cap — payloads live on disk and are only
+base64-encoded at the moment a request is built, so only your provider's own
+request limits apply. Attachments are capped at 32 per prompt as a
+runaway-token backstop.
+
+## What each provider can see
+
+Providers diverge here, and stella tracks the divergence per wire dialect
+rather than assuming parity:
+
+| Provider | Images | PDFs | Audio | Video |
+| --- | --- | --- | --- | --- |
+| `anthropic` | yes | yes | — | — |
+| `openai` | yes | yes | — | — |
+| `gemini`, `vertex` | yes | yes | yes | yes |
+| `bedrock` | yes | yes | — | yes |
+| OpenAI-compatible (`zai`, `openrouter`, `xai`, `deepseek`, `local`) | vision models only | — | — | — |
+
+On the OpenAI-compatible dialect, image support is per-model: GLM vision
+variants (the `v` in `glm-4.5v`) take images, plain GLM text models do not,
+and other vendors' models reached through a gateway are assumed
+vision-capable rather than having an image silently withheld.
+
+## When the model can't see it
+
+An attachment a model cannot ingest **never errors the turn**. Sending an
+image to a text-only model would be a hard API failure that loses your
+prompt; stella instead replaces the payload with a short text note telling
+the model exactly what was attached — the filename, the kind, and that it
+cannot view it. The model can then say so honestly, or open the file with a
+tool where that makes sense (a text-extractable PDF, a file worth
+inspecting), instead of hallucinating contents it never saw.
+
+The practical consequence: you can paste a screenshot without first checking
+which model is resolved. On a vision model it is seen; on anything else the
+model knows what it missed and tells you.
+
+Video is currently understood natively on Gemini, Vertex, and Bedrock;
+elsewhere it degrades to the descriptive note.


### PR DESCRIPTION
## What

A dedicated user-docs page (`/docs/multimodal-input`, in the Do section of the nav) for the multimodal input capability, which until now had only a single sentence in the chat command reference.

Covers, each claim read from the source rather than from memory:

- The three attach paths: **Ctrl-V** clipboard paste in the deck (`crates/stella-tui/src/clipboard.rs`, wired at `deck_shell.rs`), bare path mentions, and `@`-mentions with their inline-vs-attach asymmetry (`crates/stella-cli/src/attachments.rs`).
- What each `AttachmentKind` becomes on the wire, the no-stella-side-size-cap rule, and the 32-attachment backstop.
- The per-provider ingestion matrix, transcribed from the adapters' `DialectCaps` declarations (`anthropic.rs:491`, `openai.rs:254`, `gemini.rs:152`, `bedrock.rs:257`, `zai.rs::caps_for`; vertex shares `to_gemini_request_parts`, so it inherits Gemini's row).
- The degradation contract: unsupported media never errors the turn, it becomes a note naming the file — including the per-model GLM `v`-marker rule and its deny/permit asymmetry.
- Video's current reach (native on Gemini/Vertex/Bedrock only); the keyframe-sampling upgrade for the other dialects is tracked in #3340 (Refs, not closed).

The chat page's one-liner now links to the new page.

## Witness

Docs-only — no witness test. `make guards-fast` is green (brand-case, doc-links, command-docs included).

Refs #3340

## Summary by Sourcery

Add a dedicated user documentation page explaining multimodal input behavior across attachment methods and providers, and link to it from the chat command docs.

Documentation:
- Document multimodal input workflows, including Ctrl-V paste handling, path and @-mentions, attachment kinds, provider-specific media support, and degradation behavior for unsupported media.
- Update chat command documentation to reference the new multimodal input page for detailed rules and provider ingestion matrix.