### PR TITLE
docs(stella-cli): customs are withheld from dispatched workers on purpose (#3339)

### DIFF
--- a/crates/stella-cli/src/agent/tool_stack.rs
+++ b/crates/stella-cli/src/agent/tool_stack.rs
@@ -90,6 +90,20 @@ pub(crate) fn session_stack_with_gate<'a>(
 /// over a base that already carries the complete surface — a subsession
 /// lane's claim tap, a fleet worker's, or the bare registry under
 /// process-free authority (which strips the custom layer deliberately).
+///
+/// # Customs are withheld from dispatched workers on purpose (#3339)
+///
+/// A `.stella/tools/*.toml` tool is an unreviewed local script
+/// (`ToolContract::declared`, graded `High`), and the surfaces that carry it
+/// — the deck, a one-shot turn, the goal loop — all have the human at the
+/// keyboard as their principal. A subsession lane or fleet worker runs
+/// *autonomously*, and its writes are coordinated through the claim tap it
+/// uses as its base; a custom script's side effects are invisible to that
+/// coordination (no `FileChange` events, no claim acquisition), so handing
+/// an unreviewed script to an unattended worker would soften #2716's trust
+/// posture twice over. A worker that needs a custom tool argues for
+/// promoting the tool through the foundry adoption gate, not for widening
+/// this chain.
 pub(crate) fn policy_stack<'a>(
     base: &'a dyn ToolExecutor,
     cfg: &Config,

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -699,7 +699,10 @@ async fn run_task(
     let claims = crate::claims::ClaimTap::new(&committed, claims_store, claim_holder);
     // A fleet worker runs the operator's tool policy and the authorization
     // gate, same as every other driver — an isolated worktree is not a
-    // different trust posture. The principal names the dispatched task.
+    // different trust posture. Deliberately NOT `session_stack`:
+    // `.stella/tools` customs are withheld from autonomous workers on
+    // purpose (#3339, see `policy_stack`'s docs). The principal names the
+    // dispatched task.
     let permitted = agent::tool_stack::policy_stack(
         &claims,
         &cfg,

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -711,10 +711,14 @@ async fn run_worker(
         execution.as_ref().map(|(store, _)| store.clone()),
         format!("{session_id}/{}", spec.lane),
     );
-    // A worker's tool surface is the session's, so the operator's switches
-    // and the authorization gate apply to it identically — a sub-agent must
-    // not be a way to reach a tool the lead was denied. The principal names
-    // the lane, not the human, so a gate can tell the two apart.
+    // A worker's tool surface is the session's built-in/MCP surface, so the
+    // operator's switches and the authorization gate apply to it identically
+    // — a sub-agent must not be a way to reach a tool the lead was denied.
+    // Deliberately NOT `session_stack`: `.stella/tools` customs are withheld
+    // from autonomous lanes on purpose (#3339, see `policy_stack`'s docs) —
+    // an unreviewed script's writes would bypass the claim coordination this
+    // tap exists to enforce. The principal names the lane, not the human, so
+    // a gate can tell the two apart.
     let permitted = agent::tool_stack::policy_stack(
         &claims,
         cfg,


### PR DESCRIPTION
## Why

#3339 asked which of two things the missing custom layer in subsession/fleet chains is — deliberate posture or oversight. It is deliberate, and this writes the decision down where it lives.

## The decision

A `.stella/tools/*.toml` tool is an unreviewed local script (`ToolContract::declared`, graded `High`). Every surface that carries customs — the deck, a one-shot turn, the goal loop, resume — has the human at the keyboard as its principal. A subsession lane or fleet worker runs **autonomously**, and its writes are coordinated through the claim tap it uses as its base; a custom script's side effects are invisible to that coordination (no `FileChange` events, no claim acquisition). Handing an unreviewed script to an unattended worker would soften #2716's trust posture twice over.

The route from claim to trust stays the foundry adoption gate — a worker that needs a custom tool argues for promoting the tool, not for widening the chain.

## What

- `agent/tool_stack.rs`: `policy_stack` docs state the withholding and why (the seam, per #3339's constraint — not per-driver).
- `subsession.rs` / `fleet_cmd.rs` call sites say they chose `policy_stack` over `session_stack` knowingly, and correct the comment that claimed the worker's surface "is the session's".

Docs-only; no behavior change, so no witness (per the PR contract for pure docs).

Closes #3339
Refs #3283 #2716

## Summary by Sourcery

Document the deliberate withholding of `.stella/tools` custom tools from autonomous subsession and fleet workers to preserve the trust and claim-coordination model.

Documentation:
- Explain in `policy_stack` documentation why customs are excluded from dispatched workers and reference the related trust posture decisions.
- Clarify subsession worker comments to state they use only the session's built-in/MCP tool surface and intentionally exclude `.stella/tools` customs.
- Clarify fleet worker comments to note they share the operator's tool policy, intentionally avoid `session_stack`, and exclude `.stella/tools` customs.