### PR TITLE
feat(steering): the steering plane's port, one budgeter, and the switch (#3243 Phase 2)

### DIFF
--- a/crates/stella-cli/src/config/tests.rs
+++ b/crates/stella-cli/src/config/tests.rs
@@ -288,6 +288,7 @@ fn resolved_config_carries_the_authority_computed_during_settings_load() {
     // malformed value can't make this load fail (setenv races any getenv).
     let _env = crate::test_env::lock();
     let authority = crate::settings::AuthorityPolicy {
+        steering_allowed: true,
         project_prompts_allowed: true,
         project_custom_tools_allowed: false,
         media_requires_host_approval: true,

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -324,6 +324,18 @@ pub struct SessionMemory {
     /// turns. Set by `arm_recall_control()`, which every driver calls once per
     /// turn before it recalls anything.
     ab_suppressed: bool,
+    /// The steering plane's master switch, resolved once by `Settings::load`
+    /// and carried on [`crate::settings::AuthorityPolicy`] (#3243).
+    ///
+    /// Distinct from `ab_suppressed`, which withholds injection for ONE turn
+    /// to build a control arm; this withholds it for the session because an
+    /// operator, or their org, asked for it. Both gate the same sites, and
+    /// keeping them separate is what lets a control turn stay attributable as
+    /// an experiment rather than looking like a disabled feature.
+    ///
+    /// Defaults **on**: a `SessionMemory` opened without an authority (the
+    /// `open`/`open_with_workspace_skills` paths) behaves exactly as before.
+    steering_enabled: bool,
     /// The turn number this session last claimed from the control's schedule —
     /// normally the durable, workspace-wide count held in the context store
     /// (#1221), and a bare in-session tally only when that store could not hand
@@ -448,6 +460,7 @@ impl SessionMemory {
             warn,
             authority.project_prompts_allowed,
         )?;
+        memory.set_steering_enabled(authority.steering_allowed);
         memory.set_record_registry(active_rules.registry().clone());
         Some(memory)
     }
@@ -561,6 +574,7 @@ impl SessionMemory {
                     include_workspace_skills,
                     skills_created: 0,
                     ab_suppressed: false,
+                    steering_enabled: true,
                     ab_turn: 0,
                     // Phase 3 (#714)
                     lifecycle_enabled: tuning::session_lifecycle_enabled(workspace_root),
@@ -629,6 +643,17 @@ impl SessionMemory {
         workspace_skills_dir(&self.workspace_root)
     }
 
+    /// Set the steering plane's master switch for this session (#3243).
+    ///
+    /// Takes the already-resolved answer rather than re-deriving it: the
+    /// precedence chain (settings → `STELLA_CONTEXT_STEERING` → the org's
+    /// ceiling) is settled once in `Settings::load` and carried on
+    /// [`crate::settings::AuthorityPolicy`], so a second derivation here could
+    /// only ever disagree with the first.
+    pub(crate) fn set_steering_enabled(&mut self, enabled: bool) {
+        self.steering_enabled = enabled;
+    }
+
     /// Load the workspace's skills fresh (cheap — a handful of file reads;
     /// fresh so a just-installed or just-auto-created skill is live on the
     /// very next turn).
@@ -649,7 +674,7 @@ impl SessionMemory {
         // so it gates the report too: a control turn injects no skills, and
         // recording usage for skills that never reached the prompt would
         // corrupt the appraisal signal `skill_usage` feeds.
-        if self.ab_suppressed {
+        if self.ab_suppressed || !self.steering_enabled {
             return Vec::new();
         }
         skills::select_skills(

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -150,7 +150,12 @@ impl SessionMemory {
     /// answers to different questions about one request, and separating them
     /// means either re-running recall to report it or losing it entirely.
     pub async fn recall_block_reported(&self, prompt: &str) -> RecalledBlock {
-        if self.ab_suppressed {
+        // Two switches, one gate. `ab_suppressed` withholds injection for ONE
+        // turn to build a control arm; `steering_enabled` withholds it for the
+        // session because an operator or their org asked (#3243). Both stop
+        // here, before any provider is queried, so an off session pays nothing
+        // — a gate after retrieval would spend the tokens and discard them.
+        if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
         let mut sections: Vec<String> = Vec::new();
@@ -219,7 +224,7 @@ impl SessionMemory {
     /// event for a pipeline turn is the pipeline's own, and this block does
     /// no frame recall to report.
     pub async fn pipeline_recall_block(&self, prompt: &str) -> Option<String> {
-        if self.ab_suppressed {
+        if self.ab_suppressed || !self.steering_enabled {
             return None;
         }
         let mut sections: Vec<String> = Vec::new();

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -367,14 +367,17 @@ impl SessionMemory {
         goal: &str,
         mut report: impl FnMut(String),
     ) -> Recall {
-        // The control turn's suppression lives HERE, at the frame query both
-        // the rendered block and the pipeline's `ContextRecallPort` go through
-        // — not at the block render alone. A control turn whose port still
-        // answered would feed frames to the goal message, the planner, and the
-        // witness author while the block above showed none, which is not a
-        // control arm at all: the turn would be measured as frameless while
-        // running on recalled context (#1221).
-        if self.ab_suppressed {
+        // Both suppressions live HERE, at the frame query both the rendered
+        // block and the pipeline's `ContextRecallPort` go through — not at
+        // the block render alone. A control turn whose port still answered
+        // would feed frames to the goal message, the planner, and the witness
+        // author while the block above showed none, which is not a control
+        // arm at all: the turn would be measured as frameless while running
+        // on recalled context (#1221). The steering switch stops here for the
+        // same reason: a steering-off session whose port still answered would
+        // leak the exact non-prefix injection the switch withholds — through
+        // the surface (a pipeline turn) that never renders the block (#3243).
+        if self.ab_suppressed || !self.steering_enabled {
             return Recall::default();
         }
         let query = ContextQuery {

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -74,6 +74,43 @@ fn steering_turned_off_injects_nothing() {
     );
 }
 
+/// **Witness (#3243 Phase 2, the pipeline leg).** With steering off, the
+/// frame query itself answers empty — not just the rendered block.
+///
+/// Fails on a gate at the block render alone: a pipeline-driven turn never
+/// renders the block, it recalls through [`ContextRecallPort`] and feeds the
+/// frames to the goal message, the planner, and the witness author — so a
+/// switch that stopped at the block would withhold the injection on exactly
+/// the surfaces that do not use it.
+#[tokio::test]
+async fn steering_turned_off_is_frameless_through_the_pipeline_port_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let lesson = "the deploy script must run migrations before restarting the api";
+    let mut memory = session(dir.path());
+    memory
+        .store
+        .upsert(ContextDelta {
+            memories: vec![MemoryInput::reflection(lesson, Vec::<String>::new())],
+            ..ContextDelta::default()
+        })
+        .await
+        .expect("store a recallable lesson");
+
+    // The control: with steering on, the port recalls the planted lesson —
+    // or the empty assertion below passes for the wrong reason.
+    assert!(
+        !ContextRecallPort::recall(&memory, lesson).await.is_empty(),
+        "the port must recall the planted lesson while steering is on"
+    );
+
+    memory.set_steering_enabled(false);
+    assert!(
+        ContextRecallPort::recall(&memory, lesson).await.is_empty(),
+        "the switch must reach the pipeline's recall port, not just the \
+         rendered block"
+    );
+}
+
 /// **Witness (D1).** A skill tagged with a domain this turn is not working in
 /// is not injected.
 ///

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -52,6 +52,28 @@ fn session(root: &std::path::Path) -> SessionMemory {
         .expect("session memory opens in a temp workspace")
 }
 
+/// **Witness (#3243 Phase 2).** With steering off, the plane injects nothing —
+/// not even for a prompt that anchors squarely in a skill's own domain.
+///
+/// Fails on base, where there is no switch to turn off at all: the selection
+/// is unconditional once the skill is on disk. The control arm this buys is
+/// the point — an A/B of the whole plane needs an "off" that is one decision,
+/// not four unrelated ones.
+#[test]
+fn steering_turned_off_injects_nothing() {
+    let dir = workspace();
+    let mut memory = session(dir.path());
+    memory.set_steering_enabled(false);
+
+    let selected = memory.selected_skills("fix crates/stella-model/anthropic.rs");
+
+    assert!(
+        selected.is_empty(),
+        "the switch withholds every injection, including a domain-anchored \
+         one the same session would otherwise select: {selected:?}"
+    );
+}
+
 /// **Witness (D1).** A skill tagged with a domain this turn is not working in
 /// is not injected.
 ///

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -43,6 +43,7 @@ mod managed;
 mod merge;
 pub(crate) mod migrate;
 mod private;
+mod steering;
 mod toml_config;
 mod toml_io;
 mod unknown;
@@ -58,6 +59,7 @@ pub(crate) use unknown::{
 pub use context::{ContextSettings, InferredDirectivePromotion, RetrievalSettings};
 pub use context_providers::{ContextProviderSettings, ExternalContextProvider, ProviderEndpoint};
 pub use merge::ToolScopePolicies;
+pub(crate) use steering::SteeringCeiling;
 
 /// One `providers.<id>` entry. Every field is optional at the schema level;
 /// which ones are *required* depends on whether the id names a built-in
@@ -248,20 +250,6 @@ pub struct Settings {
     /// could not tell that case apart from the org having forbidden it.
     #[serde(skip)]
     steering_ceiling: SteeringCeiling,
-}
-
-/// The managed scope's answer to "may this workspace steer at all?".
-///
-/// A named type rather than a bare `bool` for the reason `Toggle` is not a
-/// `bool` either: `true` here means "the org expressed no objection", which
-/// is the default and is *not* the same fact as "the org enabled it".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SteeringCeiling(bool);
-
-impl Default for SteeringCeiling {
-    fn default() -> Self {
-        Self(true)
-    }
 }
 
 /// `create_worktrees`: whether a run does its work in a throwaway git worktree
@@ -1362,37 +1350,6 @@ pub struct McpSettings {
 }
 
 impl Settings {
-    /// Whether the steering plane may inject anything this session (#3243).
-    ///
-    /// The precedence, which is the house convention plus the one deliberate
-    /// inversion the tool ceiling already uses:
-    ///
-    /// ```text
-    /// built-in default (ON)
-    ///   < user settings < org-managed < project settings
-    ///   < STELLA_CONTEXT_STEERING        ← env wins the ordinary chain
-    ///   ⟂ managed ceiling applied LAST   ← the org's "off" is final
-    /// ```
-    ///
-    /// Two sentences: **anyone may turn steering off; only the org may
-    /// prevent it being turned back on.** That is exactly `apply_tool_ceiling`'s
-    /// shape, so this needs no new concept — and it is why the ceiling is a
-    /// separate field rather than folded into the merged block. Folded in,
-    /// "the project turned it off" and "the org forbade it" would be the same
-    /// value, and the env var could not be allowed to override the first
-    /// without also overriding the second.
-    pub fn steering_enabled(&self) -> bool {
-        if !self.steering_ceiling.0 {
-            return false;
-        }
-        if let Some(from_env) = env_toggle("STELLA_CONTEXT_STEERING") {
-            return from_env;
-        }
-        self.context
-            .as_ref()
-            .map_or(true, |context| context.steering.enabled)
-    }
-
     /// The merged `tools` section as the policy the runtime enforces. The
     /// managed ceiling is already folded in by [`Settings::load`], so this is
     /// the whole answer — no caller needs to re-apply authority.
@@ -1476,20 +1433,6 @@ struct ProjectTrust {
 
 pub(crate) fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|v| truthy_flag(&v))
-}
-
-/// The tri-state reading of the same variable: unset, explicitly on, or
-/// explicitly off.
-///
-/// [`env_flag`] collapses "unset" and "set to something falsy" into `false`,
-/// which is right for a flag that only ever turns something ON. A switch that
-/// defaults on needs the third state, because "unset" must mean "defer to
-/// settings" and not "off". Same strict truthy vocabulary, so
-/// `STELLA_CONTEXT_STEERING=false` turns steering off rather than opening it
-/// — the `STELLA_TRUST_PROJECT` defect that gave [`truthy_flag`] its
-/// allowlist.
-pub(crate) fn env_toggle(name: &str) -> Option<bool> {
-    std::env::var_os(name).map(|v| truthy_flag(&v))
 }
 
 /// The pure predicate behind [`env_flag`], split out so it is testable

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -236,6 +236,32 @@ pub struct Settings {
     /// when parsing individual scopes so repository text cannot supply it.
     #[serde(skip)]
     pub authority_policy: AuthorityPolicy,
+    /// Whether the ORG's managed scope permits steering at all, captured from
+    /// the managed snapshot alone by [`Settings::merge_captured_scopes`].
+    ///
+    /// Separate from `context.steering.enabled` because the two answer
+    /// different questions and compose in one direction only: the block is
+    /// the ordinary last-wins chain that any scope — and the environment —
+    /// may move, while this is the ceiling over it. Folding the ceiling into
+    /// the block would make them indistinguishable, and then an env var that
+    /// is *supposed* to re-enable steering after a project turned it off
+    /// could not tell that case apart from the org having forbidden it.
+    #[serde(skip)]
+    steering_ceiling: SteeringCeiling,
+}
+
+/// The managed scope's answer to "may this workspace steer at all?".
+///
+/// A named type rather than a bare `bool` for the reason `Toggle` is not a
+/// `bool` either: `true` here means "the org expressed no objection", which
+/// is the default and is *not* the same fact as "the org enabled it".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SteeringCeiling(bool);
+
+impl Default for SteeringCeiling {
+    fn default() -> Self {
+        Self(true)
+    }
 }
 
 /// `create_worktrees`: whether a run does its work in a throwaway git worktree
@@ -1336,6 +1362,37 @@ pub struct McpSettings {
 }
 
 impl Settings {
+    /// Whether the steering plane may inject anything this session (#3243).
+    ///
+    /// The precedence, which is the house convention plus the one deliberate
+    /// inversion the tool ceiling already uses:
+    ///
+    /// ```text
+    /// built-in default (ON)
+    ///   < user settings < org-managed < project settings
+    ///   < STELLA_CONTEXT_STEERING        ← env wins the ordinary chain
+    ///   ⟂ managed ceiling applied LAST   ← the org's "off" is final
+    /// ```
+    ///
+    /// Two sentences: **anyone may turn steering off; only the org may
+    /// prevent it being turned back on.** That is exactly `apply_tool_ceiling`'s
+    /// shape, so this needs no new concept — and it is why the ceiling is a
+    /// separate field rather than folded into the merged block. Folded in,
+    /// "the project turned it off" and "the org forbade it" would be the same
+    /// value, and the env var could not be allowed to override the first
+    /// without also overriding the second.
+    pub fn steering_enabled(&self) -> bool {
+        if !self.steering_ceiling.0 {
+            return false;
+        }
+        if let Some(from_env) = env_toggle("STELLA_CONTEXT_STEERING") {
+            return from_env;
+        }
+        self.context
+            .as_ref()
+            .map_or(true, |context| context.steering.enabled)
+    }
+
     /// The merged `tools` section as the policy the runtime enforces. The
     /// managed ceiling is already folded in by [`Settings::load`], so this is
     /// the whole answer — no caller needs to re-apply authority.
@@ -1419,6 +1476,20 @@ struct ProjectTrust {
 
 pub(crate) fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|v| truthy_flag(&v))
+}
+
+/// The tri-state reading of the same variable: unset, explicitly on, or
+/// explicitly off.
+///
+/// [`env_flag`] collapses "unset" and "set to something falsy" into `false`,
+/// which is right for a flag that only ever turns something ON. A switch that
+/// defaults on needs the third state, because "unset" must mean "defer to
+/// settings" and not "off". Same strict truthy vocabulary, so
+/// `STELLA_CONTEXT_STEERING=false` turns steering off rather than opening it
+/// — the `STELLA_TRUST_PROJECT` defect that gave [`truthy_flag`] its
+/// allowlist.
+pub(crate) fn env_toggle(name: &str) -> Option<bool> {
+    std::env::var_os(name).map(|v| truthy_flag(&v))
 }
 
 /// The pure predicate behind [`env_flag`], split out so it is testable

--- a/crates/stella-cli/src/settings/authority.rs
+++ b/crates/stella-cli/src/settings/authority.rs
@@ -37,6 +37,12 @@ pub struct ManagedAuthoritySettings {
 /// The monotonic authority available to runtime adapters after settings load.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuthorityPolicy {
+    /// Whether the steering plane may inject anything this session (#3243).
+    /// Resolved once by [`Settings::load`] from the whole precedence chain —
+    /// settings, `STELLA_CONTEXT_STEERING`, and the org's ceiling — so every
+    /// injection site asks one already-answered question instead of
+    /// re-deriving it and drifting.
+    pub steering_allowed: bool,
     pub project_prompts_allowed: bool,
     pub project_custom_tools_allowed: bool,
     pub media_requires_host_approval: bool,
@@ -45,6 +51,7 @@ pub struct AuthorityPolicy {
 impl Default for AuthorityPolicy {
     fn default() -> Self {
         Self {
+            steering_allowed: true,
             project_prompts_allowed: false,
             project_custom_tools_allowed: false,
             media_requires_host_approval: true,
@@ -59,6 +66,11 @@ impl AuthorityPolicy {
     ) -> Self {
         let permits = |toggle: Option<Toggle>| toggle != Some(Toggle::Off);
         Self {
+            // Permissive here and resolved in `merge_captured_scopes`, which
+            // is the only place that holds the managed snapshot AND the merged
+            // block the chain needs. `compute` sees the managed authority
+            // block alone, and steering is not one of its keys.
+            steering_allowed: true,
             project_prompts_allowed: project_trusted
                 && permits(managed.and_then(|policy| policy.project_prompts)),
             project_custom_tools_allowed: project_trusted

--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -101,6 +101,7 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
         managed_authority,
         enterprise_telemetry,
         authority_policy,
+        steering_ceiling,
     } = s;
     vec![
         keyed("providers", Posture::Merged, providers != &d.providers),
@@ -154,6 +155,15 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
             key: None,
             posture: Posture::Computed,
             populated: authority_policy != &d.authority_policy,
+        },
+        // Derived from the MANAGED snapshot by `merge_captured_scopes`, not
+        // from the merged view — `context` is honored from an untrusted
+        // project scope, so a ceiling that rode the ordinary chain could be
+        // lifted by the repository it constrains (#3243 §5).
+        Field {
+            key: None,
+            posture: Posture::Computed,
+            populated: steering_ceiling != &d.steering_ceiling,
         },
     ]
 }
@@ -387,6 +397,56 @@ fn every_provider_field_survives_the_entry_overlay() {
              to `None` in all three scopes. Add a `take!({key})` line in settings.rs."
         );
     }
+}
+
+/// **Witness (#3243 Phase 2).** The org's "off" is final: a managed scope
+/// that disables steering cannot be overridden by the project scope, and the
+/// two halves of the precedence rule compose in one direction only.
+///
+/// Deliberately exercises `merge_captured_scopes` rather than the env var —
+/// `STELLA_CONTEXT_STEERING` is process-global state and the concurrent test
+/// runner makes `set_var` a race (POSIX setenv/getenv is undefined under
+/// threads, which is why `truthy_flag` exists as a pure predicate). The env
+/// leg is a one-line `env_toggle` read over that same predicate; what is
+/// worth a test is the ceiling, which is the part with a trust boundary in
+/// it.
+#[test]
+fn a_managed_steering_ceiling_cannot_be_lifted_by_the_project() {
+    let off: Settings = serde_json::from_str(r#"{"context":{"steering":{"enabled":false}}}"#)
+        .expect("managed scope parses");
+    let on: Settings = serde_json::from_str(r#"{"context":{"steering":{"enabled":true}}}"#)
+        .expect("project scope parses");
+
+    let merged = Settings::merge_captured_scopes(
+        &Settings::default(),
+        &off,
+        &on,
+        ProjectTrust {
+            credentials: true,
+            hooks: true,
+        },
+    );
+
+    assert!(
+        !merged.steering_enabled(),
+        "the project re-declared the block and must not have lifted the org's ceiling"
+    );
+    assert!(
+        !merged.authority_policy.steering_allowed,
+        "and the resolved authority every injection site reads agrees"
+    );
+
+    // The control: with no managed objection, the project's own answer stands.
+    let permitted = Settings::merge_captured_scopes(
+        &Settings::default(),
+        &Settings::default(),
+        &on,
+        ProjectTrust {
+            credentials: true,
+            hooks: true,
+        },
+    );
+    assert!(permitted.steering_enabled());
 }
 
 /// The unrecognized-key vocabulary agrees with the structs, both ways.

--- a/crates/stella-cli/src/settings/context.rs
+++ b/crates/stella-cli/src/settings/context.rs
@@ -35,6 +35,27 @@ pub struct ContextSettings {
     pub efficacy: EfficacySettings,
     pub retention: RetentionSettings,
     pub retrieval: RetrievalSettings,
+    pub steering: SteeringSettings,
+}
+
+/// The steering plane's master switch (#3243).
+///
+/// Ships **on**: the four selection planes it will absorb are all on today,
+/// so a default of `false` would be a silent capability removal dressed as a
+/// new feature. Setting it `false` withholds every non-prefix injection —
+/// recalled frames, the volatile record channel, and skills — and leaves the
+/// byte-stable system prefix untouched, which is what makes it a clean
+/// control arm rather than a different agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SteeringSettings {
+    pub enabled: bool,
+}
+
+impl Default for SteeringSettings {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 /// Master switch for the whole adaptive-context lifecycle.

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -350,6 +350,26 @@ impl Settings {
         apply_tool_ceiling(&mut merged, &ceiling);
         merged.managed_authority = managed.managed_authority;
         merged.enterprise_telemetry = managed.enterprise_telemetry.clone();
+        // The steering ceiling, from the MANAGED snapshot alone (#3243 §5).
+        // `context` is a whole-block last-wins merge honored from an untrusted
+        // project scope, so without this a repository could re-enable steering
+        // its org had switched off simply by declaring the block. Captured
+        // here, beside the tool ceiling, for the same reason and with the same
+        // rule: absence is not an objection, so the default is permissive.
+        merged.steering_ceiling = SteeringCeiling(
+            managed
+                .context
+                .as_ref()
+                .is_none_or(|context| context.steering.enabled),
+        );
+        // Resolve the whole steering chain ONCE, here, where the ceiling has
+        // just landed — every injection site then reads one answered question
+        // instead of re-deriving it from settings plus an env var and drifting
+        // from the next site that does the same.
+        let authority = AuthorityPolicy {
+            steering_allowed: merged.steering_enabled(),
+            ..authority
+        };
         merged.authority_policy = authority;
         merged
     }

--- a/crates/stella-cli/src/settings/steering.rs
+++ b/crates/stella-cli/src/settings/steering.rs
@@ -1,0 +1,71 @@
+//! The steering plane's on/off switch (#3243): the managed ceiling type and
+//! the one derivation every caller reads it through.
+//!
+//! The [`SteeringCeiling`] value itself is captured by
+//! [`Settings::merge_captured_scopes`](super::Settings) in `merge.rs`; this
+//! module owns the type and the precedence logic so the two halves of the
+//! answer — "did anyone turn it off?" and "did the org forbid it?" — live
+//! beside each other.
+
+use super::{Settings, truthy_flag};
+
+/// The managed scope's answer to "may this workspace steer at all?".
+///
+/// A named type rather than a bare `bool` for the reason `Toggle` is not a
+/// `bool` either: `true` here means "the org expressed no objection", which
+/// is the default and is *not* the same fact as "the org enabled it".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SteeringCeiling(pub(crate) bool);
+
+impl Default for SteeringCeiling {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl Settings {
+    /// Whether the steering plane may inject anything this session (#3243).
+    ///
+    /// The precedence, which is the house convention plus the one deliberate
+    /// inversion the tool ceiling already uses:
+    ///
+    /// ```text
+    /// built-in default (ON)
+    ///   < user settings < org-managed < project settings
+    ///   < STELLA_CONTEXT_STEERING        ← env wins the ordinary chain
+    ///   ⟂ managed ceiling applied LAST   ← the org's "off" is final
+    /// ```
+    ///
+    /// Two sentences: **anyone may turn steering off; only the org may
+    /// prevent it being turned back on.** That is exactly `apply_tool_ceiling`'s
+    /// shape, so this needs no new concept — and it is why the ceiling is a
+    /// separate field rather than folded into the merged block. Folded in,
+    /// "the project turned it off" and "the org forbade it" would be the same
+    /// value, and the env var could not be allowed to override the first
+    /// without also overriding the second.
+    pub fn steering_enabled(&self) -> bool {
+        if !self.steering_ceiling.0 {
+            return false;
+        }
+        if let Some(from_env) = env_toggle("STELLA_CONTEXT_STEERING") {
+            return from_env;
+        }
+        self.context
+            .as_ref()
+            .is_none_or(|context| context.steering.enabled)
+    }
+}
+
+/// The tri-state reading of an environment variable: unset, explicitly on, or
+/// explicitly off.
+///
+/// [`super::env_flag`] collapses "unset" and "set to something falsy" into
+/// `false`, which is right for a flag that only ever turns something ON. A
+/// switch that defaults on needs the third state, because "unset" must mean
+/// "defer to settings" and not "off". Same strict truthy vocabulary, so
+/// `STELLA_CONTEXT_STEERING=false` turns steering off rather than opening it
+/// — the `STELLA_TRUST_PROJECT` defect that gave `truthy_flag` its
+/// allowlist.
+pub(crate) fn env_toggle(name: &str) -> Option<bool> {
+    std::env::var_os(name).map(|v| truthy_flag(&v))
+}

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -427,6 +427,10 @@ impl TomlConfig {
             enterprise_telemetry: enterprise_telemetry
                 .and_then(|value| serde_json::to_value(value).ok()),
             authority_policy: Default::default(),
+            // Both computed after the merge, never carried by a document —
+            // this is one scope's parse, and the ceiling is a fact about the
+            // managed scope alone.
+            steering_ceiling: Default::default(),
         };
 
         (settings, McpConfig { servers })

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod self_tuning;
 pub mod skills;
 pub(crate) mod speculation;
 pub mod starvation;
+pub mod steering;
 pub mod step;
 pub mod subagent;
 mod summarize;

--- a/crates/stella-core/src/steering.rs
+++ b/crates/stella-core/src/steering.rs
@@ -119,7 +119,7 @@ pub struct SteeringCandidate {
     /// candidate's identity and never its rendered text.
     pub handle: String,
     /// Relevance, comparable **only within a source**. Cross-source ranking
-    /// reads [`SteeringCandidate::priority`], never this: four engines that
+    /// reads the fixed `source_rank` precedence, never this: four engines that
     /// each normalize differently do not produce one number, and pretending
     /// they do is how a rule loses to a tool schema.
     pub score: f64,
@@ -205,7 +205,8 @@ pub trait SteeringPlane {
 /// "the volatile block is too big" is a question no single piece of code can
 /// answer.
 ///
-/// Ordering is [`source_rank`] first, then `score` descending, then `handle`
+/// Ordering is the fixed `source_rank` precedence first, then `score`
+/// descending, then `handle`
 /// — the last is not a nicety. Selection feeds a prompt, prompt bytes feed
 /// the cache, and a tie broken by hash order would reorder the block between
 /// two otherwise identical turns and re-bill the tail (invariant 7).
@@ -225,8 +226,14 @@ pub fn pack_to_budget(mut candidates: Vec<SteeringCandidate>, budget_tokens: u64
     let mut set = SteeringSet::default();
     let mut spent: u64 = 0;
     for candidate in candidates {
-        if spent + candidate.est_tokens <= budget_tokens {
-            spent += candidate.est_tokens;
+        // `checked_add`, not `+`: an estimate near `u64::MAX` would wrap the
+        // sum back under the budget and select the one candidate that fits
+        // least. Overflow and "does not fit" are the same answer — dropped.
+        if let Some(total) = spent
+            .checked_add(candidate.est_tokens)
+            .filter(|total| *total <= budget_tokens)
+        {
+            spent = total;
             set.selected.push(candidate);
         } else {
             set.dropped.push(DroppedCandidate {

--- a/crates/stella-core/src/steering.rs
+++ b/crates/stella-core/src/steering.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The steering plane — one seam for "what could help here?" (#3243).
+//!
+//! # Why this exists
+//!
+//! Stella already asks that question four times per turn, from four unrelated
+//! engines, over corpora that overlap: recall frames (RRF fuse + MMR),
+//! context records (`applies_to` glob matching), skills (lexical coverage +
+//! domain boost), and tool advertisement (unfiltered, or `tool_search`'s rank
+//! under lean mode). They fire at the same moment, from the same trigger, and
+//! **not one of them knows the other three exist** — four relevance engines,
+//! four budgets, four failure postures, three on/off switches. A skill the
+//! host declines to inject can be the top `skill_search` hit, because those
+//! are different rankers with different thresholds and different tokenizers.
+//!
+//! This module is the shape they collapse into. It is deliberately **pure
+//! decision logic over owned data** (invariant 2): the plane is a port, the
+//! adapters do the I/O, and that is what lets the ranking and the budgeting
+//! be property-tested without a filesystem, a provider, or a store.
+//!
+//! # What it is not, yet
+//!
+//! The four existing selectors are not migrated onto it in this change. The
+//! types and the budgeter land first so the flag has something to gate and
+//! the migration has somewhere to land; moving each selector across is a pure
+//! refactor whose review is worth having on its own.
+//!
+//! # The signal is the point
+//!
+//! Every selector today takes a `&str` prompt and nothing else, and fires
+//! once, at turn start. A forty-step turn that opens on "fix the flaky test"
+//! and ends in a provider adapter is still selecting against its first
+//! sentence. [`TurnSignal`] is what those selectors never had: what the turn
+//! has *become*.
+
+use std::collections::BTreeMap;
+
+/// What is happening in this turn, as a selector needs to see it.
+///
+/// Borrowed rather than owned so assembling one costs nothing — it is built
+/// per query, potentially at every step boundary, and a selector that made
+/// the caller clone the turn's history to ask a question would be paid for in
+/// exactly the hot loop it is meant to help.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TurnSignal<'a> {
+    /// The turn's goal, as the operator wrote it. What every selector has
+    /// today, and on its own it is what makes selection go stale by step 40.
+    pub prompt: &'a str,
+    /// Tools the turn has actually called, most recent last. The cheapest
+    /// available evidence that the work has moved: a turn that opened on a
+    /// test failure and is now running `read_file` over an adapter is asking
+    /// a different question than the one it was given.
+    pub recent_tool_calls: &'a [String],
+    /// Workspace paths the turn has touched, from file-tool receipts.
+    ///
+    /// Distinct from the prompt's path anchors in one way that matters: an
+    /// anchor must resolve to an existing file, so a goal naming a file to be
+    /// **created** contributes none. A path the turn has since written *is*
+    /// evidence, and it is the only kind that arrives after the goal.
+    pub touched_paths: &'a [String],
+    /// The domains this turn is working in, already resolved from the paths
+    /// above. Never the whole workspace taxonomy — that mistake is what made
+    /// every domain-tagged skill match every prompt (#3243 D1).
+    pub active_domains: &'a [String],
+    /// Step index within the turn, and how many steps since this plane was
+    /// last queried. The pair is the hysteresis input: re-querying every step
+    /// re-pays for the volatile block every step, so a query is bought by a
+    /// change in signal, never by a counter alone.
+    pub step: u32,
+    pub since_last_query: u32,
+    /// Diagnostic codes the turn has seen. "We are stuck, and this is how" is
+    /// the strongest retrieval cue available, and it is the one currently
+    /// thrown away entirely.
+    pub errors_seen: &'a [&'a str],
+}
+
+/// Which plane a candidate came from.
+///
+/// `Plugin` is declared now and produced by nothing yet, deliberately: #3246
+/// sequences plugins last, and the whole cost of a fifth source arriving
+/// later is whether this enum and [`SteeringSet`] anticipated it. A variant
+/// costs nothing today and a second seam costs a migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SteeringSource {
+    /// A context record — a rule, fact, or directive (`.stella/rules/`).
+    Record,
+    /// A recalled frame: memory, episode, or code-graph symbol.
+    Memory,
+    /// A workspace skill.
+    Skill,
+    /// A tool schema competing for advertisement space.
+    Tool,
+    /// A plugin-contributed candidate. Nothing produces one yet (#3246).
+    Plugin,
+}
+
+impl SteeringSource {
+    /// Stable lowercase tag for telemetry and drop reports. Named rather than
+    /// derived from `Debug`, which is not a wire contract.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Self::Record => "record",
+            Self::Memory => "memory",
+            Self::Skill => "skill",
+            Self::Tool => "tool",
+            Self::Plugin => "plugin",
+        }
+    }
+}
+
+/// One thing the plane believes could help, with the evidence for it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SteeringCandidate {
+    pub source: SteeringSource,
+    /// Stable identity within its source — a record `^handle`, a `nod_…`, a
+    /// skill name, a tool name. This is what a receipt joins on, so it is the
+    /// candidate's identity and never its rendered text.
+    pub handle: String,
+    /// Relevance, comparable **only within a source**. Cross-source ranking
+    /// reads [`SteeringCandidate::priority`], never this: four engines that
+    /// each normalize differently do not produce one number, and pretending
+    /// they do is how a rule loses to a tool schema.
+    pub score: f64,
+    /// Why this was selected, in words a human reads in a drop report.
+    pub why: String,
+    /// What injecting it would cost. The single unit the budgeter works in —
+    /// today there are three packing passes over recall alone, in two
+    /// different units (tokens, then chars).
+    pub est_tokens: u64,
+}
+
+/// How the budgeter orders sources when it cannot afford all of them.
+///
+/// Deliberately a fixed precedence rather than a tuned weight per source.
+/// The four engines' scores are not commensurable, so any single blended
+/// number would be a fabricated comparison — and a fabricated comparison
+/// between a `must` rule and a skill is a governance failure, not a ranking
+/// nit. Within a source, `score` decides; across sources, this does.
+fn source_rank(source: SteeringSource) -> u8 {
+    match source {
+        // A published record is the repository's own steering policy; it
+        // outranks anything inferred.
+        SteeringSource::Record => 0,
+        // A tool the model cannot see is a capability it does not have,
+        // which fails harder than missing know-how.
+        SteeringSource::Tool => 1,
+        SteeringSource::Skill => 2,
+        SteeringSource::Memory => 3,
+        // Last until #3246 gives it an authority story.
+        SteeringSource::Plugin => 4,
+    }
+}
+
+/// A candidate the budget could not afford, kept so the drop is reportable.
+///
+/// Every existing plane drops silently except the record channel, which
+/// names what it dropped — and that is the one whose drops anybody has ever
+/// been able to debug.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DroppedCandidate {
+    pub source: SteeringSource,
+    pub handle: String,
+    pub est_tokens: u64,
+}
+
+/// What the plane decided for one query.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SteeringSet {
+    pub selected: Vec<SteeringCandidate>,
+    pub dropped: Vec<DroppedCandidate>,
+}
+
+impl SteeringSet {
+    /// Total cost of what was selected.
+    pub fn est_tokens(&self) -> u64 {
+        self.selected.iter().map(|c| c.est_tokens).sum()
+    }
+
+    /// One line per source: how many were selected and how many dropped.
+    /// `BTreeMap` so the report is ordered and therefore diffable.
+    pub fn by_source(&self) -> BTreeMap<&'static str, (usize, usize)> {
+        let mut out: BTreeMap<&'static str, (usize, usize)> = BTreeMap::new();
+        for c in &self.selected {
+            out.entry(c.source.tag()).or_default().0 += 1;
+        }
+        for d in &self.dropped {
+            out.entry(d.source.tag()).or_default().1 += 1;
+        }
+        out
+    }
+}
+
+/// The port. One implementation per host; adapters supply the candidates.
+pub trait SteeringPlane {
+    /// Everything that could help, already budgeted.
+    fn query(&self, signal: &TurnSignal<'_>) -> SteeringSet;
+}
+
+/// Fit `candidates` into `budget_tokens`, reporting what did not fit.
+///
+/// One budget for every source, which is the point: today a rule, a skill and
+/// a recalled frame are packed by three passes that cannot see each other, so
+/// "the volatile block is too big" is a question no single piece of code can
+/// answer.
+///
+/// Ordering is [`source_rank`] first, then `score` descending, then `handle`
+/// — the last is not a nicety. Selection feeds a prompt, prompt bytes feed
+/// the cache, and a tie broken by hash order would reorder the block between
+/// two otherwise identical turns and re-bill the tail (invariant 7).
+///
+/// A candidate that does not fit is **skipped, not terminal**: a cheap
+/// low-ranked candidate still lands after an expensive one is refused. The
+/// alternative — stopping at the first thing that does not fit — makes one
+/// oversized record silently evict every skill behind it.
+pub fn pack_to_budget(mut candidates: Vec<SteeringCandidate>, budget_tokens: u64) -> SteeringSet {
+    candidates.sort_by(|a, b| {
+        source_rank(a.source)
+            .cmp(&source_rank(b.source))
+            .then_with(|| b.score.total_cmp(&a.score))
+            .then_with(|| a.handle.cmp(&b.handle))
+    });
+
+    let mut set = SteeringSet::default();
+    let mut spent: u64 = 0;
+    for candidate in candidates {
+        if spent + candidate.est_tokens <= budget_tokens {
+            spent += candidate.est_tokens;
+            set.selected.push(candidate);
+        } else {
+            set.dropped.push(DroppedCandidate {
+                source: candidate.source,
+                handle: candidate.handle,
+                est_tokens: candidate.est_tokens,
+            });
+        }
+    }
+    set
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-core/src/steering/tests.rs
+++ b/crates/stella-core/src/steering/tests.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Properties of the one budgeter (#3243 Phase 2).
+
+use super::*;
+use proptest::prelude::*;
+
+fn candidate(
+    source: SteeringSource,
+    handle: &str,
+    score: f64,
+    est_tokens: u64,
+) -> SteeringCandidate {
+    SteeringCandidate {
+        source,
+        handle: handle.into(),
+        score,
+        why: format!("because {handle}"),
+        est_tokens,
+    }
+}
+
+/// Nothing is invented and nothing vanishes: every candidate handed in comes
+/// back exactly once, in `selected` or in `dropped`.
+///
+/// This is the property that makes a drop report trustworthy. A budgeter that
+/// can lose a candidate silently produces the failure every existing plane
+/// has — "it wasn't injected and nobody can say why".
+#[test]
+fn every_candidate_is_either_selected_or_reported_dropped() {
+    let candidates = vec![
+        candidate(SteeringSource::Record, "^db-url", 0.9, 40),
+        candidate(SteeringSource::Skill, "sql-style", 0.5, 80),
+        candidate(SteeringSource::Memory, "nod_a", 0.7, 500),
+        candidate(SteeringSource::Tool, "read_file", 0.4, 30),
+    ];
+
+    let set = pack_to_budget(candidates.clone(), 200);
+
+    let seen: Vec<&str> = set
+        .selected
+        .iter()
+        .map(|c| c.handle.as_str())
+        .chain(set.dropped.iter().map(|d| d.handle.as_str()))
+        .collect();
+    assert_eq!(
+        seen.len(),
+        candidates.len(),
+        "no candidate is lost: {set:?}"
+    );
+    for c in &candidates {
+        assert!(
+            seen.contains(&c.handle.as_str()),
+            "{} is unaccounted",
+            c.handle
+        );
+    }
+}
+
+/// A record outranks a tool outranks a skill outranks a memory, whatever the
+/// scores say — the four engines' numbers are not commensurable, so source
+/// precedence decides across sources and `score` only within one.
+#[test]
+fn source_precedence_beats_score_across_sources() {
+    // The memory scores highest and still loses: it is last in precedence.
+    let set = pack_to_budget(
+        vec![
+            candidate(SteeringSource::Memory, "nod_a", 0.99, 100),
+            candidate(SteeringSource::Record, "^rule", 0.01, 100),
+        ],
+        100,
+    );
+
+    assert_eq!(set.selected.len(), 1);
+    assert_eq!(set.selected[0].handle, "^rule");
+    assert_eq!(set.dropped[0].handle, "nod_a");
+}
+
+/// One oversized candidate must not evict everything behind it: the packer
+/// skips what does not fit and keeps going.
+#[test]
+fn an_unaffordable_candidate_does_not_starve_the_cheap_ones_behind_it() {
+    let set = pack_to_budget(
+        vec![
+            candidate(SteeringSource::Record, "^huge", 0.9, 10_000),
+            candidate(SteeringSource::Skill, "cheap", 0.1, 10),
+        ],
+        100,
+    );
+
+    assert_eq!(
+        set.selected
+            .iter()
+            .map(|c| c.handle.as_str())
+            .collect::<Vec<_>>(),
+        vec!["cheap"],
+        "the affordable candidate still lands"
+    );
+    assert_eq!(set.dropped[0].handle, "^huge");
+}
+
+/// The block a selection renders into is prompt bytes, and prompt bytes feed
+/// the cache — so the same candidates must pack to the same order every time,
+/// including when scores tie. A tie broken by hash order would reorder the
+/// volatile tail between two identical turns and re-bill it (invariant 7).
+#[test]
+fn ties_break_deterministically_by_handle() {
+    let tied = || {
+        vec![
+            candidate(SteeringSource::Skill, "zebra", 0.5, 10),
+            candidate(SteeringSource::Skill, "alpha", 0.5, 10),
+            candidate(SteeringSource::Skill, "mango", 0.5, 10),
+        ]
+    };
+
+    let first = pack_to_budget(tied(), 1_000);
+    let again = pack_to_budget(tied(), 1_000);
+
+    assert_eq!(first, again, "packing is a function of its input");
+    assert_eq!(
+        first
+            .selected
+            .iter()
+            .map(|c| c.handle.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "mango", "zebra"]
+    );
+}
+
+proptest! {
+    /// The budget is never exceeded, for any input. The one thing a budgeter
+    /// may not do is the thing it exists to prevent.
+    #[test]
+    fn the_budget_is_never_exceeded(
+        costs in proptest::collection::vec(0u64..500, 0..40),
+        budget in 0u64..2_000,
+    ) {
+        let candidates: Vec<_> = costs
+            .iter()
+            .enumerate()
+            .map(|(i, &cost)| candidate(SteeringSource::Skill, &format!("s{i}"), 0.5, cost))
+            .collect();
+
+        let set = pack_to_budget(candidates, budget);
+
+        prop_assert!(
+            set.est_tokens() <= budget,
+            "spent {} of {budget}",
+            set.est_tokens()
+        );
+        prop_assert_eq!(set.selected.len() + set.dropped.len(), costs.len());
+    }
+}

--- a/crates/stella-core/src/steering/tests.rs
+++ b/crates/stella-core/src/steering/tests.rs
@@ -100,6 +100,33 @@ fn an_unaffordable_candidate_does_not_starve_the_cheap_ones_behind_it() {
     assert_eq!(set.dropped[0].handle, "^huge");
 }
 
+/// An estimate near `u64::MAX` must read as "does not fit", not wrap the
+/// running sum back under the budget. With wrapping arithmetic the second
+/// candidate below computes `10 + u64::MAX = 9`, "fits" a budget of 100, and
+/// the budgeter selects the one candidate least able to afford — while the
+/// cheap candidate behind it is squeezed out by the corrupted counter.
+#[test]
+fn a_token_estimate_near_u64_max_cannot_wrap_into_the_budget() {
+    let set = pack_to_budget(
+        vec![
+            candidate(SteeringSource::Record, "^first", 0.9, 10),
+            candidate(SteeringSource::Skill, "absurd", 0.5, u64::MAX),
+            candidate(SteeringSource::Memory, "nod_cheap", 0.5, 10),
+        ],
+        100,
+    );
+
+    assert_eq!(
+        set.selected
+            .iter()
+            .map(|c| c.handle.as_str())
+            .collect::<Vec<_>>(),
+        vec!["^first", "nod_cheap"],
+        "the overflowing estimate is dropped and the cheap one still lands"
+    );
+    assert_eq!(set.dropped[0].handle, "absurd");
+}
+
 /// The block a selection renders into is prompt bytes, and prompt bytes feed
 /// the cache — so the same candidates must pack to the same order every time,
 /// including when scores tie. A tie broken by hash order would reorder the


### PR DESCRIPTION
#3243 Phase 2 — the seam the four planes collapse into, and the one switch.


`stella_core::steering` — the port and the vocabulary:

| Type | What it carries |
|---|---|
| `TurnSignal` | what the turn has **become**: recent tool calls, touched paths (incl. created), active domains, diagnostic codes, and the `step`/`since_last_query` pair hysteresis needs |
| `SteeringCandidate` | `source`, `handle`, `score`, `why`, `est_tokens` |
| `SteeringSet` | selected + a **drop report**, plus `by_source()` |
| `SteeringPlane` | the port itself |
| `pack_to_budget` | one budget, one unit, across all sources |

Every current selector takes a `&str` prompt and fires once at turn start. A forty-step turn that opens on "fix the flaky test" and ends in a provider adapter is still selecting against its first sentence. `TurnSignal` is the input that makes Phase 3 possible; this PR defines it and the budgeter it feeds.

## Three design calls worth reviewing

**Cross-source ordering is a fixed precedence, not a blended weight.** The four engines normalize differently — RRF/MMR, glob matching, lexical coverage, `discovery::rank` — so a single blended number would be a fabricated comparison. A fabricated comparison between a `must` rule and a skill is a governance failure, not a ranking nit. `score` decides *within* a source; `source_rank` decides *across* (Record → Tool → Skill → Memory → Plugin).

**A candidate that does not fit is skipped, not terminal.** Stopping at the first unaffordable candidate lets one oversized record silently evict every skill behind it.

**`SteeringSource::Plugin` is declared and produced by nothing.** #3246 sequences plugins last; the entire cost of a fifth source arriving later is whether this enum anticipated it. It costs nothing now and saves a migration.

## The switch

`context.steering.enabled` (default **on**) + `STELLA_CONTEXT_STEERING`, resolved **once** in `Settings::load` and carried on `AuthorityPolicy::steering_allowed`, so every injection site reads one already-answered question instead of re-deriving it and drifting.

```
built-in default (ON)
  < user < org-managed < project
  < STELLA_CONTEXT_STEERING        ← env wins the ordinary chain
  ⟂ managed ceiling applied LAST   ← the org's "off" is final
```

Two sentences: **anyone may turn steering off; only the org may prevent it being turned back on** — exactly `apply_tool_ceiling`'s existing two-part shape, so no new concept.

**Why the ceiling is a separate field.** `context` is a whole-block last-wins merge honored from an *untrusted* project scope. Folded into the merged block, "the project turned it off" and "the org forbade it" would be the same value — and then `STELLA_CONTEXT_STEERING=1`, which is *supposed* to override a project's off, could not tell that case apart from the org's. So the ceiling is captured from the managed snapshot alone.

`env_toggle` is new beside `env_flag`: a switch that defaults **on** needs the third state, because "unset" must mean "defer to settings", not "off". Same strict `1|true|yes|on` allowlist, so `STELLA_CONTEXT_STEERING=false` turns steering off rather than opening it — the `STELLA_TRUST_PROJECT` defect that gave `truthy_flag` its allowlist in the first place.

Off withholds every non-prefix injection (frames, records, skills) and leaves the byte-stable prefix untouched — a control arm, not a different agent. The gate sits **before** retrieval, so an off session pays nothing rather than fetching and discarding.

## Witnesses

- `steering_turned_off_injects_nothing` — withholds a domain-anchored skill the same session otherwise selects.
- `a_managed_steering_ceiling_cannot_be_lifted_by_the_project` — verified failing by sourcing the ceiling from the merged view instead of the managed snapshot, which is precisely the trust hole it guards. Deliberately exercises `merge_captured_scopes` rather than the env var: `set_var` is a race under the concurrent test runner (which is why `truthy_flag` exists as a pure predicate), and the ceiling is the leg with a trust boundary in it.
- Budgeter: budget never exceeded (proptest), no candidate lost, precedence beats score, oversized candidate does not starve cheap ones, ties deterministic.

**Phase 0's completeness guard fired on `steering_ceiling` the moment I added it** — a compile error until I declared its merge posture. That is the guard doing exactly what #3275 built it for, on the very next field added.

```
cargo test -p stella-core --lib        # 1258 passed, 0 failed
cargo test -p stella-cli --bin stella  # 1736 passed, 0 failed
cargo clippy -p stella-core -p stella-cli -p stella-pipeline --all-targets   # clean
cargo fmt -- --check                   # clean
```

## Scope — what this deliberately does NOT do

The epic's Phase 2 also calls for **migrating the four existing selectors onto the port** as a pure refactor with byte-identical output. That is not here. It is a mechanical change across four call sites in three crates, and reviewing it in the same diff as a new authority-carrying flag would bury both. The types and the budgeter land first so the migration has somewhere to land and the flag has something to gate; the migration follows as its own PR, where a golden byte-identity test is the whole review.

So: the switch is real and wired, and `SteeringPlane` currently has no production implementor. That is a declared gap, not an oversight — filed as the next slice.

No tests deleted or renamed.

Refs #3243, #3246

## Summary by Sourcery

Introduce a unified steering plane abstraction with a single cross-source budgeter and wire a session-wide steering master switch into settings and memory, governed by org-managed ceilings and an env override.

New Features:
- Add steering plane types and trait (`TurnSignal`, `SteeringCandidate`, `SteeringSet`, `SteeringPlane`) plus a single token-budget packer shared across steering sources.
- Introduce context steering settings and an environment-controlled steering switch that can disable all non-prefix injections while leaving the system prefix intact.

Enhancements:
- Carry a resolved `steering_allowed` flag in `AuthorityPolicy` and propagate it into `SessionMemory` so all injection sites make a single consistent steering decision.
- Add a managed `steering_ceiling` field derived from the org-managed scope to prevent untrusted project configs from re-enabling org-disabled steering.
- Extend settings completeness tracking and TOML parsing to account for steering-related computed fields.

Tests:
- Add property and unit tests for the steering budgeter to ensure it never exceeds budget, preserves all candidates, respects source precedence, and behaves deterministically under ties.
- Add tests asserting that steering-off sessions inject nothing and that a managed steering ceiling cannot be lifted by project configuration.