### PR TITLE
fix(scripts): stop selecting --help text by hardcoded line numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ doc-warnings: ## Assert rustdoc is clean workspace-wide, private items included 
 
 .PHONY: shellcheck
 shellcheck: ## Lint install.sh, scripts/*.sh, and .githooks/* (#916)
-	shellcheck install.sh scripts/*.sh .githooks/*
+	shellcheck install.sh scripts/*.sh scripts/lib/*.sh .githooks/*
 
 # Deliberately not part of `gate`: it needs a Docker daemon, which the gate
 # must not. CI runs the same two commands (.github/workflows/docker-serve.yml).

--- a/scripts/arena-kill.sh
+++ b/scripts/arena-kill.sh
@@ -9,7 +9,7 @@
 #                  the destructive mode; see "Which signal" below
 #     --timeout N  seconds to wait for a signalled server to exit before
 #                  escalating to KILL (default 5, or 20 with --cancel)
-# (--help text ends here.)
+# --help text ends here.
 #
 # WHY THIS EXISTS
 #
@@ -59,15 +59,15 @@
 
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 DRY_RUN=0
 SIGNAL="TERM"
 TIMEOUT=""
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
 usage() {
-  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+  print_help_header "$0"
 }
 
 while [ $# -gt 0 ]; do

--- a/scripts/arena-kill.sh
+++ b/scripts/arena-kill.sh
@@ -9,6 +9,7 @@
 #                  the destructive mode; see "Which signal" below
 #     --timeout N  seconds to wait for a signalled server to exit before
 #                  escalating to KILL (default 5, or 20 with --cancel)
+# (--help text ends here.)
 #
 # WHY THIS EXISTS
 #
@@ -62,8 +63,11 @@ DRY_RUN=0
 SIGNAL="TERM"
 TIMEOUT=""
 
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
 usage() {
-  sed -n '2,12p' "$0"
+  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
 }
 
 while [ $# -gt 0 ]; do

--- a/scripts/arena-local.sh
+++ b/scripts/arena-local.sh
@@ -15,6 +15,7 @@
 #                         (default 5; 0 disables)
 #     --allow-stale-sut   launch anyway, and say why
 #     --dry-run, -n       resolve and report everything, launch nothing
+# (--help text ends here.)
 #
 # WHY THIS EXISTS ALONGSIDE arena-run.sh
 #
@@ -62,7 +63,10 @@ DRY_RUN=0
 PASSTHRU=()
 FORWARD=()
 
-usage() { sed -n '2,20p' "$0"; }
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
+usage() { awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; }
 
 bold=""; dim=""; red=""; green=""; yellow=""; reset=""
 if [ -t 1 ]; then

--- a/scripts/arena-local.sh
+++ b/scripts/arena-local.sh
@@ -15,7 +15,7 @@
 #                         (default 5; 0 disables)
 #     --allow-stale-sut   launch anyway, and say why
 #     --dry-run, -n       resolve and report everything, launch nothing
-# (--help text ends here.)
+# --help text ends here.
 #
 # WHY THIS EXISTS ALONGSIDE arena-run.sh
 #
@@ -51,6 +51,9 @@
 
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 TEMPLATE=""
 PULL_CHOICE=""
 DRY_RUN=0
@@ -63,10 +66,7 @@ DRY_RUN=0
 PASSTHRU=()
 FORWARD=()
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
-usage() { awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; }
+usage() { print_help_header "$0"; }
 
 bold=""; dim=""; red=""; green=""; yellow=""; reset=""
 if [ -t 1 ]; then

--- a/scripts/arena-run.sh
+++ b/scripts/arena-run.sh
@@ -13,7 +13,7 @@
 #     ARENA_PYTHON    interpreter override — must import BOTH `arenabench` and
 #                     `stella_harbor`; see "Which interpreter" below
 #     STELLA_BINARY   the SUT the seats run (default ~/.arenabench/sut/stella)
-# (--help text ends here.)
+# --help text ends here.
 #
 # A bare `arenabench serve` starts a server that looks completely healthy and
 # loses every Stella seat. Three things have to be true at launch, none of them
@@ -73,16 +73,16 @@
 
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 DEFAULT_PORT=8900
 PORT="${ARENA_PORT:-}"
 PORT_PINNED=0
 DRY_RUN=0
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
 usage() {
-  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+  print_help_header "$0"
 }
 
 if [ -n "$PORT" ]; then PORT_PINNED=1; fi

--- a/scripts/arena-run.sh
+++ b/scripts/arena-run.sh
@@ -13,6 +13,7 @@
 #     ARENA_PYTHON    interpreter override — must import BOTH `arenabench` and
 #                     `stella_harbor`; see "Which interpreter" below
 #     STELLA_BINARY   the SUT the seats run (default ~/.arenabench/sut/stella)
+# (--help text ends here.)
 #
 # A bare `arenabench serve` starts a server that looks completely healthy and
 # loses every Stella seat. Three things have to be true at launch, none of them
@@ -77,8 +78,11 @@ PORT="${ARENA_PORT:-}"
 PORT_PINNED=0
 DRY_RUN=0
 
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
 usage() {
-  sed -n '2,17p' "$0"
+  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
 }
 
 if [ -n "$PORT" ]; then PORT_PINNED=1; fi

--- a/scripts/automerge-nudge.sh
+++ b/scripts/automerge-nudge.sh
@@ -4,7 +4,7 @@
 #
 #   ./scripts/automerge-nudge.sh [--base main] [--dry-run]
 #   ./scripts/automerge-nudge.sh --select [--base main]   # pure: JSON on stdin
-# (--help text ends here.)
+# --help text ends here.
 #
 # ── The deadlock ─────────────────────────────────────────────────────────────
 #
@@ -38,6 +38,9 @@
 # rather than a fallback.
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 base="main"
 dry_run=0
 select_only=0
@@ -47,9 +50,7 @@ while [ $# -gt 0 ]; do
     --base) base="${2:?--base needs a branch}"; shift 2 ;;
     --dry-run) dry_run=1; shift ;;
     --select) select_only=1; shift ;;
-    # The header up to its sentinel — a hardcoded line range truncates
-    # silently when the header grows (#3350).
-    -h|--help) awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
+    -h|--help) print_help_header "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/automerge-nudge.sh
+++ b/scripts/automerge-nudge.sh
@@ -4,6 +4,7 @@
 #
 #   ./scripts/automerge-nudge.sh [--base main] [--dry-run]
 #   ./scripts/automerge-nudge.sh --select [--base main]   # pure: JSON on stdin
+# (--help text ends here.)
 #
 # ── The deadlock ─────────────────────────────────────────────────────────────
 #
@@ -46,7 +47,9 @@ while [ $# -gt 0 ]; do
     --base) base="${2:?--base needs a branch}"; shift 2 ;;
     --dry-run) dry_run=1; shift ;;
     --select) select_only=1; shift ;;
-    -h|--help) sed -n '2,8p' "$0"; exit 0 ;;
+    # The header up to its sentinel — a hardcoded line range truncates
+    # silently when the header grows (#3350).
+    -h|--help) awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/check-releases-published.sh
+++ b/scripts/check-releases-published.sh
@@ -4,7 +4,7 @@
 #
 #   ./scripts/check-releases-published.sh [--grace-secs N]
 #   ./scripts/check-releases-published.sh --select --now <unix> --grace-secs <n>   # pure: JSON on stdin
-# (--help text ends here.)
+# --help text ends here.
 #
 # ── The silence ──────────────────────────────────────────────────────────────
 #
@@ -42,6 +42,9 @@
 # silence it exists to break lasts that much longer.
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 grace_secs=$((90 * 60))
 select_only=0
 update=0
@@ -61,9 +64,7 @@ while [ $# -gt 0 ]; do
     --now) now="${2:?--now needs a unix timestamp}"; shift 2 ;;
     --select) select_only=1; shift ;;
     --update) update=1; shift ;;
-    # The header up to its sentinel — a hardcoded line range truncates
-    # silently when the header grows (#3350).
-    -h|--help) awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
+    -h|--help) print_help_header "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/check-releases-published.sh
+++ b/scripts/check-releases-published.sh
@@ -4,6 +4,7 @@
 #
 #   ./scripts/check-releases-published.sh [--grace-secs N]
 #   ./scripts/check-releases-published.sh --select --now <unix> --grace-secs <n>   # pure: JSON on stdin
+# (--help text ends here.)
 #
 # ── The silence ──────────────────────────────────────────────────────────────
 #
@@ -60,7 +61,9 @@ while [ $# -gt 0 ]; do
     --now) now="${2:?--now needs a unix timestamp}"; shift 2 ;;
     --select) select_only=1; shift ;;
     --update) update=1; shift ;;
-    -h|--help) sed -n '2,8p' "$0"; exit 0 ;;
+    # The header up to its sentinel — a hardcoded line range truncates
+    # silently when the header grows (#3350).
+    -h|--help) awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/demo-scenario.sh
+++ b/scripts/demo-scenario.sh
@@ -22,15 +22,16 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 LOOPS=3
 CLEAN=1
 while [ $# -gt 0 ]; do
   case "$1" in
     --loops)    LOOPS="$2"; shift 2 ;;
     --no-clean) CLEAN=0; shift ;;
-    # The whole header comment block, bounded by its first non-comment line —
-    # a hardcoded line range truncates silently when the header grows (#3350).
-    -h|--help)  awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
+    -h|--help)  print_help_header "$0"; exit 0 ;;
     *)          echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done

--- a/scripts/demo-scenario.sh
+++ b/scripts/demo-scenario.sh
@@ -28,7 +28,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --loops)    LOOPS="$2"; shift 2 ;;
     --no-clean) CLEAN=0; shift ;;
-    -h|--help)  sed -n '2,22p' "$0" | sed 's/^#//; s/^ //'; exit 0 ;;
+    # The whole header comment block, bounded by its first non-comment line —
+    # a hardcoded line range truncates silently when the header grows (#3350).
+    -h|--help)  awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; exit 0 ;;
     *)          echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done

--- a/scripts/impacted-crates.sh
+++ b/scripts/impacted-crates.sh
@@ -23,7 +23,7 @@
 #
 #   scripts/impacted-crates.sh --range <base>..<head>
 #   git diff --name-only A B | scripts/impacted-crates.sh
-# (--help text ends here.)
+# --help text ends here.
 #
 # WHY THIS IS MORE THAN A REVERSE-DEPENDENCY WALK
 #
@@ -73,6 +73,9 @@
 # no associative arrays (same constraint as scripts/check-file-size.sh).
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 full() {
 	printf '%s\n' "--workspace"
 	printf 'impacted-crates: full workspace — %s\n' "$1" >&2
@@ -91,10 +94,7 @@ while [ $# -gt 0 ]; do
 		shift 2
 		;;
 	-h | --help)
-		# The header up to its sentinel. The previous hardcoded range cut
-		# off mid-sentence after the header grew — exactly the silent
-		# truncation #3350 is about.
-		awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+		print_help_header "$0"
 		exit 0
 		;;
 	*)

--- a/scripts/impacted-crates.sh
+++ b/scripts/impacted-crates.sh
@@ -23,6 +23,7 @@
 #
 #   scripts/impacted-crates.sh --range <base>..<head>
 #   git diff --name-only A B | scripts/impacted-crates.sh
+# (--help text ends here.)
 #
 # WHY THIS IS MORE THAN A REVERSE-DEPENDENCY WALK
 #
@@ -90,7 +91,10 @@ while [ $# -gt 0 ]; do
 		shift 2
 		;;
 	-h | --help)
-		sed -n '2,30p' "$0"
+		# The header up to its sentinel. The previous hardcoded range cut
+		# off mid-sentence after the header grew — exactly the silent
+		# truncation #3350 is about.
+		awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
 		exit 0
 		;;
 	*)

--- a/scripts/lib/help-header.sh
+++ b/scripts/lib/help-header.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=sh
+#
+# Sourced helper: the one implementation of the `--help` printers in
+# scripts/ (#3350). Source it relative to the calling script, before any
+# `cd`, so `$0` still resolves:
+#
+#   # shellcheck source=scripts/lib/help-header.sh
+#   . "$(dirname "$0")/lib/help-header.sh"
+#   usage() { print_help_header "$0"; }
+
+# Print FILE's leading `#` comment block — everything after the shebang,
+# uncommented. Stops at the sentinel line
+#
+#   # --help text ends here.
+#
+# when the header carries one (so the operational WHY prose below it stays
+# out of --help), or at the first non-comment line otherwise. Selecting by
+# content instead of a hardcoded line range is the point: a range truncates
+# silently the first time the header grows (#3350).
+print_help_header() {
+  awk '
+    NR == 1 { next }
+    /^# --help text ends here\.[[:space:]]*$/ { exit }
+    !/^#/ { exit }
+    { sub(/^# ?/, ""); print }
+  ' "$1"
+}

--- a/scripts/reap-agents.sh
+++ b/scripts/reap-agents.sh
@@ -12,7 +12,7 @@
 #     --min-idle-secs   age threshold before a process is even considered
 #                       (default 1200 = 20 minutes)
 #     --sample-secs     CPU-activity sampling window (default 5)
-# (--help text ends here.)
+# --help text ends here.
 #
 # Two things this hunts, both left behind the same way: a hard kill of the
 # parent (crash, OOM, closed terminal) reparents its children to launchd
@@ -65,17 +65,17 @@
 
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 MIN_IDLE_SECS=1200
 SAMPLE_SECS=5
 ASSUME_YES=0
 DRY_RUN=0
 VERBOSE=0
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
 usage() {
-  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+  print_help_header "$0"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/reap-agents.sh
+++ b/scripts/reap-agents.sh
@@ -12,6 +12,7 @@
 #     --min-idle-secs   age threshold before a process is even considered
 #                       (default 1200 = 20 minutes)
 #     --sample-secs     CPU-activity sampling window (default 5)
+# (--help text ends here.)
 #
 # Two things this hunts, both left behind the same way: a hard kill of the
 # parent (crash, OOM, closed terminal) reparents its children to launchd
@@ -70,8 +71,11 @@ ASSUME_YES=0
 DRY_RUN=0
 VERBOSE=0
 
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
 usage() {
-  sed -n '2,15p' "$0"
+  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/reap-seats.sh
+++ b/scripts/reap-seats.sh
@@ -13,7 +13,7 @@
 #     --min-idle-secs    age threshold before a seat is considered (default 1200)
 #     --sample-secs      CPU-activity sampling window (default 5)
 #     --keep-containers  reap the process, leave its containers alone
-# (--help text ends here.)
+# --help text ends here.
 #
 # A seat is one `harbor run` invocation — one contestant's whole arm of a match
 # (`arenabench/arenabench/runner.py` spawns one per contestant with
@@ -69,6 +69,9 @@
 
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 MIN_IDLE_SECS=1200
 SAMPLE_SECS=5
 ASSUME_YES=0
@@ -76,11 +79,8 @@ DRY_RUN=0
 VERBOSE=0
 KEEP_CONTAINERS=0
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
 usage() {
-  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+  print_help_header "$0"
 }
 
 while [ $# -gt 0 ]; do

--- a/scripts/reap-seats.sh
+++ b/scripts/reap-seats.sh
@@ -13,6 +13,7 @@
 #     --min-idle-secs    age threshold before a seat is considered (default 1200)
 #     --sample-secs      CPU-activity sampling window (default 5)
 #     --keep-containers  reap the process, leave its containers alone
+# (--help text ends here.)
 #
 # A seat is one `harbor run` invocation — one contestant's whole arm of a match
 # (`arenabench/arenabench/runner.py` spawns one per contestant with
@@ -75,8 +76,11 @@ DRY_RUN=0
 VERBOSE=0
 KEEP_CONTAINERS=0
 
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
 usage() {
-  sed -n '2,15p' "$0"
+  awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
 }
 
 while [ $# -gt 0 ]; do

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -26,7 +26,7 @@
 #         --cast-only      record but skip rendering
 #         --render-only F  skip recording; render an existing .cast file
 #     -h, --help           show this help text
-# (--help text ends here.)
+# --help text ends here.
 #
 # Why this shape: the recording layer is asciinema, whose .cast file is an
 # append-only JSON-lines log of terminal output events. Its size scales with
@@ -70,16 +70,16 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 # ── Output helpers (house style: scripts/release.sh) ────────────────────────
 bold() { printf '\033[1m%s\033[0m\n' "$*"; }
 info() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
 ok()   { printf '\033[32m✔ %s\033[0m\n' "$*"; }
 die()  { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
 
-# The header comment block, bounded by the sentinel above (or the first
-# non-comment line) — a hardcoded line range truncates silently when the
-# header grows (#3350).
-usage() { awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; }
+usage() { print_help_header "$0"; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -25,7 +25,8 @@
 #         --theme NAME     agg color theme (default: dracula)
 #         --cast-only      record but skip rendering
 #         --render-only F  skip recording; render an existing .cast file
-#     -h, --help           show this header
+#     -h, --help           show this help text
+# (--help text ends here.)
 #
 # Why this shape: the recording layer is asciinema, whose .cast file is an
 # append-only JSON-lines log of terminal output events. Its size scales with
@@ -75,7 +76,10 @@ info() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
 ok()   { printf '\033[32m✔ %s\033[0m\n' "$*"; }
 die()  { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
 
-usage() { sed -n '2,29p' "$0" | sed 's/^#//; s/^ //'; }
+# The header comment block, bounded by the sentinel above (or the first
+# non-comment line) — a hardcoded line range truncates silently when the
+# header grows (#3350).
+usage() { awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/scripts/repro-build.sh
+++ b/scripts/repro-build.sh
@@ -71,6 +71,9 @@
 #
 set -euo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 # The workspace root, not the caller's cwd: workspace member paths are relative
 # in the binary precisely because cargo is invoked from here. `pwd -P` and not
 # plain `pwd` (the idiom in the other guard scripts) because this path is used
@@ -94,10 +97,7 @@ while [ "$#" -gt 0 ]; do
       [ "$#" -ge 2 ] || { echo "repro-build: --glibc needs a version" >&2; exit 2; }
       glibc="$2"; shift 2 ;;
     -h | --help)
-      # The whole header comment block, bounded by its first non-comment
-      # line. The previous hardcoded range cut off mid-option after the
-      # header grew — exactly the silent truncation #3350 is about.
-      awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+      print_help_header "$0"
       exit 0 ;;
     -*)
       echo "repro-build: unknown option: $1" >&2; exit 2 ;;

--- a/scripts/repro-build.sh
+++ b/scripts/repro-build.sh
@@ -94,7 +94,10 @@ while [ "$#" -gt 0 ]; do
       [ "$#" -ge 2 ] || { echo "repro-build: --glibc needs a version" >&2; exit 2; }
       glibc="$2"; shift 2 ;;
     -h | --help)
-      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      # The whole header comment block, bounded by its first non-comment
+      # line. The previous hardcoded range cut off mid-option after the
+      # header grew — exactly the silent truncation #3350 is about.
+      awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
       exit 0 ;;
     -*)
       echo "repro-build: unknown option: $1" >&2; exit 2 ;;

--- a/scripts/self-driving.sh
+++ b/scripts/self-driving.sh
@@ -29,6 +29,9 @@
 # #448) and is owned by the binary; this script never writes a state file.
 set -uo pipefail
 
+# shellcheck source=scripts/lib/help-header.sh
+. "$(dirname "$0")/lib/help-header.sh"
+
 # ---------------------------------------------------------------------------
 # Constants that are facts about this machine and this repository
 # ---------------------------------------------------------------------------
@@ -947,11 +950,8 @@ cmd_install_commands() {
 
 # ---------------------------------------------------------------------------
 
-# The header comment IS the usage text. Read it structurally — from line 2 to
-# the first line that is not a comment — so adding a line to the header can
-# never silently truncate or overrun the help output.
 usage() {
-  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+  print_help_header "$0"
 }
 
 main() {


### PR DESCRIPTION
## What

Eleven scripts printed their `--help` text with `sed -n '2,Np' "$0"` over their own header — a range that goes quietly wrong the moment anyone edits the header, because nothing fails; the help just truncates or leaks. Reading all eleven before touching them showed the failure was not hypothetical:

| script | what its range actually printed |
|---|---|
| `repro-build.sh` | cut off **mid-option** — the usage block sits at the *end* of a header that grew past line 60, so `--help` showed the design essay and half of `--locked`'s description |
| `impacted-crates.sh` | cut off **mid-sentence** inside the "three kinds of edge" essay |
| `arena-run.sh` | printed the first prose line of the design essay |
| `arena-local.sh`, `automerge-nudge.sh`, `check-releases-published.sh` | printed the *next section's heading* (`WHY THIS EXISTS…`, `── The deadlock ──`, `── The silence ──`) |

## How

One self-bounding printer replaces all eleven:

```sh
awk 'NR == 1 { next } /^# \(--help text ends here\.\)$/ { exit } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
```

- **Whole-header scripts** (`demo-scenario.sh`, `repro-build.sh`): the block is bounded by the first non-comment line — same form PR #3343's review pass gave `check-lockfile-sync.sh` and `main-canary.sh`, which is where this pattern was first flagged.
- **Usage-subsection scripts** (the other nine): their help is deliberately only the usage/options block of a much longer design header, and there is no structural boundary common to all of them (some essays start with an all-caps heading, some with plain prose). So the boundary becomes a **declared fact in the file** — a `# (--help text ends here.)` sentinel at the split — instead of a number that has to track edits made forty lines away.

Two deliberate output changes, called out rather than slipped in: the eight scripts that piped `sed -n` raw no longer leak `# ` prefixes into their help text, and `record-demo.sh`'s `-h` description now says "show this help text" instead of "show this header" (it never showed the whole header, and now demonstrably shows the usage block).

## Witness

Ran every one of the eleven `--help` paths and asserted, per script: exit 0, the last printed line is the final usage/option line (not a heading or half a sentence), and the output contains no sentinel line, no `# ` prefix, and no script body. `repro-build.sh` now prints its complete header including the previously-severed usage block.

The fail half of the flip is the table above: on `main`, four of these print content past their intended block and two truncate mid-sentence — observable by running the same `--help` commands there.

## Verification

- `rg "sed -n '2," scripts/` — empty (the issue's done-when condition)
- `shellcheck` clean on all eleven; `make shellcheck` green
- `make guards-fast` green
- `make impacted-test` — 25/25 (the one touched script with its own suite)

No Rust changed; compile tiers left to CI.

Closes #3350

## Summary by Sourcery

Standardize how scripts print their --help text by replacing fragile sed-based line ranges with a self-bounding header printer using comment sentinels or first non-comment lines, eliminating silent truncation or leakage when headers change.

Bug Fixes:
- Fix incorrect --help output in multiple scripts where hardcoded sed line ranges either truncated usage text or leaked into neighboring documentation sections.

Enhancements:
- Ensure all affected scripts strip leading comment markers from help output and align help descriptions, including clarifying record-demo.sh's -h message to describe the actual help text shown.