### PR TITLE
fix(stella-tools): restore the silent-success stamp the #3346 merge dropped

### DIFF
--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -857,7 +857,9 @@ impl ToolExecutor for McpToolSet {
     /// `readOnlyHint`/`idempotentHint` preserved verbatim at untrusted
     /// provenance, `destructiveHint` *raising* the grade. The placeholder
     /// tools (needs-auth, resources) resolve through the same declared path
-    /// via [`Self::declared_contract`]'s route miss.
+    /// via `Self::declared_contract`'s route miss (a private helper, so no
+    /// intra-doc link — rustdoc's `-D private-intra-doc-links` would reject
+    /// one from this public doc).
     fn contracts(&self) -> Vec<stella_protocol::ToolContract> {
         let mut contracts = Vec::new();
         if let Some(native) = &self.native {

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -730,6 +730,15 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
         // checker the registry runs (#3285). A breach is the tool's own
         // defect — `Internal`, never model misuse.
         let Some(expected) = &tool.output_schema else {
+            // A silent success (exit 0, empty stdout) renders the
+            // deterministic input-stamped line, never the empty string —
+            // an every-call-identical output is what the stagnation
+            // detector kills a loop over (#3303). A schema-declaring
+            // manifest never takes this arm: its empty stdout is a
+            // contract breach reported below.
+            if output.stdout.is_empty() {
+                return ToolOutput::ok(silent_success_stamp(&tool.name, input));
+            }
             return ToolOutput::ok(content);
         };
         let parsed: Value = match serde_json::from_str(stdout.trim()) {


### PR DESCRIPTION
## What

Two regressions landed on main within minutes of each other and are keeping `fmt + clippy + test` red on every commit since. This PR unreds main.

**1. The #3346 merge dropped #3335's silent-success stamp.** The conflict resolution in `run_custom`'s success path kept only the output-schema flow: a silent custom-tool success (exit 0, empty stdout) rendered as the empty string again — the every-call-identical output shape the engine's stagnation detector kills a loop over (#3303). `silent_success_stamp` was left defined with no caller on the success path.

**2. The #3287 merge broke the rustdoc gate.** The public doc on the MCP toolset's `contracts()` (`crates/stella-mcp/src/toolset.rs:860`) intra-doc-links the private `Self::declared_contract`, which `-D warnings` (`rustdoc::private_intra_doc_links`) rejects. Fixed by dropping the link to plain code font.

## Witness

`custom::tests::silent_success_is_stamped_with_the_input_identity` (already in tree, from #3335):

- **fails on main tip** `c47b5623a` (verified: `cargo test -p stella-tools silent_success_is_stamped` → FAILED, 256/257 otherwise green — the sole test failure on main)
- **passes with this change**

The restored arm lives inside the schema-less path deliberately: a manifest that declares `[output_schema]` never takes it — its empty stdout stays a contract breach reported as `Internal`.

The rustdoc half is witnessed by the gate itself: `make doc-warnings` fails on main tip and exits 0 here.

## Local sweep on this branch

fmt clean · clippy `-D warnings` clean · `make doc-warnings` exit 0 · `cargo test --workspace` exit 0.

Refs #3303

Closes #3359 (the composition defect this repairs is written up there).