### PR TITLE
fix(stella-tools): restore the silent-success stamp #3345's branch rewrite dropped

### DIFF
--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -723,6 +723,16 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     if output.status.success() {
+        // A silent success (exit 0, empty stdout) renders the input-identity
+        // stamp, never the empty string — see [`silent_success_stamp`] (#3303).
+        // Only for schema-less tools: a declared `[output_schema]` promises
+        // JSON on stdout, so empty stdout falls through to the contract
+        // breach below. Restored after the #3345 rewrite of this branch
+        // merged past #3335 and silently dropped the call — the two were
+        // developed in parallel and composed red (#3359).
+        if output.stdout.is_empty() && tool.output_schema.is_none() {
+            return ToolOutput::ok(silent_success_stamp(&tool.name, input));
+        }
         let content = crate::exec::truncate_middle_capped(&stdout, MAX_OUTPUT_BYTES);
         // A manifest that declares `[output_schema]` promises its stdout is
         // JSON matching it (#3287): the whole stdout is parsed into the


### PR DESCRIPTION
## What

`main` is red: `custom::tests::silent_success_is_stamped_with_the_input_identity` fails because #3345's rewrite of `run_custom`'s success branch (5e7343be9), developed in parallel with #3335 (34ef87ab8), merged textually clean and silently dropped the `silent_success_stamp` call site. The stamp function and its witness test survived; nothing called it. First surfaced on PR #3348's CI, which touches no stella-tools code — CI tests the merge with main.

This restores the guard clause at the top of the success branch, for schema-less tools only: a declared `[output_schema]` promises JSON on stdout, so an empty stdout keeps falling through to the #3287 output-contract breach (`Internal`), which is the correct composed behavior of the two features.

## Witness

`cargo test -p stella-tools --lib silent_success` fails on `main` (both renders are `""`) and passes with this change. The existing #3335 test is the witness; no new test needed.

Full `cargo test -p stella-tools` (257 tests) and `cargo clippy -p stella-tools --all-targets -- -D warnings` are green locally.

## Residue

None left behind — the defect and its history are recorded in #3359.

Closes #3359

## Summary by Sourcery

Bug Fixes:
- Fix regression where successful custom tools with empty stdout no longer produced the expected input-identity stamp output for schema-less tools.