### PR TITLE
feat(stella-core): AuthzTrace — the rule-by-rule account behind every authorization decision (#3289)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -357,7 +357,13 @@ async fn run_pipeline_one_shot(
     let result = {
         // Customs, the operator's switches, and the authorization gate,
         // outermost-last (#3283) — one assembly for every driver.
-        let tools = tool_stack::session_stack(base_tools, custom_tools, cfg, Principal::User);
+        let tools = tool_stack::session_stack(
+            base_tools,
+            custom_tools,
+            cfg,
+            Principal::User,
+            registry.hook_bus(),
+        );
 
         let ws_ports = workspace_ports(
             cfg.workspace_root.clone(),
@@ -1683,7 +1689,8 @@ async fn run_turn(
         // and the authorization gate must still hold above the session tool
         // stack — mirroring every other driver path, so disabled tools cannot
         // be invoked here either.
-        let permitted = tool_stack::policy_stack(registry, cfg, Principal::User);
+        let permitted =
+            tool_stack::policy_stack(registry, cfg, Principal::User, registry.hook_bus());
         let config = engine::engine_config_for_kind(cfg, kind);
         let engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
             .with_calibration(calibration)
@@ -1693,8 +1700,13 @@ async fn run_turn(
     } else {
         // Customs, the operator's switches, and the authorization gate,
         // outermost-last (#3283) — one assembly for every driver.
-        let tools =
-            tool_stack::session_stack(base_tools, custom_tools.to_vec(), cfg, Principal::User);
+        let tools = tool_stack::session_stack(
+            base_tools,
+            custom_tools.to_vec(),
+            cfg,
+            Principal::User,
+            registry.hook_bus(),
+        );
         let hook_runner = ShellHookRunner;
         // A PreToolUse hook's `require_approval` parks on the #2676 broker
         // flow (#2684). Snapshotted here, after assembly attached any

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -357,13 +357,8 @@ async fn run_pipeline_one_shot(
     let result = {
         // Customs, the operator's switches, and the authorization gate,
         // outermost-last (#3283) — one assembly for every driver.
-        let tools = tool_stack::session_stack(
-            base_tools,
-            custom_tools,
-            cfg,
-            Principal::User,
-            registry.hook_bus(),
-        );
+        let bus = registry.hook_bus();
+        let tools = tool_stack::session_stack(base_tools, custom_tools, cfg, Principal::User, bus);
 
         let ws_ports = workspace_ports(
             cfg.workspace_root.clone(),
@@ -1689,8 +1684,8 @@ async fn run_turn(
         // and the authorization gate must still hold above the session tool
         // stack — mirroring every other driver path, so disabled tools cannot
         // be invoked here either.
-        let permitted =
-            tool_stack::policy_stack(registry, cfg, Principal::User, registry.hook_bus());
+        let bus = registry.hook_bus();
+        let permitted = tool_stack::policy_stack(registry, cfg, Principal::User, bus);
         let config = engine::engine_config_for_kind(cfg, kind);
         let engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
             .with_calibration(calibration)
@@ -1700,13 +1695,9 @@ async fn run_turn(
     } else {
         // Customs, the operator's switches, and the authorization gate,
         // outermost-last (#3283) — one assembly for every driver.
-        let tools = tool_stack::session_stack(
-            base_tools,
-            custom_tools.to_vec(),
-            cfg,
-            Principal::User,
-            registry.hook_bus(),
-        );
+        let bus = registry.hook_bus();
+        let tools =
+            tool_stack::session_stack(base_tools, custom_tools.to_vec(), cfg, Principal::User, bus);
         let hook_runner = ShellHookRunner;
         // A PreToolUse hook's `require_approval` parks on the #2676 broker
         // flow (#2684). Snapshotted here, after assembly attached any

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -556,6 +556,7 @@ pub(crate) async fn run_goal_turn(
             custom_tools.to_vec(),
             cfg,
             Principal::User,
+            registry.hook_bus(),
         );
         let hook_runner = ShellHookRunner;
         let mut engine =
@@ -748,6 +749,7 @@ async fn run_goal_pipeline_turn(
             custom_tools.to_vec(),
             cfg,
             Principal::User,
+            registry.hook_bus(),
         );
 
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -202,6 +202,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
             custom_tools.to_vec(),
             cfg,
             Principal::User,
+            tools_registry.hook_bus(),
         );
         let hook_runner = ShellHookRunner;
         match restored {

--- a/crates/stella-cli/src/agent/tool_stack.rs
+++ b/crates/stella-cli/src/agent/tool_stack.rs
@@ -33,6 +33,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use stella_core::bus::HookBus;
 use stella_core::ports::{AuthzGate, NoAuthz, Principal, ToolExecutor};
 use stella_tools::custom::{CustomTool, CustomToolSet};
 use stella_tools::gated::GatedToolSet;
@@ -59,15 +60,30 @@ pub(crate) fn session_stack<'a>(
     custom_tools: Vec<CustomTool>,
     cfg: &Config,
     principal: Principal,
+    bus: Option<HookBus>,
 ) -> GatedToolSet<'a> {
-    session_stack_with_gate(
-        base,
-        custom_tools,
-        cfg.workspace_root.clone(),
-        session_tool_policy(cfg),
-        session_gate(),
-        principal,
+    with_journal(
+        session_stack_with_gate(
+            base,
+            custom_tools,
+            cfg.workspace_root.clone(),
+            session_tool_policy(cfg),
+            session_gate(),
+            principal,
+        ),
+        bus,
     )
+}
+
+/// Attach the session bus the gate journals its evaluations onto (#3289),
+/// when the driver carries one — `registry.hook_bus()` at every shipped call
+/// site, so the authorization plane's `(principal, tool, decision, trace)`
+/// lands in the same journal the rest of the policy plane already rides.
+fn with_journal(stack: GatedToolSet<'_>, bus: Option<HookBus>) -> GatedToolSet<'_> {
+    match bus {
+        Some(bus) => stack.with_bus(bus),
+        None => stack,
+    }
 }
 
 /// [`session_stack`] with every dependency explicit — the seam the witness
@@ -108,9 +124,13 @@ pub(crate) fn policy_stack<'a>(
     base: &'a dyn ToolExecutor,
     cfg: &Config,
     principal: Principal,
+    bus: Option<HookBus>,
 ) -> GatedToolSet<'a> {
     let permitted = PolicyToolSet::new(base, session_tool_policy(cfg));
-    GatedToolSet::new_boxed(Box::new(permitted), session_gate(), principal)
+    with_journal(
+        GatedToolSet::new_boxed(Box::new(permitted), session_gate(), principal),
+        bus,
+    )
 }
 
 /// [`policy_stack`] owning its base by `Arc` — for a best-of-N candidate
@@ -121,9 +141,13 @@ pub(crate) fn policy_stack_owned(
     base: Arc<dyn ToolExecutor>,
     policy: ToolPolicy,
     principal: Principal,
+    bus: Option<HookBus>,
 ) -> GatedToolSet<'static> {
     let permitted = PolicyToolSet::new_owned(base, policy);
-    GatedToolSet::new_owned(Arc::new(permitted), session_gate(), principal)
+    with_journal(
+        GatedToolSet::new_owned(Arc::new(permitted), session_gate(), principal),
+        bus,
+    )
 }
 
 #[cfg(test)]
@@ -245,6 +269,7 @@ mod tests {
             Arc::new(Leaf::new()),
             ToolPolicy::allow_all(),
             Principal::Role("worker".into()),
+            None,
         );
         assert!(matches!(
             stack.execute("get_state", &json!({})).await,

--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -441,6 +441,11 @@ impl GitCandidateWorkspaces {
                 // (the workspace outlives every borrow). Custom tools re-root
                 // to `ws_root`, so their subprocesses run in the shadow.
                 let board = registry.task_board();
+                // Captured while `registry` is still concrete, like the
+                // attachments above: the gate journals its evaluations onto
+                // the same bus `attach_rule_guards` gave this candidate
+                // (#3289).
+                let candidate_bus = registry.hook_bus();
                 let registry: Arc<dyn stella_core::ToolExecutor> = Arc::new(registry);
                 // `canon_root`, not `self.root`: the frame screen compares
                 // spellings, and the goal's paths are phrased against the
@@ -469,6 +474,7 @@ impl GitCandidateWorkspaces {
                         tools,
                         self.policy.clone(),
                         stella_core::ports::Principal::Role("worker".into()),
+                        candidate_bus,
                     ));
                 // Outside even the policy wrap, like the deck's session tap
                 // (#1719) — see `task_events`'s module doc.

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -3954,8 +3954,13 @@ async fn run_lead_turn(
     let outcome = {
         // Customs, the operator's switches, and the authorization gate
         // (#3283) — the deck's lead turn acts as the human at the keyboard.
-        let permitted =
-            agent::tool_stack::session_stack(&claims, custom_tools.to_vec(), cfg, Principal::User);
+        let permitted = agent::tool_stack::session_stack(
+            &claims,
+            custom_tools.to_vec(),
+            cfg,
+            Principal::User,
+            registry.hook_bus(),
+        );
         let tapped = TaskTap::new(&permitted, tx.clone(), registry, Some(sup_tx.clone()));
         let hook_runner = ShellHookRunner;
         let mut engine = Engine::with_sleeper(

--- a/crates/stella-cli/src/command_deck/pipeline_turn.rs
+++ b/crates/stella-cli/src/command_deck/pipeline_turn.rs
@@ -89,6 +89,7 @@ pub(super) async fn run_lead_pipeline_turn(
             custom_tools.to_vec(),
             cfg,
             stella_core::ports::Principal::User,
+            registry.hook_bus(),
         );
         let tapped = TaskTap::new(&permitted, tx.clone(), registry, Some(sup_tx.clone()));
 

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -707,6 +707,7 @@ async fn run_task(
         &claims,
         &cfg,
         stella_core::ports::Principal::SubAgent(task.id.to_string()),
+        registry.hook_bus(),
     );
     // Every fleet attempt owns the same durable event/accounting envelope as
     // a one-shot or deck turn. The store is rooted in the task worktree so

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -723,6 +723,7 @@ async fn run_worker(
         &claims,
         cfg,
         stella_core::ports::Principal::SubAgent(format!("{session_id}/{}", spec.lane)),
+        registry.hook_bus(),
     );
     // Registry-born events (task board, sub-agent lifecycle) ride this
     // lane's own channel, so the lane's live view and its journal agree.

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -8,7 +8,10 @@ use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::{Provider, ToolOutput, ToolSchema};
 
-pub use authz::{AuthzDecision, AuthzEvalError, AuthzGate, NoAuthz, Principal, RiskCeiling};
+pub use authz::{
+    AuthzContribution, AuthzDecision, AuthzEvalError, AuthzEvaluation, AuthzGate, AuthzRuleTrace,
+    AuthzTrace, NoAuthz, Principal, RiskCeiling,
+};
 
 /// Executes one tool call. Implemented by `stella-tools::ToolRegistry` (and
 /// by test doubles). The engine treats it as a black box that never panics.

--- a/crates/stella-core/src/ports/authz.rs
+++ b/crates/stella-core/src/ports/authz.rs
@@ -121,6 +121,82 @@ impl From<AuthzDecision> for HookDecision {
     }
 }
 
+/// What one rule inside a gate contributed to a decision (#3289).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthzContribution {
+    /// The rule matched and would allow the call.
+    Allow,
+    /// The rule matched and would refuse the call.
+    Deny,
+    /// The rule matched and would park the call on a human.
+    RequireApproval,
+    /// The rule was evaluated and did not match — recorded so "was this
+    /// rule even consulted" is answerable after the fact.
+    None,
+}
+
+/// One evaluated rule inside an [`AuthzTrace`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AuthzRuleTrace {
+    /// The rule's identifier, as its gate spells it. An identifier, never
+    /// content: no tool inputs, no paths, no model output (the trace may
+    /// ride audit surfaces, and invariant #3 governs what those carry).
+    pub rule: String,
+    /// Whether the rule matched this call.
+    pub matched: bool,
+    /// What the rule contributed when it matched.
+    pub contribution: AuthzContribution,
+    /// Whether this rule's contribution is the one that decided the call.
+    /// At most one entry per trace carries `true`.
+    pub deciding: bool,
+}
+
+/// The rule-by-rule account of one authorization decision (#3289): which
+/// rules were evaluated, in order, which matched, and which one decided.
+///
+/// "Why was this denied" as a **value** — serde-first, so it survives into
+/// the journal and a test can assert on it, instead of a log line somebody
+/// greps. Built by pure resolvers over prefetched data (invariant #2).
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AuthzTrace {
+    /// The evaluated rules, in evaluation order.
+    pub rules: Vec<AuthzRuleTrace>,
+}
+
+impl AuthzTrace {
+    /// The honest trace for a gate that is itself one rule — [`NoAuthz`],
+    /// [`RiskCeiling`], any gate that does not override
+    /// [`AuthzGate::check_traced`]: one entry, named after the gate,
+    /// matched and deciding, contributing whatever the gate decided.
+    #[must_use]
+    pub fn single(rule: impl Into<String>, decision: &AuthzDecision) -> Self {
+        let contribution = match decision {
+            AuthzDecision::Allow => AuthzContribution::Allow,
+            AuthzDecision::Deny { .. } => AuthzContribution::Deny,
+            AuthzDecision::RequireApproval { .. } => AuthzContribution::RequireApproval,
+        };
+        Self {
+            rules: vec![AuthzRuleTrace {
+                rule: rule.into(),
+                matched: true,
+                contribution,
+                deciding: true,
+            }],
+        }
+    }
+}
+
+/// A decision together with its rule-by-rule account (#3289) — what
+/// [`AuthzGate::check_traced`] returns, and what a call site journals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthzEvaluation {
+    /// What the gate decided.
+    pub decision: AuthzDecision,
+    /// How it got there.
+    pub trace: AuthzTrace,
+}
+
 /// A gate that could not reach a decision.
 ///
 /// Named and typed rather than a bare `String` (invariant #5) because the
@@ -181,6 +257,27 @@ pub trait AuthzGate: Send + Sync {
         principal: &Principal,
         input: &Value,
     ) -> Result<AuthzDecision, AuthzEvalError>;
+
+    /// [`Self::check`], returning the decision together with its
+    /// rule-by-rule [`AuthzTrace`] (#3289) — what the dispatch seams call,
+    /// so every journaled decision carries its account.
+    ///
+    /// The default derives the honest trace for a gate that is itself one
+    /// rule: a single entry named after the gate, matched and deciding. A
+    /// gate with internal rule structure overrides this — and keeps the
+    /// `Result` split exactly as [`Self::check`] has it: the trace is not
+    /// an excuse to soften an evaluation failure into a partial answer.
+    fn check_traced(
+        &self,
+        contract: &ToolContract,
+        principal: &Principal,
+        input: &Value,
+    ) -> Result<AuthzEvaluation, AuthzEvalError> {
+        self.check(contract, principal, input).map(|decision| {
+            let trace = AuthzTrace::single(self.name(), &decision);
+            AuthzEvaluation { decision, trace }
+        })
+    }
 }
 
 /// The explicit "no authorization plane is installed" gate.
@@ -400,6 +497,119 @@ mod tests {
                 other => panic!("softened={softened} must still deny, got {other:?}"),
             }
         }
+    }
+
+    /// **The #3289 witness.** A gate with three rules, of which the second
+    /// denies: the emitted trace names all three in evaluation order, marks
+    /// exactly the second as deciding, and survives a serde round trip —
+    /// "why was this denied" is a value, not a log grep.
+    #[test]
+    fn a_three_rule_gate_traces_all_three_and_marks_the_decider() {
+        struct ThreeRules;
+
+        impl AuthzGate for ThreeRules {
+            fn name(&self) -> &'static str {
+                "three-rules"
+            }
+            fn check(
+                &self,
+                contract: &ToolContract,
+                principal: &Principal,
+                input: &Value,
+            ) -> Result<AuthzDecision, AuthzEvalError> {
+                self.check_traced(contract, principal, input)
+                    .map(|evaluation| evaluation.decision)
+            }
+            fn check_traced(
+                &self,
+                contract: &ToolContract,
+                _principal: &Principal,
+                _input: &Value,
+            ) -> Result<AuthzEvaluation, AuthzEvalError> {
+                // A pure resolver over prefetched data (invariant #2): every
+                // rule is evaluated, the first matching non-allow decides.
+                let trace = AuthzTrace {
+                    rules: vec![
+                        AuthzRuleTrace {
+                            rule: "allow-reads".into(),
+                            matched: false,
+                            contribution: AuthzContribution::None,
+                            deciding: false,
+                        },
+                        AuthzRuleTrace {
+                            rule: "deny-mutations".into(),
+                            matched: true,
+                            contribution: AuthzContribution::Deny,
+                            deciding: true,
+                        },
+                        AuthzRuleTrace {
+                            rule: "default-allow".into(),
+                            matched: true,
+                            contribution: AuthzContribution::Allow,
+                            deciding: false,
+                        },
+                    ],
+                };
+                Ok(AuthzEvaluation {
+                    decision: AuthzDecision::Deny {
+                        reason: format!("`{}` mutates and mutations are denied", contract.name()),
+                    },
+                    trace,
+                })
+            }
+        }
+
+        let evaluation = ThreeRules
+            .check_traced(
+                &contract("write_file", RiskLevel::Medium),
+                &Principal::User,
+                &serde_json::json!({}),
+            )
+            .unwrap();
+        assert!(matches!(evaluation.decision, AuthzDecision::Deny { .. }));
+
+        let trace = &evaluation.trace;
+        assert_eq!(
+            trace
+                .rules
+                .iter()
+                .map(|rule| rule.rule.as_str())
+                .collect::<Vec<_>>(),
+            ["allow-reads", "deny-mutations", "default-allow"],
+            "every evaluated rule is named, in order"
+        );
+        let deciders: Vec<&str> = trace
+            .rules
+            .iter()
+            .filter(|rule| rule.deciding)
+            .map(|rule| rule.rule.as_str())
+            .collect();
+        assert_eq!(deciders, ["deny-mutations"], "exactly one rule decides");
+
+        let json = serde_json::to_string(trace).unwrap();
+        let back: AuthzTrace = serde_json::from_str(&json).unwrap();
+        assert_eq!(&back, trace, "the trace survives a serde round trip");
+    }
+
+    /// A gate that does not override `check_traced` still produces an honest
+    /// account: itself, as the one rule, deciding.
+    #[test]
+    fn an_untraced_gate_derives_its_single_rule_trace() {
+        let evaluation = RiskCeiling::new(RiskLevel::Medium)
+            .check_traced(
+                &contract("bash", RiskLevel::High),
+                &Principal::User,
+                &serde_json::json!({}),
+            )
+            .unwrap();
+        assert!(matches!(evaluation.decision, AuthzDecision::Deny { .. }));
+        assert_eq!(evaluation.trace.rules.len(), 1);
+        assert_eq!(evaluation.trace.rules[0].rule, "risk-ceiling");
+        assert_eq!(
+            evaluation.trace.rules[0].contribution,
+            AuthzContribution::Deny
+        );
+        assert!(evaluation.trace.rules[0].deciding);
     }
 
     /// The other half: an operator deny outranks a gate that allows.

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -84,7 +84,7 @@ use stella_core::hooks::decision::{
     ApprovalRoute, ApprovalRouteRequest, ApprovalRouteResolution, GateVerdict, OperatorPosture,
 };
 use stella_core::ports::authz::authz_verdict;
-use stella_core::ports::{AuthzGate, Principal, ToolExecutor};
+use stella_core::ports::{AuthzDecision, AuthzEvalError, AuthzGate, Principal, ToolExecutor};
 use stella_protocol::tool::{ErrorClass, ToolOutput, ToolSchema};
 
 use crate::contracts;
@@ -126,6 +126,16 @@ pub struct GatedToolSet<'a> {
     /// `stella-tty::human_can_answer` derivation, made once where the
     /// responder is attached — this decorator never re-derives presence.
     approvals: Option<Arc<dyn ApprovalRoute>>,
+    /// The session's hook bus, when the assembly attached one (#3289) —
+    /// where each evaluation's `(principal, tool, decision, trace)` is
+    /// emitted as a `policy.evaluated` event. The registry's
+    /// `bridge_policy_plane` already forwards that name into the journal as
+    /// [`stella_protocol::AgentEvent::PolicyDecision`], carrying the
+    /// `decision` payload verbatim — so the rule-by-rule account is
+    /// reconstructable after the fact without a second event vocabulary.
+    /// Optional like [`Self::approvals`]: a stack with no bus journals
+    /// nothing, it never fails a call over telemetry.
+    bus: Option<stella_core::bus::HookBus>,
     /// Contracts for everything the inner stack advertised at construction,
     /// resolved once. `execute` is on the hot path of every call and
     /// re-materializing the full schema list per call would re-serialize
@@ -155,6 +165,7 @@ impl<'a> GatedToolSet<'a> {
             gate,
             principal,
             approvals: None,
+            bus: None,
             contracts,
         }
     }
@@ -170,6 +181,63 @@ impl<'a> GatedToolSet<'a> {
     pub fn with_approval_route(mut self, route: Arc<dyn ApprovalRoute>) -> Self {
         self.approvals = Some(route);
         self
+    }
+
+    /// Attach the session bus this gate journals its evaluations onto
+    /// (#3289) — see the `bus` field for the route into the journal. Opt-in
+    /// like [`Self::with_approval_route`], attached by `agent::tool_stack`
+    /// wherever the session carries a bus.
+    #[must_use]
+    pub fn with_bus(mut self, bus: stella_core::bus::HookBus) -> Self {
+        self.bus = Some(bus);
+        self
+    }
+
+    /// Emit one evaluation's full account onto the attached bus, if any:
+    /// who asked, for what, what the gate said, and rule by rule why. The
+    /// `decision` field is what `bridge_policy_plane` copies verbatim into
+    /// the journaled `PolicyDecision`, so the trace rides it.
+    fn journal_evaluation(
+        &self,
+        name: &str,
+        evaluation: &Result<stella_core::ports::AuthzEvaluation, AuthzEvalError>,
+    ) {
+        let Some(bus) = &self.bus else { return };
+        let decision = match evaluation {
+            Ok(evaluation) => {
+                let verdict = match &evaluation.decision {
+                    AuthzDecision::Allow => serde_json::json!({ "verdict": "allow" }),
+                    AuthzDecision::Deny { reason } => {
+                        serde_json::json!({ "verdict": "deny", "reason": reason })
+                    }
+                    AuthzDecision::RequireApproval { reason } => {
+                        serde_json::json!({ "verdict": "require_approval", "reason": reason })
+                    }
+                };
+                let mut decision = verdict;
+                decision["trace"] =
+                    serde_json::to_value(&evaluation.trace).unwrap_or(serde_json::Value::Null);
+                decision
+            }
+            // An errored evaluation is journaled too — it is the arm the
+            // fail-closed rule exists for, and the audit trail must show it
+            // as "could not tell", never as a silent deny.
+            Err(error) => serde_json::json!({
+                "verdict": "error",
+                "gate": error.gate,
+                "detail": error.detail,
+            }),
+        };
+        bus.emit_named(
+            stella_core::bus::names::POLICY_EVALUATED,
+            serde_json::json!({
+                "event_name": "authz.gate",
+                "tool": name,
+                "principal": self.principal.label(),
+                "gate": self.gate.name(),
+                "decision": decision,
+            }),
+        );
     }
 
     /// Own the inner executor by value — for an assembly function that builds
@@ -188,6 +256,7 @@ impl<'a> GatedToolSet<'a> {
             gate,
             principal,
             approvals: None,
+            bus: None,
             contracts,
         }
     }
@@ -231,6 +300,7 @@ impl GatedToolSet<'static> {
             gate,
             principal,
             approvals: None,
+            bus: None,
             contracts,
         }
     }
@@ -252,7 +322,11 @@ impl ToolExecutor for GatedToolSet<'_> {
 
     async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
         let contract = self.contract(name);
-        let evaluation = self.gate.check(&contract, &self.principal, input);
+        let evaluation = self.gate.check_traced(&contract, &self.principal, input);
+        // Journal before folding (#3289): the trace must survive whatever the
+        // verdict is, and the fold consumes the evaluation.
+        self.journal_evaluation(name, &evaluation);
+        let evaluation = evaluation.map(|evaluation| evaluation.decision);
 
         // Routed through the shared fold rather than matched here, so the
         // fail-closed rule (an `Err` denies whatever any softening flag says)
@@ -704,5 +778,72 @@ mod tests {
             ToolOutput::Ok { .. }
         ));
         assert!(route.asked().is_empty(), "no approval was ever requested");
+    }
+
+    /// **The #3289 consumer witness**: with a bus attached, every evaluation
+    /// lands as a `policy.evaluated` event whose `decision` payload carries
+    /// the rule-by-rule trace — the exact field `bridge_policy_plane` copies
+    /// verbatim into the journaled `PolicyDecision`, so "why was this
+    /// denied" is reconstructable after the fact.
+    #[tokio::test]
+    async fn an_attached_bus_journals_the_decision_with_its_trace() {
+        let bus = stella_core::bus::HookBus::new("test-session");
+        let seen: Arc<std::sync::Mutex<Vec<Value>>> = Arc::default();
+        let sink = Arc::clone(&seen);
+        bus.on(stella_core::bus::names::POLICY_EVALUATED, move |event| {
+            sink.lock().unwrap().push(event.payload.clone());
+            Ok(())
+        })
+        .detach();
+
+        let leaf = Leaf::new();
+        let gated = GatedToolSet::new(
+            &leaf,
+            Arc::new(RiskCeiling::new(RiskLevel::Medium)),
+            Principal::SubAgent("lane-1".into()),
+        )
+        .with_bus(bus);
+
+        // A refused call and an allowed one both journal.
+        assert!(gated.execute(THIRD_PARTY, &input()).await.is_error());
+        assert!(matches!(
+            gated.execute(READ, &input()).await,
+            ToolOutput::Ok { .. }
+        ));
+
+        let events = seen.lock().unwrap();
+        assert_eq!(events.len(), 2, "one account per evaluation: {events:?}");
+
+        let denied = &events[0];
+        assert_eq!(denied["event_name"], "authz.gate");
+        assert_eq!(denied["tool"], THIRD_PARTY);
+        assert_eq!(denied["principal"], "subagent:lane-1");
+        assert_eq!(denied["gate"], "risk-ceiling");
+        assert_eq!(denied["decision"]["verdict"], "deny");
+        let rules = denied["decision"]["trace"]["rules"]
+            .as_array()
+            .expect("the trace rides the decision payload");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0]["rule"], "risk-ceiling");
+        assert_eq!(rules[0]["deciding"], true);
+
+        assert_eq!(events[1]["decision"]["verdict"], "allow");
+    }
+
+    /// With no bus attached — the default every constructor produces —
+    /// nothing is journaled and nothing fails: the account is telemetry,
+    /// never a toll on the call.
+    #[tokio::test]
+    async fn no_bus_means_no_journal_and_no_failure() {
+        let leaf = Leaf::new();
+        let gated = GatedToolSet::new(&leaf, session_default(), Principal::User);
+        assert!(matches!(
+            gated.execute(READ, &input()).await,
+            ToolOutput::Ok { .. }
+        ));
+    }
+
+    fn session_default() -> Arc<dyn AuthzGate> {
+        Arc::new(NoAuthz)
     }
 }

--- a/crates/stella-tools/src/registry/approval.rs
+++ b/crates/stella-tools/src/registry/approval.rs
@@ -301,8 +301,11 @@ impl ToolRegistry {
 
     /// The session's attached hook bus, if any (cheap clone — shared
     /// inner). For the #2684 bridge, whose approval flow emits its
-    /// `approval.*` audit events on the same bus the registry's gates use.
-    pub(crate) fn hook_bus(&self) -> Option<HookBus> {
+    /// `approval.*` audit events on the same bus the registry's gates use —
+    /// and `pub` since #3289 so the tool-chain assembly (`stella-cli`'s
+    /// `agent::tool_stack`) can hand the same bus to the authorization
+    /// gate's evaluation journal without a second attachment path.
+    pub fn hook_bus(&self) -> Option<HookBus> {
         self.bus.read().unwrap_or_else(|p| p.into_inner()).clone()
     }
 


### PR DESCRIPTION
## Why

The #2716 directive puts *auditable* second only to the loop itself: every tool call's authorization decision should be a value with a rule-by-rule trace, reconstructable after the fact from the journal. PR #3281 landed the decision as a value; `Deny { reason: String }` carried one prose sentence, and "which rules were evaluated, which matched, which decided" was not recoverable at all. It was left out of #3281 deliberately rather than stubbed — this PR is where the trace gets its consumer.

## What

- **`AuthzTrace` / `AuthzRuleTrace` / `AuthzContribution`** (serde-first, `stella-core::ports::authz`) and **`AuthzEvaluation`** pairing a decision with its account. Rule entries carry **identifiers only** — never tool inputs, paths, or model output (invariant #3's posture for anything audit-shaped).
- **`AuthzGate::check_traced`**, defaulted: a gate that is itself one rule (`NoAuthz`, `RiskCeiling`, every existing impl) derives its honest single-entry trace; a rule-structured gate overrides it as a **pure resolver over prefetched data** (invariant #2), so "why was this denied" is a thing a test asserts on. The `Result<_, AuthzEvalError>` split is untouched — the trace is not an excuse to soften an evaluation failure.
- **The consumer** — the deviation from the issue's sketch, made deliberately: rather than minting a new `AgentEvent` variant, `GatedToolSet` journals every evaluation (`principal`, `tool`, `gate`, `decision` + `trace`) as a `policy.evaluated` hook event whose `decision` payload `bridge_policy_plane` **already copies verbatim** into the journaled `AgentEvent::PolicyDecision` — the variant that exists for exactly this plane, with its invariant-#10 consumers row already declared. One event vocabulary, zero wire change, and the account lands in the same journal the rest of the policy plane rides. Errored evaluations journal as `verdict: "error"` — the audit trail shows *could not tell* distinctly from *refused*.
- **Wired everywhere**: `agent::tool_stack` threads the session bus (`ToolRegistry::hook_bus()`, the accessor #2684's bridge already used internally) into every shipped chain — one-shot, goal loop, resume, deck lead + pipeline turns, subsession lanes, fleet workers, best-of-N candidates. A stack with no bus journals nothing and never fails a call over telemetry.

## Witnesses (fail on main)

- `ports::authz::tests::a_three_rule_gate_traces_all_three_and_marks_the_decider` — the issue's witness: three rules, second denies; the trace names all three in order, marks exactly the second as deciding, and survives a serde round trip.
- `ports::authz::tests::an_untraced_gate_derives_its_single_rule_trace`.
- `gated::tests::an_attached_bus_journals_the_decision_with_its_trace` — the consumer witness: deny and allow both land on the bus with the trace riding the `decision` payload the bridge journals verbatim.

Note: `custom::tests::silent_success_is_stamped_with_the_input_identity` fails on main independently of this branch (#3287's merge clobbered #3303's stamp; #3354 is the restore).

Follow-up once this and #3356 both land: switch `RemoteToolExecutor`'s gate call to `check_traced` and journal on the serve bus — noted on #3356.

Closes #3289
Refs #2716 #3281 #2701

## Summary by Sourcery

Add rule-by-rule authorization tracing and journal it for all tool calls via the session hook bus.

New Features:
- Introduce AuthzTrace, AuthzRuleTrace, AuthzContribution, and AuthzEvaluation to capture structured, serde-serializable traces for authorization decisions.
- Add AuthzGate::check_traced as the traced evaluation entrypoint used by dispatch seams so decisions are paired with their rule-level accounts.

Enhancements:
- Have GatedToolSet emit policy.evaluated hook events for every gate evaluation, including decision verdict and trace, and wire the session hook bus through all drivers and candidate workers.
- Expose ToolRegistry::hook_bus publicly and thread the optional bus into all tool-stack constructors so authorization journals share the existing policy plane channel.

Tests:
- Add tests proving multi-rule gates produce complete, deciding traces, default gates derive honest single-rule traces, bus-attached stacks journal decisions with traces, and stacks without a bus remain telemetry-free and non-failing.