### PR TITLE
docs(stella-mcp): unlink the private declared_contract intra-doc reference

### DIFF
--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -857,7 +857,7 @@ impl ToolExecutor for McpToolSet {
     /// `readOnlyHint`/`idempotentHint` preserved verbatim at untrusted
     /// provenance, `destructiveHint` *raising* the grade. The placeholder
     /// tools (needs-auth, resources) resolve through the same declared path
-    /// via [`Self::declared_contract`]'s route miss.
+    /// via `Self::declared_contract`'s route miss.
     fn contracts(&self) -> Vec<stella_protocol::ToolContract> {
         let mut contracts = Vec::new();
         if let Some(native) = &self.native {


### PR DESCRIPTION
Main's `doc-warnings` gate step is red since c47b5623a (#3352): the doc comment on `McpToolSet::contracts` links to the private `Self::declared_contract`, which `-D warnings` rejects as `rustdoc::private_intra_doc_links` (it only resolved because the gate passes `--document-private-items`). This drops the link to plain code formatting.

Verified locally: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-mcp --document-private-items` now finishes clean; before this change it fails with the exact CI error.

Docs-only, no witness test. Unblocks #3360, whose merge-CI inherits this failure from the base.

Refs #3352

## Summary by Sourcery

Documentation:
- Update the McpToolSet::contracts documentation to use plain code formatting instead of a link to a private declared_contract item.