### PR TITLE
feat(stella-serve): journal the AuthzTrace for remoted tool calls (#3362)

### DIFF
--- a/crates/stella-core/src/ports/authz.rs
+++ b/crates/stella-core/src/ports/authz.rs
@@ -356,6 +356,62 @@ impl AuthzGate for RiskCeiling {
     }
 }
 
+/// The `policy.evaluated` payload one gate evaluation journals (#3362): who
+/// asked, for what, what the gate said, and — inside the `decision` field,
+/// which `bus::bridge_policy_plane` copies verbatim into the journaled
+/// [`stella_protocol::AgentEvent::PolicyDecision`] — the rule-by-rule
+/// [`AuthzTrace`].
+///
+/// One pure builder, called by the CLI's `GatedToolSet` and the serve wire's
+/// `RemoteToolExecutor` alike. The two surfaces evaluate the same gate at the
+/// same position and must therefore journal the same account; a second copy
+/// of this shape is a second place for it to drift, and the parity row
+/// `tools.contracts` would not catch a divergence in the payload's *fields*.
+///
+/// An errored evaluation is journaled too, as `verdict: "error"` — it is the
+/// arm the fail-closed rule exists for, and an audit trail must show *could
+/// not tell* distinctly from *refused*.
+///
+/// Content-free by construction (invariant #3): tool name, principal label,
+/// gate name, verdict, gate-authored reasons, and rule identifiers. The
+/// call's `input` is deliberately not a parameter — this payload can ride an
+/// audit surface, and tool arguments must never follow it there.
+#[must_use]
+pub fn evaluation_journal_payload(
+    tool: &str,
+    principal: &Principal,
+    gate: &str,
+    evaluation: &Result<AuthzEvaluation, AuthzEvalError>,
+) -> Value {
+    let decision = match evaluation {
+        Ok(evaluation) => {
+            let mut decision = match &evaluation.decision {
+                AuthzDecision::Allow => serde_json::json!({ "verdict": "allow" }),
+                AuthzDecision::Deny { reason } => {
+                    serde_json::json!({ "verdict": "deny", "reason": reason })
+                }
+                AuthzDecision::RequireApproval { reason } => {
+                    serde_json::json!({ "verdict": "require_approval", "reason": reason })
+                }
+            };
+            decision["trace"] = serde_json::to_value(&evaluation.trace).unwrap_or(Value::Null);
+            decision
+        }
+        Err(error) => serde_json::json!({
+            "verdict": "error",
+            "gate": error.gate,
+            "detail": error.detail,
+        }),
+    };
+    serde_json::json!({
+        "event_name": "authz.gate",
+        "tool": tool,
+        "principal": principal.label(),
+        "gate": gate,
+        "decision": decision,
+    })
+}
+
 /// Fold an operator posture and a gate evaluation into the verdict dispatch
 /// acts on.
 ///

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -678,12 +678,16 @@ mod tests {
 
     /// API sources a witness may live in: the serve crate's unit tests plus
     /// its end-to-end suites.
-    fn api_sources() -> [&'static str; 15] {
+    fn api_sources() -> [&'static str; 16] {
         [
             include_str!("../../stella-serve/src/server.rs"),
             // The remoted ports — home of the `tools.contracts` witness
             // (#3286).
             include_str!("../../stella-serve/src/remote.rs"),
+            // `remote.rs` split its tests into a sibling submodule under the
+            // file-size gate, so the witnesses live here — the same reason
+            // `agent/tests.rs`'s children are listed above.
+            include_str!("../../stella-serve/src/remote/tests.rs"),
             include_str!("../../stella-serve/tests/calibration.rs"),
             include_str!("../../stella-serve/tests/checkpoint.rs"),
             include_str!("../../stella-serve/tests/hooks.rs"),

--- a/crates/stella-serve/src/remote.rs
+++ b/crates/stella-serve/src/remote.rs
@@ -550,7 +550,24 @@ impl ToolExecutor for RemoteToolExecutor {
         // gate denies whatever any softening flag says.
         let evaluation = self
             .gate
-            .check(&self.contract_for(name), &self.principal, input);
+            .check_traced(&self.contract_for(name), &self.principal, input);
+        // The rule-by-rule account (#3362), journaled before the fold
+        // consumes the evaluation — same builder, same event name, same
+        // payload shape as the CLI's `GatedToolSet`, so a host reading the
+        // policy plane sees one vocabulary across both surfaces. Telemetry:
+        // a session with no bus journals nothing and the call is unaffected.
+        if let Some(bus) = &self.bus {
+            bus.emit_named(
+                hook_names::POLICY_EVALUATED,
+                stella_core::ports::authz::evaluation_journal_payload(
+                    name,
+                    &self.principal,
+                    self.gate.name(),
+                    &evaluation,
+                ),
+            );
+        }
+        let evaluation = evaluation.map(|evaluation| evaluation.decision);
         match authz_verdict(&OperatorPosture::NoOpinion, evaluation, false) {
             GateVerdict::Allow => {}
             GateVerdict::Deny { reason } => {

--- a/crates/stella-serve/src/remote/tests.rs
+++ b/crates/stella-serve/src/remote/tests.rs
@@ -488,6 +488,20 @@ async fn a_denying_gate_refuses_a_remoted_call_before_any_frame_leaves() {
         read_only: false,
         speculation_safe: false,
     });
+    // A bus recording `policy.evaluated`: the served surface must journal
+    // the same rule-by-rule account the CLI's `GatedToolSet` does (#3362).
+    let bus = HookBus::new("turn-authztest0");
+    let seen: Arc<Mutex<Vec<serde_json::Value>>> = Arc::default();
+    let journal = Arc::clone(&seen);
+    bus.on(hook_names::POLICY_EVALUATED, move |event: &HookEvent| {
+        journal
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(event.payload.clone());
+        Ok(())
+    })
+    .detach();
+
     let port = RemoteToolExecutor::new(
         vec![contract],
         Arc::new(DenyAll),
@@ -495,7 +509,7 @@ async fn a_denying_gate_refuses_a_remoted_call_before_any_frame_leaves() {
         sink,
         pending,
         Duration::from_millis(50),
-        None,
+        Some(bus),
     );
 
     let out = port.execute("deploy", &serde_json::json!({})).await;
@@ -509,6 +523,29 @@ async fn a_denying_gate_refuses_a_remoted_call_before_any_frame_leaves() {
     assert!(
         rx.try_recv().is_err(),
         "a denied call must never reach the host — no frame may exist"
+    );
+
+    // **The #3362 witness**: the account reaches the policy plane, carrying
+    // the trace inside `decision` — the field `bridge_policy_plane` copies
+    // verbatim into the journaled `PolicyDecision`. Byte-parallel with the
+    // CLI surface's, because both come from `evaluation_journal_payload`.
+    let events = seen.lock().unwrap_or_else(|p| p.into_inner());
+    assert_eq!(events.len(), 1, "one account per evaluation: {events:?}");
+    let account = &events[0];
+    assert_eq!(account["event_name"], "authz.gate");
+    assert_eq!(account["tool"], "deploy");
+    assert_eq!(account["principal"], "host:acme");
+    assert_eq!(account["gate"], "deny-all");
+    assert_eq!(account["decision"]["verdict"], "deny");
+    let rules = account["decision"]["trace"]["rules"]
+        .as_array()
+        .expect("the trace rides the decision payload");
+    assert_eq!(rules.len(), 1, "the default single-rule trace: {rules:?}");
+    assert_eq!(rules[0]["rule"], "deny-all");
+    assert_eq!(rules[0]["deciding"], true);
+    assert!(
+        account["input"].is_null() && account["decision"]["input"].is_null(),
+        "the call's arguments must never ride an audit payload (invariant #3)"
     );
 }
 

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -84,7 +84,7 @@ use stella_core::hooks::decision::{
     ApprovalRoute, ApprovalRouteRequest, ApprovalRouteResolution, GateVerdict, OperatorPosture,
 };
 use stella_core::ports::authz::authz_verdict;
-use stella_core::ports::{AuthzDecision, AuthzEvalError, AuthzGate, Principal, ToolExecutor};
+use stella_core::ports::{AuthzEvalError, AuthzGate, Principal, ToolExecutor};
 use stella_protocol::tool::{ErrorClass, ToolOutput, ToolSchema};
 
 use crate::contracts;
@@ -203,40 +203,18 @@ impl<'a> GatedToolSet<'a> {
         evaluation: &Result<stella_core::ports::AuthzEvaluation, AuthzEvalError>,
     ) {
         let Some(bus) = &self.bus else { return };
-        let decision = match evaluation {
-            Ok(evaluation) => {
-                let verdict = match &evaluation.decision {
-                    AuthzDecision::Allow => serde_json::json!({ "verdict": "allow" }),
-                    AuthzDecision::Deny { reason } => {
-                        serde_json::json!({ "verdict": "deny", "reason": reason })
-                    }
-                    AuthzDecision::RequireApproval { reason } => {
-                        serde_json::json!({ "verdict": "require_approval", "reason": reason })
-                    }
-                };
-                let mut decision = verdict;
-                decision["trace"] =
-                    serde_json::to_value(&evaluation.trace).unwrap_or(serde_json::Value::Null);
-                decision
-            }
-            // An errored evaluation is journaled too — it is the arm the
-            // fail-closed rule exists for, and the audit trail must show it
-            // as "could not tell", never as a silent deny.
-            Err(error) => serde_json::json!({
-                "verdict": "error",
-                "gate": error.gate,
-                "detail": error.detail,
-            }),
-        };
+        // The shape lives in `stella-core` (#3362), not here: the serve
+        // wire's `RemoteToolExecutor` journals the same account from the
+        // same gate at the same position, and two copies of this payload
+        // would be two places for it to drift.
         bus.emit_named(
             stella_core::bus::names::POLICY_EVALUATED,
-            serde_json::json!({
-                "event_name": "authz.gate",
-                "tool": name,
-                "principal": self.principal.label(),
-                "gate": self.gate.name(),
-                "decision": decision,
-            }),
+            stella_core::ports::authz::evaluation_journal_payload(
+                name,
+                &self.principal,
+                self.gate.name(),
+                evaluation,
+            ),
         );
     }
 


### PR DESCRIPTION
## Why

#3286 gave the serve wire the same `AuthzGate` call as the CLI; #3289 gave every decision a rule-by-rule `AuthzTrace` and journaled it from `GatedToolSet`. The two shipped in parallel and neither could depend on the other, so the served surface evaluated with the untraced `check` and journaled nothing — the gap this issue was filed for as the pair merged.

## What

- **One shared payload builder**: `stella_core::ports::authz::evaluation_journal_payload` — the `policy.evaluated` shape (`event_name`, `tool`, `principal`, `gate`, and the `decision` object the policy-plane bridge copies verbatim into `AgentEvent::PolicyDecision`, trace inside it). Both surfaces emit through it, because they evaluate the same gate at the same position and a second copy of the shape is a second place for it to drift. **Content-free by construction**: the call's `input` is not even a parameter, so tool arguments cannot follow this payload onto an audit surface (invariant #3).
- **`RemoteToolExecutor`** now calls `check_traced` and emits the account before the fold consumes the evaluation. No `stella-serve` → `stella-tools` edge is created — the builder lives in `stella-core`, which both already depend on.
- **`GatedToolSet::journal_evaluation`** collapses to a call of the same builder; behavior and payload bytes unchanged (its #3289 witness still passes untouched).

## A real latent bug found on the way

`stella-parity`'s `every_api_witness_exists` was **red on main**: #3286's file-size split moved the serve witness into `remote/tests.rs`, which `api_sources()` did not include, so the `tools.contracts` row's witness could not be found. Fixed in the second commit — and this is exactly the failure mode that sweep's own doc comment predicts ("fails loudly, never silently"), working as designed.

## Witnesses

- `remote::tests::a_denying_gate_refuses_a_remoted_call_before_any_frame_leaves` — extended: the served refusal now also journals `policy.evaluated` with the trace inside `decision`, asserts the payload fields byte-parallel with the CLI's, and asserts no `input` rides the audit payload. Fails on main (nothing was emitted at all).
- `stella-parity::tests::every_api_witness_exists` — passes again.

Closes #3362
Refs #3289 #3286 #2716

## Summary by Sourcery

Add a shared authorization evaluation journal payload and ensure remote tool executions emit traced policy evaluation events, while fixing parity tests to account for newly located API witnesses.

New Features:
- Journal traced authorization gate evaluations for remote tool executions via the existing policy evaluation bus hook.

Enhancements:
- Introduce a shared evaluation journal payload builder in stella-core used by both CLI and served surfaces to keep policy evaluation telemetry consistent and content-free.

Tests:
- Extend the remote denial witness test to assert the presence and shape of the policy.evaluated payload for remoted calls, including trace content and absence of tool inputs.
- Update stella-parity API source discovery to include remote tool test modules so parity witnesses are detected correctly.