### PR TITLE
fix(stella-parity): api_sources misses the split remote/tests.rs — main's parity gate is red

### DIFF
--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -678,12 +678,14 @@ mod tests {
 
     /// API sources a witness may live in: the serve crate's unit tests plus
     /// its end-to-end suites.
-    fn api_sources() -> [&'static str; 15] {
+    fn api_sources() -> [&'static str; 16] {
         [
             include_str!("../../stella-serve/src/server.rs"),
             // The remoted ports — home of the `tools.contracts` witness
-            // (#3286).
+            // (#3286). The witness tests live in the split-out submodule
+            // file, which `include_str!` of the parent does not pull in.
             include_str!("../../stella-serve/src/remote.rs"),
+            include_str!("../../stella-serve/src/remote/tests.rs"),
             include_str!("../../stella-serve/tests/calibration.rs"),
             include_str!("../../stella-serve/tests/checkpoint.rs"),
             include_str!("../../stella-serve/tests/hooks.rs"),


### PR DESCRIPTION
main is red: `stella-parity`'s `every_api_witness_exists` fails on the last three main CI runs (tip `d3b2b742`) with

    api witness for `tools.contracts` not found: a_denying_gate_refuses_a_remoted_call_before_any_frame_leaves

The test exists and runs — `crates/stella-serve/src/remote/tests.rs:457`. #3356 split the remoted-ports unit tests into that sibling module file, and `api_sources()` only `include_str!`s `remote.rs`; unlike compilation, `include_str!` does not follow the `mod tests` declaration into the split file, so the scan cannot see the witness. `cli_sources()` already documents exactly this shape for the CLI side.

One line plus the arity bump: add `include_str!("../../stella-serve/src/remote/tests.rs")`, `[&'static str; 15]` → `16`.

Witness (the artisanal check): `cargo test -p stella-parity --lib` fails on `main`, passes on this branch — 9 passed, 0 failed.

This is the composed-tree shape from AGENTS.md: the parity row and the split test file landed via different PRs, both green pre-merge, red once composed. Filed standalone from fresh main per the red-main rule. Note PR #3370 (a feature PR) also touches `stella-parity/src/lib.rs`; if it carries the same include, the merge is textually identical and clean.

Refs #3356

## Summary by Sourcery

Ensure stella-parity correctly scans all remote API test sources so the api witness for tools.contracts is detected and main’s parity gate passes.

Bug Fixes:
- Include the split remote tests module in stella-parity’s API source scan to restore detection of the tools.contracts witness.

Enhancements:
- Clarify documentation around the remoted ports witness location and the impact of split test modules on include_str!-based scanning.