### PR TITLE
ci: hand scripts/lib/*.sh to shellcheck so the sourced helper is followed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,11 @@ jobs:
       # them fails open (#916).
       - name: shellcheck
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
-        run: shellcheck install.sh scripts/*.sh .githooks/*
+        # scripts/lib/*.sh must be inputs too: the help-header helper is
+        # sourced by most scripts (#3353), and shellcheck only follows a
+        # sourced file it was handed — otherwise every sourcing script
+        # trips SC1091. Keep this glob list matching the Makefile target.
+        run: shellcheck install.sh scripts/*.sh scripts/lib/*.sh .githooks/*
 
       # NOTE: despite the action's name, this job does not build on `stable`.
       # rust-toolchain.toml pins the repo to a concrete toolchain (1.97.0), and


### PR DESCRIPTION
The last remaining red on main's gate job (after #3371): the ci.yml `shellcheck` step fails with SC1091 on every script that sources `scripts/lib/help-header.sh`.

#3353 gave most scripts a `. "$(dirname "$0")/lib/help-header.sh"` line and updated the **Makefile's** shellcheck target to pass `scripts/lib/*.sh` — shellcheck follows a sourced file only when it is also an input, so that glob is what suppresses SC1091. ci.yml's hand-copied invocation (`.github/workflows/ci.yml:327`) kept the old argument list, so `make shellcheck` passes locally (verified, exit 0) while the CI step fails on any PR against current main — masked until now behind the parity failure #3371 fixed.

One-line fix: ci.yml's step now runs the same glob list as the Makefile target, with a comment pinning the two together.

Witness: the shellcheck step's own run on this PR — it fails on main's list (see #3371's run 31972550171) and passes with the glob added. Verified locally: `shellcheck install.sh scripts/*.sh .githooks/*` exits 1 on this tree; adding `scripts/lib/*.sh` exits 0.

Refs #3353

## Summary by Sourcery

CI:
- Update the CI shellcheck command to also pass scripts/lib/*.sh so sourced helpers are analyzed and the step matches the Makefile configuration.