### PR TITLE
chore(gate): regenerate the file-size baseline to clear inherited drift on main

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -7,7 +7,7 @@
 # must be split instead. Raising an existing ceiling is allowed but is
 # never silent — it lands as a visible diff here, to be justified in
 # review like any other change.
-1503 arenabench/arenabench/runner.py
+1501 arenabench/arenabench/runner.py
 1864 bench/harbor_adapter/stella_harbor/__init__.py
 4381 bench/harbor_adapter/stella_harbor/secure_launcher.py
 2356 bench/harbor_adapter/tests/test_adapter.py
@@ -16,20 +16,20 @@
 1911 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4339 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-1837 crates/stella-cli/src/agent.rs
-4097 crates/stella-cli/src/command_deck.rs
+1815 crates/stella-cli/src/agent.rs
+4010 crates/stella-cli/src/command_deck.rs
 1891 crates/stella-core/src/bus.rs
-1922 crates/stella-core/src/driver.rs
-2985 crates/stella-core/src/driver/tests.rs
-1781 crates/stella-model/src/anthropic/tests.rs
-2078 crates/stella-model/src/openai.rs
-1862 crates/stella-model/src/zai/tests.rs
-2792 crates/stella-pipeline/src/pipeline.rs
-2394 crates/stella-pipeline/src/pipeline/tests.rs
+1919 crates/stella-core/src/driver.rs
+2931 crates/stella-core/src/driver/tests.rs
+1779 crates/stella-model/src/anthropic/tests.rs
+2077 crates/stella-model/src/openai.rs
+1861 crates/stella-model/src/zai/tests.rs
+2783 crates/stella-pipeline/src/pipeline.rs
+2382 crates/stella-pipeline/src/pipeline/tests.rs
 1750 crates/stella-store/src/lib.rs
-2264 crates/stella-store/src/tests.rs
+2266 crates/stella-store/src/tests.rs
 1916 crates/stella-store/src/usage.rs
 1527 crates/stella-tui/src/deck_render.rs
 4003 crates/stella-tui/src/deck_ui.rs
 1599 crates/stella-tui/src/views/engine.rs
-1609 crates/stella-tui/src/views/session.rs
+1611 crates/stella-tui/src/views/session.rs


### PR DESCRIPTION
Clears the inherited baseline drift `scripts/check-file-size.sh` has been printing on `main` and on every PR branched from it.

## What changed

`make file-size-update` only. Two ceilings **rise** — exactly the two the drift block named:

| File | Was | Now |
|---|---|---|
| `crates/stella-store/src/tests.rs` | 2264 | 2266 |
| `crates/stella-tui/src/views/session.rs` | 1609 | 1611 |

The other ten changed lines all move **down**. `--update` retightens every ceiling to its file's current size, so those files have shrunk since their entry was written and the ratchet follows them. Tightening is the ratchet's intent (it is down-only by design), so they are recorded rather than held back.

No ceiling is widened beyond its file's actual size, and no new entry is added.

## Verification

```
$ ./scripts/check-file-size.sh
check-file-size: OK — 1382 Rust/Python/shell files, 26 grandfathered over 1500 lines,
and nothing went over by this change. Judged against 94311efbd.   # exit 0, no drift block

$ ./scripts/check-god-files.sh
check-god-files: OK — 17 god file(s) across 6 crate(s), named identically in AGENTS.md
and every crate README.

$ make guards-fast   # all green
```

`god-files` stays green because no file entered or left the >1500-line set — the counts (26 grandfathered / 17 Rust god files) are unchanged, so AGENTS.md and the crate READMEs need no edit.

## Witness

None, and deliberately: this changes no code path. `scripts/file-size-baseline.txt` is a generated artifact and the guard reading it is its own test — it exits non-zero with a drift block before this change and clean after, which is shown above.

## Notes

Landed on its own from a fresh `main`, per AGENTS.md § "God files": the baseline is one shared cell every growing PR writes, and folding a regeneration into a feature branch is the repo's #1 cause of a red `main`. Please merge promptly or re-run `make file-size-update` if another baseline-touching PR lands first.

Closes #3378

## Summary by Sourcery

Regenerate the file size baseline to eliminate drift on main and keep guard scripts passing without altering any code paths.

Build:
- Update the generated file-size baseline artifact used by scripts/check-file-size.sh to match current file sizes without widening ceilings.

Chores:
- Refresh baseline metadata so future branches no longer inherit file-size drift from main.