### PR TITLE
feat(stella-core): TurnCapabilities — every engine seam is answered, or it does not compile (#3387)

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -127,6 +127,7 @@ use loop_evidence::{ResultIdentities, snapshot_result_identities};
 use stella_protocol::ToolResult;
 use tokio::sync::mpsc::UnboundedSender;
 
+pub mod capabilities;
 mod completion;
 pub(crate) mod deadline_notice;
 mod dispatch;

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -1,0 +1,248 @@
+//! The engine's optional capability slots, as one value that must be
+//! answered in full — #3274 slice 2, #3387.
+//!
+//! # The defect this closes
+//!
+//! [`Engine::with_sleeper`](super::Engine::with_sleeper) returns an engine
+//! with every optional seam set to `None`, and each one is turned on by its
+//! own builder call. Those builders are public and work correctly; the
+//! problem is that **nothing makes a caller use them**. An assembly site that
+//! wants the pause gate and forgets `with_gate` compiles, runs, and quietly
+//! spends through a pause — and reads identically to a site that decided it
+//! did not want a gate. `goal.rs::assess` shipped exactly that bug against
+//! three seams at once.
+//!
+//! It was tempting to state this as "the constructor *cannot* carry those
+//! seams" (the framing in #3274 slice 2 and slide 22 of the turn-loop deck).
+//! That is not true of this tree and a witness written against it passes
+//! unchanged on `main`: `with_gate`/`with_steering`/`with_hooks` are `pub`
+//! and callers outside this crate use them today. The real property is
+//! **totality** — a decision must be recorded for every slot — and that is
+//! what this type enforces.
+//!
+//! # Why there is no `Default`, and no `#[non_exhaustive]`
+//!
+//! Both omissions are the mechanism, not an oversight.
+//!
+//! - **No `Default`.** A default is precisely the forgotten decision this
+//!   type exists to abolish. `..Default::default()` at an assembly site would
+//!   restore the defect with better syntax.
+//! - **No `#[non_exhaustive]`.** That attribute forbids struct-literal
+//!   construction outside the defining crate, which would force every
+//!   external lane through setters — and setters are optional calls, which is
+//!   the defect again. Leaving the struct exhaustive is what makes adding a
+//!   slot a **compile error at every assembly site in the workspace**, which
+//!   is the whole point.
+//!
+//! The cost is real and accepted: adding a field here is a breaking change
+//! for out-of-tree callers. That is the correct trade for an in-tree
+//! guarantee, and it is why a plugin-contributed lane gets the weaker
+//! load-time regime instead (`doc:turn-lane-assembly` §9.2) — you cannot give
+//! an out-of-tree file a build failure.
+
+use std::sync::Arc;
+
+use stella_protocol::ModelCallRole;
+
+use super::{Engine, EngineConfig, HooksHandle};
+use crate::estimator::CalibrationMap;
+use crate::hooks::{HookRunner, Hooks};
+use crate::ports::{
+    FallbackResolver, ProviderOutcomes, SteeringRequery, ToolExecutor, TurnGate, TurnSteering,
+};
+use crate::retry::Sleeper;
+use stella_protocol::Provider;
+
+/// Every optional seam an [`Engine`] can carry, answered in full.
+///
+/// There is no `Default` and no `#[non_exhaustive]`; see the module doc for
+/// why both are load-bearing. Construct with a struct literal naming every
+/// field — [`TurnCapabilities::none`] exists for the genuine no-seams case
+/// (tests, the bare loop) and is itself written as an exhaustive literal, so
+/// a new slot breaks it too.
+pub struct TurnCapabilities<'a> {
+    /// Lifecycle hooks and the port that executes them. Both or neither —
+    /// the config alone spawns nothing.
+    pub hooks: Option<(&'a Hooks, &'a dyn HookRunner)>,
+    /// Where a `PreToolUse` hook's `require_approval` decision parks (#2684).
+    pub hook_approvals: Option<&'a dyn crate::hooks::decision::ApprovalRoute>,
+    /// Token-drift calibration, owned by the caller across turns.
+    pub calibration: Option<&'a CalibrationMap>,
+    /// Boundary pause gate — Pause/Resume at step granularity.
+    pub gate: Option<&'a dyn TurnGate>,
+    /// Step-boundary steering — mid-turn messages and the soft stop.
+    pub steering: Option<&'a dyn TurnSteering>,
+    /// Step-boundary context re-query (#3243 Phase 3).
+    pub requery: Option<&'a dyn SteeringRequery>,
+    /// Extension hook bus — observer-only.
+    pub bus: Option<&'a crate::bus::HookBus>,
+    /// Call-outcome feedback for a router's circuit breaker (#2673).
+    pub outcomes: Option<&'a dyn ProviderOutcomes>,
+    /// Mid-turn provider fallback at the retries-exhausted boundary (#2679).
+    pub fallback: Option<&'a dyn FallbackResolver>,
+    /// What this engine's model calls are attributed to. Not an `Option`:
+    /// every call has a role, and [`ModelCallRole::Worker`] is the ordinary
+    /// answer rather than the absence of one.
+    pub call_role: ModelCallRole,
+}
+
+impl<'a> TurnCapabilities<'a> {
+    /// The bare loop: no optional seam attached, worker attribution.
+    ///
+    /// Written as an exhaustive literal on purpose — adding a slot fails to
+    /// compile here as well, so "none" stays a decision about every seam
+    /// rather than a shrinking one.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            hooks: None,
+            hook_approvals: None,
+            calibration: None,
+            gate: None,
+            steering: None,
+            requery: None,
+            bus: None,
+            outcomes: None,
+            fallback: None,
+            call_role: ModelCallRole::Worker,
+        }
+    }
+}
+
+impl<'a> HooksHandle<'a> {
+    /// The pair back out, for a caller assembling a child engine from a
+    /// parent's already-bound handle (`crate::subagent`). Lives here rather
+    /// than in `driver.rs` because that file is a grandfathered god file
+    /// closed to growth; a child module reaches the private fields just the
+    /// same.
+    pub(crate) fn parts(self) -> (&'a Hooks, &'a dyn HookRunner) {
+        (self.hooks, self.runner)
+    }
+}
+
+impl<'a> Engine<'a> {
+    /// The blessed constructor: assemble an engine from its required ports
+    /// and one [`TurnCapabilities`] answering every optional seam.
+    ///
+    /// This is what a lane — builtin or plugin-driven — is expected to call.
+    /// [`Engine::with_sleeper`](Engine::with_sleeper) plus the individual
+    /// `with_*` builders remain for existing call sites and behave exactly as
+    /// before; what they cannot offer is the guarantee that every seam was
+    /// considered.
+    pub fn assemble(
+        provider: &'a dyn Provider,
+        tools: &'a dyn ToolExecutor,
+        config: EngineConfig,
+        sleeper: &'a dyn Sleeper,
+        capabilities: TurnCapabilities<'a>,
+    ) -> Self {
+        // Destructured, never field-accessed: a new slot that this function
+        // forgets to wire is then a compile error here too, which is the
+        // same guarantee the assembly sites get.
+        let TurnCapabilities {
+            hooks,
+            hook_approvals,
+            calibration,
+            gate,
+            steering,
+            requery,
+            bus,
+            outcomes,
+            fallback,
+            call_role,
+        } = capabilities;
+
+        Self {
+            provider,
+            tools,
+            sleeper,
+            config,
+            call_role,
+            hooks: hooks.map(|(hooks, runner)| HooksHandle { hooks, runner }),
+            hook_approvals,
+            calibration,
+            gate,
+            steering,
+            requery,
+            bus,
+            outcomes,
+            fallback,
+            provider_override: Arc::new(std::sync::OnceLock::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The totality witness (#3387).
+    ///
+    /// This test does not assert a runtime behaviour — it asserts a *shape*,
+    /// and it does so by destructuring [`TurnCapabilities`] with no `..`
+    /// rest pattern. Adding a slot to the struct without adding it here fails
+    /// to compile, which is the property the type exists to provide.
+    ///
+    /// It is deliberately not written as "a fork carries gate/steering/hooks":
+    /// that passes on `main` unchanged, because the fork already carries them
+    /// and the builders that attach them are public. See the module doc.
+    #[test]
+    fn every_capability_slot_is_named_by_this_test() {
+        let TurnCapabilities {
+            hooks,
+            hook_approvals,
+            calibration,
+            gate,
+            steering,
+            requery,
+            bus,
+            outcomes,
+            fallback,
+            call_role,
+        } = TurnCapabilities::none();
+
+        assert!(hooks.is_none());
+        assert!(hook_approvals.is_none());
+        assert!(calibration.is_none());
+        assert!(gate.is_none());
+        assert!(steering.is_none());
+        assert!(requery.is_none());
+        assert!(bus.is_none());
+        assert!(outcomes.is_none());
+        assert!(fallback.is_none());
+        assert_eq!(call_role, ModelCallRole::Worker);
+    }
+
+    /// The second half: `assemble` must actually wire what it is handed.
+    ///
+    /// The shape test above proves every slot is named; this proves the
+    /// blessed constructor does not silently drop one on the way into the
+    /// engine. Both are needed — a slot could be named in the struct and
+    /// still be forgotten in `assemble`, which is the original defect moved
+    /// one level in.
+    #[test]
+    fn assemble_carries_the_bare_capability_set_onto_the_engine() {
+        let provider = crate::subagent::tests::ScriptedProvider::new(vec![]);
+        let tools = crate::subagent::tests::MixedTools::default();
+        let sleeper = crate::subagent::tests::NoSleep;
+
+        let engine = Engine::assemble(
+            &provider,
+            &tools,
+            EngineConfig::default(),
+            &sleeper,
+            TurnCapabilities::none(),
+        );
+
+        assert!(engine.hooks.is_none());
+        assert!(engine.hook_approvals.is_none());
+        assert!(engine.calibration.is_none());
+        assert!(engine.gate.is_none());
+        assert!(engine.steering.is_none());
+        assert!(engine.requery.is_none());
+        assert!(engine.bus.is_none());
+        assert!(engine.outcomes.is_none());
+        assert!(engine.fallback.is_none());
+        assert_eq!(engine.call_role, ModelCallRole::Worker);
+    }
+}

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -62,6 +62,7 @@ pub use accounted_call::{AccountedCall, AccountedCallError, ReceiptContext, run_
 pub use bus::{
     ExtensionFailure, HookBus, HookDecision, HookEventDraft, HookSubscription, PolicyOutcome,
 };
+pub use driver::capabilities::TurnCapabilities;
 pub use driver::{Engine, EngineConfig, SOFT_STOP_REASON, TurnOutcome};
 pub use estimator::{Calibration, CalibrationMap};
 pub use event_sender::{EventSendError, EventSender};

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -58,10 +58,15 @@
 //! and `truncated` says so rather than hiding it.
 //!
 //! **Every seam the parent has, the child has** — except the one it must
-//! not. [`Engine::with_sleeper`] cannot carry `gate`/`steering`/`hooks`
-//! (they are builder-set private fields), which is precisely why
-//! `goal.rs::assess` silently dropped all three when it hand-rolled a verifier
-//! engine. Constructing the child here, in the same crate, carries them:
+//! not. [`Engine::with_sleeper`] leaves `gate`/`steering`/`hooks` unset, and
+//! each is turned on by its own further builder call, so a caller that means
+//! to carry them and forgets one gets an engine that quietly does less —
+//! which is how `goal.rs::assess` silently dropped all three when it
+//! hand-rolled a verifier engine. (The builders are public and work; the
+//! defect was that nothing *required* them. #3387 is the fix: this fork is
+//! built through [`Engine::assemble`], whose [`TurnCapabilities`] has no
+//! `Default`, so a seam added later cannot reach a child as an unexamined
+//! `None`.) What the child carries:
 //!
 //! - The pause gate propagates. A child that ignored it would keep spending
 //!   through a pause.
@@ -113,7 +118,8 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::budget::BudgetGuard;
 use crate::bus::HookBus;
-use crate::driver::{Engine, EngineConfig, TurnOutcome};
+use crate::driver::capabilities::TurnCapabilities;
+use crate::driver::{Engine, EngineConfig, HooksHandle, TurnOutcome};
 use crate::event_sender::EventSender;
 use crate::ports::{ReadOnlyTools, ToolExecutor, TurnControls, TurnSteering};
 
@@ -669,11 +675,10 @@ impl Engine<'_> {
             .as_ref()
             .map(|steering| steering as &dyn TurnSteering);
 
-        let child = Engine {
-            provider: host.provider,
+        let child = Engine::assemble(
+            host.provider,
             tools,
-            sleeper: self.sleeper,
-            config: EngineConfig {
+            EngineConfig {
                 max_output_tokens: spec.max_output_tokens,
                 temperature: spec.temperature,
                 // A forked skill's `effort:` override (#2682); absent, the
@@ -705,50 +710,57 @@ impl Engine<'_> {
                 checkpoint_sink: None,
                 ..self.config.clone()
             },
-            call_role: spec.role,
-            // Every seam the parent has, the child has — this is the whole
-            // reason the child is built here rather than through
-            // `Engine::with_sleeper`, which cannot carry these three.
-            hooks: self.hooks,
-            // The child's hooks route approvals the same way the parent's
-            // do: a hook asking for a human is asking about the session's
-            // workspace, whichever agent's call tripped it (#2684).
-            hook_approvals: self.hook_approvals,
-            // The drift map is keyed per model, so a cross-family child
-            // learns its own model's drift without blending into the
-            // parent's — and starts warm instead of cold.
-            calibration: self.calibration,
-            gate: self.gate,
-            steering,
-            // Not inherited: the re-query plane belongs to the session's own
-            // turn. A child queries against ITS goal at dispatch (its prompt
-            // is fresh by construction), and a parent-scoped plane answering
-            // a child's signal would inject the parent's context into a
-            // delegated transcript. Wiring children is its own decision.
-            requery: None,
-            // The child rides the parent's bus. A sub-agent's steps and model
-            // calls are work the session really did — billed to it, visible
-            // in its spend — so hiding them from an observer would make the
-            // lifecycle stream disagree with the cost. `HookEvent` carries
-            // `agent_id`, which is what lets a consumer tell parent work from
-            // child work without a second bus.
-            bus: self.bus,
-            // A child's model calls are real observed outcomes for the same
-            // provider — the breaker they feed is session state, like the
-            // calibration map above (#2673).
-            outcomes: self.outcomes,
-            // Deliberately NOT inherited: the child's provider is the spec's
-            // explicit choice (possibly a pinned cross-family adapter), so a
-            // mid-turn re-route is not the engine's call to make here — a
-            // child that exhausts its ladder surfaces the failure into the
-            // parent's tool result instead (#2679).
-            fallback: None,
-            // A FRESH cell, deliberately not shared with the parent: the
-            // child's provider is the spec's explicit choice (see `fallback`
-            // above), so the parent's latched replacement is not the child's
-            // to inherit any more than the parent's resolver is.
-            provider_override: std::sync::Arc::new(std::sync::OnceLock::new()),
-        };
+            self.sleeper,
+            // Every seam the parent has, the child has — and since #3387 that
+            // is a claim the compiler checks. `TurnCapabilities` has no
+            // `Default`, so a seam added to the engine later cannot reach this
+            // fork as a silent `None`: this literal stops compiling until
+            // somebody decides what a child does with it. That is the
+            // difference between the decision below and the ones that used to
+            // read identically to an oversight.
+            TurnCapabilities {
+                call_role: spec.role,
+                hooks: self.hooks.map(HooksHandle::parts),
+                // The child's hooks route approvals the same way the parent's
+                // do: a hook asking for a human is asking about the session's
+                // workspace, whichever agent's call tripped it (#2684).
+                hook_approvals: self.hook_approvals,
+                // The drift map is keyed per model, so a cross-family child
+                // learns its own model's drift without blending into the
+                // parent's — and starts warm instead of cold.
+                calibration: self.calibration,
+                gate: self.gate,
+                steering,
+                // Not inherited: the re-query plane belongs to the session's own
+                // turn. A child queries against ITS goal at dispatch (its prompt
+                // is fresh by construction), and a parent-scoped plane answering
+                // a child's signal would inject the parent's context into a
+                // delegated transcript. Wiring children is its own decision.
+                requery: None,
+                // The child rides the parent's bus. A sub-agent's steps and model
+                // calls are work the session really did — billed to it, visible
+                // in its spend — so hiding them from an observer would make the
+                // lifecycle stream disagree with the cost. `HookEvent` carries
+                // `agent_id`, which is what lets a consumer tell parent work from
+                // child work without a second bus.
+                bus: self.bus,
+                // A child's model calls are real observed outcomes for the same
+                // provider — the breaker they feed is session state, like the
+                // calibration map above (#2673).
+                outcomes: self.outcomes,
+                // Deliberately NOT inherited: the child's provider is the spec's
+                // explicit choice (possibly a pinned cross-family adapter), so a
+                // mid-turn re-route is not the engine's call to make here — a
+                // child that exhausts its ladder surfaces the failure into the
+                // parent's tool result instead (#2679).
+                fallback: None,
+            },
+        );
+        // The provider-override cell is FRESH, and `assemble` is what makes it
+        // so: it mints a new `OnceLock` per engine. Deliberately not shared
+        // with the parent — the child's provider is the spec's explicit choice
+        // (see `fallback` above), so the parent's latched replacement is not
+        // the child's to inherit any more than the parent's resolver is.
 
         // The child's private transcript. It is a local: nothing outside
         // this function can observe it, and it is dropped on return. That
@@ -979,4 +991,4 @@ fn last_assistant_text(messages: &[CompletionMessage]) -> Option<&str> {
 #[cfg(test)]
 mod fork_scope_tests;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -19,7 +19,7 @@
 1815 crates/stella-cli/src/agent.rs
 4010 crates/stella-cli/src/command_deck.rs
 1891 crates/stella-core/src/bus.rs
-1919 crates/stella-core/src/driver.rs
+1920 crates/stella-core/src/driver.rs
 2931 crates/stella-core/src/driver/tests.rs
 1779 crates/stella-model/src/anthropic/tests.rs
 2077 crates/stella-model/src/openai.rs


### PR DESCRIPTION
## What

`TurnCapabilities` — one value holding the engine's nine optional seams plus
`call_role` — and `Engine::assemble`, the blessed constructor that takes it.
The subagent fork, the site whose whole purpose is carrying every seam, is
migrated onto it.

#3274 slice 2, scoped to the type and one migrated site. The remaining six
builtin lanes and the deprecated builder shims are slice 3.

## The defect, corrected

#3274 slice 2 and slide 22 of the turn-loop deck both say `with_sleeper`
*cannot* carry `gate`/`steering`/`hooks` because they are private builder
fields. **That is not true of this tree**, and I checked before building
against it:

- `with_gate`, `with_steering`, `with_hooks` are all `pub` —
  `driver.rs:746`, `:787`, `:794`.
- Callers outside `stella-core` use them today: `pipeline.rs:1552`/`:1557`,
  `attachments.rs:75`, `fanout_stage.rs:308`, `subsession.rs:750`.
- The subagent fork already carried all three, by struct literal in-crate.

So the witness that slice proposed — "a fork carries gate/steering/hooks" —
**passes on `main` unchanged**. It would have been a green test proving
nothing.

The real defect is **forgettability**: `with_sleeper` returns an engine with
every seam `None`, each turned on by a further optional call, and nothing
requires a caller to consider them. A site that wanted a pause gate and forgot
`with_gate` compiled, ran, and spent through a pause — reading identically to a
site that decided it wanted none. `goal.rs::assess` shipped exactly that
against three seams at once.

The correction is recorded in #3387's body and in `subagent.rs`'s module doc,
which stated the same overreach.

## Why no `Default` and no `#[non_exhaustive]`

Both omissions are the mechanism, and both are documented in the module doc so
a future reader does not "fix" them:

- **No `Default`** — a default *is* the forgotten decision this type abolishes.
- **No `#[non_exhaustive]`** — it forbids struct-literal construction outside
  the defining crate, forcing external lanes through setters, and setters are
  optional calls: the same defect with better syntax. An exhaustive struct is
  what makes adding a slot a compile error at every assembly site in the
  workspace.

The cost is accepted and stated: adding a field is a breaking change for
out-of-tree callers. That is the right trade for an in-tree guarantee, and it
is why a plugin-contributed lane gets the weaker load-time regime instead
(`doc:turn-lane-assembly` §9.2) — you cannot give an out-of-tree file a build
failure.

## Witness

Two tests in `driver/capabilities.rs`, both destructuring with **no rest
pattern**, so a slot added later fails to compile until it is named:

1. `every_capability_slot_is_named_by_this_test` — the shape.
2. `assemble_carries_the_bare_capability_set_onto_the_engine` — that the
   constructor actually wires what it is handed. Both are needed: a slot could
   be named in the struct and still be dropped inside `assemble`, which is the
   original defect moved one level in.

These fail on `main` for a structural reason — there is no struct to
destructure. They assert a *shape*, not a runtime behaviour, which is the
honest description of what this slice changes.

`assemble` itself destructures its argument for the same reason.

## Notes

- `driver.rs` is a grandfathered god file: the new code is in
  `driver/capabilities.rs` and `driver.rs` gains exactly one `mod` line
  (1919 → 1920 against a 1922 ceiling). `HooksHandle::parts` lives in the
  child module for the same reason — a child module reaches the private
  fields just the same.
- `subagent::tests` becomes `pub(crate)` so the new tests reuse the crate's
  existing doubles instead of adding a third set.
- No behaviour change. The fork's per-field decisions and their comments are
  preserved verbatim; `assemble` mints the same fresh `provider_override`
  cell the literal did.

## Verification

- `cargo test -p stella-core` — 1270 passed, 0 failed.
- `cargo build --workspace` — clean.
- `cargo clippy -p stella-core --all-targets` — clean.
- `make file-size`, `make doc-warnings` — green.

Refs #3387
Refs #3274

## Summary by Sourcery

Introduce a TurnCapabilities value and Engine::assemble constructor to make all engine capability seams explicit at assembly sites, and migrate the subagent fork to use them so missing seams become compile-time failures instead of silent runtime omissions.

New Features:
- Add TurnCapabilities as a single struct capturing all optional engine capability seams plus call_role.
- Expose Engine::assemble as the primary constructor that builds an engine from required ports and a TurnCapabilities set.

Enhancements:
- Refactor subagent child-engine construction to use Engine::assemble and TurnCapabilities instead of a manual Engine literal, preserving existing behaviour while making seam decisions explicit.
- Publish TurnCapabilities from the crate root and move HooksHandle::parts into the new driver::capabilities module to support capability wiring without growing driver.rs.

Tests:
- Add compilation-shape tests in driver/capabilities.rs that destructure TurnCapabilities and validate Engine::assemble correctly carries the bare capability set onto the engine.
- Adjust subagent test visibility to pub(crate) so existing doubles can be reused by the new capability tests.