### PR TITLE
feat(stella-store): executions.kind is the door, pipeline_variant is the wrapper (#3388)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -55,7 +55,7 @@ mod graph;
 mod init;
 pub(crate) mod outcome;
 mod output;
-mod persistence;
+pub(crate) mod persistence;
 mod presence;
 mod prompt;
 mod reflect;
@@ -278,7 +278,7 @@ async fn run_pipeline_one_shot(
     // Machine-wide presence: the deck's SESSIONS overlay sees this run live
     // and can replay its journal after it ends.
     let mut presence = SessionPresence::announce(cfg, prompt);
-    let execution = begin_execution(&store, "pipeline", prompt, cfg, Some(presence.id()));
+    let execution = persistence::begin_pipeline_execution(&store, prompt, cfg, presence.id());
 
     let (raw_tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let (tx, durable_pre_persisted) = event_sender_for_run(raw_tx, format);
@@ -1612,7 +1612,7 @@ async fn run_turn(
 ) -> Result<(), CliFailure> {
     budget.begin_turn();
     let turn_start = Instant::now();
-    let execution = begin_execution(store, kind, prompt, cfg, session);
+    let execution = begin_execution(store, kind, prompt, cfg, session, None);
     stamp_and_record_skill_usage(
         &execution,
         session_memory.as_deref_mut(),

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -513,7 +513,7 @@ pub(crate) async fn run_goal_turn(
     session_memory: Option<&mut crate::memory::SessionMemory>,
 ) -> Result<(), crate::failure::CliFailure> {
     let turn_start = Instant::now();
-    let execution = begin_execution(store, "goal", goal, cfg, session);
+    let execution = begin_execution(store, "goal", goal, cfg, session, None);
     stamp_and_record_skill_usage(&execution, session_memory, goal, &cfg.workspace_root);
 
     // Route the VERIFIER role. `Some` only when a distinct-family verifier was
@@ -668,7 +668,7 @@ async fn run_goal_pipeline_turn(
     session_memory: Option<&mut crate::memory::SessionMemory>,
 ) -> Result<(), crate::failure::CliFailure> {
     let turn_start = Instant::now();
-    let execution = begin_execution(store, "goal", goal, cfg, session);
+    let execution = begin_execution(store, "goal", goal, cfg, session, None);
     // Rebound mutable and NOT consumed by the seam, so the same memory can
     // double as the pipeline's recall port below.
     let mut session_memory = session_memory;

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -16,18 +16,34 @@ pub(crate) fn seed_calibration(store: &Option<Arc<Store>>, cfg: &Config) -> Cali
     stella_runtime::seed_calibration(store.as_ref(), cfg.provider.id, &cfg.model_id)
 }
 
+/// The wrapper variant the staged pipeline records (#3388/#3381). Named once
+/// here so the value the store groups by cannot drift from the value the
+/// pipeline calls itself.
+pub(crate) const PIPELINE_VARIANT_CLASSIC: &str = "classic";
+
 /// Begin an execution record; a failure degrades to "no persistence for this
 /// execution" rather than blocking the work.
+///
+/// `kind` is the **door** — which command the user ran — and nothing else.
+/// Which wrapper ran, if any, is `variant`: two separate facts in two
+/// separate columns, because they used to share one and a deck turn's door
+/// changed depending on whether the pipeline was on (#3388).
 pub(crate) fn begin_execution(
     store: &Option<Arc<Store>>,
     kind: &str,
     prompt: &str,
     cfg: &Config,
     session: Option<&str>,
+    variant: Option<&str>,
 ) -> Option<(Arc<Store>, i64)> {
     let store = store.as_ref()?;
     match store.begin_execution(kind, prompt, cfg.provider.id, &cfg.model_id) {
         Ok(id) => {
+            // Best-effort like the session link below: an unrecorded variant
+            // costs a row in a comparison, never the turn.
+            if let Some(variant) = variant {
+                let _ = store.set_pipeline_variant(id, variant);
+            }
             // Link the execution to its session (store schema v8) — what
             // lets the deck's SESSIONS overlay reassemble and replay the
             // session's full journal later. Best-effort like every other
@@ -39,6 +55,33 @@ pub(crate) fn begin_execution(
         }
         Err(_) => None,
     }
+}
+
+/// Begin the execution row for a `stella run` turn that the staged pipeline
+/// wraps.
+///
+/// The door is **`run`** — this is `stella run`, whatever wrapped it. That
+/// the pipeline wrapped it is the `variant`, a separate fact in a separate
+/// column (#3388). It used to be recorded as a door called `"pipeline"`,
+/// which made the door depend on the wrapper and split one door in two for
+/// anything grouping by it.
+///
+/// It lives here rather than at its one call site because `agent.rs` is a
+/// grandfathered god file closed to growth.
+pub(crate) fn begin_pipeline_execution(
+    store: &Option<Arc<Store>>,
+    prompt: &str,
+    cfg: &Config,
+    session: &str,
+) -> Option<(Arc<Store>, i64)> {
+    begin_execution(
+        store,
+        "run",
+        prompt,
+        cfg,
+        Some(session),
+        Some(PIPELINE_VARIANT_CLASSIC),
+    )
 }
 
 #[derive(Default)]

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -176,7 +176,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
             eprintln!("  {marker} {line}");
         }
     }
-    let execution = begin_execution(&store, "resume", &record.title, cfg, Some(&record.id));
+    let execution = begin_execution(&store, "resume", &record.title, cfg, Some(&record.id), None);
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let events = stella_core::EventSender::new(tx.clone());
     tools_registry.bridge_policy_plane(events.clone());

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -1506,15 +1506,15 @@ pub async fn run_deck_session(
 
         // The execution record outlives the turn future so a cancelled turn
         // can still be closed out in the store.
-        // The session link (store schema v8) is what lets the SESSIONS
-        // overlay's `Enter` reassemble and replay the full journal long
-        // after this process is gone.
+        // The session link (store schema v8) is what lets the SESSIONS overlay's
+        // `Enter` reassemble and replay the full journal after this process is gone.
         let execution = agent::begin_execution(
             &store,
-            if pipeline_on { "deck-pipeline" } else { "deck" },
+            "deck",
             &prompt,
             cfg,
             Some(&session_record.id),
+            pipeline_on.then_some(agent::persistence::PIPELINE_VARIANT_CLASSIC),
         );
         if let Some((_, id)) = &execution {
             last_execution_id = Some(*id);

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -715,7 +715,7 @@ async fn run_task(
     let store = agent::open_store(root);
     // Owned above the pipeline so it outlives every engine it builds (#1595).
     let calibration = agent::seed_calibration(&store, &cfg);
-    let execution = agent::begin_execution(&store, "fleet", &task.prompt, &cfg, None);
+    let execution = agent::begin_execution(&store, "fleet", &task.prompt, &cfg, None, None);
     // From here on this attempt's spend is durable in the store even if this
     // thread never lives to report it — publish the handle that makes it
     // readable from the dispatch side (#1216).

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -684,7 +684,14 @@ async fn run_worker(
 
     let store = agent::open_store(&cfg.workspace_root);
     let calibration = agent::seed_calibration(&store, cfg);
-    let execution = agent::begin_execution(&store, "deck-sub", &spec.prompt, cfg, Some(session_id));
+    let execution = agent::begin_execution(
+        &store,
+        "deck-sub",
+        &spec.prompt,
+        cfg,
+        Some(session_id),
+        None,
+    );
     let execution_id = execution.as_ref().map(|(_, id)| *id);
 
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -88,7 +88,8 @@ pub(crate) const EXECUTIONS_DDL: &str = "CREATE TABLE IF NOT EXISTS executions (
        usage_complete INTEGER NOT NULL DEFAULT 0 CHECK(usage_complete IN (0, 1)),
        usage_status TEXT NOT NULL DEFAULT 'pending'
          CHECK(usage_status IN ('pending', 'complete', 'incomplete')),
-       journal_era INTEGER NOT NULL DEFAULT 0
+       journal_era INTEGER NOT NULL DEFAULT 0,
+       pipeline_variant TEXT
      );
      CREATE INDEX IF NOT EXISTS executions_by_session
        ON executions(session_id, id);

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -38,7 +38,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 25] = [
+pub(crate) const MIGRATIONS: [Migration; 26] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -21,9 +21,11 @@ use crate::{Result, StoreError};
 
 mod abandoned_state;
 mod error_class;
+mod pipeline_variant;
 mod token_unit;
 
 use error_class::migrate_v24_to_v25;
+use pipeline_variant::migrate_v25_to_v26;
 use token_unit::migrate_v18_to_v19;
 
 /// One schema migration: upgrades an existing database exactly one
@@ -159,6 +161,10 @@ pub(crate) const MIGRATIONS: [Migration; 25] = [
     // older failure exists nowhere but its prose, and classifying by string
     // match is the practice this column replaces.
     migrate_v24_to_v25,
+    // v25 → v26: `executions.kind` becomes the door and only the door, and
+    // which wrapper ran moves to `executions.pipeline_variant` (#3388).
+    // Additive column plus a narrow backfill; see the module's own doc.
+    migrate_v25_to_v26,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -193,7 +199,8 @@ pub(crate) const MIGRATIONS: [Migration; 25] = [
     //
     //   v24 → v25: CLAIMED above by `tool_calls.error_class` (#3145).
     //
-    // Nothing is reserved now: take v25 → v26 and add your own line here.
+    //   v25 → v26: CLAIMED above by the door/wrapper split (#3388).
+    // Nothing is reserved now: take v26 → v27 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations/pipeline_variant.rs
+++ b/crates/stella-store/src/migrations/pipeline_variant.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The v25 → v26 schema migration: `executions.kind` becomes the door and
+//! only the door, and which wrapper ran moves to its own column (#3388).
+//!
+//! Split out of [`super`] for the same reason `error_class` was: that module
+//! sits close under the 1500-line ratchet, and a step that carries a real
+//! backfill plus its tests deserves the room.
+
+use super::{column_exists, table_exists};
+use crate::Result;
+
+/// v25 → v26: add `executions.pipeline_variant`, and rewrite the two `kind`
+/// values that named a wrapper instead of a door.
+///
+/// # The defect
+///
+/// `kind` is documented and read as the **door** — which command the user
+/// ran. Two write sites disagreed: `stella run`'s pipeline path wrote
+/// `'pipeline'`, and the Command Deck wrote `'deck-pipeline'` when the
+/// pipeline was on. So a deck turn recorded a different door depending on
+/// whether a wrapper ran, and one fact (which wrapper) was hiding inside
+/// another (which door).
+///
+/// # Why the column and the rewrite are one step
+///
+/// Renaming alone would **destroy information**: after it, nothing would
+/// record that those runs went through the pipeline at all. Adding the column
+/// alone would leave two columns answering one question and disagreeing.
+/// Neither half is safe on its own, so they are one migration.
+///
+/// # The backfill, and why it is exhaustive by mapping
+///
+/// Every `'pipeline'` row becomes `kind='run', pipeline_variant='classic'`,
+/// and every `'deck-pipeline'` row becomes `kind='deck',
+/// pipeline_variant='classic'`. `'classic'` is the name the staged pipeline
+/// carries as a wrapper variant, and it is the only wrapper those rows could
+/// have run under — there was no second one.
+///
+/// The `WHERE` clauses name the exact legacy values rather than anything
+/// cleverer, because the set of values was read off the write sites in the
+/// current tree. A value written by an older build that nothing in this tree
+/// writes would not have been in that list, and a broad rewrite would corrupt
+/// it. Naming the two we know keeps an unknown third untouched.
+///
+/// # What a NULL means afterwards
+///
+/// No wrapper ran. That is a fact, not an absence — the raw turn loop is the
+/// ordinary case, and it must not read as "we forgot to record it". Rows that
+/// predate this column and were not one of the two rewritten kinds are
+/// genuinely unwrapped, so NULL is correct for them too.
+pub(super) fn migrate_v25_to_v26(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !table_exists(tx, "executions")? {
+        return Ok(());
+    }
+    if !column_exists(tx, "executions", "pipeline_variant")? {
+        tx.execute_batch("ALTER TABLE executions ADD COLUMN pipeline_variant TEXT;")?;
+    }
+    // Idempotent by construction: after the first pass no row matches either
+    // WHERE, so a re-run is a no-op rather than a second rewrite.
+    tx.execute_batch(
+        "UPDATE executions SET kind = 'run', pipeline_variant = 'classic' \
+           WHERE kind = 'pipeline';
+         UPDATE executions SET kind = 'deck', pipeline_variant = 'classic' \
+           WHERE kind = 'deck-pipeline';",
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    fn v25_executions(conn: &mut Connection) {
+        conn.execute_batch(
+            "CREATE TABLE executions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               kind TEXT NOT NULL,
+               prompt TEXT NOT NULL,
+               provider TEXT NOT NULL,
+               model TEXT NOT NULL,
+               started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+               finished_at TEXT,
+               outcome TEXT,
+               cost_usd REAL NOT NULL DEFAULT 0,
+               session_id TEXT,
+               usage_complete INTEGER NOT NULL DEFAULT 0,
+               usage_status TEXT NOT NULL DEFAULT 'pending',
+               journal_era INTEGER NOT NULL DEFAULT 0);
+             INSERT INTO executions (kind, prompt, provider, model) VALUES
+               ('pipeline', 'p', 'zai', 'glm-5.2'),
+               ('deck-pipeline', 'p', 'zai', 'glm-5.2'),
+               ('deck', 'p', 'zai', 'glm-5.2'),
+               ('goal', 'p', 'zai', 'glm-5.2');",
+        )
+        .expect("seed");
+    }
+
+    fn rows(conn: &Connection) -> Vec<(String, Option<String>)> {
+        let mut stmt = conn
+            .prepare("SELECT kind, pipeline_variant FROM executions ORDER BY id")
+            .expect("prepare");
+        let mapped = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .expect("query");
+        mapped.map(|r| r.expect("row")).collect()
+    }
+
+    /// The witness for #3388: a wrapped run and a wrapped deck turn keep the
+    /// fact that a wrapper ran, while their `kind` becomes the door they
+    /// actually came in by. Fails before this migration exists, where
+    /// `kind` is the only record and it conflates the two.
+    #[test]
+    fn v26_moves_the_wrapper_out_of_the_door_column() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        v25_executions(&mut conn);
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("migrate");
+
+        assert_eq!(
+            rows(&conn),
+            vec![
+                ("run".to_string(), Some("classic".to_string())),
+                ("deck".to_string(), Some("classic".to_string())),
+                ("deck".to_string(), None),
+                ("goal".to_string(), None),
+            ]
+        );
+    }
+
+    /// A deck turn that ran a wrapper and one that did not now record the
+    /// SAME door and differ only in the variant — which is the whole point:
+    /// before this, `GROUP BY kind` split one door into two.
+    #[test]
+    fn a_wrapped_and_an_unwrapped_deck_turn_share_one_door() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        v25_executions(&mut conn);
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("migrate");
+
+        let decks: Vec<_> = rows(&conn).into_iter().filter(|r| r.0 == "deck").collect();
+        assert_eq!(decks.len(), 2, "both deck turns count as the deck door");
+        assert_eq!(decks[0].1.as_deref(), Some("classic"));
+        assert_eq!(decks[1].1, None);
+    }
+
+    /// Re-running the ladder over an already-migrated file changes nothing.
+    #[test]
+    fn the_backfill_is_idempotent() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        v25_executions(&mut conn);
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("migrate");
+        let after_first = rows(&conn);
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("second pass");
+        assert_eq!(rows(&conn), after_first);
+    }
+
+    /// A door value this tree does not write is left exactly as it was — the
+    /// backfill names the two legacy values it knows rather than guessing at
+    /// a general rule.
+    #[test]
+    fn an_unrecognised_kind_is_untouched() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE executions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               kind TEXT NOT NULL, prompt TEXT NOT NULL,
+               provider TEXT NOT NULL, model TEXT NOT NULL);
+             INSERT INTO executions (kind, prompt, provider, model)
+               VALUES ('some-older-build-value', 'p', 'zai', 'glm-5.2');",
+        )
+        .expect("seed");
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("migrate");
+
+        assert_eq!(
+            rows(&conn),
+            vec![("some-older-build-value".to_string(), None)]
+        );
+    }
+
+    /// A file with no executions table at all is a no-op, not an error.
+    #[test]
+    fn a_file_with_no_executions_table_migrates_cleanly() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        apply_migration(&mut conn, migrate_v25_to_v26, 26).expect("no data plane is fine");
+    }
+}

--- a/crates/stella-store/src/telemetry.rs
+++ b/crates/stella-store/src/telemetry.rs
@@ -257,6 +257,32 @@ impl Store {
         Ok(())
     }
 
+    /// Record which wrapper variant ran this turn (#3388) — called right
+    /// after [`Store::begin_execution`] on a wrapped run, and not at all on
+    /// an unwrapped one.
+    ///
+    /// # NULL means "no wrapper", and that is a fact
+    ///
+    /// The raw turn loop is the ordinary case, so a NULL here is a positive
+    /// statement rather than a missing measurement. That is why nothing
+    /// writes a placeholder string for the unwrapped case: `'none'` and
+    /// "nobody recorded it" would then be indistinguishable, which is the
+    /// exact confusion this column was split out of `kind` to end.
+    ///
+    /// # Why this lives beside the accounting updates
+    ///
+    /// `kind` and this column are the two axes every per-variant comparison
+    /// groups by, and this module already owns the execution row's
+    /// column-level updates. It is deliberately not in `lib.rs`: that file is
+    /// a grandfathered god file closed to growth.
+    pub fn set_pipeline_variant(&self, execution_id: i64, variant: &str) -> Result<()> {
+        self.lock().execute(
+            "UPDATE executions SET pipeline_variant = ? WHERE id = ?",
+            params![variant, execution_id],
+        )?;
+        Ok(())
+    }
+
     /// The spend one execution has already SETTLED: the sum of the durable
     /// per-call receipts it wrote as it ran.
     ///

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -1107,8 +1107,8 @@ fn skill_usage_records_per_execution_version_rows() {
     //       `execution_reflection.parse_error` (#2175). v24 splits
     //       `'abandoned'` from `'error'` in `tool_calls.state` (#3146). v25
     //       `tool_calls.error_class` (#3145): which KIND of failure, so an
-    //       error rate can exclude model misuse and policy refusals.
-    assert_eq!(SCHEMA_VERSION, 25);
+    //       error rate can exclude misuse. v26 splits wrapper from door (#3388).
+    assert_eq!(SCHEMA_VERSION, 26);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
## What

`executions.kind` becomes the **door** (which command the user ran) and only
the door. Which wrapper ran moves to a new `executions.pipeline_variant`
column. Schema v25 → v26.

Closes #3388. Unblocks the column half of #3381.

## The defect

`kind` is documented and read as the door. Two write sites recorded a wrapper
there instead:

```
crates/stella-cli/src/agent.rs:281          begin_execution(&store, "pipeline", …)
crates/stella-cli/src/command_deck.rs:1514  if pipeline_on { "deck-pipeline" } else { "deck" }
```

So a deck turn recorded a different door depending on whether the pipeline was
on, and `GROUP BY kind` split one door into two. This is the measurement
surface the wrapper programme is about to compare variants on, so it had to be
right before the first number is taken.

## Why the column and the rewrite are one migration

Neither half is safe alone:

- **Renaming alone destroys information** — after it, nothing records that
  those runs were wrapped at all.
- **Adding the column alone** leaves two columns answering one question and
  disagreeing whenever the mapping is imperfect.

## The backfill is narrow on purpose

`'pipeline'` → `kind='run', variant='classic'`; `'deck-pipeline'` →
`kind='deck', variant='classic'`. The `WHERE` clauses name those two values
exactly rather than applying a general rule, because the value set was read off
the **write sites in this tree**. A value written by an older build would not
have been in that list, and a broad rewrite would corrupt it. There is a test
for that case (`an_unrecognised_kind_is_untouched`).

`NULL` means no wrapper ran. Nothing writes a placeholder string, so "no
wrapper" and "nobody recorded it" cannot be confused — which is the exact
confusion this split ends.

## Witness

In `crates/stella-store/src/migrations/pipeline_variant.rs`:

1. `v26_moves_the_wrapper_out_of_the_door_column` — the wrapped run and wrapped
   deck turn keep the wrapper fact while `kind` becomes the real door.
2. `a_wrapped_and_an_unwrapped_deck_turn_share_one_door` — the point of the
   change, stated as a test.
3. `the_backfill_is_idempotent`, `an_unrecognised_kind_is_untouched`,
   `a_file_with_no_executions_table_migrates_cleanly`.

All fail before this migration exists, where `kind` is the only record and
conflates the two facts.

## What the survey turned up, and what I did about it

I mapped this with four parallel read-only agents before editing. Three
findings are worth recording:

- **The one real behavioural risk was `engine_config_for_kind`**
  (`crates/stella-cli/src/agent/engine.rs:250`), which sets
  `completion_gate = kind == "run"`. Renaming `"pipeline"` → `"run"` could
  have flipped it. **Checked: it cannot.** That function has exactly two
  callers (`agent.rs:1665`, `:1685`), both inside `run_turn`, which the
  pipeline path never reaches — the pipeline uses
  `pipeline_engine_config_for`, which sets the gate to `true` unconditionally.
- **`kind` is tri-meaning, not bi-meaning.**
  `crates/stella-cli/src/accounted_call.rs:180-206` writes four *role* strings
  (`domain_inference`, `agent_author`, `reflection`, `skill_author`) into the
  same column. Out of scope here and filed rather than silently left.
- **The usage hub is a second database** (`~/.stella/usage.db`) holding
  already-replicated `pipeline`/`deck-pipeline` rows above a durable cursor.
  A project-store backfill does not reach them. Filed.

## God files

`agent.rs`, `command_deck.rs` and `stella-store/src/lib.rs` are all
grandfathered and closed to growth, and all three end **net-zero**:

- the new `begin_pipeline_execution` helper lives in `agent/persistence.rs`;
- the deck's call absorbed its extra argument by reflowing the comment above it;
- `set_pipeline_variant` lives in `stella-store/src/telemetry.rs`, which
  already owns the execution row's column-level updates.

**`migrations.rs` is now at exactly 1500 lines** — passing, with zero room.
The next migration cannot be added without splitting it. Filed.

## Verification

- `cargo test -p stella-store` — 339 + 31 passed, 0 failed.
- `cargo test -p stella-cli` — 8 suites, 0 failed.
- `cargo clippy -p stella-store -p stella-cli --all-targets` — clean.
- `make file-size` — green.

Two guards caught the version bump for me and are worth noting as working:
`MIGRATIONS`' array length is spelled out in its type, and `SCHEMA_VERSION` is
asserted against a narrative comment in `tests.rs`.

Closes #3388
Refs #3381

## Summary by Sourcery

Split execution door and wrapper tracking so executions.kind records the command run while executions.pipeline_variant records the pipeline variant, with schema migrated to v26 and CLI wiring updated accordingly.

New Features:
- Add pipeline_variant column on executions to track which wrapper variant ran for a turn.
- Introduce a dedicated begin_pipeline_execution helper for wrapped stella run turns that consistently records the classic pipeline variant.

Bug Fixes:
- Correct execution kind values so deck and pipeline paths record a stable door independent of whether the pipeline wrapper is enabled, preventing GROUP BY kind from splitting one door into two.

Enhancements:
- Extend execution persistence APIs to accept an optional wrapper variant and update the store via a dedicated telemetry helper.
- Wire the new schema migration v25 → v26 into the migrations ladder with tests ensuring idempotent, safe backfill and clear semantics for NULL pipeline_variant.

Tests:
- Add migration-focused tests covering wrapper/door splitting, idempotent backfill, handling of unknown legacy kind values, and databases without an executions table.