### PR TITLE
fix(arenabench): name the wallet the balance preflight priced, and stop one trial assembling into two cells (#3308, #3324)

### DIFF
--- a/arenabench/arenabench/assemble.py
+++ b/arenabench/arenabench/assemble.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any

--- a/arenabench/arenabench/assemble.py
+++ b/arenabench/arenabench/assemble.py
@@ -216,6 +216,8 @@ def discover_trials(run_dir: Path, slugs: Sequence[str]) -> list[TrialArtifact]:
     submission record survived.
     """
     trials: list[TrialArtifact] = []
+    roots = _fetch_roots(run_dir)
+    seen: set[tuple[str, tuple[str, ...]]] = set()
     for path in sorted(run_dir.glob(_TRIAL_GLOB)):
         if not path.is_dir():
             continue
@@ -223,6 +225,16 @@ def discover_trials(run_dir: Path, slugs: Sequence[str]) -> list[TrialArtifact]:
             # Harbor writes siblings beside its trial directories; a directory
             # with neither half is not a trial and must not become a cell.
             continue
+        view = _trial_view(run_dir, path, roots)
+        if view in seen:
+            # The same trial, fetched twice into two roots. A `cloud run` that
+            # watches a gate downloads each job's whole prefix into its label
+            # directory, and the fetch tail downloads it again into the job-uuid
+            # directory — two byte-identical trees of one trial, both matching
+            # the glob above. Filing both produced a twin cell named `<trial>x2`
+            # and doubled every aggregate computed over cells (#3324).
+            continue
+        seen.add(view)
         job_dir = path.parent
         seat = seat_for_job_dir(job_dir.name, slugs)
         if seat is None:
@@ -240,6 +252,49 @@ def discover_trials(run_dir: Path, slugs: Sequence[str]) -> list[TrialArtifact]:
             )
         )
     return trials
+
+
+def _fetch_roots(run_dir: Path) -> dict[str, str]:
+    """Which fetch root directories name the same Batch job.
+
+    A trial's first path segment is the root it was fetched into, and one job
+    can own two of them: the gate watcher downloads a job's whole prefix into
+    its **label** directory while the fetch tail downloads it again into the
+    **job-uuid** directory. The submission sidecar carries both names on one
+    record, which is what makes this an equality rather than a guess — the
+    alternative, treating equal paths under different roots as one trial, would
+    silently drop a genuine cross-container name collision, the very case
+    :func:`link_name` exists for.
+
+    Maps every known root to its job id. A root the sidecar does not mention —
+    or a fetch that left no sidecar — maps to nothing and is deduplicated
+    against nothing, which is the pre-#3324 behaviour and the safe direction.
+    """
+    try:
+        record = json.loads((run_dir / "jobs.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    roots: dict[str, str] = {}
+    for job in record.get("jobs", []) if isinstance(record, dict) else []:
+        if not isinstance(job, dict) or not job.get("id"):
+            continue
+        job_id = str(job["id"])
+        roots[job_id] = job_id
+        if job.get("label"):
+            roots[str(job["label"])] = job_id
+    return roots
+
+
+def _trial_view(
+    run_dir: Path, trial: Path, roots: Mapping[str, str]
+) -> tuple[str, tuple[str, ...]]:
+    """A trial as (the job it belongs to, its path below that job's root).
+
+    Two fetch roots of one job yield the same view for the same upload, and
+    two different jobs never do — so equal views are one trial seen twice.
+    """
+    parts = trial.relative_to(run_dir).parts
+    return roots.get(parts[0], parts[0]), parts[1:]
 
 
 def _job_id_of(run_dir: Path, trial: Path) -> str:

--- a/arenabench/arenabench/balance.py
+++ b/arenabench/arenabench/balance.py
@@ -34,10 +34,14 @@ from typing import Literal
 __all__ = [
     "Balance",
     "Verdict",
+    "Wallet",
     "fetch_openrouter_balance",
     "openrouter_key",
     "verdict",
 ]
+
+#: Environment variables an OpenRouter key may arrive in, in preference order.
+KEY_ENV_NAMES = ("OPENROUTER_API_KEY", "OPENROUTER_KEY")
 
 #: How much headroom over the projected spend counts as comfortable. A run
 #: priced at exactly its balance is a run that ends in a 402 partway through,
@@ -58,6 +62,34 @@ class Balance:
 
 
 @dataclass(frozen=True)
+class Wallet:
+    """Which wallet a reading priced — by name, never by value.
+
+    A cloud run prices the submitting host's own key and then spends a key
+    the seats read from SSM. Those are two accounts that merely tend to be
+    the same one, and when they are not, a clean verdict over a funded local
+    wallet is byte-indistinguishable from a clean verdict over the wallet
+    that will actually pay — which is the exact reading that returned three
+    runs to the empty-balance loss this preflight exists to stop (#3308).
+    So a priced verdict says whose money it counted.
+    """
+
+    #: The environment variable the priced key was read from on this host.
+    env_name: str
+    #: The credential name the trial seats will spend instead, when the run
+    #: knows one. ``None`` when nothing is declared — the local key is then
+    #: all there is to name, and naming it is still the whole point.
+    seat_credential: str | None = None
+
+    def provenance(self) -> str:
+        """The parenthetical an operator reads to place the number."""
+        priced = f"priced against {self.env_name} on this host"
+        if self.seat_credential is None:
+            return priced
+        return f"{priced}; seats spend the SSM-provided {self.seat_credential}"
+
+
+@dataclass(frozen=True)
 class Verdict:
     """The preflight's answer: whether to submit, and what to tell the human."""
 
@@ -74,6 +106,7 @@ def verdict(
     remaining_usd: float | None,
     trials: int,
     cost_per_trial_usd: float | None,
+    wallet: Wallet | None = None,
 ) -> Verdict:
     """Whether a wallet holding ``remaining_usd`` should fund this run.
 
@@ -86,45 +119,70 @@ def verdict(
     ``remaining_usd`` of ``None`` means the balance could not be read, which
     is reported and never blocks: an unreachable gateway must not be able to
     stop a run that would have succeeded.
+
+    ``wallet`` names whose money was counted and is appended to every arm
+    that priced one. The unknown arm deliberately carries none: no wallet
+    was read, so there is nothing to attribute.
     """
     if remaining_usd is None:
         return Verdict("unknown", "balance not checked — the gateway did not answer")
     if remaining_usd <= 0:
-        return Verdict(
+        return _priced(
             "refuse",
+            wallet,
             f"the gateway balance is ${remaining_usd:.2f} — every trial would 402 "
             "on its first model call and score as an operational abort",
         )
     if cost_per_trial_usd is None or cost_per_trial_usd <= 0:
-        return Verdict(
+        return _priced(
             "ok",
+            wallet,
             f"gateway balance ${remaining_usd:.2f}; projected spend unknown "
             "(pass --est-cost-per-trial to have it checked)",
         )
     projected = trials * cost_per_trial_usd
     if remaining_usd < projected:
-        return Verdict(
+        return _priced(
             "refuse",
+            wallet,
             f"the gateway balance is ${remaining_usd:.2f} but this run projects "
             f"${projected:.2f} ({trials} trials x ${cost_per_trial_usd:.2f}) — the "
             "money would run out partway through and the trials it kills would "
             "score as operational aborts",
         )
     if remaining_usd < projected * COMFORTABLE_HEADROOM:
-        return Verdict(
+        return _priced(
             "warn",
+            wallet,
             f"gateway balance ${remaining_usd:.2f} against a projected "
             f"${projected:.2f} — under {COMFORTABLE_HEADROOM:g}x headroom, and a "
             "panel's expensive tail spends multiples of the mean",
         )
-    return Verdict(
+    return _priced(
         "ok",
+        wallet,
         f"gateway balance ${remaining_usd:.2f} against a projected ${projected:.2f}",
     )
 
 
-def openrouter_key() -> str | None:
-    """The submitting host's own OpenRouter key, if it has one.
+def _priced(
+    level: Literal["ok", "warn", "refuse"],
+    wallet: Wallet | None,
+    message: str,
+) -> Verdict:
+    """A verdict over a wallet that was actually read, attributed if it can be."""
+    if wallet is None:
+        return Verdict(level, message)
+    return Verdict(level, f"{message} ({wallet.provenance()})")
+
+
+def openrouter_key() -> tuple[str, str] | None:
+    """The submitting host's own OpenRouter key and the name it came from.
+
+    The name travels with the key because the verdict has to print it: a
+    reading that cannot say which variable it read cannot be told from a
+    reading of the wrong account (#3308). Names are printable; the key is
+    not, and nothing but :func:`fetch_openrouter_balance` may see it.
 
     Deliberately local-only. A cloud run's seats read their credentials from
     SSM and the submitting host may legitimately hold none of them — in which
@@ -132,10 +190,10 @@ def openrouter_key() -> str | None:
     secret this process does not otherwise need, purely to price a run, is a
     worse trade than an unchecked preflight.
     """
-    for name in ("OPENROUTER_API_KEY", "OPENROUTER_KEY"):
+    for name in KEY_ENV_NAMES:
         value = os.environ.get(name)
         if value:
-            return value
+            return name, value
     return None
 
 

--- a/arenabench/arenabench/cloud.py
+++ b/arenabench/arenabench/cloud.py
@@ -79,7 +79,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from . import preflight
+from . import balance, preflight
 from .model import MatchSpec, slugify
 from .registry import DEFAULT_REGISTRY
 from .sut import is_full_sha, is_safe_ref
@@ -100,6 +100,7 @@ __all__ = [
     "ref_safe",
     "refused_seats",
     "register_cli",
+    "seat_gateway_credential",
     "select_queue",
     "slice_spec",
     "ssm_env_name",
@@ -483,6 +484,27 @@ def refused_seats(
     return out
 
 
+def seat_gateway_credential(
+    needed: Mapping[str, list[str]],
+    available: Iterable[str],
+) -> str | None:
+    """The gateway credential the seats will spend, if SSM will supply one.
+
+    The preflight prices the submitting host's own key, which is a different
+    account from the one the trials spend whenever the two hosts differ. This
+    names the second account so the verdict can print both (#3308): a seat's
+    declared candidate that SSM actually provides and that is a gateway key
+    name. ``None`` when nothing matches — there is then no second wallet to
+    name, and inventing one would be worse than saying nothing.
+    """
+    provided = set(available)
+    for candidates in needed.values():
+        for name in candidates:
+            if name in provided and name in balance.KEY_ENV_NAMES:
+                return name
+    return None
+
+
 def unknown_tasks(declared: Iterable[str], known: Iterable[str]) -> list[str]:
     """Declared task names the dataset does not contain, in declared order.
 
@@ -717,7 +739,8 @@ def _cmd_cloud_run(
     # credentials will not exist in the trial environment must not launch.
     needed = required_env(spec)
     seat_env = {c.id: c.env for c in spec.contestants}
-    refused = refused_seats(needed, seat_env, executor.available_credentials())
+    available = executor.available_credentials()
+    refused = refused_seats(needed, seat_env, available)
     if refused:
         names = {c.id: c.name for c in spec.contestants}
         print(
@@ -764,7 +787,9 @@ def _cmd_cloud_run(
     plans = plan_trials(spec)
 
     money = preflight.balance_verdict(
-        len(plans), getattr(args, "est_cost_per_trial", None)
+        len(plans),
+        getattr(args, "est_cost_per_trial", None),
+        seat_gateway_credential(needed, available),
     )
     print(f"balance   : {money.message}")
     if money.blocks and not getattr(args, "ignore_balance", False):

--- a/arenabench/arenabench/preflight.py
+++ b/arenabench/arenabench/preflight.py
@@ -59,18 +59,32 @@ def require_known_tasks(spec: MatchSpec, registry: Registry) -> None:
         )
 
 
-def balance_verdict(trials: int, cost_per_trial_usd: float | None) -> balance.Verdict:
+def balance_verdict(
+    trials: int,
+    cost_per_trial_usd: float | None,
+    seat_credential: str | None = None,
+) -> balance.Verdict:
     """Price ``trials`` against whatever balance this host can read.
 
     The key is read from the submitting host's own environment only: a cloud
     seat reads its credentials from SSM and this host may hold none of them,
     and reaching into SSM for a secret the process does not otherwise need,
     purely to price a run, is a worse trade than an unchecked preflight.
+
+    That trade is settled, and ``seat_credential`` is what keeps it honest.
+    A verdict priced against one wallet and spent from another must say so,
+    or a false all-clear reads exactly like a real one (#3308) — so the
+    caller passes the credential name the seats will actually spend when it
+    knows one, and the verdict names both.
     """
-    key = balance.openrouter_key()
-    reading = balance.fetch_openrouter_balance(key) if key else None
+    found = balance.openrouter_key()
+    if found is None:
+        return balance.verdict(None, trials, cost_per_trial_usd)
+    env_name, key = found
+    reading = balance.fetch_openrouter_balance(key)
     return balance.verdict(
         reading.remaining_usd if reading else None,
         trials,
         cost_per_trial_usd,
+        balance.Wallet(env_name=env_name, seat_credential=seat_credential),
     )

--- a/arenabench/tests/test_assemble.py
+++ b/arenabench/tests/test_assemble.py
@@ -22,6 +22,7 @@ test touches S3.
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -175,6 +176,63 @@ def test_the_longest_matching_slug_wins() -> None:
     assert seat_for_job_dir("abc-stella-bare", ["stella", "stella-bare"]) == (
         "stella-bare"
     )
+
+
+def test_one_trial_fetched_into_two_roots_is_discovered_once(tmp_path: Path) -> None:
+    """The `cloud run` layout: a gate watcher downloads each job's whole prefix
+    into its label directory and the fetch tail downloads it again into the
+    job-uuid directory. Two byte-identical trees of one trial both matched the
+    trial glob, so the assembler filed a twin cell named `<trial>x2` and every
+    aggregate over cells double-counted the run (#3324).
+    """
+    run_dir = tmp_path / "twinned"
+    run_dir.mkdir(parents=True)
+    (run_dir / "match.toml").write_text(MATCH_TOML, encoding="utf-8")
+    label = "000-stella-bare-loop-fix-git"
+    _write_trial(run_dir, "job-uuid", "stella-bare-loop", "fix-git", 1)
+    shutil.copytree(run_dir / "job-uuid", run_dir / label)
+    (run_dir / "jobs.json").write_text(
+        json.dumps({
+            "run_id": "twinned",
+            "jobs": [{"id": "job-uuid", "label": label, "task": "fix-git"}],
+        }),
+        encoding="utf-8",
+    )
+
+    trials = discover_trials(run_dir, ["stella-bare-loop", "claude-code"])
+    assert len(trials) == 1, [str(t.path) for t in trials]
+
+    assembly = assemble_run(run_dir, workspace=tmp_path / "arena")
+    manifest = json.loads(
+        (assembly.match_dir / ASSEMBLY_NAME).read_text(encoding="utf-8")
+    )
+    names = [cell["trial"] for cell in manifest["cells"]]
+    assert names == ["fix-git__a1xyz"], names
+
+
+def test_two_different_trials_sharing_a_name_are_both_kept(tmp_path: Path) -> None:
+    """The guard is identity, not name equality.
+
+    Harbor's `<task>__<suffix>` carries no uniqueness guarantee across the
+    separate containers a fan-out uses — which is why `link_name` exists. Two
+    genuinely different trials that collide on every path segment must both
+    survive and be disambiguated, exactly as before.
+    """
+    run_dir = tmp_path / "collided"
+    run_dir.mkdir(parents=True)
+    (run_dir / "match.toml").write_text(MATCH_TOML, encoding="utf-8")
+    _write_trial(run_dir, "job-000", "stella-bare-loop", "fix-git", 1, reward=1.0)
+    _write_trial(run_dir, "job-001", "stella-bare-loop", "fix-git", 1, reward=0.0)
+    (run_dir / "jobs.json").write_text(
+        json.dumps({"jobs": [
+            {"id": "job-000", "label": "000-stella-bare-loop-fix-git"},
+            {"id": "job-001", "label": "001-stella-bare-loop-fix-git"},
+        ]}),
+        encoding="utf-8",
+    )
+
+    trials = discover_trials(run_dir, ["stella-bare-loop", "claude-code"])
+    assert len(trials) == 2, [str(t.path) for t in trials]
 
 
 def test_a_colliding_trial_name_keeps_its_task() -> None:

--- a/arenabench/tests/test_balance.py
+++ b/arenabench/tests/test_balance.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import pytest
 
-from arenabench.balance import COMFORTABLE_HEADROOM, verdict
+from arenabench.balance import COMFORTABLE_HEADROOM, Wallet, openrouter_key, verdict
+from arenabench.cloud import seat_gateway_credential
 
 
 class TestBalanceVerdict:
@@ -60,3 +61,79 @@ class TestBalanceVerdict:
         answer = verdict(remaining_usd=50.0, trials=89, cost_per_trial_usd=estimate)
         assert answer.level == "ok"
         assert "--est-cost-per-trial" in answer.message
+
+
+class TestWalletProvenance:
+    """A verdict must say whose money it counted (#3308).
+
+    The preflight prices the submitting host's key and the trials spend a
+    key from SSM. When those are different accounts, an unattributed clean
+    verdict is byte-indistinguishable from a real all-clear — which is the
+    reading that returned three runs to the empty-balance loss this whole
+    preflight exists to stop.
+    """
+
+    LOCAL = Wallet(env_name="OPENROUTER_API_KEY")
+    SPLIT = Wallet(env_name="OPENROUTER_KEY", seat_credential="OPENROUTER_API_KEY")
+
+    def test_a_clean_verdict_names_both_wallets_when_the_seats_spend_another(self):
+        answer = verdict(200.0, 89, 0.40, self.SPLIT)
+        assert answer.level == "ok"
+        assert "priced against OPENROUTER_KEY on this host" in answer.message
+        assert "seats spend the SSM-provided OPENROUTER_API_KEY" in answer.message
+
+    def test_with_no_declared_seat_credential_only_the_env_var_is_named(self):
+        answer = verdict(200.0, 89, 0.40, self.LOCAL)
+        assert "priced against OPENROUTER_API_KEY on this host" in answer.message
+        assert "seats spend" not in answer.message
+
+    @pytest.mark.parametrize(
+        ("remaining", "estimate", "level"),
+        [(0.0, None, "refuse"), (12.0, 0.40, "refuse"), (40.0, 0.40, "warn"),
+         (50.0, None, "ok")],
+    )
+    def test_every_arm_that_priced_a_wallet_attributes_it(
+        self, remaining, estimate, level
+    ):
+        """Including the refusals: a refusal over the wrong wallet is a false
+        refusal, and the operator can only see that if it is named."""
+        answer = verdict(remaining, 89, estimate, self.SPLIT)
+        assert answer.level == level
+        assert "priced against OPENROUTER_KEY on this host" in answer.message
+
+    def test_an_unread_balance_attributes_nothing(self):
+        """No wallet was read, so there is no wallet to name."""
+        answer = verdict(None, 89, 0.40, self.SPLIT)
+        assert answer.level == "unknown"
+        assert "priced against" not in answer.message
+
+    def test_the_key_arrives_with_the_name_it_was_read_from(self, monkeypatch):
+        """`verdict` can only name the variable if `openrouter_key` says which
+        one answered — the fallback name is not the primary one."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_KEY", "sk-not-a-real-key")
+        assert openrouter_key() == ("OPENROUTER_KEY", "sk-not-a-real-key")
+
+    def test_no_key_at_all_reads_as_no_reading(self, monkeypatch):
+        for name in ("OPENROUTER_API_KEY", "OPENROUTER_KEY"):
+            monkeypatch.delenv(name, raising=False)
+        assert openrouter_key() is None
+
+
+class TestSeatGatewayCredential:
+    """Which wallet the seats will spend, derived from what SSM will supply."""
+
+    def test_a_declared_gateway_key_that_ssm_provides_is_named(self):
+        needed = {"stella": ["OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"]}
+        available = {"OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"}
+        assert seat_gateway_credential(needed, available) == "OPENROUTER_API_KEY"
+
+    def test_a_declared_key_ssm_will_not_supply_is_not_named(self):
+        """Naming a credential the trial will not hold would be a second false
+        reassurance, not a fix for the first."""
+        needed = {"stella": ["OPENROUTER_API_KEY"]}
+        assert seat_gateway_credential(needed, {"ANTHROPIC_API_KEY"}) is None
+
+    def test_seats_spending_no_gateway_key_name_nothing(self):
+        needed = {"cc": ["ANTHROPIC_API_KEY"]}
+        assert seat_gateway_credential(needed, {"ANTHROPIC_API_KEY"}) is None


### PR DESCRIPTION
Two independent cloud-path bench-ops defects, both of which cost real runs.

## The preflight never said whose money it counted (#3308)

`balance.verdict` priced whatever wallet the submitting host's
`OPENROUTER_API_KEY` opens and reported the number with no attribution, so a
clean all-clear over a local wallet was byte-indistinguishable from one over
the wallet the seats actually spend. That is the reading that returns an
operator to the empty-balance loss this preflight was built to stop (three
runs: h2h891 16 trials, fivetools5 30/30, gate89high1 35/89).

- `balance.Wallet` names the env var the key was read from and, when the run
  knows one, the credential the seats will spend instead. Names only, never
  values.
- `openrouter_key()` now returns `(name, key)` — the verdict can only name the
  variable if the lookup says which one answered.
- Every arm that priced a wallet is attributed, including the refusals: a
  refusal over the wrong wallet is a false refusal, and only naming it lets
  the operator see that. The `unknown` arm attributes nothing — no wallet was
  read.
- `cloud.seat_gateway_credential` derives the seats' wallet from what SSM will
  actually supply, and names nothing when nothing matches.

**No SSM read is added.** The settled trade in the issue stays settled; this
PR fixes only the consequence it left visible to nobody. Fail-open stays
fail-open.

## One trial assembled into two cells (#3324)

A `cloud run` that watches a gate downloads each job's whole S3 prefix into its
label directory (`gate_watch.py:85-89`) and the fetch tail downloads it again
into the job-uuid directory (`cloud_executor.py:518`). Both trees match the
assembler's trial glob, so the second sighting became an `x2`-suffixed twin —
`matches/fable5rep1/assembly.json` holds 40 cells for 20 trials, and every
aggregate computed over cells double-counted the run.

`discover_trials` now recognises the two roots as one job through the
submission sidecar's `id`/`label` pairing. That is deliberately an **equality,
not an inference**: deduplicating on "equal paths under different roots" would
silently drop the genuine cross-container name collision `link_name` exists
for, and a second test pins that two different trials sharing every path
segment are both still kept. A fetch that left no sidecar deduplicates nothing
— the pre-#3324 behaviour, which is the safe direction.

## Witness

`test_one_trial_fetched_into_two_roots_is_discovered_once` fails on `main`
(`assert 2 == 1`, the twin present) and passes here; the collision test passes
on both, as it must. The #3308 tests reference `balance.Wallet`, which does not
exist on `main`.

```
uv run --project arenabench pytest arenabench/tests -q
```

No test was deleted or renamed.

## Residue

Filed #3400: the double *download* itself is still wasted egress and disk. This
PR fixes the assembly consequence only — the fetch-layout change is a separate,
observable change to `~/arenabench-results/<run>/`.

Closes #3308
Closes #3324

## Summary by Sourcery

Clarify gateway balance preflight output and avoid double-counting trials when assembling cloud runs.

Bug Fixes:
- Ensure balance preflight messages attribute the wallet whose funds were priced, including when seats spend a different SSM-provided credential.
- Prevent single trials fetched under both job-id and label roots from being discovered twice and assembled into twin cells that double-count aggregates.

Enhancements:
- Introduce a Wallet abstraction and propagate OpenRouter key provenance so preflight verdicts can report which environment variable and seat credential were used.
- Derive the seat gateway credential from available SSM-supplied keys so cloud runs can price the same account the trials will spend.
- Make trial discovery aware of fetch roots via jobs.json metadata so equivalent views of the same job are treated as one trial while genuine cross-container name collisions remain distinct.

Tests:
- Add balance verdict tests covering wallet provenance, OpenRouter key lookup, and seat gateway credential resolution.
- Add assembler tests to verify that a trial fetched into two roots is discovered once and that two distinct trials sharing the same path name are both retained.