### PR TITLE
fix(ci): deck-fit measures decks at any depth, and names what it skips (#3376)

### DIFF
--- a/.github/workflows/deck-fit.yml
+++ b/.github/workflows/deck-fit.yml
@@ -89,21 +89,53 @@ jobs:
           echo "  npx --yes playwright-core@1.62.1 install chromium" >&2
           exit 1
 
-      # Every deck in the directory, not just the investor deck: a second deck
-      # added later is covered the day it lands rather than the day someone
-      # remembers this file exists.
+      # Every HTML file anywhere under the directory, at any depth — not just the
+      # investor deck, and not just the top level. A deck added later is covered
+      # the day it lands rather than the day someone remembers this file exists,
+      # and that now holds for a deck given its own subdirectory (the natural
+      # choice once a deck carries assets), which the old non-recursive glob
+      # triggered this workflow for and then never measured (#3376).
+      #
+      # Not every HTML file under here is a deck, so the walk is recursive and
+      # the *classification* is the script's: it exits 3 for a file that is not
+      # a fixed-canvas deck and prints the path and the reason. That is reported
+      # here as a skip. A skip is never a pass — a silent one is exactly the bug
+      # this step keeps re-learning.
       - name: every slide fits the canvas at every viewport
         run: |
-          shopt -s nullglob
-          decks=(website/public/presentations/*.html)
+          # `git ls-files`, not a `**` glob: `**` needs `shopt -s globstar`, and
+          # a shell without it (bash 3.2, still the system bash on macOS, where
+          # this gets run by hand) does not error — it silently degrades `**` to
+          # `*` and drops every top-level deck. A check that quietly measures
+          # less than it claims is the bug being fixed here, so the enumeration
+          # must not have a mode where it does that. A git pathspec matches
+          # across `/` at any depth on every version, sorts deterministically,
+          # and restricts the walk to tracked files, which is what CI measures.
+          decks=()
+          while IFS= read -r -d '' deck; do
+            decks+=("$deck")
+          done < <(git ls-files -z 'website/public/presentations/*.html')
           if [ ${#decks[@]} -eq 0 ]; then
-            echo "deck-fit: no decks under website/public/presentations/" >&2
+            echo "deck-fit: no HTML under website/public/presentations/" >&2
             exit 1
           fi
           status=0
+          measured=0
+          skipped=0
           for deck in "${decks[@]}"; do
             echo "::group::$deck"
-            node scripts/deck-fit.mjs "$deck" || status=1
+            # `|| rc=$?`, not a bare call followed by `rc=$?`: the default shell
+            # here is `bash -e`, which would abort the step on the first failing
+            # deck before the status was ever read — losing both the remaining
+            # decks and the summary line below.
+            rc=0
+            node scripts/deck-fit.mjs "$deck" || rc=$?
             echo "::endgroup::"
+            case $rc in
+              0) measured=$((measured + 1)) ;;
+              3) skipped=$((skipped + 1)); echo "deck-fit: SKIPPED $deck (not a fixed-canvas deck)" ;;
+              *) measured=$((measured + 1)); status=1 ;;
+            esac
           done
+          echo "deck-fit: ${#decks[@]} file(s) found, $measured measured, $skipped skipped."
           exit $status

--- a/scripts/deck-fit.mjs
+++ b/scripts/deck-fit.mjs
@@ -23,7 +23,22 @@
 //
 //   CHROME=/path/to/chrome node scripts/deck-fit.mjs
 //
-// Exit status is 0 when every slide fits at every viewport, 1 otherwise.
+// Exit status is 0 when every slide fits at every viewport, 1 otherwise — with
+// two statuses reserved for "the measurement never happened", because the
+// workflow above now walks the whole tree recursively (#3376) and hands this
+// script HTML that was never authored as a fixed-canvas deck:
+//
+//   0  every slide fits every viewport
+//   1  a slide overflows, or the file claims to be a deck and is malformed
+//   2  the harness is missing (no such file, no playwright-core)
+//   3  not a fixed-canvas deck — skipped, with the reason printed
+//
+// 3 exists so a skip is a named event rather than a silent pass. The shape it
+// names is the one this script can actually measure: `.slide` elements each
+// wrapping a `.frame`, the fixed stage the overflow is measured against. A
+// scrolling document under the same directory (website/public/presentations/
+// turn-loop/index.html has 34 `.slide` sections and no `.frame` at all) is not
+// that shape and must not be counted as either a pass or a failure.
 
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
@@ -61,6 +76,45 @@ try {
 }
 
 const browser = await chromium.launch({ executablePath: CHROME });
+
+// Ask what shape this file is before measuring it, in one cheap load. The
+// recursive walk in deck-fit.yml means "is this a deck?" is now a real question
+// with three answers, and each gets a different exit status rather than a
+// guess: nothing to measure (skip), a stage to measure (proceed), or a deck
+// that lost a `.frame` somewhere (a defect this script should report, not
+// crash on — `slide.querySelector(".frame")` used to be dereferenced blind).
+{
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.goto(pathToFileURL(DECK).href);
+  await page.waitForLoadState("networkidle");
+  const shape = await page.evaluate(() => {
+    const slides = [...document.querySelectorAll(".slide")];
+    return {
+      slides: slides.length,
+      framed: slides.filter((s) => s.querySelector(".frame")).length,
+    };
+  });
+  await page.close();
+
+  if (shape.slides === 0 || shape.framed === 0) {
+    const reason =
+      shape.slides === 0
+        ? "no .slide elements"
+        : `${shape.slides} .slide elements, none wrapping a .frame`;
+    console.log(`deck-fit: skipping ${DECK} — not a fixed-canvas deck (${reason})`);
+    await browser.close();
+    process.exit(3);
+  }
+  if (shape.framed < shape.slides) {
+    console.error(
+      `deck-fit: ${DECK} — ${shape.slides - shape.framed} of ${shape.slides} slides have no .frame; ` +
+        "a fixed-canvas deck measures overflow against that stage, so this deck cannot be measured as authored.",
+    );
+    await browser.close();
+    process.exit(1);
+  }
+}
+
 let failures = 0;
 
 for (const vp of VIEWPORTS) {


### PR DESCRIPTION
fix(ci): deck-fit measures decks at any depth, and names what it skips

The workflow triggered on a recursive path filter and enumerated with a
non-recursive glob, so a deck at website/public/presentations/<name>/index.html
started the job and was never measured — the job then reported success. Same
shape as the bug that created the workflow (#2425): a check that is green while
covering less than a reader believes.

Enumeration is now `git ls-files` over a pathspec rather than a `**` glob:
`**` needs `shopt -s globstar`, and a shell without it does not error, it
silently degrades to `*` and drops the top level — the same failure mode being
fixed, reintroduced by the fix.

A recursive walk hands the script HTML that was never a deck, so deck-fit.mjs
probes shape before measuring and exits 3 with the path and the reason, which
the step reports as a skip and never as a pass. The shape probed is `.slide`
elements wrapping a `.frame`, not the issue's "zero .slide elements": the file
that prompted this, turn-loop/index.html, has 34 .slide sections and no .frame
at all, so the narrower predicate would have measured it and crashed on a null
`.frame` deref. That deref is now a named error instead.

The per-deck status is captured with `|| rc=$?` because the default shell is
`bash -e`, which would otherwise abort the step on the first failing deck and
lose both the remaining decks and the summary.

Witness (local — a committed always-failing deck would live under the measured
tree and red-line CI by construction): a fixture tree with a passing top-level
deck, an overflowing deck in a subdirectory, and a frameless document. The
pre-change step exits 0 and never opens the subdirectory deck; the post-change
step exits 1 naming +500px on that slide, measures the top-level deck, and
skips the document by name. Against the real tree it exits 0 — investor-deck
21/21 slides at 5 viewports, turn-loop skipped with its reason printed.

Closes #3376

## Summary by Sourcery

Ensure the deck-fit CI workflow measures all HTML presentations recursively and distinguishes real deck failures from non-deck HTML skips.

New Features:
- Classify HTML files as fixed-canvas decks based on `.slide` elements wrapping `.frame` and report non-deck files as explicit skips with a dedicated exit code.

Bug Fixes:
- Fix CI enumeration so all HTML presentations at any directory depth are discovered using `git ls-files` instead of a non-recursive glob that could silently miss decks.
- Prevent non-deck HTML files from being counted as passing checks by exiting with a specific status and printing the skip reason.
- Avoid silent crashes on malformed decks missing `.frame` elements by treating them as measurement failures with a clear error.

Enhancements:
- Capture per-deck exit codes in the workflow to aggregate measured vs skipped decks and to preserve processing of all files despite failures.
- Extend deck-fit script exit status semantics to distinguish successful measurements, deck failures, missing harness, and non-deck skips, and log a summary of found, measured, and skipped files in CI.