### PR TITLE
feat(stella-plugin): wrapper stages become a manifest with a closed condition grammar (#3381)

### DIFF
--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -18,6 +18,25 @@ credential or a URL. Unknown keys, unknown hook names, and unknown grades are
 load errors (`deny_unknown_fields` everywhere, the #1400 rule this crate
 inherits).
 
+`[wrapper]` (#3381) is the turn-loop wrapper's stage order, declared instead
+of hardcoded: an ordered `[[wrapper.stages]]` list under one variant id — the
+id the store's `pipeline_variant` column records (#3388). Two properties make
+it a gate rather than documentation:
+
+- **The `if` field is a closed grammar**, not an expression language:
+  `[no-]<boolean-signal>` or `<count-signal> <op> <number>`, over a published
+  signal set, evaluated by a pure function. A condition naming a signal the
+  host does not publish is a load error — a manifest that quietly does nothing
+  is worse than one that refuses to load.
+- **The stage graph is load-checked.** A condition reading a signal that only
+  a *later* stage publishes is rejected at load, so a hand-written variant
+  fails with a reason instead of wedging mid-run.
+
+Nothing here dispatches a stage: the four wrapper interception points are
+#3380 and do not exist yet, so a stage name is a declared name that
+load-checks. The crate is a leaf by contract, which is what lets the load-time
+contract be complete ahead of the socket it describes.
+
 The one function a host must never bypass is
 `LoopGrant::permits_hook(event)` — the authoritative filter behind the
 epic's rule that **an undeclared hook is never invoked**, even if the
@@ -61,11 +80,17 @@ before it crosses.
   `Participation`, `HookEvent`, `Oracle`, `Subloop`, `Role`), parsing, and
   every cross-field validation rule, each documented on the `ManifestError`
   variant that enforces it.
+- `src/wrapper.rs` — the `[wrapper]` block: `Wrapper`, `WrapperStage`, the
+  closed `StageName` and `Signal` vocabularies, the `Condition` grammar and
+  its parser, and the load-time stage-graph check.
 - `src/error.rs` — `ManifestError`, typed per rule (invariant 5).
 - `tests/manifest_grades.rs` + `tests/fixtures/*.toml` — slice A's
   acceptance: one fixture per grade, round-tripped through both TOML and
   `serde_json` (invariant 4), and the undeclared-hook filter proven against
   the fixtures.
+- `tests/wrapper_stages.rs` + `tests/fixtures/wrapper-*.toml` — #3381's
+  acceptance: the shipped stage order and a cheaper second variant, differing
+  in nothing but their text, plus one rejection test per load rule.
 
 ## Consumers
 

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -6,6 +6,7 @@
 //! the fix be obvious.
 
 use crate::manifest::{HookEvent, Participation};
+use crate::wrapper::{Signal, SignalKind, StageName};
 
 /// A manifest failed to parse or failed validation.
 ///
@@ -186,4 +187,112 @@ pub enum ManifestError {
     /// grant, chip, and hold attribution hangs off.
     #[error("manifest name must not be empty")]
     EmptyName,
+
+    /// `[wrapper]` was declared below `steering`. A wrapper intercepts the
+    /// turn loop — it adds context, gathers evidence, and asks for another
+    /// turn. That is participation, which `none` and `observer` have
+    /// disclaimed.
+    #[error(
+        "[wrapper] is only meaningful at participation = \"steering\" or \
+         above (declared grade: \"{participation}\")"
+    )]
+    WrapperRequiresSteering {
+        /// The declared grade, below `steering`.
+        participation: Participation,
+    },
+
+    /// `[wrapper] id` was empty. The id is what the store's
+    /// `pipeline_variant` column records (#3388), so it is the join key of
+    /// every per-variant comparison; a blank one makes a measured run
+    /// indistinguishable from an unmeasured one.
+    #[error("[wrapper] id must not be empty: it is the variant id every execution row records")]
+    EmptyWrapperId,
+
+    /// `[[wrapper.stages]]` declared no stages. A wrapper that runs no
+    /// stages is the raw loop with extra ceremony; omit the block instead.
+    #[error("[wrapper] must declare at least one [[wrapper.stages]] entry")]
+    EmptyWrapperStages,
+
+    /// The same stage was declared twice. Order is the whole point of the
+    /// list, and a repeated stage makes both its position and its condition
+    /// ambiguous.
+    #[error("[wrapper] declares stage \"{stage}\" more than once")]
+    DuplicateWrapperStage {
+        /// The stage that appeared twice.
+        stage: StageName,
+    },
+
+    /// A stage's `if` text is outside the closed condition grammar.
+    ///
+    /// Deliberately not a parser suggestion box: the grammar is two shapes
+    /// and stays that way, because a Turing-complete condition in a manifest
+    /// is a second program with no gate on it
+    /// (`doc:turn-loop-wrappers` §9.4).
+    #[error("[wrapper] stage \"{stage}\" has an unreadable condition \"{condition}\": {reason}")]
+    UnparsableCondition {
+        /// The stage carrying the condition.
+        stage: StageName,
+        /// The condition text as written.
+        condition: String,
+        /// Which grammar rule it failed, phrased as the fix.
+        reason: String,
+    },
+
+    /// A condition named a signal the host does not publish.
+    ///
+    /// The rule #3381 carries from #3245 slice A, made mechanical: a
+    /// manifest that quietly does nothing is worse than one that refuses to
+    /// load, so an unpublished signal is a load error rather than a
+    /// condition that silently never fires.
+    #[error(
+        "[wrapper] stage \"{stage}\" reads \"{signal}\" in condition \
+         \"{condition}\", which the host does not publish; published \
+         signals are: {published}"
+    )]
+    UnknownSignal {
+        /// The stage carrying the condition.
+        stage: StageName,
+        /// The condition text as written.
+        condition: String,
+        /// The unpublished name.
+        signal: String,
+        /// The published set, comma-joined, so the fix needs no doc lookup.
+        published: String,
+    },
+
+    /// A count signal was read as a boolean, or a boolean compared against a
+    /// number. The typed half of "each stage has a typed input and a typed
+    /// output": a mismatch is a load error, never a coercion.
+    #[error(
+        "[wrapper] stage \"{stage}\" reads \"{signal}\" as a {declared} \
+         signal, but it is a {actual} signal"
+    )]
+    ConditionTypeMismatch {
+        /// The stage carrying the condition.
+        stage: StageName,
+        /// The signal read at the wrong type.
+        signal: Signal,
+        /// The type the condition's shape implied.
+        declared: SignalKind,
+        /// The type the signal actually has.
+        actual: SignalKind,
+    },
+
+    /// A condition read a signal that only a **later** stage publishes.
+    ///
+    /// The stage-graph check. Without it, a hand-written variant's failure
+    /// mode is a wedged run at round three; with it, the same manifest is a
+    /// rejection with a reason at load.
+    #[error(
+        "[wrapper] stage \"{stage}\" reads \"{signal}\", which \"{publisher}\" \
+         publishes — but \"{publisher}\" is not declared before it"
+    )]
+    SignalNotYetPublished {
+        /// The stage whose condition reads too early.
+        stage: StageName,
+        /// The signal read before it exists.
+        signal: Signal,
+        /// The stage that publishes it, declared later or not at all.
+        publisher: StageName,
+    },
 }

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -10,15 +10,24 @@
 //! the sub-agent primitive) lives elsewhere and merely consumes this crate's
 //! answers.
 //!
+//! `[wrapper]` (#3381) joins them: the stage order a turn-loop wrapper runs,
+//! and the condition under which each stage runs, declared instead of
+//! hardcoded. See [`Condition`] for the closed condition grammar and the
+//! load-time stage-graph check that make "a condition naming a signal the
+//! host does not publish is a load error" mechanical rather than
+//! aspirational.
+//!
 //! The one function a host must not bypass is [`LoopGrant::permits_hook`]:
 //! it is the authoritative filter behind the epic's rule that an undeclared
 //! hook is never invoked, even if the plugin's process registers for it.
 
 mod error;
 mod manifest;
+mod wrapper;
 
 pub use error::ManifestError;
 pub use manifest::{
     FlipPolicy, HookEvent, LoopGrant, Oracle, OracleCommand, Participation, PluginManifest, Role,
     Subloop, TamperPolicy,
 };
+pub use wrapper::{CompareOp, Condition, Signal, SignalKind, StageName, Wrapper, WrapperStage};

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -29,6 +29,7 @@ use std::collections::{BTreeMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ManifestError;
+use crate::wrapper::Wrapper;
 
 /// How much of a say in the turn loop a plugin has declared (#3245 §2).
 ///
@@ -276,6 +277,11 @@ pub struct PluginManifest {
     /// Routing intents for subloop stages. Requires `[subloop]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roles: Option<BTreeMap<String, Role>>,
+    /// Steering and above: the wrapper's stage order and the conditions
+    /// under which each stage runs (#3381). Absent = this plugin is not a
+    /// turn-loop wrapper.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wrapper: Option<Wrapper>,
 }
 
 /// `skip_serializing_if` needs a named predicate; "the grant is the default"
@@ -394,6 +400,13 @@ impl PluginManifest {
                     });
                 }
             }
+        }
+
+        if let Some(wrapper) = &self.wrapper {
+            if !participation.includes(Participation::Steering) {
+                return Err(ManifestError::WrapperRequiresSteering { participation });
+            }
+            wrapper.validate()?;
         }
 
         if let Some(roles) = &self.roles {

--- a/crates/stella-plugin/src/wrapper.rs
+++ b/crates/stella-plugin/src/wrapper.rs
@@ -1,0 +1,534 @@
+//! The `[wrapper]` block — a turn-loop wrapper's stage order, declared.
+//!
+//! Slice of #3381: today the conditional stage order the staged pipeline runs
+//! is hardcoded branches inside `crates/stella-pipeline/src/pipeline.rs`, a
+//! file on the god-file list and closed to growth — so the design cannot
+//! absorb another variant even if we wanted one. A wrapper plugin declares the
+//! order instead, and the conditions become a line you can read and change.
+//!
+//! Two rules carried from #3245 slice A, not re-derived here:
+//!
+//! - An unknown key is a **load error** (every table denies unknown fields).
+//! - A condition naming a signal the host does not publish is **also a load
+//!   error**. A manifest that quietly does nothing is worse than one that
+//!   refuses to load.
+//!
+//! What this module adds is the machinery that makes the second rule
+//! mechanically checkable rather than aspirational (`doc:turn-loop-wrappers`
+//! §9.4). The `if` field is a **closed** grammar over a **published** signal
+//! set, evaluated by a pure function — never an expression language. A
+//! Turing-complete condition in a manifest is a second program with no gate on
+//! it.
+//!
+//! It also load-checks the stage graph: a condition reading a signal that some
+//! *later* stage publishes is rejected at load, so the failure mode of a
+//! hand-written variant is a rejection with a reason instead of a wedged run at
+//! round three.
+//!
+//! # Scope — what this module deliberately does not do
+//!
+//! Nothing here binds a stage to the loop. The four wrapper interception
+//! points (`before_turn` / `after_turn` / `judge` / `again?`) are #3380 and do
+//! not exist yet; until they do, a [`StageName`] is a declared name that
+//! load-checks, not a dispatch target. This crate is a leaf by contract — pure
+//! parsing and validation over borrowed text — so it can be complete and
+//! correct ahead of the socket it will eventually describe.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ManifestError;
+
+/// The `[wrapper]` block — an ordered, conditional stage list under one id.
+///
+/// The id is what the store's `pipeline_variant` column records (#3388), so
+/// it is the join key of the whole A/B setup: cost, outcome, and
+/// verified-versus-unverified rate per variant is one `GROUP BY` once the
+/// wrapper that ran wrote its id.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Wrapper {
+    /// The variant id — `"staged-v1"` in #3381's sketch, `"classic"` for the
+    /// order that ships today. Non-empty, and written to the execution row
+    /// **only when this manifest was the thing that ran**: a default or
+    /// fallback path writes the default's id, never a blank, because a
+    /// missing measurement must not render as a negative one.
+    pub id: String,
+    /// The stages, in execution order. Non-empty, no duplicates.
+    #[serde(default)]
+    pub stages: Vec<WrapperStage>,
+}
+
+/// One `[[wrapper.stages]]` entry — a stage name and the condition under
+/// which it runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WrapperStage {
+    /// Which stage. A closed vocabulary: an unknown name is a load error,
+    /// because a stage the host cannot dispatch is exactly the manifest that
+    /// quietly does nothing.
+    pub name: StageName,
+    /// The condition under which this stage runs; absent means
+    /// unconditional.
+    ///
+    /// Kept as the author's own text so the manifest round-trips
+    /// byte-for-byte (invariant 4) while [`WrapperStage::condition`] hands
+    /// back the parsed form. A value that came from
+    /// [`PluginManifest::from_toml_str`] has already had this parsed and
+    /// graph-checked, so that accessor cannot fail for such a value.
+    ///
+    /// [`PluginManifest::from_toml_str`]: crate::PluginManifest::from_toml_str
+    #[serde(rename = "if", default, skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+}
+
+impl WrapperStage {
+    /// The parsed condition, or `None` for an unconditional stage.
+    ///
+    /// Infallible in the sense that matters: validation already rejected any
+    /// manifest whose condition text does not parse, so a stage reached
+    /// through a validated [`Wrapper`] always answers `Ok`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same [`ManifestError`] validation would, for a
+    /// hand-constructed value that never went through the constructor.
+    pub fn condition(&self) -> Result<Option<Condition>, ManifestError> {
+        match &self.condition {
+            None => Ok(None),
+            Some(text) => Condition::parse(self.name, text).map(Some),
+        }
+    }
+}
+
+/// A stage the host can dispatch.
+///
+/// Closed by design, the [`FlipPolicy`] reasoning applied to stages: an
+/// unknown value must be a load error rather than a silently shorter run, and
+/// a future stage adds a variant here. The names and their order mirror
+/// `stage_rank` in `crates/stella-pipeline/src/replay.rs`, which is the
+/// canonical ordering today.
+///
+/// [`FlipPolicy`]: crate::FlipPolicy
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StageName {
+    /// Classify the task and name what must be researched.
+    Triage,
+    /// Pull prior context for the goal.
+    Recall,
+    /// Answer triage's questions with read-only sub-agents.
+    Research,
+    /// Turn the goal into steps.
+    Plan,
+    /// Review the plan's scope before spending on it.
+    Scope,
+    /// Run the turn.
+    Execute,
+    /// Author the failing test that will measure the turn.
+    Witness,
+    /// Turn evidence into a verdict.
+    Verify,
+}
+
+impl StageName {
+    /// The signals this stage publishes for later stages to read.
+    ///
+    /// This is the typed-output half of the graph check: a condition may only
+    /// name a signal that the host publishes or that an **earlier** stage
+    /// produces.
+    #[must_use]
+    pub fn publishes(self) -> &'static [Signal] {
+        match self {
+            Self::Triage => &[
+                Signal::Conversational,
+                Signal::Questions,
+                Signal::Plans,
+                Signal::Verifies,
+            ],
+            Self::Recall
+            | Self::Research
+            | Self::Plan
+            | Self::Scope
+            | Self::Execute
+            | Self::Witness
+            | Self::Verify => &[],
+        }
+    }
+
+    /// The name this stage is written as in a manifest.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Triage => "triage",
+            Self::Recall => "recall",
+            Self::Research => "research",
+            Self::Plan => "plan",
+            Self::Scope => "scope",
+            Self::Execute => "execute",
+            Self::Witness => "witness",
+            Self::Verify => "verify",
+        }
+    }
+}
+
+impl std::fmt::Display for StageName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A fact a condition may read.
+///
+/// The **published set** — naming anything outside it is a load error. Every
+/// entry is a fact the staged pipeline already branches on today, so this is a
+/// description of live behaviour rather than a vocabulary invented for the
+/// manifest:
+///
+/// - `test-command` — `Pipeline::config.test_command`, the host fact gating
+///   witness authoring.
+/// - `conversational`, `questions`, `plans`, `verifies` — triage's assessment,
+///   which decides the conversational fast path, whether the research stage
+///   runs at all, and whether the class plans and verifies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Signal {
+    /// Boolean, host: a `--test-command` is configured for this run.
+    TestCommand,
+    /// Boolean, triage: this turn is chat, not a software task.
+    Conversational,
+    /// Count, triage: how many research questions triage named.
+    Questions,
+    /// Boolean, triage: this task class plans.
+    Plans,
+    /// Boolean, triage: this task class verifies unconditionally.
+    Verifies,
+}
+
+impl Signal {
+    /// Every published signal, for the "did you mean" half of an error and
+    /// for tests that must fail when the set grows without a decision.
+    pub const ALL: &'static [Signal] = &[
+        Signal::TestCommand,
+        Signal::Conversational,
+        Signal::Questions,
+        Signal::Plans,
+        Signal::Verifies,
+    ];
+
+    /// Resolve a wire name to a signal. `None` is the load error the caller
+    /// turns into [`ManifestError::UnknownSignal`].
+    #[must_use]
+    pub fn from_wire(name: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|s| s.as_str() == name)
+    }
+
+    /// The name this signal is written as in a condition.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TestCommand => "test-command",
+            Self::Conversational => "conversational",
+            Self::Questions => "questions",
+            Self::Plans => "plans",
+            Self::Verifies => "verifies",
+        }
+    }
+
+    /// Whether this signal is a boolean or a count — the typed half of "each
+    /// stage has a typed input". A count in boolean position (or the reverse)
+    /// is a load error, not a coercion.
+    #[must_use]
+    pub fn kind(self) -> SignalKind {
+        match self {
+            Self::Questions => SignalKind::Count,
+            Self::TestCommand | Self::Conversational | Self::Plans | Self::Verifies => {
+                SignalKind::Boolean
+            }
+        }
+    }
+
+    /// Which stage publishes this signal, or `None` when the host does.
+    ///
+    /// The other half of the graph check: a host fact is readable by any
+    /// stage, a stage-published fact only by stages declared after its
+    /// publisher.
+    #[must_use]
+    pub fn publisher(self) -> Option<StageName> {
+        match self {
+            Self::TestCommand => None,
+            Self::Conversational | Self::Questions | Self::Plans | Self::Verifies => {
+                Some(StageName::Triage)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Signal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Whether a signal carries a truth value or a number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalKind {
+    /// Readable bare (`conversational`) or negated (`no-conversational`).
+    Boolean,
+    /// Readable only through a comparison (`questions > 0`).
+    Count,
+}
+
+impl std::fmt::Display for SignalKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Boolean => "boolean",
+            Self::Count => "count",
+        })
+    }
+}
+
+/// How a count is compared against a literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareOp {
+    /// `>`
+    Greater,
+    /// `>=`
+    GreaterOrEqual,
+    /// `<`
+    Less,
+    /// `<=`
+    LessOrEqual,
+    /// `==`
+    Equal,
+    /// `!=`
+    NotEqual,
+}
+
+impl CompareOp {
+    /// Every operator, in the order an error message lists them.
+    pub const ALL: &'static [CompareOp] = &[
+        CompareOp::Greater,
+        CompareOp::GreaterOrEqual,
+        CompareOp::Less,
+        CompareOp::LessOrEqual,
+        CompareOp::Equal,
+        CompareOp::NotEqual,
+    ];
+
+    fn from_wire(text: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|op| op.as_str() == text)
+    }
+
+    /// The operator as written in a condition.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Greater => ">",
+            Self::GreaterOrEqual => ">=",
+            Self::Less => "<",
+            Self::LessOrEqual => "<=",
+            Self::Equal => "==",
+            Self::NotEqual => "!=",
+        }
+    }
+
+    /// Apply the operator. Pure — this is the whole evaluator for the count
+    /// half of the grammar.
+    #[must_use]
+    pub fn apply(self, left: u64, right: u64) -> bool {
+        match self {
+            Self::Greater => left > right,
+            Self::GreaterOrEqual => left >= right,
+            Self::Less => left < right,
+            Self::LessOrEqual => left <= right,
+            Self::Equal => left == right,
+            Self::NotEqual => left != right,
+        }
+    }
+}
+
+/// A parsed condition — the whole closed grammar, in two shapes.
+///
+/// ```text
+/// condition := boolean | comparison
+/// boolean   := [ "no-" ] <boolean-signal>
+/// comparison:= <count-signal> <op> <integer>
+/// op        := ">" | ">=" | "<" | "<=" | "==" | "!="
+/// ```
+///
+/// That is the entire language, and it is meant to stay small enough to read
+/// in one sitting. Anything a wrapper wants that this cannot express is a new
+/// [`Signal`] the host publishes — a reviewable addition — never a richer
+/// expression syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Condition {
+    /// A boolean signal, optionally negated.
+    Boolean {
+        /// The signal read.
+        signal: Signal,
+        /// `true` when the condition was written with the `no-` prefix, so
+        /// the stage runs when the signal is **false**.
+        negated: bool,
+    },
+    /// A count signal compared against a literal.
+    Compare {
+        /// The signal read.
+        signal: Signal,
+        /// The comparison applied.
+        op: CompareOp,
+        /// The literal compared against.
+        value: u64,
+    },
+}
+
+impl Condition {
+    /// Parse condition text against the closed grammar.
+    ///
+    /// `stage` is carried only so a rejection can name where it was written;
+    /// it does not affect what parses.
+    ///
+    /// # Errors
+    ///
+    /// [`ManifestError::UnparsableCondition`] for text outside the grammar,
+    /// [`ManifestError::UnknownSignal`] for a signal the host does not
+    /// publish, and [`ManifestError::ConditionTypeMismatch`] for a count read
+    /// as a boolean or a boolean compared against a number.
+    pub fn parse(stage: StageName, text: &str) -> Result<Self, ManifestError> {
+        let unparsable = |reason: &str| ManifestError::UnparsableCondition {
+            stage,
+            condition: text.to_string(),
+            reason: reason.to_string(),
+        };
+
+        // Whitespace-separated, which is the only tokenisation the grammar
+        // needs: every accepted comparison writes its operator as its own
+        // token. That leaves `questions>0` — an attempted comparison with the
+        // spaces left out — landing in the one-token arm, where it would
+        // otherwise be reported as the unpublished signal `"questions>0"`.
+        // That rejection is correct and useless, so the arm names the real
+        // mistake instead. The grammar is unchanged: this recognises a
+        // failure, it does not accept a second spelling.
+        let tokens: Vec<&str> = text.split_whitespace().collect();
+        match tokens.as_slice() {
+            [bare] if bare.contains(['<', '>', '=', '!']) => Err(unparsable(
+                "a comparison must separate its operator from its operands \
+                 with spaces, as in \"questions > 0\"",
+            )),
+            [bare] => {
+                let (name, negated) = match bare.strip_prefix("no-") {
+                    Some(rest) => (rest, true),
+                    None => (*bare, false),
+                };
+                let signal = Self::resolve(stage, text, name)?;
+                if signal.kind() != SignalKind::Boolean {
+                    return Err(ManifestError::ConditionTypeMismatch {
+                        stage,
+                        signal,
+                        declared: SignalKind::Boolean,
+                        actual: signal.kind(),
+                    });
+                }
+                Ok(Self::Boolean { signal, negated })
+            }
+            [name, op, value] => {
+                let signal = Self::resolve(stage, text, name)?;
+                if signal.kind() != SignalKind::Count {
+                    return Err(ManifestError::ConditionTypeMismatch {
+                        stage,
+                        signal,
+                        declared: SignalKind::Count,
+                        actual: signal.kind(),
+                    });
+                }
+                let op = CompareOp::from_wire(op).ok_or_else(|| {
+                    unparsable(&format!(
+                        "unknown comparison \"{op}\"; the operators are {}",
+                        joined(CompareOp::ALL.iter().map(|o| o.as_str()))
+                    ))
+                })?;
+                let value = value.parse::<u64>().map_err(|_| {
+                    unparsable(&format!("\"{value}\" is not a non-negative whole number"))
+                })?;
+                Ok(Self::Compare { signal, op, value })
+            }
+            _ => Err(unparsable(
+                "expected either a boolean signal (optionally prefixed \"no-\") \
+                 or a comparison of the form \"<signal> <op> <number>\"",
+            )),
+        }
+    }
+
+    fn resolve(stage: StageName, text: &str, name: &str) -> Result<Signal, ManifestError> {
+        Signal::from_wire(name).ok_or_else(|| ManifestError::UnknownSignal {
+            stage,
+            condition: text.to_string(),
+            signal: name.to_string(),
+            published: joined(Signal::ALL.iter().map(|s| s.as_str())),
+        })
+    }
+
+    /// The signal this condition reads — what the graph check needs to know
+    /// without caring which shape the condition took.
+    #[must_use]
+    pub fn signal(self) -> Signal {
+        match self {
+            Self::Boolean { signal, .. } | Self::Compare { signal, .. } => signal,
+        }
+    }
+}
+
+/// Render a name list for an error message. Small enough to inline, but it is
+/// used from three places and a comma-join written three times drifts.
+fn joined<'a>(names: impl Iterator<Item = &'a str>) -> String {
+    names.collect::<Vec<_>>().join(", ")
+}
+
+impl Wrapper {
+    /// The cross-field rules for `[wrapper]`, called from the manifest's
+    /// `validate`.
+    ///
+    /// Three checks, in the order a reader meets a problem: the block itself
+    /// is well-formed, each condition parses against the closed grammar, and
+    /// the stage graph is satisfiable — no condition reads a signal that only
+    /// a later stage publishes.
+    pub(crate) fn validate(&self) -> Result<(), ManifestError> {
+        if self.id.trim().is_empty() {
+            return Err(ManifestError::EmptyWrapperId);
+        }
+        if self.stages.is_empty() {
+            return Err(ManifestError::EmptyWrapperStages);
+        }
+
+        // Walked in declaration order, accumulating what is readable so far:
+        // the host's facts always, plus each stage's outputs once that stage
+        // has been declared. Checking against this running set — rather than
+        // against "is the publisher anywhere in the list" — is what makes an
+        // out-of-order manifest a load error instead of a run that reads a
+        // fact nothing has produced yet.
+        let mut published: Vec<Signal> = Vec::new();
+        let mut seen: Vec<StageName> = Vec::with_capacity(self.stages.len());
+        for stage in &self.stages {
+            if seen.contains(&stage.name) {
+                return Err(ManifestError::DuplicateWrapperStage { stage: stage.name });
+            }
+            seen.push(stage.name);
+
+            if let Some(condition) = stage.condition()? {
+                let signal = condition.signal();
+                if let Some(publisher) = signal.publisher()
+                    && !published.contains(&signal)
+                {
+                    return Err(ManifestError::SignalNotYetPublished {
+                        stage: stage.name,
+                        signal,
+                        publisher,
+                    });
+                }
+            }
+
+            published.extend_from_slice(stage.name.publishes());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/stella-plugin/tests/fixtures/wrapper-lean-v1.toml
+++ b/crates/stella-plugin/tests/fixtures/wrapper-lean-v1.toml
@@ -1,0 +1,33 @@
+# A deliberately cheaper second variant.
+#
+# #3381's definition of done asks for a second variant "even a trivially
+# cheaper one", because one manifest describing one path proves nothing: it
+# is a description of the code, not a declaration the code reads. This one
+# drops recall, research, plan and scope — a cheap task should not pay for
+# ceremony it cannot use — and keeps only the stages that produce or grade
+# work.
+#
+# It differs from `wrapper-staged-v1.toml` in nothing but the manifest, which
+# is the whole claim being made.
+name = "lean"
+description = "Triage, do the work, grade it. No planning ceremony."
+
+[loop]
+participation = "steering"
+
+[wrapper]
+id = "lean-v1"
+
+[[wrapper.stages]]
+name = "triage"
+
+[[wrapper.stages]]
+name = "execute"
+
+[[wrapper.stages]]
+name = "witness"
+if = "no-test-command"
+
+[[wrapper.stages]]
+name = "verify"
+if = "verifies"

--- a/crates/stella-plugin/tests/fixtures/wrapper-staged-v1.toml
+++ b/crates/stella-plugin/tests/fixtures/wrapper-staged-v1.toml
@@ -1,0 +1,47 @@
+# The stage order the staged pipeline runs today, as a manifest.
+#
+# Every condition here transcribes a branch that lives in
+# `crates/stella-pipeline/src/pipeline.rs::run` — a file at its file-size
+# ceiling and closed to growth, which is why the order has to leave Rust
+# before another variant can exist (#3381).
+name = "staged"
+description = "The stage order Stella has shipped since the staged pipeline landed."
+
+[loop]
+participation = "steering"
+
+[wrapper]
+id = "classic"
+
+# Triage first: it publishes the signals every later condition reads.
+[[wrapper.stages]]
+name = "triage"
+
+[[wrapper.stages]]
+name = "recall"
+
+# "Empty questions skip the stage byte-for-byte" — pipeline.rs's own words.
+[[wrapper.stages]]
+name = "research"
+if = "questions > 0"
+
+[[wrapper.stages]]
+name = "plan"
+if = "plans"
+
+[[wrapper.stages]]
+name = "scope"
+if = "plans"
+
+[[wrapper.stages]]
+name = "execute"
+
+# The authored-witness decision: no configured --test-command, so the run
+# must build its own measuring stick.
+[[wrapper.stages]]
+name = "witness"
+if = "no-test-command"
+
+[[wrapper.stages]]
+name = "verify"
+if = "verifies"

--- a/crates/stella-plugin/tests/wrapper_stages.rs
+++ b/crates/stella-plugin/tests/wrapper_stages.rs
@@ -1,0 +1,362 @@
+//! #3381's acceptance for the manifest half: the stage order leaves Rust,
+//! and every way of writing a manifest that would quietly do nothing is a
+//! named load error instead.
+//!
+//! The two fixtures are the load-bearing claim. `wrapper-staged-v1.toml`
+//! transcribes the order `crates/stella-pipeline/src/pipeline.rs` runs today;
+//! `wrapper-lean-v1.toml` is a cheaper second shape. They differ in nothing
+//! but their text, which is what makes the manifest a declaration the code
+//! reads rather than a description of one hardcoded path.
+//!
+//! What these tests deliberately do **not** claim: that either variant *runs*.
+//! Binding a stage name to the loop needs the four wrapper interception
+//! points of #3380, which do not exist yet. Everything here is the load-time
+//! contract, which is complete on its own.
+
+use stella_plugin::{
+    CompareOp, Condition, ManifestError, PluginManifest, Signal, SignalKind, StageName,
+};
+
+const STAGED_V1: &str = include_str!("fixtures/wrapper-staged-v1.toml");
+const LEAN_V1: &str = include_str!("fixtures/wrapper-lean-v1.toml");
+
+fn parse(text: &str) -> Result<PluginManifest, ManifestError> {
+    PluginManifest::from_toml_str(text)
+}
+
+/// A `[wrapper]` block with `participation = "steering"` and the given
+/// stage list, so each rejection test varies exactly one thing.
+fn wrapper_manifest(stages: &str) -> String {
+    format!(
+        "name = \"probe\"\n\
+         [loop]\n\
+         participation = \"steering\"\n\
+         [wrapper]\n\
+         id = \"probe-v1\"\n\
+         {stages}"
+    )
+}
+
+// --- The two variants both load, from the same code. ---------------------
+
+#[test]
+fn todays_stage_order_loads_as_a_manifest() {
+    let manifest = parse(STAGED_V1).expect("the shipped order must load");
+    let wrapper = manifest.wrapper.expect("[wrapper] must parse");
+
+    assert_eq!(wrapper.id, "classic", "the variant id the store records");
+    let names: Vec<StageName> = wrapper.stages.iter().map(|s| s.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            StageName::Triage,
+            StageName::Recall,
+            StageName::Research,
+            StageName::Plan,
+            StageName::Scope,
+            StageName::Execute,
+            StageName::Witness,
+            StageName::Verify,
+        ],
+        "the order must match stage_rank in stella-pipeline's replay.rs"
+    );
+}
+
+#[test]
+fn a_second_cheaper_variant_loads_from_the_same_code() {
+    let staged = parse(STAGED_V1).unwrap().wrapper.unwrap();
+    let lean = parse(LEAN_V1).unwrap().wrapper.unwrap();
+
+    assert_ne!(staged.id, lean.id, "two variants need two join keys");
+    assert!(
+        lean.stages.len() < staged.stages.len(),
+        "the lean variant must actually be cheaper, not merely differently named"
+    );
+    // The claim that matters: nothing in Rust distinguishes them.
+    assert!(
+        lean.stages
+            .iter()
+            .all(|s| staged.stages.iter().any(|t| t.name == s.name)),
+        "the lean variant must be a subset of the shipped vocabulary"
+    );
+}
+
+#[test]
+fn the_shipped_conditions_parse_to_the_branches_they_transcribe() {
+    let wrapper = parse(STAGED_V1).unwrap().wrapper.unwrap();
+    let condition = |name: StageName| {
+        wrapper
+            .stages
+            .iter()
+            .find(|s| s.name == name)
+            .expect("stage declared")
+            .condition()
+            .expect("condition parses")
+    };
+
+    assert_eq!(
+        condition(StageName::Research),
+        Some(Condition::Compare {
+            signal: Signal::Questions,
+            op: CompareOp::Greater,
+            value: 0,
+        }),
+        "\"empty questions skip the stage byte-for-byte\""
+    );
+    assert_eq!(
+        condition(StageName::Witness),
+        Some(Condition::Boolean {
+            signal: Signal::TestCommand,
+            negated: true,
+        }),
+        "witness authoring is gated on there being no configured test command"
+    );
+    assert_eq!(
+        condition(StageName::Recall),
+        None,
+        "an omitted `if` is unconditional, not a condition that never fires"
+    );
+}
+
+#[test]
+fn both_variants_round_trip_through_toml_and_json() {
+    for text in [STAGED_V1, LEAN_V1] {
+        let parsed = parse(text).unwrap();
+
+        let via_toml = parse(&toml::to_string(&parsed).unwrap()).unwrap();
+        assert_eq!(parsed, via_toml, "TOML round-trip diverged");
+
+        let json = serde_json::to_string(&parsed).unwrap();
+        let via_json: PluginManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, via_json, "JSON round-trip diverged (invariant 4)");
+    }
+}
+
+// --- The witness tests #3381's definition of done names. ------------------
+
+#[test]
+fn an_unknown_key_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"triage\"\n\
+         unless = \"conversational\"\n",
+    );
+    assert!(
+        matches!(parse(&text), Err(ManifestError::Parse(_))),
+        "an unknown key must fail the load, never be ignored"
+    );
+}
+
+#[test]
+fn a_condition_naming_an_unpublished_signal_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"triage\"\n\
+         if = \"moon-is-full\"\n",
+    );
+    match parse(&text) {
+        Err(ManifestError::UnknownSignal { signal, stage, .. }) => {
+            assert_eq!(signal, "moon-is-full");
+            assert_eq!(stage, StageName::Triage);
+        }
+        other => panic!("expected UnknownSignal, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unpublished_signal_error_names_the_published_set() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"triage\"\n\
+         if = \"moon-is-full\"\n",
+    );
+    let rendered = parse(&text).unwrap_err().to_string();
+    for signal in Signal::ALL {
+        assert!(
+            rendered.contains(signal.as_str()),
+            "the rejection must name every published signal so the fix needs \
+             no doc lookup; \"{signal}\" was missing from: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn an_unknown_stage_name_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"reticulate-splines\"\n",
+    );
+    assert!(
+        matches!(parse(&text), Err(ManifestError::Parse(_))),
+        "a stage the host cannot dispatch is a manifest that quietly does nothing"
+    );
+}
+
+// --- The §9.4 amendments: a closed grammar and a checked graph. -----------
+
+#[test]
+fn a_condition_outside_the_grammar_is_a_load_error() {
+    // No expression language: this is the shape a manifest author reaches for
+    // once they assume one exists.
+    for condition in [
+        "questions > 0 && plans",
+        "questions>0",
+        "not conversational",
+    ] {
+        let text = wrapper_manifest(&format!(
+            "[[wrapper.stages]]\n\
+             name = \"triage\"\n\
+             if = \"{condition}\"\n"
+        ));
+        assert!(
+            matches!(parse(&text), Err(ManifestError::UnparsableCondition { .. })),
+            "\"{condition}\" must be rejected: the grammar is closed"
+        );
+    }
+}
+
+#[test]
+fn a_count_signal_read_as_a_boolean_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"triage\"\n\
+         if = \"questions\"\n",
+    );
+    match parse(&text) {
+        Err(ManifestError::ConditionTypeMismatch {
+            signal,
+            declared,
+            actual,
+            ..
+        }) => {
+            assert_eq!(signal, Signal::Questions);
+            assert_eq!(declared, SignalKind::Boolean);
+            assert_eq!(actual, SignalKind::Count);
+        }
+        other => panic!("expected ConditionTypeMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_boolean_signal_compared_against_a_number_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"triage\"\n\
+         if = \"conversational > 0\"\n",
+    );
+    assert!(matches!(
+        parse(&text),
+        Err(ManifestError::ConditionTypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn a_stage_reading_a_signal_no_earlier_stage_publishes_is_a_load_error() {
+    // `questions` is triage's output, and triage is declared *after* the
+    // stage that reads it. Without the graph check this manifest loads and
+    // wedges at run time.
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"research\"\n\
+         if = \"questions > 0\"\n\
+         [[wrapper.stages]]\n\
+         name = \"triage\"\n",
+    );
+    match parse(&text) {
+        Err(ManifestError::SignalNotYetPublished {
+            stage,
+            signal,
+            publisher,
+        }) => {
+            assert_eq!(stage, StageName::Research);
+            assert_eq!(signal, Signal::Questions);
+            assert_eq!(publisher, StageName::Triage);
+        }
+        other => panic!("expected SignalNotYetPublished, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_host_fact_is_readable_by_the_very_first_stage() {
+    // The other side of the graph check: `test-command` has no publisher
+    // stage, so ordering cannot make it unavailable.
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"execute\"\n\
+         if = \"no-test-command\"\n",
+    );
+    assert!(parse(&text).is_ok(), "a host fact needs no earlier stage");
+}
+
+// --- Well-formedness of the block itself. --------------------------------
+
+#[test]
+fn a_duplicate_stage_is_a_load_error() {
+    let text = wrapper_manifest(
+        "[[wrapper.stages]]\n\
+         name = \"execute\"\n\
+         [[wrapper.stages]]\n\
+         name = \"execute\"\n",
+    );
+    assert!(matches!(
+        parse(&text),
+        Err(ManifestError::DuplicateWrapperStage {
+            stage: StageName::Execute
+        })
+    ));
+}
+
+#[test]
+fn an_empty_variant_id_is_a_load_error() {
+    let text = "name = \"probe\"\n\
+                [loop]\n\
+                participation = \"steering\"\n\
+                [wrapper]\n\
+                id = \"  \"\n\
+                [[wrapper.stages]]\n\
+                name = \"execute\"\n";
+    assert!(
+        matches!(parse(text), Err(ManifestError::EmptyWrapperId)),
+        "a blank variant id makes a measured run indistinguishable from an \
+         unmeasured one"
+    );
+}
+
+#[test]
+fn a_wrapper_with_no_stages_is_a_load_error() {
+    let text = "name = \"probe\"\n\
+                [loop]\n\
+                participation = \"steering\"\n\
+                [wrapper]\n\
+                id = \"probe-v1\"\n";
+    assert!(matches!(
+        parse(text),
+        Err(ManifestError::EmptyWrapperStages)
+    ));
+}
+
+#[test]
+fn a_wrapper_below_steering_is_a_load_error() {
+    let text = "name = \"probe\"\n\
+                [loop]\n\
+                participation = \"observer\"\n\
+                [wrapper]\n\
+                id = \"probe-v1\"\n\
+                [[wrapper.stages]]\n\
+                name = \"execute\"\n";
+    assert!(
+        matches!(
+            parse(text),
+            Err(ManifestError::WrapperRequiresSteering { .. })
+        ),
+        "an observer may only watch; intercepting the turn is steering"
+    );
+}
+
+#[test]
+fn a_manifest_with_no_wrapper_block_is_not_a_wrapper() {
+    let text = "name = \"probe\"\n\
+                [loop]\n\
+                participation = \"steering\"\n";
+    assert!(parse(text).unwrap().wrapper.is_none());
+}


### PR DESCRIPTION
## What and why

#3381 asks for three things: stages as a manifest, a variant column, and the
`--pipeline` flag inversion. This PR delivers **the manifest half**, which is
the part that is buildable today. The scope call is explained below and in the
issue's own terms.

Today the staged pipeline's conditional stage order is hardcoded branches in
`crates/stella-pipeline/src/pipeline.rs::run`. That file is **2783 lines and
sits exactly at its ceiling** in `scripts/file-size-baseline.txt` — closed to
growth — so the current design cannot absorb another variant even if we wanted
one, which is precisely the problem #3381 states.

A wrapper plugin now declares the order instead:

```toml
[wrapper]
id = "classic"

[[wrapper.stages]]
name = "triage"

[[wrapper.stages]]
name = "research"
if = "questions > 0"

[[wrapper.stages]]
name = "witness"
if = "no-test-command"
```

## The two §9.4 amendments, implemented rather than deferred

The issue's appendix says the `if` sketch is two grammars in one field and
needs to become a **closed** set of named predicates, and that the stage graph
must be **load-checked**. Both are here, because they are what turn #3381's
existing rule — "a condition naming a signal the host does not publish is a
load error" — from aspirational into mechanical:

- **Closed grammar, two shapes only**: `[no-]<boolean-signal>` or
  `<count-signal> <op> <number>`, evaluated by a pure function. Never an
  expression language — a Turing-complete condition in a manifest is a second
  program with no gate on it.
- **Typed signals**: a count read as a boolean (or a boolean compared against a
  number) is a load error, not a coercion. This is the "typed input / typed
  output" the issue asks for, made checkable.
- **Load-checked stage graph**: a condition reading a signal that only a
  *later* stage publishes is rejected at load. The failure mode of a
  hand-written variant becomes a rejection with a reason instead of a wedged
  run at round three.

## The published signals describe live behaviour

Every `Signal` transcribes a branch that exists today, so the vocabulary is a
description of the shipped pipeline rather than one invented for the manifest:

| Signal | Kind | Publisher | The branch it transcribes |
|---|---|---|---|
| `test-command` | boolean | host | `Pipeline::config.test_command` (`pipeline.rs:1138`) |
| `conversational` | boolean | triage | the conversational fast path (`pipeline.rs:1189`) |
| `questions` | count | triage | "empty questions skip the stage byte-for-byte" (`pipeline.rs:1153-1159`) |
| `plans` | boolean | triage | `task_class.plans()` (`pipeline.rs:1195`) |
| `verifies` | boolean | triage | `task_class.verifies_unconditionally()` (`pipeline.rs:1123-1127`) |

Signals the pipeline gates on that are **not** published yet are named and
tracked in #3408 rather than quietly omitted.

## Two variants, differing in nothing but their text

`wrapper-staged-v1.toml` transcribes the shipped order; `wrapper-lean-v1.toml`
is a cheaper second shape. #3381 asks for a second variant because one manifest
describing one path proves nothing — it would be a description of the code
rather than a declaration the code reads.

## Witness tests

`crates/stella-plugin/tests/wrapper_stages.rs`, 18 tests. The two the issue's
definition of done names explicitly:

- `an_unknown_key_is_a_load_error`
- `a_condition_naming_an_unpublished_signal_is_a_load_error`

plus an unknown stage name, a condition outside the grammar (three shapes an
author reaches for once they assume an expression language exists), a count
read as a boolean, a boolean compared against a number, a signal read before
its publisher, a duplicate stage, an empty variant id, a wrapper below
`steering`, and both fixtures round-tripping through TOML and `serde_json`
(invariant 4).

On `main` they fail as a **compile error**, not a failed assertion:
`StageName`, `Signal`, `Condition` and `PluginManifest::wrapper` do not exist
there (verified — `git show origin/main:crates/stella-plugin/src/lib.rs` names
none of them). That is the expected witness shape for a slice whose subject is
a new type: the seam the test names is absent, so the test cannot link. The
behavioural half is witnessed inside the PR instead — every rejection test
names the specific `ManifestError` variant, so a rule that silently stopped
firing fails its test rather than passing vacuously.

## Scope — what this deliberately does not do, and why

**Stated out loud rather than shipped quietly, per CLAUDE.md.**

- **No stage is bound to the loop.** The four wrapper interception points
  (`before_turn` / `after_turn` / `judge` / `again?`) are #3380 and do not
  exist anywhere in the tree — verified: no such trait or item in
  `stella-core`, `stella-runtime`, `stella-pipeline`, or `stella-plugin`; every
  hit is prose in `docs/spec/turn-loop-wrappers.md`. #3380 is itself blocked by
  #3379. `stella-plugin` is a leaf by contract, which is what lets the
  load-time contract be complete and correct ahead of the socket it describes.
  **The wiring is filed as #3408**, so this scaffolding is not unwired code
  with no handoff.
- **The column half already shipped.** #3388 (PR #3393) added
  `executions.pipeline_variant` and disentangled `kind` into a door-only
  column; `PIPELINE_VARIANT_CLASSIC = "classic"` in
  `crates/stella-cli/src/agent/persistence.rs` is already the id this PR's
  shipped-order fixture declares, so the two halves agree without a change
  here.
- **The flag inversion is not in this PR, by the issue's own terms.** #3381's
  appendix §9.6 records that every published Stella benchmark number was
  produced with the pipeline as the default, and that whether to spend a
  side-by-side bench or flip ungated is "the maintainer's call — recorded here
  rather than decided". It also depends on wrappers actually being plugins
  (#3380). I have not decided it. The four `no_pipeline` flags are untouched
  (`cli.rs:512`, `:585`, `:607`, `:781`).

## Gate

`make guards-fast` green; `check-file-size`, `check-god-files`,
`check-left-behind`, `check-doc-links`, `check-invariants`, `check-brand-case`
each green individually; `cargo test -p stella-plugin` 46 passed / 0 failed;
clippy `-D warnings` and rustdoc `-D warnings` clean on the crate.

No new dependencies. No test deleted.

Refs #3381, #3380, #3388, #3245, #2889, #3408.
