### PR TITLE
fix(stella-cli): restore the raw run's terminal complete, lost in #3417's merge (main is red)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1620,7 +1620,7 @@ async fn run_turn(
         &cfg.workspace_root,
     );
     let (raw_tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
-    let (tx, durable_pre_persisted) = event_sender_for_run(raw_tx, format);
+    let (tx, durable_pre_persisted) = event_sender_for_raw_run(raw_tx, format);
     // The proactive re-query (#3243 Phase 3): the engine consults this at
     // every step boundary; the adapter's hysteresis makes an undrifted turn
     // free. Seeded from `messages` so the turn-opening block is never

--- a/crates/stella-core/src/event_sender.rs
+++ b/crates/stella-core/src/event_sender.rs
@@ -131,3 +131,118 @@ impl From<UnboundedSender<AgentEvent>> for EventSender {
         Self::new(sender)
     }
 }
+
+#[cfg(test)]
+mod run_ending_tests {
+    use super::*;
+
+    fn drain(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            out.push(event);
+        }
+        out
+    }
+
+    /// The contract a raw run's consumers actually depend on: the engine's
+    /// per-turn ending goes through untouched, and the run's own follows it.
+    ///
+    /// This exists because losing it is silent. The wiring is one call at one
+    /// call site, and when a merge dropped that call (#3379 landing against
+    /// #3414, which rewrote the same lines) the only complaint was a dead-code
+    /// lint on the now-uncalled constructor. Nothing said the thing that
+    /// actually broke: a raw `stella run` emitted `turn_complete` and then
+    /// simply stopped, so every consumer waiting for the terminal event waited
+    /// forever. A lint on the producer is not a test of the behaviour.
+    #[test]
+    fn a_wrapped_turn_ending_is_forwarded_and_followed_by_the_run_ending() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let events = RunEnding::sealing(EventSender::new(tx));
+        events
+            .send(AgentEvent::TurnComplete {
+                model: "opus".to_string(),
+                cost_usd: 0.25,
+            })
+            .expect("the receiver is alive");
+        drop(events);
+
+        let seen = drain(&mut rx);
+        assert!(
+            matches!(
+                seen.as_slice(),
+                [
+                    AgentEvent::TurnComplete { .. },
+                    AgentEvent::Complete { model, cost_usd },
+                ] if model == "opus" && (*cost_usd - 0.25).abs() < f64::EPSILON
+            ),
+            "the turn ending passes through unedited and the run's follows it, \
+             carrying that turn's model and spend: {seen:?}"
+        );
+    }
+
+    /// Several turns settle as one run ending carrying their total — and the
+    /// per-turn endings are still all present, because this observes rather
+    /// than replaces them.
+    #[test]
+    fn several_turns_end_the_run_once_with_their_total() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let events = RunEnding::sealing(EventSender::new(tx));
+        for cost_usd in [0.1, 0.2, 0.3] {
+            events
+                .send(AgentEvent::TurnComplete {
+                    model: "opus".to_string(),
+                    cost_usd,
+                })
+                .expect("the receiver is alive");
+        }
+        drop(events);
+
+        let seen = drain(&mut rx);
+        assert_eq!(
+            seen.iter()
+                .filter(|e| matches!(e, AgentEvent::TurnComplete { .. }))
+                .count(),
+            3,
+            "every turn ending survives: {seen:?}"
+        );
+        let terminal: Vec<&AgentEvent> = seen
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::Complete { .. }))
+            .collect();
+        assert!(
+            matches!(
+                terminal.as_slice(),
+                [AgentEvent::Complete { cost_usd, .. }]
+                    if (*cost_usd - 0.6).abs() < 1e-9
+            ),
+            "exactly one run ending, carrying the run's total: {terminal:?}"
+        );
+        assert!(
+            matches!(seen.last(), Some(AgentEvent::Complete { .. })),
+            "and it is last: {seen:?}"
+        );
+    }
+
+    /// A run no turn of which succeeded ends on `Error`, never on `Complete` —
+    /// the same rule the engine used to apply one turn at a time.
+    #[test]
+    fn a_run_with_no_successful_turn_emits_no_run_ending() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let events = RunEnding::sealing(EventSender::new(tx));
+        events
+            .send(AgentEvent::Error {
+                message: "provider refused".to_string(),
+                retryable: false,
+            })
+            .expect("the receiver is alive");
+        drop(events);
+
+        let seen = drain(&mut rx);
+        assert!(
+            !seen
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Complete { .. })),
+            "a failed run must not be sealed as a success: {seen:?}"
+        );
+    }
+}


### PR DESCRIPTION
## main is red, and worse than red

`main` currently fails `clippy -D warnings`:

```
error: function `event_sender_for_raw_run` is never used
  --> crates/stella-cli/src/agent/output.rs:179:15
```

That lint is the *quiet* half. The loud half has no diagnostic at all: a raw
`stella run` turn emits `turn_complete` and then stops. **No `complete` ever
reaches stdout, the durable stream-json sink, or any consumer waiting for the
terminal event.**

## How it happened

Two PRs, both correct on their own, that neither git nor either author's CI
could see composing wrongly — the shared-cell shape AGENTS.md describes, but
on a *line* rather than a generated file:

- **#3417** (#3379) pointed the CLI's raw one-shot turn at
  `event_sender_for_raw_run`, which wraps the sender in `RunEnding` so the run
  emits the terminal `Complete` the engine deliberately stopped claiming.
- **#3414** rewrote the very same lines to thread `tx` into the re-query
  (#3366).

The merge kept #3414's version of that region. No conflict was reported,
because one side simply does not contain the other's change. #3417's pre-merge
CI *did* go red on exactly this — I read the failure after the merge had
already landed.

## The fix

One word at the call site restores it.

## What is actually worth reviewing

The wiring was **one call at one call site with no test behind it**, so its
loss could only ever surface as a dead-code lint on the producer — a message
about the constructor being uncalled, not about runs losing their ending. A
lint on the producer is not a test of the behaviour.

`run_ending_tests` in `crates/stella-core/src/event_sender.rs` now pins the
contract where it lives:

- a turn ending is forwarded **unedited** and followed by the run's, carrying
  that turn's model and spend;
- several turns settle as **one** run ending carrying their total, and it is
  **last**, with every per-turn ending still present (this observes, it does
  not replace);
- a run with no successful turn is **never** sealed as a success — a failed run
  ends on `Error`, the same rule the engine used to apply one turn at a time.

Any future merge that drops the call site fails these instead of merely
linting.

## Verification

`make gate` — green, all 29 steps, run against this merge (not against
#3417's base).

## Deleted tests

None.

Refs #3379, #3417

## Summary by Sourcery

Restore raw run terminal completion events and pin the RunEnding contract with tests to prevent regressions.

Bug Fixes:
- Restore use of the raw-run-specific event sender so raw `stella run` emits the final `Complete` event instead of stopping after `turn_complete`.

Tests:
- Add run-ending tests to verify that per-turn completions are forwarded unchanged, a single aggregate run completion is emitted last with the correct total cost, and failed runs do not emit a success completion.