### PR TITLE
fix(stella-cli): restore event_sender_for_raw_run, drop the dead pipeline filter (main does not compile)

### DIFF
--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use stella_core::event_sender::RunEnding;
 use stella_core::ports::Clock;
 use stella_core::{EventSendError, EventSender};
 use stella_protocol::AgentEvent;
@@ -160,35 +161,27 @@ pub(super) fn event_sender_for_run(
     (EventSender::new(sender), false)
 }
 
-/// The sender the pipeline itself emits on, for a one-shot run.
+/// [`event_sender_for_run`] for a run the CLI drives as bare engine turns,
+/// with no pipeline above it (#3379).
 ///
-/// On `stream-json` the caller emits its own terminal `Complete` once
-/// reflection and accounting have settled, carrying the all-calls total — so
-/// the pipeline's earlier, pre-reflection one is dropped here rather than left
-/// to be "replaced" downstream. It never was replaced anywhere it mattered:
-/// the renderer only ever *displayed* the last `Complete`, but the durable
-/// JSONL sink appends every event it is handed, so both landed in the
-/// benchmark evidence file and a consumer that stopped at the first terminal
-/// event read the pre-reflection cost (#960).
+/// The difference is who ends the run. A staged run's ending is the
+/// pipeline's, authored from a verdict it alone holds. A raw run has no such
+/// author: the engine ends each turn with `TurnComplete` and deliberately
+/// says nothing about the run, so the CLI — the owner here — emits the
+/// terminal `RunComplete` itself. [`RunEnding`] does that when this sender's
+/// last clone drops, which is precisely when the run's stream closes and
+/// therefore the only moment "last" is guaranteed rather than assumed.
 ///
-/// Suppression is exactly as wide as the replacement. The pipeline emits
-/// `Complete` only on an `Ok` outcome, and the one-shot path sends its
-/// replacement for every `Ok` outcome, so a run that had a terminal event
-/// before still has exactly one — never zero.
-///
-/// Every other format keeps the pipeline's `Complete`: it is the only one they
-/// get.
-pub(super) fn pipeline_event_sender(events: &EventSender, format: OutputFormat) -> EventSender {
-    if format != OutputFormat::StreamJson {
-        return events.clone();
-    }
-    let inner = events.clone();
-    EventSender::from_fn(move |event| {
-        if matches!(event, AgentEvent::Complete { .. }) {
-            return Ok(());
-        }
-        inner.send(event)
-    })
+/// Wrapping *outside* the durability boundary above is deliberate: the
+/// terminal event is journaled through the same persist-first sender as
+/// everything before it, so a durable stream still ends on the event that
+/// ended the run.
+pub(super) fn event_sender_for_raw_run(
+    sender: mpsc::UnboundedSender<AgentEvent>,
+    format: OutputFormat,
+) -> (EventSender, bool) {
+    let (events, durable_pre_persisted) = event_sender_for_run(sender, format);
+    (RunEnding::sealing(events), durable_pre_persisted)
 }
 
 /// The durable sink, and the point at which an event becomes a *line*.


### PR DESCRIPTION
**`main` does not compile.** Two errors on `c67185bab`, one of them mine:

```
error[E0425]: cannot find function `event_sender_for_raw_run` in this scope
  --> crates/stella-cli/src/agent.rs:1623:39
error[E0599]: no variant named `Complete` found for enum `stella_protocol::AgentEvent`
  --> crates/stella-cli/src/agent/output.rs:187:40
```

### E0425 — my fault, corrected here

#3425 deleted `event_sender_for_raw_run` as dead code. I read the then-open #3418 as the author's intent to remove it. That branch was cut **before** #3418 landed (`b5224d502`) and merged **after**, so the deletion was decided against a tree that no longer existed — the stale-base composition hazard. Meanwhile #3426 wired the function at `agent.rs:1623`, which is exactly the call site #3425 declined to guess at. My call was wrong twice over: wrong to delete, and wrong to reason from a stale base without re-checking that main had moved.

Restored verbatim. The doc comment now names `RunComplete`, since that is what `RunEnding` seals with after #3417's rename.

### E0599 — #3418's leftover

#3418 removed every caller of `pipeline_event_sender` but not the function itself, which still matches on the `AgentEvent::Complete` variant #3417 renamed to `TurnComplete`/`RunComplete`. Confirmed it has **no callers anywhere in the workspace** (`rg pipeline_event_sender crates/` returns only its own definition).

Deleting it is also what the design says: it is the wrapper-side suppressor #3379 abolishes — *"a wrapper never suppresses, rewrites, or re-emits an engine event to manufacture an ending"* (`stella-protocol/src/event.rs`, `RunComplete` docs) — which is what #3417's title means by "and nobody filters it".

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p stella-cli --bins` — 1743 passed
- Both errors reproduce on `c67185bab` before this change.

Failing runs: https://github.com/macanderson/stella/actions/runs/31989851489

Refs #3379

## Summary by Sourcery

Restore raw run event sender in the CLI and remove the obsolete pipeline event filter so main builds and run completion is handled correctly.

Bug Fixes:
- Fix missing `event_sender_for_raw_run` in stella-cli to resolve compilation failure.
- Remove unused pipeline-level event sender that incorrectly matched on a renamed completion event variant.

Enhancements:
- Clarify documentation around how raw runs are ended and how the terminal `RunComplete` event is emitted for durable streams.