### PR TITLE
fix(stella-cli): main does not compile, and a raw run has no terminator (#3417/#3418/#3425 composition)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1620,7 +1620,7 @@ async fn run_turn(
         &cfg.workspace_root,
     );
     let (raw_tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
-    let (tx, durable_pre_persisted) = event_sender_for_raw_run(raw_tx, format);
+    let (tx, durable_pre_persisted) = event_sender_for_run(raw_tx, format);
     // The proactive re-query (#3243 Phase 3): the engine consults this at
     // every step boundary; the adapter's hysteresis makes an undrifted turn
     // free. Seeded from `messages` so the turn-opening block is never
@@ -1699,6 +1699,14 @@ async fn run_turn(
     // events and a consumer folding the stream must see them inside the turn
     // they describe. See `crate::turn_files` for why a measurement, not a hook.
     crate::turn_files::emit_shared_tree_changes(cfg, &tx);
+    // This path owns its run — one raw engine turn, no pipeline above it — so
+    // it owes the run's terminator (#3379). The engine ends the turn with
+    // `TurnComplete` and deliberately says nothing about the run, and every
+    // other owner (the deck, fleet, goal, resume, the pipeline one-shot) goes
+    // through this same seam; without it a raw `stella run` ended on
+    // `turn_complete` and simply stopped, leaving every consumer waiting for a
+    // terminal event that never came. Last, after the turn's own events above.
+    persistence::emit_run_complete_for_turn(&tx, &cfg.model_id, &outcome);
     // The re-query adapter holds an `EventSender` clone of this run's channel
     // (#3366 telemetry), so it must be released here too — otherwise it keeps
     // the channel open and the renderer's `recv()` loop never ends (#2290).

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -160,37 +160,6 @@ pub(super) fn event_sender_for_run(
     (EventSender::new(sender), false)
 }
 
-/// The sender the pipeline itself emits on, for a one-shot run.
-///
-/// On `stream-json` the caller emits its own terminal `Complete` once
-/// reflection and accounting have settled, carrying the all-calls total — so
-/// the pipeline's earlier, pre-reflection one is dropped here rather than left
-/// to be "replaced" downstream. It never was replaced anywhere it mattered:
-/// the renderer only ever *displayed* the last `Complete`, but the durable
-/// JSONL sink appends every event it is handed, so both landed in the
-/// benchmark evidence file and a consumer that stopped at the first terminal
-/// event read the pre-reflection cost (#960).
-///
-/// Suppression is exactly as wide as the replacement. The pipeline emits
-/// `Complete` only on an `Ok` outcome, and the one-shot path sends its
-/// replacement for every `Ok` outcome, so a run that had a terminal event
-/// before still has exactly one — never zero.
-///
-/// Every other format keeps the pipeline's `Complete`: it is the only one they
-/// get.
-pub(super) fn pipeline_event_sender(events: &EventSender, format: OutputFormat) -> EventSender {
-    if format != OutputFormat::StreamJson {
-        return events.clone();
-    }
-    let inner = events.clone();
-    EventSender::from_fn(move |event| {
-        if matches!(event, AgentEvent::Complete { .. }) {
-            return Ok(());
-        }
-        inner.send(event)
-    })
-}
-
 /// The durable sink, and the point at which an event becomes a *line*.
 ///
 /// The line carries this sink's own `ts` (#2111). The renderer publishes the

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -873,6 +873,67 @@ mod usage_recovery_tests {
 }
 
 #[cfg(test)]
+mod run_terminator_tests {
+    use super::*;
+
+    fn drain(rx: &mut mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            out.push(event);
+        }
+        out
+    }
+
+    /// A completed raw turn ends its run; an aborted one does not, because the
+    /// abort already crossed the stream as `Error` and a run must never end on
+    /// both.
+    ///
+    /// The rule was documented on [`emit_run_complete_for_turn`] and nowhere
+    /// asserted, which is how the raw one-shot path came to call nothing at all
+    /// (#3379 landing against #3418/#3425): the only signal was a dead-code
+    /// lint on an uncalled helper, and a lint on the producer says nothing
+    /// about whether a run still ends.
+    #[test]
+    fn a_completed_turn_ends_the_run_and_an_aborted_one_does_not() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let events = stella_core::EventSender::new(tx);
+
+        emit_run_complete_for_turn(
+            &events,
+            "worker",
+            &TurnOutcome::Completed {
+                text: "done".into(),
+                cost_usd: 0.5,
+            },
+        );
+        let seen = drain(&mut rx);
+        assert!(
+            matches!(
+                seen.as_slice(),
+                [AgentEvent::RunComplete { model, cost_usd }]
+                    if model == "worker" && (*cost_usd - 0.5).abs() < f64::EPSILON
+            ),
+            "a completed turn ends the run, carrying its model and spend: {seen:?}"
+        );
+
+        emit_run_complete_for_turn(
+            &events,
+            "worker",
+            &TurnOutcome::Aborted {
+                reason: "budget".into(),
+                kind: stella_core::AbortKind::DeliberateStop,
+                cost_usd: 0.5,
+            },
+        );
+        assert!(
+            drain(&mut rx).is_empty(),
+            "an aborted turn already sent Error; sealing it as a success would \
+             make the run end on both"
+        );
+    }
+}
+
+#[cfg(test)]
 mod stream_tests {
     use super::*;
 

--- a/crates/stella-core/src/event_sender.rs
+++ b/crates/stella-core/src/event_sender.rs
@@ -172,7 +172,7 @@ mod run_ending_tests {
                 seen.as_slice(),
                 [
                     AgentEvent::TurnComplete { .. },
-                    AgentEvent::Complete { model, cost_usd },
+                    AgentEvent::RunComplete { model, cost_usd },
                 ] if model == "opus" && (*cost_usd - 0.25).abs() < f64::EPSILON
             ),
             "the turn ending passes through unedited and the run's follows it, \
@@ -207,18 +207,18 @@ mod run_ending_tests {
         );
         let terminal: Vec<&AgentEvent> = seen
             .iter()
-            .filter(|e| matches!(e, AgentEvent::Complete { .. }))
+            .filter(|e| matches!(e, AgentEvent::RunComplete { .. }))
             .collect();
         assert!(
             matches!(
                 terminal.as_slice(),
-                [AgentEvent::Complete { cost_usd, .. }]
+                [AgentEvent::RunComplete { cost_usd, .. }]
                     if (*cost_usd - 0.6).abs() < 1e-9
             ),
             "exactly one run ending, carrying the run's total: {terminal:?}"
         );
         assert!(
-            matches!(seen.last(), Some(AgentEvent::Complete { .. })),
+            matches!(seen.last(), Some(AgentEvent::RunComplete { .. })),
             "and it is last: {seen:?}"
         );
     }
@@ -241,7 +241,7 @@ mod run_ending_tests {
         assert!(
             !seen
                 .iter()
-                .any(|e| matches!(e, AgentEvent::Complete { .. })),
+                .any(|e| matches!(e, AgentEvent::RunComplete { .. })),
             "a failed run must not be sealed as a success: {seen:?}"
         );
     }


### PR DESCRIPTION
## main does not compile

```
error[E0425]: cannot find function `event_sender_for_raw_run` in this scope
  --> crates/stella-cli/src/agent.rs:1623
error[E0599]: no variant named `Complete` found for enum `AgentEvent`
  --> crates/stella-cli/src/agent/output.rs:187
```

And underneath the build break, a live behavioural gap: **a raw `stella run`
ended on `turn_complete` and simply stopped.** No `run_complete` reached
stdout, the durable stream-json sink, or any consumer waiting for a terminal
event.

## How

Three PRs implemented #3379 concurrently:

- **#3417** (mine) — split the ending, wired the raw path through
  `event_sender_for_raw_run`/`RunEnding`.
- **#3418** — the fuller implementation (also closing #3398): renamed
  `Complete` → `RunComplete`, added `StageScope`, and standardised every run
  owner on a `persistence::emit_run_complete*` seam.
- **#3425** — deleted `event_sender_for_raw_run`, correctly, as unwired after
  #3418.
- **#3426** — restored the call site, against a base that predated #3418.

Every one of those is right on its own. No two of them conflict textually, so
neither git nor any pre-merge CI run could see the composition break. This is
the shared-cell hazard AGENTS.md describes, at line granularity rather than on
a generated file.

## Resolution — #3418's design, throughout

I resolved in favour of #3418 everywhere, because that is what the tree is
built around and it is the better factoring:

- The raw one-shot path now calls **`persistence::emit_run_complete_for_turn`**
  — the same seam the deck, fleet, goal, resume, and the pipeline one-shot
  already use — rather than reintroducing the second, `RunEnding`-based
  mechanism #3425 had correctly removed. `RunEnding` stays exactly where #3418
  kept it, serving `stella-serve`.
- **`pipeline_event_sender` is deleted.** #3418 removed its callers on purpose:
  with the pipeline no longer emitting a duplicate terminator, there is nothing
  left for it to suppress.

## The part worth reviewing

Both defects were invisible in the same way, and it is the same way the
original one was: **the wiring is a single call with nothing asserting it**, so
its absence can only ever surface as a dead-code lint about an uncalled helper
— a message about the producer, which says nothing about whether runs still
end.

Two tests close that:

- `a_completed_turn_ends_the_run_and_an_aborted_one_does_not` — the
  `emit_run_complete_for_turn` contract, documented since #3418 and never
  asserted, which my new call site depends on.
- `RunEnding`'s three cases, carried from #3426 and renamed to the current
  vocabulary.

Also worth noting for anyone verifying locally: **`cargo build --workspace` was
clean while `--all-targets` was not**, because the tests carrying the old name
are not built by a plain build. `make gate` caught it; a build did not.

## Verification

`make gate` — green, all 29 steps, run against this tree (current `main`, not
an older base).

## Deleted tests

None. `pipeline_event_sender` is deleted as dead code; it had no tests of its
own.

Refs #3379, #3398, #3417, #3418, #3425, #3426

## Summary by Sourcery

Ensure raw one-shot runs emit a proper terminal run completion event and align agent event naming with the current design.

Bug Fixes:
- Fix raw `stella run` so that a completed turn now emits a `RunComplete` terminal event instead of ending silently.
- Restore compilation by updating tests and event handling to use the `RunComplete` variant and the standard run event sender.

Enhancements:
- Standardize the raw run path on `event_sender_for_run` and the shared `emit_run_complete_for_turn` seam used by other run owners.
- Remove the obsolete `pipeline_event_sender` helper now that the pipeline no longer emits a separate terminal event.

Tests:
- Add run terminator tests covering the `emit_run_complete_for_turn` contract for completed vs aborted turns.
- Update `RunEnding` tests to assert behavior in terms of the `RunComplete` event variant.