### PR TITLE
fix(stella-cli): drop event_sender_for_raw_run, superseded by the explicit run terminator

### DIFF
--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -3,7 +3,6 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use stella_core::event_sender::RunEnding;
 use stella_core::ports::Clock;
 use stella_core::{EventSendError, EventSender};
 use stella_protocol::AgentEvent;
@@ -159,29 +158,6 @@ pub(super) fn event_sender_for_run(
         }
     }
     (EventSender::new(sender), false)
-}
-
-/// [`event_sender_for_run`] for a run the CLI drives as bare engine turns,
-/// with no pipeline above it (#3379).
-///
-/// The difference is who ends the run. A staged run's ending is the
-/// pipeline's, authored from a verdict it alone holds. A raw run has no such
-/// author: the engine ends each turn with `TurnComplete` and deliberately
-/// says nothing about the run, so the CLI — the owner here — emits the
-/// terminal `RunComplete` itself. [`RunEnding`] does that when this sender's
-/// last clone drops, which is precisely when the run's stream closes and
-/// therefore the only moment "last" is guaranteed rather than assumed.
-///
-/// Wrapping *outside* the durability boundary above is deliberate: the
-/// terminal event is journaled through the same persist-first sender as
-/// everything before it, so a durable stream still ends on the event that
-/// ended the run.
-pub(super) fn event_sender_for_raw_run(
-    sender: mpsc::UnboundedSender<AgentEvent>,
-    format: OutputFormat,
-) -> (EventSender, bool) {
-    let (events, durable_pre_persisted) = event_sender_for_run(sender, format);
-    (RunEnding::sealing(events), durable_pre_persisted)
 }
 
 /// The durable sink, and the point at which an event becomes a *line*.


### PR DESCRIPTION
`main` is red on `cargo clippy -D warnings`:

```
error: function `event_sender_for_raw_run` is never used
  --> crates/stella-cli/src/agent/output.rs:179:15
```

This function has now been in three states in one evening, so here is the evidence for deleting it **this** time, which is different from last time.

#3431 did not merely drop the call site — it **replaced the mechanism**. `run_turn` went back to `event_sender_for_run` and now emits the terminator explicitly:

```rust
persistence::emit_run_complete_for_turn(&tx, &cfg.model_id, &outcome);
```

So the drop-sealing `RunEnding` wrapper is superseded by design, not merely uncalled. `agent/resume.rs:316` already carries the matching comment ("No `RunEnding` wrapper here: this function emits the resumed…"), i.e. the CLI has moved off wrapper-sealing entirely.

For the record: my #3425 deleted this same function reasoning from a stale base, and #3429 restored it. Neither is the reason it goes now — the reason is that the run's ending now has an owner that emits it, which is what #3379 asked for.

The unused `RunEnding` import goes with it. `rg 'event_sender_for_raw_run|RunEnding' crates/stella-cli/src` leaves only that one explanatory comment.

### Verification

Checked **by exit code**, not by grepping cargo's output — an earlier check in this session reported a false green because ANSI-prefixed `error:` lines never match `^error`:

- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo fmt --all --check` → exit 0

Failing run: https://github.com/macanderson/stella/actions/runs/31991070822

Refs #3379

## Summary by Sourcery

Remove the obsolete raw-run event sender now that run completion is emitted explicitly.

Enhancements:
- Simplify CLI event handling by dropping the RunEnding-based raw-run sender in favor of explicit run completion ownership.

Chores:
- Clean up unused RunEnding import and associated raw-run helper to satisfy clippy warnings.