### PR TITLE
feat(steering): skills' and frames' evictions reach SteeringSet.dropped (#3358)

### DIFF
--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -168,10 +168,13 @@ impl SessionMemory {
         if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
-        let recall = self.recalled_frames(prompt).await;
+        let RecalledFrames {
+            recall,
+            dropped: frame_drops,
+        } = self.recalled_frames(prompt).await;
 
         let all_skills = self.load_skills();
-        let selected = skills::select_skills(
+        let selected = skills::select_skills_reporting(
             &all_skills,
             prompt,
             &self.active_domains(prompt),
@@ -189,14 +192,20 @@ impl SessionMemory {
             prompt,
             ..Default::default()
         };
-        let set = query_gathered_plane(&signal, &recall.frames, &selected, record.as_ref());
+        let set = query_gathered_plane(
+            &signal,
+            &recall.frames,
+            &frame_drops,
+            &selected,
+            record.as_ref(),
+        );
         report_record_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
 
         let mut sections: Vec<String> = Vec::new();
         if let Some(section) = render_context_section(&kept_frames(&recall.frames, &set)) {
             sections.push(section);
         }
-        let kept = kept_skills(&selected, &set);
+        let kept = kept_skills(&selected.selected, &set);
         if !kept.is_empty() {
             sections.push(skills::render_skills_section(&kept));
         }
@@ -248,7 +257,7 @@ impl SessionMemory {
             return None;
         }
         let all_skills = self.load_skills();
-        let selected = skills::select_skills(
+        let selected = skills::select_skills_reporting(
             &all_skills,
             prompt,
             &self.active_domains(prompt),
@@ -260,11 +269,11 @@ impl SessionMemory {
             prompt,
             ..Default::default()
         };
-        let set = query_gathered_plane(&signal, &[], &selected, record.as_ref());
+        let set = query_gathered_plane(&signal, &[], &[], &selected, record.as_ref());
         report_record_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
 
         let mut sections: Vec<String> = Vec::new();
-        let kept = kept_skills(&selected, &set);
+        let kept = kept_skills(&selected.selected, &set);
         if !kept.is_empty() {
             sections.push(skills::render_skills_section(&kept));
         }
@@ -319,11 +328,18 @@ impl SessionMemory {
         }
         let domains = crate::contextgraph::query_domain_scope(&self.domains, &anchors);
 
-        let recall = self.recalled_frames_anchored(prompt, anchors, |_| {}).await;
+        let RecalledFrames {
+            recall,
+            dropped: frame_drops,
+        } = self.recalled_frames_anchored(prompt, anchors, |_| {}).await;
 
         let all_skills = self.load_skills();
-        let selected =
-            skills::select_skills(&all_skills, prompt, &domains, &SelectionConfig::default());
+        let selected = skills::select_skills_reporting(
+            &all_skills,
+            prompt,
+            &domains,
+            &SelectionConfig::default(),
+        );
 
         let mut paths = turn_path_tokens(prompt);
         for path in signal.touched_paths {
@@ -342,14 +358,20 @@ impl SessionMemory {
             )
         });
 
-        let set = query_gathered_plane(signal, &recall.frames, &selected, record.as_ref());
+        let set = query_gathered_plane(
+            signal,
+            &recall.frames,
+            &frame_drops,
+            &selected,
+            record.as_ref(),
+        );
         report_record_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
 
         let mut sections: Vec<String> = Vec::new();
         if let Some(section) = render_context_section(&kept_frames(&recall.frames, &set)) {
             sections.push(section);
         }
-        let kept = kept_skills(&selected, &set);
+        let kept = kept_skills(&selected.selected, &set);
         if !kept.is_empty() {
             sections.push(skills::render_skills_section(&kept));
         }
@@ -475,9 +497,12 @@ impl SessionMemory {
 
     /// Authoritative prompt and pipeline recall, including a fresh quarantine
     /// read so prior-turn feedback applies immediately.
-    async fn recalled_frames(&self, goal: &str) -> Recall {
-        self.recalled_frames_reporting(goal, |message| eprintln!("  {} {message}", "!".yellow()))
-            .await
+    async fn recalled_frames(&self, goal: &str) -> RecalledFrames {
+        let anchors = goal_path_anchors(goal, &self.workspace_root);
+        self.recalled_frames_anchored(goal, anchors, |message| {
+            eprintln!("  {} {message}", "!".yellow())
+        })
+        .await
     }
     /// Recall with an injectable diagnostic sink to avoid global stderr capture in tests.
     pub(super) async fn recalled_frames_reporting(
@@ -486,7 +511,9 @@ impl SessionMemory {
         report: impl FnMut(String),
     ) -> Recall {
         let anchors = goal_path_anchors(goal, &self.workspace_root);
-        self.recalled_frames_anchored(goal, anchors, report).await
+        self.recalled_frames_anchored(goal, anchors, report)
+            .await
+            .recall
     }
 
     /// [`Self::recalled_frames_reporting`] with the anchor set chosen by the
@@ -498,7 +525,7 @@ impl SessionMemory {
         goal: &str,
         anchors: Vec<String>,
         mut report: impl FnMut(String),
-    ) -> Recall {
+    ) -> RecalledFrames {
         // Both withholding switches live HERE, at the frame query the rendered
         // block, the pipeline's `ContextRecallPort`, and the mid-turn re-query
         // all go through — not at the block renders alone. A control turn
@@ -511,7 +538,7 @@ impl SessionMemory {
         // into pipeline, fleet, and resumed turns after the org said no
         // (#3243).
         if self.ab_suppressed || !self.steering_enabled {
-            return Recall::default();
+            return RecalledFrames::default();
         }
         let query = ContextQuery {
             goal: goal.to_string(),
@@ -552,7 +579,7 @@ impl SessionMemory {
                 report(format!(
                     "memory recall disabled: suppression state unavailable: {error}"
                 ));
-                return Recall::default();
+                return RecalledFrames::default();
             }
         };
         // The usage report accounts for the fan-out that produced this turn's
@@ -584,20 +611,68 @@ impl SessionMemory {
                 ));
             }
         }
-        Recall {
-            frames: recalled
-                .frames
-                .into_iter()
-                .filter_map(project_recalled_frame)
-                .filter(|frame| !is_suppressed_local_frame(frame, &quarantined))
-                .collect(),
-            usage: Some(recalled.usage),
-            latency_ms,
-            // The host fan-out does not carry the accelerator flag across the
-            // provider-result boundary, and reporting `false` would read as
-            // "the index never fires" rather than "nobody said".
-            used_ann_index: None,
+        // ...and the same report goes to the ledger, which is the half that
+        // used to end here (#3358): the stderr line above is a warning a human
+        // sees once, on one of the several surfaces that recall, while
+        // `SteeringSet::dropped` is what the plane can be *queried* about.
+        let dropped = recalled.dropped.iter().map(frame_drop).collect();
+        RecalledFrames {
+            recall: Recall {
+                frames: recalled
+                    .frames
+                    .into_iter()
+                    .filter_map(project_recalled_frame)
+                    .filter(|frame| !is_suppressed_local_frame(frame, &quarantined))
+                    .collect(),
+                usage: Some(recalled.usage),
+                latency_ms,
+                // The host fan-out does not carry the accelerator flag across
+                // the provider-result boundary, and reporting `false` would
+                // read as "the index never fires" rather than "nobody said".
+                used_ann_index: None,
+            },
+            dropped,
         }
+    }
+}
+
+/// One turn's frame recall **and** what the host's merge could not fit.
+///
+/// A sibling channel rather than two more fields on [`Recall`]: `Recall` is a
+/// `stella-pipeline` type and the drop report is the CLI's own host-merge
+/// type over a `stella-context` reason, and the pipeline does not depend on
+/// the context crate (`ports.rs` states that direction deliberately). Mapping
+/// to `DroppedCandidate` here — at the one call site that has all of them in
+/// scope — keeps that boundary intact and still gets the drops to the plane.
+#[derive(Debug, Default)]
+pub(super) struct RecalledFrames {
+    pub recall: Recall,
+    /// The host merge's evictions, already in ledger shape.
+    pub dropped: Vec<stella_core::steering::DroppedCandidate>,
+}
+
+/// A host-merge eviction as a ledger entry.
+///
+/// The handle follows [`super::steering::frame_handle`]'s precedence — the
+/// stable `nod_…` id when the frame has one, its citation label otherwise —
+/// so a drop and a later selection of the same frame join on one identity.
+///
+/// `est_tokens` is the **host's** `token_cost`, not an estimate over
+/// [`frame_recall_line`]: a dropped frame never reached this process with a
+/// body, so there is no recall line to measure. The host's number is the one
+/// the budget actually refused, which is also what a caller sizing
+/// `context.retrieval.max_tokens` needs.
+pub(super) fn frame_drop(
+    drop: &crate::contextgraph::HostDroppedFrame,
+) -> stella_core::steering::DroppedCandidate {
+    stella_core::steering::DroppedCandidate {
+        source: stella_core::steering::SteeringSource::Memory,
+        handle: if drop.id.is_empty() {
+            drop.citation_label.clone()
+        } else {
+            drop.id.clone()
+        },
+        est_tokens: u64::from(drop.token_cost),
     }
 }
 
@@ -698,7 +773,7 @@ pub(super) fn goal_path_anchors(goal: &str, root: &std::path::Path) -> Vec<Strin
 #[async_trait::async_trait]
 impl ContextRecallPort for SessionMemory {
     async fn recall(&self, goal: &str) -> Recall {
-        self.recalled_frames(goal).await
+        self.recalled_frames(goal).await.recall
     }
 }
 
@@ -745,17 +820,19 @@ pub(super) fn frame_recall_line(f: &RecalledFrame) -> String {
 /// [`stella_core::steering::SteeringPlane`] query every context source now
 /// goes through (#3349). The frame slice is empty on pipeline-driven turns,
 /// whose frames travel on the pipeline's own recall port.
-fn query_gathered_plane(
+pub(super) fn query_gathered_plane(
     signal: &stella_core::steering::TurnSignal<'_>,
     frames: &[RecalledFrame],
-    selected: &[skills::SelectedSkill],
+    frame_drops: &[stella_core::steering::DroppedCandidate],
+    selected: &skills::SkillSelection,
     record: Option<&(&stella_core::records::Registry, RenderedChannel)>,
 ) -> stella_core::steering::SteeringSet {
     use stella_core::steering::{SteeringPlane, adapt};
 
     let mut candidates = super::steering::frame_candidates(frames);
-    candidates.extend(adapt::skill_candidates(selected));
-    let mut source_drops = Vec::new();
+    candidates.extend(adapt::skill_candidates(&selected.selected));
+    let mut source_drops = frame_drops.to_vec();
+    source_drops.extend(adapt::skill_drops(selected));
     if let Some((registry, rendered)) = record {
         candidates.extend(adapt::record_candidates(registry, rendered));
         source_drops.extend(adapt::record_drops(registry, rendered));

--- a/crates/stella-cli/src/memory/steering.rs
+++ b/crates/stella-cli/src/memory/steering.rs
@@ -66,9 +66,17 @@ pub(super) fn frame_handle(frame: &RecalledFrame) -> String {
 /// of #3243, not smuggled into a refactor.
 pub(super) struct GatheredSteering {
     pub candidates: Vec<SteeringCandidate>,
-    /// Drops the sources' own budgets already decided — today the record
-    /// channel's named evictions, the behavior `SteeringSet::dropped`
-    /// generalizes.
+    /// Drops the sources' own budgets already decided, from all three sources
+    /// since #3358: the record channel's named evictions, the recall host's
+    /// merge report, and the skills selector's top-k and section cuts.
+    ///
+    /// One asymmetry is deliberate and worth stating, because `by_source`
+    /// counts it: a skill omitted by `render_skills_section`'s own token
+    /// budget appears in **both** `selected` and `dropped`. The plane
+    /// authorized it and the section renderer then left it out — those are two
+    /// true facts about one skill, and the plane suppressing it instead would
+    /// change the rendered bytes, which is the Phase 4 budget merge (#3243),
+    /// not this ledger slice.
     pub source_drops: Vec<DroppedCandidate>,
 }
 

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -262,3 +262,88 @@ async fn an_answered_requery_emits_one_context_recall() {
         "the event names the frames the re-query spent on"
     );
 }
+
+/// **Witness (#3358, frames).** A frame the recall host's cross-provider merge
+/// evicted is named in `SteeringSet::dropped` under `SteeringSource::Memory`,
+/// beside the frames the same turn kept.
+///
+/// Fails on base: `recalled_frames_anchored` consumed `recalled.dropped` for
+/// the stderr warning and then discarded it — `Recall` carries frames and
+/// usage but no drop list, so by the time the plane gathered its candidates
+/// there was nothing left to map, and neither `frame_drop` nor the plane's
+/// frame-drop channel existed to map it into.
+///
+/// The merge's own drop *report* is exercised where it is produced (the CGP
+/// composition conformance run in `contextgraph::tests`, which asserts every
+/// non-admitted frame is named); a local one-provider recall cannot reach it,
+/// since the provider applies the same budget first and leaves the merge
+/// nothing to evict. So the kept side here is a real recall and the evicted
+/// side is a merge drop of exactly the shape that run admits.
+#[tokio::test]
+async fn a_frame_the_host_merge_evicted_reaches_the_ledger() {
+    let dir = tempfile::tempdir().unwrap();
+    let goal = "the deploy script must run migrations before restarting the api";
+    let memory = session(dir.path());
+    memory
+        .store
+        .upsert(ContextDelta {
+            memories: vec![MemoryInput::reflection(goal, Vec::<String>::new())],
+            ..ContextDelta::default()
+        })
+        .await
+        .expect("store a recallable lesson");
+
+    let recalled = memory.recalled_frames_anchored(goal, vec![], |_| {}).await;
+    assert_eq!(
+        recalled.recall.frames.len(),
+        1,
+        "the control: the planted lesson is recalled"
+    );
+
+    let evicted = crate::memory::recall::frame_drop(&crate::contextgraph::HostDroppedFrame {
+        provider: "local".into(),
+        id: "nod_evicted".into(),
+        citation_label: "[evicted lesson]".into(),
+        token_cost: 120,
+        reason: stella_context::DropReason::TokenBudget,
+    });
+    assert_eq!(
+        (evicted.source, evicted.handle.as_str(), evicted.est_tokens),
+        (
+            stella_core::steering::SteeringSource::Memory,
+            "nod_evicted",
+            120
+        ),
+        "a merge eviction keeps its stable id and the cost the budget refused"
+    );
+
+    let empty = stella_core::skills::select_skills_reporting(
+        &[],
+        goal,
+        &[],
+        &stella_core::skills::SelectionConfig::default(),
+    );
+    let signal = stella_core::steering::TurnSignal {
+        prompt: goal,
+        ..Default::default()
+    };
+    let set = crate::memory::recall::query_gathered_plane(
+        &signal,
+        &recalled.recall.frames,
+        std::slice::from_ref(&evicted),
+        &empty,
+        None,
+    );
+
+    assert_eq!(
+        set.by_source().get("memory").copied(),
+        Some((1, 1)),
+        "the plane reports true (selected, dropped) counts for the memory \
+         source: {set:?}"
+    );
+    assert!(
+        set.dropped.contains(&evicted),
+        "the eviction is named in the ledger: {:?}",
+        set.dropped
+    );
+}

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -429,6 +429,34 @@ pub fn select_skills(
     active_domains: &[String],
     config: &SelectionConfig,
 ) -> Vec<SelectedSkill> {
+    select_skills_reporting(skills, prompt, active_domains, config).selected
+}
+
+/// One selection pass, **including what the top-k cut threw away** (#3358).
+///
+/// [`select_skills`] returns only the survivors, which is all a renderer needs
+/// and exactly what made this source's evictions invisible: a skill that
+/// scores well every turn and loses the fifth seat every turn is
+/// indistinguishable, from outside, from a skill that never matched. The cut
+/// is the same `truncate` it always was — this form just keeps the tail so the
+/// steering ledger can name it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillSelection {
+    /// The top-k survivors, highest score first — byte-identical to what
+    /// [`select_skills`] returns, by construction.
+    pub selected: Vec<SelectedSkill>,
+    /// Skills that cleared `min_score` and corroboration but lost a seat to
+    /// `config.max_skills`, in the same descending order.
+    pub over_top_k: Vec<SelectedSkill>,
+}
+
+/// [`select_skills`] with the top-k tail retained. See [`SkillSelection`].
+pub fn select_skills_reporting(
+    skills: &[Skill],
+    prompt: &str,
+    active_domains: &[String],
+    config: &SelectionConfig,
+) -> SkillSelection {
     let prompt_terms: HashSet<String> = score_terms(prompt).into_iter().collect();
 
     let mut selected: Vec<SelectedSkill> = Vec::new();
@@ -482,8 +510,11 @@ pub fn select_skills(
             .total_cmp(&a.score)
             .then_with(|| a.skill.name.cmp(&b.skill.name))
     });
-    selected.truncate(config.max_skills);
-    selected
+    let over_top_k = selected.split_off(config.max_skills.min(selected.len()));
+    SkillSelection {
+        selected,
+        over_top_k,
+    }
 }
 
 // Rendering — the volatile context block injected after the stable prefix
@@ -571,23 +602,43 @@ pub fn render_skills_section(selected: &[SelectedSkill]) -> String {
     if selected.is_empty() {
         return String::new();
     }
+    let fit = section_fit(selected);
     let mut out =
         String::from("\n## Applicable skills (selected for this task — apply the relevant ones)\n");
-    let mut used_tokens: u64 = 0;
-    let mut rendered_any = false;
-
-    for sel in selected {
-        let block = rendered_skill_block(sel);
-        let block_tokens = stella_protocol::estimate_tokens(&block);
-        if rendered_any && used_tokens + block_tokens > SKILLS_SECTION_TOKEN_BUDGET {
-            out.push_str(SKILLS_SECTION_OMISSION_MARKER);
-            break;
-        }
-        out.push_str(&block);
-        used_tokens += block_tokens;
-        rendered_any = true;
+    for sel in &selected[..fit] {
+        out.push_str(&rendered_skill_block(sel));
+    }
+    if fit < selected.len() {
+        out.push_str(SKILLS_SECTION_OMISSION_MARKER);
     }
     out
+}
+
+/// How many of `selected`, in order, fit `SKILLS_SECTION_TOKEN_BUDGET` — the
+/// section renderer's own cut, as a number the ledger can also read.
+///
+/// The rule is unchanged and stated once: the top skill always renders (a
+/// budget that can select nothing is not a budget, it is a mute), and the
+/// first skill that would carry the running total past the section budget
+/// ends the section — the remainder is omitted rather than skipped over, so
+/// what renders is always a prefix of the ranking.
+///
+/// Split out of [`render_skills_section`]'s loop for the reason
+/// [`rendered_skill_block`] was: the steering adapter
+/// (`crate::steering::adapt::skill_drops`) must name the omitted skills, and
+/// a second copy of this arithmetic would be a second answer to "what fits"
+/// — the ledger would then under- or over-report a cut the prompt actually
+/// made (#3358, the #3334 single-producer discipline).
+pub fn section_fit(selected: &[SelectedSkill]) -> usize {
+    let mut used_tokens: u64 = 0;
+    for (index, sel) in selected.iter().enumerate() {
+        let block_tokens = stella_protocol::estimate_tokens(&rendered_skill_block(sel));
+        if index > 0 && used_tokens + block_tokens > SKILLS_SECTION_TOKEN_BUDGET {
+            return index;
+        }
+        used_tokens += block_tokens;
+    }
+    selected.len()
 }
 
 // Auto-creation — mining observations into new skills (the user requirement)

--- a/crates/stella-core/src/steering/adapt.rs
+++ b/crates/stella-core/src/steering/adapt.rs
@@ -54,6 +54,37 @@ fn skill_why(sel: &SelectedSkill) -> String {
     }
 }
 
+/// The skills this turn's two skill budgets evicted, as ledger entries
+/// (#3358) — the drops that used to be the loudest silence on the plane.
+///
+/// Two cuts, and they are genuinely different questions, which is why both
+/// are reported and neither is inferred from the other:
+///
+/// - **Top-k** ([`skills::SkillSelection::over_top_k`]) — matched, scored,
+///   and lost a seat to `SelectionConfig::max_skills`. Estimated over the
+///   block it would have rendered, the same producer the survivors' costs
+///   come from, so "what would it have cost to widen `max_skills`" is
+///   answerable from the ledger rather than by re-running selection.
+/// - **Section budget** — survived top-k and then did not fit
+///   `render_skills_section`'s own token budget, per
+///   [`skills::section_fit`]. These candidates are still *selected* on the
+///   plane, deliberately: the section renderer, not the plane, made this cut,
+///   and the plane re-enacting it would change the rendered bytes. The ledger
+///   reports it; folding the section budget into the plane's shared budget is
+///   Phase 4 behavior change (#3243), sequenced apart from this ledger slice.
+pub fn skill_drops(selection: &skills::SkillSelection) -> Vec<DroppedCandidate> {
+    let fit = skills::section_fit(&selection.selected);
+    selection.selected[fit..]
+        .iter()
+        .chain(selection.over_top_k.iter())
+        .map(|sel| DroppedCandidate {
+            source: SteeringSource::Skill,
+            handle: sel.skill.name.clone(),
+            est_tokens: stella_protocol::estimate_tokens(&skills::rendered_skill_block(sel)),
+        })
+        .collect()
+}
+
 /// The records the volatile channel rendered this turn, as candidates.
 ///
 /// `score` flattens the exact importance `render::survivors` drops by —

--- a/crates/stella-core/src/steering/tests.rs
+++ b/crates/stella-core/src/steering/tests.rs
@@ -322,3 +322,98 @@ fn record_scores_preserve_the_channels_force_then_precedence_rank() {
         info.score
     );
 }
+
+// ---- skill drops (#3358) ----
+
+/// A skill whose name and description both carry the prompt's terms, so
+/// selection is decided by score order rather than by whether it matched.
+fn scoring_skill(name: &str, body_bytes: usize) -> crate::skills::Skill {
+    crate::skills::Skill {
+        name: name.to_string(),
+        description: "format sql queries nicely".to_string(),
+        domains: vec!["sql".to_string()],
+        body: "x".repeat(body_bytes),
+        source_path: format!("{name}.md"),
+        origin: crate::skills::SkillOrigin::Workspace,
+    }
+}
+
+/// **Witness (#3358, skills / top-k).** A skill that matched, scored, and lost
+/// the last seat to `SelectionConfig::max_skills` is named in the ledger.
+///
+/// Fails on base, where `select_skills` `truncate`s and returns only the
+/// survivors: the tail is gone before any adapter can see it, so a skill that
+/// systematically loses its seat is indistinguishable from one that never
+/// matched — the exact coverage gap #2709 made observable for records.
+#[test]
+fn a_skill_cut_by_top_k_is_named_in_the_ledger() {
+    let skills: Vec<_> = ["a", "b", "c"]
+        .iter()
+        .map(|n| scoring_skill(n, 10))
+        .collect();
+    let config = crate::skills::SelectionConfig {
+        max_skills: 2,
+        ..crate::skills::SelectionConfig::default()
+    };
+
+    let selection = crate::skills::select_skills_reporting(
+        &skills,
+        "please format the sql for me",
+        &["sql".to_string()],
+        &config,
+    );
+    assert_eq!(
+        selection.selected.len(),
+        2,
+        "top-k still cuts at max_skills"
+    );
+
+    let drops = adapt::skill_drops(&selection);
+    let handles: Vec<&str> = drops.iter().map(|d| d.handle.as_str()).collect();
+    assert_eq!(handles, vec!["c"], "the cut skill is named: {drops:?}");
+    assert!(
+        drops.iter().all(|d| d.source == SteeringSource::Skill
+            && d.est_tokens
+                == stella_protocol::estimate_tokens(&crate::skills::rendered_skill_block(
+                    &selection.over_top_k[0]
+                ))),
+        "and costed over the block it would have rendered: {drops:?}"
+    );
+}
+
+/// **Witness (#3358, skills / section budget).** A skill the section renderer
+/// omits to fit `SKILLS_SECTION_TOKEN_BUDGET` is named in the ledger — and the
+/// rendered bytes are untouched, because the renderer still makes that cut
+/// itself.
+///
+/// Fails on base: the omission was an inline prose marker and nothing else, so
+/// which skills it stood for reached neither stderr nor the plane.
+#[test]
+fn a_skill_omitted_by_the_section_budget_is_named_without_changing_the_bytes() {
+    // Four skills whose bodies each fill the per-skill budget: three fit the
+    // section budget, and the fourth is the one the renderer omits.
+    let skills: Vec<_> = ["a", "b", "c", "d"]
+        .iter()
+        .map(|n| scoring_skill(n, 40_000))
+        .collect();
+    let selection = crate::skills::select_skills_reporting(
+        &skills,
+        "please format the sql for me",
+        &["sql".to_string()],
+        &crate::skills::SelectionConfig::default(),
+    );
+    assert_eq!(selection.selected.len(), 4, "all four survive top-k");
+
+    let rendered = crate::skills::render_skills_section(&selection.selected);
+    assert!(
+        rendered.contains("### c") && !rendered.contains("### d"),
+        "the renderer's own cut is unchanged: {rendered}"
+    );
+
+    let drops = adapt::skill_drops(&selection);
+    assert_eq!(
+        drops.iter().map(|d| d.handle.as_str()).collect::<Vec<_>>(),
+        vec!["d"],
+        "the omitted skill is named rather than left to the prose marker: {drops:?}"
+    );
+}


### PR DESCRIPTION
## What

`SteeringSet::dropped` now carries all three context sources, not just the record channel #3349 generalized it for.

- **Skills / top-k.** `select_skills_reporting` keeps the tail `select_skills`'s `truncate` used to discard; `select_skills` is now a thin `.selected` over it, so there is one selection pass, not two.
- **Skills / section budget.** `render_skills_section`'s own cut is extracted as `skills::section_fit` and read by both the renderer and the new `adapt::skill_drops` — the #3334 single-producer discipline, so the ledger cannot disagree with what the prompt actually carried.
- **Frames.** The recall host's merge report, which `recalled_frames_anchored` consumed for its stderr warning and then dropped on the floor, rides back on a `RecalledFrames` sibling channel and is mapped to `DroppedCandidate`s at the one site that has all three crates in scope — `Recall` stays a `stella-pipeline` type with no `stella-context` dependency.

`SteeringSet::by_source` therefore reports true `(selected, dropped)` counts per source.

## What deliberately did not change

**The rendered bytes.** Source drops are additive to `dropped` and are never withheld from `selected`, so the section renderer still makes its own cut — the golden block test passes untouched. One consequence is stated in the code rather than hidden: a skill omitted by the section budget appears in **both** `selected` and `dropped`, because the plane authorized it and the renderer then left it out, and those are two true facts. Collapsing them means the plane owning the section budget, which is Phase 4 behavior change (#3243), sequenced apart exactly as the issue asks.

**The stderr report** stays record-only (`report_record_drops`), per the single-producer constraint in the issue. Surfacing skill/frame drops to a human is filed as follow-up rather than invented here.

## Witnesses

One per source, all three failing on base (the tail, the fit function, and the drop channel do not exist there):

- `stella-core::steering::tests::a_skill_cut_by_top_k_is_named_in_the_ledger`
- `stella-core::steering::tests::a_skill_omitted_by_the_section_budget_is_named_without_changing_the_bytes` — also asserts the rendered section is unchanged
- `stella-cli::memory::tests::steering_selection::a_frame_the_host_merge_evicted_reaches_the_ledger`

An honest note on the third: a local one-provider recall cannot make the *host merge* drop anything, because the provider applies the same budget first and leaves the merge nothing to evict. So its kept side is a real recall and its evicted side is a merge drop of the shape the CGP composition conformance run in `contextgraph::tests` already admits. The merge's own report is exercised there; this witness covers the link that used to end at stderr.

## Verification

`cargo test -p stella-core -p stella-cli` (1745 lib + every integration target, 0 failures), `cargo clippy --all-targets -D warnings`, `cargo doc --no-deps`, `make guards`. The two `check-file-size` lines are inherited base drift on `event.rs` and `command_deck.rs`, untouched by this change.

Refs #3243, #3349
Closes #3358

## Summary by Sourcery

Track and report evicted skills and frames from all context sources in the steering ledger without changing rendered output or stderr behavior.

New Features:
- Expose a consolidated SkillSelection structure that retains both selected skills and those cut by top-k for reporting.
- Surface host merge frame evictions as DroppedCandidate entries alongside recalled frames in the steering ledger.

Enhancements:
- Extend steering plane gathering to accept explicit frame-drop and skill-selection inputs and to populate SteeringSet::dropped from skills, frames, and records.
- Factor out the skills section token-fit calculation so both the renderer and steering adapters share a single definition of which skills the section budget omits.

Tests:
- Add steering and CLI tests that assert skills dropped by top-k or the section budget and frames evicted by host merge are all reflected in SteeringSet::dropped and per-source counts.