### PR TITLE
fix(stella-cli): drop the doubly-restored event_sender_for_raw_run (main is red)

### DIFF
--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -3,7 +3,6 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use stella_core::event_sender::RunEnding;
 use stella_core::ports::Clock;
 use stella_core::{EventSendError, EventSender};
 use stella_protocol::AgentEvent;
@@ -159,29 +158,6 @@ pub(super) fn event_sender_for_run(
         }
     }
     (EventSender::new(sender), false)
-}
-
-/// [`event_sender_for_run`] for a run the CLI drives as bare engine turns,
-/// with no pipeline above it (#3379).
-///
-/// The difference is who ends the run. A staged run's ending is the
-/// pipeline's, authored from a verdict it alone holds. A raw run has no such
-/// author: the engine ends each turn with `TurnComplete` and deliberately
-/// says nothing about the run, so the CLI — the owner here — emits the
-/// terminal `RunComplete` itself. [`RunEnding`] does that when this sender's
-/// last clone drops, which is precisely when the run's stream closes and
-/// therefore the only moment "last" is guaranteed rather than assumed.
-///
-/// Wrapping *outside* the durability boundary above is deliberate: the
-/// terminal event is journaled through the same persist-first sender as
-/// everything before it, so a durable stream still ends on the event that
-/// ended the run.
-pub(super) fn event_sender_for_raw_run(
-    sender: mpsc::UnboundedSender<AgentEvent>,
-    format: OutputFormat,
-) -> (EventSender, bool) {
-    let (events, durable_pre_persisted) = event_sender_for_run(sender, format);
-    (RunEnding::sealing(events), durable_pre_persisted)
 }
 
 /// The durable sink, and the point at which an event becomes a *line*.


### PR DESCRIPTION
## main is red

```
error: function `event_sender_for_raw_run` is never used
  --> crates/stella-cli/src/agent/output.rs:179:15
  = note: `-D dead-code` implied by `-D warnings`
```

## How

#3429 and #3431 fixed the same broken build **in opposite directions**, and
both landed:

- **#3429** restored `event_sender_for_raw_run` — the `RunEnding` mechanism.
- **#3431** (mine) pointed the raw one-shot path at
  `persistence::emit_run_complete_for_turn`, the seam every other run owner
  already uses, and deleted the helper.

The merge kept #3431's call site and #3429's helper. Neither branch is wrong;
the composition is.

## Resolution

Keeping **#3431's side**: one mechanism for the run terminator, the one the
deck, fleet, goal, resume and the pipeline one-shot already share.

Worth naming what the merge *nearly* did: had it kept #3429's call site too,
the raw path would emit **two** `run_complete` events — that is #960 verbatim,
and a `replay::validate_stream` violation. It landed on the harmless side of
that by luck, not by design.

`RunEnding` itself stays. `stella-serve` uses it, and its tests stay with it.

## Verification

`make gate` — green, all 29 steps, against this tree.

## Context, because this is the fourth red main from one issue

#3379 was implemented concurrently by #3417, #3418, #3425, #3426, #3429 and
#3431. Every one of them passes its own gate; the tree has now been broken four
times by their compositions, each time on lines no two of them conflict on.
Nothing pre-merge can see this class of break — it is the shared-cell hazard
AGENTS.md documents, at line granularity, and `main-canary.yml` is the
mechanism that exists for it.

I am not proposing a process change in this PR; I am flagging that the residual
risk here is coordination, not code.

## Deleted tests

None.

Refs #3379, #3429, #3431

## Summary by Sourcery

Bug Fixes:
- Fix main build break by deleting the unused `event_sender_for_raw_run` helper and associated import from the CLI agent output module.