### PR TITLE
fix(stella-cli): restore rustfmt, and scope a test-only recall helper to tests

### DIFF
--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -140,8 +140,7 @@ pub(crate) fn spawn_forwarder(
                     },
                 },
             };
-            let event = if owes_stage_execute
-                && !matches!(event, AgentEvent::ContextRecall { .. })
+            let event = if owes_stage_execute && !matches!(event, AgentEvent::ContextRecall { .. })
             {
                 // First event that is not the turn's recall: open the stage
                 // ahead of it, and let it ride the next iteration.

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -505,6 +505,14 @@ impl SessionMemory {
         .await
     }
     /// Recall with an injectable diagnostic sink to avoid global stderr capture in tests.
+    ///
+    /// `#[cfg(test)]` because that is the whole truth about it: production
+    /// recall goes through [`Self::recalled_frames`] (which reports to stderr)
+    /// or [`Self::recalled_frames_anchored`] (which takes the caller's own
+    /// sink), and #3435 left this wrapper with test callers alone. Gating it
+    /// is what makes `-D dead-code` agree with the doc comment, rather than an
+    /// `#[allow]` asserting over the top of it.
+    #[cfg(test)]
     pub(super) async fn recalled_frames_reporting(
         &self,
         goal: &str,


### PR DESCRIPTION
`main` is red on `ci` twice over:

```
cargo fmt --check   crates/stella-cli/src/command_deck/forwarder.rs:140   (#3427)
-D warnings         method `recalled_frames_reporting` is never used      (#3435)
```

### 1. rustfmt

A plain rustfmt application — one `if` condition rustfmt joins onto a single line. Whitespace only, no logic touched.

### 2. The dead method

`SessionMemory::recalled_frames_reporting` (`memory/recall.rs:508`) is a **test helper**, and its own doc comment already said so: *"Recall with an injectable diagnostic sink to avoid global stderr capture in tests."* #3435 moved production recall onto `recalled_frames_anchored`, leaving only test callers — `memory/tests/{quarantine,golden_block,trigger_recall}.rs`.

So it is gated `#[cfg(test)]`, matching `memory.rs:868`'s already-gated `mod tests`.

Deliberately **not** the two easier options:
- Not `#[allow(dead_code)]` — that asserts over the top of the doc comment; the gate makes the compiler *agree* with it.
- Not wired to a new production caller — nothing in production wants an injected diagnostic sink (`recalled_frames` reports to stderr, `recalled_frames_anchored` takes the caller's own sink). Inventing a caller to satisfy a lint is the expedient.

### Verification (by exit code)

- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo fmt --all --check` → 0
- `cargo test -p stella-cli --bins` → 0 (**1748 passed**)

Failing runs: https://github.com/macanderson/stella/actions/runs/31994352365

Refs #3427, #3435

## Summary by Sourcery

Scope a test-only session memory recall helper to test builds and reformat a command deck forwarder conditional to satisfy rustfmt and dead-code lints.

Bug Fixes:
- Restrict the test-only `SessionMemory::recalled_frames_reporting` helper to test configurations to resolve dead-code warnings.

Enhancements:
- Apply rustfmt formatting to the forwarder event conditional in the command deck to comply with style checks.