### PR TITLE
fix(scripts): file-size --update may move a ceiling, never grandfather a new god file (#3441)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,7 +556,16 @@ inputs, not review afterthoughts:
   is the pattern). A ceiling moves only via `make file-size-update`, which
   lands as a reviewable baseline diff to be justified like any other change —
   an escape hatch for a genuinely irreducible line (a module declaration in
-  an already-oversized `lib.rs`), never something a plan may assume.
+  an already-oversized `lib.rs`), never something a plan may assume. It moves
+  a ceiling and nothing else: `--update` **refuses to add** an entry for a file
+  that is not already in the baseline, naming it and pointing at the split
+  remedy (#3441). Before that it recorded every over-limit file it could see,
+  so a run clearing an unrelated ceiling drift would quietly grandfather
+  whatever first-time crossing happened to be sitting in the tree — inside a
+  diff whose stated purpose was the bump, and green forever after. If a
+  crossing is genuinely irreducible, say so out loud with
+  `./scripts/check-file-size.sh --update --grandfather <path>` and justify it
+  in review.
 
 **The ratchet judges your change, not the tree** (#2004). A file over the line
 fails only when `current > max(its own limit, size in the base tree)` — where

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -152,7 +152,112 @@ current_sizes() {
   done
 }
 
+# ── What --update may write: a ceiling, never a new exemption (#3441) ────────
+#
+# The checker above names two remedies and they are NOT interchangeable: a
+# grandfathered file whose ceiling drifted is cleared by regenerating the
+# baseline, while a file crossing the limit for the first time must be split
+# and is never given an entry. `--update` regenerated from the tree alone, so
+# it could not tell those apart and simply recorded every file currently over
+# the line — writing exactly the entry the checker forbids.
+#
+# The two are needed at the same moment, which is what made this dangerous
+# rather than theoretical: both failures are triggered by the same shared cell
+# going stale, so the run of `--update` that clears a +4 ceiling bump is the
+# run most likely to find an unrelated first-time crossing sitting in the tree
+# waiting to be absorbed. It lands as an extra hunk in a diff whose stated
+# purpose was the bump, permanently grandfathers a god file, and turns the gate
+# green so nothing downstream ever objects again. On `main` at 1016925c9 that
+# file was crates/stella-protocol/src/event.rs at 1533 lines.
+#
+# So `--update` now judges its own write the way the checker judges a change:
+# an existing entry is rewritten to the current size (the down-ratchet must
+# keep working, and a deliberate ceiling raise is still allowed and still
+# visible in review), and a path with no entry is REFUSED. The escape hatch is
+# `--grandfather <path>`, deliberately explicit, repeatable, and required to
+# name a path that actually needs it — a hatch that can be passed pointlessly
+# is a hatch that gets pasted into a command line and stops meaning anything.
+#
+# A baseline that does not exist yet is the one case where every file is new by
+# definition, and the checker itself tells a fresh tree to run `--update` to
+# create one. That bootstrap writes whatever it finds; there is no prior
+# decision for it to contradict.
 if [ "${1:-}" = "--update" ]; then
+  shift
+  grandfathered_arg="$(mktemp)"
+  trap 'rm -f "$grandfathered_arg"' EXIT
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --grandfather)
+      if [ "$#" -lt 2 ]; then
+        echo "check-file-size: --grandfather needs a path." >&2
+        exit 2
+      fi
+      printf '%s\n' "$2" >>"$grandfathered_arg"
+      shift 2
+      ;;
+    --grandfather=*)
+      printf '%s\n' "${1#--grandfather=}" >>"$grandfathered_arg"
+      shift
+      ;;
+    *)
+      echo "check-file-size: unknown argument '$1' after --update." >&2
+      exit 2
+      ;;
+    esac
+  done
+
+  over="$(current_sizes | awk -v limit="$LIMIT" '$1 > limit' | LC_ALL=C sort -k2)"
+
+  if [ -f "$baseline" ]; then
+    # `|| true`: an all-comment baseline — every god file split, which is the
+    # goal — makes `grep -v` exit 1 under `set -e`, and this ran before any
+    # verdict, so the whole command died silently with no message at all. Same
+    # trap the `grep -cv` at the foot of this script carries a note about
+    # (#1800); it is the second time this file has been bitten by it.
+    known="$(grep -v '^#' "$baseline" 2>/dev/null | awk 'NF { print $2 }' | LC_ALL=C sort || true)"
+    over_paths="$(printf '%s' "$over" | awk 'NF { print $2 }' | LC_ALL=C sort)"
+    # Over the limit and carrying no prior decision: either the caller asked
+    # for it by name, or this is the crossing that must be split instead.
+    additions="$(LC_ALL=C comm -23 <(printf '%s\n' "$over_paths") <(printf '%s\n' "$known") | awk 'NF')"
+    asked="$(LC_ALL=C sort -u "$grandfathered_arg" | awk 'NF')"
+    refused="$(LC_ALL=C comm -23 <(printf '%s\n' "$additions") <(printf '%s\n' "$asked") | awk 'NF')"
+    # A --grandfather that names nothing needing it: a stale flag left on a
+    # command line, silently claiming a decision nobody is making today.
+    pointless="$(LC_ALL=C comm -13 <(printf '%s\n' "$additions") <(printf '%s\n' "$asked") | awk 'NF')"
+
+    if [ -n "$pointless" ]; then
+      {
+        echo "check-file-size: --grandfather named path(s) that need no new entry:"
+        printf '%s\n' "$pointless" | sed 's/^/  /'
+        echo ""
+        echo "Each is either already in the baseline or under the ${LIMIT}-line limit."
+        echo "Drop the flag: it is meant to record one deliberate exemption, and one"
+        echo "that applies to nothing teaches a reader the opposite."
+      } >&2
+      exit 1
+    fi
+
+    if [ -n "$refused" ]; then
+      {
+        echo "check-file-size: refusing to ADD baseline entries for:"
+        printf '%s\n' "$refused" | sed 's/^/  /'
+        echo ""
+        echo "These files crossed the ${LIMIT}-line limit for the first time; they are not"
+        echo "grandfathered, and the baseline only ever covered files that predate the"
+        echo "guard. Writing an entry here would grandfather a new god file inside a diff"
+        echo "whose purpose is something else, and turn the gate green so nothing objects"
+        echo "again. Split them into submodules instead (AGENTS.md, \"God files\")."
+        echo ""
+        echo "The baseline was NOT modified. If a crossing is genuinely irreducible, say so"
+        echo "explicitly and justify it in review:"
+        echo ""
+        printf '%s\n' "$refused" | sed 's|^|  ./scripts/check-file-size.sh --update --grandfather |'
+      } >&2
+      exit 1
+    fi
+  fi
+
   {
     echo "# Grandfathered files over the ${LIMIT}-line ratchet. See #629 and"
     echo "# scripts/check-file-size.sh. Format: <ceiling> <path>."
@@ -167,7 +272,9 @@ if [ "${1:-}" = "--update" ]; then
     # on every machine. A UTF-8 locale sorts punctuation differently (macOS
     # orders agent/tests.rs before agent.rs), which reshuffles untouched lines
     # and buries the one ceiling that actually moved.
-    current_sizes | awk -v limit="$LIMIT" '$1 > limit' | LC_ALL=C sort -k2
+    # Already computed above, and deliberately not recomputed: the set written
+    # must be the exact set the refusal check judged.
+    if [ -n "$over" ]; then printf '%s\n' "$over"; fi
   } >"$baseline.tmp"
   mv "$baseline.tmp" "$baseline"
   echo "check-file-size: baseline updated — $(grep -cv '^#' "$baseline") grandfathered file(s) over $LIMIT lines."

--- a/scripts/test-file-size.sh
+++ b/scripts/test-file-size.sh
@@ -312,6 +312,130 @@ want "B9 growth on top of an inherited first-time crossing still fails" \
   expect-fail "$r" "src/big.rs is 1650 lines, over the 1500-line limit"
 unset FILE_SIZE_BASE_REF
 
+# ── What --update is allowed to WRITE (#3441) ────────────────────────────────
+#
+# Everything above tests the checker. These test the generator, which had the
+# complementary bug: the checker refuses a first-time crossing and names
+# "split it" as the remedy, while `--update` — the documented remedy for the
+# OTHER failure — silently recorded every over-limit file it could see and so
+# wrote exactly the entry the checker forbids. The two failures share a trigger
+# (the baseline going stale), so the moment `--update` is run is the moment an
+# unrelated crossing is most likely to be absorbed by it.
+#
+# U1 is the witness: it fails on the old script, which wrote the entry.
+
+# want_update <name> <expect-pass|expect-fail> <repo> <substring> [args...]
+#
+# Asserts the verdict, the message, AND — on a refusal — that the baseline is
+# byte-identical afterwards. The last part is the half that matters: a refusal
+# that has already rewritten the file has not refused anything.
+want_update() {
+  local name="$1" expect="$2" dir="$3" sub="$4"
+  shift 4
+  local bl="$dir/scripts/file-size-baseline.txt" before after out rc
+  before="$(cat "$bl" 2>/dev/null || true)"
+  out="$("$dir/scripts/check-file-size.sh" --update "$@" 2>&1)"
+  rc=$?
+  after="$(cat "$bl" 2>/dev/null || true)"
+  if [ "$expect" = "expect-fail" ]; then
+    if [ "$rc" -eq 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — --update succeeded where it should have refused:"; echo "$out"
+      return
+    fi
+    if [ "$before" != "$after" ]; then
+      fail=$((fail + 1)); echo "FAIL $name — refused, but rewrote the baseline anyway."
+      return
+    fi
+  elif [ "$rc" -ne 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — expected --update to succeed, got:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — wrong message (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# The witness. A tree carrying BOTH failures at once, which is the realistic
+# shape: one grandfathered ceiling has drifted (the reason anyone runs
+# --update) and one unrelated file has crossed the limit for the first time.
+r="$(new_repo "update_refuses_new_entry")"
+plant "$r" "src/god.rs" 2004
+plant "$r" "src/fresh.rs" 1600
+set_baseline "$r" "2000 src/god.rs"
+commit "$r" "a drifted ceiling and an unrelated first-time crossing"
+want_update "U1 --update refuses to grandfather a file that is not already in the baseline" \
+  expect-fail "$r" "src/fresh.rs"
+
+# The down-ratchet, and the deliberate raise, must both keep working — this is
+# the whole reason --update exists and the refusal must not cost it.
+r="$(new_repo "update_rewrites_existing")"
+plant "$r" "src/shrunk.rs" 1600
+plant "$r" "src/grown.rs" 2004
+set_baseline "$r" "2400 src/shrunk.rs" "2000 src/grown.rs"
+commit "$r" "one entry retightens, one is deliberately raised"
+want_update "U2 --update still rewrites existing entries in both directions" \
+  expect-pass "$r" "baseline updated"
+bl="$r/scripts/file-size-baseline.txt"
+if grep -q '^1600 src/shrunk.rs$' "$bl" && grep -q '^2004 src/grown.rs$' "$bl"; then
+  pass=$((pass + 1)); echo "ok   U2b both ceilings were rewritten to the current sizes"
+else
+  fail=$((fail + 1)); echo "FAIL U2b ceilings not rewritten:"; cat "$bl"
+fi
+
+# An entry that dropped under the limit must still be retired, which is a
+# removal — the refusal only ever guards ADDITIONS.
+r="$(new_repo "update_retires_obsolete")"
+plant "$r" "src/fixed.rs" 900
+set_baseline "$r" "2000 src/fixed.rs"
+commit "$r" "the file was split and no longer needs an exemption"
+want_update "U3 --update still retires an obsolete entry" expect-pass "$r" "baseline updated"
+if grep -q 'src/fixed.rs' "$r/scripts/file-size-baseline.txt"; then
+  fail=$((fail + 1)); echo "FAIL U3b the obsolete entry survived --update"
+else
+  pass=$((pass + 1)); echo "ok   U3b the obsolete entry was retired"
+fi
+
+# The escape hatch: explicit, and it works.
+r="$(new_repo "update_grandfather_hatch")"
+plant "$r" "src/irreducible.rs" 1600
+set_baseline "$r"
+commit "$r" "a crossing someone has decided to grandfather deliberately"
+want_update "U4 --grandfather admits the named path" \
+  expect-pass "$r" "baseline updated" --grandfather src/irreducible.rs
+if grep -q '^1600 src/irreducible.rs$' "$r/scripts/file-size-baseline.txt"; then
+  pass=$((pass + 1)); echo "ok   U4b the deliberately grandfathered entry was written"
+else
+  fail=$((fail + 1)); echo "FAIL U4b --grandfather did not write the entry"
+fi
+
+# ...and it is scoped to the path it names, so passing it does not open the
+# door for everything else over the line in the same run.
+r="$(new_repo "update_grandfather_is_scoped")"
+plant "$r" "src/irreducible.rs" 1600
+plant "$r" "src/other.rs" 1700
+set_baseline "$r"
+commit "$r" "two crossings, one of them decided"
+want_update "U5 --grandfather does not admit the paths it did not name" \
+  expect-fail "$r" "src/other.rs" --grandfather src/irreducible.rs
+
+# A hatch that can be passed pointlessly stops meaning anything.
+r="$(new_repo "update_grandfather_pointless")"
+plant "$r" "src/small.rs" 10
+set_baseline "$r"
+commit "$r" "nothing is over the limit"
+want_update "U6 --grandfather naming a path that needs no entry is an error" \
+  expect-fail "$r" "need no new entry" --grandfather src/small.rs
+
+# Bootstrap: with no baseline at all there is no prior decision to contradict,
+# and the checker itself tells a fresh tree to run --update to create one.
+r="$(new_repo "update_bootstrap")"
+rm -f "$r/scripts/file-size-baseline.txt"
+plant "$r" "src/big.rs" 1600
+commit "$r" "a tree with no baseline yet"
+want_update "U7 --update bootstraps a missing baseline without refusing" \
+  expect-pass "$r" "baseline updated"
+
 echo
 echo "passed ${pass}, failed ${fail}"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
fix(scripts): --update may move a ceiling, never grandfather a new god file

check-file-size.sh names two remedies and they are not interchangeable: a
grandfathered file whose ceiling drifted is cleared by regenerating the
baseline, while a file crossing 1500 lines for the first time must be split
and is never given an entry. `--update` regenerated from the tree alone, so
it could not tell those apart and recorded every over-limit file it saw —
writing exactly the entry the checker forbids.

The two failures share a trigger (the shared baseline cell going stale), so
the run of `--update` that clears a +4 ceiling bump is the run most likely to
find an unrelated first-time crossing waiting to be absorbed. It lands as an
extra hunk in a diff whose stated purpose was the bump, permanently
grandfathers a god file, and turns the gate green so nothing objects again.
On main at 1016925c9 that file was stella-protocol/src/event.rs at 1533 lines.

`--update` now judges its own write the way the checker judges a change: an
existing entry is rewritten to the current size in both directions, and a path
with no entry is refused with the split remedy named. The hatch is
`--grandfather <path>` — explicit, repeatable, and rejected when it names a
path that needs no entry, because a hatch that can be passed pointlessly stops
meaning anything. A missing baseline still bootstraps: there is no prior
decision for it to contradict.

Also fixes a silent death this uncovered: `grep -v` exits 1 on an all-comment
baseline, which under `set -e` killed the whole command with no output. Same
trap the `grep -cv` at the foot of the file already carries a note about
(#1800).

Witness: scripts/test-file-size.sh gains U1-U7. U1, U5 and U6 fail on main
(`--update` succeeds where it should refuse) and pass here; U2-U4 and U7 pin
the down-ratchet, obsolete-entry retirement, the hatch and bootstrap against
regression. `make file-size-test` — 26 passed, 0 failed.

Closes #3441

## Summary by Sourcery

Tighten the file-size baseline updater so it can only adjust ceilings for already-grandfathered files, never silently grandfather new oversized files, and document this behavior.

Bug Fixes:
- Prevent `check-file-size.sh --update` from adding new baseline entries for files that cross the size limit for the first time, enforcing that they must be split instead.
- Fix a silent failure when processing an all-comment baseline by tolerating `grep -v` exiting with status 1 under `set -e`.

Enhancements:
- Introduce an explicit `--grandfather <path>` escape hatch to deliberately add exemptions for specific files, with validation to reject pointless or mismatched usage.
- Make `--update` treat its own writes consistently with the checker by only rewriting existing entries and refusing unapproved additions, while preserving bootstrap behavior when no baseline exists.

Documentation:
- Clarify in AGENTS.md that the file-size update script only moves existing ceilings, refuses to add new exemptions, and requires explicit `--grandfather` usage for irreducible crossings.

Tests:
- Extend `scripts/test-file-size.sh` with targeted cases (U1–U7) to cover `--update` refusal semantics, down-ratchet and ceiling raises, obsolete entry retirement, the `--grandfather` hatch behavior, and baseline bootstrapping.