### PR TITLE
fix(gate): main-canary checks file-size, and asks the absolute question (#3447)

### DIFF
--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -152,6 +152,15 @@ current_sizes() {
   done
 }
 
+# See `resolve_base_commit` for what this changes and why only the canary wants
+# it. Read before the `--update` arm below so the two flags cannot be confused:
+# `--update` rewrites the baseline, `--absolute` only judges against it.
+ABSOLUTE_MODE=""
+if [ "${1:-}" = "--absolute" ]; then
+  ABSOLUTE_MODE=1
+  shift
+fi
+
 if [ "${1:-}" = "--update" ]; then
   {
     echo "# Grandfathered files over the ${LIMIT}-line ratchet. See #629 and"
@@ -193,6 +202,21 @@ fi
 # reader should not have to know that rule to see it.
 resolve_base_commit() {
   local candidate mb
+  # `--absolute` asks the other question: not "did this change grow a file?"
+  # but "is this tree within its ceilings at all?" Returning no base collapses
+  # `max(ceiling, base)` to the ceiling, which is the strict read.
+  #
+  # It exists for the post-merge canary (#3447). Every rung below is
+  # base-relative on purpose — inherited drift must not fail an author who did
+  # not cause it (#2004, #2397) — but that same mercy makes drift already
+  # sitting on `main` invisible to every branch in flight, and on a push to
+  # `main` the last rung compares against `HEAD^1`, so a violation introduced
+  # two commits ago goes unseen forever. Somebody has to ask the absolute
+  # question once the merge has happened, and this is the flag that asks it.
+  if [ -n "${ABSOLUTE_MODE:-}" ]; then
+    printf ''
+    return 0
+  fi
   # An explicit override wins, for hand runs and for the hermetic tests in
   # scripts/test-file-size.sh, which have no origin to infer one from.
   if [ -n "${FILE_SIZE_BASE_REF:-}" ]; then

--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -144,6 +144,23 @@ short_sha="${sha:0:9}"
 # Each row is "<name>|<command>". The command runs from the repo root.
 checks=(
   "lockfile-sync|./scripts/check-lockfile-sync.sh${manifest_dir:+ --manifest-dir $manifest_dir}"
+  # The other shared cell this file's header already names, and the one
+  # AGENTS.md calls the single biggest cause of a red `main` (#3447). It earns
+  # its row on the rule above rather than on thoroughness: the pre-merge guard
+  # is deliberately base-relative (#2004, #2397) and fails a PR only for growth
+  # past what it inherited, so drift already sitting on `main` is invisible to
+  # every branch in flight — by design, which is precisely what makes it
+  # unfixable before a merge. On 2026-08-17 `command_deck.rs` sat 4 lines over
+  # its ceiling on `main` while every open PR stayed correctly green; it was
+  # found by hand during an unrelated merge and fixed by #3444.
+  #
+  # `--absolute` is load-bearing and not a tidiness flag. Without it the guard
+  # judges a push to `main` against `HEAD^1`, so it would only ever notice
+  # drift the newest commit introduced — and the 2026-08-17 drift, already two
+  # commits old by the time anyone looked, passes that test cleanly. Verified
+  # by simulation before this row was added: with the baseline set back to
+  # 4010, the default invocation still reported ok.
+  "file-size|./scripts/check-file-size.sh --absolute"
 )
 
 failures=""

--- a/scripts/test-file-size.sh
+++ b/scripts/test-file-size.sh
@@ -86,15 +86,17 @@ commit() {
   git -C "$1" commit -q -m "$2"
 }
 
-# want <name> <expect-pass|expect-fail> <repo> [substring]
+# want <name> <expect-pass|expect-fail> <repo> [substring] [flag]
+#
+# `flag` is passed through to the guard — `--absolute` is the only one today.
 #
 # The substring is checked on BOTH verdicts. On expect-fail it pins which file
 # was flagged; on expect-pass it pins what a passing run still reported — a
 # drift note is a real finding that happens not to be fatal, and a guard that
 # passed by forgetting the file would satisfy a bare expect-pass.
 want() {
-  local name="$1" expect="$2" dir="$3" sub="${4:-}" out rc
-  out="$("$dir/scripts/check-file-size.sh" 2>&1)"
+  local name="$1" expect="$2" dir="$3" sub="${4:-}" flag="${5:-}" out rc
+  out="$("$dir/scripts/check-file-size.sh" ${flag:+"$flag"} 2>&1)"
   rc=$?
   if [ "$expect" = "expect-pass" ]; then
     if [ "$rc" -ne 0 ]; then
@@ -311,6 +313,34 @@ export FILE_SIZE_BASE_REF="HEAD^1"
 want "B9 growth on top of an inherited first-time crossing still fails" \
   expect-fail "$r" "src/big.rs is 1650 lines, over the 1500-line limit"
 unset FILE_SIZE_BASE_REF
+
+# ── --absolute: the post-merge canary's question (#3447) ─────────────────────
+#
+# Every case above is base-relative, which is the right mercy for an author who
+# inherited a violation. Its cost is that drift already sitting on `main` fails
+# nobody, so nothing ever reports it — and on a push to `main` the base is
+# `HEAD^1`, so even the canary sees only what the newest commit did. These two
+# pin the flag that lets the canary ask whether the tree is within its ceilings
+# at all. C1 is the witness: the SAME repo state that B7 forgives must fail.
+r="$(new_repo "absolute_inherited_drift")"
+plant "$r" "src/big.rs" 1600
+commit "$r" "base: a first-time crossing lands on main"
+plant "$r" "src/unrelated.rs" 10
+commit "$r" "head: an unrelated change walks past it"
+export FILE_SIZE_BASE_REF="HEAD^1"
+want "C1 --absolute flags inherited drift that the default run forgives" \
+  expect-fail "$r" "src/big.rs is 1600 lines" "--absolute"
+want "C2 the same tree, without the flag, is still only drift" \
+  expect-pass "$r" "inherited drift"
+unset FILE_SIZE_BASE_REF
+
+# The flag must not invent violations: a tree inside every ceiling still passes,
+# or the canary would file an issue against a healthy `main` every day.
+r="$(new_repo "absolute_clean_tree")"
+plant "$r" "src/small.rs" 100
+commit "$r" "a tree well inside the limit"
+want "C3 --absolute passes a tree within its ceilings" \
+  expect-pass "$r" "check-file-size: OK" "--absolute"
 
 echo
 echo "passed ${pass}, failed ${fail}"


### PR DESCRIPTION
## What

`main-canary` now checks `file-size`, the shared cell its own header names — and `check-file-size.sh` gains the `--absolute` mode that makes that check mean anything.

Closes #3447.

## The problem

`scripts/main-canary.sh`'s header names `scripts/file-size-baseline.txt` as the archetype of the failure it exists for, and AGENTS.md calls that baseline the single biggest cause of a red `main`. Its `checks=()` array contained one row: `lockfile-sync`.

That gap has a cost on the record. On 2026-08-17 `command_deck.rs` sat 4 lines over its recorded ceiling on `main`. Every open PR was correctly green — the ratchet judges a change against its base tree, so each branch inherited the drift without failing — and the canary, the layer built for exactly this, said nothing. It was found by hand during an unrelated merge (#3418) and fixed by #3444.

## Why adding the row is not enough

I added it, and it did not work. This is the part worth reading.

Every rung of `resolve_base_commit` is base-relative on purpose (#2004, #2397): a violation is *this change's* fault only if this change grew the file past what it inherited. On a push to `main` the last rung resolves the base as `HEAD^1`, so the guard asks **"did the newest commit grow a god file?"** — and drift that is even two commits old passes cleanly.

Simulated against the real historical state (baseline back to 4010, file at 4014), the unmodified canary reported:

```
main-canary: ok   lockfile-sync
main-canary: ok   file-size
main-canary: OK — main composes green at b46eb1ac1.
```

My first draft of #3447 asserted the guard would fall back to a strict whole-tree read here. That was wrong, and only testing the failing direction caught it.

## The change

`check-file-size.sh --absolute` resolves no base at all, collapsing `max(ceiling, size at base)` to the ceiling — "is this tree within its ceilings?" rather than "did this change grow one?". The canary passes it; nothing else does.

It is a flag rather than a new default because both questions are correct in their own place: base-relative before a merge, so inherited drift never fails an author who did not cause it; absolute after one, because by then somebody has to own the tree. **No pre-merge behaviour changes.**

## Witness

In the guard's own suite, not by hand. C1 and C2 are the **same repository state** and differ only in the flag:

| | |
|---|---|
| `C1 --absolute flags inherited drift that the default run forgives` | fails, as it must |
| `C2 the same tree, without the flag, is still only drift` | passes, unchanged |
| `C3 --absolute passes a tree within its ceilings` | passes |

C3 is not ceremony — without it the flag could satisfy C1 by failing everything, and the canary would open an issue against a healthy `main` every morning.

C1 fails on `main` today (the flag does not exist) and passes here, so it is a witness in the repo's sense.

## Verification

- `./scripts/test-file-size.sh` — **19 passed, 0 failed** (16 before).
- `make main-canary` on `b46eb1ac1` — green as the tree stands; **FAIL naming `file-size`** with the baseline set back to 4010, which is the historical bug reproduced and then caught.
- `make file-size` — unchanged, still reports the inherited-drift note without failing.
- `make shellcheck`, `make gate-parity`, `make left-behind` — green. No new gate step, so the parity block needs no edit.

## Deliberately not in this PR

The workflow's `cancel-in-progress: true`. Several canary runs show `cancelled` under the 2026-08-17 merge burst, which reads like a defect and is not: the canary reconciles state rather than reacting to an event, so under a burst only the last tree is worth judging, and every action it takes is idempotent. That reasoning is argued in place in the workflow, and I see no reason to overturn it.

## Summary by Sourcery

Add an absolute file-size ceiling check to the main canary to detect drift already present on main while preserving base-relative behavior pre-merge.

Enhancements:
- Extend file-size guard to support an --absolute mode that enforces ceilings against the current tree instead of a base commit.
- Wire the main-canary workflow to run the file-size guard in absolute mode alongside existing lockfile-sync checks.
- Expand the file-size test suite with scenarios covering absolute-mode behavior, including inherited drift and clean trees.