### PR TITLE
feat(stella-cli): adopted changes reach files_touched, the durable half of #2907

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -366,7 +366,7 @@ async fn run_pipeline_one_shot(
             cfg,
             active_rules.clone(),
             mcp.clone(),
-            SessionPlane::new(tx.clone()).with_sub_agents(registry.sub_agent_dispatcher()),
+            SessionPlane::for_run(tx.clone(), &registry, execution.clone()),
         )?;
 
         let breaker = CircuitBreaker::new(Box::new(SystemClock::new()));

--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -351,6 +351,10 @@ pub(crate) struct SessionPlane {
     /// as unavailable — which, with no command-executing built-in, leaves a
     /// worker there unable to act at all.
     sub_agents: Option<Arc<dyn stella_core::subagent::SubAgentDispatcher>>,
+    /// The execution adopted changes are attributed to (#3419), and the store
+    /// holding it. `None` when the session opened no store — the only case in
+    /// which an empty `files_touched` is the right answer.
+    adoption: Option<(Arc<stella_store::Store>, i64)>,
 }
 
 impl SessionPlane {
@@ -360,7 +364,36 @@ impl SessionPlane {
         Self {
             events: Some(events),
             sub_agents: None,
+            adoption: None,
         }
+    }
+
+    /// Attribute this session's adoptions to the run's `executions` row
+    /// (#3419). Pass the pair `persistence::begin_pipeline_execution` returned
+    /// — a driver that opened no store passes nothing and keeps the no-op.
+    pub(crate) fn with_adoption(
+        mut self,
+        execution: Option<(Arc<stella_store::Store>, i64)>,
+    ) -> Self {
+        self.adoption = execution;
+        self
+    }
+
+    /// The complete plane a pipeline run needs: its event sink, the session's
+    /// sub-agent runner, and the execution its adoptions are attributed to.
+    ///
+    /// Composed here rather than at the call site because that call site is in
+    /// `agent.rs`, a grandfathered god file closed to growth — the builder
+    /// chain spelled out there costs it lines it does not have, and this is
+    /// the sibling module the plane already lives in.
+    pub(crate) fn for_run(
+        events: stella_core::EventSender,
+        registry: &stella_tools::ToolRegistry,
+        execution: Option<(Arc<stella_store::Store>, i64)>,
+    ) -> Self {
+        Self::new(events)
+            .with_sub_agents(registry.sub_agent_dispatcher())
+            .with_adoption(execution)
     }
 
     /// Share the session's sub-agent runner with every candidate workspace
@@ -388,7 +421,11 @@ pub(crate) fn workspace_ports(
     mcp: Option<Arc<stella_mcp::McpToolSet>>,
     session: SessionPlane,
 ) -> Result<WorkspacePorts, String> {
-    let SessionPlane { events, sub_agents } = session;
+    let SessionPlane {
+        events,
+        sub_agents,
+        adoption,
+    } = session;
     crate::enterprise_telemetry::authorize_execution_surface(
         crate::enterprise_telemetry::ExecutionSurface::WorkspacePorts,
     )?;
@@ -425,6 +462,9 @@ pub(crate) fn workspace_ports(
     }
     if let Some(dispatcher) = sub_agents {
         candidate_workspaces = candidate_workspaces.with_sub_agents(dispatcher);
+    }
+    if let Some((store, execution_id)) = adoption {
+        candidate_workspaces = candidate_workspaces.with_adoption_ledger(store, execution_id);
     }
     Ok(WorkspacePorts {
         repo_structure: GitRepoStructure { root: root.clone() },

--- a/crates/stella-cli/src/candidate_ws.rs
+++ b/crates/stella-cli/src/candidate_ws.rs
@@ -123,6 +123,7 @@ use crate::agent::{
 };
 
 mod adopt;
+mod adoption_ledger;
 mod escape;
 mod modes;
 mod oracle_writes;
@@ -310,6 +311,11 @@ pub(crate) struct GitCandidateWorkspaces {
     /// `None` leaves the `task` tool reporting sub-agents as unavailable —
     /// see [`GitCandidateWorkspaces::with_sub_agents`].
     sub_agents: Option<Arc<dyn stella_core::subagent::SubAgentDispatcher>>,
+    /// Where adopted changes are attributed durably (#3419). `None` leaves
+    /// `attribute_adopted` the no-op it has always been — which is correct
+    /// for a session with no store open, and was silently the case for every
+    /// session until this existed.
+    adoption_ledger: Option<adoption_ledger::AdoptionLedger>,
 }
 
 impl GitCandidateWorkspaces {
@@ -327,7 +333,23 @@ impl GitCandidateWorkspaces {
             candidate_mcp: None,
             events: None,
             sub_agents: None,
+            adoption_ledger: None,
         }
+    }
+
+    /// Attribute every adoption these candidates deliver to `execution_id`.
+    ///
+    /// The durable half of #2907's "one adoption, two projections": the
+    /// `FileChange` events already ride the session's stream, and this is what
+    /// puts the same rows in `files_touched`. Without it the table is empty
+    /// for every run and `stella export`'s files dump renders nothing (#3419).
+    pub(crate) fn with_adoption_ledger(
+        mut self,
+        store: Arc<stella_store::Store>,
+        execution_id: i64,
+    ) -> Self {
+        self.adoption_ledger = Some(adoption_ledger::AdoptionLedger::new(store, execution_id));
+        self
     }
 
     /// Let every candidate delegate through the session's sub-agent runner.
@@ -513,6 +535,7 @@ impl GitCandidateWorkspaces {
                     task_board,
                     sole_candidate: AtomicBool::new(false),
                     omitted,
+                    adoption_ledger: self.adoption_ledger.clone(),
                 })
             }
             Err(reason) => {
@@ -738,6 +761,10 @@ pub(crate) struct GitCandidateWorkspace {
     /// see [`snapshot_gaps`]. A display list for the candidate's context, not
     /// a set anything branches on.
     omitted: Vec<String>,
+    /// Where this candidate's adopted changes are recorded durably (#3419).
+    /// `None` when the session opened no store, which is the only case in
+    /// which having no durable record is correct.
+    adoption_ledger: Option<adoption_ledger::AdoptionLedger>,
 }
 
 impl GitCandidateWorkspace {
@@ -933,6 +960,19 @@ impl GitCandidateWorkspace {
 impl CandidateWorkspace for GitCandidateWorkspace {
     fn root(&self) -> &str {
         &self.root
+    }
+
+    /// The durable half of the adoption (#3419).
+    ///
+    /// The trait's default is a no-op, and this port took it for as long as it
+    /// existed — so `files_touched` was empty in production for every run
+    /// while the `FileChange` events describing the same adoption rode the
+    /// stream. See [`adoption_ledger`] for the row shape and why a write
+    /// failure here is never allowed to fail the adoption.
+    fn attribute_adopted(&self, adopted: &[AdoptedChange]) {
+        if let Some(ledger) = &self.adoption_ledger {
+            ledger.record(adopted);
+        }
     }
 
     fn tools(&self) -> &dyn stella_core::ToolExecutor {

--- a/crates/stella-cli/src/candidate_ws/adoption_ledger.rs
+++ b/crates/stella-cli/src/candidate_ws/adoption_ledger.rs
@@ -1,0 +1,155 @@
+//! The durable half of adoption attribution: `AdoptedChange` → `files_touched`.
+//!
+//! #2907's stated goal was that "the stream and the durable record are two
+//! projections of one adoption". #3413 landed the stream projection; this is
+//! the durable one, which had no producer at all — `Store::record_files_touched`
+//! sat with no production caller in the workspace and the table was empty for
+//! every run, isolated and shared-tree alike (#3419).
+//!
+//! Lives in its own module rather than in `candidate_ws.rs` because that file
+//! is large and this is a separable concern: one mapping, one write, and the
+//! decision about what a row means.
+
+use std::sync::Arc;
+use stella_pipeline::ports::AdoptedChange;
+use stella_protocol::FileChangeKind;
+use stella_store::{FileTouchRow, Store};
+
+/// Where one candidate's adopted changes are attributed.
+///
+/// Cloned into every candidate the session builds, so each one writes against
+/// the execution that owns the run — the id is resolved once, when the run's
+/// `executions` row is opened, and never re-derived here.
+#[derive(Clone)]
+pub(crate) struct AdoptionLedger {
+    store: Arc<Store>,
+    execution_id: i64,
+}
+
+impl AdoptionLedger {
+    pub(crate) fn new(store: Arc<Store>, execution_id: i64) -> Self {
+        Self {
+            store,
+            execution_id,
+        }
+    }
+
+    /// Persist one `files_touched` row per adopted path.
+    ///
+    /// Best-effort by construction: this is **observability, not evidence**
+    /// (#2882), exactly as `CandidateWorkspace::attribute_adopted` documents.
+    /// A failed write must never fail an adoption that git has already
+    /// completed — the user's tree has the bytes either way, and turning a
+    /// telemetry error into a delivery error would make the record's absence
+    /// destroy the thing it was recording.
+    pub(crate) fn record(&self, adopted: &[AdoptedChange]) {
+        if adopted.is_empty() {
+            return;
+        }
+        let rows: Vec<FileTouchRow> = adopted.iter().map(file_touch_row).collect();
+        if let Err(error) = self.store.record_files_touched(self.execution_id, &rows) {
+            // Deliberately stderr and not the event stream: the stream's copy
+            // of this fact is the `FileChange` events emitted beside the same
+            // rows, which are unaffected by a store failure. Saying it twice
+            // there would imply the two projections disagreed.
+            eprintln!("  ⚠ could not attribute adopted files: {error}");
+        }
+    }
+}
+
+/// One adopted change as a durable row.
+fn file_touch_row(change: &AdoptedChange) -> FileTouchRow {
+    FileTouchRow {
+        path: change.path.clone(),
+        ops: ops_letter(change.kind).to_string(),
+        lines_added: u64::from(change.added),
+        lines_removed: u64::from(change.removed),
+        events_json: events_json(change),
+    }
+}
+
+/// The `ops` alphabet is CRUD letters, not the change-kind names.
+///
+/// Fixed by the reader, not by preference: `Store::execution_rollup` counts a
+/// run's written files with `ops LIKE '%C%' OR ops LIKE '%U%' OR ops LIKE
+/// '%D%'` (`stella-store/src/lib.rs`), so a row spelled "Modified" — or "M" —
+/// is a row that query cannot see. `FileTouchRow`'s own doc gives `"RUD"` as
+/// its example for the same reason.
+fn ops_letter(kind: FileChangeKind) -> &'static str {
+    match kind {
+        FileChangeKind::Created => "C",
+        FileChangeKind::Read => "R",
+        FileChangeKind::Modified => "U",
+        FileChangeKind::Deleted => "D",
+    }
+}
+
+/// The row's audit log: the ordered `{event, reason, lines_added,
+/// lines_removed}` objects `FileTouchRow::events_json` documents.
+///
+/// An adoption contributes exactly one entry, because it *is* one event: git
+/// applied the candidate's bytes to the user's tree in a single delivery. The
+/// per-file diff is deliberately not carried here — `AdoptedChange::diff` can
+/// be the whole file, `files_touched` is a per-execution index rather than a
+/// content store, and the diff already rides the `FileChange` event beside
+/// this row.
+fn events_json(change: &AdoptedChange) -> String {
+    serde_json::json!([{
+        "event": "adopted",
+        "reason": "candidate adopted into the session tree",
+        "lines_added": change.added,
+        "lines_removed": change.removed,
+    }])
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(path: &str, kind: FileChangeKind, added: u32, removed: u32) -> AdoptedChange {
+        AdoptedChange {
+            path: path.into(),
+            kind,
+            added,
+            removed,
+            diff: Some("@@ -1 +1 @@".into()),
+        }
+    }
+
+    /// The letters the digest query greps for. A rename of the kind enum that
+    /// silently changed these would make `files_written` count zero while the
+    /// table filled up.
+    #[test]
+    fn ops_are_the_crud_letters_the_digest_query_matches() {
+        assert_eq!(ops_letter(FileChangeKind::Created), "C");
+        assert_eq!(ops_letter(FileChangeKind::Read), "R");
+        assert_eq!(ops_letter(FileChangeKind::Modified), "U");
+        assert_eq!(ops_letter(FileChangeKind::Deleted), "D");
+    }
+
+    #[test]
+    fn a_row_carries_the_line_counts_and_one_audit_entry() {
+        let row = file_touch_row(&change("src/lib.rs", FileChangeKind::Modified, 12, 3));
+        assert_eq!(row.path, "src/lib.rs");
+        assert_eq!(row.ops, "U");
+        assert_eq!(row.lines_added, 12);
+        assert_eq!(row.lines_removed, 3);
+
+        let events: serde_json::Value = serde_json::from_str(&row.events_json).expect("json");
+        let entries = events.as_array().expect("an array");
+        assert_eq!(entries.len(), 1, "one adoption is one audit entry");
+        assert_eq!(entries[0]["event"], "adopted");
+        assert_eq!(entries[0]["lines_added"], 12);
+    }
+
+    /// The diff is the event stream's to carry, not the ledger's.
+    #[test]
+    fn the_row_does_not_carry_the_file_diff() {
+        let row = file_touch_row(&change("src/lib.rs", FileChangeKind::Modified, 1, 0));
+        assert!(
+            !row.events_json.contains("@@"),
+            "files_touched indexes an execution's paths; the diff rides the FileChange event"
+        );
+    }
+}

--- a/crates/stella-cli/src/candidate_ws/tests.rs
+++ b/crates/stella-cli/src/candidate_ws/tests.rs
@@ -805,3 +805,81 @@ async fn a_repo_without_commits_is_a_clean_snapshot_error() {
     assert_no_candidate_worktrees(&root);
     std::fs::remove_dir_all(&root).ok();
 }
+
+/// The witness for #3419: an adoption reaches the durable ledger, not just
+/// the event stream.
+///
+/// `Store::record_files_touched` had no production caller anywhere in the
+/// workspace and `CandidateWorkspace::attribute_adopted`'s trait default is a
+/// no-op that this port never overrode, so `files_touched` was empty for every
+/// run that ever adopted a candidate — while the `FileChange` events
+/// describing the very same rows rode the session's stream. #2907 asked for
+/// "the stream and the durable record are two projections of one adoption";
+/// #3413 landed the stream half and this is the other one.
+///
+/// Asserted through `export_all_json`, deliberately: that is the surface the
+/// issue names as operating on a table nothing writes, so a pass here is a
+/// pass for `stella export`'s files dump rather than for a private helper.
+///
+/// The `attribute_adopted` call is made here rather than by a driven
+/// pipeline, because that is precisely the contract the trait states — "called
+/// by the pipeline immediately after every successful delivery, with exactly
+/// the rows that delivery returned". The pipeline's three call sites
+/// (`pipeline/delivery.rs`, `pipeline/execute_stage.rs` twice) already exist
+/// and are not what was missing; the override they call was. So this feeds it
+/// exactly what `adopt` returned, which is what those sites pass.
+#[tokio::test]
+async fn an_adoption_lands_in_files_touched_keyed_to_the_run_execution() {
+    let root = scaffold("adoption-ledger");
+    let store = std::sync::Arc::new(stella_store::Store::open(&root).expect("store"));
+    let execution_id = store
+        .begin_execution("run", "attribute an adoption", "test", "test-model")
+        .expect("execution");
+
+    let port = GitCandidateWorkspaces::new(
+        root.clone(),
+        Default::default(),
+        Vec::new(),
+        crate::rules::ResolvedRules::default(),
+    )
+    .with_adoption_ledger(store.clone(), execution_id);
+
+    let ws = port.create_workspace().await.unwrap();
+    std::fs::write(ws.dir().join("adopted.rs"), "fn adopted() {}\n").unwrap();
+    ws.seal().await.unwrap();
+    let adopted = ws.adopt(&[]).await.unwrap();
+    assert_eq!(adopted.len(), 1, "the fixture adopts exactly one file");
+    // What the pipeline does with the rows delivery returned.
+    ws.attribute_adopted(&adopted);
+
+    let dumps = store.export_all_json().expect("export");
+    let files = dumps
+        .iter()
+        .find(|(table, _)| *table == "files_touched")
+        .map(|(_, json)| json.clone())
+        .expect("files_touched is an exported table");
+    let rows: serde_json::Value = serde_json::from_str(&files).expect("json");
+    let rows = rows.as_array().expect("an array of rows");
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "the adoption must leave exactly one row, not zero (#3419) and not a \
+         duplicate per delivery: got {files}"
+    );
+    assert_eq!(rows[0]["path"], "adopted.rs");
+    assert_eq!(
+        rows[0]["execution_id"],
+        serde_json::json!(execution_id),
+        "the row is keyed to the run's execution, which is what makes it \
+         joinable to everything else that run recorded"
+    );
+    assert_eq!(
+        rows[0]["ops"], "C",
+        "a newly created file is a `C`, the letter `Store::execution_rollup` \
+         greps for — spelling it `Created` or `M` makes files_written blind"
+    );
+
+    ws.remove().await;
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/crates/stella-pipeline/src/ports/workspace.rs
+++ b/crates/stella-pipeline/src/ports/workspace.rs
@@ -274,6 +274,28 @@ pub trait CandidateWorkspace: Send + Sync {
     /// changes no decision — not the verdict, not the ladder, not delivery. It
     /// is a report of what git already did.
     ///
+    /// # The durable ledger is adoption-only, deliberately (#3419)
+    ///
+    /// This is the sole writer of `files_touched`. A shared-tree run — where
+    /// the shared-tree `FileChange` producer (`turn_files` /
+    /// `WorkJournal::snapshot_worktree`, #3413) measures the turn — writes no
+    /// row, and that is the decision rather than a gap.
+    ///
+    /// The two are not the same claim. Adoption knows *who* changed the file:
+    /// a candidate's edits became the user's tree's, at one instant, by one
+    /// `git apply`. The shared-tree producer measures the turn, not the actor,
+    /// and says so — anything that ran during the turn, the user's own editor
+    /// included, is inside its diff. Folding that into a per-execution ledger
+    /// would attribute a teammate's concurrent save to the agent's execution
+    /// id, permanently and with no way to tell the two apart afterwards. The
+    /// event stream can carry a measurement that honest consumers read as one;
+    /// a row in a table keyed by `execution_id` reads as attribution.
+    ///
+    /// So the two projections #2907 asked for are equal for the isolated case
+    /// and deliberately unequal for the shared one. A shared-tree run's file
+    /// activity is observable in its `FileChange` events, and is absent from
+    /// `files_touched` on purpose.
+    ///
     /// Default: no-op — a substrate whose edits are already the session's has
     /// nothing to attribute, and neither has one that keeps no such record.
     fn attribute_adopted(&self, _adopted: &[AdoptedChange]) {}


### PR DESCRIPTION
Closes #3419

## What was true

`Store::record_files_touched` had **no production caller anywhere in the workspace**, and `CandidateWorkspace::attribute_adopted`'s trait default is a no-op that `stella-cli`'s port never overrode. So `files_touched` was empty in production for every run that ever adopted a candidate — while the `FileChange` events describing the very same rows rode the session's stream. `stella export`'s files dump and `Store::prune`'s cascade both operated on a table nothing writes.

#2907 asked for *"the stream and the durable record are two projections of one adoption"*. #3413 landed the stream half; this is the other one.

## The change

- **`candidate_ws/adoption_ledger.rs`** (new) maps `AdoptedChange` → `FileTouchRow` and writes it.
  - `ops` is **CRUD letters**, fixed by the reader rather than by preference: `Store::execution_rollup` counts a run's written files with `ops LIKE '%C%' OR ops LIKE '%U%' OR ops LIKE '%D%'`, so a row spelled `Modified` — or `M`, as some test fixtures use — is invisible to it. `FileTouchRow`'s own doc gives `"RUD"` for the same reason.
  - `events_json` carries **one** audit entry: an adoption *is* one event. The per-file diff is deliberately excluded — it rides the `FileChange` event, and `files_touched` is a per-execution index, not a content store.
- **Plumbing** (the part the issue flagged as the actual work): the store and execution id reach the candidate through the existing `SessionPlane` seam, from the `(Arc<Store>, i64)` pair `begin_pipeline_execution` already returns. `None` keeps the previous no-op, correct for a session with no store open.
- **A write failure never fails the adoption.** This is observability, not evidence (#2882); git has already moved the bytes, and turning a telemetry error into a delivery error would let the record's absence destroy the thing it records.

## The shared-tree decision (third DoD item)

Answered in `attribute_adopted`'s doc: the durable ledger is **adoption-only, by decision**.

Adoption knows *who* changed the file — a candidate's edits became the user's tree's, at one instant, by one `git apply`. The shared-tree producer measures *the turn, not the actor*, and says so; anything that ran during the turn, including the user's own editor, is inside its diff. Folding that into a table keyed by `execution_id` would attribute a teammate's concurrent save to the agent's execution, permanently and unseparably. An event stream can carry a measurement; a row keyed to an execution reads as attribution.

## God-file discipline

`agent.rs` is grandfathered and closed to growth. The builder chain spelled out at the call site cost it 5 lines, so the composition moved into `agent/tools.rs` as `SessionPlane::for_run`. **`agent.rs` ends at exactly 1799 lines — its ceiling — and no baseline moved.**

## Witness

`an_adoption_lands_in_files_touched_keyed_to_the_run_execution` asserts through `export_all_json`, deliberately: that is the surface the issue names as reading an unwritten table, so a pass here is a pass for `stella export` rather than for a private helper. It checks the row count, the path, the **execution id**, and the `C` letter.

Flip demonstrated by neutering the override back to the trait default: fails with `got []` (0 rows), passes with it restored.

## Verification (by exit code)

```
cargo clippy --workspace --all-targets -- -D warnings   0
cargo fmt --all --check                                 0
cargo test -p stella-cli --bins                         0   (1752 passed)
cargo test -p stella-pipeline                           0
check-file-size / god-files / left-behind               0
check-typed-errors / module-reachability                0
```

Refs #3413, #2907

## Summary by Sourcery

Persist adopted file changes into the durable files_touched ledger and wire execution attribution through the session pipeline.

New Features:
- Introduce an adoption ledger that maps AdoptedChange entries into files_touched rows keyed by execution_id.
- Allow candidate workspaces to attribute adoptions to a specific store execution via adoption_ledger configuration.

Enhancements:
- Extend SessionPlane and workspace port wiring so pipeline runs pass store and execution context to candidate workspaces.
- Clarify CandidateWorkspace documentation around adoption-only durability versus shared-tree measurement semantics.

Tests:
- Add integration and unit tests ensuring adopted files are exported from files_touched with correct path, ops letter, and execution_id, and validating the ledger row format and audit entries.