### PR TITLE
fix(stella-protocol): bring AgentEvent into doc scope, main is red on rustdoc

### DIFF
--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The leaf payload types an [`AgentEvent`](super::AgentEvent) variant carries
+//! The leaf payload types an [`AgentEvent`] variant carries
 //! — file-change kinds, verdict evidence, scope/hunk proposals, media refs, PR
 //! and CI status, and the task-board item.
 //!
@@ -18,6 +18,18 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ladder::LadderSnapshot;
+
+/// Brought into scope for the `[`AgentEvent::…`]` intra-doc links below, which
+/// resolved inline in `event.rs` and stopped resolving when #3440 moved these
+/// types into a child module (`rustdoc -D warnings` is a gate step).
+///
+/// `#[cfg(doc)]` rather than a plain `use` because nothing here names the type
+/// in code, and rather than qualifying each link as `(super::AgentEvent::…)`
+/// because these doc comments are exported verbatim into
+/// `docs/wire/agentevent.d.ts` — a Rust module path in the public TypeScript
+/// contract would be a leak, not a link.
+#[cfg(doc)]
+use super::AgentEvent;
 
 /// What happened to a file in a [`AgentEvent::FileChange`] event.
 ///


### PR DESCRIPTION
## `main` is red

`make gate` fails at `doc-warnings` on `main` (`b46eb1ac1`):

```
error: unresolved link to `AgentEvent::FileChange`     crates/stella-protocol/src/event/payload.rs:22, :39, :62
error: unresolved link to `AgentEvent::MediaComplete`  crates/stella-protocol/src/event/payload.rs:197
error: unresolved link to `AgentEvent::MediaProgress`  crates/stella-protocol/src/event/payload.rs:212
error: could not document `stella-protocol`
make: *** [doc-warnings] Error 101
```

#3440 split the leaf payload types out of `event.rs` into `event/payload.rs`.
The doc comments moved verbatim and are correct as prose, but `AgentEvent` is
declared in `event.rs` and is not in scope in the new child module, so five
intra-doc links that resolved inline stopped resolving after the move.

Being a `doc-warnings` failure, it also **masks every gate step after it** —
which is how the `wire-schema` interaction below stayed invisible.

## Fix

`#[cfg(doc)] use super::AgentEvent;`, plus dropping the module header's
now-redundant explicit link target.

## Why not just qualify the links

I tried that first — `[`AgentEvent::X`](super::AgentEvent::X)` on all five.
It fixes rustdoc, and then fails `wire-schema`:

These doc comments are **exported verbatim into `docs/wire/agentevent.d.ts`**.
Qualifying pushed five Rust module paths into the public TypeScript wire
contract, which contains no `super::` anywhere today:

```diff
-   * [`AgentEvent::MediaProgress`] events carried.
+   * [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.
```

A Rust module path in a consumer-facing contract is a leak, not a link, and
"regenerate the artifact" would have committed it. The `cfg(doc)` import
resolves every link while changing **no rendered text and no wire artifact** —
`git diff --stat` touches one file.

Two smaller notes:

- `#[cfg(doc)]` rather than a plain `use` because nothing in this module names
  the type in code, so a plain import is dead under `clippy -D warnings`. The
  import exists exactly when the links need it and never otherwise.
- With the type in scope, the header's `[`AgentEvent`](super::AgentEvent)`
  trips `rustdoc::redundant_explicit_links`, so it becomes the bare `[`AgentEvent`]`.
  Module docs are not exported to the `.d.ts`, so this changes no artifact either.

No `#[allow]` is added anywhere.

## Verification

`make gate` — **exit 0**, whole workspace, run against this tree.

Captured as a real exit code, not a piped one: `make gate > log 2>&1; echo $?`.
The first run of this investigation reported success through a `| tail` pipe
while `make` had actually exited 2, which is worth flagging for anyone
verifying locally.

Individually, before and after the full run:

| Step | Before | After |
|---|---|---|
| `make doc-warnings` | 101 | **0** |
| `make wire-schema` | 0 (masked — never ran) | **0** |
| `make gate` | 2 | **0** |

## Witness

Not applicable in the fail-on-old/pass-on-new sense: the defect is a build-time
rustdoc failure, not a behaviour, and the gate step *is* the test — it fails on
`main` and passes here. No runtime behaviour changes; this is doc scope only.

## Deleted tests

None.

Refs #3436, #3440

## Summary by Sourcery

Fix rustdoc and gate failures in stella-protocol by ensuring AgentEvent is in scope for intra-doc links in the payload module.

Bug Fixes:
- Resolve broken intra-doc links to AgentEvent variants in the payload module that caused rustdoc -D warnings and make gate to fail.

Enhancements:
- Adjust payload module documentation to avoid leaking Rust module paths into the generated TypeScript wire schema while keeping links functional.