### PR TITLE
fix(stella-protocol): resolve payload.rs's AgentEvent doc links without editing the wire contract (main is red)

### DIFF
--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The leaf payload types an [`AgentEvent`](super::AgentEvent) variant carries
+//! The leaf payload types an [`AgentEvent`] variant carries
 //! — file-change kinds, verdict evidence, scope/hunk proposals, media refs, PR
 //! and CI status, and the task-board item.
 //!
@@ -18,6 +18,18 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ladder::LadderSnapshot;
+// Rustdoc-only. These types moved out of `event.rs` (#3436) and their doc
+// comments still cite the variants that carry them, which no longer resolve
+// from here — `doc-warnings` is `-D warnings`, so that is a red gate.
+//
+// Importing rather than writing `crate::AgentEvent` in the links is
+// deliberate: `schemars` publishes every doc comment verbatim as the wire
+// schema's `description`, so qualifying the paths would have leaked a Rust
+// module path into `docs/wire/*.schema.json` and the generated `.d.ts` — a
+// silent edit to the published contract to satisfy a lint. This keeps the
+// documented text byte-identical.
+#[allow(unused_imports)]
+use crate::AgentEvent;
 
 /// What happened to a file in a [`AgentEvent::FileChange`] event.
 ///


### PR DESCRIPTION
## main is red

```
error: unresolved link to `AgentEvent::FileChange`
  --> crates/stella-protocol/src/event/payload.rs:22:36
  ... 5 occurrences
error: could not document `stella-protocol`
```

#3436 split the leaf payload types out of `event.rs`. Their doc comments still
cite the variants that carry them, and those links no longer resolve from the
new module. `doc-warnings` runs rustdoc at `-D warnings`, so this is a red gate,
and a red `main` reds every open PR.

Unclaimed when I picked it up — no open PR or issue targeted it.

## The obvious fix is the wrong one

Qualifying the links to `crate::AgentEvent::…` clears the lint. It also
**silently rewrites the published wire contract**: `schemars` emits every doc
comment verbatim as the schema's `description`, so five descriptions across
`docs/wire/agentevent.schema.json`, `docs/wire/serveframe.schema.json` and the
generated `.d.ts` would have gained a Rust module path:

```diff
-      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\n…"
+      "description": "What happened to a file in a [`crate::AgentEvent::FileChange`] event.\n\n…"
```

I wrote that version first and `wire-schema` caught it, which is exactly what
that gate exists for. A lint satisfied by editing a published contract is a
defect, not a fix.

## What this does instead

A **rustdoc-only** `use crate::AgentEvent;`. The links resolve, the documented
text stays byte-identical, and the schema does not move. It carries
`#[allow(unused_imports)]` with the reason written at the import, since nothing
in the module's code refers to the type.

One consequence worth flagging: with the import in scope, the module doc's
explicit target `[`AgentEvent`](super::AgentEvent)` became a `redundant
explicit link target` error — also `-D warnings` — so it is now the plain
`[`AgentEvent`]`. That is a `//!` comment rather than a schema description, so
it likewise leaves the wire alone.

## Verification

Exit codes, not piped output — a `| tail` on `make gate` reported success for a
failing run earlier today, so every check here was captured explicitly:

| check | exit |
|---|---|
| `make doc-warnings` | 0 |
| `scripts/check-wire-schema.sh` | 0 — no diff against the committed artifacts |
| `make gate` | 0 — all 29 steps |

## Deleted tests

None.

Refs #3436

## Summary by Sourcery

Enhancements:
- Adjust payload module documentation to rely on in-scope AgentEvent rather than an explicit link target, avoiding redundant link warnings.