### PR TITLE
fix(stella-protocol): restore the docs build after the event.rs split and the recall test-scoping

### DIFF
--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -93,8 +93,9 @@ impl SessionMemory {
     }
 
     /// The record channel's section and eviction report, with an injectable
-    /// diagnostic sink — the same split as
-    /// [`Self::recalled_frames_reporting`] and for the same reason: the
+    /// diagnostic sink — the same split as `recalled_frames_reporting` (not
+    /// linked: that one is `#[cfg(test)]`, so the path does not resolve in a
+    /// docs build, which has no test cfg) and for the same reason: the
     /// eviction report must be testable without capturing global stderr. A
     /// record reported here MATCHED this turn's facts — the selector chose it
     /// and the budget evicted it — which is the coverage gap #2709 requires

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The leaf payload types an [`AgentEvent`](super::AgentEvent) variant carries
+//! The leaf payload types an [`AgentEvent`] variant carries
 //! — file-change kinds, verdict evidence, scope/hunk proposals, media refs, PR
 //! and CI status, and the task-board item.
 //!
@@ -17,6 +17,15 @@
 
 use serde::{Deserialize, Serialize};
 
+// Imported for the doc links below, not for code: several payload types
+// document the `AgentEvent` variant they ride in, and an unresolved intra-doc
+// link is a `cargo doc -D warnings` failure. rustc cannot see a use that only
+// rustdoc makes, so `unused_imports` is wrong here specifically — and the
+// alternative, spelling `(super::AgentEvent::X)` in each link, would publish
+// Rust module paths into the `description` strings of docs/wire/*.d.ts, which
+// is the consumer-facing wire contract.
+#[allow(unused_imports)]
+use super::AgentEvent;
 use crate::ladder::LadderSnapshot;
 
 /// What happened to a file in a [`AgentEvent::FileChange`] event.


### PR DESCRIPTION
## Problem

`main` is red on `cargo doc -D warnings`, so **every open PR is red on a step none of them broke** — including #3432 and #3439, which is how this was found.

Six unresolved intra-doc links, from two commits that landed within the hour, with the same shape: a link whose target moved out from under it.

- **#3440** (`refactor(stella-protocol): split event.rs's payload types`) moved the payload types into `crates/stella-protocol/src/event/payload.rs`. Five links to `AgentEvent` variants resolved from the old module and do not from the new one.
- **#3443** (`scope a test-only recall helper to tests`) gated `recalled_frames_reporting` behind `#[cfg(test)]`. A sibling's doc comment links it, and a docs build has no test cfg, so the item is genuinely not there.

Neither is a defect in the change that caused it — both are the ordinary cost of moving an item, and nothing pre-merge asked the question, because `cargo doc` only fails once both halves are in one tree.

## Fix

**`payload.rs`** — a doc-only `use super::AgentEvent;` with `#[allow(unused_imports)]` and a comment stating why the lint is wrong *here*: rustc cannot see a use that only rustdoc makes.

The obvious alternative — spelling `[`AgentEvent::FileChange`](super::AgentEvent::FileChange)` at each of the five sites — was written first and rejected on evidence. `schemars` builds each `description` from the doc text, so it changed four committed artifacts and published Rust module paths (`super::AgentEvent::FileChange`) into `docs/wire/agentevent.d.ts` and `serveframe.d.ts`, which are the consumer-facing wire contract. The regenerated diff is in the branch history if a reviewer wants to see it. With the import, `make wire-schema` is OK and the committed schema is byte-identical.

The module doc's `[`AgentEvent`](super::AgentEvent)` loses its now-redundant explicit target (rustdoc's `redundant_explicit_link` fires once the import exists). Module docs do not feed `schemars`, so this too leaves the schema untouched.

**`recall.rs`** — the reference becomes plain `` `recalled_frames_reporting` `` with a parenthetical saying it is `#[cfg(test)]` and therefore not linkable from a docs build. Correct rather than clever: the item really is absent there, so a link would be a lie in the rendered docs.

## Verification

`make gate`, green end to end on this branch off `f1848b855` — including `doc-warnings`, `wire-schema`, `fmt --check`, `clippy -D warnings`, and `cargo test --workspace`.

The control that matters: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going` exits **101** on `origin/main` and **0** here.

## Witness

None, and deliberately: the gate step *is* the test. `doc-warnings` fails on the old tree and passes on the new one, which is the fail→pass flip in the form this repo already enforces on every PR. Adding a Rust test asserting "rustdoc emits no warnings" would duplicate `make gate` with a slower copy.

## Deleted tests

None.

Refs #3440, #3443

## Summary by Sourcery

Restore successful docs and schema builds by fixing intra-doc links broken by recent refactors in stella-protocol and stella-cli.

Documentation:
- Adjust payload module documentation to refer to AgentEvent via an imported symbol, keeping intra-doc links resolving without altering generated wire schemas.
- Clarify recall documentation to reference the test-only recalled_frames_reporting helper without a broken link, noting its cfg(test) status.