### PR TITLE
fix(stella-protocol): repair main's red doc-warnings gate (5 broken intra-doc links)

### DIFF
--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ladder::LadderSnapshot;
 
-/// What happened to a file in a [`AgentEvent::FileChange`] event.
+/// What happened to a file in a [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.
 ///
 /// Both live producers measure a tree against a tree, so every kind emitted
 /// today is a mutation — see [`Self::Read`] for the one that is not, and why
@@ -36,7 +36,7 @@ pub enum FileChangeKind {
     /// again. Neither surviving producer can: both diff a tree against a tree,
     /// and a read leaves no trace in a tree to diff. Re-acquiring one would
     /// mean going back to declaring file operations from tool inputs, which is
-    /// the defect [`AgentEvent::FileChange`] documents rather than a capability
+    /// the defect [`AgentEvent::FileChange`](super::AgentEvent::FileChange) documents rather than a capability
     /// worth restoring.
     ///
     /// It stays in the kind space because journals recorded before the purge
@@ -59,7 +59,7 @@ impl FileChangeKind {
     ///
     /// A `true` here is not a licence to claim the *agent* changed the file:
     /// the shared-tree producer measures the turn, not the actor (see
-    /// [`AgentEvent::FileChange`]).
+    /// [`AgentEvent::FileChange`](super::AgentEvent::FileChange)).
     #[must_use]
     pub fn is_mutation(self) -> bool {
         !matches!(self, FileChangeKind::Read)
@@ -194,7 +194,7 @@ pub enum MediaJobState {
     Queued,
     /// Generation is under way.
     Running,
-    /// The artifact landed; a [`AgentEvent::MediaComplete`] follows.
+    /// The artifact landed; a [`AgentEvent::MediaComplete`](super::AgentEvent::MediaComplete) follows.
     Succeeded,
     /// Generation failed terminally.
     Failed {
@@ -209,7 +209,7 @@ pub enum MediaJobState {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MediaArtifactRef {
     /// The artifact id, matching the `artifact_id` its
-    /// [`AgentEvent::MediaProgress`] events carried.
+    /// [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.
     pub id: String,
     /// What was produced.
     pub kind: MediaKind,

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -394,7 +394,7 @@ export type DeliveryOutcome = {
 export type ErrorClass = "invalid_input" | "not_found" | "permission_denied" | "refused_by_policy" | "timeout" | "environment" | "internal" | "other";
 
 /**
- * What happened to a file in a [`AgentEvent::FileChange`] event.
+ * What happened to a file in a [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.
  *
  * Both live producers measure a tree against a tree, so every kind emitted
  * today is a mutation — see [`Self::Read`] for the one that is not, and why
@@ -728,7 +728,7 @@ export interface ManifestEntry {
 export interface MediaArtifactRef {
   /**
    * The artifact id, matching the `artifact_id` its
-   * [`AgentEvent::MediaProgress`] events carried.
+   * [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.
    */
   id: string;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -546,11 +546,11 @@
       ]
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
       "oneOf": [
         {
           "const": "read",
-          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
+          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`](super::AgentEvent::FileChange) documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
           "type": "string"
         },
         {
@@ -874,7 +874,7 @@
       "description": "A completed media artifact: id + kind + where it landed on disk.",
       "properties": {
         "id": {
-          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.",
+          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.",
           "type": "string"
         },
         "kind": {
@@ -928,7 +928,7 @@
           "type": "object"
         },
         {
-          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.",
+          "description": "The artifact landed; a [`AgentEvent::MediaComplete`](super::AgentEvent::MediaComplete) follows.",
           "properties": {
             "state": {
               "const": "succeeded",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -1159,7 +1159,7 @@ export type DeliveryOutcome = {
 export type ErrorClass = "invalid_input" | "not_found" | "permission_denied" | "refused_by_policy" | "timeout" | "environment" | "internal" | "other";
 
 /**
- * What happened to a file in a [`AgentEvent::FileChange`] event.
+ * What happened to a file in a [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.
  *
  * Both live producers measure a tree against a tree, so every kind emitted
  * today is a mutation — see [`Self::Read`] for the one that is not, and why
@@ -1536,7 +1536,7 @@ export interface ManifestEntry {
 export interface MediaArtifactRef {
   /**
    * The artifact id, matching the `artifact_id` its
-   * [`AgentEvent::MediaProgress`] events carried.
+   * [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.
    */
   id: string;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -2121,11 +2121,11 @@
       ]
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
       "oneOf": [
         {
           "const": "read",
-          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
+          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`](super::AgentEvent::FileChange) documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
           "type": "string"
         },
         {
@@ -2527,7 +2527,7 @@
       "description": "A completed media artifact: id + kind + where it landed on disk.",
       "properties": {
         "id": {
-          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.",
+          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events carried.",
           "type": "string"
         },
         "kind": {
@@ -2581,7 +2581,7 @@
           "type": "object"
         },
         {
-          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.",
+          "description": "The artifact landed; a [`AgentEvent::MediaComplete`](super::AgentEvent::MediaComplete) follows.",
           "properties": {
             "state": {
               "const": "succeeded",


### PR DESCRIPTION
## `main` is red

`make doc-warnings` fails on `origin/main` right now, and has since #3440
merged. This is not a change any subsequent PR made — every branch cut from
`main` inherits it, and because a red gate step masks the ones after it, the
failure a PR author sees is not their own.

```
error: unresolved link to `AgentEvent::MediaProgress`
  --> crates/stella-protocol/src/event/payload.rs:212:11
   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
error: could not document `stella-protocol`
make: *** [doc-warnings] Error 101
```

## Cause

#3436 (PR #3440) split `event.rs`'s payload types out into
`event/payload.rs` to clear the file-size ratchet. The doc comments travelled
with the types, and five `[`AgentEvent::…`]` links that resolved from
`event.rs` — where `AgentEvent` is a sibling item — resolve to nothing from
the child module.

A pure code motion, which is exactly the shape that carries a link break
invisibly: nothing about the moved lines changed.

## Fix

Name the path explicitly, `(super::AgentEvent::…)` — the form line 4 of the
same file already uses for the module-level link, so this makes the file
internally consistent rather than introducing a convention.

Five links, all in `crates/stella-protocol/src/event/payload.rs`; that is the
complete set the gate reports, verified by re-running it to green.

## The second commit: regenerated wire artifacts

Doc comments on wire types become JSON Schema `description` strings, so the
repair changes `docs/wire/` and `wire-schema` fails until those are
regenerated and committed (`make wire-schema-update`).

Kept as a separate commit so the reviewable claim is checkable at a glance:
the diff is **prose only** — four description strings across the two schemas
and their two `.d.ts` twins. No type, field, variant, or shape changed. That
is the guard working, not a contract change wearing a doc fix.

## Verification

`make gate` — `GATE_EXIT=0` on this branch, red at `doc-warnings` on the
parent commit.

No witness test. The gate step *is* the witness, and a test asserting a doc
link resolves would be a worse copy of it.

Refs #3436