### PR TITLE
feat(stella-core): a turn says which lane assembled it (#3410)

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -76,16 +76,25 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionRequestRef, FinishReason, MessageRole, Provider,
-    ProviderError, ReasoningEffort, ToolCall, ToolOutput,
+    ProviderError, ToolCall, ToolOutput,
 };
 
 use crate::budget::{BudgetAxis, BudgetGuard, BudgetOutcome};
 use crate::bus;
 use crate::compaction::compact_measured;
 use crate::receipts::TranscriptRevision;
+pub use config::{EngineConfig, TurnHalt};
+// These moved to `config` with the fields that use them; the test modules
+// below reach them through `use super::*`, so keep them nameable here rather
+// than editing four test files to import what they always saw.
+#[cfg(test)]
+use crate::loop_detect::LoopDetectionConfig;
+#[cfg(test)]
+use crate::retry::RetryPolicy;
 use lifecycle::step_outcome_label;
 
 mod confident_zero;
+mod config;
 pub mod lifecycle;
 mod live_services;
 pub(crate) mod loop_escalation;
@@ -94,10 +103,9 @@ mod truncation;
 use crate::estimator::{CalibrationMap, estimate_conversation_tokens};
 use crate::event_sender::EventSender;
 use crate::hooks::{HookEvent, HookRunner, Hooks, any_matcher_matches};
-use crate::loop_detect::LoopDetectionConfig;
 use crate::ports::ToolExecutor;
 use crate::receipts::ReceiptLedger;
-use crate::retry::{RetryOutcome, RetryPolicy, Sleeper};
+use crate::retry::{RetryOutcome, Sleeper};
 use crate::speculation::{SpeculationGate, SpeculationPool, SpeculativeResult};
 use crate::step::{
     AbortKind, BorrowedTurn, CompactionPass, SpeculationDropGuard, StepOutcome, StreamProgress,
@@ -145,260 +153,6 @@ pub(crate) mod user_hooks;
 mod waiting;
 use overflow_recovery::ModelCallFailure;
 use settlement::{BudgetWarnings, emit_budget_warning, record_settled_cost};
-
-/// Everything about a turn's execution that isn't the provider/tools
-/// themselves: prompt shape, retry/compaction/loop tuning, and hard
-/// backstops. `Default` gives sensible starting values for `stella-cli`.
-#[derive(Debug, Clone)]
-pub struct EngineConfig {
-    pub max_output_tokens: Option<u32>,
-    pub temperature: Option<f32>,
-    pub effort: Option<ReasoningEffort>,
-    /// Thinking-mode enable/disable forwarded to every completion —
-    /// `CompletionRequest::reasoning` semantics (`None` = provider default).
-    pub reasoning: Option<bool>,
-    /// Sampling/routing overrides forwarded to every completion —
-    /// `CompletionRequest::params` semantics (each adapter forwards the
-    /// subset its dialect supports).
-    pub params: Option<stella_protocol::GenerationParams>,
-    pub retry_policy: RetryPolicy,
-    pub loop_detection: LoopDetectionConfig,
-    /// Compaction fires once the estimated conversation size exceeds this
-    /// many tokens (`crate::estimator`). When calibration is attached
-    /// ([`Engine::with_calibration`]) the comparison uses the
-    /// drift-corrected estimate, so this budget is honored in the model's
-    /// own observed tokens rather than raw heuristic tokens.
-    pub compaction_budget_tokens: u64,
-    /// Age-based tool-result retention (#1285): results older than this many
-    /// tool-bearing steps are middle-out aged on every step, gated so the
-    /// prompt-cache prefix is rewritten only when real bytes come back
-    /// (`compaction::RETENTION_MIN_RECLAIM_CHARS`). This is what holds the
-    /// standing context roughly flat through a long turn — the budget above
-    /// fires only near the context ceiling, which on a long trial is the very
-    /// end of exactly the runs it should have shaped from the middle
-    /// (measured: 4× more input per step than a comparator that trims old
-    /// tool output, and ~quadratic total input growth). `None` disables the
-    /// pass, restoring pure budget-triggered compaction.
-    pub tool_result_horizon_steps: Option<usize>,
-    /// When eviction/dedup/aging alone cannot reach the compaction budget
-    /// (the oversized content is protected user/assistant text, or already
-    /// stubbed), replace the oldest span of the conversation with a
-    /// model-written summary instead of letting the next call overflow the
-    /// provider's context window. Costs one cheap completion, metered into
-    /// the same [`BudgetGuard`] as every other call.
-    pub summarize_overflow: bool,
-    /// Messages at the conversation tail the summarizer never touches —
-    /// the recent work the model is actively reasoning over.
-    pub summarize_keep_recent: usize,
-    /// Hard backstop on step count, independent of loop detection — belt
-    /// and suspenders, never the *primary* stuck-loop defense (that's
-    /// `crate::loop_detect`).
-    pub max_steps: usize,
-    /// Hard backstop on how long one tool dispatch may run, independent of
-    /// each tool's own bound — the same belt-and-suspenders philosophy as
-    /// [`Self::max_steps`], and never the *primary* mechanism.
-    ///
-    /// Per-tool bounds are the real defense (bash clamps its own timeout,
-    /// scripts cap out, MCP bounds each call), but each is that tool's own
-    /// responsibility. A tool that misses its bound — a future native tool,
-    /// an MCP server that overrides its timeout upward, a wedged blocking
-    /// read — would otherwise park the step forever: loop detection, budget
-    /// checks and soft-stop all fire at *step boundaries*, so a headless
-    /// `stella run` hangs indefinitely with no way out but a hard cancel.
-    ///
-    /// When the ceiling trips, the call resolves to a `ToolOutput::Error`
-    /// the model can react to, turning "hung forever" into one failed call
-    /// the loop routes around. Deliberately generous (15 minutes) so it
-    /// never pre-empts a legitimately slow tool. `None` disables the
-    /// backstop entirely, restoring the unbounded await.
-    ///
-    /// Note this is the one place the engine may interrupt a tool in
-    /// flight; the budget-abort invariant (clean aborts at step boundaries,
-    /// never mid-tool) is unaffected, because a trip is surfaced as a tool
-    /// *result*, not as a turn abort.
-    pub tool_timeout: Option<Duration>,
-    /// Backstop on a **single generation** — one provider dispatch, excluding
-    /// the backoff sleeps between attempts. `None` restores the unbounded
-    /// await.
-    ///
-    /// Without it nothing above the transport bounds a model call: the only
-    /// limit is whichever reqwest deadline the adapter happens to carry, and
-    /// those are per-read stalls, not whole-response bounds. Bedrock is the
-    /// worst case — it is unary, so its 600s `UNARY_READ_TIMEOUT` covers the
-    /// entire generation, and its expiry used to classify as retryable
-    /// `Transport`, so one wedged request cost four full 600s attempts
-    /// (~40 minutes) before surfacing.
-    ///
-    /// A trip is reported as `ProviderError::Terminal`, never `Transport`,
-    /// following `stella-serve`'s reverse-RPC deadline: a provider that is
-    /// simply not answering must not be handed the same unbounded wait again
-    /// once per retry, which would multiply the very window the deadline
-    /// exists to close.
-    ///
-    /// 13.6 minutes of SILENCE, not of elapsed time: `bounded_generation`
-    /// measures idle gaps between stream fragments, so a generation that
-    /// keeps producing is never cut however long it runs. The number is
-    /// measured rather than chosen. It was 10 minutes (matching
-    /// `UNARY_READ_TIMEOUT`) on the reasoning that no generation a caller
-    /// still wants goes longer without progress. Context for the size: on
-    /// the Terminal-Bench 2.1 gate a comparator on the same model, same API
-    /// and same effort earned reward `1.0` on single steps of 624s and 756s
-    /// — steps that stream throughout and are untouched by an idle bound,
-    /// but that shaped the margin chosen here for a provider that has
-    /// genuinely stopped answering.
-    ///
-    /// The rule fixing the constant is "never be the side that stops first":
-    /// 60s above the longest single step the comparator was ever rewarded for
-    /// (756s). Raising it is what makes a raised output ceiling reachable —
-    /// the two are one budget, and moving either alone provably does nothing,
-    /// which is why the earlier 16384 → 32000 → 64000 attempts each traded
-    /// one truncation mode for another instead of clearing it.
-    ///
-    /// This bounds the *streaming* path, which is the real request path:
-    /// adapters bound their streams by `STREAM_IDLE_TIMEOUT` (120s between
-    /// chunks, not a total), so nothing under this cuts a generation that
-    /// keeps producing. A non-streaming adapter still carries its own
-    /// `UNARY_READ_TIMEOUT` (600s) and will bind before this does — that
-    /// ceiling is untouched here and remains a per-adapter transport concern.
-    pub model_timeout: Option<Duration>,
-    /// Wall clock one turn may spend, used to decide whether a length
-    /// continuation is affordable. `None` — the default — leaves the
-    /// continuation allowance a pure count, exactly as before.
-    ///
-    /// This is not a timeout and nothing enforces it: no future is cancelled
-    /// when it elapses. It exists so the engine can decline to *start* work it
-    /// cannot finish. The constraint being modelled is external — a harness
-    /// kills a trial on elapsed time (Terminal-Bench at 900s) — and an engine
-    /// blind to it will spend its whole continuation allowance and be
-    /// destroyed mid-continuation, turning a truthful truncated answer into an
-    /// `AgentTimeoutError` that reads at the results layer exactly like the
-    /// agent failing the task.
-    ///
-    /// Set it slightly below the real deadline: the useful behaviour is
-    /// stopping with an honest partial while time remains, not racing the
-    /// harness to the last second.
-    pub turn_budget: Option<Duration>,
-    /// Working directory reported to lifecycle hooks (`crate::hooks`) as the
-    /// `cwd` of every [`crate::hooks::HookPayload`]. Kept here — rather than sniffed via
-    /// `std::env::current_dir()` inside the engine — so `stella-core`
-    /// performs no I/O of its own: the caller
-    /// (which already knows the workspace root) supplies the real path, and
-    /// the `"."` default keeps hook-free turns unaffected. Only read when
-    /// hooks are actually configured.
-    pub cwd: String,
-    /// Monotonic per-session turn index stamped onto this turn's context
-    /// receipts (`BlockRegistered`/`StepManifest`, spec §3). Groups a
-    /// `run_turn`'s steps across executions in one session without an
-    /// event-order correlation. `0` when the caller does not track turns
-    /// (the receipt is still valid — `(execution_id, step)` disambiguates
-    /// within an execution).
-    pub turn_instance: u32,
-    /// `context.lifecycle.enabled` — Phase 2 (#713). Gates the compiled-frame
-    /// identity on this turn's step manifests. The setting ships on; this
-    /// field still defaults `false` so a programmatically-built config opts in
-    /// deliberately rather than inheriting a product default it never read.
-    pub lifecycle_enabled: bool,
-    /// Where this engine's turns write their resume point, if anywhere.
-    ///
-    /// `None` — the default — is the behaviour every caller had before: a turn
-    /// interrupted mid-flight is gone, and the host recovers by re-dispatching
-    /// the prompt and paying for the work again. Attaching a sink makes the
-    /// turn itself recoverable; see [`crate::step::CheckpointSink`] for the failure
-    /// contract, and [`Engine::resume_turn`] for the other half.
-    ///
-    /// Kept here rather than passed to `run_turn` because it is a property of
-    /// the host's durability arrangement, not of any one turn — the same
-    /// reasoning that puts [`Self::cwd`] here rather than making the engine
-    /// sniff it.
-    pub checkpoint_sink: Option<Arc<dyn crate::step::CheckpointSink>>,
-    /// A host-supplied "the goal is already met — stop now" signal, consulted
-    /// at every step boundary.
-    ///
-    /// `None` — the default — is exactly the behaviour every caller had
-    /// before: the turn runs until the model stops asking for tools, the
-    /// budget bites, or the step cap does.
-    ///
-    /// This exists because those are all *external* stopping conditions, and
-    /// an agent that has already met its goal will happily keep spending
-    /// against them — the measured story (Terminal-Bench run `or1`, task
-    /// `pypi-server`) lives in `stella-pipeline::flip_halt`'s module doc.
-    ///
-    /// The host owns the predicate because only the host knows what "done"
-    /// means. `stella-pipeline` supplies one that fires when its flip oracle
-    /// observes the tracked test go fail→pass.
-    pub turn_halt: Option<Arc<dyn TurnHalt>>,
-    /// Task-mode opt-in (#2663): a completing turn that mutated the workspace
-    /// and was not yet challenged is nudged once to prove its work
-    /// before the declaration is accepted (`confident_zero::check`, rung 4).
-    pub completion_gate: bool,
-}
-
-/// A caller's answer to "is the goal already met?", asked once per step
-/// boundary.
-///
-/// Debug is a supertrait for the same reason [`crate::step::CheckpointSink`]
-/// carries it: [`EngineConfig`] derives `Debug`, and a config that cannot be
-/// printed is a config nobody can diagnose.
-pub trait TurnHalt: Send + Sync + std::fmt::Debug {
-    /// `Some(reason)` ends the turn cleanly at the next step boundary;
-    /// `None` lets it continue.
-    ///
-    /// Asked per committed step AND inside the dispatch loop (#2661): cheap,
-    /// never blocking. A mid-dispatch fire kills in-flight sibling tools and
-    /// answers their calls synthetically — the transcript stays paired.
-    fn halt_reason(&self) -> Option<String>;
-}
-
-impl Default for EngineConfig {
-    fn default() -> Self {
-        Self {
-            // 16k, not 8k: reasoning models (e.g. glm-5.2) can spend their whole
-            // output budget on chain-of-thought and get cut off before emitting
-            // any answer. 16k gives the answer room to land after reasoning and
-            // is within every seeded catalog model's output ceiling — and it is
-            // only the fallback: a model whose catalog entry declares its own
-            // output ceiling overrides this at engine assembly
-            // (stella-cli::agent::engine::tuned_engine_config).
-            max_output_tokens: Some(16384),
-            temperature: Some(0.0),
-            effort: None,
-            reasoning: None,
-            params: None,
-            retry_policy: RetryPolicy::standard(),
-            loop_detection: LoopDetectionConfig::default(),
-            compaction_budget_tokens: 150_000,
-            // Eight tool-bearing steps of verbatim results, matching
-            // `summarize_keep_recent`'s notion of "the recent work the model
-            // is actively reasoning over". Older results keep head+tail; the
-            // stub says how to re-fetch the rest.
-            tool_result_horizon_steps: Some(8),
-            summarize_overflow: true,
-            summarize_keep_recent: 8,
-            max_steps: 200,
-            tool_timeout: Some(Duration::from_secs(15 * 60)),
-            model_timeout: Some(Duration::from_secs(816)),
-            // Off by default: only a caller that knows its own deadline can
-            // supply a true one, and a guessed budget would decline work the
-            // caller had time for.
-            turn_budget: None,
-            cwd: ".".to_string(),
-            turn_instance: 0,
-            lifecycle_enabled: false,
-            // Off by default for the same reason `turn_budget` is: only a
-            // caller that owns durable storage can say where a resume point
-            // belongs, and a default location invented here would write one
-            // process's turns into another's session.
-            checkpoint_sink: None,
-            // Off by default: a turn with no host-supplied notion of "done"
-            // must behave exactly as it always has. Only a caller holding a
-            // real completion signal — the pipeline's flip oracle — can say
-            // the goal is met, and inventing one here would end turns that
-            // had more to do.
-            turn_halt: None,
-            completion_gate: false,
-        }
-    }
-}
 
 /// How a turn ended.
 #[derive(Debug, Clone, PartialEq)]
@@ -488,6 +242,11 @@ pub struct Engine<'a> {
     pub(crate) sleeper: &'a dyn Sleeper,
     pub(crate) config: EngineConfig,
     pub(crate) call_role: stella_protocol::ModelCallRole,
+    /// Which lane assembled this engine (#3386/#3410), stamped onto
+    /// `agent.turn.started`. `None` means the engine came through
+    /// [`Engine::with_sleeper`] and the individual builders, which have no
+    /// lane to report -- an honest "unattributed", not a forgotten one.
+    pub(crate) lane: Option<stella_protocol::TurnLane>,
     /// Lifecycle hooks, off by default. Attached via [`Engine::with_hooks`]
     /// so `with_sleeper` keeps its existing signature. When `None`,
     /// no hook is ever consulted and the turn path adds zero work.
@@ -629,6 +388,9 @@ impl<'a> Engine<'a> {
             sleeper,
             config,
             call_role: stella_protocol::ModelCallRole::Worker,
+            // The legacy builder path names no lane. `assemble` is where a
+            // lane is declared.
+            lane: None,
             hooks: None,
             hook_approvals: None,
             calibration: None,
@@ -682,6 +444,7 @@ impl<'a> Engine<'a> {
                 ..self.config.clone()
             },
             call_role: self.call_role,
+            lane: self.lane.clone(),
             hooks: self.hooks,
             hook_approvals: self.hook_approvals,
             calibration: self.calibration,
@@ -721,6 +484,7 @@ impl<'a> Engine<'a> {
                 ..self.config.clone()
             },
             call_role: self.call_role,
+            lane: self.lane.clone(),
             hooks: self.hooks,
             hook_approvals: self.hook_approvals,
             calibration: self.calibration,

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -71,6 +71,9 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+// Only the `tests` submodule below names this; the non-test build of the
+// driver stopped doing so when the timeout config moved to `driver::config`.
+#[cfg(test)]
 use std::time::Duration;
 
 use futures_util::StreamExt;

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -42,7 +42,7 @@
 
 use std::sync::Arc;
 
-use stella_protocol::ModelCallRole;
+use stella_protocol::{ModelCallRole, TurnLane};
 
 use super::{Engine, EngineConfig, HooksHandle};
 use crate::estimator::CalibrationMap;
@@ -84,6 +84,17 @@ pub struct TurnCapabilities<'a> {
     /// every call has a role, and [`ModelCallRole::Worker`] is the ordinary
     /// answer rather than the absence of one.
     pub call_role: ModelCallRole,
+    /// Which lane is assembling this engine (#3386, #3410), stamped onto
+    /// `agent.turn.started`.
+    ///
+    /// An `Option`, and the `None` is a real answer rather than a gap: a
+    /// caller that genuinely belongs to no named lane (a test, a bare loop)
+    /// says so. What the missing `Default` buys is that the answer must still
+    /// be *written* -- a struct literal cannot omit this field, so
+    /// "unattributed" is always a decision somebody typed. That is the same
+    /// rule #3388 applies to `pipeline_variant`'s NULL: a placeholder has to
+    /// be distinguishable from "nobody recorded it".
+    pub lane: Option<TurnLane>,
 }
 
 impl<'a> TurnCapabilities<'a> {
@@ -105,6 +116,7 @@ impl<'a> TurnCapabilities<'a> {
             outcomes: None,
             fallback: None,
             call_role: ModelCallRole::Worker,
+            lane: None,
         }
     }
 }
@@ -157,6 +169,17 @@ pub struct OwnedTurnCapabilities {
     pub fallback: Option<Arc<dyn FallbackResolver>>,
     /// What this engine's model calls are attributed to.
     pub call_role: ModelCallRole,
+    /// Which lane is assembling this engine (#3386, #3410), stamped onto
+    /// `agent.turn.started`.
+    ///
+    /// An `Option`, and the `None` is a real answer rather than a gap: a
+    /// caller that genuinely belongs to no named lane (a test, a bare loop)
+    /// says so. What the missing `Default` buys is that the answer must still
+    /// be *written* -- a struct literal cannot omit this field, so
+    /// "unattributed" is always a decision somebody typed. That is the same
+    /// rule #3388 applies to `pipeline_variant`'s NULL: a placeholder has to
+    /// be distinguishable from "nobody recorded it".
+    pub lane: Option<TurnLane>,
 }
 
 impl OwnedTurnCapabilities {
@@ -175,6 +198,7 @@ impl OwnedTurnCapabilities {
             outcomes: None,
             fallback: None,
             call_role: ModelCallRole::Worker,
+            lane: None,
         }
     }
 
@@ -200,6 +224,7 @@ impl OwnedTurnCapabilities {
             outcomes,
             fallback,
             call_role,
+            lane,
         } = self;
 
         TurnCapabilities {
@@ -213,6 +238,7 @@ impl OwnedTurnCapabilities {
             outcomes: outcomes.as_deref(),
             fallback: fallback.as_deref(),
             call_role: *call_role,
+            lane: lane.clone(),
         }
     }
 }
@@ -258,6 +284,7 @@ impl<'a> Engine<'a> {
             outcomes,
             fallback,
             call_role,
+            lane,
         } = capabilities;
 
         Self {
@@ -275,6 +302,7 @@ impl<'a> Engine<'a> {
             bus,
             outcomes,
             fallback,
+            lane,
             provider_override: Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -307,6 +335,7 @@ mod tests {
             outcomes,
             fallback,
             call_role,
+            lane,
         } = TurnCapabilities::none();
 
         assert!(hooks.is_none());
@@ -319,6 +348,7 @@ mod tests {
         assert!(outcomes.is_none());
         assert!(fallback.is_none());
         assert_eq!(call_role, ModelCallRole::Worker);
+        assert!(lane.is_none());
     }
 
     /// The owned-slot witness (#3387): a lane that **owns** its seams can

--- a/crates/stella-core/src/driver/config.rs
+++ b/crates/stella-core/src/driver/config.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! [`EngineConfig`] -- what a turn is configured to do, as opposed to what
+//! drives it.
+//!
+//! Split out of `driver.rs` (#3410). That file is a grandfathered god file
+//! sitting exactly on its ceiling, and the lane stamp needed room; this is
+//! the coherent unit to move rather than the smallest one. The config is a
+//! genuinely separate concern from the step loop -- it is the *declaration*
+//! a caller makes, where `driver.rs` is the machinery that honours it -- and
+//! `driver/settlement.rs` and `driver/capabilities.rs` are the precedent for
+//! a sibling submodule reaching the same private state.
+//!
+//! Behaviour is unchanged: the struct, its field docs, [`TurnHalt`] and the
+//! `Default` impl moved whole, and `driver` re-exports them, so every
+//! existing path (`stella_core::EngineConfig`, `driver::EngineConfig`) still
+//! resolves.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use stella_protocol::ReasoningEffort;
+
+use crate::loop_detect::LoopDetectionConfig;
+use crate::retry::RetryPolicy;
+
+// Named only by this module's doc comments, which moved here with the fields
+// that carry them. Importing them keeps those intra-doc links resolving
+// instead of degrading the prose to plain text.
+#[allow(unused_imports)]
+use super::Engine;
+#[allow(unused_imports)]
+use crate::budget::BudgetGuard;
+
+/// Everything about a turn's execution that isn't the provider/tools
+/// themselves: prompt shape, retry/compaction/loop tuning, and hard
+/// backstops. `Default` gives sensible starting values for `stella-cli`.
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    pub max_output_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub effort: Option<ReasoningEffort>,
+    /// Thinking-mode enable/disable forwarded to every completion —
+    /// `CompletionRequest::reasoning` semantics (`None` = provider default).
+    pub reasoning: Option<bool>,
+    /// Sampling/routing overrides forwarded to every completion —
+    /// `CompletionRequest::params` semantics (each adapter forwards the
+    /// subset its dialect supports).
+    pub params: Option<stella_protocol::GenerationParams>,
+    pub retry_policy: RetryPolicy,
+    pub loop_detection: LoopDetectionConfig,
+    /// Compaction fires once the estimated conversation size exceeds this
+    /// many tokens (`crate::estimator`). When calibration is attached
+    /// ([`Engine::with_calibration`]) the comparison uses the
+    /// drift-corrected estimate, so this budget is honored in the model's
+    /// own observed tokens rather than raw heuristic tokens.
+    pub compaction_budget_tokens: u64,
+    /// Age-based tool-result retention (#1285): results older than this many
+    /// tool-bearing steps are middle-out aged on every step, gated so the
+    /// prompt-cache prefix is rewritten only when real bytes come back
+    /// (`compaction::RETENTION_MIN_RECLAIM_CHARS`). This is what holds the
+    /// standing context roughly flat through a long turn — the budget above
+    /// fires only near the context ceiling, which on a long trial is the very
+    /// end of exactly the runs it should have shaped from the middle
+    /// (measured: 4× more input per step than a comparator that trims old
+    /// tool output, and ~quadratic total input growth). `None` disables the
+    /// pass, restoring pure budget-triggered compaction.
+    pub tool_result_horizon_steps: Option<usize>,
+    /// When eviction/dedup/aging alone cannot reach the compaction budget
+    /// (the oversized content is protected user/assistant text, or already
+    /// stubbed), replace the oldest span of the conversation with a
+    /// model-written summary instead of letting the next call overflow the
+    /// provider's context window. Costs one cheap completion, metered into
+    /// the same [`BudgetGuard`] as every other call.
+    pub summarize_overflow: bool,
+    /// Messages at the conversation tail the summarizer never touches —
+    /// the recent work the model is actively reasoning over.
+    pub summarize_keep_recent: usize,
+    /// Hard backstop on step count, independent of loop detection — belt
+    /// and suspenders, never the *primary* stuck-loop defense (that's
+    /// `crate::loop_detect`).
+    pub max_steps: usize,
+    /// Hard backstop on how long one tool dispatch may run, independent of
+    /// each tool's own bound — the same belt-and-suspenders philosophy as
+    /// [`Self::max_steps`], and never the *primary* mechanism.
+    ///
+    /// Per-tool bounds are the real defense (bash clamps its own timeout,
+    /// scripts cap out, MCP bounds each call), but each is that tool's own
+    /// responsibility. A tool that misses its bound — a future native tool,
+    /// an MCP server that overrides its timeout upward, a wedged blocking
+    /// read — would otherwise park the step forever: loop detection, budget
+    /// checks and soft-stop all fire at *step boundaries*, so a headless
+    /// `stella run` hangs indefinitely with no way out but a hard cancel.
+    ///
+    /// When the ceiling trips, the call resolves to a `ToolOutput::Error`
+    /// the model can react to, turning "hung forever" into one failed call
+    /// the loop routes around. Deliberately generous (15 minutes) so it
+    /// never pre-empts a legitimately slow tool. `None` disables the
+    /// backstop entirely, restoring the unbounded await.
+    ///
+    /// Note this is the one place the engine may interrupt a tool in
+    /// flight; the budget-abort invariant (clean aborts at step boundaries,
+    /// never mid-tool) is unaffected, because a trip is surfaced as a tool
+    /// *result*, not as a turn abort.
+    pub tool_timeout: Option<Duration>,
+    /// Backstop on a **single generation** — one provider dispatch, excluding
+    /// the backoff sleeps between attempts. `None` restores the unbounded
+    /// await.
+    ///
+    /// Without it nothing above the transport bounds a model call: the only
+    /// limit is whichever reqwest deadline the adapter happens to carry, and
+    /// those are per-read stalls, not whole-response bounds. Bedrock is the
+    /// worst case — it is unary, so its 600s `UNARY_READ_TIMEOUT` covers the
+    /// entire generation, and its expiry used to classify as retryable
+    /// `Transport`, so one wedged request cost four full 600s attempts
+    /// (~40 minutes) before surfacing.
+    ///
+    /// A trip is reported as `ProviderError::Terminal`, never `Transport`,
+    /// following `stella-serve`'s reverse-RPC deadline: a provider that is
+    /// simply not answering must not be handed the same unbounded wait again
+    /// once per retry, which would multiply the very window the deadline
+    /// exists to close.
+    ///
+    /// 13.6 minutes of SILENCE, not of elapsed time: `bounded_generation`
+    /// measures idle gaps between stream fragments, so a generation that
+    /// keeps producing is never cut however long it runs. The number is
+    /// measured rather than chosen. It was 10 minutes (matching
+    /// `UNARY_READ_TIMEOUT`) on the reasoning that no generation a caller
+    /// still wants goes longer without progress. Context for the size: on
+    /// the Terminal-Bench 2.1 gate a comparator on the same model, same API
+    /// and same effort earned reward `1.0` on single steps of 624s and 756s
+    /// — steps that stream throughout and are untouched by an idle bound,
+    /// but that shaped the margin chosen here for a provider that has
+    /// genuinely stopped answering.
+    ///
+    /// The rule fixing the constant is "never be the side that stops first":
+    /// 60s above the longest single step the comparator was ever rewarded for
+    /// (756s). Raising it is what makes a raised output ceiling reachable —
+    /// the two are one budget, and moving either alone provably does nothing,
+    /// which is why the earlier 16384 → 32000 → 64000 attempts each traded
+    /// one truncation mode for another instead of clearing it.
+    ///
+    /// This bounds the *streaming* path, which is the real request path:
+    /// adapters bound their streams by `STREAM_IDLE_TIMEOUT` (120s between
+    /// chunks, not a total), so nothing under this cuts a generation that
+    /// keeps producing. A non-streaming adapter still carries its own
+    /// `UNARY_READ_TIMEOUT` (600s) and will bind before this does — that
+    /// ceiling is untouched here and remains a per-adapter transport concern.
+    pub model_timeout: Option<Duration>,
+    /// Wall clock one turn may spend, used to decide whether a length
+    /// continuation is affordable. `None` — the default — leaves the
+    /// continuation allowance a pure count, exactly as before.
+    ///
+    /// This is not a timeout and nothing enforces it: no future is cancelled
+    /// when it elapses. It exists so the engine can decline to *start* work it
+    /// cannot finish. The constraint being modelled is external — a harness
+    /// kills a trial on elapsed time (Terminal-Bench at 900s) — and an engine
+    /// blind to it will spend its whole continuation allowance and be
+    /// destroyed mid-continuation, turning a truthful truncated answer into an
+    /// `AgentTimeoutError` that reads at the results layer exactly like the
+    /// agent failing the task.
+    ///
+    /// Set it slightly below the real deadline: the useful behaviour is
+    /// stopping with an honest partial while time remains, not racing the
+    /// harness to the last second.
+    pub turn_budget: Option<Duration>,
+    /// Working directory reported to lifecycle hooks (`crate::hooks`) as the
+    /// `cwd` of every [`crate::hooks::HookPayload`]. Kept here — rather than sniffed via
+    /// `std::env::current_dir()` inside the engine — so `stella-core`
+    /// performs no I/O of its own: the caller
+    /// (which already knows the workspace root) supplies the real path, and
+    /// the `"."` default keeps hook-free turns unaffected. Only read when
+    /// hooks are actually configured.
+    pub cwd: String,
+    /// Monotonic per-session turn index stamped onto this turn's context
+    /// receipts (`BlockRegistered`/`StepManifest`, spec §3). Groups a
+    /// `run_turn`'s steps across executions in one session without an
+    /// event-order correlation. `0` when the caller does not track turns
+    /// (the receipt is still valid — `(execution_id, step)` disambiguates
+    /// within an execution).
+    pub turn_instance: u32,
+    /// `context.lifecycle.enabled` — Phase 2 (#713). Gates the compiled-frame
+    /// identity on this turn's step manifests. The setting ships on; this
+    /// field still defaults `false` so a programmatically-built config opts in
+    /// deliberately rather than inheriting a product default it never read.
+    pub lifecycle_enabled: bool,
+    /// Where this engine's turns write their resume point, if anywhere.
+    ///
+    /// `None` — the default — is the behaviour every caller had before: a turn
+    /// interrupted mid-flight is gone, and the host recovers by re-dispatching
+    /// the prompt and paying for the work again. Attaching a sink makes the
+    /// turn itself recoverable; see [`crate::step::CheckpointSink`] for the failure
+    /// contract, and [`Engine::resume_turn`] for the other half.
+    ///
+    /// Kept here rather than passed to `run_turn` because it is a property of
+    /// the host's durability arrangement, not of any one turn — the same
+    /// reasoning that puts [`Self::cwd`] here rather than making the engine
+    /// sniff it.
+    pub checkpoint_sink: Option<Arc<dyn crate::step::CheckpointSink>>,
+    /// A host-supplied "the goal is already met — stop now" signal, consulted
+    /// at every step boundary.
+    ///
+    /// `None` — the default — is exactly the behaviour every caller had
+    /// before: the turn runs until the model stops asking for tools, the
+    /// budget bites, or the step cap does.
+    ///
+    /// This exists because those are all *external* stopping conditions, and
+    /// an agent that has already met its goal will happily keep spending
+    /// against them — the measured story (Terminal-Bench run `or1`, task
+    /// `pypi-server`) lives in `stella-pipeline::flip_halt`'s module doc.
+    ///
+    /// The host owns the predicate because only the host knows what "done"
+    /// means. `stella-pipeline` supplies one that fires when its flip oracle
+    /// observes the tracked test go fail→pass.
+    pub turn_halt: Option<Arc<dyn TurnHalt>>,
+    /// Task-mode opt-in (#2663): a completing turn that mutated the workspace
+    /// and was not yet challenged is nudged once to prove its work
+    /// before the declaration is accepted (`confident_zero::check`, rung 4).
+    pub completion_gate: bool,
+}
+
+/// A caller's answer to "is the goal already met?", asked once per step
+/// boundary.
+///
+/// Debug is a supertrait for the same reason [`crate::step::CheckpointSink`]
+/// carries it: [`EngineConfig`] derives `Debug`, and a config that cannot be
+/// printed is a config nobody can diagnose.
+pub trait TurnHalt: Send + Sync + std::fmt::Debug {
+    /// `Some(reason)` ends the turn cleanly at the next step boundary;
+    /// `None` lets it continue.
+    ///
+    /// Asked per committed step AND inside the dispatch loop (#2661): cheap,
+    /// never blocking. A mid-dispatch fire kills in-flight sibling tools and
+    /// answers their calls synthetically — the transcript stays paired.
+    fn halt_reason(&self) -> Option<String>;
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            // 16k, not 8k: reasoning models (e.g. glm-5.2) can spend their whole
+            // output budget on chain-of-thought and get cut off before emitting
+            // any answer. 16k gives the answer room to land after reasoning and
+            // is within every seeded catalog model's output ceiling — and it is
+            // only the fallback: a model whose catalog entry declares its own
+            // output ceiling overrides this at engine assembly
+            // (stella-cli::agent::engine::tuned_engine_config).
+            max_output_tokens: Some(16384),
+            temperature: Some(0.0),
+            effort: None,
+            reasoning: None,
+            params: None,
+            retry_policy: RetryPolicy::standard(),
+            loop_detection: LoopDetectionConfig::default(),
+            compaction_budget_tokens: 150_000,
+            // Eight tool-bearing steps of verbatim results, matching
+            // `summarize_keep_recent`'s notion of "the recent work the model
+            // is actively reasoning over". Older results keep head+tail; the
+            // stub says how to re-fetch the rest.
+            tool_result_horizon_steps: Some(8),
+            summarize_overflow: true,
+            summarize_keep_recent: 8,
+            max_steps: 200,
+            tool_timeout: Some(Duration::from_secs(15 * 60)),
+            model_timeout: Some(Duration::from_secs(816)),
+            // Off by default: only a caller that knows its own deadline can
+            // supply a true one, and a guessed budget would decline work the
+            // caller had time for.
+            turn_budget: None,
+            cwd: ".".to_string(),
+            turn_instance: 0,
+            lifecycle_enabled: false,
+            // Off by default for the same reason `turn_budget` is: only a
+            // caller that owns durable storage can say where a resume point
+            // belongs, and a default location invented here would write one
+            // process's turns into another's session.
+            checkpoint_sink: None,
+            // Off by default: a turn with no host-supplied notion of "done"
+            // must behave exactly as it always has. Only a caller holding a
+            // real completion signal — the pipeline's flip oracle — can say
+            // the goal is met, and inventing one here would end turns that
+            // had more to do.
+            turn_halt: None,
+            completion_gate: false,
+        }
+    }
+}

--- a/crates/stella-core/src/driver/drive.rs
+++ b/crates/stella-core/src/driver/drive.rs
@@ -89,6 +89,7 @@ impl Engine<'_> {
                 state.messages().len(),
                 self.config.max_steps,
                 self.call_role,
+                self.lane.as_ref(),
             )
         });
         let outcome = self.step_loop(state, events).await;

--- a/crates/stella-core/src/driver/lifecycle.rs
+++ b/crates/stella-core/src/driver/lifecycle.rs
@@ -43,17 +43,25 @@
 use super::{StepOutcome, TurnOutcome};
 
 /// What `agent.turn.started` carries: how much conversation the turn opened
-/// with, the loop bound it runs under, and which role is driving it. No
-/// message *content* — see the module docs.
+/// with, the loop bound it runs under, which role is driving it, and which
+/// lane assembled it. No message *content* — see the module docs.
+///
+/// `lane` is `null` for an engine built through the legacy
+/// [`Engine::with_sleeper`](super::Engine::with_sleeper) path, which names no
+/// lane. That null is a positive statement — "this engine was not assembled
+/// by a named lane" — and an observer grouping by lane must read it as its
+/// own bucket rather than dropping the turn (#3410).
 pub fn turn_started_payload(
     message_count: usize,
     max_steps: usize,
     role: stella_protocol::ModelCallRole,
+    lane: Option<&stella_protocol::TurnLane>,
 ) -> serde_json::Value {
     serde_json::json!({
         "message_count": message_count,
         "max_steps": max_steps,
         "role": role,
+        "lane": lane,
     })
 }
 

--- a/crates/stella-core/src/driver/tests/lifecycle_bus.rs
+++ b/crates/stella-core/src/driver/tests/lifecycle_bus.rs
@@ -146,6 +146,85 @@ async fn run_one_turn(provider: &dyn Provider, bus: &HookBus) -> TurnOutcome {
     engine.run_turn(&mut messages, &mut budget, &tx).await
 }
 
+/// Drive one turn through `Engine::assemble`, declaring a lane.
+async fn run_one_turn_in_lane(
+    provider: &dyn Provider,
+    bus: &HookBus,
+    lane: stella_protocol::TurnLane,
+) -> TurnOutcome {
+    let tools = NoTools;
+    let sleeper = NoSleep;
+    let engine = Engine::assemble(
+        provider,
+        &tools,
+        EngineConfig::default(),
+        &sleeper,
+        crate::driver::capabilities::TurnCapabilities {
+            bus: Some(bus),
+            lane: Some(lane),
+            ..no_seams()
+        },
+    );
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("hi")];
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    engine.run_turn(&mut messages, &mut budget, &tx).await
+}
+
+/// `TurnCapabilities` has no `Default`, so `..` needs a base value; this is
+/// the "every seam off" one, written once for the two tests below.
+fn no_seams<'a>() -> crate::driver::capabilities::TurnCapabilities<'a> {
+    crate::driver::capabilities::TurnCapabilities::none()
+}
+
+/// The witness for #3410: the lane a turn ran in reaches the wire.
+///
+/// Fails before this change for a structural reason — `turn_started_payload`
+/// had no `lane` argument and the engine had nowhere to hold one, so the
+/// field simply does not exist in the emitted payload.
+#[tokio::test]
+async fn a_turn_stamps_the_lane_that_assembled_it() {
+    let (bus, recorder) = Recorder::attach();
+    let outcome = run_one_turn_in_lane(
+        &OneShotProvider,
+        &bus,
+        stella_protocol::TurnLane::Builtin(stella_protocol::BuiltinLane::FleetWorker),
+    )
+    .await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+    let started = recorder
+        .first(names::AGENT_TURN_STARTED)
+        .expect("the turn opened");
+    assert_eq!(
+        started.payload.get("lane"),
+        Some(&serde_json::json!({ "builtin": "fleet_worker" })),
+        "the lane rides the turn-started payload in its wire shape",
+    );
+}
+
+/// The other half, and the reason `lane` is an `Option`: an engine built
+/// through the legacy builder path reports `null` rather than guessing a
+/// lane. An observer grouping by lane must be able to tell "no lane was
+/// declared" from a lane it does not recognise — the same rule #3388 applies
+/// to `pipeline_variant`'s NULL.
+#[tokio::test]
+async fn the_legacy_builder_path_reports_no_lane_rather_than_a_wrong_one() {
+    let (bus, recorder) = Recorder::attach();
+    let outcome = run_one_turn(&OneShotProvider, &bus).await;
+    assert!(matches!(outcome, TurnOutcome::Completed { .. }));
+
+    let started = recorder
+        .first(names::AGENT_TURN_STARTED)
+        .expect("the turn opened");
+    assert_eq!(
+        started.payload.get("lane"),
+        Some(&serde_json::Value::Null),
+        "the key is present and null -- not absent, which would be indistinguishable \
+         from an older build that never recorded a lane",
+    );
+}
+
 /// The #1133 acceptance for the turn and step boundaries: a registered
 /// observer sees the turn open, the step open and close, and the turn close.
 #[tokio::test]

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -111,8 +111,8 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use stella_protocol::{
-    AgentEvent, CompletionMessage, MessageRole, ModelCallRole, Provider, SubAgentPhase,
-    SubAgentStatus,
+    AgentEvent, BuiltinLane, CompletionMessage, MessageRole, ModelCallRole, Provider,
+    SubAgentPhase, SubAgentStatus, TurnLane,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -720,6 +720,10 @@ impl Engine<'_> {
             // read identically to an oversight.
             TurnCapabilities {
                 call_role: spec.role,
+                // This fork is the subagent-fork lane, and now says so
+                // (#3410). Naming it here is what lets a reader group a
+                // child's turns apart from the parent's.
+                lane: Some(TurnLane::Builtin(BuiltinLane::SubagentFork)),
                 hooks: self.hooks.map(HooksHandle::parts),
                 // The child's hooks route approvals the same way the parent's
                 // do: a hook asking for a human is asking about the session's


### PR DESCRIPTION
#3386 landed the lane **vocabulary** (`TurnLane`, `BuiltinLane`, `LaneId`) with a round-trip witness, but nothing constructed one — an enum with no speaker. This makes a turn say which lane assembled it.

Closes #3410
Refs #3386, #3274, #3388

---

## What a reviewer should check first

`agent.turn.started` now carries a `lane`:

```json
{"message_count": 1, "max_steps": 40, "role": "worker", "lane": {"builtin": "fleet_worker"}}
```

Two witnesses, and the second is the one worth arguing about:

- `a_turn_stamps_the_lane_that_assembled_it` — a lane declared at `Engine::assemble` reaches the wire in its documented shape. Fails before this change for a structural reason: `turn_started_payload` had no `lane` parameter and the engine had nowhere to hold one, so the key does not exist.
- `the_legacy_builder_path_reports_no_lane_rather_than_a_wrong_one` — an engine built through `with_sleeper` + builders emits `"lane": null`. **The key is present and null, not absent.** An absent key is indistinguishable from an older build that never recorded a lane; an explicit null says "this engine was not assembled by a named lane". That is #3388's rule about `pipeline_variant`'s NULL, applied here.

## The design point: `lane` is `Option`, but not optional

`TurnCapabilities` still has no `Default`, so a struct literal **cannot omit** `lane`. The `Option` expresses "this engine belongs to no named lane"; it does not let a caller skip the question. So "unattributed" is always a decision somebody typed.

The compiler already proved this works: adding the slot broke exactly one construction site — the subagent fork — which now declares `BuiltinLane::SubagentFork`. That is the totality property from #3387 doing its job on its first real exercise, and it is why the enum's other six variants are still unclaimed rather than guessed at: the remaining lanes assemble through `with_sleeper` and are #3274 slice 3's job. They emit `null` today, honestly.

## `driver.rs` had to be split, and this is the part to review

`driver.rs` was at **exactly** its 1920-line ceiling. #3410 says so itself: that is why the stamping was deferred out of #3386 rather than forced through a ceiling raise, which CLAUDE.md forbids.

So `EngineConfig` + `TurnHalt` + the `Default` impl moved whole into `driver/config.rs` (253 lines), leaving `driver.rs` at **1668**. That is the coherent unit rather than the smallest one: the config is the *declaration* a caller makes, `driver.rs` is the machinery that honours it. `driver/settlement.rs` and `driver/capabilities.rs` are the precedent.

**No baseline entry was added and no ceiling was raised** — `check-file-size` reports "nothing went over by this change". Two consequences of the move that I want seen rather than buried:

- `driver.rs` keeps `#[cfg(test)] use` of `LoopDetectionConfig` and `RetryPolicy`. Four test modules reach them through `use super::*` and always did; re-importing them under `cfg(test)` was preferable to editing four unrelated test files.
- `driver/config.rs` carries two `#[allow(unused_imports)]` (`BudgetGuard`, `Engine`). They are named only by doc comments that moved with their fields, and importing them keeps those intra-doc links resolving instead of degrading the prose. Each has a comment saying so, per the no-bare-`#[allow]` rule.

## Verification

- `make guards-fast`: all green, including `file-size`, `god-files`, `module-reachability`, `invariants`.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test --workspace`: zero failures.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core`: clean.
- No tests deleted.

## One thing this PR does not fix

**`main` is currently red** and has been for four commits — `cargo doc -D warnings` fails on unresolved `AgentEvent` doc links in `crates/stella-protocol/src/event/payload.rs`, introduced by #3440's split. It is unrelated to this change (this branch touches no `stella-protocol` file) and I deliberately did not fold a fix in, per AGENTS.md's rule about not repairing an inherited red gate inside an unrelated PR.

Three PRs are already open for it — #3450, #3451, #3453 — so I did not add a fourth. **This PR's `make gate` will not go fully green until one of them lands**; every other step passes.

## Summary by Sourcery

Stamp the assembling lane onto turn start events and propagate lane attribution through engine capabilities, while splitting engine configuration into a dedicated driver/config module to keep driver.rs within size limits and re-exporting existing config APIs.

New Features:
- Include the assembling lane in agent.turn.started payloads so turns can be attributed to lanes on the wire.
- Allow engines to carry an explicit lane via TurnCapabilities, with legacy builder paths reporting a deliberate null lane rather than omitting the field.
- Tag subagent forked engines with a dedicated BuiltinLane variant to distinguish child turns from their parents.

Enhancements:
- Refactor engine configuration, TurnHalt, and their Default implementation into a new driver/config submodule, keeping public paths and behaviour unchanged.

Tests:
- Add lifecycle bus tests that assert lane stamping for assembled engines and explicit null lanes for legacy builder paths.