### PR TITLE
fix(stella-cli): a fleet worker closes the stage it opened (#3428)

### DIFF
--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -643,6 +643,26 @@ async fn stop_or_abandoned(
     }
 }
 
+/// The sender a **raw** fleet worker hands the engine.
+///
+/// `StageKind` is the run owner's vocabulary — the engine emits no boundary of
+/// its own (#3416) — and this lane is the owner. The opener is sent outright at
+/// the turn's start; the closer cannot be, because it must arrive *ahead of*
+/// the `TurnComplete` it annotates, and that event is emitted from inside the
+/// turn. So it rides a combinator instead of a send after the race
+/// ([`stella_core::EventSender::pairing_stage_complete`], which also holds the
+/// completed-only rule: a cancelled or aborted worker gets no boundary claiming
+/// its run finished).
+///
+/// A named seam rather than an inline `.pairing_stage_complete()` so the wiring
+/// has something to test. It went missing once already: the lane emitted an
+/// opener and no closer, framing half a turn, and nothing failed — the fleet
+/// renders lanes from the ledger rather than a stage HUD, so the asymmetry was
+/// invisible to every consumer that exists today (#3428).
+fn worker_event_sender(tx: &mpsc::UnboundedSender<AgentEvent>) -> stella_core::EventSender {
+    stella_core::EventSender::new(tx.clone()).pairing_stage_complete()
+}
+
 /// One worker turn in `root`, on the calling thread's runtime. When
 /// `use_pipeline` is true (the default), the turn runs through the staged
 /// pipeline (triage → recall → plan → execute → witness → verify → verdict);
@@ -948,12 +968,9 @@ async fn run_task(
                     engine = engine.with_hooks(hooks, &hook_runner);
                 }
                 // A fleet worker owns its lane's stage vocabulary; the engine
-                // emits no `Stage` of its own (#3416). Opening boundary only:
-                // the closing one pairs onto the engine's `TurnComplete`
-                // through `EventSender::pairing_stage_complete`, and this lane
-                // hands the engine a sender built here rather than a wrapped
-                // seam — the fleet renders lanes from the ledger, not from a
-                // stage HUD, so the gap costs nothing here.
+                // emits no `Stage` of its own (#3416). The opener is here; the
+                // closer rides `worker_event_sender` below, ahead of the
+                // engine's `TurnComplete` (#3428).
                 let _ = tx.send(AgentEvent::Stage {
                     name: stella_protocol::StageKind::Execute,
                     scope: stella_protocol::StageScope::Run,
@@ -964,7 +981,7 @@ async fn run_task(
                 // than sealed on drop here: a cancelled or aborted worker must
                 // end on `Error` alone, and only the code after the race knows
                 // which of the three ways this lane ended.
-                let worker = stella_core::EventSender::new(tx.clone());
+                let worker = worker_event_sender(&tx);
                 tokio::select! {
                     outcome = engine.run_turn_with_sender(&mut messages, &mut budget, &worker) => {
                         Raced::Outcome(outcome)

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -370,3 +370,71 @@ async fn watch_branch_treats_a_ci_timeout_as_red() {
         })
     ));
 }
+
+/// A raw fleet worker frames its turn on both sides (#3428).
+///
+/// #3416 moved stage boundaries out of the engine and into each run owner. The
+/// fleet lane took only the opening half: it sent `Stage(Execute)` and never a
+/// closer, so a worker's journal ended on `TurnComplete` with the run still
+/// nominally executing — where every other run owner's ends with the pair.
+/// Nothing caught it, because the fleet renders lanes from the ledger rather
+/// than from a stage HUD, so no consumer that exists today reads the boundary
+/// it was missing. That is exactly the shape a test has to hold.
+///
+/// The ordering is the substance, not a detail: the closer must arrive AHEAD
+/// of the terminal event it annotates, because `TurnComplete` is emitted from
+/// inside the turn and a consumer that stops there would never see a boundary
+/// appended afterwards.
+#[test]
+fn a_raw_worker_closes_the_stage_it_opened() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<AgentEvent>();
+    let worker = worker_event_sender(&tx);
+    worker
+        .send(AgentEvent::TurnComplete {
+            model: "opus".to_string(),
+            cost_usd: 0.5,
+        })
+        .expect("the receiver is alive");
+
+    let mut seen = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        seen.push(event);
+    }
+    assert!(
+        matches!(
+            seen.as_slice(),
+            [
+                AgentEvent::Stage {
+                    name: stella_protocol::StageKind::Complete,
+                    scope: stella_protocol::StageScope::Run,
+                },
+                AgentEvent::TurnComplete { .. },
+            ]
+        ),
+        "the closing boundary rides ahead of the terminal event it annotates: {seen:?}"
+    );
+}
+
+/// ...and only for a turn that finished. An aborted worker reached no
+/// completion, and a boundary claiming otherwise would be the journal's last
+/// word on a run that failed.
+#[test]
+fn an_unfinished_worker_turn_claims_no_closing_boundary() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<AgentEvent>();
+    let worker = worker_event_sender(&tx);
+    worker
+        .send(AgentEvent::Error {
+            message: "the turn aborted".to_string(),
+            retryable: false,
+        })
+        .expect("the receiver is alive");
+
+    let mut seen = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        seen.push(event);
+    }
+    assert!(
+        matches!(seen.as_slice(), [AgentEvent::Error { .. }]),
+        "a turn that never completed gets no closing boundary: {seen:?}"
+    );
+}


### PR DESCRIPTION
> **Stacked on #3455** (main's red `doc-warnings`). Retarget to `main` once
> that merges — this branch's own change is the last commit only.

## What

#3416 moved stage boundaries out of the engine and into each run owner. The
fleet lane took only the opening half: it sent `Stage(Execute)` and never a
closer, so a worker's journal ended on `TurnComplete` with the run still
nominally executing — where every other run owner's ends with the pair.

I filed this against my own change when I noticed the asymmetry and could not
close it cleanly at the time: the lane handed the engine a bare
`UnboundedSender`, so there was no `EventSender` to wrap. #3379 has since
moved it to `run_turn_with_sender`, and the seam now exists.

## How

The closer cannot be a send after the race. It must arrive **ahead of** the
`TurnComplete` it annotates, and that event is emitted from inside the turn —
anything appended afterwards lands behind the terminal event some consumers
stop at. `EventSender::pairing_stage_complete` is the combinator that already
solves this for the CLI's raw paths and the served session, and it carries the
completed-only rule with it: a cancelled or aborted worker gets no boundary
claiming its run finished.

So the change is one line. It lands behind a named `worker_event_sender`
rather than inline for a specific reason: **the wiring needed something to
test.** The gap was invisible to every consumer that exists today — the fleet
renders lanes from the ledger, not a stage HUD — which is precisely the shape
that comes back silently after the next refactor of these lines.

## Witnesses

Both verified failing with the wrap removed, passing with it:

- `a_raw_worker_closes_the_stage_it_opened` — `Stage(Complete)` precedes
  `TurnComplete`, and the ordering is the assertion, not an incidental.
- `an_unfinished_worker_turn_claims_no_closing_boundary` — an `Error` turn
  gets nothing.

No test was deleted.

## Verification

`make gate` — `GATE_EXIT=0`.

Refs #3416, #3379

Closes #3428

## Summary by Sourcery

Ensure fleet workers correctly emit matching stage boundaries for completed turns and expose a dedicated sender seam for testing.

Enhancements:
- Introduce a dedicated worker_event_sender helper that wraps the fleet worker event channel with stage completion pairing semantics.

Tests:
- Add tests asserting that a raw fleet worker emits a closing stage boundary before TurnComplete and that unfinished turns do not claim a completion boundary.