### PR TITLE
fix(stella-protocol): re-resolve payload.rs's AgentEvent doc links after the #3440 split

### DIFF
--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -19,12 +19,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::ladder::LadderSnapshot;
 
-/// What happened to a file in a
-/// [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.
+/// What happened to a file in a [`AgentEvent::FileChange`] event.
 ///
 /// Both live producers measure a tree against a tree, so every kind emitted
 /// today is a mutation — see [`Self::Read`] for the one that is not, and why
 /// it stays in the space anyway.
+///
+/// [`AgentEvent::FileChange`]: super::AgentEvent::FileChange
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
@@ -37,13 +38,15 @@ pub enum FileChangeKind {
     /// again. Neither surviving producer can: both diff a tree against a tree,
     /// and a read leaves no trace in a tree to diff. Re-acquiring one would
     /// mean going back to declaring file operations from tool inputs, which is
-    /// the defect [`AgentEvent::FileChange`](super::AgentEvent::FileChange)
-    /// documents rather than a capability worth restoring.
+    /// the defect [`AgentEvent::FileChange`] documents rather than a capability
+    /// worth restoring.
     ///
     /// It stays in the kind space because journals recorded before the purge
     /// carry it and replay must parse them — deleting the variant would make
     /// those streams unreadable. Consumers must keep handling it, and must not
     /// treat its absence from a live stream as evidence that nothing was read.
+    ///
+    /// [`AgentEvent::FileChange`]: super::AgentEvent::FileChange
     Read,
     /// The file did not exist before this change.
     Created,
@@ -60,7 +63,9 @@ impl FileChangeKind {
     ///
     /// A `true` here is not a licence to claim the *agent* changed the file:
     /// the shared-tree producer measures the turn, not the actor (see
-    /// [`AgentEvent::FileChange`](super::AgentEvent::FileChange)).
+    /// [`AgentEvent::FileChange`]).
+    ///
+    /// [`AgentEvent::FileChange`]: super::AgentEvent::FileChange
     #[must_use]
     pub fn is_mutation(self) -> bool {
         !matches!(self, FileChangeKind::Read)
@@ -195,8 +200,9 @@ pub enum MediaJobState {
     Queued,
     /// Generation is under way.
     Running,
-    /// The artifact landed; a
-    /// [`AgentEvent::MediaComplete`](super::AgentEvent::MediaComplete) follows.
+    /// The artifact landed; a [`AgentEvent::MediaComplete`] follows.
+    ///
+    /// [`AgentEvent::MediaComplete`]: super::AgentEvent::MediaComplete
     Succeeded,
     /// Generation failed terminally.
     Failed {
@@ -211,8 +217,9 @@ pub enum MediaJobState {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MediaArtifactRef {
     /// The artifact id, matching the `artifact_id` its
-    /// [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events
-    /// carried.
+    /// [`AgentEvent::MediaProgress`] events carried.
+    ///
+    /// [`AgentEvent::MediaProgress`]: super::AgentEvent::MediaProgress
     pub id: String,
     /// What was produced.
     pub kind: MediaKind,

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -19,7 +19,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::ladder::LadderSnapshot;
 
-/// What happened to a file in a [`AgentEvent::FileChange`] event.
+/// What happened to a file in a
+/// [`AgentEvent::FileChange`](super::AgentEvent::FileChange) event.
 ///
 /// Both live producers measure a tree against a tree, so every kind emitted
 /// today is a mutation — see [`Self::Read`] for the one that is not, and why
@@ -36,8 +37,8 @@ pub enum FileChangeKind {
     /// again. Neither surviving producer can: both diff a tree against a tree,
     /// and a read leaves no trace in a tree to diff. Re-acquiring one would
     /// mean going back to declaring file operations from tool inputs, which is
-    /// the defect [`AgentEvent::FileChange`] documents rather than a capability
-    /// worth restoring.
+    /// the defect [`AgentEvent::FileChange`](super::AgentEvent::FileChange)
+    /// documents rather than a capability worth restoring.
     ///
     /// It stays in the kind space because journals recorded before the purge
     /// carry it and replay must parse them — deleting the variant would make
@@ -59,7 +60,7 @@ impl FileChangeKind {
     ///
     /// A `true` here is not a licence to claim the *agent* changed the file:
     /// the shared-tree producer measures the turn, not the actor (see
-    /// [`AgentEvent::FileChange`]).
+    /// [`AgentEvent::FileChange`](super::AgentEvent::FileChange)).
     #[must_use]
     pub fn is_mutation(self) -> bool {
         !matches!(self, FileChangeKind::Read)
@@ -194,7 +195,8 @@ pub enum MediaJobState {
     Queued,
     /// Generation is under way.
     Running,
-    /// The artifact landed; a [`AgentEvent::MediaComplete`] follows.
+    /// The artifact landed; a
+    /// [`AgentEvent::MediaComplete`](super::AgentEvent::MediaComplete) follows.
     Succeeded,
     /// Generation failed terminally.
     Failed {
@@ -209,7 +211,8 @@ pub enum MediaJobState {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MediaArtifactRef {
     /// The artifact id, matching the `artifact_id` its
-    /// [`AgentEvent::MediaProgress`] events carried.
+    /// [`AgentEvent::MediaProgress`](super::AgentEvent::MediaProgress) events
+    /// carried.
     pub id: String,
     /// What was produced.
     pub kind: MediaKind,

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -399,6 +399,8 @@ export type ErrorClass = "invalid_input" | "not_found" | "permission_denied" | "
  * Both live producers measure a tree against a tree, so every kind emitted
  * today is a mutation — see [`Self::Read`] for the one that is not, and why
  * it stays in the space anyway.
+ *
+ * [`AgentEvent::FileChange`]: super::AgentEvent::FileChange
  */
 export type FileChangeKind = "read" | "created" | "modified" | "deleted";
 
@@ -729,6 +731,8 @@ export interface MediaArtifactRef {
   /**
    * The artifact id, matching the `artifact_id` its
    * [`AgentEvent::MediaProgress`] events carried.
+   *
+   * [`AgentEvent::MediaProgress`]: super::AgentEvent::MediaProgress
    */
   id: string;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -546,11 +546,11 @@
       ]
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.\n\n[`AgentEvent::FileChange`]: super::AgentEvent::FileChange",
       "oneOf": [
         {
           "const": "read",
-          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
+          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.\n\n[`AgentEvent::FileChange`]: super::AgentEvent::FileChange",
           "type": "string"
         },
         {
@@ -874,7 +874,7 @@
       "description": "A completed media artifact: id + kind + where it landed on disk.",
       "properties": {
         "id": {
-          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.",
+          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.\n\n[`AgentEvent::MediaProgress`]: super::AgentEvent::MediaProgress",
           "type": "string"
         },
         "kind": {
@@ -928,7 +928,7 @@
           "type": "object"
         },
         {
-          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.",
+          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.\n\n[`AgentEvent::MediaComplete`]: super::AgentEvent::MediaComplete",
           "properties": {
             "state": {
               "const": "succeeded",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -1164,6 +1164,8 @@ export type ErrorClass = "invalid_input" | "not_found" | "permission_denied" | "
  * Both live producers measure a tree against a tree, so every kind emitted
  * today is a mutation — see [`Self::Read`] for the one that is not, and why
  * it stays in the space anyway.
+ *
+ * [`AgentEvent::FileChange`]: super::AgentEvent::FileChange
  */
 export type FileChangeKind = "read" | "created" | "modified" | "deleted";
 
@@ -1537,6 +1539,8 @@ export interface MediaArtifactRef {
   /**
    * The artifact id, matching the `artifact_id` its
    * [`AgentEvent::MediaProgress`] events carried.
+   *
+   * [`AgentEvent::MediaProgress`]: super::AgentEvent::MediaProgress
    */
   id: string;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -2121,11 +2121,11 @@
       ]
     },
     "FileChangeKind": {
-      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.",
+      "description": "What happened to a file in a [`AgentEvent::FileChange`] event.\n\nBoth live producers measure a tree against a tree, so every kind emitted\ntoday is a mutation — see [`Self::Read`] for the one that is not, and why\nit stays in the space anyway.\n\n[`AgentEvent::FileChange`]: super::AgentEvent::FileChange",
       "oneOf": [
         {
           "const": "read",
-          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.",
+          "description": "Content was successfully read — no mutation, never a diff.\n\n**Replay-only, permanently, and this is the decision rather than a gap\nawaiting one (#3413).** It had a producer when a `read` built-in\nexisted; the 12-tool purge (#3244) removed it, and nothing will emit it\nagain. Neither surviving producer can: both diff a tree against a tree,\nand a read leaves no trace in a tree to diff. Re-acquiring one would\nmean going back to declaring file operations from tool inputs, which is\nthe defect [`AgentEvent::FileChange`] documents rather than a capability\nworth restoring.\n\nIt stays in the kind space because journals recorded before the purge\ncarry it and replay must parse them — deleting the variant would make\nthose streams unreadable. Consumers must keep handling it, and must not\ntreat its absence from a live stream as evidence that nothing was read.\n\n[`AgentEvent::FileChange`]: super::AgentEvent::FileChange",
           "type": "string"
         },
         {
@@ -2527,7 +2527,7 @@
       "description": "A completed media artifact: id + kind + where it landed on disk.",
       "properties": {
         "id": {
-          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.",
+          "description": "The artifact id, matching the `artifact_id` its\n[`AgentEvent::MediaProgress`] events carried.\n\n[`AgentEvent::MediaProgress`]: super::AgentEvent::MediaProgress",
           "type": "string"
         },
         "kind": {
@@ -2581,7 +2581,7 @@
           "type": "object"
         },
         {
-          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.",
+          "description": "The artifact landed; a [`AgentEvent::MediaComplete`] follows.\n\n[`AgentEvent::MediaComplete`]: super::AgentEvent::MediaComplete",
           "properties": {
             "state": {
               "const": "succeeded",


### PR DESCRIPTION
Refs #3440, #3449

## What is broken

`main` is red on the `doc-warnings` gate step, and has been since #3440 merged.

That PR split the payload types out of `crates/stella-protocol/src/event.rs`
into `event/payload.rs`. In `event.rs`, `AgentEvent` was a sibling item, so the
bare link `` [`AgentEvent::FileChange`] `` resolved. One module down it does
not, and `rustdoc -D warnings` turns each unresolved link into an error:

```
error: unresolved link to `AgentEvent::FileChange`
  --> crates/stella-protocol/src/event/payload.rs:22:36
   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
...
error: could not document `stella-protocol`
```

Five links, three targets: `FileChange` ×3, `MediaComplete`, `MediaProgress`.

This is also the whole of why **#3449's `ci` run was red** — its `fmt + clippy
+ test` job failed at this step; clippy passed and every test passed (1752 in
`stella-cli` alone). #3449 was merged over an inherited failure it did not
cause, so the red moved onto `main` with it.

## The change

Each link gets a **reference-style definition** (`` [`AgentEvent::FileChange`]:
super::AgentEvent::FileChange ``) rather than an inline `(super::…)` target.

That distinction is the substance of this PR, not style. **These doc comments
are exported:** schemars lifts each one into the `description` field of the
generated `docs/wire/*.schema.json` and `*.d.ts`, so how the link is spelled is
a wire-contract question. Spelling it inline rewrites five consumer-facing
sentences to carry a `(super::AgentEvent::MediaProgress)` Rust path that means
nothing to a TypeScript consumer reading the contract. A definition appends one
line that rustdoc consumes when rendering and leaves every sentence untouched.

No `use` was added: importing a type solely so a doc link resolves is an unused
import in every non-doc build.

`docs/wire/` is regenerated in the same commit (`wire-schema` is a gate step
and the artifacts are committed). The diff there is **pure additions** — the
appended definition lines only. No field, type, variant, or required-ness
moved, so the additive-only contract holds.

## Verification (by exit code)

| command | this branch | parent commit (`acd43094`) |
| --- | --- | --- |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol --no-deps` | 0 | 101, `could not document stella-protocol` |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 | — |
| `make wire-schema` | 0 | 0 |
| `cargo fmt --all --check` | 0 | 0 |
| `cargo check -p stella-protocol --all-targets` | 0 | 0 |

The workspace doc run is the one that matters beyond the immediate fix: it
confirms `stella-protocol` was the *only* crate carrying this rot, so the gate
step goes green rather than advancing to the next broken crate.

## Witness

None, and for the honest reason rather than an exemption: the failing gate step
*is* the witness. `cargo doc` exits 101 on the parent and 0 here — a fail→pass
flip, run twice, recorded above. There is no runtime behaviour to assert on; no
`#[test]` can observe whether an intra-doc link resolves.

The wire half is witnessed the same way, by its own guard: `make wire-schema`
failed on the first push of this branch (the artifacts were stale) and passes
now.

## Deleted tests

None.
