### PR TITLE
docs(spec): every wrapper is a plugin — the full extraction plan

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -331,6 +331,25 @@
       "status": "living",
       "title": "Where Stella puts things on your disk"
     },
+    "pipeline-as-plugins": {
+      "path": "docs/spec/pipeline-as-plugins.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "status": "proposed",
+      "title": "Every wrapper is a plugin: the full extraction plan"
+    },
     "pipeline-journey": {
       "path": "docs/design/pipeline-journey.md",
       "sections": [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -350,6 +350,19 @@
       "status": "proposed",
       "title": "Every wrapper is a plugin: the full extraction plan"
     },
+    "pipeline-as-plugins-execution": {
+      "path": "docs/playbooks/pipeline-as-plugins-execution.md",
+      "sections": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "status": "living",
+      "title": "Executing the plugin extraction \u2014 the autonomous run protocol"
+    },
     "pipeline-journey": {
       "path": "docs/design/pipeline-journey.md",
       "sections": [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -334,6 +334,7 @@
     "pipeline-as-plugins": {
       "path": "docs/spec/pipeline-as-plugins.md",
       "sections": [
+        0,
         1,
         2,
         3,

--- a/docs/playbooks/pipeline-as-plugins-execution.md
+++ b/docs/playbooks/pipeline-as-plugins-execution.md
@@ -1,0 +1,258 @@
+---
+id: pipeline-as-plugins-execution
+title: "Executing the plugin extraction — the autonomous run protocol"
+status: living
+---
+
+# Executing the plugin extraction — the autonomous run protocol
+
+The plan is `doc:pipeline-as-plugins`. **This document is how it gets
+executed** — the order, the audit bar every change must clear, the merge policy,
+and the three points where the run must stop and ask a human.
+
+It is written to be executed by an autonomous session with no human watching, so
+everything a human would normally supply — judgement about when to stop, what
+counts as done, what must never be auto-merged — is written down here instead.
+
+---
+
+## 0. Standing rules for the whole run
+
+1. **The gate is the floor, not the bar.** `make gate` green is necessary and
+   never sufficient. Nothing merges on a green gate alone.
+2. **One logical change per PR.** A PR that touches two work items gets split.
+3. **Never widen a baseline to pass.** Not `scripts/file-size-baseline.txt`, not
+   `deny.toml`, not `scripts/typed-errors-baseline.txt`. If a change needs a
+   ceiling raised, that is a signal to split the file, and the split is the work.
+4. **Never delete a test to make a change pass.** If a test must go, name it in
+   the PR description and say why.
+5. **Nothing left behind.** Every defect noticed and not fixed becomes a GitHub
+   issue written as a handoff before the phase closes.
+6. **Stop and file rather than guess.** If a work item turns out to depend on
+   something this document did not anticipate, open an issue describing the
+   dependency and move to the next independent item. Do not improvise an
+   architectural decision.
+7. **Report the unflattering number.** If a benchmark comparison goes against
+   the plugin path, say so plainly and stop the phase.
+
+---
+
+## 1. The adversarial audit bar
+
+Every PR this run opens must clear an adversarial audit **before** it is
+eligible to merge. A self-review does not count — the point is that the author
+and the auditor are different contexts.
+
+### The protocol
+
+For each PR, spawn **three independent auditors** with no shared context, each
+given the diff and a distinct lens:
+
+| Lens | Asks |
+|---|---|
+| **Correctness** | Where is this wrong? Name inputs and the wrong output. |
+| **Architecture** | Which invariant does this break? Cite it by number. Is a port becoming a concretion? |
+| **Security / authority** | What can a plugin do after this that it could not before? Who is the principal? |
+
+Each auditor is prompted to **refute**, not to approve, and defaults to
+"blocking" when uncertain. A finding is only recorded if it names a concrete
+failure — inputs plus wrong behaviour, or an invariant plus the line that breaks
+it. "This could be cleaner" is not a finding.
+
+### The decision
+
+- **Any auditor raises a blocking finding** → fix it and re-audit from scratch.
+  Do not argue with the auditor in place of fixing.
+- **Two or more auditors independently raise the same non-blocking finding** →
+  treat as blocking. Independent agreement is signal.
+- **All three clear it** → eligible to merge, subject to §2.
+
+### The audits that must be deeper
+
+Three work items get **five** auditors instead of three, because a defect in
+them is not recoverable by a follow-up PR:
+
+- **A1 (plugin identity)** — a mistake here silently grants authority.
+- **A3 (the wrapper socket)** — every plugin binds to it; its shape is
+  effectively permanent once implementations exist.
+- **D3 (self-driving's authority grant)** — the widest grant any plugin will
+  hold.
+
+---
+
+## 2. Merge policy
+
+A PR merges when **all** of the following hold. This list is exhaustive; if a
+condition is not listed, it is not a reason to merge.
+
+1. `make gate` is green **locally on the merge result**, not just on the branch.
+   A green branch and a green base can still compose into a red `main` — that is
+   the shared-cell failure this repository has hit repeatedly with
+   `Cargo.lock` and `scripts/file-size-baseline.txt`.
+2. CI is green on the actual head commit. Re-fetch before believing it: checks
+   can display the previous head.
+3. The adversarial audit of §1 cleared.
+4. The item is **not** behind a human gate (§3).
+5. The PR description names any test it deleted and cites the issues it closes,
+   with `Closes #N` **both** in the description and as a commit trailer.
+
+**Never** force-push, never merge with admin override, never merge a PR whose
+base is a topic branch believing it reaches `main`.
+
+After each merge, re-run the composition check on `main` (`make main-canary`).
+If `main` goes red, **stop the entire run** and fix it before opening anything
+else. A red `main` makes every subsequent PR red and destroys the signal this
+whole run depends on.
+
+---
+
+## 3. The three human gates — stop and ask
+
+These are architectural decisions with one-way doors. The run **must not**
+decide them, and must not proceed past them by picking the option that unblocks
+itself.
+
+| Gate | Question | Where it is argued |
+|---|---|---|
+| **G1 — transport** | Shell-hook protocol, or MCP plus a lifecycle extension? | `doc:pipeline-as-plugins` §5, #3246 §O5 |
+| **G2 — `judge`** | Does `judge` stay in-process and pure, with plugins supplying evidence and declaring rules as data? | `doc:pipeline-as-plugins` §6 |
+| **G3 — self-driving authority** | May a plugin hold `gh`, AWS, `brew`, `~/.zshrc` and daemon powers, and under what gate? | `doc:pipeline-as-plugins` §10 |
+
+At each gate: post the evidence gathered, state the recommendation and its
+reasoning, name what would falsify it, and **stop**. Do not open the dependent
+PRs. Work on an independent item instead, or end the run cleanly with a summary.
+
+**G1 is preceded by a spike, not by an argument.** Implement the Stop-hook path
+twice — once as a shell hook, once as an MCP server with a lifecycle extension —
+compare them on latency, failure modes, and how much a non-Rust author has to
+understand. Present the comparison, not a preference.
+
+**G2 is preceded by a falsifier.** Express one genuinely different definition of
+done — not Vera's — as declarative data. What will not fit is the evidence for
+widening the grammar. Run this before A3 freezes the socket.
+
+---
+
+## 4. Execution order
+
+Phases are ordered by dependency. Within a phase, items may run in parallel only
+where marked; otherwise sequential, because each builds on the last.
+
+### Phase 0 — Orientation
+
+Read `doc:pipeline-as-plugins`, `doc:turn-loop-wrappers`, `AGENTS.md`, and the
+capability audit comment on #3380. Re-verify the plan's claims against the tree
+before acting on them — the plan cites file:line precisely so this is cheap, and
+the tree will have moved. **Any claim that no longer holds is reported, and the
+plan is corrected in the same run.**
+
+### Phase 1 — Independent work that unblocks nothing else
+
+Can start immediately, in parallel, gated by nothing:
+
+- **D1** — move the self-driving decision core out of `stella-core` into a
+  **shared leaf crate**. Not into a plugin: `stella-observatory` links it, and
+  burying it re-creates the #1613 drift where the dashboard and the CLI
+  disagreed about loop health. Property tests move with it, unchanged.
+- **#3280** — delete `stella-runtime`'s unused `stella-pipeline` dependency.
+- **#3473** — correct the ladder outcome count in `AGENTS.md` and
+  `docs/spec/turn-loop-wrappers.md`.
+- **#3408** — wire the `[wrapper]` manifest so something reads it.
+
+### Phase 2 — Track A substrate, sequential
+
+**A1** (plugin identity) → **A2** (#3387 blessed constructor) → **G1 spike** →
+**G1 gate** → **G2 falsifier** → **G2 gate** → **A3a + A3b** (socket, both halves
+authored together) → **A4** (loader) → **A5** (`[runtime]` manifest block) →
+**A6** (structured verdicts) → **A7** (`max_holds`) → **A8** (stages and
+signals) → **A9** (plugin events and the trace fold) → **A10** (serializable
+worktree handle).
+
+A1 is first and is not negotiable. Nothing that grants a plugin any capability
+merges before Stella can tell a plugin apart from its operator.
+
+### Phase 3 — Track C, the language proof
+
+Runs **immediately after A5**, not at the end. The examples are the test that
+Track A produced a platform rather than a library, and finding that out late is
+the expensive failure mode.
+
+Three plugins in `macanderson/stella-examples` under `plugins/`, implementing
+the same behaviour: `verify-rs`, `verify-py`, `verify-ts`. Identical manifests
+except `[runtime].argv`. No SDK — stdlib and a JSON parser only. CI runs all
+three on every PR there, and a smoke check runs in `stella`.
+
+**If the Python or TypeScript plugin needs a manifest shape the Rust one does
+not, that is a Track A bug. Stop, file it, fix it in Track A.**
+
+### Phase 4 — Track B extraction, sequential by risk
+
+`stella-research` → `stella-plan` → **vera** → `stella-candidates` →
+`stella-goal`.
+
+Each ships behind `--pipeline <variant>` with the wrapper id recorded on the
+executions row. **A side-by-side benchmark must hold before the built-in path is
+deleted** — and a five-task solve rate cannot resolve anything smaller than a
+catastrophe, so comparisons need repeats per task and any two runs differing by
+more than one commit are confounded and must be reported as such.
+
+Cutting `stella-cli`'s dependency on `stella-pipeline` is the **last** slice.
+
+### Phase 5 — Track D, self-driving as a plugin
+
+**G3 gate first.** Then the command surface, then the plugin. Keep
+`make self-driving-test` green with its assertions intact — if one has to be
+relaxed, behaviour changed and that is a bug in the move. Verify the
+observatory's `/api/self-driving` route still works rather than assuming it.
+
+### Phase 6 — Documentation, internal and external
+
+**This phase is not optional and does not get skipped for time.** A platform
+whose documentation still describes the previous architecture is not shipped.
+
+**Internal:**
+
+- `AGENTS.md` — the workspace layout table, the crate routing rules, the
+  invariants list if the socket added one, and the god-file table if any file
+  moved. `CLAUDE.md` if the hard rules changed.
+- Every affected crate `README.md` — boundary, layout, invariants, gotchas,
+  extension recipe. `stella-core`'s must say it has no built-in wrappers;
+  `stella-plugin`'s must stop saying it has no consumers.
+- `doc:turn-loop-wrappers` and `doc:pipeline-as-plugins` — mark what shipped and
+  correct anything the run discovered was wrong. A spec left saying `proposed`
+  after it shipped is a lie by omission.
+- The three-copy god-file rule: `AGENTS.md`, each crate README, and
+  `scripts/file-size-baseline.txt` must agree, and `make god-files` enforces it.
+
+**External:**
+
+- `website/content/docs/` — the plugin platform: what a plugin is, the
+  participation grades, the four points, how to install one, how to write one in
+  Rust, Python and TypeScript. The inference-pipeline page must stop describing
+  stages the engine no longer owns.
+- `macanderson/stella-examples` — a top-level `plugins/README.md` explaining the
+  model, linked from the repo README.
+- `llms.txt` and the commands parity lock, if command surfaces changed.
+- The turn-loop deck under `website/public/presentations/` — it is the artifact
+  the original directive came from, and it now describes a superseded design.
+  Slides must fit the 1600x900 canvas; `deck-fit.yml` checks it.
+
+**The documentation bar:** a competent developer who has never seen this
+repository should be able to read the external docs and ship a working Python
+plugin without reading any Rust. If they cannot, the phase is not done.
+
+---
+
+## 5. Ending the run
+
+The run ends — cleanly, with a report — when any of these is true:
+
+- All phases are complete.
+- A human gate is reached and the recommendation has been posted.
+- `main` is red and the run could not repair it.
+- A benchmark comparison went against the plugin path.
+- Two consecutive phases produced no mergeable work.
+
+The final report states: what merged, what is open, what was filed, which gates
+are waiting on a human, and — explicitly — **anything that was shipped as an
+expedient**, because shipping a shortcut quietly is the one unrecoverable move.

--- a/docs/playbooks/pipeline-as-plugins-execution.md
+++ b/docs/playbooks/pipeline-as-plugins-execution.md
@@ -7,129 +7,153 @@ status: living
 # Executing the plugin extraction — the autonomous run protocol
 
 The plan is `doc:pipeline-as-plugins`. **This document is how it gets
-executed** — the order, the audit bar every change must clear, the merge policy,
-and the three points where the run must stop and ask a human.
+executed** — the order, when an audit is worth running, and how to merge.
 
-It is written to be executed by an autonomous session with no human watching, so
-everything a human would normally supply — judgement about when to stop, what
-counts as done, what must never be auto-merged — is written down here instead.
+It is written for an autonomous session with no human watching. The bias
+throughout is **shipping over ceremony**: there are no customers on this yet, so
+nearly every mistake is one commit away from being fixed, and the protocol is
+deliberately lighter than this repository's usual bar. Where it is strict, it is
+strict about the handful of things that are genuinely hard to undo.
 
 ---
 
 ## 0. Standing rules for the whole run
 
-1. **The gate is the floor, not the bar.** `make gate` green is necessary and
-   never sufficient. Nothing merges on a green gate alone.
-2. **One logical change per PR.** A PR that touches two work items gets split.
-3. **Never widen a baseline to pass.** Not `scripts/file-size-baseline.txt`, not
-   `deny.toml`, not `scripts/typed-errors-baseline.txt`. If a change needs a
-   ceiling raised, that is a signal to split the file, and the split is the work.
-4. **Never delete a test to make a change pass.** If a test must go, name it in
-   the PR description and say why.
-5. **Nothing left behind.** Every defect noticed and not fixed becomes a GitHub
-   issue written as a handoff before the phase closes.
-6. **Stop and file rather than guess.** If a work item turns out to depend on
-   something this document did not anticipate, open an issue describing the
-   dependency and move to the next independent item. Do not improvise an
-   architectural decision.
-7. **Report the unflattering number.** If a benchmark comparison goes against
-   the plugin path, say so plainly and stop the phase.
+**Bias to shipping.** There are no customers on this yet and every mistake here
+is recoverable by another commit. Velocity is worth more than ceremony, so the
+rules below are deliberately few. When a rule and progress conflict, and the
+mistake would be cheap to undo, ship and fix forward.
 
----
+1. **Say what you did.** The one rule that never relaxes. If you widened a
+   baseline, deleted a test, added an `#[allow]`, or shipped a shortcut — write
+   it in the PR description. Undoing a mistake is cheap; finding an
+   undocumented one six weeks later is not.
+2. **One logical change per PR**, where that is natural. Do not spend time
+   splitting a coherent change to satisfy the rule.
+3. **Prefer fixing to filing**, and prefer filing to forgetting. A one-line
+   issue is fine here — the handoff-quality bar applies to work you are handing
+   off, not to a note for yourself next week.
+4. **Report the unflattering number.** If a benchmark goes against the plugin
+   path, say so. This one is not ceremony: a flattering benchmark spends the
+   exact credibility the project is trying to build.
+5. **Do not improvise an architectural decision** that would be expensive to
+   reverse — the socket's shape, or who a principal is. Everything else, decide
+   and move.
 
-## 1. The adversarial audit bar
+## 1. Adversarial audit — scaled to the blast radius
 
-Every PR this run opens must clear an adversarial audit **before** it is
-eligible to merge. A self-review does not count — the point is that the author
-and the auditor are different contexts.
+Audits are for the changes where a defect is *expensive*, not for every diff.
+Most of this work is mechanical and its errors are loud.
 
-### The protocol
+**Skip the audit entirely** for documentation, renames, dependency deletions,
+file moves, and anything the compiler and tests already prove.
 
-For each PR, spawn **three independent auditors** with no shared context, each
-given the diff and a distinct lens:
+**One auditor** for ordinary code changes. Give it the diff, prompt it to
+**refute** rather than approve, and ask for concrete failures only — inputs plus
+wrong output, or an invariant plus the line that breaks it. "This could be
+cleaner" is not a finding. Fix what it finds if the fix is quick; file it and
+merge if not.
 
-| Lens | Asks |
+**Three auditors, and they block**, for the four changes where a defect is not
+recoverable by a follow-up PR:
+
+| Item | Why it blocks |
 |---|---|
-| **Correctness** | Where is this wrong? Name inputs and the wrong output. |
-| **Architecture** | Which invariant does this break? Cite it by number. Is a port becoming a concretion? |
-| **Security / authority** | What can a plugin do after this that it could not before? Who is the principal? |
+| **A1** plugin identity | a mistake here silently grants authority |
+| **A3** the wrapper socket | every plugin binds to it; its shape sets once implementations exist |
+| **A5/A3b** the wire contract | the same, for every non-Rust plugin |
+| **D3** self-driving's grant | the widest authority any plugin will hold |
 
-Each auditor is prompted to **refute**, not to approve, and defaults to
-"blocking" when uncertain. A finding is only recorded if it names a concrete
-failure — inputs plus wrong behaviour, or an invariant plus the line that breaks
-it. "This could be cleaner" is not a finding.
+Use three lenses there: correctness, architecture (cite the invariant by
+number), and authority (what can a plugin do now that it could not before?).
+Anything one of them blocks gets fixed before merge.
 
-### The decision
+## 2. Merge policy — light
 
-- **Any auditor raises a blocking finding** → fix it and re-audit from scratch.
-  Do not argue with the auditor in place of fixing.
-- **Two or more auditors independently raise the same non-blocking finding** →
-  treat as blocking. Independent agreement is signal.
-- **All three clear it** → eligible to merge, subject to §2.
+Merge when the change works and the audit (if §1 required one) cleared. That is
+the whole policy.
 
-### The audits that must be deeper
+Specifically:
 
-Three work items get **five** auditors instead of three, because a defect in
-them is not recoverable by a follow-up PR:
+- **CI green is the goal, not a gate.** If CI is red for a reason your diff did
+  not cause — a known flake, an already-broken base, an unrelated guard — say so
+  in the PR and merge anyway. Re-running a flake three times is time spent
+  buying nothing.
+- **Do not run the full `make gate` locally on every PR.** Run what your change
+  plausibly touches. The whole workspace test suite is not a per-PR cost worth
+  paying here.
+- **Do not stop the run when `main` goes red.** Note it, open a fix, keep
+  working. Repair it before the phase closes, not before the next commit.
+- **Fix forward over revert**, unless the breakage blocks other work.
 
-- **A1 (plugin identity)** — a mistake here silently grants authority.
-- **A3 (the wrapper socket)** — every plugin binds to it; its shape is
-  effectively permanent once implementations exist.
-- **D3 (self-driving's authority grant)** — the widest grant any plugin will
-  hold.
+Two things still hold, because they are about not losing information rather
+than about caution: never force-push over someone else's work, and never merge a
+PR whose base is a topic branch while believing it reaches `main`.
 
----
+## 3. Decisions — what is settled, and what the evidence decides
 
-## 2. Merge policy
+**No decision blocks this run.** An earlier draft of this playbook held three
+open gates; two of them were questions the evidence answers, and holding them
+open was over-caution rather than caution. What follows is the current state.
 
-A PR merges when **all** of the following hold. This list is exhaustive; if a
-condition is not listed, it is not a reason to merge.
+### D-1 — `judge` stays in-process. SETTLED (Mac, 2026-08-17).
 
-1. `make gate` is green **locally on the merge result**, not just on the branch.
-   A green branch and a green base can still compose into a red `main` — that is
-   the shared-cell failure this repository has hit repeatedly with
-   `Cargo.lock` and `scripts/file-size-baseline.txt`.
-2. CI is green on the actual head commit. Re-fetch before believing it: checks
-   can display the previous head.
-3. The adversarial audit of §1 cleared.
-4. The item is **not** behind a human gate (§3).
-5. The PR description names any test it deleted and cites the issues it closes,
-   with `Closes #N` **both** in the description and as a commit trailer.
+`judge` remains synchronous, I/O-free and total, so "calls no model" stays a
+property of the signature rather than a rule someone polices
+(`doc:turn-loop-wrappers` §9.2). Plugins participate by:
 
-**Never** force-push, never merge with admin override, never merge a PR whose
-base is a topic branch believing it reaches `main`.
+- supplying **evidence** out-of-process, in any language, inside the subprocess
+  budget — running a test suite is exactly the workload the in-process bus
+  cannot host; and
+- declaring their **verdict rule as data** — the closed condition grammar,
+  `[requirements]`, and the `[oracle]` flip/tamper policy. Data has no
+  programming language, so a Python author and a Rust author write the identical
+  artifact.
 
-After each merge, re-run the composition check on `main` (`make main-canary`).
-If `main` goes red, **stop the entire run** and fix it before opening anything
-else. A red `main` makes every subsequent PR red and destroys the signal this
-whole run depends on.
+Do not re-litigate this per plugin. Cite this section.
 
----
+**One task still runs, and it is a falsifier, not a gate.** Before A3 freezes
+the socket, express one genuinely different definition of done — not Vera's — as
+declarative data. Anything that will not fit is evidence for **widening the
+grammar**, not for reopening the decision. Report what did not fit; widen the
+grammar in the same phase if the gap is real.
 
-## 3. The three human gates — stop and ask
+### D-2 — transport: decided by the spike, not by a preference.
 
-These are architectural decisions with one-way doors. The run **must not**
-decide them, and must not proceed past them by picking the option that unblocks
-itself.
+Implement the Stop-hook path twice — once as a shell hook, once as an MCP server
+with a lifecycle extension — and compare on latency, failure modes, and how much
+a non-Rust author must understand to write a plugin.
 
-| Gate | Question | Where it is argued |
-|---|---|---|
-| **G1 — transport** | Shell-hook protocol, or MCP plus a lifecycle extension? | `doc:pipeline-as-plugins` §5, #3246 §O5 |
-| **G2 — `judge`** | Does `judge` stay in-process and pure, with plugins supplying evidence and declaring rules as data? | `doc:pipeline-as-plugins` §6 |
-| **G3 — self-driving authority** | May a plugin hold `gh`, AWS, `brew`, `~/.zshrc` and daemon powers, and under what gate? | `doc:pipeline-as-plugins` §10 |
+**Then pick the winner and proceed.** This is a measurement, and a run that
+stops to ask a human which number is larger is not automating anything. Record
+the comparison in the PR so the choice is reviewable.
 
-At each gate: post the evidence gathered, state the recommendation and its
-reasoning, name what would falsify it, and **stop**. Do not open the dependent
-PRs. Work on an independent item instead, or end the run cleanly with a summary.
+Escalate **only** if the spike is genuinely inconclusive — neither option clearly
+better on the three axes — and say precisely which axis tied.
 
-**G1 is preceded by a spike, not by an argument.** Implement the Stop-hook path
-twice — once as a shell hook, once as an MCP server with a lifecycle extension —
-compare them on latency, failure modes, and how much a non-Rust author has to
-understand. Present the comparison, not a preference.
+### D-3 — self-driving authority: the default is "no new power".
 
-**G2 is preceded by a falsifier.** Express one genuinely different definition of
-done — not Vera's — as declarative data. What will not fit is the evidence for
-widening the grammar. Run this before A3 freezes the socket.
+Self-driving already holds `gh`, AWS, `brew`, `~/.zshrc` and daemon powers
+today, as a shell script running with full user authority. Making it a plugin
+**relocates** that authority; it does not grant it. So the default is settled:
+**the plugin gets exactly what the shell script has today, and not one
+capability more.**
+
+The real requirement this places on Track A is on the authority system, not on
+the decision: `Principal` and the gate must be **able to express** a grant that
+wide, and a user must be able to see it at install time. Build to that.
+
+Escalate only if A1 lands and it turns out the grant **cannot** be expressed or
+**cannot** be shown to the user before install — that is a design gap worth a
+human, and it is a different question from "may it".
+
+### The standing rule underneath all three
+
+Decide from evidence and proceed. Escalate when the evidence is genuinely
+ambiguous or when a choice would grant authority nobody asked for — not merely
+because a decision feels weighty. When escalating, post the evidence, the
+recommendation, and what would falsify it, then work an independent item rather
+than idling.
 
 ---
 
@@ -161,8 +185,10 @@ Can start immediately, in parallel, gated by nothing:
 
 ### Phase 2 — Track A substrate, sequential
 
-**A1** (plugin identity) → **A2** (#3387 blessed constructor) → **G1 spike** →
-**G1 gate** → **G2 falsifier** → **G2 gate** → **A3a + A3b** (socket, both halves
+**A1** (plugin identity) → **A2** (#3387 blessed constructor) → **transport
+spike** (D-2: run it, pick the winner, record the comparison) → **grammar
+falsifier** (D-1: express a non-Vera definition of done as data; widen the
+grammar if it does not fit) → **A3a + A3b** (socket, both halves
 authored together) → **A4** (loader) → **A5** (`[runtime]` manifest block) →
 **A6** (structured verdicts) → **A7** (`max_holds`) → **A8** (stages and
 signals) → **A9** (plugin events and the trace fold) → **A10** (serializable
@@ -191,16 +217,24 @@ not, that is a Track A bug. Stop, file it, fix it in Track A.**
 `stella-goal`.
 
 Each ships behind `--pipeline <variant>` with the wrapper id recorded on the
-executions row. **A side-by-side benchmark must hold before the built-in path is
-deleted** — and a five-task solve rate cannot resolve anything smaller than a
-catastrophe, so comparisons need repeats per task and any two runs differing by
-more than one commit are confounded and must be reported as such.
+executions row, so both paths coexist and can be compared later.
 
-Cutting `stella-cli`'s dependency on `stella-pipeline` is the **last** slice.
+**Do not gate each extraction on a benchmark.** Keeping both paths alive is what
+makes that safe — a plugin that turns out worse is a flag flip away from being
+bypassed, not a rollback. Benchmark once, near the end, before deleting the
+built-in path for good. When you do, say plainly if the number goes the wrong
+way; a five-task solve rate resolves only catastrophes, so do not read a small
+difference as a result.
+
+Cutting `stella-cli`'s dependency on `stella-pipeline` is the **last** slice —
+it is the one step that removes the fallback.
 
 ### Phase 5 — Track D, self-driving as a plugin
 
-**G3 gate first.** Then the command surface, then the plugin. Keep
+Per D-3 the authority question is settled — the plugin gets exactly what the
+shell script holds today and nothing more — so proceed straight to the command
+surface, then the plugin. Escalate only if that grant cannot be expressed by the
+authority system or shown to the user before install. Keep
 `make self-driving-test` green with its assertions intact — if one has to be
 relaxed, behaviour changed and that is a bug in the move. Verify the
 observatory's `/api/self-driving` route still works rather than assuming it.
@@ -245,14 +279,11 @@ plugin without reading any Rust. If they cannot, the phase is not done.
 
 ## 5. Ending the run
 
-The run ends — cleanly, with a report — when any of these is true:
+Keep going while there is mergeable work. End with a report when the phases are
+done, when an escalation under §3 is genuinely warranted, or when two
+consecutive phases produce nothing mergeable.
 
-- All phases are complete.
-- A human gate is reached and the recommendation has been posted.
-- `main` is red and the run could not repair it.
-- A benchmark comparison went against the plugin path.
-- Two consecutive phases produced no mergeable work.
-
-The final report states: what merged, what is open, what was filed, which gates
-are waiting on a human, and — explicitly — **anything that was shipped as an
-expedient**, because shipping a shortcut quietly is the one unrecoverable move.
+The report says: what merged, what is open, what you filed, anything awaiting a
+human — and **explicitly, every shortcut you shipped**. That last one is the
+whole reason the light protocol above is safe: a documented shortcut is a task,
+an undocumented one is a trap.

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -32,7 +32,7 @@ The work splits into four tracks that must land roughly in order:
 | **A — Substrate** | The socket, a loader, a plugin identity, structured verdicts | Nothing below can dispatch without it |
 | **B — Extraction** | The pipeline's stages become plugins, one at a time | Each is independently shippable once A exists |
 | **C — Proof** | Python and TypeScript plugins in `stella-examples`, running in CI | A one-language plugin surface is a library, not a platform |
-| **D — Self-driving** | The autonomous loop leaves the binary | Depends on A, and on capabilities B does not need |
+| **D — Self-driving** | The autonomous loop leaves the binary | Its first step depends on nothing; its last depends only on A1 |
 
 The single most important constraint, stated once and enforced throughout:
 **`judge` stays in-process, pure, and total.** Plugins declare their verdict
@@ -491,24 +491,81 @@ out-of-process host seam. Forcing it through a turn-granularity socket would
 widen that socket for a single caller — the kind of generalisation that is
 cheaper to add later, when a second caller exists to shape it.
 
+### It already runs out-of-process — that is the feasibility proof
+
+This is not a speculative port. `scripts/self-driving.sh` **already drives the
+loop from outside the binary**, delegating every ported decision one-for-one to
+`stella self-driving …` verbs (#1548). An external program calling a documented
+command surface *is* the plugin shape. What is missing is packaging and
+authority, not mechanism.
+
+That also means **Track D does not depend on the wrapper socket at all.** It was
+listed as depending on Track A; that is too coarse. D1 depends on nothing, and
+the plugin depends only on A1 (identity), not on #3380.
+
 ### The work
 
-- **D1.** Move `self_driving.rs` and its tests out of `stella-core` unchanged.
-  Pure functions over owned data port without edits; the property tests come
-  with them. Core's `lib.rs` loses the module.
-- **D2.** Decide the granularity question above. Blocking on D3.
-- **D3.** Give the plugin a command surface — whatever `scripts/self-driving.sh`
-  needs to drive a cycle, expressed so an out-of-process plugin can call it.
-  Reuse `stella-serve`'s framing if the spike in §5.3 selects a compatible
-  transport.
-- **D4.** Keep the observatory view working. It reads JSONL from a fixed path
-  and never writes; if the plugin keeps writing the same shapes, the view needs
-  no change. Verify this rather than assume it — a broken dashboard is how a
-  monitor gets muted.
-- **D5.** Keep `make self-driving-test` green. The control logic it covers is
-  moving, not changing, so the harness should follow it with its assertions
-  intact. If an assertion has to be relaxed to make the move pass, the move
-  changed behaviour and that is a bug in D1.
+- **D1. Move the pure core to a leaf crate — not into the plugin.** The module
+  imports only `std`, `serde` and `sha2`, nothing in `stella-core` calls it, and
+  `lib.rs:44` is the sole reference. Mechanically it is one `mod` line and three
+  `use` lines.
+
+  **It must land in a shared leaf crate, not inside the plugin binary**, because
+  `stella-observatory` links it deliberately — `Cargo.toml` carries the reason,
+  and it is a scar: the observatory previously carried its own `fold_runs` and
+  the two implementations drifted, so the dashboard and
+  `stella self-driving metrics` disagreed about whether the loop was `NOISY`
+  for every odd cycle count (#1613). Burying the fold in a plugin executable
+  re-creates that bug. A leaf crate on the `stella-diff` / `stella-home` pattern
+  keeps one copy for both readers.
+
+  Depends on nothing. Can land immediately, independent of every other track.
+
+- **D2. The plugin is a host, not a wrapper.** Settled by §10's granularity
+  argument and by the fact that the shell driver already works this way. It
+  needs a stable command surface, not the four points.
+
+- **D3. Finish the authority story before the plugin ships.** This, not core, is
+  the real gate — see below.
+
+- **D4.** Keep the observatory route working (`/api/self-driving`, plus its
+  912-line reader). It reads JSONL from a fixed path and never writes, so if the
+  plugin keeps writing the same shapes it needs no change. Verify rather than
+  assume: a broken dashboard is how a monitor gets muted.
+
+- **D5.** Keep `make self-driving-test` green. It is hermetic, drives the shell
+  face end-to-end through the delegation map, and is the behavioural golden for
+  the Rust port. It moves with the feature or the plugin ships untested. If an
+  assertion has to be relaxed to make the move pass, the move changed behaviour
+  and that is a bug in D1.
+
+- **D6.** Carry the rest: `stella-home`'s four resolvers including the
+  legacy-path migration, and the `/self-driving*` slash-command install path.
+
+### The real blocker is authority, not core
+
+Ejecting the decision core is mechanical. The I/O half is not, and the reason is
+the size of the grant it needs: reading and filing GitHub issues, creating PRs,
+starting and stopping a paid EC2 rig, `brew` installs from a tap, **rewriting a
+line in `~/.zshrc`**, daemonising itself, and invoking a different agent product
+through installed slash commands.
+
+A plugin holding that is effectively root on the developer's machine. Today
+Stella cannot tell a plugin from its operator (§A1), so installing this as a
+plugin *right now* would grant all of it with no gate in front. That is a wider
+grant than the tool-contract vocabulary currently expresses.
+
+**Consequence for sequencing:** D1 is safe to land whenever. D3 must wait for
+A1, and self-driving is the right forcing function for A1 precisely because it
+is the most dangerous plugin anyone will install.
+
+### What is not being ejected
+
+Missions (`doc:self-driving-missions`, #2347 merged as a spec; #2345 closed
+not-planned) are **spec only** — there is no `mission` or `campaign` code under
+`crates/`. Ejecting today moves the stewardship loop, not the objective-driven
+one. The missions design is greenfield and the plugin can adopt it without a
+migration.
 
 ### Capabilities self-driving needs that the pipeline does not
 

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -427,7 +427,104 @@ Track A actually delivered a platform.
 
 ---
 
-## 10. Definition of done for the whole plan
+## 10. Track D — self-driving leaves core
+
+Self-driving differs from the pipeline in one respect that matters: **it is
+genuinely in `stella-core` today.** The pipeline left core long ago (core
+declares no `stella-pipeline` and holds no witness, ladder or flip code); this
+does not. `crates/stella-core/src/self_driving.rs` is 945 lines inside the
+engine crate.
+
+### What is there now
+
+The feature is already split three ways, and the split is good:
+
+| Layer | Where | What |
+|---|---|---|
+| Decision | `crates/stella-core/src/self_driving.rs` | The AIMD controller sizing a cycle to its machine, the aperture ladder, the dry-streak oracle, digest normalization for the dedup set, the ledger folds. Pure, synchronous, owned data, property-tested. |
+| I/O | `crates/stella-cli/src/self_driving_cmd.rs` (+ `probes.rs`, `state.rs`) | Machine probes, state files, process spawning. Feeds results in, writes decisions out. |
+| Observation | `crates/stella-observatory/src/self_driving.rs` | Read-only fold over `~/.stella/self-driving/<slug>/` JSONL. Never writes. |
+
+There is also a shell driver (`scripts/self-driving.sh`) that delegates its
+decisions to the CLI verbs rather than carrying a second copy (#1548), a gate
+step `self-driving-test` (`scripts/test-self-driving.sh`) covering the control
+logic hermetically, and a daemon path (`crates/stella-cli/src/daemon/`).
+Two specs already exist: `doc:self-driving-missions` and
+`doc:self-driving-foundry`.
+
+### Why it is in core, and why that is now wrong
+
+The module doc gives the reason plainly: the deterministic half lives in core so
+"the model never has to re-derive it and cannot get it subtly wrong", and
+keeping it free of I/O is what makes it property-testable.
+
+That reasoning is sound and the code is good. What has changed is the premise —
+core is meant to be a bare loop with minimal tools and one model, and an
+opinionated perpetual-delivery policy is not part of a bare loop. The AIMD
+controller and the aperture ladder are exactly the kind of policy Vera is
+leaving for. The purity that justified its placement is a property of the code,
+not of the crate it sits in: it stays property-testable in a plugin.
+
+### The honest problem: granularity
+
+The wrapper contract is defined **per turn** — `before_turn`, `after_turn`,
+`judge`, `again?`. Self-driving is an **outer** loop over whole runs: a cycle is
+fix-a-batch → audit → file → benchmark → ship, and each of those is many turns.
+
+So self-driving does not simply drop onto the four points, and this plan should
+not pretend otherwise. Three options, and this needs a decision rather than a
+default:
+
+1. **`again?` at run granularity.** Treat a self-driving cycle as the unit and
+   let the plugin request another one. Requires the socket to admit a second
+   granularity, which is a real addition to #3380 rather than a use of it.
+2. **A host-verb plugin.** Self-driving does not participate in a turn at all —
+   it *drives* Stella from outside, the way `scripts/self-driving.sh` already
+   does. Then it needs a plugin-callable command surface, not the wrapper
+   socket, and it is closer to `stella-serve`'s shape than to Vera's.
+3. **Both.** The cycle controller is option 2; anything it wants to enforce
+   inside a single turn is a separate wrapper plugin.
+
+**Recommendation: option 2, with the pure core moved as-is.** Self-driving's
+relationship to the engine is that of a host, and the tree already has a proven
+out-of-process host seam. Forcing it through a turn-granularity socket would
+widen that socket for a single caller — the kind of generalisation that is
+cheaper to add later, when a second caller exists to shape it.
+
+### The work
+
+- **D1.** Move `self_driving.rs` and its tests out of `stella-core` unchanged.
+  Pure functions over owned data port without edits; the property tests come
+  with them. Core's `lib.rs` loses the module.
+- **D2.** Decide the granularity question above. Blocking on D3.
+- **D3.** Give the plugin a command surface — whatever `scripts/self-driving.sh`
+  needs to drive a cycle, expressed so an out-of-process plugin can call it.
+  Reuse `stella-serve`'s framing if the spike in §5.3 selects a compatible
+  transport.
+- **D4.** Keep the observatory view working. It reads JSONL from a fixed path
+  and never writes; if the plugin keeps writing the same shapes, the view needs
+  no change. Verify this rather than assume it — a broken dashboard is how a
+  monitor gets muted.
+- **D5.** Keep `make self-driving-test` green. The control logic it covers is
+  moving, not changing, so the harness should follow it with its assertions
+  intact. If an assertion has to be relaxed to make the move pass, the move
+  changed behaviour and that is a bug in D1.
+
+### Capabilities self-driving needs that the pipeline does not
+
+Concretely, from the current implementation: machine probing (disk, memory,
+compute — `self_driving_cmd/probes.rs`), durable cross-run state under
+`~/.stella/self-driving/` (`state.rs`), process spawning for tools and
+benchmarks, a daemon/scheduling path (`crates/stella-cli/src/daemon/`), and —
+per the fullauto phases — GitHub issue filing and release installation.
+
+None of these belong in the wrapper socket. All of them argue for option 2: they
+are host powers, and a plugin holding them needs the authority story of §A1 to
+be finished first, not approximated.
+
+---
+
+## 11. Definition of done for the whole plan
 
 - `stella-cli/Cargo.toml` does not declare `stella-pipeline`.
 - Core ships zero built-in wrappers and one role (`default`); every other role
@@ -446,7 +543,7 @@ Track A actually delivered a platform.
 
 ---
 
-## 11. Risks
+## 12. Risks
 
 - **The socket ships Rust-shaped.** Mitigated by §5's three commitments. This is
   the risk most likely to be discovered too late.

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -372,6 +372,61 @@ mode this project exists to end.
 
 ---
 
+## 9. Track C — proving three languages in `stella-examples`
+
+`macanderson/stella-examples` is public and already organised by capability —
+`agents/`, `commands/`, `fleet/`, `hooks/`, `mcp/`, `memory/`, `rules/`,
+`scripting/`, `settings/`, `skills/`, `tools/`. A `plugins/` directory slots in
+beside them.
+
+Today every executable example in that repo is a shell script
+(`hooks/scripts/{guard-bash,log-tool-use,session-context}.sh`,
+`scripting/{ci-autofix,nightly-goal}.sh`). So a Python plugin and a TypeScript
+plugin are genuinely new artefacts, and that is the point: they are the proof,
+not the documentation.
+
+### The three reference plugins
+
+All three implement the **same** plugin so they can be diffed against each
+other — a verification plugin that runs a test command in `after_turn`, reports
+the flip as evidence, and declares its verdict rule as data. Small enough to
+read in one sitting, real enough to be non-trivial.
+
+| Path | Language | Demonstrates |
+|---|---|---|
+| `plugins/verify-rs/` | Rust | the reference implementation, and the in-process fast path |
+| `plugins/verify-py/` | Python | no SDK beyond stdlib; `argv = ["python3", "${plugin_dir}/main.py"]` |
+| `plugins/verify-ts/` | TypeScript | `argv = ["node", "${plugin_dir}/dist/main.js"]`, with the build step shown |
+
+Each directory carries its manifest, its entrypoint, a README explaining what
+the plugin does and how to install it, and a test.
+
+### The rules that keep it honest
+
+1. **Identical manifests except `[runtime].argv`.** If the Python plugin needs a
+   different manifest shape than the Rust one, the abstraction has leaked and
+   that is a bug in Track A, discovered here.
+2. **The Rust example uses the wire path in CI.** It may additionally have an
+   in-process path, but if only Rust can reach a capability, the wire contract
+   is second-class and will rot (§5.2).
+3. **No SDK in the first cut.** Python and TypeScript should work with the
+   standard library and a JSON parser. An SDK is a convenience added once the
+   protocol is stable — if a plugin *cannot* be written without an SDK, the
+   protocol is too complicated.
+4. **CI runs all three on every PR**, in `stella-examples` and as a smoke check
+   in `stella` itself, so a protocol change that breaks a non-Rust plugin fails
+   the PR that made it rather than being discovered by a user.
+
+### Why this is a hard requirement rather than a nice-to-have
+
+A plugin surface exercised only by its authors' language is a library with
+extra steps. The adoption case is explicit: developers who do not write Rust
+will not adopt a Rust-only extension surface, and the marketplace has nothing to
+sell if every listing must be compiled from Rust. Track C is the test that
+Track A actually delivered a platform.
+
+---
+
 ## 10. Definition of done for the whole plan
 
 - `stella-cli/Cargo.toml` does not declare `stella-pipeline`.

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -20,6 +20,44 @@ observation, it says so.
 
 ---
 
+## 0. The architectural north star
+
+**Stella is a loop that drops into any application and runs over any surface —
+embedded as a library, over HTTP, from a CLI.** Everything below is judged
+against that sentence. Where speed and soundness conflict, speed wins on the
+things a later commit can fix, and soundness wins on the seams — because a seam
+is what a later commit cannot cheaply change.
+
+Four consequences, and they are acceptance criteria, not aspirations:
+
+1. **The wrapper socket must not assume a host.** A wrapper that only works when
+   a terminal, a git workspace, or `stella-cli`'s process is present is not a
+   socket, it is a CLI feature. The test: can `stella-serve` drive the same
+   wrapper an embedded library does?
+2. **The wire contract is the primary contract; in-process is an
+   optimisation.** This is the same conclusion §5 reaches for Python and
+   TypeScript, arrived at from a different direction — a loop driven over HTTP
+   and a plugin spoken to over a pipe need the same thing: the loop's
+   participation points expressed as data rather than as Rust borrows. Building
+   the wire contract twice, once for hosts and once for plugins, is the failure
+   to avoid.
+3. **No ambient authority anywhere on the path.** `stella-serve` already proves
+   the shape — its engine holds no credentials and remotes every model and tool
+   call to its host. A wrapper must be handed its capabilities, never reach for
+   them. This is what makes the loop embeddable in an application whose
+   filesystem, credentials and lifecycle belong to somebody else.
+4. **`stella-engine` and `stella-serve` are first-class consumers of this
+   work**, not surfaces to update afterwards. If a wrapper lands that
+   `stella-cli` can drive and they cannot, the seam is wrong and the fix is in
+   the seam.
+
+The failure mode this section exists to prevent is subtle and common: the
+extraction succeeds, every plugin works, and the socket has quietly grown a
+dependency on the CLI's process model — so the loop is excellent and only
+embeddable in one thing.
+
+---
+
 ## 1. The short version
 
 Nine plugins replace one pipeline and one built-in autonomous loop. Core keeps
@@ -583,6 +621,10 @@ be finished first, not approximated.
 
 ## 11. Definition of done for the whole plan
 
+- **The embeddability test passes**: one wrapper plugin runs unchanged when
+  driven by `stella-cli`, by `stella-serve` over HTTP, and by a minimal embedded
+  host linking `stella-engine`. Prove it with a test that exercises all three,
+  not with an argument that it should work (§0).
 - `stella-cli/Cargo.toml` does not declare `stella-pipeline`.
 - Core ships zero built-in wrappers and one role (`default`); every other role
   in `/models` is contributed by an installed plugin and disappears when it is

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -1,0 +1,406 @@
+---
+id: pipeline-as-plugins
+title: "Every wrapper is a plugin: the full extraction plan"
+status: proposed
+---
+
+# Every wrapper is a plugin: the full extraction plan
+
+**Status:** proposed, 2026-08-17.
+
+`doc:turn-loop-wrappers` established the direction — one loop, six doors,
+wrappers are plugins — and sequenced its first three moves. This document is the
+completion plan: what remains until **every part of the staged pipeline, and
+self-driving, runs as a plugin outside core Stella**, with the plugin surface
+proven in three languages rather than asserted in one.
+
+Everything said here about today's code was read out of the tree, and the file
+is named so it can be checked. Where a claim is an inference rather than an
+observation, it says so.
+
+---
+
+## 1. The short version
+
+Nine plugins replace one pipeline and one built-in autonomous loop. Core keeps
+one turn loop, one wrapper socket, and zero built-in wrappers.
+
+The work splits into four tracks that must land roughly in order:
+
+| Track | What it delivers | Why it is first |
+|---|---|---|
+| **A — Substrate** | The socket, a loader, a plugin identity, structured verdicts | Nothing below can dispatch without it |
+| **B — Extraction** | The pipeline's stages become plugins, one at a time | Each is independently shippable once A exists |
+| **C — Proof** | Python and TypeScript plugins in `stella-examples`, running in CI | A one-language plugin surface is a library, not a platform |
+| **D — Self-driving** | The autonomous loop leaves the binary | Depends on A, and on capabilities B does not need |
+
+The single most important constraint, stated once and enforced throughout:
+**`judge` stays in-process, pure, and total.** Plugins declare their verdict
+rule as data and supply evidence out-of-process; they do not ship verdict code.
+§6 argues this rather than assuming it.
+
+---
+
+## 2. What is actually true today
+
+The starting position is better than "nothing" and worse than "nearly there".
+
+**Landed and working:**
+
+- The engine owns its own ending (#3379). `crates/stella-pipeline/src/pipeline.rs:15-27`
+  documents the one-directional connection: the pipeline no longer edits the
+  engine's stream. This was the hard blocker — a plugin cannot hold a private
+  channel into the engine.
+- **The turn-completion gate is real, async, and already out-of-process.**
+  `Engine::stop_hook_feedback` (`crates/stella-core/src/driver/user_hooks.rs:291`)
+  runs at completion; a `Deny` holds the turn open and the engine keeps
+  stepping (`crates/stella-core/src/driver/completion.rs:183`). It is bounded by
+  `MAX_STOP_CONSULTS = 3` (`user_hooks.rs:99`), spent *before* the hooks run, and
+  the final round announces itself (`STOP_FINAL_ROUND_NOTE`, `:105`). It is
+  fail-open by design (`:55-59`) — a hook that fails never blocks, because
+  failing closed here means never completing.
+- Subprocess hooks: JSON on stdin, a `HookDecision` on stdout, 60s default and a
+  600s ceiling (`crates/stella-core/src/hooks.rs:75`). **This is the
+  any-language plane, and it works now.**
+- `TurnLane::Plugin(LaneId)` (`crates/stella-protocol/src/lane.rs:165`).
+- The manifest grammar: participation ladder, `LoopGrant`, `[oracle]`,
+  `[requirements]`, `[subloop]`, `[roles]`, and a closed condition grammar with
+  a load-time stage-graph check (`crates/stella-plugin/src/{manifest,wrapper}.rs`).
+
+**The governing gap:** `stella-plugin` has **zero consumers**. Nothing calls
+`PluginManifest::from_toml_str`, there is no `.stella/plugins/` resolver, no
+install command, no loader. `crates/stella-plugin/src/wrapper.rs:29-33` says it
+plainly — a `StageName` is "a declared name that load-checks, not a dispatch
+target".
+
+So the manifest describes a socket that does not exist. Track A builds the
+socket; everything else is downstream of it.
+
+---
+
+## 3. The nine plugins
+
+The staged pipeline is not one thing. Splitting it by *what would be installed
+separately* rather than by current module boundaries:
+
+| Plugin | Replaces | Points used | Ships |
+|---|---|---|---|
+| **vera** | witness authoring, flip oracle, verification ladder, reward labelling | `after_turn`, `judge` | Oxagen, private |
+| **stella-plan** | triage, plan, scope | `before_turn` | first-party, open |
+| **stella-research** | research sub-agents, recall | `before_turn` | first-party, open |
+| **stella-candidates** | worktree candidates, best-of-N fan-out, steering mirror | `before_turn`, `again?` | first-party, open |
+| **stella-selfdriving** | the autonomous delivery loop | `again?`, host verbs | first-party, open |
+| **stella-goal** | goal mode, `stella monitor` | `judge`, `again?` | first-party, open |
+| **example-py** | a working Python plugin | `after_turn` | `stella-examples`, public |
+| **example-ts** | a working TypeScript plugin | `after_turn` | `stella-examples`, public |
+| **example-rs** | the reference Rust plugin | all four | `stella-examples`, public |
+
+Two notes on that table. `stella-goal` is included because #3380 already
+observes goal mode and the pipeline are the same shape written twice —
+extracting one and leaving the other rebuilds the drift. And the three examples
+are listed as deliverables, not documentation, because a language is supported
+when a plugin written in it runs in CI, and not before.
+
+---
+
+## 4. Track A — the substrate
+
+Ordered by dependency. Each item names the files it touches.
+
+### A1. A plugin is not the user
+
+**Today Stella cannot tell a plugin apart from the human.** The authority
+vocabulary landed — `Principal` (`crates/stella-core/src/ports/authz.rs:62`),
+`AuthzGate` (`:244`), `RiskLevel` and `ToolContract`
+(`crates/stella-protocol/src/contract.rs:68`, `:197`) — but every call site
+passes the constant `Principal::User`
+(`crates/stella-cli/src/agent.rs:362`, `:1657`, `:1672`).
+
+`Principal::Host(String)` (`authz.rs:74-76`) is already the right shape and is
+deliberately opaque so core grows no opinion about who hosts are. Thread a real
+principal through dispatch and make plugin identity one.
+
+This is **first** and not negotiable: a marketplace shipped on top of a
+system that cannot distinguish an installed plugin from its operator grants
+every plugin the operator's authority. Related: #2793 (MCP and custom tools
+bypass the blocking policy chains) is the same hole one layer down and should
+close alongside.
+
+### A2. The blessed constructor (#3387)
+
+#3380 lists this as its own precondition. The pipeline still builds its own
+engine via `Engine::with_sleeper` (`crates/stella-pipeline/src/pipeline.rs:1530`)
+and re-attaches `hooks`/`steering` by hand (`:1537`, `:1542`). A hand-rolled
+child engine that silently drops `gate`, `steering` or `hooks` is the bug goal
+mode already shipped. One constructor, or every wrapper re-authors the defect.
+
+### A3. The wrapper socket (#3380)
+
+The four points, defined in **`stella-runtime`** — not `stella-core`, because
+`before_turn` performs recall and `after_turn` spawns processes, and invariant 2
+bans I/O in the engine (`doc:turn-loop-wrappers` §9.1).
+
+Two halves, and they are separable:
+
+- **A3a — the in-process contract.** A Rust trait in `stella-runtime`, plus the
+  manifest vocabulary for the four points (which `[wrapper]` does not yet have —
+  it declares stages, not points).
+- **A3b — the wire contract.** The same four points expressed as serialized
+  request/response, so a plugin can be a separate process. This is the half that
+  decides whether Python and TypeScript are first-class or bolted on, and §5
+  argues it must be designed **with** A3a rather than after it.
+
+### A4. A loader
+
+`.stella/plugins/` and `~/.stella/plugins/` resolvers (`crates/stella-home/`),
+`stella plugin install|list|remove` (`crates/stella-cli/`), a consent prompt on
+install that shows the declared participation grade and hook grants, and
+`LoopGrant::permits_hook` (`manifest.rs:134-139`) as the routing filter.
+
+**Uninstall must actually uninstall.** Hook settings currently *concatenate*
+across scopes and no scope can remove another's entries
+(`crates/stella-cli/src/settings/merge.rs:47`, `:171-172`). Correct for operator
+hooks, wrong for plugins.
+
+### A5. A process declaration in the manifest
+
+Today only the oracle may name an executable — `OracleCommand{argv,
+timeout_secs}` (`crates/stella-plugin/src/manifest.rs:163-170`), "never a shell
+string", with `${plugin_dir}` interpolation as the host's job. There is no
+`runtime`, `language`, or `entrypoint` field on `PluginManifest`
+(`:227-259`), and `deny_unknown_fields` on every table means one cannot be added
+without editing the crate.
+
+Add `[runtime]` modelled directly on `OracleCommand`: `argv`, `timeout_secs`, an
+env allowlist. Deliberately **not** a `language` field — `argv` already
+expresses `["python3", "${plugin_dir}/main.py"]` and
+`["node", "${plugin_dir}/main.js"]` without Stella learning what a language is.
+
+### A6. Structured verdicts
+
+`HookDecision::Deny` carries only a `String` (`crates/stella-core/src/bus.rs:144`).
+A verification plugin must return which witness, which command, whether the flip
+was achieved, and the digest. This is invariant 5's own test — the driver and the
+trace fold both branch on it (#3246 §O1.2).
+
+While here: `RequireApproval` is surfaced as inapplicable at a turn boundary
+(`user_hooks.rs:~322`). A paid plugin that must ask "verification budget
+exhausted, continue?" needs a real answer.
+
+### A7. `max_holds` becomes real
+
+`LoopGrant::max_holds` is declared and read by nothing
+(`manifest.rs:120-124`); the live bound is the constant `MAX_STOP_CONSULTS`
+(`user_hooks.rs:99`). Clamp the declared value to a host ceiling. A verification
+plugin needing four rounds cannot currently ask for them.
+
+### A8. Signals and stages grow to cover the pipeline
+
+`StageName` is 8 of 12 — `verdict`, `reflect`, `contextwrite`, `complete` are
+undeclarable (`wrapper.rs:114-131` against `StageKind` in
+`crates/stella-protocol/src/event.rs:137+`). `Signal` is 5 values and only
+`Triage` publishes any (`wrapper.rs:140-156`), so no condition can read a diff
+size, a flip state, a test result, or a budget — which are precisely the
+pipeline's live skip conditions (`pipeline.rs:1141-1159`, `:1198`).
+
+Grow both to cover what the pipeline actually branches on. Keep the closed
+grammar: `wrapper.rs:16-21` is right that "a Turing-complete condition in a
+manifest is a second program with no gate on it."
+
+### A9. Plugin events and the trace fold
+
+A `plugin.<id>.*` namespace in the bus catalog — already contemplated at
+`crates/stella-core/src/bus/names.rs:3-4` — plus the fold arm that reads it.
+
+**Plugins do not write traces.** They emit journal events; the trace is a fold
+(`crates/stella-cli/src/trace.rs:8-18`). Contributed facts then inherit
+replayability, `TRACE_SCHEMA_VERSION` skip-on-unknown, redaction, and the
+guarantee that nothing reaches `store.db`. A plugin writing `traces.jsonl`
+directly routes around all four.
+
+### A10. A worktree handle that crosses a process
+
+`CandidateWorkspacePort` + `CandidateWorkspace` are 21 methods returning
+borrowed trait objects (`crates/stella-pipeline/src/ports/workspace.rs:94-334`).
+`after_turn` is defined as "author a witness, run the oracle, read the flip" —
+all of which need the candidate worktree, and none of which has a serializable
+handle. Custom tools currently pin a child's cwd to the workspace root
+(`crates/stella-tools/src/custom.rs:41-42`), not a candidate.
+
+Define the minimum serializable subset: create, root path, run-test, seal,
+adopt, remove. The host fences filesystem access; tamper snapshotting stays
+host-side, which `TamperPolicy::ArtifactIdentity` (`manifest.rs:187-192`)
+already assumes.
+
+---
+
+## 5. Multi-language is a design input, not a later port
+
+The hard requirement is Python and TypeScript plugins. The risk is not that they
+are impossible — the subprocess plane already proves they are not — it is that
+A3a ships first as a Rust trait, A3b is deferred, and the trait's shape then
+dictates a wire protocol it was never designed for.
+
+Three commitments prevent that:
+
+1. **The wire contract is authored in the same PR as the trait.** Not
+   implemented in the same PR — authored. If a point cannot be expressed as
+   serialized request/response, that is discovered while the trait is still
+   editable.
+2. **The reference Rust plugin is a client of the wire contract too.** If Rust
+   gets a private in-process path that Python cannot use, the wire contract
+   becomes a second-class citizen and rots. Rust may *additionally* have an
+   in-process fast path, but the wire path must be the one CI exercises.
+3. **The transport is chosen by spike, not by argument.** #3246 §O5 asks for the
+   Stop-hook path implemented twice — once as a shell hook, once as an MCP
+   server with a lifecycle extension — and compared. That spike is a Track A
+   deliverable, scheduled before A3.
+
+What is already settled and should not be relitigated: **do not embed CPython**
+(#3246 §O5 — the GIL on an async runtime, a per-platform packaging story, and a
+concretion inside crates invariant 1 keeps free of them). The SDK is a thin
+client over whatever the spike selects.
+
+---
+
+## 6. Why `judge` stays in-process
+
+`doc:turn-loop-wrappers` §9.2 sharpens "`judge` may not call a model" into a
+property of the signature: `judge` is synchronous and I/O-free over owned data,
+so the rule is enforced by the compiler rather than by review.
+
+An out-of-process `judge` is I/O by construction and destroys that property.
+Since Python plugins are a hard requirement, this needs an explicit resolution
+rather than a silent one. **The resolution is: plugins declare the verdict rule;
+the host evaluates it.**
+
+- A plugin supplies **evidence** out-of-process, in any language, with the
+  600s subprocess budget — running a test suite is exactly the workload the
+  in-process bus cannot host, and #3246 §O3 is right that out-of-process is the
+  *better* substrate for it.
+- A plugin supplies its **verdict rule as data** — the closed condition grammar,
+  `[requirements]`, and the `[oracle]` flip/tamper policy. Data has no
+  programming language, so a Python author and a Rust author write the identical
+  artifact.
+
+Three reasons this is the better decision, not merely the conservative one:
+
+1. **The failure it forecloses is the one the project exists to prevent.** A
+   verification plugin that quietly calls a model to decide "done" is the worker
+   grading its own work, and a passing verdict looks identical either way. Today
+   that is impossible by construction.
+2. **A compiler-enforced guarantee is free forever; a policed one needs a
+   policeman**, who needs tests, and drifts.
+3. **The costs are asymmetric and one direction is one-way.** Widening a closed
+   grammar later is additive. Re-imposing the guarantee after plugins depend on
+   arbitrary verdict code is not possible.
+
+The honest cost: a plugin author cannot write a verdict as a loop in Python.
+Given `ladder_decision` is already deterministic and terminal at six outcomes,
+the interesting variation lives in what counts as evidence and what done means —
+both of which stay open.
+
+**The falsifier, and it should be run before A3 freezes:** express one genuinely
+different definition of done — not Vera's — as declarative data. What will not
+fit is the evidence for widening the grammar, and it is far cheaper to find
+before the socket exists than after.
+
+---
+
+## 7. Track B — extraction order
+
+Each plugin ships behind the flag inversion of #3381 (`--pipeline <variant>`
+replacing `--no-pipeline`), with the wrapper id recorded on the executions row
+so two variants can be compared. That column and migration already shipped
+(`crates/stella-store/src/ddl.rs:115`, `migrations.rs:29`) but the only writer
+passes the constant `PIPELINE_VARIANT_CLASSIC`
+(`crates/stella-cli/src/agent/persistence.rs:22`, `:45`) — wiring `Wrapper::id`
+to it is a Track A tail item, because without it the A/B comparison this whole
+plan is justified by cannot distinguish two variants.
+
+Order, easiest and least risky first:
+
+1. **stella-research** — `before_turn` only, read-only, no worktree. The safest
+   possible first real plugin.
+2. **stella-plan** — `before_turn`, needs the triage signals A8 publishes.
+3. **vera** — `after_turn` + `judge`. Needs A10 (worktrees) and A6 (structured
+   verdicts). Ported, not copied: see §8.
+4. **stella-candidates** — the heaviest, needs `again?` with different setup per
+   round.
+5. **stella-goal** — folded in last so it stops being a second copy.
+
+**The bar for each:** a side-by-side benchmark holds before the built-in path is
+deleted. The dependency cut — `stella-cli` no longer declaring
+`stella-pipeline`, today 166 references across 41 files — is the **last** slice,
+never the first.
+
+---
+
+## 8. Vera specifically
+
+Vera is a port, not a lift. It takes the verification nucleus and leaves the
+orchestration.
+
+**Ports** (pure functions over owned data, which is what makes this realistic):
+`crates/stella-pipeline/src/verify.rs` (`FlipOracle`, `FlipState`,
+`ladder_decision`, the evidence builders, `strip_witness_hunks`),
+`witness.rs` (prompt construction, `parse_test_invocation`, `runner_probe`, the
+three acceptance validators), `witness/airlock.rs`, `flip_halt.rs`, and
+`reward.rs` for the training labels.
+
+**Carry over first:** the property test
+`flip_requires_a_prior_failing_observation`. A flip with no prior failing
+observation is not a flip.
+
+**Lift, do not copy:** tamper exclusion currently lives inside
+`Pipeline::verify_candidate` in the god file `src/pipeline.rs` rather than beside
+the oracle.
+
+**Vera contributes model roles** to the `/models` table — the worker whose output
+is judged, and the independent verifier that authors the witness. Verifier
+independence becomes Vera's invariant to enforce; the roster already refuses a
+responsibility whose agent is the worker's (`roster.rs:656-660`). Blocked on
+#3472 (the role table must be plugin-populated; `EngineRole` is a closed
+six-variant enum at `crates/stella-tui/src/envelope.rs:993`).
+
+**Net-new, not ported:** the durable flip record. Today a `LadderSnapshot` rides
+inside `AgentEvent::Verdict`, but there is no dedicated flip-transition event and
+the `verdict` tag's consumer posture is `Unclassified` (#2703) — nothing is
+declared to read it. Vera owns a declared flip record whose named consumer is
+the fine-tuning corpus. A verification signal nothing reads is the exact failure
+mode this project exists to end.
+
+---
+
+## 10. Definition of done for the whole plan
+
+- `stella-cli/Cargo.toml` does not declare `stella-pipeline`.
+- Core ships zero built-in wrappers and one role (`default`); every other role
+  in `/models` is contributed by an installed plugin and disappears when it is
+  removed.
+- `stella plugin install` works for a plugin written in each of Rust, Python and
+  TypeScript, and CI runs all three on every PR.
+- A side-by-side benchmark holds for the plugin path against the built-in path
+  before each built-in is deleted.
+- `judge` remains synchronous and I/O-free; no configuration restores a model
+  verdict.
+- Plugin-contributed facts appear in traces via the journal fold, and a
+  fine-tuning export can join trace to oracle flip.
+- `make gate` green throughout; no baseline entry added to
+  `scripts/file-size-baseline.txt` to accommodate this work.
+
+---
+
+## 11. Risks
+
+- **The socket ships Rust-shaped.** Mitigated by §5's three commitments. This is
+  the risk most likely to be discovered too late.
+- **`judge` gets relitigated per-plugin** rather than settled once. §6 is meant
+  to be cited, not re-argued.
+- **The pipeline is deleted before the plugin is as good.** The benchmark bar in
+  §7 exists for this; a five-task solve rate cannot resolve it, so comparisons
+  need repeats per task.
+- **Extraction stalls half-done**, leaving two code paths and the drift #3380
+  already identifies between goal mode and the pipeline. The flag inversion is
+  the forcing function: if inverting the default feels unsafe, the extraction is
+  not finished.


### PR DESCRIPTION
## What

A spec and implementation plan for the remaining work to rebuild **every** part
of the staged pipeline — and self-driving — as plugins outside core Stella, with
the plugin surface proven in Rust, Python and TypeScript.

`doc:turn-loop-wrappers` set the direction and sequenced its first three moves.
This is the completion plan: `doc:pipeline-as-plugins`.

## Why now

Move one (#3379, the engine owning its own ending) has landed, which was the
hard blocker — a plugin cannot hold a private channel into the engine. Move
three's manifest half landed but is inert (#3408). Move two (#3380, the wrapper
socket) is unstarted, and it is the gate for everything else.

Before writing the socket it is worth knowing what it has to carry. The audit
behind this document (posted as a comment on #3380) found the plugin
architecture expresses roughly 15% of what the pipeline does, and none of it
dispatches — `stella-plugin` has zero consumers.

## Shape

Four tracks: **A** substrate (socket, loader, plugin identity, structured
verdicts), **B** extraction (the stages become plugins, ordered by risk), **C**
proof (three reference plugins in `stella-examples`, all in CI), **D**
self-driving leaves core.

Two findings worth a reviewer's attention:

- **Self-driving really is in `stella-core`** (`src/self_driving.rs`, 945 lines),
  unlike the pipeline which left long ago. But it is an outer loop over runs, not
  turns, so it does not drop onto a per-turn wrapper contract. §10 lays out three
  options and recommends the host-verb shape over widening the socket for a
  single caller.
- **`judge` staying in-process needs deciding explicitly**, because Python
  plugins are a hard requirement and an out-of-process `judge` destroys the
  I/O-free signature property `doc:turn-loop-wrappers` §9.2 relies on. §6 argues
  the resolution — plugins declare the verdict rule as data and supply evidence
  out-of-process — and names the falsifier that should be run before the socket
  freezes.

## Witness

Documentation only — no behaviour change, so no witness test. The claims about
today's code were read out of the tree and cite file:line so a reviewer can
check them; two were verified independently while writing
(`crates/stella-core/src/self_driving.rs` exists; the ladder is terminal at six
outcomes, not five).

## Related

- Refs #3380 — the capability audit is a comment there; this plan is what the
  socket must satisfy.
- Refs #3408, #3387, #3246, #2793.
- Refs #3472 — the `/models` role table must be plugin-populated.
- Refs #3473 — the ladder is terminal at six outcomes; `AGENTS.md` and
  `docs/spec/turn-loop-wrappers.md` both say five.

## Summary by Sourcery

Document the full plan for extracting Stella’s pipeline and self-driving loop into embeddable plugins across Rust, Python, and TypeScript.

Enhancements:
- Define the complete architecture and phased extraction plan for moving the staged pipeline and self-driving capabilities into embeddable, multi-language plugins.
- Specify the plugin substrate, authority model, wire protocol, loader, structured verdicts, lifecycle boundaries, and trace integration required to support plugin dispatch.
- Establish the extraction order, language-proof strategy, self-driving host-plugin approach, acceptance criteria, risks, and autonomous execution protocol.

Documentation:
- Add the proposed “Every wrapper is a plugin” specification covering the nine planned plugins, architectural decisions, sequencing, and definition of done.
- Add the living playbook for executing, auditing, sequencing, and merging the plugin extraction work.
- Register the new specification and execution playbook in the documentation manifest.