### PR TITLE
docs: the verification ladder is terminal at every arm, not at five (#3473)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,9 +438,15 @@ one verifier-tier call the pipeline still spends, and it survives because it
 creates the oracle rather than substituting for one — its test either goes
 fail→pass or does not, and that is decided by running it. Everything downstream
 is deterministic: `ladder_decision`
-(`crates/stella-pipeline/src/verify.rs`) is terminal at all five of its outcomes
-(`SubmitFast`, `Revise`, `NothingAttempted`, `Unverifiable`, `Unverified`), and
-the verify stage emits the `Verdict` event from that answer directly — the
+(`crates/stella-pipeline/src/verify.rs`) is terminal at **every** one of its
+outcomes — the `LadderDecision` enum beside it is the enumeration, and today
+that is `SubmitFast`, `Revise`, `WitnessUnsatisfiable`, `NothingAttempted`,
+`Unverifiable` and `Unverified`. The count is deliberately not the load-bearing
+half of that sentence: what matters is that no arm escalates to a model, which
+the enum's own doc comments each state. (This paragraph said "all five" and
+omitted `WitnessUnsatisfiable` for as long as that variant existed — #3473,
+the shared-cell drift this file warns about, in this file.) The verify stage
+emits the `Verdict` event from that answer directly — the
 pipeline never emits `StageKind::Verdict` itself, which is why the rank above is
 an ordering, not a stage the run passes through. The model verdict and the
 distress-guidance call are gone (#2584), structurally rather than by default —

--- a/docs/spec/turn-loop-wrappers.md
+++ b/docs/spec/turn-loop-wrappers.md
@@ -131,10 +131,16 @@ to plug in, and nothing else:
 | `judge` | after `after_turn` | turn the evidence into a verdict | call a model |
 | `again?` | after `judge` | say "another turn, here is the correction" or "stop, here is the outcome" | fake an ending the engine did not emit |
 
-`judge` calls no model on purpose. That is already the rule in the pipeline
-(`ladder_decision` in `crates/stella-pipeline/src/verify.rs` is terminal at all
-five outcomes, and #2584 removed the model verdict structurally). The wrapper
-contract keeps that rule instead of re-arguing it.
+`judge` calls no model on purpose. That is already the rule in the pipeline:
+`ladder_decision` in `crates/stella-pipeline/src/verify.rs` is terminal at every
+arm of `LadderDecision` — that enum is the enumeration, and this document
+deliberately does not restate it or its count, because a number copied into a
+second file drifts (#3473) — and #2584 removed the model verdict structurally.
+The wrapper contract keeps that rule instead of re-arguing it.
+
+The arm a plugin author most needs from that enum is `WitnessUnsatisfiable`: the
+witness was authored and its red does not discriminate, so `judge` must be able
+to say "the instrument is broken", not only "the work failed".
 
 `before_turn` is where the steering plane (#3243) is asked its one question —
 "what could help here?" — for a wrapped run. It is not a fifth plane.


### PR DESCRIPTION
`LadderDecision` (`crates/stella-pipeline/src/verify.rs:380`) has **six**
variants. `AGENTS.md` and `docs/spec/turn-loop-wrappers.md` both said "five" and
both enumerated the same wrong set, omitting `WitnessUnsatisfiable`.

## The fix, and why it is not "change five to six"

#3473's definition of done asks that the enumeration live in one place and the
other cite it, rather than a corrected count that can drift again. So:

- `docs/spec/turn-loop-wrappers.md` now restates **neither** the list nor the
  count — it cites `LadderDecision` and adds the one arm a plugin author
  actually needs to know about, `WitnessUnsatisfiable`, because that is how
  `judge` says "the instrument is broken" rather than "the work failed".
- `AGENTS.md` keeps an enumeration (it is the orientation document) but says out
  loud that the count is not the load-bearing half of the sentence — no arm
  escalating to a model is — and names #3473 in place, so the next reader sees
  the drift was real rather than assuming the number was always right.

## Evidence

```
$ rg -n 'SubmitFast|^    Revise|WitnessUnsatisfiable|NothingAttempted|^    Unverifiable|^    Unverified' crates/stella-pipeline/src/verify.rs
384:    SubmitFast,
387:    Revise,
399:    WitnessUnsatisfiable,
404:    NothingAttempted,
411:    Unverifiable,
```
Six arms, `Unverified` following at the tail of the same enum (`:380`).

## Witness

None, and deliberately: this is a prose correction with no behaviour change, so
there is nothing that fails on `main` and passes here except reading the two
files. The falsifiable claim is the enum listing above.

## Tests deleted

None.

## Gate

`make guards-fast` green locally (the rung the pre-push hook selects for a
push touching no crate): `invariants`, `doc-links`, `command-docs`,
`brand-case`, `file-size`, `god-files`, `gate-parity`, `left-behind`,
`role-names`, `lockfile-sync`, `fmt --check` all OK.

Closes #3473
Refs #3380

## Summary by Sourcery

Align verification documentation with the complete terminal `LadderDecision` enum and make its authoritative source explicit.

Bug Fixes:
- Correct documentation of the terminal verification ladder to include all six `LadderDecision` variants, including `WitnessUnsatisfiable`.

Enhancements:
- Centralize the authoritative ladder enumeration in `LadderDecision` while clarifying that every arm is terminal and none escalates to a model.
- Highlight the plugin-facing meaning of `WitnessUnsatisfiable` as an instrument failure rather than a failed work item.

Documentation:
- Update the verification and turn-loop documentation to prevent duplicated variant lists and stale outcome counts.