### PR TITLE
refactor(stella-runtime): the assembly seam declares no edge to the pipeline (#3280)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,7 +3198,6 @@ dependencies = [
  "stella-graph",
  "stella-mcp",
  "stella-model",
- "stella-pipeline",
  "stella-protocol",
  "stella-store",
  "stella-tools",

--- a/crates/stella-runtime/Cargo.toml
+++ b/crates/stella-runtime/Cargo.toml
@@ -17,7 +17,6 @@ stella-store = { path = "../stella-store" }
 stella-mcp = { path = "../stella-mcp" }
 stella-context = { path = "../stella-context" }
 stella-graph = { path = "../stella-graph" }
-stella-pipeline = { path = "../stella-pipeline" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stella-runtime/tests/no_pipeline_edge.rs
+++ b/crates/stella-runtime/tests/no_pipeline_edge.rs
@@ -1,0 +1,86 @@
+//! `stella-runtime` does not depend on `stella-pipeline`, and says so
+//! executably.
+//!
+//! The runtime is the assembly bottom half that `stella-serve` and embedded
+//! hosts link to obtain an engine without the CLI. The staged pipeline is a
+//! *policy* layered on top of a loop, not part of the loop's construction —
+//! so an edge from here to there makes the pipeline look like part of the
+//! runtime's contract when it is not. That is the exact coupling
+//! `doc:turn-lane-assembly` §10.2 counts and `doc:pipeline-as-plugins` §0.4
+//! is trying to keep out of the seam: a wrapper that `stella-cli` can drive
+//! and `stella-serve` cannot is a CLI feature wearing a socket's name.
+//!
+//! It also costs real time. `scripts/impacted-crates.sh` walks *declared*
+//! dependencies, so a phantom edge drags this crate and everything
+//! downstream of it into `CARGO_SCOPE` whenever the pipeline changes, and
+//! costs every consumer a compile of a tree it never calls (#3280).
+//!
+//! This is the witness for a subtraction, which cannot be witnessed by
+//! calling anything: the assertion is over the manifest, and it fails before
+//! the dependency line is deleted and passes after. Lives in `tests/`
+//! alongside `no_ambient_reads.rs`, and for the same reason — an in-crate
+//! test would have to exempt its own needles from the scan.
+
+/// Workspace crates the runtime must never declare an edge to, and why.
+///
+/// Deliberately a list rather than a single check: the next crate that must
+/// stay out of the assembly seam is added here, not re-derived.
+const FORBIDDEN_DEPENDENCIES: &[(&str, &str)] = &[(
+    "stella-pipeline",
+    "the staged pipeline is a policy above the loop, not part of assembling \
+     one — see the module doc and #3280",
+)];
+
+/// Dependency names declared by this crate's own manifest.
+///
+/// Hand-parsed rather than pulled through a TOML dependency: the shape being
+/// read is one line per dependency in a known table, and adding a crate to
+/// `[dev-dependencies]` to read four lines is a worse trade than the parse.
+/// `env!("CARGO_MANIFEST_DIR")` is resolved by the compiler, so this reads no
+/// ambient process state and does not disturb `no_ambient_reads.rs`.
+fn declared_dependencies() -> Vec<String> {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("the crate's own Cargo.toml is readable");
+
+    let mut names = Vec::new();
+    let mut in_dependency_table = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if let Some(header) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            // `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
+            // and their `[target.'…'.dependencies]` forms all count: a
+            // phantom edge in any of them still reaches the resolver.
+            in_dependency_table = header.ends_with("dependencies");
+            continue;
+        }
+        if !in_dependency_table || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((name, _)) = line.split_once('=') {
+            names.push(name.trim().trim_matches('"').to_string());
+        }
+    }
+    names
+}
+
+#[test]
+fn the_assembly_seam_declares_no_edge_to_a_policy_crate() {
+    let declared = declared_dependencies();
+
+    // Guard the parser itself: a rename or a reformat that made
+    // `declared_dependencies` return nothing would make the assertion below
+    // vacuously true, which is the failure mode a subtraction test is most
+    // exposed to.
+    assert!(
+        declared.iter().any(|d| d == "stella-core"),
+        "parsed no `stella-core` edge out of the manifest, so the scan is \
+         broken rather than clean; declared = {declared:?}"
+    );
+
+    for (forbidden, why) in FORBIDDEN_DEPENDENCIES {
+        assert!(
+            !declared.iter().any(|d| d == forbidden),
+            "stella-runtime declares `{forbidden}`: {why}"
+        );
+    }
+}


### PR DESCRIPTION
`crates/stella-runtime/Cargo.toml:20` declared `stella-pipeline`; nothing under
`crates/stella-runtime/src/` ever referenced it. `rg stella_pipeline
crates/stella-runtime/` returned exactly one hit, the declaration itself.

## Why this is more than tidiness

`stella-runtime` is the crate `stella-serve` and embedded hosts link to obtain
an engine without the CLI. `doc:pipeline-as-plugins` §0 makes that the whole
point of the current work — the loop drops into any application — and §0.4 names
the failure mode: a seam that quietly grows a dependency on a policy layer above
it. A phantom edge from the assembly seam to the staged pipeline is a small,
literal instance of exactly that.

It also cost time. `scripts/impacted-crates.sh` walks **declared** dependencies,
so any change to `stella-pipeline` dragged `stella-runtime` and its dependents
into `CARGO_SCOPE` for the pre-push hook and CI, and every consumer paid a
compile of a tree it never called.

`doc:turn-lane-assembly` §10.2 counts this as one of three coupling sites and §8
schedules it as "XS, free, can go first".

## Witness

`crates/stella-runtime/tests/no_pipeline_edge.rs` — a subtraction cannot be
witnessed by calling anything, so the assertion is over the crate's own
manifest:

```
$ git stash && cargo test -p stella-runtime --test no_pipeline_edge
thread 'the_assembly_seam_declares_no_edge_to_a_policy_crate' panicked:
stella-runtime declares `stella-pipeline`: the staged pipeline is a policy
above the loop, not part of assembling one — see the module doc and #3280
test result: FAILED
```

and it passes on this commit. The test guards itself against becoming vacuous —
the failure mode of a manifest scan is a parser that silently matches nothing —
by asserting it still finds `stella-core` before it asserts an absence. It reads
`env!("CARGO_MANIFEST_DIR")`, resolved by the compiler, so it does not disturb
the crate's `tests/no_ambient_reads.rs` contract.

`FORBIDDEN_DEPENDENCIES` is a list rather than a single check so the next crate
that must stay out of the assembly seam is added there rather than re-derived.

## Verification run

- `cargo test -p stella-runtime` — green, including `no_ambient_reads`
- `cargo clippy -p stella-runtime --all-targets -- -D warnings` — clean
- `cargo check -p stella-cli` — green; `stella-cli` is the only dependent of
  `stella-runtime` and declares `stella-pipeline` itself
  (`crates/stella-cli/Cargo.toml:67`), so nothing was relying on the transitive
  edge
- `./scripts/check-lockfile-sync.sh` — OK; `Cargo.lock` is updated in this commit
- `cargo fmt --check` — clean

Per the light protocol I did not run the full workspace `make gate`; the change
touches one manifest, one new test file and one `Cargo.lock` line.

## Tests deleted

None.

## Shortcuts shipped

None.

`crates/stella-runtime/README.md` names no pipeline prose, so it needed no edit.

Closes #3280
Refs #3273, #3246

## Summary by Sourcery

Keep `stella-runtime` independent of the staged pipeline and guard that dependency boundary with a regression test.

Enhancements:
- Remove the unused `stella-pipeline` dependency from `stella-runtime` to preserve the assembly seam’s independence from the policy layer.
- Add a manifest-level regression test to prevent forbidden dependencies from being introduced into `stella-runtime`.

Build:
- Update `Cargo.lock` to reflect the dependency graph change.

Tests:
- Add coverage that verifies `stella-runtime` declares its expected dependencies while rejecting `stella-pipeline`.