### PR TITLE
fix(stella-cli): the stubborn-run fixture must not block in a forked child

### DIFF
--- a/crates/stella-cli/src/daemon/tests.rs
+++ b/crates/stella-cli/src/daemon/tests.rs
@@ -450,10 +450,31 @@ fn the_liveness_fallback_takes_a_lock_that_does_not_exist_yet() {
 /// Deliberately slow: it waits out the real [`STOP_GRACE`], because a test
 /// that shortened the grace would be testing a different constant than the one
 /// that ships.
+///
+/// # The script must not block in a forked child (#1721)
+///
+/// `stop` signals the process GROUP — `signal_group` is `kill(-pgid, …)` —
+/// so a `trap` in the shell protects only the shell. The original fixture was
+/// `trap '' TERM; sleep 120`, where `sleep` is a separate process that never
+/// ignored anything: the group `SIGTERM` killed it outright, `sh` reaped it
+/// and exited normally, and the lock was released in ~81ms. That is why this
+/// test "flaked" — twice at 81.41ms and 81.65ms, agreeing to a quarter of a
+/// millisecond, which is a deterministic path and not a scheduler race. It had
+/// been re-hardened three times as a load problem it never was.
+///
+/// So the shell itself has to be the thing that survives, and it must stay
+/// runnable rather than parked inside a child: the loop below keeps `sh` — the
+/// process holding the liveness lock and leading the group — alive across the
+/// whole grace, while its short-lived `sleep` children are free to die to the
+/// same signal without ending the run.
 #[test]
 fn a_run_that_ignores_term_is_killed_after_the_grace_period() {
     let (dir, registry) = temp_registry("stop-ignores-term");
-    let mut run = spawn_sh(&registry, "stubborn", "trap '' TERM; sleep 120");
+    let mut run = spawn_sh(
+        &registry,
+        "stubborn",
+        "trap '' TERM; while :; do sleep 1; done",
+    );
     let sidecar = registry.sidecar_dir(&run.id);
     let id = run.id.clone();
 


### PR DESCRIPTION
Closes #1721

## Not a flake

This test has been re-hardened three times as a load problem (#1993, #2393, #2804, #2902 are all the same test) and kept failing. The decisive evidence is the timing: two failures 17 hours and many commits apart measured

| Run | Elapsed before the kill |
|---|---|
| [32042644942](https://github.com/macanderson/stella/actions/runs/32042644942) | `81.413994ms` |
| [31982282553](https://github.com/macanderson/stella/actions/runs/31982282553) | `81.646586ms` |

**0.23 ms apart.** A contended scheduler does not reproduce to a quarter of a millisecond; a deterministic code path does.

## The cause is the fixture, not the code under test

`stop` signals the process **group** — `signal_group` is `kill(-pgid, …)` in `daemon.rs` — and the script was:

```sh
trap '' TERM; sleep 120
```

`trap` protects the **shell**. `sleep` is a separate process in the same group that never ignored anything. So the group `SIGTERM` killed `sleep` outright, `sh` reaped it and exited normally, and the liveness lock released in ~81 ms.

The test therefore measured a run that ended on the **first** signal, while asserting about the escalation to `SIGKILL` after the grace. It never exercised the rung it is named for. Both failing runs had already passed the `lock_is_held` precondition an earlier fix added, so the "was already finished" branch the in-code comment blamed was not what happened.

## The fix

The shell itself has to survive, and must stay runnable rather than parked inside a child:

```sh
trap '' TERM; while :; do sleep 1; done
```

`sh` — the lock holder and group leader — stays alive across the whole grace, while its short-lived children are free to die to the same signal without ending the run.

## Witness

The test now takes **8.09 s**, the full `STOP_GRACE`, where it previously returned in ~81 ms. **That duration is the assertion**: the child survived the grace and was killed at the end of it.

```
cargo test -p stella-cli --bins a_run_that_ignores_term  → 1 passed (8.09s)
cargo fmt --all --check                                  → 0
```

## Summary by Sourcery

Ensure the stubborn-run test fixture survives the initial termination signal so the grace-period kill behavior is tested deterministically.

Bug Fixes:
- Fix the stubborn-run fixture so it remains alive through the stop grace period and reliably exercises termination escalation.

Enhancements:
- Document why the fixture must keep the shell process runnable while its child processes receive group signals.

Tests:
- Harden the daemon termination test against false early exits caused by the fixture's child process.