### PR TITLE
fix(bench): loop-bench sets no spend cap, so its trials can finish

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -44,10 +44,6 @@ on:
         description: "Provider/model (blank = the pinned nightly model)"
         required: false
         type: string
-      budget:
-        description: "Per-task USD cap (blank = the pinned nightly budget)"
-        required: false
-        type: string
       min_pass:
         description: "Fail if fewer than N tasks pass; 0 disables (blank = the pinned floor)"
         required: false
@@ -78,7 +74,6 @@ env:
   # every night. Pinned here rather than inherited from the harness default for
   # the same reason as the task list.
   LOOP_BENCH_MODEL: "openrouter/z-ai/glm-4.7-flash"
-  LOOP_BENCH_BUDGET: "0.20"
   # The pass-rate floor (#873), OFF until this job has a history to set it
   # from. A floor guessed rather than observed is red every night on a
   # flash-tier model under a $0.20 cap, and a gate that is always red is a gate
@@ -219,7 +214,6 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           TASKS: ${{ inputs.tasks || env.LOOP_BENCH_TASKS }}
           MODEL: ${{ inputs.model || env.LOOP_BENCH_MODEL }}
-          BUDGET: ${{ inputs.budget || env.LOOP_BENCH_BUDGET }}
           MIN_PASS: ${{ inputs.min_pass || env.LOOP_BENCH_MIN_PASS }}
         run: |
           set -euo pipefail
@@ -236,7 +230,6 @@ jobs:
           cargo run --quiet -p loop-bench -- \
             --tasks "$TASKS" \
             --model "$MODEL" \
-            --budget "$BUDGET" \
             --min-pass "$MIN_PASS" \
             --timeout "$LOOP_BENCH_HARBOR_TIMEOUT" \
             --json-out loop-bench-out/report.json \

--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -29,8 +29,8 @@ cargo run -p loop-bench -- --analyze-only --jobs-dir <dir> --job-name <name>   #
 ```
 
 Defaults: 4 tasks from `DEFAULT_POOL`, `openrouter/z-ai/glm-4.7-flash`,
-`--budget 0.20` USD/task (passed on as `STELLA_SPEND_LIMIT`), `--concurrent 4`,
-`--dataset terminal-bench`, output under `loop-bench-jobs/loop-bench/`.
+`--concurrent 4`, `--dataset terminal-bench`, output under
+`loop-bench-jobs/loop-bench/`.
 `--stella-binary` / `$STELLA_BINARY` names the uploaded binary; `--json` emits
 the report for CI instead of the table, and `--json-out <path>` writes that same
 report to a file while the table still goes to stdout.
@@ -308,10 +308,12 @@ way.
   the verifier must not read as a verifier failure. Only harbor's
   `verifier/reward.txt` is read, not its `reward.json` alternative; a
   `--dataset` whose verifier writes the JSON form under-credits every trial.
-- A `--budget` that is non-finite, non-positive, **or smaller than the `0.0001`
-  the cap is transmitted at** denies the very first model call, so every task
-  reports as a loop failure: the harness manufacturing the signal it gates on.
-  It warns rather than proceeding silently.
+- There is **no per-trial spend cap, deliberately** (#3009). The adapter
+  refuses `STELLA_SPEND_LIMIT` outright (#2411) because a cap truncates a trial
+  into a loss — and loss is exactly what this harness measures, so a cap would
+  manufacture the silent-death and zero-work signals it gates on. Cost is bounded
+  by the flash-tier default model, the task count, `--timeout`, and the provider
+  key, which fails a run visibly instead of truncating one.
 - `$STELLA_BINARY` must be a **Linux amd64** build; that is what the task
   containers run. Unset, it warns, and the adapter then resolves `stella` on
   `PATH` before `target/release/stella` — on a dev machine the `PATH` hit is a

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -9,14 +9,14 @@
 //! Stella's own event stream, and they show up on a **cheap** model just as
 //! clearly as an expensive one.
 //!
-//! So this tool runs N Terminal-Bench tasks through Stella — cheap model,
-//! budget-capped, in parallel — and reports the correctness signals that the
+//! So this tool runs N Terminal-Bench tasks through Stella — cheap model, in
+//! parallel — and reports the correctness signals that the
 //! pass-rate number hides. The report types, verdict vocabulary, and
 //! distillation live in this crate's library (`src/lib.rs`), where the
 //! contract is documented; this binary is the CLI + subprocess orchestration.
 //!
 //! ```bash
-//! # cheapest: 4 tasks on a flash-tier model, $0.20/task cap, 4 concurrent
+//! # cheapest: 4 tasks on a flash-tier model, 4 concurrent
 //! cargo run -p loop-bench -- --n 4
 //!
 //! # pick tasks + model explicitly
@@ -115,16 +115,20 @@ struct Args {
     tasks: Vec<String>,
 
     /// Provider/model to run. Defaults to a flash-tier model for cheapness.
+    ///
+    /// Cheapness is the cost control here, along with the task count and
+    /// harbor's own timeout. There is deliberately **no `--budget`**: a
+    /// per-trial `STELLA_SPEND_LIMIT` is refused by the adapter (#2411)
+    /// because a cap truncates a trial into a loss, and this harness is the
+    /// worst possible place for that — silent-death and zero-work are the
+    /// exact signals it reports, so a cap would manufacture the failures it
+    /// exists to detect. Bound spend at the provider key (#3009).
     #[arg(short = 'm', long, default_value = DEFAULT_MODEL)]
     model: String,
 
     /// Concurrent trials.
     #[arg(long, default_value_t = 4)]
     concurrent: usize,
-
-    /// Per-task USD budget cap (STELLA_SPEND_LIMIT).
-    #[arg(long, default_value_t = 0.20)]
-    budget: f64,
 
     /// Harbor dataset name.
     #[arg(long, default_value = "terminal-bench")]
@@ -518,22 +522,6 @@ fn resolve_tasks(args: &Args) -> Vec<String> {
 /// `model` and `job_name` are parameters rather than reads off `args` because
 /// `--compare` runs this once per arm, each into its own job directory.
 fn run_harbor(args: &Args, tasks: &[String], model: &str, job_name: &str) -> Result<(), i32> {
-    // A non-positive (or NaN) cap denies the very first model call, which
-    // would report as a zero-work loop failure for every task — the harness
-    // manufacturing the signal it gates on. Warn loudly rather than hand
-    // harbor a cap that cannot pass. The threshold is not `<= 0.0` because the
-    // cap reaches stella at four decimals (see the `STELLA_SPEND_LIMIT` env below),
-    // so a positive-but-tinier-than-that cap is rounded to `0.0000` and is
-    // exactly as unspendable — check the value that will actually be sent, not
-    // the one the operator typed.
-    if !args.budget.is_finite() || args.budget < 0.000_05 {
-        eprintln!(
-            "warning: --budget {} reaches stella as {:.4}, which is not a spendable \
-             cap; every trial will be denied before its first tool call and report as \
-             a loop failure",
-            args.budget, args.budget
-        );
-    }
     // Floored like `--n` (#611): harbor's behavior at `-n 0` is undefined
     // from here, and an operator asking for zero concurrency meant one.
     let concurrent = args.concurrent.max(1);
@@ -566,7 +554,6 @@ fn run_harbor(args: &Args, tasks: &[String], model: &str, job_name: &str) -> Res
         cmd.args(["-i", task]);
     }
 
-    cmd.env("STELLA_SPEND_LIMIT", format!("{:.4}", args.budget));
     match &args.stella_binary {
         Some(path) => {
             cmd.env("STELLA_BINARY", path);
@@ -591,11 +578,10 @@ fn run_harbor(args: &Args, tasks: &[String], model: &str, job_name: &str) -> Res
     cmd.env("PYTHONPATH", pythonpath);
 
     eprintln!(
-        "▶ loop-bench: {} task(s) × {} trial(s) on {} (budget ${:.2}/task, {} concurrent)",
+        "▶ loop-bench: {} task(s) × {} trial(s) on {} ({} concurrent)",
         tasks.len(),
         args.trials.max(1),
         model,
-        args.budget,
         concurrent
     );
     let mut child = cmd.spawn().map_err(|e| {


### PR DESCRIPTION
Closes #3009

Every nightly-bench run has been reporting `LOOP: 4/4 broken … SPEND: $0.00` — not the model failing four tasks, but **no trial reaching a model call at all**. The adapter refuses `STELLA_SPEND_LIMIT` outright (#2411), and loop-bench set it from `--budget` on every invocation, so every trial died in setup.

## Why the flag is removed, not defaulted to empty

Any non-empty value killed the run, so it had **no working setting**. A flag whose only two outcomes are "kills every trial" and "unset" is not a control, and leaving it would invite the same red nightly the next time someone passed one.

## Why a cap is especially wrong here

#2411's reasoning is that a cap "truncates a trial into a loss". Loss is precisely what this harness measures — silent death, zero work, a stuck loop. **A spend cap manufactures the failure signals the tool exists to detect.** loop-bench already said so in its own warning about a too-small cap, which is now unreachable and removed with it.

## What still bounds the cost

A flash-tier default model, the task count, harbor's wall-clock `--timeout`, and the provider key — which fails a run visibly instead of silently truncating one, exactly as the refusal prescribes.

## Also

Removes the `budget` workflow input, `LOOP_BENCH_BUDGET`, and the `--budget` argument, and clears two stale module-doc claims ("budget-capped", "$0.20/task cap") that would otherwise describe a flag that no longer exists.

```
cargo build -p loop-bench                             → 0
cargo clippy -p loop-bench --all-targets -D warnings  → 0
cargo fmt --all --check                               → 0
check-action-pins                                     → 0
```

## Summary by Sourcery

Remove per-trial spending limits from loop-bench so trials can execute normally and report genuine benchmark failures.

Bug Fixes:
- Remove the loop-bench spend cap that prevented trials from reaching model calls and falsely reported loop failures.

Enhancements:
- Update loop-bench documentation and runtime messaging to reflect provider-key and execution settings as the remaining cost controls.

CI:
- Remove the nightly workflow's budget input, environment variable, and CLI argument.

Documentation:
- Document the deliberate absence of a per-trial spend cap and remove stale budget-cap guidance.