### PR TITLE
docs(stella-pipeline): the LadderDecision enum is the enumeration, not six copies of it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,13 +439,15 @@ creates the oracle rather than substituting for one — its test either goes
 fail→pass or does not, and that is decided by running it. Everything downstream
 is deterministic: `ladder_decision`
 (`crates/stella-pipeline/src/verify.rs`) is terminal at **every** one of its
-outcomes — the `LadderDecision` enum beside it is the enumeration, and today
-that is `SubmitFast`, `Revise`, `WitnessUnsatisfiable`, `NothingAttempted`,
-`Unverifiable` and `Unverified`. The count is deliberately not the load-bearing
-half of that sentence: what matters is that no arm escalates to a model, which
-the enum's own doc comments each state. (This paragraph said "all five" and
-omitted `WitnessUnsatisfiable` for as long as that variant existed — #3473,
-the shared-cell drift this file warns about, in this file.) The verify stage
+outcomes, and **no arm escalates to a model** — which is the load-bearing half
+and is *not* implied by terminality, since a terminal arm could spend a verifier
+call and then stop. That guarantee is stated once, in the `LadderDecision`
+enum's own doc comment, quantified over the variants beside it; this file
+deliberately does not restate the list or its count, because a number copied
+into a second file drifts. It did: this paragraph said "all five" and omitted
+`WitnessUnsatisfiable` for as long as that variant existed, and so did five
+other copies including the enum doc it now cites (#3473) — the shared-cell
+failure this file warns about, in this file. The verify stage
 emits the `Verdict` event from that answer directly — the
 pipeline never emits `StageKind::Verdict` itself, which is why the rank above is
 an ordering, not a stage the run passes through. The model verdict and the

--- a/crates/stella-pipeline/README.md
+++ b/crates/stella-pipeline/README.md
@@ -50,7 +50,7 @@ The three moves, in dependency order:
    it — triage/recall/research/plan/scope are `before_turn`, witness is `after_turn`,
    verify is `judge`, revise is `again?`. `judge` may not call a model, which
    [`src/verify.rs`](src/verify.rs)'s `ladder_decision` already satisfies: it is
-   terminal at all five outcomes and #2584 removed the model verdict structurally.
+   terminal at every arm and #2584 removed the model verdict structurally.
 3. **Stages become a manifest** (#3381, open): the ordered stage list moves into the
    `[wrapper]` block [`stella-plugin`](../stella-plugin) already parses, keyed by a
    variant id the store's `pipeline_variant` column records (#3388, landed) so two
@@ -192,8 +192,12 @@ loop). A mismatch aborts the candidate *before* the ladder runs. It is
 an authority boundary, not evidence for a model to weigh, and no verifier can override it.
 
 **The evidence ladder is the whole decision, and every rung is terminal.**
-`ladder_decision` is a pure function over `LadderInputs` returning one of five outcomes, in
-order: touched tests red → `Revise` (already deterministic; nothing is spent confirming it);
+`ladder_decision` is a pure function over `LadderInputs` returning one arm of `LadderDecision`
+— that enum is the enumeration, and this list is an ordering rather than a second copy of it
+(#3473). In order: an authored witness that failed *the same way* on both trees →
+`WitnessUnsatisfiable` (#2540 — its red says nothing about the change, and the worker cannot
+repair an instrument, so this outranks `Revise`); touched tests red → `Revise` (already
+deterministic; nothing is spent confirming it);
 a turn that dispatched nothing that could mutate → `NothingAttempted`; every channel dark →
 `Unverifiable` (abstain); flip + green + within budget + no fresh diagnostics + a
 non-tautological witness that covered the diff → `SubmitFast`; anything else →
@@ -372,7 +376,7 @@ contract.
   this crate enforces at runtime; "Architecture: ports, not concretions" for the inherited
   no-I/O and byte-stable-prompt rules.
 - [`../../website/content/docs/inference-pipeline.mdx`](../../website/content/docs/inference-pipeline.mdx)
-  — the full stage flow, the five terminal ladder outcomes, and the `/pipeline` deck toggle.
+  — the full stage flow, the terminal ladder outcomes, and the `/pipeline` deck toggle.
 - [`../../docs/spec/replay-golden-trajectories.md`](../../docs/spec/replay-golden-trajectories.md) — the
   recording procedure and the reference-engine adapter contract.
 - [`../stella-core`](../stella-core) — `Engine::run_turn`, the loop this crate composes.

--- a/crates/stella-pipeline/src/verify.rs
+++ b/crates/stella-pipeline/src/verify.rs
@@ -369,13 +369,24 @@ pub fn normalize_command(command: &str) -> String {
     command.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// The five ways the evidence ladder resolves a turn — all of them terminal,
-/// and all of them decided from deterministic observations alone (L-E11).
+/// The ways the evidence ladder resolves a turn — all of them terminal, and
+/// all of them decided from deterministic observations alone (L-E11).
 ///
-/// There is deliberately no "ask a model" arm. Every variant here is a
+/// **This enum is the enumeration**, and prose elsewhere cites it rather than
+/// restating the list. That is not a style preference: this doc comment said
+/// "the five ways" for as long as there had been six variants, and the wrong
+/// count had been copied into `AGENTS.md`, `doc:turn-loop-wrappers`,
+/// `doc:witness-protocol`, this crate's README and two public web surfaces
+/// before anyone counted the arms (#3473).
+///
+/// There is deliberately no "ask a model" arm — the property that matters, and
+/// the one terminality alone does **not** imply, since a terminal arm could in
+/// principle spend a verifier call and then stop. Every variant here is a
 /// conclusion the oracle reached itself; a turn the oracle cannot settle
 /// resolves to [`Self::Unverified`], which is an honest "not proven" rather
-/// than a second model's opinion wearing a verdict's clothes.
+/// than a second model's opinion wearing a verdict's clothes. A seventh arm
+/// that bought a model call would break this sentence, which is why the
+/// guarantee is stated here, once, beside the variants it quantifies over.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LadderDecision {
     /// Deterministic pass: flip achieved + touched-tests-green + diff within

--- a/docs/prompts/verdict.md
+++ b/docs/prompts/verdict.md
@@ -39,7 +39,7 @@ They answer different questions, and only one of them has an oracle.
 that failed before the change and passes after it settles it, and where no such
 flip exists, no amount of reading settles it either. That is the pipeline's
 question, and #2584 replaced its model verdict with
-`LadderDecision`'s five terminal outcomes — measured, that verdict agreed with
+`LadderDecision`'s terminal outcomes — measured, that verdict agreed with
 Terminal-Bench's grader 46% of the time and 17 of its false passes cost 5 tasks
 outright.
 

--- a/docs/spec/witness-protocol.md
+++ b/docs/spec/witness-protocol.md
@@ -47,7 +47,8 @@ Anything below that would weaken these is out of scope by construction.
 **Update (#2584): the ladder took the principle to its end.** This document was
 written when the ladder's inconclusive arm escalated to a model verifier, and
 several sections below reason about *when that call is bought*. It is no longer
-bought at any rung — `ladder_decision` is terminal at all five outcomes, and
+bought at any rung — `ladder_decision` is terminal at every arm of
+`LadderDecision`, that enum being the enumeration (#3473), and
 inconclusive evidence resolves to `LadderRung::Unverified` with no model
 consulted. Read every "buys/spares the verifier call" below as **"buys/spares
 the escalation"**: the decisions still happen and the guards still run, but what

--- a/website/public/presentations/turn-loop/index.html
+++ b/website/public/presentations/turn-loop/index.html
@@ -1978,7 +1978,7 @@ var STAGES=[
   d:["Run the oracle. Did the command flip from failing to passing? Was the witness file tampered with? What does the diff actually show?",
      "This spends <b>no model call</b>. The one verifier-tier call in the whole story was writing the test, and that survives because it creates the measuring stick rather than replacing it."]},
  {t:"Verdict",c:"#5fcf94",cond:"always · terminal",
-  d:["A deterministic ladder produces one of five outcomes: submit, revise, nothing was attempted, unverifiable, or unverified. Every one is terminal.",
+  d:["A deterministic ladder produces one outcome: submit, revise, an unsatisfiable witness, nothing was attempted, unverifiable, or unverified. Every one is terminal.",
      "The pipeline does not emit a separate verdict stage — it reads the ladder's answer directly. Which is why the stage order is an ordering, not a place the run passes through."]},
  {t:"Revise",c:"#f0a35f",cond:"bounded loop",
   d:["A verdict of “revise” sends the run back — and it lands on <b>execute</b>, not on plan.",


### PR DESCRIPTION
## What

`#3477` fixed AGENTS.md's "all five" but left the same hardcoded ladder-arm
count in six other places — including the `LadderDecision` doc comment every
one of those copies was derived from. This retires the count everywhere and
states the guarantee once, beside the variants it quantifies over.

Files swept:

- `crates/stella-pipeline/src/verify.rs` — the enum doc comment, which said
  "the five ways" for as long as there had been six variants.
- `crates/stella-pipeline/README.md` (two copies) — plus the ladder listing
  gains the `WitnessUnsatisfiable` rung it was missing, ranked above `Revise`
  per #2540.
- `docs/spec/witness-protocol.md`, `docs/prompts/verdict.md`
- `website/public/presentations/turn-loop/index.html` — the Verdict slide
  enumerated five arms to a public audience.
- `AGENTS.md` — sharpened: the load-bearing claim is not terminality but that
  **no arm escalates to a model**, which terminality alone does not imply
  (a terminal arm could spend a verifier call and then stop).

## Why

This is the shared-cell drift AGENTS.md itself warns about: a count copied into
a second file drifts, and this one drifted into seven. The fix is to make the
enum the single enumeration and have prose cite it.

## Witness

Docs/prose only — no behavior change, so no witness test. Verified with
`make guards-fast` (green, including `doc-links`, `file-size`, `gate-parity`),
`RUSTDOCFLAGS="-D warnings" cargo doc -p stella-pipeline --no-deps` (clean), and
`cargo test -p stella-pipeline --lib` (742 passed).

No tests were deleted.

Refs #3473

## Summary by Sourcery

Align ladder documentation around `LadderDecision` as the authoritative enumeration and clarify its no-model-escalation guarantee.

Bug Fixes:
- Correct outdated ladder outcome counts and restore the missing `WitnessUnsatisfiable` outcome across pipeline documentation and public presentation content.

Enhancements:
- Make the `LadderDecision` enum the single source of truth for ladder outcomes and clarify that every arm is terminal without escalating to a model.

Documentation:
- Update crate, specification, prompt, agent guidance, and presentation documentation to reference all terminal ladder arms without duplicating a fragile count.