### PR TITLE
docs(website): the turn-loop deck says who owns a turn's ending, and where the loop is going

### DIFF
--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -44,20 +44,29 @@ Stella has two ways to run a prompt:
   No stages, no verification.
 - **The staged pipeline** (`stella run`, the default; per-turn in the Command
   Deck while `/pipeline` is ON): the step loop wrapped in the stages below,
-  with deterministic verification and terminal-event ownership moved up into
-  `Pipeline::run`.
+  with deterministic verification and a run-level ending of its own, emitted
+  beside the engine's per-turn endings rather than in place of them.
 
 "Full pipeline mode" is the second one. The engine still does all the actual
 work — reading files, editing, running commands — but the pipeline decides
 *when* the engine runs, *what evidence* is collected around it, and *whether
 the result may be called done*.
 
-The pipeline owns the terminal events. `Engine::run_turn` emits its own
-`Stage { Complete }` per turn, which is correct for one turn but wrong for a
-multi-step or revising run — so the pipeline gives each engine turn a private
-channel, forwards everything except the engine's stage/terminal events, and is
-the single authority for `Complete` / terminal `Error` (see the "Event
-ownership" section of the `pipeline.rs` module docs).
+**The engine owns each turn's ending; the pipeline owns the run's** (#3379).
+`Engine::run_turn` ends every turn with its own `TurnComplete` — *this turn is
+over*, never *the work is over* — and each one reaches the consumer unedited,
+so a three-turn plan puts three in the journal. A plan step or a revise round
+simply requests another turn. The pipeline's own ending is a separate event
+with a separate name: `Complete` on success or a non-retryable `Error` on
+failure, exactly once and last, enforced by `crate::replay::validate_stream`.
+
+Until #3379 the connection ran both ways: the pipeline handed each turn a
+private channel and forwarded everything except the engine's stage/terminal
+events, making itself the single authority on when a run was over. That is the
+shape `doc:turn-loop-wrappers` §3 retired — a wrapper reads the engine's
+stream and never edits it, which is also the precondition for the wrapper ever
+being a plugin. See the "Event ownership" section of the `pipeline.rs` module
+docs for the current contract.
 
 ## 1. Intake: triage and recall run side by side
 

--- a/website/public/presentations/turn-loop/index.html
+++ b/website/public/presentations/turn-loop/index.html
@@ -204,7 +204,8 @@ text{font-family:var(--sans);fill:var(--ink2)}
       <a href="#s-record"><span class="n">27</span><span>Writing the turn down</span></a>
       <a href="#s-reflect"><span class="n">28</span><span>Reflection → memories → skills</span></a>
       <a href="#s-foundry"><span class="n">29</span><span>The tool foundry (short version)</span></a>
-      <a href="#s-next"><span class="n">30</span><span>What the next two decks cover</span></a>
+      <a href="#s-plugins"><span class="n">30</span><span>Where the loop is going — wrappers become plugins</span></a>
+      <a href="#s-next"><span class="n">31</span><span>What the next two decks cover</span></a>
     </div>
     <div class="toc-part">
       <div class="h">Appendix</div>
@@ -872,11 +873,21 @@ text{font-family:var(--sans);fill:var(--ink2)}
       from failing to passing, what does the diff say. There is exactly <b>one</b> extra model
       call in the whole verification story, and it is the one that <em>writes the test</em>. That
       survives because it creates the measuring stick rather than replacing it.</p></div>
-    <div class="card"><h4>The pipeline owns the ending</h4>
-      <p>The engine emits its own "complete" event, which is right for one turn and wrong for a
-      plan with a revise loop. So each turn gets a private channel; the pipeline forwards
-      everything except those, and emits the real ending itself.</p></div>
+    <div class="card"><h4>The engine owns its turn's ending</h4>
+      <p>Each turn ends with the engine's own event, meaning <em>this turn is over</em> — never
+      <em>the work is over</em>. A plan step or a revise round just asks for another turn, and
+      three turns put three endings in the journal, unedited. The pipeline's own ending is a
+      separate event with a separate name, emitted once and last.</p>
+      <p class="meta" style="font-family:var(--mono);font-size:12px;color:var(--ink3)">
+      crates/stella-pipeline/src/pipeline.rs — "Event ownership"</p></div>
   </div>
+
+  <div class="note green"><p><b>This one changed, and it is worth knowing why.</b> The pipeline
+  used to hand every turn a private channel and forward everything except the engine's own
+  ending, so it could be the single authority on when a run was over. That was a two-way
+  connection between the engine and one of its callers — and a dropped event or a
+  double-closed channel produced a run that looked finished and was not. It is now
+  one-directional (#3379): the wrapper reads the engine's stream, it never edits it.</p></div>
 </section>
 
 <!-- ============ 20 stage walker ============ -->
@@ -1190,9 +1201,59 @@ text{font-family:var(--sans);fill:var(--ink2)}
   which is why an exact repeat is explicitly not a foundry proposal.</p></div>
 </section>
 
-<!-- ============ 30 next ============ -->
-<section class="slide" id="s-next" data-title="What comes next">
+<!-- ============ 30 wrappers become plugins ============ -->
+<section class="slide" id="s-plugins" data-title="Where the loop is going">
   <p class="eyebrow">Part 5 · 30</p>
+  <h2>Where the loop is going — wrappers become plugins</h2>
+  <p class="lead">Everything in Part 4 describes what ships today: <b>one step loop, one built-in
+  wrapper, and the wrapper is still the default.</b> The direction is to keep the loop and move
+  the wrapper out of the binary. Some of that has landed. Most has not, and this slide says
+  which is which — because a deck that promises the end state is how a reader ends up
+  believing a shipped binary already has it.</p>
+
+  <h3>The four points a wrapper gets</h3>
+  <div class="scroller"><table>
+    <tr><th>Point</th><th>When it runs</th><th>What it may do</th><th>What it may not do</th></tr>
+    <tr><td class="mono">before_turn</td><td>before the loop is asked for a turn</td>
+      <td>add context, pick a plan, narrow scope, choose a model role</td><td>run the loop itself</td></tr>
+    <tr><td class="mono">after_turn</td><td>once the turn's ending lands</td>
+      <td>gather evidence — run a test, read a diff, author a witness</td><td>change the turn that just ran</td></tr>
+    <tr><td class="mono">judge</td><td>after <code>after_turn</code></td>
+      <td>turn the evidence into a verdict</td><td>call a model</td></tr>
+    <tr><td class="mono">again?</td><td>after <code>judge</code></td>
+      <td>ask for another turn, or stop with an outcome</td><td>fake an ending the engine did not emit</td></tr>
+  </table></div>
+  <p><code>judge</code> and <code>again?</code> are synchronous and the <em>host</em> runs them, so
+  a plugin declares its verdict rule as data and supplies evidence — it never ships verdict code.
+  That is the same rule the staged pipeline already keeps, carried across rather than re-argued.</p>
+
+  <div class="grid g2">
+    <div class="card"><div class="num" style="color:var(--green)">LANDED</div><h4>The parts you can read today</h4>
+      <p>The engine owns its turn's ending, so no wrapper holds a private channel (#3379). The
+      wrapper socket exists — four points, two transports, and the wire one is what CI exercises
+      (<code>crates/stella-runtime/src/wrapper/</code>). A manifest grammar and an installer
+      exist (<code>stella plugin</code>). Turn records already separate <em>which door</em> from
+      <em>which wrapper ran</em>, and a NULL there means the raw loop, which is a fact rather
+      than a missing value.</p></div>
+    <div class="card"><div class="num" style="color:var(--orange)">NOT YET</div><h4>The parts that are still ahead</h4>
+      <p>Nothing dispatches through the socket: every call to it in the tree is in its own tests
+      (#3494), and no installed plugin's hooks are routed into a session either (#3521). The
+      staged pipeline is still a built-in crate, still the default, and <code>--no-pipeline</code>
+      is still the opt-out. Inverting that flag is deliberately the <em>last</em> move, because it
+      is the claim that the earlier ones worked.</p></div>
+  </div>
+
+  <div class="note blue"><p><b>How to read this deck against the binary.</b> Slide 03 says
+  <em>two loops, six doors</em>, and that is still literally true of what you install. The end
+  state is one loop, six doors, and zero built-in wrappers — at which point slide 03 gets
+  rewritten, not before.</p>
+  <p class="meta" style="font-family:var(--mono);font-size:12px;color:var(--ink3)">
+  doc:turn-loop-wrappers · doc:pipeline-as-plugins · doc:wrapper-socket</p></div>
+</section>
+
+<!-- ============ 31 next ============ -->
+<section class="slide" id="s-next" data-title="What comes next">
+  <p class="eyebrow">Part 5 · 31</p>
   <h2>What the next two decks cover</h2>
   <div class="grid g3">
     <div class="card"><div class="num" style="color:var(--gold)">THIS DECK</div>


### PR DESCRIPTION
## What & why

This started as an audit to confirm the staged pipeline had been removed and Stella now ships one simple loop. **It has not been removed, and the audit says so.** Read out of the tree at `4db593a`:

| Claim | Evidence |
|---|---|
| `stella-pipeline` still ships | 53,947 lines of Rust; a workspace member in the root `Cargo.toml`; depended on by `crates/stella-cli/Cargo.toml:78` and `crates/stella-serve/Cargo.toml:37` |
| It is still the default for `stella run` | `crates/stella-cli/src/agent.rs::run_one_shot` branches on `use_pipeline`, and `main.rs:1061` passes `!no_pipeline` — the pipeline is the default and `--no-pipeline` the opt-out |
| It is still the default for the Command Deck | `command_deck.rs:686` — "the deck drives turns through the staged pipeline by default"; `/pipeline` toggles to the raw loop |
| It is still reachable over the wire | `crates/stella-serve/src/pipeline_run.rs` drives `Pipeline::run` |

So the deck's "two loops, six doors" framing (slide 03) is still literally true of what a user installs, and this PR does **not** touch it. What did need fixing is below.

### 1. Route B's second card stated the opposite of the current contract

Slide 19 said *"The pipeline owns the ending"* — each turn gets a private channel, the pipeline forwards everything except the engine's own ending, and emits the real one itself.

#3379 retired exactly that. `crates/stella-pipeline/src/pipeline.rs`'s "Event ownership" section now documents a **one-directional** connection: the engine ends every turn with its own `TurnComplete` (*this turn is over*, never *the work is over*), each reaches the consumer unedited, and the pipeline's ending is a separate event emitted exactly once and last — enforced by `replay::validate_stream`. The card now states that, cites the module doc, and a note records what changed and why, since the two-way connection is the bug class the change deleted.

`docs/design/pipeline-journey.md` — a **living** document, the maintainer companion to the Inference Pipeline page — carried the identical stale claim and pointed the reader at the `pipeline.rs` module docs that now contradict it. Fixed in the same breath rather than left for later.

### 2. Nothing in the deck said where the loop is going

New slide 30, **"Where the loop is going — wrappers become plugins"**: the four wrapper-socket points, why `judge` and `again?` are synchronous and host-run (a plugin declares its verdict rule as data and never ships verdict code), and a landed / not-yet split that names issues instead of implying an end state has shipped.

The not-yet half is the load-bearing one, and it is the part most likely to be misremembered as done:

- The socket exists (`crates/stella-runtime/src/wrapper/`, four points, two transports) and a loader exists (`stella plugin`, `crates/stella-cli/src/plugin_cmd/roster.rs`) — **but every call to the socket in the tree is inside `crates/stella-runtime/tests/`** (#3494), and `PluginRoster::compose`/`hook_routes` have no caller outside `roster.rs`'s own `#[cfg(test)]` block, which begins at line 434 (#3521). No installed plugin participates in any turn today.
- The staged pipeline is still a built-in crate and still the default; inverting `--no-pipeline` is deliberately the last move, because it is the claim that the earlier ones worked.

`s-next` renumbers 30 → 31 and the contents slide follows.

Refs #3379
Refs #3494
Refs #3521
Refs #3573

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this changes two prose documents and one static HTML asset. No Rust, no behavior, no flags.

Verified instead by rendering the deck headlessly (Chromium via `playwright-core`, 1440x900):

- 35 slides enumerate, nav reports `1 / 35`, **no JS errors or console errors**;
- every table-of-contents `href` resolves to a slide `id`, and the only slides absent from the contents are `s-title` and `s-toc` (as before);
- the new slide renders with its four-row table intact, and the Route B card reads "The engine owns its turn's ending";
- all 22 code-map paths in appendix A1 exist on disk — hand-checked, because nothing guards them, which is what #3573 is for.

`scripts/deck-fit.mjs` does **not** measure this deck: it is a scrolling document rather than a `.slide`/`.frame` fixed-canvas one, so the script skips it with its reserved status 3. There is no layout regression to check here, and no `deck-fit.yml` signal either way.

## The gate

- [x] Docs updated where behavior/flags changed — n/a, nothing behavioral changed; the docs are the change
- [x] `doc-links` — 474 citations resolve across 75 documents
- [x] `invariants`, `command-docs`, `brand-case`, `left-behind`, `file-size`, `god-files`, `doc-warnings` — all green
- [x] `Refs #N` appears both here and as commit trailers (no `Closes` — this PR finishes no issue)
- [ ] `cargo fmt --check` / `clippy` / `cargo test --workspace` — not run: no Rust file is touched by this diff
- [ ] `shellcheck` — **did not run**: the binary is absent from this container, which stops `make guards-fast` at that step. No shell script is touched by this diff, so it has nothing to say about it; flagging it rather than implying the rung passed.

## Nothing left behind

- [x] Filed: **#3573** — the deck's code map cites 22 file paths that no guard checks, so a rename strands them silently. Written as a handoff: the proposed matcher, the two path spellings the table mixes, the `::`/`—` suffixes to strip, the `GATE_STEPS` + `AGENTS.md` + `CONTRIBUTING.md` parity requirement, and the note that `docs-guards.yml`'s triggers do not currently cover `website/public/**`.

Already tracked, so linked rather than duplicated: **#3494** (wrapper socket has no host caller), **#3521** (nothing dispatches `PluginHookRoute`), **#3387** (the blessed constructor — the pipeline still hand-rolls its engine via `Engine::with_sleeper` at `pipeline.rs:1530`, which is why the deck's "a real bug worth knowing" note on slide 22 is still accurate and was left alone).

One judgement call worth naming: `docs/spec/turn-loop-wrappers.md` §2–§3 still describes the two-way coupling in the present tense. I left it. It is `status: proposed` and pins its own reading to a named commit ("read out of the tree at `main` `730f2286c`"), so its "what happens today" is self-dating rather than stale — the honesty convention working as intended. `pipeline-journey.md` is `status: living` and made no such promise, which is why that one is fixed here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The framing question is a product decision, not a docs one.** Slide 30 commits the deck to a position: *one loop, six doors, and zero built-in wrappers is the destination, and slide 03 gets rewritten when the binary gets there, not before.* That matches `doc:turn-loop-wrappers` and `doc:pipeline-as-plugins`, both `status: proposed`. If the intended destination has changed, this slide is the wrong shape and I would rather hear that than have it ship as settled.

I deliberately did **not** rewrite the deck to describe a single loop. Doing so would have made the deck false against the binary it documents, in the direction that is hardest for a reader to detect — the deck is aimed at new engineers making their first engine change, who have no way to check it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192t8xHdJbbdxyvAhN4gsz1)_

## Summary by Sourcery

Align the turn-loop presentation and pipeline documentation with current event ownership and clarify the roadmap for moving wrappers into plugins.

New Features:
- Add a presentation slide explaining the planned transition from built-in wrappers to plugins, distinguishing shipped capabilities from future work.

Bug Fixes:
- Correct the documented event-ownership contract so engine turn endings remain visible and the pipeline emits a separate run ending exactly once and last.
- Update the pipeline journey documentation to reflect the current per-turn and run-level ending behavior.

Documentation:
- Renumber the subsequent presentation slide and update its contents of navigation and table of contents accordingly.