### PR TITLE
fix(cargo): record stella-diff's optional serde_json dep in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,9 @@ dependencies = [
 [[package]]
 name = "stella-diff"
 version = "0.9.82"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "stella-embed"


### PR DESCRIPTION
Unblocks `main`, which has been red on the required **"Cargo.lock is in sync with the manifests"** check since `132d16e02`. Because that check is required, every PR opened since inherited the red gate.

## What broke

#3560 gave `crates/stella-diff` its first dependency — `serde_json`, optional and behind an off-by-default `json` feature:

```toml
[features]
json = ["dep:serde_json"]

[dependencies]
serde_json = { workspace = true, optional = true }
```

The `Cargo.lock` delta that landed with it is exactly one line, adding `stella-diff` to `stella-tui`'s dependency list. The **`stella-diff` package block itself** was never regenerated, so the lock still recorded the crate as having no dependencies at all:

```
name = "stella-diff"
version = "0.9.82"

[[package]]
name = "stella-embed"
```

`cargo metadata --locked` requires an optional dependency to be recorded too, so the lock stopped matching the manifests.

**This is not the #3336 shape**, despite the identical symptom. I checked: every workspace member reads `0.9.82` in both the manifests and the lock, so there is no version skew and the release version-sync is not implicated.

## The change

Regenerated with `cargo metadata --offline`, specifically so no dependency version could drift while fixing a lockfile. The whole diff:

```diff
 [[package]]
 name = "stella-diff"
 version = "0.9.82"
+dependencies = [
+ "serde_json",
+]
```

Landed on its own from a fresh `main` rather than folded into another PR, per AGENTS.md's shared-cell guidance.

## Verification

| Check | Before | After |
|---|---|---|
| `cargo metadata --format-version 1 --locked` | exit 101 | exit 0 |
| `scripts/check-lockfile-sync.sh` | fails | `OK — Cargo.lock resolves against the manifests.` |
| `scripts/main-canary.sh` | `FAIL — main is red at 39f4023ba (lockfile-sync)` | `OK — main composes green at 39f4023ba.` |

The failure was reproduced locally on a clean checkout of `origin/main` before the change, so the before/after distinguishes the fix from a coincidence.

## Witness test

None, and deliberately: this is a generated-artifact repair, not a behaviour change. The witness is `scripts/check-lockfile-sync.sh` itself, which already exists, already gates, and flips fail → pass across this commit — the table above is that flip.

## Deleted tests

None.

## One thing this PR does *not* settle, and one it now does

1. **Why no pre-merge check caught it.** `ci.yml`'s lockfile step should have failed on #3560's own branch. Either it passed there and this is a merge composition against the 0.9.82 sync (#3570) that landed between — the canary working exactly as designed — or a required check has a hole. Only #3560's run log settles it, and I have not read it, so I am claiming neither. The second case is a much larger problem than this lockfile and would deserve its own issue.

2. **The `docker-serve` failure has the same root cause** — diagnosed after opening this PR, so this replaces an earlier note here that guessed it might be unrelated. Run `32074851984` fails at `Dockerfile.serve:29`:

```
RUN cargo build --release --locked --bin stella-serve
error: cannot update the lock file /src/Cargo.lock because --locked was passed to prevent this
```

That is the identical stale-lock error, so this PR clears both red runs rather than one. It also demonstrates the cost AGENTS.md names: `install.sh` builds `--locked`, so a stale lock is a broken release build, not only a red check.

Closes #3572
