### PR TITLE
fix(stella-serve): a served session carries the output ceiling it learned (#3568)

### DIFF
--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -214,6 +214,13 @@ pub(crate) async fn handle_session_turn(
         };
         config.max_steps = effective;
     }
+    // Share the session's learned output ceilings with this turn (#3568).
+    // Filled in here, and not left to the host, for the same reason
+    // `checkpoint` is: an embedder has no way to know it is expected to supply
+    // one, and a session without it is indistinguishable from a session that
+    // has simply never been refused — it just silently re-pays the
+    // affordability 402 on every turn.
+    config.session_output_ceilings = Some(sess.output_ceilings());
     let mut reverse_request_timeout = SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT;
     if let Some(requested_ms) = request.reverse_request_timeout_ms {
         let Some(effective) = validate_reverse_request_timeout(requested_ms) else {

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -75,6 +75,16 @@ pub struct SessionSpec {
     pub messages: Vec<CompletionMessage>,
     /// Engine knobs (step cap, compaction budget, sampling). `Default` is a
     /// sane starting point.
+    ///
+    /// One field here is session-scoped rather than turn-scoped and so is not
+    /// served by `Default` on a multi-turn embedder:
+    /// `EngineConfig::session_output_ceilings`, the carry that stops every
+    /// turn re-paying the affordability 402 it already learned about (#3307).
+    /// The `/v1/sessions` route fills it from the session registry (#3568); a
+    /// host driving [`Session`] directly across several turns attaches one
+    /// handle of its own and clones it into each turn's config. A handle
+    /// minted per turn is worse than none — it reads as wired and carries
+    /// nothing.
     pub config: EngineConfig,
     /// Spend guard for the turn.
     pub budget: BudgetGuard,

--- a/crates/stella-serve/src/sessions.rs
+++ b/crates/stella-serve/src/sessions.rs
@@ -80,6 +80,7 @@ use std::time::{Duration, Instant};
 
 use rand::Rng as _;
 use stella_core::BudgetGuard;
+use stella_core::driver::output_budget_recovery::SessionOutputCeilings;
 use stella_protocol::CompletionMessage;
 
 use crate::observe::SharedObserver;
@@ -147,6 +148,7 @@ impl SessionRegistry {
                     idle_since: Mutex::new(Instant::now()),
                     live: Mutex::new(None),
                     next_token: AtomicU64::new(0),
+                    output_ceilings: Arc::new(SessionOutputCeilings::default()),
                     core: Mutex::new(SessionCore {
                         history,
                         budget,
@@ -244,6 +246,17 @@ pub(crate) struct SessionEntry {
     /// The live-turn reservation — see the module docs for why a token.
     live: Mutex<Option<LiveTurn>>,
     next_token: AtomicU64,
+    /// What this session has already learned its providers will fund (#3307),
+    /// minted **once per session** and cloned into every turn's
+    /// `EngineConfig`.
+    ///
+    /// It lives here rather than beside the `checkpoint_sink` fill-in in
+    /// `crate::session::run_session` because that site runs once per *turn*: a
+    /// handle minted there would be a fresh empty cell every turn, which reads
+    /// as wired and carries nothing (#3568). The session is the shortest-lived
+    /// thing that outlives a turn, and a balance is a fact about the account
+    /// behind the session, not about one turn of it.
+    output_ceilings: Arc<SessionOutputCeilings>,
     core: Mutex<SessionCore>,
 }
 
@@ -273,6 +286,14 @@ pub(crate) struct SessionView {
 }
 
 impl SessionEntry {
+    /// The session's learned output ceilings, for this turn's `EngineConfig`
+    /// to share (#3568). One handle for the session's whole life, so a turn
+    /// refused a ceiling it cannot fund spares every later turn the same
+    /// wasted 402 round-trip.
+    pub(crate) fn output_ceilings(&self) -> Arc<SessionOutputCeilings> {
+        Arc::clone(&self.output_ceilings)
+    }
+
     /// How long this session has been idle beyond `ttl`, or `None` when it is
     /// live, recently used, or momentarily contended.
     fn idle_for(&self, now: Instant, ttl: Duration) -> Option<Duration> {

--- a/crates/stella-serve/tests/output_ceilings.rs
+++ b/crates/stella-serve/tests/output_ceilings.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A served session carries what it learned about what its account can fund
+//! (#3568).
+//!
+//! #3307 gave the output-budget clamp a session lifetime, and `stella-cli`
+//! attaches the handle that carries it. `stella-serve` did not: every served
+//! turn re-sent the configured ceiling, ate the affordability 402, and only
+//! then retried reduced — pure latency, once per turn, for as long as the
+//! balance stayed low.
+//!
+//! The shape of the witness is the counting one, because that is the only
+//! thing that can tell a handle that carries from a handle that is merely
+//! attached: a `Some(Default::default())` minted per turn would satisfy every
+//! `is_some()` assertion and still spend the wasted round-trip. Two turns of
+//! one session against a host that refuses any ask above what it can afford
+//! spend **three** provider calls, not four.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{TOKEN, next_event, open_sse, post_json};
+use serde_json::json;
+
+/// What the scripted host can fund, and the ceiling the turns ask for.
+const AFFORDABLE: u32 = 117_676;
+const CONFIGURED_CEILING: u32 = 128_000;
+
+async fn create_session(addr: std::net::SocketAddr) -> String {
+    let (status, body) = post_json(
+        addr,
+        "/v1/sessions",
+        Some(TOKEN),
+        &json!({ "system_prompt": "You are stella." }).to_string(),
+    )
+    .await;
+    assert!(status.contains("200"), "create session: {status} {body}");
+    serde_json::from_str::<serde_json::Value>(&body).unwrap()["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Start one turn of `session_id` asking for [`CONFIGURED_CEILING`] output
+/// tokens.
+async fn create_turn(addr: std::net::SocketAddr, session_id: &str, prompt: &str) -> String {
+    let create = json!({
+        "provider_id": "mock",
+        "tools": [],
+        "input": [{ "role": "user", "content": prompt }],
+        "reverse_request_timeout_ms": 20_000,
+        "engine": { "max_output_tokens": CONFIGURED_CEILING },
+    })
+    .to_string();
+    let (status, body) = post_json(
+        addr,
+        &format!("/v1/sessions/{session_id}/turns"),
+        Some(TOKEN),
+        &create,
+    )
+    .await;
+    assert!(status.contains("200"), "create turn: {status} {body}");
+    serde_json::from_str::<serde_json::Value>(&body).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Drive one turn to completion playing a gateway that prices the *ask*:
+/// anything above [`AFFORDABLE`] is refused with the 402 the engine's output
+/// budget recovery keys on, and the engine is left to repair it.
+///
+/// Returns every ceiling the turn asked for, in order.
+async fn run_turn_answering_affordably(
+    addr: std::net::SocketAddr,
+    turn_id: &str,
+) -> Vec<Option<u64>> {
+    let mut sse = open_sse(addr, &format!("/v1/turns/{turn_id}/events"), TOKEN).await;
+    let mut asked = Vec::new();
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), next_event(&mut sse))
+            .await
+            .expect("the turn must make progress")
+            .expect("the stream must not end before turn_complete");
+        match frame["type"].as_str() {
+            Some("provider_request") => {
+                let ask = frame["request"]["max_output_tokens"].as_u64();
+                asked.push(ask);
+                let outcome = if ask.is_none_or(|ask| ask > u64::from(AFFORDABLE)) {
+                    json!({
+                        "status": "error",
+                        "error": {
+                            "kind": "output_budget_exceeded",
+                            "message": "This request requires more credits, or fewer \
+                                        max_tokens.",
+                            "affordable_output_tokens": AFFORDABLE,
+                        },
+                    })
+                } else {
+                    json!({
+                        "status": "ok",
+                        "result": common::model_result("recovered"),
+                    })
+                };
+                let mut body = outcome;
+                body["request_id"] = frame["request_id"].clone();
+                let (status, body) = post_json(
+                    addr,
+                    &format!("/v1/turns/{turn_id}/provider-result"),
+                    Some(TOKEN),
+                    &body.to_string(),
+                )
+                .await;
+                assert!(status.contains("200"), "provider-result: {status} {body}");
+            }
+            Some("turn_complete") => {
+                assert_eq!(
+                    frame["outcome"]["status"], "completed",
+                    "the refusal must be repaired, not fatal: {frame}"
+                );
+                break;
+            }
+            _ => {}
+        }
+    }
+    asked
+}
+
+/// The carry, counted. Turn 1 learns the hard way — two calls, the second at
+/// the clamp. Turn 2 must open *at* the clamp, so the session spends three
+/// provider calls across two turns rather than four.
+///
+/// On `main` this fails with four: `session_output_ceilings` is left `None`
+/// for a served session, so turn 2 re-asks for the configured ceiling and
+/// re-pays the 402.
+#[tokio::test]
+async fn a_served_session_carries_its_learned_output_ceiling_between_turns() {
+    let addr = common::start_server().await;
+    let session_id = create_session(addr).await;
+
+    let turn1 = create_turn(addr, &session_id, "hi").await;
+    let first = run_turn_answering_affordably(addr, &turn1).await;
+    assert_eq!(
+        first.len(),
+        2,
+        "turn 1 asks the configured ceiling, is refused, and retries reduced: {first:?}"
+    );
+    assert_eq!(
+        first[0],
+        Some(u64::from(CONFIGURED_CEILING)),
+        "turn 1's first ask is the configured ceiling: {first:?}"
+    );
+    let clamp = first[1].expect("the retry names a ceiling");
+    assert!(
+        clamp <= u64::from(AFFORDABLE),
+        "the retry must ask for something the account can fund: {first:?}"
+    );
+
+    let turn2 = create_turn(addr, &session_id, "and again").await;
+    let second = run_turn_answering_affordably(addr, &turn2).await;
+    assert_eq!(
+        second,
+        vec![Some(clamp)],
+        "turn 2 must open at the ceiling turn 1 learned — one call, no second 402"
+    );
+
+    assert_eq!(
+        first.len() + second.len(),
+        3,
+        "three provider calls across two turns; four is the pre-#3568 behaviour"
+    );
+}


### PR DESCRIPTION
## Problem

#3307 gave the output-budget clamp a session lifetime: `EngineConfig` carries an optional `Arc<SessionOutputCeilings>`, and a turn that learns "this account cannot fund a 128K ceiling" spares every later turn of the session the wasted 402 round-trip it paid to find out. `stella-cli` attaches it; **`stella-serve` did not**. A served session left `session_output_ceilings: None` — the pre-#3307 behaviour, re-paying the refusal every turn as long as the balance stays low. Pure latency, once per turn.

## The fix

The handle is minted **once per session** on `SessionEntry` (`crates/stella-serve/src/sessions.rs`) and cloned into each turn's `EngineConfig` in `handle_session_turn` (`crates/stella-serve/src/routes/sessions.rs`).

Deliberately **not** beside the `checkpoint_sink` fill-in in `session::run_session`, which the issue names as the precedent: that site runs once per *turn*, so a handle minted there would be a fresh empty cell every time — wired to inspection, carrying nothing, and green against any `is_some()` assertion. That trap is what the counting witness below exists to decide.

Filled in by the server rather than left to the embedder for the same reason `checkpoint` is: an embedder has no way to know it is expected to supply one, and the failure is silent. A host driving `Session` directly across turns can still attach its own handle — `SessionSpec::config` is public, and its doc comment now names this as the one session-scoped field `Default` does not serve.

## Witness

`crates/stella-serve/tests/output_ceilings.rs` — two turns of one served session against a host that refuses any ask above what it can afford (`RefuseAskAbove`'s shape, over the wire's `output_budget_exceeded`). Turn 1 asks 128000, is refused, retries at 105916. Turn 2's **first** ask must already be 105916, so the session spends **3** provider calls across the two turns.

Fails on `main` with exactly the pre-fix count:

```
assertion `left == right` failed: turn 2 must open at the ceiling turn 1 learned
  left: [Some(128000), Some(105916)]
 right: [Some(105916)]
```

`make gate CARGO_SCOPE="-p stella-serve"` exits 0.

## Deleted tests

None.

Closes #3568
Refs #3307, #3528

## Summary by Sourcery

Carry learned output ceilings across served-session turns to avoid retrying unaffordable output requests.

Bug Fixes:
- Preserve learned output-budget ceilings across turns in served sessions, preventing repeated affordability refusals and unnecessary provider round trips.

Enhancements:
- Document session-scoped output-ceiling state for direct embedders and initialize it once per registered session.

Tests:
- Add an integration test verifying that a served session reuses its learned output ceiling on subsequent turns.