### PR TITLE
test(stella-tools,stella-cli): runtime prose may only name a tool that exists, and every built-in must be advertised

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -742,5 +742,11 @@ pub(crate) fn expected_isolated_pipeline_prompt(workspace_root: &std::path::Path
 #[cfg(test)]
 mod parity;
 
+/// The other half of that discipline, pointed at the tool names the steering
+/// contract spells out in prose: every built-in is introduced, and no retired
+/// one is still promised (#3557).
+#[cfg(test)]
+mod tool_names;
+
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/agent/prompt/tool_names.rs
+++ b/crates/stella-cli/src/agent/prompt/tool_names.rs
@@ -1,0 +1,146 @@
+//! The static prompts and the tool catalog, coupled in both directions
+//! (#3557).
+//!
+//! `tool_steering!()` is the one place a prompt can say what the schemas
+//! cannot — which tool to reach for first, and where each capability comes
+//! from. To do that it names all eighteen built-ins in prose, and until this
+//! module existed that prose was tied to nothing:
+//!
+//! - **A retired name could linger.** This is the defect #3557 was filed for,
+//!   found in `bash`'s sleep advisory (#3555) rather than here, but the prompt
+//!   is the larger surface: it is sent on every turn, not on a threshold.
+//! - **A new tool could be left out.** Add a tool, register it, declare its
+//!   catalog row, and every existing test stays green while the steering
+//!   paragraph still describes the surface as it was. The model is then told
+//!   its coordination tools are an enumeration that is missing one, which is a
+//!   *closed* list in the reader's eyes — the paragraph ends "use exactly what
+//!   is advertised and never assume a capability no schema names".
+//!
+//! Both directions are checked against `stella_tools::catalog`, which is the
+//! canonical table (#450), over the assembled prompt bytes rather than
+//! `prompt.rs`'s source text — the bytes are what the model receives.
+//!
+//! # Why over both prompts
+//!
+//! `PIPELINE_SYSTEM_PROMPT` is what `stella run` sends and what every bench
+//! measurement exercises, so a steering paragraph correct in `SYSTEM_PROMPT`
+//! alone is invisible to the numbers this project makes decisions from — the
+//! asymmetry `parity.rs` was written for. Both are iterated from the same
+//! `STATIC_PROMPTS` registry that module derives, so a third prompt joins
+//! these checks by existing.
+
+use stella_tools::catalog;
+
+use super::parity::STATIC_PROMPTS;
+
+/// Whether `text` names `word` as a whole word.
+///
+/// Substring matching cannot answer this question here: `task` is a tool and
+/// so are the six `task_*` rows, so a `contains("task")` is satisfied by
+/// `task_create` alone and the delegation tool could go missing unnoticed.
+/// Underscore counts as a word character for exactly that reason.
+fn names_word(text: &str, word: &str) -> bool {
+    let is_word_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    text.match_indices(word).any(|(at, _)| {
+        let before_ok = text[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_word_char(c));
+        let after_ok = text[at + word.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_word_char(c));
+        before_ok && after_ok
+    })
+}
+
+/// Anti-vacuity: these checks iterate two registries, and either coming up
+/// empty would read as a pass.
+#[test]
+fn the_registries_under_test_are_not_empty() {
+    assert!(
+        !STATIC_PROMPTS.is_empty(),
+        "no static prompt to scan — the checks below would pass vacuously"
+    );
+    assert!(
+        !catalog::ALL_NAMES.is_empty(),
+        "the tool catalog is empty — the checks below would pass vacuously"
+    );
+    assert!(
+        !catalog::RETIRED_TOOL_NAMES.is_empty(),
+        "the retired-name list is empty, so the forward check proves nothing"
+    );
+}
+
+/// The reverse direction of #3557: a built-in that exists but goes unmentioned.
+///
+/// The remedy is a sentence in `tool_steering!()`, in the group the tool
+/// belongs to — not a deletion here. A tool the steering block cannot be
+/// bothered to introduce is one the model will under-reach for, which is the
+/// exact failure the paragraph leads with `search` to fix.
+#[test]
+fn every_built_in_tool_is_named_by_the_static_prompts() {
+    let mut missing = Vec::new();
+    for (label, prompt) in STATIC_PROMPTS {
+        for name in catalog::ALL_NAMES {
+            if !names_word(prompt, name) {
+                missing.push(format!("{label}: never names the `{name}` tool"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "a built-in tool is absent from the cross-tool steering. The prompt \
+         presents its groups as complete lists, so an unmentioned tool reads \
+         as one that does not exist — introduce it in `tool_steering!()` \
+         alongside its group:\n\n{}",
+        missing.join("\n")
+    );
+}
+
+/// The forward direction: prose promising an instrument that was deleted.
+///
+/// `grep` and `glob` are deliberately not scanned — see
+/// [`catalog::RETIRED_NAMES_TOO_AMBIGUOUS_TO_SCAN`]; the steering block says
+/// "bash with grep only when you need every occurrence of one exact literal
+/// string", which is about the shell command and is true.
+#[test]
+fn no_static_prompt_names_a_retired_tool() {
+    let mut violations = Vec::new();
+    for (label, prompt) in STATIC_PROMPTS {
+        for retired in catalog::RETIRED_TOOL_NAMES {
+            if names_word(prompt, retired) {
+                violations.push(format!("{label}: names `{retired}`, retired in #3244"));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "a static prompt names a tool the agent does not have. Every turn then \
+         opens by pointing the model at an instrument that is not on its menu, \
+         which is worse than saying nothing (#3031):\n\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The checks above are only as good as `names_word`, and both of them pass
+/// when it is too lax *and* when it is too strict. This pins the two
+/// confusions that would matter.
+#[test]
+fn whole_word_matching_separates_task_from_task_create() {
+    // Too lax: the six board rows must not satisfy the delegation tool.
+    assert!(!names_word(
+        "the board: task_create, task_list, task_start",
+        "task"
+    ));
+    assert!(names_word("task_create, task_list", "task_create"));
+    // Too strict: ordinary punctuation and sentence position still count.
+    assert!(names_word("call search first", "search"));
+    assert!(names_word("(search)", "search"));
+    assert!(names_word("search", "search"));
+    assert!(names_word("use search.", "search"));
+    // A retired name inside a longer identifier is not a mention of it.
+    assert!(!names_word("read_output_buffer", "read_output"));
+}

--- a/crates/stella-tools/src/catalog.rs
+++ b/crates/stella-tools/src/catalog.rs
@@ -19,11 +19,18 @@
 //! - every built-in's [`stella_protocol::ToolContract`] ([`crate::contracts`]).
 //!
 //! **To add a tool:** register it in
-//! [`ToolRegistry::new`](crate::registry::ToolRegistry), then add one line
-//! here. Nothing else needs a count bumped. Two PRs adding different tools
-//! merge to the correct union instead of a wrong integer, and a tool
-//! registered but never declared here fails the registry tests by *name*,
-//! not by an off-by-one.
+//! [`ToolRegistry::new`](crate::registry::ToolRegistry), add one line here,
+//! and introduce it in `stella-cli`'s `tool_steering!()` prose. Nothing else
+//! needs a count bumped. Two PRs adding different tools merge to the correct
+//! union instead of a wrong integer, and a tool registered but never declared
+//! here fails the registry tests by *name*, not by an off-by-one.
+//!
+//! The third step is enforced too (#3557): the steering block presents each
+//! group as a complete list, so a tool it never mentions reads to the model
+//! as one that does not exist. `stella-cli`'s `agent::prompt::tool_names`
+//! fails by name when a row here goes unintroduced, and both it and
+//! `tests/tool_name_liveness_witness.rs` fail when prose points the model at
+//! a name in [`RETIRED_TOOL_NAMES`] instead.
 
 use stella_protocol::RiskLevel;
 

--- a/crates/stella-tools/src/catalog.rs
+++ b/crates/stella-tools/src/catalog.rs
@@ -191,6 +191,55 @@ catalog! {
     "get_environment"     => (true, true, Low, Always, "environment"),
 }
 
+/// Tool names Stella once dispatched and no longer does.
+///
+/// This list exists because #3244 deleted a tool surface that prose kept
+/// referring to. `bash`'s long-sleep advisory told the model to *"poll with
+/// `read_output`/`wait_for` instead"* for weeks after both tools stopped
+/// existing, and the test covering that string asserted it *contained*
+/// `read_output` — so the suite held the dead reference green until a manual
+/// sweep found it (#3555, #3557).
+///
+/// A retired name is the one that actually bites: a runtime string naming it
+/// hands the model a directive with nothing behind it, which is worse than
+/// silence — it teaches the model to discount the next directive too (#3031).
+/// So the liveness guards scan for **these** names rather than trying to
+/// decide in general which prose token is tool-shaped, and cannot false-fire
+/// on ordinary English.
+///
+/// Every entry must be absent from [`ALL_NAMES`], which
+/// `no_retired_name_is_also_a_live_tool` pins: restoring a tool means deleting
+/// its line here, in the same change.
+pub const RETIRED_TOOL_NAMES: &[&str] = &[
+    "apply_edits",
+    "ask_user",
+    "build_project",
+    "format_code",
+    "gather_context",
+    "graph_query",
+    "project_overview",
+    "read_output",
+    "read_symbol",
+    "run_lint",
+    "run_script",
+    "run_tests",
+    "start_process",
+    "verify_done",
+    "wait_for",
+];
+
+/// Retired names that are also ordinary words outside Stella — deliberately
+/// **not** in [`RETIRED_TOOL_NAMES`].
+///
+/// `grep` and `glob` were tool names before #3120 folded them into `search`,
+/// but they are also the shell command and the pattern syntax, and the prompt
+/// legitimately says "bash with grep only when you need every occurrence of
+/// one exact literal string". Scanning for them would fire on correct prose,
+/// so they are excluded and recorded here instead of silently omitted — the
+/// guards err toward missing a stale reference rather than blocking a true
+/// sentence, the same posture `bash.rs`'s `is_symbol_shaped` takes.
+pub const RETIRED_NAMES_TOO_AMBIGUOUS_TO_SCAN: &[&str] = &["glob", "grep"];
+
 /// Look up a tool's canonical row by dispatch name.
 pub fn get(name: &str) -> Option<&'static ToolEntry> {
     CATALOG.iter().find(|entry| entry.name == name)

--- a/crates/stella-tools/tests/tool_name_liveness_witness.rs
+++ b/crates/stella-tools/tests/tool_name_liveness_witness.rs
@@ -1,0 +1,280 @@
+//! Runtime-facing prose may only name a tool that exists (#3557).
+//!
+//! `bash`'s long-sleep advisory told the model to *"poll with
+//! `read_output`/`wait_for` instead"* for weeks after #3244 deleted both
+//! tools and the eighteen-tool restore declined to bring them back. Every
+//! bare `sleep` over the threshold handed the model a directive with nothing
+//! behind it — worse than the silence it replaced, because a directive the
+//! model cannot follow teaches it to discount the next one too (#3031).
+//!
+//! It was found by a manual issue sweep, and the test covering that exact
+//! string had been holding it green: the assertion was that the note
+//! *contains* `read_output`. #3555 fixed the string. This is the guard that
+//! makes the next one fail a test instead of shipping.
+//!
+//! # What is scanned, and why only that
+//!
+//! Two layers, both authoritative over a different thing:
+//!
+//! - [`every_advertised_schema_names_only_live_tools`] walks the live
+//!   [`ToolRegistry`] and reads each `ToolSchema` as the model receives it.
+//!   Complete by construction: a tool added tomorrow is covered without this
+//!   file being touched, because the registry is the enumeration.
+//! - [`no_runtime_string_names_a_retired_tool`] reads this crate's own
+//!   sources, which is the only way to reach the strings appended to tool
+//!   *output* — `SEARCH_TIP`, `drift_advisory`, `sleep_advisory`, `read.rs`'s
+//!   binary-file refusal, `edit.rs`'s drift echo, `ctx.rs`'s scope refusals.
+//!   Those are emitted from a dozen `format!` sites and reach the model just
+//!   as surely as a schema does.
+//!
+//! # The token rule errs toward missing
+//!
+//! Deciding in general which prose token is tool-shaped cannot be done
+//! without false-firing on ordinary English, and a guard that cries wolf gets
+//! deleted. So the scan looks only for the names that actually bite: the
+//! retired ones, declared in [`catalog::RETIRED_TOOL_NAMES`] with the two
+//! ambiguous exclusions recorded beside them. A name that never existed is
+//! not caught, and that is the deliberate trade — the same posture
+//! `bash.rs`'s `is_symbol_shaped` takes.
+//!
+//! # Doc comments stay legal
+//!
+//! Only runtime strings reach the model, so only they are scanned. `bash.rs`
+//! legitimately explains that a constant is sized the way it is because "the
+//! managed process family's `read_output`, deleted in #3244" was its original
+//! consumer — the reasoning survives its example, and deleting it would make
+//! a future reader re-derive the ratio argument. Comment lines are skipped,
+//! and `#[cfg(test)]` code is too: a test that pins the *absence* of a
+//! retired name has to be able to write it down.
+
+use std::path::{Path, PathBuf};
+
+use stella_tools::catalog;
+use stella_tools::registry::ToolRegistry;
+
+/// A line every reader of `bash.rs` recognises. Asserted before anything else
+/// so "the scan found nothing" can never be confused with "the scan was
+/// pointed at the wrong text" — the anti-vacuity discipline
+/// `stella-cli/src/agent/prompt/parity.rs` sets out.
+const BASH_ANCHOR: &str = "fn sleep_advisory";
+
+/// Files whose whole contents are test code. `#[cfg(test)]` truncation
+/// (below) handles inline modules; a crate that puts its tests in their own
+/// file needs the filename rule too.
+fn is_test_only_file(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == "tests.rs")
+}
+
+fn source_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir).expect("crate src/ is readable");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            source_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Every `` `backticked` `` token in `text`.
+///
+/// Backticks are how this codebase spells a tool name in prose, and requiring
+/// them is most of what keeps the scan off ordinary English: the word "search"
+/// in a sentence is not a claim about a tool, `` `search` `` is.
+fn backticked_tokens(text: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut rest = text;
+    while let Some(open) = rest.find('`') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('`') else { break };
+        let token = &after[..close];
+        if !token.is_empty() {
+            tokens.push(token);
+        }
+        rest = &after[close + 1..];
+    }
+    tokens
+}
+
+/// Retired names named by `text`, matched as whole backticked tokens.
+fn retired_names_in(text: &str) -> Vec<&'static str> {
+    let tokens = backticked_tokens(text);
+    catalog::RETIRED_TOOL_NAMES
+        .iter()
+        .copied()
+        .filter(|retired| tokens.contains(retired))
+        .collect()
+}
+
+/// The retired list is only meaningful while it is disjoint from the live one.
+/// Restoring a tool means deleting its line from `RETIRED_TOOL_NAMES` in the
+/// same change; otherwise this guard would forbid prose from naming a tool the
+/// agent actually has.
+#[test]
+fn no_retired_name_is_also_a_live_tool() {
+    for retired in catalog::RETIRED_TOOL_NAMES {
+        assert!(
+            !catalog::ALL_NAMES.contains(retired),
+            "`{retired}` is declared retired but is a live catalog row — a restored \
+             tool must lose its RETIRED_TOOL_NAMES line in the same change"
+        );
+    }
+    for ambiguous in catalog::RETIRED_NAMES_TOO_AMBIGUOUS_TO_SCAN {
+        assert!(
+            !catalog::ALL_NAMES.contains(ambiguous),
+            "`{ambiguous}` is recorded as an unscannable retired name but is live — \
+             delete its line, it is a real tool again"
+        );
+        assert!(
+            !catalog::RETIRED_TOOL_NAMES.contains(ambiguous),
+            "`{ambiguous}` is in both retired lists; the scannable one wins or the \
+             exclusion is meaningless"
+        );
+    }
+}
+
+/// The schemas as the model receives them. `ToolSchema::description` is what
+/// decides whether the model calls a tool at all, so a description pointing
+/// at a tool that does not exist misroutes the call it was meant to steer.
+#[test]
+fn every_advertised_schema_names_only_live_tools() {
+    let root = tempfile::tempdir().expect("a tempdir for the registry root");
+    let registry = ToolRegistry::new(root.path().to_path_buf());
+    let schemas = registry.schemas();
+    assert!(
+        !schemas.is_empty(),
+        "the registry advertised nothing — this test would pass vacuously"
+    );
+
+    let mut violations = Vec::new();
+    for schema in &schemas {
+        // The input schema's own `description` fields reach the model too.
+        let input = serde_json::to_string(&schema.input_schema).expect("a schema serializes");
+        for text in [schema.description.as_str(), input.as_str()] {
+            for retired in retired_names_in(text) {
+                violations.push(format!(
+                    "tool `{}`: schema names `{retired}`, retired in #3244",
+                    schema.name
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "an advertised schema names a tool the agent does not have — name a live \
+         tool from catalog::ALL_NAMES, or describe the capability without \
+         promising an instrument:\n\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The strings appended to tool output, which no schema walk can reach.
+#[test]
+fn no_runtime_string_names_a_retired_tool() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    source_files(&src, &mut files);
+    files.retain(|path| !is_test_only_file(path));
+    assert!(!files.is_empty(), "found no sources to scan under {src:?}");
+    assert!(
+        files.iter().any(|path| path.ends_with("bash.rs")),
+        "bash.rs is not among the scanned files — the scan is pointed at the \
+         wrong tree, not at a clean one"
+    );
+
+    let mut violations = Vec::new();
+    let mut anchor_seen = false;
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("source file is valid UTF-8");
+        // Tests must be able to write a retired name down in order to pin its
+        // absence. By convention they sit at the end of the file.
+        let runtime = match text.find("#[cfg(test)]") {
+            Some(cut) => &text[..cut],
+            None => &text[..],
+        };
+        for (index, line) in runtime.lines().enumerate() {
+            if line.contains(BASH_ANCHOR) {
+                anchor_seen = true;
+            }
+            // A doc comment explaining why a retired tool mattered is history,
+            // not a directive: it never reaches the model.
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            for retired in retired_names_in(line) {
+                violations.push(format!(
+                    "{}:{}: names `{retired}`, retired in #3244\n    {}",
+                    file.display(),
+                    index + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        anchor_seen,
+        "`{BASH_ANCHOR}` was not found in any scanned runtime source — the \
+         truncation or comment rules are eating the code under test"
+    );
+    assert!(
+        violations.is_empty(),
+        "a runtime string names a tool the agent does not have. The model is \
+         told to reach for an instrument that is not on its menu, which is \
+         worse than saying nothing (#3031). Name a live tool from \
+         catalog::ALL_NAMES, or give guidance the current surface can \
+         follow:\n\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The historical string this guard exists for, verbatim from `bash.rs` at
+/// `4db593a8d^` — the advisory that shipped for weeks before #3555.
+///
+/// Kept as a fixture rather than only checked out once, so the detector's
+/// power is re-proved on every run. Without it, a later "simplification" of
+/// [`retired_names_in`] could quietly stop catching the original defect while
+/// the two scans above stayed green against a clean tree.
+const PRE_3555_SLEEP_ADVISORY: &str = "\
+    it. If you are waiting on a background process, poll with `read_output`/`wait_for` \
+    instead";
+
+#[test]
+fn the_scan_catches_the_advisory_that_shipped() {
+    let caught = retired_names_in(PRE_3555_SLEEP_ADVISORY);
+    assert!(
+        caught.contains(&"read_output") && caught.contains(&"wait_for"),
+        "the pre-#3555 advisory must be caught by name, got {caught:?}"
+    );
+}
+
+/// The exclusions are load-bearing in the other direction: the prompt says
+/// "bash with grep only when you need every occurrence of one exact literal
+/// string", which is true and must stay sayable.
+#[test]
+fn ordinary_prose_and_ambiguous_names_do_not_fire() {
+    for benign in [
+        "use `bash` with grep only when you need one exact literal string",
+        "call `search` first; it returns the files that answer the question",
+        "reading the output of a `read_file` call",
+        "glob patterns and grep expressions are shell vocabulary",
+        "the search results are ranked",
+    ] {
+        assert!(
+            retired_names_in(benign).is_empty(),
+            "false positive on benign prose: {benign:?}"
+        );
+    }
+}
+
+#[test]
+fn the_tokenizer_reads_only_backticked_tokens() {
+    assert_eq!(backticked_tokens("a `one` b `two`"), vec!["one", "two"]);
+    // An unterminated backtick contributes nothing rather than swallowing the
+    // rest of the line as one token.
+    assert!(backticked_tokens("dangling `read_output").is_empty());
+    // A bare mention is not a claim about a tool.
+    assert!(retired_names_in("read_output as prose").is_empty());
+}


### PR DESCRIPTION
Nothing checked that runtime prose named a tool that exists. `bash`'s sleep advisory told the model to *"poll with `read_output`/`wait_for` instead"* for weeks after #3244 deleted both tools, and the test covering that string asserted it *contained* `read_output` — so the suite held the dead reference green until a manual sweep found it. #3555 fixed the string; this is the guard.

The issue comment asks for the reverse too — *"I can add a new tool and leave it out of what is advertised to the model"* — so both directions are covered.

## What lands

**`catalog::RETIRED_TOOL_NAMES`** — the fifteen names Stella once dispatched and no longer does, declared beside the live table with a comment saying #3244 deleted them. `RETIRED_NAMES_TOO_AMBIGUOUS_TO_SCAN` records `grep` and `glob` as deliberate exclusions rather than silent omissions: they are also the shell command and the pattern syntax, and the steering block legitimately says "bash with grep only when you need every occurrence of one exact literal string". `no_retired_name_is_also_a_live_tool` pins both lists disjoint from `ALL_NAMES`, so restoring a tool must delete its retired line in the same change.

**`stella-tools/tests/tool_name_liveness_witness.rs`** — two layers, over a different authority each:

- `every_advertised_schema_names_only_live_tools` walks the live `ToolRegistry` and reads each `ToolSchema` as the model receives it. Complete by construction — a tool added tomorrow is covered without this file being touched, because the registry is the enumeration.
- `no_runtime_string_names_a_retired_tool` reads the crate's own sources, the only way to reach the strings appended to tool *output*: `SEARCH_TIP`, `drift_advisory`, `sleep_advisory`, `read.rs`'s binary-file refusal, `edit.rs`'s drift echo, `ctx.rs`'s scope refusals.

**`stella-cli/src/agent/prompt/tool_names.rs`** — the prompt bytes, both directions, over the `STATIC_PROMPTS` registry `parity.rs` derives, so `PIPELINE_SYSTEM_PROMPT` (what `stella run` sends and every bench measurement exercises) is checked alongside `SYSTEM_PROMPT`:

- `every_built_in_tool_is_named_by_the_static_prompts` — the comment's direction. `tool_steering!()` presents each group as a complete list and ends "use exactly what is advertised and never assume a capability no schema names", so a tool it never mentions reads to the model as one that does not exist.
- `no_static_prompt_names_a_retired_tool` — the forward direction on the surface sent every turn, not on a threshold.

## The token rule errs toward missing

Deciding in general which prose token is tool-shaped cannot be done without false-firing on ordinary English, and a guard that cries wolf gets deleted. So the scan looks only for *retired* names — the ones that actually bite — matched as whole `` `backticked` `` tokens in stella-tools and as whole words in the prompts. `names_word` treats `_` as a word character because `contains("task")` is satisfied by `task_create` alone, which would let the delegation tool go missing unnoticed. Same posture as `bash.rs`'s `is_symbol_shaped`.

Doc comments stay legal, as the issue requires: only runtime strings reach the model. `bash.rs` still explains that a constant is sized as it is because "the managed process family's `read_output`, deleted in #3244" was its original consumer. Comment lines are skipped, and `#[cfg(test)]` code is too — a test pinning the *absence* of a retired name has to be able to write it down.

## Scope, stated rather than assumed

The source scan covers `stella-tools/src` only. Widening it to `stella-core` or `stella-pipeline` would false-fire: `verify_done` is a retired *tool* name and a live pipeline identifier. The stella-cli half is therefore over the assembled prompt bytes, not that crate's whole source.

## Verification — falsified, not assumed

Both directions were checked against a real failing tree, per the DoD.

**The pre-#3555 advisory.** `git show 4db593a8d^:crates/stella-tools/src/bash.rs` restored over the current file, then the guard run:

```
crates/stella-tools/src/bash.rs:635: names `read_output`, retired in #3244
    it. If you are waiting on a background process, poll with `read_output`/`wait_for` \
crates/stella-tools/src/bash.rs:635: names `wait_for`, retired in #3244
```

Two names, one line, reported as `file:line`. The doc-comment mentions on lines 86, 579 and 626 of that same file were correctly ignored — the half that proves the comment exemption works, rather than merely that the scan fires. `bash.rs` was then restored with `git checkout --`. `the_scan_catches_the_advisory_that_shipped` keeps that string as a fixture so the detector's power is re-proved on every run instead of resting on a checkout done once.

**A new tool left unadvertised.** A phantom `"open_pull_request"` row added to the catalog:

```
SYSTEM_PROMPT: never names the `open_pull_request` tool
PIPELINE_SYSTEM_PROMPT: never names the `open_pull_request` tool
```

Reverted after.

`make gate` — exit 0, 20 steps OK, no failing tests. Run unpiped: `make gate 2>&1 | tail` reports *`tail`'s* exit code, and an earlier run's apparent green was that artifact rather than a result.

## No ratchet, no baseline

The correct count is zero and it is zero today, so nothing here has a grandfather list. No test was deleted.

## Remaining work

`PolicyToolSet::schemas` retain-filters the advertised list (`stella-cli/src/tool_policy.rs:91`), so `"tools": {"search": "off"}` withholds a tool the static prompt still names. These guards are static and cannot see a policy decision; that is #3031's scope — steering as data on the *resolved* tool set — and the finding is recorded there rather than duplicated as a new issue.

Closes #3557

## Summary by Sourcery

Enforce consistency between Stella’s live tool surface and every runtime or prompt-facing reference to built-in tools.

Bug Fixes:
- Prevent stale runtime prose and tool schemas from advertising retired tools to the model.

Enhancements:
- Add bidirectional liveness guards ensuring every built-in tool is named by both static prompts and no retired tool is referenced.
- Define canonical retired-tool and intentionally ambiguous-name registries with consistency checks.
- Validate runtime source strings, advertised schemas, and assembled prompts while avoiding false positives in comments, tests, and ordinary prose.

Documentation:
- Update catalog guidance to require introducing new tools in the CLI steering prose as well as registering them.

Tests:
- Add coverage for retired-name detection, prompt/catalog parity, schema references, tokenizer behavior, and anti-vacuity safeguards.