### PR TITLE
docs(demo): name the two re-cut sections for the different questions they answer

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -142,7 +142,7 @@ that the deck's own layout decides, so a layout change can move content out of
 shot — or into a frame that shows a rendering defect — without failing anything.
 Nothing in the pipeline can check composition for you.
 
-## Re-cutting it
+## Changing what it shows
 
 The shot list is data, in `shots()`. A shot is a scene, a duration, a camera
 track, a cursor range, and how much of the scripted session has streamed in by


### PR DESCRIPTION
## What & why

#3592 added a **"Re-cut it every release"** section to `docs/demo/README.md`
directly above the existing **"Re-cutting it"**. Two adjacent headings a word
apart, answering unrelated questions — one is the release-process obligation,
the other is how to change the shot list — and a reader scanning the contents
cannot tell which is which. The second is the one someone editing the film is
usually looking for.

Renamed to **"Changing what it shows"**. No content change; the diff is one
line.

My own leftover from #3592 rather than something a reviewer flagged.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — a section heading in a
      Markdown file.

Verified: `make doc-links` passes (the heading is not a citation target, and
nothing links to it by anchor — checked before renaming).

## The gate

- [x] Docs updated where behavior changed — this *is* the doc change
- [ ] CLA signed
- [x] No `Closes` — this finishes no issue

Not run: the compile tiers. The diff touches one Markdown heading and no code,
so `guards-fast` is the honest rung here; `doc-links` is the guard that actually
covers this file and it passes.

## Nothing left behind

- [x] There is nothing new. Two issues from this line of work remain open and
      are unaffected: **#3591** (the composer footer's unbudgeted steer hint —
      correctly still open; #3592 used `Refs`, not `Closes`, and deliberately
      did not fix it) and **#3556** (cut the film from a real captured run).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Nothing risky here. Worth flagging only that Sourcery's automated assessment on
#3592 reported #3591 as "not addressed" — that is accurate and intended: #3592
linked it with `Refs` and its description explains why the cheap fix was written,
measured, and reverted.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mCxY8oVvG2GV85gA8ASkw)_

## Summary by Sourcery

Clarify the demo documentation heading for the section about changing the film’s shot list.

Enhancements:
- Rename the demo documentation section heading to clarify that it explains how to change what the film shows.

Documentation:
- Clarify the distinction between the demo documentation’s release recut guidance and shot-list editing guidance.