### PR TITLE
fix(plugins): three defects the adversarial audit of #3590 confirmed

### DIFF
--- a/crates/stella-cli/src/context_records/tests.rs
+++ b/crates/stella-cli/src/context_records/tests.rs
@@ -482,12 +482,21 @@ fn a_promotion_grant_does_not_arm_a_record_a_plugin_shipped() {
     let lineage = "ctx.acme.web.no-force-push";
     append_promotion(root.path(), grant(lineage, "measured over 30 days")).unwrap();
 
-    // A plugin ships that exact lineage, and the workspace ships none.
+    // A plugin ships that exact lineage, and the workspace ships none. The
+    // manifest must *declare* that record: a package whose directories exceed
+    // its declaration reconciles against nothing and contributes nothing
+    // (`plugin_cmd::package::reconciles_with_disk`), which would make this
+    // witness pass for the wrong reason — the record never loading at all,
+    // rather than loading unarmed.
     let plugin = stella_home::resolve_project_plugins_dir(root.path()).join("vera");
     std::fs::create_dir_all(plugin.join("rules")).unwrap();
     std::fs::write(
         plugin.join(crate::plugin_cmd::roster::MANIFEST_FILE),
-        "name = \"vera\"\n",
+        format!(
+            "name = \"vera\"\n\n\
+             [[records]]\nlineage = \"{lineage}\"\n\
+             statement = \"Never force-push to a shared branch.\"\n"
+        ),
     )
     .unwrap();
     std::fs::write(

--- a/crates/stella-cli/src/plugin_cmd/package.rs
+++ b/crates/stella-cli/src/plugin_cmd/package.rs
@@ -66,6 +66,15 @@
 //!   direction. The host renders **nothing** of its own about what a package
 //!   ships; it used to, and the cost was an embedding host showing a document
 //!   that omitted executable code entering the agent's tool surface.
+//!
+//!   Consent is a one-time transaction, but the directories it approved are
+//!   not — a plugin is an ordinary subprocess with no filesystem sandbox, so
+//!   its own process can write a new `tools/*.toml` any time after install
+//!   completes. [`dirs_of`] re-runs `reconcile` against the disk on **every**
+//!   load, not only the one `stella plugin install` performs, so a directory
+//!   that drifted from the consented manifest after install contributes
+//!   nothing rather than loading silently on the next session
+//!   ([`reconciles_with_disk`]).
 //! - **Retraction.** Structural, per above.
 //!
 //! # The trust gate is the roster's, not a second one
@@ -110,7 +119,10 @@ pub(crate) struct ContributedDir {
     pub(crate) dir: PathBuf,
 }
 
-/// Every plugin's contributed directory of one kind, in roster order.
+/// Every plugin's contributed directory of one kind, in roster order,
+/// withholding any plugin whose directories no longer reconcile against what
+/// its manifest declared and a human consented to (see
+/// [`reconciles_with_disk`]).
 ///
 /// Roster order is name order, and it is the precedence order for
 /// plugin-versus-plugin name collisions: the first plugin to claim a name
@@ -120,11 +132,43 @@ fn dirs_of(roster: &PluginRoster, kind: &str) -> Vec<ContributedDir> {
     roster
         .plugins()
         .iter()
+        .filter(|plugin| reconciles_with_disk(plugin))
         .map(|plugin| ContributedDir {
             plugin: plugin.manifest.name.clone(),
             dir: plugin.dir.join(kind),
         })
         .collect()
+}
+
+/// Re-run, on every load, the check `stella plugin install` runs once.
+///
+/// [`PluginManifest::reconcile`](stella_plugin::PluginManifest::reconcile) —
+/// a package's `tools/`, `skills/` and `rules/` directories must match
+/// exactly what the manifest declared and a human consented to — used to be
+/// invoked only from `stella plugin install` (`plugin_cmd.rs`), which makes
+/// "the shown document is provably complete" true for exactly one instant:
+/// install time. A plugin runs as an ordinary OS subprocess with no
+/// filesystem sandbox beyond the env-var allowlist
+/// (`crates/stella-runtime/src/wrapper/subprocess.rs`), so its own process —
+/// or any process running as the same user — can write a new
+/// `<plugin_dir>/tools/backdoor.toml` or `<plugin_dir>/rules/*.toml` at any
+/// point after install completes. Without this check, the next session's
+/// [`dirs_of`] would read that new file straight off disk with no new
+/// consent prompt anywhere on the path. Running the same check here, on
+/// every call, is what makes the guarantee hold for every session a plugin
+/// is loaded into rather than only the one that installed it.
+///
+/// A plugin that fails reconciliation contributes **nothing** of any kind —
+/// not a partial read of whatever entry still happens to match — because a
+/// package that grew one undeclared entry is not a package whose other,
+/// still-declared entries can still be trusted to be the ones consented to.
+/// The whole package is withheld until it is reinstalled against what is
+/// actually on disk, which re-shows the declaration and asks again.
+fn reconciles_with_disk(plugin: &InstalledPlugin) -> bool {
+    plugin
+        .manifest
+        .reconcile(&Inventory::of_package(&plugin.dir).listing())
+        .is_ok()
 }
 
 /// The roster this workspace's session runs under, or an empty one.

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -899,6 +899,74 @@ fn a_plugins_tool_installs_runs_as_the_plugin_and_retracts_with_it() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// **The re-check witness.** `reconcile` used to run only once, from
+/// `stella plugin install` — which makes the consent document "provably
+/// complete" true for exactly one instant. A plugin runs as an ordinary
+/// subprocess with no filesystem sandbox beyond the env-var allowlist, so its
+/// own process can write a new `tools/*.toml` into its own installed
+/// directory at any point after install completes, with no new consent
+/// transaction anywhere on the path. This test simulates exactly that write
+/// rather than trusting a hostile plugin's process to demonstrate it.
+///
+/// Before the fix, `contributed_tools` reads the installed directory straight
+/// off disk and the `backdoor` assertion fails. After the fix, a plugin whose
+/// directories no longer agree with its manifest contributes nothing at all —
+/// not even `vera_review`, which it still declares truthfully — because a
+/// package that grew one undeclared entry is not a package whose other
+/// entries can still be trusted to be the ones a human consented to.
+#[test]
+fn a_plugin_that_drifts_from_its_declaration_after_install_contributes_nothing() {
+    let _env = crate::test_env::lock();
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
+    let root = temp_root("package-drift");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let source = package(&root, "vera");
+    ships_a_package(&source, "vera");
+    install(
+        &root,
+        &source,
+        PluginScope::Project,
+        true,
+        &Settings::default(),
+    )
+    .expect("install must succeed");
+
+    assert_eq!(
+        contributed_tools(&root)
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>(),
+        vec!["vera_review".to_string()],
+        "the declared tool loads normally right after install"
+    );
+
+    // What a hostile plugin's own subprocess can do at any time while it
+    // runs: write a new file into its own installed `tools/` directory.
+    let installed_dir = stella_home::resolve_project_plugins_dir(&root).join("vera");
+    std::fs::write(
+        installed_dir.join(package::TOOLS_DIR).join("backdoor.toml"),
+        "name = \"backdoor\"\ndescription = \"not consented to\"\ncommand = [\"/bin/true\"]\n",
+    )
+    .expect("simulated post-install write");
+
+    let after = contributed_tools(&root);
+    assert!(
+        after.iter().all(|tool| tool.name != "backdoor"),
+        "an undeclared tool written after install must never be loaded: {after:?}"
+    );
+    assert!(
+        after.iter().all(|tool| tool.name != "vera_review"),
+        "a package that drifted from its declaration is withheld whole, not just the \
+         undeclared entry: {after:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// **The clone witness, extended to the sharpest contribution (#3509 +
 /// #3380).** A contributed tool is executable code that a `git clone`
 /// carried in, so it must sit behind exactly the same trust gate the

--- a/crates/stella-runtime/src/wrapper/error.rs
+++ b/crates/stella-runtime/src/wrapper/error.rs
@@ -149,6 +149,37 @@ pub enum WrapperError {
         call: stella_plugin::HostCall,
     },
 
+    /// The plugin asked for a host call after the channel that answers it had
+    /// already died, mid-conversation.
+    ///
+    /// **Distinct from [`WrapperError::UnannouncedCall`] on purpose**, even
+    /// though both leave a call unanswered: that variant means the manifest
+    /// declares no `[loop] calls`, or no [`HostCallGate`](super::HostCallGate)
+    /// was ever attached — a manifest or host misconfiguration, fixed by
+    /// editing `[loop] calls` or attaching a gate. Neither is true here — this
+    /// fires only after at least one call was already answered through this
+    /// exact gate, which proves both were fine. The fault is transport-level:
+    /// the write that carried a previous call's answer back to the child's
+    /// stdin failed (a closed stdin, a broken pipe), the writer task exited
+    /// because of it, and the plugin then pipelined another call before
+    /// noticing — a pipelining shape the framing explicitly allows. `source`
+    /// is that write failure, recovered by joining the writer task rather than
+    /// discarded: aborting it without awaiting, as the caller once did, throws
+    /// the one clue that explains what actually happened.
+    #[error(
+        "wrapper `{program}` asked the host for \"{call}\", but the channel answering an earlier \
+         call in this conversation had already failed: {source}"
+    )]
+    AnswerChannelFailed {
+        /// `argv[0]`, as declared.
+        program: String,
+        /// The capability the plugin asked for after the channel had died.
+        call: stella_plugin::HostCall,
+        /// The write failure that killed the channel.
+        #[source]
+        source: std::io::Error,
+    },
+
     /// The plugin's last message was a host call and then its stdout ended, so
     /// it could not have read the answer it asked for.
     ///

--- a/crates/stella-runtime/src/wrapper/subprocess.rs
+++ b/crates/stella-runtime/src/wrapper/subprocess.rs
@@ -223,6 +223,29 @@ impl std::fmt::Debug for SubprocessWrapper {
     }
 }
 
+/// The writer task's state for one conversation, bundled so [`SubprocessWrapper::converse`]
+/// takes it as one parameter rather than two.
+///
+/// The two fields move together for a reason, not just to satisfy
+/// `clippy::too_many_arguments`: every place `converse` reads or clears
+/// `frames` is also a place that may need to reach `writer` — a call
+/// arriving after a prior send already failed joins `writer` to recover the
+/// fault that killed it (`WrapperError::AnswerChannelFailed`) rather than
+/// reporting the unrelated "no gate" error. Splitting them back into two
+/// parameters would not remove that coupling, only hide it.
+struct WriterState<'a> {
+    /// The channel a host call is answered through. `None` from the start
+    /// when no conversation was ever offered (no gate, or the manifest
+    /// declares no `[loop] calls`); moves from `Some` to `None` when a send
+    /// finds the writer already gone.
+    frames: Option<mpsc::Sender<Vec<u8>>>,
+    /// The writer task, taken (and joined) only when a call arrives with
+    /// `frames` already `None` and the conversation was genuinely open — the
+    /// one case where the real transport fault has to be recovered rather
+    /// than discarded.
+    writer: &'a mut Option<tokio::task::JoinHandle<std::io::Result<()>>>,
+}
+
 impl SubprocessWrapper {
     /// Declare a wrapper process.
     ///
@@ -389,10 +412,15 @@ impl SubprocessWrapper {
         // host writes a recall answer the plugin is not reading because it is
         // writing something the host is not reading.
         let (frames, outbox) = mpsc::channel::<Vec<u8>>(1);
-        let writer = tokio::spawn(write_frames(stdin, outbox));
-        // A send failing means the writer is gone, which the join below
-        // diagnoses with the actual I/O error; there is nothing better to say
-        // here than "carry on and read what the child has to say".
+        // `Option`, not a bare handle: `converse` takes it the moment it needs
+        // the writer's actual outcome — a host call arriving after a prior
+        // send already failed — so the fault that killed it is joined and
+        // reported instead of discarded (`WrapperError::AnswerChannelFailed`).
+        // Left `Some` here, it is this function's to abort or join below.
+        let mut writer = Some(tokio::spawn(write_frames(stdin, outbox)));
+        // A send failing means the writer is gone, which a join diagnoses with
+        // the actual I/O error; there is nothing better to say here than
+        // "carry on and read what the child has to say".
         let _ = frames.send(body).await;
 
         // Stdin closes now unless the plugin can actually ask for something.
@@ -402,6 +430,10 @@ impl SubprocessWrapper {
         let conversation = self.gate.as_ref().filter(|gate| gate.offers_calls());
         let channel = conversation.map(|gate| gate.open());
         let frames = channel.is_some().then_some(frames);
+        let writer_state = WriterState {
+            frames,
+            writer: &mut writer,
+        };
 
         let mut stderr_seen = Vec::new();
         let mut read = 0usize;
@@ -410,7 +442,7 @@ impl SubprocessWrapper {
                 .converse(
                     &mut stdout,
                     &mut stderr,
-                    frames,
+                    writer_state,
                     channel.as_ref(),
                     &mut stderr_seen,
                     &mut read,
@@ -419,9 +451,16 @@ impl SubprocessWrapper {
             // `converse` has dropped the sender, so the writer has shut stdin
             // down and the child has its EOF. Waiting for the exit *after* the
             // answer is what keeps a plugin that answers and then dies loudly
-            // an `Exit` rather than a success.
+            // an `Exit` rather than a success. Trailing stdout is drained too
+            // — see `settle`'s own doc for why that half is not optional.
             let status = self
-                .settle(&mut child, &mut stderr, &mut stderr_seen, &mut read)
+                .settle(
+                    &mut child,
+                    &mut stdout,
+                    &mut stderr,
+                    &mut stderr_seen,
+                    &mut read,
+                )
                 .await?;
             Ok::<_, WrapperError>((response, status))
         })
@@ -436,13 +475,21 @@ impl SubprocessWrapper {
                 // the direct child alone.
                 #[cfg(unix)]
                 guard.kill_now();
-                writer.abort();
+                // `converse` already joined the writer when it needed to
+                // report its own failure (`AnswerChannelFailed`) — nothing to
+                // abort at that point, the task is gone. Any other error path
+                // leaves it running, so it is aborted here as before.
+                if let Some(writer) = writer.take() {
+                    writer.abort();
+                }
                 return Err(error);
             }
             Err(_) => {
                 #[cfg(unix)]
                 guard.kill_now();
-                writer.abort();
+                if let Some(writer) = writer.take() {
+                    writer.abort();
+                }
                 return Err(WrapperError::Timeout {
                     program: self.program.clone(),
                     timeout: self.timeout,
@@ -459,20 +506,26 @@ impl SubprocessWrapper {
         // broken pipe it causes says nothing about the answer. Any other write
         // failure did lose the request, so it is reported. A join failure — the
         // writer task panicked or was cancelled — is the same class of loss.
-        match writer.await {
-            Ok(Err(source)) if source.kind() != std::io::ErrorKind::BrokenPipe => {
-                return Err(WrapperError::Transport {
-                    program: self.program.clone(),
-                    source,
-                });
+        //
+        // `writer` is always `Some` on this path: `converse` only ever takes
+        // it on its way to returning an error, and this branch is reached
+        // only when `converse` returned `Ok`.
+        if let Some(writer) = writer {
+            match writer.await {
+                Ok(Err(source)) if source.kind() != std::io::ErrorKind::BrokenPipe => {
+                    return Err(WrapperError::Transport {
+                        program: self.program.clone(),
+                        source,
+                    });
+                }
+                Err(join) => {
+                    return Err(WrapperError::Transport {
+                        program: self.program.clone(),
+                        source: std::io::Error::other(join),
+                    });
+                }
+                Ok(_) => {}
             }
-            Err(join) => {
-                return Err(WrapperError::Transport {
-                    program: self.program.clone(),
-                    source: std::io::Error::other(join),
-                });
-            }
-            Ok(_) => {}
         }
 
         if !status.success() {
@@ -531,11 +584,18 @@ impl SubprocessWrapper {
         &self,
         stdout: &mut tokio::process::ChildStdout,
         stderr: &mut tokio::process::ChildStderr,
-        mut frames: Option<mpsc::Sender<Vec<u8>>>,
+        mut writer_state: WriterState<'_>,
         channel: Option<&super::host_call::PointChannel<'_>>,
         stderr_seen: &mut Vec<u8>,
         read: &mut usize,
     ) -> Result<Option<WrapperResponse>, WrapperError> {
+        // Whether a conversation was ever open, decided once and fixed for the
+        // whole call: `writer_state.frames` only ever moves from `Some` to
+        // `None` below (a send failure), never the reverse, so this is
+        // exactly what tells a later `None` apart from the manifest/gate case
+        // that starts `None` and stays there. See the two arms below where a
+        // call finds no sender.
+        let conversation_was_open = writer_state.frames.is_some();
         let mut framer = Framer::default();
         let mut chunk = vec![0u8; READ_CHUNK];
         let mut errchunk = vec![0u8; READ_CHUNK];
@@ -586,7 +646,49 @@ impl SubprocessWrapper {
                     PluginMessage::Response(response) => return Ok(Some(response)),
                     PluginMessage::Call(call) => {
                         let asked = call.call();
-                        let Some(sender) = &frames else {
+                        let Some(sender) = &writer_state.frames else {
+                            // Two different shapes read as "no sender", and
+                            // conflating them was the defect: reporting both
+                            // as a manifest/gate problem sends whoever is
+                            // debugging a broken pipe to edit `[loop] calls`,
+                            // which does nothing.
+                            if conversation_was_open {
+                                // The channel was open — the manifest declares
+                                // this call and a gate was attached, proven by
+                                // the fact that something was already sent
+                                // through it. It failed transport-side after
+                                // that, most likely because the child closed
+                                // its stdin without reading a prior answer
+                                // (the framing this socket documents blesses a
+                                // plugin pipelining calls ahead of reading
+                                // them). Join the writer — it has already
+                                // exited, or this call could not have found
+                                // `frames` empty — to recover *why*, rather
+                                // than aborting it unread the way the caller
+                                // once did.
+                                let source = match writer_state.writer.take() {
+                                    Some(handle) => match handle.await {
+                                        Ok(Err(source)) => source,
+                                        Ok(Ok(())) => std::io::Error::other(
+                                            "the writer task exited normally, but a send to it \
+                                             had already failed",
+                                        ),
+                                        Err(join) => std::io::Error::other(join),
+                                    },
+                                    // Unreachable in practice: nothing else
+                                    // takes `writer` before this arm can run.
+                                    // Named rather than unwrapped, per
+                                    // invariant 5.
+                                    None => std::io::Error::other(
+                                        "the writer task's outcome was already taken",
+                                    ),
+                                };
+                                return Err(WrapperError::AnswerChannelFailed {
+                                    program: self.program.clone(),
+                                    call: asked,
+                                    source,
+                                });
+                            }
                             // Stdin is already closed because the manifest
                             // declared no callable capability, so there is no
                             // way to tell the plugin it may not have this. A
@@ -612,9 +714,17 @@ impl SubprocessWrapper {
                         .map_err(WrapperError::Encode)?;
                         if sender.send(answer).await.is_err() {
                             // The writer is gone, so no further answer can
-                            // reach the plugin. Stop pretending otherwise;
-                            // the join in `exchange` reports why.
-                            frames = None;
+                            // reach the plugin. Stop pretending otherwise. If
+                            // the point response is what arrives next anyway,
+                            // `exchange`'s own join on `writer` reports why
+                            // once this function returns; if instead another
+                            // call arrives while `frames` is `None`, the
+                            // branch above joins it here and reports
+                            // `AnswerChannelFailed` directly, since
+                            // `conversation_was_open` proves that call is not
+                            // the manifest/gate problem `UnannouncedCall`
+                            // means.
+                            writer_state.frames = None;
                         }
                     }
                 }
@@ -656,41 +766,68 @@ impl SubprocessWrapper {
             })
     }
 
-    /// Drain what the child still has to say and wait for it to exit.
+    /// Drain what the child still has to say on **both** streams and wait for
+    /// it to exit.
     ///
-    /// Stderr is read to EOF first: the child may be blocked writing a
-    /// diagnostic into a pipe nobody is emptying, and waiting for a process
-    /// that cannot finish its own error message is a deadlock with a
-    /// helpful-looking cause.
+    /// `converse` stops reading stdout the instant it finds the point
+    /// response — there is no more of the wire contract left to parse — but
+    /// the pipe behind that file descriptor does not know the conversation is
+    /// over, and neither does a child still writing to it. A plugin that
+    /// prints trailing output after answering (an unflushed logger that also
+    /// targets stdout, a debug print, anything past one OS pipe buffer, ~64
+    /// KiB on Linux) fills that pipe and blocks in `write(2)`, and a child
+    /// blocked in `write(2)` never reaches `exit(2)` — so `child.wait()` below
+    /// would hang until the outer timeout killed the group, turning a plugin
+    /// that had already answered correctly into a `Timeout`. Stdout is
+    /// therefore read to EOF here exactly as stderr already was, for the
+    /// identical reason stated on that half below: waiting for a process that
+    /// cannot finish writing is a deadlock with a helpful-looking cause. The
+    /// bytes themselves are discarded — the response was already parsed and
+    /// returned — only the ceiling still applies, over both streams together,
+    /// the same accounting `converse` uses.
     async fn settle(
         &self,
         child: &mut tokio::process::Child,
+        stdout: &mut tokio::process::ChildStdout,
         stderr: &mut tokio::process::ChildStderr,
         stderr_seen: &mut Vec<u8>,
         read: &mut usize,
     ) -> Result<std::process::ExitStatus, WrapperError> {
         let mut chunk = vec![0u8; READ_CHUNK];
-        loop {
-            let filled =
-                stderr
-                    .read(&mut chunk)
-                    .await
-                    .map_err(|source| WrapperError::Transport {
-                        program: self.program.clone(),
-                        source,
-                    })?;
+        let mut errchunk = vec![0u8; READ_CHUNK];
+        let mut stdout_open = true;
+        let mut stderr_open = true;
+        while stdout_open || stderr_open {
+            let (result, is_stdout) = tokio::select! {
+                result = stdout.read(&mut chunk), if stdout_open => (result, true),
+                result = stderr.read(&mut errchunk), if stderr_open => (result, false),
+            };
+            let filled = result.map_err(|source| WrapperError::Transport {
+                program: self.program.clone(),
+                source,
+            })?;
             if filled == 0 {
-                break;
+                if is_stdout {
+                    stdout_open = false;
+                } else {
+                    stderr_open = false;
+                }
+                continue;
             }
             *read += filled;
             if *read > MAX_CAPTURE_BYTES {
                 return Err(WrapperError::OutputCap {
                     program: self.program.clone(),
-                    stream: "stderr",
+                    stream: if is_stdout { "stdout" } else { "stderr" },
                     cap: MAX_CAPTURE_BYTES,
                 });
             }
-            stderr_seen.extend_from_slice(&chunk[..filled]);
+            if !is_stdout {
+                stderr_seen.extend_from_slice(&errchunk[..filled]);
+            }
+            // Trailing stdout carries nothing this transport reads — the point
+            // response already ended the conversation — so it is drained and
+            // dropped, never buffered.
         }
         child
             .wait()

--- a/crates/stella-runtime/tests/wrapper_host_call.rs
+++ b/crates/stella-runtime/tests/wrapper_host_call.rs
@@ -312,3 +312,69 @@ async fn a_grant_below_steering_leaks_no_capability() {
         "an observer's declared call is not a call this host will answer"
     );
 }
+
+/// **A dead writer is not the same defect as a missing gate, and the real
+/// fault must not be discarded.**
+///
+/// The plugin here closes its own stdin right after reading the request —
+/// legitimate for a script that pipelines calls ahead of reading their
+/// answers, exactly as the framing doc at the top of `host_call.rs` blesses —
+/// and then keeps asking. The manifest declares `recall` and a gate is
+/// attached and answers the first ask or two normally; only once the host's
+/// write back to the child's closed stdin has actually failed and the
+/// internal writer task has exited does a further ask find no way to be
+/// answered.
+///
+/// Before the fix this returned `WrapperError::UnannouncedCall` — the
+/// manifest/no-gate error — even though the manifest plainly declares
+/// `[loop] calls = ["recall"]` and `gate` is plainly attached, which is an
+/// operator being told to fix a config that was never broken while the real
+/// transport fault (a broken pipe) is silently dropped by `writer.abort()`
+/// never being joined. This asserts the distinct, correctly-named error and
+/// that it carries the real I/O error rather than nothing.
+#[tokio::test]
+async fn a_dead_writer_mid_conversation_is_not_reported_as_a_missing_gate() {
+    let manifest = manifest(RECALLING_MANIFEST);
+    let generous = LoopGrant {
+        max_calls: Some(8),
+        ..manifest.loop_grant.clone()
+    };
+    let gate = gate(generous, DEFAULT_HOST_MAX_CALLS);
+
+    // Closing stdin immediately after the request is read guarantees the
+    // host's very first answer write lands on an already-closed pipe: no
+    // race against the host's own scheduling is needed for this test to be
+    // reliable. Three asks follow with no read in between — pipelining ahead
+    // rather than a round trip — with a short pause between each so the
+    // writer task, once it fails, has had time to exit and drop its receiver
+    // before the next ask's guard is checked.
+    let script = r#"
+read -r request
+exec 0<&-
+printf '%s\n' '{"call":"recall","id":1,"args":{"goal":"first"}}'
+sleep 0.2
+printf '%s\n' '{"call":"recall","id":2,"args":{"goal":"second"}}'
+sleep 0.2
+printf '%s\n' '{"call":"recall","id":3,"args":{"goal":"third"}}'
+"#;
+
+    let error = plugin(script, Arc::clone(&gate), Duration::from_secs(10))
+        .before_turn(before())
+        .await
+        .expect_err("a channel that died mid-conversation cannot answer a further ask");
+
+    let WrapperError::AnswerChannelFailed { call, source, .. } = &error else {
+        panic!(
+            "a dead writer must be reported as its own fault, not the manifest/gate error: \
+             {error}"
+        );
+    };
+    assert_eq!(*call, HostCall::Recall);
+    // The real cause reached the caller instead of being thrown away by an
+    // unjoined `writer.abort()`.
+    assert_eq!(
+        source.kind(),
+        std::io::ErrorKind::BrokenPipe,
+        "the recovered error names the actual transport fault: {source}"
+    );
+}

--- a/crates/stella-runtime/tests/wrapper_transport_limits.rs
+++ b/crates/stella-runtime/tests/wrapper_transport_limits.rs
@@ -202,3 +202,48 @@ async fn a_timed_out_plugin_leaves_no_surviving_grandchild() {
          evidence for",
     );
 }
+
+/// **Witness 3.** A plugin that keeps writing to stdout after it has already
+/// answered the point does not wedge the exchange.
+///
+/// `converse` stops reading stdout the instant it finds the point response —
+/// there is nothing left in the wire contract to parse — so anything the
+/// child writes after that sits in the OS pipe (about 64 KiB on Linux)
+/// nobody is draining. Before `settle` also drained stdout, a child that
+/// filled that pipe blocked in `write(2)` and could never reach `exit(2)`, so
+/// `child.wait()` hung until the outer budget below fired and the process
+/// group was killed — turning a plugin that had already answered correctly
+/// into a `Timeout`. The script writes comfortably past one pipe buffer
+/// (three times over) after its response, which is enough to reproduce the
+/// deadlock on the old code without needing anywhere near the capture
+/// ceiling.
+#[tokio::test]
+async fn a_plugin_that_talks_after_answering_does_not_wedge_the_exchange() {
+    let budget = Duration::from_secs(8);
+    let trailing_past_one_pipe_buffer = 3 * 64 * 1024;
+    let script = format!(
+        "printf '%s\\n' '{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\"context\":[]}}}}'\n\
+         yes stella | tr -d '\\n' | head -c {trailing_past_one_pipe_buffer}\n",
+    );
+
+    let started = Instant::now();
+    let response = plugin(&script, budget).before_turn(before()).await.expect(
+        "a plugin that answered correctly and then kept talking is not lost to a pipe \
+             deadlock",
+    );
+    let elapsed = started.elapsed();
+
+    assert!(
+        response.context.is_empty(),
+        "the point response itself is unaffected by what came after it"
+    );
+    // The old code did not fail differently here — it hung for the whole
+    // budget and then failed as `Timeout`. This bound is what tells the two
+    // apart: an exchange that drains the trailing output returns in well
+    // under a second, not most of an 8-second budget.
+    assert!(
+        elapsed < budget / 2,
+        "answered in {elapsed:?} of a {budget:?} budget — settle() waited on the child's exit \
+         without draining its trailing stdout, exactly the deadlock this test exists to catch",
+    );
+}


### PR DESCRIPTION
## What & why

Follow-up to #3590, which merged before these landed. An adversarial audit of
that branch — five finders over disjoint lenses, then two independent reviewers
per finding *instructed to refute it and to default to refuted when uncertain* —
confirmed three defects. All three are fixed here, none were filed.

Two are in the transport rather than the protocol, which is where the branch's
own tests were weakest: every wrapper test on #3590 used a well-behaved plugin,
and a socket has to survive a badly-behaved one.

**1. `settle()` never drained stdout — a plugin that talks after answering
wedges the host** (critical, `stella-runtime`). `converse()` returns the moment
it finds the point response; `settle()` then drained only *stderr* to EOF before
`child.wait()`. Trailing stdout sat in the OS pipe, and once it filled (~64 KiB
on Linux) the child blocked in `write(2)` and never exited — so the exchange
hung until the wrapper timeout fired (60s default, up to 600s) and the process
group was SIGKILLed, discarding a response that had already arrived and was
valid. A real regression: the implementation this replaced read both streams
concurrently via `exec::capture`; the `converse`/`settle` split added the
stderr-drain **with a comment about this exact deadlock hazard** and omitted the
stdout half. `settle()` now drains both concurrently under the shared
`MAX_CAPTURE_BYTES` ceiling.

**2. A dead answer-writer was misreported as a manifest problem** (major,
`stella-runtime`). When the task relaying host-call answers to the plugin's
stdin died, the next `PluginMessage::Call` returned `WrapperError::UnannouncedCall`
— whose text asserts "its manifest declares no `[loop] calls`, or this host
attached no gate." Both were false: the state is only reachable *after* a call
was already answered through that same gate. Meanwhile `exchange()` called
`writer.abort()` without joining, so the real `std::io::Error` was discarded
entirely. An operator was sent to edit `[loop] calls`, which does nothing, while
a broken pipe went unrecorded. Now `converse()` distinguishes "a channel that
died mid-conversation" from "no channel was ever offered", joins the writer to
recover the real error, and reports `WrapperError::AnswerChannelFailed { program,
call, source }`.

**3. Consent was kept for exactly one instant** (critical, `stella-cli`).
`PluginManifest::reconcile` ran only from `stella plugin install`; every session
load went through `dirs_of`, which read the installed directories straight off
disk. A plugin is an ordinary subprocess with no filesystem sandbox, so its own
process can write `<plugin_dir>/tools/backdoor.toml` after install completes —
and on the next session start that file was discovered, registered, and
attributed to `Principal::Plugin`, a callable tool the consent document never
named. `dirs_of` now filters through `reconciles_with_disk`, re-running
`reconcile` against a fresh read on **every** load. A drifted package
contributes nothing from any of the three surfaces — deliberately not the
still-matching subset, since a partial load lets an attacker keep whatever
already got past a human while adding to it.

Refs #3581 — this delivers that issue's load-time reconciliation, **not** its
notice. See "Nothing left behind" below.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Three, each verified **both ways** by stashing only the source file and keeping
the test:

- `a_plugin_that_talks_after_answering_does_not_wedge_the_exchange`
  (`tests/wrapper_transport_limits.rs`) — a plugin answers, then writes 192 KiB
  (3× a Linux pipe buffer) to stdout. Pre-fix: `test result: FAILED`, panicking
  on `WrapperError::Timeout` after the full 8s budget — the deadlock reproduced.
  Post-fix: passes in well under half the budget.
- `a_dead_writer_mid_conversation_is_not_reported_as_a_missing_gate`
  (`tests/wrapper_host_call.rs`) — an `sh` plugin closes its own stdin, then
  pipelines three `recall` calls. Asserts `AnswerChannelFailed` with
  `source.kind() == BrokenPipe`, i.e. the real transport error reaches the caller.
- `a_plugin_that_drifts_from_its_declaration_after_install_contributes_nothing`
  (`plugin_cmd/tests.rs`) — installs a package declaring one tool, confirms it
  loads, writes an undeclared `tools/backdoor.toml` into the *installed*
  directory without re-running install, then asserts the backdoor never loads
  **and** the declared tool stops loading too. Falsifier re-run by hand:
  stashing only `package.rs` fails it at `tests.rs:957`; restoring passes.

## Deleted tests

None. One fixture was **corrected** in `1db8f216`:
`a_promotion_grant_does_not_arm_a_record_a_plugin_shipped` hand-built a package
whose manifest declared nothing while `rules/set.toml` shipped a record. Change
3 withholds such a package whole, so the record stopped reaching the registry
and the test failed at its `.expect` on *finding* the entry — i.e. the new
behaviour is right and the fixture was stale. Declaring the record keeps the
witness testing what it was written to test; leaving it undeclared would have
made it pass for the wrong reason.

## The gate

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p stella-runtime --all-targets -- -D warnings`, and
      `-p stella-cli` likewise — **per-crate, not `--workspace`**
- [x] `cargo test -p stella-runtime` — 82 passed
- [x] `cargo test -p stella-cli` — 1805 passed, run three times (see below)
- [ ] `cargo test --workspace` — not run locally; CI is the authority
- [x] Docs updated where behavior/flags changed
- [x] CLA signed
- [x] Issue reference appears both above and as a commit trailer

**A correction to an earlier version of this description.** It claimed
`cargo test -p stella-cli (1801)` passed. That run was *filtered* to one test
(`1 passed; 1800 filtered out`) and I reported the total as a passing count —
one test ran, not 1801. That is what let the stale fixture above reach the push
instead of being caught before it. The numbers above are from the full suite,
actually run.

Three full runs on `1db8f216`: `1804 passed; 1 failed`, then `1805 passed`
twice. The single failure is
`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period` —
the known flake in #3559 and #3588 (previously closed four times as #2393,
#2804, #2828, #2902), where the child is reaped ~82 ms into an 8 s grace period
because it has not installed its `SIGTERM` handler under load. It passes alone,
and `daemon.rs` references neither `plugin_cmd` nor the wrapper, so nothing here
reaches it. No third duplicate filed.

A `WriterState` struct was introduced to stay under `too_many_arguments` after
`converse()` gained the writer-join parameter, rather than `#[allow]`-ing it.
`subprocess.rs` is 1085 lines and `error.rs` 329, both under the ceiling; no
baseline touched.

**CI is currently red here for a reason that is not this diff.** `main` is red
at `eb7c2dd48`, this branch's base, on the `Cargo.lock`-versus-manifests check
(`stella-transcript` pinned at `0.9.77` against a `0.9.83` workspace). Filed by
the canary as #3594; #3595 is the one-line repair, open against the same base
and itself `blocked` — a red `main` reds the PR that fixes `main`. I reproduced
it in a pristine worktree of `eb7c2dd48` containing none of these commits, and
`git diff eb7c2dd4..HEAD -- Cargo.lock Cargo.toml 'crates/*/Cargo.toml'` is
empty, so nothing here can move that line. I have deliberately **not** folded
the one-line fix in, though it would turn these checks green immediately —
#3594's own instructions and AGENTS.md § Gotchas both say to land it on its own
from a fresh `main`.

## Nothing left behind

One gap, tracked rather than hidden: **#3581 asked for a notice naming the
mismatch, and this PR does not emit one.** Withholding is silent — a user whose
plugin stops contributing gets no explanation. Sourcery's review caught that I
had written `Closes #3581`; the commit and this description now say `Refs`, and
#3581 carries a comment stating which half landed, why the notice is not a
one-liner (`session_roster` drops `PluginRoster::load`'s notices on purpose, and
is called once per surface, so the naive version prints three times per
session), two candidate designs, and a definition of done.

The audit itself produced exactly the three findings above and all three are
fixed; its `not_fixed` list came back empty. Two of its five lenses —
architecture-invariants and test-quality — returned **zero** findings, reported
as empty rather than padded.

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde — `AnswerChannelFailed`
      is a host-side error type and never crosses the wire

## Anything reviewers should know?

**The audit's verification design is the reason to trust these three.** Each
finding faced two reviewers told to prove it *wrong*, with "refute if uncertain"
as the default, and all three survived — refuted count zero. The same pass
produced no speculative findings, which is what makes that zero meaningful.

**#3581 was previously filed rather than fixed** — by me, earlier today, when I
noticed the install-time-only reconciliation and wrote it up instead of closing
it. The audit rated it critical. Worth stating as a calibration point: the thing
I judged as follow-up work was the most serious defect on the branch.
