### PR TITLE
docs(agents): the crate counts follow stella-transcript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,7 +525,7 @@ empty and is meant to stay empty.
 
 ## Workspace layout — where a change goes
 
-Twenty-five crates, every one under the `crates/` directory (`crates/stella-core`,
+Twenty-six crates, every one under the `crates/` directory (`crates/stella-core`,
 `crates/stella-cli`, …; the two bench members stay under `bench/`). The
 one-sentence rule of thumb below routes you to the right one; **each crate's
 own `README.md`** (linked from the table) then covers its boundary, layout,
@@ -628,7 +628,7 @@ a plan needs and the part that rarely changes:
 | `stella-store` | `src/tests.rs`, `src/lib.rs`, `src/usage.rs` |
 | `stella-tui` | `src/deck_ui.rs`, `src/views/engine.rs`, `src/views/session.rs`, `src/deck_render.rs` |
 
-The other nineteen crates carry no god files — keep it that way. Each crate's
+The other twenty crates carry no god files — keep it that way. Each crate's
 README repeats its own list under "God files — do not add lines", so the
 constraint is in view wherever planning starts.
 


### PR DESCRIPTION
#3585 added `crates/stella-transcript` and left both counts in AGENTS.md's workspace-layout section describing the tree as it was.

| Claim | Says | Is |
|---|---|---|
| `crates/` members | Twenty-five | Twenty-six (`ls -d crates/*/ \| wc -l`) |
| Crates with no god files | "the other nineteen" | Twenty — `check-god-files` reports 17 god files across **6** crates, and 26 − 6 = 20 |

Both are corrected here, and nothing else is touched.

## Why no guard caught it

`god-files` (`scripts/check-god-files.sh`) checks that the *named files* agree between `scripts/file-size-baseline.txt`, AGENTS.md and every crate README — the part that drifts dangerously, since a stale name sends a plan into a closed file. It says nothing about the surrounding sentence's arithmetic, and passes on both the old and the new wording. `module-reachability` counts crates (`28 crate(s)`, including the two bench members) but never compares that to prose.

So these two numbers are precisely the shared cell AGENTS.md warns about in the section they sit in — a count spelled out in prose, with nobody watching. Adding a guard for them is not obviously right (the file's own argument is that a count in prose is the thing to *avoid*, and the deliberate absence of a gate-step total is the worked example), so this PR corrects the numbers rather than ratifying them with a check.

## Deliberately not fixed here

`AGENTS.md:197` and `CONTRIBUTING.md:134` both say the pre-push hook narrows "rather than all 23 members". `cargo metadata --no-deps` reports **28** members today (26 crates + `loop-bench` + `request-bench`). That drift is long-standing, predates #3585, and is a different claim about a different number in a different section — folding it in would make this diff a sweep whose parts have to be reviewed separately anyway. Filed as its own issue and linked below.

## Verification

- `ls -d crates/*/ | wc -l` → 26
- `./scripts/check-god-files.sh` → OK, "17 god file(s) across 6 crate(s)" → 26 − 6 = 20
- `make guards-fast` → every guard OK through `check-diagnostic-codes`, then `lockfile-sync` FAILs on `Cargo.lock` being out of sync with the manifests.

**That lockfile failure is pre-existing on `main` and not from this change**: this commit's diff is `AGENTS.md | 4 ++--`, one file, which cannot desync a lockfile. It is what #3595 (open, mergeable) fixes. `ci.yml` path-ignores `*.md`, so the required job that runs `lockfile-sync` is not expected to start for this PR at all; if it does, it goes green once #3595 lands.

No witness test: prose-only, per CONTRIBUTING.md. No test was deleted.

Refs #3585

## Summary by Sourcery

Correct the crate and god-file counts in the workspace layout documentation.

Enhancements:
- Correct workspace documentation to report the current crate count and the number of crates without god files.

Documentation:
- Update AGENTS.md workspace-layout counts to reflect the current repository structure.