### PR TITLE
fix(stella-transcript): the grid renderer keeps prose the step loop cannot reach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "stella-transcript"
-version = "0.9.77"
+version = "0.9.83"
 dependencies = [
  "proptest",
  "serde",

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -232,6 +232,15 @@ fn render_turn(out: &mut Vec<Line>, ctx: &Ctx<'_>, turn: &Turn, index: usize) {
         }
         step_lines(out, ctx, step, index, si, &offsets[si]);
     }
+    // Prose the step loop cannot reach: reasoning emitted after the last step,
+    // and — the case that has no step at all — a turn that produced only prose.
+    // Mirrors the trailing pass in `steps_and_prose` in html.rs; without it the
+    // two renderers disagree about which prose exists.
+    for (pi, prose) in turn.prose.iter().enumerate() {
+        if prose.before_step >= turn.steps.len() {
+            prose_lines(out, ctx, prose, index, pi);
+        }
+    }
 
     if let Some(answer) = &turn.answer {
         out.push(spine_blank());

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -611,6 +611,32 @@ fn unpunctuated_prose_expands_to_its_full_body() {
     );
 }
 
+/// Reasoning emitted *after* the last step belongs to no `before_step` the step
+/// loop visits. Both renderers must still carry it, and for the same reason:
+/// one model, two renderers — a fact that exists for one and not the other is a
+/// defect in whichever is missing it, never a rendering choice.
+#[test]
+fn prose_after_the_last_step_reaches_both_renderers() {
+    let mut run = run_with(vec![step(bash("ls", &["a.txt"], Status::Ok), 0)]);
+    run.turns[0].prose = vec![Prose {
+        text: "now checking the bibliography wrapping".to_string(),
+        before_step: 1, // == turn.steps.len(), so the step loop never reaches it
+    }];
+
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+
+    assert!(
+        html::render_run(&run, &state).contains("bibliography"),
+        "HTML dropped prose sitting after the last step"
+    );
+    let grid = grid::render(&run, &state, 100);
+    assert!(
+        grid::to_ansi256(&grid).contains("bibliography"),
+        "grid dropped prose sitting after the last step"
+    );
+}
+
 // ------------------------------------------------------------------ render
 
 #[test]


### PR DESCRIPTION
Second of the two failures keeping `main` red at `eb7c2dd48`. #3595 fixes the lockfile; this fixes the test failure in `ci`'s `fmt + clippy + test` job. **Both must land for `main` to go green.**

## The failure

```
thread 'tests::unpunctuated_prose_expands_to_its_full_body' panicked at
crates/stella-transcript/src/tests.rs:608:5:
expanded grid prose lost the body of the reasoning
```

## What is actually wrong

Not folding. `grid::render_turn` emitted prose only from **inside** its step loop:

```rust
for (si, step) in turn.steps.iter().enumerate() {
    for (pi, prose) in turn.prose.iter().enumerate() {
        if prose.before_step == si { prose_lines(...) }
    }
    step_lines(...);
}
```

Any prose whose `before_step` is at or past `turn.steps.len()` has no iteration to match it, so it is dropped. Two populations:

- reasoning emitted **after the last step**;
- **every prose in a turn with no steps at all** — the loop body never runs, and the turn renders as though the agent said nothing.

The failing test builds `run_with(vec![])` — zero steps — so the prose was never rendered at all. The assertion *reads* like a fold bug, which is the misleading part: `Zoom::Everything` opens the node correctly and `prose_lines` already has the `strip_prefix` fallback for elided heads. The fold logic was never involved. The node simply never got rendered.

`html::steps_and_prose` already had the trailing pass that covers both cases:

```rust
for (pi, prose) in turn.prose.iter().enumerate() {
    if prose.before_step >= turn.steps.len() { prose_block(...) }
}
```

Only the grid was missing it — so the two renderers disagreed about which prose exists, in a crate whose stated premise is one model behind two renderers. That is why the fix mirrors html rather than inventing a grid-specific rule.

## Witness

The repo's contract is fail-on-old, pass-on-new, and I checked it the artisanal way rather than asserting it: with `grid.rs` reverted and the tests kept, **both** fail; with it restored, all 36 pass.

```
test tests::prose_after_the_last_step_reaches_both_renderers ... FAILED
test tests::unpunctuated_prose_expands_to_its_full_body ... FAILED
test result: FAILED. 34 passed; 2 failed;
```

`unpunctuated_prose_expands_to_its_full_body` (already in the tree, currently red on `main`) covers the zero-step case. It does **not** cover the other half the loop cannot reach, so this PR adds `prose_after_the_last_step_reaches_both_renderers` — a turn that *has* steps, with prose past the last one — and asserts both renderers carry it, since the defect was a divergence rather than a grid bug as such.

## Verification

- `cargo test -p stella-transcript` — 36 passed, 0 failed.
- `cargo fmt --check -p stella-transcript` — clean.
- `cargo clippy -p stella-transcript --all-targets -- -D warnings` — clean.

## Deleted tests

None.

## How this reached `main`

#3585 merged at `23:34:53`; its `fmt + clippy + test` run was created at `23:34:50` and had not reported. The gate that would have caught this failing test never got the chance — the same mechanism that let the stale lockfile through 85 minutes earlier. Filed as **#3596** (P0). This PR repairs the symptom; #3596 is the reason there were two symptoms in one evening.

Refs #3596

## Summary by Sourcery

Preserve all turn prose in grid rendering, including prose-only turns and reasoning emitted after the final step.

Bug Fixes:
- Ensure the grid renderer preserves prose emitted after the final step and prose-only turns, keeping grid and HTML output consistent.

Tests:
- Add coverage verifying prose after the last step is rendered by both output formats.