### PR TITLE
docs: update workspace members count from 23 to 28

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ running at all.
 
 The hook derives `CARGO_SCOPE` from the pushed diff via
 `scripts/impacted-crates.sh`, so a change confined to one crate compiles and
-tests that crate and its dependents rather than all 23 members (#1135). It
+tests that crate and its dependents rather than all 28 members (#1135). It
 widens to the whole workspace for a push to `main`, a tag, a diff touching a
 workspace-root manifest / `Cargo.lock` / a build script / the gate machinery,
 and for anything it cannot narrow with confidence. Two escape hatches sit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ for the server-side checks.
 
 The hook scopes the three compile tiers — clippy, rustdoc, test — to the crates
 your diff can actually reach, so a change confined to one crate no longer pays
-for all 23 members (#1135). It falls back to the whole workspace for a push to
+for all 28 members (#1135). It falls back to the whole workspace for a push to
 `main`, a tag, a diff touching a workspace-root manifest / `Cargo.lock` / a
 build script / the gate machinery, and for anything it cannot narrow with
 confidence. See what it would choose with `make impacted`. Under time pressure,


### PR DESCRIPTION
## Summary

Correct the workspace member count in AGENTS.md and CONTRIBUTING.md.

The workspace has **28 members** (26 crates under `crates/` + 2 bench members under `bench/`), not 23. The count has drifted since #1135 was written as crates were added.

## Changes

- `AGENTS.md:197`: `all 23 members` → `all 28 members`
- `CONTRIBUTING.md:134`: `all 23 members` → `all 28 members`

## Testing

Prose-only change per CONTRIBUTING.md; no new test needed.

Refs: #3603

## Summary by Sourcery

Documentation:
- Update workspace member counts in AGENTS.md and CONTRIBUTING.md from 23 to 28.