### PR TITLE
docs(design): the issue surface is introduced, not generalized from issue_ops.rs (#3600)

### DIFF
--- a/docs/design/agent-native-delivery.md
+++ b/docs/design/agent-native-delivery.md
@@ -356,12 +356,12 @@ manifest of the same name shadows the shipped one.
 
 This is not tidiness. It is the only way to know the extension surface is
 adequate: if Linear cannot be expressed as a manifest, no customer's tracker
-can be either. Today `IssueBackend` is a three-variant enum with Linear's
-GraphQL, GitHub's REST, and `gh` shelling all interleaved through
-`issue_ops.rs`, and every one of Linear's semantics — that `ENG-123` is the
-identifier shape, that Linear supplies a canonical branch name, that a team id
-scopes creation — is compiled in. Extracting Linear is therefore both the
-proof and the first migration. **It is filed as its own issue and is the
+can be either. No issue toolset ships today — there is no `IssueBackend` enum
+and no issue module in the tree — so Linear's semantics are not code to be
+extracted but the first thing the format has to carry from zero: that
+`ENG-123` is the identifier shape, that Linear supplies a canonical branch
+name, that a team id scopes creation. Expressing Linear is therefore both the
+proof and the first provider. **It is filed as its own issue and is the
 Phase 1 deliverable (§11).**
 
 ### 4.6 Binding a workspace to a provider
@@ -763,7 +763,7 @@ P4 is the phase that pays for the document. P0–P3 are the substrate it needs.
 | `Issue`, `IssueState`, `IssueClass`, `ResidueItem` | `stella-protocol` (wire types) |
 | Residue detection Pass 1 + Pass 2, policy evaluation, discharge rules | `stella-core` (pure, proptestable, no I/O) |
 | The gate stage, Pass 3's verifier call | `stella-pipeline`, beside `verify` and `witness` |
-| Provider manifests, transports, the `exec` adapter | `stella-tools`, generalizing `issue_ops.rs` |
+| Provider manifests, transports, the `exec` adapter | `stella-tools`, as new code — no issue surface exists to generalize |
 | `[delivery]`, `.stella/issues/*.toml` discovery | `crates/stella-cli/src/settings` |
 | Issue claims | `stella-fleet` ledger |
 | Receipts carrying the issue key | `stella-core::receipts` |

--- a/docs/design/agent-native-delivery/provider.linear.toml
+++ b/docs/design/agent-native-delivery/provider.linear.toml
@@ -4,14 +4,14 @@
 #
 # This file is the proof obligation of `docs/design/agent-native-delivery.md`
 # §4.5: if Linear cannot be expressed as a manifest, no customer's tracker can
-# be either, and the extension surface is decorative. Everything Stella
-# currently knows about Linear is compiled into `IssueBackend::Linear` and
-# `issue_ops.rs` — the GraphQL endpoint, that `ENG-123` is the identifier
-# shape, that Linear supplies a canonical branch name per issue, that a team
-# scopes creation. Every one of those facts appears below as data.
+# be either, and the extension surface is decorative. Stella ships no issue
+# toolset today, so none of what Linear needs is compiled in anywhere — the
+# GraphQL endpoint, that `ENG-123` is the identifier shape, that Linear
+# supplies a canonical branch name per issue, that a team scopes creation.
+# Every one of those facts appears below as data.
 #
-# Extracting Linear is therefore both the proof that the format is adequate
-# and the first migration onto it. It is filed as its own issue and is the
+# Expressing Linear is therefore both the proof that the format is adequate
+# and the first provider onto it. It is filed as its own issue and is the
 # Phase 1 deliverable (§11).
 #
 # WHAT THIS FILE MUST NOT NEED: a `linear = true` special case anywhere in the

--- a/docs/design/backlog-self-driving.md
+++ b/docs/design/backlog-self-driving.md
@@ -81,11 +81,11 @@ Nothing below proposes changing it.
 | The host-call channel: `recall`, `child_turn`, `run_test` | `crates/stella-plugin/src/host_call.rs`, `crates/stella-runtime/src/wrapper/host_call.rs` | **Built** (#3590), and reachable only from inside a turn. The capability self-driving needs exists and is out of its reach. |
 
 One correction to the record, because a design doc is a claim and not a fact:
-[`doc:agent-native-delivery`](agent-native-delivery.md) §11.1 lands the provider
-transports in `stella-tools` "generalizing `issue_ops.rs`". **There is no
-`issue_ops.rs` in this tree** — `find . -name 'issue_ops*'` is empty. That
-phase therefore starts from nothing, not from a refactor, which makes B1 below
-larger than §11.1 implies.
+[`doc:agent-native-delivery`](agent-native-delivery.md) §11.1 used to land the
+provider transports in `stella-tools` "generalizing `issue_ops.rs`", a file
+that has never existed in this tree — `find . -name 'issue_ops*'` is empty.
+That phase starts from nothing, not from a refactor, which makes B1 below
+larger than §11.1 implied. §11.1 and §4.5 now say so (#3600).
 
 ### 1.3 Never designed, and absent
 


### PR DESCRIPTION
`agent-native-delivery` §11.1 landed the provider transports in `stella-tools`
"generalizing `issue_ops.rs`", and §4.5 described Linear's semantics as
compiled into an `IssueBackend` enum. Neither file nor type has ever existed
in this tree, and the document's own preamble says the opposite — no issue
toolset ships, so building this design introduces an issue surface rather than
extending one. §11.1 is the half a planner reads when sizing P1, so the
contradiction mispriced the phase as a refactor.

Fixes all three copies of the claim (§4.5, §11.1, and the `provider.linear.toml`
header that restates §4.5's proof obligation), and updates the correction note
in `backlog-self-driving.md` §1.2 that recorded the defect.

`docs/spec/remote-sandboxes.md` carries the same false premise inside a wider
stale tool census (59 tools, `tracker_auth`, `verify_done`); that is beyond
this fix and is filed as #3606.

Docs only — no witness test.

Closes #3600
Refs #3599, #3606

## Summary by Sourcery

Correct the issue-provider design documentation to establish that the provider surface must be built from scratch rather than generalized from existing code.

Enhancements:
- Correct the agent-native delivery design and Linear provider manifest to describe issue-provider support as new functionality rather than an extraction from a nonexistent issue implementation.
- Update the backlog correction note to reflect the corrected implementation baseline and planning impact.

Documentation:
- Clarify the design, provider manifest, and backlog documentation so their descriptions consistently reflect that no issue toolset currently exists.