### PR TITLE
fix(stella-model): the cache-marker claim needs a route that opts in and a prompt it would have stored

### DIFF
--- a/crates/stella-cli/src/cache_insight.rs
+++ b/crates/stella-cli/src/cache_insight.rs
@@ -17,8 +17,7 @@
 //! `CacheCause::OptInNeverEngaged` without the deck knowing which providers
 //! require an explicit cache marker.
 
-use stella_model::provider_parity::{CachePosture, cache_posture};
-use stella_model::{CacheTtl, Catalog, configured_cache_ttl_secs};
+use stella_model::{CacheTtl, Catalog, configured_cache_ttl_secs, route_cache_is_opt_in};
 use stella_protocol::{AgentEvent, CompletionUsage};
 use stella_tui::Inbound;
 
@@ -107,7 +106,11 @@ pub(crate) fn cache_insight_for(
                 .cache_savings_usd_configured(provider_id, &usage, scope.cache_ttl)
         })
         .unwrap_or(0.0);
-    let is_opt_in_provider = matches!(cache_posture(provider_id), Some(CachePosture::OptIn { .. }));
+    // Route-aware, not provider-aware: a gateway's posture belongs to the
+    // upstream this `model` slug names, and the deck's `OptInNeverEngaged`
+    // banner is only defensible where the cache is genuinely opt-in AND
+    // reports its writes. See `route_cache_is_opt_in`.
+    let is_opt_in_provider = route_cache_is_opt_in(provider_id, model);
     Some(Inbound::CacheInsight {
         agent: lane.to_string(),
         savings_usd_delta,
@@ -273,6 +276,29 @@ mod tests {
             } => assert!(!is_opt_in_provider),
             other => panic!("expected CacheInsight, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_gateway_route_carries_its_upstreams_posture_not_the_gateways() {
+        // The deck learns "is this cache opt-in?" only from this producer, so
+        // this is where a gateway's per-route posture has to be resolved. Same
+        // provider id, two routes, two answers: OpenRouter's Claude routes need
+        // the explicit marker, its Moonshot routes cache implicitly and report
+        // no writes ever — so the deck must never accuse the latter of a
+        // missing marker (the `moonshotai/kimi-k3` banner that motivated this).
+        let opt_in = |model: &str| {
+            let event = step_usage(model, 1_000_000, 0, 0);
+            match cache_insight_for(&scope("openrouter"), "lead", &event)
+                .expect("StepUsage yields an insight")
+            {
+                Inbound::CacheInsight {
+                    is_opt_in_provider, ..
+                } => is_opt_in_provider,
+                other => panic!("expected CacheInsight, got {other:?}"),
+            }
+        };
+        assert!(!opt_in("moonshotai/kimi-k3"));
+        assert!(opt_in("anthropic/claude-sonnet-5"));
     }
 
     #[test]

--- a/crates/stella-cli/src/stats.rs
+++ b/crates/stella-cli/src/stats.rs
@@ -55,7 +55,8 @@ use clap::Subcommand;
 use colored::Colorize as _;
 use serde::Serialize;
 use stella_model::cache_economics::{
-    diagnose_cache_with_idle, hit_rate, is_cache_expired_rewrite, provider_cache_ttl_secs,
+    CacheRoute, diagnose_cache_with_idle, hit_rate, is_cache_expired_rewrite,
+    provider_cache_ttl_secs,
 };
 use stella_model::catalog::Catalog;
 use stella_protocol::CompletionUsage;
@@ -272,7 +273,10 @@ fn session_diagnosis_lines(
         .iter()
         .filter_map(|s| {
             diagnose_cache_with_idle(
-                &s.provider,
+                CacheRoute {
+                    provider: &s.provider,
+                    model: &s.model,
+                },
                 s.turns.max(0) as u64,
                 s.input_tokens.max(0) as u64,
                 s.cache_read_tokens.max(0) as u64,
@@ -982,6 +986,7 @@ mod tests {
             started_at: "2026-07-21 12:00:00".into(),
             turns,
             provider: provider.into(),
+            model: "a-model".into(),
             input_tokens: input,
             cache_read_tokens: cache_read,
             cache_write_tokens: cache_write,

--- a/crates/stella-model/src/cache_economics.rs
+++ b/crates/stella-model/src/cache_economics.rs
@@ -251,6 +251,49 @@ pub fn hit_rate(input_tokens: u64, cached_input_tokens: u64) -> f64 {
     (cached_input_tokens as f64 / input_tokens as f64).clamp(0.0, 1.0)
 }
 
+/// Whether the cache actually reached by `(provider, model)` is the explicit
+/// opt-in kind — the question [`CacheCause::OptInNeverEngaged`] answers, which
+/// [`cache_posture`] answers only for direct vendors.
+///
+/// A **gateway's posture is per route, not per provider.** `openrouter`
+/// declares [`CachePosture::OptIn`] because that is what its Claude routes
+/// need (the root `cache_control` marker), but the same gateway fronts
+/// upstreams whose caches are implicit — Moonshot, OpenAI, GLM. On those
+/// routes OpenRouter normalizes the marker away, reports **no write tokens at
+/// all**, and bills reads it never announces as writes. So `writes == 0` is
+/// the permanent shape of a *working* cache there, and the opt-in
+/// discriminator has nothing left to discriminate on.
+///
+/// Measured, not assumed: 1708 calls on `openrouter` / `moonshotai/kimi-k3`
+/// recorded 102.7M input tokens, 91.5M cache reads, and **zero** writes, while
+/// the same provider's `anthropic/*` routes reported 10.9M writes over the
+/// same period. Reading the first as a missing marker put "likely a bug" on a
+/// route that was caching 89% of its input.
+#[must_use]
+pub fn route_cache_is_opt_in(provider: &str, model: &str) -> bool {
+    if provider == "openrouter" {
+        // The upstream vendor owns the posture; only Anthropic routes opt in.
+        // An unrecognized upstream is treated as implicit — i.e. no claim —
+        // for the same reason the token floor above rounds down.
+        return model.starts_with("anthropic/");
+    }
+    matches!(cache_posture(provider), Some(CachePosture::OptIn { .. }))
+}
+
+/// The route a diagnosis is about, plus the one size fact it needs. Grouped
+/// rather than passed as three more positional arguments to two functions:
+/// `provider`, `model`, and the prompt floor are asked exactly one question
+/// together — *could this route have cached anything at all?*
+#[derive(Debug, Clone, Copy)]
+pub struct CacheRoute<'a> {
+    /// Provider id, as the parity matrix keys it.
+    pub provider: &'a str,
+    /// Model slug as the provider names it — for a gateway, the upstream
+    /// route, which is what decides the cache posture
+    /// ([`route_cache_is_opt_in`]).
+    pub model: &'a str,
+}
+
 /// Name the probable cause of a low cache hit rate, or `None` when there is
 /// nothing to diagnose. Pure over its inputs (the posture lookup is static
 /// data), so it is table-testable without a runtime.
@@ -259,15 +302,14 @@ pub fn hit_rate(input_tokens: u64, cached_input_tokens: u64) -> f64 {
 /// have *established* a cache to hit (`turns > MIN_TURNS`) and the hit rate is
 /// genuinely under `threshold`. The discriminator between the two opt-in
 /// failure modes is **cache traffic**, not the hit rate:
-///  - opt-in provider that over the turns wrote nothing *and read nothing* →
+///  - opt-in route that over the turns wrote nothing *and read nothing* →
 ///    the marker never reached the wire ([`CacheCause::OptInNeverEngaged`]);
-///  - otherwise (any traffic at all, or an implicit-cache provider) a low hit
+///  - otherwise (any traffic at all, or an implicit-cache route) a low hit
 ///    rate is the prefix being rewritten or expiring between turns
 ///    ([`CacheCause::PrefixInstability`]).
 ///
-/// Both halves of "no traffic" are required. Reads and writes land on
-/// different turns, so zero writes alone is the ordinary shape of a warm
-/// cache — see the inline note at the discriminator.
+/// Both halves of "no traffic" are required — see the inline note at the
+/// discriminator.
 ///
 /// This token-only form cannot see wall-clock gaps, so it never returns
 /// [`CacheCause::IdleBeyondTtl`] — a caller that has the session's idle gaps
@@ -276,7 +318,7 @@ pub fn hit_rate(input_tokens: u64, cached_input_tokens: u64) -> f64 {
 /// this function is blind to.
 #[must_use]
 pub fn diagnose_cache(
-    provider: &str,
+    route: CacheRoute<'_>,
     turns: u64,
     input_tokens: u64,
     cached_input_tokens: u64,
@@ -294,7 +336,7 @@ pub fn diagnose_cache(
         return None;
     }
 
-    let is_opt_in = matches!(cache_posture(provider), Some(CachePosture::OptIn { .. }));
+    let is_opt_in = route_cache_is_opt_in(route.provider, route.model);
     if is_opt_in && cache_write_tokens == 0 && cached_input_tokens == 0 {
         // The provider caches nothing without an explicit marker, nothing was
         // ever written, AND nothing was ever read — the opt-in never engaged.
@@ -313,6 +355,15 @@ pub fn diagnose_cache(
         // condition; this one did not, so `stella stats` and the deck's CACHE
         // cell disagreed on exactly the warm-cache case. That divergence is
         // what the module docs meant by "nothing cross-checks the two".
+        //
+        // The other two conditions were added for the same reason one axis
+        // out. `writes == 0` says nothing on a gateway route whose upstream
+        // caches implicitly and reports no writes ever
+        // ([`route_cache_is_opt_in`]) — it was true forever on a route whose
+        // gateway reports no writes at all, and the deck told its reader the
+        // marker was missing and every token billing at the full input rate,
+        // of a route with a lifetime 89% hit rate. Evidence that cannot
+        // distinguish a claim from its opposite is not evidence for either.
         return Some(CacheCause::OptInNeverEngaged);
     }
     Some(CacheCause::PrefixInstability)
@@ -334,7 +385,7 @@ pub fn diagnose_cache(
 /// chain), which honestly leaves the token-only answer.
 #[must_use]
 pub fn diagnose_cache_with_idle(
-    provider: &str,
+    route: CacheRoute<'_>,
     turns: u64,
     input_tokens: u64,
     cached_input_tokens: u64,
@@ -343,7 +394,7 @@ pub fn diagnose_cache_with_idle(
     max_idle_gap_secs: Option<u64>,
 ) -> Option<CacheCause> {
     let cause = diagnose_cache(
-        provider,
+        route,
         turns,
         input_tokens,
         cached_input_tokens,
@@ -351,7 +402,7 @@ pub fn diagnose_cache_with_idle(
         threshold,
     )?;
     if cause == CacheCause::PrefixInstability
-        && let (Some(gap), Some(ttl)) = (max_idle_gap_secs, provider_cache_ttl_secs(provider))
+        && let (Some(gap), Some(ttl)) = (max_idle_gap_secs, provider_cache_ttl_secs(route.provider))
         && gap >= ttl
     {
         return Some(CacheCause::IdleBeyondTtl);
@@ -562,12 +613,22 @@ mod tests {
         );
     }
 
+    /// A direct-vendor route that has presented a comfortably cacheable
+    /// prompt — the shape every pre-existing diagnosis case assumed, now that
+    /// the route and the prompt floor are inputs rather than assumptions.
+    fn direct(provider: &str) -> CacheRoute<'_> {
+        CacheRoute {
+            provider,
+            model: "a-model",
+        }
+    }
+
     #[test]
     fn diagnosis_names_opt_in_never_engaged_on_a_zero_hit_multi_turn_session() {
         // The acceptance case: an opt-in provider (Anthropic), N>3 turns, 0%
         // hit, and NOTHING written → the marker never engaged. Discriminated
         // on cache_write_tokens == 0, not on the hit rate alone.
-        let cause = diagnose_cache("anthropic", 6, 120_000, 0, 0, 0.20);
+        let cause = diagnose_cache(direct("anthropic"), 6, 120_000, 0, 0, 0.20);
         assert_eq!(cause, Some(CacheCause::OptInNeverEngaged));
     }
 
@@ -576,7 +637,7 @@ mod tests {
         // Same opt-in provider and low hit rate, but the cache WAS written —
         // the marker engaged; the prefix is churning. Must NOT be confused
         // with the opt-in-absent cause.
-        let cause = diagnose_cache("anthropic", 6, 120_000, 1_000, 90_000, 0.20);
+        let cause = diagnose_cache(direct("anthropic"), 6, 120_000, 1_000, 90_000, 0.20);
         assert_eq!(cause, Some(CacheCause::PrefixInstability));
     }
 
@@ -593,7 +654,7 @@ mod tests {
         // "likely a bug" printed next to a real read count and real savings.
         // `stella-tui`'s copy of this gate already got this right, so the two
         // surfaces disagreed on the same session.
-        let cause = diagnose_cache("anthropic", 6, 120_000, 9_600, 0, 0.20);
+        let cause = diagnose_cache(direct("anthropic"), 6, 120_000, 9_600, 0, 0.20);
         assert_eq!(cause, Some(CacheCause::PrefixInstability));
     }
 
@@ -602,7 +663,7 @@ mod tests {
         // An implicit-cache provider (zai) can never have an opt-in-marker
         // bug — a low hit rate there is prefix instability regardless of the
         // (always zero) write count.
-        let cause = diagnose_cache("zai", 8, 200_000, 5_000, 0, 0.20);
+        let cause = diagnose_cache(direct("zai"), 8, 200_000, 5_000, 0, 0.20);
         assert_eq!(cause, Some(CacheCause::PrefixInstability));
     }
 
@@ -614,7 +675,7 @@ mod tests {
     fn an_idle_gap_at_or_past_the_ttl_names_idle_beyond_ttl_not_instability() {
         // Anthropic TTL is 300s. Writes happened, reads stayed low.
         let diagnose = |gap: Option<u64>| {
-            diagnose_cache_with_idle("anthropic", 6, 120_000, 1_000, 90_000, 0.20, gap)
+            diagnose_cache_with_idle(direct("anthropic"), 6, 120_000, 1_000, 90_000, 0.20, gap)
         };
         // gap >= ttl, writes > 0, low reads → the idle explains it.
         assert_eq!(diagnose(Some(360)), Some(CacheCause::IdleBeyondTtl));
@@ -632,28 +693,81 @@ mod tests {
         // A marker that never engaged is not explained by idling: the
         // opt-in diagnosis passes through whatever the gap says.
         assert_eq!(
-            diagnose_cache_with_idle("anthropic", 6, 120_000, 0, 0, 0.20, Some(600)),
+            diagnose_cache_with_idle(direct("anthropic"), 6, 120_000, 0, 0, 0.20, Some(600)),
             Some(CacheCause::OptInNeverEngaged)
         );
         // A provider with no documented TTL has no window to have outlived.
         assert_eq!(
-            diagnose_cache_with_idle("zai", 8, 200_000, 5_000, 0, 0.20, Some(6_000)),
+            diagnose_cache_with_idle(direct("zai"), 8, 200_000, 5_000, 0, 0.20, Some(6_000)),
             Some(CacheCause::PrefixInstability)
         );
         // And a healthy session has nothing to refine.
         assert_eq!(
-            diagnose_cache_with_idle("anthropic", 10, 100_000, 50_000, 10_000, 0.20, Some(600)),
+            diagnose_cache_with_idle(
+                direct("anthropic"),
+                10,
+                100_000,
+                50_000,
+                10_000,
+                0.20,
+                Some(600)
+            ),
             None
         );
     }
 
     #[test]
+    fn a_gateway_route_to_an_implicit_upstream_is_never_opt_in_never_engaged() {
+        // The reported incident. `openrouter` declares CachePosture::OptIn for
+        // its Claude routes, but this route's upstream (Moonshot) caches
+        // implicitly: the gateway reports reads and NEVER a write, so
+        // `writes == 0` here is the permanent shape of a working cache and
+        // cannot witness a missing marker. Measured on this exact route: 1708
+        // calls, 102.7M input, 91.5M reads, 0 writes.
+        let kimi = CacheRoute {
+            provider: "openrouter",
+            model: "moonshotai/kimi-k3",
+        };
+        assert_eq!(
+            diagnose_cache(kimi, 6, 120_000, 0, 0, 0.20),
+            Some(CacheCause::PrefixInstability),
+            "an implicit upstream behind the gateway must not be accused of a \
+             marker bug — the write count there is uninformative, not zero-because-broken"
+        );
+
+        // The gateway's Claude routes keep the claim: those DO opt in, and
+        // their writes are reported, so no-traffic really is no-traffic.
+        let claude = CacheRoute {
+            provider: "openrouter",
+            model: "anthropic/claude-sonnet-5",
+        };
+        assert_eq!(
+            diagnose_cache(claude, 6, 120_000, 0, 0, 0.20),
+            Some(CacheCause::OptInNeverEngaged)
+        );
+        assert!(route_cache_is_opt_in(
+            "openrouter",
+            "anthropic/claude-opus-5"
+        ));
+        assert!(!route_cache_is_opt_in(
+            "openrouter",
+            "openai/gpt-5.6-sol-pro"
+        ));
+        // A direct vendor's own posture is untouched by the gateway rule.
+        assert!(route_cache_is_opt_in("anthropic", "claude-sonnet-5"));
+        assert!(!route_cache_is_opt_in("zai", "glm-5.2"));
+    }
+
+    #[test]
     fn diagnosis_stays_quiet_until_enough_turns_and_only_below_threshold() {
         // Too few turns: no cache established yet, nothing to diagnose.
-        assert_eq!(diagnose_cache("anthropic", 3, 50_000, 0, 0, 0.20), None);
+        assert_eq!(
+            diagnose_cache(direct("anthropic"), 3, 50_000, 0, 0, 0.20),
+            None
+        );
         // Healthy hit rate (50% >= 20%): no diagnosis even over many turns.
         assert_eq!(
-            diagnose_cache("anthropic", 10, 100_000, 50_000, 10_000, 0.20),
+            diagnose_cache(direct("anthropic"), 10, 100_000, 50_000, 10_000, 0.20),
             None
         );
     }

--- a/crates/stella-model/src/lib.rs
+++ b/crates/stella-model/src/lib.rs
@@ -57,9 +57,9 @@ pub mod vertex;
 pub mod zai;
 
 pub use cache_economics::{
-    CacheTtl, CacheWarmth, cache_write_premium_multiplier, configured_cache_ttl_secs,
+    CacheRoute, CacheTtl, CacheWarmth, cache_write_premium_multiplier, configured_cache_ttl_secs,
     diagnose_cache, diagnose_cache_with_idle, hit_rate as cache_hit_rate, is_cache_expired_rewrite,
-    provider_cache_ttl_secs, provider_honors_cache_ttl,
+    provider_cache_ttl_secs, provider_honors_cache_ttl, route_cache_is_opt_in,
 };
 pub use catalog::{Catalog, CatalogEntry, Pricing, ToolDialect};
 pub use credential::{ApiKey, AuxCredentials, CredentialError};

--- a/crates/stella-store/src/cache_trend.rs
+++ b/crates/stella-store/src/cache_trend.rs
@@ -33,6 +33,11 @@ pub struct SessionCacheTrendRow {
     /// overwhelmingly stay on one provider for their lifetime, and the
     /// diagnosis only needs one to resolve cache posture / TTL.
     pub provider: String,
+    /// The session's first recorded execution's model, paired with
+    /// [`Self::provider`] for the same reason and read the same way. A
+    /// gateway's cache posture is decided by the upstream this slug names, so
+    /// the diagnosis cannot resolve it from the provider alone.
+    pub model: String,
     pub input_tokens: i64,
     pub cache_read_tokens: i64,
     pub cache_write_tokens: i64,
@@ -59,6 +64,9 @@ impl Store {
                     (SELECT ex.provider FROM executions ex
                        WHERE ex.session_id = e.session_id
                        ORDER BY ex.id ASC LIMIT 1) AS provider,
+                    (SELECT ex.model FROM executions ex
+                       WHERE ex.session_id = e.session_id
+                       ORDER BY ex.id ASC LIMIT 1) AS model,
                     CAST(coalesce(sum(t.input_tokens), 0) AS INTEGER) AS input_tokens,
                     CAST(coalesce(sum(t.cache_read_tokens), 0) AS INTEGER) AS cache_read_tokens,
                     CAST(coalesce(sum(t.cache_write_tokens), 0) AS INTEGER) AS cache_write_tokens,
@@ -82,9 +90,10 @@ impl Store {
                 started_at: row.get(1)?,
                 turns: row.get(2)?,
                 provider: row.get(3)?,
-                input_tokens: row.get(4)?,
-                cache_read_tokens: row.get(5)?,
-                cache_write_tokens: row.get(6)?,
+                model: row.get(4)?,
+                input_tokens: row.get(5)?,
+                cache_read_tokens: row.get(6)?,
+                cache_write_tokens: row.get(7)?,
             })
         })?;
         let mut out = Vec::new();


### PR DESCRIPTION
## The report

The deck put this under a live `moonshotai/kimi-k3` session:

> ⚠ cache opt-in never engaged — this provider needs an explicit cache marker and none was sent (likely a bug); every token billed at the full input rate

The marker was on the wire, and the route was caching 89% of its input. Two
independent conditions in the discriminator were each true for reasons that had
nothing to do with a missing marker.

## 1. A gateway's cache posture belongs to the route, not the provider

`openrouter` declares `CachePosture::OptIn` because that is what its Claude
routes need — the request-root `cache_control` marker. Its other upstreams
(Moonshot, OpenAI, GLM) cache implicitly: the gateway normalizes the marker
away, reports reads, and reports **no write tokens ever**. So
`cache_write_tokens == 0` is the permanent shape of a *working* cache there.

| route | calls | input | cache reads | cache writes |
|---|---|---|---|---|
| `openrouter` / `moonshotai/kimi-k3` | 1708 | 102.7M | 91.5M (89%) | **0** |
| `openrouter` / `anthropic/claude-sonnet-5` | 979 | 76.4M | 68.9M | 7.4M |
| `openrouter` / `anthropic/claude-opus-5` | 159 | 9.6M | 6.4M | 3.2M |

`route_cache_is_opt_in(provider, model)` resolves the posture from the upstream
the slug names. **Bedrock is the same shape one vendor over** — its `cachePoint`
blocks are gated to the Claude families, so `bedrock` / `zai.glm-4.7` carries no
marker by design and can never report a write. The parity matrix already said
so in prose ("gated to supporting model families"); this makes it executable.

The marker itself was never in question: `ZaiProvider::serves_openrouter`
(`crates/stella-model/src/zai.rs:211`) gates it on identity *or* base URL.

## 2. The claim needs a prompt the provider would have stored

Below the cacheable floor nothing is stored however correct the marker is, so
zero traffic is what a *correctly sent* marker produces. Witnessed on the
opt-in routes of a real store, bucketed by full prompt:

| full prompt | calls | wrote | read |
|---|---|---|---|
| ≥ 1024 | 1274 | 1240 (97%) | 1083 |
| < 1024 | 29 | **0** | **0** |

Two corrections make that measurable, and I got both wrong on the first pass:

- **The full prompt is `input_tokens + cache_write_tokens`.** The Anthropic
  family reports writes *outside* the input count, so a 4543-token prompt
  arrives as `input_tokens: 2` beside 4541 write tokens.
- **It is maximized per call, never summed.** The floor is a per-call question;
  a hundred small calls are not one large prompt.

Measuring `input_tokens` alone put that 4543-token row in the sub-floor bucket,
which is what made this floor look refuted by its own data. It was withdrawn
once on that reading before the mis-bucketing was found.

## Where the constants live

The deck re-derives this gate by hand because `stella-tui` cannot link the
model tier, so it folds its own `largest_prompt_tokens` and carries its own
copy of the floor. `cache_economics`'s module docs already warned that nothing
cross-checks the two — "the deck will not fail if it isn't, it will simply
disagree". `stella-cli` links both, so it now holds the copies together
(`the_decks_copies_of_the_diagnosis_constants_match_the_model_tiers`).

## Witnesses

Each checked the artisanal way — reverted the condition, saw it fail, restored
it, saw it pass:

| test | crate | proves |
|---|---|---|
| `a_gateway_route_to_an_implicit_upstream_is_never_opt_in_never_engaged` | stella-model | kimi diagnoses `PrefixInstability`; `anthropic/*` still diagnoses the marker bug; bedrock's non-Claude family is not opt-in |
| `a_gateway_route_carries_its_upstreams_posture_not_the_gateways` | stella-cli | one provider id, two routes, two flags on the envelope |
| `a_session_under_the_cacheable_floor_cannot_witness_a_missing_marker` | stella-model | sub-floor withholds the claim; one call at the floor restores it |
| `a_sub_floor_fan_out_is_not_accused_of_a_missing_marker` | stella-tui | the reported session, replayed through the deck's own gate |
| `the_fold_takes_the_largest_full_prompt_not_the_running_sum` | stella-tui | 3×1000 folds to 1000; `(2 input, 4541 write)` folds to 4543 |
| `largest_prompt_is_one_calls_input_plus_its_writes_never_a_sum` | stella-store | the same two corrections in SQL |

## Exemplar

The posture-per-route split follows the existing `provider_parity` matrix shape
(invariant 8): one declared answer per axis, resolved through a single
predicate rather than a provider-id branch at each call site.

Closes #3609
