### PR TITLE
fix: five P1/P2 defects from the 1283–2343 backlog

### DIFF
--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -47,6 +47,24 @@
 //! emitted beside the label, so a reader can re-derive a label under other
 //! weights without trusting this one.
 //!
+//! ## The unvouched turns are reachable, never silently (#2123)
+//!
+//! "Excluded under the default filter" implies a non-default path, and
+//! `--include-unverified-transcripts` is it: a store whose history predates
+//! the receipts plane holds no `step_receipt` row at all, so the default
+//! filter exports **zero** records from it even though the journal fold can
+//! still recover every one of those turns' prompt/tool-call/change
+//! trajectories. Under the flag those turns are exported with
+//! [`DatasetRecord::calls`] empty and
+//! [`DatasetRecord::transcript_verified`] false — the trajectory without the
+//! transcript, never unverified bytes wearing a verified transcript's shape.
+//! The gate itself stays era-blind, exactly as
+//! [`stella_store::Reconstruction::is_verified`] is: the benign
+//! compaction-era explanation for a mismatch is *reported* on the record
+//! ([`DatasetRecord::transcript_mismatch_severity`], read from
+//! [`stella_store::Reconstruction::mismatch_severity`] rather than
+//! re-derived), never used to admit one.
+//!
 //! ## What a "diff" can honestly be here
 //!
 //! There is no unified diff anywhere in `store.db`. `files_touched` holds
@@ -79,7 +97,7 @@ use sha2::{Digest, Sha256};
 use stella_core::redact::{PLACEHOLDER, redact_secrets};
 use stella_pipeline::reward::{RewardLabel, RewardPolicy, Settlement, TrajectoryCost, label};
 use stella_protocol::AgentEvent;
-use stella_store::{FinishedExecution, RecordedCall, Store};
+use stella_store::{FinishedExecution, MismatchSeverity, RecordedCall, Store};
 
 /// Bump when [`DatasetRecord`]'s shape changes incompatibly, so a reader can
 /// refuse a dataset it does not understand instead of misparsing it.
@@ -88,7 +106,15 @@ use stella_store::{FinishedExecution, RecordedCall, Store};
 /// and the reward label ([`DatasetRecord::reward`], #1043), and tightened the
 /// default filter to transcript-verified executions — so a v1 dataset is not
 /// comparable to a v2 one even where the shared fields agree.
-pub const DATASET_SCHEMA_VERSION: u32 = 2;
+///
+/// `3` (#2123) added [`DatasetRecord::transcript_verified`] and
+/// [`DatasetRecord::transcript_mismatch_severity`], which
+/// `--include-unverified-transcripts` needs to state that a record's `calls`
+/// are absent because nothing could vouch for them. A v2 reader would take a
+/// v3 record's empty `calls` for a verified execution that made no model call,
+/// which v2 could not produce — so the shape is not compatible even though
+/// every v2 field is still present and still means what it did.
+pub const DATASET_SCHEMA_VERSION: u32 = 3;
 
 /// The dataset file written under `--output`.
 pub const DATASET_FILE: &str = "dataset.jsonl";
@@ -124,8 +150,8 @@ const SCAN_BATCH: u32 = 500;
 /// This is the journal half of the stated predicate. The transcript half —
 /// every recorded model call reconstructing digest-verified — needs the
 /// receipts plane rather than the fold, so [`accepted_record`] applies it via
-/// [`verified_transcripts`] after this returns true, and the manifest counts
-/// what it excludes.
+/// [`transcripts`] after this returns true, and the manifest counts what it
+/// excludes.
 fn is_accepted(outcome: &str, fold: &JournalFold, require_verdict: bool) -> bool {
     ACCEPTED_OUTCOMES.contains(&outcome)
         && !fold.changes.is_empty()
@@ -135,11 +161,21 @@ fn is_accepted(outcome: &str, fold: &JournalFold, require_verdict: bool) -> bool
 /// The predicate [`is_accepted`] applies, in words, for the manifest. Stated
 /// rather than described: a reader has to be able to reproduce the selection
 /// without reading this file.
-fn acceptance_predicate(require_verdict: bool) -> String {
+///
+/// Both flags rewrite it rather than annotating it: a manifest that states the
+/// default rule beside a flag that loosened it is a manifest nobody can
+/// reproduce the selection from.
+fn acceptance_predicate(require_verdict: bool, include_unverified_transcripts: bool) -> String {
+    let transcripts = if include_unverified_transcripts {
+        "AND (at least one recorded model call, every one reconstructing \
+         digest-verified (Reconstruction::is_verified) — OR exported with \
+         transcript_verified=false and no calls)"
+    } else {
+        "AND at least one recorded model call, every one reconstructing \
+         digest-verified (Reconstruction::is_verified)"
+    };
     let base = format!(
-        "executions.outcome in {{{}}} AND at least one mutating file_change event \
-         AND at least one recorded model call, every one reconstructing \
-         digest-verified (Reconstruction::is_verified)",
+        "executions.outcome in {{{}}} AND at least one mutating file_change event {transcripts}",
         ACCEPTED_OUTCOMES.join(", ")
     );
     if require_verdict {
@@ -191,6 +227,14 @@ pub enum DatasetCmd {
         /// a turn the deterministic ladder cleared never reaches a verifier.
         #[arg(long)]
         require_verdict: bool,
+        /// Also export otherwise-accepted turns whose transcripts cannot be
+        /// digest-verified — a store predating the receipts plane records no
+        /// model call at all, and exports nothing without this. Their `calls`
+        /// are empty and `transcript_verified` is false: the trajectory
+        /// without the transcript, never unverified bytes passed off as
+        /// verified ones.
+        #[arg(long)]
+        include_unverified_transcripts: bool,
     },
 }
 
@@ -233,10 +277,41 @@ pub struct DatasetRecord {
     pub prompt: String,
     /// Every model call, in wire order, each with the exact messages it was
     /// sent — reconstructed from the receipts plane and digest-verified
-    /// before admission (#2083). Never empty: an execution whose transcripts
-    /// do not all verify is excluded by the default filter, not exported
-    /// with a gap here.
+    /// before admission (#2083). Empty exactly when
+    /// [`Self::transcript_verified`] is false, which only
+    /// `--include-unverified-transcripts` can produce: an unvouched
+    /// transcript is withheld whole rather than emitted with a silent gap in
+    /// it.
     pub calls: Vec<DatasetCall>,
+    /// Whether [`Self::calls`] is the receipts plane's own digest-verified
+    /// answer to "what did each model call see" (#2123).
+    ///
+    /// `true` on every record the default filter produces. `false` only under
+    /// `--include-unverified-transcripts`, and then it is a statement about
+    /// this execution's *receipts*, not about its trajectory: `tool_calls`,
+    /// `changes` and `verdict` come from the journal and are exactly as
+    /// trustworthy as on any other record.
+    pub transcript_verified: bool,
+    /// What a digest mismatch in this execution's reconstructions means, as
+    /// [`stella_store::MismatchSeverity`]'s wire token — `none`,
+    /// `compaction`, or `integrity`, the worst across its recorded calls.
+    /// Spelled by [`crate::inspect::severity_tag`], so a dataset record, a
+    /// `stella inspect --json` payload and the observatory all say the same
+    /// three words about the same verdict.
+    ///
+    /// Read from [`stella_store::Reconstruction::mismatch_severity`], the one
+    /// place the two compaction-journaling eras are told apart, so this file
+    /// never re-derives that distinction. It reports; it decides nothing —
+    /// admission is [`stella_store::Reconstruction::is_verified`]'s
+    /// deliberately era-blind answer, so a benign `compaction` record is
+    /// excluded by default exactly like an `integrity` one, and a consumer of
+    /// an `--include-unverified-transcripts` dataset can still tell a legacy
+    /// rewrite from bytes that are unaccounted for.
+    ///
+    /// `none` whenever no block's digest mismatched — which includes every
+    /// verified record, and an unverified one whose blocks simply could not be
+    /// resolved (a store with no receipts at all, or a missing preimage).
+    pub transcript_mismatch_severity: String,
     /// Every tool invocation, in journal order.
     pub tool_calls: Vec<DatasetToolCall>,
     /// Every mutating file change, in journal order.
@@ -357,14 +432,20 @@ pub struct DatasetFilter {
     pub since: Option<String>,
     pub until: Option<String>,
     pub require_verdict: bool,
+    /// Whether the unvouched turns were exported rather than excluded (#2123).
+    pub include_unverified_transcripts: bool,
     /// Settled executions read from the store.
     pub executions_scanned: u64,
     /// Of those, how many fell inside the `since`/`until` window.
     pub executions_in_window: u64,
     /// Of the executions the outcome-and-change half of the predicate
-    /// accepted, how many were excluded because their transcripts did not
-    /// verify: no recorded model call at all, or some call's reconstruction
-    /// short of [`stella_store::Reconstruction::is_verified`] (#2083).
+    /// accepted, how many could not vouch for their transcripts: no recorded
+    /// model call at all, or some call's reconstruction short of
+    /// [`stella_store::Reconstruction::is_verified`] (#2083).
+    ///
+    /// Counted identically in both modes, so the two are comparable: under
+    /// [`Self::include_unverified_transcripts`] these are the records carrying
+    /// `transcript_verified: false` rather than the ones left out (#2123).
     pub executions_transcripts_unverified: u64,
     /// Of those, how many the whole predicate accepted. Equals `records`.
     pub executions_accepted: u64,
@@ -389,12 +470,14 @@ pub fn run_dataset(cmd: &DatasetCmd) -> Result<(), String> {
             since,
             until,
             require_verdict,
+            include_unverified_transcripts,
         } => run_export(&ExportArgs {
             format: *format,
             output: output.clone(),
             since: since.clone(),
             until: until.clone(),
             require_verdict: *require_verdict,
+            include_unverified_transcripts: *include_unverified_transcripts,
         }),
     }
 }
@@ -406,6 +489,7 @@ struct ExportArgs {
     since: Option<String>,
     until: Option<String>,
     require_verdict: bool,
+    include_unverified_transcripts: bool,
 }
 
 fn run_export(args: &ExportArgs) -> Result<(), String> {
@@ -495,10 +579,14 @@ fn extract(
     }
 
     let filter = DatasetFilter {
-        acceptance_predicate: acceptance_predicate(args.require_verdict),
+        acceptance_predicate: acceptance_predicate(
+            args.require_verdict,
+            args.include_unverified_transcripts,
+        ),
         since: args.since.clone(),
         until: args.until.clone(),
         require_verdict: args.require_verdict,
+        include_unverified_transcripts: args.include_unverified_transcripts,
         executions_scanned: scanned,
         executions_in_window: counts.in_window,
         executions_transcripts_unverified: counts.transcripts_unverified,
@@ -515,7 +603,9 @@ struct ScanCounts {
     in_window: u64,
     /// Executions the outcome-and-change predicate accepted whose transcripts
     /// then failed to verify — see
-    /// [`DatasetFilter::executions_transcripts_unverified`].
+    /// [`DatasetFilter::executions_transcripts_unverified`]. Counted whether
+    /// they were then excluded or exported unvouched, so the two modes report
+    /// the same number for the same store.
     transcripts_unverified: u64,
 }
 
@@ -562,9 +652,19 @@ fn accepted_record(
     let receipts = store
         .recorded_calls(id)
         .map_err(|e| format!("cannot read receipts for execution {id}: {e}"))?;
-    let Some(calls) = verified_transcripts(store, id, &receipts)? else {
-        counts.transcripts_unverified += 1;
-        return Ok(None);
+    let (calls, transcript_verified, severity) = match transcripts(store, id, &receipts)? {
+        Transcripts::Verified(calls) => (calls, true, MismatchSeverity::None),
+        Transcripts::Unvouched { severity } => {
+            counts.transcripts_unverified += 1;
+            if !args.include_unverified_transcripts {
+                return Ok(None);
+            }
+            // The trajectory without the transcript: the journal half of this
+            // record is untouched, and the reconstructed messages are withheld
+            // whole rather than emitted with a gap the record does not admit
+            // to.
+            (Vec::new(), false, severity)
+        }
     };
     let reward = reward_label(&fold, receipts.len(), summary.cost_usd, policy);
 
@@ -582,6 +682,8 @@ fn accepted_record(
         cost_usd: summary.cost_usd,
         prompt: summary.prompt,
         calls,
+        transcript_verified,
+        transcript_mismatch_severity: crate::inspect::severity_tag(severity).to_string(),
         tool_calls: fold.tool_calls,
         changes: fold.changes,
         verdict: fold.verdict,
@@ -591,20 +693,46 @@ fn accepted_record(
     Ok(Some(redact_after_assembly(&record)?))
 }
 
-/// Every recorded call's exact prompt transcript, digest-verified — or `None`
-/// when this execution cannot vouch for its own: it recorded no model call at
-/// all, or some call's reconstruction fell short of
-/// [`stella_store::Reconstruction::is_verified`]. `None` is an exclusion the
-/// manifest counts, never a silent downgrade to an unverified transcript.
-fn verified_transcripts(
+/// What one execution's receipts can prove about the transcripts of its own
+/// model calls. All-or-nothing by construction: there is no arm carrying some
+/// verified calls beside an unvouched one, because a record that mixed them
+/// would need a per-call caveat nothing downstream reads.
+enum Transcripts {
+    /// Every recorded call reconstructed digest-verified — these are the exact
+    /// messages each one was sent.
+    Verified(Vec<DatasetCall>),
+    /// This execution cannot vouch for what its model saw: it recorded no
+    /// model call at all, or some call's reconstruction fell short of
+    /// [`stella_store::Reconstruction::is_verified`].
+    Unvouched {
+        /// The worst [`MismatchSeverity`] across the recorded calls — what a
+        /// digest mismatch here *means*, straight from
+        /// [`stella_store::Reconstruction::mismatch_severity`].
+        /// [`MismatchSeverity::None`] when nothing mismatched and the shortfall
+        /// was an unresolved block (or there were no receipts to check).
+        severity: MismatchSeverity,
+    },
+}
+
+/// Reconstruct every recorded call and judge the set as a whole.
+///
+/// Every receipt is reconstructed even once one has already failed, so the
+/// severity reported is the worst across the execution rather than whichever
+/// call happened to fail first — a benign compaction rewrite must not mask an
+/// integrity mismatch two calls later.
+fn transcripts(
     store: &Store,
     execution_id: i64,
     receipts: &[RecordedCall],
-) -> Result<Option<Vec<DatasetCall>>, String> {
+) -> Result<Transcripts, String> {
     if receipts.is_empty() {
-        return Ok(None);
+        return Ok(Transcripts::Unvouched {
+            severity: MismatchSeverity::None,
+        });
     }
     let mut calls = Vec::with_capacity(receipts.len());
+    let mut verified = true;
+    let mut severity = MismatchSeverity::None;
     for receipt in receipts {
         let reconstruction = store
             .reconstruct_call(
@@ -619,8 +747,15 @@ fn verified_transcripts(
                     receipt.turn_instance, receipt.step, receipt.call_seq
                 )
             })?;
+        severity = worst_severity(severity, reconstruction.mismatch_severity());
         if !reconstruction.is_verified() {
-            return Ok(None);
+            verified = false;
+        }
+        if !verified {
+            // Unvouched, here or at an earlier receipt: the rest of this
+            // execution's calls are reconstructed for their severity alone,
+            // and nothing built past this point would be emitted.
+            continue;
         }
         let mut prompt_messages = Vec::with_capacity(reconstruction.messages.len());
         for message in &reconstruction.messages {
@@ -639,7 +774,24 @@ fn verified_transcripts(
             prompt_messages,
         });
     }
-    Ok(Some(calls))
+    if verified {
+        Ok(Transcripts::Verified(calls))
+    } else {
+        Ok(Transcripts::Unvouched { severity })
+    }
+}
+
+/// The graver of two severities: `Integrity` outranks `Compaction`, which
+/// outranks `None`. The ordering is stated here rather than derived from the
+/// enum's declaration order, so reordering the variants cannot silently
+/// reverse it.
+fn worst_severity(a: MismatchSeverity, b: MismatchSeverity) -> MismatchSeverity {
+    let rank = |severity: MismatchSeverity| match severity {
+        MismatchSeverity::None => 0u8,
+        MismatchSeverity::Compaction => 1,
+        MismatchSeverity::Integrity => 2,
+    };
+    if rank(b) > rank(a) { b } else { a }
 }
 
 /// The record's training label, when the journal holds anything to derive one
@@ -973,21 +1125,40 @@ fn report(
     );
     println!("  accepted when: {}", filter.acceptance_predicate);
     if filter.executions_transcripts_unverified > 0 {
-        println!(
-            "  {} otherwise-accepted turn(s) excluded: transcripts not digest-verified",
-            filter.executions_transcripts_unverified
-        );
+        if filter.include_unverified_transcripts {
+            println!(
+                "  {} turn(s) exported with transcript_verified=false: transcripts not \
+                 digest-verified, so their calls are withheld",
+                filter.executions_transcripts_unverified
+            );
+        } else {
+            println!(
+                "  {} otherwise-accepted turn(s) excluded: transcripts not digest-verified \
+                 (--include-unverified-transcripts exports them without their calls)",
+                filter.executions_transcripts_unverified
+            );
+        }
     }
     println!("  {}", dataset_path.display().to_string().cyan());
     println!("  {}", manifest_path.display().to_string().cyan());
     if records.is_empty() {
-        println!(
-            "\nNothing matched. Turns qualify only once they have settled with a \
-             success outcome, changed a file, AND can prove what each model call \
-             saw (every recorded call reconstructing digest-verified); a \
-             read-only, aborted, or unvouched turn is recorded but is not a \
-             trajectory to distil from."
-        );
+        if filter.include_unverified_transcripts {
+            println!(
+                "\nNothing matched. Turns qualify only once they have settled with a \
+                 success outcome and changed a file; a read-only or aborted turn is \
+                 recorded but is not a trajectory to distil from."
+            );
+        } else {
+            println!(
+                "\nNothing matched. Turns qualify only once they have settled with a \
+                 success outcome, changed a file, AND can prove what each model call \
+                 saw (every recorded call reconstructing digest-verified); a \
+                 read-only, aborted, or unvouched turn is recorded but is not a \
+                 trajectory to distil from. A store predating the receipts plane can \
+                 prove no transcript at all — export it with \
+                 --include-unverified-transcripts."
+            );
+        }
         return;
     }
     let redacted = records.iter().filter(|r| r.redacted).count();

--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -114,6 +114,14 @@ use stella_store::{FinishedExecution, MismatchSeverity, RecordedCall, Store};
 /// v3 record's empty `calls` for a verified execution that made no model call,
 /// which v2 could not produce — so the shape is not compatible even though
 /// every v2 field is still present and still means what it did.
+///
+/// The same bump covers `reward.cost.steps` becoming nullable: a record the
+/// receipts plane holds nothing for reports an unrecorded step count and a
+/// `steps_unknown` discard rather than a scalar shaped against a zero. It is
+/// not a separate version because no v3 dataset can exist without it: `3` is
+/// unreleased at the time both halves were written, and only
+/// `--include-unverified-transcripts` can produce a record either one is
+/// visible on.
 pub const DATASET_SCHEMA_VERSION: u32 = 3;
 
 /// The dataset file written under `--output`.
@@ -291,6 +299,11 @@ pub struct DatasetRecord {
     /// this execution's *receipts*, not about its trajectory: `tool_calls`,
     /// `changes` and `verdict` come from the journal and are exactly as
     /// trustworthy as on any other record.
+    ///
+    /// [`Self::reward`] is the one field that is neither: its outcome term is
+    /// the journal's, but its shaping prices the receipts plane's step count.
+    /// An execution the plane holds nothing for therefore carries a discarded
+    /// label (`steps_unknown`) rather than a scalar — see [`Self::reward`].
     pub transcript_verified: bool,
     /// What a digest mismatch in this execution's reconstructions means, as
     /// [`stella_store::MismatchSeverity`]'s wire token — `none`,
@@ -324,6 +337,15 @@ pub struct DatasetRecord {
     /// journal holds no verdict at all: there is no proof or ladder evidence
     /// to derive a label from, and synthesizing a discard under a policy the
     /// run never saw would claim more than the store knows.
+    ///
+    /// A *present* label may still carry no scalar. Under
+    /// `--include-unverified-transcripts` an execution whose receipts plane
+    /// holds nothing has an unrecorded step count, and the shaping refuses to
+    /// price it as zero, so the label reports
+    /// `stella_pipeline::reward::DiscardReason::StepsUnknown` with its rung,
+    /// its outcome term and its policy intact. That is the discard's whole
+    /// point here: the row stays selectable and re-shapeable, and only the
+    /// number that would have been wrong is withheld.
     pub reward: Option<RewardLabel>,
     /// Whether redaction actually replaced something anywhere in this record.
     /// Recorded so "this was redacted" is a visible fact rather than an
@@ -804,9 +826,18 @@ fn worst_severity(a: MismatchSeverity, b: MismatchSeverity) -> MismatchSeverity 
 /// role, not just the worker's) and revisions the verdicts beyond the
 /// settling one — the same fold `trace.rs` applies, so a dataset label and a
 /// trace label of one execution agree.
+///
+/// The step count is [`TrajectoryCost::recorded_steps`]'s, so an execution
+/// with no receipt at all — the shape
+/// `--include-unverified-transcripts` exists to admit — carries `steps: null`
+/// and a `steps_unknown` discard rather than a scalar shaped as though the
+/// turn had bought no model call. Reading that absence as zero would drop the
+/// step penalty from precisely the records whose provenance is weakest and
+/// leave them pooling with verified ones as though they had been cheaper
+/// (#2123).
 fn reward_label(
     fold: &JournalFold,
-    steps: usize,
+    recorded_calls: usize,
     cost_usd: f64,
     policy: &RewardPolicy,
 ) -> Option<RewardLabel> {
@@ -814,7 +845,7 @@ fn reward_label(
     Some(label(
         settlement,
         TrajectoryCost {
-            steps: u32::try_from(steps).unwrap_or(u32::MAX),
+            steps: TrajectoryCost::recorded_steps(recorded_calls),
             cost_usd,
             revisions: fold.verdicts.saturating_sub(1),
         },

--- a/crates/stella-cli/src/dataset_cmd/tests.rs
+++ b/crates/stella-cli/src/dataset_cmd/tests.rs
@@ -194,8 +194,57 @@ fn require_verdict_demands_a_passing_judgement() {
     let failed = fold_journal(&journal(events));
     assert!(!is_accepted("completed", &failed, true));
 
-    assert!(!acceptance_predicate(false).contains("verdict"));
-    assert!(acceptance_predicate(true).contains("verdict"));
+    assert!(!acceptance_predicate(false, false).contains("verdict"));
+    assert!(acceptance_predicate(true, false).contains("verdict"));
+}
+
+/// `--include-unverified-transcripts` loosens the transcript clause rather
+/// than annotating it, so the manifest states the rule that actually ran
+/// (#2123) — and the two flags compose instead of overwriting each other.
+#[test]
+fn the_transcript_opt_in_rewrites_the_predicate_it_loosens() {
+    let strict = acceptance_predicate(false, false);
+    let loose = acceptance_predicate(false, true);
+
+    assert!(
+        strict.contains(
+            "AND at least one recorded model call, every one reconstructing \
+             digest-verified (Reconstruction::is_verified)"
+        ),
+        "the default states the transcript gate: {strict}"
+    );
+    assert!(
+        loose.contains("OR exported with transcript_verified=false and no calls"),
+        "the loosened rule names the non-default path: {loose}"
+    );
+    assert_ne!(
+        strict, loose,
+        "a flag that changed the selection must change the stated predicate"
+    );
+    assert!(
+        acceptance_predicate(true, true).contains("verdict"),
+        "loosening the transcript clause does not drop the verdict clause"
+    );
+}
+
+/// The severity carried on a record is the worst across the execution's
+/// calls, so a benign compaction rewrite cannot mask an integrity mismatch
+/// recorded a call later.
+#[test]
+fn the_reported_severity_is_the_gravest_one_not_the_first() {
+    use MismatchSeverity::{Compaction, Integrity, None as NoMismatch};
+
+    assert_eq!(worst_severity(NoMismatch, Compaction), Compaction);
+    assert_eq!(worst_severity(Compaction, NoMismatch), Compaction);
+    assert_eq!(worst_severity(Compaction, Integrity), Integrity);
+    assert_eq!(worst_severity(Integrity, Compaction), Integrity);
+    assert_eq!(worst_severity(NoMismatch, NoMismatch), NoMismatch);
+
+    // The wire spelling is `inspect`'s, not a second one: a dataset record and
+    // a `stella inspect --json` payload must not disagree about a verdict.
+    assert_eq!(crate::inspect::severity_tag(NoMismatch), "none");
+    assert_eq!(crate::inspect::severity_tag(Compaction), "compaction");
+    assert_eq!(crate::inspect::severity_tag(Integrity), "integrity");
 }
 
 /// A `Verdict` event whose evidence names a rung — or none, for the
@@ -346,6 +395,8 @@ fn redaction_runs_after_assembly_over_every_string_leaf() {
                 "content": "deploy with AKIAIOSFODNN7EXAMPLE",
             })],
         }],
+        transcript_verified: true,
+        transcript_mismatch_severity: "none".into(),
         tool_calls: vec![DatasetToolCall {
             seq: 1,
             turn_instance: 0,
@@ -382,7 +433,7 @@ fn redaction_runs_after_assembly_over_every_string_leaf() {
     // Serializing the STRUCT (not the intermediate Value) pins the key order
     // to the declaration order, whatever `serde_json::Map` happens to be.
     assert!(
-        line.starts_with(r#"{"schema":2,"execution_id":1,"session_id":"ses-fixture""#),
+        line.starts_with(r#"{"schema":3,"execution_id":1,"session_id":"ses-fixture""#),
         "declaration order is the wire order: {line}"
     );
     // The transcript is a string leaf like any other: the key planted in
@@ -413,6 +464,8 @@ fn a_clean_record_is_not_reported_as_redacted() {
         cost_usd: 0.0,
         prompt: "fix the failing test".into(),
         calls: Vec::new(),
+        transcript_verified: false,
+        transcript_mismatch_severity: "compaction".into(),
         tool_calls: Vec::new(),
         changes: Vec::new(),
         verdict: None,

--- a/crates/stella-cli/src/inspect.rs
+++ b/crates/stella-cli/src/inspect.rs
@@ -939,7 +939,12 @@ struct ReconstructionJson {
 
 /// The stable JSON spelling of an era. Named constants rather than `Debug`,
 /// because these are a wire contract for `--format json` consumers.
-fn era_tag(era: JournalEra) -> &'static str {
+///
+/// `pub(crate)` for the same reason [`severity_tag`] is: the trace writer
+/// (`crate::trace`) stamps the era onto every `TraceCall`, and a second
+/// spelling of these two words is exactly the drift the pinning tests below
+/// exist to prevent (#2030).
+pub(crate) fn era_tag(era: JournalEra) -> &'static str {
     match era {
         JournalEra::CompactionUnjournaled => "compaction_unjournaled",
         JournalEra::CompactionJournaled => "compaction_journaled",

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -98,7 +98,7 @@ impl From<Vec<Rule>> for ResolvedRules {
 /// 0011 ratified. Both are read from the same directories in the same order, so
 /// there is one precedence order rather than one per format — see
 /// [`stella_core::records::registry`].
-const RULE_EXTENSIONS: &[&str] = &["md", "toml"];
+pub(crate) const RULE_EXTENSIONS: &[&str] = &["md", "toml"];
 
 /// File names inside a rules directory that are **governance, not policy**, and
 /// so must never be parsed as records.
@@ -120,7 +120,7 @@ const RULE_EXTENSIONS: &[&str] = &["md", "toml"];
 /// [`RULE_EXTENSIONS`], so it is already never read.
 ///
 /// [g]: stella_core::records::promotion::Governance
-const RESERVED_RULE_FILENAMES: &[&str] = &["governance.toml"];
+pub(crate) const RESERVED_RULE_FILENAMES: &[&str] = &["governance.toml"];
 
 /// The production [`RuleSource`]: real `std::fs` reads over each directory
 /// in `dirs`, in the given order — every `.md` and `.toml` file's contents,

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -51,6 +51,7 @@ mod steering;
 mod toml_config;
 pub(crate) mod toml_io;
 mod unknown;
+mod withheld;
 pub use authority::{AuthorityPolicy, ManagedAuthoritySettings};
 pub use toml_config::ConfigScope;
 pub(crate) use unknown::{

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -411,7 +411,7 @@ impl Settings {
     /// file that fails to parse is a hard error naming the file.
     ///
     /// **The project scope is a trust boundary.** A cloned repo's
-    /// `.stella/settings.json` is untrusted input, and two kinds of entry in
+    /// `.stella/settings.json` is untrusted input, and three kinds of entry in
     /// it can act on your behalf without you asking:
     ///
     /// - **Hooks** run arbitrary shell commands automatically.
@@ -433,6 +433,13 @@ impl Settings {
     /// tool switches and replacement prompts are likewise restored from the
     /// trusted scopes while untrusted. Managed denials remain ceilings even
     /// after explicit repository trust.
+    ///
+    /// **Every one of those refusals is spoken, once.** The same trust verdict
+    /// also withholds the rest of the repository's steering plane — memories,
+    /// rules and records, skills, commands, agents — which lives outside
+    /// `settings.json` and so is suppressed at its own load sites; this is the
+    /// one place that holds the resolved verdict *and* runs before any of them,
+    /// so it is where [`super::withheld::notice`] is spoken too (#2302).
     pub fn load(workspace_root: &Path) -> Result<Self, String> {
         if filesystem_settings_disabled() {
             return Ok(Self::default());
@@ -566,6 +573,20 @@ impl Settings {
                     redacted.join(", "),
                 );
             }
+        }
+
+        // The steering plane's half of the same refusal. Its verdict is read
+        // off the merged policy rather than re-derived from `trust`, because
+        // an org-managed `project_prompts = "off"` withholds steering from a
+        // repository the user *did* trust — re-deriving here would announce
+        // the opposite of what the session got.
+        if announce
+            && let Some(line) = super::withheld::notice(
+                workspace_root,
+                merged.authority_policy.project_prompts_allowed,
+            )
+        {
+            eprintln!("{line}");
         }
         Ok(merged)
     }

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -575,15 +575,20 @@ impl Settings {
             }
         }
 
-        // The steering plane's half of the same refusal. Its verdict is read
-        // off the merged policy rather than re-derived from `trust`, because
-        // an org-managed `project_prompts = "off"` withholds steering from a
-        // repository the user *did* trust — re-deriving here would announce
-        // the opposite of what the session got.
+        // The steering plane's half of the same refusal. Whether anything was
+        // withheld is read off the merged policy rather than re-derived from
+        // `trust`, because an org-managed `project_prompts = "off"` withholds
+        // steering from a repository the user *did* trust — re-deriving here
+        // would announce the opposite of what the session got. The managed
+        // block goes along so the line can name a remedy that works on the arm
+        // it is actually on: the ceiling is not lifted by trusting the repo.
         if announce
             && let Some(line) = super::withheld::notice(
                 workspace_root,
-                merged.authority_policy.project_prompts_allowed,
+                super::withheld::withholder(
+                    merged.authority_policy.project_prompts_allowed,
+                    merged.managed_authority.as_ref(),
+                ),
             )
         {
             eprintln!("{line}");

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -1280,3 +1280,98 @@ fn env_flag_accepts_only_truthy_spellings() {
         );
     }
 }
+
+/// An untrusted checkout that actually has steering on disk says so — in
+/// counts, never in content — and names the opt-in (#2302).
+///
+/// Three arms, because the notice is only right if it is also *absent* twice:
+/// a trusted workspace is getting its steering and is owed nothing, and an
+/// untrusted workspace with nothing to withhold must not warn about a
+/// suppression that cost it nothing. The memory body carries a marker the
+/// assertions look for by its absence: the whole point of a counts-only notice
+/// is that a refusal to load repository text cannot itself print repository
+/// text.
+#[test]
+fn an_untrusted_workspace_names_the_steering_it_withheld() {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = dir.path().join("repo");
+    let stella = workspace.join(".stella");
+    std::fs::create_dir_all(stella.join("memories")).unwrap();
+    std::fs::create_dir_all(stella.join("rules")).unwrap();
+    std::fs::create_dir_all(stella.join("skills").join("triage")).unwrap();
+    std::fs::write(
+        stella.join("memories").join("00-marker.md"),
+        "SECRET-MARKER-BODY",
+    )
+    .unwrap();
+    std::fs::write(stella.join("rules").join("style.toml"), "").unwrap();
+    std::fs::write(stella.join("rules").join("review.toml"), "").unwrap();
+    // Governance is not a record, and the loader already skips it by name.
+    std::fs::write(stella.join("rules").join("governance.toml"), "").unwrap();
+    std::fs::write(
+        stella.join("skills").join("triage").join("SKILL.md"),
+        "# triage",
+    )
+    .unwrap();
+
+    let withheld = super::withheld::survey(&workspace);
+    assert_eq!(withheld.memories, 1);
+    assert_eq!(withheld.records, 2, "governance.toml is not a record");
+    assert_eq!(withheld.skills, 1);
+    assert_eq!(withheld.commands, 0);
+    assert_eq!(withheld.agents, 0);
+
+    let line = super::withheld::notice(&workspace, false)
+        .expect("an untrusted workspace with steering on disk is owed a notice");
+    // The whole inventory in one assertion: singular/plural per count, and the
+    // two empty categories omitted rather than reported as `0 commands`.
+    assert!(
+        line.contains("(1 memory, 2 context records, 1 skill)"),
+        "{line}"
+    );
+    assert!(line.contains("STELLA_TRUST_PROJECT=1"), "{line}");
+    assert!(
+        !line.contains("SECRET-MARKER-BODY") && !line.contains("00-marker"),
+        "the notice must carry counts, never content or filenames: {line}"
+    );
+
+    assert!(
+        super::withheld::notice(&workspace, true).is_none(),
+        "a trusted workspace is getting its steering and is owed no notice"
+    );
+    let bare = dir.path().join("bare");
+    std::fs::create_dir_all(&bare).unwrap();
+    assert!(
+        super::withheld::notice(&bare, false).is_none(),
+        "a repo with no steering must not warn about a suppression that cost it nothing"
+    );
+
+    // …and the verdict `Settings::load` hands the notice really is the untrusted
+    // one, so the arm proved above is the arm a cloned repo actually takes. The
+    // pure arms are what this test is for; this is the join to the call site.
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "HOME",
+        "STELLA_MANAGED_SETTINGS",
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+    ]);
+    let home = dir.path().join("home");
+    std::fs::create_dir_all(home.join(".stella")).unwrap();
+    // SAFETY: serialized behind the binary-wide env lock.
+    unsafe {
+        std::env::set_var("HOME", &home);
+        std::env::set_var(
+            "STELLA_MANAGED_SETTINGS",
+            dir.path().join("no-such-managed.json"),
+        );
+        std::env::remove_var("STELLA_TRUST_PROJECT");
+        std::env::remove_var("STELLA_PROJECT_HOOKS");
+    }
+    let merged = Settings::load(&workspace).unwrap();
+    assert!(
+        super::withheld::notice(&workspace, merged.authority_policy.project_prompts_allowed)
+            .is_some(),
+        "an untrusted load must resolve to the arm that speaks"
+    );
+}

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -1321,7 +1321,8 @@ fn an_untrusted_workspace_names_the_steering_it_withheld() {
     assert_eq!(withheld.commands, 0);
     assert_eq!(withheld.agents, 0);
 
-    let line = super::withheld::notice(&workspace, false)
+    let untrusted = Some(super::withheld::Withholder::ProjectUntrusted);
+    let line = super::withheld::notice(&workspace, untrusted)
         .expect("an untrusted workspace with steering on disk is owed a notice");
     // The whole inventory in one assertion: singular/plural per count, and the
     // two empty categories omitted rather than reported as `0 commands`.
@@ -1336,14 +1337,28 @@ fn an_untrusted_workspace_names_the_steering_it_withheld() {
     );
 
     assert!(
-        super::withheld::notice(&workspace, true).is_none(),
-        "a trusted workspace is getting its steering and is owed no notice"
+        super::withheld::notice(&workspace, None).is_none(),
+        "a workspace that got its steering is owed no notice"
     );
     let bare = dir.path().join("bare");
     std::fs::create_dir_all(&bare).unwrap();
     assert!(
-        super::withheld::notice(&bare, false).is_none(),
+        super::withheld::notice(&bare, untrusted).is_none(),
         "a repo with no steering must not warn about a suppression that cost it nothing"
+    );
+
+    // The managed ceiling withholds the same steering and takes a different
+    // remedy, because it is the one the user cannot lift.
+    let managed = super::withheld::notice(
+        &workspace,
+        Some(super::withheld::Withholder::ManagedCeiling),
+    )
+    .expect("a managed ceiling withholds the same steering");
+    assert!(managed.contains("authority.project_prompts"), "{managed}");
+    assert!(
+        !managed.contains("set STELLA_TRUST_PROJECT=1"),
+        "the ceiling is not lifted by the flag, so the line must not tell anyone to set it: \
+         {managed}"
     );
 
     // …and the verdict `Settings::load` hands the notice really is the untrusted
@@ -1369,9 +1384,63 @@ fn an_untrusted_workspace_names_the_steering_it_withheld() {
         std::env::remove_var("STELLA_PROJECT_HOOKS");
     }
     let merged = Settings::load(&workspace).unwrap();
-    assert!(
-        super::withheld::notice(&workspace, merged.authority_policy.project_prompts_allowed)
-            .is_some(),
-        "an untrusted load must resolve to the arm that speaks"
+    assert_eq!(
+        super::withheld::withholder(
+            merged.authority_policy.project_prompts_allowed,
+            merged.managed_authority.as_ref(),
+        ),
+        untrusted,
+        "an untrusted load must resolve to the arm that speaks, and to the remedy the user can \
+         actually apply"
     );
+}
+
+/// The remedy the notice names is decided by attribution, and attribution is
+/// checked against the resolver itself rather than restated (#2302).
+///
+/// [`AuthorityPolicy::compute`] resolves `project_prompts_allowed` as a
+/// conjunction, so a withheld verdict has two possible causes and only one of
+/// them is lifted by `STELLA_TRUST_PROJECT=1`. This walks every combination of
+/// (repository trusted?, managed `project_prompts`) and asserts the attribution
+/// agrees with the real resolver — so a change to `compute` that moved the
+/// causes around would fail here instead of silently printing advice that
+/// cannot work.
+#[test]
+fn a_managed_ceiling_and_an_untrusted_repo_are_attributed_apart() {
+    use super::withheld::{Withholder, withholder};
+
+    for trusted in [false, true] {
+        for managed_toggle in [None, Some(Toggle::On), Some(Toggle::Off)] {
+            let managed = ManagedAuthoritySettings {
+                project_prompts: managed_toggle,
+                ..ManagedAuthoritySettings::default()
+            };
+            let policy = AuthorityPolicy::compute(Some(&managed), trusted);
+            let attributed = withholder(policy.project_prompts_allowed, Some(&managed));
+
+            let expected = match (trusted, managed_toggle) {
+                // The ceiling wins whenever it is down: setting the flag does
+                // not lift it, so it is the cause worth reporting even when the
+                // repository is also untrusted.
+                (_, Some(Toggle::Off)) => Some(Withholder::ManagedCeiling),
+                (false, _) => Some(Withholder::ProjectUntrusted),
+                (true, _) => None,
+            };
+            assert_eq!(
+                attributed, expected,
+                "trusted={trusted} managed={managed_toggle:?} \
+                 allowed={}",
+                policy.project_prompts_allowed
+            );
+        }
+    }
+
+    // A workspace with no managed scope at all is the ordinary case, and must
+    // never be attributed to a ceiling that does not exist.
+    assert_eq!(
+        withholder(false, None),
+        Some(Withholder::ProjectUntrusted),
+        "no managed scope means no ceiling"
+    );
+    assert_eq!(withholder(true, None), None);
 }

--- a/crates/stella-cli/src/settings/withheld.rs
+++ b/crates/stella-cli/src/settings/withheld.rs
@@ -1,0 +1,168 @@
+//! What an untrusted checkout's project steering would have contributed, and
+//! the one line that says it did not (#2302).
+//!
+//! [`AuthorityPolicy::project_prompts_allowed`](super::AuthorityPolicy) is the
+//! fail-closed answer to "may this repository steer this session?", and every
+//! consumer of it drops its project tier without a word: workspace memories
+//! never reach the system prompt (`agent::prompt::assemble_system_prompt`),
+//! `.claude/rules` and `.stella/rules` never reach the rules section or the
+//! record registry (`rules::load_workspace_rules`), and workspace skills,
+//! commands and agents never reach the extension menus
+//! (`extensions::CustomExtensions`). Withholding
+//! them is correct — a `git clone` must not steer a session before the user
+//! opts in — but the silence is not: the user believes their memories and rules
+//! are live, and until this module the only way to find out otherwise was to
+//! reconstruct the wire prompt with `stella inspect`. It is the same defect
+//! architecture invariant #8 names for a pinned reasoning effort against a
+//! provider that cannot honour it: configuration the user wrote, dropped
+//! without a boot notice.
+//!
+//! So this module answers the one question a notice needs — **is there anything
+//! on disk the trust gate is holding back, and how much of it?** Counts only.
+//! The notice must never carry a memory body, a record's text, or even a
+//! filename: those are repository-controlled strings, and a refusal that echoed
+//! them would become the exfiltration channel it exists to prevent. Nothing
+//! here opens a file — [`survey`] is `read_dir` plus a name test — so there is
+//! no body to leak by accident.
+//!
+//! Returning the notice as data and letting the caller print it is the shape
+//! `plugin_cmd::roster::read_project_tier` established for the plugin tier's
+//! identical refusal (#3509): it is what lets the three arms below be asserted
+//! by a test instead of scraped off stderr.
+
+use std::path::Path;
+
+/// How much project steering the trust gate is holding back, by category.
+///
+/// Each count is a question about the **filesystem**, not a prediction of what
+/// the matching loader would have produced. A definition that would have failed
+/// to parse was withheld just the same, and re-deriving each loader's discovery
+/// rules here would be a second copy of them, free to drift from the first.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WithheldSteering {
+    /// `<root>/.stella/memories/*.md`.
+    pub(crate) memories: usize,
+    /// The rule files under `<root>/.claude/rules` and `<root>/.stella/rules`
+    /// — markdown rules and published TOML context records alike, since one
+    /// gate withholds both.
+    pub(crate) records: usize,
+    /// `<root>/.stella/skills` — a `<slug>.md` file or a `<slug>/SKILL.md`
+    /// directory, the two layouts the skill source reads.
+    pub(crate) skills: usize,
+    /// Visible top-level entries of `<root>/.stella/commands`. A namespace
+    /// directory counts once: the notice reports that the repository has
+    /// commands here, not how many `/name`s the loader would have resolved.
+    pub(crate) commands: usize,
+    /// Visible top-level entries of `<root>/.stella/agents`, counted exactly
+    /// like [`commands`](Self::commands).
+    pub(crate) agents: usize,
+}
+
+impl WithheldSteering {
+    /// Whether the trust gate is holding anything back at all. The overwhelming
+    /// majority of repositories ship no `.stella/` steering and must stay
+    /// silent, which is the same reason the plugin tier speaks only when its
+    /// directory exists.
+    pub(crate) fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// The parenthesised inventory — `"3 memories, 2 context records, 1 skill"`.
+    /// Zero-count categories are omitted rather than printed as `0`, and each
+    /// surviving one is singular or plural to match its count.
+    fn parts(&self) -> String {
+        [
+            part(self.memories, "memory", "memories"),
+            part(self.records, "context record", "context records"),
+            part(self.skills, "skill", "skills"),
+            part(self.commands, "command", "commands"),
+            part(self.agents, "agent", "agents"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(", ")
+    }
+}
+
+fn part(count: usize, one: &str, many: &str) -> Option<String> {
+    (count > 0).then(|| format!("{count} {}", if count == 1 { one } else { many }))
+}
+
+/// The one line an untrusted checkout with steering on disk is owed, or `None`.
+///
+/// `None` on two arms, and both are load-bearing: a **trusted** workspace is
+/// getting its steering and has nothing to be told, and an untrusted workspace
+/// with **nothing to withhold** must not warn about a suppression that cost it
+/// nothing — a notice printed in every repository is one nobody reads.
+pub(crate) fn notice(workspace_root: &Path, project_prompts_allowed: bool) -> Option<String> {
+    if project_prompts_allowed {
+        return None;
+    }
+    let withheld = survey(workspace_root);
+    if withheld.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "  ! project steering in {} was NOT loaded ({}) — set STELLA_TRUST_PROJECT=1 to let \
+         this repo's memories, rules, skills, commands and agents steer this session",
+        workspace_root.display(),
+        withheld.parts(),
+    ))
+}
+
+/// Count the project steering present on disk, opening nothing.
+pub(crate) fn survey(workspace_root: &Path) -> WithheldSteering {
+    let stella = workspace_root.join(".stella");
+    WithheldSteering {
+        memories: count_in(&stella.join("memories"), is_markdown),
+        // Both rule directories `stella_core::rules::rule_search_dirs` hands
+        // the project tier, folded into one count because one gate withholds
+        // them.
+        records: count_in(&workspace_root.join(".claude").join("rules"), is_rule_file)
+            + count_in(&stella.join("rules"), is_rule_file),
+        skills: count_in(&stella.join("skills"), |path| {
+            is_markdown(path) || path.join("SKILL.md").is_file()
+        }),
+        commands: count_in(&stella.join("commands"), is_visible),
+        agents: count_in(&stella.join("agents"), is_visible),
+    }
+}
+
+/// Entries of `dir` satisfying `keep`. A missing or unreadable directory is
+/// zero: it is the common case, and a permissions error is not something a
+/// trust notice can act on.
+fn count_in(dir: &Path, keep: impl Fn(&Path) -> bool) -> usize {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| keep(&entry.path()))
+        .count()
+}
+
+fn is_markdown(path: &Path) -> bool {
+    path.extension().and_then(|ext| ext.to_str()) == Some("md")
+}
+
+/// The filter `rules::FsRuleSource` applies, reading its constants rather than
+/// restating them so the two answers cannot disagree about what a rule file is.
+fn is_rule_file(path: &Path) -> bool {
+    let has_rule_extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| crate::rules::RULE_EXTENSIONS.contains(&ext));
+    let is_reserved = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| crate::rules::RESERVED_RULE_FILENAMES.contains(&name));
+    has_rule_extension && !is_reserved
+}
+
+/// The extension loaders skip dot-entries (`.DS_Store`, lock files); so does
+/// the count, or a repository with no commands at all would report one.
+fn is_visible(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| !name.starts_with('.'))
+}

--- a/crates/stella-cli/src/settings/withheld.rs
+++ b/crates/stella-cli/src/settings/withheld.rs
@@ -25,19 +25,94 @@
 //! here opens a file — [`survey`] is `read_dir` plus a name test — so there is
 //! no body to leak by accident.
 //!
+//! It answers a second question the first one cannot: **which authority
+//! withheld it**, because that decides the only remedy the line may honestly
+//! name. Repository trust and the org's ceiling both resolve
+//! `project_prompts_allowed` to `false`, and they are not interchangeable — a
+//! `STELLA_TRUST_PROJECT=1` printed against a managed `project_prompts = "off"`
+//! tells a user who has *already set that flag* to set it again. See
+//! [`Withholder`].
+//!
 //! Returning the notice as data and letting the caller print it is the shape
 //! `plugin_cmd::roster::read_project_tier` established for the plugin tier's
-//! identical refusal (#3509): it is what lets the three arms below be asserted
-//! by a test instead of scraped off stderr.
+//! identical refusal (#3509): it is what lets the arms below be asserted by a
+//! unit test. It does not replace the end-to-end witness — the notice is only
+//! *user-visible* because [`super::Settings::load`] prints it, and that wiring
+//! is proved by a process test
+//! (`crates/stella-cli/tests/settings_warnings_cli.rs`), not by this module.
+//!
+//! **stderr is the only carrier today.** #2302 also asks for the counts in the
+//! `--output-format stream-json`/`json` output so a harness sees them without
+//! scraping the human channel; that half is unimplemented and tracked in #3616.
+//! It needs a wire carrier, not a new answer — [`survey`] and [`withholder`]
+//! already return everything it would emit.
 
 use std::path::Path;
 
+use super::Toggle;
+use super::authority::ManagedAuthoritySettings;
+
+/// Which authority is holding the steering back, and therefore what the notice
+/// may tell the user to do about it.
+///
+/// [`super::AuthorityPolicy::compute`] resolves `project_prompts_allowed` as
+/// `project_trusted && managed.project_prompts != Off` — a conjunction, so a
+/// `false` has two possible causes with two different remedies. The managed arm
+/// is a **ceiling**: it is not lifted by trusting the repository, so a notice
+/// that named `STELLA_TRUST_PROJECT=1` there would be advice that cannot work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Withholder {
+    /// This process was not told to trust the repository. The user holds the
+    /// remedy themselves.
+    ProjectUntrusted,
+    /// The org-managed scope pins `authority.project_prompts = "off"`, which
+    /// takes precedence: it withholds the steering whether or not the user
+    /// trusts this checkout, and no environment variable lifts it.
+    ManagedCeiling,
+}
+
+/// Attribute an already-resolved withholding to the authority that caused it,
+/// or `None` when the steering was in fact loaded.
+///
+/// **`project_prompts_allowed` is read, never re-derived** — it is the verdict
+/// the session actually ran under, and the whole point of the call site passing
+/// it is that a second derivation could announce the opposite of what happened.
+/// The managed block is consulted only to *attribute* a withholding this
+/// argument has already established, which is why the ceiling is checked first:
+/// when both causes hold, the one the user cannot lift is the one to report.
+pub(crate) fn withholder(
+    project_prompts_allowed: bool,
+    managed: Option<&ManagedAuthoritySettings>,
+) -> Option<Withholder> {
+    if project_prompts_allowed {
+        return None;
+    }
+    Some(
+        if managed.and_then(|managed| managed.project_prompts) == Some(Toggle::Off) {
+            Withholder::ManagedCeiling
+        } else {
+            Withholder::ProjectUntrusted
+        },
+    )
+}
+
 /// How much project steering the trust gate is holding back, by category.
 ///
-/// Each count is a question about the **filesystem**, not a prediction of what
-/// the matching loader would have produced. A definition that would have failed
-/// to parse was withheld just the same, and re-deriving each loader's discovery
-/// rules here would be a second copy of them, free to drift from the first.
+/// Each count is a question about the **workspace's steering directories**, not
+/// a prediction of what the matching loader would have produced. A definition
+/// that would have failed to parse was withheld just the same, and re-deriving
+/// each loader's discovery rules here would be a second copy of them, free to
+/// drift from the first.
+///
+/// **One withheld source is deliberately not counted**: the extension-authored
+/// rules `rules::store_rule_files` reads out of `.stella/private/store.db`, which
+/// the same gate suppresses (`rules::load_workspace_rules`'s `include_project`
+/// arm). Counting them means `stella_store::Store::open`, and that is not a
+/// read — it creates and hardens the state directory, runs migrations, and
+/// writes through `reconcile_interrupted_executions`. None of that may happen as
+/// a side effect of loading settings, which every `stella` invocation does. A
+/// workspace whose *only* steering is store rules therefore stays silent; it
+/// needs a read-only count exposed by the store, tracked in #3617.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct WithheldSteering {
     /// `<root>/.stella/memories/*.md`.
@@ -89,23 +164,31 @@ fn part(count: usize, one: &str, many: &str) -> Option<String> {
     (count > 0).then(|| format!("{count} {}", if count == 1 { one } else { many }))
 }
 
-/// The one line an untrusted checkout with steering on disk is owed, or `None`.
+/// The one line a checkout whose steering was withheld is owed, or `None`.
 ///
-/// `None` on two arms, and both are load-bearing: a **trusted** workspace is
-/// getting its steering and has nothing to be told, and an untrusted workspace
-/// with **nothing to withhold** must not warn about a suppression that cost it
+/// `None` on two arms, and both are load-bearing: a workspace whose steering
+/// **was loaded** (`withheld_by` is `None`) has nothing to be told, and one with
+/// **nothing to withhold** must not warn about a suppression that cost it
 /// nothing — a notice printed in every repository is one nobody reads.
-pub(crate) fn notice(workspace_root: &Path, project_prompts_allowed: bool) -> Option<String> {
-    if project_prompts_allowed {
-        return None;
-    }
+pub(crate) fn notice(workspace_root: &Path, withheld_by: Option<Withholder>) -> Option<String> {
+    let withheld_by = withheld_by?;
     let withheld = survey(workspace_root);
     if withheld.is_empty() {
         return None;
     }
+    let remedy = match withheld_by {
+        Withholder::ProjectUntrusted => {
+            "set STELLA_TRUST_PROJECT=1 to let this repo's memories, rules, skills, commands \
+             and agents steer this session"
+        }
+        Withholder::ManagedCeiling => {
+            "your org's managed settings set authority.project_prompts = \"off\", so no \
+             repository may steer a session on this machine — STELLA_TRUST_PROJECT does not \
+             lift it"
+        }
+    };
     Some(format!(
-        "  ! project steering in {} was NOT loaded ({}) — set STELLA_TRUST_PROJECT=1 to let \
-         this repo's memories, rules, skills, commands and agents steer this session",
+        "  ! project steering in {} was NOT loaded ({}) — {remedy}",
         workspace_root.display(),
         withheld.parts(),
     ))

--- a/crates/stella-cli/src/trace.rs
+++ b/crates/stella-cli/src/trace.rs
@@ -163,7 +163,24 @@ pub struct TraceCall {
     /// ([`stella_store::Reconstruction::is_verified`]). A trace with
     /// `false` here is still honest — it says so.
     pub reconstruction_verified: bool,
-    /// Why reconstruction fell short, when it did.
+    /// Which compaction-journaling era wrote this execution's journal —
+    /// `compaction_journaled` or `compaction_unjournaled`, the same two words
+    /// `stella inspect --format json` and `/api/execution-context` emit.
+    /// `None` only when reconstruction failed outright and produced no
+    /// [`stella_store::Reconstruction`] to read it from: unknown is recorded
+    /// as unknown, never guessed (#2030).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub journal_era: Option<String>,
+    /// What this call's digest mismatches mean — `none`, `compaction`, or
+    /// `integrity`. Present whenever a reconstruction was produced, including
+    /// the verified path, so "did any call in this run raise a real integrity
+    /// signal" is one grep over a field rather than a regex over
+    /// [`Self::reconstruction_error`]'s prose (#2030, #1981). `None` carries
+    /// the same meaning as on [`Self::journal_era`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest_mismatch_severity: Option<String>,
+    /// Why reconstruction fell short, when it did. The human sentence; the two
+    /// fields above are what a consumer filters on.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconstruction_error: Option<String>,
     /// Tools the model requested after this call, in order.
@@ -250,6 +267,17 @@ pub fn capture(
     append_trace(workspace_root, &record)
 }
 
+/// One call's reconstruction, already reduced to the shape [`TraceCall`]
+/// stores. A struct rather than a tuple because the two arms below now settle
+/// five values, and a five-tuple destructure names none of them.
+struct CallReconstruction {
+    messages: Vec<serde_json::Value>,
+    verified: bool,
+    journal_era: Option<String>,
+    digest_mismatch_severity: Option<String>,
+    error: Option<String>,
+}
+
 /// Build the [`TraceRecord`] for `execution_id`. Read after closeout so
 /// `outcome`, `cost_usd`, and the full journal are settled.
 pub fn assemble(
@@ -274,7 +302,7 @@ pub fn assemble(
     let mut calls = Vec::with_capacity(receipts.len());
     for receipt in &receipts {
         let key = (receipt.turn_instance, receipt.step, receipt.call_seq);
-        let (prompt_messages, verified, error) = match store.reconstruct_call(
+        let reconstructed = match store.reconstruct_call(
             execution_id,
             receipt.turn_instance,
             receipt.step,
@@ -282,12 +310,6 @@ pub fn assemble(
         ) {
             Ok(reconstruction) => {
                 let verified = reconstruction.is_verified();
-                // The severity rides along with the ids, because a trace is
-                // read long after the run and by someone who cannot ask which
-                // build wrote it. `compaction` says the mismatch is the
-                // pre-#1667 journal's routine one; `integrity` says nothing
-                // routine explains it. Same verdict `stella inspect` and the
-                // deck render — one source, four surfaces (#1981).
                 let error = (!verified).then(|| {
                     format!(
                         "unresolved: [{}]; digest mismatches ({}): [{}]",
@@ -296,17 +318,36 @@ pub fn assemble(
                         reconstruction.digest_mismatches.join(", ")
                     )
                 });
-                (
-                    redact_messages(&reconstruction.messages, &mut redacted),
+                CallReconstruction {
+                    messages: redact_messages(&reconstruction.messages, &mut redacted),
                     verified,
+                    // The era and the severity ride along with the ids as
+                    // fields, because a trace is read long after the run, by a
+                    // machine, and by someone who cannot ask which build wrote
+                    // it. `compaction` says the mismatch is the pre-#1667
+                    // journal's routine one; `integrity` says nothing routine
+                    // explains it. Stamped on the verified path too, where the
+                    // answer is `none`: a reader should never have to infer a
+                    // verdict from a field's absence. Same words `stella
+                    // inspect` and the deck render — one source, four surfaces
+                    // (#1981, #2030).
+                    journal_era: Some(crate::inspect::era_tag(reconstruction.journal_era).into()),
+                    digest_mismatch_severity: Some(
+                        crate::inspect::severity_tag(reconstruction.mismatch_severity()).into(),
+                    ),
                     error,
-                )
+                }
             }
-            Err(e) => (
-                Vec::new(),
-                false,
-                Some(format!("reconstruction failed: {e}")),
-            ),
+            // Nothing was read, so nothing is known: the era and severity stay
+            // absent rather than defaulting to a word that would read as a
+            // verdict.
+            Err(e) => CallReconstruction {
+                messages: Vec::new(),
+                verified: false,
+                journal_era: None,
+                digest_mismatch_severity: None,
+                error: Some(format!("reconstruction failed: {e}")),
+            },
         };
         let usage = fold.usage_by_call.get(&key);
         calls.push(TraceCall {
@@ -317,9 +358,11 @@ pub fn assemble(
             stage: fold.stage_by_call.get(&key).cloned().flatten(),
             provider: receipt.provider.clone(),
             model: receipt.model.clone(),
-            prompt_messages,
-            reconstruction_verified: verified,
-            reconstruction_error: error,
+            prompt_messages: reconstructed.messages,
+            reconstruction_verified: reconstructed.verified,
+            journal_era: reconstructed.journal_era,
+            digest_mismatch_severity: reconstructed.digest_mismatch_severity,
+            reconstruction_error: reconstructed.error,
             tool_uses: fold.tools_by_call.get(&key).cloned().unwrap_or_default(),
             input_tokens: usage.map(|u| u.input_tokens),
             output_tokens: usage.map(|u| u.output_tokens),
@@ -915,6 +958,12 @@ mod tests {
         assert_eq!(record.calls.len(), 1);
         assert!(!record.calls[0].reconstruction_verified);
         assert!(record.calls[0].reconstruction_error.is_some());
+        // Unresolved is not a digest mismatch: the severity says `none` while
+        // `reconstruction_verified` says false. That distinction is exactly
+        // what the prose sentence cannot express (#2030).
+        let call = &serde_json::to_value(&record).unwrap()["calls"][0];
+        assert_eq!(call["digest_mismatch_severity"], "none");
+        assert_eq!(call["journal_era"], "compaction_journaled");
         assert_eq!(record.change_digest, None);
         assert!(record.outcome.is_none(), "unsettled execution says so");
         // No verdict reached the journal, so the label says exactly that
@@ -923,6 +972,93 @@ mod tests {
         assert_eq!(
             record.reward.discard,
             Some(stella_pipeline::reward::DiscardReason::NoVerdict)
+        );
+    }
+
+    /// #2030: a digest mismatch on a current-era journal is a real integrity
+    /// signal, and the trace record says so in a field a consumer can filter
+    /// on — not only inside `reconstruction_error`'s sentence. Asserted
+    /// against the serialized line rather than the struct, because the JSONL
+    /// artifact is what a dataset reader actually greps.
+    #[test]
+    fn a_digest_mismatch_is_a_field_not_a_substring() {
+        let store = Store::in_memory().unwrap();
+        // `begin_execution` stamps the current era, which is what makes an
+        // unexplained mismatch `integrity` rather than routine `compaction`.
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        store
+            .record_event(
+                id,
+                0,
+                &AgentEvent::ToolResult {
+                    call_id: "call_1".to_string(),
+                    output: ToolOutput::Ok {
+                        content: "fn login() {}".to_string(),
+                        data: None,
+                    },
+                    duration_ms: 5,
+                    speculated: false,
+                },
+            )
+            .unwrap();
+        // The block resolves through the journal by `call_id`, but its
+        // recorded digest is not the digest of those bytes — a mismatch by
+        // construction. `gap_block` cannot express this: it stores `content`
+        // locally, which short-circuits the digest check to true.
+        store
+            .record_context_block(
+                id,
+                &ContextBlockRow {
+                    block_id: "blk_tool".to_string(),
+                    kind: "tool_result".to_string(),
+                    origin_turn: 0,
+                    origin_step: 0,
+                    call_id: Some("call_1".to_string()),
+                    memory_id: None,
+                    token_cost: Some(1),
+                    content_digest: format!("sha256:{}", "0".repeat(64)),
+                    citation_label: None,
+                    content: None,
+                },
+            )
+            .unwrap();
+        store
+            .record_step_manifest(
+                id,
+                &StepManifestRow {
+                    turn_instance: 0,
+                    step: 0,
+                    call_seq: 0,
+                    provider: "zai".to_string(),
+                    model: "glm-5.2".to_string(),
+                    call_role: "worker".to_string(),
+                    effective_budget_tokens: 1000,
+                    calibration_factor: 1.0,
+                    estimated_input_tokens: 10,
+                    compiled_frame_id: None,
+                    frame_hash: None,
+                    blocks: vec![manifest_entry("blk_tool", 0)],
+                },
+            )
+            .unwrap();
+
+        let record = assemble(&store, id, &RewardPolicy::default()).unwrap();
+        assert_eq!(record.calls.len(), 1);
+        assert!(!record.calls[0].reconstruction_verified);
+
+        let call = &serde_json::to_value(&record).unwrap()["calls"][0];
+        assert_eq!(
+            call["digest_mismatch_severity"], "integrity",
+            "the verdict is a key, not a substring: {call}"
+        );
+        assert_eq!(call["journal_era"], "compaction_journaled");
+        // The human sentence stays: the fields are additive to it, not a
+        // replacement for it.
+        assert!(
+            call["reconstruction_error"]
+                .as_str()
+                .is_some_and(|e| e.contains("blk_tool")),
+            "the prose still names the block: {call}"
         );
     }
 

--- a/crates/stella-cli/src/trace.rs
+++ b/crates/stella-cli/src/trace.rs
@@ -80,7 +80,15 @@ use stella_store::Store;
 /// yet, and the alternative is every future reader carrying "v2 implies the
 /// 2026-08 defaults" as a permanent special case. Skipping is cheaper and
 /// cannot rot.
-pub const TRACE_SCHEMA_VERSION: u32 = 3;
+///
+/// `4` makes the label's step count nullable ([`TrajectoryCost::steps`]).
+/// A v3 record whose execution recorded no model call wrote `steps: 0` and a
+/// reward scalar shaped as though the turn had bought none — the step penalty
+/// silently absent from every trace of a store predating the receipts plane
+/// (#2123). v4 writes `steps: null` and discards the scalar instead, so a v3
+/// line is skipped rather than pooled beside a v4 one that priced the same
+/// trajectory differently.
+pub const TRACE_SCHEMA_VERSION: u32 = 4;
 
 /// The append-only trace file, one JSON record per line, under
 /// `.stella/private/`.
@@ -383,7 +391,7 @@ pub fn assemble(
     let reward = label(
         fold.settlement.unwrap_or(Settlement::Absent),
         TrajectoryCost {
-            steps: u32::try_from(calls.len()).unwrap_or(u32::MAX),
+            steps: TrajectoryCost::recorded_steps(calls.len()),
             cost_usd: summary.cost_usd,
             revisions: fold.verdicts.saturating_sub(1),
         },
@@ -1103,10 +1111,20 @@ mod tests {
             record.reward.cost.revisions, 1,
             "two verdicts, one revision"
         );
-        assert_eq!(record.reward.cost.steps, 0, "no receipts in this fixture");
-        // 1.0 − 0.02·0 − 0.5·0.40 − 0.1·1 = 0.70
-        let reward = record.reward.reward.expect("scored");
-        assert!((reward - 0.70).abs() < 1e-9, "got {reward}");
+        // No receipts in this fixture, so how many calls the turn bought was
+        // never recorded. Shaped against a zero it would have scored
+        // 1.0 − 0.02·0 − 0.5·0.40 − 0.1·1 = 0.70, a step penalty lighter than
+        // any counted trajectory pays; the label withholds the scalar instead
+        // and keeps the rung and the outcome term, which are still true.
+        assert_eq!(
+            record.reward.cost.steps, None,
+            "no receipts in this fixture"
+        );
+        assert_eq!(record.reward.reward, None);
+        assert_eq!(
+            record.reward.discard,
+            Some(stella_pipeline::reward::DiscardReason::StepsUnknown)
+        );
 
         // The airlock at the trace seam: the verifier's own sentence is in the
         // journal this was folded from, and nowhere in the label.

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -12,6 +12,13 @@
 //! the #2123 assertions fail on the pre-#2123 tree, where
 //! `--include-unverified-transcripts` is not an argument at all and the
 //! unvouched turn is unreachable by any invocation.
+//!
+//! The last of those is the pre-receipts turn's reward label: read the empty
+//! receipts plane as a zero step count and the record exports a scalar
+//! *above* what the same trajectory earns once its calls are counted, on the
+//! records whose provenance is weakest. That is what
+//! `a_turn_with_no_receipts_at_all_withholds_the_reward_scalar_it_cannot_shape`
+//! pins.
 
 use std::path::Path;
 use std::process::Command;
@@ -136,7 +143,17 @@ fn ladder(rung: LadderRung) -> Option<Box<LadderSnapshot>> {
     }))
 }
 
-/// A workspace whose store holds four settled executions, one per filter arm:
+/// The seeded workspace and the execution ids the assertions name.
+struct Seeded {
+    dir: tempfile::TempDir,
+    flipped: i64,
+    tampered: i64,
+    /// The turn whose receipts plane holds nothing at all — see
+    /// [`seeded_workspace`].
+    pre_receipts: i64,
+}
+
+/// A workspace whose store holds five settled executions, one per filter arm:
 ///
 /// - `flipped`: accepted — `completed`, a mutating change, a digest-verified
 ///   worker transcript, and a `SubmitFast` verdict (the deterministic flip,
@@ -146,12 +163,18 @@ fn ladder(rung: LadderRung) -> Option<Box<LadderSnapshot>> {
 /// - one `aborted` turn, excluded by outcome;
 /// - one `completed` turn whose only receipt cites a block with no journal
 ///   preimage, so its reconstruction cannot verify: excluded by the
-///   transcript gate and counted in the manifest.
+///   transcript gate and counted in the manifest;
+/// - `pre_receipts`: a `completed` turn with a mutating change and a passing
+///   verdict but **no `step_receipt` row at all** — the shape of a whole store
+///   predating the receipts plane, which is the headline case #2123 exists
+///   for. It reaches the unvouched arm by the other route (nothing to
+///   reconstruct rather than a reconstruction that fell short), and it is the
+///   only fixture on which the reward's step term has nothing to count.
 ///
 /// A project-scope `.stella/settings.json` pins the default reward weights
 /// explicitly, so the labels asserted below cannot drift with whatever the
 /// developer's user-scope settings say.
-fn seeded_workspace() -> (tempfile::TempDir, i64, i64) {
+fn seeded_workspace() -> Seeded {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open(dir.path()).expect("store");
     std::fs::write(
@@ -366,7 +389,51 @@ fn seeded_workspace() -> (tempfile::TempDir, i64, i64) {
         .finish_execution(unvouched, "completed", 0.01)
         .expect("finish");
 
-    (dir, flipped, tampered)
+    // A settled success from before the receipts plane existed: the journal
+    // holds the change and the verdict, and `step_receipt` holds nothing, so
+    // there is no recorded model call to reconstruct — and no count of how
+    // many calls the turn actually bought.
+    let pre_receipts = store
+        .begin_execution(
+            "run",
+            "a turn from before the receipts plane",
+            "zai",
+            "glm-5.2",
+        )
+        .expect("execution");
+    let pre_receipts_events = [
+        AgentEvent::FileChange {
+            path: "src/legacy.rs".into(),
+            kind: FileChangeKind::Modified,
+            added: 4,
+            removed: 1,
+            diff: None,
+        },
+        AgentEvent::Verdict {
+            passed: true,
+            evidence: VerdictEvidence {
+                summary: "the touched tests are green".into(),
+                deterministic: true,
+                evidence_refs: Vec::new(),
+                ladder: ladder(LadderRung::SubmitFast),
+            },
+        },
+    ];
+    for (seq, event) in pre_receipts_events.iter().enumerate() {
+        store
+            .record_event(pre_receipts, seq as u64, event)
+            .expect("event");
+    }
+    store
+        .finish_execution(pre_receipts, "completed", 0.10)
+        .expect("finish");
+
+    Seeded {
+        dir,
+        flipped,
+        tampered,
+        pre_receipts,
+    }
 }
 
 fn export(dir: &tempfile::TempDir, out: &str, extra: &[&str]) -> String {
@@ -401,10 +468,15 @@ fn read(dir: &Path, out: &str, file: &str) -> Vec<u8> {
 /// and the reward labels the issues describe.
 #[test]
 fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
-    let (dir, flipped, tampered) = seeded_workspace();
+    let Seeded {
+        dir,
+        flipped,
+        tampered,
+        ..
+    } = seeded_workspace();
     let summary = export(&dir, "out", &[]);
     assert!(
-        summary.contains("2 accepted turn(s) from 4 settled execution(s)"),
+        summary.contains("2 accepted turn(s) from 5 settled execution(s)"),
         "the summary reports what it kept and what it read: {summary}"
     );
 
@@ -412,7 +484,7 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
     assert_eq!(
         jsonl.lines().count(),
         2,
-        "the aborted and the unvouched executions are excluded: {jsonl}"
+        "the aborted and the two unvouched executions are excluded: {jsonl}"
     );
     let mut lines = jsonl.lines();
     let record: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
@@ -491,8 +563,8 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
     let manifest: serde_json::Value =
         serde_json::from_slice(&read(dir.path(), "out", "manifest.json")).expect("manifest json");
     assert_eq!(manifest["records"], 2);
-    assert_eq!(manifest["filter"]["executions_scanned"], 4);
-    assert_eq!(manifest["filter"]["executions_transcripts_unverified"], 1);
+    assert_eq!(manifest["filter"]["executions_scanned"], 5);
+    assert_eq!(manifest["filter"]["executions_transcripts_unverified"], 2);
     assert_eq!(manifest["filter"]["include_unverified_transcripts"], false);
     assert_eq!(manifest["filter"]["executions_accepted"], 2);
     assert_eq!(
@@ -515,7 +587,7 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
 /// detail can hide a leak.
 #[test]
 fn a_planted_key_in_the_prompt_or_a_tool_argument_never_reaches_the_output() {
-    let (dir, _, _) = seeded_workspace();
+    let dir = seeded_workspace().dir;
     export(&dir, "out", &[]);
 
     for file in ["dataset.jsonl", "manifest.json"] {
@@ -547,7 +619,7 @@ fn a_planted_key_in_the_prompt_or_a_tool_argument_never_reaches_the_output() {
 /// files. Run twice into different directories and compare the bytes.
 #[test]
 fn the_same_store_and_filter_export_byte_identical_files() {
-    let (dir, _, _) = seeded_workspace();
+    let dir = seeded_workspace().dir;
     export(&dir, "first", &[]);
     export(&dir, "second", &[]);
 
@@ -564,13 +636,13 @@ fn the_same_store_and_filter_export_byte_identical_files() {
 /// rule rather than the default one.
 #[test]
 fn the_date_window_and_require_verdict_are_reported_as_applied() {
-    let (dir, _, _) = seeded_workspace();
+    let dir = seeded_workspace().dir;
 
     export(&dir, "future", &["--since", "2099-01-01"]);
     let manifest: serde_json::Value =
         serde_json::from_slice(&read(dir.path(), "future", "manifest.json")).expect("json");
     assert_eq!(manifest["records"], 0);
-    assert_eq!(manifest["filter"]["executions_scanned"], 4);
+    assert_eq!(manifest["filter"]["executions_scanned"], 5);
     assert_eq!(manifest["filter"]["executions_in_window"], 0);
     assert_eq!(manifest["filter"]["since"], "2099-01-01");
     assert_eq!(manifest["execution_id_range"], serde_json::Value::Null);
@@ -603,28 +675,28 @@ fn the_date_window_and_require_verdict_are_reported_as_applied() {
 /// modes stay comparable.
 #[test]
 fn the_unvouched_turn_is_reachable_only_under_the_transcript_opt_in() {
-    let (dir, _, _) = seeded_workspace();
+    let dir = seeded_workspace().dir;
 
-    // The default is unchanged: the unvouched turn is still excluded.
+    // The default is unchanged: neither unvouched turn is exported.
     export(&dir, "strict", &[]);
     let strict = String::from_utf8(read(dir.path(), "strict", "dataset.jsonl")).expect("utf8");
-    assert_eq!(strict.lines().count(), 2, "the default still excludes it");
+    assert_eq!(strict.lines().count(), 2, "the default still excludes them");
 
     let summary = export(&dir, "loose", &["--include-unverified-transcripts"]);
     assert!(
-        summary.contains("3 accepted turn(s) from 4 settled execution(s)"),
-        "the unvouched turn is now kept: {summary}"
+        summary.contains("4 accepted turn(s) from 5 settled execution(s)"),
+        "both unvouched turns are now kept: {summary}"
     );
     assert!(
-        summary.contains("1 turn(s) exported with transcript_verified=false"),
+        summary.contains("2 turn(s) exported with transcript_verified=false"),
         "the summary says the transcripts were withheld, not that nothing happened: {summary}"
     );
 
     let jsonl = String::from_utf8(read(dir.path(), "loose", "dataset.jsonl")).expect("utf8");
     assert_eq!(
         jsonl.lines().count(),
-        3,
-        "the unvouched execution joins the two verified ones: {jsonl}"
+        4,
+        "the two unvouched executions join the two verified ones: {jsonl}"
     );
     let unvouched: serde_json::Value =
         serde_json::from_str(jsonl.lines().nth(2).unwrap()).expect("record json");
@@ -659,13 +731,13 @@ fn the_unvouched_turn_is_reachable_only_under_the_transcript_opt_in() {
         manifest["schema"], 3,
         "the record shape changed, so did the schema"
     );
-    assert_eq!(manifest["records"], 3);
+    assert_eq!(manifest["records"], 4);
     assert_eq!(manifest["filter"]["include_unverified_transcripts"], true);
     assert_eq!(
-        manifest["filter"]["executions_transcripts_unverified"], 1,
+        manifest["filter"]["executions_transcripts_unverified"], 2,
         "the same count in both modes is what makes them comparable"
     );
-    assert_eq!(manifest["filter"]["executions_accepted"], 3);
+    assert_eq!(manifest["filter"]["executions_accepted"], 4);
     assert_eq!(
         manifest["filter"]["acceptance_predicate"],
         "executions.outcome in {completed, goal_met} AND at least one mutating \
@@ -686,6 +758,70 @@ fn the_unvouched_turn_is_reachable_only_under_the_transcript_opt_in() {
     }
 }
 
+/// #2123, the headline case: a store predating the receipts plane holds no
+/// `step_receipt` row, so nothing recorded how many model calls its turns
+/// bought. The flag exports those turns — and the reward label refuses to
+/// price a step count nobody wrote down.
+///
+/// Read as zero, the shaping subtracts nothing, so the record would carry a
+/// scalar strictly ABOVE what the same trajectory earns once its calls are
+/// counted: `1.0 − 0.5·$0.10 = 0.95` here, against `0.93` for a five-call
+/// version of the identical turn. That inflation would land on exactly the
+/// records whose provenance is weakest, and nothing on the record would say
+/// so. The label reports `steps_unknown` instead, keeping the rung, the
+/// outcome term and the policy — everything a consumer needs to re-shape it
+/// under a count of its own.
+#[test]
+fn a_turn_with_no_receipts_at_all_withholds_the_reward_scalar_it_cannot_shape() {
+    let Seeded {
+        dir, pre_receipts, ..
+    } = seeded_workspace();
+    export(&dir, "loose", &["--include-unverified-transcripts"]);
+
+    let jsonl = String::from_utf8(read(dir.path(), "loose", "dataset.jsonl")).expect("utf8");
+    let record: serde_json::Value = jsonl
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("record json"))
+        .find(|record: &serde_json::Value| record["execution_id"] == pre_receipts)
+        .expect("the pre-receipts turn is exported under the flag");
+
+    // The journal half is intact: this is a real trajectory, worth exporting.
+    assert_eq!(record["outcome"], "completed");
+    assert_eq!(record["changes"][0]["path"], "src/legacy.rs");
+    assert_eq!(record["verdict"]["passed"], true);
+    assert_eq!(record["transcript_verified"], false);
+    assert_eq!(record["calls"].as_array().map(Vec::len), Some(0));
+    assert_eq!(
+        record["transcript_mismatch_severity"], "none",
+        "there is nothing to reconstruct, so nothing mismatched"
+    );
+
+    // The label half: everything true is published, and only the number that
+    // would have been wrong is withheld.
+    assert_eq!(record["reward"]["rung"], "submit_fast");
+    assert_eq!(record["reward"]["outcome"], 1.0);
+    assert_eq!(record["reward"]["policy"]["shaping"]["per_step"], 0.02);
+    assert!(
+        record["reward"]["cost"]["steps"].is_null(),
+        "an unrecorded step count is null, never a zero that prices as free: {record}"
+    );
+    assert!(
+        record["reward"]["reward"].is_null(),
+        "no scalar is claimed for a trajectory whose step cost is unknown: {record}"
+    );
+    assert_eq!(
+        record["reward"]["discard"], "steps_unknown",
+        "and the reason is named, so the row is selectable rather than lost"
+    );
+
+    // A turn whose receipts DID record its calls still scores, unverified
+    // transcript or not: the gap is the step count, not the flag.
+    let verified: serde_json::Value =
+        serde_json::from_str(jsonl.lines().next().unwrap()).expect("record json");
+    assert_eq!(verified["reward"]["cost"]["steps"], 1);
+    assert!(verified["reward"]["reward"].as_f64().is_some());
+}
+
 /// The dataset carries redacted prompts and full tool outputs, which is at
 /// least as sensitive as the session archive that was hardened for the same
 /// reason — so the directory is owner-only and so are both files.
@@ -694,7 +830,7 @@ fn the_unvouched_turn_is_reachable_only_under_the_transcript_opt_in() {
 fn the_dataset_and_its_directory_are_owner_only() {
     use std::os::unix::fs::PermissionsExt;
 
-    let (dir, _, _) = seeded_workspace();
+    let dir = seeded_workspace().dir;
     export(&dir, "out", &[]);
 
     let out = dir.path().join("out");

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -8,7 +8,10 @@
 //! Every assertion here fails on the pre-#872 tree, where the subcommand does
 //! not parse at all (clap exits 2 with "unrecognized subcommand"); the #2083
 //! assertions fail on the pre-#2083 tree, where records carry no `calls` or
-//! `reward` and the unvouched execution is exported instead of counted.
+//! `reward` and the unvouched execution is exported instead of counted; and
+//! the #2123 assertions fail on the pre-#2123 tree, where
+//! `--include-unverified-transcripts` is not an argument at all and the
+//! unvouched turn is unreachable by any invocation.
 
 use std::path::Path;
 use std::process::Command;
@@ -448,6 +451,11 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
     assert_eq!(call["role"], "worker");
     assert_eq!(call["turn_instance"], 0);
     assert_eq!(call["call_seq"], 0);
+    assert_eq!(
+        record["transcript_verified"], true,
+        "a default-filter record's transcript is the digest-verified one (#2123)"
+    );
+    assert_eq!(record["transcript_mismatch_severity"], "none");
     let messages = call["prompt_messages"].as_array().expect("messages");
     assert_eq!(messages.len(), 4, "system, goal, tool call, tool result");
     assert_eq!(messages[0]["role"], "system");
@@ -485,6 +493,7 @@ fn export_writes_one_record_per_accepted_turn_with_its_provenance() {
     assert_eq!(manifest["records"], 2);
     assert_eq!(manifest["filter"]["executions_scanned"], 4);
     assert_eq!(manifest["filter"]["executions_transcripts_unverified"], 1);
+    assert_eq!(manifest["filter"]["include_unverified_transcripts"], false);
     assert_eq!(manifest["filter"]["executions_accepted"], 2);
     assert_eq!(
         manifest["filter"]["acceptance_predicate"],
@@ -583,6 +592,98 @@ fn the_date_window_and_require_verdict_are_reported_as_applied() {
             .is_some_and(|p| p.contains("verdict")),
         "the tightened predicate is what the manifest states: {manifest}"
     );
+}
+
+/// #2123: "excluded under the default filter" implies a non-default path, and
+/// this is it. The unvouched turn — the shape a whole store predating the
+/// receipts plane has — is absent by default and present under
+/// `--include-unverified-transcripts`, carrying its journal trajectory with
+/// its transcript honestly withheld rather than faked. The manifest states the
+/// loosened rule verbatim and keeps counting the same executions, so the two
+/// modes stay comparable.
+#[test]
+fn the_unvouched_turn_is_reachable_only_under_the_transcript_opt_in() {
+    let (dir, _, _) = seeded_workspace();
+
+    // The default is unchanged: the unvouched turn is still excluded.
+    export(&dir, "strict", &[]);
+    let strict = String::from_utf8(read(dir.path(), "strict", "dataset.jsonl")).expect("utf8");
+    assert_eq!(strict.lines().count(), 2, "the default still excludes it");
+
+    let summary = export(&dir, "loose", &["--include-unverified-transcripts"]);
+    assert!(
+        summary.contains("3 accepted turn(s) from 4 settled execution(s)"),
+        "the unvouched turn is now kept: {summary}"
+    );
+    assert!(
+        summary.contains("1 turn(s) exported with transcript_verified=false"),
+        "the summary says the transcripts were withheld, not that nothing happened: {summary}"
+    );
+
+    let jsonl = String::from_utf8(read(dir.path(), "loose", "dataset.jsonl")).expect("utf8");
+    assert_eq!(
+        jsonl.lines().count(),
+        3,
+        "the unvouched execution joins the two verified ones: {jsonl}"
+    );
+    let unvouched: serde_json::Value =
+        serde_json::from_str(jsonl.lines().nth(2).unwrap()).expect("record json");
+
+    // The trajectory the journal fold can still prove.
+    assert_eq!(unvouched["outcome"], "completed");
+    assert_eq!(unvouched["prompt"], "an unprovable transcript");
+    assert_eq!(unvouched["changes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(unvouched["changes"][0]["path"], "src/lib.rs");
+
+    // ...and the transcript it cannot. Empty calls beside an explicit marker,
+    // never unverified bytes wearing a verified transcript's shape.
+    assert_eq!(unvouched["transcript_verified"], false);
+    assert_eq!(
+        unvouched["calls"].as_array().map(Vec::len),
+        Some(0),
+        "an unvouched transcript is withheld whole: {unvouched}"
+    );
+    assert_eq!(
+        unvouched["transcript_mismatch_severity"], "none",
+        "this fixture's receipt cites an unresolvable block; nothing mismatched"
+    );
+    // The verified records are unaffected by the flag.
+    let verified: serde_json::Value =
+        serde_json::from_str(jsonl.lines().next().unwrap()).expect("record json");
+    assert_eq!(verified["transcript_verified"], true);
+    assert_eq!(verified["calls"].as_array().map(Vec::len), Some(1));
+
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&read(dir.path(), "loose", "manifest.json")).expect("manifest json");
+    assert_eq!(
+        manifest["schema"], 3,
+        "the record shape changed, so did the schema"
+    );
+    assert_eq!(manifest["records"], 3);
+    assert_eq!(manifest["filter"]["include_unverified_transcripts"], true);
+    assert_eq!(
+        manifest["filter"]["executions_transcripts_unverified"], 1,
+        "the same count in both modes is what makes them comparable"
+    );
+    assert_eq!(manifest["filter"]["executions_accepted"], 3);
+    assert_eq!(
+        manifest["filter"]["acceptance_predicate"],
+        "executions.outcome in {completed, goal_met} AND at least one mutating \
+         file_change event AND (at least one recorded model call, every one \
+         reconstructing digest-verified (Reconstruction::is_verified) — OR exported \
+         with transcript_verified=false and no calls)",
+        "the manifest states the rule that actually ran, not the default one"
+    );
+
+    // Determinism survives the non-default path.
+    export(&dir, "loose-again", &["--include-unverified-transcripts"]);
+    for file in ["dataset.jsonl", "manifest.json"] {
+        assert_eq!(
+            read(dir.path(), "loose", file),
+            read(dir.path(), "loose-again", file),
+            "{file} is not byte-stable under --include-unverified-transcripts"
+        );
+    }
 }
 
 /// The dataset carries redacted prompts and full tool outputs, which is at

--- a/crates/stella-cli/tests/settings_warnings_cli.rs
+++ b/crates/stella-cli/tests/settings_warnings_cli.rs
@@ -1,4 +1,6 @@
-//! End-to-end witness for the settings.json unrecognized-key warning.
+//! End-to-end witnesses for the notices `Settings::load` speaks on stderr —
+//! the unrecognized-key warning, and the untrusted checkout's withheld
+//! steering (#2302).
 //!
 //! Every settings type in `stella-cli` is deliberately tolerant of unknown
 //! fields — `deny_unknown_fields` would turn a key written by a newer stella
@@ -10,6 +12,12 @@
 //! Only a process can prove the whole path: the file is read from the real
 //! scope chain, the warning reaches stderr, stdout stays clean for whoever is
 //! piping it, and the command still succeeds (advisory, never a gate).
+//!
+//! That last sentence is why the steering notice is witnessed *here* and not
+//! only by `settings::tests`. Those tests exercise `settings::withheld`, which
+//! is pure — they would stay green with the `eprintln!` that makes the notice
+//! user-visible deleted outright, which is to say they prove the answer and not
+//! the announcement.
 
 use std::process::{Command, Output};
 
@@ -24,9 +32,28 @@ fn workspace(settings: &str) -> (tempfile::TempDir, tempfile::TempDir) {
 }
 
 /// `stella models` loads the full scope chain and needs no provider or key —
-/// the cheapest command that exercises the merge.
+/// the cheapest command that exercises the merge. Untrusted, because that is
+/// what a fresh `git clone` is: the trust variables are *removed* rather than
+/// merely unset, so a developer who exports `STELLA_TRUST_PROJECT` in their own
+/// shell cannot turn these assertions green or red from outside.
 fn models(dir: &tempfile::TempDir, home: &tempfile::TempDir) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_stella"))
+    models_with(dir, home, &[])
+}
+
+/// [`models`] with `STELLA_TRUST_PROJECT=1` — the opt-in every trust notice
+/// names, so the arm where nothing is withheld is exercised by the flag itself
+/// rather than by a stand-in for it.
+fn models_trusting_the_project(dir: &tempfile::TempDir, home: &tempfile::TempDir) -> Output {
+    models_with(dir, home, &[("STELLA_TRUST_PROJECT", "1")])
+}
+
+fn models_with(
+    dir: &tempfile::TempDir,
+    home: &tempfile::TempDir,
+    extra_env: &[(&str, &str)],
+) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_stella"));
+    command
         .arg("models")
         .current_dir(dir.path())
         .env("HOME", home.path())
@@ -40,8 +67,28 @@ fn models(dir: &tempfile::TempDir, home: &tempfile::TempDir) -> Output {
             home.path().join("no-managed.json"),
         )
         .env_remove("STELLA_MODEL")
-        .output()
-        .expect("run stella models")
+        .env_remove("STELLA_TRUST_PROJECT")
+        .env_remove("STELLA_PROJECT_HOOKS");
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command.output().expect("run stella models")
+}
+
+/// A workspace whose **steering plane** the trust gate withholds: one memory
+/// and one published context record. It deliberately writes no `settings.json`
+/// — the steering plane lives outside that file, which is the whole reason its
+/// suppression was silent (#2302). The memory body carries a marker the
+/// assertions look for by its absence.
+fn steering_workspace() -> (tempfile::TempDir, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("workspace");
+    let home = tempfile::tempdir().expect("home");
+    let stella = dir.path().join(".stella");
+    std::fs::create_dir_all(stella.join("memories")).expect("memories dir");
+    std::fs::create_dir_all(stella.join("rules")).expect("rules dir");
+    std::fs::write(stella.join("memories/00-marker.md"), "SECRET-MARKER-BODY").expect("memory");
+    std::fs::write(stella.join("rules/style.toml"), "").expect("record");
+    (dir, home)
 }
 
 #[test]
@@ -127,5 +174,84 @@ fn the_warning_is_printed_once_per_process_not_once_per_settings_load() {
         stderr.matches("unrecognized key").count(),
         1,
         "expected exactly one notice: {stderr}"
+    );
+}
+
+/// A `git clone` the user has not trusted is told, on stderr, that its
+/// memories and records were withheld — in counts, never in content — and how
+/// to opt in (#2302).
+///
+/// This is the witness for the *announcement*, which is the behaviour the issue
+/// is about: delete the `eprintln!` in `Settings::load` and only this test goes
+/// red. It also pins the two properties that make the notice safe to print at
+/// all — the counts-only rule (repository text must not reach stderr via the
+/// refusal to load it) and stdout staying clean for whoever is piping it.
+#[test]
+fn an_untrusted_checkouts_withheld_steering_is_named_on_stderr() {
+    let (dir, home) = steering_workspace();
+    let output = models(&dir, &home);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "the notice is advisory and must never gate a command: {stderr}"
+    );
+    assert!(
+        stderr.contains("project steering in"),
+        "the suppression must be stated, not merely implied: {stderr}"
+    );
+    assert!(
+        stderr.contains("(1 memory, 1 context record)"),
+        "the notice must say how much was withheld: {stderr}"
+    );
+    assert!(
+        stderr.contains("STELLA_TRUST_PROJECT=1"),
+        "a notice that does not name the opt-in leaves the user stuck: {stderr}"
+    );
+    assert!(
+        !stderr.contains("SECRET-MARKER-BODY") && !stderr.contains("00-marker"),
+        "counts, never content or filenames — a refusal that echoed repository \
+         text would be the exfiltration channel it exists to prevent: {stderr}"
+    );
+    assert!(
+        !stdout.contains("project steering"),
+        "the notice belongs on stderr: {stdout}"
+    );
+    // Latched with the notices it sits beside: one launch loads the chain
+    // several times over.
+    assert_eq!(
+        stderr.matches("project steering in").count(),
+        1,
+        "expected exactly one notice: {stderr}"
+    );
+}
+
+/// The two silent arms, through the real binary: a checkout the user trusted is
+/// getting its steering, and a checkout with nothing on disk lost nothing.
+///
+/// Both matter as much as the arm that speaks. A notice printed in every
+/// repository is one nobody reads, and one printed at a workspace that *did*
+/// load its memories is simply false.
+#[test]
+fn a_trusted_checkout_and_one_with_no_steering_say_nothing() {
+    let (dir, home) = steering_workspace();
+    let trusted = models_trusting_the_project(&dir, &home);
+    let stderr = String::from_utf8_lossy(&trusted.stderr);
+    assert_eq!(trusted.status.code(), Some(0), "{stderr}");
+    assert!(
+        !stderr.contains("project steering"),
+        "a trusted workspace is getting its steering and is owed no notice: {stderr}"
+    );
+
+    let (bare_dir, bare_home) = workspace(r#"{}"#);
+    let bare = models(&bare_dir, &bare_home);
+    let stderr = String::from_utf8_lossy(&bare.stderr);
+    assert_eq!(bare.status.code(), Some(0), "{stderr}");
+    assert!(
+        !stderr.contains("project steering"),
+        "a repo with no steering must not warn about a suppression that cost it \
+         nothing: {stderr}"
     );
 }

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -141,6 +141,7 @@ lib.rs), never as a planning assumption.
 | [`src/compaction.rs`](src/compaction.rs) | `compact()` — dedup, supersession, aging, eviction. Open when the conversation is being rewritten wrongly. |
 | [`src/estimator.rs`](src/estimator.rs) | Conservative token estimate plus `Calibration`/`CalibrationMap`, the per-model drift correction fed by reported usage. |
 | [`src/loop_detect.rs`](src/loop_detect.rs) | `detect_loop()` — exact repeats and short cycles over `CallRecord`s. |
+| [`src/shell_text.rs`](src/shell_text.rs) | Reading a shell command as *text*: the quote-aware `shell_words` splitter, `is_operator_word`, and `bare_sleep_seconds` — the stall classifier the `bash` advisory and the engine's stall rung ([`src/driver/loop_escalation.rs`](src/driver/loop_escalation.rs)) share, so one operator list serves both (#2022). |
 | [`src/retry.rs`](src/retry.rs) | `RetryPolicy`, backoff computation, `retry_with_backoff*`, and the `Sleeper` port. |
 | [`src/starvation.rs`](src/starvation.rs) | Reasoning-starvation arithmetic: output-contract headroom, the empty-`length` signature, and the retry cap. Shared by `stella-pipeline`'s management chokepoint and `stella-cli`'s standalone-call chokepoint, because one copy is what makes a fix reach both (#2128, #2174). |
 | [`src/repair.rs`](src/repair.rs) | `plan_repair()` — whether a verdict that refuted the model's success claim earns another attempt, bounded by an explicit cap and by the budget/wall-clock headroom the caller measured. |

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -27,15 +27,25 @@
 //! `EngineConfig::max_steps`, which is the exact outcome loop detection
 //! exists to prevent. [`MAX_LOOP_STEERS`] is the bound.
 //!
+//! # The stall rung
+//!
+//! One more thing lives here, on the arm where the detector found nothing: a
+//! turn that has asked to `sleep` away its allowance (#2022). It is the same
+//! claim — this turn is stuck — reached by the one route loop detection
+//! structurally cannot take, because sleeps separated by any other call read
+//! as a progressing window and idling costs $0 against a spend-based budget.
+//! It rides the same seam ([`STALL_STEER_PREFIX`] extends `LOOP_STEER_PREFIX`)
+//! and deliberately carries no abort: see [`steer_stalled_turn`].
+//!
 //! Split out of `driver.rs` the same way `super::settlement` was: the parent
 //! file sits at its file-size ceiling. The module is `pub(crate)` so
 //! `crate::step::TurnState` can hold the budget it checkpoints; the ladder's
 //! policy belongs beside the ladder, not in the state container.
 
-use stella_protocol::{AgentEvent, CompletionMessage};
+use stella_protocol::{AgentEvent, CompletionMessage, MessageRole};
 
 use crate::event_sender::EventSender;
-use crate::loop_detect::{LoopIdentity, LoopVerdict, detect_loop};
+use crate::loop_detect::{CallRecord, LoopIdentity, LoopVerdict, detect_loop};
 use crate::ports::ToolExecutor;
 use crate::step::AbortKind;
 
@@ -212,7 +222,12 @@ pub(super) fn check_loop_detection(
     // verdict is also the healthy-turn early return, so there is exactly
     // one place that decides "is this a loop".
     let (kind, pattern, repeats) = match &verdict {
-        LoopVerdict::NoLoop => return None,
+        // No loop is not the same as no trouble: the stall rung is exactly
+        // the turn the detector above cannot see (#2022).
+        LoopVerdict::NoLoop => {
+            steer_stalled_turn(messages, turn_stall_seconds(&records), events);
+            return None;
+        }
         LoopVerdict::ExactRepeat { tool, count, .. } => {
             ("exact_repeat", vec![tool.clone()], *count)
         }
@@ -357,6 +372,138 @@ fn steer_text(
          checking it differently cannot change it. Instead, {sizing}; then check once. \
          If nothing lets you wait, report what you are blocked on and stop. \
          {consequence}"
+    )
+}
+
+/// The seconds of *pure* `sleep` one turn may ask for before the engine says
+/// something about it (#2022).
+///
+/// The rung this bounds is the one no loop detector can reach. The measured
+/// shape — `sleep 300; echo done` ×3 with a poll between each, 1,089s of a
+/// 900s allowance — trips nothing: exact repeat needs the calls adjacent, the
+/// interleaved rung is suppressed because the polls answer differently and the
+/// window therefore "progresses", and the budget guard is spend-based, so
+/// idling costs $0.
+///
+/// 120s, from the fleet-wide census in that issue rather than from taste: 6 of
+/// 51 trials slept more than 30s, and the distribution splits cleanly — 47s,
+/// 73s and 114s for trials that sleep incidentally, then 307s and 1,089s for
+/// the two that sleep instead of working. A threshold above the first group
+/// and below the second buys the pathological shape and pays nothing for the
+/// ordinary one. It sits deliberately far above `bash`'s own 30s per-call
+/// advisory (`stella_tools::bash`): this is the escalation, not a second copy
+/// of that notice.
+pub(crate) const STALL_STEER_THRESHOLD_SECS: u64 = 120;
+
+/// The opening of the stalled-turn steer, for the warn-once scan below.
+///
+/// A qualifier on `LOOP_STEER_PREFIX`, not a marker of its own. `crate::engine_markers`
+/// is a closed table: a genuinely new marker has to join it, be classified by
+/// `crate::receipts::user_block_kind`, and be taught verbatim by both static
+/// system prompts — real cost, and for nothing here, because a stalled turn is
+/// the same claim the loop steer makes ("this turn is stuck") arrived at by a
+/// different route. Riding the existing prefix means every consumer that
+/// already handles a loop steer — the receipt classifier, the injection-defense
+/// contract, and `super::loop_evidence::turn_start_index`, which must not read
+/// an engine injection as a user turn boundary — handles this one unchanged.
+/// `stall_steer_prefix_extends_the_loop_steer_marker` is what keeps that true.
+pub(crate) const STALL_STEER_PREFIX: &str = "[stuck-loop warning] this turn is stalling";
+
+/// The seconds of pure `sleep` this turn has asked for, summed over every
+/// call in the window.
+///
+/// Reads the calls' own text, so it is *requested* seconds rather than
+/// measured ones — deliberately, and in both directions: a static text-shape
+/// check keeps the same transcript classifying the same way every step (a
+/// timing here would make this rung nondeterministic), and the request is the
+/// thing the model chose and can be steered about. Any call carrying a
+/// `command` string counts, so the shell tool and the shell-shaped custom
+/// tools are covered without `stella-core` learning a tool's name; the
+/// classifier is strict enough (`stella_core::shell_text::bare_sleep_seconds`
+/// answers `None` the moment a segment does real work) that a non-shell tool
+/// would have to carry a `command` field whose entire value is a sleep before
+/// it could contribute.
+///
+/// Saturating, never wrapping: the seconds come from model-authored text, and
+/// `sleep 99999999999999999999` must not be an arithmetic overflow panic
+/// (invariant 5).
+///
+/// The `contains` is a fast path, not a second classifier: this window is
+/// rebuilt on every step and a `bash` command can carry a whole heredoc, so
+/// tokenizing every command every step would be quadratic across a long turn
+/// (the same cost `super::loop_evidence` borrows its records to avoid). A
+/// command with no `sleep` anywhere in its bytes cannot be a bare sleep, so
+/// the scan is exact — it only skips work the tokenizer would have thrown
+/// away.
+fn turn_stall_seconds(records: &[CallRecord<'_>]) -> u64 {
+    records
+        .iter()
+        .filter_map(|record| record.call.input.get("command")?.as_str())
+        .filter(|command| command.contains("sleep"))
+        .filter_map(crate::shell_text::bare_sleep_seconds)
+        .fold(0u64, |total, secs| total.saturating_add(secs))
+}
+
+/// Steer a turn that is sleeping away its allowance — once.
+///
+/// Warn-once is read off the transcript rather than held in
+/// [`LoopSteerBudget`] or `crate::step::TurnState`: a steer the model can see
+/// is the only state this rung needs, and no checkpoint field, wire change or
+/// resume-reconciliation rule has to be invented to carry it. The one
+/// consequence worth naming is that compaction can drop the marker, after
+/// which a still-sleeping turn earns a second warning — which is the right
+/// answer anyway, since the model can no longer see the first.
+///
+/// No abort ladder here, on purpose. A loop detection proves the turn cannot
+/// make progress; a large `sleep` total proves only that the turn chose a
+/// costly way to wait, and killing a turn for that would spend resolve rate on
+/// a shape that is sometimes merely wasteful. Steer, and let the wall-clock
+/// deadline (`crate::budget::BudgetGuard::check_deadline`) be the thing that
+/// ends a turn.
+fn steer_stalled_turn(
+    messages: &mut Vec<CompletionMessage>,
+    stall_secs: u64,
+    events: &EventSender,
+) {
+    if stall_secs < STALL_STEER_THRESHOLD_SECS {
+        return;
+    }
+    if messages
+        .iter()
+        .any(|m| m.role == MessageRole::User && m.content.starts_with(STALL_STEER_PREFIX))
+    {
+        return;
+    }
+    let text = stall_steer_text(stall_secs);
+    let _ = events.send(AgentEvent::Steered { text: text.clone() });
+    messages.push(CompletionMessage::user(text));
+}
+
+/// What the stalled-turn steer says.
+///
+/// It prescribes a bounded polling loop the shell can run unaided, and names
+/// **no** tool the catalog does not carry. That constraint is the scar from
+/// #3555: the sibling `bash` advisory spent months telling the model to use
+/// `read_output`/`wait_for`, deleted in #3244, and an instruction that cannot
+/// be followed teaches the model to discount the next one too. The parked wait
+/// (`crate::waiting`) is the mechanism this shape is a worse version of, but it
+/// is deposited by a *tool*, not requested by the model, and no built-in
+/// deposits one today — so naming it here would repeat that defect exactly.
+///
+/// It also does not say "vary the arguments": #1473 established that the
+/// generic loop steer made a waiting model strictly worse, and blind `sleep`
+/// calls were the behaviour it produced.
+fn stall_steer_text(stall_secs: u64) -> String {
+    format!(
+        "{LOOP_STEER_PREFIX}] this turn is stalling: you have asked for {stall_secs}s of pure \
+         `sleep` in this turn — commands whose entire body is a sleep, doing no other work. A \
+         blind sleep charges the whole interval to the turn whether or not the thing you are \
+         waiting for finished in its first second, and that wall clock is the same one this \
+         task is measured against. If you are waiting on something, poll for the condition \
+         instead of sleeping through it: a bounded retry loop that checks and exits as soon \
+         as the check passes (for example `for i in $(seq 30); do <check> && break; sleep 1; \
+         done`) costs a fraction of a blind wait. If you are not waiting on anything, stop \
+         sleeping and do the work — or report what you are blocked on and stop."
     )
 }
 
@@ -959,6 +1106,252 @@ mod tests {
                     prop_assert_eq!(Some(&warned), budget.warned());
                 }
                 prop_assert!(budget.warned().is_some());
+            }
+        }
+    }
+
+    mod stall {
+        use super::StatusAndBash;
+        use crate::driver::config::EngineConfig;
+        use crate::driver::loop_escalation::{
+            LOOP_STEER_PREFIX, LoopSteerBudget, STALL_STEER_PREFIX, STALL_STEER_THRESHOLD_SECS,
+            check_loop_detection, steer_stalled_turn, turn_stall_seconds,
+        };
+        use crate::driver::loop_evidence::ResultIdentities;
+        use crate::event_sender::EventSender;
+        use crate::loop_detect::CallRecord;
+        use proptest::prelude::*;
+        use std::borrow::Cow;
+        use stella_protocol::tool::{ToolCall, ToolOutput, ToolResult};
+        use stella_protocol::{AgentEvent, CompletionMessage, MessageRole};
+
+        /// One resolved `bash` call and the bytes it produced, as the pair of
+        /// transcript messages the driver would have accumulated.
+        fn call(id: &str, command: &str, output: &str) -> [CompletionMessage; 2] {
+            let mut assistant = CompletionMessage::assistant("");
+            assistant.tool_calls = vec![ToolCall {
+                call_id: id.to_string(),
+                name: "bash".to_string(),
+                input: serde_json::json!({ "command": command }),
+            }];
+            let mut result = CompletionMessage {
+                role: MessageRole::Tool,
+                content: String::new(),
+                tool_calls: Vec::new(),
+                tool_results: Vec::new(),
+                attachments: Vec::new(),
+            };
+            result.tool_results = vec![ToolResult {
+                call_id: id.to_string(),
+                output: ToolOutput::ok(output),
+            }];
+            [assistant, result]
+        }
+
+        /// A window of `bash` calls, as [`CallRecord`]s — the shape
+        /// [`turn_stall_seconds`] reads, without a transcript around it.
+        fn records(commands: &[&str]) -> Vec<CallRecord<'static>> {
+            commands
+                .iter()
+                .enumerate()
+                .map(|(i, command)| CallRecord {
+                    call: Cow::Owned(ToolCall {
+                        call_id: format!("c{i}"),
+                        name: "bash".to_string(),
+                        input: serde_json::json!({ "command": command }),
+                    }),
+                    output: Some(Cow::Owned(ToolOutput::ok("done"))),
+                    identity: None,
+                })
+                .collect()
+        }
+
+        /// #2022's witness, in the shape the trace recorded: three
+        /// `sleep 300; echo done` calls with a poll between each, 900s of a
+        /// 900s allowance spent waiting.
+        ///
+        /// Every loop rung is silent on it *correctly*, which is why nothing
+        /// caught it for months — exact repeat needs the sleeps adjacent and
+        /// they are not; the interleaved rung counts all three but is
+        /// suppressed because the polls answer differently, so the window
+        /// reads as progressing; stagnation needs one tool's output to stop
+        /// changing and the polls' does not; and the budget guard is
+        /// spend-based, so none of this costs a cent. The turn is steered
+        /// anyway.
+        #[test]
+        fn a_turn_that_sleeps_away_its_budget_is_steered_though_no_loop_fires() {
+            let mut messages = vec![
+                CompletionMessage::system("sys"),
+                CompletionMessage::user("optimize the portfolio"),
+            ];
+            messages.extend(call("c1", "sleep 300; echo done", "done"));
+            messages.extend(call("c2", "tail -n 5 build.log", "line A"));
+            messages.extend(call("c3", "sleep 300; echo done", "done"));
+            messages.extend(call("c4", "tail -n 5 build.log", "line B"));
+            messages.extend(call("c5", "sleep 300; echo done", "done"));
+
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let events = EventSender::new(tx);
+            let outcome = check_loop_detection(
+                &EngineConfig::default(),
+                &StatusAndBash,
+                &mut messages,
+                &ResultIdentities::default(),
+                &mut LoopSteerBudget::default(),
+                0.0,
+                &events,
+            );
+
+            assert!(outcome.is_none(), "a stalled turn is steered, never killed");
+            let drained: Vec<AgentEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+            assert!(
+                !drained
+                    .iter()
+                    .any(|e| matches!(e, AgentEvent::LoopDetected { .. })),
+                "no loop rung fires on this window — that is the whole point: {drained:?}"
+            );
+
+            let steer = messages
+                .last()
+                .expect("the transcript is not empty")
+                .clone();
+            assert_eq!(steer.role, MessageRole::User);
+            assert!(
+                steer.content.starts_with(STALL_STEER_PREFIX),
+                "the turn must carry the stalled-turn steer: {:?}",
+                steer.content
+            );
+            assert!(
+                steer.content.contains("900s"),
+                "the steer names what the turn asked for: {:?}",
+                steer.content
+            );
+            assert!(
+                drained
+                    .iter()
+                    .any(|e| matches!(e, AgentEvent::Steered { text } if text == &steer.content)),
+                "the steer is on the transcript AND on the wire: {drained:?}"
+            );
+
+            // Warn once: a second pass over the same (still stalling) window
+            // adds nothing, because the marker it would add is already there.
+            let before = messages.len();
+            let outcome = check_loop_detection(
+                &EngineConfig::default(),
+                &StatusAndBash,
+                &mut messages,
+                &ResultIdentities::default(),
+                &mut LoopSteerBudget::default(),
+                0.0,
+                &events,
+            );
+            assert!(outcome.is_none());
+            assert_eq!(messages.len(), before, "the stalled turn is steered once");
+        }
+
+        /// The steer rides `LOOP_STEER_PREFIX` rather than minting a marker of
+        /// its own, which is what lets every existing consumer — the receipt
+        /// classifier, the prompt's injection-defense contract, and the turn
+        /// boundary scan that must not read an engine injection as a user turn
+        /// — handle it unchanged. If these ever come apart, a stalled turn's
+        /// steer starts reading as the user speaking.
+        #[test]
+        fn stall_steer_prefix_extends_the_loop_steer_marker() {
+            assert!(
+                STALL_STEER_PREFIX.starts_with(LOOP_STEER_PREFIX),
+                "{STALL_STEER_PREFIX:?} must extend {LOOP_STEER_PREFIX:?}"
+            );
+            assert!(crate::engine_markers::ENGINE_MARKERS.contains(&LOOP_STEER_PREFIX));
+        }
+
+        /// The remedy has to be one the agent can actually perform. The
+        /// sibling `bash` advisory spent months naming `read_output` /
+        /// `wait_for` / `start_process`, deleted in #3244 (#3555) — and the
+        /// parked wait, which this shape really is a worse version of, is
+        /// deposited by a tool and cannot be asked for by the model at all.
+        #[test]
+        fn the_stall_steer_names_no_instrument_the_model_cannot_reach() {
+            let text = super::super::stall_steer_text(900);
+            assert!(text.contains("poll"), "{text}");
+            for gone in [
+                "read_output",
+                "wait_for",
+                "start_process",
+                "parked wait",
+                "vary the arguments",
+            ] {
+                assert!(
+                    !text.contains(gone),
+                    "the steer names `{gone}`, which the model cannot reach: {text}"
+                );
+            }
+        }
+
+        /// The threshold is a turn-level escalation, not a second copy of
+        /// `bash`'s 30s per-call advisory.
+        #[test]
+        fn a_turn_under_the_threshold_is_left_alone() {
+            let quiet = records(&["sleep 60", "cargo test"]);
+            let secs = turn_stall_seconds(&quiet);
+            assert_eq!(secs, 60, "only the bare sleep counts, not the test run");
+            assert!(secs < STALL_STEER_THRESHOLD_SECS);
+
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let events = EventSender::new(tx);
+            let mut messages = vec![CompletionMessage::user("build it")];
+            steer_stalled_turn(&mut messages, secs, &events);
+            assert_eq!(
+                messages.len(),
+                1,
+                "60s is `bash`'s per-call advisory territory, not the turn rung's"
+            );
+            assert!(
+                rx.try_recv().is_err(),
+                "and nothing goes on the wire either"
+            );
+        }
+
+        /// Model-authored seconds are runtime data: an absurd request
+        /// saturates rather than overflowing (invariant 5).
+        #[test]
+        fn an_absurd_sleep_request_saturates() {
+            let absurd = records(&["sleep 99999999999999999999", "sleep 99999999999999999999"]);
+            assert_eq!(turn_stall_seconds(&absurd), u64::MAX);
+        }
+
+        proptest! {
+            /// The expensive direction. A sleep beside real work is an
+            /// ordinary retry backoff, and however long the backoff or however
+            /// many of them a turn makes, it can never earn a stall steer —
+            /// clamping or scolding a legitimate retry loop breaks real tasks,
+            /// which is why the classifier is biased toward silence.
+            #[test]
+            fn a_sleep_beside_real_work_never_stalls_a_turn(
+                secs in proptest::collection::vec(1u64..600, 1..12),
+                work in proptest::collection::vec(
+                    proptest::sample::select(vec![
+                        "curl -sf http://localhost:8080/health",
+                        "cargo test -p stella-core",
+                        "tail -n 20 build.log",
+                        "git status --porcelain",
+                    ]),
+                    1..12,
+                ),
+            ) {
+                let commands: Vec<String> = secs
+                    .iter()
+                    .zip(work.iter().cycle())
+                    .enumerate()
+                    .map(|(i, (s, cmd))| {
+                        if i % 2 == 0 {
+                            format!("sleep {s} && {cmd}")
+                        } else {
+                            format!("{cmd}; sleep {s}")
+                        }
+                    })
+                    .collect();
+                let borrowed: Vec<&str> = commands.iter().map(String::as_str).collect();
+                prop_assert_eq!(turn_stall_seconds(&records(&borrowed)), 0);
             }
         }
     }

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -49,7 +49,7 @@ use crate::loop_detect::{CallRecord, LoopIdentity, LoopVerdict, detect_loop};
 use crate::ports::ToolExecutor;
 use crate::step::AbortKind;
 
-use super::loop_evidence::{ResultIdentities, recent_call_records};
+use super::loop_evidence::{ResultIdentities, recent_call_records, turn_start_index};
 use super::{EngineConfig, LOOP_STEER_PREFIX, TurnOutcome};
 
 /// How many stuck-loop steering warnings one turn may spend.
@@ -393,6 +393,11 @@ fn steer_text(
 /// ordinary one. It sits deliberately far above `bash`'s own 30s per-call
 /// advisory (`stella_tools::bash`): this is the escalation, not a second copy
 /// of that notice.
+///
+/// A `const` and not a `crate::loop_detect::LoopDetectionConfig` field, unlike
+/// every threshold beside it — a declared gap, tracked in #3623, not a
+/// silence: a session that legitimately waits cannot raise it and a bench
+/// harness cannot lower it to study the rung.
 pub(crate) const STALL_STEER_THRESHOLD_SECS: u64 = 120;
 
 /// The opening of the stalled-turn steer, for the warn-once scan below.
@@ -416,7 +421,13 @@ pub(crate) const STALL_STEER_PREFIX: &str = "[stuck-loop warning] this turn is s
 /// measured ones — deliberately, and in both directions: a static text-shape
 /// check keeps the same transcript classifying the same way every step (a
 /// timing here would make this rung nondeterministic), and the request is the
-/// thing the model chose and can be steered about. Any call carrying a
+/// thing the model chose and can be steered about. It follows that a call
+/// that never spent what it asked for — killed by the shell's own timeout,
+/// refused by policy, erroring before it slept — still contributes its full
+/// request, so this is an upper bound on wall clock and not a measurement of
+/// it. That is why [`stall_steer_text`] says "asked for" and claims nothing
+/// about what the clock was actually charged; whether the *threshold* should
+/// discount such a call is the open question in #3624. Any call carrying a
 /// `command` string counts, so the shell tool and the shell-shaped custom
 /// tools are covered without `stella-core` learning a tool's name; the
 /// classifier is strict enough (`stella_core::shell_text::bare_sleep_seconds`
@@ -444,7 +455,7 @@ fn turn_stall_seconds(records: &[CallRecord<'_>]) -> u64 {
         .fold(0u64, |total, secs| total.saturating_add(secs))
 }
 
-/// Steer a turn that is sleeping away its allowance — once.
+/// Steer a turn that is sleeping away its allowance — once *per turn*.
 ///
 /// Warn-once is read off the transcript rather than held in
 /// [`LoopSteerBudget`] or `crate::step::TurnState`: a steer the model can see
@@ -453,6 +464,19 @@ fn turn_stall_seconds(records: &[CallRecord<'_>]) -> u64 {
 /// consequence worth naming is that compaction can drop the marker, after
 /// which a still-sleeping turn earns a second warning — which is the right
 /// answer anyway, since the model can no longer see the first.
+///
+/// **The scan is bounded by [`turn_start_index`], and that is load-bearing.**
+/// A transcript is session-scoped — `run_turn` is handed the same `Vec` every
+/// turn, with each new user prompt appended and nothing trimmed — while the
+/// seconds this gates come from `super::loop_evidence::recent_call_records`,
+/// which *is* turn-bounded. Scanning the whole vector therefore made the rung
+/// fire at most once per **session**: turn 1 sleeps 130s and is steered, and
+/// turn 5 can sleep 1,089s in silence because turn 1's marker is still sitting
+/// upstream. That is precisely the shape #2022 is about, and it is why the
+/// same boundary the evidence uses is the one the marker scan has to use. The
+/// boundary rule already skips a `LOOP_STEER_PREFIX` message when it looks for
+/// the turn's opening prompt, so this turn's own steer stays inside the window
+/// it has to be visible in.
 ///
 /// No abort ladder here, on purpose. A loop detection proves the turn cannot
 /// make progress; a large `sleep` total proves only that the turn chose a
@@ -468,7 +492,8 @@ fn steer_stalled_turn(
     if stall_secs < STALL_STEER_THRESHOLD_SECS {
         return;
     }
-    if messages
+    let turn_start = turn_start_index(messages);
+    if messages[turn_start..]
         .iter()
         .any(|m| m.role == MessageRole::User && m.content.starts_with(STALL_STEER_PREFIX))
     {
@@ -497,8 +522,8 @@ fn stall_steer_text(stall_secs: u64) -> String {
     format!(
         "{LOOP_STEER_PREFIX}] this turn is stalling: you have asked for {stall_secs}s of pure \
          `sleep` in this turn — commands whose entire body is a sleep, doing no other work. A \
-         blind sleep charges the whole interval to the turn whether or not the thing you are \
-         waiting for finished in its first second, and that wall clock is the same one this \
+         blind sleep charges its whole interval to the turn whether or not the thing you are \
+         waiting for finished in its first second, and wall clock — not spend — is what this \
          task is measured against. If you are waiting on something, poll for the condition \
          instead of sleeping through it: a bounded retry loop that checks and exits as soon \
          as the check passes (for example `for i in $(seq 30); do <check> && break; sleep 1; \
@@ -1247,6 +1272,84 @@ mod tests {
             );
             assert!(outcome.is_none());
             assert_eq!(messages.len(), before, "the stalled turn is steered once");
+        }
+
+        /// Warn-once means once per **turn**, and the transcript it is read
+        /// off is session-scoped: `run_turn` is handed the same `Vec` every
+        /// turn, with each new prompt appended and nothing trimmed.
+        ///
+        /// So an unbounded marker scan silently downgrades this rung to once
+        /// per *session* — turn 1 is steered, and every later turn can sleep
+        /// its whole allowance away in silence because turn 1's marker is
+        /// still sitting upstream. That is the exact shape #2022 is about,
+        /// arrived at from the other end. The seconds were always turn-bounded
+        /// (`recent_call_records`); only the marker scan was not.
+        #[test]
+        fn a_later_turn_that_sleeps_away_its_budget_is_steered_on_its_own_account() {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let events = EventSender::new(tx);
+            let steer_once = |messages: &mut Vec<CompletionMessage>| {
+                check_loop_detection(
+                    &EngineConfig::default(),
+                    &StatusAndBash,
+                    messages,
+                    &ResultIdentities::default(),
+                    &mut LoopSteerBudget::default(),
+                    0.0,
+                    &events,
+                )
+            };
+
+            let mut messages = vec![
+                CompletionMessage::system("sys"),
+                CompletionMessage::user("optimize the portfolio"),
+            ];
+            messages.extend(call("a1", "sleep 300; echo done", "done"));
+            messages.extend(call("a2", "tail -n 5 build.log", "line A"));
+            assert!(steer_once(&mut messages).is_none());
+            assert!(
+                messages
+                    .last()
+                    .is_some_and(|m| m.content.starts_with(STALL_STEER_PREFIX)),
+                "turn 1 stalls and is steered: {:?}",
+                messages.last()
+            );
+
+            // The user answers; turn 2 opens on the same transcript and
+            // stalls just as badly.
+            messages.push(CompletionMessage::user("now try the hedged variant"));
+            messages.extend(call("b1", "sleep 300; echo done", "done"));
+            messages.extend(call("b2", "tail -n 5 build.log", "line B"));
+            let before = messages.len();
+            assert!(steer_once(&mut messages).is_none());
+
+            let steer = messages.last().expect("the transcript is not empty");
+            assert_eq!(
+                messages.len(),
+                before + 1,
+                "turn 2 stalled on its own account and must hear about it"
+            );
+            assert_eq!(steer.role, MessageRole::User);
+            assert!(
+                steer.content.starts_with(STALL_STEER_PREFIX),
+                "{:?}",
+                steer.content
+            );
+            assert!(
+                steer.content.contains("300s"),
+                "the steer names what THIS turn asked for, not the session total: {:?}",
+                steer.content
+            );
+
+            // Still once within turn 2: a second pass adds nothing.
+            let before = messages.len();
+            assert!(steer_once(&mut messages).is_none());
+            assert_eq!(messages.len(), before, "and still exactly once per turn");
+
+            let steers = std::iter::from_fn(|| rx.try_recv().ok())
+                .filter(|e| matches!(e, AgentEvent::Steered { .. }))
+                .count();
+            assert_eq!(steers, 2, "one steer per stalled turn, on the wire too");
         }
 
         /// The steer rides `LOOP_STEER_PREFIX` rather than minting a marker of

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod rules;
 pub mod scoreboard;
 pub mod search;
 pub mod self_tuning;
+pub mod shell_text;
 pub mod skills;
 pub(crate) mod speculation;
 pub mod starvation;

--- a/crates/stella-core/src/shell_text.rs
+++ b/crates/stella-core/src/shell_text.rs
@@ -1,0 +1,205 @@
+//! Reading a shell command as *text* — never running one.
+//!
+//! Two questions live here, and they are one subject: how a command splits
+//! into words and separators, and what the resulting shape says about whether
+//! the command does any work at all.
+//!
+//! It sits in `stella-core` rather than beside the shell tool because **two
+//! planes ask the same question of the same string**. The `bash` tool asks it
+//! per call, to append an advisory to a result
+//! (`stella_tools::bash::sleep_advisory`); the engine asks it per turn, over
+//! the calls already sitting in the transcript, to decide whether the turn is
+//! stalling ([`crate::driver`]'s stall rung). `stella-tools` depends on
+//! `stella-core`, so one implementation can serve both — and the alternative
+//! was a second copy of the operator list, which is the failure this splitter
+//! was extracted to end in the first place: four near-copies had accumulated
+//! inside `bash.rs` and had already diverged (#2301).
+//!
+//! Pure functions over borrowed text (invariant 2): no process, no clock, no
+//! filesystem. In particular the stall classifier is a *static text-shape*
+//! check and never a measured elapsed time, so the same transcript always
+//! classifies the same way — a timing here would make loop detection
+//! nondeterministic.
+
+/// Words the tokenizer emits as command separators, and the one predicate
+/// every consumer of [`shell_words`] asks about them.
+///
+/// Four near-copies of this list had accumulated in `stella-tools`' `bash.rs`
+/// — the `cd` skip list, the grep-scan boundary, `segment_args` and
+/// [`bare_sleep_seconds`] — and they had already diverged: the grep boundary
+/// omitted `&`, so `ls & grep -rn "struct X" .` scanned past the background
+/// operator (#2301).
+///
+/// A newline is an operator here for the same reason `;` is: it ends one
+/// command and begins the next. Redirection tokens (`2>&1`, `>>`, `<`) are
+/// deliberately **not** operator words — they neither end a command nor start
+/// one, and `stella-tools`' `redirect_target` reads them as ordinary words.
+pub fn is_operator_word(word: &str) -> bool {
+    matches!(word, ";" | "&" | "&&" | "|" | "||" | "\n")
+}
+
+/// A quote-aware word split — enough to pull a `cd` target or a `grep`
+/// pattern out of the common command shapes, returning each word already
+/// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
+/// path with spaces stays one word) and preserves backslash escapes like
+/// `\|` (so an alternation survives into `stella-tools`' `is_symbol_shaped`);
+/// unquoted operators (`&&`, `||`, `|`, `;`, `&`, and a bare newline) come
+/// back as their own words to bound a scan — including when attached to a
+/// word, so `cd /app; ls` yields the target `/app`, not the unresolvable
+/// `/app;` a paid bench trial saw warned about as an escape from its own
+/// session root.
+pub fn shell_words(command: &str) -> Vec<String> {
+    let mut words: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut has_word = false;
+    let (mut in_single, mut in_double) = (false, false);
+    let mut chars = command.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                has_word = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                has_word = true;
+            }
+            c @ (';' | '&' | '|') if !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                let mut op = String::from(c);
+                // `&&` / `||` are one operator; `;;` never appears in the
+                // shapes this scans, so `;` stays single.
+                if c != ';' && chars.peek() == Some(&c) {
+                    chars.next();
+                    op.push(c);
+                }
+                words.push(op);
+            }
+            '\\' if !in_single => {
+                // Keep the escape literal (covers `\|`, `\"`, …); we don't
+                // interpret it, just preserve it for the symbol test.
+                cur.push('\\');
+                if let Some(n) = chars.next() {
+                    cur.push(n);
+                }
+                has_word = true;
+            }
+            // A newline separates two commands as surely as `;` does, so it
+            // is an operator word rather than plain whitespace. Without it a
+            // command-position rule cannot see the second line of
+            // `ls\ncd /outside` as a command at all.
+            '\n' if !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                words.push(String::from('\n'));
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_word = true;
+            }
+        }
+    }
+    if has_word {
+        words.push(cur);
+    }
+    words
+}
+
+/// The accumulated seconds a *bare* sleep command blocks for, or `None` if
+/// any segment does real work beyond sleeping and a harmless no-op.
+///
+/// Only a bare sleep is worth naming: `sleep 2 && curl` retry backoffs are
+/// ordinary and must stay unflagged, so this requires **every** segment of
+/// the command to be `sleep N` or an inert no-op (`echo`, `printf`, `true`)
+/// — anything else (a real command sharing the line) disqualifies the whole
+/// command. That matches the pathological shape #2022 observed
+/// (`sleep 300; echo done`) rather than a compound one that happens to
+/// contain a sleep, and it is deliberately biased toward saying nothing: the
+/// expensive direction here is the false positive, because clamping or
+/// scolding a legitimate retry loop breaks real tasks.
+pub fn bare_sleep_seconds(command: &str) -> Option<u64> {
+    let words = shell_words(command);
+    let mut segments: Vec<&[String]> = Vec::new();
+    let mut start = 0;
+    for (i, w) in words.iter().enumerate() {
+        if is_operator_word(w) {
+            segments.push(&words[start..i]);
+            start = i + 1;
+        }
+    }
+    segments.push(&words[start..]);
+
+    let mut total_secs = 0u64;
+    let mut saw_sleep = false;
+    for segment in &segments {
+        match segment {
+            [] => {}
+            [cmd, arg] if cmd == "sleep" => {
+                let secs = arg.parse::<f64>().ok()?;
+                total_secs += secs.round() as u64;
+                saw_sleep = true;
+            }
+            [cmd, ..] if matches!(cmd.as_str(), "echo" | "printf" | "true") => {}
+            _ => return None,
+        }
+    }
+    saw_sleep.then_some(total_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bare_sleep_seconds, is_operator_word, shell_words};
+
+    #[test]
+    fn shell_words_splits_operators_attached_to_a_word_in_core() {
+        assert_eq!(shell_words("cd /app; ls"), ["cd", "/app", ";", "ls"]);
+        assert_eq!(shell_words("a&&b"), ["a", "&&", "b"]);
+        assert_eq!(shell_words("echo 'a;b'"), ["echo", "a;b"]);
+    }
+
+    #[test]
+    fn every_separator_the_splitter_emits_is_an_operator_word_in_core() {
+        for word in [";", "&", "&&", "|", "||", "\n"] {
+            assert!(is_operator_word(word), "{word} should be an operator word");
+        }
+        for word in [">", ">>", "2>&1", "<", "<<<"] {
+            assert!(
+                !is_operator_word(word),
+                "{word} should not be an operator word"
+            );
+        }
+    }
+
+    /// The shapes #2022 measured, and the accumulation across one command.
+    #[test]
+    fn a_bare_sleep_is_detected_and_summed() {
+        assert_eq!(bare_sleep_seconds("sleep 300; echo done"), Some(300));
+        assert_eq!(bare_sleep_seconds("sleep 120"), Some(120));
+        assert_eq!(bare_sleep_seconds("sleep 30 && sleep 30"), Some(60));
+        assert_eq!(bare_sleep_seconds("sleep 2.5"), Some(3));
+    }
+
+    /// The expensive direction: anything doing real work beside the sleep
+    /// answers `None`, whatever the sleep is worth.
+    #[test]
+    fn a_sleep_beside_real_work_is_never_bare() {
+        assert_eq!(
+            bare_sleep_seconds("sleep 2 && curl -s http://localhost:8080"),
+            None
+        );
+        assert_eq!(bare_sleep_seconds("sleep 5; tail -f build.log"), None);
+        assert_eq!(bare_sleep_seconds("echo waiting; sleep 5; ls"), None);
+        assert_eq!(bare_sleep_seconds("cargo test"), None);
+    }
+}

--- a/crates/stella-core/src/shell_text.rs
+++ b/crates/stella-core/src/shell_text.rs
@@ -116,6 +116,36 @@ pub fn shell_words(command: &str) -> Vec<String> {
     words
 }
 
+/// One `sleep` argument read as whole seconds, or `None` when it is not a
+/// duration at all.
+///
+/// GNU `sleep` takes an optional unit suffix — `s`, `m`, `h`, `d` — and
+/// `sleep 10m` asks for exactly the 600 seconds `sleep 600` does. Reading only
+/// the bare number made every suffixed form invisible to
+/// [`bare_sleep_seconds`], and invisible in the worst direction: the `?` below
+/// is a whole-command answer, so `sleep 10m; echo done` did not merely
+/// contribute zero, it classified as *not a sleep at all*.
+///
+/// **Saturating, never wrapping, in both directions.** The argument is
+/// model-authored text, so `sleep 99999999999999999999` is runtime data and
+/// must not be an arithmetic overflow panic (invariant 5). Rust's float→int
+/// cast already saturates, which puts an absurd request on `u64::MAX` and a
+/// negative or `NaN` one on `0` — and `sleep` itself rejects both of those,
+/// so contributing nothing is the honest reading.
+fn sleep_arg_seconds(arg: &str) -> Option<u64> {
+    // Byte-wise, so the slice below always lands on a char boundary: the
+    // suffixes are ASCII, and a multi-byte final char takes the default arm.
+    let (digits, per_unit_secs) = match arg.as_bytes().last()? {
+        b's' => (&arg[..arg.len() - 1], 1.0),
+        b'm' => (&arg[..arg.len() - 1], 60.0),
+        b'h' => (&arg[..arg.len() - 1], 3600.0),
+        b'd' => (&arg[..arg.len() - 1], 86400.0),
+        _ => (arg, 1.0),
+    };
+    let secs = digits.parse::<f64>().ok()?;
+    Some((secs * per_unit_secs).round() as u64)
+}
+
 /// The accumulated seconds a *bare* sleep command blocks for, or `None` if
 /// any segment does real work beyond sleeping and a harmless no-op.
 ///
@@ -128,6 +158,12 @@ pub fn shell_words(command: &str) -> Vec<String> {
 /// contain a sleep, and it is deliberately biased toward saying nothing: the
 /// expensive direction here is the false positive, because clamping or
 /// scolding a legitimate retry loop breaks real tasks.
+///
+/// The accumulation across segments saturates for the reason
+/// `sleep_arg_seconds` does: two absurd sleeps on one line
+/// (`sleep 99999999999999999999; sleep 99999999999999999999`) each saturate to
+/// `u64::MAX`, and a plain `+` on that pair is an overflow panic on model
+/// text in library code.
 pub fn bare_sleep_seconds(command: &str) -> Option<u64> {
     let words = shell_words(command);
     let mut segments: Vec<&[String]> = Vec::new();
@@ -146,8 +182,7 @@ pub fn bare_sleep_seconds(command: &str) -> Option<u64> {
         match segment {
             [] => {}
             [cmd, arg] if cmd == "sleep" => {
-                let secs = arg.parse::<f64>().ok()?;
-                total_secs += secs.round() as u64;
+                total_secs = total_secs.saturating_add(sleep_arg_seconds(arg)?);
                 saw_sleep = true;
             }
             [cmd, ..] if matches!(cmd.as_str(), "echo" | "printf" | "true") => {}
@@ -188,6 +223,44 @@ mod tests {
         assert_eq!(bare_sleep_seconds("sleep 120"), Some(120));
         assert_eq!(bare_sleep_seconds("sleep 30 && sleep 30"), Some(60));
         assert_eq!(bare_sleep_seconds("sleep 2.5"), Some(3));
+    }
+
+    /// Two absurd sleeps on ONE line, which is the pair the per-segment
+    /// accumulation adds. Both saturate to `u64::MAX` on the float→int cast,
+    /// so a plain `+` here panics `attempt to add with overflow` in every
+    /// overflow-checked build — on model-authored text, in library code
+    /// (invariant 5). The sibling assertion in `driver::loop_escalation`
+    /// cannot see this: its two sleeps are two separate calls, so it only
+    /// exercises the fold that already saturated.
+    #[test]
+    fn two_absurd_sleeps_in_one_command_saturate_rather_than_overflowing() {
+        assert_eq!(
+            bare_sleep_seconds("sleep 99999999999999999999"),
+            Some(u64::MAX)
+        );
+        assert_eq!(
+            bare_sleep_seconds("sleep 99999999999999999999; sleep 99999999999999999999"),
+            Some(u64::MAX)
+        );
+    }
+
+    /// GNU `sleep`'s suffix forms are the same wait spelled differently, and
+    /// the `?` made the unsuffixed reading fail *closed*: `sleep 10m` used to
+    /// answer `None` — not "a sleep worth 0s", but "not a sleep at all" —
+    /// so the pathological shape wearing a suffix bypassed the rung entirely.
+    #[test]
+    fn a_suffixed_sleep_is_read_in_seconds() {
+        assert_eq!(bare_sleep_seconds("sleep 300s"), Some(300));
+        assert_eq!(bare_sleep_seconds("sleep 5m"), Some(300));
+        assert_eq!(bare_sleep_seconds("sleep 10m; echo done"), Some(600));
+        assert_eq!(bare_sleep_seconds("sleep 1h"), Some(3600));
+        assert_eq!(bare_sleep_seconds("sleep 1d"), Some(86400));
+        assert_eq!(bare_sleep_seconds("sleep 2m && sleep 30"), Some(150));
+        // A suffix with no number is not a duration, and a duration this
+        // cannot read still disqualifies the whole command rather than
+        // silently counting as zero.
+        assert_eq!(bare_sleep_seconds("sleep m"), None);
+        assert_eq!(bare_sleep_seconds("sleep later"), None);
     }
 
     /// The expensive direction: anything doing real work beside the sleep

--- a/crates/stella-pipeline/src/reward.rs
+++ b/crates/stella-pipeline/src/reward.rs
@@ -294,6 +294,13 @@ pub enum DiscardReason {
     /// The shaping terms could not be computed — a non-finite cost. A reward
     /// that is `NaN` is not a smaller reward, it is a corrupt one.
     CostNotFinite,
+    /// How many model calls the trajectory spent was never recorded, so the
+    /// step term of the shaping has no value ([`TrajectoryCost::steps`] is
+    /// `None`). Distinct from zero steps in the direction that matters: a zero
+    /// would subtract nothing and hand back a *larger* reward than the same
+    /// trajectory earns once its calls are counted, so every such row would
+    /// pool as though it had been cheaper than the ones beside it.
+    StepsUnknown,
     /// The workspace set its judged weight to `0.0`: this verifier is not trusted
     /// to label anything. Distinct from a `0.0` reward, which would assert that
     /// a neutral outcome was observed.
@@ -365,7 +372,16 @@ pub struct TrajectoryCost {
     /// Model calls in the trajectory — every role, not just the worker's,
     /// because a turn that bought three verifier calls did cost three verifier
     /// calls.
-    pub steps: u32,
+    ///
+    /// `None` when nothing recorded them, which is **not** the same fact as
+    /// zero: a store predating the receipts plane holds no `step_receipt` row
+    /// for turns that did make model calls, and reading that absence as `0`
+    /// silently drops the whole step penalty from the scalar. Such a
+    /// trajectory is discarded with [`DiscardReason::StepsUnknown`] rather
+    /// than shaped against a number nothing observed. Build it with
+    /// [`Self::recorded_steps`] wherever the count comes from the receipts
+    /// plane, so no surface has to re-decide what an empty plane means.
+    pub steps: Option<u32>,
     /// Settled USD for the whole trajectory.
     pub cost_usd: f64,
     /// Verification rounds beyond the first: how many times verify sent the
@@ -377,6 +393,21 @@ pub struct TrajectoryCost {
     /// deliberate: shaping only ever subtracts, so the error under-rewards an
     /// expensive turn rather than over-rewarding it.
     pub revisions: u32,
+}
+
+impl TrajectoryCost {
+    /// The step term for a trajectory whose model calls are counted from the
+    /// receipts plane.
+    ///
+    /// One rule in one place: an empty plane is [`TrajectoryCost::steps`]
+    /// `None` ("nobody wrote down what this turn spent"), never `Some(0)`
+    /// ("this turn called no model"). `stella trace` and `stella dataset
+    /// export` both count that way and are documented to agree on the label of
+    /// one execution, which they only can while the rule has a single home.
+    #[must_use]
+    pub fn recorded_steps(recorded_calls: usize) -> Option<u32> {
+        (recorded_calls > 0).then(|| u32::try_from(recorded_calls).unwrap_or(u32::MAX))
+    }
 }
 
 /// One trajectory's training label: the rung it came to rest on, the outcome
@@ -426,8 +457,9 @@ impl RewardLabel {
 
 /// Label one trajectory under `policy`.
 ///
-/// Total: every settlement, every rung, any cost — including a non-finite one —
-/// and any policy, including an invalid one, resolves to a `RewardLabel`, never
+/// Total: every settlement, every rung, any cost — including a non-finite one
+/// and one whose step count was never recorded — and any policy, including an
+/// invalid one, resolves to a `RewardLabel`, never
 /// a panic (invariant #5). A trajectory that cannot be scored says so in
 /// [`RewardLabel::discard`], and the policy is stamped on the result either way.
 pub fn label(settlement: Settlement, cost: TrajectoryCost, policy: &RewardPolicy) -> RewardLabel {
@@ -464,9 +496,17 @@ pub fn label(settlement: Settlement, cost: TrajectoryCost, policy: &RewardPolicy
         Err(discard) => return unscored(discard, None),
     };
 
+    // An unrecorded step count is refused rather than read as zero: the
+    // shaping only ever subtracts, so a missing count does not shrink the
+    // reward, it inflates it — and it inflates exactly the rows whose
+    // provenance is weakest.
+    let Some(steps) = cost.steps else {
+        return unscored(DiscardReason::StepsUnknown, Some(outcome));
+    };
+
     let shaping = &policy.shaping;
     let reward = outcome
-        - shaping.per_step * f64::from(cost.steps)
+        - shaping.per_step * f64::from(steps)
         - shaping.per_usd * cost.cost_usd
         - shaping.per_revision * f64::from(cost.revisions);
     if !reward.is_finite() {

--- a/crates/stella-pipeline/src/reward/tests.rs
+++ b/crates/stella-pipeline/src/reward/tests.rs
@@ -8,7 +8,7 @@ use super::*;
 
 fn cost(steps: u32, cost_usd: f64, revisions: u32) -> TrajectoryCost {
     TrajectoryCost {
-        steps,
+        steps: Some(steps),
         cost_usd,
         revisions,
     }
@@ -95,7 +95,7 @@ fn shaping_prices_steps_cost_and_revisions() {
     assert!((reward - 0.4).abs() < 1e-9, "got {reward}");
     // The inputs travel with the label, so a consumer can re-shape without
     // re-reading the journal.
-    assert_eq!(label.cost.steps, 10);
+    assert_eq!(label.cost.steps, Some(10));
     assert_eq!(label.cost.revisions, 2);
 }
 
@@ -223,6 +223,63 @@ fn a_non_finite_cost_withholds_the_scalar_only() {
             "the rung's own term is still true"
         );
     }
+}
+
+/// An unrecorded step count is refused, not read as zero.
+///
+/// The direction is what makes this a defect rather than an imprecision:
+/// shaping only ever subtracts, so a missing count does not shrink the reward,
+/// it *raises* it above what the same trajectory earns once its calls are
+/// counted — and it raises it on exactly the rows whose provenance is
+/// weakest, which then pool with the trustworthy ones as though they had been
+/// cheaper.
+#[test]
+fn an_unrecorded_step_count_is_discarded_rather_than_priced_as_zero() {
+    let policy = RewardPolicy::default();
+    let unknown = label(
+        settled(LadderRung::SubmitFast, true),
+        TrajectoryCost {
+            steps: None,
+            cost_usd: 0.10,
+            revisions: 0,
+        },
+        &policy,
+    );
+    assert_eq!(unknown.reward, None, "no scalar is claimed");
+    assert_eq!(unknown.discard, Some(DiscardReason::StepsUnknown));
+    assert_eq!(
+        unknown.outcome,
+        Some(1.0),
+        "the rung's own term is still true, so the row stays selectable"
+    );
+    assert_eq!(unknown.cost.steps, None, "the gap travels with the label");
+
+    // Priced as zero it would have out-scored the same trajectory with its
+    // calls counted, which is the failure this refuses.
+    let counted = label(
+        settled(LadderRung::SubmitFast, true),
+        cost(5, 0.10, 0),
+        &policy,
+    );
+    assert!(
+        counted.reward.expect("scored") < 1.0 - 0.5 * 0.10,
+        "the counted trajectory pays its step penalty"
+    );
+}
+
+/// The receipts plane's empty answer is "nobody wrote it down", never "zero
+/// calls" — one rule, so `stella trace` and `stella dataset export` cannot
+/// drift on the labels they are documented to agree about.
+#[test]
+fn an_empty_receipts_plane_is_an_unknown_step_count_not_a_zero_one() {
+    assert_eq!(TrajectoryCost::recorded_steps(0), None);
+    assert_eq!(TrajectoryCost::recorded_steps(1), Some(1));
+    assert_eq!(TrajectoryCost::recorded_steps(7), Some(7));
+    assert_eq!(
+        TrajectoryCost::recorded_steps(usize::MAX),
+        Some(u32::MAX),
+        "a count past the field saturates rather than panicking or wrapping"
+    );
 }
 
 /// A policy with a helper for the common case: restate the unit, keep the rest.

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -68,6 +68,7 @@ use crate::registry::Tool;
 
 mod words;
 
+use stella_core::shell_text::bare_sleep_seconds;
 use words::{cd_escape_target, is_operator_word, shell_words};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
@@ -484,54 +485,22 @@ fn drift_advisory(command: &str, root: &Path) -> Option<String> {
     None
 }
 
-/// A bare `sleep` blocking the whole trial budget goes undetected today:
-/// loop detection sees other calls between the sleeps, so the
-/// interleaved-repeat rung reads the window as progressing, and the budget
-/// guard is spend-based, so idling costs $0. (The shape #2022 observed
-/// interleaved `read_output` polls; that tool is gone, but any interleaved
-/// call produces the same blind spot, so the reasoning is unchanged.) #2022's first step is honest
-/// visibility, not a refusal — a static text-shape check on the command, not
-/// a measured elapsed time, so it stays deterministic for the loop detector
-/// (never embed a timing here; see `stella-tool-timings-must-not-ride-tooloutput`).
+/// The per-call half of #2022: a bare `sleep` long enough to be worth naming
+/// in the result the model reads.
 ///
-/// Only a *bare* sleep is worth naming: `sleep 2 && curl` retry backoffs are
-/// ordinary and must stay unflagged, so this requires every segment of the
-/// command to be `sleep N` or an inert no-op (`echo`, `printf`, `true`) —
-/// anything else (a real command sharing the line) disqualifies the whole
-/// command, matching the observed pathological shape (`sleep 300; echo
-/// done`) rather than a compound one that happens to contain a sleep.
+/// Deliberately the cheap rung, and deliberately low — 30s catches the shape
+/// on the very call that made it, before any accumulation. What it cannot see
+/// is the *turn*: loop detection reads interleaved calls as progress and the
+/// budget guard is spend-based, so idling costs $0. That blind spot is the
+/// engine's to close, over the seconds a whole turn has asked for
+/// (`stella_core`'s stall rung, `driver::loop_escalation`), and this advisory
+/// is not it.
+///
+/// Honest visibility, not a refusal, on either rung: a static text-shape check
+/// on the command ([`bare_sleep_seconds`]), never a measured elapsed time, so
+/// it stays deterministic for the loop detector (never embed a timing here;
+/// see `stella-tool-timings-must-not-ride-tooloutput`).
 const SLEEP_ADVISORY_THRESHOLD_SECS: u64 = 30;
-
-/// The accumulated seconds a *bare* sleep command blocks for, or `None` if
-/// any segment does real work beyond sleeping and a harmless no-op.
-fn bare_sleep_seconds(command: &str) -> Option<u64> {
-    let words = shell_words(command);
-    let mut segments: Vec<&[String]> = Vec::new();
-    let mut start = 0;
-    for (i, w) in words.iter().enumerate() {
-        if is_operator_word(w) {
-            segments.push(&words[start..i]);
-            start = i + 1;
-        }
-    }
-    segments.push(&words[start..]);
-
-    let mut total_secs = 0u64;
-    let mut saw_sleep = false;
-    for segment in &segments {
-        match segment {
-            [] => {}
-            [cmd, arg] if cmd == "sleep" => {
-                let secs = arg.parse::<f64>().ok()?;
-                total_secs += secs.round() as u64;
-                saw_sleep = true;
-            }
-            [cmd, ..] if matches!(cmd.as_str(), "echo" | "printf" | "true") => {}
-            _ => return None,
-        }
-    }
-    saw_sleep.then_some(total_secs)
-}
 
 /// A footer naming a bare `sleep` that crossed the advisory threshold, and a
 /// remedy the agent can actually perform.

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -66,6 +66,10 @@ use tokio::process::Command;
 
 use crate::registry::Tool;
 
+mod words;
+
+use words::{cd_escape_target, is_operator_word, shell_words};
+
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 /// Byte cap on one `bash` result before head+tail elision
 /// ([`crate::exec::truncate_middle_capped`]). [`crate::custom`] aliases this
@@ -92,103 +96,6 @@ pub(crate) const MAX_OUTPUT_BYTES: usize = 64 * 1024;
 /// grep-family commands whose first positional arg is a search pattern.
 const GREP_CMDS: &[&str] = &["grep", "egrep", "fgrep", "rg", "ripgrep", "ag"];
 
-/// A quote-aware word split — enough to pull a `cd` target or a `grep`
-/// pattern out of the common command shapes, returning each word already
-/// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
-/// path with spaces stays one word) and preserves backslash escapes like
-/// `\|` (so an alternation survives into [`is_symbol_shaped`]); unquoted
-/// operators (`&&`, `||`, `|`, `;`, `&`) come back as their own words to
-/// bound a scan — including when attached to a word, so `cd /app; ls` yields
-/// the target `/app`, not the unresolvable `/app;` a paid bench trial saw
-/// warned about as an escape from its own session root.
-fn shell_words(command: &str) -> Vec<String> {
-    let mut words: Vec<String> = Vec::new();
-    let mut cur = String::new();
-    let mut has_word = false;
-    let (mut in_single, mut in_double) = (false, false);
-    let mut chars = command.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '\'' if !in_double => {
-                in_single = !in_single;
-                has_word = true;
-            }
-            '"' if !in_single => {
-                in_double = !in_double;
-                has_word = true;
-            }
-            c @ (';' | '&' | '|') if !in_single && !in_double => {
-                if has_word {
-                    words.push(std::mem::take(&mut cur));
-                    has_word = false;
-                }
-                let mut op = String::from(c);
-                // `&&` / `||` are one operator; `;;` never appears in the
-                // shapes this scans, so `;` stays single.
-                if c != ';' && chars.peek() == Some(&c) {
-                    chars.next();
-                    op.push(c);
-                }
-                words.push(op);
-            }
-            '\\' if !in_single => {
-                // Keep the escape literal (covers `\|`, `\"`, …); we don't
-                // interpret it, just preserve it for the symbol test.
-                cur.push('\\');
-                if let Some(n) = chars.next() {
-                    cur.push(n);
-                }
-                has_word = true;
-            }
-            c if c.is_whitespace() && !in_single && !in_double => {
-                if has_word {
-                    words.push(std::mem::take(&mut cur));
-                    has_word = false;
-                }
-            }
-            c => {
-                cur.push(c);
-                has_word = true;
-            }
-        }
-    }
-    if has_word {
-        words.push(cur);
-    }
-    words
-}
-
-/// If the command `cd`s somewhere outside the workspace `root`, return that
-/// target — every other tool is confined to `root`, so an edit under a drifted
-/// tree is invisible to the file tools, the turn's diff, and verification (and
-/// ungraphed besides, the cross-tree gap the telemetry showed). Targets we
-/// can't resolve (`$VAR`, `~`, `-`, a flag) are skipped: better a missed note
-/// than a wrong one.
-fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
-    let words = shell_words(command);
-    for pair in words.windows(2) {
-        if pair[0] != "cd" {
-            continue;
-        }
-        let target = pair[1].as_str();
-        // `-` (cd to previous dir) is caught by the `-` prefix below. An
-        // operator word means the `cd` had no target at all (`cd && make`):
-        // that goes to `$HOME`, which we skip for the same reason as `~`.
-        if target.is_empty()
-            || target.starts_with('$')
-            || target.starts_with('~')
-            || target.starts_with('-')
-            || matches!(target, ";" | "&" | "&&" | "|" | "||")
-        {
-            continue;
-        }
-        if crate::resolve_within_root(root, target).is_none() {
-            return Some(target.to_string());
-        }
-    }
-    None
-}
-
 /// Does the command run a grep-family search whose pattern is symbol-shaped —
 /// the `grep -rn "struct X"` that graph_query answers better? The dominant
 /// path in the telemetry (symbol searches ran through bash, not the native
@@ -202,7 +109,7 @@ fn bash_grep_is_symbol_shaped(command: &str) -> bool {
             continue;
         }
         for next in &words[i + 1..] {
-            if matches!(next.as_str(), "|" | "||" | "&&" | ";") {
+            if is_operator_word(next) {
                 break;
             }
             if next.starts_with('-') {
@@ -485,7 +392,7 @@ fn segment_args(words: &[String], command_index: usize) -> Vec<&str> {
     words[command_index + 1..]
         .iter()
         .map(String::as_str)
-        .take_while(|word| !matches!(*word, ";" | "&" | "&&" | "|" | "||"))
+        .take_while(|word| !is_operator_word(word))
         .collect()
 }
 
@@ -602,7 +509,7 @@ fn bare_sleep_seconds(command: &str) -> Option<u64> {
     let mut segments: Vec<&[String]> = Vec::new();
     let mut start = 0;
     for (i, w) in words.iter().enumerate() {
-        if matches!(w.as_str(), ";" | "&" | "&&" | "|" | "||") {
+        if is_operator_word(w) {
             segments.push(&words[start..i]);
             start = i + 1;
         }
@@ -1164,60 +1071,6 @@ mod tests {
             ToolOutput::Ok { content, .. } => content,
             ToolOutput::Error { message, .. } => message,
         }
-    }
-
-    #[test]
-    fn cd_escape_target_flags_out_of_root_only() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
-        // In-root cd — no drift.
-        assert_eq!(cd_escape_target("cd sub && ls", dir.path()), None);
-        assert_eq!(cd_escape_target("cd . && cargo build", dir.path()), None);
-        // Out-of-root — the target is returned.
-        assert_eq!(
-            cd_escape_target("cd / && grep -rn x .", dir.path()).as_deref(),
-            Some("/")
-        );
-        assert!(cd_escape_target("cd ../.. && ls", dir.path()).is_some());
-        // Unresolvable / no cd — skipped.
-        assert_eq!(cd_escape_target("cd $HOME && ls", dir.path()), None);
-        assert_eq!(cd_escape_target("cd ~/foo && ls", dir.path()), None);
-        assert_eq!(cd_escape_target("grep -rn x .", dir.path()), None);
-    }
-
-    #[test]
-    fn shell_words_splits_operators_attached_to_a_word() {
-        assert_eq!(shell_words("cd /app; ls"), ["cd", "/app", ";", "ls"]);
-        assert_eq!(shell_words("a&&b"), ["a", "&&", "b"]);
-        assert_eq!(
-            shell_words("a || b|c & d"),
-            ["a", "||", "b", "|", "c", "&", "d"]
-        );
-        // Quoted and escaped operators stay inside the word.
-        assert_eq!(shell_words("echo 'a;b'"), ["echo", "a;b"]);
-        assert_eq!(shell_words(r"grep x\|y ."), ["grep", r"x\|y", "."]);
-    }
-
-    /// The false positive a paid bench trial hit: `cd /app; …` with session
-    /// root `/app` drew the "work here is invisible to the diff and to
-    /// verification" warning, because the target parsed as the unresolvable
-    /// `/app;`.
-    #[test]
-    fn an_attached_separator_does_not_fake_a_cd_escape() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().canonicalize().unwrap();
-        std::fs::create_dir_all(root.join("sub")).unwrap();
-        // In-root cd with the separator attached — no drift, no warning.
-        assert_eq!(cd_escape_target("cd sub; ls", &root), None);
-        assert_eq!(
-            cd_escape_target(&format!("cd {}; ls", root.display()), &root),
-            None
-        );
-        // A real escape still warns, and names the clean target.
-        assert_eq!(cd_escape_target("cd /; ls", &root).as_deref(), Some("/"));
-        // A bare `cd` before an operator goes to `$HOME` — unresolvable
-        // here, so it is skipped rather than misnamed.
-        assert_eq!(cd_escape_target("cd && ls", &root), None);
     }
 
     #[test]

--- a/crates/stella-tools/src/bash/words.rs
+++ b/crates/stella-tools/src/bash/words.rs
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The command-text splitter every `bash` advisory reads, and the one
+//! advisory that needs more than words: the `cd`-escape detector.
+//!
+//! It lives beside [`super`] rather than inside it because `bash.rs` sits
+//! against the 1500-line ceiling, and because these three concerns — how a
+//! command is split, what counts as an operator, and where a word is *data*
+//! rather than a command — are one subject that the tool's spawn/timeout/
+//! policy body is not.
+//!
+//! # What "data" means here, and why only `cd` pays for it
+//!
+//! A shell command carries text that is never executed: a heredoc body being
+//! written to a file, a `#` comment, an echoed argument. Reading a `cd` out of
+//! one of those and telling the agent its work is invisible to verification is
+//! the false warning #2301 was filed for — the same defect class #2282 killed
+//! for operator attachment, with the same cost per occurrence.
+//!
+//! [`cd_escape_target`] therefore strips those regions and requires the `cd`
+//! to sit in **command position** before it will name a target. The audit in
+//! [`super::shell_write_audit`] deliberately does neither: it is a fence
+//! around what the shell may be about to overwrite, so a path appearing
+//! anywhere in the text is exactly what it wants to see.
+
+use std::path::Path;
+
+/// Words the tokenizer emits as command separators, and the one predicate
+/// every consumer of [`shell_words`] asks about them.
+///
+/// Four near-copies of this list had accumulated in `bash.rs` — the `cd` skip
+/// list, the grep-scan boundary, [`super::segment_args`] and
+/// [`super::bare_sleep_seconds`] — and they had already diverged: the grep
+/// boundary omitted `&`, so `ls & grep -rn "struct X" .` scanned past the
+/// background operator (#2301).
+///
+/// A newline is an operator here for the same reason `;` is: it ends one
+/// command and begins the next. Redirection tokens (`2>&1`, `>>`, `<`) are
+/// deliberately **not** operator words — they neither end a command nor start
+/// one, and [`super::redirect_target`] reads them as ordinary words.
+pub(super) fn is_operator_word(word: &str) -> bool {
+    matches!(word, ";" | "&" | "&&" | "|" | "||" | "\n")
+}
+
+/// A quote-aware word split — enough to pull a `cd` target or a `grep`
+/// pattern out of the common command shapes, returning each word already
+/// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
+/// path with spaces stays one word) and preserves backslash escapes like
+/// `\|` (so an alternation survives into [`super::is_symbol_shaped`]);
+/// unquoted operators (`&&`, `||`, `|`, `;`, `&`, and a bare newline) come
+/// back as their own words to bound a scan — including when attached to a
+/// word, so `cd /app; ls` yields the target `/app`, not the unresolvable
+/// `/app;` a paid bench trial saw warned about as an escape from its own
+/// session root.
+pub(super) fn shell_words(command: &str) -> Vec<String> {
+    let mut words: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut has_word = false;
+    let (mut in_single, mut in_double) = (false, false);
+    let mut chars = command.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                has_word = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                has_word = true;
+            }
+            c @ (';' | '&' | '|') if !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                let mut op = String::from(c);
+                // `&&` / `||` are one operator; `;;` never appears in the
+                // shapes this scans, so `;` stays single.
+                if c != ';' && chars.peek() == Some(&c) {
+                    chars.next();
+                    op.push(c);
+                }
+                words.push(op);
+            }
+            '\\' if !in_single => {
+                // Keep the escape literal (covers `\|`, `\"`, …); we don't
+                // interpret it, just preserve it for the symbol test.
+                cur.push('\\');
+                if let Some(n) = chars.next() {
+                    cur.push(n);
+                }
+                has_word = true;
+            }
+            // A newline separates two commands as surely as `;` does, so it
+            // is an operator word rather than plain whitespace. Without it a
+            // command-position rule cannot see the second line of
+            // `ls\ncd /outside` as a command at all.
+            '\n' if !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                words.push(String::from('\n'));
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_word = true;
+            }
+        }
+    }
+    if has_word {
+        words.push(cur);
+    }
+    words
+}
+
+/// One pending heredoc: the delimiter that ends its body, and whether `<<-`
+/// asked for leading tabs to be ignored on that terminator line.
+struct Heredoc {
+    delimiter: String,
+    strip_tabs: bool,
+}
+
+/// The command with its **non-executed text removed** — heredoc bodies and
+/// `#` comments — so a scan cannot mistake data for a command.
+///
+/// Newlines outside the dropped regions are preserved, because command
+/// position is read from them. Quoting is tracked well enough to know whether
+/// a `<<` or a `#` is live: `echo "# not a comment"` and `echo '<<EOF'` keep
+/// their text. Everything else is copied through byte for byte — this removes
+/// regions, it does not rewrite words.
+///
+/// Deliberately partial, on the "better a missed note than a wrong one"
+/// posture this whole module holds: a delimiter produced by expansion
+/// (`<<$END`) is taken literally, and an unterminated heredoc swallows the
+/// rest of the command rather than guessing where it ended. Both directions
+/// lose a warning; neither invents one.
+fn strip_data_regions(command: &str) -> String {
+    let chars: Vec<char> = command.chars().collect();
+    let mut out = String::with_capacity(command.len());
+    let mut pending: Vec<Heredoc> = Vec::new();
+    let (mut in_single, mut in_double) = (false, false);
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                out.push(c);
+                i += 1;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                out.push(c);
+                i += 1;
+            }
+            '\\' if !in_single => {
+                out.push(c);
+                i += 1;
+                if let Some(&next) = chars.get(i) {
+                    out.push(next);
+                    i += 1;
+                }
+            }
+            // `#` opens a comment only at the start of a word: `echo foo#bar`
+            // passes a literal `#` and `curl host/#frag` names a fragment.
+            '#' if !in_single && !in_double && starts_a_word(&chars, i) => {
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+            }
+            // `<<` opens a heredoc; `<<<` is a here-string, whose word is
+            // ordinary text on the same line and needs no skipping.
+            '<' if !in_single
+                && !in_double
+                && chars.get(i + 1) == Some(&'<')
+                && chars.get(i + 2) != Some(&'<')
+                && i.checked_sub(1).map(|prev| chars[prev]) != Some('<') =>
+            {
+                i += 2;
+                let strip_tabs = chars.get(i) == Some(&'-');
+                if strip_tabs {
+                    i += 1;
+                }
+                while matches!(chars.get(i), Some(' ' | '\t')) {
+                    i += 1;
+                }
+                let (delimiter, after) = read_delimiter(&chars, i);
+                i = after;
+                if !delimiter.is_empty() {
+                    pending.push(Heredoc {
+                        delimiter,
+                        strip_tabs,
+                    });
+                }
+                // The operator and its delimiter are gone; keep the word
+                // boundary they occupied.
+                out.push(' ');
+            }
+            '\n' if !in_single && !in_double && !pending.is_empty() => {
+                out.push('\n');
+                i += 1;
+                for heredoc in std::mem::take(&mut pending) {
+                    i = skip_heredoc_body(&chars, i, &heredoc);
+                }
+            }
+            c => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Is the character at `at` the first of a word — start of input, or preceded
+/// by whitespace or an operator character?
+fn starts_a_word(chars: &[char], at: usize) -> bool {
+    match at.checked_sub(1).map(|prev| chars[prev]) {
+        None => true,
+        Some(prev) => prev.is_whitespace() || matches!(prev, ';' | '&' | '|' | '('),
+    }
+}
+
+/// The heredoc delimiter beginning at `from`, unquoted, and the index just
+/// past it. `<<'EOF'`, `<<"EOF"` and `<<\EOF` all name `EOF` — the quoting
+/// only decides whether the body expands, which is not a question this asks.
+fn read_delimiter(chars: &[char], from: usize) -> (String, usize) {
+    let mut delimiter = String::new();
+    let (mut in_single, mut in_double) = (false, false);
+    let mut i = from;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '\\' if !in_single => {
+                i += 1;
+                match chars.get(i) {
+                    Some(&next) => delimiter.push(next),
+                    None => break,
+                }
+            }
+            c if !in_single && !in_double && (c.is_whitespace() || is_delimiter_end(c)) => break,
+            c => delimiter.push(c),
+        }
+        i += 1;
+    }
+    (delimiter, i)
+}
+
+/// Characters that end a heredoc delimiter word without being part of it.
+fn is_delimiter_end(c: char) -> bool {
+    matches!(c, ';' | '&' | '|' | '<' | '>')
+}
+
+/// Skip from `from` to just past the line that terminates `heredoc`'s body,
+/// or to the end of input if that line never comes.
+fn skip_heredoc_body(chars: &[char], from: usize, heredoc: &Heredoc) -> usize {
+    let mut i = from;
+    while i < chars.len() {
+        let line_start = i;
+        while i < chars.len() && chars[i] != '\n' {
+            i += 1;
+        }
+        let line: String = chars[line_start..i].iter().collect();
+        if i < chars.len() {
+            i += 1; // consume the newline that ends this body line
+        }
+        let candidate = if heredoc.strip_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line.as_str()
+        };
+        // The terminator is the delimiter alone on its line; `\r` is tolerated
+        // so a CRLF-authored command still closes.
+        if candidate.trim_end_matches('\r') == heredoc.delimiter {
+            return i;
+        }
+    }
+    i
+}
+
+/// If the command `cd`s somewhere outside the workspace `root`, return that
+/// target — every other tool is confined to `root`, so an edit under a drifted
+/// tree is invisible to the file tools, the turn's diff, and verification (and
+/// ungraphed besides, the cross-tree gap the telemetry showed). Targets we
+/// can't resolve (`$VAR`, `~`, `-`, a flag) are skipped: better a missed note
+/// than a wrong one.
+///
+/// Two rules keep a `cd` that is *data* from being read as a directory change
+/// (#2301): the non-executed regions come off first
+/// ([`strip_data_regions`]), and the word must sit in **command position** —
+/// first in the text, or right after an operator word. `echo cd /outside`
+/// therefore says nothing, while `ls\ncd /outside` still warns, because the
+/// newline is an operator word.
+pub(super) fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
+    let words = shell_words(&strip_data_regions(command));
+    for (index, word) in words.iter().enumerate() {
+        if word != "cd" || (index > 0 && !is_operator_word(&words[index - 1])) {
+            continue;
+        }
+        let Some(target) = words.get(index + 1).map(String::as_str) else {
+            continue;
+        };
+        // `-` (cd to previous dir) is caught by the `-` prefix below. An
+        // operator word means the `cd` had no target at all (`cd && make`):
+        // that goes to `$HOME`, which we skip for the same reason as `~`.
+        if target.is_empty()
+            || target.starts_with('$')
+            || target.starts_with('~')
+            || target.starts_with('-')
+            || is_operator_word(target)
+        {
+            continue;
+        }
+        if crate::resolve_within_root(root, target).is_none() {
+            return Some(target.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cd_escape_target_flags_out_of_root_only() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        // In-root cd — no drift.
+        assert_eq!(cd_escape_target("cd sub && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("cd . && cargo build", dir.path()), None);
+        // Out-of-root — the target is returned.
+        assert_eq!(
+            cd_escape_target("cd / && grep -rn x .", dir.path()).as_deref(),
+            Some("/")
+        );
+        assert!(cd_escape_target("cd ../.. && ls", dir.path()).is_some());
+        // Unresolvable / no cd — skipped.
+        assert_eq!(cd_escape_target("cd $HOME && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("cd ~/foo && ls", dir.path()), None);
+        assert_eq!(cd_escape_target("grep -rn x .", dir.path()), None);
+    }
+
+    #[test]
+    fn shell_words_splits_operators_attached_to_a_word() {
+        assert_eq!(shell_words("cd /app; ls"), ["cd", "/app", ";", "ls"]);
+        assert_eq!(shell_words("a&&b"), ["a", "&&", "b"]);
+        assert_eq!(
+            shell_words("a || b|c & d"),
+            ["a", "||", "b", "|", "c", "&", "d"]
+        );
+        // Quoted and escaped operators stay inside the word.
+        assert_eq!(shell_words("echo 'a;b'"), ["echo", "a;b"]);
+        assert_eq!(shell_words(r"grep x\|y ."), ["grep", r"x\|y", "."]);
+    }
+
+    /// The false positive a paid bench trial hit: `cd /app; …` with session
+    /// root `/app` drew the "work here is invisible to the diff and to
+    /// verification" warning, because the target parsed as the unresolvable
+    /// `/app;`.
+    #[test]
+    fn an_attached_separator_does_not_fake_a_cd_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        // In-root cd with the separator attached — no drift, no warning.
+        assert_eq!(cd_escape_target("cd sub; ls", &root), None);
+        assert_eq!(
+            cd_escape_target(&format!("cd {}; ls", root.display()), &root),
+            None
+        );
+        // A real escape still warns, and names the clean target.
+        assert_eq!(cd_escape_target("cd /; ls", &root).as_deref(), Some("/"));
+        // A bare `cd` before an operator goes to `$HOME` — unresolvable
+        // here, so it is skipped rather than misnamed.
+        assert_eq!(cd_escape_target("cd && ls", &root), None);
+    }
+
+    /// #2301 witness: writing a script with a heredoc is a very common agent
+    /// shape, and the `cd` in its body is text being written to a file — not
+    /// a directory change this session ever makes.
+    #[test]
+    fn a_heredoc_body_cd_is_not_an_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(
+            cd_escape_target(
+                "cat > setup.sh <<'EOF'\ncd /workspace\nmake\nEOF\nbash setup.sh",
+                &root
+            ),
+            None
+        );
+        // The unquoted-delimiter and tab-stripping spellings behave the same.
+        assert_eq!(
+            cd_escape_target("cat <<-EOF > s.sh\n\tcd /workspace\n\tEOF\nls", &root),
+            None
+        );
+        // A here-string is not a heredoc: nothing after it is a body, so the
+        // real `cd` on the next line is still seen.
+        assert_eq!(
+            cd_escape_target("grep x <<< \"$body\"\ncd /", &root).as_deref(),
+            Some("/")
+        );
+    }
+
+    /// #2301 witness: an echoed `cd` is an argument to `echo`, not a command.
+    #[test]
+    fn an_echoed_cd_is_not_an_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(cd_escape_target("echo cd /outside", &root), None);
+        assert_eq!(cd_escape_target("echo \"cd /outside\"", &root), None);
+        assert_eq!(cd_escape_target(r"printf 'cd /tmp\n'", &root), None);
+    }
+
+    /// #2301 witness: a `#` comment is never executed, so neither is the `cd`
+    /// somebody left in one.
+    #[test]
+    fn a_commented_cd_is_not_an_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(cd_escape_target("make build # cd /old-path", &root), None);
+        assert_eq!(cd_escape_target("# cd /old-path\nmake build", &root), None);
+        // A `#` inside a word is not a comment, and a quoted one is text.
+        assert_eq!(cd_escape_target("echo \"# cd /old-path\"", &root), None);
+    }
+
+    /// The over-suppression guard for the two rules above: requiring command
+    /// position without making a newline an operator word would stop warning
+    /// on the second line of a multi-line command, which is a real escape.
+    #[test]
+    fn a_real_cd_on_a_later_line_still_warns() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(cd_escape_target("ls\ncd /", &root).as_deref(), Some("/"));
+        assert_eq!(
+            cd_escape_target("make build # build first\ncd /", &root).as_deref(),
+            Some("/")
+        );
+        assert_eq!(
+            cd_escape_target("cat > s.sh <<'EOF'\necho hi\nEOF\ncd /", &root).as_deref(),
+            Some("/")
+        );
+    }
+
+    /// The four inline copies this predicate replaced had already diverged:
+    /// the grep-scan boundary omitted `&`.
+    #[test]
+    fn is_operator_word_covers_every_separator_the_splitter_emits() {
+        for word in [";", "&", "&&", "|", "||", "\n"] {
+            assert!(is_operator_word(word), "{word} should be an operator word");
+        }
+        // Redirections are not separators — they belong to the command.
+        for word in [">", ">>", "2>&1", "<", "<<<"] {
+            assert!(
+                !is_operator_word(word),
+                "{word} should not be an operator word"
+            );
+        }
+    }
+}

--- a/crates/stella-tools/src/bash/words.rs
+++ b/crates/stella-tools/src/bash/words.rs
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The command-text splitter every `bash` advisory reads, and the one
-//! advisory that needs more than words: the `cd`-escape detector.
+//! Where a word is *data* rather than a command: the `cd`-escape detector,
+//! the one `bash` advisory that needs more than words.
 //!
 //! It lives beside [`super`] rather than inside it because `bash.rs` sits
-//! against the 1500-line ceiling, and because these three concerns — how a
-//! command is split, what counts as an operator, and where a word is *data*
-//! rather than a command — are one subject that the tool's spawn/timeout/
-//! policy body is not.
+//! against the 1500-line ceiling, and because this concern — which parts of a
+//! command text are never executed — is one subject that the tool's
+//! spawn/timeout/policy body is not.
+//!
+//! The splitter itself moved out of this crate entirely (#2022): the engine's
+//! stall rung reads the same command strings out of the transcript that the
+//! `bash` advisories read out of one call, so [`shell_words`] and
+//! [`is_operator_word`] now live in [`stella_core::shell_text`] and are
+//! re-exported here for the scans below. Two copies of that operator list is
+//! the exact drift this module was created to end.
 //!
 //! # What "data" means here, and why only `cd` pays for it
 //!
@@ -26,100 +32,10 @@
 
 use std::path::Path;
 
-/// Words the tokenizer emits as command separators, and the one predicate
-/// every consumer of [`shell_words`] asks about them.
-///
-/// Four near-copies of this list had accumulated in `bash.rs` — the `cd` skip
-/// list, the grep-scan boundary, [`super::segment_args`] and
-/// [`super::bare_sleep_seconds`] — and they had already diverged: the grep
-/// boundary omitted `&`, so `ls & grep -rn "struct X" .` scanned past the
-/// background operator (#2301).
-///
-/// A newline is an operator here for the same reason `;` is: it ends one
-/// command and begins the next. Redirection tokens (`2>&1`, `>>`, `<`) are
-/// deliberately **not** operator words — they neither end a command nor start
-/// one, and [`super::redirect_target`] reads them as ordinary words.
-pub(super) fn is_operator_word(word: &str) -> bool {
-    matches!(word, ";" | "&" | "&&" | "|" | "||" | "\n")
-}
-
-/// A quote-aware word split — enough to pull a `cd` target or a `grep`
-/// pattern out of the common command shapes, returning each word already
-/// unquoted. NOT a shell parser: it respects `'…'` and `"…"` (so a pattern or
-/// path with spaces stays one word) and preserves backslash escapes like
-/// `\|` (so an alternation survives into [`super::is_symbol_shaped`]);
-/// unquoted operators (`&&`, `||`, `|`, `;`, `&`, and a bare newline) come
-/// back as their own words to bound a scan — including when attached to a
-/// word, so `cd /app; ls` yields the target `/app`, not the unresolvable
-/// `/app;` a paid bench trial saw warned about as an escape from its own
-/// session root.
-pub(super) fn shell_words(command: &str) -> Vec<String> {
-    let mut words: Vec<String> = Vec::new();
-    let mut cur = String::new();
-    let mut has_word = false;
-    let (mut in_single, mut in_double) = (false, false);
-    let mut chars = command.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '\'' if !in_double => {
-                in_single = !in_single;
-                has_word = true;
-            }
-            '"' if !in_single => {
-                in_double = !in_double;
-                has_word = true;
-            }
-            c @ (';' | '&' | '|') if !in_single && !in_double => {
-                if has_word {
-                    words.push(std::mem::take(&mut cur));
-                    has_word = false;
-                }
-                let mut op = String::from(c);
-                // `&&` / `||` are one operator; `;;` never appears in the
-                // shapes this scans, so `;` stays single.
-                if c != ';' && chars.peek() == Some(&c) {
-                    chars.next();
-                    op.push(c);
-                }
-                words.push(op);
-            }
-            '\\' if !in_single => {
-                // Keep the escape literal (covers `\|`, `\"`, …); we don't
-                // interpret it, just preserve it for the symbol test.
-                cur.push('\\');
-                if let Some(n) = chars.next() {
-                    cur.push(n);
-                }
-                has_word = true;
-            }
-            // A newline separates two commands as surely as `;` does, so it
-            // is an operator word rather than plain whitespace. Without it a
-            // command-position rule cannot see the second line of
-            // `ls\ncd /outside` as a command at all.
-            '\n' if !in_single && !in_double => {
-                if has_word {
-                    words.push(std::mem::take(&mut cur));
-                    has_word = false;
-                }
-                words.push(String::from('\n'));
-            }
-            c if c.is_whitespace() && !in_single && !in_double => {
-                if has_word {
-                    words.push(std::mem::take(&mut cur));
-                    has_word = false;
-                }
-            }
-            c => {
-                cur.push(c);
-                has_word = true;
-            }
-        }
-    }
-    if has_word {
-        words.push(cur);
-    }
-    words
-}
+/// The command-text splitter and its operator predicate, re-exported from
+/// [`stella_core::shell_text`] where they now live so the engine's stall rung
+/// and these advisories read one implementation (#2022).
+pub(super) use stella_core::shell_text::{is_operator_word, shell_words};
 
 /// One pending heredoc: the delimiter that ends its body, and whether `<<-`
 /// asked for leading tabs to be ignored on that terminator line.

--- a/crates/stella-tools/src/bash/words.rs
+++ b/crates/stella-tools/src/bash/words.rs
@@ -28,7 +28,14 @@
 //! to sit in **command position** before it will name a target. The audit in
 //! [`super::shell_write_audit`] deliberately does neither: it is a fence
 //! around what the shell may be about to overwrite, so a path appearing
-//! anywhere in the text is exactly what it wants to see.
+//! anywhere in the text is exactly what it wants to see. That is the right
+//! call for the write half and an open question for the read half, where the
+//! same data text can refuse a read the shell never performs (#3618).
+//!
+//! Command position is read from the word *before* the `cd`, so it is only as
+//! good as the splitter's word boundaries: `(` and `)` are ordinary word
+//! characters there, which is why the glued `(cd /outside; ls)` is still
+//! missed (#3619). Every miss here is silence, never a wrong note.
 
 use std::path::Path;
 
@@ -53,11 +60,16 @@ struct Heredoc {
 /// their text. Everything else is copied through byte for byte — this removes
 /// regions, it does not rewrite words.
 ///
+/// An arithmetic expansion is copied through whole, because the `<<` in
+/// `$((1 << 3))` is a left shift and not a heredoc opener — reading it as one
+/// registers a delimiter (`3))`) that never arrives and swallows every later
+/// line, silencing a real `cd`.
+///
 /// Deliberately partial, on the "better a missed note than a wrong one"
 /// posture this whole module holds: a delimiter produced by expansion
-/// (`<<$END`) is taken literally, and an unterminated heredoc swallows the
-/// rest of the command rather than guessing where it ended. Both directions
-/// lose a warning; neither invents one.
+/// (`<<$END`) is taken literally (#3620), and an unterminated heredoc
+/// swallows the rest of the command rather than guessing where it ended. Both
+/// directions lose a warning; neither invents one.
 fn strip_data_regions(command: &str) -> String {
     let chars: Vec<char> = command.chars().collect();
     let mut out = String::with_capacity(command.len());
@@ -92,6 +104,15 @@ fn strip_data_regions(command: &str) -> String {
                 while i < chars.len() && chars[i] != '\n' {
                     i += 1;
                 }
+            }
+            // `$(( … ))` is arithmetic, where `<<` is a shift operator. Copy
+            // the whole expansion through so the heredoc arm never sees it.
+            '$' if !in_single
+                && !in_double
+                && chars.get(i + 1) == Some(&'(')
+                && chars.get(i + 2) == Some(&'(') =>
+            {
+                i = copy_arithmetic_expansion(&chars, i, &mut out);
             }
             // `<<` opens a heredoc; `<<<` is a here-string, whose word is
             // ordinary text on the same line and needs no skipping.
@@ -135,6 +156,30 @@ fn strip_data_regions(command: &str) -> String {
         }
     }
     out
+}
+
+/// Copy the `$(( … ))` expansion beginning at `from` into `out` verbatim, and
+/// return the index just past its closing `))`.
+///
+/// Parentheses are counted rather than matched textually so a nested group
+/// (`$(( (1 << 3) + 2 ))`) closes where it really closes. An expansion that is
+/// never closed copies to the end of input, which loses nothing: the text is
+/// still scanned as ordinary words.
+fn copy_arithmetic_expansion(chars: &[char], from: usize, out: &mut String) -> usize {
+    let mut i = from;
+    out.push_str("$((");
+    i += 3;
+    let mut depth = 2usize;
+    while i < chars.len() && depth > 0 {
+        match chars[i] {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            _ => {}
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    i
 }
 
 /// Is the character at `at` the first of a word — start of input, or preceded
@@ -205,6 +250,61 @@ fn skip_heredoc_body(chars: &[char], from: usize, heredoc: &Heredoc) -> usize {
     i
 }
 
+/// Does the word *after* `word` sit in command position, given whether `word`
+/// itself does?
+///
+/// Command position is where the shell expects a command name, and it is
+/// reached three ways, not one. An operator word ends the previous command
+/// unconditionally. A reserved word introduces a command list (`then`, `do`,
+/// `{`, `!`, …) — but only when the reserved word is itself in command
+/// position, because `echo then cd /x` passes `then` to `echo` as an ordinary
+/// argument. A transparent prefix keeps the position open across itself: a
+/// variable assignment, or one of the three words that can precede the `cd`
+/// **builtin** (`time`, `command`, `builtin`) — `sudo`, `env` and `nohup` are
+/// deliberately absent, since none of them can execute a shell builtin.
+///
+/// The narrow rule this replaces — "right after an operator word" — silently
+/// stopped warning on `if …; then cd /outside; fi`, `for … do cd /outside`,
+/// `{ cd /outside; }`, `FOO=1 cd /outside` and `time cd /outside`, every one
+/// of which the `windows(2)` scan before #2301 did catch. Those are real
+/// escapes, and losing them was a regression, not a posture.
+fn next_word_is_a_command(word: &str, word_is_a_command: bool) -> bool {
+    if is_operator_word(word) {
+        return true;
+    }
+    word_is_a_command && (introduces_a_command(word) || is_transparent_prefix(word))
+}
+
+/// Reserved words after which the shell reads another command.
+///
+/// `for`, `select`, `case` and `in` are absent on purpose: what follows them
+/// is a name or a word list, not a command, and the command only starts at
+/// the `do`/`)` that closes the header.
+fn introduces_a_command(word: &str) -> bool {
+    matches!(
+        word,
+        "if" | "then" | "elif" | "else" | "while" | "until" | "do" | "{" | "(" | "!"
+    )
+}
+
+/// Words that may sit in front of a command without being one: a variable
+/// assignment (`FOO=1 cd /x`), and the prefixes that can still run a builtin.
+///
+/// An assignment is recognised structurally rather than by name — a leading
+/// `NAME=`, where `NAME` is a shell identifier. `=` alone, `1FOO=x` and
+/// `--flag=v` are not assignments and correctly leave command position.
+fn is_transparent_prefix(word: &str) -> bool {
+    if matches!(word, "time" | "command" | "builtin") {
+        return true;
+    }
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// If the command `cd`s somewhere outside the workspace `root`, return that
 /// target — every other tool is confined to `root`, so an edit under a drifted
 /// tree is invisible to the file tools, the turn's diff, and verification (and
@@ -214,14 +314,16 @@ fn skip_heredoc_body(chars: &[char], from: usize, heredoc: &Heredoc) -> usize {
 ///
 /// Two rules keep a `cd` that is *data* from being read as a directory change
 /// (#2301): the non-executed regions come off first
-/// ([`strip_data_regions`]), and the word must sit in **command position** —
-/// first in the text, or right after an operator word. `echo cd /outside`
-/// therefore says nothing, while `ls\ncd /outside` still warns, because the
-/// newline is an operator word.
+/// ([`strip_data_regions`]), and the word must sit in **command position**
+/// ([`next_word_is_a_command`]). `echo cd /outside` says nothing, while
+/// `ls\ncd /outside` still warns, because the newline is an operator word.
 pub(super) fn cd_escape_target(command: &str, root: &Path) -> Option<String> {
     let words = shell_words(&strip_data_regions(command));
+    let mut command_position = true;
     for (index, word) in words.iter().enumerate() {
-        if word != "cd" || (index > 0 && !is_operator_word(&words[index - 1])) {
+        let here = command_position;
+        command_position = next_word_is_a_command(word, here);
+        if word != "cd" || !here {
             continue;
         }
         let Some(target) = words.get(index + 1).map(String::as_str) else {
@@ -367,6 +469,76 @@ mod tests {
         assert_eq!(
             cd_escape_target("cat > s.sh <<'EOF'\necho hi\nEOF\ncd /", &root).as_deref(),
             Some("/")
+        );
+    }
+
+    /// Command position is not "right after an operator": a shell keyword, a
+    /// brace group and an assignment prefix all introduce a command too, and
+    /// the `windows(2)` scan this replaced caught every one of them.
+    #[test]
+    fn a_cd_after_a_keyword_or_a_prefix_is_still_an_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        for command in [
+            "if [ -d /x ]; then cd /outside; fi",
+            "if [ -d /x ]; then :; else cd /outside; fi",
+            "for f in a b; do cd /outside; done",
+            "while read -r l; do cd /outside; done",
+            "{ cd /outside; }",
+            "( cd /outside )",
+            "FOO=1 BAR=2 cd /outside",
+            "time cd /outside",
+            "command cd /outside",
+            "! cd /outside",
+        ] {
+            assert_eq!(
+                cd_escape_target(command, &root).as_deref(),
+                Some("/outside"),
+                "{command} escapes the root and must still warn"
+            );
+        }
+    }
+
+    /// The other half of the rule above: a keyword or a prefix word that is
+    /// itself an *argument* introduces nothing, so the `cd` behind it is
+    /// still data.
+    #[test]
+    fn a_keyword_shaped_argument_does_not_promote_a_cd() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        for command in [
+            "echo then cd /outside",
+            "echo time cd /outside",
+            "echo FOO=1 cd /outside",
+            "git commit -m do cd /outside",
+        ] {
+            assert_eq!(
+                cd_escape_target(command, &root),
+                None,
+                "{command} runs no cd and must stay silent"
+            );
+        }
+    }
+
+    /// `<<` inside an arithmetic expansion is a left shift, not a heredoc
+    /// opener — reading it as one swallows the rest of the command and
+    /// silences a real `cd`.
+    #[test]
+    fn an_arithmetic_shift_is_not_a_heredoc() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(
+            cd_escape_target("echo $((1 << 3))\ncd /outside", &root).as_deref(),
+            Some("/outside")
+        );
+        assert_eq!(
+            cd_escape_target("n=$(( (1 << 3) + 2 ))\ncd /outside", &root).as_deref(),
+            Some("/outside")
+        );
+        // A real heredoc beside an arithmetic expansion still hides its body.
+        assert_eq!(
+            cd_escape_target("cat <<'EOF' $((1 << 3))\ncd /outside\nEOF", &root),
+            None
         );
     }
 

--- a/website/content/docs/commands/dataset.mdx
+++ b/website/content/docs/commands/dataset.mdx
@@ -79,7 +79,9 @@ The transcript clause is what a store predating the receipts plane cannot satisf
 - `transcript_verified` is `false`, so the record says why;
 - `transcript_mismatch_severity` reports what a digest mismatch here *means* — `none`, `compaction` (the journal predates compaction journaling its rewrites, so the mismatched bytes are a routine pre-compaction preimage), or `integrity` (compaction is no longer an available explanation).
 
-The gate itself stays era-blind: a benign `compaction` record is excluded by default exactly like an `integrity` one. The severity is reported so a consumer can tell them apart, never used to admit one. `tool_calls`, `changes`, `verdict`, and `reward` come from the journal and are exactly as trustworthy on these records as on any other.
+The gate itself stays era-blind: a benign `compaction` record is excluded by default exactly like an `integrity` one. The severity is reported so a consumer can tell them apart, never used to admit one. `tool_calls`, `changes`, and `verdict` come from the journal and are exactly as trustworthy on these records as on any other.
+
+`reward` is the one field that is not purely journal-derived, and on the pre-receipts shape it says so. Its outcome term comes from the journal's verdict, but its shaping prices the *step count*, which comes from the receipts plane — and a plane holding no row for a turn has not recorded that the turn made zero calls, it has recorded nothing. Read as zero the step penalty would simply vanish, handing exactly these records a scalar **above** what the same trajectory earns once its calls are counted. So `cost.steps` is `null` and the label reports `discard: "steps_unknown"` instead, keeping its rung, its outcome term and its policy so the row stays selectable and re-shapeable under a count of your own. A record whose receipts exist but fail to verify is unaffected: its calls were recorded, so its step count is real and its reward scores normally.
 
 ## The record
 
@@ -156,7 +158,7 @@ Every record carries the same keys — absence is spelled `null`, never omitted 
 
 `calls` is every model call in wire order, each with the exact messages it was sent — rebuilt from the receipts plane by the same reconstruction `stella inspect` reads, and admitted only once its digest verifies. That is what makes an SFT pair derivable from a record alone. It is empty exactly when `transcript_verified` is `false`, which only `--include-unverified-transcripts` can produce.
 
-`reward` is the training label the settled verdict earned, computed under the workspace's resolved reward policy — and the policy rides on the label, so a scalar stays interpretable outside the workspace that produced it. It is `null` when the journal holds no verdict at all: there is nothing to derive a label from, and synthesizing one under a policy the run never saw would claim more than the store knows. The raw `verdict` is carried beside it so a reader can re-derive a label under different weights.
+`reward` is the training label the settled verdict earned, computed under the workspace's resolved reward policy — and the policy rides on the label, so a scalar stays interpretable outside the workspace that produced it. It is `null` when the journal holds no verdict at all: there is nothing to derive a label from, and synthesizing one under a policy the run never saw would claim more than the store knows. The raw `verdict` is carried beside it so a reader can re-derive a label under different weights. A label that *is* present may still carry no scalar — `reward.reward` is `null` beside a named `reward.discard` whenever the trajectory cannot be priced honestly, including the `steps_unknown` case described above.
 
 ### Provenance
 

--- a/website/content/docs/commands/dataset.mdx
+++ b/website/content/docs/commands/dataset.mdx
@@ -15,7 +15,8 @@ Offline: reads `.stella/private/store.db` only, needs no API key, and never writ
 
 ```bash
 stella dataset export --output <dir> \
-    [--format jsonl] [--since <timestamp>] [--until <timestamp>] [--require-verdict]
+    [--format jsonl] [--since <timestamp>] [--until <timestamp>] [--require-verdict] \
+    [--include-unverified-transcripts]
 ```
 
 ## What it does
@@ -51,17 +52,34 @@ writes two files into `./trajectories`, both owner-only (`0600`) inside an owner
     Additionally require a verifier verdict of `passed`. Off by default — a turn the deterministic
     ladder cleared never reaches a verifier at all.
   </OptionCard>
+  <OptionCard name="--include-unverified-transcripts" defaultValue="off">
+    Also export otherwise-accepted turns whose transcripts cannot be digest-verified, with `calls`
+    empty and `transcript_verified` false. Off by default — an unvouched transcript must never reach
+    a training set silently.
+  </OptionCard>
 </CardGrid>
 
 ## What counts as an accepted turn
 
 The store has no "accepted" column, so the rule is named, applied in one place, and echoed verbatim into the manifest:
 
-> `executions.outcome` in {`completed`, `goal_met`} **and** at least one mutating `file_change` event
+> `executions.outcome` in {`completed`, `goal_met`} **and** at least one mutating `file_change` event **and** at least one recorded model call, every one reconstructing digest-verified
 
-Both halves matter. A turn that reported success but changed nothing is a real outcome and a poor training example — there is no diff to learn from. Every other outcome the engine writes (`goal_unmet`, `verification_failed`, `aborted`, `cancelled`, `failed`, `error`, `interrupted`) is excluded.
+All three halves matter. A turn that reported success but changed nothing is a real outcome and a poor training example — there is no diff to learn from. Every other outcome the engine writes (`goal_unmet`, `verification_failed`, `aborted`, `cancelled`, `failed`, `error`, `interrupted`) is excluded. And a turn that cannot prove what its model calls actually saw cannot contribute an SFT pair, so it is excluded too and counted in the manifest as `executions_transcripts_unverified`.
 
-`--require-verdict` adds a third clause and rewrites the predicate in the manifest to match.
+`--require-verdict` adds a fourth clause; `--include-unverified-transcripts` loosens the third. Either one rewrites the predicate in the manifest to match — the manifest always states the rule that actually ran.
+
+### Turns that cannot vouch for their transcripts
+
+The transcript clause is what a store predating the receipts plane cannot satisfy: with no `step_receipt` rows there is no recorded model call at all, so the default filter exports **zero** records from it even though the journal still holds every one of those turns' prompt, tool calls, and changes.
+
+`--include-unverified-transcripts` exports them anyway, with the transcript honestly withheld rather than faked:
+
+- `calls` is `[]` — an unvouched transcript is withheld whole, never emitted with a silent gap in it;
+- `transcript_verified` is `false`, so the record says why;
+- `transcript_mismatch_severity` reports what a digest mismatch here *means* — `none`, `compaction` (the journal predates compaction journaling its rewrites, so the mismatched bytes are a routine pre-compaction preimage), or `integrity` (compaction is no longer an available explanation).
+
+The gate itself stays era-blind: a benign `compaction` record is excluded by default exactly like an `integrity` one. The severity is reported so a consumer can tell them apart, never used to admit one. `tool_calls`, `changes`, `verdict`, and `reward` come from the journal and are exactly as trustworthy on these records as on any other.
 
 ## The record
 
@@ -69,7 +87,7 @@ Every record carries the same keys — absence is spelled `null`, never omitted 
 
 ```json
 {
-  "schema": 1,
+  "schema": 3,
   "execution_id": 412,
   "session_id": "ses-9f2c",
   "repo": "3a7e1c04b9d2f5e8",
@@ -81,6 +99,22 @@ Every record carries the same keys — absence is spelled `null`, never omitted 
   "outcome": "completed",
   "cost_usd": 0.0143,
   "prompt": "make the flaky retry test deterministic",
+  "calls": [
+    {
+      "turn_instance": 0,
+      "step": 0,
+      "call_seq": 0,
+      "role": "worker",
+      "provider": "zai",
+      "model": "glm-5.2",
+      "prompt_messages": [
+        { "role": "system", "content": "…" },
+        { "role": "user", "content": "make the flaky retry test deterministic" }
+      ]
+    }
+  ],
+  "transcript_verified": true,
+  "transcript_mismatch_severity": "none",
   "tool_calls": [
     {
       "seq": 12,
@@ -104,9 +138,25 @@ Every record carries the same keys — absence is spelled `null`, never omitted 
     }
   ],
   "verdict": { "passed": true, "deterministic": true, "summary": "cargo test flipped fail -> pass" },
+  "reward": {
+    "rung": "submit_fast",
+    "outcome": 1.0,
+    "reward": 0.93285,
+    "cost": { "steps": 3, "cost_usd": 0.0143, "revisions": 0 },
+    "policy": {
+      "outcome": { "deterministic": 1.0 },
+      "shaping": { "per_step": 0.02, "per_usd": 0.5, "per_revision": 0.1 }
+    }
+  },
   "redacted": false
 }
 ```
+
+### The transcript
+
+`calls` is every model call in wire order, each with the exact messages it was sent — rebuilt from the receipts plane by the same reconstruction `stella inspect` reads, and admitted only once its digest verifies. That is what makes an SFT pair derivable from a record alone. It is empty exactly when `transcript_verified` is `false`, which only `--include-unverified-transcripts` can produce.
+
+`reward` is the training label the settled verdict earned, computed under the workspace's resolved reward policy — and the policy rides on the label, so a scalar stays interpretable outside the workspace that produced it. It is `null` when the journal holds no verdict at all: there is nothing to derive a label from, and synthesizing one under a policy the run never saw would claim more than the store knows. The raw `verdict` is carried beside it so a reader can re-derive a label under different weights.
 
 ### Provenance
 
@@ -130,18 +180,20 @@ The manifest's `redaction.behavior_digest` fingerprints the redactor by its **de
 
 ```json
 {
-  "schema": 1,
+  "schema": 3,
   "format": "jsonl",
   "file": "dataset.jsonl",
   "records": 37,
   "repo": "3a7e1c04b9d2f5e8",
   "filter": {
-    "acceptance_predicate": "executions.outcome in {completed, goal_met} AND at least one mutating file_change event",
+    "acceptance_predicate": "executions.outcome in {completed, goal_met} AND at least one mutating file_change event AND at least one recorded model call, every one reconstructing digest-verified (Reconstruction::is_verified)",
     "since": null,
     "until": null,
     "require_verdict": false,
+    "include_unverified_transcripts": false,
     "executions_scanned": 214,
     "executions_in_window": 214,
+    "executions_transcripts_unverified": 6,
     "executions_accepted": 37
   },
   "redaction": {
@@ -153,6 +205,10 @@ The manifest's `redaction.behavior_digest` fingerprints the redactor by its **de
   "execution_id_range": [178, 412]
 }
 ```
+
+`executions_transcripts_unverified` counts the same executions in both modes — under `--include-unverified-transcripts` those are the records carrying `transcript_verified: false` rather than the ones left out — so the two modes stay comparable.
+
+`schema` is bumped whenever the record shape changes incompatibly, so a reader can refuse a dataset it does not understand instead of misparsing it.
 
 `store_watermark` is the store's own newest timestamp, not the wall clock: the extraction reads no clock anywhere, so re-running it against the same store produces byte-identical files.
 


### PR DESCRIPTION
## What & why

A sweep of the open P1/P2 issues in the range #1283–#2343. Forty were open when
the sweep started; thirty-three were closed as `not_planned` during it (the
bench/arena backlog retirement), and of the seven that remain, five were
verifiable defects fixable in-tree. This lands those five.

**This PR breaks the repo's "one logical change per PR" rule, deliberately and
visibly.** Five independent defects across four crates would normally be five
PRs; the session was pinned to a single branch. Each fix is a self-contained
commit with its own witness, so they are reviewable — and splittable — one at a
time. Say the word and I'll break it up.

| Commit | Issue | What it fixes |
|---|---|---|
| `9d6ae74` | #2030 | `TraceCall` carries the reconstruction verdict as `journal_era` / `digest_mismatch_severity` fields instead of only inside a free-text `reconstruction_error` sentence, so a consumer can act on severity without regexing prose. |
| `3be6878` + `647a79d` | #2123 | `stella dataset export --include-unverified-transcripts`: a non-default path for executions that cannot prove their transcripts, and a refusal to price a step count nobody recorded. |
| `b23b9ea` + `38d089b` | #2302 | An untrusted checkout now says what steering it withheld (counts only, never content), with a remedy line that is correct under an org-managed `project_prompts = "off"`. |
| `91f931e` + `5e5a5f3` | #2301 | `cd` appearing as *data* — heredoc bodies, unquoted `echo` arguments, comments — no longer draws a workspace-escape note, without dropping the real `cd` shapes the old scan caught. |
| `7de1b26` + `a1aacff` | #2022 | A turn sleeping its allowance away is steered, per turn, without panicking on absurd sleep text. |

Closes #2030
Closes #2123
Closes #2301
Closes #2022
Refs #2302

`Refs`, not `Closes`, for #2302: its Definition of Done is met on stderr, but its
Constraints also ask for the counts in `--output-format stream-json`/`json`, and
that half is not implemented here — it needs a new wire variant with a declared
`ConsumerPosture` row (invariant #10) and a `docs/wire/**` regeneration, which is
a contract decision for a maintainer. Tracked as #3616.

### Exemplars followed

- `crates/stella-cli/src/plugin_cmd/roster.rs`'s untrusted-project notice (#3509)
  is the shape #2302's notice copies: computed as data so it can be asserted,
  printed by the caller, spoken only when there is something to speak about.
- `crates/stella-protocol/src/event/consumers.rs`'s "reviewed row per surface,
  enforced from both sides" is cited as the target shape in #3625, not adopted
  here.
- #2301's tokenizer moved into a sibling submodule (`bash/words.rs`) following
  `src/search.rs` + `src/search/`, because `bash.rs` was 1395 lines against the
  1500 ceiling with no baseline entry. **No baseline was raised.**

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

One per fix, each verified in **both** directions — the fail side was observed,
not assumed:

| Issue | Witness | Observed failure without the fix |
|---|---|---|
| #2030 | `trace::tests::a_digest_mismatch_is_a_field_not_a_substring` | `left: Null, right: "integrity"` — asserts on `serde_json::to_value`, so it fails at runtime rather than merely failing to compile |
| #2123 | `a_turn_with_no_receipts_at_all_withholds_the_reward_scalar_it_cannot_shape` | exported `"steps":0,"reward":0.95` where the same trajectory with five recorded calls earns `0.93` |
| #2302 | `settings_warnings_cli::an_untrusted_checkouts_withheld_steering_is_named_on_stderr` | spawns the real binary; deleting the `eprintln!` reds this test and nothing else |
| #2301 | `a_heredoc_body_cd_is_not_an_escape` (+ echoed, commented, and an over-suppression guard) | `Some("/workspace")` where `None` is correct |
| #2022 | `a_turn_that_sleeps_away_its_budget_is_steered_though_no_loop_fires` | no steer emitted |

#2302's original witness was **rejected in review as worthless** — it asserted
only against the pure functions and stayed green with the entire user-visible
wiring deleted. It was replaced with the process-level test above.

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p stella-core -p stella-tools -p stella-pipeline -p stella-cli --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — **see below**
- [x] `cargo test -p stella-core -p stella-tools -p stella-pipeline` — all green
- [x] Docs updated: module headers on the new modules,
      `website/content/docs/commands/dataset.mdx` corrected where it contradicted
      the Rust doc, `crates/stella-core/README.md` for the new module
- [x] `Closes #N` appears both here and as commit trailers

**`cargo test -p stella-cli` is 1770 passed / 1 failed, and the failure is a
pre-existing flake, not this branch.** It is
`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`
(#3588, #3559). Evidence, because the first measurement was misleading and the
method belongs on the record:

- This branch touches no daemon file — `git diff --name-only e8b7091..HEAD` has
  no match for `daemon`.
- A first control run on a pristine `e8b7091` worktree passed **4/4** (~8.1s
  each), which looked like this branch had caused it. That reading was wrong:
  the control had run immediately after a fresh full build, on a quiet machine.
- Re-run **interleaved** under the same load, unmodified `e8b7091` fails **2/3**
  and the branch tip fails **2/3** — indistinguishable. Failures return in
  ~0.33s against ~8.1s when passing, a bimodal signature matching #3559's
  "kills the child ~100x early under a full workspace test run".

`make gate` and `make guards-fast` cannot complete in this container at all —
`shellcheck` is not installed (filed as #3615). The individual gate steps were
run by hand instead: `check-file-size.sh`, `check-god-files.sh`,
`check-left-behind.sh`, `check-typed-errors.py`, `check-no-scratch.sh`,
`check-invariants.sh`, `make command-docs`, `make doc-links`, and
`RUSTDOCFLAGS="-D warnings" cargo doc`.

## Nothing left behind

- [x] Filed: #3612, #3613, #3614, #3615, #3616, #3617, #3618, #3619, #3620,
      #3621, #3622, #3623, #3624, #3625, #3626

Fifteen issues, each written as a standalone handoff. The ones a reviewer should
look at first are #3616 (#2302's unimplemented stream-json half — the reason
this PR says `Refs` there) and #3622 (`AgentEvent::Steered` now carries two
structurally different causes with nothing on the wire distinguishing them,
which is invariant #10's question about the signal this PR adds).

## Ground-rule check

- [x] **No I/O added to `stella-core`.** #2022's stall rung is pure synchronous
      logic over owned data. It adds one new module,
      `crates/stella-core/src/shell_text.rs` — a tokenizer and a sleep
      classifier over borrowed strings, referencing no `std::fs`,
      `std::process`, or network type. `stella-tools`' `bash/words.rs` is backed
      by it, so there is **one** tokenizer rather than two copies.
- [x] **No new dependencies.** `stella-tools` already depended on `stella-core`
      (`crates/stella-tools/Cargo.toml:13`); no manifest in this diff changed.
- [x] No new outbound network calls
- [x] Cross-boundary types round-trip through serde

**Both schema constants moved, and both are deliberate:**

- `TRACE_SCHEMA_VERSION` **3 → 4** — `TraceCall` gained two fields.
- `DATASET_SCHEMA_VERSION` **2 → 3** — `DatasetRecord` gained
  `transcript_verified` and `transcript_mismatch_severity`, and
  `TrajectoryCost::steps` became optional.

Both are additive-optional, but the record shape changed, so both were bumped
once each in the commit that changed the shape — the remediation commits add no
second bump.

## Anything reviewers should know?

**#2123's fix reaches outside its issue, on purpose.** Making
`TrajectoryCost::steps` an `Option<u32>` forces every call site to state
something, and `stella trace` carried the identical defect from the same source
(its own test pinned `steps == 0` beside a scored `0.70`, with the comment "no
receipts in this fixture"). Passing `Some(0)` there would have been knowingly
writing the false statement in the very commit that added the vocabulary to say
it correctly. That is why two shipped schema constants move in one PR — flagged
here rather than buried.

**Two issues in the range were verified as already fixed** and are candidates to
close without work: #2156 (the premise is false at HEAD — every
`CompletionResult` site sets `model: self.model.clone()`, the configured id, so
the calibration join matches) and #2281 (the 402 classifier for #3209 sits
upstream of the monitor, so a defunded trial can no longer satisfy
`_premature_complete`'s predicate).

**#1854 (P1) looks mis-prioritised.** Its structural claim holds — our
`cache_control` rides the request root, not the message content parts — but its
stated consequence, "Claude via OpenRouter runs at 0% cache, actively costing
money", is contradicted by telemetry already committed in this repo: match
`dd52a57a6f49` (2026-08-04, `openrouter` / `anthropic/claude-fable-5`) shows
cached input covering ~98% of the prefix from step 1 on, with per-step cost
reconciling to OpenRouter's cache-read rates. What that cannot settle is
attribution — whether our root-level field engaged the cache or OpenRouter
caches Anthropic routes regardless — which needs a two-request A/B on a live
key. Worth re-scoping rather than leaving at P1. No comment was posted on the
issue.

**#1383 was verified real and left alone** — a container-native
`CandidateWorkspacePort` is a fifteen-method trait plus a substrate-selection
seam that does not exist yet, which is a multi-session change, not a bug fix.

**These commits will show as Unverified.** `commit.gpgsign` is on and
`gpg.format=ssh`, but the configured key
(`/home/claude/.ssh/commit_signing_key.pub`) is a 0-byte file with no private
key, so the build container cannot sign. That needs a provisioned key, not a
history rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG9eWVqVYR2KLWHUaMdneP
