### PR TITLE
docs: true up the user docs against the shipped surface

### DIFF
--- a/website/content/docs/agent-engine-in-your-app.mdx
+++ b/website/content/docs/agent-engine-in-your-app.mdx
@@ -90,7 +90,7 @@ Confirm what you built:
 
 ```bash
 ./target/release/stella-serve --version
-# stella-serve 0.6.44
+# stella-serve <version>   — the program name, one space, a bare semver
 ```
 
 Record that version in your repo next to the client code. The wire format is
@@ -403,26 +403,34 @@ Reporting a rate limit as `terminal` silently disables the backoff you wanted.
 
 ## What is not built yet
 
-Re-verified absent as of 0.6.10, so design around them rather than discovering them:
+Re-verified against 0.9.86, so design around them rather than discovering them:
 
-- **No stream resumption.** Frames carry no sequence number and no history is
-  retained. A dropped connection loses whatever streamed while it was down.
-  Persist frames on receipt if you need durability.
-- **No server-side conversation state.** One turn per request. Your app owns
-  history and replays it.
-- **No approval route.** Steering and pause/resume *have* shipped since this
-  list was written — `POST /v1/turns/{id}/steer`, `/pause` and `/resume`, with
-  the hold announced on the stream as `turn_held` / `turn_released` so a
-  client that reconnects mid-hold still knows the turn is waiting on it. What
-  is still absent is `/approve`: the `scope_review` event has no reverse
-  endpoint, so an approval gate has to live in your app, in front of the turn.
-- **No token-level streaming from the engine.** It forwards whole completions.
-  To stream tokens to your users, stream them from your own provider call, which
-  you already control.
-- **No SIGTERM drain**, no `/readyz`, and no `/metrics`.
-- **Most engine knobs are fixed.** Only `max_steps` and
-  `reverse_request_timeout_ms` are settable per turn. Temperature, output token
-  cap, reasoning effort, and the compaction budget come from the engine defaults.
+- **A resume point can expire.** Frames *are* sequenced and replayable — see
+  below — but retention is a bounded ring (4096 frames per live turn). Ask to
+  resume from a `seq` older than the window and you are told the point is gone
+  rather than handed a stream with a silent hole in it. Persist frames on
+  receipt if you need durability beyond that window.
+- **No `/approve` bypass.** The route exists, but a turn that raises
+  `scope_review` blocks until something answers it. A caller running unattended
+  sets `auto_approve` on the turn; otherwise your app must answer, and a client
+  that never does leaves the turn parked until its deadline.
+- **`retry_policy` and `loop_detection` are operator policy**, not caller
+  policy. They bound what one request can cost the process, so no per-turn
+  override widens them. Unknown keys in the `engine` object are refused rather
+  than ignored — a typoed knob that parsed would be a knob silently not honored.
+
+Several entries that stood here through the 0.6 line have since shipped, and are
+worth naming because a client written against the old list is leaving them on the
+floor:
+
+| Was listed absent | Now |
+| --- | --- |
+| Stream resumption | `?after=<seq>`, or an `EventSource`'s automatic `Last-Event-ID` — every frame carries a monotonic `seq` and each SSE frame an `id:` |
+| Server-side conversation state | `POST /v1/sessions`, then `POST /v1/sessions/{id}/turns` — the server threads one transcript, so the byte-stable prefix earns its cache discount and compaction becomes reachable |
+| The approval route | `POST /v1/turns/{id}/approve`, answering a `scope_review` by `request_id` |
+| Token-level streaming | `POST /v1/turns/{id}/provider-delta` — batched `text` / `reasoning` fragments for an in-flight completion, advisory exactly like `text_delta` |
+| SIGTERM drain, `/readyz`, `/metrics` | All three: `SIGTERM`/`SIGINT` start a graceful drain bounded by `STELLA_SERVE_SHUTDOWN_GRACE_SECS`, and both endpoints route |
+| Per-turn engine knobs | An optional `engine` object on turn create sets output cap, temperature, effort and the rest, each clamped to an operator ceiling |
 
 ## Licensing: AGPL or commercial
 

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -41,7 +41,9 @@ refresh` re-syncs from [models.dev](https://models.dev).
 | Provider / model | Context | In | Out | Cached in |
 | --- | --- | --- | --- | --- |
 | `zai/glm-5.2` | 200k | 0.60 | 2.20 | 0.11 |
-| `anthropic/claude-fable-5` | 200k | 3.00 | 15.00 | 0.30 |
+| `anthropic/claude-fable-5` | 1M | 10.00 | 50.00 | 1.00 |
+| `anthropic/claude-opus-5` | 1M | 5.00 | 25.00 | 0.50 |
+| `anthropic/claude-sonnet-5` | 1M | 3.00 | 15.00 | 0.30 |
 | `openai/gpt-5.5` | 400k | 1.25 | 10.00 | 0.125 |
 | `xai/grok-4` | 256k | 3.00 | 15.00 | 0.75 |
 | `deepseek/deepseek-chat` | 128k | 0.27 | 1.10 | 0.07 |

--- a/website/content/docs/api-providers/models.mdx
+++ b/website/content/docs/api-providers/models.mdx
@@ -22,7 +22,9 @@ your provider before budgeting — prices and lineups drift.
 
 | Model | Provider | Context | In $/Mtok | Out $/Mtok | Cached-in $/Mtok | Released | Best for |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| <ProviderMark id="anthropic" /> `claude-fable-5` | `anthropic` | 200k | 3.00 | 15.00 | 0.30 | 2026 | The strongest coding/agentic model in the catalog — first of the Claude 5 family. Best-in-class worker for hard multi-file changes; superb verifier. |
+| <ProviderMark id="anthropic" /> `claude-fable-5` | `anthropic` | 1M | 10.00 | 50.00 | 1.00 | 2026 | The strongest coding/agentic model in the catalog, and the most expensive — first of the Claude 5 family. Best-in-class worker for hard multi-file changes; superb verifier. |
+| <ProviderMark id="anthropic" /> `claude-opus-5` | `anthropic` | 1M | 5.00 | 25.00 | 0.50 | 2026 | Half Fable's list price with the same 1M window. The Claude 5 tier to reach for when Fable's worker quality is more than the task needs. |
+| <ProviderMark id="anthropic" /> `claude-sonnet-5` | `anthropic` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Sonnet pricing with a 1M window. A strong default worker where the budget rules out the tiers above. |
 | <ProviderMark id="openai" /> `gpt-5.5` | `openai` | 400k | 1.25 | 10.00 | 0.125 | late 2025 | Top-tier reasoning with a 400k window at a mid price. Excellent cross-family verifier over a Claude or GLM worker; strong worker. |
 | <ProviderMark id="gemini" /> `gemini-3-pro` | `gemini` (also `vertex`) | 1M | 1.25 | 10.00 | 0.31 | Q4 2025 | The 1M-token window: whole-repo comprehension, long-log analysis. Solid worker, good verifier. |
 | <ProviderMark id="xai" /> `grok-4` | `xai` | 256k | 3.00 | 15.00 | 0.75 | Q3 2025 | Strong reasoning; a distinct model family, useful as an alternate verifier. |
@@ -145,7 +147,9 @@ shop on — it is the cost of entry you amortize:
 
 | Model | Provider | In $/Mtok | Cache-write $/Mtok | Premium |
 | --- | --- | --- | --- | --- |
-| `claude-fable-5` | `anthropic` | 3.00 | 3.75 | 1.25x |
+| `claude-fable-5` | `anthropic` | 10.00 | 12.50 | 1.25x |
+| `claude-opus-5` | `anthropic` | 5.00 | 6.25 | 1.25x |
+| `claude-sonnet-5` | `anthropic` | 3.00 | 3.75 | 1.25x |
 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 3.00 | 3.75 | 1.25x |
 | `gpt-5.5` | `openai` | 1.25 | 1.25 | 1x |
 | `gemini-3-pro` | `gemini`, `vertex` | 1.25 | 1.25 | 1x |

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -80,11 +80,21 @@ agent** (a scope review, a hunk review, or a question the approvals plane put to
 submit answers the gate rather than steering or starting anything. Answer it first, then steer.
 </Callout>
 
-### Reviewing a write hunk by hunk
+### Reviewing a write hunk by hunk — not yet reachable
 
-With [`agent_engine_config.hunk_review`](/docs/configuration/agent-engine-config) on, every
-write pauses on a card listing the hunks it would apply, and only the ones you keep are written.
-A turn that produces one wanted and one unwanted change is no longer all-or-nothing.
+<Callout type="warn">
+  **This gate does not fire today, and no setting turns it on.** The deck can render a
+  per-hunk approval card and its key map is implemented and tested, but nothing emits the
+  `hunk_review` event that would raise one, and `hunk_review` is not a key any settings
+  struct reads — writing it into `agent_engine_config` sets nothing. Tracked in
+  [#3633](https://github.com/macanderson/stella/issues/3633). The key map below is
+  recorded for when it lands; skip to [multimodal input](#multimodal-input) for what the
+  deck does now.
+</Callout>
+
+The intended behavior: every write pauses on a card listing the hunks it would apply, and
+only the ones you keep are written, so a turn that produces one wanted and one unwanted
+change is no longer all-or-nothing.
 
 | Key | Effect |
 | --- | --- |
@@ -98,6 +108,8 @@ while the composer is empty, so they never eat a line you are typing.
 
 Declined hunks are reported back to the model, so it knows why the file does not look the way
 it wrote it — a silent partial apply would look to it like somebody else edited the file.
+
+### Line breaks and soft-stop
 
 A *modified* `⏎` (`⌘⏎` / `⌃⏎` / `⌥⏎`) inserts a line break instead of submitting, and the break
 is kept verbatim in the prompt. On a terminal that cannot report the chord it folds back to a
@@ -288,7 +300,11 @@ Like `/model`, the change applies to sessions started from now on; the running s
 
 ### Plain REPL (`--plain`)
 
-The line REPL has a smaller, different set:
+The line REPL has a smaller, different set — this is the whole of it, and a `/word`
+outside this list is not a command there. Unlike the deck, which answers an unknown
+bare `/word` with a correction, the REPL lets it through as an ordinary prompt, so a
+deck command typed here (`/files`, `/diff`, `/graph`, …) costs a model call and
+answers nothing.
 
 <CardGrid size="sm">
   <OptionCard name="/help">
@@ -305,9 +321,6 @@ The line REPL has a smaller, different set:
   </OptionCard>
   <OptionCard name="/goal <goal>">
     Run a goal-driven turn toward the stated goal.
-  </OptionCard>
-  <OptionCard name="/files">
-    Show files touched this session.
   </OptionCard>
   <OptionCard name="/agents">
     List custom agents, from `.stella/agents` or `~/.stella/agents`.

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -67,7 +67,7 @@ stella models list --all
 Stella — Model Catalog
 
   provider/slug  ·  $in / $out / $cached-in per Mtok  ·  context  ·  maker  [pricing v]
-  anthropic/claude-fable-5  $3.00 / $15.00 / $0.30  ctx 200k  anthropic  thinks  [v3]
+  anthropic/claude-fable-5  $10.00 / $50.00 / $1.00  ctx 1000k  anthropic  thinks  [v3]
   zai/glm-5.2  $0.60 / $2.20 / $0.11  ctx 200k  z-ai  thinks  [v1]
 
   2 models. Pricing shown is each card's latest version.

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -8,8 +8,8 @@ List every tool available to the agent for the current session — built-in tool
 ## Synopsis
 
 ```bash
-stella tools [--validate [DIR]] [--author [NAME]] [--adopt NAME]
-             [--enable NAME] [--disable NAME] [--foundry] [global flags]
+stella tools [--validate [DIR]] [--adopt NAME] [--enable NAME]
+             [--disable NAME] [--foundry] [global flags]
 ```
 
 ## What it does
@@ -33,11 +33,6 @@ Custom tools come from a `<name>.toml` manifest dropped in `<workspace>/.stella/
     `<name>.toml` in `.stella/tools/` and `~/.stella/tools/` — or in the given `DIR` —
     reports errors, warnings, and info per manifest, and exits non-zero if any manifest
     has errors.
-  </OptionCard>
-  <OptionCard name="--author [NAME]">
-    Author a tool-foundry proposal into a staged custom tool: writes `NAME.toml` +
-    `NAME.sh` under `.stella/tools/proposed/`, where discovery cannot see them. Omit
-    `NAME` to list the proposals currently mined from recent `bash` receipts.
   </OptionCard>
   <OptionCard name="--adopt NAME">
     Move a staged tool into `.stella/tools/` and run its **capability witness**: the same
@@ -79,11 +74,11 @@ Validate one directory of manifests before installing them:
 stella tools --validate ./contrib/stella-tools
 ```
 
-Take a tool-foundry proposal all the way from receipts to a usable tool:
+Take a staged tool all the way to a usable one:
 
 ```bash
-stella tools --author            # list current proposals
-stella tools --author jq         # stage jq.toml + jq.sh in .stella/tools/proposed/
+# Stage the pair by hand under .stella/tools/proposed/, where discovery
+# cannot see it: jq.toml (with a [foundry] table) + jq.sh.
 stella tools --validate .stella/tools/proposed
 stella tools --adopt jq          # run its witness; records the proof, stays disabled
 stella tools --enable jq         # the one human approval
@@ -92,14 +87,27 @@ stella tools --foundry           # what was adopted, and what it has been worth
 
 ## Self-authored tools
 
-When the agent keeps reconstructing the same shell shape by hand, the tool foundry
-proposes a reusable tool in `/inbox`. What qualifies is a shape that is genuinely
+A self-authored tool is a manifest + script pair staged under
+`.stella/tools/proposed/`, where tool discovery cannot see it, and promoted from
+there by the `--adopt` → `--enable` sequence above. The generated script expands
+every parameter as a quoted `"$STELLA_INPUT_*"` reference, so parameter values stay
+data rather than shell syntax.
+
+<Callout type="warn">
+  **Staging is manual today.** The gap detector that mines candidate shapes from
+  recent `bash` receipts ships in `stella-core`, and the authoring pass that turns
+  one candidate into a manifest + script pair ships in `stella-tools` — but nothing
+  in the CLI or the deck calls either one on a live session, so no command lists
+  proposals or writes the staged pair for you. `--adopt` onwards is fully wired and
+  is what the rest of this section describes. Tracked in
+  [#3629](https://github.com/macanderson/stella/issues/3629).
+</Callout>
+
+What the detector looks for, when it is wired up, is a shape that is genuinely
 *reused*: it must recur across at least two distinct argument sets, each of them
 retyped about three times over. A command whose arguments are different every single
-time — `sed -n '<expr>' <file>` across a thousand files — is the shell, not a tool, and
-never reaches the inbox. Proposals are listed most-reused-first, not most-run-first.
-`--author` turns one proposal into a reviewable manifest + script pair. The generated script expands every parameter as a quoted
-`"$STELLA_INPUT_*"` reference, so parameter values stay data rather than shell syntax.
+time — `sed -n '<expr>' <file>` across a thousand files — is the shell, not a tool.
+Proposals rank most-reused-first, not most-run-first.
 
 An authored tool carries a `[foundry]` table, and a manifest carrying one registers only
 while **all three** of these hold:

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -11,10 +11,11 @@ Print the version of the installed `stella` binary and exit.
 stella version
 ```
 
-A top-level flag prints the version too, in clap's default format (no `v` prefix):
+Two top-level flags print it too, and they do **not** print the same thing:
 
 ```bash
-stella --version
+stella -V         # one line, bare version
+stella --version  # three lines, with the build's target and profile
 ```
 
 ## Output
@@ -22,18 +23,27 @@ stella --version
 The `version` subcommand prints a `v`-prefixed line:
 
 ```text
-stella v0.6.44
+stella v0.9.86
 ```
 
-`stella --version` prints clap's default form instead — the binary name, a space, then the
-bare version:
+`stella -V` prints the short form — the binary name, a space, then the bare version, no
+`v`:
 
 ```text
-stella 0.6.44
+stella 0.9.86
+```
+
+`stella --version` prints the **long** form: the same first line, then the target triple
+and the build profile the binary was compiled with.
+
+```text
+stella 0.9.86
+target:  aarch64-apple-darwin
+profile: release
 ```
 
 The exact number tracks the release you installed. Binaries built in dev mode
-(`scripts/dev.sh`) append a git-sha stamp, e.g. `stella v0.6.44-dev.abc1234`; released
+(`scripts/dev.sh`) append a git-sha stamp, e.g. `stella v0.9.86-dev.abc1234`; released
 binaries print the bare semver.
 
 Use it to confirm an install or upgrade, or to capture the version in a CI log. This
@@ -47,11 +57,18 @@ Confirm what you just installed:
 stella version
 ```
 
-Capture the bare semver for a CI log or a build label — strip the `v` from the
-subcommand's form, or use the flag, which never emits one:
+Capture the bare semver for a CI log or a build label. Use `-V`, not `--version`:
+the long form's extra lines would each be fed through `cut` too, so you would get the
+version, a blank, and the profile.
 
 ```bash
-stella --version | cut -d' ' -f2
+stella -V | cut -d' ' -f2
+```
+
+Or take just the first line of either flag:
+
+```bash
+stella --version | head -1 | cut -d' ' -f2
 ```
 
 Check that a binary is on `PATH` at all before a script depends on it:

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -83,10 +83,6 @@ pin just the verifier model while your user scope keeps everything else.
     // aborting at the gate that has nobody to ask.
     "headless_scope_bypass": "off",
 
-    // "on" = every write pauses on a per-hunk approval card, and only the
-    // hunks you keep are applied. Interactive surfaces only.
-    "hunk_review": "off",
-
     // How many times a task may be attempted. Revisions are spent only on a
     // verification that already failed; candidates are paid on every task.
     "pipeline_max_revisions": 2,
@@ -271,21 +267,6 @@ Set any of the three autos to `"on"` and stop thinking about it:
     instead of stopping at the gate that has nobody to ask. Off deliberately:
     turn it on only where the working tree is disposable and the budget cap is
     the real guard — a benchmark container, CI on a scratch checkout.
-  </OptionCard>
-  <OptionCard name="hunk_review" defaultValue="off">
-    Every file-writing tool call pauses on a per-hunk
-    approval card before it writes, and only the hunks you keep are applied —
-    so a turn that produces one wanted and one unwanted change stops being
-    all-or-nothing. Declined hunks are reported back to the model, so it knows
-    why the file does not look the way it wrote it.
-
-    Read only by surfaces that **have** a reviewer. A headless run ignores it
-    entirely rather than blocking on a card nobody will see — a gate with
-    nobody to ask must be absent, not auto-approving.
-
-    Off by default: this is the one gate that fires on ordinary work rather
-    than above a threshold, so it trades throughput for control. Worth it while
-    pointing the agent at code you are not ready to let it change freely.
   </OptionCard>
   <OptionCard name="pipeline_max_revisions" defaultValue="2">
     Revision turns per candidate after a **failed** verification. A run that

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -755,12 +755,16 @@ cannot silently become permissive.
   "authority": {
     "project_prompts": "off",
     "project_custom_tools": "off",
-    "bash": "off",
-    "web": "off",
     "media_requires_host_approval": "on"
   }
 }
 ```
+
+Those three are the whole section — it takes no others, and because the block is
+`deny_unknown_fields`, adding one is the hard load error described above rather than a
+key that is quietly ignored. In particular it is deliberately **not** a second tool
+table: to pin a tool or a group off from the managed scope, use the managed `"tools"`
+table, which addresses any tool, group, or `*`.
 
 An `"off"` capability is a non-overridable ceiling. `"on"` only permits a later explicit
 grant; it never enables a capability by itself. For example, `project_custom_tools: "on"`

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -41,28 +41,43 @@ That holds in both directions:
     An unknown event must survive the round trip, not abort the parse.
   </SpecCard>
   <SpecCard
-    title="A renamed or removed event type"
+    title="A renamed event type"
     meta={[
-      { label: "Older client", value: "does not happen", mono: false },
-      { label: "Newer client", value: "does not happen", mono: false },
+      { label: "Older client", value: "stops seeing it", mono: false },
+      { label: "Newer client", value: "never sees the old name", mono: false },
     ]}
   >
-    The vocabulary is **additive only** — this row exists to say the case is ruled out,
-    not handled.
+    Rare, and it has happened once — see the rename below. A rename is a breaking
+    change, announced as one, not a routine event.
   </SpecCard>
 </CardGrid>
 
-Event type names and field names are never renamed or repurposed once shipped.
-Growth is by addition.
+Field names are never repurposed once shipped: a field that is renamed keeps the
+old spelling as an accepted alias, so a recorded stream never stops parsing. `text`
+carries `#[serde(alias = "delta")]` for exactly this reason, and `text_delta`
+accepts the reverse.
 
-A worked example of that rule holding under pressure: stella needed a way to say
-"one turn of this run finished", and a run can be several turns. The tempting
-move was to let `complete` mean that — it would have fired several times per run,
-fired early, and fired on runs that ultimately failed, breaking every client that
-had believed the promise above. Instead the new fact got a new name,
-`turn_complete`, and `complete` still means exactly what it always meant: the run
-is over, once, last, on success. Clients that ignore unknown types were unaffected;
-clients that want per-turn boundaries read the new event.
+**Event type names are a weaker promise, and one rename has happened.** The
+terminal event was `complete` until [#3379](https://github.com/macanderson/stella/issues/3379).
+The problem it fixed: one word meant "this turn is over" when the engine said it
+and "the whole job is over" when a wrapper — the staged pipeline, goal mode — said
+it, and nothing reading the journal could tell which contract it was holding. So
+the word was split in two:
+
+| Today | Means | Fires |
+| --- | --- | --- |
+| `turn_complete` | One turn finished | Once per turn, several times in a wrapped run |
+| `run_complete` | The run finished — the stream's terminator | Exactly once, last, on success |
+
+`complete` is **not** aliased to either; every call site was moved. A client
+written before #3379 that waits for `{"type":"complete"}` will read the whole
+stream, treat the terminator as an unrecognized event under rule 1 below, and
+then wait forever. Match on `run_complete` for "nothing more is coming", and on
+`turn_complete` if you want per-turn boundaries.
+
+This is the case the vocabulary tries hard to avoid, and the reason the row above
+says "rare" rather than "ruled out": the honest contract is that new facts get new
+names, and that a rename is a breaking change announced as one.
 
 ## The two rules that matter
 
@@ -112,7 +127,10 @@ occurrence, not an exceptional one.
 
 ```ts
 // TypeScript: the shape the contract asks for.
-const KNOWN = new Set(["stage", "text", "text_delta", "tool_start", "tool_result", "complete", /* … */]);
+const KNOWN = new Set([
+  "stage", "text", "text_delta", "tool_start", "tool_result",
+  "turn_complete", "run_complete", /* … */
+]);
 
 for (const line of stream) {
   if (!line.trim()) continue;
@@ -139,19 +157,23 @@ for (const line of stream) {
 
 ## Unrecognized events in practice
 
-Suppose a future stella adds a `spline_reticulated` event. A client built before
+Suppose a future stella adds a `quantum_reticulation` event. A client built before
 it existed sees:
 
 ```json
-{"type":"stage","name":"execute"}
-{"type":"spline_reticulated","call_id":"q_1","splines":["alpha","beta"]}
+{"type":"stage","name":"execute","scope":"run"}
+{"type":"quantum_reticulation","call_id":"q_1","splines":["alpha","beta"]}
 {"type":"text","text":"Done."}
-{"type":"complete","model":"m","cost_usd":0.002}
+{"type":"run_complete","model":"m","cost_usd":0.002}
 ```
 
-It processes `stage`, `text`, and `complete` exactly as before, and treats line 2
-as inert. The run is fully usable. Nothing is lost that the client could have
-understood anyway.
+It processes `stage`, `text`, and `run_complete` exactly as before, and treats
+line 2 as inert. The run is fully usable. Nothing is lost that the client could
+have understood anyway.
+
+That is not a hypothetical spelling: `quantum_reticulation` is one of the two
+invented types in the conformance fixture below, so this snippet is a slice of a
+file you can actually run your client against.
 
 If your client re-emits or stores events, keep unrecognized ones **whole**. A
 proxy or recorder that drops them silently degrades the stream for whatever reads
@@ -192,6 +214,13 @@ anchor.
 
 - **Ordering between event types** beyond what the pipeline documents. `text_delta`
   lines interleave with other events.
+- **That `stage` events form one sequence.** Two disjoint authorities emit them,
+  and `scope` says which: the engine emits its own vocabulary once per turn with
+  `"scope":"turn"`, while a wrapper — the staged pipeline, a goal loop — emits its
+  own once per run with `"scope":"run"`. A client that branches on stage
+  transitions must select on `scope` first, or it reads two interleaved
+  vocabularies as one and sees a wrapper's backwards-looking boundary as an engine
+  regression.
 - **A monotonic `ts`.** See above: it is a wall clock, and it can repeat or move
   backwards.
 - **That every event has a stable meaning to you.** `text_delta` is an explicit

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -19,15 +19,22 @@ run, an unfamiliar repository, a budget you have to hold — see the
 | --- | --- | --- | --- | --- | --- |
 | [Single key](#single-key) | 1 | your model | same model | same model | varies |
 | [Dirt cheap](#dirt-cheap) | 2 | `deepseek-chat` | `glm-5.2` | `deepseek-chat` | $0.01 – $0.10 |
-| [Balanced](#balanced) | 3 | `glm-5.2` | `claude-fable-5` | `deepseek-chat` | $0.05 – $0.50 |
-| [Maximum quality](#maximum-quality) | 3 | `claude-fable-5` | `gpt-5.5` | `deepseek-chat` | $0.40 – $2.50 |
+| [Balanced](#balanced) | 3 | `glm-5.2` | `claude-fable-5` | `deepseek-chat` | $0.10 – $0.80 |
+| [Maximum quality](#maximum-quality) | 3 | `claude-fable-5` | `gpt-5.5` | `deepseek-chat` | $1.30 – $8.00 |
 | [One gateway key](#one-gateway-key-openrouter) | 1 | any vendor | any vendor | any vendor | as routed |
 | [Local / air-gapped](#local-and-air-gapped) | 0 | your server | your server | your server | $0 |
 | [Enterprise cloud](#enterprise-cloud-vertex-and-bedrock) | cloud creds | Vertex or Bedrock | same | same | contract rates |
 
 Estimates are for a medium task — a focused multi-file change with one revision — at
-catalog list prices with prompt caching working normally. Your real numbers are in
-[`stella stats`](/docs/commands/stats) and the [Observatory](/docs/telemetry/dashboard).
+catalog list prices with prompt caching working normally. They are illustrative, derived
+from list price and a typical token mix, **not** measured run data: your real numbers are
+in [`stella stats`](/docs/commands/stats) and the
+[Observatory](/docs/telemetry/dashboard).
+
+The two rows using `claude-fable-5` are the expensive ones because Fable lists at
+$10/$50 per Mtok. If those ranges are more than the task needs, `claude-opus-5` (half
+Fable's price) and `claude-sonnet-5` (roughly a third) are drop-in swaps on the same 1M
+window — see [the catalog](/docs/api-providers/models#the-catalog).
 
 ## Where the money goes
 
@@ -122,7 +129,7 @@ To use another provider, swap the four model strings and `allowed_models`:
 
 | Key you hold | Model string | Window | $/Mtok in/out | Effort honoured? |
 | --- | --- | --- | --- | --- |
-| Anthropic | `anthropic/claude-fable-5` | 200k | 3.00 / 15.00 | yes, all five tiers |
+| Anthropic | `anthropic/claude-fable-5` | 1M | 10.00 / 50.00 | yes, all five tiers |
 | OpenAI | `openai/gpt-5.5` | 400k | 1.25 / 10.00 | yes; `xhigh`/`max` → `high` |
 | Z.ai | `zai/glm-5.2` | 200k | 0.60 / 2.20 | **no — dropped on the wire** |
 | DeepSeek | `deepseek/deepseek-chat` | 128k | 0.27 / 1.10 | **no — dropped on the wire** |

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -47,12 +47,14 @@ script says so and prints the `export` line to add. Two env vars tune it:
 </CardGrid>
 
 ```bash
-STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.6.44 \
+STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.9.0 \
   sh -c "$(curl -fsSL https://stella.oxagen.sh/install.sh)"
 ```
 
-Pick the tag from the
-[releases page](https://github.com/macanderson/stella/releases).
+`v0.9.0` there is only a shape — every merge to `main` cuts a patch release, so
+pick the tag you actually want from the
+[releases page](https://github.com/macanderson/stella/releases) rather than from
+this page, which cannot stay current with a line that moves daily.
 
 ### Homebrew
 

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -122,8 +122,11 @@ The load-bearing edge is **dataset → eval**. #836's own stated first slice is 
   <SpecCard title="Shipped in slices — the Tool Foundry">
     #830. The capability-gap detector is `stella-core`'s `tool_foundry`; authoring, the witness,
     and the adoption gate are `stella-tools`' `foundry_author` / `foundry_witness` /
-    `foundry_gate`, driven by `stella tools --author`, `--adopt` and `--enable`. A proposed tool
-    is inert until it is **both** adopted and enabled.
+    `foundry_gate`. The promotion half ships as [`stella tools --adopt`, `--enable`,
+    `--disable` and `--foundry`](/docs/commands/tools), and a proposed tool is inert until it is
+    **both** adopted and enabled. The detection and authoring half has no live caller yet — no
+    command mines proposals from a running session or writes the staged pair, so staging is by
+    hand ([#3629](https://github.com/macanderson/stella/issues/3629)).
   </SpecCard>
 </CardGrid>
 

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -201,7 +201,7 @@ exporter dropped the rest".
 
 Workspace-wide analytics have their own home:
 [`stella stats`](/docs/commands/stats) and the
-[Observatory](/docs/telemetry/observatory) both read across every session, and
+[Observatory](/docs/telemetry/dashboard) both read across every session, and
 neither produces a file that leaves the machine.
 
 <Callout type="info">


### PR DESCRIPTION
## What & why

A pass over `website/content/docs/`, checking every claim that can be checked against a source of truth rather than read for plausibility: the clap tree (built binary, `stella help` over all 37 subcommands **and their subtrees** — 138 help pages), `stella-tools`' catalog, `stella-protocol`'s event tag table, the settings deserializers, the seed model catalog, and `stella-serve`'s router.

**The flag surface came out clean in both directions** — every flag the docs name exists, and every real flag is documented. That is worth stating because it is what `check-command-docs` cannot see: it asserts a page exists per subcommand, not that the page describes the command. What had drifted was the prose around the flags.

### The wire contract — the one a client actually breaks on

`event-stream-compatibility.mdx` told client authors to match `{"type":"complete"}`. **That tag does not exist.** #3379 split it into `turn_complete` and `run_complete`, and the old name carries no serde alias — a client following this page reads the whole stream, treats the terminator as unrecognized under the page's own rule 1, and waits forever.

The page did not merely go stale. Its *worked example* presented the rename as proof that the additive-only rule holds under pressure — "`complete` still means exactly what it always meant" — when it is the counterexample. #3379's findings section explicitly named `event-stream-compatibility.mdx:55` as carrying the promise the change was about to break; the change shipped in #3417/#3418 and the page was never updated.

Rewritten to state what happened, why the word was split, and what a pre-#3379 client must change. Also:

- The invented-event example now uses the conformance fixture's own `quantum_reticulation` and terminates on `run_complete`, so the snippet is a literal slice of the file the page tells you to test against.
- Documented `scope` on `stage`. Two disjoint authorities emit stage events; a consumer that does not select on `scope` first reads a wrapper's backwards-looking boundary as an engine regression.
- The "renamed or removed event type: does not happen" card now says what is true.

### `stella-serve`'s "What is not built yet"

Stamped "re-verified absent as of 0.6.10", with six entries. All six had shipped. Verified against `router.rs`, `history.rs`, `sessions.rs`, `engine_overrides.rs`, `frame.rs` and `lifecycle.rs`:

| Was listed absent | Actually |
| --- | --- |
| Stream resumption; "frames carry no sequence number" | Every frame carries a monotonic `seq`; `?after=<seq>` and `Last-Event-ID` both resume |
| Server-side conversation state | `POST /v1/sessions` + `/v1/sessions/{id}/turns` |
| `/approve` | `POST /v1/turns/{id}/approve` |
| Token-level streaming | `POST /v1/turns/{id}/provider-delta` |
| SIGTERM drain, `/readyz`, `/metrics` | All three |
| Per-turn engine knobs beyond two | An `engine` object, each field clamped to an operator ceiling |

The four constraints that genuinely remain are stated, and the shipped six are tabled rather than silently deleted, so a client written to the old list can see what it is leaving unused.

### Documented, but not present

- **`stella tools --author`** — not a flag, and never was. The tool foundry's detect/author half (`detect_tool_gaps`, `foundry_author::author`) has no non-test caller at all; `--adopt` onwards is fully wired. Filed **#3629**.
- **`hunk_review`** — not a field of any settings struct, and nothing constructs a `HunkProposal` or emits `AgentEvent::HunkReview`. The TUI renderer and key map exist and are tested, so the key map is kept and labelled rather than deleted. Filed **#3633**.
- **The managed `authority` example** carried `"bash"` and `"web"`. The block is `deny_unknown_fields` with exactly three fields — that example is a hard load error, in a section whose own next paragraph explains that unknown keys are a hard load error.
- **`/files` under the plain REPL**, which has no such command. `REPL_RESERVED` is the whole vocabulary and an unrecognized `/word` falls through to a paid model turn, so the doc was routing users into a wasted call.

### Catalog and version drift

- `claude-fable-5` was tabled at 200k / \$3 / \$15 / \$0.30 in five places. The seed catalog carries **1M / \$10 / \$50 / \$1.00** — the row was corrected in code with a comment noting the old one under-reported spend by 3.3x, and the docs never followed. Added the `claude-opus-5` and `claude-sonnet-5` rows that were missing from a table headed "The catalog", and moved the two `examples.mdx` cost estimates that ride on Fable.
- `stella --version` prints **three** lines (`long_version`), not clap's one-line default. The documented CI recipe `stella --version | cut -d' ' -f2` therefore returned the version, a blank, and the profile. Documented `-V` vs `--version` and fixed the recipe (both forms verified against the binary).
- Dropped `v0.6.44` install and `stella-serve` examples from a tree at 0.9.86.
- Fixed a broken `/docs/telemetry/observatory` link.

Refs #3629, #3633, #3379

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this changes only `.mdx` under `website/content/docs/`. No Rust, no behavior.

Verified instead by making the binary the oracle rather than reading for plausibility:

- `cargo build -p stella-cli --bin stella`, then `stella help <cmd>` walked to depth 3 over every `Command` variant — 138 help pages — and diffed against the docs' flags in both directions by script.
- Every corrected fact was read at the definition: `catalog.rs` for tools and models, `tags.rs`/`event.rs` for event tags and aliases, `router.rs` and friends for the serve surface, `authority.rs`/`engine.rs` for settings fields, `agent.rs`'s `REPL_RESERVED` for the plain REPL.
- The two "documented but absent" findings were each confirmed by ripgrep showing **no non-test caller**, not by absence from one file.
- Both `stella version` recipes were run and their output checked.

## The gate

- [x] `cargo fmt --check` — untouched (no Rust in this diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — untouched
- [x] `cargo test --workspace` — untouched
- [x] Docs updated where behavior/flags changed — this PR is that
- [x] CLA signed
- [x] No `Closes #N` here on purpose: #3629 and #3633 are the work this PR *documents as missing*, not work it finishes, so both are `Refs`

Doc guards run locally and green: `command-docs`, `doc-links`, `brand-case`, `invariants`, `file-size`, `god-files`, `gate-parity`, `left-behind`, `role-names`, `module-reachability`, `diagnostic-codes`. Broken internal routes went 1 → 0.

**CI is green on `5e63060`** — all nine runs: `ci`, `docs-guards`, `docs`, `file-size`, `duplicate-claims`, `dependency-review`, `bench`, `empty-diff` success, `cla` skipped, plus the Vercel docs deploy. I originally noted that `shellcheck` is not installed in this container so I could not run `make guards-fast` end to end; `ci.yml`'s required job runs shellcheck (step at `.github/workflows/ci.yml:325`) and passed, so that gap is closed by CI rather than left open.

## Nothing left behind

- [x] Filed: **#3629** (tool foundry authoring unwired), **#3633** (`hunk_review` has no key and no producer)

One thing noticed and deliberately not changed: `docs/wire/README.md` §3 states "The contract is **additive-only** … re-tagging a variant … breaks every consumer at once." #3379 re-tagged a variant. The sentence is a statement of the contract clients should rely on rather than a claim about a specific event, and it is in-repo spec rather than user docs, so I left it — but a reviewer who wants it hedged in the same breath as the user-facing page is right to say so.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The judgement call worth checking is the two cost estimates in `examples.mdx`.** They were stated as "at catalog list prices", and Fable's list price tripled, so leaving them was not an option. But they were never measured — so rather than compute false precision I scaled them with the price change, labelled them explicitly as illustrative and not run data, and pointed at `stella stats` for real numbers. If you would rather they were dropped than scaled, that is a reasonable different call.

Two smaller ones:

- I kept the full hunk-review key map in `chat.mdx` behind a warning callout instead of deleting it. It is real, implemented and tested against the TUI model — just unreachable. Deleting it would lose work; leaving it unmarked was the bug.
- The `install.sh` example now pins `v0.9.0` with a sentence saying the tag is only a shape. Any concrete version in prose goes stale — `release-notes.mdx` already tells the story of this exact failure — so the alternative is dropping the example, which costs a copyable line.

Not covered by this pass, and worth its own: `docs/` outside `website/content/docs/` (specs, ADRs, playbooks). `make doc-links` reports 14 documents nothing cites, several `proposed` and months old; that is a retire-or-adopt sweep, not a truing-up.