### PR TITLE
feat(stella-plugin): the driver channel — a plugin at grade `none` can hold a capability (#3599 B0)

### DIFF
--- a/crates/stella-cli/tests/self_driving_consent.rs
+++ b/crates/stella-cli/tests/self_driving_consent.rs
@@ -212,3 +212,59 @@ fn the_declared_grant_and_the_loop_name_the_same_powers() {
         );
     }
 }
+
+/// **The driver grant is shown before install, family by family.**
+///
+/// The `[driver]` block is the second consent this manifest carries and it is
+/// a materially different one from the `[loop]` grade above: a grade says how
+/// much say a plugin has *inside* a turn, and this says what it may ask Stella
+/// to do to your repository between them. A user who reads only the first has
+/// not been told about the second, which is the failure
+/// `doc:backlog-self-driving` §6.1 calls "the grant must actually bind".
+///
+/// It also asserts the two deliberate absences. Each is a decision recorded in
+/// the manifest, and a later widening should have to delete an assertion that
+/// says why rather than quietly adding a line to a list.
+#[test]
+fn the_prompt_shows_the_driver_grant_and_its_deliberate_limits() {
+    let text = consent_text();
+
+    assert!(
+        text.contains("DRIVES Stella"),
+        "the install prompt must say the plugin drives Stella, not just that it takes no say in a \
+         turn: {text}"
+    );
+    // Read by family, because "pushes branches, opens pull requests, reads CI,
+    // and merges" is the sentence a human weighs, and `deliver_merge` on its
+    // own is not.
+    for family in [
+        "reads and writes your issue tracker",
+        "runs Stella against an issue in an isolated worktree",
+        "pushes branches, opens pull requests, reads CI, and merges",
+        "runs audit tooling over this workspace and files what it finds",
+        "proposes new tools, context records and skills",
+    ] {
+        assert!(
+            text.contains(family),
+            "missing driver family `{family}`: {text}"
+        );
+    }
+    assert!(
+        text.contains("this plugin holds no credential"),
+        "the prompt must say every driver capability is performed BY Stella: {text}"
+    );
+
+    // `curate_accept` is withheld because this repository is governance mode
+    // `regulated` (§7), and no release verb is on the channel at all (§6.4).
+    assert!(
+        !text.contains("curate_accept"),
+        "the loop may propose an authority and grant itself none: {text}"
+    );
+    // Narrowly `release_`, not `release`: the `bash` capability above legitimately
+    // says "the release install", and asserting on the bare word would fail on
+    // a sentence that has nothing to do with the channel.
+    assert!(
+        !text.contains("release_"),
+        "a release verb is not on the driver channel at B0-B6: {text}"
+    );
+}

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -192,6 +192,7 @@ pub fn consent_text(manifest: &PluginManifest) -> String {
 
     lines.push(String::new());
     lines.extend(loop_say(manifest));
+    lines.extend(driver_say(manifest));
     lines.extend(oracle_self_report(manifest));
     lines.push(String::new());
     lines.extend(capability_grant(manifest));
@@ -300,6 +301,18 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
         });
     }
 
+    // The host-call channel, which until now was declared in the manifest and
+    // shown to nobody — `LoopGrant::calls` says a plugin "may not ask for a
+    // capability a human never read at install", and this is the line that
+    // makes the second half of that sentence true.
+    if !grant.calls.is_empty() {
+        let calls: Vec<String> = grant.calls.iter().map(ToString::to_string).collect();
+        lines.push(format!(
+            "  - asks the host for these capabilities while answering a point: {}",
+            calls.join(", ")
+        ));
+    }
+
     if let Some(subloop) = &manifest.subloop {
         let stages: Vec<String> = subloop.stages.iter().map(|stage| one_line(stage)).collect();
         lines.push(format!(
@@ -321,6 +334,65 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
         ));
     }
 
+    lines
+}
+
+/// The "what it does *outside* your turns" half: that this plugin drives
+/// Stella, and every capability family it may ask for while driving.
+///
+/// A separate paragraph from [`loop_say`] rather than another bullet under it,
+/// because the two are different consents and reading them as one is exactly
+/// the confusion `doc:backlog-self-driving` §3.0 keeps the ladder out of: a
+/// grade says how much say a plugin has *inside* a turn, and this says what it
+/// may do to your repository between them.
+///
+/// Rendered by family rather than verb by verb — "pushes branches, opens pull
+/// requests, reads CI, and merges" is the sentence a human weighs, and
+/// `deliver_merge` on its own is not. The verbs are printed beside it so the
+/// declaration stays checkable against the block.
+fn driver_say(manifest: &PluginManifest) -> Vec<String> {
+    let Some(driver) = &manifest.driver else {
+        return Vec::new();
+    };
+    let mut lines = vec![
+        String::new(),
+        format!(
+            "Say outside your turn loop: `{}` DRIVES Stella. It is not a participant in a \
+             turn — it starts them.",
+            one_line(&manifest.name)
+        ),
+    ];
+
+    if driver.calls.is_empty() {
+        // A driver that asks for nothing is a coherent declaration and a
+        // remarkable one, so it is said rather than left as an absence.
+        lines.push("  - asks the host for no capability at all".into());
+        return lines;
+    }
+
+    for family in driver.families() {
+        let verbs: Vec<String> = driver
+            .calls
+            .iter()
+            .filter(|call| call.family() == family)
+            .map(ToString::to_string)
+            .collect();
+        lines.push(format!(
+            "  - {} ({})",
+            family.consent_sentence(),
+            verbs.join(", ")
+        ));
+    }
+
+    lines.push(match driver.max_calls {
+        Some(max) => format!("  - asks for up to {max} of those per driver session"),
+        None => "  - asks for as many of those per driver session as the host allows".into(),
+    });
+    lines.push(
+        "  - every one of those is performed BY Stella on request: this plugin holds no \
+         credential, no provider and no forge token of its own."
+            .into(),
+    );
     lines
 }
 

--- a/crates/stella-plugin/src/driver.rs
+++ b/crates/stella-plugin/src/driver.rs
@@ -1,0 +1,851 @@
+//! The driver channel — the wire half of a second dispatch context, for a
+//! plugin that **drives** turns rather than sitting inside one.
+//!
+//! `doc:backlog-self-driving` §3.0 is the design and this module is its wire
+//! half. [`crate::host_call`] is the same apparatus for the wrapper socket, and
+//! everything load-bearing there is carried over verbatim: a plugin **asks**
+//! the host for a capability and never reaches for one, an undeclared ask is
+//! refused with a code the plugin branches on, and a refusal is a value rather
+//! than a death. Only the *context* differs — the conversation is opened by a
+//! driver session, not by a wrapper point.
+//!
+//! # Why a second context rather than a wider first one
+//!
+//! [`LoopGrant::permits_call`](crate::LoopGrant::permits_call) requires
+//! `participation >= Steering`, and a host call may be made "during
+//! `before_turn` or `after_turn` and nowhere else". Both are conditions about
+//! standing **inside** a turn. A driver has no turn to stand in — it is what
+//! starts them — so no grade on the [`Participation`](crate::Participation)
+//! ladder would let it in, and raising its grade would be answering the wrong
+//! question. `plugins/stella-selfdriving` declares `participation = "none"`
+//! honestly and was, before this module, structurally unable to hold any
+//! capability at all (#3599 §2.1).
+//!
+//! The ladder is therefore **not extended and not renumbered**. Driving is a
+//! different axis from in-turn influence, and conflating them would make
+//! `arbiter` — already "the strongest grant" over a turn's completion —
+//! silently also mean "may merge to `main`". A separate [`DriverGrant`] with
+//! its own call list keeps the two consents legible to the human reading them.
+//!
+//! # The shape
+//!
+//! ```text
+//! host  → { "point": "drive", "body": { "session": "…" } }
+//! driver→ { "call": "backlog_next", "id": 1 }
+//! host  → { "result": 1, "ok": {} }
+//! driver→ { "point": "drive", "body": { "next": { "sleep": { "secs": 900 } } } }
+//! ```
+//!
+//! [`DriverMessage`] is the union of the two things a driver may write, and it
+//! is closed for the reason [`PluginMessage`](crate::PluginMessage) is: a
+//! message carrying both a `point` and a `call` is not a typo, it is two claims
+//! about what the driver is doing, and believing one of them silently is how a
+//! session ends in the wrong place (#3500).
+//!
+//! # What a call carries at B0, and what it does not
+//!
+//! **No arguments, and no result payload.** Every one of the eighteen verbs in
+//! [`DriverCall`] is named by `doc:backlog-self-driving` §3.1–§3.5 and
+//! implemented by none of them yet — B0 is the phase that makes a driver able
+//! to *hold* a capability, and B1–B6 are the phases that give each one
+//! something to do. Inventing eighteen argument tables and eighteen result
+//! tables here would be writing a wire contract for behaviour no host code can
+//! typecheck against, and every one of them would change at the phase that
+//! implemented it. So the argument and result shapes land **with the verb that
+//! needs them**, and what B0 pins down is the part consent depends on: which
+//! capabilities exist, which of them this driver declared, and what happens
+//! when it asks for one it did not.
+//!
+//! [`DriverOk`] is consequently an empty table today — "the host performed it"
+//! — and grows a field per verb that has something to report.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::host_call::HostCallFailure;
+
+/// The capabilities a **driver** may ask the host for.
+///
+/// Closed, and [`DriverGrant::calls`] declares which of them a given driver may
+/// use. The eighteen are exactly the verbs `doc:backlog-self-driving` §3.1–§3.5
+/// tabulates, in five families:
+///
+/// - **`backlog`** (§3.1) — the provider-agnostic issue port that replaces
+///   three hardcoded `gh` call sites. Every other family depends on it: `work`
+///   needs a unit, `sweep` needs somewhere to file, `deliver` needs something
+///   to close.
+/// - **`work`** (§3.2) — one unit of backlog through Stella's own staged
+///   pipeline, in `candidate_ws.rs`'s shadow worktree, with the pipeline's
+///   verdict as the definition of done.
+/// - **`deliver`** (§3.3) — branch, PR, CI, review, merge, driven by a pure
+///   state machine that buys no model call.
+/// - **`sweep`** (§3.4) — where the next question comes from.
+/// - **`curate`** (§3.5) — proposals for tools, context records and skills,
+///   which the loop may *propose* and never grant itself (§7).
+///
+/// Two things are deliberately absent, and both are `doc:backlog-self-driving`
+/// §3.6's own rules rather than an oversight: there is **no `release` verb** at
+/// B0–B6, and there is **no verb that edits a driver's own grant** — a
+/// capability that could widen `calls` would make the grant advisory.
+///
+/// Every verb is its own variant rather than a family with a mode parameter,
+/// because invariant 9 governs a capability the same way it governs a tool: a
+/// parameter may scope an operation, never select one. `curate accept` and
+/// `curate reject` would be two calls, not one with a boolean — which is why
+/// the latter is simply not here yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriverCall {
+    /// The ranked readiness queue.
+    BacklogNext,
+    /// Take a cooperative lease on an issue, or report who holds it.
+    BacklogClaim,
+    /// File a finding as an issue, deduplicated by fingerprint.
+    BacklogFile,
+    /// Close an issue with a receipt naming the evidence.
+    BacklogClose,
+    /// Bind an `execution_id` to an issue key, so spend is attributable.
+    BacklogLink,
+    /// Run one unit of backlog through the staged pipeline.
+    WorkStart,
+    /// The in-flight unit: stage, spend, elapsed, checkpoint.
+    WorkStatus,
+    /// Release the claim and the worktree, recording why.
+    WorkAbandon,
+    /// Branch, commit, push, and open the pull request as a draft.
+    DeliverOpen,
+    /// One read of the forge — CI, reviews, mergeability, base drift.
+    DeliverObserve,
+    /// The deterministic next action, given the observation.
+    DeliverNext,
+    /// Merge, when and only when `deliver_next` says so.
+    DeliverMerge,
+    /// Run the open lens's tooling and emit the findings not yet seen.
+    SweepAudit,
+    /// Re-run the witnesses named by closed issues' receipts.
+    SweepRegress,
+    /// Fold the ledger and emit the loop's own pathologies as findings.
+    SweepMeta,
+    /// Emit a proposal — a tool, a context record, a skill — with evidence.
+    CuratePropose,
+    /// Pending proposals and their evidence counts.
+    CurateList,
+    /// Apply a proposal, if the workspace's declared authority permits it.
+    CurateAccept,
+}
+
+impl DriverCall {
+    /// The name this capability is written as on the wire and in
+    /// `[driver] calls`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BacklogNext => "backlog_next",
+            Self::BacklogClaim => "backlog_claim",
+            Self::BacklogFile => "backlog_file",
+            Self::BacklogClose => "backlog_close",
+            Self::BacklogLink => "backlog_link",
+            Self::WorkStart => "work_start",
+            Self::WorkStatus => "work_status",
+            Self::WorkAbandon => "work_abandon",
+            Self::DeliverOpen => "deliver_open",
+            Self::DeliverObserve => "deliver_observe",
+            Self::DeliverNext => "deliver_next",
+            Self::DeliverMerge => "deliver_merge",
+            Self::SweepAudit => "sweep_audit",
+            Self::SweepRegress => "sweep_regress",
+            Self::SweepMeta => "sweep_meta",
+            Self::CuratePropose => "curate_propose",
+            Self::CurateList => "curate_list",
+            Self::CurateAccept => "curate_accept",
+        }
+    }
+
+    /// Which of the five families this verb belongs to.
+    ///
+    /// Consent reads by family, because "may read and write your issue tracker"
+    /// is the sentence a human weighs and `backlog_file` on its own is not.
+    #[must_use]
+    pub fn family(self) -> DriverFamily {
+        match self {
+            Self::BacklogNext
+            | Self::BacklogClaim
+            | Self::BacklogFile
+            | Self::BacklogClose
+            | Self::BacklogLink => DriverFamily::Backlog,
+            Self::WorkStart | Self::WorkStatus | Self::WorkAbandon => DriverFamily::Work,
+            Self::DeliverOpen | Self::DeliverObserve | Self::DeliverNext | Self::DeliverMerge => {
+                DriverFamily::Deliver
+            }
+            Self::SweepAudit | Self::SweepRegress | Self::SweepMeta => DriverFamily::Sweep,
+            Self::CuratePropose | Self::CurateList | Self::CurateAccept => DriverFamily::Curate,
+        }
+    }
+
+    /// Every verb, in declaration order.
+    ///
+    /// Exhaustive by construction rather than by discipline: the `match` in
+    /// [`DriverCall::as_str`] fails to compile if a variant is added and this
+    /// list is generated from the same source of truth as the consent
+    /// rendering and the wire corpus, so a new capability cannot ship
+    /// undocumented.
+    #[must_use]
+    pub const fn all() -> &'static [Self] {
+        &[
+            Self::BacklogNext,
+            Self::BacklogClaim,
+            Self::BacklogFile,
+            Self::BacklogClose,
+            Self::BacklogLink,
+            Self::WorkStart,
+            Self::WorkStatus,
+            Self::WorkAbandon,
+            Self::DeliverOpen,
+            Self::DeliverObserve,
+            Self::DeliverNext,
+            Self::DeliverMerge,
+            Self::SweepAudit,
+            Self::SweepRegress,
+            Self::SweepMeta,
+            Self::CuratePropose,
+            Self::CurateList,
+            Self::CurateAccept,
+        ]
+    }
+}
+
+impl std::fmt::Display for DriverCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The five capability families a driver's calls fall into.
+///
+/// A consent-rendering vocabulary, not a wire tag: nothing on the wire spells a
+/// family, because a grant is declared verb by verb and a family-level grant
+/// would be a mode selector wearing a consent prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DriverFamily {
+    /// The issue port.
+    Backlog,
+    /// One unit of backlog through the pipeline.
+    Work,
+    /// Branch, PR, CI, review, merge.
+    Deliver,
+    /// Where the next question comes from.
+    Sweep,
+    /// Proposals for tools, context records and skills.
+    Curate,
+}
+
+impl DriverFamily {
+    /// The sentence a human reads at install for this family.
+    ///
+    /// Stated as what the plugin will do **to their machine and their forge**,
+    /// not as the name of a subsystem: `doc:pipeline-as-plugins` §6.1's rule
+    /// that a grant a user cannot read before installing is not meaningfully
+    /// declared.
+    #[must_use]
+    pub fn consent_sentence(self) -> &'static str {
+        match self {
+            Self::Backlog => {
+                "reads and writes your issue tracker: ranks the queue, claims issues, \
+                              files findings, closes with receipts"
+            }
+            Self::Work => {
+                "runs Stella against an issue in an isolated worktree, spending model \
+                           calls and your provider budget"
+            }
+            Self::Deliver => "pushes branches, opens pull requests, reads CI, and merges",
+            Self::Sweep => "runs audit tooling over this workspace and files what it finds",
+            Self::Curate => {
+                "proposes new tools, context records and skills, and applies the ones \
+                             your declared authority permits"
+            }
+        }
+    }
+
+    /// The family's name, as the consent rendering labels it.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Backlog => "backlog",
+            Self::Work => "work",
+            Self::Deliver => "deliver",
+            Self::Sweep => "sweep",
+            Self::Curate => "curate",
+        }
+    }
+}
+
+impl std::fmt::Display for DriverFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The `[driver]` block — a plugin's declaration that it drives Stella, and of
+/// exactly which capabilities it will ask for while doing so.
+///
+/// **Absent means a plugin is not a driver at all.** That is the outer half of
+/// the gate and it is why [`crate::PluginManifest::driver`] is an `Option`
+/// rather than a defaulting struct: a manifest with no `[driver]` block opens
+/// no driver session, so there is nothing for a call list to be consulted
+/// against. The inner half is [`DriverGrant::permits_call`].
+///
+/// Deliberately carries **no participation grade**. There is no grade to carry:
+/// [`Participation`](crate::Participation) is a ladder of in-turn influence and
+/// a driver is not on it (§3.0). A plugin may hold both a `[loop]` grant and a
+/// `[driver]` grant — a wrapper that also drives is coherent — and neither one
+/// grants any part of the other.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriverGrant {
+    /// The capabilities this driver may ask for, exhaustively — an undeclared
+    /// call is refused, even if the driver's process asks for it.
+    ///
+    /// Empty is a complete answer and the default: a driver that only reads
+    /// what the session handed it declares nothing here. What it may not do is
+    /// ask for a capability a human never read at install, which is
+    /// [`DriverGrant::permits_call`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub calls: Vec<DriverCall>,
+    /// The most calls per driver session this plugin asks for.
+    ///
+    /// **An ask, never an authority** — the
+    /// [`LoopGrant::max_calls`](crate::LoopGrant::max_calls) discipline, in the
+    /// other dispatch context. The host clamps it against its own ceiling
+    /// (`stella_runtime::wrapper::DEFAULT_DRIVER_MAX_CALLS`) and a spent
+    /// allowance refuses further calls *to the driver* rather than killing it.
+    /// Absent means "the host's ceiling", never "unbounded".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_calls: Option<u32>,
+}
+
+impl DriverGrant {
+    /// Whether the host may perform `call` when this driver asks for it — the
+    /// authoritative filter behind "an undeclared call is refused".
+    ///
+    /// One condition rather than
+    /// [`LoopGrant::permits_call`](crate::LoopGrant::permits_call)'s two, and
+    /// the asymmetry is the design rather than a gap: there the first condition
+    /// grades the plugin's standing inside a turn, and here the *existence of
+    /// this grant* is that standing. A manifest with no `[driver]` block yields
+    /// no `DriverGrant` to ask through, which is the same refusal one layer
+    /// out.
+    #[must_use]
+    pub fn permits_call(&self, call: DriverCall) -> bool {
+        self.calls.contains(&call)
+    }
+
+    /// The families this grant touches, deduplicated and in family order.
+    ///
+    /// What the consent rendering reads: a human weighs "may push branches and
+    /// merge" rather than four verb names.
+    #[must_use]
+    pub fn families(&self) -> Vec<DriverFamily> {
+        let mut families: Vec<DriverFamily> = self.calls.iter().map(|call| call.family()).collect();
+        families.sort_unstable();
+        families.dedup();
+        families
+    }
+}
+
+/// One message a driver writes while a session is open.
+///
+/// Closed, and the *session response terminates the conversation* — the framing
+/// rule [`PluginMessage`](crate::PluginMessage) states, in the driver's context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriverMessage {
+    /// A capability ask, mid-session. The conversation continues.
+    Call(DriverCallRequest),
+    /// The session response. The conversation ends here.
+    Response(DriveResponse),
+}
+
+impl Serialize for DriverMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Call(call) => call.serialize(serializer),
+            Self::Response(response) => response.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DriverMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        DriverEnvelope::deserialize(deserializer)?.into_message()
+    }
+}
+
+/// Every key either shape of driver message may carry, and no others.
+///
+/// One envelope for both shapes, for [`crate::host_call`]'s reason: the check
+/// that matters is the *cross* one, and `deny_unknown_fields` on two separate
+/// envelopes would reject a stray `point` as an unknown field rather than as
+/// the contradiction it is.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DriverEnvelope {
+    #[serde(default)]
+    point: Option<DrivePoint>,
+    #[serde(default)]
+    body: Option<DriveBody>,
+    #[serde(default)]
+    call: Option<DriverCall>,
+    #[serde(default)]
+    id: Option<u32>,
+}
+
+impl DriverEnvelope {
+    fn into_message<E: serde::de::Error>(self) -> Result<DriverMessage, E> {
+        match (self.point, self.call) {
+            (Some(_), Some(_)) => Err(E::custom(
+                "a driver message carries either `point` (the response that ends the session) or \
+                 `call` (a capability ask), never both",
+            )),
+            (Some(DrivePoint::Drive), None) => {
+                if self.id.is_some() {
+                    return Err(E::custom(
+                        "a session response carries `point` and `body` only; `id` belongs to a \
+                         capability ask",
+                    ));
+                }
+                let body = self
+                    .body
+                    .ok_or_else(|| E::custom("a session response must carry `body`"))?;
+                Ok(DriverMessage::Response(DriveResponse { next: body.next }))
+            }
+            (None, Some(call)) => {
+                if self.body.is_some() {
+                    return Err(E::custom(
+                        "a capability ask carries `call` and `id`; `body` belongs to a session \
+                         response",
+                    ));
+                }
+                let id = self
+                    .id
+                    .ok_or_else(|| E::custom("a capability ask must carry `id`"))?;
+                Ok(DriverMessage::Call(DriverCallRequest { id, call }))
+            }
+            (None, None) => Err(E::custom(
+                "a driver message must carry either `point` (a session response) or `call` (a \
+                 capability ask)",
+            )),
+        }
+    }
+}
+
+/// The one point a driver session dispatches.
+///
+/// A closed single-variant enum rather than a bare string, so `"point":
+/// "before_turn"` written into a driver session is a decode error rather than
+/// something a reader shrugs at. A second driver point would be a reviewable
+/// addition here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DrivePoint {
+    /// The driver session itself.
+    Drive,
+}
+
+/// The host's opening of a driver session: `{"point": "drive", "body": {…}}`.
+///
+/// The body carries the session identity and nothing else at B0. The loop state
+/// `doc:backlog-self-driving` §3.0 sketches beside it is `LoopState`, which is
+/// B2's — pure, in `stella-autonomy`, and not yet written. Naming a field for
+/// it here would be pinning a wire shape to a type that does not exist.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriveRequest {
+    /// Which point is open. Always [`DrivePoint::Drive`]; present so the
+    /// request is self-describing on the wire.
+    pub point: DrivePoint,
+    /// The session body.
+    pub body: DriveSession,
+}
+
+impl DriveRequest {
+    /// Open a session.
+    #[must_use]
+    pub fn new(session: impl Into<String>) -> Self {
+        Self {
+            point: DrivePoint::Drive,
+            body: DriveSession {
+                session: session.into(),
+            },
+        }
+    }
+}
+
+/// What the host tells a driver when it opens the session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriveSession {
+    /// The host's identifier for this session, echoed into its telemetry.
+    pub session: String,
+}
+
+/// The response that ends a driver session.
+///
+/// A driver does not simply stop: it says what it wants to happen next, and
+/// both answers are terminal for *this* session. That is
+/// `doc:backlog-self-driving` §3.7's discipline at the wire — **a loop that
+/// cannot halt is not autonomous, it is unsupervised**, and a loop that halts
+/// without saying why is worse than one that keeps running.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriveResponse {
+    /// What the driver wants to happen after this session.
+    pub next: DriveNext,
+}
+
+impl<'de> Deserialize<'de> for DriveResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Through the shared envelope, so a response is read by exactly the
+        // reader that would have rejected it inside a [`DriverMessage`] — two
+        // readers for one shape is how the halves drift.
+        match DriverEnvelope::deserialize(deserializer)?.into_message()? {
+            DriverMessage::Response(response) => Ok(response),
+            DriverMessage::Call(_) => Err(serde::de::Error::custom(
+                "expected a session response, found a capability ask",
+            )),
+        }
+    }
+}
+
+/// The response body, as the shared envelope reads and writes it.
+///
+/// Private, because `{"next": …}` is a shape of the envelope rather than a type
+/// a driver author handles: what they build is a [`DriveResponse`], and the
+/// `point`/`body` framing around it is the channel's.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DriveBody {
+    next: DriveNext,
+}
+
+impl Serialize for DriveResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("DriveResponse", 2)?;
+        state.serialize_field("point", &DrivePoint::Drive)?;
+        state.serialize_field(
+            "body",
+            &DriveBody {
+                next: self.next.clone(),
+            },
+        )?;
+        state.end()
+    }
+}
+
+/// What a driver asks to happen after this session.
+///
+/// Two answers, both of them terminal for the session and neither of them a
+/// silence. `Sleep` is `doc:backlog-self-driving` §3.7's `Watch`, reduced to the
+/// only wake condition B0 can honestly serve — a duration. The condition-shaped
+/// wakes (`WakeCondition`) arrive with the supply model in B4.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriveNext {
+    /// Re-open a session after this many seconds.
+    Sleep {
+        /// How long to wait. The host clamps it; a driver cannot buy an
+        /// unbounded absence by asking for one.
+        secs: u32,
+    },
+    /// Stop, and say why. Reached for a spent budget, a revoked grant, an
+    /// operator stop, or work the driver declines to continue.
+    Halt {
+        /// The sentence a human reads in the loop's ledger.
+        reason: String,
+    },
+}
+
+/// One capability ask: `{"call": …, "id": …}`.
+///
+/// The `id` is the driver's own correlation number and the host echoes it back
+/// as [`DriverCallResponse::result`], for
+/// [`HostCallRequest`](crate::HostCallRequest)'s reason: a driver that
+/// pipelines two asks needs to tell the answers apart, and a number the host
+/// assigned would arrive too late to be useful.
+///
+/// There is no `args` key, and its absence is checked rather than tolerated —
+/// see this module's header. The verb that needs arguments brings them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct DriverCallRequest {
+    /// What the driver calls this ask, echoed on the answer.
+    pub id: u32,
+    /// Which capability.
+    pub call: DriverCall,
+}
+
+impl<'de> Deserialize<'de> for DriverCallRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match DriverEnvelope::deserialize(deserializer)?.into_message()? {
+            DriverMessage::Call(call) => Ok(call),
+            DriverMessage::Response(_) => Err(serde::de::Error::custom(
+                "expected a capability ask, found a session response",
+            )),
+        }
+    }
+}
+
+/// The host's answer to one capability ask: `{"result": …, "ok"|"err": {…}}`.
+///
+/// `Deserialize` is written out by hand over a denying envelope for the reason
+/// [`HostCallResponse`](crate::HostCallResponse) measured rather than assumed:
+/// serde's flat-map reader takes the first key it recognises and drops the
+/// rest, so a derived reader would decode `{"result":1,"ok":{},"err":{…}}` as a
+/// success and the refusal beside it would vanish.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DriverCallResponse {
+    /// The [`DriverCallRequest::id`] this answers.
+    pub result: u32,
+    /// What came of it.
+    #[serde(flatten)]
+    pub outcome: DriverCallOutcome,
+}
+
+/// The three keys an answer may carry, and the only three.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DriverResultEnvelope {
+    result: u32,
+    #[serde(default)]
+    ok: Option<DriverOk>,
+    #[serde(default)]
+    err: Option<HostCallFailure>,
+}
+
+impl<'de> Deserialize<'de> for DriverCallResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let envelope = DriverResultEnvelope::deserialize(deserializer)?;
+        let outcome = match (envelope.ok, envelope.err) {
+            (Some(ok), None) => DriverCallOutcome::Ok(ok),
+            (None, Some(err)) => DriverCallOutcome::Err(err),
+            (Some(_), Some(_)) => {
+                return Err(serde::de::Error::custom(
+                    "a driver-call answer carries either `ok` or `err`, never both",
+                ));
+            }
+            (None, None) => {
+                return Err(serde::de::Error::custom(
+                    "a driver-call answer must carry either `ok` or `err`",
+                ));
+            }
+        };
+        Ok(Self {
+            result: envelope.result,
+            outcome,
+        })
+    }
+}
+
+impl DriverCallResponse {
+    /// An answer carrying what the host did.
+    #[must_use]
+    pub fn ok(result: u32, ok: DriverOk) -> Self {
+        Self {
+            result,
+            outcome: DriverCallOutcome::Ok(ok),
+        }
+    }
+
+    /// An answer carrying why the host would not, or could not.
+    #[must_use]
+    pub fn err(result: u32, failure: HostCallFailure) -> Self {
+        Self {
+            result,
+            outcome: DriverCallOutcome::Err(failure),
+        }
+    }
+}
+
+/// Whether a capability ask succeeded, as the one key that distinguishes them.
+///
+/// The failure half is [`HostCallFailure`] itself, reused rather than mirrored:
+/// the six reasons a capability is not performed — undeclared, forbidden,
+/// unsupported, allowance spent, unavailable, failed — are properties of asking
+/// a host for something, not of which dispatch context asked. A driver branches
+/// on the same closed [`HostCallRefusal`](crate::HostCallRefusal) codes a
+/// wrapper does, and a second copy of that enum would be two vocabularies for
+/// one concept.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriverCallOutcome {
+    /// The host performed the call.
+    Ok(DriverOk),
+    /// The host refused it, or tried it and it failed. Either way the driver is
+    /// told, and is expected to degrade honestly rather than die.
+    Err(HostCallFailure),
+}
+
+/// What a successful capability ask returned.
+///
+/// **Empty today, and that is the honest shape rather than a placeholder.** No
+/// verb is implemented at B0 (this module's header says why), so there is
+/// nothing for a result table to describe. The phase that implements a verb
+/// adds the field it reports — and because this table denies unknown fields, a
+/// host answering with a payload the contract does not have is a decode error
+/// on the driver's side rather than a value silently dropped.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriverOk {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host_call::HostCallRefusal;
+
+    #[test]
+    fn every_call_has_a_distinct_wire_name_and_a_family() {
+        let mut names: Vec<&str> = DriverCall::all().iter().map(|call| call.as_str()).collect();
+        let count = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count, "two capabilities share a wire name");
+        // Eighteen verbs across five families, and every family reachable —
+        // a family no verb belongs to would be a consent sentence nothing can
+        // ever print.
+        let mut families: Vec<DriverFamily> =
+            DriverCall::all().iter().map(|call| call.family()).collect();
+        families.sort_unstable();
+        families.dedup();
+        assert_eq!(families.len(), 5);
+    }
+
+    #[test]
+    fn all_is_exhaustive_over_the_enum() {
+        // Round-tripping every wire name back through the deserializer proves
+        // `all()` and the enum agree, without a hand-maintained count.
+        for call in DriverCall::all() {
+            let json = serde_json::to_string(call).expect("a call serializes");
+            let back: DriverCall = serde_json::from_str(&json).expect("and reads back");
+            assert_eq!(back, *call);
+        }
+        let missed = serde_json::from_str::<DriverCall>("\"release\"");
+        assert!(
+            missed.is_err(),
+            "`release` is deliberately not a capability"
+        );
+    }
+
+    #[test]
+    fn an_undeclared_call_is_not_permitted_and_a_declared_one_is() {
+        let grant = DriverGrant {
+            calls: vec![DriverCall::BacklogNext],
+            max_calls: None,
+        };
+        assert!(grant.permits_call(DriverCall::BacklogNext));
+        assert!(!grant.permits_call(DriverCall::DeliverMerge));
+    }
+
+    #[test]
+    fn families_are_deduplicated_and_ordered() {
+        let grant = DriverGrant {
+            calls: vec![
+                DriverCall::DeliverMerge,
+                DriverCall::BacklogNext,
+                DriverCall::BacklogFile,
+            ],
+            max_calls: None,
+        };
+        assert_eq!(
+            grant.families(),
+            vec![DriverFamily::Backlog, DriverFamily::Deliver]
+        );
+    }
+
+    #[test]
+    fn a_message_carrying_both_a_point_and_a_call_is_refused() {
+        let err = serde_json::from_str::<DriverMessage>(
+            r#"{"point":"drive","body":{"next":{"halt":{"reason":"x"}}},"call":"backlog_next","id":1}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("never both"), "{err}");
+    }
+
+    #[test]
+    fn a_capability_ask_may_not_carry_arguments_yet() {
+        // `args` is not a key of this contract at B0, and the envelope denies
+        // it rather than ignoring it — a driver written against a later phase's
+        // arguments must fail loudly against a host that has none.
+        let err = serde_json::from_str::<DriverCallRequest>(
+            r#"{"call":"backlog_next","id":1,"args":{"limit":5}}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("args"), "{err}");
+    }
+
+    #[test]
+    fn a_session_round_trips_through_both_message_shapes() {
+        let ask = DriverMessage::Call(DriverCallRequest {
+            id: 1,
+            call: DriverCall::BacklogNext,
+        });
+        let json = serde_json::to_string(&ask).expect("an ask serializes");
+        assert_eq!(json, r#"{"id":1,"call":"backlog_next"}"#);
+        assert_eq!(
+            serde_json::from_str::<DriverMessage>(&json).expect("and reads back"),
+            ask
+        );
+
+        let done = DriverMessage::Response(DriveResponse {
+            next: DriveNext::Sleep { secs: 900 },
+        });
+        let json = serde_json::to_string(&done).expect("a response serializes");
+        assert_eq!(
+            json,
+            r#"{"point":"drive","body":{"next":{"sleep":{"secs":900}}}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<DriverMessage>(&json).expect("and reads back"),
+            done
+        );
+    }
+
+    #[test]
+    fn an_answer_carrying_both_ok_and_err_does_not_decode_as_success() {
+        let err = serde_json::from_str::<DriverCallResponse>(
+            r#"{"result":1,"ok":{},"err":{"refusal":"undeclared","detail":"x"}}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("never both"), "{err}");
+    }
+
+    #[test]
+    fn a_refusal_round_trips_with_its_code_intact() {
+        let refused = DriverCallResponse::err(
+            7,
+            HostCallFailure::new(HostCallRefusal::Undeclared, "not in [driver] calls"),
+        );
+        let json = serde_json::to_string(&refused).expect("a refusal serializes");
+        let back: DriverCallResponse = serde_json::from_str(&json).expect("and reads back");
+        assert_eq!(back, refused);
+        match back.outcome {
+            DriverCallOutcome::Err(failure) => {
+                assert_eq!(failure.refusal, HostCallRefusal::Undeclared);
+            }
+            DriverCallOutcome::Ok(_) => panic!("a refusal decoded as a success"),
+        }
+    }
+}

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -5,6 +5,7 @@
 //! of these to a plugin author should be able to print it verbatim and have
 //! the fix be obvious.
 
+use crate::driver::DriverCall;
 use crate::host_call::HostCall;
 use crate::manifest::{HookEvent, Participation};
 use crate::package::ContributionKind;
@@ -97,6 +98,29 @@ pub enum ManifestError {
          never make one"
     )]
     CallsRequirePoints,
+
+    /// `[driver] calls` listed the same capability twice — the
+    /// [`ManifestError::DuplicateCall`] rule, for the driver channel.
+    #[error("[driver] calls declares {call} more than once")]
+    DuplicateDriverCall {
+        /// The capability that appeared twice.
+        call: DriverCall,
+    },
+
+    /// `[driver] max_calls` was declared with no `[driver] calls` to bound.
+    #[error(
+        "[driver] max_calls has nothing to bound: declare the capabilities in \
+         [driver] calls, or drop the allowance"
+    )]
+    DriverMaxCallsRequiresCalls,
+
+    /// `[driver] max_calls = 0` — an allowance that forbids the calls the same
+    /// block declares. Asking for none is an empty `calls` list, not a zero.
+    #[error(
+        "[driver] max_calls = 0 contradicts the capabilities [driver] calls \
+         declares: asking for none is an empty list, not a zero allowance"
+    )]
+    ZeroDriverMaxCalls,
 
     /// `[loop] max_calls` was declared with no `[loop] calls` to bound.
     #[error(

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -92,6 +92,7 @@
 //! would answer or ask for one.
 
 mod consent;
+mod driver;
 mod error;
 mod evidence;
 mod host_call;
@@ -112,6 +113,11 @@ pub mod wire_corpus;
 mod wrapper;
 
 pub use consent::{Capability, RiskLevel, consent_text, highest_risk};
+pub use driver::{
+    DriveNext, DrivePoint, DriveRequest, DriveResponse, DriveSession, DriverCall,
+    DriverCallOutcome, DriverCallRequest, DriverCallResponse, DriverFamily, DriverGrant,
+    DriverMessage, DriverOk,
+};
 pub use error::ManifestError;
 pub use evidence::{MeasurementRule, OracleCheck, UnmetCheck};
 pub use host_call::{

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -36,6 +36,7 @@ use std::collections::{BTreeMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::consent::{Capability, validate_capabilities};
+use crate::driver::DriverGrant;
 use crate::error::ManifestError;
 use crate::evidence::OracleCheck;
 use crate::host_call::HostCall;
@@ -441,6 +442,22 @@ pub struct PluginManifest {
     /// The `[loop]` registration. Absent = no participation.
     #[serde(rename = "loop", default, skip_serializing_if = "is_default_grant")]
     pub loop_grant: LoopGrant,
+    /// The `[driver]` registration — this plugin drives turns rather than
+    /// sitting inside one, and these are the capabilities it may ask for while
+    /// doing it (`doc:backlog-self-driving` §3.0).
+    ///
+    /// **Absent = not a driver**, which is the outer half of the gate: no
+    /// `[driver]` block means no driver session is ever opened, so there is
+    /// nothing for [`DriverGrant::permits_call`] to be consulted against. It is
+    /// an `Option` rather than a defaulting struct for exactly that reason —
+    /// "this plugin declared no driver capabilities" and "this plugin is not a
+    /// driver" are different consents and must not share a representation.
+    ///
+    /// Independent of [`Self::loop_grant`] in both directions: a driver needs
+    /// no [`Participation`] grade (there is no grade for driving, §3.0) and a
+    /// grade buys no driver capability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver: Option<DriverGrant>,
     /// Arbiter only: the enumerable definition of done. Keys are the names
     /// a hold cites; values are the human-readable statement of each
     /// requirement. A `BTreeMap` so iteration order is deterministic
@@ -624,6 +641,29 @@ impl PluginManifest {
             // for the same shape one rung up.
             Some(0) => return Err(ManifestError::ZeroMaxCalls),
             _ => {}
+        }
+
+        // The driver channel gets the same three rules and *not* the grade
+        // check, which is the one asymmetry in this function and the whole
+        // point of the block: a driver is not on the `Participation` ladder, so
+        // there is no grade to be above (`doc:backlog-self-driving` §3.0). Nor
+        // is there a `points` prerequisite — a driver call is made during a
+        // driver session, and the `[driver]` block *is* the declaration that
+        // this plugin has one.
+        if let Some(driver) = &self.driver {
+            let mut seen = HashSet::with_capacity(driver.calls.len());
+            for call in &driver.calls {
+                if !seen.insert(*call) {
+                    return Err(ManifestError::DuplicateDriverCall { call: *call });
+                }
+            }
+            match driver.max_calls {
+                Some(_) if driver.calls.is_empty() => {
+                    return Err(ManifestError::DriverMaxCallsRequiresCalls);
+                }
+                Some(0) => return Err(ManifestError::ZeroDriverMaxCalls),
+                _ => {}
+            }
         }
 
         if grant.hooks.contains(&HookEvent::Stop) && !participation.includes(Participation::Arbiter)
@@ -1225,6 +1265,73 @@ mod tests {
         )
         .expect("a coherent ask loads");
         assert_eq!(asked.loop_grant.max_calls, Some(4));
+    }
+
+    /// **Witness for #3599 B0, the manifest half.** A driver holds its
+    /// capabilities through a `[driver]` block that the `Participation` ladder
+    /// neither grants nor gates.
+    ///
+    /// The load-bearing assertion is the first one: `participation = "none"` —
+    /// the honest grade for a plugin that never runs inside a turn — used to
+    /// make every capability unreachable, and that is the defect the phase
+    /// exists to fix. The rest pin the asymmetry deliberately: no grade is
+    /// required, no `points` prerequisite applies (a driver call is made during
+    /// a driver session, not during a wrapper point), and the `[loop]` rules
+    /// that *do* transfer — deduplicated, a coherent allowance — still hold.
+    #[test]
+    fn a_driver_holds_capabilities_without_a_participation_grade() {
+        use crate::driver::DriverCall;
+        let driving = parse(
+            "name = \"x\"\n[loop]\nparticipation = \"none\"\n\n[driver]\ncalls = [\"backlog_next\", \"deliver_open\"]",
+        )
+        .expect("a driver at grade `none` loads");
+        let grant = driving.driver.expect("the [driver] block is parsed");
+        assert!(grant.permits_call(DriverCall::BacklogNext));
+        assert!(grant.permits_call(DriverCall::DeliverOpen));
+        // Declared is exhaustive, in the driver's context as in the wrapper's.
+        assert!(!grant.permits_call(DriverCall::DeliverMerge));
+        // And the ladder is untouched: the same manifest still takes no say in
+        // any turn.
+        assert_eq!(driving.loop_grant.participation, Participation::None);
+
+        // Absent is not empty. "Not a driver" and "a driver that asks for
+        // nothing" must not share a representation.
+        assert!(
+            parse("name = \"x\"")
+                .expect("a bare manifest loads")
+                .driver
+                .is_none()
+        );
+        assert_eq!(
+            parse("name = \"x\"\n[driver]")
+                .expect("an empty [driver] block loads")
+                .driver,
+            Some(DriverGrant::default())
+        );
+
+        // The capability set is closed, not an RPC surface — and `release` is
+        // deliberately not in it (§6.4).
+        assert!(matches!(
+            parse("name = \"x\"\n[driver]\ncalls = [\"release\"]").unwrap_err(),
+            ManifestError::Parse(_)
+        ));
+
+        // The `[loop] calls` rules that transfer.
+        assert!(matches!(
+            parse("name = \"x\"\n[driver]\ncalls = [\"sweep_audit\", \"sweep_audit\"]")
+                .unwrap_err(),
+            ManifestError::DuplicateDriverCall {
+                call: DriverCall::SweepAudit
+            }
+        ));
+        assert!(matches!(
+            parse("name = \"x\"\n[driver]\nmax_calls = 4").unwrap_err(),
+            ManifestError::DriverMaxCallsRequiresCalls
+        ));
+        assert!(matches!(
+            parse("name = \"x\"\n[driver]\ncalls = [\"sweep_audit\"]\nmax_calls = 0").unwrap_err(),
+            ManifestError::ZeroDriverMaxCalls
+        ));
     }
 
     /// **Witness for #3501 item 1.** The oracle may be the plugin's own

--- a/crates/stella-plugin/src/wire_corpus.rs
+++ b/crates/stella-plugin/src/wire_corpus.rs
@@ -73,11 +73,12 @@ use stella_protocol::candidate::CandidateHandle;
 
 use crate::{
     AfterTurnRequest, AfterTurnResponse, BeforeTurnRequest, BeforeTurnResponse, CandidateGrant,
-    ChildTurnArgs, ChildTurnResult, FlipObservation, HostCall, HostCallArgs, HostCallFailure,
-    HostCallOk, HostCallRefusal, HostCallRequest, HostCallResponse, ObservedEvidence,
-    PROTOCOL_VERSION, PublishedSignal, RecallArgs, RecallFrame, RecallResult, RunTestArgs, Signal,
-    SignalKind, SignalValue, StageName, TestBaseline, TestPlan, TurnOutcome, VolatileContext,
-    WrapperPoint, WrapperRequest, WrapperResponse,
+    ChildTurnArgs, ChildTurnResult, DriveNext, DriveRequest, DriveResponse, DriverCall,
+    DriverCallRequest, DriverCallResponse, DriverOk, FlipObservation, HostCall, HostCallArgs,
+    HostCallFailure, HostCallOk, HostCallRefusal, HostCallRequest, HostCallResponse,
+    ObservedEvidence, PROTOCOL_VERSION, PublishedSignal, RecallArgs, RecallFrame, RecallResult,
+    RunTestArgs, Signal, SignalKind, SignalValue, StageName, TestBaseline, TestPlan, TurnOutcome,
+    VolatileContext, WrapperPoint, WrapperRequest, WrapperResponse,
 };
 
 /// The committed artifact's filename.
@@ -122,6 +123,9 @@ pub fn corpus() -> Result<Value, serde_json::Error> {
         "responses": responses()?,
         "host_calls": host_calls()?,
         "host_results": host_results()?,
+        "driver_session": driver_session()?,
+        "driver_calls": driver_calls()?,
+        "driver_results": driver_results()?,
         "parts": parts()?,
         "vocabulary": vocabulary()?,
     }))
@@ -230,6 +234,77 @@ fn host_results() -> Result<Value, serde_json::Error> {
     ]))
 }
 
+/// The driver channel's session frames — the host's opening and the two
+/// answers that end it (`doc:backlog-self-driving` §3.0, #3599 B0).
+///
+/// A second dispatch context, published beside the first rather than folded
+/// into it, because the two are different consents and a reader of this corpus
+/// should be able to see that a `drive` point is not a wrapper point.
+fn driver_session() -> Result<Value, serde_json::Error> {
+    Ok(Value::Array(vec![
+        case("open", &DriveRequest::new("cycle-7"))?,
+        // Both terminal answers, because a driver that halts and a driver that
+        // sleeps are the two shapes a host must handle and neither is the
+        // other's default.
+        case(
+            "sleep",
+            &DriveResponse {
+                next: DriveNext::Sleep { secs: 900 },
+            },
+        )?,
+        case(
+            "halt",
+            &DriveResponse {
+                next: DriveNext::Halt {
+                    reason: "budget spent".into(),
+                },
+            },
+        )?,
+    ]))
+}
+
+/// A capability ask, in the one shape it has at B0.
+///
+/// No `args` key, and no `full`/`minimal` pair, because the request carries no
+/// optional member — the arguments land with the verb that needs them, and an
+/// `args` appearing here later is exactly the diff that should be reviewed.
+fn driver_calls() -> Result<Value, serde_json::Error> {
+    Ok(Value::Array(vec![case(
+        "backlog_next",
+        &DriverCallRequest {
+            id: 1,
+            call: DriverCall::BacklogNext,
+        },
+    )?]))
+}
+
+/// The host's answers to those asks.
+fn driver_results() -> Result<Value, serde_json::Error> {
+    Ok(Value::Array(vec![
+        // The empty `ok` table is the contract, not an omission: a host
+        // answering with a payload the driver's reader denies is a decode
+        // error, so this case going non-empty is a wire change.
+        case("ok", &DriverCallResponse::ok(1, DriverOk {}))?,
+        case(
+            "err/undeclared",
+            &DriverCallResponse::err(
+                2,
+                HostCallFailure::new(
+                    HostCallRefusal::Undeclared,
+                    "this plugin's manifest does not declare \"deliver_merge\" in [driver] calls",
+                ),
+            ),
+        )?,
+        case(
+            "err/unsupported",
+            &DriverCallResponse::err(
+                3,
+                HostCallFailure::new(HostCallRefusal::Unsupported, "B0 serves no capability yet"),
+            ),
+        )?,
+    ]))
+}
+
 /// The nested types, in the forms the four messages above do not reach.
 ///
 /// A message's `minimal` case omits its optional members entirely, so the
@@ -281,6 +356,11 @@ fn vocabulary() -> Result<Value, serde_json::Error> {
             HostCallRefusal::Undeclared,
             host_call_refusal_after,
         ))?,
+        // Published from `DriverCall::all()` rather than walked with a
+        // successor function: the list is already the enum's own source of
+        // truth for the consent rendering, and a second walk would be a second
+        // thing to keep exhaustive.
+        "driver_call": values(DriverCall::all().to_vec())?,
     }))
 }
 

--- a/crates/stella-runtime/src/wrapper/driver_call.rs
+++ b/crates/stella-runtime/src/wrapper/driver_call.rs
@@ -1,0 +1,435 @@
+//! The host half of the **driver channel** — the gate, the ceiling, and the
+//! report, for a plugin that drives turns rather than sitting inside one.
+//!
+//! `doc:backlog-self-driving` §3.0. [`super::host_call`] is the identical
+//! apparatus for the wrapper socket, and this module is deliberately its
+//! sibling rather than its generalisation: the two share the refusal
+//! vocabulary ([`HostCallRefusal`]) because the reasons a host declines are
+//! properties of asking, not of who asked — and share nothing else, because the
+//! *grants* are different consents and merging them is precisely how `arbiter`
+//! would come to mean "may merge to `main`".
+//!
+//! ```text
+//!  driver           transport           DriverCallGate        DriverCapabilities
+//!    │  {"call":…}      │                     │                       │
+//!    ├─────────────────>│  session.call(…)    │                       │
+//!    │                  ├────────────────────>│ permits_call? spent?  │
+//!    │                  │                     ├──────────────────────>│
+//!    │  {"result":…}    │                     │<──────── ok / err ────┤
+//!    │<─────────────────┤<────────────────────┤                       │
+//! ```
+//!
+//! # The three bounds, restated for a session that outlives a turn
+//!
+//! 1. **The allowance is per driver session**, not per point, because a session
+//!    is the unit a driver is dispatched in. [`DriverCallGate::open`] hands out
+//!    a fresh one each time, which is what makes a long-running loop's next
+//!    cycle unaffected by the last one's spending.
+//! 2. **The ceiling is the host's, and the manifest's number is an ask.**
+//!    `max_calls.unwrap_or(ceiling).min(ceiling)` — the
+//!    [`HostCallGate`](super::HostCallGate) clamp, unchanged.
+//! 3. **A refused or failed call is answered, not fatal.** This is the bound
+//!    the witness for B0 is about: a driver denied `deliver_merge` degrades to
+//!    opening the pull request and stopping, and says so. Killing it would turn
+//!    an undeclared capability into a crashed loop, and a loop that dies on a
+//!    refusal teaches its author nothing.
+//!
+//! # What this host can actually do at B0
+//!
+//! Nothing yet, and that is stated rather than implied: [`NoDriverCapabilities`]
+//! answers every verb [`HostCallRefusal::Unsupported`], which is invariant 10's
+//! discipline pointed at capabilities — a declared gap delivered *to* the
+//! driver, never a silence. B1–B6 (#3599) implement the verbs, one family at a
+//! time; this module is what makes it possible for any of them to be held.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use async_trait::async_trait;
+use stella_plugin::{
+    DriverCall, DriverCallOutcome, DriverGrant, DriverOk, HostCallFailure, HostCallRefusal,
+};
+
+/// The host's own ceiling on capability asks per driver session, when a caller
+/// states none.
+///
+/// A driver session is a whole cycle — claim an issue, work it, deliver it,
+/// sweep, and around again — so the number is an order of magnitude above
+/// [`DEFAULT_HOST_MAX_CALLS`](super::DEFAULT_HOST_MAX_CALLS)'s eight, which
+/// bounds one point of one turn. It is still a bound rather than a courtesy:
+/// each ask is work the host performs inside a budget the user is paying for,
+/// and a driver that has asked a hundred and twenty-eight times without
+/// reaching a `next` is not making progress, it is spinning.
+pub const DEFAULT_DRIVER_MAX_CALLS: u32 = 128;
+
+/// What a host can actually do when a driver asks.
+///
+/// One method over the closed [`DriverCall`], so the compiler makes an
+/// implementor answer for every capability rather than letting an unhandled one
+/// become a silence. A host that implements only some of them returns
+/// [`HostCallRefusal::Unsupported`] for the rest.
+///
+/// This is the port the *gate* calls **after** it has checked the grant, so an
+/// implementor is never the thing that decides whether a driver may ask. It
+/// takes no arguments and returns no payload today for the reason
+/// `stella_plugin::driver` states: no verb is implemented at B0, so there is
+/// nothing honest for either shape to carry. The phase that implements a
+/// family widens this signature along with the wire.
+#[async_trait]
+pub trait DriverCapabilities: Send + Sync {
+    /// Perform `call`, or say why not.
+    async fn perform(&self, call: DriverCall) -> Result<DriverOk, HostCallFailure>;
+}
+
+/// A host that implements no driver capability yet.
+///
+/// The honest state of `stella-cli` at B0, and a real value rather than a test
+/// double: a driver bound to this one is told `unsupported` for every verb and
+/// keeps running, which is the same answer it will get in production until the
+/// phase that serves the verb lands.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoDriverCapabilities;
+
+#[async_trait]
+impl DriverCapabilities for NoDriverCapabilities {
+    async fn perform(&self, call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+        Err(HostCallFailure::new(
+            HostCallRefusal::Unsupported,
+            format!(
+                "this host does not perform \"{call}\" yet; the driver channel is B0 and the \
+                 {} capabilities land in B1-B6 (#3599)",
+                call.family()
+            ),
+        ))
+    }
+}
+
+/// One capability ask the gate answered with a refusal or a failure.
+///
+/// Recorded so the host can say what a driver did not get. The driver already
+/// knows — it read the `err` — and a host that cannot see the same fact is a
+/// host whose user cannot be told why the loop degraded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefusedDriverCall {
+    /// The capability that was asked for.
+    pub call: DriverCall,
+    /// Which refusal, as the driver read it.
+    pub refusal: HostCallRefusal,
+    /// Why, in the words the driver was given.
+    pub detail: String,
+}
+
+impl std::fmt::Display for RefusedDriverCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} refused ({}): {}",
+            self.call, self.refusal, self.detail
+        )
+    }
+}
+
+/// The declared `[driver]` grant, the host's ceiling, and the capabilities
+/// behind them.
+///
+/// Held for the whole of a driver's life and opened once per session
+/// ([`DriverCallGate::open`]).
+pub struct DriverCallGate {
+    declared: DriverGrant,
+    max_calls: u32,
+    capabilities: Box<dyn DriverCapabilities>,
+    refusals: Mutex<Vec<RefusedDriverCall>>,
+}
+
+impl std::fmt::Debug for DriverCallGate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DriverCallGate")
+            .field("declared", &self.declared.calls)
+            .field("max_calls", &self.max_calls)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DriverCallGate {
+    /// Bind a driver's declared grant to what this host can do.
+    ///
+    /// The whole [`DriverGrant`] is taken rather than its `calls` list because
+    /// [`DriverGrant::permits_call`] is the authoritative filter, and a gate
+    /// that consulted a bare list would be a second implementation of the rule
+    /// the manifest crate already owns.
+    #[must_use]
+    pub fn declare(
+        grant: DriverGrant,
+        host_max_calls: u32,
+        capabilities: Box<dyn DriverCapabilities>,
+    ) -> Self {
+        let max_calls = grant
+            .max_calls
+            .unwrap_or(host_max_calls)
+            .min(host_max_calls);
+        Self {
+            declared: grant,
+            max_calls,
+            capabilities,
+            refusals: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The effective allowance per session, after the clamp.
+    #[must_use]
+    pub fn max_calls(&self) -> u32 {
+        self.max_calls
+    }
+
+    /// Whether any call this gate could admit exists.
+    ///
+    /// A transport asks before opening a session, for the reason
+    /// [`HostCallGate::offers_calls`](super::HostCallGate::offers_calls) is
+    /// asked: a driver that can never be served must not be left holding a
+    /// conversation open until the session timeout.
+    #[must_use]
+    pub fn offers_calls(&self) -> bool {
+        self.max_calls > 0
+            && self
+                .declared
+                .calls
+                .iter()
+                .any(|call| self.declared.permits_call(*call))
+    }
+
+    /// Open the conversation for one driver session.
+    #[must_use]
+    pub fn open(&self) -> DriverSession<'_> {
+        DriverSession {
+            gate: self,
+            spent: AtomicU32::new(0),
+        }
+    }
+
+    /// Every call this gate refused or failed, in the order it happened.
+    #[must_use]
+    pub fn refusals(&self) -> Vec<RefusedDriverCall> {
+        // A poisoned lock means some other call panicked mid-record; losing the
+        // report because of an unrelated panic would be the silence this
+        // apparatus refuses, which is also invariant 5's line for an `unwrap`
+        // on runtime state.
+        self.refusals
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Record an answer the driver will read as `err`.
+    fn record(&self, call: DriverCall, failure: &HostCallFailure) {
+        self.refusals
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(RefusedDriverCall {
+                call,
+                refusal: failure.refusal,
+                detail: failure.detail.clone(),
+            });
+    }
+}
+
+/// The conversation a driver holds while one session is open.
+///
+/// [`Self::spent`] is per session, which is the unit the ceiling is declared
+/// in. Atomic rather than behind a `&mut` because the session is shared by
+/// reference with whatever is answering it, and a driver that pipelines two
+/// asks must not be able to spend the same allowance twice.
+#[derive(Debug)]
+pub struct DriverSession<'gate> {
+    gate: &'gate DriverCallGate,
+    spent: AtomicU32,
+}
+
+impl DriverSession<'_> {
+    /// How many calls have been admitted in this session so far.
+    #[must_use]
+    pub fn spent(&self) -> u32 {
+        self.spent.load(Ordering::Relaxed)
+    }
+
+    /// Ask the host for a capability.
+    ///
+    /// Infallible by construction: a refusal is a [`DriverCallOutcome::Err`]
+    /// value the driver reads, never an error that ends the session.
+    pub async fn call(&self, call: DriverCall) -> DriverCallOutcome {
+        // The grant first, and before anything is spent: an undeclared call
+        // costs the driver nothing from an allowance it was never entitled to
+        // use.
+        if !self.gate.declared.permits_call(call) {
+            let failure = HostCallFailure::new(
+                HostCallRefusal::Undeclared,
+                format!(
+                    "this plugin's manifest does not declare \"{call}\" in [driver] calls, so the \
+                     host did not perform it"
+                ),
+            );
+            self.gate.record(call, &failure);
+            return DriverCallOutcome::Err(failure);
+        }
+
+        // Then the allowance. `fetch_add` rather than load-then-store so two
+        // pipelined asks cannot both read the last slot as free.
+        let spent = self.spent.fetch_add(1, Ordering::Relaxed);
+        if spent >= self.gate.max_calls {
+            let failure = HostCallFailure::new(
+                HostCallRefusal::AllowanceSpent,
+                format!(
+                    "this driver session's allowance of {} capability asks is spent; the host \
+                     will perform no more until the next session",
+                    self.gate.max_calls
+                ),
+            );
+            self.gate.record(call, &failure);
+            return DriverCallOutcome::Err(failure);
+        }
+
+        match self.gate.capabilities.perform(call).await {
+            Ok(ok) => DriverCallOutcome::Ok(ok),
+            Err(failure) => {
+                self.gate.record(call, &failure);
+                DriverCallOutcome::Err(failure)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A host that serves everything, so a test can isolate the *gate's* answer
+    /// from the capability's.
+    struct Serves;
+
+    #[async_trait]
+    impl DriverCapabilities for Serves {
+        async fn perform(&self, _call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+            Ok(DriverOk {})
+        }
+    }
+
+    fn grant(calls: &[DriverCall], max_calls: Option<u32>) -> DriverGrant {
+        DriverGrant {
+            calls: calls.to_vec(),
+            max_calls,
+        }
+    }
+
+    /// **The B0 witness.** Both directions, because either alone is half a
+    /// gate: an undeclared capability is refused with a code the driver can
+    /// branch on *and the session keeps going*, and a declared one is served.
+    #[tokio::test]
+    async fn an_undeclared_call_is_refused_and_the_session_keeps_running() {
+        let gate = DriverCallGate::declare(
+            grant(&[DriverCall::BacklogNext], None),
+            DEFAULT_DRIVER_MAX_CALLS,
+            Box::new(Serves),
+        );
+        let session = gate.open();
+
+        let refused = session.call(DriverCall::DeliverMerge).await;
+        match refused {
+            DriverCallOutcome::Err(failure) => {
+                assert_eq!(failure.refusal, HostCallRefusal::Undeclared);
+                assert!(failure.detail.contains("[driver] calls"), "{failure}");
+            }
+            DriverCallOutcome::Ok(_) => panic!("an undeclared capability was performed"),
+        }
+        // Refused, and not charged for: the refusal must not eat the allowance
+        // the driver was actually granted.
+        assert_eq!(session.spent(), 0);
+
+        // And the session is still alive and still able to be served — the
+        // half that makes the refusal a value rather than a death.
+        assert_eq!(
+            session.call(DriverCall::BacklogNext).await,
+            DriverCallOutcome::Ok(DriverOk {})
+        );
+        assert_eq!(session.spent(), 1);
+
+        // The host's own half of "a refusal is reported, never silent".
+        let refusals = gate.refusals();
+        assert_eq!(refusals.len(), 1);
+        assert_eq!(refusals[0].call, DriverCall::DeliverMerge);
+        assert_eq!(refusals[0].refusal, HostCallRefusal::Undeclared);
+    }
+
+    #[tokio::test]
+    async fn the_manifests_allowance_is_an_ask_and_the_host_clamps_it() {
+        let gate = DriverCallGate::declare(
+            grant(&[DriverCall::BacklogNext], Some(9_000)),
+            4,
+            Box::new(Serves),
+        );
+        assert_eq!(gate.max_calls(), 4);
+
+        let session = gate.open();
+        for _ in 0..4 {
+            assert!(matches!(
+                session.call(DriverCall::BacklogNext).await,
+                DriverCallOutcome::Ok(_)
+            ));
+        }
+        match session.call(DriverCall::BacklogNext).await {
+            DriverCallOutcome::Err(failure) => {
+                assert_eq!(failure.refusal, HostCallRefusal::AllowanceSpent);
+            }
+            DriverCallOutcome::Ok(_) => panic!("the ceiling did not hold"),
+        }
+    }
+
+    #[tokio::test]
+    async fn each_session_gets_a_fresh_allowance() {
+        let gate = DriverCallGate::declare(
+            grant(&[DriverCall::SweepAudit], Some(1)),
+            8,
+            Box::new(Serves),
+        );
+        for _ in 0..3 {
+            let session = gate.open();
+            assert!(matches!(
+                session.call(DriverCall::SweepAudit).await,
+                DriverCallOutcome::Ok(_)
+            ));
+        }
+        assert!(gate.refusals().is_empty());
+    }
+
+    #[tokio::test]
+    async fn this_host_serves_no_capability_yet_and_says_so() {
+        let gate = DriverCallGate::declare(
+            grant(&[DriverCall::WorkStart], None),
+            DEFAULT_DRIVER_MAX_CALLS,
+            Box::new(NoDriverCapabilities),
+        );
+        match gate.open().call(DriverCall::WorkStart).await {
+            DriverCallOutcome::Err(failure) => {
+                assert_eq!(failure.refusal, HostCallRefusal::Unsupported);
+                // The gap names the family and the epic, so a driver author
+                // reading the log knows which phase they are waiting on.
+                assert!(failure.detail.contains("work"), "{failure}");
+                assert!(failure.detail.contains("#3599"), "{failure}");
+            }
+            DriverCallOutcome::Ok(_) => panic!("a capability nothing implements was performed"),
+        }
+    }
+
+    #[test]
+    fn a_grant_that_can_never_be_served_offers_nothing() {
+        assert!(!DriverCallGate::declare(grant(&[], None), 8, Box::new(Serves)).offers_calls());
+        assert!(
+            DriverCallGate::declare(grant(&[DriverCall::CurateList], None), 8, Box::new(Serves))
+                .offers_calls()
+        );
+        // A zero ceiling the host itself imposed leaves nothing admissible, and
+        // the transport must be able to see that before it opens a session.
+        assert!(
+            !DriverCallGate::declare(grant(&[DriverCall::CurateList], None), 0, Box::new(Serves))
+                .offers_calls()
+        );
+    }
+}

--- a/crates/stella-runtime/src/wrapper/mod.rs
+++ b/crates/stella-runtime/src/wrapper/mod.rs
@@ -80,6 +80,7 @@
 
 mod child_turn;
 mod dispatch;
+mod driver_call;
 mod error;
 mod host_call;
 mod in_process;
@@ -97,6 +98,10 @@ pub use child_turn::{ChildTurnPlane, ChildTurnSpend, ChildTurns, DEFAULT_HOST_MA
 pub use dispatch::{
     DEFAULT_HOST_MAX_HOLDS, DispatchReport, DrivenTurn, RoundInput, TurnDriver, TurnPrelude,
     WrapperDispatch,
+};
+pub use driver_call::{
+    DEFAULT_DRIVER_MAX_CALLS, DriverCallGate, DriverCapabilities, DriverSession,
+    NoDriverCapabilities, RefusedDriverCall,
 };
 pub use error::WrapperError;
 pub use host_call::{

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -119,7 +119,7 @@
       "title": "Ultraudit round 3 \u2014 2026-08-04"
     },
     "backlog-self-driving": {
-      "path": "docs/design/backlog-self-driving.md",
+      "path": "docs/spec/backlog-self-driving.md",
       "sections": [
         0,
         1,
@@ -135,7 +135,7 @@
         11,
         12
       ],
-      "status": "proposed",
+      "status": "living",
       "title": "Backlog Self-Driving \u2014 the loop that owns a queue, not a task"
     },
     "brand": {

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -1,19 +1,25 @@
 ---
 id: backlog-self-driving
 title: "Backlog Self-Driving — the loop that owns a queue, not a task"
-status: proposed
+status: living
 ---
 
 # Backlog Self-Driving — the loop that owns a queue, not a task
 
-Status: proposal, unbuilt. Phases in §9.
+Status: **B0 built, B1–B7 designed and unbuilt.** Phases in §9. The driver
+channel §3.0 specifies exists — `stella_plugin::driver` is its wire half,
+`stella_runtime::wrapper::DriverCallGate` its host half, and
+`plugins/stella-selfdriving/plugin.toml` declares the `[driver]` grant a human
+reads at install. **No capability on it is served yet**: every one of the
+eighteen verbs §3.1–§3.5 names answers `unsupported` and the driver degrades,
+which is what B1–B6 land family by family.
 
-**Reads on top of:** [`doc:pipeline-as-plugins`](../spec/pipeline-as-plugins.md) §10
+**Reads on top of:** [`doc:pipeline-as-plugins`](pipeline-as-plugins.md) §10
 (self-driving is a *host*, not a wrapper — that decision is upstream of this
-document and is not reopened here); [`doc:wrapper-socket`](../spec/wrapper-socket.md)
+document and is not reopened here); [`doc:wrapper-socket`](wrapper-socket.md)
 §6b (the host-call channel — *"a plugin may ask, never reach"* — whose second
 dispatch context is the mechanism this design turns on, §2.1); and
-[`doc:agent-native-delivery`](agent-native-delivery.md) (the issue kernel, the
+[`doc:agent-native-delivery`](../design/agent-native-delivery.md) (the issue kernel, the
 provider manifests, and the residue gate — designed, unbuilt, and a hard
 dependency of §3.1 and §5).
 
@@ -74,14 +80,15 @@ Nothing below proposes changing it.
 
 | Capability | Where | State |
 |---|---|---|
-| The `Issue` kernel, provider manifests, `kind = "exec"` | [`doc:agent-native-delivery`](agent-native-delivery.md) §3–§4 | Design only. Epic closed `not_planned` under a freeze that has since lifted. |
-| The residue gate — a prose follow-up becomes undischargeable | [`doc:agent-native-delivery`](agent-native-delivery.md) §7 | Design only. This is the mechanism that makes "file new tickets" a *guarantee* rather than a habit. |
-| Backlog dedup + decay | [`doc:agent-native-delivery`](agent-native-delivery.md) §10.1 | Design only. |
-| Self-driving as a plugin that actually drives | #3546, [`doc:pipeline-as-plugins`](../spec/pipeline-as-plugins.md) §10 D6 | Manifest exists (`plugins/stella-selfdriving/plugin.toml`); it starts nothing, and could not drive anything if it did — §2.1. |
-| The host-call channel: `recall`, `child_turn`, `run_test` | `crates/stella-plugin/src/host_call.rs`, `crates/stella-runtime/src/wrapper/host_call.rs` | **Built** (#3590), and reachable only from inside a turn. The capability self-driving needs exists and is out of its reach. |
+| The `Issue` kernel, provider manifests, `kind = "exec"` | [`doc:agent-native-delivery`](../design/agent-native-delivery.md) §3–§4 | Design only. Epic closed `not_planned` under a freeze that has since lifted. |
+| The residue gate — a prose follow-up becomes undischargeable | [`doc:agent-native-delivery`](../design/agent-native-delivery.md) §7 | Design only. This is the mechanism that makes "file new tickets" a *guarantee* rather than a habit. |
+| Backlog dedup + decay | [`doc:agent-native-delivery`](../design/agent-native-delivery.md) §10.1 | Design only. |
+| Self-driving as a plugin that actually drives | #3546, [`doc:pipeline-as-plugins`](pipeline-as-plugins.md) §10 D6 | Manifest exists (`plugins/stella-selfdriving/plugin.toml`) and now declares a `[driver]` grant a human reads at install. It still starts nothing (B2), and every capability it declares answers `unsupported` (B1–B6) — but it **can** hold one, which it could not before B0. |
+| The host-call channel: `recall`, `child_turn`, `run_test` | `crates/stella-plugin/src/host_call.rs`, `crates/stella-runtime/src/wrapper/host_call.rs` | **Built** (#3590), and reachable only from inside a turn. |
+| The driver channel: the same apparatus, opened by a driver session | `crates/stella-plugin/src/driver.rs`, `crates/stella-runtime/src/wrapper/driver_call.rs` | **Built** (B0). A driver at grade `none` holds capability through `[driver]`, and an undeclared ask is refused with a code rather than a death. Serves no verb yet. |
 
 One correction to the record, because a design doc is a claim and not a fact:
-[`doc:agent-native-delivery`](agent-native-delivery.md) §11.1 used to land the
+[`doc:agent-native-delivery`](../design/agent-native-delivery.md) §11.1 used to land the
 provider transports in `stella-tools` "generalizing `issue_ops.rs`", a file
 that has never existed in this tree — `find . -name 'issue_ops*'` is empty.
 That phase starts from nothing, not from a refactor, which makes B1 below
@@ -120,8 +127,15 @@ why.
 
 ### 2.1 The plugin platform grants capability only to *in-turn* plugins
 
+> **Resolved by B0.** This section is the diagnosis as it stood before the
+> driver channel existed, kept because the argument for the channel's shape is
+> the argument for why the `Participation` ladder was the wrong place to fix
+> it. What follows is now history for the first half — `[driver]` grants
+> capability to a plugin at grade `none` — and still live for the second: the
+> channel exists and serves nothing yet.
+
 Self-driving already **is** a plugin. `plugins/stella-selfdriving/plugin.toml`
-exists, [`doc:pipeline-as-plugins`](../spec/pipeline-as-plugins.md) §10 chose
+exists, [`doc:pipeline-as-plugins`](pipeline-as-plugins.md) §10 chose
 *host* over *wrapper*, and #3546 tracks finishing the move. So "it should be a
 plugin" cannot be the missing step. The useful question is the next one down:
 **a plugin gets capability from the host by what mechanism, and does
@@ -224,7 +238,7 @@ plugin→ { "call": "backlog_next", "id": 1, "args": { "limit": 5 } }
 host  → { "result": 1, "ok": { "issues": [ … ] } }
 plugin→ { "call": "work_start",   "id": 2, "args": { "issue": "…" } }
 host  → { "result": 2, "ok": { "verdict": "…", "diff": … } }
-plugin→ { "point": "drive", "body": { "next": "sleep", "secs": 900 } }   ← ends it
+plugin→ { "point": "drive", "body": { "next": { "sleep": { "secs": 900 } } } }  ← ends it
 ```
 
 Three properties carried over deliberately, because each already earned its
@@ -258,10 +272,20 @@ Each of the five below is a variant on the driver channel's call enum, declared
 in the manifest's `[driver] calls` list, and refused with a `HostCallRefusal`
 code the driver can branch on when undeclared.
 
+**The `args` and `ok` tables in the sketch above are illustrative, and B0 ships
+neither.** A call is `{"call": …, "id": …}` and a served answer is
+`{"result": …, "ok": {}}`, because no verb is implemented yet and an argument
+table written ahead of the code that reads it is a wire contract nothing can
+be checked against — it would also change at the phase that implemented it, so
+the channel would break once per family. Each verb brings its own arguments and
+its own result, typed, in the phase that serves it. What B0 fixes in place is
+the part consent depends on: which capabilities exist, which of them a driver
+declared, and what a driver is told when it asks for one it did not.
+
 ### 3.1 `backlog` — the issue port
 
 The provider-agnostic replacement for three hardcoded `gh` call sites. Built on
-[`doc:agent-native-delivery`](agent-native-delivery.md) §3–§4 without
+[`doc:agent-native-delivery`](../design/agent-native-delivery.md) §3–§4 without
 modification: four states, four classes, title, description, comments, parent
 edge, and everything else in a source-tracked TOML manifest under
 `.stella/issues/`.
@@ -449,7 +473,7 @@ lens ever meant.
 
 This is the half the user singled out — *"re-auditing and verifying work is
 super important"* — and it is the strongest available answer to the
-[`doc:agent-native-delivery`](agent-native-delivery.md) §10.1 objection that an
+[`doc:agent-native-delivery`](../design/agent-native-delivery.md) §10.1 objection that an
 agent inflates a backlog faster than it drains one.
 
 When the loop closes an issue it records a **receipt** naming the witness test
@@ -475,7 +499,7 @@ Three things fall out, and all three are worth more than the sweep costs:
 
 **Infinite supply is not infinite value, and this design can produce a very
 expensive make-work machine.** The failure mode is real, it is named in
-[`doc:agent-native-delivery`](agent-native-delivery.md) §10.1, and no mechanism
+[`doc:agent-native-delivery`](../design/agent-native-delivery.md) §10.1, and no mechanism
 above prevents it on its own. Three mitigations, none of which is a solved
 problem:
 
@@ -501,7 +525,7 @@ queue-only.
 ## 5. Re-audit, and what makes a `done` falsifiable later
 
 §4.3 covers regression of *fixed* work. The other direction — work claimed done
-that was never really done — is [`doc:agent-native-delivery`](agent-native-delivery.md)
+that was never really done — is [`doc:agent-native-delivery`](../design/agent-native-delivery.md)
 §7's residue gate, and this design depends on it rather than restating it.
 
 The one thing worth adding here is *why it matters more for an autonomous loop
@@ -539,7 +563,7 @@ all three recorded in the ledger so `metrics` can fold spend against yield.
 ### 6.3 Concurrency
 
 Issue claims extend the fleet ledger's cooperative lease from paths to issue
-keys, exactly as [`doc:agent-native-delivery`](agent-native-delivery.md) §10.4
+keys, exactly as [`doc:agent-native-delivery`](../design/agent-native-delivery.md) §10.4
 prescribes. A tracker's assignee field is not a lock; the ledger's lease is one,
 it is cross-process, and it expires on its own.
 
@@ -553,7 +577,7 @@ that runs the loop:
    reach but not attach to.
 3. **Tracker** — a declared label on a declared issue. This is the one that
    matters, and it follows from
-   [`doc:agent-native-delivery`](agent-native-delivery.md) §2.2: in an
+   [`doc:agent-native-delivery`](../design/agent-native-delivery.md) §2.2: in an
    agent-only shop the tracker is where a human steers, so it must be able to
    stop the loop, not merely describe work to it.
 
@@ -635,12 +659,12 @@ its witness — a test that fails on `main` and passes with the change.
 
 | Phase | Deliverable | Witness | Unblocks |
 |---|---|---|---|
-| **B0** | **The driver channel** (§3.0). A second dispatch context for the existing host-call machinery, opened by a driver session rather than a wrapper point; a `[driver]` block with its own `calls` list; `permits_call` extended to it *without* touching the `Participation` ladder. `plugins/stella-selfdriving` becomes a program the host actually runs. | A driver whose manifest omits a call is refused it with a `HostCallRefusal` code and **keeps running**; a driver that declares it is served. Both directions, because either alone is half a gate. | everything below |
+| **B0** — **built** | **The driver channel** (§3.0). A second dispatch context for the existing host-call machinery, opened by a driver session rather than a wrapper point; a `[driver]` block with its own `calls` list and its own `permits_call`, *without* touching the `Participation` ladder; the grant rendered at install consent. `stella-plugin/src/driver.rs` is the wire half and `stella-runtime/src/wrapper/driver_call.rs` the host half. **A call carries no arguments and returns no payload yet** — no verb is implemented, so no argument or result table can be written honestly; each lands with the verb that needs it. `plugins/stella-selfdriving` declares its `[driver]` grant but is still not a program the host runs, which is B2. | `an_undeclared_call_is_refused_and_the_session_keeps_running` (`stella-runtime/src/wrapper/driver_call.rs`): a driver whose manifest omits a call is refused it with a `HostCallRefusal` code, is not charged for it, and **keeps running**; a declared one is served. Both directions, because either alone is half a gate. Plus `a_driver_holds_capabilities_without_a_participation_grade` (`stella-plugin/src/manifest.rs`) — the defect itself, that `participation = "none"` made every capability unreachable. | everything below |
 | **B1** | **The issue port.** `Issue` kernel in `stella-protocol`; `IssueProvider` port; GitHub as a shipped manifest under `.stella/issues/`; the `backlog` calls on the channel; the CLI's `queue` row reshaped, `HOST_SURFACE_VERSION` → 2. | The ranked queue is produced against a fixture provider with **no `gh` on `PATH`**. | "any issue provider" |
 | **B2** | **`work` + the loop step machine.** `LoopStep`/`step` pure in `stella-autonomy`; `work_start`/`work_status`/`work_abandon` served over the channel from `stella-cli`, built on the existing `child_turn` dispatcher rather than a second one; the plugin becomes a policy loop over declared calls; the eight slash commands and `scripts/self-driving.sh` retire **only after** `scripts/test-self-driving.sh` is green against the new path with every assertion intact. | One issue goes from `backlog next` to a verified diff with no Claude Code and no human. | the headline |
 | **B3** | **`deliver`.** `PrState` pure; open/observe/next/merge; `Escalated` reachable and terminal; `CiRed` vs `BaseBroken` distinguished. | A PR whose CI is red *on its base branch* transitions to `BaseBroken`, and the loop does not push a fix. |  PR rhythm (#2374's named weakness) |
 | **B4** | **Supply.** Ladder re-arm on baseline delta; `sweep regress` over closed-issue receipts; `sweep meta`. Per-supply switch, default queue-only. | A lens dry at `HEAD` re-opens after the declared baseline delta and yields **only** digests absent from `seen.txt`. | never runs out |
-| **B5** | **The residue gate** ([`doc:agent-native-delivery`](agent-native-delivery.md) §7) in `warn`, plus fingerprint dedup and decay. | A run stating a follow-up in prose and claiming `done` fails the gate; the same run with the item `filed` passes. | filing is a guarantee |
+| **B5** | **The residue gate** ([`doc:agent-native-delivery`](../design/agent-native-delivery.md) §7) in `warn`, plus fingerprint dedup and decay. | A run stating a follow-up in prose and claiming `done` fails the gate; the same run with the item `filed` passes. | filing is a guarantee |
 | **B6** | **`curate`.** Proposals from ledger evidence; acceptance gated on declared authority; `regulated` keeps the human on context records. | A skill proposal reaching the recurrence threshold is *proposed* and, under `regulated`, **not** applied. | self-curation |
 | **B7** | **`release`,** opt-in, gated on green `main` + quiet canary + derivable changelog. | Deliberately deferred — see §6.4. | shipping |
 
@@ -676,7 +700,7 @@ land early if the residue gate is wanted sooner than the autonomy.
 | The loop pushes a bad fix repeatedly | Repeat-failure counting in `PrState`; `Escalated` terminal | Low |
 | Spend runs away overnight | §6.2 three-tier ceilings, ledger-recorded | Low, once built |
 | Two workers on one issue | §6.3 ledger lease | Low — the primitive exists |
-| Tracker text as instruction | Issue text enters as data, never `directive` ([`doc:agent-native-delivery`](agent-native-delivery.md) §10.2) | Low |
+| Tracker text as instruction | Issue text enters as data, never `directive` ([`doc:agent-native-delivery`](../design/agent-native-delivery.md) §10.2) | Low |
 | Gate-gaming — the loop stops saying the sentences that trip the residue gate | §10.5's structural Pass 2; suppression telemetry | **Partly mitigable only** |
 | The loop merges something that breaks `main` | `main-canary.yml` files an issue; `sweep regress` catches the witness | Medium — the canary is post-merge by construction |
 | A regression sweep that is mostly flaky tests | Flakes are a finding about the test suite, filed as such | Medium |

--- a/docs/wire/wrapper.wire.json
+++ b/docs/wire/wrapper.wire.json
@@ -1,4 +1,79 @@
 {
+  "driver_calls": [
+    {
+      "case": "backlog_next",
+      "message": {
+        "call": "backlog_next",
+        "id": 1
+      }
+    }
+  ],
+  "driver_results": [
+    {
+      "case": "ok",
+      "message": {
+        "ok": {},
+        "result": 1
+      }
+    },
+    {
+      "case": "err/undeclared",
+      "message": {
+        "err": {
+          "detail": "this plugin's manifest does not declare \"deliver_merge\" in [driver] calls",
+          "refusal": "undeclared"
+        },
+        "result": 2
+      }
+    },
+    {
+      "case": "err/unsupported",
+      "message": {
+        "err": {
+          "detail": "B0 serves no capability yet",
+          "refusal": "unsupported"
+        },
+        "result": 3
+      }
+    }
+  ],
+  "driver_session": [
+    {
+      "case": "open",
+      "message": {
+        "body": {
+          "session": "cycle-7"
+        },
+        "point": "drive"
+      }
+    },
+    {
+      "case": "sleep",
+      "message": {
+        "body": {
+          "next": {
+            "sleep": {
+              "secs": 900
+            }
+          }
+        },
+        "point": "drive"
+      }
+    },
+    {
+      "case": "halt",
+      "message": {
+        "body": {
+          "next": {
+            "halt": {
+              "reason": "budget spent"
+            }
+          }
+        },
+        "point": "drive"
+      }
+    }
+  ],
   "host_calls": [
     {
       "case": "recall/full",
@@ -384,6 +459,26 @@
     }
   ],
   "vocabulary": {
+    "driver_call": [
+      "backlog_next",
+      "backlog_claim",
+      "backlog_file",
+      "backlog_close",
+      "backlog_link",
+      "work_start",
+      "work_status",
+      "work_abandon",
+      "deliver_open",
+      "deliver_observe",
+      "deliver_next",
+      "deliver_merge",
+      "sweep_audit",
+      "sweep_regress",
+      "sweep_meta",
+      "curate_propose",
+      "curate_list",
+      "curate_accept"
+    ],
     "flip_observation": [
       "not-attempted",
       "achieved",

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -86,3 +86,62 @@ scope = [
   "`stella run` once per cycle with the cycle prompt on stdin, under SELF_DRIVING_BUDGET_USD (default $10) per cycle — it does not ask before each one",
   "killing that cycle's whole process group on stop, so a `daemon stop` actually stops the spending",
 ]
+
+# ---------------------------------------------------------------------------
+# THE DRIVER GRANT — what this plugin may ask Stella to do while driving it.
+#
+# Everything above is a capability this plugin exercises ITSELF, as a process
+# on your machine holding your credentials. Everything below is the opposite
+# shape and the whole point of the driver channel: a capability Stella
+# performs ON REQUEST, having first checked this list. The plugin holds no
+# provider, no forge token and no worktree of its own — it asks, and it may
+# never reach (`doc:backlog-self-driving` §3.0, #3599 B0).
+#
+# This block is NOT a `[loop]` grade. Driving is a different axis from
+# in-turn influence: `participation = "none"` above stays the honest answer,
+# because this plugin still never runs inside a turn. It starts them.
+#
+# NOTHING BELOW IS SERVED YET. B0 is the channel; the capabilities land in
+# B1-B6, and until each one does, asking for it returns `unsupported` and the
+# loop degrades rather than dying. Declaring them here now is deliberate — a
+# grant is a consent document, and a user should read the whole shape of what
+# this loop will be permitted to do before any of it works, not discover it
+# one silent widening at a time.
+#
+# WHAT IS DELIBERATELY ABSENT, and why each is a decision rather than an
+# oversight:
+#   - `curate_accept` — this repository's governance mode is `regulated`, so a
+#     human stays on context-record promotion (§7). The loop may PROPOSE any
+#     authority and grant itself none.
+#   - any release verb — a release is the one action here that is
+#     irreversible, externally visible, and not fixable by another cycle
+#     (§6.4). It stays human by default and is not on the channel at all.
+[driver]
+calls = [
+  # backlog — the ranked queue, the claim, and filing what a cycle could not
+  # fix. This replaces three hardcoded `gh` call sites, which is why it is the
+  # first family built.
+  "backlog_next",
+  "backlog_claim",
+  "backlog_file",
+  "backlog_close",
+  "backlog_link",
+  # work — one issue through Stella's own staged pipeline, in an isolated
+  # worktree, with the pipeline's verdict as the definition of done.
+  "work_start",
+  "work_status",
+  "work_abandon",
+  # deliver — the PR rhythm. `deliver_merge` is gated on the pipeline's
+  # verdict, never on the loop's opinion of it.
+  "deliver_open",
+  "deliver_observe",
+  "deliver_next",
+  "deliver_merge",
+  # sweep — where the next question comes from when the queue runs dry.
+  "sweep_audit",
+  "sweep_regress",
+  "sweep_meta",
+  # curate — proposals only. See the note above on `curate_accept`.
+  "curate_propose",
+  "curate_list",
+]


### PR DESCRIPTION
#3599 B0, the load-bearing phase: until a driver-posture plugin can hold a
capability, none of B1-B7 can be built.

## The defect

`LoopGrant::permits_call` requires `participation >= Steering`, and a host call
may be made during `before_turn` or `after_turn` and nowhere else. Both are
conditions about standing *inside* a turn. A driver has no turn to stand in —
it is what starts them — so no grade on the `Participation` ladder would let it
in, and `plugins/stella-selfdriving`, which declares `participation = "none"`
honestly, was structurally unable to hold any capability at all. That is why
the judgement half of the loop ended up outside the product, in eight Claude
Code markdown files.

## The fix

A second dispatch context over the existing host-call machinery. Same
refusal-as-a-value discipline, same closed refusal codes (`HostCallRefusal` is
reused rather than mirrored — the reasons a host declines are properties of
asking, not of who asked), and a separate `[driver]` block with its own `calls`
list so the `Participation` ladder is neither extended nor renumbered. Widening
the ladder instead would have made `arbiter` — already "the strongest grant"
over a turn's completion — silently also mean "may merge to `main`".

- `crates/stella-plugin/src/driver.rs` — the wire half: `DriverCall` (the
  eighteen verbs `doc:backlog-self-driving` §3.1-§3.5 names, one variant per
  verb because invariant 9 governs a capability as it governs a tool),
  `DriverGrant` + `permits_call`, and the `drive` session framing over the same
  denying envelope `PluginMessage` uses.
- `crates/stella-runtime/src/wrapper/driver_call.rs` — the host half:
  `DriverCallGate`, a per-session allowance clamped against the host's ceiling,
  refusals recorded so a host can say what a driver did not get, and
  `NoDriverCapabilities` as this host's honest state.
- Install consent renders the driver grant by family, and — separately — now
  renders `[loop] calls` at all. `LoopGrant::calls` has always said a plugin
  "may not ask for a capability a human never read at install"; nothing printed
  it, so the second half of that sentence was not true.

## A call carries no arguments and returns no payload

Deliberate, and stated in the module header rather than left to be inferred. No
verb is implemented at B0, so no argument or result table can be typechecked
against anything — and each would change at the phase that implemented it,
breaking the channel once per family. What B0 fixes in place is the part
consent depends on: which capabilities exist, which of them a driver declared,
and what it is told when it asks for one it did not. `DriverOk` is an empty
denying table and grows a field per verb that has something to report.

## Witnesses

- `an_undeclared_call_is_refused_and_the_session_keeps_running`
  (`driver_call.rs`) — both directions, because either alone is half a gate: an
  undeclared capability is refused with a code the driver branches on, is not
  charged against the allowance, and the session is still served afterwards.
- `a_driver_holds_capabilities_without_a_participation_grade`
  (`manifest.rs`) — the defect itself: `participation = "none"` with a
  `[driver]` block now permits a call. Fails on main, where there is no block.
- `the_prompt_shows_the_driver_grant_and_its_deliberate_limits`
  (`self_driving_consent.rs`) — the grant reaches stdout before install, and
  the two deliberate absences (`curate_accept` under `regulated` governance, no
  release verb at all) are asserted rather than assumed.

`docs/design/backlog-self-driving.md` is promoted to `docs/spec/` — the
`design-refs` guard's own remedy, since code now cites it — with §1.2, §2.1,
§3.0 and §9's B0 row corrected to what is built versus designed.

`plugins/stella-selfdriving/plugin.toml` declares its `[driver]` grant. It is
still not a program the host runs: that is B2, and the transport that would
carry a session is filed as #3634.

Refs #3599, #3546

## Summary by Sourcery

Enable plugins to hold and request explicitly consented capabilities through a dedicated driver channel independent of turn participation.

New Features:
- Add a separate driver capability channel that allows plugins to request host capabilities outside turn participation.
- Support manifest-declared driver grants with per-session call limits and explicit refusal handling.
- Expose driver session and capability wire messages, including sleep and halt outcomes.
- Render driver capability grants and loop calls in installation consent prompts.

Bug Fixes:
- Allow plugins with participation grade `none` to hold driver capabilities without widening the participation ladder.
- Ensure undeclared or unsupported driver calls are returned as refusals without terminating the session or consuming the allowance.

Enhancements:
- Reuse host-call refusal codes and provide host-side tracking of refused driver calls.
- Keep driver capabilities explicitly separate from in-turn loop permissions and omit unimplemented capability payloads at B0.

Documentation:
- Promote the self-driving backlog specification to a living B0 specification and update its implementation status and references.

Tests:
- Add coverage for driver grant validation, wire framing, refusal behavior, session allowance resets, and consent disclosure.

Chores:
- Declare the self-driving plugin's driver grant while retaining deliberate restrictions on curation acceptance and release operations.