### PR TITLE
fix(stella-model): the cache-marker claim needs a prompt the provider would have stored

### DIFF
--- a/crates/stella-cli/src/cache_insight.rs
+++ b/crates/stella-cli/src/cache_insight.rs
@@ -278,6 +278,29 @@ mod tests {
         }
     }
 
+    /// The deck re-derives `diagnose_cache`'s gate by hand because
+    /// `stella-tui` cannot link the model tier, so its constants are copies —
+    /// and the module docs of `cache_economics` say plainly that nothing
+    /// cross-checks the two: "the deck will not fail if it isn't, it will
+    /// simply disagree". This crate links both, so it is the one place the
+    /// copies can be held together. Cheap, and it turns a silent divergence
+    /// into a red test.
+    #[test]
+    fn the_decks_copies_of_the_diagnosis_constants_match_the_model_tiers() {
+        assert_eq!(
+            stella_tui::cache_panel::MIN_CACHEABLE_PROMPT_TOKENS,
+            stella_model::MIN_CACHEABLE_PROMPT_TOKENS,
+            "the deck's cacheable floor drifted from the model tier's"
+        );
+        assert!(
+            (stella_tui::cache_panel::LOW_HIT_RATE_THRESHOLD
+                - crate::stats::LOW_HIT_RATE_THRESHOLD)
+                .abs()
+                < f64::EPSILON,
+            "the deck's low-hit bar drifted from `stella stats`'s"
+        );
+    }
+
     #[test]
     fn a_gateway_route_carries_its_upstreams_posture_not_the_gateways() {
         // The deck learns "is this cache opt-in?" only from this producer, so

--- a/crates/stella-cli/src/stats.rs
+++ b/crates/stella-cli/src/stats.rs
@@ -72,7 +72,7 @@ use crate::usage_cmd::parse_age_window;
 /// hit) a row earns a diagnosis line — matches
 /// `stella_model::cache_economics::diagnose_cache`'s own "~20%" acceptance
 /// bar.
-const LOW_HIT_RATE_THRESHOLD: f64 = 0.20;
+pub(crate) const LOW_HIT_RATE_THRESHOLD: f64 = 0.20;
 
 /// Subcommands under `stella stats`. Bare `stella stats` (no subcommand) is
 /// still the report — this only adds verbs that *write*.
@@ -276,6 +276,7 @@ fn session_diagnosis_lines(
                 CacheRoute {
                     provider: &s.provider,
                     model: &s.model,
+                    largest_prompt_tokens: s.largest_prompt_tokens.max(0) as u64,
                 },
                 s.turns.max(0) as u64,
                 s.input_tokens.max(0) as u64,
@@ -988,6 +989,11 @@ mod tests {
             provider: provider.into(),
             model: "a-model".into(),
             input_tokens: input,
+            // Over the cacheable floor: every case here is about the traffic
+            // counts, and a sub-floor prompt would (correctly) withhold the
+            // diagnosis before they were read — the case
+            // `a_sub_floor_session_earns_no_marker_claim` varies.
+            largest_prompt_tokens: 40_000,
             cache_read_tokens: cache_read,
             cache_write_tokens: cache_write,
         }
@@ -1005,6 +1011,22 @@ mod tests {
         assert!(
             lines[0].contains("cache opt-in never engaged"),
             "{}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn a_sub_floor_session_earns_no_marker_claim() {
+        // `stella stats` reads the same shape the deck banner did: many turns,
+        // 0% hit, no traffic — but nothing the provider would have stored. The
+        // honest answer is the weaker one.
+        let mut small = trend_row("s-small", "anthropic", 6, 6_600, 0, 0);
+        small.largest_prompt_tokens = 900;
+        let lines = session_diagnosis_lines(&[small], &HashMap::new());
+        assert_eq!(lines.len(), 1);
+        assert!(
+            !lines[0].contains("cache opt-in never engaged"),
+            "a sub-floor session cannot witness a missing marker: {}",
             lines[0]
         );
     }

--- a/crates/stella-model/src/cache_economics.rs
+++ b/crates/stella-model/src/cache_economics.rs
@@ -269,16 +269,43 @@ pub fn hit_rate(input_tokens: u64, cached_input_tokens: u64) -> f64 {
 /// the same provider's `anthropic/*` routes reported 10.9M writes over the
 /// same period. Reading the first as a missing marker put "likely a bug" on a
 /// route that was caching 89% of its input.
+/// Bedrock is the same shape one vendor over: its `cachePoint` blocks are
+/// gated to the model families that support them, so a Converse call to any
+/// other family carries no marker **by design** and can never report a write.
+/// The parity matrix already says so — "gated to supporting model families" —
+/// and this is that sentence made executable.
 #[must_use]
 pub fn route_cache_is_opt_in(provider: &str, model: &str) -> bool {
-    if provider == "openrouter" {
+    match provider {
         // The upstream vendor owns the posture; only Anthropic routes opt in.
         // An unrecognized upstream is treated as implicit — i.e. no claim —
-        // for the same reason the token floor above rounds down.
-        return model.starts_with("anthropic/");
+        // the same conservative direction the prompt floor below takes.
+        "openrouter" => model.starts_with("anthropic/"),
+        // Bedrock namespaces its families in the model id (`anthropic.claude-…`,
+        // `zai.glm-4.7`); only the Claude families get cachePoints.
+        "bedrock" => model.starts_with("anthropic.") || model.contains("claude"),
+        _ => matches!(cache_posture(provider), Some(CachePosture::OptIn { .. })),
     }
-    matches!(cache_posture(provider), Some(CachePosture::OptIn { .. }))
 }
+
+/// The smallest prompt an opt-in cache will store. Below it the provider
+/// caches nothing however correct the marker is, so zero traffic says nothing
+/// about whether the marker engaged — which is the whole content of
+/// [`CacheCause::OptInNeverEngaged`].
+///
+/// Anthropic's documented floor is 1024 tokens (2048 on the smallest models);
+/// this takes the lower of the two, because the constant only ever *withholds*
+/// a claim — being wrong low costs a diagnosis that was already uncertain,
+/// being wrong high restores a false positive.
+///
+/// Witnessed on the opt-in routes in a real store, bucketed by **full prompt**
+/// ([`CacheRoute::largest_prompt_tokens`] — see there for why that is not
+/// `input_tokens`): of 1274 calls at or over the floor, 1240 wrote; of 29
+/// calls under it, **zero** wrote and zero read. Measuring `input_tokens`
+/// alone instead put a 4543-token prompt in the "under 1024" bucket — it
+/// reported `input_tokens: 2` and 4541 write tokens — and that single
+/// mis-bucketed row was enough to make this floor look refuted.
+pub const MIN_CACHEABLE_PROMPT_TOKENS: u64 = 1024;
 
 /// The route a diagnosis is about, plus the one size fact it needs. Grouped
 /// rather than passed as three more positional arguments to two functions:
@@ -292,6 +319,17 @@ pub struct CacheRoute<'a> {
     /// route, which is what decides the cache posture
     /// ([`route_cache_is_opt_in`]).
     pub model: &'a str,
+    /// The largest **full prompt** the session presented to this route:
+    /// `input_tokens + cache_write_tokens` for the single largest call, not
+    /// the running sum and not `input_tokens` alone.
+    ///
+    /// Both corrections are load-bearing. Caching is decided per call against
+    /// [`MIN_CACHEABLE_PROMPT_TOKENS`], so summing a hundred small calls would
+    /// claim they should have cached; and the Anthropic family reports cache
+    /// *writes* outside `input_tokens`, so a large first call arrives here as
+    /// a tiny `input_tokens` beside a large `cache_write_tokens` and reads as
+    /// sub-floor unless the two are added back together.
+    pub largest_prompt_tokens: u64,
 }
 
 /// Name the probable cause of a low cache hit rate, or `None` when there is
@@ -302,13 +340,15 @@ pub struct CacheRoute<'a> {
 /// have *established* a cache to hit (`turns > MIN_TURNS`) and the hit rate is
 /// genuinely under `threshold`. The discriminator between the two opt-in
 /// failure modes is **cache traffic**, not the hit rate:
-///  - opt-in route that over the turns wrote nothing *and read nothing* →
-///    the marker never reached the wire ([`CacheCause::OptInNeverEngaged`]);
-///  - otherwise (any traffic at all, or an implicit-cache route) a low hit
-///    rate is the prefix being rewritten or expiring between turns
-///    ([`CacheCause::PrefixInstability`]).
+///  - opt-in route that over the turns wrote nothing *and read nothing*,
+///    having presented a prompt big enough to cache → the marker never
+///    reached the wire ([`CacheCause::OptInNeverEngaged`]);
+///  - otherwise (any traffic at all, an implicit-cache route, or nothing over
+///    the cacheable floor) a low hit rate is the prefix being rewritten or
+///    expiring between turns ([`CacheCause::PrefixInstability`]).
 ///
-/// Both halves of "no traffic" are required — see the inline note at the
+/// All three conditions are required, and each was added after the missing
+/// one produced a confident wrong answer — see the inline notes at the
 /// discriminator.
 ///
 /// This token-only form cannot see wall-clock gaps, so it never returns
@@ -337,7 +377,8 @@ pub fn diagnose_cache(
     }
 
     let is_opt_in = route_cache_is_opt_in(route.provider, route.model);
-    if is_opt_in && cache_write_tokens == 0 && cached_input_tokens == 0 {
+    let could_have_cached = route.largest_prompt_tokens >= MIN_CACHEABLE_PROMPT_TOKENS;
+    if is_opt_in && could_have_cached && cache_write_tokens == 0 && cached_input_tokens == 0 {
         // The provider caches nothing without an explicit marker, nothing was
         // ever written, AND nothing was ever read — the opt-in never engaged.
         //
@@ -362,8 +403,11 @@ pub fn diagnose_cache(
         // ([`route_cache_is_opt_in`]) — it was true forever on a route whose
         // gateway reports no writes at all, and the deck told its reader the
         // marker was missing and every token billing at the full input rate,
-        // of a route with a lifetime 89% hit rate. Evidence that cannot
-        // distinguish a claim from its opposite is not evidence for either.
+        // of a route with a lifetime 89% hit rate. Nor does it say anything
+        // about a session that never presented a prompt the provider would
+        // store ([`MIN_CACHEABLE_PROMPT_TOKENS`]), where zero traffic is what
+        // a CORRECTLY sent marker produces. Evidence that cannot distinguish
+        // a claim from its opposite is not evidence for either.
         return Some(CacheCause::OptInNeverEngaged);
     }
     Some(CacheCause::PrefixInstability)
@@ -620,6 +664,7 @@ mod tests {
         CacheRoute {
             provider,
             model: "a-model",
+            largest_prompt_tokens: 40_000,
         }
     }
 
@@ -727,6 +772,7 @@ mod tests {
         let kimi = CacheRoute {
             provider: "openrouter",
             model: "moonshotai/kimi-k3",
+            largest_prompt_tokens: 40_000,
         };
         assert_eq!(
             diagnose_cache(kimi, 6, 120_000, 0, 0, 0.20),
@@ -740,6 +786,7 @@ mod tests {
         let claude = CacheRoute {
             provider: "openrouter",
             model: "anthropic/claude-sonnet-5",
+            largest_prompt_tokens: 40_000,
         };
         assert_eq!(
             diagnose_cache(claude, 6, 120_000, 0, 0, 0.20),
@@ -756,6 +803,44 @@ mod tests {
         // A direct vendor's own posture is untouched by the gateway rule.
         assert!(route_cache_is_opt_in("anthropic", "claude-sonnet-5"));
         assert!(!route_cache_is_opt_in("zai", "glm-5.2"));
+        // Bedrock is the same shape: cachePoints are gated to the Claude
+        // families, so a Converse call to any other one carries no marker BY
+        // DESIGN and can never report a write. Two `bedrock` / `zai.glm-4.7`
+        // calls in a real store confirm it: 1742 and 1699 tokens, no writes.
+        assert!(route_cache_is_opt_in(
+            "bedrock",
+            "anthropic.claude-sonnet-5-v1:0"
+        ));
+        assert!(!route_cache_is_opt_in("bedrock", "zai.glm-4.7"));
+    }
+
+    #[test]
+    fn a_session_under_the_cacheable_floor_cannot_witness_a_missing_marker() {
+        // Nothing this small is stored by any opt-in cache, so zero traffic is
+        // exactly what a CORRECTLY sent marker produces — the strong claim is
+        // not available. Witnessed on the opt-in routes of a real store: 29
+        // calls under the floor, zero writes and zero reads between them.
+        let young = CacheRoute {
+            provider: "anthropic",
+            model: "claude-sonnet-5",
+            largest_prompt_tokens: MIN_CACHEABLE_PROMPT_TOKENS - 1,
+        };
+        assert_eq!(
+            diagnose_cache(young, 6, 6_600, 0, 0, 0.20),
+            Some(CacheCause::PrefixInstability),
+        );
+
+        // One call at the floor restores it: something cacheable was
+        // presented and an opt-in route reported no traffic at all. Of 1274
+        // such calls in that same store, 1240 wrote.
+        let cacheable = CacheRoute {
+            largest_prompt_tokens: MIN_CACHEABLE_PROMPT_TOKENS,
+            ..young
+        };
+        assert_eq!(
+            diagnose_cache(cacheable, 6, 6_600, 0, 0, 0.20),
+            Some(CacheCause::OptInNeverEngaged)
+        );
     }
 
     #[test]

--- a/crates/stella-model/src/lib.rs
+++ b/crates/stella-model/src/lib.rs
@@ -57,9 +57,10 @@ pub mod vertex;
 pub mod zai;
 
 pub use cache_economics::{
-    CacheRoute, CacheTtl, CacheWarmth, cache_write_premium_multiplier, configured_cache_ttl_secs,
-    diagnose_cache, diagnose_cache_with_idle, hit_rate as cache_hit_rate, is_cache_expired_rewrite,
-    provider_cache_ttl_secs, provider_honors_cache_ttl, route_cache_is_opt_in,
+    CacheRoute, CacheTtl, CacheWarmth, MIN_CACHEABLE_PROMPT_TOKENS, cache_write_premium_multiplier,
+    configured_cache_ttl_secs, diagnose_cache, diagnose_cache_with_idle,
+    hit_rate as cache_hit_rate, is_cache_expired_rewrite, provider_cache_ttl_secs,
+    provider_honors_cache_ttl, route_cache_is_opt_in,
 };
 pub use catalog::{Catalog, CatalogEntry, Pricing, ToolDialect};
 pub use credential::{ApiKey, AuxCredentials, CredentialError};

--- a/crates/stella-store/src/cache_trend.rs
+++ b/crates/stella-store/src/cache_trend.rs
@@ -39,6 +39,14 @@ pub struct SessionCacheTrendRow {
     /// the diagnosis cannot resolve it from the provider alone.
     pub model: String,
     pub input_tokens: i64,
+    /// The largest single call's **full prompt** in the session —
+    /// `input_tokens + cache_write_tokens` for one telemetry row, maximized
+    /// over the session, never summed. The cache floor is a per-call
+    /// question, and the Anthropic family reports writes outside
+    /// `input_tokens`, so neither the sum nor `input_tokens` alone answers
+    /// it. Policy (what the floor *is*) stays in `stella-model`; this is the
+    /// fact it needs.
+    pub largest_prompt_tokens: i64,
     pub cache_read_tokens: i64,
     pub cache_write_tokens: i64,
 }
@@ -68,6 +76,8 @@ impl Store {
                        WHERE ex.session_id = e.session_id
                        ORDER BY ex.id ASC LIMIT 1) AS model,
                     CAST(coalesce(sum(t.input_tokens), 0) AS INTEGER) AS input_tokens,
+                    CAST(coalesce(max(t.largest_prompt_tokens), 0) AS INTEGER)
+                      AS largest_prompt_tokens,
                     CAST(coalesce(sum(t.cache_read_tokens), 0) AS INTEGER) AS cache_read_tokens,
                     CAST(coalesce(sum(t.cache_write_tokens), 0) AS INTEGER) AS cache_write_tokens,
                     min(e.id) AS first_id
@@ -75,6 +85,7 @@ impl Store {
              LEFT JOIN (
                SELECT execution_id,
                       sum(input_tokens) AS input_tokens,
+                      max(input_tokens + cache_write_tokens) AS largest_prompt_tokens,
                       sum(cache_read_tokens) AS cache_read_tokens,
                       sum(cache_write_tokens) AS cache_write_tokens
                FROM telemetry
@@ -92,8 +103,9 @@ impl Store {
                 provider: row.get(3)?,
                 model: row.get(4)?,
                 input_tokens: row.get(5)?,
-                cache_read_tokens: row.get(6)?,
-                cache_write_tokens: row.get(7)?,
+                largest_prompt_tokens: row.get(6)?,
+                cache_read_tokens: row.get(7)?,
+                cache_write_tokens: row.get(8)?,
             })
         })?;
         let mut out = Vec::new();
@@ -126,6 +138,43 @@ mod tests {
             tool_calls: 0,
             usage_complete: true,
         }
+    }
+
+    #[test]
+    fn largest_prompt_is_one_calls_input_plus_its_writes_never_a_sum() {
+        // Both halves of this matter to the cache-floor question upstream, and
+        // both were got wrong once. A hundred small calls must not add up to a
+        // large prompt (the floor is per call), and a call reporting a tiny
+        // `input_tokens` beside a large `cache_write_tokens` IS a large
+        // prompt — the Anthropic family reports writes outside the input
+        // count, which is how a 4543-token prompt reads as 2 tokens.
+        let store = Store::in_memory().unwrap();
+        let e1 = store
+            .begin_execution("run", "p", "anthropic", "claude")
+            .unwrap();
+        store.set_execution_session(e1, "s").unwrap();
+        // Three ordinary small calls: input 1_000 each (the helper's shape).
+        for step in 0..3 {
+            let mut call = telemetry(0, 0);
+            call.step = step;
+            store.record_telemetry(e1, &call).unwrap();
+        }
+        // One call whose prompt lives almost entirely in the write column.
+        let mut mostly_written = telemetry(0, 4_541);
+        mostly_written.step = 3;
+        mostly_written.input_tokens = 2;
+        store.record_telemetry(e1, &mostly_written).unwrap();
+
+        let rows = store.session_cache_trend().unwrap();
+        let row = rows.iter().find(|r| r.session_id == "s").unwrap();
+        assert_eq!(
+            row.largest_prompt_tokens, 4_543,
+            "the full prompt of the single largest call: 2 input + 4541 written"
+        );
+        assert!(
+            row.largest_prompt_tokens < row.input_tokens + row.cache_write_tokens,
+            "and it is a maximum, not the session's summed traffic"
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/cache_panel.rs
+++ b/crates/stella-tui/src/cache_panel.rs
@@ -24,6 +24,14 @@ use crate::theme;
 /// `stella stats`.
 pub const LOW_HIT_RATE_THRESHOLD: f64 = 0.20;
 
+/// The smallest prompt an opt-in cache stores — mirrors
+/// `stella_model::cache_economics::MIN_CACHEABLE_PROMPT_TOKENS`, which carries
+/// the evidence. Duplicated for the same reason the threshold above is: the
+/// deck cannot link the model-tier crate. The two must move together, and
+/// `stella-cli` (which links both) holds them to it in
+/// `the_decks_copies_of_the_diagnosis_constants_match_the_model_tiers`.
+pub const MIN_CACHEABLE_PROMPT_TOKENS: u64 = 1024;
+
 impl AgentEntry {
     /// Seconds of prompt-cache warmth remaining: how long until this agent's
     /// cached prefix expires, from its provider TTL minus the idle since the
@@ -78,7 +86,13 @@ impl AgentEntry {
         // printed beside it is worse than silence: it sends the reader
         // hunting for a defect that is not there, and teaches them to
         // disregard the next one.
+        //
+        // And nothing under the cacheable floor is stored by any opt-in
+        // provider, so zero traffic there is what a CORRECTLY sent marker
+        // produces — the reading that put this banner under a live session
+        // whose route was caching 89% of its input.
         if self.cache_is_opt_in_provider
+            && self.largest_prompt_tokens >= MIN_CACHEABLE_PROMPT_TOKENS
             && self.cache_write_tokens == 0
             && self.cache_read_tokens == 0
         {
@@ -238,7 +252,79 @@ mod tests {
         a.cache_write_tokens = cache_write_tokens;
         a.cache_call_count = cache_call_count;
         a.cache_is_opt_in_provider = is_opt_in;
+        // Comfortably cacheable unless a case says otherwise — every legacy
+        // case here is about the traffic counts, and a sub-floor prompt
+        // (correctly) withholds the marker claim before they are read.
+        a.largest_prompt_tokens = 40_000;
         m.agents.remove(0)
+    }
+
+    #[test]
+    fn a_sub_floor_fan_out_is_not_accused_of_a_missing_marker() {
+        // The reported session, replayed: seven calls, none of whose prompts
+        // any opt-in cache would store, zero reads and zero writes. That is
+        // what a CORRECTLY sent marker produces at this size, so the banner
+        // must not claim the marker was missing.
+        let mut small = entry(7_000, 0, 0, 7, true);
+        small.largest_prompt_tokens = 1_000;
+        assert_eq!(
+            small.cache_diagnosis(0.20),
+            Some(CacheCause::PrefixInstability)
+        );
+
+        // The same session once one call clears the floor: an opt-in route
+        // that stored nothing is a marker that never engaged.
+        let mut cacheable = entry(7_000, 0, 0, 7, true);
+        cacheable.largest_prompt_tokens = MIN_CACHEABLE_PROMPT_TOKENS;
+        assert_eq!(
+            cacheable.cache_diagnosis(0.20),
+            Some(CacheCause::OptInNeverEngaged)
+        );
+    }
+
+    #[test]
+    fn the_fold_takes_the_largest_full_prompt_not_the_running_sum() {
+        // Writes ride outside `input_tokens` on the Anthropic family, so the
+        // fold must add them back per call — and must maximize, since the
+        // floor is a per-call question. Three 1000-token calls are not a
+        // 3000-token prompt.
+        let mut m = WorkspaceModel::new();
+        m.apply_inbound(&crate::envelope::Inbound::Register(
+            crate::envelope::AgentMeta::new("lead", "goal", 0),
+        ));
+        let step = |input: u64, write: u64| crate::envelope::Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::StepUsage {
+                upstream_provider: None,
+                reasoning_tokens: None,
+                output_text: None,
+                step: 1,
+                role: stella_protocol::event::ModelCallRole::Worker,
+                provider: "anthropic".into(),
+                model: "claude-sonnet-5".into(),
+                input_tokens: input,
+                output_tokens: 0,
+                cached_input_tokens: 0,
+                cache_write_tokens: write,
+                estimated_input_tokens: 0,
+                cost_usd: 0.0,
+                duration_ms: 1,
+                retries: 0,
+                tool_calls: 0,
+                complete: true,
+                finish_reason: None,
+            },
+        };
+        m.apply_inbound(&step(1_000, 0));
+        m.apply_inbound(&step(1_000, 0));
+        m.apply_inbound(&step(1_000, 0));
+        assert_eq!(
+            m.agents[0].largest_prompt_tokens, 1_000,
+            "maximum, not the 3000-token sum"
+        );
+        // One call reporting almost its whole prompt in the write column.
+        m.apply_inbound(&step(2, 4_541));
+        assert_eq!(m.agents[0].largest_prompt_tokens, 4_543);
     }
 
     #[test]
@@ -397,6 +483,10 @@ mod tests {
             a.tokens_in = 40_000;
             a.cache_call_count = 5;
             a.cache_is_opt_in_provider = true;
+            // A prompt the provider would have stored — without it the honest
+            // answer is the weaker `PrefixInstability`, and this row is about
+            // the marker claim specifically.
+            a.largest_prompt_tokens = 40_000;
         }
         let ui = DeckUi::default();
         // Three rows: the label/value pair, then the earned diagnosis — the

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -139,6 +139,14 @@ pub struct AgentEntry {
     /// `turns` a low-hit-rate diagnosis needs enough of before a 0% hit rate
     /// is meaningful (turn 1 always writes, never reads).
     pub cache_call_count: u64,
+    /// The largest **full prompt** this agent has presented —
+    /// `input_tokens + cache_write_tokens` of one call, maximized over the
+    /// session. Below the cacheable floor an opt-in provider stores nothing,
+    /// so zero cache traffic is what a CORRECTLY sent marker produces and
+    /// [`Self::cache_diagnosis`] must not read it as a missing one. Mirrors
+    /// `stella_model::cache_economics::CacheRoute::largest_prompt_tokens`,
+    /// which carries the reasoning for both corrections.
+    pub largest_prompt_tokens: u64,
     /// Wall-clock ms of the agent's most recent metered model call (a
     /// `StepUsage`) — the anchor the cache-warmth countdown measures idle from.
     /// `None` before any call has landed.
@@ -247,6 +255,7 @@ impl AgentEntry {
             cache_ttl_secs: 0,
             cache_is_opt_in_provider: false,
             cache_call_count: 0,
+            largest_prompt_tokens: 0,
             last_provider_call_ms: None,
             max_idle_gap_secs: 0,
             context_tokens: 0,
@@ -689,6 +698,7 @@ impl WorkspaceModel {
                     entry.cache_ttl_secs = 0;
                     entry.cache_is_opt_in_provider = false;
                     entry.cache_call_count = 0;
+                    entry.largest_prompt_tokens = 0;
                     entry.last_provider_call_ms = None;
                     entry.max_idle_gap_secs = 0;
                     entry.context_tokens = 0;
@@ -823,6 +833,14 @@ impl WorkspaceModel {
                     entry.cache_read_tokens += cached_input_tokens;
                     entry.cache_write_tokens += cache_write_tokens;
                     entry.cache_call_count += 1;
+                    // The FULL prompt of this call — writes are reported
+                    // outside `input_tokens` on the Anthropic family, so a
+                    // large first call arrives as a tiny input beside a large
+                    // write. Maximized, never summed: the cacheable floor is a
+                    // per-call question. See `cache_diagnosis`.
+                    entry.largest_prompt_tokens = entry
+                        .largest_prompt_tokens
+                        .max(input_tokens + cache_write_tokens);
                     // A metered call just landed — fold the idle it closes
                     // (the gap the diagnosis reads), then anchor the
                     // cache-warmth countdown here (the prefix is warmest


### PR DESCRIPTION
Second half of the `cache opt-in never engaged` false positive. #3610 fixed the
route half and merged; this is the half that was still in flight when it did.

## Problem

An opt-in route reporting no cache traffic is only evidence of a missing marker
if something cacheable was ever presented. Below the provider's floor nothing is
stored however correct the marker is — so zero reads and zero writes are exactly
what a **correctly sent** marker produces, and the banner's "none was sent
(likely a bug); every token billed at the full input rate" is unfalsifiable
there.

## Evidence

Witnessed on the opt-in routes of a real store, bucketed by full prompt:

| full prompt | calls | wrote | read |
|---|---|---|---|
| ≥ 1024 | 1274 | 1240 (97%) | 1083 |
| < 1024 | 29 | **0** | **0** |

## Two corrections that make it measurable

I got both wrong on the first attempt, and the first attempt was withdrawn as
"refuted by the data" because of the second:

- **The full prompt is `input_tokens + cache_write_tokens`.** The Anthropic
  family reports cache writes *outside* the input count, so a 4543-token prompt
  arrives as `input_tokens: 2` beside 4541 write tokens. Bucketing on
  `input_tokens` alone put that row under the floor and made a correct floor
  look false.
- **It is maximized per call, never summed.** The floor is a per-call question;
  a hundred small calls are not one large prompt.

## Also: Bedrock is route-dependent too

Same shape as the gateway fix one vendor over — `cachePoint` blocks are gated to
the Claude families, so `bedrock` / `zai.glm-4.7` carries no marker **by design**
and can never report a write. The parity matrix already said so in prose ("gated
to supporting model families"); this makes it executable. Two such calls in that
store (1742 and 1699 tokens, no writes) are what surfaced it.

## Constants live in two places, and now they are held together

The deck re-derives this gate by hand because `stella-tui` cannot link the model
tier, so it folds its own `largest_prompt_tokens` and carries its own copy of the
floor. `cache_economics`'s module docs already warned that nothing cross-checks
the two — "the deck will not fail if it isn't, it will simply disagree".
`stella-cli` links both, so it now fails if they drift
(`the_decks_copies_of_the_diagnosis_constants_match_the_model_tiers`).

## Witnesses

Each checked by reverting the condition, seeing it fail, restoring it, seeing it
pass:

| test | crate | proves |
|---|---|---|
| `a_session_under_the_cacheable_floor_cannot_witness_a_missing_marker` | stella-model | sub-floor withholds the claim; one call at the floor restores it |
| `a_sub_floor_fan_out_is_not_accused_of_a_missing_marker` | stella-tui | the reported session, replayed through the deck's own gate |
| `the_fold_takes_the_largest_full_prompt_not_the_running_sum` | stella-tui | 3×1000 folds to 1000; `(2 input, 4541 write)` folds to 4543 |
| `largest_prompt_is_one_calls_input_plus_its_writes_never_a_sum` | stella-store | the same two corrections in SQL |
| the bedrock arm of `a_gateway_route_to_an_implicit_upstream_is_never_opt_in_never_engaged` | stella-model | `bedrock`/`zai.glm-4.7` is not opt-in; `anthropic.*` still is |

`make gate` green over the four touched crates; full workspace tests green
against this base.

Closes #3609

## Summary by Sourcery

Make cache-marker diagnosis require evidence that an opt-in provider had a prompt large enough to store before reporting a missing marker.

Bug Fixes:
- Prevent cache opt-in diagnostics from falsely reporting missing markers when sessions never present a provider-cacheable prompt.
- Correct cache eligibility tracking to use the largest per-call full prompt, including cache-write tokens, rather than aggregated or input-only counts.
- Make Bedrock cache opt-in detection specific to supported Anthropic/Claude model families.

Enhancements:
- Propagate largest prompt measurements through model, UI, store, and CLI cache diagnostics.
- Keep duplicated cache diagnosis constants synchronized with a cross-crate regression test.

Tests:
- Add regression coverage for sub-floor sessions, per-call prompt maxima, Anthropic write-token accounting, Bedrock route eligibility, and constant synchronization.