### PR TITLE
feat(stella-cli): offer markdown→TOML slash-command conversion once per workspace

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -72,8 +72,8 @@ pub(crate) use goal::*;
 pub(crate) use graph::spawn_session_graph;
 #[cfg(test)]
 use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
-pub(crate) use init::{InitIo, init_workspace};
 pub use init::run_init;
+pub(crate) use init::{InitIo, init_workspace};
 use outcome::{
     VerificationRequirement, pipeline_episode_outcome, pipeline_failure_reason,
     pipeline_session_status, pipeline_status_label, pipeline_status_result,

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -72,7 +72,7 @@ pub(crate) use goal::*;
 pub(crate) use graph::spawn_session_graph;
 #[cfg(test)]
 use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
-pub(crate) use init::init_workspace;
+pub(crate) use init::{InitIo, init_workspace};
 pub use init::run_init;
 use outcome::{
     VerificationRequirement, pipeline_episode_outcome, pipeline_failure_reason,
@@ -832,13 +832,13 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         }
         if input == "/init" {
             println!();
-            let mut emit = |line: String| println!("  {line}");
+            let mut io = init::InitIo::stdout_tty();
             match init_workspace(
                 Some(&*provider),
                 &cfg.workspace_root,
                 Some(&cfg.model_id),
                 remaining_budget(&budget),
-                &mut emit,
+                &mut io,
             )
             .await
             {

--- a/crates/stella-cli/src/agent/init.rs
+++ b/crates/stella-cli/src/agent/init.rs
@@ -14,6 +14,51 @@
 use super::graph::build_code_graph;
 use super::*;
 use crate::domains::{cached_taxonomy, summarize_repo};
+use crate::interactive::{AskUserIo, TtyAskUserIo};
+
+/// How init talks to the user: the progress transcript it writes, and the
+/// questions it is allowed to ask.
+///
+/// These travel together because they are two halves of one thing — the
+/// surface the human is looking at — and every surface answers both at once.
+/// The plain CLI prints to stdout and reads stdin; the Command Deck routes
+/// both through its own channels, and a `TtyAskUserIo` there would print
+/// straight through the full-screen render. Passing them as one injected
+/// seam is also what keeps `init_workspace`'s arity fixed, which matters
+/// concretely: both of its interactive call sites live in files closed to
+/// growth (`agent.rs`, `command_deck.rs`).
+///
+/// `ask` is `None` exactly when nobody can answer — a piped or redirected
+/// run. Init never derives that itself; the surface knows, and a second
+/// derivation is how two consumers end up disagreeing about whether anyone
+/// is listening.
+pub(crate) struct InitIo<'a> {
+    emit: Box<dyn FnMut(String) + 'a>,
+    ask: Option<&'a dyn AskUserIo>,
+}
+
+impl<'a> InitIo<'a> {
+    /// An io over a caller-supplied transcript sink and question channel.
+    pub(crate) fn new(emit: impl FnMut(String) + 'a, ask: Option<&'a dyn AskUserIo>) -> Self {
+        Self {
+            emit: Box::new(emit),
+            ask,
+        }
+    }
+
+    /// The plain-CLI io: the indented stdout transcript both `stella init`
+    /// and the non-deck REPL's `/init` print, with TTY questions enabled
+    /// only when [`crate::interactive::human_is_present`] says someone can
+    /// answer them.
+    pub(crate) fn stdout_tty() -> InitIo<'static> {
+        let ask: Option<&'static dyn AskUserIo> =
+            crate::interactive::human_is_present(true).then_some(&TtyAskUserIo);
+        InitIo {
+            emit: Box::new(|line: String| println!("  {line}")),
+            ask,
+        }
+    }
+}
 
 /// The domain step of init, wearing the #3102 inference-skip gate: a
 /// model-inferred taxonomy whose recorded repo-shape fingerprint still
@@ -62,8 +107,10 @@ pub(crate) async fn init_workspace(
     workspace_root: &std::path::Path,
     model_hint: Option<&str>,
     budget_limit: Option<f64>,
-    emit: &mut dyn FnMut(String),
+    io: &mut InitIo<'_>,
 ) -> Result<(Domains, f64), String> {
+    let InitIo { emit, ask } = io;
+    let emit: &mut dyn FnMut(String) = &mut **emit;
     let (domains, inference_cost_usd) =
         resolve_domains(provider, workspace_root, model_hint, budget_limit, emit).await;
 
@@ -75,6 +122,16 @@ pub(crate) async fn init_workspace(
     // `.agents/` (workspace + user scope) as symlinks into stella's own
     // directories — idempotent, never clobbers, never fatal.
     crate::extensions::sync_extensions(workspace_root, emit);
+
+    // Then, once — and only once per workspace — offer to convert the
+    // markdown definitions just adopted into TOML, the format the rest of
+    // stella's config speaks. This runs AFTER the sync deliberately: the
+    // definitions worth converting are largely the ones the sync just
+    // linked, and asking before they exist would spend the single ask this
+    // workspace gets on an empty directory. It never converts on its own —
+    // see `crate::commands_offer` for why that trade stays the user's.
+    let user_root = crate::extensions::user_config_root();
+    crate::commands_offer::offer_conversion(workspace_root, user_root.as_deref(), *ask, emit).await;
 
     let path = domains.save(workspace_root)?;
 
@@ -143,13 +200,13 @@ pub async fn run_init(
             }
         };
 
-    let mut emit = |line: String| println!("  {line}");
+    let mut io = InitIo::stdout_tty();
     let (domains, _inference_cost_usd) = init_workspace(
         provider.as_deref(),
         &workspace_root,
         model_hint.as_deref(),
         None,
-        &mut emit,
+        &mut io,
     )
     .await?;
 

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -97,8 +97,8 @@ use crate::{agent, rules};
 
 mod add_dir;
 mod authoring;
-mod init_cmd;
 pub(crate) mod forwarder;
+mod init_cmd;
 mod lead_control;
 mod model_cmd;
 mod pr_observe;

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -97,6 +97,7 @@ use crate::{agent, rules};
 
 mod add_dir;
 mod authoring;
+mod init_cmd;
 pub(crate) mod forwarder;
 mod lead_control;
 mod model_cmd;
@@ -1393,6 +1394,7 @@ pub async fn run_deck_session(
             &mut pipeline_on,
             agent::remaining_budget(&budget),
             &session_record.id,
+            &ask_io,
         )
         .await;
         if matches!(command, DeckCommand::Handled | DeckCommand::InitCompleted) {
@@ -3598,6 +3600,9 @@ async fn run_deck_command(
     // This deck's session registry id — what scopes `/export` to the session
     // the user is actually in (#2558).
     session_id: &str,
+    // The deck's question channel, so `/init`'s first-session conversion
+    // offer raises a card instead of a TTY prompt through the render.
+    ask_io: &dyn AskUserIo,
 ) -> DeckCommand {
     let trimmed = prompt.trim();
     if !trimmed.starts_with('/') {
@@ -3657,25 +3662,18 @@ async fn run_deck_command(
             });
         }
         "/init" => {
-            // Replay the launch cinematic over the reindex: the battle loops
-            // for as long as init runs, then the wordmark reveal hands the
-            // frame back to the deck. The progress lines still land in the
-            // transcript behind the splash (and any key skips straight to
-            // them). Released on BOTH outcomes — a failed init must never
-            // strand a held splash.
-            let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
-            let mut emit = |line: String| say(line);
-            let outcome = agent::init_workspace(
-                Some(provider),
+            match init_cmd::run(
+                provider,
                 &cfg.workspace_root,
-                Some(&cfg.model_id),
+                &cfg.model_id,
                 budget_limit,
-                &mut emit,
+                ask_io,
+                say,
+                init_cmd::splash_sender(in_tx),
             )
-            .await;
-            let _ = in_tx.send(Inbound::Splash(SplashCue::Release));
-            match outcome {
-                Ok((_domains, _cost_usd)) => return DeckCommand::InitCompleted,
+            .await
+            {
+                Ok(()) => return DeckCommand::InitCompleted,
                 Err(e) => say(format!("init failed: {e}")),
             }
         }

--- a/crates/stella-cli/src/command_deck/init_cmd.rs
+++ b/crates/stella-cli/src/command_deck/init_cmd.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The Command Deck's `/init` command.
+//!
+//! Extracted from `command_deck.rs` rather than added to it: that file is a
+//! grandfathered god file closed to growth (AGENTS.md § "God files"), and
+//! `/init` needed one more channel — the deck's [`AskUserIo`], so the
+//! first-session TOML conversion offer can raise a real question card instead
+//! of printing a TTY prompt straight through the full-screen render.
+//!
+//! Behaviour is unchanged from the inline arm apart from that added channel:
+//! the launch cinematic still replays over the reindex and is still released
+//! on **both** outcomes, because a failed init must never strand a held
+//! splash.
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::agent::{self, InitIo};
+use crate::interactive::AskUserIo;
+
+/// Run the deck's `/init`: replay the splash over the reindex, drive the
+/// shared [`agent::init_workspace`] flow, and release the splash whatever
+/// happens.
+///
+/// `say` writes the progress transcript behind the splash; `ask` is the
+/// deck's question channel, which init uses only for the one first-session
+/// conversion offer. Returns `Ok(())` when init completed, or the error
+/// message to surface.
+pub(super) async fn run<F>(
+    provider: &dyn stella_protocol::Provider,
+    workspace_root: &std::path::Path,
+    model_id: &str,
+    budget_limit: Option<f64>,
+    ask: &dyn AskUserIo,
+    say: F,
+    splash: impl Fn(super::SplashCue),
+) -> Result<(), String>
+where
+    F: Fn(String) + Copy,
+{
+    splash(super::SplashCue::Replay);
+    let mut io = InitIo::new(|line: String| say(line), Some(ask));
+    let outcome = agent::init_workspace(
+        Some(provider),
+        workspace_root,
+        Some(model_id),
+        budget_limit,
+        &mut io,
+    )
+    .await;
+    splash(super::SplashCue::Release);
+    outcome.map(|_| ())
+}
+
+/// Send a splash cue on the deck's inbound channel.
+pub(super) fn splash_sender(
+    in_tx: &UnboundedSender<super::Inbound>,
+) -> impl Fn(super::SplashCue) + '_ {
+    move |cue| {
+        let _ = in_tx.send(super::Inbound::Splash(cue));
+    }
+}

--- a/crates/stella-cli/src/commands_cmd.rs
+++ b/crates/stella-cli/src/commands_cmd.rs
@@ -4,15 +4,22 @@
 //! `stella commands` — list custom slash commands, and convert markdown ones
 //! to TOML.
 //!
-//! # Why conversion is opt-in and never part of `init`
+//! # Why conversion is opt-in, and what `init` may and may not do
 //!
 //! `stella init` **symlinks** `.claude/commands/` into `.stella/commands/`, so
 //! a command edited in either place stays live in both. Converting forks that:
 //! the TOML file is a copy, and the markdown original it came from keeps
 //! drifting away from it. That is a real trade — TOML buys a typed
 //! `allowed-tools` array and a delimiter-free `prompt`, and costs the live
-//! link — and it is the user's to make, per command, deliberately. So this is
-//! a command you run, never something a sync does to you.
+//! link — and it is the user's to make, deliberately. So conversion is never
+//! something a sync does to you.
+//!
+//! `init` does now *ask*, once per workspace, through
+//! [`crate::commands_offer`] — which is the same rule, not an exception to
+//! it: the offer states the cost, converts nothing without an explicit yes,
+//! stays silent when nobody can answer, and never asks a second time. What
+//! remains forbidden is the thing this paragraph originally guarded against,
+//! a conversion the user did not choose.
 //!
 //! Conversion never deletes the source, and never overwrites an existing
 //! `.toml` without `--force`. The worst outcome of a mistaken run is a file

--- a/crates/stella-cli/src/commands_offer.rs
+++ b/crates/stella-cli/src/commands_offer.rs
@@ -375,7 +375,10 @@ mod tests {
 
     #[test]
     fn a_headless_run_hints_but_stays_askable() {
-        assert_eq!(decide(2, false, false), OfferDecision::NoHuman { pending: 2 });
+        assert_eq!(
+            decide(2, false, false),
+            OfferDecision::NoHuman { pending: 2 }
+        );
         assert_eq!(decide(2, false, true), OfferDecision::Ask { pending: 2 });
     }
 

--- a/crates/stella-cli/src/commands_offer.rs
+++ b/crates/stella-cli/src/commands_offer.rs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The first-session offer to convert markdown slash commands to TOML.
+//!
+//! # Why this is an offer and not a conversion
+//!
+//! TOML is how every other piece of workspace config is spelled in stella
+//! (`.stella/tools/*.toml`, `.stella/rules/*.toml`, `.stella/domains.toml`),
+//! and a slash command written in markdown is the one holdout. Closing that
+//! gap is worth a prompt.
+//!
+//! It is *not* worth doing silently, and [`crate::commands_cmd`]'s module doc
+//! says why: `stella init` adopts `.claude/commands/` and `.agents/commands/`
+//! into `.stella/commands/` as **symlinks**, so a command edited in either
+//! place stays live in both. Converting forks that — the `.toml` is a copy,
+//! and the markdown original it came from starts drifting away from it. That
+//! trade is the user's to make, so this module asks, and only ever asks once
+//! per workspace.
+//!
+//! # The three ways this stays quiet
+//!
+//! A prompt nobody wants is worse than no feature, so the offer is suppressed
+//! whenever it would be noise, and each suppression is a distinct arm of
+//! [`decide`] rather than one fuzzy condition:
+//!
+//! - **Nothing would convert.** Counted by dry-running the real converter, so
+//!   the number in the question is exactly what accepting would write — never
+//!   a glob count that includes definitions the parser would reject anyway.
+//! - **This workspace was already asked.** The answer is recorded under
+//!   `.stella/private/`, and the presence of that marker is the whole
+//!   condition: a declined offer never comes back, on any later `stella init`
+//!   or `/init`.
+//! - **Nobody is present to answer.** `init` runs in CI and in scripts;
+//!   there, the offer degrades to a single hint line naming
+//!   `stella commands convert`, and no marker is written — so the first
+//!   *interactive* session still gets its one real ask.
+//!
+//! Accepting converts through [`crate::commands_cmd::convert_dir`], the same
+//! path `stella commands convert` drives: definitions are parsed by the
+//! loader's own parser, the markdown originals are never deleted, and an
+//! existing `.toml` is never overwritten.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands_cmd::{Converted, convert_dir};
+use crate::interactive::AskUserIo;
+
+/// The marker recording that this workspace has been asked, written beneath
+/// `.stella/private/` so it is owner-only and never committed.
+const MARKER: &str = "commands-offer.json";
+
+/// What the offer should do this run.
+///
+/// Every arm that declines to ask names *why*, because the three reasons want
+/// different behaviour downstream: a workspace with nothing to convert should
+/// say nothing at all, a headless run should leave a hint and stay askable,
+/// and an already-answered workspace must stay silent forever.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum OfferDecision {
+    /// No convertible markdown definition — say nothing.
+    NothingToConvert,
+    /// This workspace already answered once — say nothing, ever again.
+    AlreadyAsked,
+    /// Convertible definitions exist but nobody can answer — leave a hint,
+    /// write no marker, so the next interactive session still asks.
+    NoHuman { pending: usize },
+    /// Ask about `pending` convertible definitions.
+    Ask { pending: usize },
+}
+
+/// The offer decision, as a pure function of what was observed.
+///
+/// Ordering is deliberate and is the behaviour, not an implementation
+/// detail. `pending == 0` is checked first because it is the only arm that
+/// must stay silent *and* leave the workspace askable — a workspace with no
+/// commands yet has not declined anything, and writing a marker for it would
+/// consume the one ask it is owed before it ever had commands to convert.
+/// `already_asked` outranks `human_present` for the mirror reason: an
+/// answered workspace is finished, and a later headless run must not
+/// resurrect it as a hint.
+pub(crate) fn decide(pending: usize, already_asked: bool, human_present: bool) -> OfferDecision {
+    if pending == 0 {
+        return OfferDecision::NothingToConvert;
+    }
+    if already_asked {
+        return OfferDecision::AlreadyAsked;
+    }
+    if !human_present {
+        return OfferDecision::NoHuman { pending };
+    }
+    OfferDecision::Ask { pending }
+}
+
+/// The command directories the offer covers: this workspace's, then the
+/// user-global one when `user_root` names it.
+///
+/// Both are `.stella/commands/`, which is the point — `sync_extensions` has
+/// already adopted `<root>/.claude`, `<root>/.agents`, `~/.claude` and
+/// `~/.agents` into exactly these two directories by the time the offer runs,
+/// so converting them converts everything without this module needing its own
+/// idea of where another agent keeps its commands.
+///
+/// `user_root` is **passed in, never resolved here.** This function writes to
+/// every directory it returns, and a version of it that read the ambient home
+/// converted the developer's real `~/.stella/commands/` the first time the
+/// unit tests ran against a temp workspace. An injected root is what makes
+/// the blast radius a parameter a test can see rather than an environment it
+/// happens to inherit — the same discipline `stella-runtime` pins with its
+/// `no_ambient_reads` contract test.
+pub(crate) fn command_dirs(workspace_root: &Path, user_root: Option<&Path>) -> Vec<PathBuf> {
+    let workspace_commands = workspace_root.join(".stella").join("commands");
+    let mut dirs = vec![workspace_commands.clone()];
+    if let Some(user_commands) = user_root.map(|root| root.join("commands"))
+        && user_commands != workspace_commands
+    {
+        dirs.push(user_commands);
+    }
+    dirs
+}
+
+/// The definitions a conversion of `dir` would actually write, found by
+/// dry-running the real converter.
+///
+/// Deliberately not a glob: `convert_dir` skips a definition the loader
+/// cannot parse and one that already has a `.toml`, and a question offering
+/// to convert those would be a lie about what accepting does.
+fn pending_in(dir: &Path) -> Vec<Converted> {
+    convert_dir(dir, true, false)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|entry| entry.skipped.is_none())
+        .collect()
+}
+
+/// Where this workspace's answer is recorded, or `None` when the private
+/// state directory cannot be resolved.
+fn marker_path(workspace_root: &Path) -> Option<PathBuf> {
+    stella_store::workspace_private_state_path(workspace_root, MARKER).ok()
+}
+
+/// Whether this workspace has already been asked.
+///
+/// An unresolvable private directory answers `false`: failing to read the
+/// marker must not silently consume the ask, and the worst case of asking
+/// twice is a question, while the worst case of never asking is a feature
+/// nobody discovers.
+pub(crate) fn already_asked(workspace_root: &Path) -> bool {
+    marker_path(workspace_root).is_some_and(|path| path.exists())
+}
+
+/// Record that this workspace answered, so it is never asked again.
+///
+/// Best-effort: a marker that cannot be written costs one repeated question
+/// on the next init, which is not worth failing init over.
+fn record_answer(workspace_root: &Path, accepted: bool, converted: usize) {
+    let Some(path) = marker_path(workspace_root) else {
+        return;
+    };
+    let body = serde_json::json!({
+        "accepted": accepted,
+        "converted": converted,
+    });
+    let _ = std::fs::write(&path, format!("{body}\n"));
+}
+
+/// The question, naming both what accepting does and what it costs.
+///
+/// The cost half is not decoration: the definitions most likely to be sitting
+/// here are symlinks adopted from another agent's directory, and converting
+/// one trades its live edit link for typed fields. A user who is not told
+/// that cannot make the trade deliberately.
+fn question(pending: usize) -> String {
+    let noun = if pending == 1 { "command" } else { "commands" };
+    format!(
+        "{pending} markdown slash {noun} can be converted to TOML, the format the rest of \
+         stella's config uses. This writes a `.toml` beside each `.md` and deletes nothing — \
+         but a command adopted from `.claude/` or `.agents/` is a symlink, and its TOML copy \
+         stops tracking edits to the original. Convert now?"
+    )
+}
+
+/// Offer to convert this workspace's markdown slash commands to TOML, once.
+///
+/// Called from [`crate::agent::init_workspace`], so `stella init` and the
+/// deck's `/init` share one implementation and one marker. `ask` is `None`
+/// when no human can answer; passing the io rather than re-deriving presence
+/// here keeps this module honest about the one thing it cannot observe.
+pub(crate) async fn offer_conversion(
+    workspace_root: &Path,
+    user_root: Option<&Path>,
+    ask: Option<&dyn AskUserIo>,
+    emit: &mut dyn FnMut(String),
+) {
+    let dirs = command_dirs(workspace_root, user_root);
+    let pending: Vec<(PathBuf, Vec<Converted>)> = dirs
+        .into_iter()
+        .map(|dir| {
+            let found = pending_in(&dir);
+            (dir, found)
+        })
+        .filter(|(_, found)| !found.is_empty())
+        .collect();
+    let total: usize = pending.iter().map(|(_, found)| found.len()).sum();
+
+    match decide(total, already_asked(workspace_root), ask.is_some()) {
+        OfferDecision::NothingToConvert | OfferDecision::AlreadyAsked => return,
+        OfferDecision::NoHuman { pending } => {
+            emit(format!(
+                "· {pending} markdown slash command(s) could be converted to TOML — \
+                 run `stella commands convert`"
+            ));
+            return;
+        }
+        OfferDecision::Ask { .. } => {}
+    }
+
+    let options = vec![
+        "Convert them to TOML".to_string(),
+        "Keep markdown (this is asked once — you can still run `stella commands convert`)"
+            .to_string(),
+    ];
+    // An io that fails mid-prompt is a decline, never an accept: this writes
+    // files, and silence must never be read as consent. It is also not
+    // recorded, so the next interactive session gets the ask it never had.
+    let Ok(raw) = ask
+        .expect("Ask implies an io")
+        .prompt(&question(total), &options)
+        .await
+    else {
+        emit("! could not ask about TOML conversion — nothing was converted".to_string());
+        return;
+    };
+
+    let answer = raw.trim();
+    let accepted =
+        answer == "1" || answer.eq_ignore_ascii_case("yes") || answer.eq_ignore_ascii_case("y");
+    if !accepted {
+        emit("· keeping markdown commands — `stella commands convert` converts them later".into());
+        record_answer(workspace_root, false, 0);
+        return;
+    }
+
+    let mut converted = 0usize;
+    for (dir, _) in &pending {
+        match convert_dir(dir, false, false) {
+            Ok(done) => {
+                for entry in done.iter().filter(|e| e.skipped.is_none()) {
+                    converted += 1;
+                    emit(format!("✓ wrote {}", entry.target.display()));
+                }
+                for entry in done.iter().filter(|e| e.skipped.is_some()) {
+                    let why = entry.skipped.as_deref().unwrap_or("");
+                    emit(format!("! skipped {}: {why}", entry.source.display()));
+                }
+            }
+            Err(error) => emit(format!("! could not convert {}: {error}", dir.display())),
+        }
+    }
+    emit(format!(
+        "✓ {converted} command(s) converted to TOML — the markdown originals are untouched"
+    ));
+    record_answer(workspace_root, true, converted);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Scripted io: records every question it was asked, answers from a
+    /// queue, and panics if asked more often than it was scripted for —
+    /// which is how "never asks twice" becomes a test failure rather than a
+    /// silently popped `None`.
+    struct ScriptedIo {
+        answers: Mutex<Vec<String>>,
+        asked: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedIo {
+        fn new(answers: &[&str]) -> Self {
+            Self {
+                answers: Mutex::new(answers.iter().rev().map(|a| a.to_string()).collect()),
+                asked: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AskUserIo for ScriptedIo {
+        async fn prompt(&self, question: &str, _options: &[String]) -> Result<String, String> {
+            self.asked.lock().unwrap().push(question.to_string());
+            Ok(self
+                .answers
+                .lock()
+                .unwrap()
+                .pop()
+                .expect("asked more questions than the script answers"))
+        }
+    }
+
+    /// An io that fails the test if it is ever consulted — the shape "this
+    /// workspace must not be asked again" needs an observable, and a silent
+    /// no-op io would pass whether or not the suppression worked.
+    struct NeverAsk;
+
+    #[async_trait::async_trait]
+    impl AskUserIo for NeverAsk {
+        async fn prompt(&self, question: &str, _options: &[String]) -> Result<String, String> {
+            panic!("this workspace must never be asked again, but was asked: {question}");
+        }
+    }
+
+    fn command_md(name: &str) -> String {
+        format!("---\nname: {name}\ndescription: does {name}\n---\n\nRun {name} now.\n")
+    }
+
+    /// Seed a workspace with `n` markdown commands and return its root.
+    fn workspace_with_commands(names: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join(".stella").join("commands");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        for name in names {
+            std::fs::write(dir.join(format!("{name}.md")), command_md(name)).expect("write");
+        }
+        tmp
+    }
+
+    /// The offer writes only where it was told to write.
+    ///
+    /// Regression witness for a defect this module shipped with and its own
+    /// tests caught: `command_dirs` resolved the user-global root from the
+    /// ambient home, so running the suite against a temp workspace converted
+    /// the developer's real `~/.stella/commands/`. `None` must mean "no user
+    /// scope", not "go and find one".
+    #[test]
+    fn no_user_root_means_the_workspace_and_nothing_else() {
+        let dirs = command_dirs(Path::new("/ws"), None);
+        assert_eq!(dirs, vec![PathBuf::from("/ws/.stella/commands")]);
+
+        let dirs = command_dirs(Path::new("/ws"), Some(Path::new("/home/.stella")));
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/ws/.stella/commands"),
+                PathBuf::from("/home/.stella/commands"),
+            ]
+        );
+    }
+
+    /// A workspace that *is* the user root is converted once, not twice —
+    /// otherwise the second pass reports every file as "a .toml already
+    /// exists" and the transcript accuses the user of a conflict they never
+    /// had.
+    #[test]
+    fn a_workspace_that_is_its_own_user_root_is_listed_once() {
+        let dirs = command_dirs(Path::new("/ws"), Some(Path::new("/ws/.stella")));
+        assert_eq!(dirs, vec![PathBuf::from("/ws/.stella/commands")]);
+    }
+
+    #[test]
+    fn nothing_to_convert_outranks_every_other_reason() {
+        // A workspace with no commands has declined nothing, so it must not
+        // be marked as answered — the arm order is the behaviour.
+        assert_eq!(decide(0, false, true), OfferDecision::NothingToConvert);
+        assert_eq!(decide(0, true, false), OfferDecision::NothingToConvert);
+    }
+
+    #[test]
+    fn an_answered_workspace_is_silent_even_headless() {
+        assert_eq!(decide(3, true, true), OfferDecision::AlreadyAsked);
+        assert_eq!(decide(3, true, false), OfferDecision::AlreadyAsked);
+    }
+
+    #[test]
+    fn a_headless_run_hints_but_stays_askable() {
+        assert_eq!(decide(2, false, false), OfferDecision::NoHuman { pending: 2 });
+        assert_eq!(decide(2, false, true), OfferDecision::Ask { pending: 2 });
+    }
+
+    /// The witness: accepting the first-session offer converts every markdown
+    /// command to TOML, leaves the markdown in place, and — the half that
+    /// makes it a *first-session* offer rather than a nag — never asks again.
+    /// Fails on old code, where no offer existed at any init.
+    #[tokio::test]
+    async fn the_offer_converts_once_and_never_asks_again() {
+        let tmp = workspace_with_commands(&["ship", "review"]);
+        let root = tmp.path();
+        let mut lines: Vec<String> = Vec::new();
+
+        let io = ScriptedIo::new(&["1"]);
+        offer_conversion(root, None, Some(&io), &mut |line| lines.push(line)).await;
+
+        let commands = root.join(".stella").join("commands");
+        assert!(commands.join("ship.toml").is_file(), "ship converted");
+        assert!(commands.join("review.toml").is_file(), "review converted");
+        assert!(
+            commands.join("ship.md").is_file(),
+            "the markdown original is never deleted"
+        );
+        assert_eq!(io.asked.lock().unwrap().len(), 1, "asked exactly once");
+        assert!(
+            lines.iter().any(|l| l.contains("2 command(s) converted")),
+            "the conversion is stated in the transcript: {lines:?}"
+        );
+
+        // Second init over the same workspace: the marker must suppress the
+        // question outright, not merely find nothing left to do.
+        std::fs::write(commands.join("deploy.md"), command_md("deploy")).expect("write");
+        offer_conversion(root, None, Some(&NeverAsk), &mut |line| lines.push(line)).await;
+        assert!(
+            !commands.join("deploy.toml").exists(),
+            "an answered workspace converts nothing further on its own"
+        );
+    }
+
+    /// Declining is recorded just as firmly as accepting: nothing converts,
+    /// and the workspace is never asked again.
+    #[tokio::test]
+    async fn declining_converts_nothing_and_is_remembered() {
+        let tmp = workspace_with_commands(&["ship"]);
+        let root = tmp.path();
+        let mut lines: Vec<String> = Vec::new();
+
+        let io = ScriptedIo::new(&["2"]);
+        offer_conversion(root, None, Some(&io), &mut |line| lines.push(line)).await;
+
+        let commands = root.join(".stella").join("commands");
+        assert!(!commands.join("ship.toml").exists(), "nothing converted");
+        assert!(already_asked(root), "the decline is recorded");
+
+        offer_conversion(root, None, Some(&NeverAsk), &mut |line| lines.push(line)).await;
+    }
+
+    /// A headless init leaves a hint and writes no marker, so the first
+    /// interactive session still gets its one real ask. Without this, a
+    /// single CI run would permanently consume the offer for the repository.
+    #[tokio::test]
+    async fn a_headless_init_does_not_consume_the_ask() {
+        let tmp = workspace_with_commands(&["ship"]);
+        let root = tmp.path();
+        let mut lines: Vec<String> = Vec::new();
+
+        offer_conversion(root, None, None, &mut |line| lines.push(line)).await;
+
+        assert!(
+            !already_asked(root),
+            "a run nobody could answer must not count as an answer"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("stella commands convert")),
+            "the headless path names the manual route: {lines:?}"
+        );
+
+        let io = ScriptedIo::new(&["1"]);
+        offer_conversion(root, None, Some(&io), &mut |line| lines.push(line)).await;
+        assert_eq!(
+            io.asked.lock().unwrap().len(),
+            1,
+            "the first interactive session still gets asked"
+        );
+    }
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -36,6 +36,7 @@ mod cli;
 mod cloud_drain;
 mod command_deck;
 mod commands_cmd;
+mod commands_offer;
 mod config;
 mod config_wiring;
 mod context_cmd;


### PR DESCRIPTION
## What

Slash commands were the last piece of workspace config still spelled only in
markdown. This wires the existing pieces together and closes that gap with a
prompt, not a migration.

Two halves already existed and were never connected:

- `sync_extensions` (`crates/stella-cli/src/extensions.rs`) already adopts
  `<root>/.claude/commands`, `<root>/.agents/commands`, `~/.claude/commands`
  and `~/.agents/commands` — first-level `*.md` plus the `<slug>/COMMAND.md`
  namespace shape — into `.stella/commands/` as symlinks, at `init`.
- `stella commands convert` (`crates/stella-cli/src/commands_cmd.rs`) already
  renders a `CommandDef` as TOML *through the loader's own parser*, so a
  converted file means what the loader thought the markdown meant.

Nothing bridged them, so the TOML spelling was only ever found by someone who
already knew it existed. `init` now asks, once per workspace, immediately
after the adoption sync — which is the right moment, because the definitions
worth converting are largely the ones the sync just linked.

## The offer

`crates/stella-cli/src/commands_offer.rs`. `decide` is a pure function with
one arm per reason to stay quiet, because the three reasons want different
behaviour:

- **Nothing would convert** → silent, and no marker. Counted by dry-running
  the real converter, so the number in the question is exactly what accepting
  writes — never a glob count including definitions the parser would reject.
- **Already asked** → silent forever. The answer is recorded under
  `.stella/private/`; a decline never comes back.
- **Nobody can answer** → one hint line naming `stella commands convert`, and
  **no marker**, so a CI run cannot permanently consume the single ask the
  repository is owed.

Accepting goes through `convert_dir`, unchanged: markdown originals are never
deleted and an existing `.toml` is never overwritten.

## Why `init` may now ask, when `commands_cmd`'s doc said it never should

That module doc's rule was *conversion must never happen to you*, justified by
the symlink trade — an adopted command is live in both places, and its TOML
copy stops tracking edits to the original. This honours that rule rather than
carving an exception: the offer states the cost in the question, converts
nothing without an explicit yes, and asks once. The doc comment is updated in
the same PR to say what changed, rather than being left contradicting the code.

## `InitIo`

`init_workspace` previously took only an `emit` sink and so could not ask
anything. Its transcript sink and its question channel now travel together as
one injected seam. That is what lets the Command Deck answer with a real
question card while the plain CLI answers on the TTY — a `TtyAskUserIo` at the
deck would print straight through the full-screen render.

It also keeps `init_workspace`'s arity fixed, which was a hard constraint, not
a preference: both interactive call sites live in `agent.rs` and
`command_deck.rs`, which sit **exactly** at their `file-size-baseline.txt`
ceilings (1799 / 4019). The deck's `/init` arm moves to
`command_deck/init_cmd.rs` for the same reason — the sanctioned "plan around a
god file" move, and it leaves `command_deck.rs` two lines smaller.

## A defect this shipped with, and the test that caught it

The first version resolved the user-global root from the ambient home inside
`command_dirs`. Running the new unit tests against a temp workspace therefore
converted the developer's **real** `~/.stella/commands/`, writing eight
`.toml` files into a live `fullauto/` command tree. Those files were removed
and the `.md` originals were verified intact.

`command_dirs` now takes `user_root: Option<&Path>` — the blast radius is a
parameter a test can see, not an environment it inherits. Pinned by
`no_user_root_means_the_workspace_and_nothing_else`. This is the same
discipline `stella-runtime` enforces with its `no_ambient_reads` contract test.

## Witness

`the_offer_converts_once_and_never_asks_again` — accepting converts every
markdown command, leaves the markdown in place, and the second init over the
same workspace is **not asked at all** (the io panics if consulted). Fails on
old code, where no offer existed at any init.

Supporting: `declining_converts_nothing_and_is_remembered`,
`a_headless_init_does_not_consume_the_ask`, the `decide` arm-order tests, and
the two `command_dirs` scoping tests.

## Verification

- `cargo test -p stella-cli` — 1821 + integration tests, 0 failed.
- `cargo clippy -p stella-cli --all-targets` — clean.
- `cargo fmt --all`, `RUSTDOCFLAGS=-D warnings cargo doc` — clean.
- `check-file-size`, `check-god-files`, `check-left-behind` — OK.
- End-to-end, for real: `stella init` in a temp workspace seeded with
  `.claude/commands/demo.md` adopted the command and then printed
  `· 9 markdown slash command(s) could be converted to TOML — run
  `stella commands convert``. Headless, so it converted nothing and wrote no
  marker — verified zero `.toml` in both the temp tree and `~/.stella/commands`,
  and no `commands-offer.json`.

No test was deleted.

## Remaining work

Refs #3641 — `init_workspace` still resolves the ambient home one layer up, so
the accepting-from-init path has no automated end-to-end coverage (a test
would convert the developer's real commands). The issue carries the fix shape
and the god-file constraint any fix must respect.

## Summary by Sourcery

Offer users a one-time, explicit choice to convert workspace markdown slash commands to TOML during initialization.

New Features:
- Offer an opt-in, once-per-workspace conversion of markdown slash commands to TOML during interactive initialization.
- Provide a headless initialization hint for manual conversion without consuming the interactive offer.

Bug Fixes:
- Prevent command conversion tests and workflows from unintentionally accessing or modifying the ambient user command directory.

Enhancements:
- Share initialization transcript and question handling across the plain CLI, REPL, and Command Deck while preserving the Command Deck's interactive rendering behavior.
- Record accepted or declined conversion offers so answered workspaces remain silent, while keeping headless workspaces eligible for a later prompt.
- Keep markdown sources intact and avoid overwriting existing TOML files when conversion is accepted.

Documentation:
- Update command conversion documentation to clarify that init may offer conversion but never performs it without explicit user consent.

Tests:
- Add coverage for offer decision ordering, acceptance and decline persistence, headless behavior, one-time prompting, and command-directory scoping.

Chores:
- Extract Command Deck initialization handling into a dedicated module to respect file-size and god-file constraints.