### PR TITLE
feat(stella-tui): show a tool result's raw output in the fold, syntax-coloured when JSON

### DIFF
--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -51,7 +51,7 @@ const OK_PREVIEW: usize = FAIL_PREVIEW;
 /// Does this payload read as JSON, and so earn syntax coloring?
 ///
 /// Deliberately the opening delimiter rather than a parse: a tool result is
-/// middle-elided at [`OUTPUT_BUDGET`](crate::model::summarize) before it ever
+/// middle-elided at `OUTPUT_BUDGET` (`crate::model::summarize`) before it ever
 /// reaches here, so a large JSON body no longer parses and a parse test would
 /// color exactly the short results that need it least. The lexer degrades to
 /// untagged runs on anything it cannot classify, so the cost of a false

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -26,7 +26,7 @@ use crate::textline::{
 // list and `INLINE_DIFF_CAP` bounds it. A child module may reach a private
 // parent item, so the move needed no visibility change.
 use super::{INLINE_DIFF_CAP, resolve_inline_diff};
-use crate::{diff, theme};
+use crate::{diff, syntax, theme};
 
 // The context-recall table. Split out rather than grown here: it is the one
 // entry kind that lays out a *grid* — fitted columns, a heading, a rule, a
@@ -37,6 +37,47 @@ use crate::{diff, theme};
 // widening anything, exactly as `entry` itself reaches `render`'s.
 mod recall;
 use recall::recall_lines;
+
+/// How many lines of a *successful* tool result the collapsed fold shows.
+///
+/// This was 1, on the argument that a successful call's output is chatter and
+/// its size belongs in the metric column. That is wrong for the calls whose
+/// output *is* the answer — a `search`, a `read_file`, a `get_state` — where
+/// one line plus a count told a reader only that something had been found, and
+/// left the finding itself behind a keystroke they had no reason to press.
+/// Matching [`FAIL_PREVIEW`] keeps one preview rule instead of two.
+const OK_PREVIEW: usize = FAIL_PREVIEW;
+
+/// Does this payload read as JSON, and so earn syntax coloring?
+///
+/// Deliberately the opening delimiter rather than a parse: a tool result is
+/// middle-elided at [`OUTPUT_BUDGET`](crate::model::summarize) before it ever
+/// reaches here, so a large JSON body no longer parses and a parse test would
+/// color exactly the short results that need it least. The lexer degrades to
+/// untagged runs on anything it cannot classify, so the cost of a false
+/// positive is a line that renders plain — not one that renders wrong.
+fn reads_as_json(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with('{') || t.starts_with('[')
+}
+
+/// Emit one body line, syntax-colored when `json`, at the detail column.
+fn push_body_line(line: &str, json: bool, width: usize, out: &mut Vec<Line<'static>>) {
+    if !json {
+        push_detail_line(line, width, out);
+        return;
+    }
+    let spans: Vec<Span<'static>> = syntax::tokenize(line, syntax::Lang::Json)
+        .into_iter()
+        .map(|(text, tok)| match tok {
+            Some(t) => Span::styled(text, syntax::tok_style(t)),
+            // Punctuation and whitespace keep the body's muted base tone, so
+            // the colored tokens are what the eye lands on.
+            None => Span::styled(text, Style::new().fg(theme::MUTED)),
+        })
+        .collect();
+    push_detail_spans(spans, width, out);
+}
 
 // Pure content builders (unit-tested directly)
 
@@ -334,11 +375,15 @@ fn entry_body(
                 // ctrl+o: the full argument object, pretty-printed and dim.
                 // An over-budget argument may not parse (char-capped raw) —
                 // show it wrapped rather than clipped at the pane edge.
+                // Pretty-printing is what makes the coloring worth having: a
+                // compact one-line object has no shape for a key hue to mark.
+                // A body that failed to re-parse is still lexed — it is capped
+                // JSON, not another format.
                 let pretty = serde_json::from_str::<serde_json::Value>(raw)
                     .and_then(|v| serde_json::to_string_pretty(&v))
                     .unwrap_or_else(|_| raw.clone());
                 for l in pretty.lines() {
-                    push_detail_line(l, width, out);
+                    push_body_line(l, true, width, out);
                 }
             }
         }
@@ -386,12 +431,10 @@ fn entry_body(
                     Style::new().fg(theme::BAD),
                 ));
                 metric.push(Span::styled(" · ".to_string(), dim));
-            } else if total > 1 && !expanded {
-                // `⋯` is the one glyph this UI uses for "there is more behind
-                // this", so it carries the ctrl+o affordance the removed hint
-                // row used to spell out — at no extra row.
-                metric.push(Span::styled(format!("⋯ {} · ", plural_lines(total)), dim));
             }
+            // The size chip that used to sit here stated the same count as the
+            // hint row below, one of them without the affordance. Now the count
+            // is stated once, in the row that also says which key reveals it.
             metric.push(Span::styled(dur, dim));
 
             if expanded {
@@ -401,26 +444,38 @@ fn entry_body(
                     width,
                     out,
                 );
+                let json = reads_as_json(full);
                 for l in full.lines() {
-                    push_detail_line(l, width, out);
+                    push_body_line(l, json, width, out);
                 }
             } else {
                 // With a diff below, a prose summary ("Applied edit to
                 // src/agent.rs") would restate the call row above it and the
                 // diff under it in the same breath. The row carries only its
                 // metrics and gets out of the way.
+                let json = reads_as_json(full);
                 let shown: Vec<&str> = if inline.is_some() {
                     Vec::new()
                 } else {
                     // A failure never collapses to a single line. The point of
                     // reading a transcript at the moment something breaks is to
                     // see *why*, and a one-line preview of a stack trace is a
-                    // prompt to go hunting rather than an answer.
-                    let budget = if *ok { 1 } else { FAIL_PREVIEW };
-                    full.lines().skip(salient_line(full)).take(budget).collect()
+                    // prompt to go hunting rather than an answer. A success now
+                    // gets the same window, for the reason on [`OK_PREVIEW`].
+                    let budget = if *ok { OK_PREVIEW } else { FAIL_PREVIEW };
+                    // `salient_line` skips a tool's preamble to the line worth
+                    // reading. A JSON body has no preamble — its first line is
+                    // the opening delimiter, and starting anywhere else shows
+                    // an object with its shape cut off.
+                    let skip = if json { 0 } else { salient_line(full) };
+                    full.lines().skip(skip).take(budget).collect()
                 };
+                // A JSON preview stays whole in the body column. Promoting its
+                // first line to the result row would strip that line's coloring
+                // (the row is one flat style) and split an object across two
+                // different columns.
                 let head: Vec<Span<'static>> = match shown.first() {
-                    Some(l) => vec![Span::styled(
+                    Some(l) if !json => vec![Span::styled(
                         l.trim_end().to_owned(),
                         if *ok {
                             dim
@@ -428,7 +483,7 @@ fn entry_body(
                             Style::new().fg(theme::BAD)
                         },
                     )],
-                    None => Vec::new(),
+                    _ => Vec::new(),
                 };
                 push_row(
                     rail,
@@ -436,16 +491,16 @@ fn entry_body(
                     width,
                     out,
                 );
-                for l in shown.iter().skip(1) {
-                    push_detail_line(l.trim_end(), width, out);
+                for l in shown.iter().skip(usize::from(!json)) {
+                    push_body_line(l.trim_end(), json, width, out);
                 }
-                // Only a failure earns the "there is more" row: a successful
-                // result already states its size in the metric column, and
-                // saying it twice is how a dense layout turns back into a
-                // sparse one. Anchoring mid-output also means the count is
-                // "everything but the window", not "everything after it".
+                // The "there is more" row, for a success as well as a failure —
+                // it is the only place the hidden count is stated now, and the
+                // only place the ctrl+o affordance appears. Not under an inline
+                // diff: there the rendered hunk is the result, and the tool's
+                // own chatter is what would be counted.
                 let hidden = total.saturating_sub(shown.len());
-                if hidden > 0 && !*ok {
+                if hidden > 0 && inline.is_none() {
                     push_detail_line(&format!("⋯ {} · ctrl+o", plural_lines(hidden)), width, out);
                 }
             }

--- a/crates/stella-tui/src/render/row.rs
+++ b/crates/stella-tui/src/render/row.rs
@@ -204,15 +204,25 @@ pub(crate) fn push_row(
 /// aligned to [`BODY`] — so an expanded body reads as part of the same block
 /// rather than as a new top-level event.
 pub(crate) fn push_detail_line(text: &str, width: usize, out: &mut Vec<Line<'static>>) {
-    wrap_one_indent(
-        Line::from(vec![
-            Span::raw(" ".repeat(BODY)),
-            Span::styled(text.to_owned(), Style::new().fg(theme::MUTED)),
-        ]),
+    push_detail_spans(
+        vec![Span::styled(text.to_owned(), Style::new().fg(theme::MUTED))],
         width,
-        BODY,
         out,
     );
+}
+
+/// [`push_detail_line`] for content that is already styled — a syntax-colored
+/// JSON body, where the muted single style of the plain form would erase the
+/// coloring it exists to show. Indent, column, and wrapping are identical, so
+/// the two forms interleave in one body without a seam.
+pub(crate) fn push_detail_spans(
+    content: Vec<Span<'static>>,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    let mut spans = vec![Span::raw(" ".repeat(BODY))];
+    spans.extend(content);
+    wrap_one_indent(Line::from(spans), width, BODY, out);
 }
 
 /// Emit a system-note row: `↻ retry`, `⇣ compacted`, `✗ error` and friends.

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -28,6 +28,7 @@ mod inline_diff;
 mod palette;
 mod slash;
 mod thinking;
+mod tool_output;
 
 /// Flatten a `Buffer` to one `String` per row (styling stripped — content is
 /// what we assert on, never raw ANSI, per L-T6).

--- a/crates/stella-tui/src/render/tests/tool_output.rs
+++ b/crates/stella-tui/src/render/tests/tool_output.rs
@@ -62,9 +62,7 @@ fn a_successful_result_previews_its_output_rather_than_one_line() {
 
 #[test]
 fn a_truncated_success_says_how_much_is_hidden_and_which_key_shows_it() {
-    let body = (1..=40)
-        .map(|i| format!("line {i}\n"))
-        .collect::<String>();
+    let body = (1..=40).map(|i| format!("line {i}\n")).collect::<String>();
     let rendered = text_of(&collapsed(&result(&body)));
 
     // Previously failure-only: a success stated its size in the metric column

--- a/crates/stella-tui/src/render/tests/tool_output.rs
+++ b/crates/stella-tui/src/render/tests/tool_output.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A tool result's *output* in the collapsed fold.
+//!
+//! The fold used to show a successful call one line of output and a size chip,
+//! which for every tool whose output is the answer — `search`, `read_file`,
+//! `get_state` — left the answer behind a keystroke. These pin the two halves
+//! of the fix: a bounded preview is shown, and a JSON body is colored.
+
+use super::*;
+use crate::syntax;
+use crate::theme;
+
+/// A successful, non-mutating tool result carrying `body`.
+fn result(body: &str) -> TranscriptEntry {
+    TranscriptEntry::ToolResult {
+        call_id: "c1".into(),
+        name: "search".into(),
+        ok: true,
+        summary: "ok".into(),
+        full: body.into(),
+        duration_ms: 7,
+        speculated: false,
+        diff: None,
+    }
+}
+
+fn collapsed(entry: &TranscriptEntry) -> Vec<Line<'static>> {
+    let mut out = Vec::new();
+    entry_lines(entry, &[], false, false, false, 120, &mut out);
+    out
+}
+
+fn text_of(lines: &[Line<'static>]) -> String {
+    lines
+        .iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn a_successful_result_previews_its_output_rather_than_one_line() {
+    let body = "alpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\ngolf\nhotel";
+    let rendered = text_of(&collapsed(&result(body)));
+
+    // The witness: on the old one-line budget only the first payload line
+    // reached the fold. A preview shows the lines after it too.
+    for line in ["bravo", "charlie", "delta"] {
+        assert!(
+            rendered.contains(line),
+            "collapsed preview dropped {line:?}:\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn a_truncated_success_says_how_much_is_hidden_and_which_key_shows_it() {
+    let body = (1..=40)
+        .map(|i| format!("line {i}\n"))
+        .collect::<String>();
+    let rendered = text_of(&collapsed(&result(&body)));
+
+    // Previously failure-only: a success stated its size in the metric column
+    // with no affordance beside it.
+    assert!(
+        rendered.contains("ctrl+o"),
+        "no reveal affordance on a truncated success:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("lines · ctrl+o"),
+        "hidden count not stated with the affordance:\n{rendered}"
+    );
+}
+
+#[test]
+fn a_short_success_claims_nothing_is_hidden() {
+    let rendered = text_of(&collapsed(&result("only line")));
+    assert!(
+        !rendered.contains("ctrl+o"),
+        "offered to reveal output that is already fully shown:\n{rendered}"
+    );
+}
+
+/// Colors are asserted through [`syntax::tok_style`] rather than literal theme
+/// constants, so a palette change moves the test with the theme instead of
+/// breaking it.
+fn colors(lines: &[Line<'static>]) -> Vec<(String, Option<ratatui::style::Color>)> {
+    lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| (s.content.to_string(), s.style.fg))
+        .collect()
+}
+
+#[test]
+fn a_json_result_body_is_syntax_coloured() {
+    let body = "{\n  \"query\": \"needle\",\n  \"hits\": 3\n}";
+    let spans = colors(&collapsed(&result(body)));
+
+    let key = syntax::tok_style(syntax::Tok::Keyword).fg;
+    let string = syntax::tok_style(syntax::Tok::Str).fg;
+    let number = syntax::tok_style(syntax::Tok::Number).fg;
+
+    assert!(
+        spans.iter().any(|(t, c)| t == "\"query\"" && *c == key),
+        "object key not coloured as structure: {spans:?}"
+    );
+    assert!(
+        spans.iter().any(|(t, c)| t == "\"needle\"" && *c == string),
+        "string value not coloured as a string: {spans:?}"
+    );
+    assert!(
+        spans.iter().any(|(t, c)| t == "3" && *c == number),
+        "number value not coloured as a number: {spans:?}"
+    );
+    // A key and its value must not share a hue, or the object has no shape.
+    assert_ne!(key, string, "key and string value are the same colour");
+}
+
+#[test]
+fn a_plain_text_result_is_not_coloured_as_json() {
+    let spans = colors(&collapsed(&result("error: no such file\nat line 3")));
+    let key = syntax::tok_style(syntax::Tok::Keyword).fg;
+    assert!(
+        !spans.iter().any(|(_, c)| *c == key),
+        "shell output picked up JSON structure colouring: {spans:?}"
+    );
+    // It still renders in the body's own tone rather than losing its style.
+    assert!(spans.iter().any(|(_, c)| *c == Some(theme::MUTED)));
+}
+
+#[test]
+fn a_json_preview_starts_at_the_opening_brace() {
+    let body = "{\n  \"a\": 1,\n  \"b\": 2\n}";
+    let rendered = text_of(&collapsed(&result(body)));
+    // `salient_line` skips a preamble to the interesting line; for an object
+    // that would cut the shape away from its own contents.
+    assert!(
+        rendered.contains('{'),
+        "JSON preview dropped its opening delimiter:\n{rendered}"
+    );
+}

--- a/crates/stella-tui/src/syntax.rs
+++ b/crates/stella-tui/src/syntax.rs
@@ -433,9 +433,7 @@ fn json_runs(code: &str) -> Runs {
             ));
             continue;
         }
-        if c.is_ascii_digit()
-            || (c == '-' && chars.get(i + 1).is_some_and(char::is_ascii_digit))
-        {
+        if c.is_ascii_digit() || (c == '-' && chars.get(i + 1).is_some_and(char::is_ascii_digit)) {
             let start = i;
             i += 1;
             while i < chars.len() {
@@ -889,7 +887,10 @@ mod tests {
     #[test]
     fn json_separates_keys_from_string_values() {
         let runs = tokenize(r#"  "query": "needle","#, Lang::Json);
-        assert_eq!(runs.iter().find(|(t, _)| t == "\"query\"").unwrap().1, Some(Tok::Keyword));
+        assert_eq!(
+            runs.iter().find(|(t, _)| t == "\"query\"").unwrap().1,
+            Some(Tok::Keyword)
+        );
         assert_eq!(
             runs.iter().find(|(t, _)| t == "\"needle\"").unwrap().1,
             Some(Tok::Str)

--- a/crates/stella-tui/src/syntax.rs
+++ b/crates/stella-tui/src/syntax.rs
@@ -32,6 +32,11 @@ pub enum Lang {
     /// skills/agents definition format.
     Markdown,
     Toml,
+    /// JSON — tool-call arguments and tool results, which the transcript
+    /// renders verbatim ([`crate::render`]). Unlike the other languages here
+    /// this one is read far more than it is edited, and it arrives already
+    /// pretty-printed.
+    Json,
 }
 
 /// A token class we give a syntax color; `None` runs stay the base color.
@@ -73,6 +78,7 @@ pub fn lang_from_ext(ext: &str) -> Option<Lang> {
         "py" | "pyi" => Some(Lang::Python),
         "md" | "markdown" => Some(Lang::Markdown),
         "toml" => Some(Lang::Toml),
+        "json" | "jsonl" | "ndjson" => Some(Lang::Json),
         _ => None,
     }
 }
@@ -104,6 +110,7 @@ pub fn lang_from_fence(tag: &str) -> Option<Lang> {
         "py" | "python" | "python3" => Some(Lang::Python),
         "md" | "markdown" => Some(Lang::Markdown),
         "toml" => Some(Lang::Toml),
+        "json" | "jsonl" | "ndjson" => Some(Lang::Json),
         _ => None,
     }
 }
@@ -117,6 +124,7 @@ pub fn tokenize(code: &str, lang: Lang) -> Runs {
     match lang {
         Lang::Markdown => md_line(code).0,
         Lang::Toml => toml_runs(code),
+        Lang::Json => json_runs(code),
         Lang::Rust | Lang::TsJs | Lang::Python => code_runs(code, lang),
     }
 }
@@ -364,6 +372,109 @@ fn split_ordered_marker(lead: &str) -> Option<(&str, &str)> {
 /// headers and the key of a `key = value` pair as structure, and values via
 /// the generic scan (strings, numbers, booleans). Array/inline-table
 /// continuation lines fall through to the generic scan.
+/// One line of JSON, tokenized left to right.
+///
+/// A key and a string value are the same lexical thing — a quoted string — and
+/// only what follows separates them, so a closed string looks ahead to the next
+/// non-space character and takes [`Tok::Keyword`] when that is a `:`. That is
+/// the same call [`toml_runs`] makes for a bare key, and it keeps the two
+/// object-shaped formats reading alike: the shape in one hue, the data in
+/// another.
+///
+/// `true`/`false`/`null` take [`Tok::Number`] rather than a keyword hue: they
+/// are scalar constants standing where a number could stand, and coloring them
+/// like keys would make an object's shape unreadable at a glance — which is the
+/// whole reason this line is colored at all.
+///
+/// Stateless and lossless like every other lexer here. A line sliced out of a
+/// larger document (the middle-elided body of a capped tool result) simply
+/// classifies what it can see; an unterminated string runs to end of line
+/// rather than panicking or swallowing the rest of the render.
+fn json_runs(code: &str) -> Runs {
+    let chars: Vec<char> = code.chars().collect();
+    let mut runs: Runs = Vec::new();
+    let mut plain = String::new();
+    let mut i = 0;
+
+    // Punctuation and whitespace accumulate untagged until a classified token
+    // interrupts them, so the run list stays as short as the coloring needs.
+    fn flush(plain: &mut String, runs: &mut Runs) {
+        if !plain.is_empty() {
+            runs.push((std::mem::take(plain), None));
+        }
+    }
+
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '"' {
+            let start = i;
+            i += 1;
+            while i < chars.len() {
+                match chars[i] {
+                    // A backslash escapes the next char, including a quote —
+                    // clamp so a trailing lone backslash cannot step past the
+                    // end.
+                    '\\' => i = (i + 2).min(chars.len()),
+                    '"' => {
+                        i += 1;
+                        break;
+                    }
+                    _ => i += 1,
+                }
+            }
+            let key = chars[i..]
+                .iter()
+                .find(|c| !c.is_whitespace())
+                .is_some_and(|c| *c == ':');
+            flush(&mut plain, &mut runs);
+            runs.push((
+                chars[start..i].iter().collect(),
+                Some(if key { Tok::Keyword } else { Tok::Str }),
+            ));
+            continue;
+        }
+        if c.is_ascii_digit()
+            || (c == '-' && chars.get(i + 1).is_some_and(char::is_ascii_digit))
+        {
+            let start = i;
+            i += 1;
+            while i < chars.len() {
+                let d = chars[i];
+                if d.is_ascii_digit() || d == '.' {
+                    i += 1;
+                } else if matches!(d, 'e' | 'E') {
+                    // Only an exponent may carry a sign, and only right after
+                    // the `e` — otherwise `1-2` would lex as one number.
+                    i += 1;
+                    if chars.get(i).is_some_and(|s| matches!(s, '+' | '-')) {
+                        i += 1;
+                    }
+                } else {
+                    break;
+                }
+            }
+            flush(&mut plain, &mut runs);
+            runs.push((chars[start..i].iter().collect(), Some(Tok::Number)));
+            continue;
+        }
+        if c.is_ascii_alphabetic() {
+            let start = i;
+            while i < chars.len() && chars[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            let word: String = chars[start..i].iter().collect();
+            let tok = matches!(word.as_str(), "true" | "false" | "null").then_some(Tok::Number);
+            flush(&mut plain, &mut runs);
+            runs.push((word, tok));
+            continue;
+        }
+        plain.push(c);
+        i += 1;
+    }
+    flush(&mut plain, &mut runs);
+    runs
+}
+
 fn toml_runs(code: &str) -> Runs {
     let lead = code.trim_start();
     let indent = &code[..code.len() - lead.len()];
@@ -514,9 +625,10 @@ fn is_comment_start(chars: &[char], i: usize, lang: Lang) -> bool {
     match lang {
         Lang::Python | Lang::Toml => chars[i] == '#',
         Lang::Rust | Lang::TsJs => chars[i] == '/' && chars.get(i + 1) == Some(&'/'),
-        // Markdown never reaches the generic scan ([`tokenize`] dispatches it
-        // to [`md_line`]); the arm exists for exhaustiveness only.
-        Lang::Markdown => false,
+        // Markdown and JSON never reach the generic scan ([`tokenize`]
+        // dispatches them to [`md_line`] and [`json_runs`]); the arms exist for
+        // exhaustiveness only. JSON has no comment syntax in any case.
+        Lang::Markdown | Lang::Json => false,
     }
 }
 
@@ -599,7 +711,9 @@ fn is_keyword(word: &str, lang: Lang) -> bool {
         Lang::TsJs => &TSJS_KEYWORDS,
         Lang::Python => &PYTHON_KEYWORDS,
         Lang::Toml => &TOML_KEYWORDS,
-        Lang::Markdown => &[],
+        // Neither reaches the generic scan; JSON's three bare words are
+        // classified by [`json_runs`] as the scalar constants they are.
+        Lang::Markdown | Lang::Json => &[],
     };
     table.contains(&word)
 }
@@ -773,7 +887,54 @@ mod tests {
     }
 
     #[test]
+    fn json_separates_keys_from_string_values() {
+        let runs = tokenize(r#"  "query": "needle","#, Lang::Json);
+        assert_eq!(runs.iter().find(|(t, _)| t == "\"query\"").unwrap().1, Some(Tok::Keyword));
+        assert_eq!(
+            runs.iter().find(|(t, _)| t == "\"needle\"").unwrap().1,
+            Some(Tok::Str)
+        );
+    }
+
+    #[test]
+    fn json_scalars_are_numbers_not_structure() {
+        for (src, lit) in [
+            ("{\"n\": -12.5e+3}", "-12.5e+3"),
+            ("{\"n\": true}", "true"),
+            ("{\"n\": null}", "null"),
+        ] {
+            let runs = tokenize(src, Lang::Json);
+            assert_eq!(
+                runs.iter().find(|(t, _)| t == lit).map(|r| r.1),
+                Some(Some(Tok::Number)),
+                "{src} mis-classified {lit}: {runs:?}"
+            );
+        }
+    }
+
+    /// The module's stated contract: concatenating the runs reproduces the
+    /// input exactly, for any line, including malformed ones.
+    #[test]
+    fn json_tokenizing_is_lossless_and_panic_free() {
+        for src in [
+            r#"{"a": 1, "b": [true, null], "c": "x\"y"}"#,
+            r#"  "unterminated"#,
+            r#""trailing backslash\"#,
+            "",
+            "   ",
+            "}}}],,,",
+            "{\"emoji\": \"⋯ ✓ 🚀\"}",
+        ] {
+            let runs = tokenize(src, Lang::Json);
+            let rebuilt: String = runs.iter().map(|(t, _)| t.as_str()).collect();
+            assert_eq!(rebuilt, src, "lossy on {src:?}: {runs:?}");
+        }
+    }
+
+    #[test]
     fn markdown_and_toml_map_from_extensions_and_fence_tags() {
+        assert_eq!(lang_from_fence("json"), Some(Lang::Json));
+        assert_eq!(lang_from_path("docs/wire/schema.json"), Some(Lang::Json));
         assert_eq!(
             lang_from_path("skills/review/SKILL.md"),
             Some(Lang::Markdown)


### PR DESCRIPTION
## What

A tool call's collapsed fold in the Command Deck showed the tool's *arguments* but effectively none of its **output**: a successful result rendered exactly one line plus a size chip, with the rest behind `ctrl+o`. For every tool whose output *is* the answer — `search`, `read_file`, `get_state` — that left the finding behind a keystroke the reader had no reason to press, and the size chip stated the count without naming the key that would reveal it.

Three changes, all in `stella-tui`:

1. **A successful result previews `OK_PREVIEW` lines** (= `FAIL_PREVIEW`, one preview rule rather than two) instead of 1 — `crates/stella-tui/src/render/entry.rs`.
2. **The hidden-line count is stated once, in the row that carries the affordance.** The `⋯ N lines` metric chip was removed and the `⋯ N lines · ctrl+o` row — previously failure-only — now fires for a success too. Not under an inline diff, where the rendered hunk is the result and the chatter is what would be counted.
3. **JSON bodies are syntax-coloured.** `crates/stella-tui/src/syntax.rs` gains a `Lang::Json` arm and a `json_runs` lexer; tool arguments always render through it (they are JSON by construction), and a result does when it opens with `{` or `[`.

A key and a string value are the same lexical thing in JSON, so a closed string looks ahead for a `:` and takes the structure hue when it finds one — the same call `toml_runs` already makes for a bare key, which keeps the two object-shaped formats reading alike. `true`/`false`/`null` take the number hue as the scalar constants they are, so an object's shape stays readable.

## Exemplar

The lexer follows the module's existing `toml_runs` shape rather than inventing one: single left-to-right scan, stateless, lossless (concatenating runs reproduces the input), panic-free on malformed input. This is deliberate — the module's doc comment argues that a line sliced out of context must degrade to slightly-off colouring rather than a wrong render, and a tool result is middle-elided before it reaches the renderer, so that case is the normal case here, not the edge.

`push_detail_spans` was factored out of `push_detail_line` (`render/row.rs`) so styled content shares the plain form's column and wrapping exactly; `push_detail_line` now delegates to it, so the two interleave without a seam.

## Why not a parse

`reads_as_json` tests the opening delimiter rather than parsing. A result is capped at `OUTPUT_BUDGET` with its middle elided, so a large JSON body no longer parses — a parse test would colour exactly the short results that need it least. The lexer emits untagged runs for anything it cannot classify, so a false positive costs a line that renders plain, never one that renders wrong.

## Witness

`crates/stella-tui/src/render/tests/tool_output.rs`, checked the artisanal way — with `crates/stella-tui/src/{syntax.rs,render/entry.rs,render/row.rs}` restored from `main` and the tests kept, three fail:

- `a_successful_result_previews_its_output_rather_than_one_line`
- `a_truncated_success_says_how_much_is_hidden_and_which_key_shows_it`
- `a_json_result_body_is_syntax_coloured`

The other three in that file are regression guards that hold either way: a short success offers no reveal, plain shell output is *not* coloured as JSON, and a JSON preview keeps its opening delimiter. `syntax.rs` adds `json_separates_keys_from_string_values`, `json_scalars_are_numbers_not_structure`, and `json_tokenizing_is_lossless_and_panic_free` (which pins the module's stated contract across malformed, empty, and non-ASCII input).

No test was deleted. No golden needed reblessing — which is itself a finding, see below.

## Gate

`make gate CARGO_SCOPE="-p stella-tui"` exits 0.

## Left behind

Closes nothing; files #3644 — the export/grid surface (`stella-transcript`) has its own independent fold policy and got none of this, so deck and export have now diverged. That issue also records the coverage gap this change exposed: `deck_render_snapshots.rs` has no golden covering a multi-line successful tool result, which is why every existing snapshot passed unchanged through a rewrite of exactly that code path.

Refs #3644

## Summary by Sourcery

Improve collapsed tool-result folds by showing more successful output, adding an explicit reveal affordance, and applying syntax colouring to JSON content.

New Features:
- Preview multiple lines of successful tool results in the collapsed Command Deck fold.
- Syntax-colour JSON tool arguments and JSON-shaped tool result bodies.

Bug Fixes:
- Expose useful successful tool output directly in the collapsed fold and clearly indicate when additional lines are available via ctrl+o.

Enhancements:
- Share styled and plain detail-line layout and wrapping behavior for rendered tool output.
- Add lossless, panic-free JSON tokenization with distinct styling for object keys, strings, and scalar values.

Tests:
- Add regression coverage for successful-result previews, hidden-line affordances, JSON colouring, plain-text handling, and JSON preview boundaries.
- Add lexer tests covering JSON key/value classification, scalar styling, malformed input, non-ASCII text, and losslessness.