### PR TITLE
fix(stella-tui): one live counter for init's long passes, not a line per tick

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -73,7 +73,7 @@ pub(crate) use graph::spawn_session_graph;
 #[cfg(test)]
 use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
 pub use init::run_init;
-pub(crate) use init::{InitLine, init_workspace};
+pub(crate) use init::{InitLine, deck_narrator, deck_notice_narrator, init_workspace};
 use outcome::{
     VerificationRequirement, pipeline_episode_outcome, pipeline_failure_reason,
     pipeline_session_status, pipeline_status_label, pipeline_status_result,

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -72,8 +72,8 @@ pub(crate) use goal::*;
 pub(crate) use graph::spawn_session_graph;
 #[cfg(test)]
 use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
-pub(crate) use init::init_workspace;
 pub use init::run_init;
+pub(crate) use init::{InitLine, init_workspace};
 use outcome::{
     VerificationRequirement, pipeline_episode_outcome, pipeline_failure_reason,
     pipeline_session_status, pipeline_status_label, pipeline_status_result,
@@ -250,7 +250,7 @@ async fn run_pipeline_one_shot(
     // machine-readable JSON.
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,
-        Box::new(|line| eprintln!("  {line}")),
+        Box::new(init::stderr_narrator()),
         Box::new(|| {}),
     );
     let mcp = connect_mcp(
@@ -701,7 +701,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     // watcher stops when it drops.
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,
-        Box::new(|line| eprintln!("  {line}")),
+        Box::new(init::stderr_narrator()),
         Box::new(|| {}),
     );
     let base_tools: &dyn ToolExecutor = match &mcp {
@@ -832,7 +832,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         }
         if input == "/init" {
             println!();
-            let mut emit = |line: String| println!("  {line}");
+            let mut emit = init::stdout_narrator();
             match init_workspace(
                 Some(&*provider),
                 &cfg.workspace_root,

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -154,7 +154,7 @@ pub(crate) async fn run_raw_one_shot(
     // goes to stderr — stdout may be machine-readable JSON.
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,
-        Box::new(|line| eprintln!("  {line}")),
+        Box::new(crate::agent::init::stderr_narrator()),
         Box::new(|| {}),
     );
     let process_free = crate::enterprise_telemetry::process_free_authority_active();
@@ -394,7 +394,7 @@ pub async fn run_goal_cmd(
     // goal returns.
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,
-        Box::new(|line| eprintln!("  {line}")),
+        Box::new(crate::agent::init::stderr_narrator()),
         Box::new(|| {}),
     );
     let mcp = connect_mcp(

--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -17,7 +17,7 @@ mod tests;
 ///
 pub(super) async fn build_code_graph(
     workspace_root: &std::path::Path,
-    emit: &mut dyn FnMut(String),
+    emit: &mut dyn FnMut(InitLine),
 ) {
     build_code_graph_with(
         workspace_root,
@@ -37,9 +37,9 @@ pub(super) async fn build_code_graph(
 async fn build_code_graph_with(
     workspace_root: &std::path::Path,
     embed_env: &stella_embed::EmbedderEnv,
-    emit: &mut dyn FnMut(String),
+    emit: &mut dyn FnMut(InitLine),
 ) {
-    emit("◈ indexing code graph…".to_string());
+    emit(InitLine::Step("◈ indexing code graph…".to_string()));
     // A full-tree tree-sitter index is seconds-to-minutes of blocking file
     // reads + parsing + SQLite on a large repo. Run it on the blocking pool
     // so it never pins a runtime worker — the deck driver awaits `/init`
@@ -50,11 +50,11 @@ async fn build_code_graph_with(
     let root = workspace_root.to_path_buf();
     let outcome = drive_index_blocking(root, INDEX_PROGRESS_INTERVAL, emit).await;
     match outcome {
-        Ok(Ok(stats)) => emit(format_graph_stats(&stats)),
-        Ok(Err(warning)) => emit(warning),
-        Err(e) => emit(format!(
+        Ok(Ok(stats)) => emit(InitLine::Step(format_graph_stats(&stats))),
+        Ok(Err(warning)) => emit(InitLine::Step(warning)),
+        Err(e) => emit(InitLine::Step(format!(
             "! code-graph indexing task failed: {e} — run `stella init` again to retry"
-        )),
+        ))),
     }
     warm_semantic_index(workspace_root, embed_env, emit).await;
 }
@@ -120,17 +120,17 @@ pub(super) fn format_index_progress(stats: &stella_graph::IndexStats) -> String 
 /// drained before the outcome is returned. Generic over the closure so the
 /// session builder's `Send` closure keeps its task spawnable while `stella
 /// init`'s plain printer needs no such bound.
-async fn drive_index_blocking<F: FnMut(String) + ?Sized>(
+async fn drive_index_blocking<F: FnMut(InitLine) + ?Sized>(
     root: std::path::PathBuf,
     interval: Duration,
     emit: &mut F,
 ) -> Result<Result<GraphSummary, String>, tokio::task::JoinError> {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<InitLine>();
     let mut handle = tokio::task::spawn_blocking(move || {
         let mut ticker = ProgressTicker::new(interval);
         index_workspace_graph_blocking(&root, &mut |stats| {
             if ticker.ready(Instant::now()) {
-                let _ = tx.send(format_index_progress(stats));
+                let _ = tx.send(InitLine::Progress(format_index_progress(stats)));
             }
         })
     });
@@ -176,7 +176,7 @@ async fn drive_index_blocking<F: FnMut(String) + ?Sized>(
 async fn warm_semantic_index(
     workspace_root: &std::path::Path,
     embed_env: &stella_embed::EmbedderEnv,
-    emit: &mut dyn FnMut(String),
+    emit: &mut dyn FnMut(InitLine),
 ) {
     use stella_embed::Embedder;
 
@@ -188,23 +188,27 @@ async fn warm_semantic_index(
         // so it is the one moment a hint about an unused capability is help
         // instead of noise.
         stella_embed::Resolution::Unconfigured => {
-            emit(
+            emit(InitLine::Step(
                 "· semantic index: skipped — no embedding backend configured (set \
                  VOYAGE_API_KEY, OPENAI_API_KEY, or STELLA_EMBED_URL + STELLA_EMBED_MODEL to \
                  let `stella search` rank by meaning)"
                     .to_string(),
-            );
+            ));
             return;
         }
         // A half-configured backend is neither off nor working, and a typo
         // must not read as a deliberate opt-out.
         stella_embed::Resolution::Incomplete(reason) => {
-            emit(format!("! semantic index: not built — {reason}"));
+            emit(InitLine::Step(format!(
+                "! semantic index: not built — {reason}"
+            )));
             return;
         }
     };
 
-    emit("◈ embedding files for semantic search…".to_string());
+    emit(InitLine::Step(
+        "◈ embedding files for semantic search…".to_string(),
+    ));
     let mut ticker = ProgressTicker::new(INDEX_PROGRESS_INTERVAL);
     let outcome = crate::search_cmd::semantic::warm_file_vectors_with_progress(
         workspace_root,
@@ -212,22 +216,26 @@ async fn warm_semantic_index(
         MAX_FILES_PER_EAGER_PASS,
         &mut |embedded| {
             if ticker.ready(Instant::now()) {
-                emit(format!("· semantic index: {embedded} files embedded…"));
+                emit(InitLine::Progress(format!(
+                    "· semantic index: {embedded} files embedded…"
+                )));
             }
         },
     )
     .await;
-    emit(format_warm_outcome(
+    emit(InitLine::Step(format_warm_outcome(
         &outcome,
         &embedder.fingerprint().model_id,
-    ));
+    )));
 
     // The sharper rung the search ranks first (#3098): a file-level vector
     // exists but a query naming one function in a large multi-purpose file
     // loses to a file that happens to have complete per-symbol coverage,
     // regardless of which is the true answer. Same reasoning as the pass
     // above, one layer down.
-    emit("◈ embedding code chunks for search…".to_string());
+    emit(InitLine::Step(
+        "◈ embedding code chunks for search…".to_string(),
+    ));
     let mut ticker = ProgressTicker::new(INDEX_PROGRESS_INTERVAL);
     let chunk_outcome = crate::search_cmd::engine::warm_chunk_vectors_with_progress(
         workspace_root,
@@ -235,15 +243,17 @@ async fn warm_semantic_index(
         crate::search_cmd::engine::MAX_FILES_PER_CHUNK_EAGER_PASS,
         &mut |embedded| {
             if ticker.ready(Instant::now()) {
-                emit(format!("· chunk index: {embedded} files embedded…"));
+                emit(InitLine::Progress(format!(
+                    "· chunk index: {embedded} files embedded…"
+                )));
             }
         },
     )
     .await;
-    emit(format_chunk_warm_outcome(
+    emit(InitLine::Step(format_chunk_warm_outcome(
         &chunk_outcome,
         &embedder.fingerprint().model_id,
-    ));
+    )));
 }
 
 /// The one-line report of an eager embedding pass.
@@ -476,7 +486,7 @@ impl Drop for SessionGraph {
 /// there; other callers pass a no-op).
 pub(crate) fn spawn_session_graph(
     workspace_root: &std::path::Path,
-    mut status: Box<dyn FnMut(String) + Send>,
+    mut status: Box<dyn FnMut(InitLine) + Send>,
     on_ready: Box<dyn FnOnce() + Send>,
 ) -> (SessionGraph, tokio::task::JoinHandle<()>) {
     let slot: Arc<std::sync::Mutex<Option<stella_graph::CodeGraph>>> =
@@ -491,16 +501,16 @@ pub(crate) fn spawn_session_graph(
         //    and this task stays spawnable. (We drive the shared helper
         //    rather than `build_code_graph`, whose `&mut dyn FnMut` emit is
         //    not `Send` and whose embedding pass a session start skips.)
-        status("◈ indexing code graph…".to_string());
+        status(InitLine::Step("◈ indexing code graph…".to_string()));
         let outcome =
             drive_index_blocking(root.clone(), INDEX_PROGRESS_INTERVAL, &mut status).await;
         match outcome {
-            Ok(Ok(stats)) => status(format_graph_stats(&stats)),
-            Ok(Err(warning)) => status(warning),
-            Err(e) => status(format!(
+            Ok(Ok(stats)) => status(InitLine::Step(format_graph_stats(&stats))),
+            Ok(Err(warning)) => status(InitLine::Step(warning)),
+            Err(e) => status(InitLine::Step(format!(
                 "! code-graph indexing task failed: {e} — search ranks over the last good index \
                  this session"
-            )),
+            ))),
         }
         on_ready();
         // 2) Arm the live watcher on a mounted graph kept alive for the
@@ -511,9 +521,9 @@ pub(crate) fn spawn_session_graph(
             Ok(graph) => {
                 *slot_task.lock().unwrap_or_else(|p| p.into_inner()) = Some(graph);
             }
-            Err(e) => status(format!(
+            Err(e) => status(InitLine::Step(format!(
                 "! code-graph watcher unavailable: {e} — the index will refresh on the next launch"
-            )),
+            ))),
         }
     });
     (SessionGraph { graph: slot }, handle)

--- a/crates/stella-cli/src/agent/graph/tests.rs
+++ b/crates/stella-cli/src/agent/graph/tests.rs
@@ -97,7 +97,10 @@ async fn init_embeds_the_index_without_any_semantic_query_being_issued() {
     let server = embeddings_server().await;
 
     let mut lines: Vec<String> = Vec::new();
-    build_code_graph_with(&root, &env_for(&server), &mut |line| lines.push(line)).await;
+    build_code_graph_with(&root, &env_for(&server), &mut |line| {
+        lines.push(line.text().to_string())
+    })
+    .await;
 
     let fingerprint = stella_embed::HttpEmbedder::new(
         &format!("{}/v1", server.uri()),
@@ -148,7 +151,7 @@ async fn init_still_builds_the_graph_with_no_embedder_configured() {
 
     let mut lines: Vec<String> = Vec::new();
     build_code_graph_with(&root, &stella_embed::EmbedderEnv::default(), &mut |line| {
-        lines.push(line)
+        lines.push(line.text().to_string())
     })
     .await;
 
@@ -180,7 +183,7 @@ async fn a_half_configured_embedder_names_what_is_missing_and_init_survives() {
         ..Default::default()
     };
     let mut lines: Vec<String> = Vec::new();
-    build_code_graph_with(&root, &env, &mut |line| lines.push(line)).await;
+    build_code_graph_with(&root, &env, &mut |line| lines.push(line.text().to_string())).await;
 
     let graph = open_graph(&root);
     let files = graph.file_count().expect("file count");
@@ -205,7 +208,10 @@ async fn a_broken_backend_reports_and_leaves_init_successful() {
         .await;
 
     let mut lines: Vec<String> = Vec::new();
-    build_code_graph_with(&root, &env_for(&server), &mut |line| lines.push(line)).await;
+    build_code_graph_with(&root, &env_for(&server), &mut |line| {
+        lines.push(line.text().to_string())
+    })
+    .await;
 
     let graph = open_graph(&root);
     let files = graph.file_count().expect("file count");
@@ -273,7 +279,10 @@ async fn init_embeds_every_chunk_without_any_semantic_query_being_issued() {
     let server = embeddings_server().await;
 
     let mut lines: Vec<String> = Vec::new();
-    build_code_graph_with(&root, &env_for(&server), &mut |line| lines.push(line)).await;
+    build_code_graph_with(&root, &env_for(&server), &mut |line| {
+        lines.push(line.text().to_string())
+    })
+    .await;
 
     let fingerprint = stella_embed::HttpEmbedder::new(
         &format!("{}/v1", server.uri()),
@@ -338,7 +347,7 @@ async fn a_running_index_pass_streams_progress_lines() {
 
     let mut lines: Vec<String> = Vec::new();
     let outcome = drive_index_blocking(root, std::time::Duration::ZERO, &mut |line| {
-        lines.push(line)
+        lines.push(line.text().to_string())
     })
     .await
     .expect("task completes")
@@ -359,6 +368,47 @@ async fn a_running_index_pass_streams_progress_lines() {
             .all(|line| line.contains("parsed") && line.contains("unchanged")),
         "each progress line carries the live counts: {progress:?}"
     );
+}
+
+/// Witness: a per-tick count is emitted as [`InitLine::Progress`] — the kind
+/// every surface rewrites in place — while the pass's summary is an
+/// [`InitLine::Step`] that joins the record.
+///
+/// Classification is the whole fix. Both used to be a bare `String`, so a
+/// large workspace's minutes of once-a-second ticks accumulated in the deck
+/// transcript and buried the `✓` summaries under them. A tick misfiled as a
+/// `Step` would restore exactly that, silently, which is why the two kinds are
+/// asserted here rather than left to the type checker.
+#[tokio::test]
+async fn a_tick_is_progress_and_the_summary_is_a_step() {
+    let ws = workspace();
+    let root = ws.path().canonicalize().expect("canonicalize");
+
+    let mut lines: Vec<InitLine> = Vec::new();
+    // A zero quiet interval makes every per-file callback past the first a tick.
+    drive_index_blocking(root, std::time::Duration::ZERO, &mut |line| {
+        lines.push(line)
+    })
+    .await
+    .expect("task completes")
+    .expect("index succeeds");
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| matches!(line, InitLine::Progress(_))),
+        "the pass must tick: {:?}",
+        lines.iter().map(InitLine::text).collect::<Vec<_>>()
+    );
+    for line in &lines {
+        let is_tick = line.text().contains("files walked");
+        assert_eq!(
+            is_tick,
+            matches!(line, InitLine::Progress(_)),
+            "a live count is Progress and everything else is a Step: {:?}",
+            line.text()
+        );
+    }
 }
 
 /// The throttle is what keeps liveness from becoming spam: the first tick

--- a/crates/stella-cli/src/agent/init.rs
+++ b/crates/stella-cli/src/agent/init.rs
@@ -15,6 +15,46 @@ use super::graph::build_code_graph;
 use super::*;
 use crate::domains::{cached_taxonomy, summarize_repo};
 
+/// One narrated line of init, carrying whether it is part of the **record** or
+/// part of the **liveness**.
+///
+/// Both used to be the same thing — a `String` appended wherever it landed —
+/// and the liveness half won: a large workspace ticks its three long passes
+/// (the code-graph walk, then the file and chunk embedding passes) once a
+/// second for minutes, so the ✓ summaries that say what init actually did
+/// arrived buried under a hundred near-identical `· chunk index: N files
+/// embedded…` lines. The counter still has to be *live* — that is the whole
+/// reason #3102 replaced the spinner with real counts — so it stays, and only
+/// its accumulation goes: each surface rewrites the previous tick.
+///
+/// The distinction is in the type rather than in a prefix a surface could
+/// sniff (`starts_with("· ")`), because a caller adding a fourth long pass
+/// should have to answer which kind of line it emits.
+pub(crate) enum InitLine {
+    /// A permanent line: appended, and read afterwards as the record of init.
+    Step(String),
+    /// A live counter: replaces the previous `Progress` line rather than
+    /// appending. The last tick of a pass stays on screen — a counter that
+    /// erased itself would leave nothing to read, which is the failure #3102
+    /// diagnosed in the cinematic it retired.
+    Progress(String),
+}
+
+impl InitLine {
+    /// The line's text, whichever kind it is — for a test asserting on what
+    /// was said rather than on how it was shown.
+    ///
+    /// Test-only on purpose: every shipping surface has to render the two
+    /// kinds differently, and an accessor that discards the distinction is
+    /// exactly the shortcut that would put the flood back.
+    #[cfg(test)]
+    pub(crate) fn text(&self) -> &str {
+        match self {
+            Self::Step(text) | Self::Progress(text) => text,
+        }
+    }
+}
+
 /// The domain step of init, wearing the #3102 inference-skip gate: a
 /// model-inferred taxonomy whose recorded repo-shape fingerprint still
 /// matches the tree is reused **without a model call** — the cost the gate
@@ -62,10 +102,22 @@ pub(crate) async fn init_workspace(
     workspace_root: &std::path::Path,
     model_hint: Option<&str>,
     budget_limit: Option<f64>,
-    emit: &mut dyn FnMut(String),
+    emit: &mut dyn FnMut(InitLine),
 ) -> Result<(Domains, f64), String> {
-    let (domains, inference_cost_usd) =
-        resolve_domains(provider, workspace_root, model_hint, budget_limit, emit).await;
+    // The two stages that narrate nothing live keep the plain `String` sink:
+    // every line they emit is part of the record, so the wrapper naming that
+    // once is better than making each call site repeat it.
+    let (domains, inference_cost_usd) = {
+        let mut step = |line: String| emit(InitLine::Step(line));
+        resolve_domains(
+            provider,
+            workspace_root,
+            model_hint,
+            budget_limit,
+            &mut step,
+        )
+        .await
+    };
 
     // The code graph needs no provider — build it regardless of how the
     // domains were inferred, so the index exists even fully offline.
@@ -74,7 +126,10 @@ pub(crate) async fn init_workspace(
     // Adopt commands/skills/agents other code agents keep in `.claude/` and
     // `.agents/` (workspace + user scope) as symlinks into stella's own
     // directories — idempotent, never clobbers, never fatal.
-    crate::extensions::sync_extensions(workspace_root, emit);
+    {
+        let mut step = |line: String| emit(InitLine::Step(line));
+        crate::extensions::sync_extensions(workspace_root, &mut step);
+    }
 
     let path = domains.save(workspace_root)?;
 
@@ -86,18 +141,78 @@ pub(crate) async fn init_workspace(
         m.record_taxonomy(&domains).await;
     }
 
-    emit(format!(
+    emit(InitLine::Step(format!(
         "✓ {} domains ({}) → {}",
         domains.domains.len(),
         domains.inferred_by,
         path.display()
-    ));
+    )));
     if inference_cost_usd > 0.0 {
-        emit(format!(
+        emit(InitLine::Step(format!(
             "domain inference model cost: ${inference_cost_usd:.6}"
-        ));
+        )));
     }
     Ok((domains, inference_cost_usd))
+}
+
+/// The plain-stdout narrator both non-deck init paths hand to
+/// [`init_workspace`] — `stella init` and the plain REPL's `/init`.
+///
+/// An [`InitLine::Progress`] counter rewrites its own line where the terminal
+/// can take one back, and is simply appended where it cannot: a redirected
+/// `stella init` log has to stay readable, and a `\r` in a file is not. Either
+/// way the last tick survives — nothing here erases what it drew, which is the
+/// failure #3102 diagnosed in the cinematic it retired.
+pub(crate) fn stdout_narrator() -> impl FnMut(InitLine) + Send {
+    narrator(false)
+}
+
+/// [`stdout_narrator`] against stderr — what the session-startup index build
+/// uses, so its progress never lands in a machine-readable stdout
+/// (`crate::agent::spawn_session_graph`).
+pub(crate) fn stderr_narrator() -> impl FnMut(InitLine) + Send {
+    narrator(true)
+}
+
+fn narrator(to_stderr: bool) -> impl FnMut(InitLine) + Send {
+    use std::io::IsTerminal;
+
+    let rewritable = if to_stderr {
+        std::io::stderr().is_terminal()
+    } else {
+        std::io::stdout().is_terminal()
+    };
+    // True while the cursor is parked on a counter line the next tick may
+    // overwrite; a step landing there has to close it first, or it would print
+    // on top of the count.
+    let mut counter_open = false;
+    move |line: InitLine| {
+        use std::io::Write;
+
+        let mut out: Box<dyn Write> = if to_stderr {
+            Box::new(std::io::stderr())
+        } else {
+            Box::new(std::io::stdout())
+        };
+        let _ = match line {
+            InitLine::Step(text) => {
+                let lead = if std::mem::take(&mut counter_open) {
+                    "\n"
+                } else {
+                    ""
+                };
+                writeln!(out, "{lead}  {text}")
+            }
+            InitLine::Progress(text) if rewritable => {
+                counter_open = true;
+                // Erase to end of line before parking the cursor back at the
+                // start: without it, a shorter count leaves the tail of the
+                // longer one it replaced.
+                write!(out, "\r  {text}\x1b[K").and_then(|()| out.flush())
+            }
+            InitLine::Progress(text) => writeln!(out, "  {text}"),
+        };
+    }
 }
 
 /// `stella init` — infer the workspace's domain taxonomy, build the code-graph
@@ -143,7 +258,7 @@ pub async fn run_init(
             }
         };
 
-    let mut emit = |line: String| println!("  {line}");
+    let mut emit = stdout_narrator();
     let (domains, _inference_cost_usd) = init_workspace(
         provider.as_deref(),
         &workspace_root,

--- a/crates/stella-cli/src/agent/init.rs
+++ b/crates/stella-cli/src/agent/init.rs
@@ -174,6 +174,53 @@ pub(crate) fn stderr_narrator() -> impl FnMut(InitLine) + Send {
     narrator(true)
 }
 
+/// The Command Deck's narrator for `/init`: a step joins `agent`'s transcript,
+/// a counter rewrites the counter before it.
+///
+/// A step carries its own terminator because the transcript fold coalesces
+/// consecutive `Text` verbatim — without one, init's stages run together into a
+/// single paragraph.
+pub(crate) fn deck_narrator(
+    tx: tokio::sync::mpsc::UnboundedSender<stella_tui::Inbound>,
+    agent: &str,
+) -> impl FnMut(InitLine) {
+    let agent = agent.to_string();
+    move |line| {
+        let _ = tx.send(match line {
+            InitLine::Step(text) => stella_tui::Inbound::Event {
+                agent: agent.clone(),
+                event: AgentEvent::Text {
+                    text: format!("{text}\n"),
+                },
+            },
+            InitLine::Progress(text) => stella_tui::Inbound::Progress {
+                agent: agent.clone(),
+                text,
+            },
+        });
+    }
+}
+
+/// [`deck_narrator`] for the deck's session-startup index build, whose
+/// milestones are chrome rather than session speech: a step is a dwell notice,
+/// while a counter still rewrites in place rather than stacking another
+/// near-identical row in that dialog.
+pub(crate) fn deck_notice_narrator(
+    tx: tokio::sync::mpsc::UnboundedSender<stella_tui::Inbound>,
+    agent: &str,
+) -> impl FnMut(InitLine) + Send {
+    let agent = agent.to_string();
+    move |line| {
+        let _ = tx.send(match line {
+            InitLine::Step(text) => stella_tui::Inbound::Notice(text),
+            InitLine::Progress(text) => stella_tui::Inbound::Progress {
+                agent: agent.clone(),
+                text,
+            },
+        });
+    }
+}
+
 fn narrator(to_stderr: bool) -> impl FnMut(InitLine) + Send {
     use std::io::IsTerminal;
 

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -93,7 +93,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
     );
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,
-        Box::new(|line| eprintln!("  {line}")),
+        Box::new(crate::agent::init::stderr_narrator()),
         Box::new(|| {}),
     );
     let mcp = connect_mcp(

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -740,17 +740,7 @@ pub async fn run_deck_session(
     let ready_root = cfg.workspace_root.clone();
     let (_session_graph, _graph_build) = agent::spawn_session_graph(
         &cfg.workspace_root,
-        // A milestone is a notice; a counter rewrites the counter before it
-        // rather than stacking another near-identical row in the dwell dialog.
-        Box::new(move |line| {
-            let _ = match line {
-                agent::InitLine::Step(text) => status_tx.send(system_notice(text)),
-                agent::InitLine::Progress(text) => status_tx.send(Inbound::Progress {
-                    agent: LEAD.to_string(),
-                    text,
-                }),
-            };
-        }),
+        Box::new(agent::deck_notice_narrator(status_tx, LEAD)),
         Box::new(move || {
             // Populate the Graph tab now the index exists (it opened on the
             // "run stella init" hint), and assert the lead is idle — the
@@ -3672,20 +3662,7 @@ async fn run_deck_command(
             // them). Released on BOTH outcomes — a failed init must never
             // strand a held splash.
             let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
-            // A step joins the record; a counter rewrites the counter before
-            // it. Both are one line, so a step carries its own terminator —
-            // the transcript fold coalesces consecutive `Text` into one
-            // buffer verbatim, which is what ran init's stages together into
-            // a single paragraph.
-            let mut emit = |line: agent::InitLine| match line {
-                agent::InitLine::Step(text) => say(format!("{text}\n")),
-                agent::InitLine::Progress(text) => {
-                    let _ = in_tx.send(Inbound::Progress {
-                        agent: LEAD.to_string(),
-                        text,
-                    });
-                }
-            };
+            let mut emit = agent::deck_narrator(in_tx.clone(), LEAD);
             let outcome = agent::init_workspace(
                 Some(provider),
                 &cfg.workspace_root,

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -740,8 +740,16 @@ pub async fn run_deck_session(
     let ready_root = cfg.workspace_root.clone();
     let (_session_graph, _graph_build) = agent::spawn_session_graph(
         &cfg.workspace_root,
+        // A milestone is a notice; a counter rewrites the counter before it
+        // rather than stacking another near-identical row in the dwell dialog.
         Box::new(move |line| {
-            let _ = status_tx.send(system_notice(line));
+            let _ = match line {
+                agent::InitLine::Step(text) => status_tx.send(system_notice(text)),
+                agent::InitLine::Progress(text) => status_tx.send(Inbound::Progress {
+                    agent: LEAD.to_string(),
+                    text,
+                }),
+            };
         }),
         Box::new(move || {
             // Populate the Graph tab now the index exists (it opened on the
@@ -3664,7 +3672,20 @@ async fn run_deck_command(
             // them). Released on BOTH outcomes — a failed init must never
             // strand a held splash.
             let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
-            let mut emit = |line: String| say(line);
+            // A step joins the record; a counter rewrites the counter before
+            // it. Both are one line, so a step carries its own terminator —
+            // the transcript fold coalesces consecutive `Text` into one
+            // buffer verbatim, which is what ran init's stages together into
+            // a single paragraph.
+            let mut emit = |line: agent::InitLine| match line {
+                agent::InitLine::Step(text) => say(format!("{text}\n")),
+                agent::InitLine::Progress(text) => {
+                    let _ = in_tx.send(Inbound::Progress {
+                        agent: LEAD.to_string(),
+                        text,
+                    });
+                }
+            };
             let outcome = agent::init_workspace(
                 Some(provider),
                 &cfg.workspace_root,

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -593,6 +593,14 @@ impl WorkspaceModel {
                     self.agents[idx].last_activity_ms = self.now_ms;
                 }
             }
+            // One tick of a host-side pass's live counter: rewritten in place,
+            // no status change, no trace row. See `Inbound::Progress`.
+            Inbound::Progress { agent, text } => {
+                if let Some(idx) = self.index_of(agent) {
+                    self.agents[idx].model.set_progress_line(text);
+                    self.agents[idx].last_activity_ms = self.now_ms;
+                }
+            }
             Inbound::Status { agent, status } => {
                 // Auto-register an unknown id, exactly like `Event`:
                 // supervisor states (`Paused`, `Killed`, …) are not

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -140,6 +140,22 @@ pub enum Inbound {
     /// auto-registers, because a lane that does not exist is precisely the
     /// case the synthetic fallback lane already covers.
     ShellEvent { agent: AgentId, event: AgentEvent },
+    /// One tick of a long host-side pass's live counter — `/init`'s code-graph
+    /// walk and its two embedding passes. Rewrites the counter it last wrote
+    /// ([`crate::model::SessionModel::set_progress_line`]) instead of appending,
+    /// so a pass that ticks two hundred times leaves **one** line behind, next
+    /// to the ✓ summaries that are init's actual record.
+    ///
+    /// Deliberately not [`Inbound::Event`] with an `AgentEvent::Text`: that path
+    /// coalesces every line into one fold, which is what buried those summaries
+    /// under a wall of near-identical repeats. It is also not
+    /// [`Inbound::Notice`] — a notice dwells three seconds and then is gone,
+    /// while a counter's final value is the thing worth keeping.
+    ///
+    /// Transcript only: no status, no counters, and no trace row (the strip
+    /// keeps naming the milestone the pass is inside). Folding an unknown id is
+    /// a no-op, exactly like [`Inbound::ShellEvent`].
+    Progress { agent: AgentId, text: String },
     /// A supervisor lifecycle transition not carried by the event stream.
     Status { agent: AgentId, status: AgentStatus },
     /// The dispatcher took the oldest queued prompt and handed it to an

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -14,6 +14,10 @@ use std::collections::BTreeMap;
 
 use stella_protocol::AgentEvent;
 
+mod inspect;
+
+pub use inspect::{InspectMessage, InspectView, JournalEra, RecordedCallInfo};
+
 use crate::graph::GraphSnapshot;
 use crate::input::UserInput;
 
@@ -141,20 +145,18 @@ pub enum Inbound {
     /// case the synthetic fallback lane already covers.
     ShellEvent { agent: AgentId, event: AgentEvent },
     /// One tick of a long host-side pass's live counter — `/init`'s code-graph
-    /// walk and its two embedding passes. Rewrites the counter it last wrote
-    /// ([`crate::model::SessionModel::set_progress_line`]) instead of appending,
-    /// so a pass that ticks two hundred times leaves **one** line behind, next
-    /// to the ✓ summaries that are init's actual record.
+    /// walk and its two embedding passes — rewritten in place by
+    /// [`crate::model::SessionModel::set_progress_line`], which carries the
+    /// reasoning for why the fold owns the rewrite.
     ///
-    /// Deliberately not [`Inbound::Event`] with an `AgentEvent::Text`: that path
-    /// coalesces every line into one fold, which is what buried those summaries
-    /// under a wall of near-identical repeats. It is also not
-    /// [`Inbound::Notice`] — a notice dwells three seconds and then is gone,
-    /// while a counter's final value is the thing worth keeping.
+    /// Deliberately neither [`Inbound::Event`] (an `AgentEvent::Text` coalesces
+    /// into one fold, which is what buried init's ✓ summaries under a wall of
+    /// repeats) nor [`Inbound::Notice`] (a notice dwells and is gone, while a
+    /// counter's final value is the part worth keeping).
     ///
-    /// Transcript only: no status, no counters, and no trace row (the strip
-    /// keeps naming the milestone the pass is inside). Folding an unknown id is
-    /// a no-op, exactly like [`Inbound::ShellEvent`].
+    /// Transcript only: no status, no counters, and no trace row — the strip
+    /// keeps naming the milestone the pass is inside. Folding an unknown id is a
+    /// no-op, exactly like [`Inbound::ShellEvent`].
     Progress { agent: AgentId, text: String },
     /// A supervisor lifecycle transition not carried by the event stream.
     Status { agent: AgentId, status: AgentStatus },
@@ -423,116 +425,6 @@ pub enum Inbound {
     /// prompts, far larger than any other `Inbound` payload, and this variant
     /// would otherwise set the size of every channel send.
     InspectedCall(Box<InspectView>),
-}
-
-/// One recorded model call — the INSPECT overlay's row. Mirrors
-/// `stella_store::RecordedCall`; the TUI never links the store crate, so the
-/// driver maps one to the other (same contract as [`IssueRow`]).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RecordedCallInfo {
-    pub turn_instance: u32,
-    pub step: u64,
-    /// Which call at this step: 0 the engine's worker, 1 the overflow
-    /// summarizer, 2+ a pipeline management role.
-    pub call_seq: u64,
-    pub call_role: String,
-    pub provider: String,
-    pub model: String,
-    pub estimated_input_tokens: u64,
-}
-
-impl RecordedCallInfo {
-    /// The coordinate triple, for the detail header and the request echo.
-    pub fn coordinate(&self) -> (u32, u64, u64) {
-        (self.turn_instance, self.step, self.call_seq)
-    }
-}
-
-/// One message of a reconstructed call, flattened for display: tool calls and
-/// results are already rendered into `content` by the driver, so the overlay
-/// never needs the protocol types.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InspectMessage {
-    pub role: String,
-    pub content: String,
-}
-
-/// Which compaction-journaling era wrote the journal a reconstruction came
-/// from — the deck's mirror of `stella_store::JournalEra` (this crate links no
-/// store; the driver maps one to the other, exactly as it does for every other
-/// type on this envelope).
-///
-/// It exists here for one reason: it decides whether a digest mismatch is
-/// routine housekeeping or a real integrity signal, and the overlay must not
-/// guess (#1981).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum JournalEra {
-    /// Compaction rewrote tool results in place and journaled nothing about it
-    /// (#1667 and earlier), so a compacted block mismatches as a matter of
-    /// course. The default: an era the deck was not told reads as the one
-    /// where a mismatch means the least.
-    #[default]
-    CompactionUnjournaled,
-    /// Every compaction rewrite is journaled, so a compacted block resolves to
-    /// exactly what the step sent and a mismatch has no routine explanation.
-    CompactionJournaled,
-}
-
-/// The reconstructed context of one model call — what the INSPECT overlay
-/// shows. Carries the verification verdict alongside the bytes, because a
-/// transcript you cannot vouch for is worse than none.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InspectView {
-    pub call: RecordedCallInfo,
-    pub messages: Vec<InspectMessage>,
-    /// Every journal-resolved block re-hashed to its recorded digest.
-    pub verified: bool,
-    /// Blocks with no recoverable preimage — a documented coverage gap
-    /// (synthetic results, discarded speculation, attachments).
-    pub unresolved: usize,
-    /// Blocks whose recovered bytes did NOT re-hash to the digest they
-    /// recorded — the preimage shown is the closest one the journal holds, not
-    /// the exact bytes this step sent. Kept distinct from `unresolved`: the two
-    /// mean very different things. What a mismatch *means* depends on
-    /// [`Self::journal_era`] — see [`Self::digest_mismatch_line`].
-    pub digest_mismatches: usize,
-    /// Who wrote the journal these blocks were resolved from.
-    pub journal_era: JournalEra,
-}
-
-impl InspectView {
-    /// The overlay's mismatch line and whether it is a genuine integrity
-    /// signal, or `None` when nothing mismatched.
-    ///
-    /// The wording lives here rather than in the renderer for two reasons.
-    /// `deck_render.rs` is a god file at its ceiling, so a second branch there
-    /// costs lines it does not have; and the overlay **clips** rather than
-    /// wraps, so each variant has to be short enough to survive the right edge
-    /// intact — which is a property of the string, testable here, not of the
-    /// draw call. Both variants stay under 80 columns and put the *meaning*
-    /// before the detail, so the part that distinguishes them survives even on
-    /// the narrowest terminal the popup can be drawn in.
-    ///
-    /// A legacy journal's mismatch stays the benign warning #1668 introduced,
-    /// naming compaction as the cause. A journal that records every rewrite
-    /// has no such excuse, so the same mismatch reads as the alarm it is
-    /// (#1981).
-    pub fn digest_mismatch_line(&self) -> Option<(String, bool)> {
-        let n = self.digest_mismatches;
-        if n == 0 {
-            return None;
-        }
-        Some(match self.journal_era {
-            JournalEra::CompactionUnjournaled => (
-                format!("  ! {n} block(s) did not re-hash — an older journal's compaction rewrite"),
-                false,
-            ),
-            JournalEra::CompactionJournaled => (
-                format!("  !! {n} block(s) unaccounted for — this journal records its rewrites"),
-                true,
-            ),
-        })
-    }
 }
 
 /// One row of the ISSUES tab's browse list — tracker-agnostic: the driver
@@ -1464,39 +1356,6 @@ mod tests {
             AgentStatus::Killed,
         ] {
             assert!(!(s.is_active() && s.is_terminal()), "{s:?}");
-        }
-    }
-
-    /// The INSPECT overlay clips rather than wraps, and its popup is
-    /// `min(frame - 6, 120)` columns wide — so on an 80-column terminal a
-    /// banner line has about 72 to work with. Both variants are written to
-    /// that budget and put the meaning first; this pins it, because a wording
-    /// change that silently pushes the distinguishing half off the right edge
-    /// would undo #1981 without failing anything else (see #2029).
-    #[test]
-    fn both_mismatch_lines_survive_an_eighty_column_terminal() {
-        for era in [
-            JournalEra::CompactionUnjournaled,
-            JournalEra::CompactionJournaled,
-        ] {
-            let view = InspectView {
-                call: RecordedCallInfo {
-                    turn_instance: 0,
-                    step: 1,
-                    call_seq: 0,
-                    call_role: "worker".into(),
-                    provider: "zai".into(),
-                    model: "glm-5.2".into(),
-                    estimated_input_tokens: 10,
-                },
-                messages: Vec::new(),
-                verified: false,
-                digest_mismatches: 999,
-                unresolved: 0,
-                journal_era: era,
-            };
-            let (line, _) = view.digest_mismatch_line().expect("a mismatch is reported");
-            assert!(line.chars().count() <= 72, "{} cols: {line}", line.len());
         }
     }
 

--- a/crates/stella-tui/src/envelope/inspect.rs
+++ b/crates/stella-tui/src/envelope/inspect.rs
@@ -1,0 +1,158 @@
+//! The INSPECT overlay's payload types — one recorded model call, and the
+//! reconstructed context behind it.
+//!
+//! Split out of `envelope.rs` when that file reached the 1500-line limit: this
+//! cluster is the one part of the envelope that is a self-contained read-model
+//! rather than a routing tag, and nothing outside it refers to these types
+//! except the two [`Inbound`](super::Inbound) variants that carry them.
+//!
+//! Like every other type on the envelope, these mirror `stella_store` shapes
+//! the TUI never links — the driver maps one to the other.
+
+/// One recorded model call — the INSPECT overlay's row. Mirrors
+/// `stella_store::RecordedCall`; the TUI never links the store crate, so the
+/// driver maps one to the other (same contract as [`IssueRow`](super::IssueRow)).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordedCallInfo {
+    pub turn_instance: u32,
+    pub step: u64,
+    /// Which call at this step: 0 the engine's worker, 1 the overflow
+    /// summarizer, 2+ a pipeline management role.
+    pub call_seq: u64,
+    pub call_role: String,
+    pub provider: String,
+    pub model: String,
+    pub estimated_input_tokens: u64,
+}
+
+impl RecordedCallInfo {
+    /// The coordinate triple, for the detail header and the request echo.
+    pub fn coordinate(&self) -> (u32, u64, u64) {
+        (self.turn_instance, self.step, self.call_seq)
+    }
+}
+
+/// One message of a reconstructed call, flattened for display: tool calls and
+/// results are already rendered into `content` by the driver, so the overlay
+/// never needs the protocol types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectMessage {
+    pub role: String,
+    pub content: String,
+}
+
+/// Which compaction-journaling era wrote the journal a reconstruction came
+/// from — the deck's mirror of `stella_store::JournalEra` (this crate links no
+/// store; the driver maps one to the other, exactly as it does for every other
+/// type on this envelope).
+///
+/// It exists here for one reason: it decides whether a digest mismatch is
+/// routine housekeeping or a real integrity signal, and the overlay must not
+/// guess (#1981).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum JournalEra {
+    /// Compaction rewrote tool results in place and journaled nothing about it
+    /// (#1667 and earlier), so a compacted block mismatches as a matter of
+    /// course. The default: an era the deck was not told reads as the one
+    /// where a mismatch means the least.
+    #[default]
+    CompactionUnjournaled,
+    /// Every compaction rewrite is journaled, so a compacted block resolves to
+    /// exactly what the step sent and a mismatch has no routine explanation.
+    CompactionJournaled,
+}
+
+/// The reconstructed context of one model call — what the INSPECT overlay
+/// shows. Carries the verification verdict alongside the bytes, because a
+/// transcript you cannot vouch for is worse than none.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectView {
+    pub call: RecordedCallInfo,
+    pub messages: Vec<InspectMessage>,
+    /// Every journal-resolved block re-hashed to its recorded digest.
+    pub verified: bool,
+    /// Blocks with no recoverable preimage — a documented coverage gap
+    /// (synthetic results, discarded speculation, attachments).
+    pub unresolved: usize,
+    /// Blocks whose recovered bytes did NOT re-hash to the digest they
+    /// recorded — the preimage shown is the closest one the journal holds, not
+    /// the exact bytes this step sent. Kept distinct from `unresolved`: the two
+    /// mean very different things. What a mismatch *means* depends on
+    /// [`Self::journal_era`] — see [`Self::digest_mismatch_line`].
+    pub digest_mismatches: usize,
+    /// Who wrote the journal these blocks were resolved from.
+    pub journal_era: JournalEra,
+}
+
+impl InspectView {
+    /// The overlay's mismatch line and whether it is a genuine integrity
+    /// signal, or `None` when nothing mismatched.
+    ///
+    /// The wording lives here rather than in the renderer for two reasons.
+    /// `deck_render.rs` is a god file at its ceiling, so a second branch there
+    /// costs lines it does not have; and the overlay **clips** rather than
+    /// wraps, so each variant has to be short enough to survive the right edge
+    /// intact — which is a property of the string, testable here, not of the
+    /// draw call. Both variants stay under 80 columns and put the *meaning*
+    /// before the detail, so the part that distinguishes them survives even on
+    /// the narrowest terminal the popup can be drawn in.
+    ///
+    /// A legacy journal's mismatch stays the benign warning #1668 introduced,
+    /// naming compaction as the cause. A journal that records every rewrite
+    /// has no such excuse, so the same mismatch reads as the alarm it is
+    /// (#1981).
+    pub fn digest_mismatch_line(&self) -> Option<(String, bool)> {
+        let n = self.digest_mismatches;
+        if n == 0 {
+            return None;
+        }
+        Some(match self.journal_era {
+            JournalEra::CompactionUnjournaled => (
+                format!("  ! {n} block(s) did not re-hash — an older journal's compaction rewrite"),
+                false,
+            ),
+            JournalEra::CompactionJournaled => (
+                format!("  !! {n} block(s) unaccounted for — this journal records its rewrites"),
+                true,
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The INSPECT overlay clips rather than wraps, and its popup is
+    /// `min(frame - 6, 120)` columns wide — so on an 80-column terminal a
+    /// banner line has about 72 to work with. Both variants are written to
+    /// that budget and put the meaning first; this pins it, because a wording
+    /// change that silently pushes the distinguishing half off the right edge
+    /// would undo #1981 without failing anything else (see #2029).
+    #[test]
+    fn both_mismatch_lines_survive_an_eighty_column_terminal() {
+        for era in [
+            JournalEra::CompactionUnjournaled,
+            JournalEra::CompactionJournaled,
+        ] {
+            let view = InspectView {
+                call: RecordedCallInfo {
+                    turn_instance: 0,
+                    step: 1,
+                    call_seq: 0,
+                    call_role: "worker".into(),
+                    provider: "zai".into(),
+                    model: "glm-5.2".into(),
+                    estimated_input_tokens: 10,
+                },
+                messages: Vec::new(),
+                verified: false,
+                digest_mismatches: 999,
+                unresolved: 0,
+                journal_era: era,
+            };
+            let (line, _) = view.digest_mismatch_line().expect("a mismatch is reported");
+            assert!(line.chars().count() <= 72, "{} cols: {line}", line.len());
+        }
+    }
+}

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -172,6 +172,15 @@ pub struct SessionModel {
     /// timestamp is stamped outside, from the deck's injected clock
     /// (`deck::AgentEntry::parked_since_ms`), exactly as `turn_started_ms` is.
     pub parked: Option<OpenPark>,
+    /// Where the live progress counter [`Self::set_progress_line`] last wrote
+    /// begins: `(transcript index, byte offset into that entry's text)`.
+    ///
+    /// Positional rather than a bare flag so it invalidates itself: the counter
+    /// is rewritable only while it is still the very end of the transcript, and
+    /// every entry pushed after it makes the recorded index stale. That is what
+    /// makes the last tick of a pass permanent — nothing has to remember to
+    /// clear this, so no new transcript-pushing branch can forget to.
+    progress: Option<(usize, usize)>,
 }
 
 /// A parked wait that has not woken yet — the live half of the ⏳ chip.
@@ -1123,7 +1132,57 @@ impl SessionModel {
 
     /// Append a streaming text delta, coalescing into the trailing `Text`
     /// entry when the last thing emitted was also assistant text.
+    /// Write one live progress counter into the transcript **in place**: the
+    /// previous counter this wrote is replaced, not appended to.
+    ///
+    /// # Why the fold owns this rather than the emitter
+    ///
+    /// A long pass (`/init`'s code-graph walk and its two embedding passes)
+    /// narrates once a second so it cannot be mistaken for a wedge. Sent as
+    /// ordinary `Text`, a two-hundred-tick pass leaves two hundred near-identical
+    /// lines in the scrollback and buries the ✓ summaries that are the actual
+    /// record of what init did. Only the fold can rewrite what it already wrote,
+    /// so the replacement lives here and the emitter just says the number.
+    ///
+    /// Still a pure fold: the result is a function of the sequence of calls, and
+    /// the last tick of a pass survives as an ordinary line the moment anything
+    /// else is pushed — so the counter reads as history afterwards, not as a
+    /// spinner that erased itself.
+    pub fn set_progress_line(&mut self, line: &str) {
+        // Rewritable only while the counter is still the tail of the last
+        // entry; anything appended since makes it ordinary scrollback.
+        let last = self.transcript.len().wrapping_sub(1);
+        let open_at = match (self.progress, self.transcript.last()) {
+            (Some((idx, at)), Some(TranscriptEntry::Text(buf)))
+                if idx == last && at <= buf.len() =>
+            {
+                Some(at)
+            }
+            _ => None,
+        };
+        match self.transcript.last_mut() {
+            Some(TranscriptEntry::Text(buf)) => {
+                let at = open_at.unwrap_or(buf.len());
+                buf.truncate(at);
+                buf.push_str(line);
+                // The counter terminates its own line: emitters send lines
+                // without one, and the next milestone appends straight onto
+                // this buffer — so without it the ✓ summary lands ON the final
+                // count rather than under it. Inside the rewritten region, so a
+                // later tick replaces it along with the count.
+                buf.push('\n');
+                self.progress = Some((last, at));
+            }
+            _ => {
+                self.transcript
+                    .push(TranscriptEntry::Text(format!("{line}\n")));
+                self.progress = Some((self.transcript.len() - 1, 0));
+            }
+        }
+    }
+
     fn push_text(&mut self, delta: &str) {
+        self.progress = None;
         if let Some(TranscriptEntry::Text(buf)) = self.transcript.last_mut() {
             buf.push_str(delta);
         } else {

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -1118,3 +1118,75 @@ fn replay_of_the_same_log_yields_identical_models() {
     let b = SessionModel::replay(&log);
     assert_eq!(a, b);
 }
+
+/// Witness: a long pass's live counter occupies ONE transcript line however
+/// many times it ticks, and its last value survives the milestone that follows.
+///
+/// The defect it pins: `/init`'s three long passes (the code-graph walk, then
+/// the file and chunk embedding passes) narrate once a second, and every tick
+/// arrived as an `AgentEvent::Text` that [`SessionModel::push_text`] coalesced
+/// into the trailing buffer. A large workspace therefore buried the `✓`
+/// summaries — the actual record of what init did — under a hundred
+/// near-identical `· chunk index: N files embedded…` lines.
+#[test]
+fn a_progress_counter_rewrites_its_line_instead_of_stacking_them() {
+    let mut model = SessionModel::new();
+    model.apply(&text("◈ embedding code chunks for search…\n"));
+    for embedded in [2, 3, 37] {
+        model.set_progress_line(&format!("· chunk index: {embedded} files embedded…"));
+    }
+    model.apply(&text(
+        "✓ chunk index: 37 file(s) embedded by voyage-code-3\n",
+    ));
+
+    let TranscriptEntry::Text(rendered) = &model.transcript[0] else {
+        panic!(
+            "expected one coalesced text entry, got {:?}",
+            model.transcript
+        );
+    };
+    assert_eq!(
+        rendered.lines().collect::<Vec<_>>(),
+        vec![
+            "◈ embedding code chunks for search…",
+            // Exactly one counter line, holding the LAST count — the earlier
+            // ticks were rewritten, not appended.
+            "· chunk index: 37 files embedded…",
+            "✓ chunk index: 37 file(s) embedded by voyage-code-3",
+        ],
+        "{rendered}"
+    );
+}
+
+/// The counter is rewritable only while it is still the end of the transcript:
+/// once anything else has been folded, the tick it wrote is ordinary
+/// scrollback, and the next pass starts a line of its own rather than
+/// overwriting a finished pass's final count.
+#[test]
+fn a_settled_progress_line_is_never_overwritten_by_a_later_pass() {
+    let mut model = SessionModel::new();
+    model.set_progress_line("· semantic index: 12 files embedded…");
+    model.apply(&AgentEvent::Stage {
+        name: StageKind::Execute,
+        scope: stella_protocol::StageScope::Run,
+    });
+    model.set_progress_line("· chunk index: 4 files embedded…");
+
+    let rendered: Vec<&str> = model
+        .transcript
+        .iter()
+        .filter_map(|entry| match entry {
+            TranscriptEntry::Text(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        rendered,
+        vec![
+            "· semantic index: 12 files embedded…\n",
+            "· chunk index: 4 files embedded…\n",
+        ],
+        "{:?}",
+        model.transcript
+    );
+}


### PR DESCRIPTION
## What

`/init` on a large workspace rendered as a wall of near-identical progress lines, burying the `✓` summaries that are init's actual record:

```
◈ embedding code chunks for search…· chunk index: 2 files embedded…· chunk index: 3 files embedded…· chunk index: 6 files embedded… (…thirty more…)
```

Two defects, one screenshot:

1. Each of init's three long passes (the code-graph walk, then the file and chunk embedding passes) narrates once a second so it cannot be mistaken for a wedge (#3102). Every tick arrived as an `AgentEvent::Text`, which `SessionModel::push_text` coalesces into the trailing buffer — so a minutes-long pass left a hundred lines behind instead of one counter.
2. The deck sent those lines with no terminator, so they also ran together into a single paragraph.

## How

A narrated line now carries which half it belongs to — `InitLine::Step` for the record, `InitLine::Progress` for the counter — and each surface rewrites the counter it last wrote:

- **deck**: a new transcript-only `Inbound::Progress`, folded by `SessionModel::set_progress_line`.
- **plain CLI / REPL**: a carriage return where the terminal can take one back, a plain append where it cannot (a redirected `stella init` log has to stay readable).
- **session-startup index build**: a step is a dwell notice, a counter rewrites in place rather than stacking rows in that dialog.

The last tick of every pass survives as ordinary scrollback — nothing erases what it drew, which is the failure #3102 diagnosed in the cinematic it retired.

The rewrite is **positional** (transcript index + byte offset) rather than a flag: the counter is rewritable only while it is still the end of the transcript, so it invalidates itself and no future transcript-pushing branch has to remember to clear anything. The fold stays a pure function of its call sequence (L-T1).

The kind is carried in the type rather than sniffed from a `"· "` prefix, so a caller adding a fourth long pass has to answer which kind of line it emits.

## Structural changes

- `crates/stella-tui/src/envelope/inspect.rs` — the new variant put `envelope.rs` over the 1500-line limit. Split rather than baselined: the INSPECT cluster (`RecordedCallInfo`, `InspectMessage`, `JournalEra`, `InspectView`) is the one part of the envelope that is a self-contained read-model rather than a routing tag, and nothing outside it refers to those types except the two `Inbound` variants carrying them. Its 80-column test moves with it.
- The deck's two init narrators live in `agent/init.rs` beside the stdout/stderr ones — one place for every surface's rendering of an `InitLine`, and it keeps `command_deck.rs` (a grandfathered god file) under its ceiling. No baseline entry was added or raised.

## Witnesses

- `a_progress_counter_rewrites_its_line_instead_of_stacking_them` (stella-tui) — three ticks plus a milestone render as exactly three lines, the counter holding its last value.
- `a_settled_progress_line_is_never_overwritten_by_a_later_pass` (stella-tui) — a finished pass's final count is never clobbered by the next pass's first tick.
- `a_tick_is_progress_and_the_summary_is_a_step` (stella-cli) — the classification itself, asserted both ways; a tick misfiled as a `Step` would silently restore the flood.

No test was deleted. `make gate` green.

## Remaining work

Filed #3646: `say`'s other ~22 call sites still emit unterminated strings, so two deck commands in a row still render run-together. Same shape, different change — it should land on its own so a rendering regression bisects to it.

Closes #3646 is **not** claimed here — that issue is the follow-on, deliberately out of scope.

## Summary by Sourcery

Render init's long-running progress as a single live counter while preserving milestone summaries across all output surfaces.

New Features:
- Add typed init progress events so long-running counters can be rendered live without accumulating duplicate transcript lines.

Bug Fixes:
- Prevent init progress ticks from burying milestone summaries and ensure narrated output remains properly separated across deck, terminal, redirected, and startup surfaces.

Enhancements:
- Rewrite active progress counters in place while preserving the final count as scrollback and invalidate rewrites automatically when later transcript content is added.
- Move INSPECT envelope payload types into a dedicated module to keep the envelope organization manageable.

Tests:
- Add coverage for progress-line replacement, pass-boundary preservation, and correct classification of ticks versus summary steps.