### PR TITLE
fix(stella-cli): reconcile init's io seam — main does not compile

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -73,7 +73,7 @@ pub(crate) use graph::spawn_session_graph;
 #[cfg(test)]
 use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
 pub use init::run_init;
-pub(crate) use init::{InitLine, deck_narrator, deck_notice_narrator, init_workspace};
+pub(crate) use init::{InitIo, InitLine, deck_narrator, deck_notice_narrator, init_workspace};
 use outcome::{
     VerificationRequirement, pipeline_episode_outcome, pipeline_failure_reason,
     pipeline_session_status, pipeline_status_label, pipeline_status_result,
@@ -832,7 +832,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
         }
         if input == "/init" {
             println!();
-            let mut emit = init::stdout_narrator();
+            let mut io = init::InitIo::stdout_tty();
             match init_workspace(
                 Some(&*provider),
                 &cfg.workspace_root,

--- a/crates/stella-cli/src/agent/init.rs
+++ b/crates/stella-cli/src/agent/init.rs
@@ -519,6 +519,79 @@ mod tests {
         );
     }
 
+    /// The witness for the two-design collision that broke the build: one
+    /// [`InitIo`] carries **both** halves of the seam at once — the question
+    /// channel and an [`InitLine`] sink that still tells a permanent step
+    /// from a live counter.
+    ///
+    /// The two PRs that landed for this seam each kept one half and dropped
+    /// the other, so anything asserting only one of them passes on a design
+    /// that lost the other. This asserts both against one call: the record
+    /// stages narrate through `step_sink()` (the ✓ domains line), the
+    /// code-graph build narrates through the raw `sink()` (its own step), and
+    /// the sink's two kinds stay distinguishable rather than collapsing to
+    /// `String` — which is what a re-collapse of `InitIo::emit` would undo.
+    #[tokio::test]
+    async fn init_narrates_both_line_kinds_through_one_io() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let root = root.path().canonicalize().expect("canonicalize");
+        std::fs::create_dir_all(root.join("api")).expect("mkdir");
+        std::fs::write(root.join("api/routes.rs"), "pub fn route() {}\n").expect("write");
+        let provider = CountingProvider {
+            calls: AtomicUsize::new(0),
+        };
+
+        // `(is_step, text)` — the kind is the half a `String` sink erases.
+        let seen: std::sync::Mutex<Vec<(bool, String)>> = std::sync::Mutex::new(Vec::new());
+        {
+            // `ask: None` is the no-human case, and the one an automated test
+            // may take: the conversion offer must never block on stdin here.
+            let mut io = InitIo::new(
+                |line: InitLine| {
+                    let step = matches!(line, InitLine::Step(_));
+                    seen.lock()
+                        .expect("sink lock")
+                        .push((step, line.text().to_string()));
+                },
+                None,
+            );
+            init_workspace(
+                Some(&provider),
+                &root,
+                Some("counting-model"),
+                None,
+                &mut io,
+            )
+            .await
+            .expect("init_workspace");
+
+            // The kinds survive the trip through the io rather than being
+            // flattened on the way in.
+            io.emit(InitLine::Progress("· counter tick".to_string()));
+            io.step("permanent".to_string());
+        }
+
+        let seen = seen.into_inner().expect("sink lock");
+        let steps: Vec<&str> = seen
+            .iter()
+            .filter(|(step, _)| *step)
+            .map(|(_, text)| text.as_str())
+            .collect();
+        assert!(
+            steps.iter().any(|l| l.contains("domains")),
+            "the record stages must narrate through the io: {seen:?}"
+        );
+        assert!(
+            steps.iter().any(|l| l.contains("code graph")),
+            "the code-graph build must narrate through the same io: {seen:?}"
+        );
+        assert!(
+            seen.iter()
+                .any(|(step, text)| !*step && text == "· counter tick"),
+            "a counter must stay a counter, not become a step: {seen:?}"
+        );
+    }
+
     /// The gate never hides a changed repo from the model: grow the tree's
     /// shape and the next run re-infers (and pays) again.
     #[tokio::test]

--- a/crates/stella-cli/src/agent/init.rs
+++ b/crates/stella-cli/src/agent/init.rs
@@ -33,17 +33,45 @@ use crate::interactive::{AskUserIo, TtyAskUserIo};
 /// derivation is how two consumers end up disagreeing about whether anyone
 /// is listening.
 pub(crate) struct InitIo<'a> {
-    emit: Box<dyn FnMut(String) + 'a>,
+    emit: Box<dyn FnMut(InitLine) + 'a>,
     ask: Option<&'a dyn AskUserIo>,
 }
 
 impl<'a> InitIo<'a> {
     /// An io over a caller-supplied transcript sink and question channel.
-    pub(crate) fn new(emit: impl FnMut(String) + 'a, ask: Option<&'a dyn AskUserIo>) -> Self {
+    ///
+    /// The sink takes an [`InitLine`], not a `String`: a surface has to render
+    /// a live counter differently from a permanent step, and collapsing the
+    /// two here would put back the flood [`InitLine`] exists to stop.
+    pub(crate) fn new(emit: impl FnMut(InitLine) + 'a, ask: Option<&'a dyn AskUserIo>) -> Self {
         Self {
             emit: Box::new(emit),
             ask,
         }
+    }
+
+    /// Narrate one line, whichever kind it is.
+    pub(crate) fn emit(&mut self, line: InitLine) {
+        (self.emit)(line);
+    }
+
+    /// Narrate one permanent line of the record.
+    pub(crate) fn step(&mut self, text: String) {
+        self.emit(InitLine::Step(text));
+    }
+
+    /// The raw sink, for a stage that narrates both kinds itself — the
+    /// code-graph build is the only one, and its counters are the reason the
+    /// distinction exists.
+    pub(crate) fn sink(&mut self) -> &mut (dyn FnMut(InitLine) + 'a) {
+        &mut *self.emit
+    }
+
+    /// A plain `FnMut(String)` view for the stages whose every line is part
+    /// of the record. Naming that once here beats making each of the three
+    /// call sites wrap its own closure.
+    pub(crate) fn step_sink(&mut self) -> impl FnMut(String) + '_ {
+        move |text: String| (self.emit)(InitLine::Step(text))
     }
 
     /// The plain-CLI io: the indented stdout transcript both `stella init`
@@ -54,7 +82,7 @@ impl<'a> InitIo<'a> {
         let ask: Option<&'static dyn AskUserIo> =
             crate::interactive::human_is_present(true).then_some(&TtyAskUserIo);
         InitIo {
-            emit: Box::new(|line: String| println!("  {line}")),
+            emit: Box::new(stdout_narrator()),
             ask,
         }
     }
@@ -147,13 +175,13 @@ pub(crate) async fn init_workspace(
     workspace_root: &std::path::Path,
     model_hint: Option<&str>,
     budget_limit: Option<f64>,
-    emit: &mut dyn FnMut(InitLine),
+    io: &mut InitIo<'_>,
 ) -> Result<(Domains, f64), String> {
-    // The two stages that narrate nothing live keep the plain `String` sink:
+    // The stages that narrate nothing live keep the plain `String` sink:
     // every line they emit is part of the record, so the wrapper naming that
     // once is better than making each call site repeat it.
     let (domains, inference_cost_usd) = {
-        let mut step = |line: String| emit(InitLine::Step(line));
+        let mut step = io.step_sink();
         resolve_domains(
             provider,
             workspace_root,
@@ -166,13 +194,13 @@ pub(crate) async fn init_workspace(
 
     // The code graph needs no provider — build it regardless of how the
     // domains were inferred, so the index exists even fully offline.
-    build_code_graph(workspace_root, emit).await;
+    build_code_graph(workspace_root, io.sink()).await;
 
     // Adopt commands/skills/agents other code agents keep in `.claude/` and
     // `.agents/` (workspace + user scope) as symlinks into stella's own
     // directories — idempotent, never clobbers, never fatal.
     {
-        let mut step = |line: String| emit(InitLine::Step(line));
+        let mut step = io.step_sink();
         crate::extensions::sync_extensions(workspace_root, &mut step);
     }
 
@@ -184,7 +212,19 @@ pub(crate) async fn init_workspace(
     // workspace gets on an empty directory. It never converts on its own —
     // see `crate::commands_offer` for why that trade stays the user's.
     let user_root = crate::extensions::user_config_root();
-    crate::commands_offer::offer_conversion(workspace_root, user_root.as_deref(), *ask, emit).await;
+    {
+        // Read the question channel out before borrowing the sink: the offer
+        // needs both halves of the io at once, and only one of them mutably.
+        let ask = io.ask;
+        let mut step = io.step_sink();
+        crate::commands_offer::offer_conversion(
+            workspace_root,
+            user_root.as_deref(),
+            ask,
+            &mut step,
+        )
+        .await;
+    }
 
     let path = domains.save(workspace_root)?;
 
@@ -196,16 +236,16 @@ pub(crate) async fn init_workspace(
         m.record_taxonomy(&domains).await;
     }
 
-    emit(InitLine::Step(format!(
+    io.step(format!(
         "✓ {} domains ({}) → {}",
         domains.domains.len(),
         domains.inferred_by,
         path.display()
-    )));
+    ));
     if inference_cost_usd > 0.0 {
-        emit(InitLine::Step(format!(
+        io.step(format!(
             "domain inference model cost: ${inference_cost_usd:.6}"
-        )));
+        ));
     }
     Ok((domains, inference_cost_usd))
 }
@@ -360,7 +400,7 @@ pub async fn run_init(
             }
         };
 
-    let mut emit = stdout_narrator();
+    let mut io = InitIo::stdout_tty();
     let (domains, _inference_cost_usd) = init_workspace(
         provider.as_deref(),
         &workspace_root,

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -3660,22 +3660,16 @@ async fn run_deck_command(
             });
         }
         "/init" => {
-            // Replay the launch cinematic over the reindex: the battle loops
-            // for as long as init runs, then the wordmark reveal hands the
-            // frame back to the deck. The progress lines still land in the
-            // transcript behind the splash (and any key skips straight to
-            // them). Released on BOTH outcomes — a failed init must never
-            // strand a held splash.
-            let _ = in_tx.send(Inbound::Splash(SplashCue::Replay));
-            let mut emit = agent::deck_narrator(in_tx.clone(), LEAD);
-            let outcome = agent::init_workspace(
-                Some(provider),
+            // The splash replay, the narrator, and the question channel all
+            // live in `init_cmd` — this file is closed to growth.
+            match init_cmd::run(
+                provider,
                 &cfg.workspace_root,
                 &cfg.model_id,
                 budget_limit,
                 ask_io,
-                say,
-                init_cmd::splash_sender(in_tx),
+                in_tx,
+                LEAD,
             )
             .await
             {

--- a/crates/stella-cli/src/command_deck/init_cmd.rs
+++ b/crates/stella-cli/src/command_deck/init_cmd.rs
@@ -23,24 +23,23 @@ use crate::interactive::AskUserIo;
 /// shared [`agent::init_workspace`] flow, and release the splash whatever
 /// happens.
 ///
-/// `say` writes the progress transcript behind the splash; `ask` is the
-/// deck's question channel, which init uses only for the one first-session
-/// conversion offer. Returns `Ok(())` when init completed, or the error
-/// message to surface.
-pub(super) async fn run<F>(
+/// Init narrates through the deck's own narrator — a step joins the
+/// transcript behind the splash, a counter rewrites the counter before it —
+/// and `ask` is the deck's question channel, which init uses only for the one
+/// first-session conversion offer. Returns `Ok(())` when init completed, or
+/// the error message to surface.
+pub(super) async fn run(
     provider: &dyn stella_protocol::Provider,
     workspace_root: &std::path::Path,
     model_id: &str,
     budget_limit: Option<f64>,
     ask: &dyn AskUserIo,
-    say: F,
-    splash: impl Fn(super::SplashCue),
-) -> Result<(), String>
-where
-    F: Fn(String) + Copy,
-{
+    in_tx: &UnboundedSender<super::Inbound>,
+    agent_name: &str,
+) -> Result<(), String> {
+    let splash = splash_sender(in_tx);
     splash(super::SplashCue::Replay);
-    let mut io = InitIo::new(|line: String| say(line), Some(ask));
+    let mut io = InitIo::new(agent::deck_narrator(in_tx.clone(), agent_name), Some(ask));
     let outcome = agent::init_workspace(
         Some(provider),
         workspace_root,
@@ -54,9 +53,7 @@ where
 }
 
 /// Send a splash cue on the deck's inbound channel.
-pub(super) fn splash_sender(
-    in_tx: &UnboundedSender<super::Inbound>,
-) -> impl Fn(super::SplashCue) + '_ {
+fn splash_sender(in_tx: &UnboundedSender<super::Inbound>) -> impl Fn(super::SplashCue) + '_ {
     move |cue| {
         let _ = in_tx.send(super::Inbound::Splash(cue));
     }


### PR DESCRIPTION
`main` at 9fa4163fa does not build. `cargo build -p stella-cli` fails with 8 errors, so **every** `stella-cli` test and the release binary are down.

## What happened

Two PRs landed designs for the same seam and composed into a tree neither author's branch was wrong about:

- one introduced **`InitIo`** — the transcript sink *and* the question channel passed as one argument, deliberately so `init_workspace`'s arity stays fixed (both interactive call sites live in `agent.rs` and `command_deck.rs`, files closed to growth), plus `command_deck/init_cmd.rs` to hold the deck's `/init`;
- the other introduced **`InitLine`** — `Step` vs `Progress`, so a long pass's live counter rewrites its line instead of flooding the record.

The merge kept the second's signature with the first's body:

- `init_workspace` takes `&mut dyn FnMut(InitLine)` while its body still reaches for `*ask`;
- three call sites pass a `&mut io` that no longer exists (`init.rs:369`, `agent.rs:841`, and the deck);
- `InitIo` is never re-exported from `agent`, so `init_cmd.rs`'s import fails;
- the deck's `/init` arm is a textual splice of both versions and is not parseable Rust (`expected `;`, found `{``).

Nothing pre-merge could see this — it is the shared-cell shape AGENTS.md describes, with a *seam* as the shared cell rather than a baseline file.

## The fix

Neither design was wrong; they answer different questions, so both are kept. `InitIo` now carries an `FnMut(InitLine)` sink:

- `step_sink()` — the plain `String` view for the stages whose every line is part of the record (domains, extension sync, the conversion offer);
- `sink()` — the raw two-kind channel for the code-graph build, whose counters are the whole reason the distinction exists;
- `ask` rides along for the one first-session conversion offer.

The deck arm also moves the splash replay and narrator construction into `init_cmd::run`, where they belong — `command_deck.rs` is a grandfathered god file and the spliced arm had grown it. Net effect on that file is a shrink.

## Witness

The fail→pass flip is unambiguous: on `main` the crate does not compile, so all 1823 `stella-cli` tests fail to build; on this branch they build and pass.

Because that flip would also be satisfied by picking *either* design and deleting the other, `init_narrates_both_line_kinds_through_one_io` (`crates/stella-cli/src/agent/init.rs`) pins the reconciliation itself — one `init_workspace` call through one `InitIo`, asserting the record stages narrate, the code-graph build narrates through the raw sink, and a `Progress` counter stays a counter rather than collapsing into a `Step`. It fails on either single-design tree.

`make gate CARGO_SCOPE="-p stella-cli"` is green, including `test --workspace`, clippy at `-D warnings`, and the file-size ratchet.

## Summary by Sourcery

Restore the stella-cli initialization flow by combining its shared I/O seam with typed line narration and updating the command-deck integration.

Bug Fixes:
- Restore stella-cli compilation by reconciling the initialization I/O and line-narration interfaces across all callers.

Enhancements:
- Unify initialization transcript sinks and question handling through InitIo while preserving distinct permanent-step and live-progress output.
- Move command-deck initialization narration and splash management into the dedicated init command module.

Tests:
- Add coverage proving one initialization I/O seam preserves both step and progress narration across initialization stages.