### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,9 +1022,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
`cargo deny check advisories` started failing on every open PR and on main today: RUSTSEC-2026-0258 landed in the advisory DB against h2 0.4.15.

h2 accepts and queues empty DATA frames without limit; if streams are not actively drained that is unbounded memory growth, or a panic when the length overflows. Low severity. Patched upstream in 0.4.16.

**Change:** lockfile only. h2 is transitive through hyper -> reqwest, and `cargo update -p h2` moves that one package and nothing else — the diff touches only h2's version and checksum.

**Witness:** `cargo deny check advisories` reports `advisories FAILED` on the old lock and `advisories ok` on the new one. Verified locally; `cargo metadata --locked` also exits 0, so the lock is in sync.

Landed on its own branch from a fresh main rather than folded into an unrelated PR, because Cargo.lock is the shared cell that reds main when two branches each write it correctly.

No new dependency is added.

## Summary by Sourcery

Bug Fixes:
- Update the h2 dependency to 0.4.16 to resolve RUSTSEC-2026-0258 and restore advisory checks.