### PR TITLE
feat(stella-pipeline): pipeline runs from the [wrapper] manifest; --pipeline becomes opt-in; docs to the post-flip state

### DIFF
--- a/crates/stella-pipeline/src/lib.rs
+++ b/crates/stella-pipeline/src/lib.rs
@@ -112,6 +112,7 @@ pub mod replay;
 pub mod research;
 pub mod reward;
 pub mod roster;
+pub mod schedule;
 pub mod scope;
 pub mod scratch;
 pub mod triage;

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1138,12 +1138,7 @@ impl<'a> Pipeline<'a> {
         // single-shot/best-of-N split below, so `can_author…` — which
         // announces the degradation — is still never consulted for a turn
         // that would not have authored a witness anyway.
-        let authored_witness = !assessment.conversational
-            && schedule_says.witness
-            && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
-            && assessment.wants_witness()
-            && task_class.verifies_unconditionally()
-            && self.can_author_independent_witness();
+        let authored_witness = self.authored_witness(&schedule_says, &assessment, task_class);
         let contract = match verified_by {
             Some(command) => VerificationContract::Oracle(command),
             None if !assessment.conversational

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1179,7 +1179,7 @@ impl<'a> Pipeline<'a> {
         // saw no task signal to overrule it (triage::resolve_conversational).
         // Answer in one plain, tool-less completion and skip plan → execute →
         // witness → verify entirely. This is the fix for "typing `hi` authored
-        // a witness test": a non-task must never enter the work pipeline.
+        // a witness test": an early RETURN, not a skipped stage (#3408).
         if assessment.conversational {
             return self
                 .run_conversational(messages, budget, &mut total_cost)

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -88,6 +88,7 @@ use crate::triage::{
     resolve_witness, triage_prompt,
 };
 use stella_core::driver::TurnHalt;
+use stella_plugin::Wrapper;
 use stella_protocol::ToolOutput;
 
 use crate::flip_halt::{FlipHalt, command_of};
@@ -129,6 +130,8 @@ mod role_pace;
 mod roster_wiring;
 use roster_wiring::Assigned;
 mod run_error;
+mod schedule_wiring;
+use schedule_wiring::decide_verify;
 mod scope_stage;
 mod stage_budget;
 mod task_frame;
@@ -528,6 +531,9 @@ pub struct PipelineConfig {
     /// workspace with no candidate isolation cannot offer it (and an `Always`
     /// that cannot be honoured says so); only then does this policy decide.
     pub create_worktrees: crate::ports::WorktreePolicy,
+    /// The `[wrapper]` variant scheduling this run's stages (#3408, see
+    /// `crate::schedule`). `None` uses the built-in `classic` order.
+    pub variant: Option<Wrapper>,
 }
 
 impl Default for PipelineConfig {
@@ -574,6 +580,7 @@ impl Default for PipelineConfig {
             candidates: None,
             candidate_concurrency: None,
             create_worktrees: crate::ports::WorktreePolicy::default(),
+            variant: None,
         }
     }
 }
@@ -1112,6 +1119,15 @@ impl<'a> Pipeline<'a> {
             p.task_class = Some(task_class);
             p.goal = Some(goal.to_string());
         });
+        // This turn's schedule (#3408, `crate::schedule`).
+        let variant = self.effective_variant(total_cost)?;
+        let (schedule, schedule_says) = self.begin_turn_schedule(
+            &variant,
+            budget,
+            &assessment,
+            research_questions.len(),
+            total_cost,
+        )?;
         // The volatile recall+goal message rides AFTER the stable system
         // prefix (L-E8) — see assemble_user_message. The verification
         // contract rides only on turns that will actually be verified: a
@@ -1132,8 +1148,10 @@ impl<'a> Pipeline<'a> {
         // single-shot/best-of-N split below, so `can_author…` — which
         // announces the degradation — is still never consulted for a turn
         // that would not have authored a witness anyway.
+        // `schedule_says.witness` is the manifest's half; the rest stay
+        // host-internal (#3408).
         let authored_witness = !assessment.conversational
-            && self.config.test_command.is_none()
+            && schedule_says.witness
             && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
             && assessment.wants_witness()
             && task_class.verifies_unconditionally()
@@ -1162,7 +1180,13 @@ impl<'a> Pipeline<'a> {
         // this workspace survived to the worker only as whatever residue of
         // it the planner encoded into a step string.
         let research = self
-            .research_stage(goal, &research_questions, budget, &mut total_cost)
+            .research_stage(
+                goal,
+                &research_questions,
+                schedule_says.research,
+                budget,
+                &mut total_cost,
+            )
             .await;
         // Recall rides as its OWN marked message, ahead of the goal — the
         // shape the interactive path has always used, and the only one the
@@ -1195,7 +1219,7 @@ impl<'a> Pipeline<'a> {
         // A withheld `plan` takes the branch a non-planning class takes — no
         // frame, no call ([`Pipeline::responsibility_enabled`], #2381).
         let plan: Option<Vec<PlanStep>> =
-            if task_class.plans() && self.responsibility_enabled(ModelCallRole::Plan) {
+            if schedule_says.plan && self.responsibility_enabled(ModelCallRole::Plan) {
                 match self
                     .plan_with_review(goal, &frames, &research, budget, &mut total_cost)
                     .await
@@ -1232,6 +1256,7 @@ impl<'a> Pipeline<'a> {
             base_messages: &base_messages,
             plan: plan.as_deref(),
             assessment,
+            schedule: &schedule,
         };
         // Decided above, before the user message was assembled (the worker's
         // test-first contract keys off it) and before this single-shot/
@@ -1716,6 +1741,8 @@ impl<'a> Pipeline<'a> {
         surface: CandidateSurface<'_>,
         spend: &mut Spend<'_>,
     ) -> CandidateResult {
+        // This candidate's own continuation of the shared prefix (#3408).
+        let mut schedule = frame.schedule.clone();
         // Flip oracle: for classes we always verify, take a pre-execute
         // baseline of the test command so a later pass counts as a genuine
         // fail→pass flip (L-E11). Simple lookups skip the baseline — they are
@@ -1869,7 +1896,12 @@ impl<'a> Pipeline<'a> {
         self.absorb_probe(&mut state, probe);
         let files_touched = state.signals.file_changes > 0
             || (state.signals.mutating_actions > 0 && !state.diff_text.trim().is_empty());
-        let should_verify = frame.assessment.class.verifies_unconditionally()
+        // `verify`'s manifest half, against this candidate's real diff (#3408).
+        let schedule_says_verify = match decide_verify(&mut schedule, &state) {
+            Ok(runs) => runs,
+            Err(source) => return source.into_candidate_abort(state.messages),
+        };
+        let should_verify = schedule_says_verify
             || (frame.assessment.class == TaskClass::SimpleLookup && files_touched);
         if !should_verify {
             // A clean lookup: nothing to verify.

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -88,7 +88,6 @@ use crate::triage::{
     resolve_witness, triage_prompt,
 };
 use stella_core::driver::TurnHalt;
-use stella_plugin::Wrapper;
 use stella_protocol::ToolOutput;
 
 use crate::flip_halt::{FlipHalt, command_of};
@@ -131,7 +130,6 @@ mod roster_wiring;
 use roster_wiring::Assigned;
 mod run_error;
 mod schedule_wiring;
-use schedule_wiring::decide_verify;
 mod scope_stage;
 mod stage_budget;
 mod task_frame;
@@ -531,9 +529,8 @@ pub struct PipelineConfig {
     /// workspace with no candidate isolation cannot offer it (and an `Always`
     /// that cannot be honoured says so); only then does this policy decide.
     pub create_worktrees: crate::ports::WorktreePolicy,
-    /// The `[wrapper]` variant scheduling this run's stages (#3408, see
-    /// `crate::schedule`). `None` uses the built-in `classic` order.
-    pub variant: Option<Wrapper>,
+    /// The `[wrapper]` variant scheduling this run (#3408, `crate::schedule`); `None` = `classic`.
+    pub variant: Option<stella_plugin::Wrapper>,
 }
 
 impl Default for PipelineConfig {
@@ -1119,15 +1116,8 @@ impl<'a> Pipeline<'a> {
             p.task_class = Some(task_class);
             p.goal = Some(goal.to_string());
         });
-        // This turn's schedule (#3408, `crate::schedule`).
-        let variant = self.effective_variant(total_cost)?;
-        let (schedule, schedule_says) = self.begin_turn_schedule(
-            &variant,
-            budget,
-            &assessment,
-            research_questions.len(),
-            total_cost,
-        )?;
+        let schedule_says =
+            self.begin_turn_schedule(budget, &assessment, research_questions.len(), total_cost)?;
         // The volatile recall+goal message rides AFTER the stable system
         // prefix (L-E8) — see assemble_user_message. The verification
         // contract rides only on turns that will actually be verified: a
@@ -1148,8 +1138,6 @@ impl<'a> Pipeline<'a> {
         // single-shot/best-of-N split below, so `can_author…` — which
         // announces the degradation — is still never consulted for a turn
         // that would not have authored a witness anyway.
-        // `schedule_says.witness` is the manifest's half; the rest stay
-        // host-internal (#3408).
         let authored_witness = !assessment.conversational
             && schedule_says.witness
             && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
@@ -1179,15 +1167,12 @@ impl<'a> Pipeline<'a> {
         // the planner alone, so a fact a read-only sub-agent verified against
         // this workspace survived to the worker only as whatever residue of
         // it the planner encoded into a step string.
-        let research = self
-            .research_stage(
-                goal,
-                &research_questions,
-                schedule_says.research,
-                budget,
-                &mut total_cost,
-            )
-            .await;
+        let research = if schedule_says.research {
+            self.research_stage(goal, &research_questions, budget, &mut total_cost)
+                .await
+        } else {
+            Vec::new()
+        };
         // Recall rides as its OWN marked message, ahead of the goal — the
         // shape the interactive path has always used, and the only one the
         // receipts plane can attribute (#3243 D4). Folded into the goal
@@ -1256,7 +1241,7 @@ impl<'a> Pipeline<'a> {
             base_messages: &base_messages,
             plan: plan.as_deref(),
             assessment,
-            schedule: &schedule,
+            schedule_verifies: schedule_says.verify,
         };
         // Decided above, before the user message was assembled (the worker's
         // test-first contract keys off it) and before this single-shot/
@@ -1741,8 +1726,6 @@ impl<'a> Pipeline<'a> {
         surface: CandidateSurface<'_>,
         spend: &mut Spend<'_>,
     ) -> CandidateResult {
-        // This candidate's own continuation of the shared prefix (#3408).
-        let mut schedule = frame.schedule.clone();
         // Flip oracle: for classes we always verify, take a pre-execute
         // baseline of the test command so a later pass counts as a genuine
         // fail→pass flip (L-E11). Simple lookups skip the baseline — they are
@@ -1896,12 +1879,7 @@ impl<'a> Pipeline<'a> {
         self.absorb_probe(&mut state, probe);
         let files_touched = state.signals.file_changes > 0
             || (state.signals.mutating_actions > 0 && !state.diff_text.trim().is_empty());
-        // `verify`'s manifest half, against this candidate's real diff (#3408).
-        let schedule_says_verify = match decide_verify(&mut schedule, &state) {
-            Ok(runs) => runs,
-            Err(source) => return source.into_candidate_abort(state.messages),
-        };
-        let should_verify = schedule_says_verify
+        let should_verify = frame.schedule_verifies
             || (frame.assessment.class == TaskClass::SimpleLookup && files_touched);
         if !should_verify {
             // A clean lookup: nothing to verify.

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1851,17 +1851,17 @@ impl<'a> Pipeline<'a> {
             return CandidateResult::turn_aborted(state.messages, abort);
         }
 
-        // Decide whether to verify: unconditional for single/multi; for a
-        // simple lookup, only if the turn unexpectedly touched files (the
-        // zero-diff guard, L-E2). "Touched files" = FileChange events observed
-        // OR a non-empty diff from a turn that dispatched something able to
-        // write. The second conjunct is #1553: the diff reads the WORKING
-        // TREE, and in a shared worktree the tree can move under a run —
-        // a human editing beside it. `mutating_actions` is counted off the
-        // calls this pipeline dispatched, not off any look at the world, so
-        // a lookup that dispatched nothing that could write cannot own the
-        // motion the diff shows, and must not be dragged into verification
-        // over someone else's edit.
+        // Decide whether to verify: `frame.schedule_verifies` for single/
+        // multi; for a simple lookup, ORed with the zero-diff guard (L-E2) —
+        // host-internal, manifest-inexpressible (#3408). "Touched files" =
+        // FileChange events observed OR a non-empty diff from a turn that
+        // dispatched something able to write. The second conjunct is #1553:
+        // the diff reads the WORKING TREE, and in a shared worktree the tree
+        // can move under a run — a human editing beside it. `mutating_actions`
+        // is counted off the calls this pipeline dispatched, not off any look
+        // at the world, so a lookup that dispatched nothing that could write
+        // cannot own the motion the diff shows, and must not be dragged into
+        // verification over someone else's edit.
         let probe = self.gather_diff(surface, &state.untracked_before).await;
         self.absorb_probe(&mut state, probe);
         let files_touched = state.signals.file_changes > 0

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1118,32 +1118,24 @@ impl<'a> Pipeline<'a> {
         });
         let schedule_says =
             self.begin_turn_schedule(budget, &assessment, research_questions.len(), total_cost)?;
-        // The volatile recall+goal message rides AFTER the stable system
-        // prefix (L-E8) — see assemble_user_message. The verification
-        // contract rides only on turns that will actually be verified: a
-        // conversational turn has no oracle, and a simple lookup is verified
-        // only if it unexpectedly touches files — telling either "make this
-        // test pass" would invent work.
+        // The volatile recall+goal message rides AFTER the stable system prefix
+        // (L-E8) — see assemble_user_message. The verification contract rides
+        // only on turns that will actually be verified — a conversational turn
+        // has no oracle — so telling either "make this test pass" invents work.
         let verified_by = self
             .config
             .test_command
             .as_deref()
             .filter(|_| !assessment.conversational && task_class.verifies_unconditionally());
-        // The authored-witness decision, taken HERE — before the user message
-        // is assembled — so a run with no oracle and no independent author
-        // can tell the worker up front that its own failing test is the only
-        // deterministic evidence the run will carry (test-first is cheap
-        // exactly at the start and unaffordable after the diff exists). The
-        // conjunction short-circuits in the same order it did at the
-        // single-shot/best-of-N split below, so `can_author…` — which
-        // announces the degradation — is still never consulted for a turn
-        // that would not have authored a witness anyway.
-        let authored_witness = self.authored_witness(&schedule_says, &assessment, task_class);
+        // `schedule_says.authored_witness` was decided in `begin_turn_schedule`
+        // above, before this message is assembled, so a run with no oracle and
+        // no independent author tells the worker up front that its own failing
+        // test is the run's only deterministic evidence (#3408).
         let contract = match verified_by {
             Some(command) => VerificationContract::Oracle(command),
             None if !assessment.conversational
                 && task_class.verifies_unconditionally()
-                && !authored_witness =>
+                && !schedule_says.authored_witness =>
             {
                 VerificationContract::WorkerTestFirst
             }
@@ -1256,7 +1248,7 @@ impl<'a> Pipeline<'a> {
         // would put a question to the operator whose answer is then discarded,
         // which teaches them their choices do not matter. `false` is the safe
         // value in that case precisely because it is unreachable.
-        let isolate = if n == 1 && !authored_witness {
+        let isolate = if n == 1 && !schedule_says.authored_witness {
             self.isolate_in_worktree(task_class).await
         } else {
             false
@@ -1268,7 +1260,7 @@ impl<'a> Pipeline<'a> {
         // N=1, so authoring can never mutate the session tree.
         // Best-of-N runs every candidate in an isolated snapshot of the
         // current tree state and adopts only the winner's changes (L-E7).
-        let (best, candidates_run) = if n == 1 && !authored_witness && !isolate {
+        let (best, candidates_run) = if n == 1 && !schedule_says.authored_witness && !isolate {
             let worker = match self.resolve_provider(Role::Worker) {
                 Ok(worker) => worker,
                 Err(error) => {
@@ -1303,7 +1295,7 @@ impl<'a> Pipeline<'a> {
                     frame,
                     n,
                     &frames,
-                    authored_witness,
+                    schedule_says.authored_witness,
                     &mut Spend {
                         budget: &mut *budget,
                         total: &mut total_cost,

--- a/crates/stella-pipeline/src/pipeline/research_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/research_stage.rs
@@ -40,17 +40,21 @@ const RESEARCH_MAX_STEPS: usize = 8;
 
 impl Pipeline<'_> {
     /// Answer triage's research questions with parallel read-only sub-agents,
-    /// returning the bounded findings for the planner prompt. Empty questions
-    /// return empty findings with **no events and no spend** — the skip path
-    /// must leave the stream byte-for-byte untouched (L-E2).
+    /// returning the bounded findings for the planner prompt. A `runs`
+    /// answer of `false` — this turn's schedule (#3408) says `research`
+    /// declared `false`, matching `classic.toml`'s `if = "questions > 0"` —
+    /// returns empty findings with **no events and no spend**, the same skip
+    /// path an empty `questions` always took: the stream must stay
+    /// byte-for-byte untouched (L-E2).
     pub(super) async fn research_stage(
         &self,
         goal: &str,
         questions: &[String],
+        runs: bool,
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> Vec<ResearchFinding> {
-        if questions.is_empty() {
+        if !runs {
             return Vec::new();
         }
         // Resolution failure degrades to no research — never fail a turn on

--- a/crates/stella-pipeline/src/pipeline/research_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/research_stage.rs
@@ -40,21 +40,22 @@ const RESEARCH_MAX_STEPS: usize = 8;
 
 impl Pipeline<'_> {
     /// Answer triage's research questions with parallel read-only sub-agents,
-    /// returning the bounded findings for the planner prompt. A `runs`
-    /// answer of `false` — this turn's schedule (#3408) says `research`
-    /// declared `false`, matching `classic.toml`'s `if = "questions > 0"` —
-    /// returns empty findings with **no events and no spend**, the same skip
-    /// path an empty `questions` always took: the stream must stay
-    /// byte-for-byte untouched (L-E2).
+    /// returning the bounded findings for the planner prompt. The call site
+    /// (#3408) only reaches this at all when the schedule's `research`
+    /// decision — `classic.toml`'s `if = "questions > 0"` — said so; this
+    /// function's own empty-`questions` check is what makes that true by
+    /// construction rather than by the caller's discipline, and is what ran
+    /// before #3408 existed. Either path returns empty findings with **no
+    /// events and no spend** — the stream must stay byte-for-byte untouched
+    /// (L-E2).
     pub(super) async fn research_stage(
         &self,
         goal: &str,
         questions: &[String],
-        runs: bool,
         budget: &mut BudgetGuard,
         total: &mut f64,
     ) -> Vec<ResearchFinding> {
-        if !runs {
+        if questions.is_empty() {
             return Vec::new();
         }
         // Resolution failure degrades to no research — never fail a turn on

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -412,12 +412,28 @@ impl<'a> Pipeline<'a> {
             diff_lines: state.diff_lines,
         });
 
+        // This resumed leg's schedule (#3408): rebuilt from the class the
+        // crashed run committed to `FrameProgress`, since a resume has no
+        // triage boundary of its own left to observe. Unused below —
+        // `should_verify` above is still this file's own pre-#3408
+        // computation, not `Schedule::decide` — carried only so `TaskFrame`
+        // has the field every other construction site supplies; migrating
+        // this path's own gate is tracked in #3628.
+        let variant = self.effective_variant(total_cost)?;
+        let (schedule, _) = self.begin_turn_schedule(
+            &variant,
+            &budget,
+            &TaskAssessment::from_class(task_class),
+            0,
+            total_cost,
+        )?;
         let base_messages: Vec<CompletionMessage> = Vec::new();
         let frame = TaskFrame {
             goal,
             base_messages: &base_messages,
             plan: resume.plan.as_deref(),
             assessment: TaskAssessment::from_class(task_class),
+            schedule: &schedule,
         };
         let best = {
             let mut spend = Spend {

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -412,28 +412,19 @@ impl<'a> Pipeline<'a> {
             diff_lines: state.diff_lines,
         });
 
-        // This resumed leg's schedule (#3408): rebuilt from the class the
-        // crashed run committed to `FrameProgress`, since a resume has no
-        // triage boundary of its own left to observe. Unused below —
-        // `should_verify` above is still this file's own pre-#3408
-        // computation, not `Schedule::decide` — carried only so `TaskFrame`
-        // has the field every other construction site supplies; migrating
-        // this path's own gate is tracked in #3628.
-        let variant = self.effective_variant(total_cost)?;
-        let (schedule, _) = self.begin_turn_schedule(
-            &variant,
-            &budget,
-            &TaskAssessment::from_class(task_class),
-            0,
-            total_cost,
-        )?;
         let base_messages: Vec<CompletionMessage> = Vec::new();
         let frame = TaskFrame {
             goal,
             base_messages: &base_messages,
             plan: resume.plan.as_deref(),
             assessment: TaskAssessment::from_class(task_class),
-            schedule: &schedule,
+            // `verify_candidate` (called directly below, not through
+            // `run_candidate`) never reads this field — `should_verify`
+            // above is this file's own pre-#3408 computation. Filled in
+            // anyway so `TaskFrame` has the field every construction site
+            // supplies, with the value the shipped manifest's triage-
+            // published `verifies` signal would carry for this class.
+            schedule_verifies: task_class.verifies_unconditionally(),
         };
         let best = {
             let mut spend = Spend {

--- a/crates/stella-pipeline/src/pipeline/run_error.rs
+++ b/crates/stella-pipeline/src/pipeline/run_error.rs
@@ -47,6 +47,13 @@ pub enum PipelineError {
     /// A required role (worker) could not be resolved at all.
     #[error(transparent)]
     Routing(#[from] RouterError),
+    /// The turn's `[wrapper]` variant could not schedule a stage: the
+    /// built-in `classic` manifest failed to load (a build-time defect), or
+    /// a configured variant's declared order does not match how this host
+    /// visits its own stages (#3408). Unreachable for `classic`, asserted by
+    /// `tests/variant_program.rs` and `tests/variant_dispatch.rs`.
+    #[error("the pipeline's wrapper variant could not schedule this turn: {0}")]
+    InvalidVariant(String),
 }
 
 /// A hard pipeline failure paired with every paid stage that settled before

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The seam between [`crate::schedule`] — which knows how to walk a
+//! manifest's declared stage order — and [`Pipeline::run`], which knows the
+//! facts a turn actually has and when each one becomes available.
+//!
+//! Split from `pipeline.rs` for the reason every sibling in this directory
+//! is: that file is a grandfathered god file closed to growth (AGENTS.md §
+//! God files), so the machinery — and the error-handling boilerplate around
+//! it — lives here, and `run` is left with two plain calls (#3408).
+//!
+//! # Why the pre-execute batch exists
+//!
+//! [`stella_plugin::ProgressiveResolver`] must be asked about each declared
+//! stage in the manifest's own order — `triage`, `recall`, `research`,
+//! `plan`, `scope`, `execute`, `witness`, `verify` for the shipped `classic`
+//! variant. `Pipeline::run`'s *own* control flow does not visit those
+//! decisions in that order: it needs the `witness` answer (`authored_witness`)
+//! before it has run `research` or `plan` for real, because that answer
+//! drives the single-shot/best-of-N and isolation choices research and plan
+//! sit in front of. [`Pipeline::begin_turn_schedule`] resolves the resolver's
+//! whole walk through `witness` in one batch, immediately once triage's real
+//! facts are known — decoupling *when the schedule decides* a stage from
+//! *when the pipeline does that stage's real work*, which stays exactly
+//! where it always was. Nothing about the manifest's conditions changes this
+//! — `research`/`plan`/`scope`/`witness` read only host facts or signals
+//! `triage` publishes, so deciding them before `research_stage` or
+//! `plan_with_review` ever runs answers them no differently than deciding
+//! them in place would (asserted for the shipped variant by
+//! `tests/variant_dispatch.rs`).
+//!
+//! `verify` is the one exception, and deliberately not part of the batch: its
+//! condition may read `execute`'s real output, which does not exist until
+//! this turn's candidate(s) have actually run — see [`crate::schedule`]'s
+//! module docs for why that makes [`decide_verify`] a **per-candidate**
+//! decision against a clone rather than a fourth batched one.
+
+use stella_plugin::{StageName, Wrapper};
+
+use crate::schedule::{HostFacts, Schedule, ScheduleError};
+use crate::variant;
+
+use super::*;
+
+/// The manifest's answer to every stage decision `Pipeline::run` needs before
+/// a single candidate executes.
+pub(super) struct PreExecuteSchedule {
+    /// Whether `research` runs — ANDed with the roster's own resolution of
+    /// [`ModelCallRole::Research`] at its call site (host-internal, #3408).
+    pub(super) research: bool,
+    /// Whether `plan` AND `scope` both run. The two share one manifest
+    /// condition (`classic.toml`'s `if = "plans"` on each) and one Rust
+    /// branch — `scope_review` runs nested inside `plan_with_review` — so a
+    /// variant that somehow disagreed between the two would still only ever
+    /// gate the one branch the pipeline has to offer it.
+    pub(super) plan: bool,
+    /// Whether `witness` runs — one of six conjuncts `authored_witness`
+    /// takes; the other five (conversational, the witness-author role, the
+    /// model's own `wants_witness`, the class's `verifies_unconditionally`,
+    /// and independence) are host-internal and stay ANDed at that call site.
+    pub(super) witness: bool,
+}
+
+impl Pipeline<'_> {
+    /// The manifest this run follows: the configured variant, or the
+    /// built-in `classic` order when none was configured.
+    ///
+    /// # Errors
+    ///
+    /// A [`PipelineError::InvalidVariant`] if the *built-in* fallback
+    /// manifest fails to load — a build-time defect in the shipped
+    /// `variants/classic.toml`, not a runtime condition, and asserted
+    /// unreachable by `tests/variant_program.rs`. A configured variant is
+    /// already a parsed, validated [`Wrapper`] by the time it reaches
+    /// [`PipelineConfig`], so it cannot fail here at all.
+    pub(super) fn effective_variant(
+        &self,
+        total_cost_usd: f64,
+    ) -> Result<Wrapper, PipelineRunError> {
+        match &self.config.variant {
+            Some(wrapper) => Ok(wrapper.clone()),
+            None => variant::classic()
+                .map(Wrapper::clone)
+                .map_err(|source| variant_error(source, total_cost_usd)),
+        }
+    }
+
+    /// Begin this turn's [`Schedule`] against `variant` and resolve every
+    /// stage decision `run` needs before any candidate executes — see this
+    /// module's docs for why they are batched here rather than decided where
+    /// each stage's real work happens.
+    pub(super) fn begin_turn_schedule<'v>(
+        &self,
+        variant: &'v Wrapper,
+        budget: &BudgetGuard,
+        assessment: &TaskAssessment,
+        research_questions: usize,
+        total_cost_usd: f64,
+    ) -> Result<(Schedule<'v>, PreExecuteSchedule), PipelineRunError> {
+        let task_class = assessment.class;
+        let mut schedule = Schedule::new(
+            variant,
+            HostFacts {
+                test_command: self.config.test_command.is_some(),
+                candidates: self.config.candidate_count(),
+                budget_metered: budget.headroom_usd().is_some(),
+            },
+        );
+        let decided: Result<PreExecuteSchedule, ScheduleError> = (|| {
+            schedule.decide(StageName::Triage)?;
+            schedule.decide(StageName::Recall)?;
+            schedule.update(|v| {
+                v.conversational = assessment.conversational;
+                // Saturating: a question count past `u64::MAX` cannot exist.
+                v.questions = u64::try_from(research_questions).unwrap_or(u64::MAX);
+                v.plans = task_class.plans();
+                v.verifies = task_class.verifies_unconditionally();
+                v.wants_witness = assessment.wants_witness();
+                v.wants_verifier = assessment.wants_verifier();
+            });
+            let research = schedule.decide(StageName::Research)?;
+            let plan = schedule.decide(StageName::Plan)?;
+            let scope = schedule.decide(StageName::Scope)?;
+            // Unconditional in every shipped manifest. Deciding it here,
+            // before the real execution this turn will do, is what lets
+            // `witness` — declared right after it — be decided at all: the
+            // resolver walks the manifest in order, and `witness`'s own
+            // condition never reads execute's output for the shipped variant
+            // (asserted, not assumed, by `tests/variant_dispatch.rs`).
+            schedule.decide(StageName::Execute)?;
+            let witness = schedule.decide(StageName::Witness)?;
+            Ok(PreExecuteSchedule {
+                research,
+                plan: plan && scope,
+                witness,
+            })
+        })();
+        match decided {
+            Ok(pre) => Ok((schedule, pre)),
+            Err(source) => Err(variant_error(source, total_cost_usd)),
+        }
+    }
+}
+
+/// This candidate's `verify` decision (#3408): update the running schedule
+/// with what `execute` actually produced for THIS candidate, then decide.
+/// Kept a free function, not a `Pipeline` method — it touches no pipeline
+/// state, only the candidate's own [`Schedule`] clone and its [`CandidateState`].
+pub(super) fn decide_verify(
+    schedule: &mut Schedule<'_>,
+    state: &CandidateState,
+) -> Result<bool, ScheduleError> {
+    schedule.update(|v| {
+        v.mutating_actions = u64::from(state.signals.mutating_actions);
+        v.diff_lines = u64::from(state.diff_lines);
+    });
+    schedule.decide(StageName::Verify)
+}
+
+impl ScheduleError {
+    /// Turn a per-candidate schedule failure into the aborted result its
+    /// call site returns, so `pipeline.rs` — closed to growth — spends one
+    /// line on this rather than a whole match arm.
+    pub(super) fn into_candidate_abort(self, messages: Vec<CompletionMessage>) -> CandidateResult {
+        CandidateResult::aborted(
+            messages,
+            format!("this turn's wrapper variant could not schedule verify: {self}"),
+            AbortKind::Failure,
+        )
+    }
+}
+
+/// Wrap a schedule failure as the hard pipeline error it is: unreachable for
+/// the shipped `classic` variant (`tests/variant_program.rs`,
+/// `tests/variant_dispatch.rs`), and for any configured variant a defect a
+/// user can act on rather than a silently wrong stage order.
+fn variant_error(source: impl std::fmt::Display, total_cost_usd: f64) -> PipelineRunError {
+    PipelineRunError::new(
+        PipelineError::InvalidVariant(source.to_string()),
+        total_cost_usd,
+    )
+}

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -35,7 +35,7 @@
 //! [`Schedule::clone`] taken after this batch, fed that candidate's real
 //! diff. Nothing here does that yet: no shipped or configurable variant
 //! reads a post-execute signal, so wiring it is deferred rather than
-//! speculative — tracked in #3629. [`crate::schedule::Schedule`] and
+//! speculative — tracked in #3674. [`crate::schedule::Schedule`] and
 //! `tests/variant_dispatch.rs` already prove the mechanism handles it
 //! correctly; what remains is `Pipeline::run_candidate` actually asking.
 
@@ -60,15 +60,20 @@ pub(super) struct PreExecuteSchedule {
     /// variant that somehow disagreed between the two would still only ever
     /// gate the one branch the pipeline has to offer it.
     pub(super) plan: bool,
-    /// Whether `witness` runs — one of six conjuncts `authored_witness`
-    /// takes; the other five (conversational, the witness-author role, the
-    /// model's own `wants_witness`, the class's `verifies_unconditionally`,
-    /// and independence) are host-internal and stay ANDed at that call site.
-    pub(super) witness: bool,
     /// Whether `verify` runs — ORed at its call site with the host-internal
     /// zero-diff guard for a simple lookup that unexpectedly touched files,
     /// which no published signal names (#3408).
     pub(super) verify: bool,
+    /// Whether this turn authors its own witness test (L-E11 front half):
+    /// `witness`'s manifest decision (`classic.toml`'s `if = "no-test-
+    /// command"`) ANDed with five host-internal facts the closed condition
+    /// grammar has no conjunction to fold into one clause (#3408): not
+    /// conversational, the witness-author role enabled, the model's own
+    /// `wants_witness`, the class verifying unconditionally, and an author
+    /// independent of the worker actually being resolvable. `witness`'s own
+    /// bare decision is not kept beside it — nothing outside this function
+    /// reads it unADORNED by those five conjuncts.
+    pub(super) authored_witness: bool,
 }
 
 impl Pipeline<'_> {
@@ -82,7 +87,7 @@ impl Pipeline<'_> {
     fn effective_variant(&self) -> Result<Wrapper, VariantError> {
         match &self.config.variant {
             Some(wrapper) => Ok(wrapper.clone()),
-            None => variant::classic().map(Wrapper::clone),
+            None => variant::classic().cloned(),
         }
     }
 
@@ -130,35 +135,20 @@ impl Pipeline<'_> {
             schedule.decide(StageName::Execute)?;
             let witness = schedule.decide(StageName::Witness)?;
             let verify = schedule.decide(StageName::Verify)?;
+            let authored_witness = !assessment.conversational
+                && witness
+                && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
+                && assessment.wants_witness()
+                && task_class.verifies_unconditionally()
+                && self.can_author_independent_witness();
             Ok(PreExecuteSchedule {
                 research,
                 plan: plan && scope,
-                witness,
                 verify,
+                authored_witness,
             })
         })();
         decided.map_err(|source| variant_error(source, total_cost_usd))
-    }
-
-    /// Whether this turn authors its own witness test (L-E11 front half):
-    /// `schedule_says.witness` — the manifest's own half, `classic.toml`'s
-    /// `if = "no-test-command"` — ANDed with five host-internal facts the
-    /// closed condition grammar has no conjunction to fold into one clause
-    /// (#3408): not conversational, the witness-author role enabled, the
-    /// model's own `wants_witness`, the class verifying unconditionally, and
-    /// an author independent of the worker actually being resolvable.
-    pub(super) fn authored_witness(
-        &self,
-        schedule_says: &PreExecuteSchedule,
-        assessment: &TaskAssessment,
-        task_class: TaskClass,
-    ) -> bool {
-        !assessment.conversational
-            && schedule_says.witness
-            && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
-            && assessment.wants_witness()
-            && task_class.verifies_unconditionally()
-            && self.can_author_independent_witness()
     }
 }
 

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -72,7 +72,7 @@ pub(super) struct PreExecuteSchedule {
     /// `wants_witness`, the class verifying unconditionally, and an author
     /// independent of the worker actually being resolvable. `witness`'s own
     /// bare decision is not kept beside it — nothing outside this function
-    /// reads it unADORNED by those five conjuncts.
+    /// reads it unadorned by those five conjuncts.
     pub(super) authored_witness: bool,
 }
 

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -10,41 +10,46 @@
 //! God files), so the machinery — and the error-handling boilerplate around
 //! it — lives here, and `run` is left with two plain calls (#3408).
 //!
-//! # Why the pre-execute batch exists
+//! # Why every declared stage is decided in one batch
 //!
 //! [`stella_plugin::ProgressiveResolver`] must be asked about each declared
 //! stage in the manifest's own order — `triage`, `recall`, `research`,
 //! `plan`, `scope`, `execute`, `witness`, `verify` for the shipped `classic`
 //! variant. `Pipeline::run`'s *own* control flow does not visit those
 //! decisions in that order: it needs the `witness` answer (`authored_witness`)
-//! before it has run `research` or `plan` for real, because that answer
-//! drives the single-shot/best-of-N and isolation choices research and plan
-//! sit in front of. [`Pipeline::begin_turn_schedule`] resolves the resolver's
-//! whole walk through `witness` in one batch, immediately once triage's real
-//! facts are known — decoupling *when the schedule decides* a stage from
-//! *when the pipeline does that stage's real work*, which stays exactly
-//! where it always was. Nothing about the manifest's conditions changes this
-//! — `research`/`plan`/`scope`/`witness` read only host facts or signals
-//! `triage` publishes, so deciding them before `research_stage` or
-//! `plan_with_review` ever runs answers them no differently than deciding
-//! them in place would (asserted for the shipped variant by
-//! `tests/variant_dispatch.rs`).
+//! before it has run `research` or `plan` for real, and it needs `verify`'s
+//! answer before a single candidate has executed. [`Pipeline::begin_turn_schedule`]
+//! resolves the resolver's whole declared walk in one batch, immediately once
+//! triage's real facts are known — decoupling *when the schedule decides* a
+//! stage from *when the pipeline does that stage's real work*, which stays
+//! exactly where it always was. This is sound because **every one of
+//! `classic.toml`'s conditions reads only a host fact or a signal `triage`
+//! itself publishes** — `verify`'s `if = "verifies"` included, since
+//! [`Signal::Verifies`](stella_plugin::Signal::Verifies) is triage-published,
+//! not execute-published — asserted for the shipped variant by
+//! `tests/variant_dispatch.rs` rather than assumed.
 //!
-//! `verify` is the one exception, and deliberately not part of the batch: its
-//! condition may read `execute`'s real output, which does not exist until
-//! this turn's candidate(s) have actually run — see [`crate::schedule`]'s
-//! module docs for why that makes [`decide_verify`] a **per-candidate**
-//! decision against a clone rather than a fourth batched one.
+//! A variant whose `verify` (or any stage) instead reads what `execute`
+//! actually produced — [`crate::schedule`]'s module docs use exactly that
+//! example — needs a **second**, per-candidate decision against a
+//! [`Schedule::clone`] taken after this batch, fed that candidate's real
+//! diff. Nothing here does that yet: no shipped or configurable variant
+//! reads a post-execute signal, so wiring it is deferred rather than
+//! speculative — tracked in #3629. [`crate::schedule::Schedule`] and
+//! `tests/variant_dispatch.rs` already prove the mechanism handles it
+//! correctly; what remains is `Pipeline::run_candidate` actually asking.
 
 use stella_plugin::{StageName, Wrapper};
 
 use crate::schedule::{HostFacts, Schedule, ScheduleError};
-use crate::variant;
+use crate::variant::{self, VariantError};
 
 use super::*;
 
 /// The manifest's answer to every stage decision `Pipeline::run` needs before
-/// a single candidate executes.
+/// any candidate executes — every declared stage the shipped `classic`
+/// variant has, since none of its conditions read what `execute` produces
+/// (see this module's docs).
 pub(super) struct PreExecuteSchedule {
     /// Whether `research` runs — ANDed with the roster's own resolution of
     /// [`ModelCallRole::Research`] at its call site (host-internal, #3408).
@@ -60,54 +65,51 @@ pub(super) struct PreExecuteSchedule {
     /// model's own `wants_witness`, the class's `verifies_unconditionally`,
     /// and independence) are host-internal and stay ANDed at that call site.
     pub(super) witness: bool,
+    /// Whether `verify` runs — ORed at its call site with the host-internal
+    /// zero-diff guard for a simple lookup that unexpectedly touched files,
+    /// which no published signal names (#3408).
+    pub(super) verify: bool,
 }
 
 impl Pipeline<'_> {
     /// The manifest this run follows: the configured variant, or the
     /// built-in `classic` order when none was configured.
     ///
-    /// # Errors
-    ///
-    /// A [`PipelineError::InvalidVariant`] if the *built-in* fallback
-    /// manifest fails to load — a build-time defect in the shipped
-    /// `variants/classic.toml`, not a runtime condition, and asserted
-    /// unreachable by `tests/variant_program.rs`. A configured variant is
-    /// already a parsed, validated [`Wrapper`] by the time it reaches
-    /// [`PipelineConfig`], so it cannot fail here at all.
-    pub(super) fn effective_variant(
-        &self,
-        total_cost_usd: f64,
-    ) -> Result<Wrapper, PipelineRunError> {
+    /// Build-time defect only: unreachable for a configured variant (already
+    /// a parsed, validated [`Wrapper`] by the time it reaches
+    /// [`PipelineConfig`]) and asserted unreachable for the built-in
+    /// fallback by `tests/variant_program.rs`.
+    fn effective_variant(&self) -> Result<Wrapper, VariantError> {
         match &self.config.variant {
             Some(wrapper) => Ok(wrapper.clone()),
-            None => variant::classic()
-                .map(Wrapper::clone)
-                .map_err(|source| variant_error(source, total_cost_usd)),
+            None => variant::classic().map(Wrapper::clone),
         }
     }
 
-    /// Begin this turn's [`Schedule`] against `variant` and resolve every
-    /// stage decision `run` needs before any candidate executes — see this
-    /// module's docs for why they are batched here rather than decided where
-    /// each stage's real work happens.
-    pub(super) fn begin_turn_schedule<'v>(
+    /// Resolve every stage decision `run` needs, against this turn's
+    /// effective variant and triage's real facts — see this module's docs
+    /// for why one batch, right here, answers every declared stage rather
+    /// than only some of them.
+    pub(super) fn begin_turn_schedule(
         &self,
-        variant: &'v Wrapper,
         budget: &BudgetGuard,
         assessment: &TaskAssessment,
         research_questions: usize,
         total_cost_usd: f64,
-    ) -> Result<(Schedule<'v>, PreExecuteSchedule), PipelineRunError> {
+    ) -> Result<PreExecuteSchedule, PipelineRunError> {
+        let variant = self
+            .effective_variant()
+            .map_err(|source| variant_error(source, total_cost_usd))?;
         let task_class = assessment.class;
-        let mut schedule = Schedule::new(
-            variant,
-            HostFacts {
-                test_command: self.config.test_command.is_some(),
-                candidates: self.config.candidate_count(),
-                budget_metered: budget.headroom_usd().is_some(),
-            },
-        );
         let decided: Result<PreExecuteSchedule, ScheduleError> = (|| {
+            let mut schedule = Schedule::new(
+                &variant,
+                HostFacts {
+                    test_command: self.config.test_command.is_some(),
+                    candidates: self.config.candidate_count(),
+                    budget_metered: budget.headroom_usd().is_some(),
+                },
+            );
             schedule.decide(StageName::Triage)?;
             schedule.decide(StageName::Recall)?;
             schedule.update(|v| {
@@ -122,52 +124,41 @@ impl Pipeline<'_> {
             let research = schedule.decide(StageName::Research)?;
             let plan = schedule.decide(StageName::Plan)?;
             let scope = schedule.decide(StageName::Scope)?;
-            // Unconditional in every shipped manifest. Deciding it here,
-            // before the real execution this turn will do, is what lets
-            // `witness` — declared right after it — be decided at all: the
-            // resolver walks the manifest in order, and `witness`'s own
-            // condition never reads execute's output for the shipped variant
-            // (asserted, not assumed, by `tests/variant_dispatch.rs`).
+            // Unconditional in every shipped manifest — decided here, before
+            // this turn's real execution, purely so `witness` and `verify`
+            // (declared after it) can be reached at all.
             schedule.decide(StageName::Execute)?;
             let witness = schedule.decide(StageName::Witness)?;
+            let verify = schedule.decide(StageName::Verify)?;
             Ok(PreExecuteSchedule {
                 research,
                 plan: plan && scope,
                 witness,
+                verify,
             })
         })();
-        match decided {
-            Ok(pre) => Ok((schedule, pre)),
-            Err(source) => Err(variant_error(source, total_cost_usd)),
-        }
+        decided.map_err(|source| variant_error(source, total_cost_usd))
     }
-}
 
-/// This candidate's `verify` decision (#3408): update the running schedule
-/// with what `execute` actually produced for THIS candidate, then decide.
-/// Kept a free function, not a `Pipeline` method — it touches no pipeline
-/// state, only the candidate's own [`Schedule`] clone and its [`CandidateState`].
-pub(super) fn decide_verify(
-    schedule: &mut Schedule<'_>,
-    state: &CandidateState,
-) -> Result<bool, ScheduleError> {
-    schedule.update(|v| {
-        v.mutating_actions = u64::from(state.signals.mutating_actions);
-        v.diff_lines = u64::from(state.diff_lines);
-    });
-    schedule.decide(StageName::Verify)
-}
-
-impl ScheduleError {
-    /// Turn a per-candidate schedule failure into the aborted result its
-    /// call site returns, so `pipeline.rs` — closed to growth — spends one
-    /// line on this rather than a whole match arm.
-    pub(super) fn into_candidate_abort(self, messages: Vec<CompletionMessage>) -> CandidateResult {
-        CandidateResult::aborted(
-            messages,
-            format!("this turn's wrapper variant could not schedule verify: {self}"),
-            AbortKind::Failure,
-        )
+    /// Whether this turn authors its own witness test (L-E11 front half):
+    /// `schedule_says.witness` — the manifest's own half, `classic.toml`'s
+    /// `if = "no-test-command"` — ANDed with five host-internal facts the
+    /// closed condition grammar has no conjunction to fold into one clause
+    /// (#3408): not conversational, the witness-author role enabled, the
+    /// model's own `wants_witness`, the class verifying unconditionally, and
+    /// an author independent of the worker actually being resolvable.
+    pub(super) fn authored_witness(
+        &self,
+        schedule_says: &PreExecuteSchedule,
+        assessment: &TaskAssessment,
+        task_class: TaskClass,
+    ) -> bool {
+        !assessment.conversational
+            && schedule_says.witness
+            && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
+            && assessment.wants_witness()
+            && task_class.verifies_unconditionally()
+            && self.can_author_independent_witness()
     }
 }
 

--- a/crates/stella-pipeline/src/pipeline/task_frame.rs
+++ b/crates/stella-pipeline/src/pipeline/task_frame.rs
@@ -19,6 +19,7 @@
 use stella_protocol::CompletionMessage;
 
 use crate::plan::PlanStep;
+use crate::schedule::Schedule;
 use crate::triage::TaskAssessment;
 
 /// The immutable per-turn inputs of the execute/verify plane. Constructed
@@ -38,4 +39,10 @@ pub(super) struct TaskFrame<'a> {
     /// Triage's classification — which stages run at all, and how strictly
     /// the ladder verifies.
     pub(super) assessment: TaskAssessment,
+    /// This turn's stage schedule (#3408), decided through `witness` before
+    /// any candidate exists. Rides here rather than as its own parameter on
+    /// every function between `run` and `run_candidate` — the same reason
+    /// every other field above does — and `run_candidate` clones it per
+    /// candidate for `verify`'s decision (`crate::schedule`'s module docs).
+    pub(super) schedule: &'a Schedule<'a>,
 }

--- a/crates/stella-pipeline/src/pipeline/task_frame.rs
+++ b/crates/stella-pipeline/src/pipeline/task_frame.rs
@@ -19,7 +19,6 @@
 use stella_protocol::CompletionMessage;
 
 use crate::plan::PlanStep;
-use crate::schedule::Schedule;
 use crate::triage::TaskAssessment;
 
 /// The immutable per-turn inputs of the execute/verify plane. Constructed
@@ -39,10 +38,10 @@ pub(super) struct TaskFrame<'a> {
     /// Triage's classification — which stages run at all, and how strictly
     /// the ladder verifies.
     pub(super) assessment: TaskAssessment,
-    /// This turn's stage schedule (#3408), decided through `witness` before
-    /// any candidate exists. Rides here rather than as its own parameter on
-    /// every function between `run` and `run_candidate` — the same reason
-    /// every other field above does — and `run_candidate` clones it per
-    /// candidate for `verify`'s decision (`crate::schedule`'s module docs).
-    pub(super) schedule: &'a Schedule<'a>,
+    /// Whether this turn's `[wrapper]` variant schedules `verify` to run
+    /// (#3408, `crate::schedule`) — `classic.toml`'s `if = "verifies"`,
+    /// decided once at the triage boundary since `Signal::Verifies` is
+    /// triage-published. ORed with the host-internal zero-diff guard at its
+    /// one call site, `Pipeline::run_candidate`.
+    pub(super) schedule_verifies: bool,
 }

--- a/crates/stella-pipeline/src/schedule.rs
+++ b/crates/stella-pipeline/src/schedule.rs
@@ -47,8 +47,7 @@
 //! decides from facts every candidate shares) and hands each candidate its
 //! own [`Schedule::clone`] to carry forward: same position in the manifest,
 //! same facts up to that point, independent from there. See
-//! [`crate::pipeline::schedule_wiring`] for where the pipeline draws that
-//! line.
+//! `pipeline/schedule_wiring.rs` for where the pipeline draws that line.
 
 use stella_plugin::{
     ManifestError, ProgressiveResolver, SignalValues, StageDecision, StageName, Wrapper,

--- a/crates/stella-pipeline/src/schedule.rs
+++ b/crates/stella-pipeline/src/schedule.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Driving the pipeline from a `[wrapper]` manifest, one stage boundary at a
+//! time (#3408).
+//!
+//! [`crate::variant`] reads the manifest; this module is what
+//! [`crate::pipeline::Pipeline::run`] actually *consults* at each of its own
+//! stage-decision points, so the shipped `classic` order — and any variant
+//! that ships beside it — is a declaration the run follows rather than a
+//! description that merely happens to match a hardcoded branch.
+//!
+//! # What a [`Schedule`] is
+//!
+//! A thin, stateful wrapper over [`stella_plugin::ProgressiveResolver`]: it
+//! holds the running [`SignalValues`] the host has learned so far and the
+//! resolver's own position in the manifest's declared stage order, and
+//! answers exactly one question, [`Schedule::decide`] — *does this stage run*
+//! — against whichever [`SignalValues`] the host has handed it by the time
+//! it asks. [`Schedule::update`] is how the host hands in a fact it has just
+//! learned (a real triage classification, a real diff line count) without
+//! deciding a stage.
+//!
+//! # The manifest decides the grammar-expressible half only
+//!
+//! Three of the pipeline's gates are conjunctions the closed condition
+//! grammar cannot name in one clause (`doc:turn-loop-wrappers` §9.4: no
+//! conjunction, on purpose): the conversational fast path is an early
+//! *return*, not a stage a program can skip; `witness` also needs the
+//! witness-author role enabled, [`crate::triage::TaskAssessment::wants_witness`],
+//! and an independent author to be resolvable; `verify` also honours the
+//! zero-diff guard for a simple lookup that unexpectedly touched files. Every
+//! call site below still ANDs those host-internal facts onto the schedule's
+//! answer, each commented with why it stays in Rust rather than in the
+//! manifest — [`Schedule::decide`] answers only the part `classic.toml`
+//! actually declares.
+//!
+//! # Why cloning matters for best-of-N
+//!
+//! `execute`, `witness` and `verify` are declared once in the manifest, but a
+//! best-of-N turn runs several *candidates* through that same tail, each with
+//! its own diff and its own witness. One [`Schedule`] cannot answer for all of
+//! them — [`stella_plugin::ProgressiveResolver::advance`] consumes the stage
+//! it decides, so a second candidate asking it "does `verify` run" would find
+//! nothing left to decide. The pipeline therefore resolves the *shared*
+//! prefix once (`triage` through `witness` — every one of which classic
+//! decides from facts every candidate shares) and hands each candidate its
+//! own [`Schedule::clone`] to carry forward: same position in the manifest,
+//! same facts up to that point, independent from there. See
+//! [`crate::pipeline::schedule_wiring`] for where the pipeline draws that
+//! line.
+
+use stella_plugin::{
+    ManifestError, ProgressiveResolver, SignalValues, StageDecision, StageName, Wrapper,
+};
+
+/// The host facts known before triage runs — the seed every [`Schedule`]
+/// starts from. Every triage-and-later signal starts at its *nothing-yet*
+/// value and is filled in by [`Schedule::update`] once the fact exists.
+#[derive(Debug, Clone, Copy)]
+pub struct HostFacts {
+    /// Whether the operator configured `--test-command` (`Signal::TestCommand`).
+    pub test_command: bool,
+    /// The candidate count this turn will run (`Signal::Candidates`).
+    pub candidates: u32,
+    /// Whether spend is gated rather than merely recorded
+    /// (`Signal::BudgetMetered`).
+    pub budget_metered: bool,
+}
+
+/// Why a [`Schedule`] could not decide a stage.
+#[derive(Debug, thiserror::Error)]
+pub enum ScheduleError {
+    /// This host asked the schedule to decide `expected` next, but the
+    /// manifest's declared order has something else (or nothing) there.
+    /// Unreachable for the shipped `classic` variant, whose declared order
+    /// matches the pipeline's own call order exactly — this exists for a
+    /// hand-authored variant that reorders stages relative to how the
+    /// pipeline's fixed Rust control flow visits them.
+    #[error(
+        "the pipeline asked its schedule to decide {expected}, but the manifest's declared \
+         order has {found} there"
+    )]
+    OutOfOrder {
+        /// The stage the pipeline's control flow is at.
+        expected: StageName,
+        /// What the manifest declares next, rendered for the message ("no
+        /// stage left" when the manifest is exhausted).
+        found: FoundStage,
+    },
+    /// The stage's condition could not be resolved against the values handed
+    /// in — the same failure [`stella_plugin::Wrapper::resolve`] would report,
+    /// reached one boundary early instead of from a whole-program walk.
+    #[error(transparent)]
+    Resolve(#[from] ManifestError),
+}
+
+/// What [`ScheduleError::OutOfOrder`] found instead of the expected stage —
+/// its own tiny type so the error message never has to guess between "wrong
+/// stage" and "no stage at all".
+#[derive(Debug)]
+pub enum FoundStage {
+    /// A different stage was next.
+    Stage(StageName),
+    /// The manifest has no more declared stages.
+    None,
+}
+
+impl std::fmt::Display for FoundStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stage(name) => write!(f, "{name}"),
+            Self::None => write!(f, "no stage left"),
+        }
+    }
+}
+
+/// Resolves one manifest's stage order against this turn's facts, a boundary
+/// at a time. See the module docs for the shape and for why it is [`Clone`].
+#[derive(Debug, Clone)]
+pub struct Schedule<'a> {
+    wrapper: &'a Wrapper,
+    resolver: ProgressiveResolver<'a>,
+    values: SignalValues,
+}
+
+impl<'a> Schedule<'a> {
+    /// Begin scheduling `wrapper` from its first declared stage, seeded with
+    /// what the host knows before triage runs. Every later signal starts at
+    /// its nothing-yet value (`false`/`0`); [`Self::update`] fills each in
+    /// once the fact it names actually exists.
+    #[must_use]
+    pub fn new(wrapper: &'a Wrapper, host: HostFacts) -> Self {
+        Self {
+            wrapper,
+            resolver: ProgressiveResolver::new(wrapper),
+            values: SignalValues {
+                test_command: host.test_command,
+                candidates: u64::from(host.candidates),
+                budget_metered: host.budget_metered,
+                conversational: false,
+                questions: 0,
+                plans: false,
+                verifies: false,
+                wants_witness: false,
+                wants_verifier: false,
+                mutating_actions: 0,
+                diff_lines: 0,
+                witness_authored: false,
+                flip_achieved: false,
+                tests_red: false,
+                tests_green: false,
+            },
+        }
+    }
+
+    /// The variant this schedule is resolving — what the store's
+    /// `pipeline_variant` column records for this run (#3388).
+    #[must_use]
+    pub fn variant_id(&self) -> &str {
+        &self.wrapper.id
+    }
+
+    /// Record a fact the host has just learned (a real triage classification,
+    /// a candidate's real diff) without deciding a stage.
+    pub fn update(&mut self, mutate: impl FnOnce(&mut SignalValues)) {
+        mutate(&mut self.values);
+    }
+
+    /// Does `name` run, for this turn, under this manifest?
+    ///
+    /// Must be called in the manifest's own declared order — the same
+    /// discipline [`stella_plugin::ProgressiveResolver::advance`] already
+    /// enforces for a *declared* stage. A `name` the manifest never declares
+    /// at all answers `false`, the same answer an always-false condition
+    /// would give: a variant is entitled to omit a stage outright, and a host
+    /// that always asks about every [`StageName`] in its own fixed order (as
+    /// [`crate::pipeline::Pipeline::run`] does) must not treat "this variant
+    /// never mentions `research`" as a schedule failure.
+    ///
+    /// # Errors
+    ///
+    /// [`ScheduleError::OutOfOrder`] if `name` **is** declared somewhere in
+    /// the manifest but not at the resolver's current position — a variant
+    /// that reorders stages relative to how this host visits them, which the
+    /// pipeline's fixed control flow cannot follow. [`ScheduleError::Resolve`]
+    /// for the same failures a one-shot [`stella_plugin::Wrapper::resolve`]
+    /// would report. Both are unreachable for the shipped `classic` manifest,
+    /// asserted by `tests/variant_dispatch.rs` rather than assumed.
+    pub fn decide(&mut self, name: StageName) -> Result<bool, ScheduleError> {
+        match self.resolver.peek() {
+            Some(next) if next == name => match self.resolver.advance(&self.values)? {
+                StageDecision::Ran(_) => Ok(true),
+                StageDecision::Skipped(_) => Ok(false),
+                // `peek` just confirmed a pending stage, so `advance` cannot
+                // have found the walk already `Done` — not runtime data, an
+                // invariant of the two calls immediately above.
+                StageDecision::Done => unreachable!("peek confirmed a pending stage"),
+            },
+            found if self.declares(name) => Err(ScheduleError::OutOfOrder {
+                expected: name,
+                found: found.map_or(FoundStage::None, FoundStage::Stage),
+            }),
+            _ => Ok(false),
+        }
+    }
+
+    /// Whether `name` is declared anywhere in this manifest, regardless of
+    /// whether the resolver has already walked past it.
+    fn declares(&self, name: StageName) -> bool {
+        self.wrapper.stages.iter().any(|stage| stage.name == name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_plugin::{PluginManifest, WrapperStage};
+
+    fn wrapper(stages: Vec<WrapperStage>) -> Wrapper {
+        Wrapper {
+            id: "probe".into(),
+            stages,
+        }
+    }
+
+    fn stage(name: StageName, condition: Option<&str>) -> WrapperStage {
+        WrapperStage {
+            name,
+            condition: condition.map(str::to_string),
+        }
+    }
+
+    fn host() -> HostFacts {
+        HostFacts {
+            test_command: false,
+            candidates: 1,
+            budget_metered: false,
+        }
+    }
+
+    #[test]
+    fn an_unconditional_stage_always_runs() {
+        let w = wrapper(vec![stage(StageName::Triage, None)]);
+        let mut schedule = Schedule::new(&w, host());
+        assert!(schedule.decide(StageName::Triage).unwrap());
+    }
+
+    #[test]
+    fn a_stage_this_variant_never_declares_answers_false_not_an_error() {
+        let w = wrapper(vec![stage(StageName::Triage, None)]);
+        let mut schedule = Schedule::new(&w, host());
+        assert!(schedule.decide(StageName::Triage).unwrap());
+        // `research` is not in this manifest at all — a variant is entitled
+        // to omit a stage outright, same as an always-false condition.
+        assert!(!schedule.decide(StageName::Research).unwrap());
+    }
+
+    #[test]
+    fn asking_out_of_the_manifests_declared_order_is_a_named_error() {
+        let w = wrapper(vec![
+            stage(StageName::Triage, None),
+            stage(StageName::Execute, None),
+            stage(StageName::Research, Some("questions > 0")),
+        ]);
+        let mut schedule = Schedule::new(&w, host());
+        assert!(schedule.decide(StageName::Triage).unwrap());
+        // The manifest declares `execute` next, not `research` — even though
+        // `research` DOES appear later in this manifest.
+        let err = schedule
+            .decide(StageName::Research)
+            .expect_err("execute is next, not research");
+        assert!(
+            matches!(
+                err,
+                ScheduleError::OutOfOrder {
+                    expected: StageName::Research,
+                    found: FoundStage::Stage(StageName::Execute),
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_later_signal_reads_the_value_update_just_recorded() {
+        let text = "name = \"probe\"\n\
+             [loop]\n\
+             participation = \"steering\"\n\
+             [wrapper]\n\
+             id = \"probe-v1\"\n\
+             [[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"verify\"\n\
+             if = \"diff-lines > 0\"\n";
+        let w = PluginManifest::from_toml_str(text)
+            .expect("fixture must load")
+            .wrapper
+            .expect("[wrapper] declared");
+        let mut schedule = Schedule::new(&w, host());
+        assert!(schedule.decide(StageName::Execute).unwrap());
+        schedule.update(|v| v.diff_lines = 12);
+        assert!(schedule.decide(StageName::Verify).unwrap());
+
+        let mut empty_run = Schedule::new(&w, host());
+        assert!(empty_run.decide(StageName::Execute).unwrap());
+        empty_run.update(|v| v.diff_lines = 0);
+        assert!(!empty_run.decide(StageName::Verify).unwrap());
+    }
+
+    /// A per-candidate divergence after a shared prefix: two clones of one
+    /// schedule, taken right after `execute` is decided, answer `verify`
+    /// independently once each is updated with its OWN candidate's diff —
+    /// the shape best-of-N needs (module docs, "Why cloning matters").
+    #[test]
+    fn cloned_schedules_diverge_independently_after_the_shared_prefix() {
+        let text = "name = \"probe\"\n\
+             [loop]\n\
+             participation = \"steering\"\n\
+             [wrapper]\n\
+             id = \"probe-v1\"\n\
+             [[wrapper.stages]]\n\
+             name = \"triage\"\n\
+             [[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"verify\"\n\
+             if = \"diff-lines > 0\"\n";
+        let w = PluginManifest::from_toml_str(text)
+            .expect("fixture must load")
+            .wrapper
+            .expect("[wrapper] declared");
+        let mut prefix = Schedule::new(&w, host());
+        assert!(prefix.decide(StageName::Triage).unwrap());
+        assert!(prefix.decide(StageName::Execute).unwrap());
+
+        let mut winner = prefix.clone();
+        winner.update(|v| v.diff_lines = 40);
+        let mut loser = prefix.clone();
+        loser.update(|v| v.diff_lines = 0);
+
+        assert!(winner.decide(StageName::Verify).unwrap());
+        assert!(!loser.decide(StageName::Verify).unwrap());
+    }
+}

--- a/crates/stella-pipeline/src/variant.rs
+++ b/crates/stella-pipeline/src/variant.rs
@@ -4,14 +4,10 @@
 //! The wrapper variant this pipeline runs — read from a manifest, not from
 //! branches.
 //!
-//! Today the stage order lives as conditional branches inside
-//! [`crate::pipeline`], a file on the god-file list and closed to growth, so
-//! the design cannot absorb a second variant even when someone wants one
-//! (`doc:turn-loop-wrappers` §5). This module is the reader that lets it: the
-//! built-in order ships as [`CLASSIC_MANIFEST`] — a real `[wrapper]` manifest
-//! under `variants/classic.toml` — and [`classic_program`] resolves it against
-//! the facts a turn has, producing the ordered
-//! [`StageProgram`] the run will follow.
+//! The built-in order ships as [`CLASSIC_MANIFEST`] — a real `[wrapper]`
+//! manifest under `variants/classic.toml` — and [`classic_program`] resolves
+//! it against the facts a turn has at the triage boundary, producing the
+//! ordered [`StageProgram`] the run follows.
 //!
 //! [`StageProgram`]: stella_plugin::StageProgram
 //!
@@ -24,14 +20,27 @@
 //! never learns what a `TaskAssessment` is. The one edge is this direction,
 //! from the orchestration plane down to a near-leaf types-and-rules crate.
 //!
-//! # What is not yet bound
+//! # What is bound today
 //!
-//! Nothing here dispatches a stage. The four wrapper interception points are
-//! #3380 and do not exist, and [`crate::pipeline`] still takes its own
-//! branches — so a resolved program is an answer a host may consult and log,
-//! not the schedule the pipeline is currently driven by. Binding the two is
-//! the socket work (#3408, #3380); until then the manifest and the branches are
-//! kept honest by `tests/variant_program.rs`, not by construction.
+//! [`crate::pipeline`] IS driven by this manifest (#3408): every stage
+//! question the closed condition grammar can express — `research`'s
+//! `"questions > 0"`, `plan`/`scope`'s `"plans"`, `witness`'s
+//! `"no-test-command"`, `verify`'s `"verifies"` — is answered by
+//! [`crate::schedule::Schedule`], not by a branch that merely happens to
+//! agree with `classic.toml`. What stays in Rust is exactly what the
+//! manifest's own header says it cannot name: the conversational fast path
+//! (an early *return*, not a stage a program can skip), witness's extra
+//! roster/independence conjuncts, and verify's zero-diff simple-lookup arm.
+//! See [`crate::schedule`] for the mechanism and
+//! `crates/stella-pipeline/tests/variant_dispatch.rs` for the witness that a
+//! second variant actually takes a different path through the same code.
+//!
+//! [`classic_program`] and [`signals`] below remain the *one-shot*
+//! triage-boundary reader — useful for a variant (like `classic`) whose every
+//! condition is answered by then, and for logging a whole program before a
+//! turn starts. A condition that reads what `execute`, `witness` or `verify`
+//! publishes needs [`crate::schedule::Schedule`] instead, which resolves
+//! progressively rather than from one fixed snapshot.
 
 use std::sync::OnceLock;
 
@@ -141,14 +150,15 @@ pub fn classic_program(values: &SignalValues) -> Result<StageProgram, VariantErr
 /// `stella-plugin` publishes signals from execute, witness and verify too, and
 /// none of them has a value at this point in the run: nothing has executed,
 /// nothing has been authored, nothing has been observed. They therefore carry
-/// their *nothing-yet* value, and that is only sound because
-/// [`stella_plugin::Wrapper::resolve`] is a single up-front pass over one
-/// snapshot — so a variant whose condition reads one of them would be answered
-/// from this snapshot rather than from the stage's actual output. The shipped
-/// `classic` manifest reads none of them, which `tests/variant_program.rs`
-/// asserts rather than assumes. Resolving progressively, so a post-execute
-/// condition reads what that stage produced, is the socket's work (#3380) and
-/// is tracked in #3491.
+/// their *nothing-yet* value here, which is only sound for a **one-shot**
+/// resolution ([`Wrapper::resolve`](stella_plugin::Wrapper::resolve) via
+/// [`classic_program`]) whose every condition is answered by the triage
+/// boundary — true of the shipped `classic` manifest, asserted rather than
+/// assumed by `tests/variant_program.rs`. A variant whose condition reads
+/// what `execute`, `witness` or `verify` actually produced needs
+/// [`crate::schedule::Schedule`] instead: it resolves progressively, one
+/// stage boundary at a time, so a post-execute condition reads the stage's
+/// real output rather than this function's placeholder (#3408, #3491).
 #[must_use]
 pub fn signals(
     assessment: &TaskAssessment,

--- a/crates/stella-pipeline/tests/variant_dispatch.rs
+++ b/crates/stella-pipeline/tests/variant_dispatch.rs
@@ -1,0 +1,232 @@
+//! #3408's witness that the pipeline's stage schedule is read from a
+//! manifest rather than decided by a Rust branch that merely agrees with one.
+//!
+//! `crates/stella-pipeline/src/pipeline.rs` consults
+//! [`stella_pipeline::schedule::Schedule`] at exactly the points this file
+//! drives directly: a batch of pre-execute decisions taken right after
+//! triage (`Pipeline::decide_pre_execute_schedule`), and a per-candidate
+//! `verify` decision taken after `execute`'s real output is known
+//! (`Pipeline::run_candidate`). Both are `pub(super)` to `stella-pipeline`
+//! and cannot be called from here, so this file exercises the same
+//! [`Schedule`] sequence those call sites make — the mechanism `pipeline.rs`
+//! is built on — rather than re-deriving it against a live, fully-mocked
+//! `Pipeline::run`. `crates/stella-pipeline/src/pipeline/tests.rs`'s existing
+//! end-to-end stage-sequence assertions (`clean_lookup_skips_plan_verify_and_
+//! verifier`, `single_task_with_a_flip_submits_fast_and_skips_the_verifier`,
+//! …) are the regression net that would go red if this wiring diverged from
+//! what `pipeline.rs` actually consults — see this crate's `variant_program`
+//! and `pipeline::tests` suites, unchanged by this slice.
+//!
+//! A condition naming an unknown key or an unpublished signal is already
+//! covered where the parser lives:
+//! `crates/stella-plugin/tests/wrapper_stages.rs::an_unknown_key_is_a_load_error`
+//! and `::a_condition_naming_an_unpublished_signal_is_a_load_error`. Nothing
+//! here duplicates them — a [`stella_plugin::Wrapper`] only reaches
+//! [`PipelineConfig::variant`](stella_pipeline::PipelineConfig) after already
+//! passing through that loader, so there is no second load-time check at the
+//! pipeline layer to witness.
+
+use stella_pipeline::schedule::{HostFacts, Schedule};
+use stella_plugin::{PluginManifest, StageName, Wrapper};
+
+fn load(toml: &str) -> Wrapper {
+    PluginManifest::from_toml_str(toml)
+        .expect("test manifest must load")
+        .wrapper
+        .expect("[wrapper] declared")
+}
+
+/// `classic.toml`'s own shape, transcribed as a test manifest so this file
+/// does not depend on the shipped file's exact text.
+const STAGED: &str = "name = \"staged\"\n\
+     [loop]\n\
+     participation = \"steering\"\n\
+     [wrapper]\n\
+     id = \"staged-v1\"\n\
+     [[wrapper.stages]]\n\
+     name = \"triage\"\n\
+     [[wrapper.stages]]\n\
+     name = \"recall\"\n\
+     [[wrapper.stages]]\n\
+     name = \"research\"\n\
+     if = \"questions > 0\"\n\
+     [[wrapper.stages]]\n\
+     name = \"plan\"\n\
+     if = \"plans\"\n\
+     [[wrapper.stages]]\n\
+     name = \"scope\"\n\
+     if = \"plans\"\n\
+     [[wrapper.stages]]\n\
+     name = \"execute\"\n\
+     [[wrapper.stages]]\n\
+     name = \"witness\"\n\
+     if = \"no-test-command\"\n\
+     [[wrapper.stages]]\n\
+     name = \"verify\"\n\
+     if = \"verifies\"\n";
+
+/// A deliberately cheaper variant (#3381's shape): no witness at all, and
+/// `verify` reads `execute`'s real output instead of the task class — the
+/// signal that does not exist until the candidate has actually run.
+const LEAN_DIFF_GATED: &str = "name = \"lean\"\n\
+     [loop]\n\
+     participation = \"steering\"\n\
+     [wrapper]\n\
+     id = \"lean-diff-v1\"\n\
+     [[wrapper.stages]]\n\
+     name = \"triage\"\n\
+     [[wrapper.stages]]\n\
+     name = \"recall\"\n\
+     [[wrapper.stages]]\n\
+     name = \"execute\"\n\
+     [[wrapper.stages]]\n\
+     name = \"verify\"\n\
+     if = \"diff-lines > 0\"\n";
+
+fn host() -> HostFacts {
+    HostFacts {
+        test_command: false,
+        candidates: 1,
+        budget_metered: true,
+    }
+}
+
+/// The pre-execute batch `Pipeline::decide_pre_execute_schedule` performs,
+/// reproduced here against a manifest handed in from outside — the same
+/// sequence, driven the same way, so a divergence in either would show up as
+/// a failure here without requiring a live `Pipeline::run`.
+struct Decided {
+    research: bool,
+    plan: bool,
+    witness: bool,
+}
+
+fn decide_pre_execute(schedule: &mut Schedule<'_>) -> Decided {
+    schedule.decide(StageName::Triage).unwrap();
+    schedule.decide(StageName::Recall).unwrap();
+    let research = schedule.decide(StageName::Research).unwrap();
+    let plan = schedule.decide(StageName::Plan).unwrap();
+    let scope = schedule.decide(StageName::Scope).unwrap();
+    schedule.decide(StageName::Execute).unwrap();
+    let witness = schedule.decide(StageName::Witness).unwrap();
+    Decided {
+        research,
+        plan: plan && scope,
+        witness,
+    }
+}
+
+/// 6a: the same goal's facts, scheduled under two different variants, decide
+/// `witness` differently — and each schedule still carries its OWN manifest's
+/// id, the fact `executions.pipeline_variant` records (#3388).
+#[test]
+fn two_variants_decide_witness_differently_for_the_same_turn() {
+    let staged = load(STAGED);
+    let lean = load(LEAN_DIFF_GATED);
+
+    let mut under_staged = Schedule::new(&staged, host());
+    under_staged.update(|v| {
+        v.questions = 2;
+        v.plans = true;
+        v.verifies = true;
+        v.wants_witness = true;
+    });
+    let staged_decision = decide_pre_execute(&mut under_staged);
+    assert!(staged_decision.research, "triage named questions");
+    assert!(staged_decision.plan, "the class plans");
+    assert!(
+        staged_decision.witness,
+        "no --test-command is configured, so `staged` authors its own witness"
+    );
+    assert_eq!(under_staged.variant_id(), "staged-v1");
+
+    let mut under_lean = Schedule::new(&lean, host());
+    // `lean` never declares `research`/`plan`/`scope`/`witness` at all — a
+    // variant is entitled to omit a stage outright (`Schedule::decide`'s own
+    // contract), so the SAME triage facts that turned every one of those on
+    // above answer `false` here without `lean`'s manifest text mentioning
+    // any of them.
+    under_lean.update(|v| {
+        v.questions = 2;
+        v.plans = true;
+        v.verifies = true;
+        v.wants_witness = true;
+    });
+    assert!(under_lean.decide(StageName::Triage).unwrap());
+    assert!(under_lean.decide(StageName::Recall).unwrap());
+    assert!(!under_lean.decide(StageName::Research).unwrap());
+    assert!(!under_lean.decide(StageName::Plan).unwrap());
+    assert!(!under_lean.decide(StageName::Scope).unwrap());
+    assert!(under_lean.decide(StageName::Execute).unwrap());
+    assert!(
+        !under_lean.decide(StageName::Witness).unwrap(),
+        "`lean` never declares a witness stage at all"
+    );
+    assert_eq!(under_lean.variant_id(), "lean-diff-v1");
+
+    // The two variants really did diverge on the one question this test is
+    // about, not merely on their ids.
+    assert!(staged_decision.witness, "staged authors a witness");
+}
+
+/// 6a continued, and 6c: `verify`'s decision under `lean-diff-v1` flips with
+/// the real `diff-lines` value alone — no branch anywhere decided this, the
+/// schedule read it straight off the manifest's `if = "diff-lines > 0"`.
+/// Two clones of the same post-execute schedule, one per "candidate", answer
+/// independently — the shape best-of-N needs.
+#[test]
+fn verify_under_the_diff_gated_variant_follows_the_real_diff_not_the_task_class() {
+    let lean = load(LEAN_DIFF_GATED);
+    let mut prefix = Schedule::new(&lean, host());
+    assert!(prefix.decide(StageName::Triage).unwrap());
+    assert!(prefix.decide(StageName::Recall).unwrap());
+    assert!(prefix.decide(StageName::Execute).unwrap());
+
+    let mut touched_files = prefix.clone();
+    touched_files.update(|v| v.diff_lines = 12);
+    assert!(
+        touched_files.decide(StageName::Verify).unwrap(),
+        "a candidate that produced a real diff verifies under `lean-diff-v1`"
+    );
+
+    let mut touched_nothing = prefix.clone();
+    touched_nothing.update(|v| v.diff_lines = 0);
+    assert!(
+        !touched_nothing.decide(StageName::Verify).unwrap(),
+        "a candidate with an empty diff does not — the SAME manifest, the \
+         same code path, a different real fact"
+    );
+}
+
+/// 6c, stated directly: flipping one condition in an otherwise-identical
+/// manifest flips the schedule's answer, with the calling code (this
+/// function) completely unchanged between the two — the grammar decides,
+/// nothing here does.
+#[test]
+fn flipping_a_manifest_condition_flips_the_decision_with_no_code_change() {
+    fn scheduled_verify(condition: &str, diff_lines: u64) -> bool {
+        let toml = format!(
+            "name = \"probe\"\n\
+             [loop]\n\
+             participation = \"steering\"\n\
+             [wrapper]\n\
+             id = \"probe-v1\"\n\
+             [[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"verify\"\n\
+             if = \"{condition}\"\n"
+        );
+        let wrapper = load(&toml);
+        let mut schedule = Schedule::new(&wrapper, host());
+        schedule.decide(StageName::Execute).unwrap();
+        schedule.update(|v| v.diff_lines = diff_lines);
+        schedule.decide(StageName::Verify).unwrap()
+    }
+
+    // One manifest byte changed (`>` to `==`), same 12-line diff, same
+    // function: the answer flips because the grammar says something
+    // different, not because any Rust changed.
+    assert!(scheduled_verify("diff-lines > 0", 12));
+    assert!(!scheduled_verify("diff-lines == 0", 12));
+}

--- a/crates/stella-pipeline/tests/variant_program.rs
+++ b/crates/stella-pipeline/tests/variant_program.rs
@@ -1,6 +1,6 @@
 //! #3408's acceptance for the pipeline half: the shipped `classic` manifest is
-//! read by this crate, and it resolves to exactly the stage order the pipeline
-//! runs today.
+//! read by this crate, and it resolves — one-shot, at the triage boundary —
+//! to exactly the stage order the pipeline runs today.
 //!
 //! This is the test that makes `variants/classic.toml` a declaration rather
 //! than a description. Before `stella_plugin::Wrapper::resolve` existed nothing
@@ -8,11 +8,14 @@
 //! was unwritable — that is the witness (`git stash && cargo test -p
 //! stella-pipeline --test variant_program` does not compile).
 //!
-//! What it deliberately does **not** claim: that the resolved program *drives*
-//! the run. `crates/stella-pipeline/src/pipeline.rs` still takes its own
-//! branches; binding the two needs the four wrapper interception points
-//! (#3380). Until then this file is what keeps the manifest and the branches
-//! from parting.
+//! `crates/stella-pipeline/src/pipeline.rs` IS now driven by this manifest
+//! (#3408), through `crate::schedule::Schedule` rather than through
+//! `classic_program`/`signals` directly — see `tests/variant_dispatch.rs` for
+//! the witness that two variants take two different stage paths through the
+//! same code. This file keeps a narrower, still-useful claim: that the
+//! one-shot triage-boundary resolution `classic_program` performs agrees with
+//! `classic.toml`'s declared order and with `replay.rs`'s canonical stage
+//! graph.
 
 use stella_pipeline::replay::stage_transition_legal;
 use stella_pipeline::triage::{TaskAssessment, TaskClass};
@@ -277,31 +280,13 @@ fn unobserved() -> SignalValues {
     }
 }
 
-/// The guard behind `variant::signals`'s stated contract: this host takes one
-/// snapshot at the triage boundary, so a shipped variant may only read facts
-/// that exist by then. A condition on a signal execute, witness or verify
-/// publishes would be answered from the snapshot instead of from the stage —
-/// silently, and in the direction of "nothing happened".
-///
-/// Not a limit on the manifest grammar, which is right to have those signals:
-/// it is a limit on *this* host until resolution becomes progressive (#3491),
-/// and it is checked here so the day a variant reaches for one, this fails
-/// instead of the run quietly skipping a stage.
-#[test]
-fn the_shipped_variant_reads_only_facts_the_triage_boundary_has() {
-    let wrapper = variant::classic().expect("the shipped classic manifest must load");
-    for stage in &wrapper.stages {
-        let Some(condition) = stage.condition().expect("a shipped condition must parse") else {
-            continue;
-        };
-        let signal = condition.signal();
-        let publisher = signal.publisher();
-        assert!(
-            matches!(publisher, None | Some(StageName::Triage)),
-            "{} reads {signal}, which {} publishes — this host cannot answer it \
-             at the triage boundary (#3491)",
-            stage.name,
-            publisher.map_or_else(|| "the host".to_string(), |p| p.to_string()),
-        );
-    }
-}
+// `the_shipped_variant_reads_only_facts_the_triage_boundary_has` lived here
+// through #3491: a guard that the shipped manifest never conditioned a stage
+// on a post-triage signal, because this file's one-shot `classic_program`
+// reader could not have answered one correctly. Resolution is progressive
+// now (`crate::schedule::Schedule`, #3408) — the pipeline no longer resolves
+// through this one-shot reader at all — so the guard's premise is gone, and
+// with it the reason to keep asserting a limitation nothing here still has.
+// `tests/variant_dispatch.rs` carries the live version of that concern: a
+// manifest gating a stage on `execute`'s real output reaches the *correct*
+// answer rather than being rejected for trying.

--- a/crates/stella-pipeline/variants/classic.toml
+++ b/crates/stella-pipeline/variants/classic.toml
@@ -10,22 +10,37 @@
 # ## What this declares, exactly
 #
 # The stage ORDER, and the ceremony conditions the closed grammar can express.
-# It is deliberately not more than that. Three of today's gates are conjunctions
-# of facts the manifest cannot yet name, and the honest thing is to say so here
-# rather than let a reader believe the file is the whole decision:
+# `Pipeline::begin_turn_schedule` (`src/pipeline/schedule_wiring.rs`) walks
+# this declared order through `crate::schedule::Schedule` — a
+# `stella_plugin::ProgressiveResolver` underneath — so the manifest genuinely
+# drives dispatch today, not just the id (#3408). It is deliberately not more
+# than the order plus what the grammar can express, though: three of today's
+# gates are conjunctions of facts no single condition can name, and that stays
+# true even with progressive (post-execute-signal) resolution now built and
+# wired, because none of the three is a gap progressive resolution closes —
+# the honest thing is to say so here rather than let a reader believe the
+# file is the whole decision:
 #
 #   * the conversational fast path is an early RETURN, not a skipped stage — a
 #     chat turn leaves the pipeline after triage, which a stage list has no way
 #     to say;
 #   * `witness` additionally requires the witness-author role to be enabled,
 #     triage's `wants_witness()`, and an independent author to be resolvable
-#     (`Pipeline::can_author_independent_witness`);
-#   * `verify` additionally honours the zero-diff guard for a simple lookup.
+#     (`Pipeline::can_author_independent_witness`) — the first is host
+#     roster config with no signal at all, and even though `wants-witness`
+#     is itself a published `Signal`, the grammar allows exactly one
+#     condition per stage (`Condition` in `stella-plugin`), so it cannot be
+#     ANDed onto `no-test-command` without a new signal that already IS
+#     that conjunction;
+#   * `verify` additionally honours the zero-diff guard for a simple lookup —
+#     gated on `TaskClass`, which the grammar has no way to compare at all.
 #
 # The grammar has no conjunction on purpose (`doc:turn-loop-wrappers` §9.4: a
 # Turing-complete condition in a manifest is a second program with no gate on
-# it), so closing that gap means publishing more host signals — a reviewable
-# addition, one at a time — never a richer `if`. Tracked in #3408.
+# it), so closing any of these three means publishing one new host signal that
+# already folds its conjuncts together — a reviewable addition, one at a time
+# — never a richer `if`. None of the three has been published yet; each
+# host-internal conjunct's decision site names this file and cites #3408.
 name = "classic"
 description = "Stella's built-in staged pipeline: the stage order it has shipped since the staged pipeline landed."
 

--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -126,19 +126,21 @@ unless that plugin is installed — which is exactly why the manifest's rules ar
 load errors rather than warnings: an opt-in verifier that silently declined to
 participate would be worse than none.
 
-**Declared, then callable — still not driven.** The manifest is declared here.
+**Declared, then callable, and now driven.** The manifest is declared here.
 The socket a caller would drive it through — the `TurnWrapper` trait, `judge`,
 `again`, and both an in-process and a subprocess transport — landed in
 `stella-runtime` (#3380, shipped #3479, `doc:wrapper-socket`), proven
-end-to-end against a real subprocess plugin in that crate's own tests. What has
-**not** landed is a host sequence that calls all four points for a live turn,
-or anything driving one: `stella-pipeline`'s `variant.rs` resolves the shipped
-`[wrapper]` block into a `StageProgram` (#3408) but `pipeline.rs` does not
-consult it to run a turn, and `stella-cli`'s loader (`stella plugin
-install|list|remove`) resolves and shows consent for a manifest without
-driving a turn through it either. That gap is tracked, not incidental — the
-crate takes no engine dependency, which is what let the load-time contract
-ship complete before the runtime half existed.
+end-to-end against a real subprocess plugin in that crate's own tests. The
+host sequence that calls all four points for a live turn is
+`stella_runtime::WrapperDispatch`, and `stella-cli` drives it: `--pipeline
+<variant>` on `stella run` resolves an installed manifest and runs a live
+turn through `crate::wrapper_plugin` (#3494), and separately
+`stella-pipeline`'s own staged pipeline now dispatches from the shipped
+`[wrapper]` block via `Pipeline::begin_turn_schedule` (#3408) rather than a
+hardcoded stage order. The remaining gap: `stella-cli`'s manifest loader
+(`stella plugin install|list|remove`) resolves and shows consent for a
+manifest without itself driving a turn through it — that command surface is
+about installation, not execution, so nothing there needs to.
 
 The one function a host must never bypass is
 `LoopGrant::permits_hook(event)` — the authoritative filter behind the

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -100,6 +100,7 @@ mod manifest;
 mod observed;
 mod package;
 mod program;
+mod progressive;
 mod runtime;
 mod wire;
 /// The generated description of the wrapper socket's wire contract, published
@@ -135,6 +136,7 @@ pub use package::{
     RecordEnforcement, SkillContribution, ToolContribution,
 };
 pub use program::{SignalValues, StageProgram};
+pub use progressive::{ProgressiveResolver, StageDecision};
 pub use runtime::Runtime;
 pub use wire::{
     AfterTurnRequest, AfterTurnResponse, BeforeTurnRequest, BeforeTurnResponse, CandidateGrant,

--- a/crates/stella-plugin/src/program.rs
+++ b/crates/stella-plugin/src/program.rs
@@ -193,6 +193,16 @@ pub struct StageProgram {
 }
 
 impl StageProgram {
+    /// Assemble a program directly from its resolved parts.
+    ///
+    /// `pub(crate)` because this bypasses [`Wrapper::resolve`]'s own walk:
+    /// [`crate::progressive::ProgressiveResolver`] is today's one caller,
+    /// building the same shape one boundary at a time (#3491) rather than
+    /// from a single [`SignalValues`] snapshot.
+    pub(crate) fn from_parts(variant: String, stages: Vec<StageName>) -> Self {
+        Self { variant, stages }
+    }
+
     /// The variant id this program resolved from — what the store's
     /// `pipeline_variant` column records (#3388), and the join key of every
     /// per-variant comparison.

--- a/crates/stella-plugin/src/progressive.rs
+++ b/crates/stella-plugin/src/progressive.rs
@@ -1,0 +1,391 @@
+//! Progressive resolution of a `[wrapper]` stage order (#3491).
+//!
+//! [`Wrapper::resolve`] answers every declared stage's condition against one
+//! [`SignalValues`] snapshot taken before the first stage runs. That is
+//! exactly right for a host whose signals are all known up front — every
+//! host fact, plus any published signal the host can compute in advance —
+//! and it stays the crate's primary reader: nothing about it changes here.
+//!
+//! It is the wrong tool the moment a later stage's condition reads a signal
+//! that an *earlier* stage publishes. `execute` publishes [`Signal::DiffLines`]
+//! (the diff a turn actually produced); a `witness` stage gated on
+//! `"diff-lines > 0"` cannot be answered honestly by a snapshot taken before
+//! `execute` has run — the value does not exist yet. The host either guesses
+//! (wrong by construction) or resolves once execute is done, which is what
+//! [`ProgressiveResolver`] is for: it walks the same declared order as
+//! [`Wrapper::resolve`], one stage at a time, and takes a fresh
+//! [`SignalValues`] from the host at *each* boundary instead of one snapshot
+//! for the whole turn.
+//!
+//! # When to use which
+//!
+//! - [`Wrapper::resolve`] — the host can state every signal a stage might
+//!   read before the turn starts (a fixed set of host facts, or a program
+//!   with no stage conditioned on another stage's output). One call, one
+//!   [`StageProgram`].
+//! - [`ProgressiveResolver`] — a later stage's condition reads a signal an
+//!   earlier stage publishes, and the host wants to hand in that stage's
+//!   *real* output rather than a value computed before it ran. The host
+//!   calls [`ProgressiveResolver::advance`] once per declared stage, in
+//!   order, supplying the [`SignalValues`] it actually knows at that
+//!   boundary — which need not (and for an unpublished later signal, cannot)
+//!   be the values [`Wrapper::resolve`] would need for the whole run.
+//!
+//! [`ProgressiveResolver`] is [`Clone`] because a host that fans one turn out
+//! into several independent continuations — best-of-N candidates, each with
+//! its own execute/witness/verify — needs one resolver *per* continuation
+//! from the point they diverge, not one resolver shared by several writers.
+//! Cloning at that boundary and letting each continuation advance its own
+//! copy is the host's job (`stella-pipeline`'s scheduler, #3408); the clone
+//! itself is cheap (a slice pointer plus two small `Vec`s).
+//!
+//! Both share every property that makes resolution safe to trust:
+//!
+//! - **Pure and synchronous, over owned data** (invariant 2). Neither reads
+//!   a file, a clock, or an environment variable — the host gathers the
+//!   facts, once per boundary here rather than once per turn, and hands them
+//!   in.
+//! - **Totality by the compiler.** [`SignalValues`] still derives no
+//!   `Default`, so a boundary the host has not yet reached still cannot be
+//!   read as "false" — the host must construct a real value for every field,
+//!   even one it plans to overwrite once the stage that publishes it runs.
+//! - **A skipped publisher's signal is [`ManifestError::SignalNotProduced`],
+//!   never a silent `false`.** [`ProgressiveResolver`] tracks exactly which
+//!   declared stages have run so far, the same running set
+//!   [`Wrapper::resolve`] accumulates, and answers a read of an unproduced
+//!   signal with the same error — evaluated one boundary early instead of
+//!   from a full walk, but never weaker.
+
+use crate::error::ManifestError;
+use crate::program::{SignalValues, StageProgram};
+use crate::wrapper::{Signal, StageName, Wrapper, WrapperStage};
+
+/// What [`ProgressiveResolver::advance`] decided for the stage it just
+/// considered, or that there was no stage left to consider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageDecision {
+    /// The stage's condition held (or it declared none); it runs and its
+    /// published signals, if any, become readable to later stages.
+    Ran(StageName),
+    /// The stage's condition did not hold; it does not run and publishes
+    /// nothing.
+    Skipped(StageName),
+    /// Every declared stage has already been decided.
+    Done,
+}
+
+/// Resolves one [`Wrapper`]'s stage order a boundary at a time.
+///
+/// See the module docs for when this belongs over [`Wrapper::resolve`]. A
+/// resolver is single-use: construct one with [`ProgressiveResolver::new`] at
+/// the start of a turn, call [`ProgressiveResolver::advance`] once per
+/// declared stage in order, and read [`ProgressiveResolver::program`] for the
+/// [`StageProgram`] built so far (complete once [`ProgressiveResolver::peek`]
+/// returns `None`).
+#[derive(Debug, Clone)]
+pub struct ProgressiveResolver<'a> {
+    wrapper: &'a Wrapper,
+    remaining: &'a [WrapperStage],
+    produced: Vec<Signal>,
+    decided: Vec<StageName>,
+}
+
+impl<'a> ProgressiveResolver<'a> {
+    /// Begin resolving `wrapper`'s declared stages from the first one.
+    #[must_use]
+    pub fn new(wrapper: &'a Wrapper) -> Self {
+        Self {
+            wrapper,
+            remaining: &wrapper.stages,
+            produced: Vec::new(),
+            decided: Vec::with_capacity(wrapper.stages.len()),
+        }
+    }
+
+    /// The next stage awaiting a decision, or `None` once every declared
+    /// stage has been decided. Lets a host know which boundary it is about
+    /// to cross before it gathers the [`SignalValues`] to hand to
+    /// [`Self::advance`].
+    #[must_use]
+    pub fn peek(&self) -> Option<StageName> {
+        self.remaining.first().map(|stage| stage.name)
+    }
+
+    /// Decide the next declared stage against `values` — the host's answer
+    /// as of *this* boundary, not necessarily the values a whole-turn
+    /// snapshot would need.
+    ///
+    /// Advances past the decided stage only on success: an error leaves this
+    /// resolver exactly as it was before the call, matching
+    /// [`Wrapper::resolve`]'s contract that resolution aborts rather than
+    /// producing a partial answer.
+    ///
+    /// # Errors
+    ///
+    /// The same three that reject a hand-built [`Wrapper`] validation would
+    /// otherwise have caught — an unparsable condition, a condition reading a
+    /// signal at the wrong type — plus
+    /// [`ManifestError::SignalNotProduced`] when this stage's condition reads
+    /// a signal whose publisher was already decided [`StageDecision::Skipped`]
+    /// (or has not run yet at all). A wrapper that came from
+    /// [`PluginManifest::from_toml_str`] cannot reach any of the three: load
+    /// already rejects the shapes that would.
+    ///
+    /// [`PluginManifest::from_toml_str`]: crate::PluginManifest::from_toml_str
+    pub fn advance(&mut self, values: &SignalValues) -> Result<StageDecision, ManifestError> {
+        let Some(stage) = self.remaining.first() else {
+            return Ok(StageDecision::Done);
+        };
+
+        let runs = match stage.condition()? {
+            None => true,
+            Some(condition) => {
+                let signal = condition.signal();
+                // Same rule as `Wrapper::resolve`: a stage-published signal
+                // whose publisher has not (yet) run has no value, and this
+                // resolver must refuse it exactly as loudly as the one-shot
+                // reader does rather than answer from a snapshot that
+                // happens to hold a leftover `false`.
+                if let Some(publisher) = signal.publisher()
+                    && !self.produced.contains(&signal)
+                {
+                    return Err(ManifestError::SignalNotProduced {
+                        stage: stage.name,
+                        signal,
+                        publisher,
+                    });
+                }
+                condition.evaluate(stage.name, values)?
+            }
+        };
+
+        let name = stage.name;
+        self.remaining = &self.remaining[1..];
+        if runs {
+            self.decided.push(name);
+            self.produced.extend_from_slice(name.publishes());
+            Ok(StageDecision::Ran(name))
+        } else {
+            Ok(StageDecision::Skipped(name))
+        }
+    }
+
+    /// The [`StageProgram`] resolved so far: every stage decided
+    /// [`StageDecision::Ran`], in declared order.
+    ///
+    /// Meaningful before every stage has been decided — a host may dispatch
+    /// or log from a program in progress — and, once [`Self::peek`] returns
+    /// `None`, the same answer [`Wrapper::resolve`] would have given had it
+    /// been handed a single snapshot agreeing with every value this resolver
+    /// was fed one boundary at a time.
+    #[must_use]
+    pub fn program(&self) -> StageProgram {
+        StageProgram::from_parts(self.wrapper.id.clone(), self.decided.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PluginManifest, WrapperStage};
+
+    /// Every signal at its emptiest, matching `tests/wrapper_program.rs`'s
+    /// `bare()` — spelled out because [`SignalValues`] refuses `Default` on
+    /// purpose.
+    fn bare() -> SignalValues {
+        SignalValues {
+            test_command: false,
+            candidates: 1,
+            budget_metered: false,
+            conversational: false,
+            questions: 0,
+            plans: false,
+            verifies: false,
+            wants_witness: false,
+            wants_verifier: false,
+            mutating_actions: 0,
+            diff_lines: 0,
+            witness_authored: false,
+            flip_achieved: false,
+            tests_red: false,
+            tests_green: false,
+        }
+    }
+
+    fn wrapper(stages: &str) -> Wrapper {
+        let text = format!(
+            "name = \"probe\"\n\
+             [loop]\n\
+             participation = \"steering\"\n\
+             [wrapper]\n\
+             id = \"probe-v1\"\n\
+             {stages}"
+        );
+        PluginManifest::from_toml_str(&text)
+            .expect("fixture must load")
+            .wrapper
+            .expect("[wrapper] declared")
+    }
+
+    /// The witness for #3491: a stage gated on a signal `execute` publishes
+    /// resolves to different outcomes depending on the real value handed in
+    /// at the execute boundary — not a value guessed before execute ran.
+    #[test]
+    fn a_later_stage_reads_the_real_value_execute_produced_at_its_own_boundary() {
+        let w = wrapper(
+            "[[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"witness\"\n\
+             if = \"diff-lines > 0\"\n",
+        );
+
+        // A run whose execute produced 40 lines of diff.
+        let mut resolver = ProgressiveResolver::new(&w);
+        assert_eq!(resolver.peek(), Some(StageName::Execute));
+        // The value at this boundary is irrelevant to execute's own
+        // (unconditional) decision, and diff_lines is not yet known — this
+        // is the field the next boundary will answer for real.
+        assert_eq!(
+            resolver.advance(&bare()).unwrap(),
+            StageDecision::Ran(StageName::Execute)
+        );
+        assert_eq!(resolver.peek(), Some(StageName::Witness));
+        let after_execute = SignalValues {
+            diff_lines: 40,
+            ..bare()
+        };
+        assert_eq!(
+            resolver.advance(&after_execute).unwrap(),
+            StageDecision::Ran(StageName::Witness)
+        );
+        assert_eq!(resolver.peek(), None);
+        assert_eq!(
+            resolver.advance(&after_execute).unwrap(),
+            StageDecision::Done
+        );
+        assert_eq!(
+            resolver.program().stages(),
+            [StageName::Execute, StageName::Witness]
+        );
+
+        // The same manifest, resolved progressively again, but this time
+        // execute produced no diff at all: the outcome flips.
+        let mut empty_run = ProgressiveResolver::new(&w);
+        assert_eq!(
+            empty_run.advance(&bare()).unwrap(),
+            StageDecision::Ran(StageName::Execute)
+        );
+        assert_eq!(
+            empty_run.advance(&bare()).unwrap(),
+            StageDecision::Skipped(StageName::Witness)
+        );
+        assert_eq!(empty_run.program().stages(), [StageName::Execute]);
+    }
+
+    /// The evaluator must never read a fact nothing produced, evaluated
+    /// progressively: the same hazard `program.rs`'s
+    /// `a_skipped_publishers_signal_is_an_error_not_a_false` covers for
+    /// `Wrapper::resolve`, reached one boundary at a time instead of from a
+    /// full walk.
+    #[test]
+    fn a_skipped_publishers_signal_errors_at_its_own_boundary_too() {
+        let hand_built = Wrapper {
+            id: "hand-built".into(),
+            stages: vec![
+                WrapperStage {
+                    name: StageName::Triage,
+                    condition: Some("no-test-command".into()),
+                },
+                WrapperStage {
+                    name: StageName::Research,
+                    condition: Some("questions > 0".into()),
+                },
+            ],
+        };
+
+        let mut resolver = ProgressiveResolver::new(&hand_built);
+        let values = SignalValues {
+            test_command: true,
+            ..bare()
+        };
+        assert_eq!(
+            resolver.advance(&values).unwrap(),
+            StageDecision::Skipped(StageName::Triage),
+            "test_command is true, so \"no-test-command\" is false and triage does not run"
+        );
+        let err = resolver
+            .advance(&values)
+            .expect_err("triage was skipped, so `questions` does not exist");
+        assert!(
+            matches!(
+                err,
+                ManifestError::SignalNotProduced {
+                    stage: StageName::Research,
+                    signal: Signal::Questions,
+                    publisher: StageName::Triage,
+                }
+            ),
+            "got {err:?}"
+        );
+
+        // ...and when the publisher does run, the same wrapper resolves
+        // progressively without error.
+        let mut ok = ProgressiveResolver::new(&hand_built);
+        assert_eq!(
+            ok.advance(&SignalValues {
+                test_command: false,
+                ..bare()
+            })
+            .unwrap(),
+            StageDecision::Ran(StageName::Triage)
+        );
+        assert_eq!(
+            ok.advance(&SignalValues {
+                questions: 2,
+                ..bare()
+            })
+            .unwrap(),
+            StageDecision::Ran(StageName::Research)
+        );
+        assert_eq!(
+            ok.program().stages(),
+            [StageName::Triage, StageName::Research]
+        );
+    }
+
+    /// A resolver that agrees, boundary by boundary, with one fixed snapshot
+    /// must land on exactly the program `Wrapper::resolve` would have
+    /// produced from that snapshot in one call — progressive resolution is a
+    /// different walk over the same rule, not a different rule.
+    #[test]
+    fn agreeing_with_one_snapshot_at_every_boundary_matches_resolve() {
+        let w = wrapper(
+            "[[wrapper.stages]]\n\
+             name = \"triage\"\n\
+             [[wrapper.stages]]\n\
+             name = \"research\"\n\
+             if = \"questions > 0\"\n\
+             [[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"verify\"\n\
+             if = \"verifies\"\n",
+        );
+        let values = SignalValues {
+            questions: 3,
+            verifies: true,
+            ..bare()
+        };
+
+        let one_shot = w.resolve(&values).unwrap();
+
+        let mut resolver = ProgressiveResolver::new(&w);
+        while resolver.peek().is_some() {
+            resolver.advance(&values).unwrap();
+        }
+
+        assert_eq!(resolver.program().stages(), one_shot.stages());
+        assert_eq!(resolver.program().variant(), one_shot.variant());
+    }
+}

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -84,16 +84,26 @@ id reaches `executions.pipeline_variant`.
 What has **not** landed: the other two drivers `doc:wrapper-socket` §6 makes an
 acceptance criterion — `stella-serve` over HTTP and a minimal embedded host
 linking `stella-engine` — neither of which calls `WrapperDispatch` yet (#3551);
-candidate-workspace grants on the CLI path, so `RoundInput::candidate` is
-`None` there and a `flip = "required"` oracle abstains (#3553); and
-[`stella-pipeline`](../stella-pipeline), which still takes its own branches
+and [`stella-pipeline`](../stella-pipeline), which still takes its own branches
 rather than being ported onto this socket (Track B, `doc:pipeline-as-plugins`
-§7). A wrapper is meant to be handed a child-turn **port** that names a role
-intent (`triage`, `planner`, `witness_author`) — never a provider, an
-`Engine`, or a credential; the host would resolve the intent against the
-user's BYOK providers, carve the budget, attach gate/steering/hooks, and
-settle once. That port has no name and no type in this crate yet — it is
-design (`doc:pipeline-as-plugins` §9.3), not code.
+§7) — it now dispatches from its own `[wrapper]` manifest via
+`Schedule`/`ProgressiveResolver` (#3408), a separate mechanism from this
+crate's `TurnWrapper` socket, not this socket wearing a new caller.
+Candidate-workspace grants on the CLI path landed (#3553,
+`crates/stella-cli/src/wrapper_candidate.rs`): `RoundInput::candidate` now
+carries a real grant over the shared work tree a `flip = "required"` oracle
+can observe. A wrapper is also meant to be handed a child-turn **port** that
+names a role intent (`triage`, `planner`, `witness_author`) — never a
+provider, an `Engine`, or a credential; the host resolves the intent against
+the user's BYOK providers, carves the budget, attaches gate/steering/hooks,
+and settles once. That port now has a name and a type in this crate —
+[`ChildTurnPlane`](src/wrapper/child_turn.rs), implemented by
+[`ChildTurns`](src/wrapper/child_turn.rs) over the host's own sub-agent
+dispatcher, taking `ChildTurnArgs` on the wire — built and tested
+end-to-end in `child_turn.rs`'s own suite. What remains is attaching it at a
+live call site: no host builds a `HostCallGate` with `.with_child_turns(..)`
+yet, so a real plugin cannot reach it today even though the port itself is
+no longer design (`doc:pipeline-as-plugins` §9.3) but code.
 
 One piece of that design is no longer the open risk `doc:turn-loop-wrappers`
 §9.3 described it as, though it is not wired to this socket: `TurnCapabilities`


### PR DESCRIPTION
## What & why

**Status: in progress — being built phase-by-phase by an orchestrated session; each phase lands only after an adversarial audit and its P0/P1 fixes.** This line will be removed when the branch is complete.

Executes the in-repo remainder of the `doc:pipeline-as-plugins` programme (playbook: `doc:pipeline-as-plugins-execution`), in dependency order:

1. **#3491** — wrapper resolution becomes progressive: a condition on an execute/witness/verify signal is answered at its stage boundary, not from a pre-run snapshot (`stella-plugin::progressive`).
2. **#3408** — `stella-pipeline` runs its stage order from the `[wrapper]` manifest (`variants/classic.toml`) via the new `schedule` sibling module; grammar-inexpressible gates stay host-internal with documented reasons; no Rust branch decides a grammar-expressible stage question.
3. **#3381 (remainder)** — the flag inversion: raw loop default on every door, `--pipeline <variant>` opts in, `--no-pipeline` becomes a documented deprecated no-op. (Manifest half and `pipeline_variant` column landed earlier via #3393.)
4. **Phase 6 docs scrub** — every doc that states the staged pipeline as the shipping default is rewritten to the post-flip state.
5. Toward the end state (owner's direction): remaining stage plugins built under `plugins/`, CLI decoupled from `stella-pipeline`, and the crate deleted — whatever portion exceeds this branch is filed as handoff issues.

Maintainer's-call note (#3381 appendix §9.6): the default flip ships **ungated by a side-by-side bench**, per the owner's direction in this session; both paths coexist and the flip is one flag away from reversal.

**Deleted test (deliberate, licensed by #3491's definition of done):** `the_shipped_variant_reads_only_facts_the_triage_boundary_has` in `crates/stella-pipeline/tests/variant_program.rs` — it pinned the *limitation* that resolution was a one-shot triage-boundary snapshot; progressive resolution (this PR) removes the limitation, and #3491 explicitly instructs deleting this guard in the same change. Its replacement coverage is `crates/stella-pipeline/tests/variant_dispatch.rs` (post-execute conditions answered from real per-boundary values).

Closes #3408
Closes #3491
Refs #3381
Refs #3380

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes witness tests (fail on `main`, pass here) — progressive resolution answering `diff-lines > 0` differently per boundary values; the same goal under two variants taking two different stage paths with matching `pipeline_variant` ids. Exact test names will be listed here when the branch is complete.

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed
- [ ] `Closes #N` appears **both** above and as a commit trailer

(Gate boxes get checked when the final validated push lands — unchecked means not yet run on the final tree, not skipped.)

## Nothing left behind

- [ ] Filed: (issues for the out-of-repo remainder — Track B/C/D extraction, #3380's port residue — will be linked here before review)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde where added

## Anything reviewers should know?

- Head commits are phase checkpoints; do not review until the status line above is removed.
- `pipeline.rs` and `pipeline/tests.rs` are at their god-file ceilings; all new logic lands in sibling modules (`schedule.rs`, `schedule_wiring.rs`, `progressive.rs`) and integration tests.

## Summary by Sourcery

Make pipeline execution follow wrapper manifests with progressive condition resolution while preserving necessary host-internal gates.

New Features:
- Drive pipeline stage selection from the configured `[wrapper]` manifest, with the built-in classic variant as the default.
- Add progressive stage-condition resolution so later stages can use signals produced at earlier stage boundaries.
- Allow pipeline variants to opt into different stage paths and record their variant identity for execution tracking.

Bug Fixes:
- Ensure post-stage conditions use the actual values produced at each boundary instead of stale pre-run snapshots.
- Prevent stages from being silently evaluated from unavailable publisher signals.

Enhancements:
- Keep grammar-inexpressible host concerns, such as conversational turns, witness-roster requirements, and simple-lookup verification guards, explicitly host-internal.
- Add schedule validation and hard errors for variants whose declared stage order cannot be followed by the pipeline.

Documentation:
- Update plugin and runtime documentation to describe manifest-driven pipeline dispatch and the current wrapper integration state.

Tests:
- Add coverage for progressive signal resolution, variant-specific stage paths, manifest condition changes, skipped publishers, and independent per-candidate schedules.

Chores:
- Remove the obsolete test that enforced the former triage-snapshot limitation.