### PR TITLE
revert(brand): put the TUI and the investor deck back on the gold identity

### DIFF
--- a/crates/stella-cli/src/command_deck/theme_cmd.rs
+++ b/crates/stella-cli/src/command_deck/theme_cmd.rs
@@ -3,9 +3,9 @@
 //! the already-large `command_deck` dispatcher: the parser, the live switch,
 //! and the settings write live here; `command_deck` only wires them to `say`.
 //!
-//! Two themes ship. `stella-dark` (Ion on Obsidian — the comet kit at
-//! `docs/brand/README.md`) is the default; `stella-light` is the same ion
-//! darkened onto cool paper. [`blurb`] is the user-visible naming of both,
+//! Two themes ship. `stella-dark` (Phosphor Gold on Ink — the comet kit at
+//! `docs/brand/README.md`) is the default; `stella-light` is the same gold
+//! darkened onto warm paper. [`blurb`] is the user-visible naming of both,
 //! and it has drifted behind the identity before (it once named a terminal
 //! green and an ember red-orange two recolours dead) — keep it telling the
 //! truth. The switch itself is a per-frame buffer remap in
@@ -60,8 +60,8 @@ fn theme_menu() -> String {
 /// the same Phosphor Gold brand hue; the ground is what differs.
 fn blurb(theme: ThemeName) -> &'static str {
     match theme {
-        ThemeName::StellaDark => "ion on obsidian (default)",
-        ThemeName::StellaLight => "ion on paper",
+        ThemeName::StellaDark => "phosphor gold on ink (default)",
+        ThemeName::StellaLight => "phosphor gold on paper",
     }
 }
 

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -107,20 +107,18 @@ fn truncate_with_ellipsis(s: &str, max: usize) -> String {
 // only — `/color` exists so several terminal windows running stella can be told
 // apart at a glance, which needs hues that are *distinct* rather than on-brand.
 // `colored`'s named ANSI colors are the portable stand-ins, and the nearest one
-// to the brand's Ion (`theme::ACCENT`, `#00D1F9`) is bright-cyan.
+// to the brand's Phosphor Gold (`theme::ACCENT`, `#FFB81A`) is bright-yellow.
 //
-// The default used to be bright-blue (and bright-yellow, and bright-cyan
-// before those): the accent trailed the identity through recolour after
-// recolour because nothing asserted which hue the default resolves to. The
-// comet kit ended that — the brand slot is `ion` now, and the test below pins
-// it.
+// The default used to be bright-blue (and bright-cyan before that): the
+// accent trailed the identity through recolour after recolour because
+// nothing asserted which hue the default resolves to. The comet kit ends
+// that — the brand slot is `gold` now, and the test below pins it.
 //
-// The old slugs are all kept as personalisation: `gold` still lands on
-// bright-yellow, `sky` and `azure` on bright-blue (the named set holds no
-// second distinct blue), and `/color gold` keeps working for anyone whose
-// muscle memory types it — it just no longer claims to be the brand.
-const PALETTE: [(&str, Color); 8] = [
-    ("ion", Color::BrightCyan),
+// The old slugs are all kept as personalisation: `sky` and `azure` still
+// land on bright-blue (the named set holds no second distinct blue), and
+// `/color sky` keeps working for anyone whose muscle memory types it — it
+// just no longer claims to be the brand.
+const PALETTE: [(&str, Color); 7] = [
     ("gold", Color::BrightYellow),
     ("sky", Color::BrightBlue),
     ("cyan", Color::BrightCyan),
@@ -132,7 +130,7 @@ const PALETTE: [(&str, Color); 8] = [
 
 static ACCENT: AtomicUsize = AtomicUsize::new(0);
 
-/// The session accent color (defaults to the brand ion, `PALETTE[0]`).
+/// The session accent color (defaults to the brand gold, `PALETTE[0]`).
 ///
 /// `agent.rs` imports this **by name** rather than reaching for it through the
 /// module path. That is not style: `plain::accent()` is two characters longer
@@ -206,9 +204,9 @@ pub fn tool_call_card(name: &str, input: &serde_json::Value, status: &str) {
 
     // The tool name takes the session accent, matching the deck: it is the one
     // token in a transcript that carries the brand hue, because the names are
-    // what a reader scans a scrollback *for*. It was once a hard-coded
-    // `bright_yellow` — this file's own stand-in for a long-retired gold —
-    // which survived two recolours because no "gold" string named it.
+    // what a reader scans a scrollback *for*. It was `bright_yellow` — this
+    // file's own stand-in for the retired gold — which survived the recolour
+    // because no "gold" string named it.
     println!(
         "  {} {}({})",
         icon,
@@ -985,29 +983,25 @@ mod tests {
         );
     }
 
-    /// Ion is the brand, so it is the default accent -- `/color` with no
+    /// Gold is the brand, so it is the default accent -- `/color` with no
     /// argument, and a fresh session, must land on it.
     #[test]
-    fn default_accent_is_ion() {
-        assert_eq!(PALETTE[0].0, "ion");
+    fn default_accent_is_gold() {
+        assert_eq!(PALETTE[0].0, "gold");
         assert_eq!(ACCENT.load(Ordering::Relaxed) % PALETTE.len(), 0);
         // …and it must be the BRAND hue, not merely first in the list. The
         // default trailed the identity through recolour after recolour
         // because nothing asserted which colour the default slug actually
-        // resolves to. Bright-cyan is the nearest named ANSI stand-in for
-        // `theme::ACCENT` (Ion `#00D1F9`), and it is what `theme::FALLBACKS`
-        // degrades the accent to at 16 colours, so the two surfaces agree.
-        assert_eq!(PALETTE[0].1, Color::BrightCyan);
-        assert_eq!(accent(), Color::BrightCyan);
-        // The retired brand slugs survive as personalisation, then the
-        // process global returns to the brand default for any test that
-        // reads it.
-        assert!(set_accent("gold"));
-        assert_eq!(PALETTE[ACCENT.load(Ordering::Relaxed)].0, "gold");
+        // resolves to. Bright-yellow is the nearest named ANSI stand-in for
+        // `theme::ACCENT` (Phosphor Gold `#FFB81A`).
+        assert_eq!(PALETTE[0].1, Color::BrightYellow);
+        assert_eq!(accent(), Color::BrightYellow);
+        // The old brand slug survives as personalisation, then the process
+        // global returns to the brand default for any test that reads it.
         assert!(set_accent("sky"));
         assert_eq!(PALETTE[ACCENT.load(Ordering::Relaxed)].0, "sky");
-        assert!(set_accent("ion"));
-        assert_eq!(accent(), Color::BrightCyan);
+        assert!(set_accent("gold"));
+        assert_eq!(accent(), Color::BrightYellow);
     }
 
     #[test]

--- a/crates/stella-cli/src/storage_cmd.rs
+++ b/crates/stella-cli/src/storage_cmd.rs
@@ -55,10 +55,10 @@ pub fn run_observe(port: u16, open: bool) -> Result<(), String> {
     rt.block_on(stella_observatory::serve(root, port, move |addr| {
         let url = format!("http://{addr}/");
         println!();
-        // Comet kit v3.0: ion accent (bright cyan is the named ANSI stand-in
-        // `theme::FALLBACKS` degrades it to), lowercase always.
-        println!("  {} {}", "◆".bright_cyan(), "stella observatory".bold());
-        println!("  {} {}", "→".bright_cyan(), url);
+        // Comet kit v1.0: gold accent (ANSI yellow is the terminal's phosphor
+        // gold), lowercase always.
+        println!("  {} {}", "◆".yellow(), "stella observatory".bold());
+        println!("  {} {}", "→".yellow(), url);
         println!(
             "  {}",
             "reads .stella (read-only) · binds 127.0.0.1 only · Ctrl+C to stop".dimmed()

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -309,7 +309,7 @@ fn render_tab_bar(tab: DeckTab, area: Rect, buf: &mut Buffer) {
     if area.width >= 44 {
         block = block.title_top(
             Line::from(vec![
-                Span::styled("✦ ", Style::new().fg(theme::IDENTITY)),
+                Span::styled("✦ ", Style::new().fg(theme::GOLD)),
                 Span::styled("stella ", theme::muted()),
             ])
             .right_aligned(),

--- a/crates/stella-tui/src/markdown.rs
+++ b/crates/stella-tui/src/markdown.rs
@@ -392,18 +392,18 @@ fn strip_numbered(lead: &str) -> Option<(&str, &str)> {
 
 /// Build a heading line with level-appropriate styling.
 ///
-/// The hierarchy is accent → accent → paper, all bold:
-/// * **H1** is a filled ion pill — obsidian-dark [`theme::GROUND`] text on an
+/// The hierarchy is gold → gold → paper, all bold:
+/// * **H1** is a filled gold pill — ink-dark [`theme::GROUND`] text on an
 ///   [`theme::ACCENT`] background, with a space of padding each side so it
-///   reads as a solid title bar. This is the kit's one sanctioned accent
+///   reads as a solid title bar. This is the kit's one sanctioned gold
 ///   *fill* (the website's sidebar pill and CTA do the same), and the text
-///   on it must stay obsidian: obsidian-on-ion is 10.79:1 where white-on-ion
-///   is 1.83:1.
-/// * **H2** is bold ion text (no fill).
+///   on it must stay ink: ink-on-gold is 10.74:1 where white-on-gold is
+///   1.83:1.
+/// * **H2** is bold gold text (no fill).
 /// * **H3+** is bold primary-ink text.
 fn heading_line(content: &str, level: usize) -> Line<'static> {
     if level == 1 {
-        // One span so the accent fill is a single unbroken pill behind the text.
+        // One span so the gold fill is a single unbroken pill behind the text.
         let pill = Style::new()
             .bg(theme::ACCENT)
             .fg(theme::GROUND)
@@ -636,15 +636,15 @@ mod tests {
     }
 
     #[test]
-    fn h1_is_a_high_contrast_accent_pill() {
+    fn h1_is_a_high_contrast_gold_pill() {
         // The exact fix the user asked for: the H1 must be a bold, filled,
-        // high-contrast bar — obsidian on Ion — never washed-out or a
-        // light-text-on-pale-background combination (white on ion is 1.83:1;
-        // obsidian on ion is 10.79:1).
+        // high-contrast bar — ink on Phosphor Gold — never washed-out or a
+        // light-text-on-pale-background combination (white on gold is
+        // 1.83:1; ink on gold is 10.74:1).
         let lines = render("# Rust Async Patterns");
         let span = &lines[0].spans[0];
-        assert_eq!(span.style.bg, Some(theme::ACCENT), "accent fill");
-        assert_eq!(span.style.fg, Some(theme::GROUND), "obsidian text");
+        assert_eq!(span.style.bg, Some(theme::ACCENT), "gold fill");
+        assert_eq!(span.style.fg, Some(theme::GROUND), "ink text");
         assert!(span.style.add_modifier.contains(Modifier::BOLD), "bold");
     }
 

--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -1,31 +1,22 @@
 //! Raw palette values -- the single normative colour source for the terminal.
-//! Cut from the brand kit v3.0 ("the comet") at `docs/brand/` -- read
+//! Cut from the brand kit v1.0 ("the comet") at `docs/brand/` -- read
 //! `css/tokens.css` and `brand-guidelines.html` before touching a value here.
 //! Nothing here is semantic: for role names
 //! (accent, ink, rule, status) see [`crate::theme`], which is the only module
 //! that should reference these directly.
 //!
-//! The identity is **Ion on Obsidian**: one colour, owned. Ion `#00D1F9` --
-//! the comet's ion tail, an electric azure-cyan -- is the signal (the mark,
-//! the prompt, active/selected, focus) and never the surface; Obsidian
-//! `#070B10` is the ground, a cool blue-black, and the text ramp above it is
-//! a cool graphite. The v2.0 bronze/warm-neutral system is gone entirely:
-//! there is no warm hue left in the chrome, only in the functional statuses
-//! and two categorical marks. Brand and identity are one family, so `BRAND`
-//! and `IDENTITY` deliberately share values. The paper theme (`stella-light`)
-//! swaps the ground for cool paper and the ion for its deep ramp stops.
+//! The identity is **Phosphor Gold on Ink**: one colour, owned. Gold
+//! `#FFB81A` is the signal -- the mark, the prompt, active/selected, focus --
+//! and never the surface; Ink `#0B0B0C` is the ground; text is warm Paper
+//! with the kit's warm neutral ramp beneath it. The old electric-blue/gold
+//! split is gone: brand and gold are one family now, so `BRAND` and `GOLD`
+//! deliberately share values. The paper theme (`stella-light`) swaps the
+//! ground for warm paper and the gold for its deep ramp stops.
 //!
-//! Every ramp is generated in OKLCH -- the ion family at hue 218 and the
-//! neutrals at hue 250 -- so the lightness steps are perceptual rather than
-//! eyeballed in sRGB, and every contrast figure quoted below is a computed
-//! WCAG ratio against the ground named beside it.
-//!
-//! Token names are hue-neutral on purpose (`BRAND`, not `ION_ACCENT`): the
+//! Token names are hue-neutral on purpose (`BRAND`, not `GOLD_ACCENT`): the
 //! brand hue has been recoloured before (aurora → gold → sky → green → ember →
-//! blue → gold → ion) and the name must outlive the value. That rule cost the
-//! repository real work this time -- `GOLD*` was a hue in a token name and had
-//! to be renamed to `IDENTITY*` across the crate when the hue moved. Add a
-//! *value* here; name a *role* in `theme`.
+//! blue → gold) and the name must outlive the value. Add a *value* here; name
+//! a *role* in `theme`.
 //!
 //! Mirrored by `docs/brand/css/tokens.css`, `website/src/app/tokens.css` and
 //! the observatory's inlined `:root` block; all of them must be edited
@@ -36,311 +27,273 @@ use ratatui::style::Color;
 
 // ── Ground (dark) ───────────────────────────────────────────────
 //
-// Obsidian: the terminal, not pure black. The kit's dark ground is a cool
-// blue-black -- no warm cast, no brown-greys anywhere on the dark side. Pure
-// black makes an accent scream; obsidian lets it speak, and it is what the
+// Ink: the terminal, not pure black. The kit's dark ground is a warm-neutral
+// near-black -- no blue cast, no cool grays anywhere on the dark side. Pure
+// black makes an accent scream; ink lets it speak, and it is what the
 // marketing site and the observatory already render. `surface` and `raised`
 // step up for cards and popovers; the two hairlines are the seam.
 
 /// Deepest ground -- full-bleed backdrops, the splash, OG art. The
-/// observatory's `--void`. Very nearly black (relative luminance 0.0016) so
-/// a full-bleed panel reads as a hole rather than as another surface.
-pub const VOID: Color = Color::Rgb(0x01, 0x03, 0x06);
+/// observatory's `--void`.
+pub const VOID: Color = Color::Rgb(0x05, 0x05, 0x06);
 
-/// App background. Obsidian `#070B10` -- THE brand ground, painted as a real
-/// frame fill by the deck, so every contrast figure below is measured against
-/// it.
-pub const GROUND: Color = Color::Rgb(0x07, 0x0B, 0x10);
+/// App background. Ink `#0B0B0C` -- THE brand ground, painted as a real frame
+/// fill by the deck, so every contrast figure below is measured against it.
+pub const GROUND: Color = Color::Rgb(0x0B, 0x0B, 0x0C);
 
 /// Card / panel surface, one step above ground (the kit's dark `--surface`).
-pub const SURFACE: Color = Color::Rgb(0x12, 0x18, 0x1D);
+pub const SURFACE: Color = Color::Rgb(0x13, 0x13, 0x15);
 
 /// Raised surface -- popovers, selected rows, hovered cells.
-pub const RAISED: Color = Color::Rgb(0x1F, 0x25, 0x2B);
+pub const RAISED: Color = Color::Rgb(0x1B, 0x1B, 0x1E);
 
 /// Seam / rule (the kit's dark `--border`). Deliberately low-contrast on
-/// ground (1.48:1): decorative only, never the sole carrier of structure.
-pub const HAIRLINE: Color = Color::Rgb(0x2A, 0x30, 0x36);
+/// ground (1.26:1): decorative only, never the sole carrier of structure.
+pub const HAIRLINE: Color = Color::Rgb(0x23, 0x23, 0x27);
 
 /// Seam where a boundary must actually read -- panel edges, focused borders.
-/// Still below 3:1 on ground (1.94:1), so it is a *stronger* decoration, not
+/// Still below 3:1 on ground (1.57:1), so it is a *stronger* decoration, not
 /// a substitute for a glyph or a gap.
-pub const HAIRLINE_STRONG: Color = Color::Rgb(0x3C, 0x42, 0x48);
+pub const HAIRLINE_STRONG: Color = Color::Rgb(0x33, 0x33, 0x38);
 
-// ── Brand (dark: Ion) ───────────────────────────────────────────
+// ── Brand (dark: Phosphor Gold) ─────────────────────────────────
 //
 // The one owned colour. Brand marks, the prompt, active/running, focus,
-// selection, primary action -- and nothing else: ion is the signal, never the
-// surface. Reserved exactly as the gold before it was, and like that gold it
-// needs no separate text tone: `#00D1F9` measures 10.79:1 on ground, so the
-// same value is safe on a glyph, a one-cell rule, and a fill. An ion fill (a
-// pill, a selected tab) always carries GROUND text -- white on ion is 1.83:1
-// and illegible.
+// selection, primary action -- and nothing else: gold is the signal, never
+// the surface. Reserved exactly as the blue before it was, but unlike the
+// blue it needs no separate text tone: `#FFB81A` measures 11.36:1 on ground,
+// so the same value is safe on a glyph, a one-cell rule, and a fill. A gold
+// fill (a pill, a selected tab) always carries INK text -- white on gold is
+// 1.83:1 and illegible.
 
-/// Ion `#00D1F9` -- the comet's tail, kit `brand-500`. 10.79:1 on ground.
-///
-/// Unlike the bronze it replaces, this value is **not** held apart from the
-/// web kit: `docs/brand/css/tokens.css`'s `--stella-brand` is the same hex.
-/// The gold era held a brighter terminal stop for a *brightness* reason, not
-/// a contrast one -- the kit's bronze cleared 6.40:1 on the old ink ground,
-/// so it could carry a glyph; it simply did not read as CRT amber at that
-/// saturation. At hue 218 the terminal wants no such lift: one stop clears
-/// 10.79:1 on obsidian and holds its edge in a browser, so the split has
-/// nothing left to buy.
-///
-/// The comment this replaces cited #2592 as an open question about "whether
-/// the two golds should mean the same thing". That was wrong twice over, and
-/// is recorded here rather than quietly deleted: #2592 was closed `wontfix`
-/// on 2026-08-12, and it was never about the two *values* — it is about the
-/// two *rules*, that the accent marks `Running` in the terminal and identity
-/// only on the web. **This recolour does not touch that divergence**: the
-/// deck still paints activity in the accent (`status_color`), the web
-/// instruments still reserve it for the wordmark and one primary action, and
-/// both rules are stated where they always were.
-pub const BRAND: Color = Color::Rgb(0x00, 0xD1, 0xF9);
+/// Phosphor Gold `#FFB81A` -- CRT amber, the gold star. 11.36:1 on ground.
+/// Held at this value across the 2026-08-11 bronze rebrand (`10781aa`), which
+/// moved `docs/brand/css/tokens.css`'s `--stella-gold` to `#C58A32` -- this
+/// constant does **not** track that hex. The TUI palette is deliberately not
+/// the web instrument palette (see the module doc): it needs a brighter,
+/// more saturated stop than paper or a browser does to read as CRT amber on
+/// ink at 11.36:1, so it is held apart rather than re-derived from the kit's
+/// current gold ramp. Whether the two golds should mean the same thing is
+/// #2592, still open; this value does not wait on it.
+pub const BRAND: Color = Color::Rgb(0xFF, 0xB8, 0x1A);
 
-/// The bright stop of the brand sweep (kit `brand-300`, the observatory's
-/// `--brand-bright`). 13.09:1 on ground. Gradients and hover lifts only --
+/// The bright stop of the brand sweep (kit `gold-400`, the observatory's
+/// `--gold-bright`). 12.12:1 on ground. Gradients and hover lifts only --
 /// resting chrome stays on [`BRAND`].
-pub const BRAND_BRIGHT: Color = Color::Rgb(0x72, 0xE1, 0xFF);
+pub const BRAND_BRIGHT: Color = Color::Rgb(0xFD, 0xC1, 0x54);
 
 /// Pressed / gradient-deep stop, and the leading stop of the progress fill
-/// (kit `brand-600`). 7.65:1 on ground, so even the fill's tail clears AA.
-pub const BRAND_DEEP: Color = Color::Rgb(0x00, 0xB0, 0xD2);
+/// (kit `gold-600` lifted 10% with the brand). 8.77:1 on ground, so even the
+/// fill's tail clears AA.
+pub const BRAND_DEEP: Color = Color::Rgb(0xE5, 0xA0, 0x00);
 
-// ── Brand (light: ion on paper) ─────────────────────────────────
+// ── Brand (light: gold on paper) ────────────────────────────────
 //
-// The `stella-light` primary. Ion cannot hold a text edge on paper at full
-// strength (1.61:1), so the light accent walks down the kit's own ion ramp
-// until it clears AA on [`PAPER`]. Applied by the per-frame theme remap in
+// The `stella-light` primary. Gold cannot hold a text edge on paper at full
+// strength, so the light accent walks down the kit's own gold ramp until it
+// clears AA on [`PAPER`]. Applied by the per-frame theme remap in
 // [`crate::theme`], truecolor only.
 
-/// The light-theme brand hue -- kit `brand-800`, 4.59:1 on [`PAPER`] and
-/// 4.93:1 on [`SNOW`], so it carries terminal-cell text on both light
-/// surfaces.
+/// The light-theme brand hue -- 5.22:1 on [`PAPER`], held apart from the
+/// current web kit's gold ramp for the same reason as [`BRAND`] (see its
+/// doc): the two golds are not required to track hex-for-hex until #2592
+/// settles what they should mean to each other.
 ///
-/// Deliberately one step *below* [`IDENTITY_INK`]: kit `brand-700` measures
-/// 3.16:1 on the painted paper ground -- fine for chrome, under the 4.5:1
-/// floor for text -- so the ramp splits the same way the bronze one did, one
-/// stop for glyphs and one for graphics.
-pub const BRAND_INK: Color = Color::Rgb(0x00, 0x77, 0x8F);
+/// Deliberately one step *below* [`GOLD_INK`], a value this crate held onto
+/// from before the 2026-08-11 bronze rebrand -- it no longer matches
+/// `docs/brand/css/tokens.css`'s current `gold-deep`, `#8B5E1A`. [`GOLD_INK`]
+/// measures 3.79:1 on the painted paper ground -- fine for chrome, under the
+/// 4.5:1 floor for terminal-cell text. It stays in the family as
+/// [`GOLD_INK`], the light theme's *chrome* gold.
+pub const BRAND_INK: Color = Color::Rgb(0x85, 0x5E, 0x00);
 
-/// Pressed stop / leading progress stop on paper (7.77:1 on [`PAPER`]).
-pub const BRAND_INK_DEEP: Color = Color::Rgb(0x00, 0x52, 0x63);
+/// Pressed stop / leading progress stop on paper (kit `gold-900` lifted 10%,
+/// 8.76:1).
+pub const BRAND_INK_DEEP: Color = Color::Rgb(0x5A, 0x3F, 0x00);
 
-// ── Identity ────────────────────────────────────────────────────
+// ── Gold ────────────────────────────────────────────────────────
 //
 // Identity chrome: the logo's block cursor, splash rules, section markers.
-// Under the comet kit, the identity IS the brand hue, so [`IDENTITY`] and
-// [`BRAND`] share a value on purpose -- the split only survives as *names* so
-// the identity sweep ([`IDENTITY_DEEP`] → [`IDENTITY_BRIGHT`]) can run wider
-// and quieter than the progress fill's.
+// Under the comet kit, gold IS the brand, so [`GOLD`] and [`BRAND`] share a
+// value on purpose -- the split only survives as *names* so the identity
+// sweep ([`GOLD_DEEP`] → [`GOLD_BRIGHT`]) can run wider and quieter than the
+// progress fill's.
 //
-// Identity NEVER carries a verdict. Under the gold system that rule existed
-// because the accent sat 4.0° from [`WARNING`] in hue and an outcome could
-// have been read off chrome; the nearest status hue is now 35° away
-// ([`SUCCESS`]) and the warning amber 146°, so the *confusion* is gone but
-// the *rule* is not -- chrome and verdict are
-// different jobs, and `theme::identity_never_carries_a_verdict` still proves
-// no outcome mapping can return an identity value. Activity is the one status
-// identity does carry: active/running IS the accent, by kit rule.
-//
-// These constants were named `GOLD*` until the v3.0 recolour, which is
-// precisely the hazard the module doc warns about: a hue in a token name
-// falsifies itself the first time the hue moves.
+// Gold NEVER carries a verdict. It sits 4.0° from [`WARNING`] in hue, so a
+// reader must never be asked to tell an outcome from chrome by hue alone --
+// status is always glyph-paired (`theme::gold_never_carries_a_verdict`
+// enforces this). Activity is the one status gold does carry: active/running
+// IS the accent, by kit rule.
 
-/// The mark's ion -- the same value as [`BRAND`].
-pub const IDENTITY: Color = Color::Rgb(0x00, 0xD1, 0xF9);
+/// The mark's gold -- the same Phosphor Gold as [`BRAND`].
+pub const GOLD: Color = Color::Rgb(0xFF, 0xB8, 0x1A);
 
-/// Headline gradient stop -- the bright end of the identity sweep (== kit
-/// `brand-300`, [`BRAND_BRIGHT`]).
-pub const IDENTITY_BRIGHT: Color = Color::Rgb(0x72, 0xE1, 0xFF);
+/// Headline gradient stop -- the bright end of the gold sweep (== kit
+/// `gold-400`, [`BRAND_BRIGHT`]).
+pub const GOLD_BRIGHT: Color = Color::Rgb(0xFD, 0xC1, 0x54);
 
-/// Trailing stop of the identity sweep (kit `brand-700`). 5.52:1 on ground --
-/// clears AA body text and the 3:1 graphical floor, but the *progress* fill
-/// leads with the stronger [`BRAND_DEEP`] instead.
-pub const IDENTITY_DEEP: Color = Color::Rgb(0x00, 0x94, 0xB1);
+/// Trailing stop of the identity sweep (kit `gold-700`, the web kit's
+/// `gold-deep`). 4.65:1 on ground -- clears AA body text and the 3:1
+/// graphical floor, but the *progress* fill leads with the stronger
+/// [`BRAND_DEEP`] instead.
+pub const GOLD_DEEP: Color = Color::Rgb(0xA3, 0x72, 0x00);
 
-/// Identity chrome on a light ground (kit `brand-700` again -- the kit's one
-/// light-ground *graphical* ion). 3.16:1 on [`PAPER`]: a graphical tone
-/// (splash rules, the identity sweep), while light-ground ion TEXT takes
+/// Gold chrome on a light ground (kit `gold-700` again -- `gold-deep` is the
+/// kit's one light-ground gold). 3.79:1 on [`PAPER`]: a *graphical* tone
+/// (splash rules, the identity sweep), while light-ground gold TEXT takes
 /// [`BRAND_INK`].
-pub const IDENTITY_INK: Color = Color::Rgb(0x00, 0x94, 0xB1);
+pub const GOLD_INK: Color = Color::Rgb(0xA3, 0x72, 0x00);
 
 // ── Text (dark ground) ──────────────────────────────────────────
 //
-// Cool paper over the kit's cool graphite ramp -- no warm greys. Prose is
+// Warm Paper over the kit's warm neutral ramp -- no cool grays. Prose is
 // paper-white: the accent earns its meaning by being rare, which only works
 // if the default voice is uncoloured.
 
-/// Primary text. Cool Paper -- the transcript's default voice. 16.78:1 on
+/// Primary text. Warm Paper -- the transcript's default voice. 17.44:1 on
 /// [`GROUND`].
-pub const TEXT_PRIMARY: Color = Color::Rgb(0xE9, 0xED, 0xF2);
+pub const TEXT_PRIMARY: Color = Color::Rgb(0xF4, 0xF1, 0xEA);
 
 /// Secondary text (the observatory's `--text-2`, the kit's dark
-/// `--muted-fg`). The safe small-text tone on every dark ground (6.85:1).
-pub const TEXT_SECONDARY: Color = Color::Rgb(0x92, 0x99, 0xA1);
+/// `--muted-fg`). The safe small-text tone on every dark ground (6.83:1).
+pub const TEXT_SECONDARY: Color = Color::Rgb(0x9B, 0x98, 0x90);
 
-/// Labels and captions (the observatory's `--text-3`). AA body on
-/// void/ground/surface (6.05:1 / 5.96:1 / 5.40:1); on [`RAISED`] it drops to
-/// 4.67:1 -- still AA, but treat it as the floor.
-pub const TEXT_TERTIARY: Color = Color::Rgb(0x87, 0x8E, 0x96);
+/// Labels and captions (kit `neutral-500`, the observatory's `--text-3`).
+/// AA body on void/ground/surface (5.71:1 / 5.38:1); on [`RAISED`] it drops
+/// to 4.98:1 -- still AA, but treat it as the floor.
+pub const TEXT_TERTIARY: Color = Color::Rgb(0x8D, 0x8A, 0x82);
 
 // ── Status ──────────────────────────────────────────────────────
 //
 // Functional, not brand: always paired with a glyph. Hue alone never carries
-// meaning. The three status hues are the only warm colours left in the
-// system, which is what makes them read as *functional* against an entirely
-// cool chrome -- the inverse of the gold era, where a warm accent had to be
-// held 4.0° off a warm warning.
+// meaning -- which matters doubly now that warning is a hue-neighbour of the
+// gold accent (4.0° apart).
 
-/// Success / done / added (12.00:1 on ground). Also the settled cost of a
+/// Success / done / added (11.29:1 on ground). Also the settled cost of a
 /// finished turn -- money spent is a fact, and a fact reads green.
-pub const SUCCESS: Color = Color::Rgb(0x00, 0xE7, 0x86);
+pub const SUCCESS: Color = Color::Rgb(0x4A, 0xDE, 0x80);
 
-/// Warning / needs-input. Amber (10.40:1) -- 146° from the ion accent, so
-/// unlike the gold era nothing in the chrome can be mistaken for it. The
-/// glyph is still the status carrier; the hue is now merely unambiguous
-/// rather than load-bearing.
-pub const WARNING: Color = Color::Rgb(0xF2, 0xB1, 0x00);
+/// Warning / needs-input. Amber (10.26:1) -- 4.0° from the gold accent in
+/// hue, which is exactly why the glyph, never the hue, is the status
+/// carrier.
+pub const WARNING: Color = Color::Rgb(0xEA, 0xB3, 0x08);
 
-/// Error / failed / removed (7.73:1 on ground, 6.06:1 on [`RAISED`]).
-pub const DANGER: Color = Color::Rgb(0xFF, 0x74, 0x9B);
+/// Error / failed / removed (6.62:1 on ground).
+pub const DANGER: Color = Color::Rgb(0xFF, 0x5C, 0x7A);
 
 /// The oracle's pre-flip state — the witness surface's `red` token, the one
 /// sanctioned red-as-meaning in the deck (D6). A true signal red, kept
 /// distinct from [`DANGER`]'s pink-red so "the test is red before the patch"
 /// (a healthy, expected state) never shares a value with "something failed".
-/// 5.83:1 on [`GROUND`] and 4.57:1 on [`RAISED`], which is the binding
-/// surface: the witness panel is a raised card, so a value that cleared AA on
-/// ground alone would fail where this token actually renders.
-///
-/// 1.33:1 against [`DANGER`] at 23° of hue. The bronze pair managed 1.30:1 at
-/// 11.8°, so the two are now separated further by hue and marginally further
-/// by weight -- but the `red ──▸ green` wording beside them is still what
-/// carries the meaning, exactly as it was.
-pub const ORACLE_RED: Color = Color::Rgb(0xFF, 0x47, 0x34);
+/// 7.05:1 on [`GROUND`].
+pub const ORACLE_RED: Color = Color::Rgb(0xF8, 0x71, 0x71);
 
 // ── Status (light ground) ───────────────────────────────────────
 //
-// The same meanings, darkened along their own hue until they clear AA on the
-// painted paper ground. The dark-ground status tones are light colours --
-// `success` is 1.45:1 on paper -- so a light surface needs its own set for
-// the same reason the brand hue does.
+// The same three meanings, darkened along their own hue until they clear AA
+// on the painted paper ground. The dark-ground status tones are light
+// colours -- `success` is well under 2:1 on paper -- so a light surface
+// needs its own set for the same reason the brand hue does.
 
-/// Success on a light ground -- 5.12:1 on [`PAPER`].
-pub const SUCCESS_INK: Color = Color::Rgb(0x00, 0x75, 0x41);
+/// Success on a light ground -- 5.16:1 on [`PAPER`].
+pub const SUCCESS_INK: Color = Color::Rgb(0x16, 0x74, 0x4F);
 
-/// Warning on a light ground -- amber-brown, 5.65:1 on [`PAPER`].
-pub const WARNING_INK: Color = Color::Rgb(0x86, 0x54, 0x00);
+/// Warning on a light ground -- amber-brown, 5.61:1 on [`PAPER`].
+///
+/// One step darker than the web kit's `warning-ink` `#A16207`, which was
+/// tuned for white and measures 4.41:1 on the warm paper the deck actually
+/// paints -- under the 4.5:1 floor. Same hue, more ink.
+pub const WARNING_INK: Color = Color::Rgb(0x8A, 0x54, 0x05);
 
-/// Error on a light ground -- 6.69:1 on [`PAPER`].
-pub const DANGER_INK: Color = Color::Rgb(0xA8, 0x00, 0x4C);
+/// Error on a light ground -- 5.06:1 on [`PAPER`].
+pub const DANGER_INK: Color = Color::Rgb(0xC8, 0x1E, 0x3E);
 
 /// The oracle's pre-flip red on a light ground — [`ORACLE_RED`] darkened
-/// along its own hue until it clears AA on paper (7.06:1 on [`PAPER`]).
-pub const ORACLE_RED_INK: Color = Color::Rgb(0xA5, 0x06, 0x00);
+/// along its own hue until it clears AA on paper (5.3:1 on [`PAPER`]).
+pub const ORACLE_RED_INK: Color = Color::Rgb(0xB9, 0x1C, 0x1C);
 
 // ── Ground (light) ──────────────────────────────────────────────
 //
-// The paper mode: the kit's cool paper, not white. Accent here is
+// The paper mode: the kit's warm paper, not white. Accent here is
 // [`BRAND_INK`], text is [`INK`].
 
-/// Light background -- the kit's `paper-bg`, a cool off-white.
-pub const PAPER: Color = Color::Rgb(0xEE, 0xF1, 0xF5);
+/// Light background -- the kit's `paper-bg`, a warm off-white.
+pub const PAPER: Color = Color::Rgb(0xF6, 0xF2, 0xE9);
 
 /// Light surface (the kit's light `--surface`). Lifts *lighter* than paper,
-/// as the dark surface lifts lighter than obsidian.
-pub const SNOW: Color = Color::Rgb(0xF7, 0xF9, 0xFC);
+/// as the dark surface lifts lighter than ink.
+pub const SNOW: Color = Color::Rgb(0xFC, 0xFA, 0xF4);
 
 /// Light raised surface -- popovers, selected rows on paper (kit
-/// `neutral-100`-adjacent).
-pub const PAPER_RAISED: Color = Color::Rgb(0xD8, 0xDD, 0xE3);
+/// `neutral-100`).
+pub const PAPER_RAISED: Color = Color::Rgb(0xE4, 0xE2, 0xDC);
 
 /// Light seam / rule (the kit's light `--border`) -- the paper counterpart
 /// of [`HAIRLINE`].
-pub const PAPER_HAIRLINE: Color = Color::Rgb(0xCF, 0xD6, 0xDD);
+pub const PAPER_HAIRLINE: Color = Color::Rgb(0xE4, 0xDE, 0xCF);
 
-/// Primary text on paper -- Obsidian itself, 17.41:1. (The same value as
+/// Primary text on paper -- Ink itself, 17.61:1. (The same value as
 /// [`GROUND`]: the kit's one black serves as both the dark ground and the
 /// light text, which is the point of an identity this small.)
-pub const INK: Color = Color::Rgb(0x07, 0x0B, 0x10);
+pub const INK: Color = Color::Rgb(0x0B, 0x0B, 0x0C);
 
-/// Secondary text on paper (the kit's light `--muted-fg`) -- 5.04:1.
-pub const MUTED: Color = Color::Rgb(0x61, 0x67, 0x6F);
+/// Secondary text on paper (the kit's light `--muted-fg`) -- 4.83:1.
+pub const MUTED: Color = Color::Rgb(0x6E, 0x6A, 0x5F);
 
-/// Tertiary text on paper -- the paper counterpart of [`TEXT_TERTIARY`].
-/// 4.56:1 on [`PAPER`], so it clears AA body; on [`SNOW`] (4.90:1) it holds,
-/// and on [`PAPER_RAISED`] (3.78:1) it is a large-text / UI tone only,
-/// exactly as [`TEXT_TERTIARY`] is treated on [`RAISED`].
-pub const INK_DIM: Color = Color::Rgb(0x67, 0x6E, 0x75);
+/// Tertiary text on paper (kit `neutral-600`) -- the paper counterpart of
+/// [`TEXT_TERTIARY`]. 4.61:1 on [`PAPER`], so it clears AA body; on [`SNOW`]
+/// (4.94:1) it holds, and on [`PAPER_RAISED`] (3.98:1) it is a large-text /
+/// UI tone only, exactly as [`TEXT_TERTIARY`] is treated on [`RAISED`].
+pub const INK_DIM: Color = Color::Rgb(0x73, 0x6C, 0x68);
 
 // ── Data marks ──────────────────────────────────────────────────
 //
 // The categorical series palette, shared verbatim with the observatory
 // (its `--c1..--c4`). Deliberately *not* the brand hue -- a data mark must
-// not read as "active" -- and deliberately not a status hue either.
+// not read as "active" -- and deliberately not a status hue either. All are
+// complements of gold that stay warm/rich on ink: a muted violet, a warm
+// rose, a deep teal.
 //
-// Two laws govern the placement, and hue is measured the way
-// `theme::hue_deg` measures it (sRGB/HSV), because that is the guard a future
-// edit actually has to satisfy:
-//
-//   * **≥30° of hue from the accent.** The closest mark is the periwinkle at
-//     50.4°. Under the bronze/gold system `data-1` sat *0.8°* from the accent
-//     at 1.12:1, which is why it had to be stood down from every plotted
-//     surface. That distance is where this recolour buys the most.
-//   * **≥30° between marks**, so two adjacent rows are told apart by hue
-//     alone. The minimum in this set is 33.7° (orchid 278° / magenta 312°) --
-//     a shade *tighter* than the bronze set's 34.6°, stated plainly because
-//     it is the one axis on which the old placement was marginally better.
-//
-// The four status hues (oracle-red 5°, apricot-adjacent warning 44°, success
-// 155°, danger 343°) are *not* excluded zones -- eleven meanings do not fit
-// on a wheel with 30° between all of them -- so two marks are near-neighbours
-// of a status and are named as such in their own docs. Every one of those is
-// a chip or a node that carries a label; a verdict is always glyph-paired.
-// That is the same contract the gold set relied on, held at wider distances
-// everywhere except the one mark that is still confined to code bodies.
+// [`DATA_1`] and [`GOLD`] are hue 42° and 41° -- 1.06:1 against each other,
+// nothing distinguishes them but size. The observatory stands the amber mark
+// down from every plotted surface for exactly this reason; in the deck it
+// survives ONLY as the syntax-keyword tone inside code bodies, where gold
+// chrome never reaches (see `theme::SYNTAX_KEYWORD`). Never put it on a
+// chip, a node, or an agent.
 
-/// Categorical 1 -- apricot, hue 20° (170° from ion). 11.27:1 on ground. The
-/// syntax-keyword tone and the first chart series.
-///
-/// This mark stays **stood down** from chips, graph nodes and agent colours,
-/// as it was under the bronze kit -- but for a different reason. It is no
-/// longer confusable with the accent (0.8° and 1.12:1 then; 170° now); it is
-/// 24° from [`WARNING`] and 1.08:1 against it, so the two are told apart by
-/// saturation (pastel against saturated) rather than by weight. Inside a code
-/// body, where no verdict is ever painted, that is enough. On a chip beside a
-/// status glyph it would not be, so the stand-down is kept and
-/// `theme::identity_never_carries_a_verdict`'s sibling assertions still
-/// enforce it.
-pub const DATA_1: Color = Color::Rgb(0xFF, 0xB2, 0x8C);
-/// Categorical 2 -- periwinkle, hue 240° (50° from ion, the closest mark to
-/// the accent in the set). 6.20:1 on ground, 4.86:1 on [`RAISED`], and 1.74:1
-/// against [`BRAND`] -- so a process chip beside an active one differs in
-/// both hue and weight.
-pub const DATA_2: Color = Color::Rgb(0x84, 0x84, 0xF5);
-/// Categorical 3 -- magenta, hue 312° (122° from ion). 6.24:1 on ground.
-/// 31° from [`DANGER`] and 1.17:1 against it, so it never carries an error
-/// meaning and never appears without a label or glyph.
-pub const DATA_3: Color = Color::Rgb(0xF2, 0x49, 0xD0);
-/// Categorical 4 -- jade, hue 118° (72° from ion). 9.97:1 on ground. 37° from
-/// [`SUCCESS`]'s 155°, which matters more here than anywhere else in the set:
-/// this is the subagent mark, and it sits in the same column as the lead's
-/// accent and the run's verdicts.
-///
-/// It replaces a *teal* that sat at 165° under the bronze kit. Teal was 134°
-/// from a gold accent and only 24° from an ion one -- the single value in the
-/// old categorical set that a cyan brand made untenable.
-pub const DATA_4: Color = Color::Rgb(0x54, 0xD1, 0x4F);
-/// Categorical 5 -- citron, hue 78° (112° from ion, 34° from [`WARNING`] and
-/// 77° from [`SUCCESS`]). 12.50:1 on ground. The transcript's repository/VCS
-/// class.
-pub const DATA_5: Color = Color::Rgb(0xA6, 0xE0, 0x1D);
-/// Categorical 6 -- orchid, hue 278° (89° from ion, 38° from the periwinkle
-/// and 34° from the magenta). 8.00:1 on ground. The transcript's
-/// delegation/orchestration class.
-pub const DATA_6: Color = Color::Rgb(0xCF, 0x88, 0xF7);
+/// Categorical 1 -- amber. 10.11:1 on ground; see the stand-down note above.
+pub const DATA_1: Color = Color::Rgb(0xE3, 0xB3, 0x41);
+/// Categorical 2 -- muted violet, hue 256° (215° from gold). 5.29:1 on
+/// ground.
+pub const DATA_2: Color = Color::Rgb(0x8F, 0x70, 0xE8);
+/// Categorical 3 -- warm rose, hue 331° (70° from gold). 5.09:1 on ground;
+/// 1.30:1 against [`DANGER`], so it never carries an error meaning and never
+/// appears without a label or glyph.
+pub const DATA_3: Color = Color::Rgb(0xE4, 0x40, 0x8F);
+/// Categorical 4 -- deep teal, hue 175° (134° from gold). 10.54:1 on ground.
+pub const DATA_4: Color = Color::Rgb(0x2F, 0xD3, 0xC6);
+
+// The transcript's tool-class series extends the categorical set by two.
+// Five distinguishable hues were not enough to give every *kind* of tool call
+// its own colour, and the transcript is the one surface where that matters:
+// it is a log of actions, and the reader's first question of any row is what
+// KIND of thing happened -- a read, a write, a shell, a test, a push, a
+// hand-off. Both new values obey the same three laws the four above do: no
+// blue anywhere (the comet kit has none), at least 30° of hue from the gold
+// accent so neither can be mistaken for "active", and at least 30° from every
+// other categorical hue so two adjacent rows are told apart by hue alone.
+//
+// Placed in the two gaps the existing series leaves: 80.6° between gold's
+// 30° exclusion zone and the success green (142°), and 290° between the
+// violet (256°) and the rose (331°). The wrap-around gap (331° → 41°) is
+// gold's own, and stays empty.
+
+/// Categorical 5 -- citron, hue 81° (39° from gold, 61° from the success
+/// green). 11.08:1 on ground. The transcript's repository/VCS class.
+pub const DATA_5: Color = Color::Rgb(0xA3, 0xD1, 0x4B);
+/// Categorical 6 -- orchid, hue 290° (34° from the violet, 41° from the
+/// rose). 6.76:1 on ground. The transcript's delegation/orchestration class.
+pub const DATA_6: Color = Color::Rgb(0xD4, 0x6F, 0xE8);
 
 /// Every palette colour, paired with its token name.
 ///
@@ -360,10 +313,10 @@ pub const ALL: [(&str, Color); 39] = [
     ("brand-deep", BRAND_DEEP),
     ("brand-ink", BRAND_INK),
     ("brand-ink-deep", BRAND_INK_DEEP),
-    ("identity", IDENTITY),
-    ("identity-bright", IDENTITY_BRIGHT),
-    ("identity-deep", IDENTITY_DEEP),
-    ("identity-ink", IDENTITY_INK),
+    ("gold", GOLD),
+    ("gold-bright", GOLD_BRIGHT),
+    ("gold-deep", GOLD_DEEP),
+    ("gold-ink", GOLD_INK),
     ("text-primary", TEXT_PRIMARY),
     ("text-secondary", TEXT_SECONDARY),
     ("text-tertiary", TEXT_TERTIARY),

--- a/crates/stella-tui/src/progress.rs
+++ b/crates/stella-tui/src/progress.rs
@@ -28,9 +28,9 @@
 //!   never progress. It rides *on top of* the determinate fill and never
 //!   advances it; it is a scrubbed `theme::lighten` toward white, gated on
 //!   `no_anim`.
-//! - The fill rides the brand **ion** gradient (`brand-600` → Ion) —
-//!   activity is the accent, so the deck's sole activity indicator is
-//!   unmistakable against the quiet graphite chrome everywhere else.
+//! - The fill rides the brand **gold** gradient (deep gold → Phosphor Gold)
+//!   — activity is the accent, so the deck's sole activity indicator is
+//!   unmistakable against the quiet warm-neutral chrome everywhere else.
 //! - **tok/s** is the focused agent's *live turn* rate — output tokens since
 //!   the turn began over the turn's own elapsed; it is omitted (not guessed)
 //!   whenever there's nothing real to divide, including a running lane with

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -232,7 +232,7 @@ fn entry_body(
             // the `[user]:` tag and every line of the prompt ride the same
             // violet as the composer's keybind glyphs and the
             // "deterministic-first" chip (`deck_render`) — the interactive-
-            // chrome accent, never the brand ion. Rendered as plain lines
+            // chrome accent, never the brand gold. Rendered as plain lines
             // (not markdown) so nothing tints part of the prompt a 2nd color.
             let violet = Style::new().fg(theme::VIOLET);
             let lines: Vec<Line<'static>> = text
@@ -353,7 +353,7 @@ fn entry_body(
             // white/dim (`path_spans`), so the colour marks the verb and never
             // the object.
             //
-            // Not the brand accent: ion means brand/active/focus, and every
+            // Not the brand accent: gold means brand/active/focus, and every
             // tool name wearing it made the accent mean "a tool ran", which is
             // every row.
             let class = crate::tool_class::classify(name);
@@ -984,11 +984,10 @@ fn entry_body(
 
 fn pr_status_color(status: PrStatus) -> Color {
     // A ramp toward the brand accent as the PR matures, so the `[⇢ pr]:`
-    // gutter reads with the rest of the transcript: warning amber draft, the
-    // deep accent stop while open, full ion on merge, danger on close. (The
-    // "ember" family this comment used to name was retired with the
-    // aurora→gold recolour, and the gold with the gold→ion one — see
-    // `theme`'s palette-law test.)
+    // gutter reads with the rest of the transcript: warning-orange draft, deep
+    // gold while open, full gold on merge, danger on close. (The "ember"
+    // family this comment used to name was retired with the aurora→gold
+    // recolour — see `theme`'s palette-law test.)
     match status {
         PrStatus::Draft => theme::WARNING,
         PrStatus::Open => theme::ACCENT_DEEP,

--- a/crates/stella-tui/src/splash.rs
+++ b/crates/stella-tui/src/splash.rs
@@ -4,7 +4,7 @@
 //! When the frame affords it, the mark is the brand's assemble sequence
 //! (`docs/brand/spinners/spinner-lockup-*.svg`) translated to cells: the three
 //! comet trails slide in staggered, the four-point star pops with a brief
-//! bright flash, the wordmark types on letter by letter behind an ion block
+//! bright flash, the wordmark types on letter by letter behind a gold block
 //! cursor, and the cursor blinks until init hands off. The star is not stored
 //! art — it is the astroid `|x|^(2/3) + |y|^(2/3) <= r^(2/3)` rasterized into
 //! half-block pixels at whatever size ~30% of the frame height works out to,
@@ -375,7 +375,7 @@ fn render_large(
             } else {
                 CURSOR.to_string()
             };
-            spans.push(Span::styled(cursor, Style::new().fg(theme::IDENTITY)));
+            spans.push(Span::styled(cursor, Style::new().fg(theme::GOLD)));
         }
         let field_w = WORDMARK_FIELD_W.min(area.width);
         let word_rect = Rect {
@@ -454,11 +454,11 @@ fn sample(t: u64, x: f64, y: f64) -> Option<Color> {
             let dy = (y - STAR_CY).abs() / r;
             // The four-point star is the astroid |x|^(2/3) + |y|^(2/3) <= 1.
             if dx.powf(2.0 / 3.0) + dy.powf(2.0 / 3.0) <= 1.0 {
-                // Flash bright while the pop is still moving, settle to the identity.
+                // Flash bright while the pop is still moving, settle to gold.
                 return Some(if pop < 1.0 {
-                    theme::IDENTITY_BRIGHT
+                    theme::GOLD_BRIGHT
                 } else {
-                    theme::IDENTITY
+                    theme::GOLD
                 });
             }
         }
@@ -471,7 +471,7 @@ fn sample(t: u64, x: f64, y: f64) -> Option<Color> {
         let slid = ease_out_cubic(clamp01((t - start) as f64 / TRAIL_SLIDE_MS as f64));
         let off = TRAIL_FROM * (1.0 - slid);
         if (y - ty).abs() <= TRAIL_HALF && x >= x0 + off && x <= x1 + off {
-            return Some(theme::IDENTITY);
+            return Some(theme::GOLD);
         }
     }
     None
@@ -481,14 +481,14 @@ fn sample(t: u64, x: f64, y: f64) -> Option<Color> {
 fn render_compact(state: &SplashState, model: Option<&str>, area: Rect, buf: &mut Buffer) {
     // The lockup's three parts carry three different roles: the chevron is the
     // interactive/brand signal, the wordmark is ink, the cursor block is the
-    // the identity ion. All three are semantic theme tokens, so they follow the
+    // identity gold. All three are semantic theme tokens, so they follow the
     // identity and — unlike an interpolated RGB — still degrade through
     // `theme::degrade_buffer` on a 256- or 16-colour terminal.
     let (chev_style, ink_style, cursor_style, dim_style) = if state.lit() {
         (
             theme::accent(),
             Style::new().fg(theme::INK).add_modifier(Modifier::BOLD),
-            Style::new().fg(theme::IDENTITY),
+            Style::new().fg(theme::GOLD),
             theme::muted(),
         )
     } else {

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -10,33 +10,30 @@ use crate::deck::TraceKind;
 use crate::envelope::AgentStatus;
 use crate::palette;
 
-// ── stella palette — "Ion on Obsidian" (brand kit v3.0, the comet) ─────────
+// ── stella palette — "Phosphor Gold on Ink" (brand kit v1.0, the comet) ─────
 //
-// One colour, owned. The ground is Obsidian, a cool blue-black; Ion (an
-// electric azure-cyan) is the signal — reserved for brand, the prompt,
-// active/running, selection and focus, and for nothing else. Ion is the
-// signal, never the surface: if everything is ion, nothing is, so a
-// general-purpose highlight is exactly what this hue must not become. The one
-// sanctioned ion *fill* is a pill that owns attention (the H1 title bar, a
-// selected tab), and an ion fill always carries GROUND text — white on ion is
-// 1.83:1. (Ion is the *default* accent; `stella-light` swaps it for the deep
-// ion ramp on cool paper — see [`apply_theme`].)
+// One colour, owned. The ground is Ink, a warm-neutral near-black; Phosphor
+// Gold is the signal — reserved for brand, the prompt, active/running,
+// selection and focus, and for nothing else. Gold is the signal, never the
+// surface: if everything is gold, nothing is, so a general-purpose highlight
+// is exactly what this hue must not become. The one sanctioned gold *fill*
+// is a pill that owns attention (the H1 title bar, a selected tab), and a
+// gold fill always carries INK text — white on gold is 1.83:1. (Gold is the
+// *default* accent; `stella-light` swaps it for the deep gold ramp on warm
+// paper — see [`apply_theme`].)
 //
-// The identity chrome (the logo's block cursor, splash rules, section
-// markers) and the interactive accent are one colour, as they were under the
-// bronze kit this replaces. What survives of the old law, and what changes:
-// **identity never carries a verdict** — but it no longer needs the 4.0°
-// hue-collision argument that used to justify it, because the nearest status
-// hue is now 35° away and the warning amber 146°. Chrome and verdict stay
-// separate because they are
-// different jobs, not because they could be confused; status is still always
-// glyph-paired, and activity (running) is the only status that takes the
-// accent. Enforced by `identity_never_carries_a_verdict`.
+// The old blue/gold split is collapsed: the identity chrome (the logo's
+// block cursor, splash rules, section markers) and the interactive accent
+// are the same gold now. What survives of the old law: **gold never carries
+// a verdict.** Warning amber sits 4.0° from gold in hue, so an outcome may
+// never be told from chrome by hue alone — status is always glyph-paired,
+// and activity (running) is the only status that takes the accent. Enforced
+// by `gold_never_carries_a_verdict`.
 //
 // The corollary the transcript actually depends on: **prose is paper.** The
 // accent buys attention, so it may only be spent where attention is owed — on
 // the deck that means the tool being called, the active tab, and the progress
-// fill. Everything else is [`INK`] (cool paper) or [`MUTED`], and a row that
+// fill. Everything else is [`INK`] (warm paper) or [`MUTED`], and a row that
 // wants to be scannable does it with a glyph and a column, not with a hue.
 //
 // Status always pairs colour with a glyph (see [`status_glyph`]) so hue never
@@ -56,28 +53,28 @@ use crate::palette;
 // Grounds (dark → light lift).
 /// Deepest ground — full-bleed backdrops and the splash.
 pub const VOID: Color = palette::VOID;
-/// App background — Obsidian, the terminal's cool blue-black. Applied as
+/// App background — Ink, the terminal's warm-neutral near-black. Applied as
 /// a real frame fill by `render_deck`, not just assumed from the terminal.
 pub const GROUND: Color = palette::GROUND;
 /// Card / panel surface.
 pub const SURFACE: Color = palette::SURFACE;
 /// Raised panel (one step above surface).
 pub const RAISED: Color = palette::RAISED;
-/// Hairline border / rule — a cool graphite seam. Deliberately below 3.0
-/// contrast (1.48:1): it may never be the only thing conveying structure.
+/// Hairline border / rule — a warm charcoal seam. Deliberately below 3.0
+/// contrast (1.26:1): it may never be the only thing conveying structure.
 pub const HAIRLINE: Color = palette::HAIRLINE;
-/// The louder seam, for a boundary that must actually read (1.94:1). Still
+/// The louder seam, for a boundary that must actually read (1.57:1). Still
 /// decoration — a stronger rule, not a substitute for a glyph or a gap.
 pub const HAIRLINE_STRONG: Color = palette::HAIRLINE_STRONG;
 
-// Text tiers (primary → dim) — cool paper over the kit's graphite ramp; no
-// warm greys anywhere on the dark side.
+// Text tiers (primary → dim) — warm paper over the kit's warm neutral ramp;
+// no cool grays anywhere on the dark side.
 /// Primary text.
 pub const TEXT_PRIMARY: Color = palette::TEXT_PRIMARY;
 /// Secondary text. The safe small-text tone on every ground.
 pub const TEXT_SECONDARY: Color = palette::TEXT_SECONDARY;
 /// Tertiary text (labels, captions). AA body on [`GROUND`]/[`SURFACE`]
-/// (5.96:1 / 5.40:1); on [`RAISED`] (4.67:1) it sits right at the floor.
+/// (5.71:1 / 5.38:1); on [`RAISED`] (4.98:1) it sits right at the floor.
 pub const TEXT_TERTIARY: Color = palette::TEXT_TERTIARY;
 /// Dim text (the quietest legible tier) — the same tone as [`TEXT_TERTIARY`].
 /// Kept as a distinct role name for the progress track and other chrome that
@@ -90,9 +87,9 @@ pub const TEXT_DIM: Color = palette::TEXT_TERTIARY;
 pub const SUCCESS: Color = palette::SUCCESS;
 /// Success (bright — text / completed fills).
 pub const SUCCESS_BRIGHT: Color = palette::SUCCESS;
-/// Warning (base). Amber — 146° from the ion accent, so unlike the bronze
-/// era nothing in the chrome can be mistaken for it. A warning still never
-/// appears without its glyph: the glyph, not the hue, is the status carrier.
+/// Warning (base). Amber — a hue-neighbour of the gold accent (4.0° apart),
+/// which is exactly why a warning never appears without its glyph: the
+/// glyph, not the hue, is the status carrier.
 pub const WARNING: Color = palette::WARNING;
 /// Warning (bright — text).
 pub const WARNING_BRIGHT: Color = palette::WARNING;
@@ -115,98 +112,82 @@ pub const ORACLE_PRE_FLIP: Color = palette::ORACLE_RED;
 // A few surfaces need more mutually-distinguishable colours than a one-hue
 // brand palette provides: syntax tokens, graph node kinds, and one colour per
 // concurrent agent. Making those the brand hue would violate the reservation
-// above, so they are a categorical set — the *same six values* the observatory
-// paints its data marks with, so a series in a chart and a chip in the deck
-// agree. Every one sits at least 50° of hue from the ion accent and at least
-// 34° from every other mark, and every one clears AA body (6.20:1 or better)
-// on [`GROUND`]. They carry no brand meaning and must never be used for
-// brand, status, or "active".
-//
-// Under the bronze/gold system this set had to be "complements of gold that
-// stay warm on ink". A cool accent inverts that: five of the six now sit in
-// the cool half of the wheel, and the one member that used to sit 0.8° from
-// the accent (the amber) is 170° from it — still stood down from chips, but
-// for a different reason now (see [`AMBER`]).
+// above, so they are a categorical set — the *same four values* the
+// observatory paints its data marks with, so a series in a chart and a chip in
+// the deck agree. All are complements of gold that stay warm/rich on ink —
+// muted violet (215° from gold), deep teal (134°), warm rose (70°) — and every
+// one clears AA body (5.09:1 or better) on [`GROUND`]. They carry no brand
+// meaning and must never be used for brand, status, or "active".
 
-/// Periwinkle — process/structural events (links, diff hunk headers, graph
+/// Violet — process/structural events (links, diff hunk headers, graph
 /// relations, trace stages, the user's own prompt). Categorical, not the brand
-/// accent. `data-2`, 6.20:1 on ground, 50° from [`ACCENT`] — the closest mark
-/// in the set — and 1.74:1 against it.
+/// accent. `data-2`, 5.29:1 on ground.
 pub const VIOLET: Color = palette::DATA_2;
-/// Apricot — syntax keywords inside code bodies and the first chart series.
-/// `data-1`, 11.27:1 on ground.
-///
-/// Still the one stood-down mark, but the reason moved with the hue. Under
-/// the gold accent it was 0.8° and 1.12:1 from the brand and could not colour
-/// a chip, a node or an agent. It is now 170° from the accent and 24° from
-/// [`WARN`] at 1.08:1 — a pastel beside a saturated amber, which is enough
-/// inside a code body where no verdict is ever painted, and not enough on a
-/// chip standing next to a status glyph. So the confinement to
-/// [`SYNTAX_KEYWORD`] survives the recolour on its own merits.
+/// Amber — the stood-down categorical hue. `data-1` measures 1.06:1 against
+/// the gold accent — the same brass at a glance — so with gold as THE accent
+/// it may no longer colour a chip, a node, or an agent (the observatory
+/// stands the same mark down from every plotted surface). It survives in one
+/// context only: syntax keywords inside code bodies, where gold chrome never
+/// reaches and the neighbouring tones are the diff washes and the other
+/// syntax hues. 10.11:1 on ground.
 pub const AMBER: Color = palette::DATA_1;
-/// Jade — media traces, one slot of the per-agent palette, and the subagent
-/// mark. `data-4`, 9.97:1 on ground, 72° from the accent and 37° from [`OK`].
-///
-/// It replaces the *teal* the bronze kit used here. Teal was a good
-/// complement of gold (134° away) and a bad neighbour of ion (24°), which is
-/// the whole cost of moving a brand across the wheel — the one categorical
-/// value the recolour could not carry over.
-pub const JADE: Color = palette::DATA_4;
-/// Magenta — file artifacts (trace chips, graph file/module nodes) and the
-/// fourth chart series. `data-3`, 6.24:1 on ground. 122° from the accent;
-/// 1.17:1 against [`DANGER`]'s pink-red at 31° of hue, so it never carries an
-/// error meaning and never appears without a neutral label or glyph beside
-/// it.
+/// Teal — media traces and one slot of the per-agent palette. `data-4`,
+/// 10.54:1 on ground. Deep blue-green: 134° from the gold accent and far
+/// from the success green, and emphatically not the retired ice blue — it
+/// replaced a glacier blue (`AGENT_ICE`) that drifted confusable with the
+/// old accent, and it reads rich, not icy, on ink.
+pub const TEAL: Color = palette::DATA_4;
+/// Warm rose — file artifacts (trace chips, graph file/module nodes) and the
+/// fourth chart series. `data-3`, 5.09:1 on ground. 70° from gold; 1.30:1
+/// against [`DANGER`]'s red-pink, so it never carries an error meaning and
+/// never appears without a neutral label or glyph beside it.
 pub const MAGENTA: Color = palette::DATA_3;
 /// Citron — the repository/VCS tool class in the transcript. `data-5`,
-/// 12.50:1 on ground, 112° from the accent and 34°/77° from the warning amber
-/// and the success green.
+/// 11.08:1 on ground, 39° from gold and 61° from the success green.
 pub const CITRON: Color = palette::DATA_5;
 /// Orchid — the delegation/orchestration tool class in the transcript.
-/// `data-6`, 8.00:1 on ground, 89° from the accent, 38° from the periwinkle
-/// and 34° from the magenta.
+/// `data-6`, 6.76:1 on ground, 34° from the violet and 41° from the rose.
 pub const ORCHID: Color = palette::DATA_6;
 
 // ── Role aliases (what the rest of the crate references) ─────────────────────
 // Role names remap onto the palette so call sites read as intent (accent,
 // ink, rule) rather than as a hue that a future recolor would falsify.
 
-/// stella's brand accent — Ion `#00D1F9`, the kit's `brand-500` verbatim
-/// (10.79:1 on [`GROUND`]). Brand, active/running, focus, selection, and
+/// stella's brand accent — Phosphor Gold `#FFB81A`, the kit value lifted 10%
+/// in lightness (11.36:1 on [`GROUND`]). Brand, active/running, focus, selection, and
 /// progress only. In the transcript, the tool name and nothing else. The
 /// active theme's actual hue is applied per-frame by [`apply_theme`]; this is
 /// the canonical dark value every call site renders.
 ///
-/// Like the gold it replaced, ion needs no separate text tone: the same value
-/// clears AA on a glyph, a one-cell rule, and a fill on every dark ground.
-/// When it is a *fill*, the text on it must be [`GROUND`]-dark — obsidian on
-/// ion is 10.79:1 where white on ion is 1.83:1.
+/// Unlike the blue it replaced, gold needs no separate text tone: the same
+/// value clears AA on a glyph, a one-cell rule, and a fill on every dark
+/// ground. When it is a *fill*, the text on it must be [`GROUND`]-dark —
+/// ink on gold is 11.36:1 where white on gold is 1.73:1.
 pub const ACCENT: Color = palette::BRAND;
 /// The brand hue for *fills* — a pill, a bar body, a selected-tab wash. The
-/// same Ion: one owned colour means the stroke and the fill agree, and the
-/// fill's legibility comes from pairing it with obsidian text, never from a
-/// second hue.
+/// same Phosphor Gold: one owned colour means the stroke and the fill agree,
+/// and the fill's legibility comes from pairing it with ink text, never from
+/// a second hue.
 pub const ACCENT_FILL: Color = palette::BRAND;
-/// A deeper accent (gradient / pressed) — kit `brand-600`, the leading stop
-/// of the progress fill (7.65:1 on ground, so the fill's tail clears AA).
+/// A deeper accent (gradient / pressed) — kit `gold-600` lifted 10% with the
+/// brand, the leading stop of the progress fill (8.77:1 on ground, so the
+/// fill's tail clears AA).
 pub const ACCENT_DEEP: Color = palette::BRAND_DEEP;
 
-/// The identity ion — the logo's block cursor, splash rules, section markers,
-/// and brand chrome generally. The same Ion as [`ACCENT`]: under the comet
-/// kit, chrome and accent are one colour. **Never a verdict** —
-/// `identity_never_carries_a_verdict` proves no outcome mapping can return
-/// it. The old justification (it sat 4.0° from [`WARN`]) no longer applies at
-/// 136° of separation; the rule stands because chrome and verdict are
-/// different jobs. Activity (running/active) is the one status that takes the
-/// identity, by kit rule.
-pub const IDENTITY: Color = palette::IDENTITY;
-/// The bright stop of the identity sweep (headlines, the splash rule's
-/// leading edge). Kit `brand-300`.
-pub const IDENTITY_BRIGHT: Color = palette::IDENTITY_BRIGHT;
-/// The trailing stop of the identity sweep. Kit `brand-700` — the sweep runs
-/// wider and quieter than the progress fill's ([`ACCENT_DEEP`]).
-pub const IDENTITY_DEEP: Color = palette::IDENTITY_DEEP;
-/// Cool-paper primary text.
+/// The identity gold — the logo's block cursor, splash rules, section
+/// markers, and brand chrome generally. The same Phosphor Gold as [`ACCENT`]:
+/// under the comet kit, chrome and accent are one colour. **Never a
+/// verdict**: it sits 4.0° from [`WARN`] in hue, and
+/// `gold_never_carries_a_verdict` proves no outcome mapping can return it —
+/// activity (running/active) is the one status that takes gold, by kit rule.
+pub const GOLD: Color = palette::GOLD;
+/// The bright stop of the gold sweep (headlines, the splash rule's leading
+/// edge). Kit `gold-400`.
+pub const GOLD_BRIGHT: Color = palette::GOLD_BRIGHT;
+/// The trailing stop of the gold sweep. Kit `gold-700` — the identity sweep
+/// runs wider and quieter than the progress fill's ([`ACCENT_DEEP`]).
+pub const GOLD_DEEP: Color = palette::GOLD_DEEP;
+/// Warm-paper primary text.
 pub const INK: Color = TEXT_PRIMARY;
 /// Dimmed secondary text.
 pub const MUTED: Color = TEXT_SECONDARY;
@@ -214,10 +195,10 @@ pub const MUTED: Color = TEXT_SECONDARY;
 pub const RULE: Color = HAIRLINE;
 
 /// Background tint for the transcript entry selected with the arrow keys —
-/// a barely-there cool lift so the highlight reads without shouting. A full
-/// ion wash would make the selection a surface, which ion may not be; the ion
-/// *pill* treatment is reserved for single-line attention (the H1 bar, an
-/// active tab), where obsidian-on-ion text keeps it legible.
+/// a barely-there warm lift so the highlight reads without shouting. A full
+/// gold wash would make the selection a surface, which gold may not be; the
+/// gold *pill* treatment is reserved for single-line attention (the H1 bar,
+/// an active tab), where ink-on-gold text keeps it legible.
 pub const SELECT_BG: Color = palette::RAISED;
 
 /// Success / positive / added lines.
@@ -234,15 +215,15 @@ pub const RUN: Color = VIOLET;
 /// Paused / held — violet.
 pub const HELD: Color = VIOLET;
 /// A subagent's identity mark — the `◆` beside a nested lane in SESSION and
-/// the statline's `◆ N sub` count. Aliased to [`JADE`] (categorical): a
+/// the statline's `◆ N sub` count. Aliased to [`TEAL`] (categorical): a
 /// subagent is not the brand, not a status, and must never be confusable
-/// with the lead's ion `✦`.
-pub const SUBAGENT: Color = JADE;
+/// with the lead's gold `✦`.
+pub const SUBAGENT: Color = TEAL;
 
 // ── Runtime theme (the `/theme` switch) ──────────────────────────────────────
 //
 // Colours above are compile-time constants: the canonical **dark** palette
-// (Ion on Obsidian), which is what every view renders and
+// (Phosphor Gold on Ink), which is what every view renders and
 // what ships as the default. A theme switch is applied *after* the widgets draw, as a
 // per-frame value→value remap over the finished buffer ([`apply_theme`]) —
 // the exact mechanism [`degrade_buffer`] already uses for colour-depth. That
@@ -253,16 +234,16 @@ pub const SUBAGENT: Color = JADE;
 // whose interpolated cells are never equal to a token; so its source
 // ([`brand_gradient`] via [`primary_stops`]) is theme-aware directly.
 
-/// The shipped themes. `stella-dark` (Ion on Obsidian) is the default;
-/// `stella-light` (the deep ion ramp on cool paper) is its complement. The
+/// The shipped themes. `stella-dark` (Phosphor Gold on Ink) is the default;
+/// `stella-light` (the deep gold ramp on warm paper) is its complement. The
 /// names match the `/theme` argument and the `ui.theme` settings value
 /// verbatim.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ThemeName {
-    /// Ion on Obsidian. Default.
+    /// Phosphor Gold on Ink. Default.
     #[default]
     StellaDark,
-    /// The same ion darkened onto cool paper.
+    /// The same gold darkened onto warm paper.
     StellaLight,
 }
 
@@ -319,16 +300,16 @@ pub fn set_active_theme(theme: ThemeName) {
 }
 
 /// The active theme's brand gradient stops, deep → bright: `brand-deep` →
-/// `brand` (Ion) on `stella-dark`, `brand-ink-deep` → `brand-ink` on
-/// `stella-light`. Feeds [`brand_gradient`] so the progress fill and wordmark
-/// sweep recolour with the theme.
+/// `brand` (Phosphor Gold) on `stella-dark`, `brand-ink-deep` → `brand-ink`
+/// on `stella-light`. Feeds [`brand_gradient`] so the progress fill and
+/// wordmark sweep recolour with the theme.
 ///
-/// The bright end is [`ACCENT`] (the ion itself, not `brand-bright`), so
+/// The bright end is [`ACCENT`] (the gold itself, not `brand-bright`), so
 /// that the truecolor gradient lands on the same value a degraded terminal
 /// falls back to — `crate::progress` paints a solid [`ACCENT`] when
 /// [`ColorMode::is_truecolor`] is false, and a fill whose colour jumped
 /// between depths would be a downgrade-path bug. (`brand-bright` belongs to
-/// the identity sweep's high end, [`identity_stops`].)
+/// the identity sweep's high end, [`gold_stops`].)
 pub fn primary_stops() -> [Color; 2] {
     match active_theme() {
         ThemeName::StellaDark => [palette::BRAND_DEEP, palette::BRAND],
@@ -336,26 +317,25 @@ pub fn primary_stops() -> [Color; 2] {
     }
 }
 
-/// The active theme's identity gradient stops, deep → bright. The identity is
+/// The active theme's gold gradient stops, deep → bright. Gold is identity
 /// chrome: the splash rule, section markers, the wordmark's cursor block. It
 /// is never a verdict and never a data mark, so nothing that resolves an
 /// *outcome* may call this.
-pub fn identity_stops() -> [Color; 2] {
+pub fn gold_stops() -> [Color; 2] {
     match active_theme() {
-        ThemeName::StellaDark => [palette::IDENTITY_DEEP, palette::IDENTITY_BRIGHT],
-        // One identity tone on paper: `identity-ink` (kit `brand-700`, the
-        // kit's one light-ground *graphical* ion) holds the 3:1 graphical
-        // floor on paper, so the light sweep is flat by design. Ion *text* on
-        // paper is darker still — the flat-token remap sends it to
-        // `brand-ink`.
-        ThemeName::StellaLight => [palette::IDENTITY_INK, palette::IDENTITY_INK],
+        ThemeName::StellaDark => [palette::GOLD_DEEP, palette::GOLD_BRIGHT],
+        // One gold on paper: `gold-ink` (the kit's `gold-deep`, its one
+        // light-ground gold) holds the 3:1 graphical floor on paper, so the
+        // light sweep is flat by design. Gold *text* on paper is darker
+        // still — the flat-token remap sends it to `brand-ink`.
+        ThemeName::StellaLight => [palette::GOLD_INK, palette::GOLD_INK],
     }
 }
 
-/// The identity gradient sampled at `t ∈ [0, 1]` — the counterpart of
+/// The gold gradient sampled at `t ∈ [0, 1]` — the counterpart of
 /// [`brand_gradient`] for identity chrome.
-pub fn identity_gradient(t: f64) -> Color {
-    gradient_at(&identity_stops(), t)
+pub fn gold_gradient(t: f64) -> Color {
+    gradient_at(&gold_stops(), t)
 }
 
 /// The active theme's bright primary. Same value the flat
@@ -375,25 +355,23 @@ pub fn primary_deep() -> Color {
 // ── Diff panel ──────────────────────────────────────────────────────────────
 
 /// Subtle background tint behind added diff lines (the GitHub-PR reading —
-/// pair with [`OK`] foreground, 8.14:1 on this tint).
-pub const DIFF_ADD_BG: Color = Color::Rgb(0x0F, 0x36, 0x20);
-/// Subtle background tint behind removed diff lines (pair with [`BAD`],
-/// 6.09:1 on this tint).
-pub const DIFF_DEL_BG: Color = Color::Rgb(0x46, 0x20, 0x2A);
+/// pair with [`OK`] foreground).
+pub const DIFF_ADD_BG: Color = Color::Rgb(20, 44, 26);
+/// Subtle background tint behind removed diff lines (pair with [`BAD`]).
+pub const DIFF_DEL_BG: Color = Color::Rgb(52, 24, 26);
 
 /// Background behind the bytes of an added line that actually changed, when a
 /// `-`/`+` pair is close enough to word-diff. Two steps brighter than
 /// [`DIFF_ADD_BG`]: the whole line is already "added", so this has to read as
 /// a second level of emphasis *within* it rather than a different category.
-pub const DIFF_ADD_BG_EMPH: Color = Color::Rgb(0x18, 0x5B, 0x37);
-/// Background behind a live search match. Warm enough to find by eye against
-/// an entirely cool ground, muted enough not to outshout the `✗` rail beside
-/// it — a match is something you asked for, not something that went wrong.
-/// [`TEXT_PRIMARY`] measures 7.87:1 on it.
-pub const MATCH_BG: Color = Color::Rgb(0x5D, 0x43, 0x04);
+pub const DIFF_ADD_BG_EMPH: Color = Color::Rgb(26, 82, 44);
+/// Background behind a live search match. Warm enough to find by eye while
+/// scrolling, muted enough not to outshout the `✗` rail beside it — a match is
+/// something you asked for, not something that went wrong.
+pub const MATCH_BG: Color = Color::Rgb(92, 74, 0);
 
 /// The removed-line counterpart of [`DIFF_ADD_BG_EMPH`].
-pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(0x75, 0x36, 0x46);
+pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(102, 34, 42);
 
 // ── Syntax highlighting (diff bodies) ───────────────────────────────────────
 //
@@ -402,30 +380,32 @@ pub const DIFF_DEL_BG_EMPH: Color = Color::Rgb(0x75, 0x36, 0x46);
 // `crate::diff`), while a recognized token overrides only the foreground.
 // Every color is chosen to read on all three diff backdrops (add green, del
 // red, and the plain panel), and every one is *categorical*: syntax is not
-// brand, not status, and not activity. Keyword takes [`AMBER`] — a warm
-// counterpoint inside an otherwise cool body, and 174° from the accent so
-// nothing nearby can be confused for "active" — strings a soft spring green,
-// numbers the [`VIOLET`] anchor, and comments dim toward the caption tier.
+// brand, not status, and not activity. Keyword takes [`AMBER`] — the one
+// surviving home of the amber mark, legitimate here because gold chrome
+// never enters a code body, so nothing nearby can be confused for "active" —
+// strings a soft spring green, numbers the [`VIOLET`] anchor, and comments
+// dim toward the caption tier.
 
 /// Language keyword (`fn`/`let`/`def`/`import`/`return`…).
 pub const SYNTAX_KEYWORD: Color = AMBER;
 /// String / char literal.
-pub const SYNTAX_STRING: Color = Color::Rgb(0x8F, 0xE4, 0x92);
+pub const SYNTAX_STRING: Color = Color::Rgb(126, 231, 135);
 /// Numeric literal — violet, the counterpoint to the amber keyword stop.
 pub const SYNTAX_NUMBER: Color = VIOLET;
-/// Line comment (rendered dimmed + italic). The same graphite as
-/// [`TEXT_TERTIARY`] — "comments dim toward the caption tier" made literal.
+/// Line comment (rendered dimmed + italic). The same warm neutral as
+/// [`TEXT_TERTIARY`] — "comments dim toward the caption tier" made literal,
+/// and the cool gray it replaces is banned from the dark side outright.
 pub const SYNTAX_COMMENT: Color = palette::TEXT_TERTIARY;
 
 /// Inline code spans and fenced-code plain runs (`crate::markdown`). A calm
 /// sage green — quiet enough that a backticked word reads as *technical*
-/// rather than as emphasis, and 60° of hue away from [`ACCENT`] at 1.42:1
-/// against it, so it never reads as *active* (9.61:1 on ground). This
-/// replaces the warning-orange the transcript used to paint every
-/// `identifier` with: code is not a warning, and an alarm hue on every
-/// backticked word was the single loudest thing on the deck. Not a brand
-/// value — it is TUI-only and has no entry in `palette`.
-pub const CODE: Color = Color::Rgb(0x77, 0xC5, 0x99);
+/// rather than as emphasis, and 105° of hue away from [`ACCENT`] so it never
+/// reads as *active* (8.94:1 on ground). This replaces the warning-orange the
+/// transcript used to paint every `identifier` with: code is not a warning,
+/// and an alarm hue on every backticked word was the single loudest thing on
+/// the deck. Not a brand value — it is TUI-only and has no entry in
+/// `palette`.
+pub const CODE: Color = Color::Rgb(0x6F, 0xBF, 0x92);
 
 // ── Brand gradient (the wordmark sweep and the progress-bar fill) ───────────
 //
@@ -433,14 +413,14 @@ pub const CODE: Color = Color::Rgb(0x77, 0xC5, 0x99);
 // earlier generation ran two separate gradients — one for brand chrome and a
 // second for the progress bar — which is precisely the split this palette
 // collapses. Progress *is* activity, activity is the brand hue, so one
-// gradient serves both. The stops track the ACTIVE theme (ion on obsidian,
-// the deep ion ramp on paper) via [`primary_stops`]: the progress fill
+// gradient serves both. The stops track the ACTIVE theme (gold on ink, the
+// deep gold ramp on paper) via [`primary_stops`]: the progress fill
 // interpolates non-token cells the per-frame [`apply_theme`] remap can't see,
 // so its source has to be theme-aware directly.
 //
-// The identity chrome keeps its own wider two-stop sweep ([`identity_stops`]
-// / [`identity_gradient`]) — the splash rule and section markers. Same family
-// (brand-700 → brand-300 around one hue), but a separate gradient: chrome
+// The identity chrome keeps its own wider two-stop sweep ([`gold_stops`] /
+// [`gold_gradient`]) — the splash rule and section markers. Same family now
+// (gold-700 → gold-400 around the same hue), but a separate gradient: chrome
 // may sweep quiet-to-bright while the progress fill's tail must hold AA on
 // its own, and the progress bar's degraded fallback is a solid [`ACCENT`].
 
@@ -488,7 +468,7 @@ pub fn lighten(color: Color, amount: f64) -> Color {
 // ── Color-depth degradation (truecolor → 256 → 16 → none) ───────────────────
 //
 // Every palette token above is a `Color::Rgb`, which lesser terminals either
-// approximate unpredictably (a saturated cyan comes out grey-blue) or ignore. The deck
+// approximate unpredictably (amber comes out brown/grey) or ignore. The deck
 // detects the terminal's real depth once at startup ([`detect_color_mode`])
 // and narrows every cell to it once per frame ([`degrade_buffer`]):
 //
@@ -603,58 +583,61 @@ pub fn detect_color_mode() -> ColorMode {
 /// green/red cube entries for the same reason. Truecolor terminals never see
 /// either column.
 const FALLBACKS: &[(Color, u8, u8)] = &[
-    (VOID, 16, 0),
+    (VOID, 232, 0),
     (GROUND, 232, 0),
-    (SURFACE, 234, 0),
-    (RAISED, 235, 8),
-    (HAIRLINE, 236, 8),
-    (HAIRLINE_STRONG, 238, 8),
+    (SURFACE, 233, 0),
+    (RAISED, 234, 8),
+    (HAIRLINE, 235, 8),
+    (HAIRLINE_STRONG, 236, 8),
     (TEXT_PRIMARY, 255, 15),
-    (TEXT_SECONDARY, 247, 7),
+    (TEXT_SECONDARY, 246, 7),
     (TEXT_TERTIARY, 245, 8),
-    // Ion `#00D1F9` lands on cube entry 45 (0,215,255) — a two-unit miss, so
-    // the terminal cube holds the brand almost exactly, as it did for the
-    // bronze before it. The family stays on the *cyan* side everywhere:
-    // `identity-bright` takes 81 (95,215,255) and `identity-deep` 31
-    // (0,135,175), each the nearest cube entry, and each distinct from the
-    // others so the identity sweep still reads as a sweep at 256 colours. At
-    // 16 colours the accent family takes bright cyan (14) and the deep stops
-    // plain cyan (6) — nothing else in the palette claims either, which is
-    // the one thing the gold era could not have: `warning` now owns bright
-    // yellow (11) outright instead of sharing a cell with chrome.
-    (ACCENT, 45, 14), // also ACCENT_FILL and IDENTITY (one value, one entry)
-    (IDENTITY_BRIGHT, 81, 14),
-    (ACCENT_DEEP, 38, 6),
-    (IDENTITY_DEEP, 31, 6),
-    (SUCCESS, 42, 10),
-    (WARNING, 214, 11),
-    (DANGER, 211, 9),
-    // Nearest cube entry to ORACLE_PRE_FLIP's `#FF4734` is 203 (255,95,95) —
-    // eight steps from DANGER's 211, so the two stay distinct at 256 colours.
-    // At 16 colours there is only one red (9) and the pre-flip state shares
-    // it with danger; the `red ──▸ green` wording, not the hue, carries the
-    // meaning there (the same glyph-over-hue rule every status obeys).
+    // Phosphor Gold `#FFB81A` sits one unit from cube entry 214 (255,175,0) —
+    // for once the terminal cube holds the brand almost exactly. The family
+    // stays on the *yellow* side everywhere: the nearest entry to
+    // `gold-bright` is 215 (255,175,95), an orange, and orange is the one
+    // thing this identity may not render, so it takes 221 (255,215,95)
+    // instead; `gold-deep` likewise skips orange 130 for 136 (175,135,0).
+    // The progress ramp's deep stop takes 178 rather than nearest-entry 172
+    // (215,135,0, again orange) — it shares that dark yellow with `warning`,
+    // which is acceptable because a degraded terminal never paints the
+    // gradient at all (`crate::progress` collapses to solid ACCENT), while
+    // ACCENT vs ACCENT_DEEP staying distinct keeps the head-to-tail ramp
+    // honest. At 16 colours the accent family takes bright yellow (11) and
+    // the deep stop plain yellow's darker sibling is unavailable, so it
+    // shares 3 with warning under the same never-painted reasoning; GOLD
+    // family values stay on 11 so chrome never collapses onto `warning`'s
+    // plain yellow — gold is chrome, warning is a verdict, and the two may
+    // not become the same cell.
+    (ACCENT, 214, 11), // also ACCENT_FILL and GOLD (one value, one entry)
+    (GOLD_BRIGHT, 221, 11),
+    (ACCENT_DEEP, 178, 3),
+    (GOLD_DEEP, 136, 11),
+    (SUCCESS, 78, 10),
+    (WARNING, 178, 3),
+    (DANGER, 204, 9),
+    // Nearest cube entry to #F87171 is 203 (255,95,95) — one step from
+    // DANGER's 204, so the two stay distinct at 256 colours. At 16 colours
+    // there is only one red (9) and the pre-flip state shares it with
+    // danger; the `red ──▸ green` wording, not the hue, carries the meaning
+    // there (the same glyph-over-hue rule every status obeys).
     (ORACLE_PRE_FLIP, 203, 9),
-    (VIOLET, 105, 12),
-    (AMBER, 216, 3),
-    (JADE, 77, 2),
-    (MAGENTA, 206, 5),
-    // The tool-class pair. 148 (175,215,0) and 177 (215,135,255) are the
+    (VIOLET, 98, 13),
+    (AMBER, 179, 3),
+    (TEAL, 44, 6),
+    (MAGENTA, 168, 5),
+    // The tool-class pair. 149 (175,215,95) and 171 (215,95,255) are the
     // nearest cube entries; at 16 colours they share green/magenta with their
     // hue neighbours, which is the ordinary collapse every categorical hue
     // takes there — the tool NAME is always beside the colour, so the class is
     // never carried by hue alone.
-    (CITRON, 148, 10),
-    (ORCHID, 177, 13),
-    // CODE's nearest cube entry (114) is also SYNTAX_STRING's, and two syntax
-    // tones collapsing onto one cell is exactly what a degraded terminal must
-    // not do inside a code body, so CODE takes the next-nearest (108, a duller
-    // sage) and the string tone keeps 114.
-    (CODE, 108, 2),
+    (CITRON, 149, 10),
+    (ORCHID, 171, 13),
+    (CODE, 72, 2),
     (DIFF_ADD_BG, 22, 2),
     (DIFF_DEL_BG, 52, 1),
     (DIFF_ADD_BG_EMPH, 28, 2),
-    (DIFF_DEL_BG_EMPH, 88, 5),
+    (DIFF_DEL_BG_EMPH, 88, 1),
     (MATCH_BG, 58, 3),
     (SYNTAX_STRING, 114, 10),
 ];
@@ -732,45 +715,44 @@ const LIGHT_REMAP: &[(Color, Color)] = &[
     (TEXT_PRIMARY, palette::INK),
     (TEXT_SECONDARY, palette::MUTED),
     (TEXT_TERTIARY, palette::INK_DIM),
-    // Brand → the deep ion ramp. ACCENT, ACCENT_FILL and IDENTITY are one Ion
-    // value, so one entry sends every flat ion cell to `brand-ink` (kit
-    // `brand-800`, 4.59:1 on paper) — kit `brand-700` is reserved for
-    // *graphical* chrome via `identity_stops`, because at 3.16:1 it cannot
-    // carry terminal-cell text on paper.
+    // Brand → the deep gold ramp. ACCENT, ACCENT_FILL and GOLD are one
+    // Phosphor Gold value, so one entry sends every flat gold cell to
+    // `brand-ink` (kit gold-800 lifted 10%, 5.22:1 on paper) — the kit's `gold-deep`
+    // is reserved for *graphical* chrome via `gold_stops`, because at
+    // 3.79:1 it cannot carry terminal-cell text on paper.
     (ACCENT, palette::BRAND_INK),
-    (IDENTITY_BRIGHT, palette::IDENTITY_INK),
+    (GOLD_BRIGHT, palette::GOLD_INK),
     (ACCENT_DEEP, palette::BRAND_INK_DEEP),
-    // `identity-deep` already IS the kit's light-ground graphical ion; its
-    // entry is the identity so the sweep's trailing stop needs no second
-    // value.
-    (IDENTITY_DEEP, palette::IDENTITY_INK),
+    // `gold-deep` already IS the kit's light-ground gold; its entry is the
+    // identity so the sweep's trailing stop needs no second value.
+    (GOLD_DEEP, palette::GOLD_INK),
     // Status → ink variants (OK/BRIGHT share the base value).
     (SUCCESS, palette::SUCCESS_INK),
     (WARNING, palette::WARNING_INK),
     (DANGER, palette::DANGER_INK),
     (ORACLE_PRE_FLIP, palette::ORACLE_RED_INK),
-    // Inline code — a darker sage, 5.68:1 on paper.
-    (CODE, Color::Rgb(0x00, 0x6D, 0x42)),
-    // Categorical hues, darkened for AA on the cool paper (RUN/HELD/NUMBER==
-    // VIOLET, KEYWORD==AMBER). Every one is the dark-side hue walked down to
-    // OKLCH L=0.48, which clears 5.4:1 or better on `paper`.
-    (VIOLET, Color::Rgb(0x51, 0x42, 0xC9)),
-    (AMBER, Color::Rgb(0x97, 0x3F, 0x00)),
-    (JADE, Color::Rgb(0x00, 0x73, 0x01)),
-    (MAGENTA, Color::Rgb(0x9D, 0x13, 0x85)),
-    // The tool-class pair, darkened for AA on the cool paper: citron drops to
-    // an olive (5.58:1), orchid to a deep purple (6.44:1).
-    (CITRON, Color::Rgb(0x4B, 0x69, 0x00)),
-    (ORCHID, Color::Rgb(0x83, 0x29, 0xAC)),
-    // Syntax bodies. Strings take a deep green (5.64:1 on paper).
-    (SYNTAX_STRING, Color::Rgb(0x00, 0x6F, 0x1A)),
-    // Diff tints → light washes, each the dark tint's own hue lifted to the
-    // paper end of the ramp so add/remove keeps its meaning on both grounds.
-    (DIFF_ADD_BG, Color::Rgb(0xCC, 0xF8, 0xDA)),
-    (DIFF_DEL_BG, Color::Rgb(0xFF, 0xE3, 0xE8)),
-    (DIFF_ADD_BG_EMPH, Color::Rgb(0xA3, 0xED, 0xBC)),
-    (DIFF_DEL_BG_EMPH, Color::Rgb(0xFF, 0xC8, 0xD3)),
-    (MATCH_BG, Color::Rgb(0xFF, 0xE4, 0xB4)),
+    // Inline code — a darker sage, 5.26:1 on paper.
+    (CODE, Color::Rgb(0x2A, 0x71, 0x50)),
+    // Categorical hues, darkened for AA on the warm paper (RUN/HELD/NUMBER==
+    // VIOLET, KEYWORD==AMBER). Teal drops to teal-700: the old teal-600
+    // measured 3.35:1 on the kit's paper, under the 4.5:1 text floor.
+    (VIOLET, Color::Rgb(0x6D, 0x28, 0xD9)),
+    (AMBER, Color::Rgb(0x92, 0x40, 0x0E)),
+    (TEAL, Color::Rgb(0x0F, 0x76, 0x6E)),
+    (MAGENTA, Color::Rgb(0xA6, 0x18, 0x5C)),
+    // The tool-class pair, darkened for AA on the warm paper: citron drops to
+    // an olive (5.49:1), orchid to a deep purple (6.24:1).
+    (CITRON, Color::Rgb(0x4D, 0x6B, 0x12)),
+    (ORCHID, Color::Rgb(0x8B, 0x2B, 0xA8)),
+    // Syntax bodies. Strings take green-800 (6.38:1 — green-700 sat at
+    // 4.49:1 on the warm paper).
+    (SYNTAX_STRING, Color::Rgb(0x16, 0x65, 0x34)),
+    // Diff tints → light washes.
+    (DIFF_ADD_BG, Color::Rgb(0xDC, 0xFC, 0xE7)),
+    (DIFF_DEL_BG, Color::Rgb(0xFE, 0xE2, 0xE2)),
+    (DIFF_ADD_BG_EMPH, Color::Rgb(0xA7, 0xF3, 0xC6)),
+    (DIFF_DEL_BG_EMPH, Color::Rgb(0xFB, 0xB4, 0xBD)),
+    (MATCH_BG, Color::Rgb(0xFE, 0xF0, 0x8A)),
 ];
 
 /// Remap one colour through a theme table; unmapped colours pass through (the
@@ -865,9 +847,8 @@ pub fn status_color(status: AgentStatus) -> Color {
 }
 
 /// The statline stage dot's color, by pipeline stage — the planning stages
-/// read as process (periwinkle), execution as live work (the accent, the one
-/// status that takes the identity), the verification stages as the jade
-/// categorical
+/// read as process (violet), execution as live work (the accent, the one
+/// status that takes gold), the verification stages as the teal categorical
 /// (checking is neither activity nor a verdict), and the wind-down stages
 /// dim. `Complete` is the sole outcome here and takes success — paired with
 /// the stage *word* beside the dot, so hue never carries the meaning alone.
@@ -876,11 +857,11 @@ pub fn stage_color(stage: stella_protocol::StageKind) -> Color {
     match stage {
         S::Triage | S::ContextRecall | S::Research | S::Plan | S::ScopeReview | S::Witness => RUN,
         S::Execute => ACCENT,
-        S::Verify | S::Verdict => JADE,
+        S::Verify | S::Verdict => TEAL,
         // The wind-down stages *write*: reflection mines lessons into
         // `.stella/`, context-write upserts facts. They wore the neutral tier
-        // and were the only stages a reader could not see at all; the
-        // magenta is the hue the transcript paints a mutating tool call, so "this
+        // and were the only stages a reader could not see at all; the rose is
+        // the same hue the transcript paints a mutating tool call, so "this
         // phase changed something durable" is one colour wherever it appears.
         S::Reflect | S::ContextWrite => MAGENTA,
         S::Complete => OK,
@@ -891,13 +872,13 @@ pub fn stage_color(stage: stella_protocol::StageKind) -> Color {
 /// families [`stage_color`] uses, with one deliberate divergence.
 ///
 /// `Execute` is the accent on the statline, because the statline's dot is
-/// *current state* and ion means active — the one status the kit gives it. A
+/// *current state* and gold means active — the one status the kit gives it. A
 /// transcript rule is the opposite: it is history, written once and scrolled
-/// past, and by the time it is read the stage is over. The accent on a
-/// settled thing is the reservation's exact failure mode, so the execute rule
-/// takes the citron instead: the brightest categorical hue there is
-/// (12.50:1), 112° clear of the accent, and — like the stage it marks — the
-/// one that says the workspace changed here.
+/// past, and by the time it is read the stage is over. Gold on a settled thing
+/// is the reservation's exact failure mode, so the execute rule takes the
+/// citron instead: the brightest categorical hue there is (11.08:1), 39° clear
+/// of gold, and — like the stage it marks — the one that says the workspace
+/// changed here.
 pub fn stage_rule_color(stage: stella_protocol::StageKind) -> Color {
     match stage {
         stella_protocol::StageKind::Execute => CITRON,
@@ -922,9 +903,9 @@ pub fn status_glyph(status: AgentStatus) -> &'static str {
 
 /// Color a [`crate::graph::GraphNode`] by its `kind`, so the Graph tab's node
 /// list, detail panel, and node-edge sketch all agree on one palette:
-/// function/method periwinkle, struct/enum/trait green, file/module magenta —
+/// function/method violet, struct/enum/trait green, file/module warm rose —
 /// three distinct categorical hues, none of them the reserved brand accent
-/// (the magenta replaces an amber that became indistinguishable from the gold
+/// (the rose replaces an amber that became indistinguishable from the gold
 /// accent, and it matches the Traces tab's file chip so "file" is one colour
 /// everywhere). A node kind is a category, not an activity.
 pub fn graph_kind_color(kind: &str) -> Color {
@@ -974,13 +955,13 @@ pub fn spark_glyph(intensity: u8) -> char {
 /// A small rotating palette an agent id is hashed into. The point is
 /// stability, not per-color meaning: the same id always lands on the same
 /// slot, so an agent reads as one consistent color everywhere it appears.
-/// Five distinct categorical hues — periwinkle, magenta, green, jade,
-/// secondary — none of them the reserved brand hue (an agent is not "the
-/// brand"; the amber slot the magenta replaces was 1.12:1 against the gold
-/// accent, and a chip that can be mistaken for "running" is worse than no
-/// chip) and none of them danger (which reads as failure elsewhere, so it
-/// never brands a healthy agent).
-const AGENT_PALETTE: [Color; 5] = [HELD, MAGENTA, OK, TEXT_SECONDARY, JADE];
+/// Five distinct categorical hues — violet, rose, green, teal, secondary —
+/// none of them the reserved brand hue (an agent is not "the brand"; the
+/// amber slot the rose replaces was 1.06:1 against the gold accent, and a
+/// chip that can be mistaken for "running" is worse than no chip) and none
+/// of them danger (which reads as failure elsewhere, so it never brands a
+/// healthy agent).
+const AGENT_PALETTE: [Color; 5] = [HELD, MAGENTA, OK, TEXT_SECONDARY, TEAL];
 
 /// A deterministic (not randomized — stable across processes and test runs)
 /// color for one agent id, picked from `AGENT_PALETTE` by hashing the id.
@@ -1005,14 +986,14 @@ fn fnv1a(s: &str) -> u64 {
 // ── Trace kind → color (Traces tab kind chip) ───────────────────────────────
 
 /// A color per [`TraceKind`], for the Traces tab's kind chip. Grouped by
-/// meaning: `RUN` (periwinkle) for process/action events (stage, tool, vcs),
-/// `MAGENTA`/`JADE` for produced artifacts (file, media) — categorical, so
-/// an artifact never reads as "running"; the file chip's magenta sits 1.17:1
-/// from [`BAD`], which is tolerable exactly because a chip is always a
-/// coloured *word* and an error is always glyph-paired — a dim neutral for
+/// meaning: `RUN` (violet) for process/action events (stage, tool, vcs),
+/// `MAGENTA`/`TEAL` for produced artifacts (file, media) — categorical, so
+/// an artifact never reads as "running"; the file chip's warm rose sits
+/// 1.30:1 from [`BAD`], which is tolerable exactly because a chip is always
+/// a coloured *word* and an error is always glyph-paired — a dim neutral for
 /// quiet memory/context events, and the shared `OK`/`WARN`/`BAD` semantics
 /// for verdicts, spend, and errors. Memory drops to `TEXT_TERTIARY` rather
-/// than reuse the periwinkle — the process group already owns that anchor.
+/// than reuse violet — the process group already owns that anchor.
 pub fn trace_kind_color(kind: TraceKind) -> Color {
     match kind {
         TraceKind::Stage => RUN,
@@ -1023,7 +1004,7 @@ pub fn trace_kind_color(kind: TraceKind) -> Color {
         TraceKind::Budget => WARN,
         TraceKind::Context => TEXT_TERTIARY,
         TraceKind::Verdict => OK,
-        TraceKind::Media => JADE,
+        TraceKind::Media => TEAL,
         TraceKind::Vcs => RUN,
         TraceKind::Error => BAD,
         TraceKind::Complete => OK,

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -43,8 +43,8 @@ fn trace_kind_color_covers_every_variant_without_panic() {
 /// moment a new truecolor token lands without a [`FALLBACKS`] entry. Role
 /// aliases (`INK`, `OK`, `DANGER`, …) share a value with a palette token, so
 /// they are intentionally not re-listed — under the comet kit that includes
-/// `ACCENT_FILL` and `IDENTITY` (one Ion with `ACCENT`) and `SYNTAX_COMMENT`
-/// (the caption tier, `TEXT_TERTIARY`).
+/// `ACCENT_FILL` and `GOLD` (one Phosphor Gold with `ACCENT`) and
+/// `SYNTAX_COMMENT` (the caption tier, `TEXT_TERTIARY`).
 const ALL_RGB_TOKENS: &[Color] = &[
     VOID,
     GROUND,
@@ -56,16 +56,16 @@ const ALL_RGB_TOKENS: &[Color] = &[
     TEXT_SECONDARY,
     TEXT_TERTIARY,
     ACCENT,
-    IDENTITY_BRIGHT,
+    GOLD_BRIGHT,
     ACCENT_DEEP,
-    IDENTITY_DEEP,
+    GOLD_DEEP,
     SUCCESS,
     WARNING,
     DANGER,
     ORACLE_PRE_FLIP,
     VIOLET,
     AMBER,
-    JADE,
+    TEAL,
     MAGENTA,
     CITRON,
     ORCHID,
@@ -85,7 +85,7 @@ const ALL_RGB_TOKENS: &[Color] = &[
 const LIGHT_ONLY_PALETTE_TOKENS: &[&str] = &[
     "brand-ink",
     "brand-ink-deep",
-    "identity-ink",
+    "gold-ink",
     "success-ink",
     "warning-ink",
     "danger-ink",
@@ -157,20 +157,20 @@ fn every_named_token_has_a_fallback() {
 #[test]
 fn role_aliases_track_their_palette_token() {
     // Brand roles resolve to the generated palette, not to a local literal.
-    // Under the comet kit the accent IS the identity: one Ion serves text,
-    // rules and fills (10.79:1 on ground), so ACCENT, ACCENT_FILL and
-    // IDENTITY are one value on purpose.
+    // Under the comet kit the accent IS the gold: one Phosphor Gold serves
+    // text, rules and fills (11.36:1 on ground), so ACCENT, ACCENT_FILL and
+    // GOLD are one value on purpose.
     assert_eq!(ACCENT, palette::BRAND);
     assert_eq!(ACCENT_FILL, ACCENT);
-    assert_eq!(IDENTITY, ACCENT);
-    assert_eq!(palette::BRAND, palette::IDENTITY);
-    assert_eq!(palette::BRAND_BRIGHT, palette::IDENTITY_BRIGHT);
+    assert_eq!(GOLD, ACCENT);
+    assert_eq!(palette::BRAND, palette::GOLD);
+    assert_eq!(palette::BRAND_BRIGHT, palette::GOLD_BRIGHT);
     assert_eq!(ACCENT_DEEP, palette::BRAND_DEEP);
-    assert_eq!(IDENTITY_BRIGHT, palette::IDENTITY_BRIGHT);
-    assert_eq!(IDENTITY_DEEP, palette::IDENTITY_DEEP);
+    assert_eq!(GOLD_BRIGHT, palette::GOLD_BRIGHT);
+    assert_eq!(GOLD_DEEP, palette::GOLD_DEEP);
     // The identity sweep and the progress fill lead with different deep
     // stops on purpose: chrome may run quiet, the fill's tail must hold AA.
-    assert_ne!(IDENTITY_DEEP, ACCENT_DEEP);
+    assert_ne!(GOLD_DEEP, ACCENT_DEEP);
     assert_eq!(VOID, palette::VOID);
     assert_eq!(HAIRLINE_STRONG, palette::HAIRLINE_STRONG);
     assert_eq!(GROUND, palette::GROUND);
@@ -191,27 +191,23 @@ fn role_aliases_track_their_palette_token() {
     assert_eq!(AMBER, palette::DATA_1);
     assert_eq!(VIOLET, palette::DATA_2);
     assert_eq!(MAGENTA, palette::DATA_3);
-    assert_eq!(JADE, palette::DATA_4);
+    assert_eq!(TEAL, palette::DATA_4);
 }
 
-/// The kit's one hard prohibition, restated for an ion accent: **the identity
-/// never carries a verdict.** Under the bronze kit the argument was a hue
-/// collision — gold and [`WARNING`] were 4.0° apart, the same brass at a
-/// glance. At hue 190 the nearest status is 35° away, so the collision is
-/// gone and the rule is not: a reader must never be asked to tell an
-/// *outcome* (ok / warn / bad, done / failed) from chrome, because chrome and
-/// verdict are different jobs and a chrome recolour must never silently
-/// become a semantic change. The one status the identity does carry is
-/// activity: active/running IS the accent, by kit rule ("ion is the signal"),
-/// and that pairing is asserted here so it cannot silently regress to a
-/// lesser hue either. This is the test that would fail if someone reached for
-/// the prettier colour in a verdict mapping.
+/// The kit's one hard prohibition, restated for a gold accent: **gold never
+/// carries a verdict.** Gold and [`WARNING`] are 4.0° apart in hue — the
+/// same brass at a glance — so a reader must never be asked to tell an
+/// *outcome* (ok / warn / bad, done / failed) from chrome by hue. The one
+/// status gold does carry is activity: active/running IS the accent, by kit
+/// rule ("gold is the signal"), and that pairing is asserted here so it
+/// cannot silently regress to a lesser hue either. This is the test that
+/// would fail if someone reached for the prettier colour in a verdict
+/// mapping.
 #[test]
-fn identity_never_carries_a_verdict() {
-    // Activity is the identity — the one permitted (required, even) status
-    // use.
+fn gold_never_carries_a_verdict() {
+    // Activity is gold — the one permitted (required, even) status use.
     assert_eq!(status_color(AgentStatus::Running), ACCENT);
-    for identity in [IDENTITY, IDENTITY_BRIGHT, IDENTITY_DEEP] {
+    for gold in [GOLD, GOLD_BRIGHT, GOLD_DEEP] {
         for (status, name) in [
             (OK, "OK"),
             (WARN, "WARN"),
@@ -219,7 +215,7 @@ fn identity_never_carries_a_verdict() {
             (HELD, "HELD"),
             (RUN, "RUN"),
         ] {
-            assert_ne!(identity, status, "{name} must not be an identity tone");
+            assert_ne!(gold, status, "{name} must not be a gold");
         }
         for status in [
             AgentStatus::Queued,
@@ -231,8 +227,8 @@ fn identity_never_carries_a_verdict() {
         ] {
             assert_ne!(
                 status_color(status),
-                identity,
-                "status_color({status:?}) returned an identity tone"
+                gold,
+                "status_color({status:?}) returned a gold"
             );
         }
         for kind in [
@@ -252,25 +248,21 @@ fn identity_never_carries_a_verdict() {
         ] {
             assert_ne!(
                 trace_kind_color(kind),
-                identity,
-                "trace_kind_color({kind:?}) returned an identity tone"
+                gold,
+                "trace_kind_color({kind:?}) returned a gold"
             );
         }
         for i in 0..=20 {
-            assert_ne!(gauge_color(f64::from(i) / 20.0), identity);
+            assert_ne!(gauge_color(f64::from(i) / 20.0), gold);
         }
         for id in ["lead", "sub:auth", "", "agent-42"] {
-            assert_ne!(
-                agent_color(id),
-                identity,
-                "agent_color({id:?}) returned an identity tone"
-            );
+            assert_ne!(agent_color(id), gold, "agent_color({id:?}) returned a gold");
         }
         // And it is not a graph node kind either — a node is a category.
         for kind in [
             "function", "method", "struct", "enum", "trait", "file", "module", "?",
         ] {
-            assert_ne!(graph_kind_color(kind), identity);
+            assert_ne!(graph_kind_color(kind), gold);
         }
     }
 }
@@ -317,117 +309,100 @@ fn hue_separation(a: Color, b: Color) -> f64 {
 
 /// The palette law, in the form a future edit would actually break.
 ///
-/// The guard has outlived six recolours now (aurora → gold → sky → green →
-/// blue → gold → ion), which is the point: each time, the *shape* of the law
+/// The guard has outlived five recolours now (aurora → gold → sky → green →
+/// blue → gold again), which is the point: each time, the *shape* of the law
 /// survived and only the hue it names changed. Keep rewriting it rather than
 /// deleting it.
 ///
-/// The ion recolour changed the law in four real ways. First, the exact
-/// values are load-bearing, as they were for bronze: Ion `#00D1F9` and
-/// Obsidian `#070B10` are the brand, so clause 1 pins the hex. Second, the
-/// warmth clause inverts: ink was a warm-neutral near-black with warm text
-/// above it, and obsidian is a *cool* blue-black with a graphite ramp, so the
-/// clause that used to ban cool grays now requires them (b ≥ g ≥ r) and bans
-/// warm ones. Third, the ground carries a real cast for the first time since
-/// the deep-space era — a cool one — so the near-neutral clause loosens from
-/// "≤ 5 channel spread" to "cool-leaning, and never true black". Fourth, and
-/// most usefully, the reservation has **no named neighbours left**: a gold
-/// accent had two hues sitting inside 5° of it, and every chromatic role is
-/// now ≥ 30° from ion with the closest at 34.8° (success). The exception list
-/// is empty and clause 5 says so explicitly, so re-adding one is a visible
-/// edit rather than a quiet loosening.
+/// The comet recolour changed the law in three real ways. First, the exact
+/// values are load-bearing: Phosphor Gold `#FFB81A` and Ink `#0B0B0C` are
+/// the brand, so clause 1 pins the hex rather than merely the dominance.
+/// Second, the ground lost its cast: ink is a warm-neutral near-black, so
+/// the old "the canvas must carry the blue cast" clause inverts back into
+/// "the canvas may carry (almost) no cast" — and the same warmth law now
+/// covers the text ramp, because the owner banned cool grays outright.
+/// Third, the reservation has *named neighbours* again: a gold accent lives
+/// 4.0° from warning amber and 0.8° from the amber data mark, so instead of
+/// "no exceptions" the law says exactly which two hues may sit close and
+/// what confines each of them.
 ///
 /// What must hold now:
-///   1. The accent is the kit's Ion, exactly; the ground is Obsidian,
-///      exactly. Brand and identity are one family (the collapse survives the
-///      recolour).
-///   2. Every retired hue is gone — the whole bronze/gold family, the
-///      electric blue before it, and the warm neutral text ramp with them.
-///   3. Grounds lean cool and are never true black; text is a cool graphite.
+///   1. The accent is the kit's Phosphor Gold, exactly; the ground is Ink,
+///      exactly. Brand and gold are one family (the collapse IS the
+///      rebrand).
+///   2. Every retired hue is gone — the whole electric-blue family, the old
+///      warm-tinted gold, and the cool gray text ramp with them.
+///   3. Grounds are near-neutral and never true black; text is warm.
 ///   4. Warning ramps warm, success ramps green, danger ramps red.
-///   5. Ion is reserved. Every chromatic role sits ≥ 30° of hue away, with no
-///      exceptions at all.
+///   5. Gold is reserved. Every chromatic role sits ≥ 30° of hue away,
+///      except the two named neighbours: WARN (always glyph-paired) and
+///      AMBER (confined to syntax keywords in code bodies).
 #[test]
-fn palette_law_ion_is_the_brand() {
+fn palette_law_gold_is_the_brand() {
     const RETIRED_AURORA_CYAN: Color = Color::Rgb(0x3F, 0xE0, 0xFF);
     const RETIRED_EMBER_FLAME: Color = Color::Rgb(0xFF, 0x7E, 0x5F);
     const RETIRED_EMBER_CRIMSON: Color = Color::Rgb(0xC2, 0x18, 0x5B);
     const RETIRED_GOLD: Color = Color::Rgb(0xFF, 0xDD, 0x00);
     const RETIRED_GOLD_DEEP: Color = Color::Rgb(0xE0, 0xB8, 0x00);
     /// The old glacier blue, retired *because* it collided with the sky
-    /// accent — and still banned: the owner hates ice blue, and ion is a
-    /// saturated azure-cyan, not a washed-out one.
+    /// accent — and doubly banned now: the owner hates ice blue.
     const RETIRED_AGENT_ICE: Color = Color::Rgb(0xA8, 0xC7, 0xF0);
-    /// The sky blue of four recolours ago.
+    /// The sky blue of three recolours ago.
     const RETIRED_SKY: Color = Color::Rgb(0x7D, 0xD3, 0xFC);
     const RETIRED_SKY_DEEP: Color = Color::Rgb(0x38, 0xBD, 0xF8);
     /// The warning orange the "get rid of the orange" pass removed; warning
     /// is amber-yellow now and must not slide back to it.
     const RETIRED_WARNING_ORANGE: Color = Color::Rgb(0xFF, 0x8A, 0x1F);
-    /// The terminal green of three identities ago, and its deep stop.
+    /// The terminal green of two identities ago, and its deep stop.
     const RETIRED_PHOSPHOR_GREEN: Color = Color::Rgb(0x00, 0xE6, 0x76);
     const RETIRED_PHOSPHOR_GREEN_DEEP: Color = Color::Rgb(0x00, 0xB2, 0x5A);
     /// The vermilion light-theme brand ("ember") and its deep stop.
     const RETIRED_EMBER: Color = Color::Rgb(0xFF, 0x3D, 0x1F);
     const RETIRED_EMBER_DEEP: Color = Color::Rgb(0xD6, 0x2E, 0x0E);
-    /// The electric blue of two recolours ago: brand, bright, deep, and the
-    /// two paper blues. Ion is a cyan-azure at hue 190; this family sat at
-    /// 220 and must not creep back.
+    /// The electric blue this recolour retired: brand, bright, deep, and the
+    /// two paper blues. The comet kit has no blue anywhere.
     const RETIRED_ELECTRIC_BLUE: Color = Color::Rgb(0x2E, 0x7B, 0xFF);
     const RETIRED_ELECTRIC_BLUE_BRIGHT: Color = Color::Rgb(0x5A, 0xA0, 0xFF);
     const RETIRED_ELECTRIC_BLUE_DEEP: Color = Color::Rgb(0x1A, 0x5F, 0xE0);
     const RETIRED_BLUE_INK: Color = Color::Rgb(0x15, 0x50, 0xC8);
     const RETIRED_BLUE_INK_DEEP: Color = Color::Rgb(0x0F, 0x3A, 0x94);
     /// The warm-tinted gold that shipped beside the blue (`#F5C145` family).
+    /// The comet gold is `#FFB81A` exactly; the old tint may not resurface.
     const RETIRED_WARM_GOLD: Color = Color::Rgb(0xF5, 0xC1, 0x45);
     const RETIRED_WARM_GOLD_BRIGHT: Color = Color::Rgb(0xFF, 0xD8, 0x73);
     const RETIRED_WARM_GOLD_DEEP: Color = Color::Rgb(0xC9, 0x94, 0x20);
-    /// The Phosphor Gold this recolour retired, and its sweep — the identity
-    /// for the whole life of the comet kit's v1/v2. Brand, bright, deep, and
-    /// the two paper golds.
-    const RETIRED_PHOSPHOR_GOLD: Color = Color::Rgb(0xFF, 0xB8, 0x1A);
-    const RETIRED_PHOSPHOR_GOLD_BRIGHT: Color = Color::Rgb(0xFD, 0xC1, 0x54);
-    const RETIRED_PHOSPHOR_GOLD_DEEP: Color = Color::Rgb(0xE5, 0xA0, 0x00);
-    const RETIRED_GOLD_INK: Color = Color::Rgb(0xA3, 0x72, 0x00);
-    const RETIRED_GOLD_INK_DEEP: Color = Color::Rgb(0x5A, 0x3F, 0x00);
-    const RETIRED_BRAND_INK_GOLD: Color = Color::Rgb(0x85, 0x5E, 0x00);
-    /// The bronze the web kit carried beside it, and its deep stop.
-    const RETIRED_BRONZE: Color = Color::Rgb(0xC5, 0x8A, 0x32);
-    const RETIRED_BRONZE_DEEP: Color = Color::Rgb(0x8B, 0x5E, 0x1A);
-    /// The warm-neutral text ramp the graphite one replaces — the "warm
-    /// paper" tiers of the bronze kit.
-    const RETIRED_WARM_TEXT: Color = Color::Rgb(0xF4, 0xF1, 0xEA);
-    const RETIRED_WARM_TEXT_2: Color = Color::Rgb(0x9B, 0x98, 0x90);
-    const RETIRED_WARM_TEXT_3: Color = Color::Rgb(0x8D, 0x8A, 0x82);
-    /// The warm ink ground and warm paper the obsidian/frost pair replaces.
-    const RETIRED_INK_GROUND: Color = Color::Rgb(0x0B, 0x0B, 0x0C);
-    const RETIRED_WARM_PAPER: Color = Color::Rgb(0xF6, 0xF2, 0xE9);
-    /// The teal categorical that a cyan accent made untenable (24° from ion).
-    const RETIRED_TEAL_MARK: Color = Color::Rgb(0x2F, 0xD3, 0xC6);
+    /// The cool, blue-leaning gray text ramp — the "cool grays" the comet
+    /// kit's warm neutral ramp replaces.
+    const RETIRED_COOL_TEXT: Color = Color::Rgb(0xF2, 0xF5, 0xFA);
+    const RETIRED_COOL_TEXT_2: Color = Color::Rgb(0x8E, 0x97, 0xA8);
+    const RETIRED_COOL_TEXT_3: Color = Color::Rgb(0x73, 0x7D, 0x92);
+    /// The blue-cast "deep space" ground the ink ramp replaces.
+    const RETIRED_DEEP_SPACE: Color = Color::Rgb(0x08, 0x0A, 0x0F);
 
-    // 1. The accent is Ion and the ground is Obsidian — the exact kit values,
-    //    pinned by hex so the brand cannot silently drift. This is the one
-    //    clause that names numbers: `#00D1F9` on `#070B10` is the identity.
+    // 1. The accent is Phosphor Gold and the ground is Ink — the exact kit
+    //    values, pinned by hex so the brand cannot silently drift. This is
+    //    the one clause that names numbers: `#FFB81A` on `#0B0B0C` is the
+    //    identity.
     assert_eq!(
         ACCENT,
-        Color::Rgb(0x00, 0xD1, 0xF9),
-        "the accent must be Ion #00D1F9, exactly"
+        Color::Rgb(0xFF, 0xB8, 0x1A),
+        "the accent must be Phosphor Gold #FFB81A, exactly"
     );
     assert_eq!(
         GROUND,
-        Color::Rgb(0x07, 0x0B, 0x10),
-        "the ground must be Obsidian #070B10, exactly"
+        Color::Rgb(0x0B, 0x0B, 0x0C),
+        "the ground must be Ink #0B0B0C, exactly"
     );
     assert_eq!(ACCENT, palette::BRAND, "the accent comes from the palette");
     assert_eq!(
-        IDENTITY, ACCENT,
-        "brand and identity are one family under the comet"
+        GOLD, ACCENT,
+        "brand and gold are one family under the comet"
     );
-    for (ion, name) in [(ACCENT, "ACCENT"), (ACCENT_FILL, "ACCENT_FILL")] {
-        let Color::Rgb(r, g, b) = ion else {
+    for (gold, name) in [(ACCENT, "ACCENT"), (ACCENT_FILL, "ACCENT_FILL")] {
+        let Color::Rgb(r, g, b) = gold else {
             panic!("{name} must be a truecolor token");
         };
-        assert!(b > g && g > r, "{name} must be cool-dominant (b > g > r)");
+        assert!(r > g && g > b, "{name} must be warm-dominant (r > g > b)");
     }
 
     // 2. The retired hues are gone from every token and alias.
@@ -443,7 +418,7 @@ fn palette_law_ion_is_the_brand() {
         OK,
         ACCENT_DEEP,
         CODE,
-        IDENTITY,
+        GOLD,
     ]);
     all.extend(BRAND_STOPS);
     all.extend(LIGHT_REMAP.iter().map(|(_, to)| *to));
@@ -470,29 +445,19 @@ fn palette_law_ion_is_the_brand() {
             (RETIRED_WARM_GOLD, "the warm-tinted gold"),
             (RETIRED_WARM_GOLD_BRIGHT, "the warm-tinted bright gold"),
             (RETIRED_WARM_GOLD_DEEP, "the warm-tinted deep gold"),
-            (RETIRED_PHOSPHOR_GOLD, "Phosphor Gold"),
-            (RETIRED_PHOSPHOR_GOLD_BRIGHT, "bright Phosphor Gold"),
-            (RETIRED_PHOSPHOR_GOLD_DEEP, "deep Phosphor Gold"),
-            (RETIRED_GOLD_INK, "the paper gold"),
-            (RETIRED_GOLD_INK_DEEP, "the deep paper gold"),
-            (RETIRED_BRAND_INK_GOLD, "the paper brand gold"),
-            (RETIRED_BRONZE, "Bronze Gold"),
-            (RETIRED_BRONZE_DEEP, "deep Bronze Gold"),
-            (RETIRED_WARM_TEXT, "the warm primary paper"),
-            (RETIRED_WARM_TEXT_2, "the warm secondary neutral"),
-            (RETIRED_WARM_TEXT_3, "the warm tertiary neutral"),
-            (RETIRED_INK_GROUND, "the warm ink ground"),
-            (RETIRED_WARM_PAPER, "the warm paper ground"),
-            (RETIRED_TEAL_MARK, "the teal categorical"),
+            (RETIRED_COOL_TEXT, "the cool primary gray"),
+            (RETIRED_COOL_TEXT_2, "the cool secondary gray"),
+            (RETIRED_COOL_TEXT_3, "the cool tertiary gray"),
+            (RETIRED_DEEP_SPACE, "the deep-space ground"),
         ] {
             assert_ne!(*token, retired, "a token still holds {name}");
         }
     }
 
-    // 3. The ground is obsidian: cool-leaning (b ≥ g ≥ r) and never true
-    //    black — pure black makes the accent scream; obsidian lets it speak.
-    //    The text ramp is the same graphite: the warm neutrals the bronze kit
-    //    required are banned in turn, so no text tier may lean warm.
+    // 3. The ground is ink: near-neutral (a whisper of cast at most, in
+    //    either temperature), and never true black — pure black makes the
+    //    accent scream; ink lets it speak. The text ramp is warm: the owner
+    //    banned cool grays, so no text tier may lean blue.
     for (ground, name) in [
         (VOID, "VOID"),
         (GROUND, "GROUND"),
@@ -504,10 +469,10 @@ fn palette_law_ion_is_the_brand() {
         let Color::Rgb(r, g, b) = ground else {
             panic!("{name} must be a truecolor token");
         };
+        let (max, min) = (r.max(g).max(b), r.min(g).min(b));
         assert!(
-            b >= g && g >= r,
-            "{name} ({ground:?}) must be a cool near-black (b ≥ g ≥ r) — \
-             warm grounds are banned"
+            max - min <= 5,
+            "{name} ({ground:?}) must be near-neutral ink, not a cast"
         );
         assert_ne!(ground, Color::Rgb(0, 0, 0), "{name} must not be true black");
     }
@@ -520,16 +485,14 @@ fn palette_law_ion_is_the_brand() {
             panic!("{name} must be a truecolor token");
         };
         assert!(
-            b >= g && g >= r,
-            "{name} ({text:?}) must be a cool graphite (b ≥ g ≥ r) — warm \
-             neutrals are banned"
+            r >= g && g >= b,
+            "{name} ({text:?}) must be a warm neutral (r ≥ g ≥ b) — cool \
+             grays are banned"
         );
     }
 
-    // 4. Warning ramps warm (r > g > b — amber, not the orange that once
+    // 4. Warning ramps warm (r > g > b — amber, no longer the orange that
     //    dominated the transcript), success ramps green, danger ramps red.
-    //    These are the only warm hues the system still holds, which is what
-    //    makes them read as functional against entirely cool chrome.
     let Color::Rgb(wr, wg, wb) = WARNING else {
         panic!("WARNING must be a truecolor token");
     };
@@ -543,50 +506,49 @@ fn palette_law_ion_is_the_brand() {
     };
     assert!(dr > dg && dr > db, "danger must be red-dominant");
 
-    // 5. Ion is reserved for brand / active / focus / selection / progress.
+    // 5. Gold is reserved for brand / active / focus / selection / progress.
     //    Every chromatic role sits ≥ 30° of hue away — which is how
-    //    `AGENT_ICE` died, and how the bronze kit's teal categorical died in
-    //    this recolour. There is no exception list: the gold accent needed
-    //    one (WARN at 4.0°, AMBER at 0.8°) and a cool accent does not, so
-    //    re-introducing a named neighbour has to be a visible edit here.
+    //    `AGENT_ICE` died — except the two *named* neighbours below.
     for (role, name) in [
         (BAD, "BAD"),
         (OK, "OK"),
-        (WARN, "WARN"),
         (RUN, "RUN"),
         (HELD, "HELD"),
         (VIOLET, "VIOLET"),
-        (JADE, "JADE"),
+        (TEAL, "TEAL"),
         (MAGENTA, "MAGENTA"),
-        (AMBER, "AMBER"),
         (CODE, "CODE"),
         (SYNTAX_STRING, "SYNTAX_STRING"),
         (SYNTAX_NUMBER, "SYNTAX_NUMBER"),
         (CITRON, "CITRON"),
         (ORCHID, "ORCHID"),
-        (ORACLE_PRE_FLIP, "ORACLE_PRE_FLIP"),
     ] {
-        assert_ne!(role, ACCENT, "{name} must not be the reserved ion");
+        assert_ne!(role, ACCENT, "{name} must not be the reserved gold");
         let sep = hue_separation(role, ACCENT);
         assert!(
             sep >= 30.0,
-            "{name} ({role:?}) is {sep:.1}° from the ion accent; \
+            "{name} ({role:?}) is {sep:.1}° from the gold accent; \
              30° is the floor for two hues to be told apart in a cell"
         );
     }
-
-    // The apricot mark stays stood down from chips, nodes and agents. Its
-    // reason moved with the recolour — it is 170° from the accent now, but
-    // 24° from WARN at 1.08:1 — so the confinement to code bodies is asserted
-    // on its own terms rather than as a corollary of the reservation above.
-    assert!(
-        hue_separation(AMBER, WARN) < 30.0,
-        "AMBER is no longer a hue-neighbour of WARN; if it has moved ≥ 30° \
-         away, the stand-down below can be lifted — do it deliberately"
-    );
+    // The named neighbours. WARN sits 4.0° from gold: permitted because a
+    // status never appears without its glyph (`status_glyph`), so the hue is
+    // never the only carrier. AMBER sits 0.8° away: permitted because it
+    // paints syntax keywords inside code bodies and nothing else — the
+    // observatory stands the same mark down from every plotted surface, and
+    // the deck stands it down from every chip, node and agent.
+    for (neighbour, name) in [(WARN, "WARN"), (AMBER, "AMBER")] {
+        assert_ne!(neighbour, ACCENT, "{name} may neighbour gold, not BE it");
+        let sep = hue_separation(neighbour, ACCENT);
+        assert!(
+            sep < 30.0,
+            "{name} is a *named* hue-neighbour of gold ({sep:.1}°); if it \
+             has moved ≥ 30° away, promote it to the reserved list above"
+        );
+    }
     assert!(
         !AGENT_PALETTE.contains(&AMBER),
-        "the apricot mark is stood down: no agent chip may wear it"
+        "the amber mark is stood down: no agent chip may wear it"
     );
     for kind in [
         "function", "method", "struct", "enum", "trait", "file", "module", "?",
@@ -594,7 +556,7 @@ fn palette_law_ion_is_the_brand() {
         assert_ne!(
             graph_kind_color(kind),
             AMBER,
-            "the apricot mark is stood down: no graph node may wear it"
+            "the amber mark is stood down: no graph node may wear it"
         );
     }
     for kind in [
@@ -615,16 +577,16 @@ fn palette_law_ion_is_the_brand() {
         assert_ne!(
             trace_kind_color(kind),
             AMBER,
-            "the apricot mark is stood down: no trace chip may wear it"
+            "the amber mark is stood down: no trace chip may wear it"
         );
     }
 
     // 6. The brand's own tones are the only things allowed near it, and the
-    //    accent/fill pair really is one value.
+    //    accent/fill pair really is one value now.
     assert_eq!(ACCENT_FILL, ACCENT);
     assert!(hue_separation(ACCENT_DEEP, ACCENT) < 10.0);
-    assert!(hue_separation(IDENTITY_DEEP, ACCENT) < 10.0);
-    assert!(hue_separation(IDENTITY_BRIGHT, ACCENT) < 10.0);
+    assert!(hue_separation(GOLD_DEEP, ACCENT) < 10.0);
+    assert!(hue_separation(GOLD_BRIGHT, ACCENT) < 10.0);
 }
 
 #[test]
@@ -733,11 +695,11 @@ fn degrade_buffer_is_noop_when_truecolor() {
 #[test]
 fn degrade_buffer_resolves_every_cell_when_degraded() {
     let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
-    buf.content[0].fg = ACCENT; // → 45 (256) / 14 (16)
-    buf.content[0].bg = VIOLET; // → 105 (256) / 12 (16)
+    buf.content[0].fg = ACCENT; // → 214 (256) / 11 (16)
+    buf.content[0].bg = VIOLET; // → 98 (256) / 13 (16)
     degrade_buffer(&mut buf, ColorMode::Ansi256);
-    assert_eq!(buf.content[0].fg, Color::Indexed(45));
-    assert_eq!(buf.content[0].bg, Color::Indexed(105));
+    assert_eq!(buf.content[0].fg, Color::Indexed(214));
+    assert_eq!(buf.content[0].bg, Color::Indexed(98));
 }
 
 /// The two degraded paths must still separate the things a reader has to
@@ -769,15 +731,13 @@ fn degraded_paths_keep_meaningful_pairs_distinguishable() {
                 "{mode:?}: accent collapsed onto {name}"
             );
         }
-        // The identity is brand chrome and warning is a status; they may
-        // never become the same cell, at any depth. Under the gold kit this
-        // was hard-won (both were yellows); under ion they are a cyan and an
-        // amber, so it is the collapse itself the assertion guards against.
-        for identity in [IDENTITY, IDENTITY_BRIGHT, IDENTITY_DEEP] {
+        // Gold is brand chrome and warning is a status; they may never
+        // become the same cell, at any depth.
+        for gold in [GOLD, GOLD_BRIGHT, GOLD_DEEP] {
             assert_ne!(
-                idx(identity, mode),
+                idx(gold, mode),
                 idx(WARN, mode),
-                "{mode:?}: {identity:?} collapsed onto warning"
+                "{mode:?}: {gold:?} collapsed onto warning"
             );
         }
         // The progress fill keeps a head-to-tail ramp.
@@ -803,14 +763,11 @@ fn apply_theme_is_identity_for_dark_and_remaps_for_light() {
         remap_theme(ACCENT_DEEP, LIGHT_REMAP),
         palette::BRAND_INK_DEEP
     );
-    // Flat identity cells are accent cells, so they take the accent's paper
-    // text tone; the kit's own light-ground graphical ion (`identity-ink`)
-    // survives in the `identity_stops` sweep only.
-    assert_eq!(remap_theme(IDENTITY, LIGHT_REMAP), palette::BRAND_INK);
-    assert_eq!(
-        remap_theme(IDENTITY_DEEP, LIGHT_REMAP),
-        palette::IDENTITY_INK
-    );
+    // Flat gold cells are accent cells now, so they take the accent's paper
+    // text tone; the kit's own light-ground gold (`gold-ink`) survives in the
+    // graphical `gold_stops` sweep only.
+    assert_eq!(remap_theme(GOLD, LIGHT_REMAP), palette::BRAND_INK);
+    assert_eq!(remap_theme(GOLD_DEEP, LIGHT_REMAP), palette::GOLD_INK);
     assert_eq!(remap_theme(VOID, LIGHT_REMAP), palette::PAPER);
     assert_eq!(remap_theme(GROUND, LIGHT_REMAP), palette::PAPER);
     assert_eq!(remap_theme(TEXT_PRIMARY, LIGHT_REMAP), palette::INK);
@@ -887,14 +844,14 @@ fn brand_gradient_spans_deep_to_bright_accent() {
 }
 
 #[test]
-fn identity_gradient_spans_deep_to_bright_identity() {
-    assert_eq!(identity_gradient(0.0), IDENTITY_DEEP);
-    assert_eq!(identity_gradient(1.0), IDENTITY_BRIGHT);
+fn gold_gradient_spans_deep_to_bright_gold() {
+    assert_eq!(gold_gradient(0.0), GOLD_DEEP);
+    assert_eq!(gold_gradient(1.0), GOLD_BRIGHT);
     for i in 0..=20 {
-        let _ = identity_gradient(f64::from(i) / 20.0);
+        let _ = gold_gradient(f64::from(i) / 20.0);
     }
-    assert_eq!(identity_gradient(-1.0), IDENTITY_DEEP);
-    assert_eq!(identity_gradient(2.0), IDENTITY_BRIGHT);
+    assert_eq!(gold_gradient(-1.0), GOLD_DEEP);
+    assert_eq!(gold_gradient(2.0), GOLD_BRIGHT);
 }
 
 #[test]

--- a/crates/stella-tui/src/tool_class.rs
+++ b/crates/stella-tui/src/tool_class.rs
@@ -8,9 +8,9 @@
 //! A transcript is a log of actions, and the first question a reader asks of
 //! any row is not *which* tool ran but what kind of thing it did: was that a
 //! look, a change, an opaque external call, a hand-off to another agent? Every
-//! tool name used to render in one colour — the brand accent — so answering
-//! that question meant reading each name and recalling what it does. Twenty
-//! rows in, nobody does. The rest of the transcript was one neutral end to end,
+//! tool name used to render in one colour — the brand gold — so answering that
+//! question meant reading each name and recalling what it does. Twenty rows in,
+//! nobody does. The rest of the transcript was one warm neutral end to end,
 //! which is the state the deck's own owner described as "impossible to discern
 //! what is reasoning prose and what is a real tool call".
 //!
@@ -37,7 +37,7 @@
 //! # Colour law
 //!
 //! Every class hue is categorical (`crate::palette`'s `data-*` series) and
-//! therefore *not* the brand accent: ion means brand/active/focus and nothing
+//! therefore *not* the brand accent: gold means brand/active/focus and nothing
 //! else, and a tool name is none of those. `crate::theme`'s
 //! `every_tool_class_is_categorical_and_distinct` is the enforcement.
 
@@ -76,7 +76,7 @@ impl ToolClass {
     /// palette law test walks these values.
     pub fn color(self) -> Color {
         match self {
-            ToolClass::Inspect => theme::JADE,
+            ToolClass::Inspect => theme::TEAL,
             ToolClass::Mutate => theme::MAGENTA,
             ToolClass::Execute => theme::VIOLET,
             ToolClass::Delegate => theme::ORCHID,

--- a/crates/stella-tui/src/views/subagents.rs
+++ b/crates/stella-tui/src/views/subagents.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! The `◆` mark is [`theme::SUBAGENT`] — a categorical role deliberately
-//! distinct from the lead's ion `✦`. Focus stays on the existing
+//! distinct from the lead's gold `✦`. Focus stays on the existing
 //! focused-agent mechanism (`ui.focused` via the AGENTS tab / `⏎`); these
 //! rows render the *other* lanes under whichever agent is focused, so they
 //! only appear when the focused lane is not itself a subagent.

--- a/crates/stella-tui/tests/progress_brand_fill.rs
+++ b/crates/stella-tui/tests/progress_brand_fill.rs
@@ -7,9 +7,9 @@
 //! painted fill cell carries the brand accent, which pins the fill to whatever
 //! `theme::BRAND_STOPS` currently is rather than to a hue this file names.
 //!
-//! Deliberately *not* a hue predicate. An earlier version asserted `r > b`
-//! ("gold is warm") — a predicate the ion recolour would have inverted, which
-//! is exactly how an assertion drifts away from the palette it guards. The
+//! Deliberately *not* a hue predicate. The previous version asserted `r > b`
+//! ("gold is warm"), and inverting that by hand on every recolour is exactly
+//! how an assertion drifts away from the palette it is meant to guard. The
 //! gradient interpolates between the two brand stops, so a fill cell is
 //! correct iff it lies on the segment between them.
 
@@ -94,8 +94,7 @@ fn progress_bar_fill_rides_the_brand_gradient() {
         //
         // Both are read off `BRAND_STOPS`, so the next recolour re-derives them
         // instead of needing this file edited. That is the whole point: the
-        // version this replaced hardcoded "gold is warm, so r > b", which the
-        // ion recolour would
+        // version this replaced hardcoded "gold is warm, so r > b", which would
         // have had to be inverted by hand — and an assertion maintained by hand
         // against a palette is one that eventually disagrees with it.
         for (got, lo, chan) in [

--- a/website/public/presentations/investor-deck.html
+++ b/website/public/presentations/investor-deck.html
@@ -29,20 +29,20 @@
 @font-face { font-family: "JetBrains Mono"; font-style: normal; font-weight: 800; font-display: swap; src: url("../brand/fonts/jetbrains-mono-latin-800-normal.woff2") format("woff2"); }
 
 :root {
-  --gold: #00D1F9;
-  --gold-deep: #00778F;
-  --gold-300: #72E1FF;
-  --ink: #070B10;
-  --ink-soft: #12181D;
-  --paper: #E9EDF2;
-  --sheet: #E9EDF2;
-  --sheet-deep: #DBE2EA;
-  --sheet-line: #A7AEB6;
-  --surface: #12181d;
-  --border: #1F262D;
-  --muted: #9299A1;
-  --pass: #54D14F;
-  --fail: #E25DC2;
+  --gold: #D6A526;
+  --gold-deep: #8B6720;
+  --gold-300: #E6C76A;
+  --ink: #10100F;
+  --ink-soft: #181714;
+  --paper: #F2EEE5;
+  --sheet: #F4EFE4;
+  --sheet-deep: #E9E0D0;
+  --sheet-line: #C8BDAA;
+  --surface: #171614;
+  --border: #232327;
+  --muted: #9B9890;
+  --pass: #2FD3C6;
+  --fail: #E4408F;
   --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   --display: "Space Grotesk", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
   --ease-arrive: cubic-bezier(0.22, 0.9, 0.35, 1);
@@ -141,10 +141,10 @@ body {
   --paper: var(--ink-soft);
   --surface: var(--sheet-deep);
   --border: var(--sheet-line);
-  --muted: #60666D;
-  --gold: #00778F;
-  --gold-deep: #005769;
-  --gold-300: #00778F;
+  --muted: #6C6458;
+  --gold: #865D08;
+  --gold-deep: #654500;
+  --gold-300: #865D08;
 }
 .slide.tone-paper::before {
   content: "";
@@ -168,13 +168,13 @@ body {
   pointer-events: none;
 }
 .slide.tone-paper .term {
-  color: #E9EDF2;
-  --paper: #E9EDF2;
-  --surface: #12181d;
-  --border: #2F353B;
-  --muted: #90979E;
-  --gold: #00D1F9;
-  --gold-deep: #00778F;
+  color: #F2EEE5;
+  --paper: #F2EEE5;
+  --surface: #171614;
+  --border: #403B34;
+  --muted: #AAA398;
+  --gold: #D6A526;
+  --gold-deep: #8B6720;
 }
 
 .overline { font-size: 0.8rem; font-weight: 500; letter-spacing: 0.18em; color: var(--gold); margin-bottom: 14px; }
@@ -443,7 +443,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
 
 <div class="texture" aria-hidden="true"></div>
 <svg class="starfield" aria-hidden="true" viewBox="0 0 1600 900" preserveAspectRatio="none">
-  <g fill="#E9EDF2">
+  <g fill="#F2EEE5">
     <circle cx="140" cy="120" r="1.2" style="--o:.16"/><circle cx="420" cy="80" r="0.9" style="--o:.10;animation-delay:-1s"/>
     <circle cx="820" cy="150" r="1.1" style="--o:.13;animation-delay:-2s"/><circle cx="1240" cy="90" r="0.8" style="--o:.10;animation-delay:-3s"/>
     <circle cx="1520" cy="210" r="1.2" style="--o:.14;animation-delay:-4s"/><circle cx="240" cy="520" r="0.9" style="--o:.09;animation-delay:-5s"/>
@@ -451,7 +451,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <circle cx="1100" cy="740" r="0.9" style="--o:.10;animation-delay:-3.5s"/><circle cx="1460" cy="600" r="1.2" style="--o:.15;animation-delay:-4.5s"/>
     <circle cx="980" cy="420" r="0.8" style="--o:.08;animation-delay:-0.5s"/><circle cx="1330" cy="380" r="0.9" style="--o:.10;animation-delay:-5.5s"/>
   </g>
-  <g fill="#00D1F9">
+  <g fill="#D6A526">
     <circle cx="560" cy="260" r="1.1" style="--o:.14;animation-delay:-2.2s"/><circle cx="1560" cy="820" r="1.0" style="--o:.12;animation-delay:-3.8s"/>
     <circle cx="60" cy="360" r="0.9" style="--o:.10;animation-delay:-1.2s"/>
   </g>
@@ -461,10 +461,10 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
 
 <div class="chrome brand">
   <svg width="22" height="22" viewBox="0 0 96 96" fill="none" aria-hidden="true">
-    <line x1="10" y1="48" x2="30" y2="48" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-    <line x1="18" y1="34" x2="30" y2="34" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-    <line x1="18" y1="62" x2="30" y2="62" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-    <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#00D1F9"/>
+    <line x1="10" y1="48" x2="30" y2="48" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+    <line x1="18" y1="34" x2="30" y2="34" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+    <line x1="18" y1="62" x2="30" y2="62" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+    <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#D6A526"/>
   </svg>
   <span>stella · oxagen</span>
 </div>
@@ -483,10 +483,10 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <p class="overline rise">oxagen · investor briefing · august 2026</p>
         <div class="lockup rise" style="--d:1">
           <svg class="comet" width="80" height="80" viewBox="0 0 96 96" fill="none" aria-hidden="true">
-            <line x1="10" y1="48" x2="30" y2="48" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-            <line x1="18" y1="34" x2="30" y2="34" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-            <line x1="18" y1="62" x2="30" y2="62" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-            <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#00D1F9"/>
+            <line x1="10" y1="48" x2="30" y2="48" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+            <line x1="18" y1="34" x2="30" y2="34" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+            <line x1="18" y1="62" x2="30" y2="62" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+            <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#D6A526"/>
           </svg>
           <div class="wordmark">stella<sup>*</sup></div>
         </div>
@@ -575,7 +575,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <p class="lead rise" style="--d:2">The most valuable thing your team makes with a coding tool is not the code. It is the traces: every step, every fix, every decision. Today they vanish into someone else's model.</p>
     <div class="body cols c-2">
       <svg class="dia rise" style="--d:3" viewBox="0 0 660 232" role="img" aria-label="diagram: today, your engineers' traces flow out of your network into a frontier lab's shared model, which every competitor also rents">
-        <text class="lbl" x="0" y="14" fill="#9299A1">TODAY</text>
+        <text class="lbl" x="0" y="14" fill="#9B9890">TODAY</text>
         <rect class="box" x="0" y="34" width="240" height="182" rx="12" stroke-dasharray="5 5"/>
         <text class="sm" x="120" y="58" text-anchor="middle">your network</text>
         <rect class="box" x="28" y="80" width="184" height="44" rx="8"/><text class="lbl" x="120" y="108" text-anchor="middle">your engineers</text>
@@ -589,18 +589,18 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <text class="sm ff" x="306" y="162" text-anchor="middle">your asset, leaving</text>
       </svg>
       <svg class="dia rise" style="--d:4" viewBox="0 0 660 232" role="img" aria-label="diagram: with stella, traces are verified and stay inside your network and train a private model that is yours alone; nothing crosses the boundary">
-        <text class="lbl" x="0" y="14" fill="#00D1F9">WITH STELLA</text>
+        <text class="lbl" x="0" y="14" fill="#D6A526">WITH STELLA</text>
         <rect class="boxg" x="0" y="34" width="470" height="182" rx="12" stroke-width="1.5"/>
         <text class="sm" x="235" y="58" text-anchor="middle">your network</text>
         <rect class="box" x="28" y="80" width="180" height="44" rx="8"/><text class="lbl" x="118" y="108" text-anchor="middle">your engineers</text>
         <rect class="box" x="28" y="150" width="180" height="44" rx="8"/><text class="lbl" x="118" y="178" text-anchor="middle">verified traces</text>
         <path class="ln lng" d="M118 124 V150" stroke-width="1.5"/>
         <path class="lng flow" d="M208 172 H262" stroke-width="2" marker-end="url(#ar-gold)"/>
-        <rect class="box" x="272" y="116" width="172" height="94" rx="10" stroke="#00D1F9"/>
+        <rect class="box" x="272" y="116" width="172" height="94" rx="10" stroke="#D6A526"/>
         <text class="lbl gd" x="358" y="152" text-anchor="middle">your model</text>
         <text class="sm" x="358" y="174" text-anchor="middle">yours alone</text>
         <path class="lnf" d="M480 149 H560" stroke-width="2" stroke-dasharray="5 5"/>
-        <g stroke="#E25DC2" stroke-width="2.5"><line x1="510" y1="134" x2="534" y2="164"/><line x1="534" y1="134" x2="510" y2="164"/></g>
+        <g stroke="#E4408F" stroke-width="2.5"><line x1="510" y1="134" x2="534" y2="164"/><line x1="534" y1="134" x2="510" y2="164"/></g>
         <text class="sm ff" x="600" y="154" text-anchor="middle">0 bytes</text>
       </svg>
     </div>
@@ -619,7 +619,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <p class="lead rise" style="--d:2">Oxagen replaced the judge with an oracle. A task is done only when a witness test proves it — failing on the old code, passing on the new. Not an opinion. A flip.</p>
     <div class="body cols c-5-7">
       <svg class="dia rise" style="--d:3" viewBox="0 0 560 340" role="img" aria-label="diagram: an independent verifier writes one witness test in a shadow sandbox; run against the old code it must fail, run against the new code it must pass; if the worker touched the witness, the flip is void">
-        <rect class="box" x="150" y="0" width="260" height="52" rx="10" stroke="#00D1F9"/>
+        <rect class="box" x="150" y="0" width="260" height="52" rx="10" stroke="#D6A526"/>
         <text class="lbl gd" x="280" y="24" text-anchor="middle">independent verifier</text>
         <text class="sm" x="280" y="42" text-anchor="middle">separate model · shadow sandbox</text>
         <path class="ln lng draw" d="M280 52 V96" stroke-width="1.5" marker-end="url(#ar-gold)"/>
@@ -627,10 +627,10 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <text class="lbl" x="280" y="124" text-anchor="middle">one witness test</text>
         <path class="ln draw" d="M280 140 V168 H92 V196" stroke-width="1.5" marker-end="url(#ar-mute)"/>
         <path class="ln draw" d="M280 140 V168 H468 V196" stroke-width="1.5" marker-end="url(#ar-mute)"/>
-        <rect class="box" x="12" y="196" width="160" height="76" rx="10" stroke="#E25DC2"/>
+        <rect class="box" x="12" y="196" width="160" height="76" rx="10" stroke="#E4408F"/>
         <text class="lbl" x="92" y="222" text-anchor="middle">old code</text>
         <text class="lbl ff" x="92" y="250" text-anchor="middle">&#10007; must fail</text>
-        <rect class="box" x="388" y="196" width="160" height="76" rx="10" stroke="#54D14F"/>
+        <rect class="box" x="388" y="196" width="160" height="76" rx="10" stroke="#2FD3C6"/>
         <text class="lbl" x="468" y="222" text-anchor="middle">new code</text>
         <text class="lbl fp" x="468" y="250" text-anchor="middle">&#10003; must pass</text>
         <path class="lng flow" d="M172 234 H388" stroke-width="2" marker-end="url(#ar-gold)"/>
@@ -727,7 +727,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
       <path class="ln lng draw" d="M510 30 H770" stroke-width="1.5" marker-end="url(#ar-gold)"/>
       <path class="ln lng draw" d="M910 30 H1170" stroke-width="1.5" marker-end="url(#ar-gold)"/>
       <path class="ln lng draw" d="M1310 46 C1370 104 50 104 110 46" stroke-width="1.5" stroke-dasharray="6 6" marker-end="url(#ar-gold)"/>
-      <g class="sm" text-anchor="middle" fill="#E9EDF2" font-weight="700">
+      <g class="sm" text-anchor="middle" fill="#F2EEE5" font-weight="700">
         <text x="55" y="35">work</text><text x="440" y="35">witness</text><text x="840" y="35">lesson</text><text x="1240" y="35">next cycle</text>
       </g>
       <text class="sm" x="710" y="70" text-anchor="middle">the commit history is the audit trail</text>
@@ -767,8 +767,8 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
       </svg>
       <div class="rise" style="--d:4">
         <svg class="dia" viewBox="0 0 420 230" role="img" aria-label="venn diagram of the 89 task panel: 36 tasks solved by both arms, 22 solved only by stella, 8 solved only by Claude Code, 23 solved by neither">
-          <circle cx="165" cy="110" r="86" fill="rgb(214 165 38 / 0.12)" stroke="#00D1F9" stroke-width="1.5"/>
-          <circle cx="255" cy="110" r="86" fill="rgb(155 152 144 / 0.10)" stroke="#1F262D" stroke-width="1.5"/>
+          <circle cx="165" cy="110" r="86" fill="rgb(214 165 38 / 0.12)" stroke="#D6A526" stroke-width="1.5"/>
+          <circle cx="255" cy="110" r="86" fill="rgb(155 152 144 / 0.10)" stroke="#232327" stroke-width="1.5"/>
           <text class="lbl gd" x="100" y="106" text-anchor="middle" font-size="22" font-weight="800">22</text>
           <text class="sm" x="100" y="126" text-anchor="middle">stella only</text>
           <text class="lbl" x="210" y="106" text-anchor="middle" font-size="18" font-weight="800">36</text>
@@ -807,17 +807,17 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
       <svg class="dia rise" style="--d:3" viewBox="0 0 700 348" role="img" aria-label="diagram: a closed loop of run, verify, learn and compound; steps one to three ship today and step four is what this raise builds">
         <circle cx="350" cy="174" r="104" class="ln lng spin" stroke-width="1.5" stroke-dasharray="10 12" fill="none"/>
         <g>
-          <rect class="box" x="190" y="8" width="320" height="56" rx="10" stroke="#00D1F9"/>
+          <rect class="box" x="190" y="8" width="320" height="56" rx="10" stroke="#D6A526"/>
           <text class="lbl gd" x="350" y="32" text-anchor="middle">1 · RUN</text>
           <text class="sm" x="350" y="52" text-anchor="middle">real work in your environment, under RBAC</text>
         </g>
         <g>
-          <rect class="box" x="470" y="146" width="230" height="56" rx="10" stroke="#00D1F9"/>
+          <rect class="box" x="470" y="146" width="230" height="56" rx="10" stroke="#D6A526"/>
           <text class="lbl gd" x="585" y="170" text-anchor="middle">2 · VERIFY</text>
           <text class="sm" x="585" y="190" text-anchor="middle">deterministic gates, not guesses</text>
         </g>
         <g>
-          <rect class="box" x="190" y="284" width="320" height="56" rx="10" stroke="#00D1F9"/>
+          <rect class="box" x="190" y="284" width="320" height="56" rx="10" stroke="#D6A526"/>
           <text class="lbl gd" x="350" y="308" text-anchor="middle">3 · LEARN</text>
           <text class="sm" x="350" y="328" text-anchor="middle">goal · diff · proof land in your store</text>
         </g>
@@ -882,7 +882,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <div class="body cols c-6-4">
       <svg class="dia rise" style="--d:3" viewBox="0 0 700 250" role="img" aria-label="diagram of the routing thesis: deterministic tools do deterministic work at zero inference cost, a model tuned on your traces does the routine work, and frontier models are called only where novelty earns them">
         <text class="sm" x="0" y="12">THE ROUTING THESIS &mdash; cheapest capable layer first</text>
-        <rect class="box" x="0" y="30" width="700" height="58" rx="10" stroke="#00D1F9"/>
+        <rect class="box" x="0" y="30" width="700" height="58" rx="10" stroke="#D6A526"/>
         <text class="lbl gd" x="20" y="56">deterministic tools</text>
         <text class="sm" x="20" y="76">parse, edit, search, run, diff — a strict IO contract, no model in the loop</text>
         <text class="lbl gd" x="680" y="64" text-anchor="end">$0</text>
@@ -920,7 +920,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <path class="ln lng" d="M42 282 V22" stroke-width="1.5" marker-end="url(#ar-gold)"/>
         <text class="sm gd" transform="rotate(-90 22 152)" x="22" y="152" text-anchor="middle">cost of the oracle</text>
         <path class="ln lng draw" d="M60 268 H440 V186 H860 V104 H1300" stroke-width="2"/>
-        <rect class="box" x="82" y="188" width="340" height="72" rx="10" stroke="#00D1F9"/>
+        <rect class="box" x="82" y="188" width="340" height="72" rx="10" stroke="#D6A526"/>
         <text class="lbl gd" x="102" y="214">1 · WEDGE &mdash; software engineering</text>
         <text class="sm" x="102" y="236">free, instant, already running: tests,</text>
         <text class="sm" x="102" y="252">compilers, type checkers, benchmarks</text>
@@ -950,7 +950,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <div class="body cols c-7-5">
       <svg class="dia rise" style="--d:3" viewBox="0 0 820 390" role="img" aria-label="three forces converge on a market window: open-model capability, falling inference cost, and enterprise demand">
         <defs>
-          <marker id="ar-now" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0 L10 5 L0 10 z" fill="#00D1F9"/></marker>
+          <marker id="ar-now" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0 L10 5 L0 10 z" fill="#D6A526"/></marker>
         </defs>
         <text class="sm" x="12" y="26">THE CONVERGENCE</text>
         <rect class="box" x="12" y="52" width="258" height="82" rx="12"/>
@@ -968,8 +968,8 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
         <path class="lng draw" d="M282 93 C430 93 430 190 570 190" stroke-width="2" marker-end="url(#ar-now)"/>
         <path class="lng draw" d="M282 195 H570" stroke-width="2" marker-end="url(#ar-now)"/>
         <path class="lng draw" d="M282 297 C430 297 430 200 570 200" stroke-width="2" marker-end="url(#ar-now)"/>
-        <circle cx="650" cy="195" r="108" fill="#12181d" stroke="#00778F" stroke-width="1"/>
-        <circle class="pulse" cx="650" cy="195" r="78" fill="none" stroke="#00D1F9" stroke-width="2"/>
+        <circle cx="650" cy="195" r="108" fill="#171614" stroke="#8B5E1A" stroke-width="1"/>
+        <circle class="pulse" cx="650" cy="195" r="78" fill="none" stroke="#D6A526" stroke-width="2"/>
         <text class="sm gd" x="650" y="166" text-anchor="middle">THE WINDOW</text>
         <text class="lbl" x="650" y="194" text-anchor="middle">verified, private</text>
         <text class="lbl" x="650" y="218" text-anchor="middle">AI infrastructure</text>
@@ -996,7 +996,7 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <div class="body">
       <svg class="dia rise" style="--d:3; max-height: 210px;" viewBox="0 0 1420 210" role="img" aria-label="diagram: land on verification with one team, expand to governing every agent in the organization, anchor on a private model trained on the customer's own data">
         <path class="lng flow" d="M40 172 H1380" stroke-width="2" marker-end="url(#ar-gold)"/>
-        <rect class="box" x="40" y="18" width="410" height="128" rx="12" stroke="#00D1F9"/>
+        <rect class="box" x="40" y="18" width="410" height="128" rx="12" stroke="#D6A526"/>
         <text class="lbl gd" x="64" y="48">LAND</text>
         <text class="lbl" x="64" y="76" font-size="17">Verification</text>
         <text class="sm" x="64" y="100">prove trust on one team — the sharpest</text>
@@ -1107,10 +1107,10 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
     <div style="margin: auto 0;">
       <div class="lockup rise">
         <svg class="comet" width="72" height="72" viewBox="0 0 96 96" fill="none" aria-hidden="true">
-          <line x1="10" y1="48" x2="30" y2="48" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-          <line x1="18" y1="34" x2="30" y2="34" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-          <line x1="18" y1="62" x2="30" y2="62" stroke="#00D1F9" stroke-width="7" stroke-linecap="round"/>
-          <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#00D1F9"/>
+          <line x1="10" y1="48" x2="30" y2="48" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+          <line x1="18" y1="34" x2="30" y2="34" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+          <line x1="18" y1="62" x2="30" y2="62" stroke="#D6A526" stroke-width="7" stroke-linecap="round"/>
+          <path d="M64 26 C65.65 39.2 72.8 46.35 86 48 C72.8 49.65 65.65 56.8 64 70 C62.35 56.8 55.2 49.65 42 48 C55.2 46.35 62.35 39.2 64 26 Z" fill="#D6A526"/>
         </svg>
       </div>
       <h2 class="rise" style="--d:1; margin-top: 18px;"><em>verified done,</em><br>not claimed done.</h2>
@@ -1187,10 +1187,10 @@ a.ref { color: var(--gold); text-decoration: none; border-bottom: 1px solid var(
 <svg width="0" height="0" aria-hidden="true" style="position:absolute">
   <defs>
     <marker id="ar-gold" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#00D1F9"/>
+      <path d="M0 0 L10 5 L0 10 z" fill="#D6A526"/>
     </marker>
     <marker id="ar-mute" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#1F262D"/>
+      <path d="M0 0 L10 5 L0 10 z" fill="#232327"/>
     </marker>
   </defs>
 </svg>


### PR DESCRIPTION
## What & why

`d6ba4b7` (feat(brand): recolour the whole system — Ion on Obsidian, brand kit
v3.0, #3658) recoloured every Stella surface at once — website, docs/brand
kit, Observatory, MCP OAuth page, the CLI's export dashboard, the terminal
(Command Deck + plain-mode CLI output), and the investor deck — moving all of
them off the gold identity onto a cyan "Ion on Obsidian" palette.

Feedback on the result: keep the new brand everywhere it landed, **except**
the terminal and the investor deck — revert those two back to the gold
palette they had immediately before that PR.

This PR checks out the pre-#3658 (`d6ba4b7^`) content of exactly the files
that paint those two surfaces:

- `crates/stella-tui/**` — the Command Deck's palette, theme (+ tests),
  markdown/splash/progress/deck rendering
- `crates/stella-cli/src/plain.rs`, `command_deck/theme_cmd.rs`,
  `storage_cmd.rs` — the plain-mode `/color` default, `/theme` blurb, and
  `stella observe` banner, all of which mirror the terminal's accent for
  consistency with `stella-tui`
- `website/public/presentations/investor-deck.html` — the deck

Nothing else `d6ba4b7` touched is part of this change: the website's global
brand tokens, `docs/brand/`, the Observatory, the CLI's export dashboard, and
the MCP OAuth landing page all keep the Ion brand. `git log d6ba4b7..HEAD`
touched none of the 15 reverted files, so nothing downstream is lost by the
checkout.

Closes #N

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because:

This is a straight content revert to a previously-shipped, previously-tested
state, not new behavior. The existing suite is the proof: on `main` (with the
Ion recolour), `stella-tui`'s `theme::tests::palette_law_ion_is_the_brand` and
`stella-cli`'s `plain::tests::default_accent_is_ion` assert the cyan values;
after this revert those tests are gone (reverted along with their file) and
the pre-#3658 tests they replaced — `palette_law_gold_is_the_brand`,
`default_accent_is_gold`, etc. — are back and pass, i.e. the palette
assertions that failed against `main`'s code now pass against this branch's.

### Deleted tests (`check-deleted-tests` acknowledgement)

Reverting `crates/stella-tui/src/theme/tests.rs` and
`crates/stella-cli/src/plain.rs` to their pre-`d6ba4b7` content removes five
Ion-era tests that exist on `main`:

- `palette_law_ion_is_the_brand`
- `identity_never_carries_a_verdict`
- `identity_gradient_spans_deep_to_bright_identity`
- `h1_is_a_high_contrast_accent_pill`
- `default_accent_is_ion`

Each is replaced one-for-one by the gold-era test it had itself replaced in
`d6ba4b7` (`palette_law_gold_is_the_brand`, `gold_never_carries_a_verdict`,
`gold_gradient_spans_deep_to_bright_gold`, `h1_is_a_high_contrast_gold_pill`,
`default_accent_is_gold`), which are back in the tree and passing. This is a
deliberate revert, not an accidental loss.

## The gate

- [x] `cargo fmt --check -p stella-tui -p stella-cli`
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui --lib --tests` (all green, including
      `progress_brand_fill`)
- [x] `cargo test -p stella-cli --bin stella plain::` / `theme_cmd` (all
      green, including `default_accent_is_gold`)
- [x] `cargo test -p stella-cli --test design_token_parity` (all 7 pass
      unchanged — that suite checks the brand kit against the
      Observatory/website, not the TUI, so it's correctly untouched by this
      revert)
- [x] `make no-scratch`, `make left-behind`
- [x] `./scripts/check-deleted-tests.sh origin/main HEAD` — OK, 5 removed
      tests, each named above
- [ ] Docs updated where behavior/flags changed — N/A, no flags or docs text
      changed beyond the reverted source comments/blurbs themselves
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

This is a partial revert of a large, deliberate PR (#3658) — I kept the new
Ion brand everywhere except the two surfaces called out as unwanted (terminal
+ investor deck). If the intent was actually to revert the *whole* rebrand,
say so and I'll extend this to the rest of the file list.

The only red CI status is Vercel's deployment check ("Account is blocked") —
a Vercel account/billing issue unrelated to this diff.
