### PR TITLE
stella-transcript: match the reference mockups' chip/fold conventions; extend word-level diffs to export and TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "stella-runtime",
  "stella-store",
  "stella-tools",
+ "stella-transcript",
  "stella-tty",
  "stella-tui",
  "tempfile",

--- a/crates/stella-cli/Cargo.toml
+++ b/crates/stella-cli/Cargo.toml
@@ -57,6 +57,7 @@ stella-model = { path = "../stella-model" }
 # The pure unified differ behind `stella inspect --diff`, extracted to a leaf
 # crate (#1511) so the Observatory's prompt-diff route shares it.
 stella-diff = { path = "../stella-diff", features = ["json"] }
+stella-transcript = { path = "../stella-transcript" }
 # The plugin manifest and its consent rendering (#3245, #3380). The loader
 # (`stella plugin install|list|remove`) is a client of this crate and nothing
 # more: parsing, validation and the words shown at install all live there, so

--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -761,6 +761,12 @@ fn render_dashboard(
   .dx-line.add .sg {{ color: var(--ok); }}
   .dx-line.rem {{ background: rgba(255, 92, 122, .10); color: var(--text); }}
   .dx-line.rem .sg {{ color: var(--bad); }}
+  /* Word-level highlight: the exact changed tokens inside a paired
+     removal/addition, a stronger wash of the same hue the row already
+     carries — never a third colour, so the rule stays "the row's tint says
+     which side, the token's tint says which part". */
+  .dx-line.add .ww {{ background: rgba(74, 222, 128, .34); }}
+  .dx-line.rem .ww {{ background: rgba(255, 92, 122, .34); }}
   /* The elision sits between the hunks it replaces, so it has to read as
      unmistakably not a line of the file: raised ground, centred, no gutter. */
   .dx-fold {{ color: var(--text-3); background: var(--raised); text-align: center;

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -636,9 +636,18 @@ fn escape(raw: &str) -> String {
 }
 
 /// One file change's diff as the archive's `.dx` block: both line-number
-/// gutters, a sigil column, and a tinted row per change — the same shape the
-/// Observatory draws and the deck draws, because this archive is read side by
-/// side with them as evidence on a pull request.
+/// gutters, a sigil column, a tinted row per change, and — within a modified
+/// line pair — a second, stronger tint over the exact tokens that changed.
+/// The same shape the Observatory draws and the deck draws, because this
+/// archive is read side by side with them as evidence on a pull request.
+///
+/// Word-level highlighting is [`stella_transcript::word::highlight`], the
+/// same LCS-over-tokens pass the transcript surfaces use, reused rather than
+/// re-implemented: two copies of a diff tokenizer drift exactly the way two
+/// copies of a diff renderer did before this module existed. It paints with
+/// this page's own `--ok`/`--bad` tokens, not a new hue — this page's colour
+/// system is closed to categorical hues until #3630 settles that question for
+/// the transcript surfaces generally.
 ///
 /// Only the changed lines and their context, never a file listing, and never
 /// more than [`stella_diff::view::VIEW_CAP`] of them: the elided middle is
@@ -679,40 +688,7 @@ fn diff_html(diff: &str) -> String {
         // `elide` re-headers a hunk it splits: the tail's gutter has to name
         // the file's real lines, not restart from the head's.
         let (mut old_no, mut new_no) = (hunk.old_start, hunk.new_start);
-        for line in &hunk.lines {
-            let (class, sigil) = match line.op {
-                stella_diff::Op::Add => (" add", "+"),
-                stella_diff::Op::Remove => (" rem", "−"),
-                stella_diff::Op::Equal => ("", " "),
-            };
-            let old_cell = if line.op == stella_diff::Op::Add {
-                String::new()
-            } else {
-                let n = old_no;
-                old_no += 1;
-                n.to_string()
-            };
-            let new_cell = if line.op == stella_diff::Op::Remove {
-                String::new()
-            } else {
-                let n = new_no;
-                new_no += 1;
-                n.to_string()
-            };
-            let _ = write!(
-                out,
-                r#"<div class="dx-line{class}"><span class="no">{old_cell}</span>"#,
-            );
-            let _ = write!(
-                out,
-                r#"<span class="nn">{new_cell}</span><span class="sg">{sigil}</span>"#,
-            );
-            let _ = write!(
-                out,
-                r#"<span class="tx">{}</span></div>"#,
-                escape(&line.text)
-            );
-        }
+        diff_hunk_rows(&hunk.lines, &mut old_no, &mut new_no, &mut out);
         out.push_str("</div>");
     }
     if view.fold_before == Some(view.hunks.len()) {
@@ -720,6 +696,137 @@ fn diff_html(diff: &str) -> String {
     }
     out.push_str("</div>");
     out
+}
+
+/// Emit one hunk's rows, pairing each run of removals with the run of
+/// additions that follows it — positional, the `k`th removal against the
+/// `k`th addition — so a modified line gets word-level spans. Mirrors
+/// `stella_transcript::file_diff::render_hunk`'s block-pairing exactly;
+/// duplicated here rather than shared because that function consumes a
+/// `FileChange`'s raw before/after text, and this page already holds a
+/// parsed, elided `stella_diff::Hunk` with no text to rebuild it from.
+fn diff_hunk_rows(
+    lines: &[stella_diff::DiffLine],
+    old_no: &mut usize,
+    new_no: &mut usize,
+    out: &mut String,
+) {
+    let mut i = 0;
+    while i < lines.len() {
+        match lines[i].op {
+            stella_diff::Op::Equal => {
+                diff_row(
+                    " ",
+                    "",
+                    *old_no,
+                    *new_no,
+                    &[stella_transcript::word::Span {
+                        text: lines[i].text.clone(),
+                        changed: false,
+                    }],
+                    out,
+                );
+                *old_no += 1;
+                *new_no += 1;
+                i += 1;
+            }
+            stella_diff::Op::Remove | stella_diff::Op::Add => {
+                let start = i;
+                while i < lines.len() && lines[i].op == stella_diff::Op::Remove {
+                    i += 1;
+                }
+                let removals = &lines[start..i];
+                let add_start = i;
+                while i < lines.len() && lines[i].op == stella_diff::Op::Add {
+                    i += 1;
+                }
+                let additions = &lines[add_start..i];
+                diff_change_block(removals, additions, old_no, new_no, out);
+            }
+        }
+    }
+}
+
+/// One run of removals followed by its run of additions, word-highlighted
+/// where they pair. See [`diff_hunk_rows`] for why this duplicates
+/// `stella_transcript::file_diff::emit_change_block` rather than calling it.
+fn diff_change_block(
+    removals: &[stella_diff::DiffLine],
+    additions: &[stella_diff::DiffLine],
+    old_no: &mut usize,
+    new_no: &mut usize,
+    out: &mut String,
+) {
+    let paired = removals.len().min(additions.len());
+    let mut old_spans = Vec::with_capacity(removals.len());
+    let mut new_spans = Vec::with_capacity(additions.len());
+
+    for k in 0..paired {
+        let (o, n) = stella_transcript::word::highlight(&removals[k].text, &additions[k].text);
+        old_spans.push(o);
+        new_spans.push(n);
+    }
+    for line in &removals[paired..] {
+        old_spans.push(vec![stella_transcript::word::Span {
+            text: line.text.clone(),
+            changed: false,
+        }]);
+    }
+    for line in &additions[paired..] {
+        new_spans.push(vec![stella_transcript::word::Span {
+            text: line.text.clone(),
+            changed: false,
+        }]);
+    }
+
+    for spans in &old_spans {
+        diff_row("−", " rem", *old_no, 0, spans, out);
+        *old_no += 1;
+    }
+    for spans in &new_spans {
+        diff_row("+", " add", 0, *new_no, spans, out);
+        *new_no += 1;
+    }
+}
+
+/// One `.dx-line` row. `old_no`/`new_no` of `0` renders as the empty gutter
+/// cell — the same convention the old flat loop used, now driven by which
+/// side actually has a line number rather than by `line.op` directly.
+fn diff_row(
+    sigil: &str,
+    class: &str,
+    old_no: usize,
+    new_no: usize,
+    spans: &[stella_transcript::word::Span],
+    out: &mut String,
+) {
+    let old_cell = if old_no == 0 {
+        String::new()
+    } else {
+        old_no.to_string()
+    };
+    let new_cell = if new_no == 0 {
+        String::new()
+    } else {
+        new_no.to_string()
+    };
+    let _ = write!(
+        out,
+        r#"<div class="dx-line{class}"><span class="no">{old_cell}</span>"#,
+    );
+    let _ = write!(
+        out,
+        r#"<span class="nn">{new_cell}</span><span class="sg">{sigil}</span>"#,
+    );
+    out.push_str(r#"<span class="tx">"#);
+    for span in spans {
+        if span.changed {
+            let _ = write!(out, r#"<span class="ww">{}</span>"#, escape(&span.text));
+        } else {
+            out.push_str(&escape(&span.text));
+        }
+    }
+    out.push_str("</span></div>");
 }
 
 /// Parse `events.ts` (`YYYY-MM-DD HH:MM:SS`) to Unix seconds.

--- a/crates/stella-cli/src/export/transcript/tests.rs
+++ b/crates/stella-cli/src/export/transcript/tests.rs
@@ -546,6 +546,57 @@ fn a_file_diff_renders_as_a_gutter_diff_rather_than_a_wall_of_text() {
 }
 
 #[test]
+fn a_modified_line_pair_highlights_only_the_changed_token() {
+    // A whole-line tint answers "did this line change"; a reviewer's real
+    // question is "what in it changed". Reuses
+    // `stella_transcript::word::highlight` — the same pass the transcript
+    // surfaces use — rather than a second tokenizer that could drift from it.
+    let event = AgentEvent::FileChange {
+        path: "app/main.tex".into(),
+        kind: stella_protocol::FileChangeKind::Modified,
+        added: 1,
+        removed: 1,
+        diff: Some(
+            "--- a/app/main.tex\n+++ b/app/main.tex\n\
+             @@ -1,1 +1,1 @@\n\
+             -\\setlength{\\parindent}{15pt}\n\
+             +\\setlength{\\parindent}{12pt}\n"
+                .to_string(),
+        ),
+    };
+    let out = render(&at(vec![event]), &no_prompts());
+    assert!(
+        out.body.contains(r#"<span class="ww">15pt</span>"#),
+        "the removed token should carry the word tint:\n{}",
+        out.body
+    );
+    assert!(
+        out.body.contains(r#"<span class="ww">12pt</span>"#),
+        "the added token should carry the word tint:\n{}",
+        out.body
+    );
+    assert!(
+        !out.body
+            .contains(r#"<span class="ww">\setlength{\parindent}{</span>"#),
+        "the unchanged prefix must not be tinted:\n{}",
+        out.body
+    );
+}
+
+#[test]
+fn an_unpaired_addition_carries_no_word_tint() {
+    // `a_rewrite` below is additions with no matching removals — there is
+    // nothing to compare each line against, so the honest answer is a plain
+    // line tint and zero word spans.
+    let out = render(&at(vec![a_rewrite(4)]), &no_prompts());
+    assert!(
+        !out.body.contains(r#"class="ww""#),
+        "an unpaired line has nothing to diff against:\n{}",
+        out.body
+    );
+}
+
+#[test]
 fn a_long_file_diff_shows_its_beginning_and_its_end_and_marks_the_middle() {
     // Only the changed lines, never the whole file, and never more of them
     // than the shared cap — with the elision stated where it happened. A

--- a/crates/stella-transcript/src/digest.rs
+++ b/crates/stella-transcript/src/digest.rs
@@ -163,11 +163,32 @@ impl Chip {
     }
 }
 
+/// How roomy a turn's token/cost rollup renders.
+///
+/// The web surface has a whole chip pill to spend on it (`41.2k → 388 tok`);
+/// the character grid is budgeting fixed terminal columns and wants the same
+/// numbers as tight as they'll go (`41.2k→388`). One computation
+/// ([`format_tokens`]), two acceptable spellings of its output — never two
+/// different numbers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChipStyle {
+    /// `41.2k→388` — no spaces, no unit suffix.
+    Tight,
+    /// `41.2k → 388 tok` — spaced arrow, unit suffix.
+    Roomy,
+}
+
 /// The chips for one step's accounting.
 ///
-/// Order is fixed — duration, size, tokens, cost — because a right-aligned chip
-/// row whose columns move between steps is unreadable at a glance, which is the
-/// only reason to render chips rather than prose in the first place.
+/// Order is fixed — spec badge, duration, size, cost — because a right-aligned
+/// chip row whose columns move between steps is unreadable at a glance, which
+/// is the only reason to render chips rather than prose in the first place.
+///
+/// Deliberately **no token count here**: a step is one call, and a column of
+/// per-call token counts is noise a reader has to sum by hand to answer the
+/// only question it actually has — what did this turn cost. That rollup is
+/// [`turn_digest`]'s job; a step shows only its own operational facts plus its
+/// own slice of the cost.
 #[must_use]
 pub fn step_chips(step: &Step) -> Vec<Chip> {
     let mut chips = Vec::new();
@@ -183,27 +204,32 @@ pub fn step_chips(step: &Step) -> Vec<Chip> {
             chips.push(Chip::mute(format!("{lines} ln")));
         }
     }
-    chips.extend(accounting_chips(step.accounting));
+    chips.extend(cost_chip(step.accounting.micros));
     chips
 }
 
-/// The chips for a token/cost rollup.
+/// The single cost chip, when there is a cost to show.
 #[must_use]
-pub fn accounting_chips(acc: Accounting) -> Vec<Chip> {
+fn cost_chip(micros: u64) -> Option<Chip> {
+    (micros > 0).then(|| Chip::toned(format_cost(micros), "cost"))
+}
+
+/// The chips for a token/cost rollup — a turn's total, never a single step's.
+///
+/// No separate cache indicator: `cached_in` is a cost-accounting input, not a
+/// fact a reader needs held up on its own chip.
+#[must_use]
+pub fn accounting_chips(acc: Accounting, style: ChipStyle) -> Vec<Chip> {
     let mut chips = Vec::new();
     if acc.tokens_in > 0 || acc.tokens_out > 0 {
-        chips.push(Chip::mute(format!(
-            "in {} · out {}",
-            format_tokens(acc.tokens_in),
-            format_tokens(acc.tokens_out)
-        )));
+        let (tin, tout) = (format_tokens(acc.tokens_in), format_tokens(acc.tokens_out));
+        let text = match style {
+            ChipStyle::Tight => format!("{tin}→{tout}"),
+            ChipStyle::Roomy => format!("{tin} → {tout} tok"),
+        };
+        chips.push(Chip::mute(text));
     }
-    if acc.cached_in > 0 {
-        chips.push(Chip::toned("cache", "ok"));
-    }
-    if acc.micros > 0 {
-        chips.push(Chip::toned(format_cost(acc.micros), "cost"));
-    }
+    chips.extend(cost_chip(acc.micros));
     chips
 }
 
@@ -329,7 +355,7 @@ pub fn step_digest(step: &Step, object_width: usize) -> StepDigest {
             object: String::new(),
             status: Status::Ok,
             delta: None,
-            chips: accounting_chips(step.accounting),
+            chips: cost_chip(step.accounting.micros).into_iter().collect(),
             monogram: '·',
             class: "xx",
         };
@@ -413,7 +439,7 @@ pub struct TurnDigest {
 
 /// Build a turn's collapsed digest.
 #[must_use]
-pub fn turn_digest(turn: &crate::model::Turn, width: usize) -> TurnDigest {
+pub fn turn_digest(turn: &crate::model::Turn, width: usize, style: ChipStyle) -> TurnDigest {
     // A turn's wall time reads as `m:ss` rather than as a step's `1.4s`: turns
     // run for minutes, and a column of `41.0s`/`132.0s` is harder to compare at
     // a glance than `0:41`/`2:12`.
@@ -421,7 +447,7 @@ pub fn turn_digest(turn: &crate::model::Turn, width: usize) -> TurnDigest {
         Chip::mute(format!("{} steps", turn.steps.len())),
         Chip::mute(format_offset(turn.duration_ms)),
     ];
-    chips.extend(accounting_chips(turn.rollup()));
+    chips.extend(accounting_chips(turn.rollup(), style));
     TurnDigest {
         name: turn.name.clone(),
         status: turn.status,

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -250,7 +250,7 @@ fn render_turn(out: &mut Vec<Line>, ctx: &Ctx<'_>, turn: &Turn, index: usize) {
 }
 
 fn turn_frame_top(turn: &Turn, open: bool, width: usize) -> Line {
-    let dig = digest::turn_digest(turn, 40);
+    let dig = digest::turn_digest(turn, 40, digest::ChipStyle::Tight);
     let mut line = vec![
         Cell::new("╭─ ", Color::Faint),
         Cell::new(&turn.name, Color::Violet).bold(),
@@ -260,10 +260,13 @@ fn turn_frame_top(turn: &Turn, open: bool, width: usize) -> Line {
             status_color(turn.status),
         ),
         Cell::new(" ", Color::Faint),
-        Cell::new(fold_mark(open), Color::Dim),
-        Cell::new(" ", Color::Faint),
     ];
+    // An expanded turn shows its content in full, so a fold marker on its own
+    // header would be an affordance for a click that does nothing new. Only a
+    // collapsed turn — whose header stands in for hidden content — gets one.
     if !open {
+        line.push(Cell::new(fold_mark(open), Color::Dim));
+        line.push(Cell::new(" ", Color::Faint));
         line.push(Cell::new(format!("\"{}\" ", dig.prompt_line), Color::Dim));
     }
 

--- a/crates/stella-transcript/src/html.rs
+++ b/crates/stella-transcript/src/html.rs
@@ -114,7 +114,7 @@ fn turn_block(out: &mut String, run: &Run, state: &FoldState, turn: &Turn, index
         status_word(turn.status),
     );
 
-    let dig = digest::turn_digest(turn, 64);
+    let dig = digest::turn_digest(turn, 64, digest::ChipStyle::Roomy);
     if !open {
         let _ = write!(
             out,

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -209,6 +209,39 @@ fn acceptance_toggling_a_fold_shifts_zero_columns() {
     assert_eq!(differing, vec![('▸', '▾')]);
 }
 
+/// An expanded turn's own content stands in for the fold affordance, so its
+/// header carries no marker; a collapsed turn's header is the only thing on
+/// screen and does carry one.
+#[test]
+fn a_turns_own_header_shows_a_fold_marker_only_when_collapsed() {
+    let run = run_with(vec![step(bash("ls", &["a"], Status::Ok), 0)]);
+    let turn = NodeId::Turn(0);
+
+    let mut open = FoldState::new();
+    open.open(turn);
+    let open_header = grid::to_plain(&grid::render(&run, &open, 100))
+        .lines()
+        .next()
+        .expect("turn frame top")
+        .to_string();
+    assert!(
+        !open_header.contains('▸') && !open_header.contains('▾'),
+        "an expanded turn header carried a fold marker: {open_header:?}"
+    );
+
+    let mut closed = FoldState::new();
+    closed.close(turn);
+    let closed_header = grid::to_plain(&grid::render(&run, &closed, 100))
+        .lines()
+        .next()
+        .expect("turn frame top")
+        .to_string();
+    assert!(
+        closed_header.contains('▸'),
+        "a collapsed turn header lost its fold marker: {closed_header:?}"
+    );
+}
+
 /// A failed step remains expanded after the run completes — the status pins it,
 /// so neither a zoom preset nor an explicit collapse closes it.
 #[test]
@@ -552,6 +585,57 @@ fn speculation_renders_as_a_badge_not_prose() {
     call.speculated = true;
     let chips = digest::step_chips(&step(call, 0));
     assert!(chips.iter().any(|c| c.text == "⚡ spec"));
+}
+
+/// A step is one call; the token rollup is a turn's job. Per-step chips carry
+/// only the step's own cost, never a token count or a cache indicator.
+#[test]
+fn a_step_digest_shows_cost_but_never_a_token_count() {
+    let chips = digest::step_chips(&step(bash("a", &[], Status::Ok), 0));
+    assert!(
+        chips.iter().any(|c| c.text == "$0.0008"),
+        "expected the step's own cost chip, got {chips:?}"
+    );
+    assert!(
+        chips.iter().all(|c| !c.text.contains('→')),
+        "a step chip carried a token rollup: {chips:?}"
+    );
+    assert!(
+        chips.iter().all(|c| c.text != "cache"),
+        "a step chip carried a cache indicator: {chips:?}"
+    );
+}
+
+#[test]
+fn a_turn_digest_carries_one_arrow_joined_token_chip_and_no_cache_chip() {
+    let run = run_with(vec![
+        step(bash("a", &[], Status::Ok), 0),
+        step(bash("b", &[], Status::Ok), 1),
+    ]);
+    let dig = digest::turn_digest(&run.turns[0], 64, digest::ChipStyle::Tight);
+    assert!(
+        dig.chips.iter().any(|c| c.text == "14.0k→68"),
+        "expected a tight arrow-joined token chip, got {:?}",
+        dig.chips
+    );
+    assert!(
+        dig.chips.iter().all(|c| c.text != "cache"),
+        "a turn chip carried a cache indicator: {:?}",
+        dig.chips
+    );
+}
+
+/// The web surface spends a whole chip pill on the same rollup the grid packs
+/// tight — same numbers, roomier punctuation.
+#[test]
+fn the_roomy_chip_style_spaces_the_arrow_and_labels_the_unit() {
+    let run = run_with(vec![step(bash("a", &[], Status::Ok), 0)]);
+    let dig = digest::turn_digest(&run.turns[0], 64, digest::ChipStyle::Roomy);
+    assert!(
+        dig.chips.iter().any(|c| c.text == "7.0k → 34 tok"),
+        "expected a roomy, unit-labelled token chip, got {:?}",
+        dig.chips
+    );
 }
 
 #[test]

--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -277,10 +277,19 @@ fn is_meta(line: &str) -> bool {
 /// Trimming the shared prefix and suffix off a `-`/`+` pair isolates the part
 /// that changed, which the body then paints brighter than the rest of the line.
 ///
-/// Pairing is deliberately conservative: only a run of removals immediately
-/// followed by an equally long run of additions pairs up, index for index.
-/// Unequal runs mean lines were added or dropped, so no positional pairing is
-/// trustworthy and the whole-line colouring is left to speak for itself.
+/// Pairing is deliberately conservative and strictly positional: the `k`th
+/// removal in a run pairs with the `k`th addition in the run that follows it,
+/// matching `stella_transcript::file_diff`'s rule for the same shape of
+/// problem — a similarity match was considered and rejected there for the
+/// same reason it is rejected here, because a reader who sees a `−`/`+` block
+/// top to bottom already assumes that ordering, and a clever re-pairing that
+/// highlighted line 1 against line 3 would be correct and unreadable.
+///
+/// A run-length mismatch does not disqualify the whole block: it means the
+/// edit added or dropped a line partway through, so pairing continues for the
+/// shorter run's length and the surplus lines — the ones with nothing on the
+/// other side to compare against — carry no emphasis, which is the honest
+/// answer for a line that has no counterpart.
 fn word_emphasis(raw: &[&str]) -> std::collections::HashMap<usize, (usize, usize)> {
     let mut out = std::collections::HashMap::new();
     // A headerless pseudo-diff — bare `+`/`-` lines with no `@@`, which the
@@ -309,15 +318,14 @@ fn word_emphasis(raw: &[&str]) -> std::collections::HashMap<usize, (usize, usize
         }
         let add_end = i;
         let (dn, an) = (del_end - del_start, add_end - add_start);
-        if dn > 0 && dn == an {
-            for k in 0..dn {
-                let (o, n) = (raw[del_start + k], raw[add_start + k]);
-                if let Some((os, oe, ns, ne)) = changed_span(&o[1..], &n[1..]) {
-                    // +1 on every offset: the `+`/`-` marker is one ASCII byte
-                    // that the caller's slice keeps in front of the code.
-                    out.insert(del_start + k, (os + 1, oe + 1));
-                    out.insert(add_start + k, (ns + 1, ne + 1));
-                }
+        let paired = dn.min(an);
+        for k in 0..paired {
+            let (o, n) = (raw[del_start + k], raw[add_start + k]);
+            if let Some((os, oe, ns, ne)) = changed_span(&o[1..], &n[1..]) {
+                // +1 on every offset: the `+`/`-` marker is one ASCII byte
+                // that the caller's slice keeps in front of the code.
+                out.insert(del_start + k, (os + 1, oe + 1));
+                out.insert(add_start + k, (ns + 1, ne + 1));
             }
         }
         if del_end == del_start && add_end == add_start {
@@ -1004,6 +1012,72 @@ mod tests {
             Some(Some(theme::DIFF_ADD_BG)),
             "and keep the add tint the context line lacks: {:?}",
             added.spans
+        );
+    }
+
+    #[test]
+    fn a_one_token_edit_gets_a_brighter_background_on_the_changed_middle() {
+        let diff = "@@ -1,1 +1,1 @@\n-let value = old_thing();\n+let value = new_thing();";
+        let lines = body_lines(diff, None);
+        // lines[0] is the "@@" hunk header.
+        let removed = &lines[1];
+        let added = &lines[2];
+        assert!(
+            removed
+                .spans
+                .iter()
+                .any(|s| s.style.bg == Some(theme::DIFF_DEL_BG_EMPH)),
+            "the removed line's differing middle should carry the brighter \
+             del background: {:?}",
+            removed.spans
+        );
+        assert!(
+            added
+                .spans
+                .iter()
+                .any(|s| s.style.bg == Some(theme::DIFF_ADD_BG_EMPH)),
+            "the added line's differing middle should carry the brighter \
+             add background: {:?}",
+            added.spans
+        );
+    }
+
+    /// The witness for extending `word_emphasis` past equal-length runs: a
+    /// two-removal, one-addition block used to skip emphasis entirely because
+    /// `dn == an` failed. Positional pairing continues for the shorter run's
+    /// length now, so the first removal still pairs with the addition; the
+    /// second removal — nothing on the other side to compare against — is
+    /// left with no emphasis, which is the honest answer for an unpaired line.
+    #[test]
+    fn an_unequal_length_block_still_emphasizes_the_pairable_prefix() {
+        let diff = "@@ -1,2 +1,1 @@\n-let x = old_value();\n-let y = 2;\n+let x = new_value();";
+        let lines = body_lines(diff, None);
+        // lines[0] is the "@@" hunk header.
+        let (paired_removal, dropped_removal, addition) = (&lines[1], &lines[2], &lines[3]);
+        assert!(
+            paired_removal
+                .spans
+                .iter()
+                .any(|s| s.style.bg == Some(theme::DIFF_DEL_BG_EMPH)),
+            "the first removal pairs with the addition and should emphasize: {:?}",
+            paired_removal.spans
+        );
+        assert!(
+            addition
+                .spans
+                .iter()
+                .any(|s| s.style.bg == Some(theme::DIFF_ADD_BG_EMPH)),
+            "the addition should emphasize against its paired removal: {:?}",
+            addition.spans
+        );
+        assert!(
+            dropped_removal
+                .spans
+                .iter()
+                .all(|s| s.style.bg != Some(theme::DIFF_DEL_BG_EMPH)),
+            "a removal with no counterpart on the other side gets no \
+             emphasis, never a mismatched pairing: {:?}",
+            dropped_removal.spans
         );
     }
 


### PR DESCRIPTION
## What & why

Two reference mockups (a "Jet Black" web/HTML transcript and a character-grid
TUI transcript) were provided as the target look for every surface that
renders a transcript. Investigation showed `crates/stella-transcript` — the
crate meant to be the single shared model behind both a web and a
character-grid renderer — is where these mockups were actually drawn from:
its `examples/demo.rs` fixture is the exact "latex-proof" / "fix-overfull"
session shown in both images. So the crate was already close; this PR closes
the concrete gaps found by generating its output and diffing it against the
mockups byte-for-byte, then extends the one piece of it that's clearly
generalizable — word-level diff highlighting — to two more transcript
surfaces that had none.

**`stella-transcript` (`digest.rs`, `grid.rs`):**
- A turn's token/cost rollup is now a single chip, shown **only** at turn
  level (never repeated per step), formatted `41.2k→388` on the character
  grid and `41.2k → 388 tok` on the web — matching both mockups exactly.
  Previously every step repeated an `in X · out Y` chip.
- Dropped the `cache` chip — neither mockup shows one, and it was adding a
  third fact to a row whose job is duration/size/cost.
- The character-grid turn frame no longer shows a fold-mark chevron on an
  already-open turn header (only a collapsed one gets one) — matches the TUI
  mockup, which never draws one on the open `fix-overfull` turn.

**`stella-cli`'s `/export` archive (`export/transcript.rs`, `export.rs`):**
was previously whole-line-tint only for diffs. It now reuses
`stella_transcript::word::highlight` — the same LCS-over-tokens pass the
transcript surfaces use — to highlight the exact changed tokens within a
paired removal/addition, positionally pairing a removal/addition block the
same way `stella_transcript::file_diff` does. Painted with the page's own
existing `--ok`/`--bad` tokens (a stronger wash of the same hue), not a new
categorical hue — that question is still open for these surfaces in #3630,
and this PR doesn't preempt it. `crates/stella-cli/tests/design_token_parity.rs`
(the gate enforcing that palette) still passes.

**`stella-tui`'s live diff renderer (`diff.rs`):** already had word-level
emphasis (a prefix/suffix-trim highlighting the differing middle), just
restricted to *exactly equal-length* removal/addition runs. Extended the
pairing to continue positionally up to the shorter run's length — matching
`stella_transcript::file_diff`'s rule for the same problem — so a block with
any run-length mismatch (a line added or dropped alongside an edit) still
gets word emphasis on the lines it can pair, instead of getting none at all.

**Out of scope, filed as issues instead:** a full migration of the Command
Deck's live transcript rendering onto `stella_transcript::grid` is a much
larger, riskier change (two files already at the file-size gate's ceiling,
21 existing golden snapshots, a different information model) — that's
already tracked in #3578, and this PR left a comment there noting the
incremental `diff.rs` improvement made here. Also filed #3676 for
arenabench's hand-maintained TypeScript port of the transcript renderer,
which has the same word-level-highlighting gap and no parity test against
the Rust original.

Refs #3578
Refs #3630
Refs #3676

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

New tests: `a_step_digest_shows_cost_but_never_a_token_count`,
`a_turn_digest_carries_one_arrow_joined_token_chip_and_no_cache_chip`,
`the_roomy_chip_style_spaces_the_arrow_and_labels_the_unit`,
`a_turns_own_header_shows_a_fold_marker_only_when_collapsed`
(`stella-transcript`); `a_modified_line_pair_highlights_only_the_changed_token`,
`an_unpaired_addition_carries_no_word_tint` (`stella-cli`);
`a_one_token_edit_gets_a_brighter_background_on_the_changed_middle`,
`an_unequal_length_block_still_emphasizes_the_pairable_prefix` (`stella-tui`).
Each fails against the pre-change code and passes here.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (doc comments on every
      touched function explain the new rule)
- [x] CLA signed
- [x] No `Closes #N` — this PR advances but does not close #3578/#3630/#3676,
      so `Refs` is used per CONTRIBUTING.md's convention

`make gate CARGO_SCOPE="-p stella-transcript -p stella-cli -p stella-tui"`
ran clean, including `design_token_parity` (7/7) and the TUI's golden
snapshot suite (13/13, unaffected since only background colors changed).

## Nothing left behind

- [x] Filed: #3676 (arenabench word-level diff parity) — and left a status
      comment on #3578 (Command Deck migration) noting this PR's incremental
      `diff.rs` fix so its "done when" isn't misread as already satisfied.

## Ground-rule check

- [x] No I/O added to `stella-core`; new dep is `stella-transcript` added to
      `stella-cli` — justified in the `diff_html` doc comment (reuses the
      exact LCS-over-tokens pass rather than re-implementing a second
      tokenizer that could drift from it; `stella-cli` already depends on
      `stella-diff`, which `stella-transcript` also depends on)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

The two provided mockups turned out to already be `stella-transcript`'s own
design fixture, which made the highest-leverage move "diff the crate's
current output against the mockups and fix the deltas" rather than a
ground-up reimplementation. The two open design-system issues (#3630's
categorical-hue-vs-instrument-palette question, and #3578's Command Deck
migration) are both pre-existing, maintainer-tracked decisions that this PR
deliberately does not preempt — recoloring the CLI export/Observatory
dashboard or the TUI's live palette to match the mockups' cyan/violet scheme
would relitigate #3630 unilaterally, and a full Command Deck rewrite is a
separate, much larger effort already scoped in #3578.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gbackwj7fUWmBTXmhEaH3F)_

## Summary by Sourcery

Align transcript summaries with the reference chip and fold conventions and extend precise word-level diff highlighting across exported and interactive transcript views.

New Features:
- Add token-level highlighting to exported HTML diffs using the shared transcript diff logic.
- Extend TUI word-level diff emphasis to handle unequal removal and addition runs.

Bug Fixes:
- Align transcript grid and HTML rendering with the reference layout by consolidating token accounting into turn-level chips, removing cache chips, and limiting fold markers to collapsed turn headers.

Enhancements:
- Use context-appropriate formatting for turn token chips while keeping the underlying accounting consistent across transcript surfaces.

Build:
- Add the shared transcript crate as a dependency of the CLI export implementation.

Tests:
- Add coverage for transcript chip and fold conventions, exported diff token highlighting, and unequal-length TUI diff pairing.