### PR TITLE
feat(stella-tools): let a session write to the system temp directory

### DIFF
--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -407,14 +407,12 @@ fn segment_args(words: &[String], command_index: usize) -> Vec<&str> {
 /// is stored. `/dev/stdout` and `/dev/stderr` write to the pipes Stella is
 /// already capturing.
 ///
-/// The system temp directory is deliberately **not** here. It was, briefly,
-/// on the argument that `/tmp` is not the user's work — but the rule this
-/// module enforces is that a session writes inside its own directories, and
-/// `/tmp` is outside them. A session that needs scratch space has a scratch
-/// directory of its own (`STELLA_SCRATCH`, granted as a scope root by
-/// `ToolRegistry::write_scope`), which is where that work belongs and which
-/// is cleaned up with the session. An operator who genuinely wants `/tmp`
-/// writable says so with `--allow-dir /tmp`.
+/// The system temp directory is deliberately **not** here either, and this
+/// time not because it is refused: it is a genuine scope root now
+/// ([`crate::temp_roots`]), so `ctx.refuse_write` allows it on the same
+/// evidence as the workspace, and listing it as an exemption would be a second
+/// spelling of one boundary — the shape that lets `write_file` and `bash`
+/// disagree about the same path.
 const ALWAYS_WRITABLE: &[&str] = &["/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"];
 
 /// The refusal for one argument, when it resolves to something outside the

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -67,6 +67,7 @@ pub mod subagent;
 /// than maintaining a second, drifting credential deny-list.
 pub mod subprocess_env;
 pub mod tasks;
+pub mod temp_roots;
 pub mod validate;
 pub mod write;
 

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -255,7 +255,16 @@ impl ToolRegistry {
     }
 
     /// This session's write scope: the workspace root, the session scratch
-    /// directory, and whatever [`Self::allow_write_dirs`] added.
+    /// directory, the system temp directories, and whatever
+    /// [`Self::allow_write_dirs`] added.
+    ///
+    /// The system temp directories are in the scope because a write there
+    /// cannot be the lost work the confinement exists to prevent, and because
+    /// `… | tee /tmp/out.txt` is what shell convention spells rather than
+    /// something a prompt has to teach — see [`crate::temp_roots`] for the full
+    /// argument and for the earlier decision it reverses. `STELLA_SCRATCH`
+    /// remains the recommended place: it is per-session, so two concurrent runs
+    /// cannot collide on one filename, and it is removed with the session.
     ///
     /// The scratch directory is in the scope because the prompt tells the
     /// model to put working files there — "keep intermediate notes and working
@@ -273,7 +282,7 @@ impl ToolRegistry {
             .unwrap_or_else(|_| self.root.clone());
         let scratch = self.scratch_dir.iter().cloned();
         stella_core::workspace_scope::SessionScope::new(root).with_additional(
-            scratch.chain(
+            scratch.chain(crate::temp_roots::system_temp_roots()).chain(
                 self.extra_write_dirs
                     .read()
                     .unwrap_or_else(|p| p.into_inner())

--- a/crates/stella-tools/src/temp_roots.rs
+++ b/crates/stella-tools/src/temp_roots.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The system temp directories every session may write to.
+//!
+//! # Why the confinement stops short of here
+//!
+//! [`stella_core::workspace_scope`] confines writes because a write outside
+//! the session's tree is what turns a bad turn into lost work. The system temp
+//! directory is the one place on the machine where that reason does not hold:
+//! nothing the user owns lives there, the operating system reclaims it, and
+//! every other program on the machine already treats it as common scratch
+//! space. Refusing it protects nothing and costs a turn.
+//!
+//! This reverses a deliberate earlier decision — `/tmp` was exempt in
+//! `crate::bash`, was removed on the argument that a session has
+//! `STELLA_SCRATCH` for exactly this, and is now readmitted. Both halves of
+//! that argument were true; what settled it is that the model does not reach
+//! for `STELLA_SCRATCH`, it reaches for `/tmp`, because that is what shell
+//! convention is. `cargo clippy … | tee /tmp/out.txt` is an ordinary correct
+//! command, and a boundary that refuses ordinary correct commands is
+//! discovered as a bug rather than obeyed as a policy. `STELLA_SCRATCH` is
+//! still the better place — it is per-session, so it cannot collide with a
+//! sibling run, and it is cleaned up with the session — and it stays the one
+//! the prompt recommends. This makes the conventional spelling work too.
+//!
+//! # What is granted, exactly
+//!
+//! `TMPDIR` (via [`std::env::temp_dir`]) and `/tmp`. On macOS those are
+//! different directories — `TMPDIR` is a per-user `/var/folders/…` path while
+//! `/tmp` symlinks to `/private/tmp` — and a model writes to either, so both
+//! are granted. Each is canonicalized, because a scope's roots must be
+//! canonical for anything to be compared against them (see
+//! [`crate::ctx::ToolCtx::resolve_for_write`]); one that does not resolve is
+//! dropped rather than kept, because unlike an operator's `--allow-dir` typo
+//! there is no intent here to honour — a temp directory that is not there is
+//! simply not this platform's temp directory.
+
+use std::path::{Path, PathBuf};
+
+/// The canonical system temp directories, in a stable order, deduplicated.
+///
+/// Deliberately not cached: it is called once per `write_scope()` and the two
+/// `canonicalize` calls are cheap next to the tool dispatch that follows.
+pub fn system_temp_roots() -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for candidate in [std::env::temp_dir(), PathBuf::from("/tmp")] {
+        let Ok(canonical) = candidate.canonicalize() else {
+            continue;
+        };
+        if !is_usable_root(&canonical) || out.contains(&canonical) {
+            continue;
+        }
+        out.push(canonical);
+    }
+    out
+}
+
+/// Whether a resolved candidate is a directory small enough to be a grant
+/// rather than a surrender.
+///
+/// A filesystem root is refused. `TMPDIR` is environment the session inherits,
+/// so `TMPDIR=/` would otherwise hand the whole machine write access through a
+/// path meant to widen it by one directory — the shape where a permissive
+/// reading of untrusted configuration turns a confinement check off entirely.
+fn is_usable_root(path: &Path) -> bool {
+    path.parent().is_some() && path.is_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_platform_temp_directory_is_granted_and_canonical() {
+        let roots = system_temp_roots();
+        assert!(!roots.is_empty(), "every supported platform has a temp dir");
+        for root in &roots {
+            assert!(root.is_absolute(), "{root:?} must be absolute");
+            assert_eq!(
+                &root.canonicalize().expect("resolved once already"),
+                root,
+                "{root:?} must already be canonical"
+            );
+        }
+    }
+
+    /// On macOS `TMPDIR` and `/tmp` are different directories and both are
+    /// granted; on a platform where they coincide the duplicate collapses.
+    #[test]
+    fn the_roots_are_deduplicated() {
+        let roots = system_temp_roots();
+        let mut seen = roots.clone();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), roots.len(), "{roots:?}");
+    }
+
+    #[test]
+    fn a_filesystem_root_is_never_usable() {
+        assert!(!is_usable_root(Path::new("/")));
+        assert!(is_usable_root(
+            &std::env::temp_dir().canonicalize().unwrap()
+        ));
+    }
+}

--- a/crates/stella-tools/tests/write_scope_witness.rs
+++ b/crates/stella-tools/tests/write_scope_witness.rs
@@ -364,9 +364,10 @@ async fn the_shell_audit_permits_ordinary_build_and_test_commands() {
         // SOURCE outside the tree is a read, and reads are unrestricted; and
         // `2>` is a redirect the scanner must not mistake for a plain word.
         //
-        // Writing INTO `/tmp` is deliberately absent — it is outside the
-        // workspace and is refused, with the session's own scratch directory
-        // (`STELLA_SCRATCH`, a scope root) as the place that work belongs.
+        // Writing INTO the system temp directory is covered separately, by
+        // `the_system_temp_directory_is_writable`: it is a grant a real
+        // session gets from `ToolRegistry::write_scope`, and `ToolCtx::bare`
+        // deliberately carries no grants at all.
         "command -v jq >/dev/null 2>&1 && echo yes",
         "make 2>/dev/null",
         "cargo test 2>&1 >/dev/null",
@@ -458,6 +459,96 @@ async fn the_shell_audit_refuses_writing_into_a_sibling_worktree() {
             .join(".stella/worktrees/sibling-task/secret.rs")
             .exists()
     );
+}
+
+/// The witness for the system temp grant: a real session may write there, by
+/// both spellings, through both the file tools and the shell.
+///
+/// Driven through [`stella_tools::ToolRegistry::write_scope`] rather than
+/// `ToolCtx::bare`, because that is where the grant lives and `bare` carries no
+/// grants by design — using `bare` here would prove nothing about a session.
+///
+/// Fails on the old code: `/tmp/…` was `OutsideScope`, and this is the exact
+/// refusal a run hit when the model reached for `cargo clippy … | tee
+/// /tmp/clippy_out.txt`. See `stella_tools::temp_roots` for why the earlier
+/// decision to refuse it was reversed.
+#[tokio::test]
+async fn the_system_temp_directory_is_writable() {
+    let session = tempfile::tempdir().expect("session");
+    let registry = stella_tools::ToolRegistry::new(session.path().to_path_buf());
+    let ctx = ToolCtx::bare(session.path().to_path_buf()).with_scope(registry.write_scope());
+
+    // A unique leaf per run: `/tmp` is shared with every other process on the
+    // machine, which is exactly why `STELLA_SCRATCH` remains the recommended
+    // place and why a test may not assume an empty directory.
+    let leaf = format!("stella-temp-witness-{}.txt", std::process::id());
+
+    for dir in stella_tools::temp_roots::system_temp_roots() {
+        let target = dir.join(&leaf);
+        let _ = std::fs::remove_file(&target);
+
+        let out = WriteFile::default()
+            .execute(
+                &serde_json::json!({
+                    "path": target.to_string_lossy(),
+                    "content": "scratch\n"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(
+            !out.is_error(),
+            "a session must be able to write to `{}`: {out:?}",
+            target.display()
+        );
+        assert!(target.exists());
+
+        // And the shell agrees with the file tools about the same path — the
+        // two describing one boundary differently is the failure this suite
+        // exists to prevent.
+        let out = stella_tools::bash::Bash::new(None)
+            .execute(
+                &serde_json::json!({
+                    "command": format!("echo shell > {}", target.display())
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(
+            !out.is_error(),
+            "the shell audit must permit the same write: {out:?}"
+        );
+
+        let _ = std::fs::remove_file(&target);
+    }
+}
+
+/// The grant is one directory wide, not a hole in the confinement: everything
+/// else outside the session stays refused, temp directory or no.
+#[tokio::test]
+async fn the_temp_grant_does_not_widen_anything_else() {
+    let session = tempfile::tempdir().expect("session");
+    let registry = stella_tools::ToolRegistry::new(session.path().to_path_buf());
+    let ctx = ToolCtx::bare(session.path().to_path_buf()).with_scope(registry.write_scope());
+
+    // A path that is emphatically not under any temp root and not in the
+    // session tree.
+    let refused = std::path::Path::new("/usr/local/stella-must-not-write-here.txt");
+    let out = WriteFile::default()
+        .execute(
+            &serde_json::json!({
+                "path": refused.to_string_lossy(),
+                "content": "nope\n"
+            }),
+            &ctx,
+        )
+        .await;
+    let message = message(&out);
+    assert!(
+        message.contains("outside this session's writable directories"),
+        "{message}"
+    );
+    assert!(!refused.exists());
 }
 
 /// The edit tool consults the same boundary as the write tool — one session,


### PR DESCRIPTION
## What

`cargo clippy … | tee /tmp/clippy_out.txt` was refused mid-run:

```
`/private/tmp/clippy_out.txt` is outside this session's writable directories (…)
```

The system temp directories (`TMPDIR` and `/tmp`) are now scope roots, so that command works.

## Why, and what it reverses

The write confinement exists because a write outside the session's tree is what turns a bad turn into lost work. The system temp directory is the one place on the machine where that reason does not hold: nothing the user owns lives there, and the OS reclaims it.

**This reverses a deliberate earlier decision**, which was documented in `bash.rs`: `/tmp` was briefly exempt, and was removed on the argument that a session has `STELLA_SCRATCH` for exactly this. Both halves of that argument were true, and `STELLA_SCRATCH` is still the better place — it is per-session, so two concurrent runs cannot collide on one filename, and it is cleaned up with the session. It stays the one the prompt recommends.

What settles it against the earlier decision is that the model does not reach for `STELLA_SCRATCH`; it reaches for `/tmp`, because that is what shell convention spells. A boundary that refuses ordinary correct commands is discovered as a bug rather than obeyed as a policy — and the refusal was already inconsistent, since the shell audit only catches paths it can statically resolve while any subprocess writes there freely.

Flagging the reversal explicitly rather than quietly overwriting it: the earlier reasoning is in the history, and this is a maintainer's call that was made explicitly.

## How

- New `crates/stella-tools/src/temp_roots.rs` — resolves `TMPDIR` and `/tmp`, canonicalizes each (on macOS they are different directories, and a scope's roots must be canonical to be compared against), dedupes, and **refuses a candidate that resolves to a filesystem root** so an inherited `TMPDIR=/` cannot turn the confinement off entirely.
- The grant is added in `ToolRegistry::write_scope()` — the single place the shell audit and the file tools both read, so the two cannot disagree about the same path. `bash.rs`'s `ALWAYS_WRITABLE` list is deliberately *not* extended; a second spelling of one boundary is how they drift apart.
- `stella_core::workspace_scope` is unchanged and stays a pure predicate — the `canonicalize` I/O lives in `stella-tools` (invariant 2).
- `ToolCtx::bare` still carries no grants at all, so every existing refusal test is unaffected.

## Witness

`the_system_temp_directory_is_writable` in `crates/stella-tools/tests/write_scope_witness.rs`, driven through the production `ToolRegistry::write_scope()` path. Checked by reverting `registry.rs` alone:

```
a session must be able to write to `/private/var/folders/…/stella-temp-witness-54416.txt`:
Error { message: "`…` is outside this session's writable directories (…)" }
```

— the exact refusal the run hit. It passes with the change. `the_temp_grant_does_not_widen_anything_else` holds the rest of the boundary shut (`/usr/local/…` still refused).

No test was deleted.

## Verification

- `cargo test -p stella-tools` — 432 passing.
- `make gate` — exit 0.
- On the first gate run three `custom::tests` failed on a hardcoded 5000ms spawn budget under full-workspace load; they pass alone (`46 passed` in 3.20s) and two subsequent gate runs were green. Nothing in this diff touches the custom-tool spawn path. Filed as evidence on #2011, which was closed and has recurred — reopened rather than duplicated.

Refs #2011

## Summary by Sourcery

Grant sessions narrowly scoped write access to canonical system temporary directories while preserving confinement for all other paths.

New Features:
- Allow session-scoped writes to the canonical system temporary directories resolved from `TMPDIR` and `/tmp`.

Bug Fixes:
- Permit conventional temporary-file workflows, such as piping command output to `/tmp`, without weakening write confinement elsewhere.

Enhancements:
- Centralize temporary-directory scope handling so shell and file tools apply the same write boundary.
- Reject filesystem-root candidates and deduplicate canonical temporary-directory roots.

Tests:
- Add coverage confirming system temporary directories are writable through both file and shell tools while unrelated paths remain refused.