### PR TITLE
fix(stella-pipeline): verify is decided per-candidate from real signals; witness refuses post-triage conditions

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -249,6 +249,11 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
                 // that never existed.
                 pipeline_config.roster = frame_config.roster();
                 pipeline_config.max_revisions = frame_config.max_revisions;
+                // The `[wrapper]` variant the killed run was launched under
+                // (#3408) — `None` (the built-in `classic` order) for every
+                // frame written before variants were configurable, and for
+                // a run that genuinely used none.
+                pipeline_config.variant = frame_config.variant.clone();
                 // #3243 Phase 3 (D5): a resumed run recalls again. The
                 // original leg's context died with its process — the frame
                 // restores goal, roster and revisions, but frames were never

--- a/crates/stella-cli/src/resume_frame.rs
+++ b/crates/stella-cli/src/resume_frame.rs
@@ -125,6 +125,16 @@ pub struct PipelineFrame {
     /// keeps the honest bare-turn path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub progress: Option<stella_pipeline::FrameProgress>,
+    /// The `[wrapper]` variant the run was launched with (#3408), `None` for
+    /// the built-in `classic` order. `stella_plugin::Wrapper` derives
+    /// `Serialize`/`Deserialize` (invariant 4), so it round-trips here
+    /// byte-for-byte the same way [`Self::responsibilities`] does.
+    ///
+    /// Additive, so no [`FRAME_VERSION`] bump — an older frame reads it as
+    /// `None` and resumes under `classic`, which is what it would have run
+    /// under anyway before a variant was ever configurable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variant: Option<stella_plugin::Wrapper>,
 }
 
 impl PipelineFrame {
@@ -145,6 +155,7 @@ impl PipelineFrame {
             ),
             max_revisions: config.max_revisions,
             progress: None,
+            variant: config.variant.clone(),
         }
     }
 
@@ -505,6 +516,7 @@ mod tests {
             isolation_possible: true,
             max_revisions: 2,
             progress: None,
+            variant: None,
         }
     }
 
@@ -844,6 +856,61 @@ mod tests {
         assert!(
             !frame.witness_writer,
             "the legacy projection agrees with the row it is derived from"
+        );
+    }
+
+    /// **#3408 P2 witness.** A run launched under a non-default `[wrapper]`
+    /// variant comes back resuming under that SAME variant, not the built-in
+    /// `classic` fallback `PipelineFrame::of` used to silently substitute
+    /// (`PipelineConfig::variant` was not captured at all before this).
+    #[test]
+    fn a_resumed_run_gets_back_the_variant_it_was_launched_with() {
+        let variant = stella_plugin::Wrapper {
+            id: "lean-diff-v1".into(),
+            stages: vec![
+                stella_plugin::WrapperStage {
+                    name: stella_plugin::StageName::Triage,
+                    condition: None,
+                },
+                stella_plugin::WrapperStage {
+                    name: stella_plugin::StageName::Execute,
+                    condition: None,
+                },
+                stella_plugin::WrapperStage {
+                    name: stella_plugin::StageName::Verify,
+                    condition: Some("diff-lines > 0".into()),
+                },
+            ],
+        };
+        let config = stella_pipeline::PipelineConfig {
+            variant: Some(variant.clone()),
+            ..stella_pipeline::PipelineConfig::default()
+        };
+
+        let json = serde_json::to_string(&PipelineFrame::of(&config)).expect("the frame writes");
+        let ResumeFrame::Pipeline(frame) = ResumeFrame::parse(&json) else {
+            panic!("the frame this build wrote must read back: {json}");
+        };
+
+        assert_eq!(
+            frame.variant,
+            Some(variant),
+            "the resumed leg must run the SAME manifest the killed one was running, not \
+             silently fall back to classic"
+        );
+    }
+
+    /// The overwhelmingly common case — no configured variant — adds nothing
+    /// to the frame, matching `a_default_roster_run_writes_no_responsibilities_at_all`'s
+    /// posture for the roster.
+    #[test]
+    fn a_classic_run_writes_no_variant_at_all() {
+        let frame = PipelineFrame::of(&stella_pipeline::PipelineConfig::default());
+        assert!(frame.variant.is_none());
+        let json = serde_json::to_string(&frame).expect("the frame writes");
+        assert!(
+            !json.contains("variant"),
+            "the built-in `classic` fallback is skipped rather than written out: {json}"
         );
     }
 

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1116,8 +1116,14 @@ impl<'a> Pipeline<'a> {
             p.task_class = Some(task_class);
             p.goal = Some(goal.to_string());
         });
-        let schedule_says =
-            self.begin_turn_schedule(budget, &assessment, research_questions.len(), total_cost)?;
+        let variant = self.effective_variant(total_cost)?;
+        let (schedule_says, schedule) = self.begin_turn_schedule(
+            &variant,
+            budget,
+            &assessment,
+            research_questions.len(),
+            total_cost,
+        )?;
         // The volatile recall+goal message rides AFTER the stable system prefix
         // (L-E8) — see assemble_user_message. The verification contract rides
         // only on turns that will actually be verified — a conversational turn
@@ -1228,7 +1234,8 @@ impl<'a> Pipeline<'a> {
             base_messages: &base_messages,
             plan: plan.as_deref(),
             assessment,
-            schedule_verifies: schedule_says.verify,
+            schedule,
+            witness_scheduled: schedule_says.witness_scheduled,
         };
         // Decided above, before the user message was assembled (the worker's
         // test-first contract keys off it) and before this single-shot/
@@ -1275,7 +1282,7 @@ impl<'a> Pipeline<'a> {
             }
             let mut single = self
                 .run_shared_candidates(
-                    frame,
+                    frame.clone(),
                     &worker,
                     1,
                     &mut Spend {
@@ -1292,7 +1299,7 @@ impl<'a> Pipeline<'a> {
         } else {
             match self
                 .run_best_of_n(
-                    frame,
+                    frame.clone(),
                     n,
                     &frames,
                     schedule_says.authored_witness,
@@ -1542,7 +1549,7 @@ impl<'a> Pipeline<'a> {
             // into and no pristine snapshot to author blind in, so it never
             // buys a witness. The ordinal is 1-based, like the start notice.
             results.push(
-                self.run_candidate(frame, None, &engine, surface, spend)
+                self.run_candidate(frame.clone(), None, &engine, surface, spend)
                     .await,
             );
         }
@@ -1851,23 +1858,19 @@ impl<'a> Pipeline<'a> {
             return CandidateResult::turn_aborted(state.messages, abort);
         }
 
-        // Decide whether to verify: `frame.schedule_verifies` for single/
-        // multi; for a simple lookup, ORed with the zero-diff guard (L-E2) —
-        // host-internal, manifest-inexpressible (#3408). "Touched files" =
-        // FileChange events observed OR a non-empty diff from a turn that
-        // dispatched something able to write. The second conjunct is #1553:
-        // the diff reads the WORKING TREE, and in a shared worktree the tree
-        // can move under a run — a human editing beside it. `mutating_actions`
-        // is counted off the calls this pipeline dispatched, not off any look
-        // at the world, so a lookup that dispatched nothing that could write
-        // cannot own the motion the diff shows, and must not be dragged into
-        // verification over someone else's edit.
+        // Decide whether to verify, per candidate (#3408, `decide_candidate_verify`) —
+        // real diff, not a placeholder — ORed with the zero-diff guard (L-E2, #1553).
         let probe = self.gather_diff(surface, &state.untracked_before).await;
         self.absorb_probe(&mut state, probe);
         let files_touched = state.signals.file_changes > 0
             || (state.signals.mutating_actions > 0 && !state.diff_text.trim().is_empty());
-        let should_verify = frame.schedule_verifies
-            || (frame.assessment.class == TaskClass::SimpleLookup && files_touched);
+        let should_verify = (frame.assessment.class == TaskClass::SimpleLookup && files_touched)
+            || self.decide_candidate_verify(
+                frame.schedule.clone(),
+                frame.witness_scheduled,
+                state.signals.mutating_actions,
+                state.diff_lines,
+            );
         if !should_verify {
             // A clean lookup: nothing to verify.
             return state.into_unverified();

--- a/crates/stella-pipeline/src/pipeline.rs
+++ b/crates/stella-pipeline/src/pipeline.rs
@@ -1063,6 +1063,9 @@ impl<'a> Pipeline<'a> {
         if let Err(error) = self.roster_refusal() {
             return Err(PipelineRunError::new(error, total_cost));
         }
+        // Same rung, same reason: a variant whose `witness` condition this host
+        // cannot answer pre-execute is refused before the first paid call (#3408).
+        let variant = self.effective_variant(total_cost)?;
         self.report_roster_posture();
         if messages.is_empty() {
             messages.push(CompletionMessage::system(DEFAULT_SYSTEM_PROMPT));
@@ -1116,7 +1119,6 @@ impl<'a> Pipeline<'a> {
             p.task_class = Some(task_class);
             p.goal = Some(goal.to_string());
         });
-        let variant = self.effective_variant(total_cost)?;
         let (schedule_says, schedule) = self.begin_turn_schedule(
             &variant,
             budget,
@@ -1133,10 +1135,8 @@ impl<'a> Pipeline<'a> {
             .test_command
             .as_deref()
             .filter(|_| !assessment.conversational && task_class.verifies_unconditionally());
-        // `schedule_says.authored_witness` was decided in `begin_turn_schedule`
-        // above, before this message is assembled, so a run with no oracle and
-        // no independent author tells the worker up front that its own failing
-        // test is the run's only deterministic evidence (#3408).
+        // `schedule_says.authored_witness` was decided above, pre-assembly, so a
+        // run with no oracle tells the worker test-first up front (#3408).
         let contract = match verified_by {
             Some(command) => VerificationContract::Oracle(command),
             None if !assessment.conversational

--- a/crates/stella-pipeline/src/pipeline/fanout_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/fanout_stage.rs
@@ -194,6 +194,10 @@ impl<'a> Pipeline<'a> {
             futures_util::stream::iter(workspaces.iter().enumerate().map(|(index, slot)| {
                 let fan = fan.as_ref();
                 let budgets = &budgets;
+                // Cloned per candidate (#3408): each one decides `verify`
+                // independently against its own real diff, so each needs its
+                // own `Schedule` walk forward from the shared prefix.
+                let frame = frame.clone();
                 async move {
                     let ws = match slot {
                         Ok(ws) => ws.as_ref(),

--- a/crates/stella-pipeline/src/pipeline/resume_stage.rs
+++ b/crates/stella-pipeline/src/pipeline/resume_stage.rs
@@ -43,6 +43,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use stella_core::step::Checkpoint;
 
+use crate::schedule::{HostFacts, Schedule};
+
 use super::*;
 
 /// The facts the pipeline learns mid-run that a resume needs and cannot
@@ -412,19 +414,30 @@ impl<'a> Pipeline<'a> {
             diff_lines: state.diff_lines,
         });
 
+        // Never consulted: `verify_candidate` (called directly below, not
+        // through `run_candidate`) reads neither field of this frame's
+        // schedule — `should_verify` above is this file's own pre-#3408
+        // computation, unchanged (module docs, "What still does not come
+        // back"). Built anyway so `TaskFrame` has the fields every
+        // construction site supplies, from the run's own effective variant
+        // rather than a placeholder.
+        let variant = self.effective_variant(total_cost)?;
+        let schedule = Schedule::new(
+            &variant,
+            HostFacts {
+                test_command: self.config.test_command.is_some(),
+                candidates: self.config.candidate_count(),
+                budget_metered: budget.headroom_usd().is_some(),
+            },
+        );
         let base_messages: Vec<CompletionMessage> = Vec::new();
         let frame = TaskFrame {
             goal,
             base_messages: &base_messages,
             plan: resume.plan.as_deref(),
             assessment: TaskAssessment::from_class(task_class),
-            // `verify_candidate` (called directly below, not through
-            // `run_candidate`) never reads this field — `should_verify`
-            // above is this file's own pre-#3408 computation. Filled in
-            // anyway so `TaskFrame` has the field every construction site
-            // supplies, with the value the shipped manifest's triage-
-            // published `verifies` signal would carry for this class.
-            schedule_verifies: task_class.verifies_unconditionally(),
+            schedule,
+            witness_scheduled: false,
         };
         let best = {
             let mut spend = Spend {

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -24,7 +24,7 @@
 //!   its own failing test is the run's only deterministic evidence
 //!   ([`Pipeline::run`]'s `VerificationContract` assembly). So `witness` is
 //!   decided here, immediately once triage's real facts exist, and
-//!   [`refuse_witness_reading_post_triage`](crate::schedule::refuse_witness_reading_post_triage)
+//!   [`refuse_witness_reading_post_triage`]
 //!   rejects any variant whose `witness` condition could not honestly be
 //!   answered this early — one reading `execute`'s, `witness`'s own, or
 //!   `verify`'s published signals. `classic.toml`'s `if = "no-test-command"`
@@ -39,7 +39,7 @@
 //!   ([`super::task_frame::TaskFrame::schedule`]) and decides `execute`,
 //!   re-decides `witness` (asserted to agree with the answer computed here —
 //!   both read the same triage-boundary facts, so
-//!   [`refuse_witness_reading_post_triage`](crate::schedule::refuse_witness_reading_post_triage)
+//!   [`refuse_witness_reading_post_triage`]
 //!   having accepted the variant makes them the same computation run twice),
 //!   and only then decides `verify` against its own real diff —
 //!   [`Pipeline::decide_candidate_verify`], called from
@@ -189,7 +189,7 @@ impl Pipeline<'_> {
     /// authoring happens later in `run_candidate` than this decision does,
     /// so no shipped or tested variant may condition `verify` on
     /// `witness-authored` yet — closing that gap is
-    /// [#3915](https://github.com/macanderson/stella/issues/3915).
+    /// [#3682](https://github.com/macanderson/stella/issues/3682).
     ///
     /// # Panics
     /// `.expect()`s that `execute`/`witness`/`verify` resolve without a

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -24,11 +24,12 @@
 //!   its own failing test is the run's only deterministic evidence
 //!   ([`Pipeline::run`]'s `VerificationContract` assembly). So `witness` is
 //!   decided here, immediately once triage's real facts exist, and
-//!   [`refuse_witness_reading_post_triage`]
-//!   rejects any variant whose `witness` condition could not honestly be
-//!   answered this early — one reading `execute`'s, `witness`'s own, or
-//!   `verify`'s published signals. `classic.toml`'s `if = "no-test-command"`
-//!   is a host fact, so it always passes.
+//!   [`refuse_witness_reading_post_triage`] — run by
+//!   [`Pipeline::effective_variant`] on the pre-triage refusal rung, before
+//!   the first paid call — rejects any variant whose `witness` condition
+//!   could not honestly be answered this early: one reading `execute`'s,
+//!   `witness`'s own, or `verify`'s published signals. `classic.toml`'s
+//!   `if = "no-test-command"` is a host fact, so it always passes.
 //! - **`verify`, post-execute, per candidate.** A verify condition MAY read
 //!   what `execute` produced (`classic.toml`'s own `if = "verifies"` reads a
 //!   triage-published signal, but a leaner variant's need not) — and that
@@ -109,7 +110,15 @@ impl Pipeline<'_> {
             Some(wrapper) => Ok(wrapper.clone()),
             None => variant::classic().cloned(),
         };
-        resolved.map_err(|source| variant_error(source, total_cost_usd))
+        let wrapper = resolved.map_err(|source| variant_error(source, total_cost_usd))?;
+        // Refused HERE, on the pre-triage rung with the independence and
+        // roster refusals, so a variant this host cannot honestly answer is
+        // turned away before the first paid call — not after triage has
+        // already bought a trajectory the caller must throw away (#3408,
+        // same principle as #1147 above the sibling refusals).
+        refuse_witness_reading_post_triage(&wrapper)
+            .map_err(|source| variant_error(source, total_cost_usd))?;
+        Ok(wrapper)
     }
 
     /// Resolve the PRE-execute half of `variant`'s schedule against triage's
@@ -127,7 +136,6 @@ impl Pipeline<'_> {
     ) -> Result<(PreExecuteSchedule, Schedule<'v>), PipelineRunError> {
         let task_class = assessment.class;
         let decided: Result<(PreExecuteSchedule, Schedule<'v>), ScheduleError> = (|| {
-            refuse_witness_reading_post_triage(variant)?;
             let mut schedule = Schedule::new(
                 variant,
                 HostFacts {

--- a/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
+++ b/crates/stella-pipeline/src/pipeline/schedule_wiring.rs
@@ -8,48 +8,64 @@
 //! Split from `pipeline.rs` for the reason every sibling in this directory
 //! is: that file is a grandfathered god file closed to growth (AGENTS.md §
 //! God files), so the machinery — and the error-handling boilerplate around
-//! it — lives here, and `run` is left with two plain calls (#3408).
+//! it — lives here (#3408).
 //!
-//! # Why every declared stage is decided in one batch
+//! # Two decisions, at two different times
 //!
 //! [`stella_plugin::ProgressiveResolver`] must be asked about each declared
 //! stage in the manifest's own order — `triage`, `recall`, `research`,
 //! `plan`, `scope`, `execute`, `witness`, `verify` for the shipped `classic`
-//! variant. `Pipeline::run`'s *own* control flow does not visit those
-//! decisions in that order: it needs the `witness` answer (`authored_witness`)
-//! before it has run `research` or `plan` for real, and it needs `verify`'s
-//! answer before a single candidate has executed. [`Pipeline::begin_turn_schedule`]
-//! resolves the resolver's whole declared walk in one batch, immediately once
-//! triage's real facts are known — decoupling *when the schedule decides* a
-//! stage from *when the pipeline does that stage's real work*, which stays
-//! exactly where it always was. This is sound because **every one of
-//! `classic.toml`'s conditions reads only a host fact or a signal `triage`
-//! itself publishes** — `verify`'s `if = "verifies"` included, since
-//! [`Signal::Verifies`](stella_plugin::Signal::Verifies) is triage-published,
-//! not execute-published — asserted for the shipped variant by
-//! `tests/variant_dispatch.rs` rather than assumed.
+//! variant. `Pipeline::run`'s own control flow needs two of those answers at
+//! two genuinely different times, and [`Pipeline::begin_turn_schedule`]
+//! answers only the first:
 //!
-//! A variant whose `verify` (or any stage) instead reads what `execute`
-//! actually produced — [`crate::schedule`]'s module docs use exactly that
-//! example — needs a **second**, per-candidate decision against a
-//! [`Schedule::clone`] taken after this batch, fed that candidate's real
-//! diff. Nothing here does that yet: no shipped or configurable variant
-//! reads a post-execute signal, so wiring it is deferred rather than
-//! speculative — tracked in #3674. [`crate::schedule::Schedule`] and
-//! `tests/variant_dispatch.rs` already prove the mechanism handles it
-//! correctly; what remains is `Pipeline::run_candidate` actually asking.
+//! - **`witness`, pre-execute.** `authored_witness` has to be known before
+//!   the user message is assembled — it decides whether the worker is told
+//!   its own failing test is the run's only deterministic evidence
+//!   ([`Pipeline::run`]'s `VerificationContract` assembly). So `witness` is
+//!   decided here, immediately once triage's real facts exist, and
+//!   [`refuse_witness_reading_post_triage`](crate::schedule::refuse_witness_reading_post_triage)
+//!   rejects any variant whose `witness` condition could not honestly be
+//!   answered this early — one reading `execute`'s, `witness`'s own, or
+//!   `verify`'s published signals. `classic.toml`'s `if = "no-test-command"`
+//!   is a host fact, so it always passes.
+//! - **`verify`, post-execute, per candidate.** A verify condition MAY read
+//!   what `execute` produced (`classic.toml`'s own `if = "verifies"` reads a
+//!   triage-published signal, but a leaner variant's need not) — and that
+//!   value does not exist until a candidate has actually run, and differs
+//!   candidate to candidate in a best-of-N turn. This function stops at
+//!   `scope`, one stage short of `execute`, and returns the [`Schedule`]
+//!   still positioned there. Each candidate clones it
+//!   ([`super::task_frame::TaskFrame::schedule`]) and decides `execute`,
+//!   re-decides `witness` (asserted to agree with the answer computed here —
+//!   both read the same triage-boundary facts, so
+//!   [`refuse_witness_reading_post_triage`](crate::schedule::refuse_witness_reading_post_triage)
+//!   having accepted the variant makes them the same computation run twice),
+//!   and only then decides `verify` against its own real diff —
+//!   [`Pipeline::decide_candidate_verify`], called from
+//!   `Pipeline::run_candidate`.
+//!
+//! Before #3408 both were folded into one pre-execute batch, using a
+//! `diff_lines: 0` / `mutating_actions: 0` placeholder for `verify` — sound
+//! only because no shipped variant's `verify` condition read anything but a
+//! triage-published signal, and silently wrong the moment one did (a
+//! `diff-lines > 0` condition could never observe a real diff). See
+//! `tests/variant_dispatch.rs`'s end-to-end witness for the failing case this
+//! replaces.
 
 use stella_plugin::{StageName, Wrapper};
 
-use crate::schedule::{HostFacts, Schedule, ScheduleError};
+use crate::schedule::{HostFacts, Schedule, ScheduleError, refuse_witness_reading_post_triage};
 use crate::variant::{self, VariantError};
 
 use super::*;
 
-/// The manifest's answer to every stage decision `Pipeline::run` needs before
-/// any candidate executes — every declared stage the shipped `classic`
-/// variant has, since none of its conditions read what `execute` produces
-/// (see this module's docs).
+/// The manifest's PRE-execute answers `Pipeline::run` needs before any
+/// candidate exists — `research`/`plan` (both decided fully here, since
+/// nothing about them can vary per candidate) and `authored_witness` (see
+/// this module's docs for why `witness` must be decided this early). `verify`
+/// is deliberately absent: it is a per-candidate, post-execute decision now
+/// (`Pipeline::decide_candidate_verify`).
 pub(super) struct PreExecuteSchedule {
     /// Whether `research` runs — ANDed with the roster's own resolution of
     /// [`ModelCallRole::Research`] at its call site (host-internal, #3408).
@@ -60,55 +76,60 @@ pub(super) struct PreExecuteSchedule {
     /// variant that somehow disagreed between the two would still only ever
     /// gate the one branch the pipeline has to offer it.
     pub(super) plan: bool,
-    /// Whether `verify` runs — ORed at its call site with the host-internal
-    /// zero-diff guard for a simple lookup that unexpectedly touched files,
-    /// which no published signal names (#3408).
-    pub(super) verify: bool,
     /// Whether this turn authors its own witness test (L-E11 front half):
     /// `witness`'s manifest decision (`classic.toml`'s `if = "no-test-
     /// command"`) ANDed with five host-internal facts the closed condition
     /// grammar has no conjunction to fold into one clause (#3408): not
     /// conversational, the witness-author role enabled, the model's own
     /// `wants_witness`, the class verifying unconditionally, and an author
-    /// independent of the worker actually being resolvable. `witness`'s own
-    /// bare decision is not kept beside it — nothing outside this function
-    /// reads it unadorned by those five conjuncts.
+    /// independent of the worker actually being resolvable.
     pub(super) authored_witness: bool,
+    /// `witness`'s bare manifest decision, before the five conjuncts above —
+    /// carried only so each candidate's own re-decision of `witness` (see
+    /// this module's docs) can assert it agrees.
+    pub(super) witness_scheduled: bool,
 }
 
 impl Pipeline<'_> {
     /// The manifest this run follows: the configured variant, or the
-    /// built-in `classic` order when none was configured.
+    /// built-in `classic` order when none was configured. Owned, so the
+    /// caller can hold it for as long as a [`Schedule`] borrowed from it
+    /// needs to live.
     ///
     /// Build-time defect only: unreachable for a configured variant (already
     /// a parsed, validated [`Wrapper`] by the time it reaches
     /// [`PipelineConfig`]) and asserted unreachable for the built-in
-    /// fallback by `tests/variant_program.rs`.
-    fn effective_variant(&self) -> Result<Wrapper, VariantError> {
-        match &self.config.variant {
+    /// fallback by `tests/variant_program.rs`. `total_cost_usd` is only for
+    /// the error path, so the two call sites need no separate `map_err`.
+    pub(super) fn effective_variant(
+        &self,
+        total_cost_usd: f64,
+    ) -> Result<Wrapper, PipelineRunError> {
+        let resolved: Result<Wrapper, VariantError> = match &self.config.variant {
             Some(wrapper) => Ok(wrapper.clone()),
             None => variant::classic().cloned(),
-        }
+        };
+        resolved.map_err(|source| variant_error(source, total_cost_usd))
     }
 
-    /// Resolve every stage decision `run` needs, against this turn's
-    /// effective variant and triage's real facts — see this module's docs
-    /// for why one batch, right here, answers every declared stage rather
-    /// than only some of them.
-    pub(super) fn begin_turn_schedule(
+    /// Resolve the PRE-execute half of `variant`'s schedule against triage's
+    /// real facts — `research`, `plan`, and `authored_witness` — and return
+    /// the [`Schedule`] positioned right after `scope`, ready for each
+    /// candidate to clone and carry into `execute`/`witness`/`verify`. See
+    /// this module's docs for why the split falls exactly there.
+    pub(super) fn begin_turn_schedule<'v>(
         &self,
+        variant: &'v Wrapper,
         budget: &BudgetGuard,
         assessment: &TaskAssessment,
         research_questions: usize,
         total_cost_usd: f64,
-    ) -> Result<PreExecuteSchedule, PipelineRunError> {
-        let variant = self
-            .effective_variant()
-            .map_err(|source| variant_error(source, total_cost_usd))?;
+    ) -> Result<(PreExecuteSchedule, Schedule<'v>), PipelineRunError> {
         let task_class = assessment.class;
-        let decided: Result<PreExecuteSchedule, ScheduleError> = (|| {
+        let decided: Result<(PreExecuteSchedule, Schedule<'v>), ScheduleError> = (|| {
+            refuse_witness_reading_post_triage(variant)?;
             let mut schedule = Schedule::new(
-                &variant,
+                variant,
                 HostFacts {
                     test_command: self.config.test_command.is_some(),
                     candidates: self.config.candidate_count(),
@@ -129,26 +150,82 @@ impl Pipeline<'_> {
             let research = schedule.decide(StageName::Research)?;
             let plan = schedule.decide(StageName::Plan)?;
             let scope = schedule.decide(StageName::Scope)?;
-            // Unconditional in every shipped manifest — decided here, before
-            // this turn's real execution, purely so `witness` and `verify`
-            // (declared after it) can be reached at all.
-            schedule.decide(StageName::Execute)?;
-            let witness = schedule.decide(StageName::Witness)?;
-            let verify = schedule.decide(StageName::Verify)?;
+            // The shared prefix ends here. A throwaway CLONE answers
+            // `witness` once more, right now, only because `authored_witness`
+            // has to exist before any candidate does; `schedule` itself stays
+            // at `scope` for every candidate to pick up from (module docs).
+            let mut witness_probe = schedule.clone();
+            witness_probe.decide(StageName::Execute)?;
+            let witness_scheduled = witness_probe.decide(StageName::Witness)?;
             let authored_witness = !assessment.conversational
-                && witness
+                && witness_scheduled
                 && self.responsibility_enabled(ModelCallRole::WitnessAuthor)
                 && assessment.wants_witness()
                 && task_class.verifies_unconditionally()
                 && self.can_author_independent_witness();
-            Ok(PreExecuteSchedule {
-                research,
-                plan: plan && scope,
-                verify,
-                authored_witness,
-            })
+            Ok((
+                PreExecuteSchedule {
+                    research,
+                    plan: plan && scope,
+                    authored_witness,
+                    witness_scheduled,
+                },
+                schedule,
+            ))
         })();
         decided.map_err(|source| variant_error(source, total_cost_usd))
+    }
+
+    /// Per-candidate, post-execute: decide `verify` against what THIS
+    /// candidate actually produced, not the pre-execute placeholder the old
+    /// batch used (#3408 — the bug this whole module exists to fix).
+    ///
+    /// `schedule` must be [`super::task_frame::TaskFrame::schedule`]'s own
+    /// clone, positioned at `scope` by [`Pipeline::begin_turn_schedule`].
+    /// `mutating_actions` and `diff_lines` are this candidate's real,
+    /// already-measured values (`state.signals.mutating_actions`,
+    /// `state.diff_lines` in `Pipeline::run_candidate` — reused, not
+    /// recomputed). `witness_authored` is deliberately always `false` here:
+    /// authoring happens later in `run_candidate` than this decision does,
+    /// so no shipped or tested variant may condition `verify` on
+    /// `witness-authored` yet — closing that gap is
+    /// [#3915](https://github.com/macanderson/stella/issues/3915).
+    ///
+    /// # Panics
+    /// `.expect()`s that `execute`/`witness`/`verify` resolve without a
+    /// [`ScheduleError`], and a debug-only `debug_assert_eq!` that this
+    /// candidate's `witness` re-decision agrees with `witness_scheduled`.
+    /// Both are meant to be unreachable: `begin_turn_schedule` already
+    /// accepted this variant (`execute` is unconditional in every accepted
+    /// manifest, and `witness`'s condition — refused otherwise — can only
+    /// read facts identical at both decision points), so a panic here is a
+    /// genuine defect in this pairing, not a reachable runtime condition.
+    pub(super) fn decide_candidate_verify(
+        &self,
+        mut schedule: Schedule<'_>,
+        witness_scheduled: bool,
+        mutating_actions: u32,
+        diff_lines: u32,
+    ) -> bool {
+        schedule
+            .decide(StageName::Execute)
+            .expect("execute is unconditional in every variant begin_turn_schedule accepts");
+        let witness_ran = schedule
+            .decide(StageName::Witness)
+            .expect("accepted by refuse_witness_reading_post_triage (#3408)");
+        debug_assert_eq!(
+            witness_ran, witness_scheduled,
+            "a candidate's schedule disagreed with begin_turn_schedule's witness decision — \
+             both read only triage-boundary facts, so this should be impossible (#3408)"
+        );
+        schedule.update(|v| {
+            v.mutating_actions = u64::from(mutating_actions);
+            v.diff_lines = u64::from(diff_lines);
+            v.witness_authored = false;
+        });
+        schedule
+            .decide(StageName::Verify)
+            .expect("accepted by refuse_witness_reading_post_triage (#3408)")
     }
 }
 
@@ -156,7 +233,10 @@ impl Pipeline<'_> {
 /// the shipped `classic` variant (`tests/variant_program.rs`,
 /// `tests/variant_dispatch.rs`), and for any configured variant a defect a
 /// user can act on rather than a silently wrong stage order.
-fn variant_error(source: impl std::fmt::Display, total_cost_usd: f64) -> PipelineRunError {
+pub(super) fn variant_error(
+    source: impl std::fmt::Display,
+    total_cost_usd: f64,
+) -> PipelineRunError {
     PipelineRunError::new(
         PipelineError::InvalidVariant(source.to_string()),
         total_cost_usd,

--- a/crates/stella-pipeline/src/pipeline/task_frame.rs
+++ b/crates/stella-pipeline/src/pipeline/task_frame.rs
@@ -19,12 +19,21 @@
 use stella_protocol::CompletionMessage;
 
 use crate::plan::PlanStep;
+use crate::schedule::Schedule;
 use crate::triage::TaskAssessment;
 
 /// The immutable per-turn inputs of the execute/verify plane. Constructed
 /// once in `Pipeline::run` when the candidate stages begin; every stage from
 /// `run_best_of_n` down to `verify_candidate` reads the parts it needs.
-#[derive(Clone, Copy)]
+///
+/// `Clone`, not `Copy` (#3408): [`Self::schedule`] carries a
+/// [`stella_plugin::ProgressiveResolver`] underneath, which owns two small
+/// `Vec`s. A call site that needs the frame more than once — a fan-out loop,
+/// a shared/isolated split with a degrade-to-bare fallback — clones it
+/// explicitly at the point the frames diverge, the same discipline
+/// [`Schedule`] itself asks for and for the same reason: each candidate needs
+/// its own independent walk from there.
+#[derive(Clone)]
 pub(super) struct TaskFrame<'a> {
     /// The user's goal, verbatim — what triage classified and what the
     /// verifier is ultimately asked to judge the work against.
@@ -38,10 +47,19 @@ pub(super) struct TaskFrame<'a> {
     /// Triage's classification — which stages run at all, and how strictly
     /// the ladder verifies.
     pub(super) assessment: TaskAssessment,
-    /// Whether this turn's `[wrapper]` variant schedules `verify` to run
-    /// (#3408, `crate::schedule`) — `classic.toml`'s `if = "verifies"`,
-    /// decided once at the triage boundary since `Signal::Verifies` is
-    /// triage-published. ORed with the host-internal zero-diff guard at its
-    /// one call site, `Pipeline::run_candidate`.
-    pub(super) schedule_verifies: bool,
+    /// This turn's `[wrapper]` schedule, positioned right after the shared
+    /// pre-execute prefix (`triage` through `scope` — see
+    /// `Pipeline::begin_turn_schedule` and `crate::schedule`'s module docs).
+    /// `execute`, `witness`, and `verify` are NOT yet decided: each candidate
+    /// clones this and decides them independently, against its own real
+    /// outcome, in `Pipeline::run_candidate` (#3408).
+    pub(super) schedule: Schedule<'a>,
+    /// The manifest's bare `witness` decision, already made once against the
+    /// shared prefix's facts (`Pipeline::begin_turn_schedule`, needed there
+    /// to shape the worker's test-first contract before any candidate
+    /// exists). Carried so each candidate's own witness re-decision —
+    /// unavoidable to reach `verify` in [`Schedule`]'s declared-order walk —
+    /// can assert it agrees, rather than silently trusting two computations
+    /// of the same thing to stay in sync (#3408).
+    pub(super) witness_scheduled: bool,
 }

--- a/crates/stella-pipeline/src/schedule.rs
+++ b/crates/stella-pipeline/src/schedule.rs
@@ -50,7 +50,7 @@
 //! `pipeline/schedule_wiring.rs` for where the pipeline draws that line.
 
 use stella_plugin::{
-    ManifestError, ProgressiveResolver, SignalValues, StageDecision, StageName, Wrapper,
+    ManifestError, ProgressiveResolver, Signal, SignalValues, StageDecision, StageName, Wrapper,
 };
 
 /// The host facts known before triage runs — the seed every [`Schedule`]
@@ -92,6 +92,73 @@ pub enum ScheduleError {
     /// reached one boundary early instead of from a whole-program walk.
     #[error(transparent)]
     Resolve(#[from] ManifestError),
+    /// The `witness` stage's condition reads `signal`, published by
+    /// `publisher` (`execute`, `witness`, or `verify`) — but this host
+    /// decides `witness` PRE-execute, before any candidate has run, because
+    /// the decision shapes the worker's test-first `VerificationContract`
+    /// before the user message is assembled
+    /// (`crate::pipeline::Pipeline::run`). A condition here cannot honestly
+    /// wait for a stage that has not produced anything yet, so the run
+    /// refuses rather than resolve it against a placeholder. A host fact or a
+    /// signal `triage` publishes is fine — both exist by the time `witness`
+    /// is decided. See [`refuse_witness_reading_post_triage`] and #3408.
+    #[error(
+        "the witness stage's condition reads `{signal}`, published by `{publisher}` — witness \
+         is decided before execute runs (it shapes the worker's test-first contract before the \
+         user message is assembled), so it cannot read a signal that stage has not produced yet \
+         (#3408)"
+    )]
+    WitnessReadsPostTriageSignal {
+        /// The signal the `witness` stage's condition names.
+        signal: Signal,
+        /// Which stage publishes it.
+        publisher: StageName,
+    },
+}
+
+/// Refuse a variant whose `witness` stage condition reads a signal that
+/// `execute`, `witness`, or `verify` publish.
+///
+/// `witness` is a PRE-execute decision in this host (see this module's docs
+/// and `pipeline/schedule_wiring.rs`): it shapes the worker's test-first
+/// contract before the user message is assembled, so its condition may only
+/// read a host fact or a signal `triage` publishes — both exist by the time
+/// `witness` is decided. `verify` (and any other stage declared after
+/// `witness`) has no such restriction; it is decided per candidate, after
+/// `execute`'s real output exists.
+///
+/// A manifest with no `witness` stage at all, or an unconditional one, always
+/// passes — there is nothing to check. Unreachable for `classic.toml`
+/// (`if = "no-test-command"`, a host fact); asserted by
+/// `tests/variant_dispatch.rs` rather than assumed.
+///
+/// # Errors
+/// [`ScheduleError::WitnessReadsPostTriageSignal`], naming the offending
+/// signal and its publisher. [`ScheduleError::Resolve`] for a condition that
+/// does not even parse — the same failure loading this `Wrapper` would
+/// already have caught for a manifest that came from
+/// [`stella_plugin::PluginManifest::from_toml_str`].
+pub fn refuse_witness_reading_post_triage(variant: &Wrapper) -> Result<(), ScheduleError> {
+    let Some(witness_stage) = variant
+        .stages
+        .iter()
+        .find(|stage| stage.name == StageName::Witness)
+    else {
+        return Ok(());
+    };
+    let Some(condition) = witness_stage.condition()? else {
+        return Ok(());
+    };
+    let signal = condition.signal();
+    if let Some(publisher) = signal.publisher()
+        && matches!(
+            publisher,
+            StageName::Execute | StageName::Witness | StageName::Verify
+        )
+    {
+        return Err(ScheduleError::WitnessReadsPostTriageSignal { signal, publisher });
+    }
+    Ok(())
 }
 
 /// What [`ScheduleError::OutOfOrder`] found instead of the expected stage —
@@ -341,5 +408,54 @@ mod tests {
 
         assert!(winner.decide(StageName::Verify).unwrap());
         assert!(!loser.decide(StageName::Verify).unwrap());
+    }
+
+    /// #3408 P0/P1: a manifest whose `witness` condition reads `diff-lines`
+    /// — published by `execute`, which has not run when `witness` is decided
+    /// — is refused with the named error, not silently resolved against a
+    /// placeholder.
+    #[test]
+    fn a_witness_condition_reading_an_execute_signal_is_refused() {
+        let text = "name = \"probe\"\n\
+             [loop]\n\
+             participation = \"steering\"\n\
+             [wrapper]\n\
+             id = \"probe-v1\"\n\
+             [[wrapper.stages]]\n\
+             name = \"execute\"\n\
+             [[wrapper.stages]]\n\
+             name = \"witness\"\n\
+             if = \"diff-lines > 0\"\n";
+        let w = PluginManifest::from_toml_str(text)
+            .expect("fixture must load — this is a graph-valid manifest for a generic host")
+            .wrapper
+            .expect("[wrapper] declared");
+        let err = refuse_witness_reading_post_triage(&w)
+            .expect_err("execute-published diff-lines must be refused on witness");
+        assert!(
+            matches!(
+                err,
+                ScheduleError::WitnessReadsPostTriageSignal {
+                    signal: Signal::DiffLines,
+                    publisher: StageName::Execute,
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    /// The shipped shape (`classic.toml`'s `witness if = "no-test-command"`)
+    /// reads a host fact, not a stage-published signal — always accepted.
+    #[test]
+    fn a_witness_condition_reading_a_host_fact_is_accepted() {
+        let w = wrapper(vec![stage(StageName::Witness, Some("no-test-command"))]);
+        assert!(refuse_witness_reading_post_triage(&w).is_ok());
+    }
+
+    /// A manifest with no `witness` stage at all has nothing to refuse.
+    #[test]
+    fn a_manifest_with_no_witness_stage_is_accepted() {
+        let w = wrapper(vec![stage(StageName::Triage, None)]);
+        assert!(refuse_witness_reading_post_triage(&w).is_ok());
     }
 }

--- a/crates/stella-pipeline/tests/variant_dispatch.rs
+++ b/crates/stella-pipeline/tests/variant_dispatch.rs
@@ -1,21 +1,34 @@
-//! #3408's witness that the pipeline's stage schedule is read from a
-//! manifest rather than decided by a Rust branch that merely agrees with one.
+//! #3408's witness that the pipeline's stage schedule is genuinely read from
+//! a manifest, at the boundary where each decision is honestly answerable —
+//! not decided from a Rust branch that merely agrees with one, and not
+//! decided from a placeholder that happens to agree on the shipped variant.
 //!
 //! `crates/stella-pipeline/src/pipeline.rs` consults
 //! [`stella_pipeline::schedule::Schedule`] at exactly the points this file
-//! drives directly: a batch of pre-execute decisions taken right after
-//! triage (`Pipeline::decide_pre_execute_schedule`), and a per-candidate
-//! `verify` decision taken after `execute`'s real output is known
-//! (`Pipeline::run_candidate`). Both are `pub(super)` to `stella-pipeline`
-//! and cannot be called from here, so this file exercises the same
-//! [`Schedule`] sequence those call sites make — the mechanism `pipeline.rs`
-//! is built on — rather than re-deriving it against a live, fully-mocked
-//! `Pipeline::run`. `crates/stella-pipeline/src/pipeline/tests.rs`'s existing
-//! end-to-end stage-sequence assertions (`clean_lookup_skips_plan_verify_and_
-//! verifier`, `single_task_with_a_flip_submits_fast_and_skips_the_verifier`,
-//! …) are the regression net that would go red if this wiring diverged from
-//! what `pipeline.rs` actually consults — see this crate's `variant_program`
-//! and `pipeline::tests` suites, unchanged by this slice.
+//! drives directly: [`Pipeline::begin_turn_schedule`] resolves `triage`
+//! through `scope` right after triage's real facts exist (`pub(super)` to
+//! `stella-pipeline`, so this file exercises the same [`Schedule`] sequence
+//! rather than calling it), and `Pipeline::run_candidate` resolves
+//! `execute`/`witness`/`verify` **per candidate, after that candidate's real
+//! diff exists** — the fix this file's `verify_runs_or_not_by_the_real_diff`
+//! test demonstrates end to end, through an actual `Pipeline::run`, not just
+//! at the `Schedule` level.
+//!
+//! Before #3408's second half landed, `run_candidate` never consulted
+//! `Schedule` at all: `verify` was decided once, before any candidate
+//! existed, against a permanent `diff_lines: 0` / `mutating_actions: 0`
+//! placeholder. A manifest with `verify if = "diff-lines > 0"` therefore
+//! never verified ANY candidate, however large its real diff — the exact
+//! failure `verify_runs_or_not_by_the_real_diff` would have caught on the
+//! pre-fix code (see that test's own doc comment for which assertion fails
+//! and why).
+//!
+//! `crates/stella-pipeline/src/pipeline/tests.rs`'s existing end-to-end
+//! stage-sequence assertions (`clean_lookup_skips_plan_verify_and_verifier`,
+//! `single_task_with_a_flip_submits_fast_and_skips_the_verifier`, …) are the
+//! regression net that would go red if the shipped `classic` wiring
+//! diverged from what `pipeline.rs` actually consults — see this crate's
+//! `variant_program` and `pipeline::tests` suites, unchanged by this file.
 //!
 //! A condition naming an unknown key or an unpublished signal is already
 //! covered where the parser lives:
@@ -25,8 +38,30 @@
 //! [`PipelineConfig::variant`](stella_pipeline::PipelineConfig) after already
 //! passing through that loader, so there is no second load-time check at the
 //! pipeline layer to witness.
+//!
+//! [`Pipeline::begin_turn_schedule`]: stella_pipeline::pipeline::Pipeline
 
-use stella_pipeline::schedule::{HostFacts, Schedule};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use stella_core::retry::Sleeper;
+use stella_core::router::{CircuitBreaker, ProviderProfile, RoleTable};
+use stella_core::{Clock, Router, ToolExecutor};
+use stella_pipeline::ports::{
+    AlwaysAbortGate, CmdKind, CmdOutcome, DiagnosticInvocation, DiagnosticRunner, NoContextRecall,
+    NoRepoStatus, NoRepoStructure, PipelinePorts, ProviderResolver, TestInvocation, TestRunner,
+};
+use stella_pipeline::schedule::{HostFacts, Schedule, refuse_witness_reading_post_triage};
+use stella_pipeline::{Pipeline, PipelineConfig};
+use stella_protocol::event::BudgetMode;
+use stella_protocol::{
+    AgentEvent, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
+    ModelRef, Provider, ProviderError, StageKind, ToolOutput, ToolSchema,
+};
+
 use stella_plugin::{PluginManifest, StageName, Wrapper};
 
 fn load(toml: &str) -> Wrapper {
@@ -91,10 +126,12 @@ fn host() -> HostFacts {
     }
 }
 
-/// The pre-execute batch `Pipeline::decide_pre_execute_schedule` performs,
-/// reproduced here against a manifest handed in from outside — the same
-/// sequence, driven the same way, so a divergence in either would show up as
-/// a failure here without requiring a live `Pipeline::run`.
+/// The pre-execute batch `Pipeline::begin_turn_schedule` performs (through
+/// `scope`; `witness` is answered by a throwaway clone, matching the real
+/// function — see its own module doc), reproduced here against a manifest
+/// handed in from outside — the same sequence, driven the same way, so a
+/// divergence in either would show up as a failure here without requiring a
+/// live `Pipeline::run`.
 struct Decided {
     research: bool,
     plan: bool,
@@ -107,8 +144,9 @@ fn decide_pre_execute(schedule: &mut Schedule<'_>) -> Decided {
     let research = schedule.decide(StageName::Research).unwrap();
     let plan = schedule.decide(StageName::Plan).unwrap();
     let scope = schedule.decide(StageName::Scope).unwrap();
-    schedule.decide(StageName::Execute).unwrap();
-    let witness = schedule.decide(StageName::Witness).unwrap();
+    let mut witness_probe = schedule.clone();
+    witness_probe.decide(StageName::Execute).unwrap();
+    let witness = witness_probe.decide(StageName::Witness).unwrap();
     Decided {
         research,
         plan: plan && scope,
@@ -229,4 +267,286 @@ fn flipping_a_manifest_condition_flips_the_decision_with_no_code_change() {
     // different, not because any Rust changed.
     assert!(scheduled_verify("diff-lines > 0", 12));
     assert!(!scheduled_verify("diff-lines == 0", 12));
+}
+
+/// **P1 guard, restored under the new semantics.** The deleted test
+/// `the_shipped_variant_reads_only_facts_the_triage_boundary_has` protected
+/// against a manifest silently reading placeholder values by asserting the
+/// pipeline's one-shot reader (`variant.rs::classic_program`/`signals`) never
+/// resolved a post-triage signal. That premise is gone now that `witness` is
+/// answered progressively — this is its replacement: a manifest whose
+/// `witness` condition reads a signal `execute` (or `witness`, or `verify`)
+/// publishes is REFUSED with a named error at the exact boundary that would
+/// otherwise have silently resolved it against a placeholder, rather than
+/// producing a wrong answer that happens to be unreachable today.
+#[test]
+fn a_witness_condition_reading_a_post_triage_signal_is_refused() {
+    let bad = load(
+        "name = \"probe\"\n\
+         [loop]\n\
+         participation = \"steering\"\n\
+         [wrapper]\n\
+         id = \"bad-v1\"\n\
+         [[wrapper.stages]]\n\
+         name = \"execute\"\n\
+         [[wrapper.stages]]\n\
+         name = \"witness\"\n\
+         if = \"diff-lines > 0\"\n",
+    );
+    let err = refuse_witness_reading_post_triage(&bad)
+        .expect_err("a witness condition reading execute's diff-lines must be refused");
+    let message = err.to_string();
+    assert!(
+        message.contains("diff-lines") && message.contains("3408"),
+        "the refusal must name the offending signal and cite #3408: {message}"
+    );
+
+    // `classic.toml`'s own shape — `witness if = "no-test-command"`, a host
+    // fact — must still load and pass this check unchanged.
+    let classic = load(STAGED);
+    assert!(
+        refuse_witness_reading_post_triage(&classic).is_ok(),
+        "the shipped variant's witness condition reads a host fact, never a \
+         stage-published signal, and must never be refused"
+    );
+}
+
+// --- The end-to-end witness: a real `Pipeline::run`, not just `Schedule`. --
+
+/// A [`ProviderResolver`] serving one scripted [`Provider`] for every role.
+struct OneProvider<'p>(&'p ScriptedProvider);
+impl ProviderResolver for OneProvider<'_> {
+    fn provider_for(&self, _model: &ModelRef) -> Option<&dyn Provider> {
+        Some(self.0)
+    }
+}
+
+/// Answers triage, then the worker, from one ordered queue.
+struct ScriptedProvider {
+    script: Mutex<std::collections::VecDeque<CompletionResult>>,
+}
+impl ScriptedProvider {
+    fn new(results: Vec<CompletionResult>) -> Self {
+        Self {
+            script: Mutex::new(results.into_iter().collect()),
+        }
+    }
+}
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.script
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| ProviderError::Terminal("scripted provider exhausted".into()))
+    }
+}
+
+fn text_result(text: &str) -> CompletionResult {
+    CompletionResult {
+        upstream_provider: None,
+        text: text.into(),
+        tool_calls: vec![],
+        usage: CompletionUsage {
+            reported: true,
+            ..CompletionUsage::default()
+        },
+        model: "scripted".into(),
+        cost_usd: 0.0001,
+        finish_reason: None,
+    }
+}
+
+/// No tools at all: the candidate's diff comes entirely from the scripted
+/// [`DiagnosticRunner`] below, not from any tool call this run dispatches.
+struct NoTools;
+#[async_trait]
+impl ToolExecutor for NoTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        Vec::new()
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: String::new(),
+            data: None,
+        }
+    }
+}
+
+/// Reports a fixed `git diff` and a `Pass` for any test invocation — this
+/// variant declares no `witness`/`test-command`, so `run_test` is never
+/// reached, but answering harmlessly rather than panicking keeps this
+/// double honest about what it is scripting (a diff probe), not about every
+/// path the pipeline could theoretically take.
+struct ScriptedDiff {
+    diff: String,
+}
+#[async_trait]
+impl DiagnosticRunner for ScriptedDiff {
+    async fn run_diagnostic(&self, invocation: &DiagnosticInvocation) -> CmdOutcome {
+        if matches!(invocation, DiagnosticInvocation::GitDiff) {
+            return CmdOutcome {
+                exit_code: 0,
+                stdout_tail: self.diff.clone(),
+                stderr_tail: String::new(),
+                kind: CmdKind::Completed,
+            };
+        }
+        CmdOutcome {
+            exit_code: 0,
+            stdout_tail: String::new(),
+            stderr_tail: String::new(),
+            kind: CmdKind::Completed,
+        }
+    }
+}
+#[async_trait]
+impl TestRunner for ScriptedDiff {
+    async fn runner_available(&self, _probe: &TestInvocation) -> bool {
+        true
+    }
+    async fn run_test(&self, _invocation: &TestInvocation) -> CmdOutcome {
+        CmdOutcome {
+            exit_code: 0,
+            stdout_tail: String::new(),
+            stderr_tail: String::new(),
+            kind: CmdKind::Completed,
+        }
+    }
+}
+
+struct NoSleeper;
+#[async_trait]
+impl Sleeper for NoSleeper {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+struct ZeroClock;
+impl Clock for ZeroClock {
+    fn now_ms(&self) -> u64 {
+        0
+    }
+}
+
+fn router() -> Router {
+    Router::new(
+        RoleTable::new(),
+        vec![ProviderProfile::new(
+            "scripted",
+            ModelRef::new("scripted", "worker"),
+            ModelRef::new("scripted", "triage"),
+            ModelRef::new("scripted", "verifier"),
+        )],
+        CircuitBreaker::new(Box::new(ZeroClock)),
+    )
+}
+
+/// Drive `lean-diff-v1` (`verify if = "diff-lines > 0"`) through a real
+/// [`Pipeline::run`], once per real diff outcome, and assert `verify` runs
+/// exactly when the manifest says it should.
+///
+/// **What would fail on the pre-fix code.** Before `run_candidate` consulted
+/// `Schedule` at all, `verify` was decided once, before any candidate ran,
+/// against a permanent `diff_lines: 0` placeholder — so `"diff-lines > 0"`
+/// could never be true and `touched_stages.contains(&StageKind::Verify)`
+/// below would be `false` for BOTH runs (`with_diff` included), failing the
+/// first assertion. The empty-diff run's assertion happens to hold either
+/// way (`0 > 0` is false under both the placeholder and the real value), so
+/// the pre-fix code passes half this test and fails the half that proves the
+/// bug: a real diff is silently never rewarded with verification.
+async fn run_lean_diff_gated(diff: &str) -> Vec<AgentEvent> {
+    let variant = load(LEAN_DIFF_GATED);
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    let tools = NoTools;
+    let diagnostics = ScriptedDiff { diff: diff.into() };
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AlwaysAbortGate;
+    let sleeper = NoSleeper;
+    let router = router();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let config = PipelineConfig {
+        variant: Some(variant),
+        test_command: None,
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &diagnostics,
+            tests: &diagnostics,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = stella_core::BudgetGuard::new(BudgetMode::Off, None, None);
+    pipeline
+        .run("Fix the widget", &mut messages, &mut budget)
+        .await
+        .expect("run succeeds");
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
+
+fn ran_verify(events: &[AgentEvent]) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Stage {
+                name: StageKind::Verify,
+                ..
+            }
+        )
+    })
+}
+
+/// The end-to-end witness the audit demanded: `verify` runs for a candidate
+/// that produced a real diff, and does not for one that produced none — the
+/// SAME manifest, the SAME `Pipeline::run` call, driven twice.
+#[tokio::test]
+async fn verify_runs_or_not_by_the_real_diff() {
+    let with_diff = run_lean_diff_gated("@@ -1 +1 @@\n-old\n+new").await;
+    assert!(
+        ran_verify(&with_diff),
+        "a candidate producing a real diff must verify under `lean-diff-v1` \
+         (`verify if = \"diff-lines > 0\"`); events: {with_diff:#?}"
+    );
+
+    let without_diff = run_lean_diff_gated("").await;
+    assert!(
+        !ran_verify(&without_diff),
+        "a candidate producing no diff at all must not verify under the same \
+         manifest; events: {without_diff:#?}"
+    );
 }

--- a/crates/stella-pipeline/tests/variant_dispatch.rs
+++ b/crates/stella-pipeline/tests/variant_dispatch.rs
@@ -550,3 +550,87 @@ async fn verify_runs_or_not_by_the_real_diff() {
          manifest; events: {without_diff:#?}"
     );
 }
+
+/// The refusal fires on the pre-triage rung: a variant whose `witness`
+/// condition this host cannot answer is turned away before the FIRST paid
+/// call, with zero cost accrued and the provider's script untouched.
+///
+/// **What would fail on the pre-hoist code.** `refuse_witness_reading_post_triage`
+/// used to run inside `begin_turn_schedule`, which sits after triage — so the
+/// same refusal arrived with `total_cost_usd > 0` and one scripted response
+/// consumed. Both assertions below caught it (#3408; the sibling refusals'
+/// principle is #1147).
+#[tokio::test]
+async fn a_bad_variant_is_refused_before_the_first_paid_call() {
+    let bad = load(
+        "name = \"probe\"\n\
+         [loop]\n\
+         participation = \"steering\"\n\
+         [wrapper]\n\
+         id = \"bad-v1\"\n\
+         [[wrapper.stages]]\n\
+         name = \"execute\"\n\
+         [[wrapper.stages]]\n\
+         name = \"witness\"\n\
+         if = \"diff-lines > 0\"\n",
+    );
+    let provider = ScriptedProvider::new(vec![text_result("single"), text_result("done")]);
+    let resolver = OneProvider(&provider);
+    let tools = NoTools;
+    let diagnostics = ScriptedDiff {
+        diff: String::new(),
+    };
+    let recall = NoContextRecall;
+    let repo = NoRepoStructure;
+    let repo_status = NoRepoStatus;
+    let approvals = AlwaysAbortGate;
+    let sleeper = NoSleeper;
+    let router = router();
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let config = PipelineConfig {
+        variant: Some(bad),
+        test_command: None,
+        diff_diagnostic: Some(DiagnosticInvocation::GitDiff),
+        ..PipelineConfig::default()
+    };
+    let pipeline = Pipeline::new(
+        PipelinePorts {
+            router: &router,
+            providers: &resolver,
+            tools: &tools,
+            recall: &recall,
+            repo: &repo,
+            repo_status: &repo_status,
+            diagnostics: &diagnostics,
+            tests: &diagnostics,
+            lint: None,
+            mutation: None,
+            coverage: None,
+            approvals: &approvals,
+            sleeper: &sleeper,
+            hooks: None,
+            candidate_workspaces: None,
+            mcp_prefetch: None,
+            steering: None,
+        },
+        tx,
+        config,
+    );
+
+    let mut messages = vec![CompletionMessage::system("sys")];
+    let mut budget = stella_core::BudgetGuard::new(BudgetMode::Off, None, None);
+    let error = pipeline
+        .run("Fix the widget", &mut messages, &mut budget)
+        .await
+        .expect_err("a witness condition reading diff-lines must refuse the run");
+
+    assert_eq!(
+        error.total_cost_usd, 0.0,
+        "the refusal must precede the first paid call; cost says one ran: {error:?}"
+    );
+    assert_eq!(
+        provider.script.lock().unwrap().len(),
+        2,
+        "no scripted response may be consumed before the refusal"
+    );
+}

--- a/crates/stella-plugin/tests/wrapper_stages.rs
+++ b/crates/stella-plugin/tests/wrapper_stages.rs
@@ -82,13 +82,19 @@ fn a_wrapper_round_trips_through_json_byte_for_byte() {
     let json = serde_json::to_string(&wrapper).expect("a validated Wrapper always serializes");
     let restored: Wrapper =
         serde_json::from_str(&json).expect("what this crate just wrote, it can read back");
-    assert_eq!(restored, wrapper, "the round trip must reproduce the value exactly");
+    assert_eq!(
+        restored, wrapper,
+        "the round trip must reproduce the value exactly"
+    );
 
     // And the round trip is itself stable — serializing the restored value
     // again produces the identical bytes, not merely an equal value.
     let json_again =
         serde_json::to_string(&restored).expect("a value that just parsed always serializes");
-    assert_eq!(json_again, json, "re-serializing must reproduce the same bytes");
+    assert_eq!(
+        json_again, json,
+        "re-serializing must reproduce the same bytes"
+    );
 }
 
 #[test]

--- a/crates/stella-plugin/tests/wrapper_stages.rs
+++ b/crates/stella-plugin/tests/wrapper_stages.rs
@@ -15,7 +15,7 @@
 
 use stella_plugin::{
     CompareOp, Condition, ManifestError, PluginManifest, Signal, SignalKind, SignalValues,
-    StageName,
+    StageName, Wrapper,
 };
 use stella_protocol::StageKind;
 
@@ -63,6 +63,32 @@ fn todays_stage_order_loads_as_a_manifest() {
         ],
         "the order must match stage_rank in stella-pipeline's replay.rs"
     );
+}
+
+/// #3408 P2: `Wrapper` crosses a crate boundary on the wire — `stella-cli`'s
+/// `PipelineFrame::variant` persists it beside a killed run's checkpoint so a
+/// resume restores the same manifest, not the built-in `classic` fallback
+/// (invariant 4: serde-first, round-trip when a type crosses a boundary).
+/// `Wrapper`/`WrapperStage` already derive `Serialize`/`Deserialize`; this is
+/// the witness that the round-trip is actually byte-identical, not merely
+/// that the derive compiles.
+#[test]
+fn a_wrapper_round_trips_through_json_byte_for_byte() {
+    let wrapper = parse(STAGED_V1)
+        .expect("the shipped order must load")
+        .wrapper
+        .expect("[wrapper] must parse");
+
+    let json = serde_json::to_string(&wrapper).expect("a validated Wrapper always serializes");
+    let restored: Wrapper =
+        serde_json::from_str(&json).expect("what this crate just wrote, it can read back");
+    assert_eq!(restored, wrapper, "the round trip must reproduce the value exactly");
+
+    // And the round trip is itself stable — serializing the restored value
+    // again produces the identical bytes, not merely an equal value.
+    let json_again =
+        serde_json::to_string(&restored).expect("a value that just parsed always serializes");
+    assert_eq!(json_again, json, "re-serializing must reproduce the same bytes");
 }
 
 #[test]


### PR DESCRIPTION
## What & why

**Status: in progress — audit-fix round + the remaining ejection phases land here phase-by-phase.** This line will be removed when the branch is complete.

Follow-up to #3672 (merged), which shipped the manifest-driven schedule with a P0 its own adversarial audit caught **after** the merge landed:

- **P0**: `Pipeline::begin_turn_schedule` decided `witness`/`verify` in the pre-execute batch against placeholder signal values (`diff_lines: 0`, …), and `run_candidate` never consulted the `Schedule` — so a variant gating `verify` on `diff-lines > 0` silently never verified, in the "nothing happened" direction the measurement rules exist to prevent.

The fix, per the decided shape:
1. **Witness stays a pre-execute decision** (it shapes the worker's test-first contract before the prompt is assembled) — so a variant whose `witness` condition reads a post-triage signal is **refused with a typed, named error** instead of silently mis-answered. `classic.toml` is unaffected.
2. **Verify becomes genuinely per-candidate and post-execute**: each candidate carries its own `Schedule` clone, updated with the candidate's real `mutating_actions`/`diff_lines` after execute, and `verify` is decided at its own boundary.
3. The end-to-end witness test the audit demanded: a non-default variant driven through `Pipeline::run`, asserting verify runs iff the candidate's real diff satisfies the manifest condition.
4. Resume frames persist `PipelineConfig.variant` (round-trip tested) instead of silently falling back to classic.
5. Guard coverage restored for the new semantics; stale doc claims and the nonexistent function name corrected.

Remaining phases on this branch per the ejection programme: #3381 flag inversion → Phase 6 docs scrub → Track B plugins → CLI decoupling toward deleting `crates/stella-pipeline`.

Refs #3408
Refs #3491
Refs #3381

## The witness

- [x] End-to-end: a diff-gated variant through `Pipeline::run` verifies a candidate with a real diff and skips one with none — fails on the pre-fix code where `frame.schedule_verifies` was a static pre-execute bool. Exact test names listed when the branch completes.

## The gate

- [ ] Boxes checked when the final validated push lands — unchecked means not yet run on the final tree, not skipped.

## Nothing left behind

- [ ] Filed: handoff issues linked before review.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New cross-boundary serde types round-trip (variant-in-frame test)

## Anything reviewers should know?

- Head commits are phase checkpoints; hold review until the status line is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTfq37g7bM6efEE5Pkx1k5)_

## Summary by Sourcery

Correct manifest-driven pipeline scheduling so witness decisions are validated before execution and verification is evaluated per candidate against real execution results.

New Features:
- Make verification decisions independently for each candidate using its actual post-execution signals.
- Persist configured pipeline variants in resume frames so resumed runs use the original variant.

Bug Fixes:
- Prevent witness conditions from being evaluated against unavailable post-triage signals by refusing invalid variants before paid work begins.
- Ensure diff-gated verification runs when a candidate produces a real diff and is skipped when it does not.

Enhancements:
- Split schedule resolution between pre-execution witness decisions and post-execution per-candidate verification decisions.
- Add typed validation and comprehensive end-to-end coverage for manifest-driven witness and verification behavior.

Documentation:
- Update pipeline scheduling documentation to describe the separate witness and verification decision boundaries.

Tests:
- Add regression coverage for invalid witness signal dependencies, real-diff verification gating, variant persistence, and wrapper serialization round trips.