### PR TITLE
feat(stella-cli): raw loop becomes the default on every door; --pipeline <variant> opts in (#3381)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -107,11 +107,11 @@ pub(crate) fn session_persistence() -> stella_runtime::Persistence {
 }
 
 /// Run a one-shot prompt. [`PipelineChoice`](crate::wrapper_plugin::PipelineChoice)
-/// selects which wrapper runs over the turn. `test_command`, when given, arms
-/// the pipeline's deterministic verification ladder (the fail→pass flip
-/// oracle); without it, verification falls back to the model verifier on every
-/// iteration. `keep_witness` promotes an authored witness into the working tree
-/// instead of letting it die with the candidate workspace.
+/// selects which wrapper runs over the turn (`Raw` by default, #3381).
+/// `test_command`, when given, arms the pipeline's deterministic verification
+/// ladder (the fail→pass flip oracle); without it, verification falls back to
+/// the model verifier on every iteration. `keep_witness` promotes an authored
+/// witness into the working tree instead of letting it die with the candidate workspace.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_one_shot(
     cfg: &Config,

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -259,6 +259,17 @@ pub(crate) fn subsession_engine_config_for(cfg: &Config) -> EngineConfig {
 /// `"chat"` turn is conversational and keeps the ungated shape. Keyed on the
 /// same `kind` string `begin_execution` records, so the gate and the
 /// telemetry cannot disagree about which mode a turn ran in.
+///
+/// The only caller is `stella run`'s raw one-shot path (`agent.rs`), so
+/// #3381's default flip (every door raw by default) widened this gate's
+/// *population* — a plain `stella run` with no flags now reaches it, not only
+/// an explicit `--no-pipeline` — without changing the gate's own logic.
+/// `goal`'s and `fleet`'s raw rounds build their `EngineConfig` from
+/// [`engine_config_for`] directly (`agent/goal.rs`, `fleet_cmd.rs`) and never
+/// call this function at all, on either side of the flip — the `"goal"`/
+/// `"fleet"` `kind` strings `begin_execution` records for those doors would
+/// fail the `== "run"` match here even if they did, so extending the gate to
+/// them is a distinct, undone change, not a consequence of this one.
 pub(crate) fn engine_config_for_kind(cfg: &Config, kind: &str) -> EngineConfig {
     let mut engine = engine_config_for(cfg);
     engine.completion_gate = kind == "run";

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -1,9 +1,10 @@
 //! Goal-driven turns: judged rounds until a verifier confirms the goal is met.
 //!
-//! `run_goal_cmd` drives either the staged pipeline (default) or the raw
-//! `Engine::run_goal` step-loop. The goal verifier is independent of the worker
-//! model and answers "does the whole effort meet the goal?" — distinct from
-//! the pipeline's per-change verification verifier.
+//! `run_goal_cmd` drives either the raw `Engine::run_goal` step-loop (the
+//! default since #3381) or the staged pipeline, opted into with `--pipeline
+//! classic`. The goal verifier is independent of the worker model and
+//! answers "does the whole effort meet the goal?" — distinct from the
+//! pipeline's per-change verification verifier.
 
 use super::*;
 
@@ -366,15 +367,23 @@ pub(crate) async fn run_raw_one_shot(
 /// worker turns get the full tool stack (built-ins + MCP + custom), same as
 /// `run_one_shot`.
 ///
-/// `use_pipeline` (the default) runs each working round through the staged
-/// pipeline (triage → recall → plan → execute → witness → verify → verdict);
-/// `false` falls back to the raw `Engine::run_goal` step-loop.
+/// `pipeline` selects the driver for each working round (#3381): `Classic`
+/// (`--pipeline classic`) runs the staged pipeline (triage → recall → plan →
+/// execute → witness → verify → verdict); `Raw` — the default since #3381,
+/// with or without `--no-pipeline` — falls back to the raw `Engine::run_goal`
+/// step-loop. A named plugin `Variant` is refused before this is ever called
+/// (`wrapper_plugin::reject_plugin_variant_for_door`, main.rs's `Goal` arm) —
+/// this door only ever sees `Classic` or `Raw`.
 pub async fn run_goal_cmd(
     cfg: &Config,
     goal: &str,
     budget_limit: Option<f64>,
-    use_pipeline: bool,
+    pipeline: crate::wrapper_plugin::PipelineChoice<'_>,
 ) -> Result<(), crate::failure::CliFailure> {
+    // Only `Classic`/`Raw` reach this door (see the doc above); either reads
+    // as one bool for the rest of this function's branching, same shape as
+    // before #3381.
+    let use_pipeline = pipeline.is_classic();
     crate::enterprise_telemetry::authorize_execution_surface(
         crate::enterprise_telemetry::ExecutionSurface::Goal,
     )?;
@@ -592,6 +601,10 @@ pub(crate) async fn run_goal_turn(
     session_memory: Option<&mut crate::memory::SessionMemory>,
 ) -> Result<(), crate::failure::CliFailure> {
     let turn_start = Instant::now();
+    // This function is the RAW arm — `run_goal_cmd` calls it only when
+    // `pipeline.is_classic()` is false — so `variant: None` is the honest
+    // answer every time, not a placeholder (#3381, #3388): nothing wrapped
+    // this round.
     let execution = begin_execution(store, "goal", goal, cfg, session, None);
     stamp_and_record_skill_usage(&execution, session_memory, goal, &cfg.workspace_root);
 
@@ -753,7 +766,19 @@ async fn run_goal_pipeline_turn(
     session_memory: Option<&mut crate::memory::SessionMemory>,
 ) -> Result<(), crate::failure::CliFailure> {
     let turn_start = Instant::now();
-    let execution = begin_execution(store, "goal", goal, cfg, session, None);
+    // This function is the CLASSIC arm — `run_goal_cmd` calls it only when
+    // `pipeline.is_classic()` is true — so the row must name the wrapper that
+    // actually drove this round rather than leave `pipeline_variant` NULL
+    // (#3381, #3388, #3684): NULL on this path used to mean "raw OR classic",
+    // which made a per-variant comparison over `goal` rounds silently wrong.
+    let execution = begin_execution(
+        store,
+        "goal",
+        goal,
+        cfg,
+        session,
+        Some(persistence::PIPELINE_VARIANT_CLASSIC),
+    );
     // Rebound mutable and NOT consumed by the seam, so the same memory can
     // double as the pipeline's recall port below.
     let mut session_memory = session_memory;

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -808,6 +808,40 @@ mod pipeline_variant_tests {
         assert_eq!(store.pipeline_variant(bare).expect("read"), None);
     }
 
+    /// **Pins the goal/fleet honesty fix's call shape (#3381, #3388, #3684).**
+    /// `goal.rs`'s `run_goal_pipeline_turn` and `fleet_cmd.rs`'s `run_task`
+    /// used to call `begin_execution(..., None)` even while the staged
+    /// pipeline drove the round, so `NULL` meant "raw OR classic" there —
+    /// unlike `run`/`deck`. The real fix is the one-line argument each site
+    /// now passes, verified by reading those two lines directly (neither is
+    /// reachable from a unit test without a live provider); this pins that
+    /// `begin_execution`/`pipeline_variant` round-trip both call shapes
+    /// correctly for `"goal"`/`"fleet"` — see `wrapper_plugin::tests` for the
+    /// `resolve`-level witnesses that DO fail on old code.
+    #[test]
+    fn goal_and_fleet_write_classic_honestly_never_a_false_null() {
+        let provider = crate::config::PROVIDERS[0].clone();
+        let cfg = crate::config::Config::for_tests(provider, "test-model".to_string());
+        let store = Some(Arc::new(Store::in_memory().expect("in-memory store")));
+        // What `begin_execution` writes and reads back for `door`/`variant`.
+        let written = |door: &str, v| {
+            let (s, id) = begin_execution(&store, door, "prompt", &cfg, None, v).expect("begin");
+            s.pipeline_variant(id).expect("read")
+        };
+
+        for door in ["goal", "fleet"] {
+            // Classic arm: the wrapper that ran is named, not dropped. Raw
+            // arm: NULL is the honest answer here, not a gap.
+            let msg = format!("{door}: honesty rule");
+            assert_eq!(
+                written(door, Some(PIPELINE_VARIANT_CLASSIC)),
+                Some(PIPELINE_VARIANT_CLASSIC.to_string()),
+                "{msg}"
+            );
+            assert_eq!(written(door, None), None, "{msg}");
+        }
+    }
+
     /// The id the CLI records and the id the pipeline calls itself are one
     /// string, not two that happen to agree.
     #[test]

--- a/crates/stella-cli/src/arena.rs
+++ b/crates/stella-cli/src/arena.rs
@@ -23,6 +23,19 @@
 //! `event_sender_for_run` — one-shot runs are one-per-process, exactly like
 //! the env-gated Harbor sink this mirrors.
 //!
+//! **The default this adapter measures changed with #3381.** `run_arena`
+//! resolves its choice via the same `PipelineChoice::resolve(args.no_pipeline,
+//! None)` `stella run` uses, and #3381 flipped that resolution's no-flag
+//! default from the staged pipeline to the raw step-loop. Arena is the
+//! benchmark adapter, so this is not an incidental side effect: **every arena
+//! episode now measures the raw loop unless the runner passes `--pipeline
+//! <variant>`**, which this adapter does not yet expose as a flag of its own
+//! (only `--no-pipeline`, now a deprecated no-op, and `--test-command`). A
+//! panel run against this binary before and after #3381 is comparing the
+//! staged pipeline to the raw loop, not two builds of the same thing — CLAUDE.md's
+//! like-for-like rule requires that comparison be named, never silently
+//! absorbed into a "regression".
+//!
 //! [`contextgraph-trace`]: https://github.com/macanderson/context-graph-protocol/blob/6f8d7ef13b2528c26913c6472405408ba2584a85/docs/sketches/host-trace.md
 
 use std::collections::{HashMap, HashSet};
@@ -77,6 +90,9 @@ pub(crate) struct ArenaArgs {
 /// Run one arena episode invocation: honor the contract, record the journal,
 /// drive the ordinary one-shot path.
 pub(crate) async fn run_arena(mut cfg: Config, args: ArenaArgs) -> Result<(), String> {
+    if let Some(notice) = crate::wrapper_plugin::no_pipeline_deprecation_notice(args.no_pipeline) {
+        eprintln!("⚠ {notice}");
+    }
     let task_dir = args
         .task_dir
         .canonicalize()
@@ -98,7 +114,7 @@ pub(crate) async fn run_arena(mut cfg: Config, args: ArenaArgs) -> Result<(), St
         &prompt,
         None,
         OutputFormat::StreamJson,
-        crate::wrapper_plugin::PipelineChoice::resolve(args.no_pipeline, None)?,
+        crate::wrapper_plugin::PipelineChoice::resolve(args.no_pipeline, None),
         args.test_command.as_deref(),
         // The arena verifiers the task result, not the scaffolding that proved
         // it — a witness left in the tree would show up as unexplained work.

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -527,10 +527,12 @@ pub(crate) enum Command {
         /// the usual `--` separator: `stella run -- --my-prompt`.
         prompt: Option<String>,
 
-        /// Use the raw step-loop instead of the staged pipeline (triage, plan,
-        /// execute, verify, verifier). The pipeline is the default; this flag
-        /// falls back to the direct Engine::run_turn path.
-        #[arg(long)]
+        /// Deprecated, does nothing (#3381). The raw step-loop is the default
+        /// now; pass `--pipeline <variant>` to opt into a wrapper instead.
+        /// Kept parseable so no script breaks the day this changed — passing
+        /// it prints a one-line notice and has no other effect, including
+        /// alongside `--pipeline`, which always wins.
+        #[arg(long, hide = true)]
         no_pipeline: bool,
 
         /// Run this turn under an installed wrapper plugin, by the `[wrapper]
@@ -539,8 +541,9 @@ pub(crate) enum Command {
         /// its declared rule — evaluated by Stella, never by the plugin —
         /// decides whether another turn runs. The id is recorded on the
         /// execution row, so two variants can be compared. `classic` names the
-        /// built-in staged pipeline; omitted, nothing changes.
-        #[arg(long, value_name = "VARIANT", conflicts_with = "no_pipeline")]
+        /// built-in staged pipeline; omitted, the raw step-loop runs with
+        /// nothing over it (the default since #3381).
+        #[arg(long, value_name = "VARIANT")]
         pipeline: Option<String>,
 
         /// Test command the pipeline's verify stage runs deterministically
@@ -612,8 +615,11 @@ pub(crate) enum Command {
         #[arg(long)]
         resume: bool,
 
-        /// Use the raw step-loop instead of the staged pipeline.
-        #[arg(long)]
+        /// Deprecated, does nothing (#3381). The raw step-loop is the default
+        /// now — this flag named that fallback before the flip and is kept
+        /// parseable only so no script breaks; passing it prints a one-line
+        /// notice and has no other effect.
+        #[arg(long, hide = true)]
         no_pipeline: bool,
 
         /// Test command for the pipeline's deterministic verify ladder.
@@ -624,19 +630,33 @@ pub(crate) enum Command {
     /// Work in judged rounds until a verifier says the goal is met
     ///
     /// Work in judged rounds until a verifier model confirms the goal is met.
-    /// Each working round runs through the staged pipeline (triage, plan,
-    /// witness, execute, verify) by default; --no-pipeline falls back to the
-    /// raw step-loop.
+    /// Each working round runs the raw step-loop by default (#3381); pass
+    /// `--pipeline classic` to route rounds through the staged pipeline
+    /// (triage, plan, witness, execute, verify) instead.
     Goal {
         /// What must be true when done — assessed by the verifier each round.
         /// Omit it to read the goal from stdin when it is piped, or pass `-`
         /// to read stdin explicitly.
         goal: Option<String>,
 
-        /// Use the raw step-loop instead of the staged pipeline for each
-        /// working round. The pipeline is the default.
-        #[arg(long)]
+        /// Deprecated, does nothing (#3381). The raw step-loop is the default
+        /// now; pass `--pipeline <variant>` to opt into a wrapper instead.
+        /// Kept parseable so no script breaks the day this changed — passing
+        /// it prints a one-line notice and has no other effect, including
+        /// alongside `--pipeline`, which always wins.
+        #[arg(long, hide = true)]
         no_pipeline: bool,
+
+        /// Run each working round through an installed wrapper plugin, by
+        /// the `[wrapper] id` its manifest declares (`stella plugin list`).
+        /// `classic` names the built-in staged pipeline (triage → recall →
+        /// plan → witness → execute → verify); omitted, the raw step-loop
+        /// runs with nothing over it (the default since #3381). A named
+        /// plugin variant is refused today — wrapper plugins run only on
+        /// `stella run --pipeline <variant>` (#3684 tracks driving them
+        /// through a judged round).
+        #[arg(long, value_name = "VARIANT")]
+        pipeline: Option<String>,
     },
 
     /// Watch CI for a branch or PR and fix it until green
@@ -818,11 +838,24 @@ pub(crate) enum Command {
         #[arg(long)]
         watch: bool,
 
-        /// Use the raw step-loop instead of the staged pipeline (triage,
-        /// plan, witness, execute, verify) for each worker. The pipeline is
-        /// the default.
-        #[arg(long)]
+        /// Deprecated, does nothing (#3381). The raw step-loop is the default
+        /// now; pass `--pipeline <variant>` to opt into a wrapper instead.
+        /// Kept parseable so no script breaks the day this changed — passing
+        /// it prints a one-line notice and has no other effect, including
+        /// alongside `--pipeline`, which always wins.
+        #[arg(long, hide = true)]
         no_pipeline: bool,
+
+        /// Run each worker through an installed wrapper plugin, by the
+        /// `[wrapper] id` its manifest declares (`stella plugin list`).
+        /// `classic` names the built-in staged pipeline (triage, plan,
+        /// witness, execute, verify); omitted, the raw step-loop runs with
+        /// nothing over it (the default since #3381). A named plugin variant
+        /// is refused today — wrapper plugins run only on `stella run
+        /// --pipeline <variant>` (#3684 tracks driving them through a fleet
+        /// worker).
+        #[arg(long, value_name = "VARIANT")]
+        pipeline: Option<String>,
 
         /// Wall-clock ceiling per worker attempt, in seconds. On expiry the
         /// task's stop line fires (the same clean cancel the dashboard's

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -427,17 +427,18 @@ pub async fn run_deck_session(
     // is durable now, so an exit with prompts waiting is a pause, not loss.
     let mut session_exit = stella_store::SessionStatus::Complete;
     let mut sidecar_dir = session_registry.sidecar_dir(&session_record.id);
-    // Persona matches the driver: the deck runs the staged pipeline by
-    // default, so the lead gets the pipeline worker persona (methodology
-    // ladder + `agents.worker.prompt` override) that only `stella run`
-    // carried before. Chosen ONCE per session from the same state
-    // `pipeline_init` reads — the prefix is byte-stable for the session
-    // (L-E8), so a mid-session `/pipeline` toggle changes the driver but
-    // keeps the persona until the next session.
+    // Persona matches the driver: a fresh deck session runs the raw engine
+    // loop by default since #3381, so it gets the plain REPL persona now,
+    // not the pipeline worker persona (methodology ladder +
+    // `agents.worker.prompt` override) — that applies only once `/pipeline`
+    // is on (invariant #7: this changes what a NEW session starts with, not
+    // a resumed one). Chosen ONCE per session from the same state
+    // `pipeline_init` reads — byte-stable (L-E8), so a mid-session toggle
+    // changes the driver but keeps the persona until the next session.
     let pipeline_persona = resume_state
         .as_ref()
         .and_then(|rs| rs.pipeline)
-        .unwrap_or(true);
+        .unwrap_or(false);
     let system_prompt = agent::with_session_hook_context(
         if pipeline_persona {
             // Assembled once per session, before any turn resolves wiring: no
@@ -683,11 +684,11 @@ pub async fn run_deck_session(
         Arc::new(ask_io.clone()),
     );
 
-    // The deck drives turns through the staged pipeline by default (triage →
-    // recall → plan → scope → execute → witness → verify → verdict); `/pipeline`
-    // toggles back to the raw `Engine::run_turn` loop (`run_lead_turn`). A
-    // resumed session keeps whatever it last had — the same state the persona
-    // choice above read, so driver and persona start the session agreeing.
+    // A fresh deck session drives turns through the raw `Engine::run_turn`
+    // loop (`run_lead_turn`) by default since #3381; `/pipeline` toggles it
+    // ON to route through the staged pipeline instead. A resumed session
+    // keeps whatever it last had — the same state the persona choice above
+    // read, so driver and persona start the session agreeing.
     let pipeline_init = pipeline_persona;
     // Honour the persisted colour theme (`ui.theme`) before the deck spawns its
     // render task, so the very first frame — the launch cinematic — is already
@@ -832,9 +833,9 @@ pub async fn run_deck_session(
     dispatch.held = resume_hold;
     // `/pipeline`: route lead turns through the staged pipeline (triage →
     // execute → witness → verify → verdict) instead of the raw engine loop.
-    // Session-local, ON at start (the deck loads with the pipeline active)
-    // unless a resumed session had toggled it — mirrored to the PIPELINE
-    // stat box via `Inbound::Pipeline`.
+    // Session-local, OFF at start since #3381 (a fresh deck session runs the
+    // raw loop) unless a resumed session had toggled it ON — mirrored to the
+    // PIPELINE stat box via `Inbound::Pipeline`.
     let mut pipeline_on = pipeline_init;
     // An agent-creation request that arrived mid-turn: drafting needs the
     // provider (borrowed by the running turn), so it parks here and runs
@@ -1231,7 +1232,8 @@ pub async fn run_deck_session(
                                     });
                                 }
                                 queue.adopt(sidecar_dir.clone(), restored);
-                                pipeline_on = rs.pipeline.unwrap_or(true);
+                                // Same default as the start-up read above (#3381).
+                                pipeline_on = rs.pipeline.unwrap_or(false);
                                 let _ = in_tx.send(Inbound::Pipeline(pipeline_on));
                                 // `--spend-limit` means THIS session, decided and
                                 // implemented on both resume paths: reseed

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -466,9 +466,9 @@ fn render_watch_line(watch: &BranchWatch) {
     );
 }
 
-/// The engine-backed [`FleetWorker`]: one turn per task (the staged pipeline
-/// by default, or the raw step-loop with `--no-pipeline`), in the task's own
-/// workspace, with the standard (headless) tool registry.
+/// The engine-backed [`FleetWorker`]: one turn per task (the raw step-loop by
+/// default since #3381, or the staged pipeline with `--pipeline classic`), in
+/// the task's own workspace, with the standard (headless) tool registry.
 struct EngineWorker {
     cfg: Config,
     /// Per-child spend cap. Derived as `--spend-limit / max_concurrency` (not
@@ -663,10 +663,11 @@ fn worker_event_sender(tx: &mpsc::UnboundedSender<AgentEvent>) -> stella_core::E
     stella_core::EventSender::new(tx.clone()).pairing_stage_complete()
 }
 
-/// One worker turn in `root`, on the calling thread's runtime. When
-/// `use_pipeline` is true (the default), the turn runs through the staged
-/// pipeline (triage → recall → plan → execute → witness → verify → verdict);
-/// otherwise it falls back to the raw `Engine::run_turn` step-loop.
+/// One worker turn in `root`, on the calling thread's runtime. `use_pipeline`
+/// is `false` by default since #3381 — the turn runs the raw `Engine::run_turn`
+/// step-loop; `true` (`--pipeline classic`) routes it through the staged
+/// pipeline instead (triage → recall → plan → execute → witness → verify →
+/// verdict).
 #[allow(clippy::too_many_arguments)] // one caller (EngineWorker::run); composition wiring
 async fn run_task(
     cfg: &Config,
@@ -738,7 +739,20 @@ async fn run_task(
     let store = agent::open_store(root);
     // Owned above the pipeline so it outlives every engine it builds (#1595).
     let calibration = agent::seed_calibration(&store, &cfg);
-    let execution = agent::begin_execution(&store, "fleet", &task.prompt, &cfg, None, None);
+    // The variant is a fact about which driver ran THIS attempt, not a
+    // placeholder: `use_pipeline` is exactly `pipeline.is_classic()` at the
+    // door (main.rs's `Fleet` arm), so when the staged pipeline drives this
+    // worker the row must name it rather than leave `pipeline_variant` NULL
+    // (#3381, #3388, #3684) — NULL used to mean "raw OR classic" here, which
+    // made a per-variant comparison over fleet attempts silently wrong.
+    let execution = agent::begin_execution(
+        &store,
+        "fleet",
+        &task.prompt,
+        &cfg,
+        None,
+        use_pipeline.then_some(agent::persistence::PIPELINE_VARIANT_CLASSIC),
+    );
     // From here on this attempt's spend is durable in the store even if this
     // thread never lives to report it — publish the handle that makes it
     // readable from the dispatch side (#1216).

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -1042,6 +1042,9 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             require_verified,
             output_format,
         } => {
+            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
+                eprintln!("⚠ {notice}");
+            }
             let prompt = prompt_source::resolve(
                 prompt,
                 std::io::stdin().is_terminal(),
@@ -1067,7 +1070,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &prompt,
                     cli.globals.spend_limit,
                     output_format,
-                    wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref())?,
+                    wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref()),
                     test_command.as_deref(),
                     keep_witness,
                     require_verified,
@@ -1097,7 +1100,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 ),
             )?;
         }
-        Command::Goal { goal, no_pipeline } => {
+        Command::Goal {
+            goal,
+            no_pipeline,
+            pipeline,
+        } => {
+            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
+                eprintln!("⚠ {notice}");
+            }
+            let pipeline_choice =
+                wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref());
+            wrapper_plugin::reject_plugin_variant_for_door("goal", pipeline_choice)?;
             let goal = prompt_source::resolve(
                 goal,
                 std::io::stdin().is_terminal(),
@@ -1118,7 +1131,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             }
             signals::block_on_interruptible(
                 rt()?,
-                agent::run_goal_cmd(&cfg, &goal, cli.globals.spend_limit, !no_pipeline),
+                agent::run_goal_cmd(&cfg, &goal, cli.globals.spend_limit, pipeline_choice),
             )?;
         }
         Command::Fleet {
@@ -1137,9 +1150,16 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             base_ref,
             watch,
             no_pipeline,
+            pipeline,
             task_timeout,
             output_format,
         } => {
+            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
+                eprintln!("⚠ {notice}");
+            }
+            let pipeline_choice =
+                wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref());
+            wrapper_plugin::reject_plugin_variant_for_door("fleet", pipeline_choice)?;
             let posture = supervision(&cli.globals);
             if posture.supervises() {
                 return daemon::supervise_this_invocation(
@@ -1167,7 +1187,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     max_concurrency,
                     cli.globals.spend_limit,
                     watch,
-                    !no_pipeline,
+                    pipeline_choice.is_classic(),
                     task_timeout.map(std::time::Duration::from_secs),
                     output_format,
                 ),
@@ -1198,9 +1218,20 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                  only when the latest CI run for `{target}` has completed with every check \
                  successful."
             );
+            // `monitor` takes no `--pipeline`/`--no-pipeline` of its own — it is
+            // `goal` with a fixed prompt, not a door #3381 named — so its
+            // driver stays pinned to the staged pipeline exactly as before the
+            // flip, deliberately: fixing CI is exactly the multi-file,
+            // verify-gated work the pipeline's ladder was built for, and
+            // nothing here reads a user flag for the flip to invert.
             signals::block_on_interruptible(
                 rt()?,
-                agent::run_goal_cmd(&cfg, &goal, cli.globals.spend_limit, true),
+                agent::run_goal_cmd(
+                    &cfg,
+                    &goal,
+                    cli.globals.spend_limit,
+                    wrapper_plugin::PipelineChoice::Classic,
+                ),
             )?;
         }
         Command::Chat => {

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -86,16 +86,21 @@ use crate::{OutputFormat, config::Config};
 
 /// Which wrapper runs over a one-shot turn.
 ///
-/// `doc:pipeline-as-plugins` §7 plans `--pipeline <variant>` to *replace*
-/// `--no-pipeline`; this is the additive half of that inversion, so both flags
-/// exist and the third arm is the new capability. Making it an enum rather than
-/// a `bool` plus an `Option<&str>` is what keeps "the staged pipeline and a
-/// plugin both ran" unrepresentable.
+/// `doc:pipeline-as-plugins` §7 planned `--pipeline <variant>` to *replace*
+/// `--no-pipeline`; `docs/spec/turn-loop-wrappers.md` §5 "Flip the default"
+/// (#3381) is that replacement landing — the raw loop is now the default on
+/// every door this enum reaches, `--pipeline <variant>` is the sole opt-in,
+/// and `--no-pipeline` is a deprecated no-op kept parseable so no script
+/// breaks the day this ships (see [`resolve`](Self::resolve) and
+/// [`no_pipeline_deprecation_notice`]). Making this a three-way enum rather
+/// than a `bool` plus an `Option<&str>` is what keeps "the staged pipeline
+/// and a plugin both ran" unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PipelineChoice<'a> {
-    /// The built-in staged pipeline — today's default, recorded as `classic`.
+    /// The built-in staged pipeline, recorded as `classic`. Opt-in only,
+    /// since #3381 — `--pipeline classic` selects it by name.
     Classic,
-    /// The raw step-loop with nothing over it (`--no-pipeline`).
+    /// The raw step-loop with nothing over it — the default since #3381.
     Raw,
     /// The raw step-loop wrapped by an installed plugin whose `[wrapper] id` is
     /// this variant (`--pipeline <variant>`).
@@ -105,27 +110,23 @@ pub(crate) enum PipelineChoice<'a> {
 impl<'a> PipelineChoice<'a> {
     /// Read the two flags into one choice.
     ///
-    /// # Errors
-    ///
-    /// A message naming the conflict when both are given: `--no-pipeline`
-    /// asks for nothing over the turn and `--pipeline` names something, and
-    /// silently preferring one would make a user's explicit instruction a
-    /// no-op. `classic` is accepted by name so `--pipeline classic` means what
-    /// it says rather than looking for a plugin nobody installed.
-    pub(crate) fn resolve(no_pipeline: bool, pipeline: Option<&'a str>) -> Result<Self, String> {
-        match (no_pipeline, pipeline) {
-            (true, Some(variant)) => Err(format!(
-                "--no-pipeline runs nothing over the turn, but --pipeline {variant} names a \
-                 wrapper to run — pass one or the other"
-            )),
-            (true, None) => Ok(Self::Raw),
-            (false, None) => Ok(Self::Classic),
-            (false, Some(variant))
-                if variant == crate::agent::persistence::PIPELINE_VARIANT_CLASSIC =>
-            {
-                Ok(Self::Classic)
+    /// `no_pipeline` (`--no-pipeline`) is a deprecated no-op as of #3381: the
+    /// raw loop is the default with or without it, so it plays no part in the
+    /// match below and can no longer disagree with `--pipeline`. Passing both
+    /// flags together used to be a hard conflict (clap's `conflicts_with`,
+    /// removed in the same change); now the deprecated flag simply has
+    /// nothing left to veto, and `--pipeline <variant>` always wins. `classic`
+    /// is accepted by name so `--pipeline classic` means what it says rather
+    /// than looking for a plugin nobody installed. Infallible — the one case
+    /// that used to fail no longer can — so callers no longer need `?` here.
+    pub(crate) fn resolve(no_pipeline: bool, pipeline: Option<&'a str>) -> Self {
+        let _ = no_pipeline; // deprecated no-op (#3381) — see `no_pipeline_deprecation_notice`
+        match pipeline {
+            None => Self::Raw,
+            Some(variant) if variant == crate::agent::persistence::PIPELINE_VARIANT_CLASSIC => {
+                Self::Classic
             }
-            (false, Some(variant)) => Ok(Self::Plugin(variant)),
+            Some(variant) => Self::Plugin(variant),
         }
     }
 
@@ -153,6 +154,50 @@ impl<'a> PipelineChoice<'a> {
             Self::Plugin(variant) => Some(variant),
             Self::Classic | Self::Raw => None,
         }
+    }
+}
+
+/// The one-line deprecation notice owed when `--no-pipeline` was passed
+/// (#3381), or `None` when it was not.
+///
+/// A pure function returning data rather than printing directly, matching
+/// [`crate::engine_config::effort_notices`]'s shape: [`PipelineChoice::resolve`]
+/// stays a plain decision a unit test can call without capturing stderr, and
+/// each door — `main.rs`'s `Run`/`Goal`/`Fleet` arms, `arena.rs` — prints the
+/// line once, at the one place it already reads `no_pipeline` off its parsed
+/// args.
+pub(crate) fn no_pipeline_deprecation_notice(no_pipeline: bool) -> Option<&'static str> {
+    no_pipeline.then_some(
+        "--no-pipeline is deprecated and does nothing: the raw step-loop is the default now. \
+         Pass --pipeline <variant> to run a wrapper (\"classic\" names the built-in staged \
+         pipeline).",
+    )
+}
+
+/// Refuse a named wrapper plugin variant on a door that cannot drive one yet.
+///
+/// `stella run` is the only door with a real [`TurnDriver`] implementation
+/// ([`WrapperDispatch`] over one raw turn): `goal` and `fleet` each drive
+/// their own **round loop** (a judged goal round, a fleet worker's attempt),
+/// and wiring a wrapper plugin through either is a real driver — not a
+/// formatting difference — that nothing in this crate implements (#3684).
+/// `--pipeline classic` and no `--pipeline` at all both resolve to
+/// [`PipelineChoice::Classic`]/[`PipelineChoice::Raw`], which is fine on
+/// every door; only a *named* plugin variant is out of reach here, and it is
+/// refused with a message naming `stella run` as the door that can run it —
+/// never silently downgraded to raw or to classic, which would run something
+/// other than what was asked for without saying so.
+pub(crate) fn reject_plugin_variant_for_door(
+    door: &str,
+    choice: PipelineChoice<'_>,
+) -> Result<(), String> {
+    match choice.plugin() {
+        Some(variant) => Err(format!(
+            "--pipeline {variant} is not supported on `stella {door}` yet — wrapper plugins \
+             run only on `stella run --pipeline {variant}` today (#3684). Pass `--pipeline \
+             classic` for the staged pipeline, or omit --pipeline for the raw loop."
+        )),
+        None => Ok(()),
     }
 }
 
@@ -605,29 +650,95 @@ name = "execute"
         bind_installed(roster, variant, no_recall(), warn)
     }
 
-    /// The two flags cannot both decide the turn, and `classic` by name is the
-    /// built-in rather than a plugin lookup that would always fail.
+    /// **Witness (#3381 "Flip the default").** No flag at all used to mean
+    /// `Classic` — the staged pipeline was the default. This assertion fails
+    /// on the pre-#3381 code (which resolves `(false, None)` to `Classic`)
+    /// and passes on this one: the raw loop is the default now, with or
+    /// without `--no-pipeline`.
     #[test]
-    fn the_pipeline_flags_resolve_into_exactly_one_choice() {
+    fn no_flag_at_all_resolves_to_the_raw_loop() {
+        assert_eq!(PipelineChoice::resolve(false, None), PipelineChoice::Raw);
         assert_eq!(
-            PipelineChoice::resolve(false, None),
-            Ok(PipelineChoice::Classic),
-            "no flag is exactly today's behaviour"
+            PipelineChoice::resolve(true, None),
+            PipelineChoice::Raw,
+            "--no-pipeline is a deprecated no-op: it names the same choice as no flag at all"
         );
-        assert_eq!(PipelineChoice::resolve(true, None), Ok(PipelineChoice::Raw));
+    }
+
+    /// `classic` is still selectable by the id it records, and an unknown
+    /// variant still binds a plugin lookup rather than the built-in.
+    #[test]
+    fn pipeline_variant_selects_classic_or_a_plugin_by_name() {
         assert_eq!(
             PipelineChoice::resolve(false, Some("classic")),
-            Ok(PipelineChoice::Classic),
+            PipelineChoice::Classic,
             "the built-in is selectable by the id it records"
         );
         assert_eq!(
             PipelineChoice::resolve(false, Some("budget-v1")),
-            Ok(PipelineChoice::Plugin("budget-v1"))
+            PipelineChoice::Plugin("budget-v1")
         );
-        let conflict = PipelineChoice::resolve(true, Some("budget-v1"))
-            .expect_err("both flags name different things");
-        assert!(conflict.contains("--no-pipeline"), "{conflict}");
-        assert!(conflict.contains("budget-v1"), "{conflict}");
+    }
+
+    /// **Witness (#3381).** `--no-pipeline` together with `--pipeline` used to
+    /// be a hard error (`conflicts_with` in clap, then an `Err` from
+    /// `resolve`). This assertion fails on the pre-#3381 code (which returns
+    /// `Err` here) and passes on this one: a deprecated no-op flag must not
+    /// veto an explicit `--pipeline` opt-in, on either variant arm.
+    #[test]
+    fn no_pipeline_no_longer_vetoes_an_explicit_pipeline_choice() {
+        assert_eq!(
+            PipelineChoice::resolve(true, Some("budget-v1")),
+            PipelineChoice::Plugin("budget-v1"),
+            "--pipeline wins outright; the deprecated flag has nothing left to veto"
+        );
+        assert_eq!(
+            PipelineChoice::resolve(true, Some("classic")),
+            PipelineChoice::Classic
+        );
+    }
+
+    /// The notice fires exactly when `--no-pipeline` was passed, regardless of
+    /// what `--pipeline` said alongside it, and says nothing when it was not.
+    #[test]
+    fn the_deprecation_notice_fires_only_when_no_pipeline_was_passed() {
+        assert!(no_pipeline_deprecation_notice(false).is_none());
+        let notice = no_pipeline_deprecation_notice(true).expect("flag was passed");
+        assert!(notice.contains("--no-pipeline"), "{notice}");
+        assert!(notice.contains("--pipeline"), "{notice}");
+    }
+
+    /// **Witness (#3684).** `stella goal`/`stella fleet` cannot drive a
+    /// wrapper plugin today — only `stella run` implements [`TurnDriver`] over
+    /// one — so a named `--pipeline <variant>` must be refused on those doors
+    /// rather than silently downgraded to raw or promoted to classic. This
+    /// assertion fails on code that has no such gate at all (every door would
+    /// accept-and-ignore the variant) and passes on this one.
+    #[test]
+    fn a_named_plugin_variant_is_refused_on_a_door_that_cannot_drive_one() {
+        let err = reject_plugin_variant_for_door("goal", PipelineChoice::Plugin("budget-v1"))
+            .expect_err("goal has no wrapper driver");
+        assert!(err.contains("budget-v1"), "{err}");
+        assert!(err.contains("stella goal"), "{err}");
+        assert!(
+            err.contains("stella run --pipeline budget-v1"),
+            "the refusal must name the door that CAN run it: {err}"
+        );
+
+        let err = reject_plugin_variant_for_door("fleet", PipelineChoice::Plugin("budget-v1"))
+            .expect_err("fleet has no wrapper driver either");
+        assert!(err.contains("stella fleet"), "{err}");
+    }
+
+    /// `classic` and no flag at all both resolve away from `Plugin` before
+    /// reaching the gate, so neither is refused on a door with no wrapper
+    /// driver — only a *named* variant is out of reach there.
+    #[test]
+    fn classic_and_raw_are_never_refused_on_a_door_with_no_wrapper_driver() {
+        reject_plugin_variant_for_door("goal", PipelineChoice::Classic)
+            .expect("classic has no plugin to drive — nothing to refuse");
+        reject_plugin_variant_for_door("goal", PipelineChoice::Raw)
+            .expect("raw has no plugin to drive — nothing to refuse");
     }
 
     /// A wrapper plugin is a child process the host starts, so the enterprise

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -57,14 +57,30 @@ arena-bench invokes an agent with `--task-dir`/`--journal`/`--state-dir`/`[--res
     declares what was recovered, and continues the same session.
   </OptionCard>
   <OptionCard name="--no-pipeline">
-    Use the raw step-loop instead of the staged pipeline. The
-    [pipeline](/docs/inference-pipeline) is the default here exactly as it is for `stella run`.
+    Deprecated, does nothing. Every episode already runs the raw step-loop
+    (see below) — this flag named that fallback before #3381 flipped the
+    default and is kept parseable only so no runner script breaks.
   </OptionCard>
   <OptionCard name="--test-command <CMD>">
-    Test command for the pipeline's deterministic verify ladder, e.g.
-    `--test-command "cargo test -p my-crate"`.
+    Test command for the staged pipeline's deterministic verify ladder, e.g.
+    `--test-command "cargo test -p my-crate"`. Currently inert: this adapter
+    has no `--pipeline <VARIANT>` flag of its own, so an episode has no
+    ladder for it to arm — see the note below.
   </OptionCard>
 </CardGrid>
+
+<Callout type="warn">
+**Every arena episode measures the raw step-loop, unconditionally**, since
+[#3381](https://github.com/macanderson/stella/issues/3381) flipped
+`PipelineChoice::resolve`'s no-flag default from the staged pipeline to raw.
+This adapter has no `--pipeline <VARIANT>` flag the way [`stella
+run`](/docs/commands/run) does, so there is currently no way to make an arena
+episode run the staged pipeline (or a wrapper plugin) at all — `--no-pipeline`
+was always a synonym for the same no-flag default and stayed one across the
+flip. A panel run against this binary before and after #3381 is comparing the
+staged pipeline to the raw loop, not two builds of the same thing; name that
+comparison rather than reporting it as a plain regression.
+</Callout>
 
 ## Why the journal is written before the event is admitted
 
@@ -120,6 +136,6 @@ runner preserves between episodes (and wipes for the `amnesic` arm). A fixture t
 
 ## See also
 
-- [Inference pipeline](/docs/inference-pipeline) — the staged path `--no-pipeline` opts out of.
+- [Inference pipeline](/docs/inference-pipeline) — the staged path every arena episode runs without, since #3381 flipped the default and this adapter has no `--pipeline <VARIANT>` flag to opt back in.
 - [`stella run`](/docs/commands/run) — the ordinary one-shot path this adapter drives underneath.
 - [arena-bench](https://github.com/macanderson/arena-bench) — the harness that invokes this command.

--- a/website/content/docs/commands/fleet.mdx
+++ b/website/content/docs/commands/fleet.mdx
@@ -8,7 +8,7 @@ Run many tasks in parallel in **one shared working tree**, coordinated by cooper
 ## Synopsis
 
 ```bash
-stella fleet <task>... [--plan <FILE>] [--max-concurrency <N>] [--base-ref <ref>] [--watch] [--no-pipeline] [--task-timeout <SECS>]
+stella fleet <task>... [--plan <FILE>] [--max-concurrency <N>] [--base-ref <ref>] [--watch] [--no-pipeline] [--pipeline <VARIANT>] [--task-timeout <SECS>]
 stella fleet clean [--dry-run] [--force] [--age <DAYS>] [--base-ref <ref>]
 stella fleet claims [--all] [--format <text|json>]
 ```
@@ -19,7 +19,7 @@ A prompt whose **first word** is exactly a subcommand name (`clean`, `claims`) i
 
 ## What it does
 
-Each task prompt becomes an independent task running **in the shared repository root**. Workers coordinate through cooperative file claims — paths declared upfront in a plan (`claims`) plus claim-on-first-write at the tool layer — so a conflict surfaces in under a second at write time with the rival named, and commits interleave on one branch with no merge-back. A task a plan file opts into `isolation = "isolated"` instead gets a dedicated git worktree under `.stella/worktrees/<slug>` — branched from the current `HEAD` (or `--base-ref`), pinned to a SHA at start, onto a `fleet/<slug>-<hash>` branch (the hash suffix keeps re-runs from colliding with branches you kept). Tasks dispatch in dependency-ordered waves, running up to `--max-concurrency` at once within a wave. Each worker is a full engine run through the [staged pipeline](/docs/inference-pipeline) by default. Progress, attempts, commits, and cost are persisted to `.stella/private/fleet.db` and surface on the [Observatory dashboard](/docs/telemetry/dashboard)'s Fleet runs card.
+Each task prompt becomes an independent task running **in the shared repository root**. Workers coordinate through cooperative file claims — paths declared upfront in a plan (`claims`) plus claim-on-first-write at the tool layer — so a conflict surfaces in under a second at write time with the rival named, and commits interleave on one branch with no merge-back. A task a plan file opts into `isolation = "isolated"` instead gets a dedicated git worktree under `.stella/worktrees/<slug>` — branched from the current `HEAD` (or `--base-ref`), pinned to a SHA at start, onto a `fleet/<slug>-<hash>` branch (the hash suffix keeps re-runs from colliding with branches you kept). Tasks dispatch in dependency-ordered waves, running up to `--max-concurrency` at once within a wave. Each worker is a full engine run through the raw step loop by default — pass `--pipeline classic` to route every worker through the [staged pipeline](/docs/inference-pipeline) instead. This door cannot yet drive an installed wrapper plugin the way [`stella run`](/docs/commands/run) can, so a named `--pipeline <variant>` other than `classic` is refused. Progress, attempts, commits, and cost are persisted to `.stella/private/fleet.db` and surface on the [Observatory dashboard](/docs/telemetry/dashboard)'s Fleet runs card.
 
 Isolated worktrees and fleet branches are **not** cleaned up automatically: they stay on disk so you can inspect, test, and merge each result yourself. Reclaim the finished ones with [`stella fleet clean`](#stella-fleet-clean) when you are done reviewing. A failed task is never retried automatically, and its dependents end the run as `skipped`.
 
@@ -53,7 +53,17 @@ For anything beyond a handful of independent prompts, use a plan file (`--plan`)
     non-zero if any watched branch ends red.
   </OptionCard>
   <OptionCard name="--no-pipeline">
-    Workers run the raw step loop instead of the staged pipeline.
+    Deprecated, does nothing. The raw step-loop is the default now; pass
+    `--pipeline <VARIANT>` to opt into a wrapper instead. Kept parseable so no
+    script breaks — passing it prints a one-line notice and has no other
+    effect, including alongside `--pipeline`, which always wins.
+  </OptionCard>
+  <OptionCard name="--pipeline <VARIANT>">
+    Run each worker through an installed wrapper plugin, by the `[wrapper]
+    id` its manifest declares. `classic` names the built-in staged pipeline
+    (triage, plan, witness, execute, verify); omitted, the raw step-loop
+    runs with nothing over it. A named plugin variant other than `classic`
+    is refused today — see [`stella run`](/docs/commands/run) for that.
   </OptionCard>
   <OptionCard name="--task-timeout <SECS>" defaultValue="unbounded">
     Wall-clock ceiling per worker attempt. On expiry the task's stop line fires — the same

--- a/website/content/docs/commands/goal.mdx
+++ b/website/content/docs/commands/goal.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella goal
-description: Work in judged rounds until a verifier model confirms the goal is met.
+description: Work in raw step-loop rounds (or, with --pipeline classic, staged-pipeline rounds) until a verifier model confirms the goal is met.
 ---
 
 Give stella a goal and let it work in **judged rounds** until a verifier model confirms, from evidence, that the goal has actually been met.
@@ -8,12 +8,12 @@ Give stella a goal and let it work in **judged rounds** until a verifier model c
 ## Synopsis
 
 ```bash
-stella goal <goal> [--no-pipeline] [global flags]
+stella goal <goal> [--no-pipeline] [--pipeline <VARIANT>] [global flags]
 ```
 
 ## What it does
 
-`stella goal` works in rounds, each run through the [staged pipeline](/docs/inference-pipeline) by default — pass `--no-pipeline` for raw step-loop rounds instead. At the end of each round, a **verifier model** independently assesses whether the goal is met — reading the changed files, tests, and CI with read-only tools, not just the worker's narration. The loop ends when the verifier confirms success, or when a backstop trips: a hard round cap (default **8** rounds), the `--spend-limit` cap, or a worker-turn abort. Reaching a backstop ends the run reporting the goal as **not met**.
+`stella goal` works in rounds, each a raw step-loop turn by default — pass `--pipeline classic` to run every round through the [staged pipeline](/docs/inference-pipeline) instead. This door cannot yet drive an installed wrapper plugin the way [`stella run`](/docs/commands/run) can, so a named `--pipeline <variant>` other than `classic` is refused with an error naming `stella run` as the door that supports it. At the end of each round, a **verifier model** independently assesses whether the goal is met — reading the changed files, tests, and CI with read-only tools, not just the worker's narration. The loop ends when the verifier confirms success, or when a backstop trips: a hard round cap (default **8** rounds), the `--spend-limit` cap, or a worker-turn abort. Reaching a backstop ends the run reporting the goal as **not met**.
 
 Crucially, the verifier is routed **cross-family** — it is a different model family than the worker, to avoid same-model bias. If only one provider family is configured, the worker doubles as its own verifier.
 
@@ -23,12 +23,22 @@ For the full explanation of judged rounds, the cross-family verifier, and the de
 
 ## Flags
 
-`stella goal` takes the [global flags](/docs/commands), plus one of its own:
+`stella goal` takes the [global flags](/docs/commands), plus two of its own:
 
 <CardGrid size="md">
   <OptionCard name="--no-pipeline">
-    Each working round runs the raw step loop instead of the staged pipeline (triage,
-    plan, witness, execute, verify). The pipeline is the default.
+    Deprecated, does nothing. The raw step-loop is the default now; pass
+    `--pipeline <VARIANT>` to opt into a wrapper instead. Kept parseable so no
+    script breaks — passing it prints a one-line notice and has no other
+    effect, including alongside `--pipeline`, which always wins.
+  </OptionCard>
+  <OptionCard name="--pipeline <VARIANT>">
+    Run each working round through an installed wrapper plugin, by the
+    `[wrapper] id` its manifest declares. `classic` names the built-in staged
+    pipeline (triage, plan, witness, execute, verify); omitted, the raw
+    step-loop runs with nothing over it. A named plugin variant other than
+    `classic` is refused today — see [`stella run`](/docs/commands/run) for
+    that.
   </OptionCard>
   <OptionCard name="--model <provider/model_id>">
     Pin the worker model. The verifier is routed to a different family automatically when one
@@ -62,10 +72,10 @@ stella --model anthropic/claude-fable-5 --spend-limit 10.00 \
   goal "Make the CLI exit with a non-zero code on invalid input"
 ```
 
-Run raw step-loop rounds instead of the staged pipeline:
+Run every round through the staged pipeline instead of the raw step loop:
 
 ```bash
-stella goal --no-pipeline "Silence the deprecation warnings in the build"
+stella goal --pipeline classic "Silence the deprecation warnings in the build"
 ```
 
 You can also run a goal-driven turn from the plain line REPL (`stella chat --plain`) with the `/goal <goal>` command.

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella run
-description: Send a one-shot prompt through the staged pipeline and let stella work to completion, no back-and-forth — built for scripts, CI jobs, and git hooks.
+description: Send a one-shot prompt through the raw step loop (or an installed pipeline wrapper) and let stella work to completion, no back-and-forth — built for scripts, CI jobs, and git hooks.
 ---
 
 Send a one-shot prompt and let the agent work to completion without any interactive back-and-forth. This is the command to reach for in scripts, CI jobs, and Git hooks.
@@ -13,9 +13,9 @@ stella run <prompt> [--no-pipeline] [--pipeline <VARIANT>] [--test-command <CMD>
 
 ## What it does
 
-By default `stella run` sends the prompt through the **staged pipeline** — triage, plan, execute, verify, verifier — and exits when the task is done. There is no REPL and no prompt for further input; it is the non-interactive counterpart to [`stella chat`](/docs/commands/chat).
+By default `stella run` sends the prompt through the **raw step loop**: the model proposes tool calls, the tools execute, results feed back, and the loop repeats until the model stops proposing actions. There is no REPL and no prompt for further input; it is the non-interactive counterpart to [`stella chat`](/docs/commands/chat).
 
-Pass `--no-pipeline` to fall back to the raw step loop instead: the model proposes tool calls, the tools execute, results feed back, and the loop repeats until the model stops proposing actions.
+Pass `--pipeline classic` to route the turn through the **staged pipeline** instead — triage, plan, execute, verify, verifier — or `--pipeline <variant>` to run it under an installed [wrapper plugin](/docs/inference-pipeline). `--no-pipeline` is a deprecated no-op kept only so an existing script does not break; it has no effect either way.
 
 Because it is non-interactive, `stella run` is the natural place to combine `--output-format json` or `--output-format stream-json` for headless automation, and `--spend-limit` for a hard spend cap.
 
@@ -31,8 +31,10 @@ A run typed at a terminal is [supervised](/docs/commands/daemon): it survives th
 
 <CardGrid size="md">
   <OptionCard name="--no-pipeline">
-    Use the raw step loop instead of the staged pipeline (triage, plan, execute, verify,
-    verifier).
+    Deprecated, does nothing. The raw step loop is the default now; pass
+    `--pipeline <VARIANT>` to opt into a wrapper instead. Kept parseable so no
+    script breaks — passing it prints a one-line notice and has no other
+    effect, including alongside `--pipeline`, which always wins.
   </OptionCard>
   <OptionCard name="--pipeline <VARIANT>">
     Run the turn under an installed **wrapper plugin**, named by the `[wrapper] id` its
@@ -40,8 +42,8 @@ A run typed at a terminal is [supervised](/docs/commands/daemon): it survives th
     turn and gathers evidence after it; the rule it declared at install — evaluated by
     stella, never by the plugin — decides whether another turn runs. The variant id is
     recorded on the execution row, so two variants can be compared side by side.
-    `--pipeline classic` names the built-in staged pipeline; omitted, nothing changes.
-    Conflicts with `--no-pipeline`.
+    `classic` names the built-in staged pipeline (triage, plan, execute, verify,
+    verifier); omitted, the raw step loop runs with nothing over it.
   </OptionCard>
   <OptionCard name="--test-command <CMD>">
     The test command the pipeline's verify stage runs deterministically — e.g.
@@ -123,23 +125,27 @@ stella --model local/llama3.3 --base-url http://localhost:11434/v1 \
   run "Explain what main.rs does"
 ```
 
+`--test-command`, `--keep-witness`, and `--require-verified` all belong to the staged
+pipeline's verify/witness machinery, so pair them with `--pipeline classic` — on the
+raw loop (the default) there is no ladder for them to arm.
+
 Hand the verify stage a deterministic oracle, so a fixed test can submit without a
 model-verifier call:
 
 ```bash
-stella run --test-command "cargo test -p stella-store" \
+stella run --pipeline classic --test-command "cargo test -p stella-store" \
   "Fix the failing WAL checkpoint test"
 ```
 
 Keep the witness the pipeline authored, so you can review and commit it alongside the fix:
 
 ```bash
-stella run --keep-witness \
+stella run --pipeline classic --keep-witness \
   "Add retry-with-backoff to the HTTP client and prove it with a test"
 ```
 
-Skip the pipeline entirely for a small mechanical edit:
+A small mechanical edit needs nothing extra — the raw loop is already the default:
 
 ```bash
-stella run --no-pipeline "Bump the serde dependency to 1.0.220 in every crate"
+stella run "Bump the serde dependency to 1.0.220 in every crate"
 ```


### PR DESCRIPTION
## What & why

**Status: in progress — the #3381 flip and its adversarial-audit fixes land here, followed by the remaining ejection phases.** This line will be removed when the branch is complete.

The flag inversion from `doc:turn-loop-wrappers` §5 and #3381, the claim-check on the whole wrapper programme:

- Every door (`run`, `arena`, `goal`, `fleet`, the deck's `/pipeline` toggle) hits the **raw loop by default**.
- `--pipeline <variant>` opts in and names which manifest (`classic` = the built-in staged pipeline, now itself manifest-driven since #3672/#3681).
- `--no-pipeline` stays parseable as a **deprecated no-op** (hidden from help, one-line stderr notice) so no script breaks.
- Measurement honesty (#2952): classic-driven goal/fleet rounds now write `pipeline_variant = "classic"` instead of NULL — NULL means raw, everywhere.
- The `enterprise_telemetry::authorize_one_shot` surface widening (raw-only authority now admits default runs) is stated in code, not silent; the arena's default change is named where the bench adapter lives, per the like-for-like rule.

Maintainer's-call note (#3381 appendix §9.6): the flip ships **ungated by a side-by-side bench**, per the owner's direction in this session; `--pipeline classic` restores the old default exactly, so the flip is one flag away from reversal.

**Deleted test (deliberate):** `the_pipeline_flags_resolve_into_exactly_one_choice` in `crates/stella-cli/src/wrapper_plugin.rs` — it pinned the OLD flag semantics this PR exists to invert ((false, None) ⇒ Classic; --no-pipeline + --pipeline ⇒ error). Its replacement coverage is six new tests in the same module: `no_flag_at_all_resolves_to_the_raw_loop`, `pipeline_variant_selects_classic_or_a_plugin_by_name`, `no_pipeline_no_longer_vetoes_an_explicit_pipeline_choice`, `the_deprecation_notice_fires_only_when_no_pipeline_was_passed`, `a_named_plugin_variant_is_refused_on_a_door_that_cannot_drive_one`, `classic_and_raw_are_never_refused_on_a_door_with_no_wrapper_driver`.

Refs #3381
Refs #3380

## The witness

- [x] The rewritten `PipelineChoice::resolve` tests: `(false, None) => Raw` and `(--no-pipeline + --pipeline X) => accepted` both fail on the old code; per-door variant-column tests (classic round writes `"classic"`, raw writes NULL) fail on the old code.

## The gate

- [ ] Boxes checked when the final validated push lands.

## Nothing left behind

- [ ] Filed: handoff issues linked before review.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- Head commits are phase checkpoints; hold review until the status line is removed.
- Every published Stella benchmark number predates this default flip — the arena now measures the raw loop unless `--pipeline` is passed. Comparisons across the flip must name the variant.