### PR TITLE
fix: adversarial audit across all 28 crates — fix confirmed defects, declutter jargon

### DIFF
--- a/.github/workflows/wire-schema.yml
+++ b/.github/workflows/wire-schema.yml
@@ -9,7 +9,7 @@ name: wire-schema
 # (a job-level prose filter since #1892; a trigger-level `paths-ignore` before
 # that), so a pull request that touches *only* `docs/wire/` never runs it.
 # Nothing else covered the
-# gap: docs-guards.yml is deliberately toolchain-free (four shell/python guards,
+# gap: docs-guards.yml is deliberately toolchain-free (shell and python guards only,
 # five-minute timeout) and adding a Rust build to it would cost every prose PR a
 # toolchain it has no use for.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + diagnostic-codes
                          #   + wire-schema
                          #   + lockfile-sync (cargo metadata --locked)
-                         #   + doc-warnings (rustdoc -D warnings)
                          #   + format-check (fmt --check)
+                         #   + doc-warnings (rustdoc -D warnings)
                          #   + lint (clippy -D warnings)
                          #   + test (test --workspace)
                          #   + tool-docs (docs/tools/ vs the declarations)
@@ -224,7 +224,7 @@ rejects a new dependency, drop the dependency — do not widen the allow-list in
 
 ---
 
-## Architecture: ports, not concretions
+## Architecture: ports, not direct dependencies
 
 The central architectural invariant. Every design decision in the codebase
 flows from this. If a PR breaks one of these, it will be asked to restructure
@@ -238,7 +238,7 @@ comments, runtime error strings, and crate READMEs cite these by number, so
 inserting or reordering an entry silently repoints every one of those citations.
 Append; do not renumber. `scripts/check-invariants.sh` enforces both halves.
 
-1. **Ports, not concretions.** `stella-core` never imports a provider SDK, a
+1. **Ports, not direct dependencies.** `stella-core` never imports a provider SDK, a
    filesystem API, or a terminal library. Models go through the `Provider`
    trait (`stella-protocol`), tools through `ToolExecutor` (`stella-core::ports`).
    A new vendor or tool is an adapter, never a rewrite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@
   - **The agent-systems architecture is the crown.** The agent loop, the
     staged pipeline, the context plane, and the port boundaries get more
     scrutiny than anything else in the tree. Determinism, replayability, and
-    "ports, not concretions" are not negotiable there for any deadline.
+    "ports, not direct dependencies" are not negotiable there for any deadline.
   - **"Now" vs. "right" is the maintainer's call, not yours.** When you truly
     cannot have both, state which one you are giving up and why, and let a
     human choose. Deciding it silently is how a reference implementation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ A red gate is an automatic "not yet":
 ./scripts/check-cargo-install-pins.sh
 ./scripts/check-license-allowlist-parity.sh
 ./scripts/check-repro-wiring.sh
-shellcheck install.sh scripts/*.sh .githooks/*
+shellcheck install.sh scripts/*.sh scripts/lib/*.sh .githooks/*
 ./scripts/check-invariants.sh
 python3 ./scripts/check-doc-links.py check
 ./scripts/check-command-docs.sh
@@ -88,8 +88,8 @@ python3 ./scripts/check-typed-errors.py
 ./scripts/check-diagnostic-codes.sh
 ./scripts/check-wire-schema.sh
 ./scripts/check-lockfile-sync.sh
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going
 cargo fmt --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ./scripts/check-tool-docs.sh
@@ -178,7 +178,7 @@ chasing the citations in the same PR.
 
 ## Where does my change go? — a workspace tour
 
-Twenty crates — all under the `crates/` directory — sounds like a lot; the
+Twenty-six crates — all under the `crates/` directory — sounds like a lot; the
 rule of thumb is one sentence each:
 
 | You want to… | Go to |
@@ -200,6 +200,10 @@ rule of thumb is one sentence each:
 | Multi-agent fan-out, worktree isolation | `stella-fleet` |
 | The Observatory telemetry dashboard (`stella observe`) | `stella-observatory` |
 | The headless engine server a host process drives over the wire | `stella-serve` (its own binary, not linked into the CLI) |
+| Parse or validate a plugin manifest | `stella-plugin` |
+| Decide whether a human is present to answer a prompt | `stella-tty` |
+| Compute a unified diff | `stella-diff` |
+| Turn text into a vector, or compare two vectors | `stella-embed` |
 | The Context Graph Protocol (wire types / host / conformance) | external repo: [`context-graph-protocol`](https://github.com/macanderson/context-graph-protocol) |
 
 `stella-pipeline` drives the default
@@ -217,7 +221,7 @@ These are the architectural invariants the whole design hangs on. PRs that
 break them will be asked to restructure, no matter how good the feature is.
 
 **They are stated once, normatively, in
-[AGENTS.md § Architecture: ports, not concretions](AGENTS.md#architecture-ports-not-concretions)
+[AGENTS.md § Architecture: ports, not direct dependencies](AGENTS.md#architecture-ports-not-direct-dependencies)
 — read them there before your first PR.**
 
 That list is the single source, and its numbering is part of the contract:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,6 @@ dependencies = [
  "serde_json",
  "stella-core",
  "stella-protocol",
- "thiserror 2.0.20",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,6 @@ each row links to its reference page on [stella.oxagen.sh](https://stella.oxagen
 | [`init`](https://stella.oxagen.sh/docs/commands/init)                 | Infer this workspace's domain taxonomy and build the code-graph index                                             |
 | [`search <query>`](https://stella.oxagen.sh/docs/commands/search)     | Find code by meaning or by name over the code-graph index                                                         |
 | [`storage <cmd>`](https://stella.oxagen.sh/docs/commands/storage)     | Inspect the storage map: layers, namespaces, relations, fields, drift (offline)                                   |
-| [`scripts <cmd>`](https://stella.oxagen.sh/docs/commands/scripts)     | List and run the project's package-manager scripts by canonical verb (offline)                                    |
 | [`tools`](https://stella.oxagen.sh/docs/commands/tools)               | List every tool available this session; `--validate` checks custom manifests                                      |
 | [`models`](https://stella.oxagen.sh/docs/commands/models)             | List configured providers and available models                                                                    |
 | [`auth <cmd>`](https://stella.oxagen.sh/docs/commands/auth)           | Manage BYOK provider keys in `~/.stella/credentials.toml` — never prints a secret                                 |
@@ -649,7 +648,7 @@ witness-tested rather than assumed — and Stella sends **zero telemetry
 anywhere** by default.
 
 They are stated normatively, in full, in
-[AGENTS.md § Architecture: ports, not concretions](AGENTS.md#architecture-ports-not-concretions).
+[AGENTS.md § Architecture: ports, not direct dependencies](AGENTS.md#architecture-ports-not-direct-dependencies).
 That is the only copy: this section is a summary and does not govern. A PR that
 breaks one of them will be asked to restructure regardless of how good the
 feature is.
@@ -660,7 +659,7 @@ most people want to know first.
 
 ## Workspace layout
 
-Twenty `stella-*` crates make up the workspace. The Context Graph Protocol
+Twenty-six `stella-*` crates make up the workspace. The Context Graph Protocol
 (CGP) —
 the retrieval abstraction Stella's recall routes through — now lives in its own
 repository and is pulled in as registry crates pinned to exact versions in the
@@ -692,6 +691,12 @@ extending it.
 | [`stella-engine`](crates/stella-engine/README.md) | Step-scoped facade over `stella-core` for durable hosts: `run_step` + checkpoint/resume, re-exports only — consumed by `stella-serve`, never linked by the CLI                                                                          |
 | [`stella-runtime`](crates/stella-runtime/README.md) | The shared engine-assembly bottom half (`RuntimeSpec` → `SessionRuntime`): provider, registry, store, budget — construction only, and it reads no ambient environment by contract                                                       |
 | [`stella-parity`](crates/stella-parity/README.md) | The CLI-vs-API capability matrix: every engine capability declares a witnessed posture on both surfaces, so a feature cannot ship on one and silently miss the other                                                                    |
+| [`stella-autonomy`](crates/stella-autonomy/README.md) | The self-driving loop's decision core: the AIMD controller, aperture ladder, dry-streak oracle, and ledger folds — pure and shared by the CLI and the Observatory so they cannot drift                                                  |
+| [`stella-diff`](crates/stella-diff/README.md) | A pure line-oriented unified diff with git's exact hunk shape and no dependencies                                                                                                                                                      |
+| [`stella-embed`](crates/stella-embed/README.md) | The embedding seam: the `Embedder` trait, the fingerprint stamped on every stored vector, and cosine ranking                                                                                                                          |
+| [`stella-plugin`](crates/stella-plugin/README.md) | Parses and validates a plugin's manifest — what it declares in the turn loop — with no I/O                                                                                                                                             |
+| [`stella-transcript`](crates/stella-transcript/README.md) | The shared transcript model plus its two renderers: HTML for the Observatory and a character grid for the TUI                                                                                                                 |
+| [`stella-tty`](crates/stella-tty/README.md) | A no-dependency leaf that answers whether a human is around to see and answer a prompt                                                                                                                                                |
 | Context Graph Protocol                               | Its own project now: [macanderson/context-graph-protocol](https://github.com/macanderson/context-graph-protocol) — wire types, host runtime, and the public conformance suite. Stella is its reference host and depends on it as exact-version registry crates. |
 
 Alongside the Rust workspace, the documentation site

--- a/bench/loop-bench/src/lib.rs
+++ b/bench/loop-bench/src/lib.rs
@@ -469,19 +469,6 @@ pub fn fold_steps(steps: &[TrialReport]) -> TrialReport {
     folded
 }
 
-/// Read the verifier's reward for one trial. Returns the reward and, when the
-/// file exists but cannot be used, a problem description for `last_error` —
-/// a corrupt reward must not silently downgrade a passing task to `None`
-/// (#611). A *missing* file stays a quiet `None`: the trial simply never
-/// reached the verifier.
-///
-/// See [`artifacts::read_reward`] for the sources and their order; this is the
-/// path-only form, for a caller that has not already read `result.json`.
-pub fn read_reward(trial_dir: &Path) -> (Option<f64>, Option<String>) {
-    let found = artifacts::read_trial(trial_dir);
-    (found.reward, found.reward_problem)
-}
-
 /// The heart of the tool: turn one event stream into loop + context signals.
 pub fn distill_events(task: &str, raw: &str) -> TrialReport {
     let mut r = TrialReport {

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -208,9 +208,10 @@ struct Args {
 }
 
 /// The `--primary` choices, mapped onto the shared metric vocabulary. A
-/// separate enum so clap validates the flag at parse time and so the harness
-/// offers only the metrics a *model* comparison is meaningfully judged on —
-/// `retries` is a loop signal this harness already gates on separately.
+/// separate enum so clap validates the flag at parse time, and so the harness
+/// only offers metrics that judge the *model*. `stella-core` also has a
+/// `retries` metric; it is left out here because it counts model-call
+/// flakiness, not how well the model did the task.
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
 enum PrimaryMetric {
     PassRate,

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -320,8 +320,9 @@ fn analyze_reconciles_the_requested_task_set() {
 #[test]
 fn a_corrupt_reward_file_names_itself() {
     let dir = tempfile::tempdir().expect("trial dir");
+    let found = crate::artifacts::read_trial(dir.path());
     assert_eq!(
-        read_reward(dir.path()),
+        (found.reward, found.reward_problem),
         (None, None),
         "missing file is quiet"
     );
@@ -329,13 +330,16 @@ fn a_corrupt_reward_file_names_itself() {
     let verifier = dir.path().join("verifier");
     std::fs::create_dir_all(&verifier).expect("mkdir");
     std::fs::write(verifier.join("reward.txt"), "not-a-number").expect("write");
-    let (reward, problem) = read_reward(dir.path());
-    assert_eq!(reward, None);
-    let problem = problem.expect("a corrupt reward must explain itself");
+    let found = crate::artifacts::read_trial(dir.path());
+    assert_eq!(found.reward, None);
+    let problem = found
+        .reward_problem
+        .expect("a corrupt reward must explain itself");
     assert!(problem.contains("unreadable reward.txt"), "{problem}");
 
     std::fs::write(verifier.join("reward.txt"), "1.0\n").expect("write");
-    assert_eq!(read_reward(dir.path()), (Some(1.0), None));
+    let found = crate::artifacts::read_trial(dir.path());
+    assert_eq!((found.reward, found.reward_problem), (Some(1.0), None));
 }
 
 /// #873: the pass floor is a SECOND gate, independent of loop health. A run

--- a/bench/request-bench/src/main.rs
+++ b/bench/request-bench/src/main.rs
@@ -44,8 +44,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use stella_protocol::{
-    CompletionMessage, CompletionRequest, CompletionRequestRef, MessageRole, ReasoningEffort,
-    ToolCall, ToolOutput, ToolResult, ToolSchema,
+    BYTES_PER_TOKEN, CompletionMessage, CompletionRequest, CompletionRequestRef, MessageRole,
+    ReasoningEffort, ToolCall, ToolOutput, ToolResult, ToolSchema,
 };
 
 /// Cumulative bytes handed out by [`Counting`] since the last reset.
@@ -111,11 +111,6 @@ fn measure<T>(body: impl FnOnce() -> T) -> (usize, usize) {
 // Fixture
 // ---------------------------------------------------------------------------
 
-/// `stella_core::estimator::CHARS_PER_TOKEN` — duplicated rather than depended
-/// on, because pulling `stella-core` in would make this harness link the whole
-/// engine to size a `String`.
-const CHARS_PER_TOKEN: f64 = 3.5;
-
 /// Transcript size the issue names as the realistic deep-session case.
 const TARGET_TOKENS: usize = 150_000;
 /// MCP-registered tool count the issue names.
@@ -127,7 +122,7 @@ const STEPS: usize = 200;
 /// user → assistant-with-tool-call → tool-result triples, grown until it
 /// estimates at [`TARGET_TOKENS`].
 fn transcript() -> Vec<CompletionMessage> {
-    let target_chars = (TARGET_TOKENS as f64 * CHARS_PER_TOKEN) as usize;
+    let target_bytes = (TARGET_TOKENS as f64 * BYTES_PER_TOKEN) as usize;
     let mut messages = vec![
         CompletionMessage::system(
             "You are Stella, an autonomous coding agent. Prefer small diffs. \
@@ -135,9 +130,9 @@ fn transcript() -> Vec<CompletionMessage> {
         ),
         CompletionMessage::user("Fix the failing integration test in the store crate."),
     ];
-    let mut chars = 0usize;
+    let mut bytes = 0usize;
     let mut turn = 0usize;
-    while chars < target_chars {
+    while bytes < target_bytes {
         let call_id = format!("call_{turn:04}");
         let input = serde_json::json!({
             "command": format!("cargo test -p stella-store --test integration_{turn}"),
@@ -148,7 +143,7 @@ fn transcript() -> Vec<CompletionMessage> {
             "running 42 tests\n{}\ntest result: FAILED. 41 passed; 1 failed\n",
             "test store::roundtrip::case ... ok\n".repeat(48)
         );
-        chars += output.len() + 256;
+        bytes += output.len() + 256;
         messages.push(CompletionMessage {
             role: MessageRole::Assistant,
             content: format!("Checking suite {turn} before touching the fold."),

--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -66,6 +66,7 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 | File | What it holds |
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | Everything: the dedup digest, the `AimdLimits`/`Calibration`/`calibrate` controller, the `Lens`/`Tooling`/`LENSES` aperture ladder and `advance`, `CycleRecord`/`dry_streak`, the `Supply`/`Demand`/`Floors`/`CyclePlan`/`plan_cycle` governor, `Metrics`/`metrics`/`starved`, `QueueIssue`/`rank_defects`, and `Liveness`/`liveness`/`RunRow`/`fold_runs`. |
+| [`src/surface.rs`](src/surface.rs) | The host surface: `HOST_SURFACE`, `HOST_SURFACE_VERSION`, `HostVerb`, `Emits`, and the two-way `surface_drift` check the CLI's real clap tree is measured against (`doc:pipeline-as-plugins` §10, D2). |
 | [`src/tests.rs`](src/tests.rs) | Witness tests ported from `scripts/test-self-driving.sh` (#1548), plus the property tests a generator can sweep that the shell driver never could — digest normalization, controller bounds, dry-streak suffix matching, demand's one-directional effect on the plan. |
 
 ## Semantics worth knowing
@@ -131,9 +132,18 @@ never a vague health score, and add a fixture in `src/tests.rs` that raises it
 and one that stays silent — a dashboard that always warns teaches the reader
 to ignore it.
 
+Adding a host verb: add a [`HostVerb`] to [`HOST_SURFACE`] with its path, its
+[`Emits`] shape, and a one-line summary, placed in the order the cycle
+actually uses it — the list is rendered in declaration order on purpose.
+`stella-cli`'s `self_driving_cmd::surface` parity test walks the real clap
+tree and fails in both directions, so a verb cannot ship undeclared and a
+declared verb cannot vanish. Only bump [`HOST_SURFACE_VERSION`] when a verb is
+renamed or removed, or when a verb's [`Emits`] changes; a brand-new verb is
+additive and must not bump it.
+
 ## God files — none
 
-This crate has no god files: neither file exceeds the gate's 1500-line
+This crate has no god files: no file exceeds the gate's 1500-line
 ratchet (`scripts/check-file-size.sh`), and none may appear — a new file
 crossing 1500 lines fails the gate outright, and
 `scripts/file-size-baseline.txt` accepts no new entries. When a file here

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -935,8 +935,9 @@ pub fn fold_runs(
                 .and_then(serde_json::Value::as_i64)
                 .unwrap_or(0);
             let verdict = liveness(&id, live_id, heartbeat, now_unix, stale_after_secs);
-            if verdict != Liveness::Orphaned {
-                let live = live.expect("a non-orphaned run holds the live pointer");
+            if verdict != Liveness::Orphaned
+                && let Some(live) = live
+            {
                 phase = format!(
                     "{} ({}s ago)",
                     live.get("phase").and_then(|v| v.as_str()).unwrap_or("?"),

--- a/crates/stella-cli/README.md
+++ b/crates/stella-cli/README.md
@@ -336,7 +336,7 @@ unrecognized value is a hard parse error, never a silent fallback.
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions" (#7 is
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies" (#7 is
   the byte-stable-prompt rule this crate owns), "Workspace layout", and the
   `.stella/` directory table. [`../../README.md`](../../README.md) is the user-facing
   command and provider reference.

--- a/crates/stella-cli/src/memory/replay.rs
+++ b/crates/stella-cli/src/memory/replay.rs
@@ -10,7 +10,7 @@
 //! ## Why this needs no new architecture
 //!
 //! Every learner already sits below the model boundary or behind a port —
-//! invariant 1 ("ports, not concretions") and invariant 2 ("no I/O in the
+//! invariant 1 ("ports, not specific implementations") and invariant 2 ("no I/O in the
 //! engine") paying out. Of the five learners, four make **no** model call at all
 //! and the fifth makes exactly one, through the `Provider` port. So the whole
 //! harness is one test double and a clock:

--- a/crates/stella-cli/src/runtime.rs
+++ b/crates/stella-cli/src/runtime.rs
@@ -1,6 +1,6 @@
 //! Production implementations of `stella-core`'s time ports. The engine
 //! exports only the [`Clock`] and [`Sleeper`] traits (ports, not
-//! concretions), so the binary owns the concrete
+//! specific implementations), so the binary owns the concrete
 //! wall-clock/tokio impls and wires them at construction. This is what
 //! keeps `stella-core` free of production `tokio::time` calls.
 

--- a/crates/stella-context/README.md
+++ b/crates/stella-context/README.md
@@ -97,9 +97,7 @@ crossing the limit fails the gate outright, and
 approaches the limit, split it before it crosses, the way
 [`src/store.rs`](src/store.rs) already fans out into
 [`src/store/schema.rs`](src/store/schema.rs), [`src/store/node.rs`](src/store/node.rs)
-and friends — and know that [`src/store/tests.rs`](src/store/tests.rs) sits at
-1498 lines today, so the very next test added there must instead start a new
-sibling test module.
+and friends.
 
 ## Layout
 

--- a/crates/stella-context/src/provider.rs
+++ b/crates/stella-context/src/provider.rs
@@ -283,7 +283,7 @@ impl ProviderRegistry {
     /// offered to every verify-capable provider and the **first definite**
     /// answer wins. `Unknown` is not definite: a provider that cannot judge an
     /// identity must not shadow one that can. An identity no provider can
-    /// verifier stays `Unknown`, which the host treats as "do not reuse" (V2).
+    /// verify stays `Unknown`, which the host treats as "do not reuse" (V2).
     pub async fn verify_all(
         &self,
         request: &VerifyRequest,
@@ -294,7 +294,7 @@ impl ProviderRegistry {
                 continue;
             }
             // Only ask about identities still unresolved, so a provider never
-            // re-verifiers a frame another already vouched for.
+            // re-verifies a frame another already vouched for.
             let pending: Vec<_> = request
                 .frames
                 .iter()

--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -145,6 +145,8 @@ fn process_nonce() -> u64 {
 /// Insert a fact edge. `supersedes` links to the edge this one replaced (the
 /// `SUPERSEDES` relation of), or `None` for a
 /// fresh assertion. Returns the new edge's rowid.
+// The parameters are the edge row's own columns; a struct would just move
+// the same list up one level.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn insert_edge(
     conn: &Connection,

--- a/crates/stella-context/src/store/record.rs
+++ b/crates/stella-context/src/store/record.rs
@@ -9,6 +9,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::error::ContextError;
 
 /// Insert or update an episode (idempotent by `public_id`). Returns rowid.
+// The parameters are the episode row's own columns for a plain SQL insert;
+// a struct would just move the same list up one level.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn insert_episode(
     conn: &Connection,

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -181,7 +181,7 @@ lib.rs), never as a planning assumption.
 ## Key concepts
 
 **The step loop is a fixed phase sequence.** `run_turn`
-([`src/driver.rs:673`](src/driver.rs)) iterates up to `EngineConfig::max_steps`,
+([`src/driver.rs:618`](src/driver.rs)) iterates up to `EngineConfig::max_steps`,
 and each step runs the same phases in the same order: pause gate → drain
 steering / check soft stop → budget check → snapshot tool-result identities →
 compaction pass → loop detection → model call (wrapped in retry+backoff) →
@@ -229,7 +229,7 @@ its I/O behind generation.
 speculation pump. A mutating tool call runs *outside* the retried closure, after
 a model call has already succeeded, so a retried step structurally cannot
 re-execute it — proved by `retry_never_re_executes_a_tool_call`
-([`src/driver/tests.rs:1194`](src/driver/tests.rs)), which counts real executions
+([`src/driver/tests.rs:1618`](src/driver/tests.rs)), which counts real executions
 against a flaky scripted provider. Read-only calls carry no such guarantee: they
 run inside the retried closure and inside speculation, so one can execute several
 times in a step. Do not assume a `read_only` tool with an observable side channel
@@ -247,7 +247,7 @@ anything else is discarded and reported as an
 (#370).
 
 **Compaction's four mechanisms pull in opposite directions on purpose.**
-`compact()` ([`src/compaction.rs:203`](src/compaction.rs)) applies, least-lossy
+`compact()` ([`src/compaction.rs:356`](src/compaction.rs)) applies, least-lossy
 first: dedup of byte-identical tool outputs, supersession of re-run calls, aging
 (middle-out truncation of old large outputs), then eviction. Dedup keeps the
 **earliest** copy — byte-identical content is position-independent, so stubbing
@@ -261,7 +261,7 @@ system message and the latest user message are never touched.
 - **Two unrelated things are called `HookEvent`.** `hooks::HookEvent` is the
   settings-declared shell-hook lifecycle enum; `bus::HookEvent` is the
   extension-bus envelope. Only the first is re-exported at the crate root; the
-  second stays module-qualified on purpose ([`src/lib.rs:41`](src/lib.rs)).
+  second stays module-qualified on purpose ([`src/lib.rs:59`](src/lib.rs)).
 - **Loop detection ignores `ToolCall::call_id`.** `ToolCall` derives `PartialEq`
   over all fields including the id, which providers mint fresh per call — using
   derived equality here would mean the detector silently never fires.
@@ -351,7 +351,7 @@ built the mid-tool abort this crate exists to prevent.
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions"
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies"
   (invariants 1, 2 and 6 are this crate's contract) and "Testing approach".
 - [`../stella-protocol`](../stella-protocol) — `Provider`, `AgentEvent`,
   `CompletionMessage`, `ToolCall`/`ToolOutput`. [`../stella-tools`](../stella-tools)

--- a/crates/stella-core/src/bus.rs
+++ b/crates/stella-core/src/bus.rs
@@ -192,6 +192,8 @@ pub struct ExtensionFailure {
 pub type ObserverResult = Result<(), String>;
 
 type ObserverFn = dyn Fn(&HookEvent) -> ObserverResult + Send + Sync;
+// One matching observer's dispatch state, snapshotted before running handlers.
+type MatchingObserver = (String, Arc<ObserverFn>, Arc<AtomicU32>, Arc<AtomicBool>);
 type BlockingFn = dyn Fn(&HookEvent) -> HookDecision + Send + Sync;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -591,8 +593,7 @@ impl HookBus {
     /// a handler unsubscribed *during* a dispatch may still receive the
     /// in-flight event.
     fn dispatch(&self, event: &HookEvent) {
-        #[allow(clippy::type_complexity)]
-        let matching: Vec<(String, Arc<ObserverFn>, Arc<AtomicU32>, Arc<AtomicBool>)> = {
+        let matching: Vec<MatchingObserver> = {
             let observers = self
                 .inner
                 .observers

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -212,7 +212,7 @@ impl ProposalRecord {
     /// SKILL.md that informs, the other a rule that steers. Without the
     /// namespace they would collide onto one lineage, and declining the rule
     /// would silently decline the skill too.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // content-addressed constructor: every field feeds the hash, so a builder would just hide the same list
     pub fn new(
         proposal_kind: RecordProposalKind,
         status: RecordProposalStatus,
@@ -355,7 +355,6 @@ impl PromotionEventRecord {
     /// criterion, and *by any path* is only testable if there is exactly one
     /// path — a validator a caller can forget to run leaves the other paths
     /// open by construction.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         proposal_lineage_id: impl Into<String>,
         action: PromotionAction,

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -68,7 +68,7 @@ impl<'a> Engine<'a> {
     /// rides, the same way [`Self::apply_overflow_summary`] carries the budget
     /// pair it reports. `instructions` is a PreCompact hook's `modify`
     /// steering for the summarizer, appended to its request (#2684).
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
     pub(super) async fn summarize_overflow_span(
         &self,
         messages: &mut Vec<CompletionMessage>,
@@ -336,7 +336,7 @@ impl<'a> Engine<'a> {
     /// the restoration message appended after it reports its own size on the
     /// `agent.working_set.restored` lifecycle event instead of retroactively
     /// inflating the splice's number.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
     fn apply_overflow_summary(
         &self,
         messages: &mut Vec<CompletionMessage>,

--- a/crates/stella-core/src/driver/tests/compute_passes.rs
+++ b/crates/stella-core/src/driver/tests/compute_passes.rs
@@ -212,10 +212,6 @@ async fn per_step_hashing_grows_with_the_turn_not_with_its_square() {
 
     let short = hashes_for(4).await;
     let long = hashes_for(8).await;
-    eprintln!(
-        "DBG short={short} long={long} ratio={:.2}",
-        long as f64 / short as f64
-    );
 
     // Quadratic would put `long` at roughly 4x `short`. Linear puts it near 2x;
     // allow real slack for the fixed system/user blocks, which are hashed once in

--- a/crates/stella-core/src/ports/authz.rs
+++ b/crates/stella-core/src/ports/authz.rs
@@ -12,7 +12,7 @@
 //! through the same executor, and without a name they arrive
 //! indistinguishable. Any RBAC system worth the name needs that distinction,
 //! and it must be able to supply its own rules rather than convince us to
-//! hardcode them — invariant #1, ports not concretions.
+//! hardcode them — invariant #1, ports not direct dependencies.
 //!
 //! So: the engine defines [`Principal`] (who), consumes
 //! [`stella_protocol::ToolContract`] (what, and how dangerous), and delegates

--- a/crates/stella-core/src/retry.rs
+++ b/crates/stella-core/src/retry.rs
@@ -2,7 +2,7 @@
 //! decision logic plus one narrow async driver — `stella-core` has zero I/O
 //! of its own, so even the async loop here drives through an injectable
 //! [`Sleeper`] port rather than calling `tokio::time::sleep` directly, the
-//! same "ports, not concretions" seam as [`crate::ports::Clock`].
+//! same "ports, not direct dependencies" seam as [`crate::ports::Clock`].
 //!
 //! Binding lessons this module encodes:
 //!

--- a/crates/stella-diag/Cargo.toml
+++ b/crates/stella-diag/Cargo.toml
@@ -10,9 +10,10 @@ homepage.workspace = true
 publish.workspace = true
 
 # A LEAF crate, deliberately. It depends on `serde`/`serde_json` and nothing
-# else in this workspace, which is the property that lets all seventeen crates
-# depend on it without a cycle (docs/spec/diagnostics.md §5.1). Adding a
-# `stella-*` path dependency here forecloses that for whichever crate it names.
+# else in this workspace, which is the property that lets every other crate in
+# the workspace depend on it without a cycle (docs/spec/diagnostics.md §5.1).
+# Adding a `stella-*` path dependency here forecloses that for whichever crate
+# it names.
 [dependencies]
 serde.workspace = true
 # `float_roundtrip` is declared HERE rather than inherited, and it is load-bearing

--- a/crates/stella-diag/README.md
+++ b/crates/stella-diag/README.md
@@ -32,9 +32,9 @@ stream:
 ## Where it sits
 
 A **leaf**. It depends on `serde`/`serde_json` and **nothing else in the
-workspace**, which is the property that lets all twenty-three other crates depend
-on it without a cycle. Adding a `stella-*` path dependency here forecloses that
-for whichever crate it names — so don't.
+workspace**, which is the property that lets every other crate in the workspace
+depend on it without a cycle. Adding a `stella-*` path dependency here forecloses
+that for whichever crate it names — so don't.
 
 ## Direction — an embedded engine has no stdout to explain itself on
 

--- a/crates/stella-diag/src/dx.rs
+++ b/crates/stella-diag/src/dx.rs
@@ -443,6 +443,28 @@ mod tests {
         assert_eq!(dx.counters().warn, 1);
     }
 
+    /// Pins the level-to-field mapping in [`CounterSnapshot::at`] — nothing
+    /// else in the workspace calls it, so a mis-wired arm would otherwise
+    /// ship green.
+    #[test]
+    fn counter_snapshot_at_matches_the_level_it_was_emitted_at() {
+        let (dx, _records) = Dx::capturing();
+        for level in Level::ALL {
+            match level {
+                Level::Error => diag!(&dx, error, "test.at"),
+                Level::Warn => diag!(&dx, warn, "test.at"),
+                Level::Info => diag!(&dx, info, "test.at"),
+                Level::Debug => diag!(&dx, debug, "test.at"),
+                Level::Trace => diag!(&dx, trace, "test.at"),
+            }
+        }
+        let snapshot = dx.counters();
+        for level in Level::ALL {
+            assert_eq!(snapshot.at(level), 1, "{level:?}");
+        }
+        assert_eq!(snapshot.total(), 5);
+    }
+
     #[test]
     fn a_facet_renders_itself_into_the_envelope() {
         struct Migrated {

--- a/crates/stella-diag/src/filter.rs
+++ b/crates/stella-diag/src/filter.rs
@@ -4,9 +4,9 @@
 //! A real filter, not a level — `docs/spec/diagnostics.md` §6.
 //!
 //! `STELLA_SERVE_LOG` is a single level, which `serve-observability.md` §9
-//! knowingly gave up. At seventeen crates that stops being acceptable: `debug`
-//! across the workspace is noise nobody can read, so the one thing an operator
-//! actually needs is "quiet everywhere, loud in `stella_store`".
+//! knowingly gave up. Across a whole workspace of crates that stops being
+//! acceptable: `debug` everywhere is noise nobody can read, so the one thing
+//! an operator actually needs is "quiet everywhere, loud in `stella_store`".
 //!
 //! ```text
 //! STELLA_LOG=warn                                  # global

--- a/crates/stella-diag/src/record.rs
+++ b/crates/stella-diag/src/record.rs
@@ -3,7 +3,7 @@
 
 //! The envelope — `docs/spec/diagnostics.md` §5.1.
 //!
-//! One shape, shared by all seventeen crates:
+//! One shape, shared by every crate in the workspace:
 //!
 //! ```json
 //! {

--- a/crates/stella-diff/src/lib.rs
+++ b/crates/stella-diff/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
 //! A real line-oriented unified diff — the shape a developer already knows how
 //! to read, because it is the shape `git diff` produces.
 //!
@@ -479,5 +482,24 @@ mod tests {
             !diff.changed(),
             "a trailing newline adds no line, so it is not a diff"
         );
+    }
+
+    #[test]
+    fn an_input_past_the_area_cap_degrades_to_replace_all_and_says_so() {
+        // 2001 * 2001 = 4,004,001, just over LCS_AREA_CAP (4,000,000), so this
+        // takes the replace-everything fallback instead of allocating the DP
+        // table. The fallback path never allocates the table, so this test
+        // runs instantly even though the inputs are thousands of lines long.
+        let old: Vec<String> = (0..2001).map(|i| format!("old-{i}")).collect();
+        let new: Vec<String> = (0..2001).map(|i| format!("new-{i}")).collect();
+        let old = old.join("\n");
+        let new = new.join("\n");
+
+        let diff = unified_diff(&old, &new, 3);
+
+        assert!(!diff.minimal);
+        assert_eq!(diff.added, 2001);
+        assert_eq!(diff.removed, 2001);
+        assert!(!diff.hunks.is_empty());
     }
 }

--- a/crates/stella-embed/src/hash.rs
+++ b/crates/stella-embed/src/hash.rs
@@ -24,16 +24,21 @@ use crate::seam::{EmbedError, Embedder, EmbedderFingerprint, Embedding, Similari
 /// two FNV-1a hashes — one selects a dimension bucket, and the OTHER's top
 /// bit picks a sign — and accumulate ±1 into that bucket (a signed random
 /// projection that keeps the expected dot-product an unbiased similarity
-/// estimate). The sign must come from a high bit: FNV-1a's multiplier is odd,
-/// so bit 0 survives hashing, both offset bases are odd, and with
-/// power-of-two dims the bucket (`h % dims`) shares that bit — a low-bit sign
-/// was a pure function of bucket parity, collapsing the projection into an
-/// unsigned count sketch whose collisions add instead of cancel (revision 1's
-/// defect; revision 2 fixed it). The result
-/// is L2-normalized so cosine similarity is a plain dot product. Fully
-/// deterministic and platform-independent: the same string always yields the
-/// same vector, which is what makes the `(content_hash, fingerprint)` skip in
-/// `L-C2` sound.
+/// estimate).
+///
+/// The sign has to come from a high bit. FNV-1a multiplies by an odd number,
+/// and both starting values are odd, so bit 0 of the hash is carried straight
+/// through from the input. With a power-of-two `dims` the bucket is
+/// `h % dims`, which keeps that same bit. So taking the sign from bit 0 made
+/// it a pure function of which bucket the n-gram landed in — every collision
+/// then added instead of cancelling, turning the signed projection into an
+/// unsigned count sketch. That was revision 1's bug; revision 2 takes the
+/// sign from the second hash's top bit instead.
+///
+/// The result is L2-normalized so cosine similarity is a plain dot product.
+/// Fully deterministic and platform-independent: the same string always
+/// yields the same vector, which is what makes the `(content_hash,
+/// fingerprint)` skip in `L-C2` sound.
 #[derive(Debug, Clone)]
 pub struct HashEmbedder {
     dims: usize,

--- a/crates/stella-engine/Cargo.toml
+++ b/crates/stella-engine/Cargo.toml
@@ -13,7 +13,6 @@ stella-protocol = { path = "../stella-protocol" }
 stella-core = { path = "../stella-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 # `sync` only, deliberately: this crate inherits stella-core's I/O-free
 # posture and must never reach for `net`/`fs`/`process` itself.
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/stella-graph/README.md
+++ b/crates/stella-graph/README.md
@@ -119,7 +119,7 @@ ratchet (`scripts/check-file-size.sh`), and none may appear — a new file
 crossing the limit fails the gate outright, and
 `scripts/file-size-baseline.txt` accepts no new entries. When a file
 approaches the limit, split it before it crosses — and
-[`src/parse.rs`](src/parse.rs) is approaching it at 1474 lines today, so a
+[`src/parse.rs`](src/parse.rs) is approaching it at 1494 lines today, so a
 new language's decoder arm and tests may be what pushes it over: plan to
 extract per-language decoding into a submodule rather than grow the file.
 
@@ -133,7 +133,7 @@ extract per-language decoding into a submodule rather than grow the file.
 | [`src/queries.rs`](src/queries.rs) | The tree-sitter S-expression queries as `const &str` compile-time data, one symbols/imports pair per language. |
 | [`src/parse.rs`](src/parse.rs) | `Grammars` (compiled once, shared by reference) and `parse_file`: tree → `Symbol`s + raw `ImportSpec`s. Pure and synchronous. |
 | [`src/symbol.rs`](src/symbol.rs) / [`src/import.rs`](src/import.rs) | `SymbolKind` (the cross-language superset, including SQL schema objects) and `ImportKind` plus the relative-specifier resolution ladder. |
-| [`src/store.rs`](src/store.rs) | SQLite: the `MIGRATION` DDL, `index_tree`, `apply_changes`, and every read query. The largest file and the one with the durability contract. |
+| [`src/store.rs`](src/store.rs) | SQLite: the `MIGRATION` DDL, `index_tree`, `apply_changes`, and every read query. The file with the durability contract. |
 | [`src/walk.rs`](src/walk.rs) | The directory walk and `DENY_DIRS` — the cheap structural half of generated-file exclusion. |
 | [`src/generated.rs`](src/generated.rs) | The per-file half: `.gitattributes linguist-generated`, `*.min.*`, and the minified-content heuristic (issue #272). |
 | [`src/watch.rs`](src/watch.rs) | The live re-index pipeline: `notify` event source → debounce → one transactional apply, plus the `WatchInjector` test seam. |

--- a/crates/stella-graph/src/frames.rs
+++ b/crates/stella-graph/src/frames.rs
@@ -493,7 +493,7 @@ fn edge_frame(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // the nine params are the only ContextFrame fields the two callers vary; the rest are defaulted below
 fn frame(
     id: String,
     kind: FrameKind,

--- a/crates/stella-graph/src/manifest.rs
+++ b/crates/stella-graph/src/manifest.rs
@@ -83,7 +83,6 @@ pub struct RedirectDecl {
 /// same entity.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct StorageManifest {
-    #[allow(dead_code)]
     pub version: Option<u32>,
     #[serde(default)]
     pub layers: BTreeMap<String, LayerDecl>,

--- a/crates/stella-home/README.md
+++ b/crates/stella-home/README.md
@@ -67,13 +67,16 @@ which is the test — not "is it about the home directory". They still answer
 "where" and never "make it so": the lazy migration those legacy roots exist for
 is I/O with failure modes, and it stays in the CLI.
 
-`user_plugins_dir` / `resolve_project_plugins_dir` (#3380) are the same shape
-arriving **one consumer early**, and that is said out loud rather than glossed:
-`stella-cli`'s plugin loader is their only caller today. The second is the
-wrapper socket's other drivers — `stella-serve` and an embedded host — which
-`doc:wrapper-socket` §6 makes an acceptance criterion, and which must find the
-same two-tier roster without depending on the CLI to spell `.stella/plugins`.
-If that driver never lands, these belong back in `stella-cli`.
+`resolve_user_plugins_dir` / `resolve_project_plugins_dir` (#3380) are the same
+shape arriving **one consumer early**, and that is said out loud rather than
+glossed: `stella-cli`'s plugin loader is their only caller today, and it calls
+the pure `resolve_*` half directly with its own redirectable root — not the
+ambient `user_plugins_dir()` wrapper, which nothing calls yet. The second
+consumer is the wrapper socket's other drivers — `stella-serve` and an
+embedded host — which `doc:wrapper-socket` §6 makes an acceptance criterion,
+and which must find the same two-tier roster without depending on the CLI to
+spell `.stella/plugins`. If that driver never lands, these belong back in
+`stella-cli`.
 
 This crate is also the workspace's worked example of when a new crate is
 justified. The rule: a new crate is warranted only when functionality (a) sits

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -209,15 +209,12 @@ pub fn resolve_self_driving_root(stella_home: Option<PathBuf>) -> Option<PathBuf
 /// reason to fall back to the working directory, because that would install
 /// third-party code into whatever repository happened to be open.
 ///
-/// **One consumer today, and that is stated rather than glossed** (see the
-/// crate README's bar for a new resolver). `stella-cli`'s loader is the only
-/// caller as of #3380; the second is the wrapper socket's other drivers —
-/// `stella-serve` and an embedded host linking `stella-engine` — which
-/// `doc:wrapper-socket` §6 makes an acceptance criterion rather than an
-/// aspiration, and which must find the same roster the CLI does without
-/// depending on the CLI to spell it. That is the `self_driving_root` shape
-/// (two parties that must not know each other, one answer), arriving one
-/// consumer early; if that second driver never lands, this belongs back in
+/// Nothing calls this wrapper yet. `stella-cli`'s plugin loader calls the
+/// pure half, [`resolve_user_plugins_dir`], with its own redirectable root
+/// instead. The expected first caller is the wrapper socket's other
+/// drivers — `stella-serve` or an embedded host — which need the same
+/// roster without depending on `stella-cli` to spell the path
+/// (`doc:wrapper-socket` §6). If that never lands, this belongs back in
 /// `stella-cli`.
 #[must_use]
 pub fn user_plugins_dir() -> Option<PathBuf> {

--- a/crates/stella-mcp/README.md
+++ b/crates/stella-mcp/README.md
@@ -34,12 +34,14 @@ to `stella-cli`.
 
 ## Where it sits
 
-It depends on `stella-protocol` (`ToolOutput`, `ToolSchema`) and `stella-core`
+It depends on `stella-protocol` (`ToolOutput`, `ToolSchema`), `stella-core`
 (the [`ports::ToolExecutor`](../stella-core/src/ports.rs) trait it implements
 and the [`mcp_usage`](../stella-core/src/mcp_usage.rs) ledger it records calls
-into) — nothing else in the workspace. Only `stella-cli` depends on it. It also
-builds its own binary, `mcp-fixture-server`, which exists purely for
-`tests/` and is excluded from dist (`[package.metadata.dist] dist = false`).
+into), and `stella-store` (for the one shared atomic file-write helper,
+`stella_store::durable::write_atomic`) — nothing else in the workspace.
+`stella-cli` and `stella-runtime` depend on it. It also builds its own binary,
+`mcp-fixture-server`, which exists purely for `tests/` and is excluded from
+dist (`[package.metadata.dist] dist = false`).
 
 ## Layout
 
@@ -296,7 +298,7 @@ the flag in both the binary's `//!` header and the `[[bin]]` comment in
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions"
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies"
   (why `ToolExecutor` is the only seam), "The `.stella/` directory" (where
   `mcp.toml` and `mcp_oauth.json` live), and "Testing approach".
 - [`../../website/content/docs/agent-tools/mcp.mdx`](../../website/content/docs/agent-tools/mcp.mdx)

--- a/crates/stella-media/README.md
+++ b/crates/stella-media/README.md
@@ -151,8 +151,10 @@ and deterministic: parse with `roxmltree` under default options, which reject
 DTDs and so block XXE and billion-laughs before a renderer ever sees them;
 re-serialize through a deny-list (drop `<script>`, `<style>`,
 `<foreignObject>`, `<metadata>`; drop every `on*` attribute; keep only
-same-document `#fragment` hrefs; drop any value containing `//` or
-`javascript:`); then optimize lightly (comments/PIs dropped, whitespace
+same-document `#fragment` hrefs; drop any value that starts with a URL
+scheme, starts with `//`, or contains `javascript:`; drop the `style`
+attribute outright; drop elements and attributes in any other namespace);
+then optimize lightly (comments/PIs dropped, whitespace
 collapsed, a `viewBox` backfilled from `width`/`height`). Depth is bounded
 twice against `MAX_NESTING_DEPTH` (256) — textually before parsing, because
 roxmltree's tokenizer recurses per level and would overflow the stack *inside*
@@ -205,12 +207,6 @@ planted symlink), and the manifest row for a path is *replaced*, not appended.
   model-writable workspace, so a crafted id is a path fragment inside the
   vendor base URL on a request that carries the user's API key. The host is
   pinned by `base_url` and cannot be changed this way; the path can.
-- **Two SVG holes are recorded, not fixed.** Rule 6 keys on `//` and
-  `javascript:`, so a `data:` URI in a non-`href` attribute survives, and a
-  `style="…"` *attribute* has no rule of its own (only the `<style>` element
-  does). Neither is reachable through the preview ladder, which never renders
-  SVG — both matter once an artifact is inlined into HTML.
-
 ## Testing
 
 ```bash
@@ -264,7 +260,7 @@ To add a provider:
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions" (why
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies" (why
   every vendor is an adapter behind `MediaProvider`) and "Testing approach",
   whose wiremock-adapter-test line names this crate.
 - [`../stella-tools/src/media.rs`](../stella-tools/src/media.rs) — the tools

--- a/crates/stella-media/src/adapters/zai_video.rs
+++ b/crates/stella-media/src/adapters/zai_video.rs
@@ -295,19 +295,11 @@ fn is_valid_job_id(id: &str) -> bool {
 /// Deterministically derive our artifact id from the provider's job id, so a
 /// resume after a restart reconstructs the same identity for events and the
 /// final file.
-///
-/// The hex is spelled out rather than `format!("{byte:02x}")` per byte for the
-/// same reason `artifact::push_hex` is: the per-byte form allocates and drops
-/// a `String` for every byte of the digest.
 fn artifact_id_for(provider_job_id: &str) -> String {
-    const DIGITS: &[u8; 16] = b"0123456789abcdef";
     let digest = Sha256::digest(provider_job_id.as_bytes());
     let mut id = String::with_capacity("med_".len() + 12);
     id.push_str("med_");
-    for &byte in &digest[..6] {
-        id.push(DIGITS[usize::from(byte >> 4)] as char);
-        id.push(DIGITS[usize::from(byte & 0x0f)] as char);
-    }
+    crate::artifact::push_hex(&mut id, &digest[..6]);
     id
 }
 

--- a/crates/stella-media/src/artifact.rs
+++ b/crates/stella-media/src/artifact.rs
@@ -357,7 +357,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// Append `bytes` to `out` as lowercase hex. Spelled out rather than
 /// `format!("{byte:02x}")` per byte: that allocates and drops a `String` for
 /// every byte of every digest, on a path that runs twice per saved artifact.
-fn push_hex(out: &mut String, bytes: &[u8]) {
+pub(crate) fn push_hex(out: &mut String, bytes: &[u8]) {
     const DIGITS: &[u8; 16] = b"0123456789abcdef";
     for &byte in bytes {
         out.push(DIGITS[usize::from(byte >> 4)] as char);

--- a/crates/stella-media/src/provider.rs
+++ b/crates/stella-media/src/provider.rs
@@ -1,6 +1,6 @@
 //! The `MediaProvider` port and its request/response types
 //! One trait, many vendor adapters behind it —
-//! the same ports-not-concretions discipline the chat `Provider` uses.
+//! the same ports-not-direct-dependencies discipline the chat `Provider` uses.
 //!
 //! `generate_image` is sync-ish (one HTTP round trip, bytes back);
 //! `generate_video` submits an async job and returns a [`MediaJob`] handle

--- a/crates/stella-model/README.md
+++ b/crates/stella-model/README.md
@@ -37,11 +37,10 @@ Depends on exactly one workspace crate, `stella-protocol` (`Provider`,
 `CompletionRequest`/`CompletionResult`, `ProviderError`, `Attachment`); the rest
 are third-party — `reqwest`/`tokio`/`futures-util` for transport, `hmac`+`sha2`
 for Bedrock SigV4, `rpassword` for the credential prompt, `toml` for
-`~/.stella/credentials.toml`. Only `stella-cli` depends on it (`stella-core`
-never does, by design), and it constructs adapters in exactly one place:
-`build_provider_parts` in
-[`../stella-cli/src/agent/engine.rs`](../stella-cli/src/agent/engine.rs). No
-binary of its own.
+`~/.stella/credentials.toml`. `stella-cli` and `stella-runtime` depend on it
+(`stella-core` never does, by design), and both funnel into one construction
+site: `build_provider` in [`src/factory.rs`](src/factory.rs). No binary of
+its own.
 
 ## Boundary — does this change belong here?
 
@@ -208,9 +207,11 @@ make test-model          # or: cargo test -p stella-model
 ```
 
 Adapter tests are `wiremock`-based and live beside the code: inline
-`#[cfg(test)] mod tests` in `openai.rs`, `gemini.rs`, `bedrock.rs`, `vertex.rs`,
-out-of-line in [`src/anthropic/tests.rs`](src/anthropic/tests.rs) and
-[`src/zai/tests.rs`](src/zai/tests.rs). They assert both directions — the exact
+`#[cfg(test)] mod tests` in `openai.rs` and `vertex.rs`, out-of-line in
+[`src/anthropic/tests.rs`](src/anthropic/tests.rs),
+[`src/zai/tests.rs`](src/zai/tests.rs),
+[`src/gemini/tests.rs`](src/gemini/tests.rs) and
+[`src/bedrock/tests.rs`](src/bedrock/tests.rs). They assert both directions — the exact
 bytes that go out, and a `CompletionResult` reassembled from a canned SSE stream.
 No credential or network required.
 
@@ -259,10 +260,10 @@ Adding a provider. **Step 0 is the one most new providers stop at.**
      a model with no dial at all.
    - `OptIn`, `Implicit`, and `Controllable` must name a `witness` — the exact
      test function proving the behavior on the wire — and it must live in one of
-     the six files `adapter_sources()` embeds with `include_str!`
-     (`anthropic/tests.rs`, `bedrock.rs`, `openai.rs`, `gemini.rs`, `vertex.rs`,
-     `zai/tests.rs`); a witness in a *new* adapter's own test module is invisible
-     until you add that file there too. No-control variants carry a `note` instead.
+     the files `adapter_sources()` embeds with `include_str!` (see
+     [`src/provider_parity.rs`](src/provider_parity.rs) for the current list);
+     a witness in a *new* adapter's own test module is invisible until you add
+     that file there too. No-control variants carry a `note` instead.
    - What fails if you skip it: `every_seeded_provider_declares_a_cache_posture`
      / `every_seeded_provider_declares_a_reasoning_posture` (in `stella-cli`) on
      a missing row, `both_axes_cover_the_same_provider_ids` if you add one axis
@@ -280,7 +281,7 @@ axis in `provider_parity.rs` — record it as a matrix, not as adapter folklore.
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions",
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies",
   invariant 8 ("Provider feature parity is declared, not assumed"), and the
   `stella-model` row in "Workspace layout — where a change goes".
 - [`../stella-protocol/src/provider.rs`](../stella-protocol/src/provider.rs) —

--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -81,7 +81,7 @@ half of that alarm — which of the two things a digest mismatch means depends o
 the journal's era, read from `executions.journal_era` (#1981).
 
 Only [`stella-cli`](../stella-cli) depends on it: `run_observe`
-([`../stella-cli/src/storage_cmd.rs:47`](../stella-cli/src/storage_cmd.rs))
+([`../stella-cli/src/storage_cmd.rs`](../stella-cli/src/storage_cmd.rs))
 preflights the private store paths and calls `serve` (`--port`, default `7787`; `0` picks a
 free one). This crate builds no binary —
 [`examples/serve.rs`](examples/serve.rs) is the dev harness. It reads two tiers:
@@ -119,13 +119,13 @@ it crosses.
 ### The three boundaries, and what actually enforces each
 
 **Loopback-only** starts at `TcpListener::bind(("127.0.0.1", port))`
-(`src/lib.rs:299`), but the bind is not the boundary: a web page can resolve an
+(`src/lib.rs`), but the bind is not the boundary: a web page can resolve an
 attacker-controlled name to `127.0.0.1` and read this dashboard cross-origin.
-Three things close that. `host_is_local` (`src/lib.rs:356`) refuses any `Host`
+Three things close that. `host_is_local` (`src/lib.rs`) refuses any `Host`
 that does not *parse* as a loopback IP — never a prefix test, because
 `127.0.0.1.attacker.example` is a registrable name `starts_with("127.")` waves
 through. `handle` refuses an unterminated request head with `431` *before*
-routing (`src/lib.rs:385`): padding the request line past the 8 KiB cap used to
+routing (`src/lib.rs`): padding the request line past the 8 KiB cap used to
 push `Host` out of the buffer entirely, and the no-`Host` allowance then waved
 the rebound request through to a route that still parsed out of the truncated
 path. And `frame-ancestors 'none'` in the CSP stops that page framing it
@@ -133,18 +133,18 @@ instead. The no-`Host` allowance itself is deliberate — a browser `fetch`
 always sends one, so its absence means raw curl or a test, not the attack.
 
 **Read-only** is `OpenFlags::SQLITE_OPEN_READ_ONLY` at all three open sites —
-`db::open_read_only` (`src/db.rs:780`), `global::open_usage`
-(`src/global.rs:59`), `codegraph::snapshot` (`src/codegraph.rs:45`) — each with
+`db::open_read_only` (`src/db.rs`), `global::open_usage`
+(`src/global.rs`), `codegraph::snapshot` (`src/codegraph.rs`) — each with
 a 5 s `busy_timeout`, so a checkpoint or a migration's exclusive lock makes a
 poll wait rather than 500. `Observatory::new` opens nothing, and each open
 returns `None` for a missing file rather than creating it. Outside
 `#[cfg(test)]` nothing here writes to the filesystem, and non-`GET` requests get
-`405` (`src/lib.rs:454`), so there is no mutation verb to reach.
+`405` (`src/lib.rs`), so there is no mutation verb to reach.
 
-**Embedded** is three `include_str!`s (`src/lib.rs:51`–`55`).
+**Embedded** is three `include_str!`s (`src/lib.rs`).
 `dashboard_html_has_no_external_references` fails the suite if `index.html` ever
 contains `http://`, `https://`, `//cdn`, `@import` or `integrity=`, and the
-`CSP` constant (`src/lib.rs:84`) restates that to the browser (`default-src
+`CSP` constant (`src/lib.rs`) restates that to the browser (`default-src
 'self'`, `connect-src 'self'`, `img-src 'self'`). `'unsafe-inline'` on
 `script-src`/`style-src` is unavoidable and load-bearing: the page is one
 document with an inline `<script>`, an inline `<style>` and inline `style="…"`
@@ -153,11 +153,11 @@ attributes, so dropping it from `style-src` would strip the layout silently.
 
 ### `respond` is pure; there is no server state
 
-`respond(workspace_root, path)` (`src/lib.rs:134`) maps a path to a `Response`
+`respond(workspace_root, path)` (`src/lib.rs`) maps a path to a `Response`
 and is what the unit tests drive — no sockets involved. Every request opens its
 own connections and drops them; the page re-polls every 5 s while its tab is
 visible. The one twist is `?project=<id>`, accepted by every `/api/*` route: the
-id is resolved by `global::resolve_project_root` (`src/global.rs:138`) against
+id is resolved by `global::resolve_project_root` (`src/global.rs`) against
 the rollup's own `projects` table — never a path supplied by the client — and
 that root replaces the serving root for the request. Unknown ids fall back to
 the serving workspace rather than erroring, so a stale dropdown cannot break the
@@ -170,7 +170,7 @@ keep the original root.
 — one row in `executions`, the foreign key `telemetry`, `tool_calls`,
 `files_touched` and `execution_reflection` hang off; every join in
 `Observatory::executions`, `execution`, `models` and `activity` is on it.
-`run_id` appears only in `Observatory::fleet` (`src/db.rs:722`), against a
+`run_id` appears only in `Observatory::fleet` (`src/db.rs`), against a
 different file (`fleet.db`) and a different hierarchy: a fleet run fans out to
 tasks, then attempts, then commits. It is not an execution and not a session,
 and no query may join the two. AGENTS.md's glossary is the authority.
@@ -217,7 +217,7 @@ underneath the predicate fails there.
 ### Secrets never reach the browser
 
 `settings.json` and `mcp.toml` carry credentials, and both are served. `redact`
-(`src/fsview.rs:493`) replaces every string at or below a *credential scope* —
+(`src/fsview.rs`) replaces every string at or below a *credential scope* —
 a key `sensitive_key` matches, or an `env`/`headers` map whose values are
 credentials by position. The scope is **inherited, not recomputed per level**:
 settings are arbitrary user JSON, so a secret can sit a container below the key
@@ -312,14 +312,14 @@ badge context, never the hue, still say "warning".
   `executions`/`telemetry`/`tool_calls` — so the payload, the per-request
   allocation and the page's re-render all grow with the workspace's entire
   history, and the tab re-fetches all of it every 5 s.
-- **`percent_decode` (`src/lib.rs:258`) parses attacker-reachable bytes.** A
+- **`percent_decode` (`src/lib.rs`) parses attacker-reachable bytes.** A
   malformed escape (`%`, `%A`, `%ZZ`) must stay literal — never a panic, never
   a dropped byte — and decoding runs over bytes before UTF-8 validation so a
   multi-byte character split across escapes reassembles.
 - **`STELLA_DATA_DIR` is process-wide.** The two tests that set it serialize on
   `DATA_DIR_LOCK`, poison-tolerantly; a third that mutates it without the lock
   will flake the other two.
-- **The code graph is capped at 600 nodes** (`MAX_NODES`, `src/codegraph.rs:29`):
+- **The code graph is capped at 600 nodes** (`MAX_NODES`, `src/codegraph.rs`):
   the highest-degree files are kept and the rest reported as `truncated`, so a
   large workspace's graph is a sample, not the whole index.
 
@@ -342,7 +342,7 @@ schema it is checking, a real socket, `node`, or room:
 | [`tests/journal_era.rs`](tests/journal_era.rs) | The other half of the digest alarm: which of two things a mismatch means depends on `executions.journal_era` (#1981). |
 | [`tests/live_stream.rs`](tests/live_stream.rs) | Drives the live endpoint over a real socket. |
 | [`tests/page_clipper.rs`](tests/page_clipper.rs) | Executes the page's own JavaScript under `node` — see below. |
-| [`tests/rules_ledger.rs`](tests/rules_ledger.rs) | Room: [`src/tests.rs`](src/tests.rs) sits at the file-size ratchet's 1500 lines exactly and this crate carries no baseline entry, so it is closed to growth. New route coverage lands in a sibling rather than raising a ceiling. |
+| [`tests/rules_ledger.rs`](tests/rules_ledger.rs) | Room: [`src/tests.rs`](src/tests.rs) is already large, and this crate has no baseline entry, so new route coverage lands in a sibling file to keep it clear of the 1500-line ratchet. |
 
 The dominant shape: `seeded_workspace()` builds a `TempDir` with a `store.db`
 seeded from hand-written DDL, `seed_fs_surfaces()` layers on the file-backed
@@ -366,7 +366,7 @@ Adding an API route:
    char-not-byte count and `max` excluding the ellipsis stay one decision
    rather than a per-module one (#1999). The clip *lengths* are per-surface;
    the clip *shape* is not.
-2. Add the arm to the `match route` in `respond` (`src/lib.rs:148`). Take
+2. Add the arm to the `match route` in `respond` (`src/lib.rs`). Take
    filters via `query_param`, never by splitting the query string yourself.
 3. Add the path to `empty_workspace_degrades_to_empty_payloads_not_errors`'s
    list — it fails until step 1's degradation is right — then seed the table or

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -241,11 +241,8 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
         }
         // The rendered transcript (`?id=<execution id>`). Unlike every route
         // below it, this returns HTML rather than JSON: the page is rendered by
-        // `stella-transcript`, the same code the TUI draws from, so the two
-        // surfaces cannot drift the way the dashboard's hand-rolled JavaScript
-        // renderer drifted from the deck's. It is standalone — its own styles
-        // ride with it — so it opens in its own tab and needs nothing from
-        // `index.html`.
+        // `stella-transcript`. It is standalone — its own styles ride with it —
+        // so it opens in its own tab and needs nothing from `index.html`.
         "/transcript" => {
             let Some(id) = query_param(query, "id").and_then(|v| v.parse::<i64>().ok()) else {
                 return Response::error("400 Bad Request", "missing ?id=<execution id>");

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -485,11 +485,15 @@ pub static CAPABILITIES: &[Capability] = &[
             mechanism: "settings + flags resolved field-by-field into EngineConfig",
             witness: "configured_settings_beat_the_baseline_field_by_field",
         },
-        api: SurfacePosture::Deferred {
-            waiting_on: "an engine-config block on turn/session create: of EngineConfig's ~15 \
-                         knobs only max_steps is settable over the wire — an embedding host \
-                         cannot pin effort, reasoning, output caps, timeouts, or budgets-in-time \
-                         from the API",
+        api: SurfacePosture::Shipped {
+            mechanism: "an `engine` block (#1167) on POST /v1/turns and POST /v1/sessions/{id}/turns: \
+                        max_output_tokens, temperature, effort, reasoning, params, \
+                        compaction_budget_tokens, summarize_overflow, summarize_keep_recent, \
+                        tool_result_horizon_steps and model_timeout_secs each lower onto the server \
+                        default for that turn; values past an operator ceiling are clamped and the \
+                        clamp is reported in the create response. max_steps and \
+                        reverse_request_timeout_ms ride the request top level and pre-date #1167",
+            witness: "engine_overrides_reach_the_provider_request_and_clamps_are_reported",
         },
     },
     Capability {

--- a/crates/stella-pipeline/README.md
+++ b/crates/stella-pipeline/README.md
@@ -21,8 +21,10 @@ over owned data in a sibling module (`triage`, `plan`, `scope`, `verify`, `witne
 
 Depends on `stella-protocol` (wire types and `AgentEvent`) and `stella-core` (`Engine`,
 `Router`, `BudgetGuard`, `ToolExecutor`, `Sleeper`), plus `tokio`, `async-trait`, `serde`,
-`serde_json` and `thiserror`. Nothing in the workspace depends on it except `stella-cli`,
-which owns the port implementations and the `Router` itself. It builds no binary.
+`serde_json` and `thiserror`. Two crates depend on it: `stella-cli`, which owns the port
+implementations and the `Router`, and `stella-serve`, which runs `Pipeline::run` behind
+`POST /v1/turns` over its own remoted ports (for example its `RemoteApprovalGate` in
+place of the CLI's stdio gate). It builds no binary.
 
 ## Direction — this crate becomes a plugin
 
@@ -384,7 +386,7 @@ contract.
 ## See also
 
 - [`../../AGENTS.md`](../../AGENTS.md) — "The definition of done: witness tests" for the contract
-  this crate enforces at runtime; "Architecture: ports, not concretions" for the inherited
+  this crate enforces at runtime; "Architecture: ports, not direct dependencies" for the inherited
   no-I/O and byte-stable-prompt rules.
 - [`../../website/content/docs/inference-pipeline.mdx`](../../website/content/docs/inference-pipeline.mdx)
   — the full stage flow, the terminal ladder outcomes, and the `/pipeline` deck toggle.

--- a/crates/stella-pipeline/src/pipeline/raw_usage.rs
+++ b/crates/stella-pipeline/src/pipeline/raw_usage.rs
@@ -105,8 +105,9 @@ fn management_bounds(role: ModelCallRole) -> (Option<u32>, Option<ReasoningEffor
         // cap. Plan's output contract is three to eight short strings; that
         // does not need session-level deliberation to produce.
         ModelCallRole::Plan | ModelCallRole::PlanRepair => (Some(4096), Some(ReasoningEffort::Low)),
-        // "PASS or FAIL, then one line" / "at most 6 lines" by their own
-        // prompts. Effort inherited: both are judgment calls on evidence.
+        // Verdict and DistressGuidance are no longer dispatched at all
+        // (#2584). The numbers below are kept only so this match stays
+        // exhaustive over ModelCallRole; no call ever reaches them.
         ModelCallRole::Verdict | ModelCallRole::DistressGuidance => (Some(1024), None),
         // The only raw `Worker` call is the conversational fast path, whose
         // instructions say "reply briefly and warmly in plain prose".
@@ -463,7 +464,10 @@ mod tests {
     /// wire with reasoning headroom above its written output contract, so a
     /// reasoning model has room to think before its first answer token. The
     /// old caps (512 triage, 1024 verdict) are exactly the numbers that came
-    /// back empty across a whole benchmark match.
+    /// back empty across a whole benchmark match. The Verdict and
+    /// DistressGuidance rows here cover roles that are no longer dispatched
+    /// (#2584) — they stay in the table only to prove the caps would still
+    /// be correct if that ever changed.
     #[test]
     fn every_capped_role_carries_reasoning_headroom() {
         let none = RoleCallOverrides::default();

--- a/crates/stella-plugin/Cargo.toml
+++ b/crates/stella-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stella-plugin"
-description = "The plugin manifest: parsing and validation of a plugin's declared say in the turn loop — participation grades, hook grants, requirements, oracle, and subloop — pure functions over borrowed text, no I/O."
+description = "The plugin manifest and the wrapper socket's wire contract: parsing, validation, and consent rendering for what a plugin declares and what it ships — pure functions over borrowed text, no I/O."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -225,6 +225,17 @@ before it crosses.
   corpus `bin/export_wrapper_wire.rs` prints, published under `docs/wire/` and
   gate-checked by `scripts/check-wire-schema.sh`; compiled into no default
   build.
+- `src/host_call.rs` — the channel that lets a plugin ask the host for
+  something (recall, a bounded child turn, a test re-run) and read the answer
+  before it replies. The host performs the call and applies
+  `LoopGrant::permits_call`, so the plugin never reaches anything itself.
+- `src/package.rs` — the `[[tools]]`, `[[skills]]` and `[[records]]` a package
+  ships, plus `PluginManifest::reconcile`, which compares what the manifest
+  declares against what the host actually found on disk and refuses any
+  disagreement in either direction.
+- `src/driver.rs` — the `[driver]` block and the drive-session wire shapes
+  (`DriverGrant`, `DriverCall`, `DriveRequest`/`DriveResponse`): a plugin that
+  starts turns rather than taking part in one.
 - `src/error.rs` — `ManifestError`, typed per rule (invariant 5).
 - `tests/manifest_grades.rs` + `tests/fixtures/*.toml` — slice A's
   acceptance: one fixture per grade, round-tripped through both TOML and
@@ -262,10 +273,12 @@ Three, and the count is the point — this crate's own README said "None
 shipping yet, deliberately" for as long as that was true, and it is not any
 more:
 
-- **`stella-runtime`** consumes the wire contract and the verdict rule. It
-  defines the `TurnWrapper` trait and the two host functions `judge` and
-  `again` over the types in `wire.rs`, and the subprocess transport that
-  speaks them to an out-of-process plugin (`doc:wrapper-socket`).
+- **`stella-runtime`** consumes the wire contract, the verdict rule, and the
+  driver channel. It defines the `TurnWrapper` trait and the two host
+  functions `judge` and `again` over the types in `wire.rs`, the subprocess
+  transport that speaks them to an out-of-process plugin
+  (`doc:wrapper-socket`), and `src/wrapper/driver_call.rs`, which consumes
+  `DriverGrant`/`DriverCall` from `driver.rs`.
 - **`stella-cli`** consumes the manifest and the consent surface. `stella
   plugin install|list|remove` resolves `.stella/plugins/` and
   `~/.stella/plugins/`, renders `consent_text` before anything executes, and

--- a/crates/stella-plugin/src/wire_corpus.rs
+++ b/crates/stella-plugin/src/wire_corpus.rs
@@ -12,8 +12,10 @@
 //! things that crossed the process boundary until the host-call channel landed
 //! (#3540, `doc:wrapper-socket` §6b); [`crate::HostCallRequest`] and
 //! [`crate::HostCallResponse`] are the other two, and they cross the same pipes
-//! in the same conversation. All four are roots this module publishes, and
-//! everything reachable from them is published with them.
+//! in the same conversation. The driver channel (#3599 B0) adds its own
+//! roots — [`crate::DriveRequest`]/[`crate::DriveResponse`] and
+//! [`crate::DriverCallRequest`]/[`crate::DriverCallResponse`]. Every root
+//! here is published along with everything reachable from it.
 //!
 //! # Why a corpus and not a JSON Schema
 //!
@@ -89,7 +91,8 @@ const NOTE: &str = "GENERATED FILE — DO NOT EDIT. Every message the wrapper \
      socket carries, serialized by the same impls stella_runtime's subprocess \
      transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; \
      guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of \
-     truth: crates/stella-plugin/src/wire.rs and src/host_call.rs. A message \
+     truth: crates/stella-plugin/src/wire.rs, src/host_call.rs and \
+     src/driver.rs. A message \
      with an optional member appears twice — `full` populates every optional \
      field, `minimal` omits every one that may be omitted — so a field \
      changing between required and optional is a diff here. This is a corpus, not a JSON Schema: see \

--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -126,7 +126,7 @@ tests with them.
 | File | What it holds |
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The crate's flat re-export surface, and the statement of the one-directional wire-compatibility rule. Read it first. |
-| [`src/event.rs`](src/event.rs) | `AgentEvent` and its supporting types — the stream-json vocabulary, 34 wire variants plus the tagless `Unknown` fallback. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
+| [`src/event.rs`](src/event.rs) | `AgentEvent` and its supporting types — the stream-json vocabulary: every wire variant plus the tagless `Unknown` fallback. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
 | [`src/journal.rs`](src/journal.rs) | `StampedEvent` / `stamped_line` — one *line* of the event stream: an `AgentEvent` plus the optional wall-clock `ts` its sink stamps at the write boundary (#2111). Deliberately not a field of the enum: a stamp is a fact about a write, the same event reaches more than one sink, and this crate owns no clock. |
 | [`src/context_event.rs`](src/context_event.rs) | `LifecycleEventEnvelope` / `LifecycleEvent` — the *other* event channel, the one an older binary can still read. Open it when a new event must survive replay by an older reader. |
 | [`src/completion.rs`](src/completion.rs) | `CompletionRequest` / `CompletionResult` / `CompletionUsage`, `GenerationParams`, `FinishReason`. The one envelope every provider adapter translates to and from. |
@@ -347,7 +347,7 @@ knob, it also needs a row in `crates/stella-model/src/provider_parity.rs`.
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions"
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies"
   (invariants 1 and 4), and the "Glossary" table, which disambiguates
   `turn_instance` / `(step, call_seq)` from the store's `execution_id` and the
   fleet's `run_id`.

--- a/crates/stella-protocol/src/contract.rs
+++ b/crates/stella-protocol/src/contract.rs
@@ -175,14 +175,6 @@ impl std::fmt::Display for ContractError {
 
 impl std::error::Error for ContractError {}
 
-/// One tool's complete declaration: what the model may send
-/// ([`ToolSchema`]), plus what an authorization plane needs to decide whether
-/// this caller may send it at all.
-///
-/// Serde-first (invariant #4) because it crosses crate boundaries — the
-/// engine's [`crate::ToolSchema`] half already does, and the governance half
-/// is what an embedding host reads to authorize a remoted call from metadata
-/// instead of maintaining its own name → capability side-table.
 /// The contract revision this build writes — see [`ToolContract::version`].
 pub const CONTRACT_VERSION: u32 = 1;
 
@@ -192,6 +184,14 @@ fn default_contract_version() -> u32 {
     CONTRACT_VERSION
 }
 
+/// One tool's complete declaration: what the model may send
+/// ([`ToolSchema`]), plus what an authorization plane needs to decide whether
+/// this caller may send it at all.
+///
+/// Serde-first (AGENTS.md rule #4) because it crosses crate boundaries — the
+/// engine's [`crate::ToolSchema`] half already does, and the governance half
+/// is what an embedding host reads to authorize a remoted call from metadata
+/// instead of maintaining its own name → capability side-table.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ToolContract {

--- a/crates/stella-protocol/src/journal.rs
+++ b/crates/stella-protocol/src/journal.rs
@@ -19,7 +19,7 @@
 //! The same event is written to more than one sink (the durable JSONL file and
 //! stdout), the engine that produced it is a pure, replayable, clock-free fold,
 //! and `stella-protocol` carries no time source by charter. Putting `ts` inside
-//! the enum would have meant a field on all 39 variants, a clock reachable from
+//! the enum would have meant a field on every variant, a clock reachable from
 //! `stella-core`, and a stamp baked into every replay fixture.
 //!
 //! So the event vocabulary is untouched and the stamp rides in an envelope
@@ -54,7 +54,7 @@ use crate::event::AgentEvent;
 /// contract a consumer reads and the contract this module documents cannot
 /// drift apart.
 ///
-/// Deliberately terse — it is repeated on all 39 variants of a generated
+/// Deliberately terse — it is repeated on every variant of a generated
 /// artifact, and the reasoning behind each clause belongs in this module's docs
 /// and in the `.d.ts` banner, which a reader meets exactly once.
 pub const TS_DESCRIPTION: &str = "\

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -42,11 +42,14 @@
 //! the *only* way to stay readable by an older binary.
 
 #![forbid(unsafe_code)]
-// Invariant #5: library code never panics on runtime data. This crate is at
-// zero production `unwrap`/`expect`, and this keeps it there — `make lint` runs
-// clippy with `-D warnings`, so a new one fails the gate instead of arriving
-// unremarked. `not(test)` scopes the lint exactly as the invariant does: the
-// rule is about runtime data, and `unwrap` in a test is fine.
+// AGENTS.md rule #5: library code never panics on runtime data. This crate's
+// default build has zero production `unwrap`/`expect`, and `make lint` runs
+// clippy with `-D warnings` on that build, so a new one fails the gate instead
+// of arriving unremarked. The one exception is `schema_export.rs`, which is
+// only compiled under the `schema` feature (not part of `make lint` or CI's
+// clippy run) and carries its own justified `#[allow(clippy::expect_used)]`.
+// `not(test)` scopes the lint exactly as the rule does: it is about runtime
+// data, and `unwrap` in a test is fine.
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod attachment;

--- a/crates/stella-protocol/src/subagent_event.rs
+++ b/crates/stella-protocol/src/subagent_event.rs
@@ -84,7 +84,7 @@ pub enum SubAgentPhase {
     /// A child turn is about to start. Every event between this and the
     /// matching `Finished` with the same `agent_id` belongs to the child,
     /// not the parent — this bracket IS the attribution mechanism, which is
-    /// why no per-event agent field was added to the other 35 variants.
+    /// why no per-event agent field was added to the rest of the event vocabulary.
     Started {
         /// Stable id for this child, unique within the parent turn.
         agent_id: String,

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -149,6 +149,9 @@ it crosses.
 | `src/wrapper/in_process.rs` | `InProcessWrapper`/`WrapperHandler` — the fast path §3 permits for Rust, over the identical owned request/response types the subprocess transport uses. |
 | `src/wrapper/verdict.rs` | `judge` and `again` — synchronous, total, I/O-free functions over `VerdictRule` and `EvidenceSet`; property-tested (`tests/wrapper_verdict.rs`) over the closed evidence vocabulary. |
 | `src/wrapper/error.rs` | `WrapperError`, typed per failure mode (unreachable, over budget, unusable, undeclared role, mistyped signal). |
+| `src/wrapper/driver_call.rs` | The host half of the driver channel: the gate, the ceiling, and the report for a plugin that drives turns instead of sitting inside one (`doc:backlog-self-driving` §3.0). |
+| `src/wrapper/host_call.rs` | The host half of the host-call channel: a plugin may ask the host for a capability, never reach for one itself — this module is the half that decides and applies the install-time grant (`doc:wrapper-socket` §6b). |
+| `src/wrapper/child_turn.rs` | The `ChildTurn` port: the host spends a model call at a declared role intent (`triage`, `planner`, `witness_author`, …) so a plugin never holds a provider credential itself (`doc:turn-loop-wrappers` §9.3). |
 | `tests/no_ambient_reads.rs` | The executable form of the invariant above. |
 | `tests/wrapper_socket.rs` | The socket's end-to-end proof: a real `/bin/sh` subprocess plugin driven through `TurnWrapper` by the test's own round loop. It proves the socket *answers*; what it cannot prove is that anything in the workspace holds the same order, which is what `tests/wrapper_dispatch.rs` is for. `#![cfg(unix)]`; #3497 tracks the portable in-tree plugin binary a Windows-proof version needs. |
 | `tests/wrapper_dispatch.rs` | The host sequence's witness: the same kind of `/bin/sh` plugin driven through the **shipped** `WrapperDispatch`, proving a contribution reaches the turn after the stable prefix, its evidence reaches `judge`, and the verdict is what decides whether another turn runs. `#![cfg(unix)]` for the same reason. |
@@ -156,3 +159,10 @@ it crosses.
 | `tests/wrapper_env_refusal.rs` | `refuses_env_name`'s refusal list, proven against the names #3512 named. |
 | `tests/host_owned_tamper.rs` | #3499's split: `ObservedEvidence` carries no tamper field: `EvidenceSet::from_observed` is where the host's own finding is merged in. |
 | `tests/no_pipeline_edge.rs` | Executable proof that this crate declares no dependency on `stella-pipeline` — a wrapper `stella-cli` can drive and `stella-serve` cannot is a CLI feature wearing a socket's name. |
+| `tests/wrapper_host_call.rs` | The witness for the host-call channel (#3540, `doc:wrapper-socket` §6b): a plugin asks the host for a capability mid-point and is handed real frames. |
+| `tests/wrapper_transport_limits.rs` | Witnesses for #3380's transport audit: the two resources a plugin process can spend that are not its own — the host's memory, and the machine after the turn ended. |
+| `tests/wrapper_child_turn.rs` | The witness for `child_turn` (#3564, #3541, `doc:turn-loop-wrappers` §9.3): the host, not the plugin, spends the model call at a declared role intent. |
+| `tests/wrapper_decided_flip.rs` | The witness for #3553: a plugin whose `[oracle]` declares `flip = "required"` reaches a decided verdict through the real dispatch. |
+| `tests/research_plugin_conformance.rs` | The witness for Track B's first extraction: `plugins/stella-research` answers a real `before_turn` request over the wire in well-formed `stella_plugin::wire` shapes. |
+| `tests/research_plugin_dispatch.rs` | Grades `plugins/stella-research` against `WrapperDispatch` itself — the declared stage program actually calling it, not just the wire shape being correct. |
+| `tests/research_plugin_recall.rs` | The witness for the `recall` half of Track B's first extraction: the plugin answers `StageName::Recall` from frames it asked the host for, or an honest empty one when the host declines. |

--- a/crates/stella-runtime/src/spec.rs
+++ b/crates/stella-runtime/src/spec.rs
@@ -121,9 +121,6 @@ impl ProviderParts {
 /// belong: `stella-cli` fills it from a loaded `Config` plus its process
 /// globals, and `stella-serve` fills it from a session-create request. The
 /// builder itself is then a pure function of this struct.
-///
-/// No `Debug`: deriving one would put a credential (`ProviderParts::api_key`)
-/// one `{:?}` away from a log line.
 #[derive(Clone)]
 pub struct RuntimeSpec {
     /// The workspace this session is rooted at. Every store, registry and

--- a/crates/stella-serve/README.md
+++ b/crates/stella-serve/README.md
@@ -18,9 +18,12 @@ not depend on `stella-store`.
 
 ## Where it sits
 
-It depends on exactly two workspace crates — [`stella-protocol`](../stella-protocol)
-for the wire types and [`stella-core`](../stella-core) for the engine — and
-**nothing in the workspace depends on it**. It is a leaf that builds its own
+It depends on four workspace crates: [`stella-protocol`](../stella-protocol)
+for the wire types, [`stella-core`](../stella-core) for the engine,
+[`stella-engine`](../stella-engine) for the step facade (#971), and
+[`stella-pipeline`](../stella-pipeline) for the verification pipeline (#1288).
+It is not a leaf either: [`stella-parity`](../stella-parity) depends on it, to
+check that every HTTP route is claimed by a parity row. It builds its own
 binary from [`src/main.rs`](src/main.rs); `stella-cli` does not link it, and
 `make build-release` builds `-p stella-cli` only, so a change here never reaches a
 `stella` user. The corollary: `make smoke` runs the CLI and never exercises this
@@ -40,8 +43,8 @@ What that means for this crate as the plugin architecture lands:
 
 - **The engine here does not verify its own work.** The staged verification flow is
   a wrapper around the loop, and it is leaving the workspace to become a plugin
-  (#3246, `doc:turn-loop-wrappers`); nothing in this crate links
-  [`stella-pipeline`](../stella-pipeline) and nothing here ever did. A host wanting
+  (#3246, `doc:turn-loop-wrappers`); today the pipeline runs inside this crate,
+  driven over the same remoted ports as every other turn. A host wanting
   adjudication supplies it — its own test command, its own oracle, or, once the
   wrapper contract lands (#3380), the plugin — and the answer arrives as evidence
   the host owns, exactly like a tool result does today.
@@ -383,7 +386,7 @@ the wire would be silently reclassified.
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions" (why the
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies" (why the
   remoted ports are adapters, not a rewrite) and the "Workspace layout" row for
   this crate, which states the own-binary/not-linked rule.
 - [`../../docs/spec/serve-surface.md`](../../docs/spec/serve-surface.md) — the full

--- a/crates/stella-serve/src/sessions.rs
+++ b/crates/stella-serve/src/sessions.rs
@@ -107,15 +107,12 @@ const MAX_SESSIONS: usize = 64;
 /// reads the live turn id in its own scope before touching the turn registry.
 pub(crate) struct SessionRegistry {
     sessions: Mutex<HashMap<String, Arc<SessionEntry>>>,
-    /// Registration order for [`SessionEntry::seq`] — diagnostics only.
-    counter: AtomicU64,
 }
 
 impl SessionRegistry {
     pub(crate) fn new() -> Self {
         Self {
             sessions: Mutex::new(HashMap::new()),
-            counter: AtomicU64::new(0),
         }
     }
 
@@ -144,7 +141,6 @@ impl SessionRegistry {
             } else {
                 let id = new_session_id();
                 let entry = Arc::new(SessionEntry {
-                    seq: self.counter.fetch_add(1, Ordering::Relaxed),
                     idle_since: Mutex::new(Instant::now()),
                     live: Mutex::new(None),
                     next_token: AtomicU64::new(0),
@@ -236,9 +232,6 @@ fn reclaim_idle_expired(
 
 /// One retained conversation.
 pub(crate) struct SessionEntry {
-    /// Registration order. Diagnostics only — eviction is by idle time.
-    #[allow(dead_code)]
-    seq: u64,
     /// When this session last started or settled a turn. Reads (`GET`) do not
     /// touch it: observation must not extend a lease, or a dashboard polling
     /// its sessions would make every one of them immortal.

--- a/crates/stella-store/README.md
+++ b/crates/stella-store/README.md
@@ -139,7 +139,7 @@ escape hatch for an irreducible line (a module declaration in an oversized
 
 [`ddl.rs`](src/ddl.rs) says what the shape *is*; [`migrations.rs`](src/migrations.rs)
 says how an existing file *gets there*. A fresh database gets `create_latest_schema`
-in one shot and is stamped at `SCHEMA_VERSION` (`= MIGRATIONS.len()`, 22 today);
+in one shot and is stamped at `SCHEMA_VERSION` (`= MIGRATIONS.len()`);
 an existing one runs each pending step. `PRAGMA user_version` 0 is ambiguous — it
 is both "fresh empty file" and "legacy pre-versioning file" — so `Store::migrate`
 disambiguates by probing `TABLES` via `any_store_table_exists`. A file stamped
@@ -330,7 +330,7 @@ from `NotYetBuilt` to `Guarded`. `every_registered_encoder_is_content_free` and
 
 ## See also
 
-- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not concretions"
+- [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not direct dependencies"
   (invariant #3), "The `.stella/` directory", and the glossary of look-alike
   identifiers (session vs execution vs run vs task).
 - [`../../docs/spec/session-telemetry-receipts-spec.md`](../../docs/spec/session-telemetry-receipts-spec.md)

--- a/crates/stella-tools/README.md
+++ b/crates/stella-tools/README.md
@@ -287,7 +287,7 @@ discovered at startup with no registry edit. See
 ## See also
 
 - [`../../AGENTS.md`](../../AGENTS.md) — "Architecture: ports, not
-  concretions" (ports and the no-I/O rule) and invariant #9 (tool-first,
+  direct dependencies" (ports and the no-I/O rule) and invariant #9 (tool-first,
   single-purpose).
 - [`../stella-core/src/ports.rs`](../stella-core/src/ports.rs) — the
   `ToolExecutor` port this crate implements, and the `ReadOnlyTools` view

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -3,7 +3,7 @@
 //!
 //! The tool shares the session's read-state ledger (#331): when `old_string`
 //! fails to match, it compares current disk bytes against the hash of what
-//! the model last saw (recorded by `read_file`/`read_symbol` and by the
+//! the model last saw (recorded by `read_file` and by the
 //! model's own edits/writes) and *attributes* the failure — a drifted file
 //! gets a drift-named error carrying the fresh content so the model can
 //! re-issue the edit against current bytes, instead of a generic not-found

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -31,11 +31,10 @@
 //! current disk bytes to attribute a failed match to an out-of-band change
 //! instead of a generic not-found. Reads are keyed by the file's normalized
 //! workspace-relative path (so `src/./a.rs` and `src/a.rs` count as one
-//! file). One ledger lives per registry, shared by `read_file`, `read_symbol`
-//! (which reads through this same tool), `edit_file`, and `write_file` — so
-//! the ledger tracks the content the model last *saw*, whichever surface
-//! showed (or produced) it. The audit-grade equivalent (one `R` event per
-//! read) lands in the registry's file-touch ledger.
+//! file). One ledger lives per registry, shared by `read_file`, `edit_file`,
+//! and `write_file` — so the ledger tracks the content the model last *saw*,
+//! whichever surface showed (or produced) it. The audit-grade equivalent (one
+//! `R` event per read) lands in the registry's file-touch ledger.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -50,9 +49,7 @@ use stella_protocol::tool::{ToolOutput, ToolSchema};
 
 use crate::registry::Tool;
 
-/// Crate-visible so `read_symbol` (which reads through this tool) can name
-/// the cap honestly when a symbol's span exceeds it.
-pub(crate) const MAX_LINES: usize = 2000;
+const MAX_LINES: usize = 2000;
 
 /// Per-line width cap. Real source lines are far shorter; the cases this
 /// catches are machine-generated (minified JS, base64 blobs, one-line JSON),
@@ -126,7 +123,7 @@ struct ReadState {
 
 /// Session-scoped ledger of the last file content the model has *seen*.
 ///
-/// Updated by successful reads (`read_file` and `read_symbol`) and by the
+/// Updated by successful reads (`read_file`) and by the
 /// model's own successful mutations (`edit_file`, `write_file` — the model
 /// knows the content it just produced). A mismatch between an entry's hash
 /// and current disk bytes therefore means the file changed out-of-band since

--- a/crates/stella-tools/src/rootfd.rs
+++ b/crates/stella-tools/src/rootfd.rs
@@ -242,18 +242,6 @@ impl RootHandle {
     }
 }
 
-/// [`RootHandle::read`] on a blocking worker, for the async tools.
-///
-/// The walk is a handful of `openat`s and the read is unbounded, so it goes
-/// where every other blocking file operation in the crate goes rather than
-/// stalling a reactor thread.
-pub async fn read_async(handle: &Arc<RootHandle>, rel: &str) -> Result<Vec<u8>, RootError> {
-    let (handle, rel) = (Arc::clone(handle), rel.to_string());
-    tokio::task::spawn_blocking(move || handle.read(&rel))
-        .await
-        .map_err(|error| RootError::Io(io::Error::other(format!("read task failed: {error}"))))?
-}
-
 /// [`RootHandle::read_to_string`] on a blocking worker.
 pub async fn read_to_string_async(
     handle: &Arc<RootHandle>,

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -35,8 +35,6 @@
 //! the agent's search and the operator's search from drifting into two
 //! different answers to the same question.
 
-use std::path::Path;
-
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
@@ -169,12 +167,6 @@ impl Tool for Search {
             .await
             .rendered
     }
-}
-
-/// The tool's answer for one workspace, with no cache — the seam a test drives
-/// against a temp root, and the shape the one-shot CLI command uses.
-pub async fn search_in(root: &Path, query: &str, config: SearchConfig) -> ToolOutput {
-    engine::report(root, query, config).await.rendered
 }
 
 #[cfg(test)]

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -45,7 +45,6 @@ impl Tool for WriteFile {
         }
     }
 
-    #[allow(clippy::collapsible_if)]
     async fn execute(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         let root = ctx.root();
         let path = match crate::input::required_str(input, "path") {

--- a/crates/stella-transcript/README.md
+++ b/crates/stella-transcript/README.md
@@ -1,9 +1,10 @@
 # stella-transcript
 
 One transcript information model, two renderers: the jet-black web surface the
-Observatory serves, and a character grid for the TUI. Pure functions over owned
-data — nothing here reads a file, spawns a process, formats a timestamp or
-touches the network.
+Observatory serves, and a character grid renderer in the same shape a TUI
+needs — though nothing in the shipping TUI reads it yet. Pure functions over
+owned data — nothing here reads a file, spawns a process, formats a timestamp
+or touches the network.
 
 ## Boundary
 

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -18,7 +18,6 @@ use crate::digest::{self, Chip};
 use crate::file_diff::{FileDiff, RowKind};
 use crate::fold::FoldState;
 use crate::model::{Call, FileStatus, NodeId, Run, Status, Step, ToolKind, Turn};
-use crate::word::Span;
 
 /// Width of the elapsed-offset gutter, including its trailing space.
 pub const OFFSET_W: usize = 5;
@@ -716,10 +715,4 @@ fn encode(lines: &[Line], basic: bool) -> String {
         }
     }
     out
-}
-
-/// The spans of a diff row, for a caller that wants to paint them itself.
-#[must_use]
-pub fn row_spans(row: &crate::file_diff::Row) -> &[Span] {
-    &row.spans
 }

--- a/crates/stella-transcript/src/lib.rs
+++ b/crates/stella-transcript/src/lib.rs
@@ -19,8 +19,9 @@
 //!
 //! ## The two renderers
 //!
-//! [`html`] emits the jet-black web surface; [`grid`] emits a character grid for
-//! the TUI. They share [`model`], [`fold`], [`digest`], [`file_diff`] and
+//! [`html`] emits the jet-black web surface; [`grid`] emits a character grid in
+//! the same shape a TUI needs, though nothing in the shipping TUI reads it yet.
+//! They share [`model`], [`fold`], [`digest`], [`file_diff`] and
 //! [`word`] — which is the point. The previous arrangement had the Observatory
 //! re-implementing the TUI's renderer in JavaScript, and that copy had silently
 //! drifted to the point of having no diff rendering at all.

--- a/crates/stella-transcript/src/model.rs
+++ b/crates/stella-transcript/src/model.rs
@@ -74,19 +74,6 @@ pub enum NodeId {
 }
 
 impl NodeId {
-    /// The turn this node lives in — every node has exactly one.
-    #[must_use]
-    pub fn turn(self) -> usize {
-        match self {
-            NodeId::Turn(t)
-            | NodeId::Step { turn: t, .. }
-            | NodeId::Output { turn: t, .. }
-            | NodeId::Prose { turn: t, .. }
-            | NodeId::File { turn: t, .. }
-            | NodeId::Hunk { turn: t, .. } => t,
-        }
-    }
-
     /// A DOM-safe / stable string form, used as an HTML `id` and as the key a
     /// TUI cursor round-trips through a saved session.
     #[must_use]
@@ -306,12 +293,6 @@ impl Accounting {
             micros: self.micros + other.micros,
         }
     }
-
-    /// Whether there is anything worth rendering a chip for.
-    #[must_use]
-    pub fn is_empty(self) -> bool {
-        self == Self::default()
-    }
 }
 
 /// A tool call's result body, before folding.
@@ -339,12 +320,6 @@ impl Output {
     #[must_use]
     pub fn line_count(&self) -> usize {
         self.lines.len() + self.clipped
-    }
-
-    /// Whether there is nothing at all to show.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.lines.iter().all(|l| l.trim().is_empty()) && self.clipped == 0
     }
 }
 

--- a/crates/stella-tty/src/lib.rs
+++ b/crates/stella-tty/src/lib.rs
@@ -2,55 +2,24 @@
 //! might print, mid-run.** The single pure derivation of that fact, so two
 //! call sites can never disagree about whether somebody is there to ask.
 //!
-//! # Why this is its own crate
+//! See README.md for why this is a separate crate with no dependencies.
 //!
-//! This predicate has two consumers on opposite sides of a dependency
-//! direction invariant 1 (`AGENTS.md`) forbids: `stella-cli`'s own
-//! scope-review and approval prompts, and `stella-model`'s interactive
-//! credential prompt (`credential.rs`) — which must never depend on
-//! `stella-cli`, the binary above it (#3036). `stella-home` is the
-//! obvious-looking home (both crates already depend on it), but its own
-//! README draws the boundary explicitly: "this crate owns one decision: what
-//! path a process should treat as the stella home... everything else is
-//! out." A human-presence fact is not a path. `stella-home`'s README also
-//! names the rule this crate satisfies: a new leaf is warranted when
-//! functionality needs a dependency direction the current graph forbids —
-//! exactly this shape, and the same one `stella-diff` and `stella-embed`
-//! were split out for (#1139, #1511).
-//!
-//! # The three inputs, and why they stay three separate booleans
-//!
-//! Asking costs a human two capabilities, and both are needed: they must SEE
-//! the prompt and they must be able to ANSWER it. So a run has a human
-//! exactly when:
+//! A run has a human exactly when all three hold:
 //!
 //! - `interactive_output` — this run would render interactive text at all.
 //!   `false` for a machine output format (`--output-format json`) or an
-//!   invocation that has otherwise forbidden prompting, regardless of what
-//!   the terminal looks like.
+//!   invocation that has otherwise forbidden prompting.
 //! - `stdin_is_terminal` — the human can answer. A piped or redirected stdin
 //!   can accept bytes but never a keystroke meant for this question.
-//! - `prompt_is_visible` — the human can see the question in the first
-//!   place, on whichever stream this caller's prompt actually renders on.
-//!   `stella-cli`'s approval responder prints via `println!`, so its
-//!   callers pass `stdout().is_terminal()`. The daemon
-//!   console's scope-review prompt is deliberately stderr-only — stdout there
-//!   is the run's own byte-verbatim relay, and folding a prompt into it would
-//!   corrupt a machine-format caller reading that stream — so its callers
-//!   pass `stderr().is_terminal()` instead. `stella-model`'s credential
-//!   prompt goes through `rpassword`, whose default configuration writes to
-//!   `/dev/tty` directly on Unix rather than stdout; checking
-//!   `stdout().is_terminal()` there is a proxy for that, not an exact match
-//!   (tracked as its own gap, not fixed here: #3052).
+//! - `prompt_is_visible` — the human can see the question, on whichever
+//!   stream this caller's prompt actually renders on (stdout, stderr, or
+//!   whatever the caller checks).
 //!
-//! Deliberately pure over already-observed booleans rather than reading
-//! `std::io` itself: each consumer's three inputs come from a genuinely
-//! different place (a supervised child's stdin is a parked file with no real
-//! terminal to query; a JSON-format run's `interactive_output` is `false`
-//! independent of any terminal at all), so computing them here would either
-//! narrow this crate to one caller's shape or grow an API this crate has no
-//! business owning. Purity is also what makes the condition directly
-//! unit-testable without faking a terminal.
+//! `stella-model`'s credential prompt goes through `rpassword`, which writes
+//! to `/dev/tty` directly on Unix instead of stdout. Checking
+//! `stdout().is_terminal()` there is only a close stand-in, not an exact
+//! match (tracked separately: #3052).
+#[must_use]
 pub fn human_can_answer(
     interactive_output: bool,
     stdin_is_terminal: bool,

--- a/crates/stella-tui/README.md
+++ b/crates/stella-tui/README.md
@@ -101,7 +101,7 @@ ceiling in `scripts/file-size-baseline.txt`. They are god files — already too
 big, closed to growth — and this crate hosts the workspace's single worst:
 the guard's own header cites [`src/deck_ui.rs`](src/deck_ui.rs), which had
 reached 6,884 lines when the guard landed and has since been cut to its
-recorded 4,068 ceiling. Plan changes so no new line lands in any of them. The
+recorded ceiling in `scripts/file-size-baseline.txt`. Plan changes so no new line lands in any of them. The
 crate's own precedent is the [`src/views/`](src/views) directory — one render
 module per tab, split out of the deck files — so a change that adds rendering
 goes in a `views/` module, not `deck_ui.rs` or `deck_render.rs`; new modal
@@ -126,14 +126,12 @@ escape hatch for an irreducible line (a module declaration in an oversized
 | File | What it holds |
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The authoritative design statement (pure core + thin shell) and the whole public re-export surface. Read it first. |
-| [`src/model.rs`](src/model.rs) | `SessionModel` — one agent's fold. `apply` (line 319) is the *only* mutator; `replay` (line 645) rebuilds it from a log. |
-| [`src/ui.rs`](src/ui.rs) | `UiState` (scroll, composer, focus — everything *not* derived from events) and the pure `handle_key` / `ingest`. |
-| [`src/render.rs`](src/render.rs) | `render(model, ui, frame)` for the single-session REPL, plus `guarded_panel` — its entry to the panic boundary. |
-| [`src/panel_guard.rs`](src/panel_guard.rs) | The panel panic boundary itself (L-T7), shared by the REPL, the deck and the fleet dashboard — and the written argument for what a caught panic can leave in `DeckUi`. |
-| [`src/shell.rs`](src/shell.rs) | `run(...)`: terminal setup, crossterm loop, two channels, `RunOptions`, `DebugLog`. No decision logic. |
+| [`src/model.rs`](src/model.rs) | `SessionModel` — one agent's fold. `apply` (line 565) is the *only* mutator; `replay` (line 1125) rebuilds it from a log. |
+| [`src/render.rs`](src/render.rs) | Leaf panels the deck draws inside its own guarded bands — stat box, transcript rows, and the rest of the single-session drawing code. |
+| [`src/panel_guard.rs`](src/panel_guard.rs) | The panel panic boundary itself (L-T7), with `guarded_band` and `guarded_overlay` as its entry points — shared by the deck and the fleet dashboard — and the written argument for what a caught panic can leave in `DeckUi`. |
 | [`src/term.rs`](src/term.rs) | `TerminalGuard` + `PanicHookGuard`. Open this before touching anything about raw mode or panics. |
 | [`src/deck.rs`](src/deck.rs) | `WorkspaceModel` — N `SessionModel`s plus cross-agent read-models (file ledger, route log, prompt queue, unified trace). |
-| [`src/deck_ui.rs`](src/deck_ui.rs) | `DeckUi` and `handle_deck_key` — every deck keybinding, and the documented Esc precedence list (line 1222). The largest file here. |
+| [`src/deck_ui.rs`](src/deck_ui.rs) | `DeckUi` and `handle_deck_key` — every deck keybinding, and the documented Esc precedence list (line 1488). The largest file here. |
 | [`src/deck_render.rs`](src/deck_render.rs) | `render_deck`: tab bar · active view · trace strip · progress bar · composer · footer · statline. |
 | [`src/deck_shell.rs`](src/deck_shell.rs) | `run_deck(...)`: the deck's `select!` loop, plus a third arm — a 33 ms tick that advances the clock and samples resources. |
 | [`src/envelope.rs`](src/envelope.rs) | The multi-agent wire types: `Inbound` in, `WorkspaceInput` out, and every out-of-band snapshot the driver pushes. |
@@ -151,16 +149,13 @@ escape hatch for an irreducible line (a module declaration in an oversized
 
 ## Key concepts
 
-**"Pure fold" is a code-level split, not a slogan.** Verify it in three places:
-`SessionModel` has exactly one mutator, `apply` ([`src/model.rs:319`](src/model.rs)),
-and `replay` ([`src/model.rs:645`](src/model.rs)) is just `apply` in a loop.
-`render` ([`src/render.rs:46`](src/render.rs)) takes `&SessionModel` — the model
-is immutable during a draw; the `&mut UiState` exists solely so panels can
-record their viewport heights for the next keypress's scroll clamp. And
-`handle_key` ([`src/ui.rs:245`](src/ui.rs)) returns a `ShellAction` rather than
-performing anything. So every question a contributor has — "what does this key
-do", "what does the screen show after these events" — is answerable by calling
-a function with no terminal, no engine, and no tokio runtime.
+**"Pure fold" is a code-level split, not a slogan.** Verify it in two places:
+`SessionModel` has exactly one mutator, `apply` ([`src/model.rs`](src/model.rs)),
+and `replay` ([`src/model.rs`](src/model.rs)) is just `apply` in a loop. The
+panels in [`src/render.rs`](src/render.rs) take `&SessionModel` — the model is
+immutable during a draw. So every question a contributor has — "what does this
+key do", "what does the screen show after these events" — is answerable by
+calling a function with no terminal, no engine, and no tokio runtime.
 
 **Why that matters here.** AGENTS.md's [witness-test contract](../../AGENTS.md)
 names TUI rendering as the case where a witness is "genuinely impractical" —
@@ -169,20 +164,17 @@ gets one anyway: fold synthetic events into a model, render into a
 `ratatui::backend::TestBackend`, and assert on the flattened **cell buffer**,
 never on ANSI bytes. [`tests/progress_brand_fill.rs`](tests/progress_brand_fill.rs) is the
 shape to copy — its header states the goal, why it failed before the change,
-and what it asserts after. The determinism this rests on is itself
-property-tested: `replaying_a_log_renders_identical_buffers`
-([`src/render/tests.rs:1160`](src/render/tests.rs)) folds one event vector into
-two fresh models and asserts byte-identical backing buffers.
+and what it asserts after.
 
-**Two shells, one design.** [`shell::run`](src/shell.rs) drives one agent;
-[`deck_shell::run_deck`](src/deck_shell.rs) drives N. Both are near-logic-free
-`select!` loops over (inbound events, key events); the deck adds a third arm, a
-33 ms tick, because gauges and elapsed timers must repaint on a clock rather
-than only when the model streams. Anything you are tempted to write inside
-either loop belongs in `ui.rs` / `deck_ui.rs` instead.
+**One shell.** [`deck_shell::run_deck`](src/deck_shell.rs) drives N agents in a
+near-logic-free `select!` loop over (inbound events, key events), plus a third
+arm, a 33 ms tick, because gauges and elapsed timers must repaint on a clock
+rather than only when the model streams. Anything you are tempted to write
+inside that loop belongs in `deck_ui.rs` instead. A second, single-session
+shell was deleted in #936 — see [`src/lib.rs`](src/lib.rs)'s module header.
 
 **Keys are a precedence chain, not a match arm.** `handle_deck_key`
-([`src/deck_ui.rs:1251`](src/deck_ui.rs)) runs modal contexts first (splash,
+([`src/deck_ui.rs`](src/deck_ui.rs)) runs modal contexts first (splash,
 help, installed-agent editors, issues forms, queue editor, graph picker, engine
 panel, overlays), then tab navigation, then focused-agent gates, then composer
 editing, then per-tab keys, then Esc. Two rules hold throughout: bare-letter
@@ -209,7 +201,7 @@ constructed *before* the first state is acquired and flags each one (raw, alt
 screen, bracketed paste, mouse, kitty) as it lands, so a failure partway through
 `enter` still rolls back exactly what was entered. Release builds set
 `panic = "abort"`, where destructors never run, so `PanicHookGuard::install`
-([`src/term.rs:194`](src/term.rs)) additionally restores from inside the panic
+([`src/term.rs`](src/term.rs)) additionally restores from inside the panic
 hook — but **only** under `cfg!(panic = "abort")`, then delegating to the
 previous hook so the panic message prints on the real screen, not the alternate
 one. In unwind builds the hook deliberately does *not* restore: it fires for
@@ -231,7 +223,7 @@ every panic on every thread, including panel panics the session survives.
 - **Digits never switch tabs, deliberately.** They quick-pick answers on a
   pending question card and must stay typeable as a prompt's first character,
   so `Tab` / `Shift-Tab` are the only tab navigation
-  ([`src/deck_ui.rs:1418`](src/deck_ui.rs)). Adding a digit hotkey would eat a
+  ([`src/deck_ui.rs`](src/deck_ui.rs)). Adding a digit hotkey would eat a
   keystroke meant for the composer.
 - Mouse capture is off by default in both `RunOptions` and `DeckOptions` so
   native terminal selection and copy keep working. The deck's event loop
@@ -239,7 +231,7 @@ every panic on every thread, including panel panics the session survives.
   selection and buys nothing.
 - Bracketed paste is always enabled. Without it a multi-line paste arrives as
   raw key events and every newline acts as Enter, turning one paste into N
-  submissions ([`src/term.rs:101`](src/term.rs)).
+  submissions ([`src/term.rs`](src/term.rs)).
 - `⌃G`, not `⌃I`, opens the INSPECT overlay: without the kitty keyboard
   protocol (pushed only best-effort) `⌃I` is byte-identical to Tab, which is
   bound to tab switching. The collision would be silent and terminal-dependent.
@@ -274,10 +266,10 @@ Two integration tests sit in [`tests/`](tests): `deck_snapshot.rs` renders every
 tab through the real `render_deck` and writes a human-readable text "screenshot"
 to `CARGO_TARGET_TMPDIR` (deliberately outside the source tree, so a test run
 never dirties the working tree), and `progress_brand_fill.rs` is a single-assertion
-witness. `proptest` covers the two determinism-critical modules,
-`src/scroll.rs` and `src/render/`. No fixtures, env vars, or feature flags are
-needed. The one uncovered path is `shell::run` itself: its smoke test is
-`#[ignore]`d because it needs a real TTY.
+witness. `proptest` covers `src/scroll.rs`, `src/syntax.rs`, and `src/proof.rs`.
+No fixtures, env vars, or feature flags are needed. The one uncovered path is
+[`tests/deck_pty_smoke.rs`](tests/deck_pty_smoke.rs): it is `#[ignore]`d
+because it needs a real TTY.
 
 ## Extending it
 

--- a/crates/stella-tui/src/accessible/announce.rs
+++ b/crates/stella-tui/src/accessible/announce.rs
@@ -137,6 +137,9 @@ pub(crate) fn announcing_fold<T>(
 }
 
 #[cfg(test)]
+// The lint is wrong here: these fixtures build with `Type::default()` and
+// then set the few fields the test cares about, which reads better than a
+// full struct literal that lists every field.
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -22,8 +22,7 @@
 //! `Shift-Tab` only — digits deliberately never switch tabs, because they
 //! quick-pick `ask_user` answers and must stay typeable as a prompt's first
 //! character. Agent controls (`p`/`s`/`r`) only fire when the composer is
-//! empty, so they never eat a keystroke meant for a prompt (the same
-//! "quick-pick only when nothing typed" gate `crate::ui` already uses).
+//! empty, so they never eat a keystroke meant for a prompt.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
@@ -342,15 +341,6 @@ impl IssueField {
 
     pub fn prev(self) -> IssueField {
         IssueField::ALL[(self.index() + IssueField::ALL.len() - 1) % IssueField::ALL.len()]
-    }
-
-    /// The type-ahead vocabulary this field searches, if any.
-    pub fn entity_field(self) -> Option<EntityField> {
-        match self {
-            IssueField::Labels => Some(EntityField::Label),
-            IssueField::Assignee => Some(EntityField::Assignee),
-            IssueField::Title | IssueField::Body => None,
-        }
     }
 }
 
@@ -683,8 +673,7 @@ pub struct DeckUi {
     /// gate clears only when the ENGINE's follow-on event lands, so without
     /// this latch the decision keys stay live for the whole round-trip and a
     /// second press re-sends the decision. Cleared by [`ingest_inbound`] on a
-    /// fresh `ScopeReview` — the per-agent mirror of the single-session
-    /// shell's `scope_answered` (see `crate::ui`).
+    /// fresh `ScopeReview`.
     pub scope_answered: std::collections::HashSet<String>,
     /// The plan-review dialog's text input: `Some` while `r` (refine note) or
     /// `!` (shell line) has switched the dialog out of its one-keypress
@@ -1382,7 +1371,7 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
         return;
     }
     // A fresh gate re-arms its decision keys: the answered latch guards the
-    // CURRENT card only (the deck mirror of `crate::ui::ingest`'s reset).
+    // CURRENT card only.
     if let Inbound::Event { agent, event } = inbound {
         match event {
             stella_protocol::AgentEvent::ScopeReview { .. } => {
@@ -2034,9 +2023,8 @@ fn slash_matches(ui: &DeckUi) -> Vec<String> {
 
 /// Slash-popup navigation: ↑/↓ choose, Tab completes into the buffer, Enter
 /// dispatches the selection (as an enqueue, like any prompt), Esc dismisses.
-/// Returns `None` for keys the popup doesn't claim. Shared with the
-/// single-session REPL (`crate::ui`) via `crate::composer` so both surfaces
-/// stay consistent by construction.
+/// Returns `None` for keys the popup doesn't claim. The matching and
+/// navigation logic lives in `crate::composer`.
 ///
 /// Deck-local commands (tab switches, the help overlay) are intercepted here
 /// and act on the UI directly; everything else is enqueued for the driver,

--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -833,6 +833,9 @@ fn fmt_k(n: u64) -> String {
 }
 
 #[cfg(test)]
+// The lint is wrong here: these fixtures build with `Type::default()` and
+// then set the few fields the test cares about, which reads better than a
+// full struct literal that lists every field.
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;

--- a/crates/stella-tui/src/views/engine.rs
+++ b/crates/stella-tui/src/views/engine.rs
@@ -1159,7 +1159,7 @@ fn tail_chars(s: &str, max_chars: usize) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::field_reassign_with_default)]
+#[allow(clippy::field_reassign_with_default)] // fixtures build with Type::default() then set only the fields under test
 mod tests {
     use super::*;
     use crate::deck::WorkspaceModel;

--- a/crates/stella-tui/src/views/files.rs
+++ b/crates/stella-tui/src/views/files.rs
@@ -359,6 +359,9 @@ fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<(&'a str
 }
 
 #[cfg(test)]
+// The lint is wrong here: these fixtures build with `Type::default()` and
+// then set the few fields the test cares about, which reads better than a
+// full struct literal that lists every field.
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;

--- a/crates/stella-tui/src/views/graph.rs
+++ b/crates/stella-tui/src/views/graph.rs
@@ -341,6 +341,9 @@ fn circle_positions(n: usize) -> Vec<(f64, f64)> {
 }
 
 #[cfg(test)]
+// The lint is wrong here: these fixtures build with `Type::default()` and
+// then set the few fields the test cares about, which reads better than a
+// full struct literal that lists every field.
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use ratatui::Terminal;

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -172,7 +172,7 @@ impl SessionFold {
     /// into the live tail after the last entry, so it re-wraps per frame
     /// like the tail does and vanishes without residue when the
     /// authoritative `Text` clears it — never a settled entry.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // mirrors the fold's inputs one to one; a struct would just add a second shape
     fn refresh(
         &mut self,
         agent: &str,

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -185,6 +185,9 @@ fn render_empty_hint(area: Rect, buf: &mut Buffer) {
 }
 
 #[cfg(test)]
+// The lint is wrong here: these fixtures build with `Type::default()` and
+// then set the few fields the test cares about, which reads better than a
+// full struct literal that lists every field.
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -15,7 +15,7 @@ file and line.
 - [**Stella: A Defensible Technology Position**](./stella-defensible-position.md)
   — the capstone analysis. Identifies seven architectural invariants that make
   Stella's design expensive to replicate and shows why their *combination* —
-  not any single property — constitutes the moat. Covers ports-not-concretions,
+  not any single property — constitutes the moat. Covers ports-not-direct-dependencies,
   no-I/O-in-the-engine, the witness-test contract, BYOK + no-phone-home,
   prompt-cache-native memory, budget enforcement at safe boundaries, and the
   Context Graph Protocol.

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -44,7 +44,7 @@ not any individual property — constitutes the moat.
 
 1. [The convergence problem](#1-the-convergence-problem)
 2. [The seven defensible properties](#2-the-seven-defensible-properties)
-3. [Property I: Ports, not concretions — the adapter boundary](#3-property-i-ports-not-concretions--the-adapter-boundary)
+3. [Property I: Ports, not direct dependencies — the adapter boundary](#3-property-i-ports-not-direct-dependencies--the-adapter-boundary)
 4. [Property II: No I/O in the engine — decision logic is pure](#4-property-ii-no-io-in-the-engine--decision-logic-is-pure)
 5. [Property III: The witness-test contract — verified done](#5-property-iii-the-witness-test-contract--verified-done)
 6. [Property IV: BYOK + zero telemetry egress by default — the trust perimeter](#6-property-iv-byok--zero-telemetry-egress-by-default--the-trust-perimeter)
@@ -95,7 +95,7 @@ We identify seven such properties in Stella's design.
 
 | # | Property | Core invariant | Enforced by |
 |---|---|---|---|
-| I | Ports, not concretions | The engine (`stella-core`) never imports a provider SDK, filesystem API, or terminal library | Crate-level dependency boundary; `Provider` trait (`stella-protocol`) and `ToolExecutor` trait (`stella-core::ports`) |
+| I | Ports, not direct dependencies | The engine (`stella-core`) never imports a provider SDK, filesystem API, or terminal library | Crate-level dependency boundary; `Provider` trait (`stella-protocol`) and `ToolExecutor` trait (`stella-core::ports`) |
 | II | No I/O in the engine | All decision logic is synchronous functions over owned data | Architectural discipline; property-tested in `stella-core` |
 | III | Witness-test contract | A task is done only when a test fails on old code and passes on new | The pipeline's witness stage and flip oracle (`stella-pipeline`) |
 | IV | BYOK + zero telemetry egress by default | Community/default telemetry is local; only an explicitly enrolled Oxagen Enterprise managed deployment may send a signed-policy-authorized, content-free operational rollup | Architectural invariant; local SQLite (`stella-store`) plus the [managed enrollment boundary](../../website/content/docs/telemetry/index.mdx#oxagen-enterprise-managed-export) |
@@ -107,7 +107,7 @@ Each property is examined below.
 
 ---
 
-## 3. Property I: Ports, not concretions — the adapter boundary
+## 3. Property I: Ports, not direct dependencies — the adapter boundary
 
 ### The invariant
 
@@ -634,7 +634,7 @@ A rigorous analysis must consider what could erode Stella's position:
 ## 13. Conclusion
 
 Stella's defensible technology position is not a feature list. It is a set of
-**architectural invariants** — ports not concretions, no I/O in the engine,
+**architectural invariants** — ports not direct dependencies, no I/O in the engine,
 witness-test definition of done, BYOK with zero Community/default telemetry
 egress and one explicit signed Oxagen Enterprise operational exception,
 prompt-cache-native memory, budget enforcement at safe boundaries, and the Open

--- a/docs/spec/semantic-resolution-bridge.md
+++ b/docs/spec/semantic-resolution-bridge.md
@@ -84,7 +84,7 @@ strategy (`crates/stella-mcp/tests/`).
   seconds to minutes at GB-scale RSS. First-query latency violates the L-C1
   "never add latency to a query" discipline unless warmed at session start —
   which spends the memory whether or not a resolution query ever arrives.
-- **Invariant fit:** clean on "ports, not concretions" (it *is* an adapter
+- **Invariant fit:** clean on "ports, not direct dependencies" (it *is* an adapter
   behind a trait; `stella-core` never sees it); hostile to dependency-light /
   no-daemon unless gated behind a tool switch like the shell and web tools
   (`tools.bash: "off"` withholds the shell — registered by default in every
@@ -215,7 +215,7 @@ speculative.
 | `toml` already a `stella-graph` dependency | `crates/stella-graph/Cargo.toml:30` |
 | Opt-in gating precedent: bash/web off by default in every scope | `crates/stella-tools/src/bash.rs:1-12`; `crates/stella-cli/src/settings.rs:552`; `AGENTS.md` (`.stella/` table) |
 | Child-process JSON-RPC lifecycle + fixture-server test precedent | `crates/stella-mcp/src/client.rs`, `crates/stella-mcp/tests/` |
-| Invariants weighed: ports-not-concretions, no I/O in engine, byte-stable prompts, no casual dependencies | `AGENTS.md` §"Architecture: ports, not concretions", §"Code style" |
+| Invariants weighed: ports-not-direct-dependencies, no I/O in engine, byte-stable prompts, no casual dependencies | `AGENTS.md` §"Architecture: ports, not direct dependencies", §"Code style" |
 | Workspace scale used for latency framing: 376 `.rs` files, ~214k lines | `fd -e rs` count at `fef8e4b` |
 | ONNX embedder is a separate tracked follow-up | `crates/stella-context/src/lib.rs:40`, `embed.rs:5-18` |
 

--- a/docs/spec/serve-observability.md
+++ b/docs/spec/serve-observability.md
@@ -209,7 +209,7 @@ Two shape decisions worth stating:
 
 ## 5. Layer 2 — the `Observer` port
 
-Invariant 1's grain, applied to logging: ports, not concretions.
+Invariant 1's grain, applied to logging: ports, not direct dependencies.
 
 ```rust
 pub trait Observer: Send + Sync + 'static {

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -22,7 +22,7 @@ document measures *formation* and deliberately claims nothing about outcome
 ## 1. Why this can exist at all — the learner census
 
 Every learner in the tree already sits below the model boundary or behind a
-port. That is invariant 1 ("ports, not concretions") and invariant 2 ("no I/O in
+port. That is invariant 1 ("ports, not direct dependencies") and invariant 2 ("no I/O in
 the engine") paying out: replay needs **no new architecture**, only a driver and
 a clock.
 

--- a/docs/spec/turn-loop-wrappers.md
+++ b/docs/spec/turn-loop-wrappers.md
@@ -304,7 +304,7 @@ Worth stating, so nobody reads this as bigger than it is.
   measuring stick instead of replacing it.
 - The witness protocol itself: a different model writes the test, blind to the
   change, with three tools, and tampering voids the credit.
-- Ports, not concretions. `stella-core` still imports no provider SDK, no
+- Ports, not direct dependencies. `stella-core` still imports no provider SDK, no
   filesystem API, and now also never learns that plugins exist.
 
 ---

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1605,7 +1605,7 @@
       "description": "One point in a sub-agent's lifecycle. Exactly one `Started` and exactly\none `Finished` are emitted per spawn, in that order, even when the child\nis refused before its first model call (a refusal still brackets, so a\nconsumer folding these never sees an unclosed child).",
       "oneOf": [
         {
-          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the other 35 variants.",
+          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the rest of the event vocabulary.",
           "properties": {
             "agent_id": {
               "description": "Stable id for this child, unique within the parent turn.",

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -3338,7 +3338,7 @@
       "description": "One point in a sub-agent's lifecycle. Exactly one `Started` and exactly\none `Finished` are emitted per spawn, in that order, even when the child\nis refused before its first model call (a refusal still brackets, so a\nconsumer folding these never sees an unclosed child).",
       "oneOf": [
         {
-          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the other 35 variants.",
+          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the rest of the event vocabulary.",
           "properties": {
             "agent_id": {
               "description": "Stable id for this child, unique within the parent turn.",

--- a/docs/wire/wrapper.wire.json
+++ b/docs/wire/wrapper.wire.json
@@ -176,7 +176,7 @@
       }
     }
   ],
-  "note": "GENERATED FILE — DO NOT EDIT. Every message the wrapper socket carries, serialized by the same impls stella_runtime's subprocess transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of truth: crates/stella-plugin/src/wire.rs and src/host_call.rs. A message with an optional member appears twice — `full` populates every optional field, `minimal` omits every one that may be omitted — so a field changing between required and optional is a diff here. This is a corpus, not a JSON Schema: see crates/stella-plugin/src/wire_corpus.rs for what that does and does not catch (#3532).",
+  "note": "GENERATED FILE — DO NOT EDIT. Every message the wrapper socket carries, serialized by the same impls stella_runtime's subprocess transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of truth: crates/stella-plugin/src/wire.rs, src/host_call.rs and src/driver.rs. A message with an optional member appears twice — `full` populates every optional field, `minimal` omits every one that may be omitted — so a field changing between required and optional is a diff here. This is a corpus, not a JSON Schema: see crates/stella-plugin/src/wire_corpus.rs for what that does and does not catch (#3532).",
   "parts": [
     {
       "case": "candidate_grant/full",

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -3,8 +3,8 @@ title: settings.json
 description: Configure providers, agents, tools, context, and managed authority across project, org-managed, and user scopes.
 ---
 
-`settings.json` is stella's configuration file. It has ten top-level sections, each with
-its own merge rule across the [scope hierarchy](#the-scope-hierarchy):
+`settings.json` is stella's configuration file. Each top-level section has its own
+merge rule across the [scope hierarchy](#the-scope-hierarchy):
 
 <Callout type="info">
   The same configuration is also available as

--- a/website/content/docs/inference-pipeline.mdx
+++ b/website/content/docs/inference-pipeline.mdx
@@ -210,31 +210,36 @@ gathered first:
 - **The diff budget.** A small diff (≤ 400 changed lines by default) backed by
   deterministic evidence submits on the evidence alone.
 
-From those, the ladder picks one of **five** outcomes, in this order. Every one
+From those, the ladder picks one of **six** outcomes, in this order. Every one
 of them is **terminal** — the ladder is the whole decision, and no model is
 consulted at any rung:
 
 <CardGrid size="md">
-  <OptionCard name="1 · Revise">
+  <OptionCard name="1 · Witness unsatisfiable">
+    The authored witness failed **the same way** before and after the work, so its red
+    says nothing about the change. This is a claim about the test, not the work — and
+    no revision can fix an instrument, which is why it is ranked above **Revise**.
+  </OptionCard>
+  <OptionCard name="2 · Revise">
     Touched tests are **red**. That is already a deterministic failure, so the evidence
     goes straight back into a revision turn. Nothing is spent confirming a
     failure that is not in doubt.
   </OptionCard>
-  <OptionCard name="2 · Nothing attempted">
+  <OptionCard name="3 · Nothing attempted">
     The turn dispatched no call capable of changing the workspace, and nothing that
     *could* look saw a change. A determinate finding about the turn — and the one
     place the ladder reads an absence as evidence.
   </OptionCard>
-  <OptionCard name="3 · Unverifiable">
+  <OptionCard name="4 · Unverifiable">
     **Every** channel was blind — no flip, no test result, an unreadable working tree,
     and no recorded file touch. The ladder **abstains**: nothing is claimed about the
     work, in particular not that it failed.
   </OptionCard>
-  <OptionCard name="4 · Submit fast">
+  <OptionCard name="5 · Submit fast">
     Flip achieved, touched tests green, diff within budget, no fresh diagnostics.
     The full deterministic pass.
   </OptionCard>
-  <OptionCard name="5 · Unverified">
+  <OptionCard name="6 · Unverified">
     The probes looked and what they returned did not amount to a proof — no flip, or a
     diff over budget, or tests that could not run. The ladder's honest *I do not know*.
   </OptionCard>
@@ -255,7 +260,7 @@ The evidence that reaches this rung is by construction the evidence no oracle
 could settle, so a model handed it is guessing too, only with a verdict's
 authority attached. The run reports `UNVERIFIED` and says what was missing.
 
-There is one narrow case where a sixth rung, **waived**, is recorded instead: the
+There is one narrow case where a seventh rung, **waived**, is recorded instead: the
 warrant read the diff and found nothing a test could prove (a docs-only edit, a
 pure removal), or triage waived independent review and the warrant agreed from
 the change itself. A waived pass carries no evidence either way and is scored

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -92,7 +92,7 @@ them**:
   test that fails before and passes after — and escalates to a model verifier
   only when deterministic evidence is inconclusive. Evidence first, opinion
   as fallback.
-- When a model *is* asked to verifier, the setup is engineered like a
+- When a model *is* asked to verify, the setup is engineered like a
   mechanism: a different family than the worker (bias resistance), a
   strict output contract, read-only tools, a heuristic fallback if the
   call fails.


### PR DESCRIPTION
## What & why

Ran every crate in the workspace (26 under `crates/`, plus `loop-bench` and `request-bench` under `bench/`) plus root docs, the website docs, and the CI/gate scripts through an audit → independent Opus-verification → fix pipeline (31 targets, 93 subagents), then validated the whole tree together rather than trusting each fix in isolation. `arenabench/` was excluded from judging per instruction.

**[Full report with the scoring rubric, per-crate scorecard, and every finding](https://claude.ai/code/artifact/be912310-0e61-4983-abbd-276f2344fdcf)**

- 143 findings raised, 128 confirmed after adversarial review (15 rejected as false positives — an 89.5% confirmation rate).
- 75 fixed directly in this PR.
- 53 filed as GitHub issues (#3697–#3751) because they need a design decision this pass shouldn't make blind — a keep-or-delete call on dead code, an algorithm rewrite, a new test suite, or (in #3751's case) a repo-wide terminology migration too large to do safely inside a parallel pass.
- 2 more confirmed findings turned out to already be tracked (#3566, #3236) — linked instead of re-filed.

What actually changed in this diff:
- Dead code removed where a workspace-wide caller search confirmed it truly has no caller.
- Stale comments/READMEs corrected where they described behavior the code no longer has — stella-autonomy/stella-observatory's shared-`fold_runs` claim, stella-runtime's unwired host path, two website doc pages still describing the model-verifier fallback removed in #2584.
- Unjustified `#[allow]`s given the "why the lint is wrong here" comment CLAUDE.md requires, without growing any god file past its frozen ceiling (three fixes briefly did this — caught by `make file-size` before commit, rewritten as trailing comments, reverified under ceiling).
- "Concretions" renamed to "direct dependencies" everywhere it appeared (26 uses, 23 files) — including AGENTS.md's own architecture-section heading and the markdown anchor 20+ other files cite it by, done as one atomic pass and reverified with `check-doc-links.py` afterward.
- AGENTS.md's own gate-step list resynced to the Makefile's real order (`format-check` before `doc-warnings`) — a genuine drift the audit caught in the document that governs the audit.

**Deliberately not touched:** the word "invariant" (863 uses, 380 files, load-bearing numbered citations like "invariant #3" scattered through doc comments and runtime error strings). Renaming it safely means updating every citation in the same pass, not a find-and-replace — 33× the blast radius "concretions" had. Filed as #3751 for a dedicated, human-reviewed pass instead of doing it blind.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: every change here either deletes code with zero remaining callers, corrects a doc/comment to match existing (unchanged) behavior, or renames a word — none of it changes runtime behavior, so there's no fail→pass to demonstrate. Verified instead by rebuilding, relinting, and retesting the whole workspace together after all 95 files changed (see below), not just the individual crates each fix touched.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` — **8232 / 8233 tests pass** across 165 test binaries. The one failure, `daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`, is a pre-existing environment-timing flake already tracked in #3559 and #3588 — confirmed unrelated by running it in isolation against an unmodified `daemon/tests.rs` (this PR touches no file under `daemon/`).
- [x] Docs updated where behavior/flags changed (this PR's changes are docs/comments themselves, or code the docs were wrong about)
- [x] CLA signed (existing contributor)
- [ ] `Closes #N` — N/A, this PR doesn't close a single pre-existing issue; see "Nothing left behind" below for what it opens instead

Also ran and confirmed clean, beyond the checklist above: `check-gate-parity`, `check-invariants` (32 citations resolve), `check-god-files`, `check-file-size` (the ratchet — nothing over its ceiling), `check-no-scratch`, `check-left-behind`, and `check-doc-links.py` (589 citations resolve).

## Nothing left behind

- [x] Filed: #3697, #3698, #3699, #3700, #3701, #3702, #3703, #3705, #3706, #3708, #3709, #3710, #3711, #3712, #3713, #3714, #3715, #3716, #3717, #3718, #3719, #3720, #3721, #3722, #3723, #3724, #3725, #3726, #3727, #3728, #3729, #3730, #3731, #3732, #3733, #3734, #3735, #3736, #3737, #3738, #3739, #3740, #3741, #3742, #3743, #3744, #3745, #3746, #3747, #3748, #3749, #3750, #3751 — full list with titles in the [report](https://claude.ai/code/artifact/be912310-0e61-4983-abbd-276f2344fdcf).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below — the audit found zero I/O-in-the-engine or ports-boundary violations across all 28 crates
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types added

## Anything reviewers should know?

- This is intentionally one large diff (95 files, +405/−418 lines) rather than 30 small PRs, because it's one logical action (a single coordinated audit pass) rather than 30 unrelated changes — CONTRIBUTING.md's "one logical change per PR" is about the change being one thing, and it is.
- Two of the 53 filed issues found real correctness concerns worth a reviewer's attention even though they're not fixed here: #3739 (a word-level diff in stella-transcript can allocate ~10GB on one pathological line) and #3725 (an Observatory API route ignoring `workspace_root` can mix session records across projects).
- #3751 is the honest half of the "declutter jargon" ask this audit was run for — "concretions" got the full treatment, "invariant" is flagged but deliberately deferred, explained in the issue and in the report's "Deliberately not fixed blind" section.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tN5VkzUAqtwpjKLo3s4Rj)_

## Summary by Sourcery

Clean up the workspace after a coordinated audit by removing confirmed dead code, correcting drifted documentation, strengthening targeted safeguards, and standardizing architecture terminology.

Bug Fixes:
- Remove confirmed dead code and correct stale documentation and comments across the workspace.
- Harden SVG sanitization, clarify unused pipeline roles, and eliminate obsolete API helpers and dependencies.
- Add coverage for diagnostic counter mapping and oversized diff fallback behavior.

Enhancements:
- Rename the architecture terminology from “concretions” to “direct dependencies” across code and documentation.
- Refresh crate READMEs, workspace overviews, source references, and capability documentation to reflect the current architecture.
- Document justified lint suppressions and synchronize gate documentation with the actual Makefile order.
- Simplify shared implementations and improve documentation accuracy without changing runtime behavior.

Build:
- Remove an unused workspace dependency and align the request benchmark with the shared token-size constant.

CI:
- Expand shellcheck coverage to include scripts/lib and synchronize documented gate steps.

Documentation:
- Update root, crate, specification, paper, and website documentation for current crate structure, APIs, architecture terminology, and pipeline outcomes.

Tests:
- Add regression coverage for diagnostic counter snapshots and large-input diff fallback paths.
- Regenerate wire-schema artifacts after updating the documented wire contract.

Chores:
- Apply coordinated cleanup across 95 files while preserving file-size and documentation-link gates.