### PR TITLE
fix(stella-cli): refuse pipeline-only verification flags on the raw default; preserve legacy deck personas on resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,14 +426,21 @@ template. If a witness is genuinely impractical (e.g. TUI rendering), explain
 how you verified the change instead.
 
 **What follows is the staged pipeline's own witness/verify machinery, which is
-a different thing from the contract above.** It ships in-tree today and
-genuinely runs the check itself — this is the host-run half of the guarantee
-(see AGENTS.md's opening). Per the product decision recorded in
-`doc:pipeline-as-plugins` (#3511) it is being extracted into an installable
-verification plugin (Oxagen's Vera is the reference one); once it lands, a
-plugin reports its own evidence instead of Stella running the check, and this
-section's guarantee does not automatically transfer to that path. Until then,
-this section documents the mechanism as it exists: when no
+a different thing from the contract above.** It is **opt-in**, not the
+default: since #3381 a plain `stella run` resolves to the raw step-loop, and
+this machinery runs only when a turn is explicitly wrapped with `stella run
+--pipeline classic` (`crates/stella-cli/src/wrapper_plugin.rs` —
+`PipelineChoice::Classic`). It ships in-tree today and genuinely runs the
+check itself when invoked — this is the host-run half of the guarantee (see
+AGENTS.md's opening) — and `--test-command`/`--keep-witness`/
+`--require-verified` are refused on any other resolution (the raw loop, or an
+installed wrapper plugin), naming `--pipeline classic` as the remedy, rather
+than silently doing nothing. Per the product decision recorded in
+`doc:pipeline-as-plugins` (#3511) the mechanism is being extracted into an
+installable verification plugin (Oxagen's Vera is the reference one); once it
+lands, a plugin reports its own evidence instead of Stella running the check,
+and this section's guarantee does not automatically transfer to that path.
+Until then, this section documents the mechanism as it exists: when no
 `--test-command` is configured, its **witness stage** has an independent model
 (the verifier's resolution, never the worker) author the failing witness test,
 tracks its fail→pass flip in the flip oracle, and refuses to credit the flip if
@@ -443,7 +450,12 @@ executed diff and found something worth proving — so the stage order is
 triage → recall → research → plan → scope → **execute → witness** → verify → verdict
 (`stage_rank` in `crates/stella-pipeline/src/replay.rs` is the canonical
 ordering; the revise back-edges land on execute, so re-execution never
-re-authors). The witness
+re-authors). That order is not hard-coded: it is resolved at load time from
+the shipped `[wrapper]` manifest (`crates/stella-pipeline/variants/classic.toml`,
+via `src/schedule.rs` and `src/pipeline/schedule_wiring.rs`) — a witness
+condition written to read a post-triage (post-execute) signal is refused at
+load rather than silently accepted, so a manifest cannot describe an ordering
+the schedule cannot honor. The witness
 is **scaffolding for that one run**: it lives in the candidate workspace and is
 discarded with it, so an already-satisfied test is never left behind in the
 project's test tree. `stella run --keep-witness` promotes it instead.
@@ -644,7 +656,8 @@ alone, because a number in two places is how the last limit died.
 **Status — what ships.** The live runtime path is
 `stella-cli` → `stella-core` → `stella-model` / `stella-tools` / `stella-store` /
 `stella-context` (recall only) / `stella-mcp`, and the CLI also drives
-`stella-pipeline` (the default `stella run` path), `stella-fleet` (`stella fleet`),
+`stella-pipeline` (opt-in on every door via `stella run --pipeline classic`;
+the raw step-loop is the default), `stella-fleet` (`stella fleet`),
 and `stella-tui` (the Command Deck, the default interactive shell on a TTY).
 The fuller
 `stella-graph` retrieval + context plane (`stella init` builds the code-graph

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ in Rust as a workspace of focused crates.
 
 - **BYOK, auto-detected** — Set one provider's API key and Stella detects it.
   Pin a specific model per run or shell with `--model`.
-- **Deterministic definition of done** — the staged pipeline's witness stage
-  has an independent model author a test that fails on the old code and passes
-  on the new, and tracks that fail→pass flip, host-run out of the box. A green
-  suite alone is not accepted. This machinery is also becoming Vera, an
+- **Deterministic definition of done, opt-in** — `stella run --pipeline
+  classic` runs the built-in staged pipeline, whose witness stage has an
+  independent model author a test that fails on the old code and passes on
+  the new, and tracks that fail→pass flip, host-run. A green suite alone is
+  not accepted on that path. This machinery is also becoming Vera, an
   installable verification plugin — a plugin's oracle reports its own
   evidence instead of Stella re-running the check.
 - **Single-threaded engine** — One deterministic step loop: plan, fan tools out
@@ -363,7 +364,7 @@ each row links to its reference page on [stella.oxagen.sh](https://stella.oxagen
 
 | Command                                                               | What it does                                                                                                      |
 | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [`run <prompt>`](https://stella.oxagen.sh/docs/commands/run)          | Send a one-shot prompt, non-interactive — the staged pipeline by default                                          |
+| [`run <prompt>`](https://stella.oxagen.sh/docs/commands/run)          | Send a one-shot prompt, non-interactive — the raw step-loop by default; `--pipeline <variant>` opts a wrapper in    |
 | [`chat`](https://stella.oxagen.sh/docs/commands/chat)                 | Interactive session: the Command Deck TUI (also what a bare `stella` opens)                                       |
 | [`resume [id]`](https://stella.oxagen.sh/docs/commands/resume)        | Reopen a durable past session exactly where it stood; `--list` browses them                                       |
 | [`goal <goal>`](https://stella.oxagen.sh/docs/commands/goal)          | Work in judged rounds until a verifier model confirms the goal is met                                                |
@@ -481,11 +482,15 @@ deliberately **not** global: it is declared by the commands that honor it —
 `stella run` and `stella fleet` — and goes after the subcommand token
 (`stella run "…" --output-format json`); interactive
 `chat` / `goal` / `monitor` modes render human-readable output. `stella run`
-uses the staged pipeline by default; `--no-pipeline` falls back to the raw
-step-loop. In pipeline mode, `--test-command <cmd>` arms deterministic
-verification with your own test; without it an independent witness author
-writes a failing test whose fail→pass flip proves the work
-([the inference pipeline](https://stella.oxagen.sh/docs/inference-pipeline)).
+runs the raw step-loop by default; `--pipeline classic` opts into the
+built-in staged pipeline (`--pipeline <plugin-id>` opts into an installed
+wrapper plugin instead), and `--no-pipeline` is a deprecated no-op kept
+parseable so no script breaks. In staged-pipeline mode, `--test-command
+<cmd>` arms deterministic verification with your own test; without it an
+independent witness author writes a failing test whose fail→pass flip proves
+the work ([the inference pipeline](https://stella.oxagen.sh/docs/inference-pipeline)).
+`--test-command`/`--keep-witness`/`--require-verified` are refused outside
+`--pipeline classic`, naming it as the remedy.
 Post-turn reflection remains enabled for one-shot text, JSON, and stream-JSON
 runs. Ephemeral automation can suppress that additional model call explicitly
 with `STELLA_DISABLE_REFLECTION=1`; the truthy values `true`, `yes`, and `on`
@@ -556,9 +561,12 @@ document binds issuer, audience, organization/workspace, expiry, the single
 isolation, bearer-secret references, and one endpoint that must exactly match
 the administrator's credential-free HTTPS allowlist.
 
-While enrolled, only `stella run --no-pipeline` is eligible. Stella rejects
-pipeline, goal, fleet, deck/chat, interactive, workspace-port, and candidate
-workspace execution paths because they cannot prove the process-free boundary.
+While enrolled, only the default raw `stella run` (no `--pipeline` flag —
+`--no-pipeline` is a deprecated no-op and does not change eligibility) is
+eligible. Stella rejects `--pipeline classic`, an installed wrapper plugin,
+goal, fleet, deck/chat, interactive, workspace-port, and candidate workspace
+execution paths because none of them can prove the process-free boundary: a
+wrapper, of any kind, spawns a process the boundary is drawn to exclude.
 Eligible finalized runs may export only managed organization/workspace/enrollment
 identifiers; allowlisted provider/model or `other`; outcome; duration; input and
 output token counts; cost in micro-USD; tool-call and changed-file counts; and a
@@ -680,7 +688,7 @@ extending it.
 | [`stella-protocol`](crates/stella-protocol/README.md)       | Zero-logic, zero-I/O stability contract: shared serde types + the `Provider`/tool ports                                                                                                                                                |
 | [`stella-context`](crates/stella-context/README.md)         | The context plane: reflection-memory recall + embedding index, episodes, bi-temporal facts                                                                                                                                             |
 | [`stella-graph`](crates/stella-graph/README.md)             | Tree-sitter symbol + import-edge indexer (Rust/Python/JS/TS/TSX/SQL/Go/Java/C/PHP)                                                                                                                                                     |
-| [`stella-pipeline`](crates/stella-pipeline/README.md)       | The orchestration plane above the engine — the default `stella run` path: triage → plan → scope review → witness → execute → verify → verdict ([docs](https://stella.oxagen.sh/docs/inference-pipeline))                                 |
+| [`stella-pipeline`](crates/stella-pipeline/README.md)       | The orchestration plane above the engine, opt-in via `stella run --pipeline classic` — triage, plan, execute, witness, verify, verdict, in the order its `[wrapper]` manifest declares ([docs](https://stella.oxagen.sh/docs/inference-pipeline))                                 |
 | [`stella-fleet`](crates/stella-fleet/README.md)             | The multi-agent fleet behind `stella fleet`: DAG planner + wave scheduling, a shared tree with cooperative file claims by default, opt-in git-worktree isolation per task                                                              |
 | [`stella-media`](crates/stella-media/README.md)             | Multimodal generation behind one `MediaProvider` port                                                                                                                                                                                 |
 | [`stella-tui`](crates/stella-tui/README.md)                 | The Command Deck — a pure event-fold core + thin crossterm shell                                                                                                                                                                       |

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -106,12 +106,11 @@ pub(crate) fn session_persistence() -> stella_runtime::Persistence {
     }
 }
 
-/// Run a one-shot prompt. [`PipelineChoice`](crate::wrapper_plugin::PipelineChoice)
-/// selects which wrapper runs over the turn (`Raw` by default, #3381).
-/// `test_command`, when given, arms the pipeline's deterministic verification
-/// ladder (the fail→pass flip oracle); without it, verification falls back to
-/// the model verifier on every iteration. `keep_witness` promotes an authored
-/// witness into the working tree instead of letting it die with the candidate workspace.
+/// Run a one-shot prompt. [`PipelineChoice`](crate::wrapper_plugin::PipelineChoice) selects which
+/// wrapper runs over the turn (`Raw` by default, #3381). `test_command`, when given, arms the
+/// pipeline's deterministic verification ladder (the fail→pass flip oracle); without it,
+/// verification falls back to the model verifier on every iteration. `keep_witness` promotes an
+/// authored witness into the working tree instead of letting it die with the candidate workspace.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_one_shot(
     cfg: &Config,
@@ -126,6 +125,7 @@ pub async fn run_one_shot(
     // A benchmark's durable sink is part of the accounting boundary. Prove the exact mounted file
     // is writable before provider construction or any code path that can make a paid call.
     preflight_durable_stream(format)?;
+    // #3381 made Raw the default, so this now admits the common no-flag `stella run` case too.
     crate::enterprise_telemetry::authorize_one_shot(!pipeline.is_raw())?;
     if pipeline.is_classic() {
         run_pipeline_one_shot(

--- a/crates/stella-cli/src/arena.rs
+++ b/crates/stella-cli/src/arena.rs
@@ -25,16 +25,20 @@
 //!
 //! **The default this adapter measures changed with #3381.** `run_arena`
 //! resolves its choice via the same `PipelineChoice::resolve(args.no_pipeline,
-//! None)` `stella run` uses, and #3381 flipped that resolution's no-flag
-//! default from the staged pipeline to the raw step-loop. Arena is the
+//! args.pipeline)` `stella run` uses, and #3381 flipped that resolution's
+//! no-flag default from the staged pipeline to the raw step-loop. Arena is the
 //! benchmark adapter, so this is not an incidental side effect: **every arena
 //! episode now measures the raw loop unless the runner passes `--pipeline
-//! <variant>`**, which this adapter does not yet expose as a flag of its own
-//! (only `--no-pipeline`, now a deprecated no-op, and `--test-command`). A
-//! panel run against this binary before and after #3381 is comparing the
-//! staged pipeline to the raw loop, not two builds of the same thing — CLAUDE.md's
-//! like-for-like rule requires that comparison be named, never silently
-//! absorbed into a "regression".
+//! <variant>`**. That flag is exposed here for exactly that reason — a panel
+//! run against this binary before and after #3381 is otherwise comparing the
+//! staged pipeline to the raw loop, not two builds of the same thing, and
+//! CLAUDE.md's like-for-like rule requires that comparison be named, never
+//! silently absorbed into a "regression". `--test-command` names the verify
+//! ladder's oracle, so it is refused before the episode starts unless the
+//! resolved driver can honor it
+//! ([`reject_verification_flags_without_pipeline`](crate::wrapper_plugin::reject_verification_flags_without_pipeline)):
+//! a benchmark that ignores the oracle its runner asked for reports a number
+//! nobody can interpret.
 //!
 //! [`contextgraph-trace`]: https://github.com/macanderson/context-graph-protocol/blob/6f8d7ef13b2528c26913c6472405408ba2584a85/docs/sketches/host-trace.md
 
@@ -84,6 +88,7 @@ pub(crate) struct ArenaArgs {
     pub state_dir: PathBuf,
     pub resume: bool,
     pub no_pipeline: bool,
+    pub pipeline: Option<String>,
     pub test_command: Option<String>,
 }
 
@@ -114,7 +119,7 @@ pub(crate) async fn run_arena(mut cfg: Config, args: ArenaArgs) -> Result<(), St
         &prompt,
         None,
         OutputFormat::StreamJson,
-        crate::wrapper_plugin::PipelineChoice::resolve(args.no_pipeline, None),
+        crate::wrapper_plugin::PipelineChoice::resolve(args.no_pipeline, args.pipeline.as_deref()),
         args.test_command.as_deref(),
         // The arena verifiers the task result, not the scaffolding that proved
         // it — a witness left in the tree would show up as unexplained work.

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -551,7 +551,8 @@ pub(crate) enum Command {
         /// a change that flips a failing test to passing is proven done.
         /// Omitted, the pipeline's witness stage is the remaining oracle,
         /// and a turn that reaches neither is reported unverified — not
-        /// passed.
+        /// passed. Refused without `--pipeline classic` or `--pipeline
+        /// <variant>` — nothing on the raw loop consumes it (#3696).
         #[arg(long, value_name = "CMD")]
         test_command: Option<String>,
 
@@ -560,6 +561,7 @@ pub(crate) enum Command {
         /// inside the candidate workspace and is discarded with it, so an
         /// already-satisfied test is never left behind in your test tree.
         /// Pass this to promote it to a real test you can commit.
+        /// Pipeline-only: refused without `--pipeline classic` (#3696).
         #[arg(long)]
         keep_witness: bool,
 
@@ -571,7 +573,8 @@ pub(crate) enum Command {
         /// ordinary outcome and flipping it would break every existing script.
         /// Pass this in a delivery gate that must not ship unproven work — it
         /// turns "completed but unproven" into a failure exactly like a
-        /// refuted verification.
+        /// refuted verification. Pipeline-only: refused without `--pipeline
+        /// classic` (#3696).
         #[arg(long)]
         require_verified: bool,
 

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -653,7 +653,7 @@ pub(crate) enum Command {
         /// plan → witness → execute → verify); omitted, the raw step-loop
         /// runs with nothing over it (the default since #3381). A named
         /// plugin variant is refused today — wrapper plugins run only on
-        /// `stella run --pipeline <variant>` (#3684 tracks driving them
+        /// `stella run --pipeline <variant>` (#3695 tracks driving them
         /// through a judged round).
         #[arg(long, value_name = "VARIANT")]
         pipeline: Option<String>,
@@ -852,7 +852,7 @@ pub(crate) enum Command {
         /// witness, execute, verify); omitted, the raw step-loop runs with
         /// nothing over it (the default since #3381). A named plugin variant
         /// is refused today — wrapper plugins run only on `stella run
-        /// --pipeline <variant>` (#3684 tracks driving them through a fleet
+        /// --pipeline <variant>` (#3695 tracks driving them through a fleet
         /// worker).
         #[arg(long, value_name = "VARIANT")]
         pipeline: Option<String>,

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -625,7 +625,21 @@ pub(crate) enum Command {
         #[arg(long, hide = true)]
         no_pipeline: bool,
 
+        /// Run each episode under a wrapper, by the `[wrapper] id` its
+        /// manifest declares (`stella plugin list`). `classic` names the
+        /// built-in staged pipeline; omitted, the raw step-loop runs with
+        /// nothing over it (the default since #3381). The same flag
+        /// [`stella run`](crate::cli::Command::Run) takes, so a panel can
+        /// measure either driver rather than only the one the default
+        /// happens to name.
+        #[arg(long, value_name = "VARIANT")]
+        pipeline: Option<String>,
+
         /// Test command for the pipeline's deterministic verify ladder.
+        ///
+        /// Belongs to the staged pipeline's verify machinery, so it is
+        /// refused rather than silently ignored unless `--pipeline` selects
+        /// a driver that can honor it.
         #[arg(long, value_name = "CMD")]
         test_command: Option<String>,
     },

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -427,18 +427,13 @@ pub async fn run_deck_session(
     // is durable now, so an exit with prompts waiting is a pause, not loss.
     let mut session_exit = stella_store::SessionStatus::Complete;
     let mut sidecar_dir = session_registry.sidecar_dir(&session_record.id);
-    // Persona matches the driver: a fresh deck session runs the raw engine
-    // loop by default since #3381, so it gets the plain REPL persona now,
-    // not the pipeline worker persona (methodology ladder +
-    // `agents.worker.prompt` override) — that applies only once `/pipeline`
-    // is on (invariant #7: this changes what a NEW session starts with, not
-    // a resumed one). Chosen ONCE per session from the same state
-    // `pipeline_init` reads — byte-stable (L-E8), so a mid-session toggle
-    // changes the driver but keeps the persona until the next session.
-    let pipeline_persona = resume_state
-        .as_ref()
-        .and_then(|rs| rs.pipeline)
-        .unwrap_or(false);
+    // Persona matches the driver: a genuinely fresh session gets the plain REPL
+    // persona (raw is the default since #3381); one resumed with prior journal
+    // history but no explicit `Pipeline` record restores the pipeline persona
+    // instead — it predates the flip and always ran staged, so swapping
+    // personas on a mere resume would breach invariant #7. Chosen ONCE, byte-
+    // stable (L-E8): see `session_persist::initial_pipeline_persona`.
+    let pipeline_persona = crate::session_persist::initial_pipeline_persona(resume_state.as_ref());
     let system_prompt = agent::with_session_hook_context(
         if pipeline_persona {
             // Assembled once per session, before any turn resolves wiring: no
@@ -690,6 +685,8 @@ pub async fn run_deck_session(
     // keeps whatever it last had — the same state the persona choice above
     // read, so driver and persona start the session agreeing.
     let pipeline_init = pipeline_persona;
+    // Journal it once so a future flip never faces this ambiguity again.
+    let _ = in_tx.send(Inbound::Pipeline(pipeline_init));
     // Honour the persisted colour theme (`ui.theme`) before the deck spawns its
     // render task, so the very first frame — the launch cinematic — is already
     // in the chosen theme. Best-effort: an unset/unknown value keeps the
@@ -1106,6 +1103,7 @@ pub async fn run_deck_session(
                                     .send(chrome_note(format!("cannot resume `{id}`: {reason}")));
                             }
                             Ok(mut rs) => {
+                                let had_history = !rs.records.is_empty(); // before the take below
                                 // Park the CURRENT session: sync the journal,
                                 // snapshot the conversation, and either mark it
                                 // Paused — or, if nothing ever happened in it,
@@ -1232,8 +1230,10 @@ pub async fn run_deck_session(
                                     });
                                 }
                                 queue.adopt(sidecar_dir.clone(), restored);
-                                // Same default as the start-up read above (#3381).
-                                pipeline_on = rs.pipeline.unwrap_or(false);
+                                pipeline_on = crate::session_persist::derive_pipeline_persona(
+                                    had_history,
+                                    rs.pipeline,
+                                );
                                 let _ = in_tx.send(Inbound::Pipeline(pipeline_on));
                                 // `--spend-limit` means THIS session, decided and
                                 // implemented on both resume paths: reseed

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -351,6 +351,26 @@ fn supervision(globals: &cli::GlobalArgs) -> daemon::detach::Posture {
     )
 }
 
+/// Print `--no-pipeline`'s deprecation notice, if owed, once — from whichever
+/// process actually goes on to run the turn.
+///
+/// The one mechanism [`wrapper_plugin::no_pipeline_deprecation_notice`]'s doc
+/// asks every supervising door to share: call this *after* the
+/// `posture.supervises()` early-return, never before it. An `Attached`/
+/// `Detached` launch re-execs the same argv into a supervised child, which
+/// reaches this exact call site again in its own process — its own posture
+/// never supervises (the recursion backstop) — so printing here rather than
+/// before the re-exec means exactly one process ever calls it: the child
+/// under supervision, or this same process when there is no child at all.
+/// Printing before the early-return double-printed the line for every
+/// `Attached` launch, because `Supervised::follow` then relays the child's
+/// own copy back over the same stream the parent already wrote to.
+fn print_no_pipeline_notice_if_owed(no_pipeline: bool) {
+    if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
+        eprintln!("⚠ {notice}");
+    }
+}
+
 /// The registry title for a supervised run: the same
 /// `<workspace>: <prompt…>` shape a session announces for itself, so a run
 /// reads identically in `stella daemon list` and in the deck's SESSIONS view.
@@ -1042,9 +1062,17 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             require_verified,
             output_format,
         } => {
-            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
-                eprintln!("⚠ {notice}");
-            }
+            let pipeline_choice =
+                wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref());
+            // A verification flag with nowhere to land is refused before the
+            // prompt is even resolved, not silently dropped after a paid call
+            // starts (#3696).
+            wrapper_plugin::reject_verification_flags_without_pipeline(
+                pipeline_choice,
+                test_command.as_deref(),
+                keep_witness,
+                require_verified,
+            )?;
             let prompt = prompt_source::resolve(
                 prompt,
                 std::io::stdin().is_terminal(),
@@ -1063,6 +1091,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     output_format,
                 ).map_err(failure::CliFailure::from);
             }
+            print_no_pipeline_notice_if_owed(no_pipeline);
             signals::block_on_interruptible(
                 rt()?,
                 agent::run_one_shot(
@@ -1070,7 +1099,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     &prompt,
                     cli.globals.spend_limit,
                     output_format,
-                    wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref()),
+                    pipeline_choice,
                     test_command.as_deref(),
                     keep_witness,
                     require_verified,
@@ -1105,9 +1134,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             no_pipeline,
             pipeline,
         } => {
-            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
-                eprintln!("⚠ {notice}");
-            }
             let pipeline_choice =
                 wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref());
             wrapper_plugin::reject_plugin_variant_for_door("goal", pipeline_choice)?;
@@ -1129,6 +1155,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     OutputFormat::Text,
                 ).map_err(failure::CliFailure::from);
             }
+            print_no_pipeline_notice_if_owed(no_pipeline);
             signals::block_on_interruptible(
                 rt()?,
                 agent::run_goal_cmd(&cfg, &goal, cli.globals.spend_limit, pipeline_choice),
@@ -1154,9 +1181,6 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             task_timeout,
             output_format,
         } => {
-            if let Some(notice) = wrapper_plugin::no_pipeline_deprecation_notice(no_pipeline) {
-                eprintln!("⚠ {notice}");
-            }
             let pipeline_choice =
                 wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref());
             wrapper_plugin::reject_plugin_variant_for_door("fleet", pipeline_choice)?;
@@ -1177,6 +1201,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     output_format,
                 ).map_err(failure::CliFailure::from);
             }
+            print_no_pipeline_notice_if_owed(no_pipeline);
             signals::block_on_interruptible(
                 rt()?,
                 fleet_cmd::run_fleet(

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -1112,8 +1112,18 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             state_dir,
             resume,
             no_pipeline,
+            pipeline,
             test_command,
         } => {
+            // The same gate `run` applies, for the same reason: a benchmark
+            // adapter that silently ignores `--test-command` reports a number
+            // measured without the oracle the runner asked for.
+            wrapper_plugin::reject_verification_flags_without_pipeline(
+                wrapper_plugin::PipelineChoice::resolve(no_pipeline, pipeline.as_deref()),
+                test_command.as_deref(),
+                false,
+                false,
+            )?;
             signals::block_on_interruptible(
                 rt()?,
                 arena::run_arena(
@@ -1124,6 +1134,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                         state_dir,
                         resume,
                         no_pipeline,
+                        pipeline,
                         test_command,
                     },
                 ),

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -781,6 +781,63 @@ mod tests {
         );
     }
 
+    fn resume_state_with(records: Vec<JournalRecord>, pipeline: Option<bool>) -> ResumeState {
+        ResumeState {
+            record: SessionRecord::new("/tmp/ws", "t"),
+            records,
+            history: None,
+            queue: Vec::new(),
+            interrupted: Vec::new(),
+            pipeline,
+            spent_usd: None,
+        }
+    }
+
+    /// **Witness (#3381 audit finding 2).** A pre-flip session always ran the
+    /// then-default staged pipeline and never journaled a `Pipeline` record
+    /// (that record type postdates it) — so it has journal history but
+    /// `pipeline == None`. Resuming it must restore the pipeline persona,
+    /// not silently swap to the new raw default with no user action and no
+    /// record. This assertion fails on the pre-fix
+    /// `resume_state.and_then(|rs| rs.pipeline).unwrap_or(false)` derivation
+    /// (which reads `false` here) and passes on this one.
+    #[test]
+    fn a_resumed_session_with_history_but_no_pipeline_record_restores_on() {
+        let history = vec![JournalRecord::Register {
+            agent: "lead".into(),
+            title: "t".into(),
+            role: "lead".into(),
+            model: None,
+        }];
+        assert!(derive_pipeline_persona(true, None));
+        assert!(initial_pipeline_persona(Some(&resume_state_with(history, None))));
+    }
+
+    /// A genuinely fresh session — no resume state at all, or a resumed one
+    /// with an empty journal — starts under today's default: OFF.
+    #[test]
+    fn a_fresh_session_starts_off() {
+        assert!(!derive_pipeline_persona(false, None));
+        assert!(!initial_pipeline_persona(None));
+        assert!(!initial_pipeline_persona(Some(&resume_state_with(
+            Vec::new(),
+            None
+        ))));
+    }
+
+    /// An explicit `Pipeline` record always wins, in either direction,
+    /// regardless of whether the session also has prior history.
+    #[test]
+    fn an_explicit_pipeline_record_always_wins() {
+        assert!(!derive_pipeline_persona(true, Some(false)));
+        assert!(derive_pipeline_persona(false, Some(true)));
+        let history = vec![JournalRecord::Pipeline { on: false }];
+        assert!(!initial_pipeline_persona(Some(&resume_state_with(
+            history,
+            Some(false)
+        ))));
+    }
+
     #[test]
     fn journal_lanes_names_every_non_lead_lane_once_in_order() {
         let records = vec![

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -514,6 +514,42 @@ pub fn load_resume(
     })
 }
 
+/// Whether a session's driver/persona default is the staged pipeline ("on"),
+/// given whether it has any prior journal history and its last explicit
+/// `Pipeline` record, if any (#3381 audit finding 2).
+///
+/// Three cases, in order:
+/// - An explicit record always wins — a previous session (or this one, via
+///   `/pipeline`) already decided.
+/// - No record, but `has_prior_records` is true: this session predates the
+///   #3381 default flip (or simply never toggled) and the staged pipeline
+///   WAS the only default when it last ran, so resuming it must restore ON —
+///   silently swapping a session's persona out from under it on a mere
+///   resume, with no user action and no record, is exactly the invariant #7
+///   breach a byte-stable prompt exists to prevent.
+/// - No record and no prior history at all: a genuinely fresh session starts
+///   under today's default, OFF.
+///
+/// One function so both call sites in `command_deck.rs` — the persona choice
+/// at session start and the SESSIONS-overlay resume-switch — derive the same
+/// answer from the same rule rather than each encoding it inline.
+pub(crate) fn derive_pipeline_persona(
+    has_prior_records: bool,
+    pipeline_record: Option<bool>,
+) -> bool {
+    pipeline_record.unwrap_or(has_prior_records)
+}
+
+/// [`derive_pipeline_persona`] applied directly to a session's loaded
+/// [`ResumeState`] (`None` for a session with no resume state at all — a
+/// brand-new session, which has no prior records by construction).
+pub(crate) fn initial_pipeline_persona(resume_state: Option<&ResumeState>) -> bool {
+    derive_pipeline_persona(
+        resume_state.is_some_and(|rs| !rs.records.is_empty()),
+        resume_state.and_then(|rs| rs.pipeline),
+    )
+}
+
 /// Replay a loaded journal straight into the deck (bypassing the tee — a
 /// replay must never re-journal itself, or every resume would double the
 /// file). The caller replays BEFORE its first live send so ordering is the

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -810,7 +810,9 @@ mod tests {
             model: None,
         }];
         assert!(derive_pipeline_persona(true, None));
-        assert!(initial_pipeline_persona(Some(&resume_state_with(history, None))));
+        assert!(initial_pipeline_persona(Some(&resume_state_with(
+            history, None
+        ))));
     }
 
     /// A genuinely fresh session — no resume state at all, or a resumed one

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -163,9 +163,18 @@ impl<'a> PipelineChoice<'a> {
 /// A pure function returning data rather than printing directly, matching
 /// [`crate::engine_config::effort_notices`]'s shape: [`PipelineChoice::resolve`]
 /// stays a plain decision a unit test can call without capturing stderr, and
-/// each door — `main.rs`'s `Run`/`Goal`/`Fleet` arms, `arena.rs` — prints the
-/// line once, at the one place it already reads `no_pipeline` off its parsed
-/// args.
+/// each door prints the line at most once **to the user's terminal** —
+/// `arena.rs`, which never supervises, at the one place it reads `no_pipeline`
+/// off its parsed args; `main.rs`'s `Run`/`Goal`/`Fleet` arms print it only
+/// after their `Posture`'s early-return, so it fires in whichever single
+/// process actually runs the turn, not in the parent that re-execs an
+/// `Attached`/`Detached` launch's argv verbatim into a supervised child (that
+/// child reaches this same call independently, and its `Foreground` posture
+/// is what prints it — once, on its own stderr, which `Supervised::follow`
+/// then relays back live under `Attached`). Printing it before that
+/// early-return used to mean the parent printed it on its own account and the
+/// re-exec'd child printed it again on the same relayed stream, doubling the
+/// most common invocation's notice.
 pub(crate) fn no_pipeline_deprecation_notice(no_pipeline: bool) -> Option<&'static str> {
     no_pipeline.then_some(
         "--no-pipeline is deprecated and does nothing: the raw step-loop is the default now. \
@@ -180,7 +189,7 @@ pub(crate) fn no_pipeline_deprecation_notice(no_pipeline: bool) -> Option<&'stat
 /// ([`WrapperDispatch`] over one raw turn): `goal` and `fleet` each drive
 /// their own **round loop** (a judged goal round, a fleet worker's attempt),
 /// and wiring a wrapper plugin through either is a real driver — not a
-/// formatting difference — that nothing in this crate implements (#3684).
+/// formatting difference — that nothing in this crate implements (#3695).
 /// `--pipeline classic` and no `--pipeline` at all both resolve to
 /// [`PipelineChoice::Classic`]/[`PipelineChoice::Raw`], which is fine on
 /// every door; only a *named* plugin variant is out of reach here, and it is
@@ -194,11 +203,68 @@ pub(crate) fn reject_plugin_variant_for_door(
     match choice.plugin() {
         Some(variant) => Err(format!(
             "--pipeline {variant} is not supported on `stella {door}` yet — wrapper plugins \
-             run only on `stella run --pipeline {variant}` today (#3684). Pass `--pipeline \
+             run only on `stella run --pipeline {variant}` today (#3695). Pass `--pipeline \
              classic` for the staged pipeline, or omit --pipeline for the raw loop."
         )),
         None => Ok(()),
     }
+}
+
+/// Refuse a pipeline-only verification flag against a [`PipelineChoice`] that
+/// cannot honor it (#3696).
+///
+/// `--keep-witness`, `--require-verified`, and `--test-command` all belong to
+/// the staged pipeline's verification machinery — the witness-authoring stage
+/// and its fail→pass flip oracle. Before #3381 they always reached
+/// [`PipelineChoice::Classic`], because that was the default; after, `stella
+/// run` with no `--pipeline` resolves to [`PipelineChoice::Raw`], whose
+/// `run_raw_one_shot` does not accept `keep_witness`/`require_verified` as
+/// parameters at all and only threads `test_command` to an installed wrapper's
+/// own oracle. Silently dropping the flag the caller asked for is exactly the
+/// expedient CLAUDE.md forbids, so this refuses before dispatch instead of
+/// letting the run start and the flag do nothing — and it never silently
+/// implies `classic`, which would run something other than what was asked
+/// for without saying so.
+///
+/// `test_command` is meaningful on [`PipelineChoice::Plugin`] too — it arms a
+/// bound wrapper's own `[oracle]` flip check (#3553) — so only that variant
+/// passes it through; `keep_witness`/`require_verified` remain pipeline-only
+/// today and are refused on `Plugin` exactly as on `Raw`, both naming
+/// `--pipeline classic` as the remedy.
+pub(crate) fn reject_verification_flags_without_pipeline(
+    choice: PipelineChoice<'_>,
+    test_command: Option<&str>,
+    keep_witness: bool,
+    require_verified: bool,
+) -> Result<(), String> {
+    if choice.is_classic() {
+        return Ok(());
+    }
+    let mut offending: Vec<&str> = Vec::new();
+    if choice.is_raw() && test_command.is_some() {
+        offending.push("--test-command");
+    }
+    if keep_witness {
+        offending.push("--keep-witness");
+    }
+    if require_verified {
+        offending.push("--require-verified");
+    }
+    if offending.is_empty() {
+        return Ok(());
+    }
+    let where_run = match choice {
+        PipelineChoice::Raw => "the raw loop (no --pipeline)".to_string(),
+        PipelineChoice::Plugin(variant) => format!("`--pipeline {variant}`"),
+        PipelineChoice::Classic => unreachable!("classic returned Ok above"),
+    };
+    Err(format!(
+        "{} belong{} to the staged pipeline's verification machinery and {} nothing on {where_run}: \
+         pass --pipeline classic to run the staged pipeline.",
+        offending.join(", "),
+        if offending.len() == 1 { "s" } else { "" },
+        if offending.len() == 1 { "does" } else { "do" },
+    ))
 }
 
 /// One installed wrapper, bound to its process and to what this host will do
@@ -708,7 +774,7 @@ name = "execute"
         assert!(notice.contains("--pipeline"), "{notice}");
     }
 
-    /// **Witness (#3684).** `stella goal`/`stella fleet` cannot drive a
+    /// **Witness (#3695).** `stella goal`/`stella fleet` cannot drive a
     /// wrapper plugin today — only `stella run` implements [`TurnDriver`] over
     /// one — so a named `--pipeline <variant>` must be refused on those doors
     /// rather than silently downgraded to raw or promoted to classic. This
@@ -739,6 +805,83 @@ name = "execute"
             .expect("classic has no plugin to drive — nothing to refuse");
         reject_plugin_variant_for_door("goal", PipelineChoice::Raw)
             .expect("raw has no plugin to drive — nothing to refuse");
+    }
+
+    /// **Witness (#3696).** `--keep-witness`, `--require-verified`, and
+    /// `--test-command` used to reach `run_one_shot` on the `Raw` arm and be
+    /// silently dropped there (`run_raw_one_shot` takes no `keep_witness`/
+    /// `require_verified` parameter at all). This assertion fails against
+    /// that code (which has no such gate, so every call below returns `Ok`)
+    /// and passes on this one: each flag alone against `Raw` is refused, and
+    /// the message names the remedy.
+    #[test]
+    fn each_verification_flag_alone_is_refused_against_the_raw_loop() {
+        let err = reject_verification_flags_without_pipeline(
+            PipelineChoice::Raw,
+            Some("pytest"),
+            false,
+            false,
+        )
+        .expect_err("--test-command does nothing on the raw loop");
+        assert!(err.contains("--test-command"), "{err}");
+        assert!(err.contains("--pipeline classic"), "{err}");
+
+        let err =
+            reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, true, false)
+                .expect_err("--keep-witness does nothing on the raw loop");
+        assert!(err.contains("--keep-witness"), "{err}");
+
+        let err =
+            reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, true)
+                .expect_err("--require-verified does nothing on the raw loop");
+        assert!(err.contains("--require-verified"), "{err}");
+    }
+
+    /// The same three flags are accepted once `--pipeline classic` selects
+    /// the staged pipeline — the refusal only fires against a resolution
+    /// that cannot honor the flag, never against `Classic` itself.
+    #[test]
+    fn verification_flags_are_accepted_with_pipeline_classic() {
+        reject_verification_flags_without_pipeline(
+            PipelineChoice::Classic,
+            Some("pytest"),
+            true,
+            true,
+        )
+        .expect("classic runs the verification machinery these flags belong to");
+    }
+
+    /// A bare raw run with none of the three flags is unaffected — the gate
+    /// only fires when a flag was actually passed.
+    #[test]
+    fn a_bare_raw_run_with_no_verification_flags_is_unaffected() {
+        reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, false)
+            .expect("no verification flag was passed — nothing to refuse");
+    }
+
+    /// `--test-command` is meaningful on a named plugin variant too — it arms
+    /// the wrapper's own oracle (#3553) — so it is accepted there, while
+    /// `--keep-witness`/`--require-verified` remain pipeline-only and are
+    /// still refused, naming `classic` as the remedy.
+    #[test]
+    fn plugin_variant_accepts_test_command_but_still_refuses_witness_flags() {
+        reject_verification_flags_without_pipeline(
+            PipelineChoice::Plugin("budget-v1"),
+            Some("pytest"),
+            false,
+            false,
+        )
+        .expect("test-command arms the bound wrapper's own oracle");
+
+        let err = reject_verification_flags_without_pipeline(
+            PipelineChoice::Plugin("budget-v1"),
+            None,
+            true,
+            false,
+        )
+        .expect_err("keep-witness is pipeline-only, even under a named variant");
+        assert!(err.contains("--keep-witness"), "{err}");
+        assert!(err.contains("--pipeline classic"), "{err}");
     }
 
     /// A wrapper plugin is a child process the host starts, so the enterprise

--- a/crates/stella-cli/tests/verification_flags_require_pipeline_cli.rs
+++ b/crates/stella-cli/tests/verification_flags_require_pipeline_cli.rs
@@ -131,3 +131,65 @@ fn a_bare_raw_run_never_prints_the_verification_refusal() {
         "a bare run must never hit the verification-flag refusal: {stderr}"
     );
 }
+
+/// **Witness (#3696, arena door).** `stella arena` inherited the same gap:
+/// it resolved `PipelineChoice::resolve(no_pipeline, None)` — always `Raw`
+/// after #3381 — and handed `--test-command` to a driver with no verify
+/// ladder to arm, so a benchmark runner asking for an oracle got a number
+/// measured without one and no way to tell. Fails on the pre-fix tree (the
+/// flag was accepted and inert; `--pipeline` did not even parse), passes on
+/// this one.
+#[test]
+fn arena_test_command_is_refused_without_pipeline() {
+    let (workspace, data) = fresh_dirs();
+    let out = run_stella(
+        workspace.path(),
+        data.path(),
+        &[
+            "arena",
+            "--task-dir",
+            ".",
+            "--journal",
+            "journal.jsonl",
+            "--state-dir",
+            "state",
+            "--test-command",
+            "pytest",
+        ],
+    );
+    assert!(!out.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--test-command"), "{stderr}");
+    assert!(stderr.contains("--pipeline classic"), "{stderr}");
+}
+
+/// The companion half: `--pipeline classic` gives the flag a ladder to arm,
+/// so the same invocation is no longer refused. It fails later for its own
+/// reasons (no `TASK.md`, no reachable provider) — what this proves is that
+/// the refusal is scoped to the resolution that cannot honor the flag.
+#[test]
+fn arena_test_command_is_accepted_with_pipeline_classic() {
+    let (workspace, data) = fresh_dirs();
+    let out = run_stella(
+        workspace.path(),
+        data.path(),
+        &[
+            "arena",
+            "--task-dir",
+            ".",
+            "--journal",
+            "journal.jsonl",
+            "--state-dir",
+            "state",
+            "--pipeline",
+            "classic",
+            "--test-command",
+            "pytest",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("staged pipeline's verification machinery"),
+        "--pipeline classic must accept --test-command: {stderr}"
+    );
+}

--- a/crates/stella-cli/tests/verification_flags_require_pipeline_cli.rs
+++ b/crates/stella-cli/tests/verification_flags_require_pipeline_cli.rs
@@ -1,0 +1,133 @@
+//! `stella run --keep-witness` / `--require-verified` / `--test-command`
+//! silently no-op on the raw loop that #3381 made the default (#3696).
+//!
+//! `run_raw_one_shot` never accepted `keep_witness`/`require_verified` as
+//! parameters at all, and only threads `test_command` to a *bound wrapper
+//! plugin's* own oracle — so before this fix, `stella run --keep-witness
+//! "…"` (the single most common invocation shape after the flip) would start
+//! a paid model call and then simply drop the flag. These tests exercise the
+//! real binary end to end: the refusal must fire on the process's own stderr
+//! and exit code, before any provider is ever contacted — no real network
+//! host is named, and no API key is real, so if this reached a provider it
+//! would either hang or fail for an unrelated reason, not print this exact
+//! refusal text.
+//!
+//! `crates/stella-cli/src/wrapper_plugin.rs`'s
+//! `reject_verification_flags_without_pipeline` unit tests already cover the
+//! decision exhaustively; this file's only job is proving `stella run`'s
+//! door actually calls it before dispatch.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+fn run_stella(workspace: &Path, data: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_stella"))
+        .args([
+            "--model",
+            "openrouter/z-ai/glm-5.1",
+            "--api-key",
+            "sk-not-a-real-key",
+        ])
+        .args(args)
+        .current_dir(workspace)
+        .env("STELLA_DATA_DIR", data)
+        // Never read the developer's project env, and never inherit a real
+        // key: this test must not be able to reach a provider.
+        .env("STELLA_NO_ENV_FILE", "1")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run stella")
+}
+
+fn fresh_dirs() -> (tempfile::TempDir, tempfile::TempDir) {
+    (
+        tempfile::tempdir().expect("workspace"),
+        tempfile::tempdir().expect("data dir"),
+    )
+}
+
+/// **Witness (#3696).** Fails on the pre-fix tree — no such refusal exists,
+/// so this exact invocation reaches `run_one_shot` and attempts to start a
+/// provider call rather than refusing outright — and passes on this one:
+/// refused before dispatch, naming the remedy.
+#[test]
+fn keep_witness_alone_is_refused_without_pipeline() {
+    let (workspace, data) = fresh_dirs();
+    let out = run_stella(
+        workspace.path(),
+        data.path(),
+        &["run", "--keep-witness", "say hi"],
+    );
+    assert!(!out.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--keep-witness"), "{stderr}");
+    assert!(stderr.contains("--pipeline classic"), "{stderr}");
+}
+
+#[test]
+fn require_verified_alone_is_refused_without_pipeline() {
+    let (workspace, data) = fresh_dirs();
+    let out = run_stella(
+        workspace.path(),
+        data.path(),
+        &["run", "--require-verified", "say hi"],
+    );
+    assert!(!out.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--require-verified"), "{stderr}");
+    assert!(stderr.contains("--pipeline classic"), "{stderr}");
+}
+
+#[test]
+fn test_command_alone_is_refused_without_pipeline() {
+    let (workspace, data) = fresh_dirs();
+    let out = run_stella(
+        workspace.path(),
+        data.path(),
+        &["run", "--test-command", "pytest", "say hi"],
+    );
+    assert!(!out.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--test-command"), "{stderr}");
+    assert!(stderr.contains("--pipeline classic"), "{stderr}");
+}
+
+/// The refusal is scoped to the three verification flags, not to
+/// `--pipeline` being absent: with none of them passed, `stella run` never
+/// hits the refusal's error text at all (it goes on to fail differently,
+/// against the closed loopback port — the pre-existing #960 shutdown-path
+/// shape `run_exits_cli.rs` already covers).
+#[test]
+fn a_bare_raw_run_never_prints_the_verification_refusal() {
+    let (workspace, data) = fresh_dirs();
+    let out = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .args([
+            "--model",
+            "openrouter/z-ai/glm-5.1",
+            "--api-key",
+            "sk-not-a-real-key",
+            // Closed port on loopback: connection refused, at once — never a
+            // real network call.
+            "--base-url",
+            "http://127.0.0.1:1",
+            "--spend-limit",
+            "0.05",
+            "run",
+            "say hi",
+        ])
+        .current_dir(workspace.path())
+        .env("STELLA_DATA_DIR", data.path())
+        .env("STELLA_NO_ENV_FILE", "1")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run stella");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("staged pipeline's verification machinery"),
+        "a bare run must never hit the verification-flag refusal: {stderr}"
+    );
+}

--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -6,10 +6,11 @@ status: living
 
 # The journey of a prompt — full pipeline mode, in plain language
 
-**Status:** Living document. Describes the staged pipeline as of 0.6.x.
+**Status:** Living document. Describes the staged pipeline (`--pipeline classic`)
+as of 0.6.x.
 
 This is the maintainer's companion to the user-facing
-[Inference Pipeline](../website/content/docs/inference-pipeline.mdx) page. That
+[Inference Pipeline](/docs/inference-pipeline) page. That
 page explains *what* the pipeline promises; this one walks a single prompt from
 the moment it enters `stella run` to the moment the run reports done, naming
 the module that owns each step so you can find the code in one hop. Everything
@@ -36,16 +37,22 @@ a test that merely restates the patch.
 
 ## 0. What "full pipeline mode" is
 
-Stella has two ways to run a prompt:
+Stella has two ways to run a prompt, and since #3381/#3694 the raw loop is the
+default on every door (`run`, `arena`, `goal`, `fleet`, the Command Deck):
 
-- **The raw step loop** (`stella run --no-pipeline`, and interactive chat):
+- **The raw step loop** (the default; `--no-pipeline` is a deprecated hidden
+  no-op that names it explicitly, as does interactive chat):
   `stella-core::Engine::run_turn` — the model proposes tool calls, tools run,
   results feed back, repeat until the model stops or a budget/backstop fires.
   No stages, no verification.
-- **The staged pipeline** (`stella run`, the default; per-turn in the Command
-  Deck while `/pipeline` is ON): the step loop wrapped in the stages below,
-  with deterministic verification and terminal-event ownership moved up into
-  `Pipeline::run`.
+- **The staged pipeline** (`stella run --pipeline classic`, opt-in; per-turn
+  in the Command Deck while `/pipeline` is ON): the step loop wrapped in the
+  stages below, with deterministic verification and terminal-event ownership
+  moved up into `Pipeline::run`. `--pipeline classic` is one instance of the
+  general `--pipeline <variant>` opt-in — the wrapper socket
+  (`stella-runtime::wrapper`) drives an installed wrapper plugin the same way
+  for any other variant id, with `plugins/stella-research` shipped as the
+  reference plugin.
 
 "Full pipeline mode" is the second one. The engine still does all the actual
 work — reading files, editing, running commands — but the pipeline decides

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -206,10 +206,20 @@ loops on your API budget).
 
 ### The invariant
 
-Stella refuses to call a task done until a **witness test** proves it: a test
+Opted into the staged pipeline (`stella run --pipeline classic`), Stella
+refuses to call a task done until a **witness test** proves it: a test
 that **fails on the old code** (the feature is genuinely absent) and **passes
-on the new code** (the feature is genuinely present). This is enforced by the
-staged pipeline's witness stage (`stella-pipeline`):
+on the new code** (the feature is genuinely present). This is a **property of
+the path that produced the evidence, not of the binary**: the built-in staged
+pipeline's witness stage (`stella-pipeline`) runs the check itself and watches
+the fail→pass flip, as described below; verification supplied by an installed
+wrapper plugin on `--pipeline <other-variant>` is that plugin's own
+**self-reported** evidence, which Stella evaluates against a declared rule
+rather than re-running or re-checking. The raw step loop (the default on
+every door) makes no witness-test claim at all — it has no verification
+stage.
+
+The staged-pipeline mechanism, `--pipeline classic` specifically:
 
 1. The worker executes the change.
 2. When no `--test-command` is configured, an independent model — the

--- a/docs/spec/config-system/DESIGN.md
+++ b/docs/spec/config-system/DESIGN.md
@@ -278,9 +278,17 @@ test asserting the result is never more permissive than either input.
 
 ### 4.5 Pipeline stages
 
-Today the staged pipeline (triage → plan → witness → execute → verify →
-verifier) is hard-coded in `stella-pipeline`, and `--no-pipeline` is the only
-control — it turns the whole thing off and drops to the raw step-loop.
+The raw step loop is the default on every door; `stella run --pipeline
+classic` opts into the staged pipeline (`stella run --pipeline <variant>`
+opts into any other installed wrapper plugin instead, `--no-pipeline` is now
+a deprecated hidden no-op). The `classic` variant's stage order itself is no
+longer hard-coded: it is declared in `crates/stella-pipeline/variants/classic.toml`'s
+`[wrapper]` block and resolved through `Pipeline::begin_turn_schedule`
+(`src/pipeline/schedule_wiring.rs`) into the `Schedule` that actually drives
+dispatch (#3408). The manifest declares only the order and what its closed
+condition grammar can express, so the proposal below — a
+`[pipeline.stages.<name>]` config block — would need to compose with that
+manifest rather than with a single on/off switch.
 
 `[pipeline.stages.<name>]` gives each stage `enabled`, `on_disable`
 (`skip` | `fail`), and where relevant `max_revisions` / `routes_to`.

--- a/docs/spec/config-system/stella.next.toml
+++ b/docs/spec/config-system/stella.next.toml
@@ -222,11 +222,15 @@ prompt_file = ".stella/prompts/security-reviewer.md"
 # =============================================================================
 # PIPELINE  ── NEW
 # =============================================================================
-# Today the staged pipeline (triage -> plan -> witness -> execute -> verify ->
-# verdict) is hard-coded in `stella-pipeline`, and the only control is
-# `--no-pipeline`, which turns the entire thing off and drops to the raw
-# step-loop. There is no way to say "skip the verdict" or "allow three revision
-# rounds".
+# The raw step loop is the default on every door; `stella run --pipeline
+# classic` opts into the staged pipeline (triage -> plan -> witness -> execute
+# -> verify -> verdict), and `--pipeline <variant>` opts into any other
+# installed wrapper plugin the same way (`--no-pipeline` is now a deprecated
+# hidden no-op). The `classic` stage order is declared, not hard-coded --
+# `crates/stella-pipeline/variants/classic.toml`'s `[wrapper]` block, resolved
+# through `schedule_wiring.rs` (#3408) -- but that manifest has no way to say
+# "skip the verdict" or "allow three revision rounds"; that is the gap this
+# proposed block still fills.
 #
 # ONE `enabled` FLAG, NOT TWO. The original example had `[agents.*].enabled`
 # and `[pipeline.stages.*].enabled` both answering "does this run", and

--- a/docs/why-stella.md
+++ b/docs/why-stella.md
@@ -37,13 +37,16 @@ Most agents decide they are *done* when a test suite passes. That accepts two
 failure modes silently: a suite that was already green, and an edit that doesn't
 actually exercise the fix. Stella rejects both.
 
-The staged pipeline (`stella run`, on by default) demands a **witness test**:
-one that must **fail on the previous code** and **pass on your change**. A
-green suite alone is never accepted — the fail → pass
+Opt into the staged pipeline with `stella run --pipeline classic` and it demands
+a **witness test**: one that must **fail on the previous code** and **pass on
+your change**. A green suite alone is never accepted — the fail → pass
 transition *is* the evidence. Hand it your own test with `--test-command`, or
 the pipeline spawns an independent **witness author** that
 writes the failing test, tamper-excluded from the code under change, so the flip
-cannot be gamed. Deterministic definition of done, enforced by construction —
+cannot be gamed. That guarantee is host-run and belongs to the `--pipeline
+classic` path specifically — a wrapper plugin's own verification is
+self-reported evidence Stella evaluates against a declared rule rather than
+re-running itself. Deterministic definition of done, enforced by construction —
 see [the inference pipeline](https://stella.oxagen.sh/docs/inference-pipeline).
 
 ## An engine you can actually reason about

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -13,7 +13,7 @@ This command exists for **benchmarking stella, not for using it**. If you want t
 
 ```bash
 stella arena --task-dir <DIR> --journal <FILE> --state-dir <DIR> [--resume]
-             [--no-pipeline] [--test-command <CMD>]
+             [--no-pipeline] [--pipeline <VARIANT>] [--test-command <CMD>]
 ```
 
 ## What it does
@@ -61,25 +61,32 @@ arena-bench invokes an agent with `--task-dir`/`--journal`/`--state-dir`/`[--res
     (see below) — this flag named that fallback before #3381 flipped the
     default and is kept parseable only so no runner script breaks.
   </OptionCard>
+  <OptionCard name="--pipeline <VARIANT>">
+    Run every episode under a wrapper, by the `[wrapper] id` its manifest
+    declares (`stella plugin list`). `classic` names the built-in staged
+    pipeline; omitted, the raw step-loop runs with nothing over it — the
+    default since #3381. The same flag [`stella run`](/docs/commands/run)
+    takes, so a panel can measure either driver.
+  </OptionCard>
   <OptionCard name="--test-command <CMD>">
     Test command for the staged pipeline's deterministic verify ladder, e.g.
-    `--test-command "cargo test -p my-crate"`. Currently inert: this adapter
-    has no `--pipeline <VARIANT>` flag of its own, so an episode has no
-    ladder for it to arm — see the note below.
+    `--test-command "cargo test -p my-crate"`. It belongs to that ladder, so
+    pair it with `--pipeline classic` — passed against the raw default it is
+    **refused before the episode starts**, with an error naming
+    `--pipeline classic`, rather than silently arming no oracle.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-**Every arena episode measures the raw step-loop, unconditionally**, since
-[#3381](https://github.com/macanderson/stella/issues/3381) flipped
+**An arena episode measures the raw step-loop unless you say otherwise**,
+since [#3381](https://github.com/macanderson/stella/issues/3381) flipped
 `PipelineChoice::resolve`'s no-flag default from the staged pipeline to raw.
-This adapter has no `--pipeline <VARIANT>` flag the way [`stella
-run`](/docs/commands/run) does, so there is currently no way to make an arena
-episode run the staged pipeline (or a wrapper plugin) at all — `--no-pipeline`
-was always a synonym for the same no-flag default and stayed one across the
-flip. A panel run against this binary before and after #3381 is comparing the
-staged pipeline to the raw loop, not two builds of the same thing; name that
-comparison rather than reporting it as a plain regression.
+Pass `--pipeline classic` to measure the staged pipeline, or
+`--pipeline <variant>` for an installed wrapper plugin; `--no-pipeline` was
+always a synonym for the same no-flag default and stayed one across the flip.
+A panel run against this binary before and after #3381 **without** that flag
+is comparing the staged pipeline to the raw loop, not two builds of the same
+thing; name that comparison rather than reporting it as a plain regression.
 </Callout>
 
 ## Why the journal is written before the event is admitted
@@ -136,6 +143,6 @@ runner preserves between episodes (and wipes for the `amnesic` arm). A fixture t
 
 ## See also
 
-- [Inference pipeline](/docs/inference-pipeline) — the staged path every arena episode runs without, since #3381 flipped the default and this adapter has no `--pipeline <VARIANT>` flag to opt back in.
+- [Inference pipeline](/docs/inference-pipeline) — the staged path an episode runs only when `--pipeline classic` asks for it, since #3381 flipped the no-flag default to the raw loop.
 - [`stella run`](/docs/commands/run) — the ordinary one-shot path this adapter drives underneath.
 - [arena-bench](https://github.com/macanderson/arena-bench) — the harness that invokes this command.

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -50,12 +50,16 @@ A run typed at a terminal is [supervised](/docs/commands/daemon): it survives th
     `"cargo test -p my-crate"`. Arms the fail→pass flip oracle: a change that flips a
     failing test to passing is proven done. Omitted, the pipeline's witness stage is the
     remaining oracle, and a turn that reaches neither is reported unverified — not passed.
+    Refused on the raw loop (pass `--pipeline classic` or `--pipeline <variant>` — a
+    wrapper plugin's own oracle can arm it too).
   </OptionCard>
   <OptionCard name="--keep-witness">
     Keep the authored witness test as a file in your working tree. By default the witness
     is scaffolding — it proves this run's goal inside the candidate workspace and is
     discarded with it, so an already-satisfied test is never left behind in your test
-    tree. Pass this to promote it to a real test you can commit.
+    tree. Pass this to promote it to a real test you can commit. Pipeline-only: refused
+    on the raw loop and on a named `--pipeline <variant>` alike — pass `--pipeline
+    classic`.
   </OptionCard>
   <OptionCard name="--require-verified">
     Exit non-zero unless the run was actually verified. A run that finished but that
@@ -63,7 +67,7 @@ A run typed at a terminal is [supervised](/docs/commands/daemon): it survives th
     with no `--test-command` that is the ordinary outcome, so failing on it by default
     would break every existing script. Pass this in a delivery gate that must not ship
     unproven work: it turns "completed but unproven" into a failure exactly like a
-    refuted verification.
+    refuted verification. Pipeline-only, same refusal as `--keep-witness`.
   </OptionCard>
 </CardGrid>
 
@@ -127,7 +131,8 @@ stella --model local/llama3.3 --base-url http://localhost:11434/v1 \
 
 `--test-command`, `--keep-witness`, and `--require-verified` all belong to the staged
 pipeline's verify/witness machinery, so pair them with `--pipeline classic` — on the
-raw loop (the default) there is no ladder for them to arm.
+raw loop (the default) there is no ladder for them to arm, and `stella run` refuses
+the combination outright rather than silently ignoring the flag.
 
 Hand the verify stage a deterministic oracle, so a fixed test can submit without a
 model-verifier call:


### PR DESCRIPTION
## What & why

Five findings from the #3694 flip's post-merge adversarial audit (3 P1, 2 P2), all fixed and re-audited:

1. **P1** — `stella run --keep-witness` / `--require-verified` / `--test-command` were silently dropped on the now-default raw loop (also flagged by the Vercel review bot; #3696). Now refused before dispatch via `wrapper_plugin::reject_verification_flags_without_pipeline`, naming `--pipeline classic` as the remedy: `Raw` refuses all three, `Plugin(variant)` accepts `--test-command` and refuses the other two, `Classic` accepts all. **Arena included**: `1332dd1` (thanks @macanderson) gives `stella arena` the same `--pipeline <VARIANT>` flag and wires the identical refusal, so `--test-command` there is honored or refused, never inert — `arena.mdx` updated to match.
2. **P1** — a pre-flip deck session that never touched `/pipeline` was indistinguishable from an always-raw one and silently swapped driver + system-prompt persona on resume (invariant 7). `session_persist::derive_pipeline_persona`/`initial_pipeline_persona`: an explicit journal record wins; history-without-record restores ON (the default that session ran under); fresh sessions start raw. Session start now journals the resolved value so no future flip faces the ambiguity.
3. **P1** — the comment stating the `authorize_one_shot(!pipeline.is_raw())` surface widening now exists at the call site (`agent.rs:128`).
4. **P2** — the goal/fleet plugin-variant refusal now cites its real tracking issue #3695 (was #3684).
5. **P2** — the `--no-pipeline` deprecation notice printed twice under the supervised terminal posture; now printed exactly once, after the supervision decision.

Refs #3381
Closes #3696

## The witness

- [x] `crates/stella-cli/tests/verification_flags_require_pipeline_cli.rs` (6 tests, end-to-end through the real binary): each verification flag alone under the raw default is refused; accepted with `--pipeline classic`; arena both ways (`arena_test_command_is_refused_without_pipeline`, `arena_test_command_is_accepted_with_pipeline_classic`). `session_persist::tests`: legacy-history-restores-ON / fresh-starts-OFF / explicit-record-wins. All fail on the pre-fix tree.

## The gate

- [x] `cargo fmt --check` (clean)
- [x] `cargo clippy -p stella-cli -p stella-store -p stella-tui --all-targets -- -D warnings` (clean)
- [x] `cargo test`: stella-cli 1843/1843, tui 889 (+1 pre-existing ignored), store 357+31 — 0 failed; full workspace runs in CI on this head
- [x] Docs updated where flags changed (`run.mdx`, `arena.mdx`, clap help)
- [x] `Closes #3696` above and as a commit trailer

## Nothing left behind

- [x] Tracked: #3695 (wrapper driver through goal/fleet), #3682 (witness_authored placeholder), #3684 (flip umbrella). Nothing new left untracked by this round.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- One flaky unrelated test observed once in a full `-p stella-cli` run (`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`, a SIGTERM grace-timing test); it passes alone and on re-run.
- Draft status is the owner's; the branch is complete and validated from this session's side.

## Summary by Sourcery

Prevent verification options from being silently ignored and preserve compatible pipeline personas when resuming legacy sessions.

New Features:
- Add pipeline selection to `stella arena`, enabling raw, classic, and installed wrapper-plugin benchmark runs.

Bug Fixes:
- Reject verification flags when the selected driver cannot honor them instead of silently ignoring them.
- Restore the staged-pipeline persona for legacy deck sessions on resume and persist the resolved persona for future resumes.
- Print the `--no-pipeline` deprecation notice only once during supervised runs.

Enhancements:
- Clarify that the raw loop is the default and the staged pipeline is opt-in across CLI behavior and user-facing documentation.
- Correct the tracking reference for unsupported plugin variants on goal and fleet commands.

Documentation:
- Update CLI, arena, README, design, and guidance documentation to reflect opt-in pipeline behavior and verification-flag restrictions.

Tests:
- Add unit and end-to-end coverage for verification-flag refusals, arena pipeline selection, and legacy-session persona restoration.