### PR TITLE
fix(stella-embed): redact API keys in Debug, cover STELLA_EMBED_FLOOR parsing

### DIFF
--- a/crates/stella-embed/src/http.rs
+++ b/crates/stella-embed/src/http.rs
@@ -34,6 +34,7 @@
 //! [`Resolution::Incomplete`], which names the missing piece rather than
 //! silently behaving as if nothing were configured at all.
 
+use std::fmt;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -75,7 +76,7 @@ const KNOWN_DIMS: &[(&str, usize)] = &[
 
 /// The environment [`resolve`] reads, captured as data so resolution is a pure
 /// function and its table of precedences is testable.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct EmbedderEnv {
     /// `STELLA_EMBED_URL`.
     pub url: Option<String>,
@@ -111,6 +112,39 @@ impl EmbedderEnv {
             voyage_api_key: read("VOYAGE_API_KEY"),
             openai_api_key: read("OPENAI_API_KEY"),
         }
+    }
+}
+
+/// A secret field's *presence*, never its value. Debug output is the one
+/// rendering of these structs that reaches a log line, a `dbg!()`, or a panic
+/// message without anyone deciding it should, so the key never travels in it —
+/// while whether a key was set at all is exactly what a reader is debugging.
+struct Redacted<'a>(&'a Option<String>);
+
+impl fmt::Debug for Redacted<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(_) => f.write_str("Some(<redacted>)"),
+            None => f.write_str("None"),
+        }
+    }
+}
+
+/// Hand-rolled so the three key fields cannot be printed. Deriving `Debug`
+/// here would put a live API key one `{:?}` away from a log file; this crate
+/// is a leaf and cannot borrow `stella-model`'s `ApiKey`, so it copies the
+/// shape of that type's redacting impl (`crates/stella-model/src/credential.rs`).
+impl fmt::Debug for EmbedderEnv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EmbedderEnv")
+            .field("url", &self.url)
+            .field("model", &self.model)
+            .field("api_key", &Redacted(&self.api_key))
+            .field("dims", &self.dims)
+            .field("floor", &self.floor)
+            .field("voyage_api_key", &Redacted(&self.voyage_api_key))
+            .field("openai_api_key", &Redacted(&self.openai_api_key))
+            .finish()
     }
 }
 
@@ -220,7 +254,6 @@ fn dims_for(model: &str, override_dims: Option<&str>) -> Result<usize, String> {
 }
 
 /// An embedder backed by an OpenAI-shaped `/embeddings` endpoint.
-#[derive(Debug)]
 pub struct HttpEmbedder {
     endpoint: String,
     model: String,
@@ -262,6 +295,22 @@ impl HttpEmbedder {
     /// user *where* its vectors came from without re-deriving the URL.
     pub fn endpoint(&self) -> &str {
         &self.endpoint
+    }
+}
+
+/// Hand-rolled for the same reason as [`EmbedderEnv`]'s: the bearer token this
+/// struct holds must not reach a log line through a derived `Debug`.
+/// [`Resolution`] keeps its derive, since the key is only reachable through
+/// here.
+impl fmt::Debug for HttpEmbedder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpEmbedder")
+            .field("endpoint", &self.endpoint)
+            .field("model", &self.model)
+            .field("api_key", &Redacted(&self.api_key))
+            .field("dims", &self.dims)
+            .field("admission_floor", &self.admission_floor)
+            .finish_non_exhaustive()
     }
 }
 
@@ -466,6 +515,69 @@ mod tests {
             panic!("expected a configured embedder");
         };
         assert_eq!(embedder.fingerprint().model_id, "voyage-code-3");
+    }
+
+    /// #3713: a derived `Debug` on either type put a live bearer token one
+    /// `{:?}` away from a log line. Fails on the derive, passes on the
+    /// hand-rolled impls.
+    #[test]
+    fn debug_never_prints_a_key_from_the_environment() {
+        let env = env_with(&[
+            ("STELLA_EMBED_API_KEY", "sk-secret-value"),
+            ("VOYAGE_API_KEY", "vk-secret-value"),
+            ("OPENAI_API_KEY", "os-secret-value"),
+            ("STELLA_EMBED_URL", "http://127.0.0.1:11434/v1"),
+        ]);
+        let debug = format!("{env:?}");
+        assert!(!debug.contains("sk-secret-value"), "{debug}");
+        assert!(!debug.contains("vk-secret-value"), "{debug}");
+        assert!(!debug.contains("os-secret-value"), "{debug}");
+        assert!(debug.contains("redacted"), "{debug}");
+        // Presence is not the secret, and it is the thing being debugged.
+        assert!(debug.contains("http://127.0.0.1:11434/v1"), "{debug}");
+    }
+
+    /// #3713, the transitive half: `Resolution` keeps a derived `Debug`, so
+    /// the embedder's own impl is what stops the key travelling with it.
+    #[test]
+    fn debug_never_prints_the_key_a_resolution_carries() {
+        let resolution = resolve(&env_with(&[("OPENAI_API_KEY", "sk-secret-value")]));
+        let debug = format!("{resolution:?}");
+        assert!(!debug.contains("sk-secret-value"), "{debug}");
+        assert!(debug.contains("redacted"), "{debug}");
+    }
+
+    /// #3714: `parse::<f32>` accepts `nan` and `inf`, so the `is_finite`
+    /// guard is the only thing rejecting them. Nothing exercised it.
+    #[test]
+    fn a_malformed_floor_is_rejected_rather_than_swallowed() {
+        for raw in ["not-a-number", "nan", "inf", "-inf"] {
+            let env = env_with(&[("STELLA_EMBED_FLOOR", raw), ("OPENAI_API_KEY", "sk")]);
+            let Resolution::Incomplete(message) = resolve(&env) else {
+                panic!("expected `{raw}` to be rejected");
+            };
+            assert!(message.contains("STELLA_EMBED_FLOOR"), "{message}");
+            assert!(message.contains(raw), "{message}");
+        }
+    }
+
+    /// #3714: the floor has to reach the embedder, not just parse. Compared
+    /// against `DEFAULT_ADMISSION_FLOOR` so a silently-ignored override fails
+    /// here rather than degrading retrieval quality in the field.
+    #[test]
+    fn a_parsed_floor_reaches_the_embedder() {
+        let env = env_with(&[("STELLA_EMBED_FLOOR", "0.6"), ("OPENAI_API_KEY", "sk")]);
+        let Resolution::Configured(embedder) = resolve(&env) else {
+            panic!("expected a configured embedder");
+        };
+        let SimilarityPosture::Semantic { admission_floor } = embedder.similarity_posture() else {
+            panic!("expected a semantic posture");
+        };
+        assert_eq!(admission_floor, 0.6);
+        assert_ne!(
+            admission_floor, DEFAULT_ADMISSION_FLOOR,
+            "the override must not collapse to the default"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Two `stella-embed` findings from the same audit pass, both in `crates/stella-embed/src/http.rs`.

**Redaction (#3713).** `EmbedderEnv` and `HttpEmbedder` derived `Debug` over fields holding live bearer tokens (`api_key`, `voyage_api_key`, `openai_api_key`; `api_key`). Nothing printed them today, which is what made it a trap rather than a leak: the derive was one `dbg!()`, log line or panic message away from a raw credential in a log file. Both types now carry a hand-rolled `Debug` that prints a `Redacted` marker for each key field and the real value for everything else — presence is not the secret, and *whether* a key was set is exactly what a reader is debugging, so `Redacted` renders `Some(<redacted>)` / `None` rather than flattening both to one string.

`stella-embed` is a leaf crate (no workspace dependencies, by contract in its `Cargo.toml`) and cannot borrow `stella-model`'s `ApiKey`, so this copies the *shape* of that type's redacting impl — `crates/stella-model/src/credential.rs:255` — not the type. `Resolution` keeps its derive as the issue specifies: the key is only reachable through the nested `HttpEmbedder`, which no longer prints it, and the second witness below pins that transitively.

**Coverage (#3714).** `STELLA_EMBED_FLOOR` had zero tests on either path. `parse::<f32>` accepts the strings `nan` and `inf`, so the separate `is_finite()` guard is the only thing rejecting them — a guard a careless edit could drop silently. Nor did anything prove a parsed floor actually reaches the embedder rather than collapsing to `DEFAULT_ADMISSION_FLOOR` (0.25). No production code changed for this half; it is four new cases plus a success path.

Closes #3713
Closes #3714

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four tests, each checked against the pre-fix code by mutating it back and re-running (not asserted from the diff):

| Mutation | Test that turns red |
|---|---|
| restore `#[derive(Debug)]` on both structs | `debug_never_prints_a_key_from_the_environment`, `debug_never_prints_the_key_a_resolution_carries` (both) |
| drop the `is_finite()` guard | `a_malformed_floor_is_rejected_rather_than_swallowed` (on `nan` / `inf`; the `not-a-number` case survives, which is why the loop carries all four) |
| pass `DEFAULT_ADMISSION_FLOOR` instead of the parsed `floor` | `a_parsed_floor_reaches_the_embedder` |

Each mutation was reverted and the suite re-run green afterwards.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

`make gate CARGO_SCOPE="-p stella-embed -p stella-tools -p stella-cli"` exits 0. Scoped to the three crates the diff reaches: `stella-embed` plus the two consumers that enable its `http` feature (`stella-tools`, `stella-cli`). `stella-context` and `stella-graph` take the crate without that feature, so this code is not compiled into them.

Note the `http` module is behind the non-default `http` feature — a bare `cargo test -p stella-embed` runs none of these tests. `cargo test -p stella-embed --features http`: 40 passed.

## Nothing left behind

- [x] There is nothing new: everything I noticed is fixed in this PR

One thing worth stating rather than filing: the first `make gate` run failed on `daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period` (child killed after 82ms of its 8s window). It is unrelated to this diff and already tracked twice — #3559 and #3588 — so I linked rather than duplicated. Control run: the full `stella-cli` suite on the stashed tree passed, and the same three-crate scope with this change passed 2/2 and the full gate then exited 0.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

`stella-embed`'s leaf status is preserved — no dependency added, workspace or external.

## Anything reviewers should know?

`HttpEmbedder`'s impl ends in `finish_non_exhaustive()`, which elides the `reqwest::Client` field. That is deliberate: the client carries no secret but its own `Debug` is noise, and `..` states honestly that a field was withheld. `EmbedderEnv` uses plain `finish()` — every one of its fields is accounted for.

Field order in both impls follows declaration order, so a future field added to either struct is a visible omission in review rather than a silent one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSjCr5r7eEei3vXoLRweyp)_

## Summary by Sourcery

Protect stella-embed credentials in debug output and validate and apply embedding admission-floor configuration.

Bug Fixes:
- Prevent API keys from appearing in debug output for embedder environment, HTTP embedder, and nested resolutions.
- Reject non-finite and otherwise malformed STELLA_EMBED_FLOOR values instead of silently accepting them.
- Ensure valid STELLA_EMBED_FLOOR overrides are applied to the configured embedder.

Tests:
- Add regression coverage for API-key redaction, malformed floor values, and propagation of parsed admission floors.