### PR TITLE
refactor(stella-store): typed StoreError enum, plus the missing efficacy.rs tests

### DIFF
--- a/crates/stella-store/README.md
+++ b/crates/stella-store/README.md
@@ -117,6 +117,7 @@ escape hatch for an irreducible line (a module declaration in an oversized
 | File | What it holds |
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The `Store` handle, `open`/`in_memory`/`migrate`, the row types, and most of the query surface. Start here. |
+| [`src/error.rs`](src/error.rs) | `StoreError` — every failure this crate returns, as named variants. A caller tells a corrupt file from a stale binary from an ordinary SQLite error by matching, not by reading prose (#3735). Add a variant only when a caller can act differently on it; everything else is `StoreError::Other`. |
 | [`src/ddl.rs`](src/ddl.rs) | Every table and index as DDL at the **current** `SCHEMA_VERSION`, plus the `TABLES` allowlist. The one place today's shape is written down. |
 | [`src/migrations.rs`](src/migrations.rs) | The ordered `MIGRATIONS` list, the fresh-file bootstrap, and the transactional runner. Open it to add a version. |
 | [`src/content_free.rs`](src/content_free.rs) | The zero-egress guard: the reviewed hub-column allowlist and the sentinel harness every egress encoder registers with. |

--- a/crates/stella-store/src/catalog.rs
+++ b/crates/stella-store/src/catalog.rs
@@ -650,7 +650,7 @@ impl CatalogStore {
             )
             .optional()?;
         let Some(model_provider) = model_provider else {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "cannot learn alias `{alias}`: model card {model_card_id} does not exist"
             )));
         };

--- a/crates/stella-store/src/content_free.rs
+++ b/crates/stella-store/src/content_free.rs
@@ -250,7 +250,7 @@ impl EncodedSample {
     /// Build a sample from a JSON encoding, flattening nested object keys.
     pub fn from_json(value: &Value) -> Result<Self> {
         let bytes = serde_json::to_vec(value)
-            .map_err(|err| StoreError(format!("cannot serialize encoder sample: {err}")))?;
+            .map_err(|err| StoreError::serde("cannot serialize encoder sample", err))?;
         let mut keys = BTreeSet::new();
         collect_keys(value, &mut keys);
         Ok(Self { bytes, keys })
@@ -554,7 +554,7 @@ impl ContentFreeEncoder for NativeDrainGuard {
     fn encode_poisoned_sample(&self) -> Result<EncodedSample> {
         let batch = DrainBatch::from_events(&[poisoned_cloud_event()]);
         let value = serde_json::to_value(&batch)
-            .map_err(|err| StoreError(format!("cannot encode drain batch: {err}")))?;
+            .map_err(|err| StoreError::serde("cannot encode drain batch", err))?;
         EncodedSample::from_json(&value)
     }
 }
@@ -700,7 +700,7 @@ impl ContentFreeEncoder for EnterpriseOperationalGuard {
         )?;
         let event = StellaOperationalEventV1::from_finalized_rollup(&context, &rollup)?;
         let value = serde_json::to_value(&event)
-            .map_err(|err| StoreError(format!("cannot encode operational event: {err}")))?;
+            .map_err(|err| StoreError::serde("cannot encode operational event", err))?;
         EncodedSample::from_json(&value)
     }
 }

--- a/crates/stella-store/src/durable.rs
+++ b/crates/stella-store/src/durable.rs
@@ -148,13 +148,13 @@ pub fn sync_directory(dir: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         let file = std::fs::File::open(dir).map_err(|e| {
-            StoreError(format!(
-                "cannot open directory {} for fsync: {e}",
-                dir.display()
-            ))
+            StoreError::io(
+                format!("cannot open directory {} for fsync", dir.display()),
+                e,
+            )
         })?;
         file.sync_all()
-            .map_err(|e| StoreError(format!("cannot fsync directory {}: {e}", dir.display())))?;
+            .map_err(|e| StoreError::io(format!("cannot fsync directory {}", dir.display()), e))?;
     }
     #[cfg(not(unix))]
     {
@@ -173,9 +173,9 @@ fn temp_sibling(path: &Path) -> Result<std::path::PathBuf> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
 
-    let name = path
-        .file_name()
-        .ok_or_else(|| StoreError(format!("durable path {} has no filename", path.display())))?;
+    let name = path.file_name().ok_or_else(|| {
+        StoreError::Other(format!("durable path {} has no filename", path.display()))
+    })?;
     let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
     let mut temp_name = name.to_os_string();
     temp_name.push(format!(".stella-tmp.{}.{sequence}", std::process::id()));
@@ -195,30 +195,30 @@ fn write_temp_then_rename(temp: &Path, path: &Path, bytes: &[u8], mode: u32) -> 
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
     let mut file = options
         .open(temp)
-        .map_err(|e| StoreError(format!("cannot create {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot create {}", temp.display()), e))?;
     let metadata = file
         .metadata()
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", temp.display()), e))?;
     if !metadata.is_file() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "temporary path {} is not a regular file",
             temp.display()
         )));
     }
     file.write_all(bytes)
-        .map_err(|e| StoreError(format!("cannot write {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot write {}", temp.display()), e))?;
     // After the write, never before: POSIX clears set-user-ID/set-group-ID on
     // write, so a mode applied first loses exactly the bits hardest to notice
     // missing. Before the fsync, so the metadata change is covered by it.
     // `set_permissions` rather than the `.mode()` above alone, because that
     // one is masked by the umask.
     file.set_permissions(std::fs::Permissions::from_mode(mode))
-        .map_err(|e| StoreError(format!("cannot set mode on {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot set mode on {}", temp.display()), e))?;
     file.sync_all()
-        .map_err(|e| StoreError(format!("cannot fsync {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot fsync {}", temp.display()), e))?;
     drop(file);
     std::fs::rename(temp, path)
-        .map_err(|e| StoreError(format!("cannot replace {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot replace {}", path.display()), e))?;
     if let Some(parent) = path.parent() {
         sync_directory(parent)?;
     }
@@ -237,17 +237,17 @@ fn write_temp_then_rename(temp: &Path, path: &Path, bytes: &[u8], _mode: u32) ->
         .write(true)
         .create_new(true)
         .open(temp)
-        .map_err(|e| StoreError(format!("cannot create {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot create {}", temp.display()), e))?;
     file.write_all(bytes)
-        .map_err(|e| StoreError(format!("cannot write {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot write {}", temp.display()), e))?;
     file.sync_all()
-        .map_err(|e| StoreError(format!("cannot fsync {}: {e}", temp.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot fsync {}", temp.display()), e))?;
     drop(file);
     // `std::fs::rename` is MoveFileEx(MOVEFILE_REPLACE_EXISTING) here, which
     // does replace an existing destination — the one thing the naive
     // "rename never overwrites on Windows" folklore gets wrong.
     std::fs::rename(temp, path)
-        .map_err(|e| StoreError(format!("cannot replace {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot replace {}", path.display()), e))?;
     Ok(())
 }
 
@@ -291,13 +291,13 @@ pub fn ensure_converged_schema_version(
 ) -> Result<()> {
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if version < 0 {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "{store} carries a negative schema version ({version}), so it is not a stella store \
              or its header was overwritten. Move the file aside and reopen to start a fresh one."
         )));
     }
     if version > current {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "{store} is at schema version {version}, but this build only knows {current} — your \
              stella binary is older than the workspace, not the other way round. Upgrade stella \
              (brew upgrade stella, install.sh, or a newer release build) and reopen."
@@ -313,7 +313,7 @@ pub fn ensure_converged_schema_version(
             |row| row.get(0),
         )?;
         if present == 0 {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "{store} is missing the table {table} that its schema declares, so it cannot be \
                  stamped at version {current}. Move the file aside and reopen to rebuild it."
             )));
@@ -373,11 +373,8 @@ mod tests {
 
         let error = write_atomic(&target, b"replacement", MODE_PRIVATE)
             .expect_err("renaming over a non-empty directory must fail");
-        assert!(
-            error.0.contains("cannot replace"),
-            "unexpected: {}",
-            error.0
-        );
+        let message = error.to_string();
+        assert!(message.contains("cannot replace"), "unexpected: {message}");
         assert!(
             strays(&dir).is_empty(),
             "a failed write left a temp behind: {:?}",
@@ -499,7 +496,8 @@ mod tests {
 
         let error = ensure_converged_schema_version(&conn, "test.db", 2, &["thing"])
             .expect_err("a newer store must fail closed");
-        assert!(error.0.contains("schema version 9"), "{}", error.0);
+        let message = error.to_string();
+        assert!(message.contains("schema version 9"), "{message}");
         assert_eq!(version(&conn), 9, "the future stamp must not be downgraded");
     }
 
@@ -508,7 +506,8 @@ mod tests {
         let conn = Connection::open_in_memory().expect("open");
         let error = ensure_converged_schema_version(&conn, "test.db", 1, &["thing"])
             .expect_err("an unconverged store must fail closed");
-        assert!(error.0.contains("missing the table thing"), "{}", error.0);
+        let message = error.to_string();
+        assert!(message.contains("missing the table thing"), "{message}");
         assert_eq!(version(&conn), 0, "no version is stamped onto a bad shape");
     }
 
@@ -520,6 +519,7 @@ mod tests {
             .expect("set");
         let error = ensure_converged_schema_version(&conn, "test.db", 1, &["thing"])
             .expect_err("a negative stamp must fail closed");
-        assert!(error.0.contains("negative schema version"), "{}", error.0);
+        let message = error.to_string();
+        assert!(message.contains("negative schema version"), "{message}");
     }
 }

--- a/crates/stella-store/src/efficacy.rs
+++ b/crates/stella-store/src/efficacy.rs
@@ -130,3 +130,238 @@ impl Store {
         Ok(executions)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{MemoryCitationRow, Store, ToolCallRow, ToolCallState};
+
+    /// One store with one finished execution, ready to hang rows off.
+    fn store() -> Store {
+        Store::in_memory().expect("in-memory store")
+    }
+
+    fn started(store: &Store, prompt: &str) -> i64 {
+        store
+            .begin_execution("run", prompt, "zai", "glm-5.2")
+            .expect("execution")
+    }
+
+    fn finished(store: &Store, prompt: &str) -> i64 {
+        let id = started(store, prompt);
+        store
+            .finish_execution(id, "completed", 0.0)
+            .expect("finish execution");
+        id
+    }
+
+    fn citation(memory_id: &str, remark: &str) -> MemoryCitationRow {
+        MemoryCitationRow {
+            memory_id: memory_id.into(),
+            useful_score: 4,
+            truthful: true,
+            remark: remark.into(),
+        }
+    }
+
+    fn call(name: &str, state: ToolCallState, error: &str) -> ToolCallRow {
+        ToolCallRow {
+            call_id: format!("call-{name}-{error}"),
+            name: name.into(),
+            surface: "native".into(),
+            args_json: "{}".into(),
+            args_digest: String::new(),
+            reason: String::new(),
+            state,
+            error: error.into(),
+            error_class: None,
+            bytes_out: 0,
+            duration_ms: 1,
+        }
+    }
+
+    /// The `outcome IS NOT NULL` filter is the whole point of the read: an
+    /// in-flight execution has no outcome to attribute a use to, and
+    /// extracting it early mints a `ContextUse` whose feedback can never
+    /// arrive.
+    #[test]
+    fn an_unfinished_execution_is_never_attributed() {
+        let store = store();
+        let running = started(&store, "still going");
+        let closed = finished(&store, "done");
+
+        let seen: Vec<i64> = store
+            .finished_executions_after(0, 10)
+            .expect("read")
+            .into_iter()
+            .map(|row| row.execution_id)
+            .collect();
+
+        assert_eq!(seen, vec![closed], "only the closed turn is attributable");
+        assert!(
+            !seen.contains(&running),
+            "an execution with a NULL outcome must not be extracted"
+        );
+    }
+
+    /// `after_execution_id` is a durable watermark: paging with it must walk
+    /// every finished row exactly once, in id order, with no gap and no
+    /// repeat.
+    #[test]
+    fn paging_by_the_watermark_walks_every_row_once_in_order() {
+        let store = store();
+        let ids: Vec<i64> = (0..5)
+            .map(|n| finished(&store, &format!("turn {n}")))
+            .collect();
+
+        let mut cursor = 0;
+        let mut walked = Vec::new();
+        loop {
+            let page = store.finished_executions_after(cursor, 2).expect("read");
+            if page.is_empty() {
+                break;
+            }
+            assert!(page.len() <= 2, "the limit is honoured: {}", page.len());
+            for row in &page {
+                assert!(
+                    row.execution_id > cursor,
+                    "a page must start strictly after the watermark"
+                );
+                walked.push(row.execution_id);
+            }
+            cursor = page.last().expect("non-empty").execution_id;
+        }
+
+        assert_eq!(walked, ids, "every finished row, once, oldest first");
+    }
+
+    /// A finished execution's outcome and session id are read back as written
+    /// — the fields an attribution is keyed on.
+    #[test]
+    fn a_finished_row_carries_its_outcome_and_session() {
+        let store = store();
+        let id = started(&store, "aborted turn");
+        store
+            .set_execution_session(id, "sess-1")
+            .expect("stamp session");
+        store
+            .finish_execution(id, "aborted", 0.0)
+            .expect("finish execution");
+
+        let row = store
+            .finished_executions_after(0, 10)
+            .expect("read")
+            .pop()
+            .expect("one finished execution");
+        assert_eq!(row.execution_id, id);
+        assert_eq!(row.outcome, "aborted");
+        assert_eq!(row.session_id.as_deref(), Some("sess-1"));
+        assert!(
+            row.finished_at.is_some(),
+            "a closed-out row carries its finish timestamp"
+        );
+    }
+
+    /// Only real failures are mined: a call that succeeded is the expected
+    /// case, and a call with no error text has nothing to say — a `running`
+    /// row is a turn still in flight, not a failure.
+    ///
+    /// `ok = 0` and `error <> ''` are not redundant, which is why `noisy` is
+    /// in the fixture: the columns are independent (`ok` is derived from
+    /// `state`, `error` is free text), so a succeeded call carrying text in
+    /// its `error` column is excluded by the `ok` clause alone, and a failed
+    /// call with nothing to say is excluded by the `error` clause alone. Drop
+    /// either and this test goes red.
+    #[test]
+    fn only_calls_that_failed_with_a_message_are_mined() {
+        let store = store();
+        let id = finished(&store, "mixed calls");
+        store
+            .record_tool_calls(
+                id,
+                &[
+                    call("bash", ToolCallState::Ok, ""),
+                    call("noisy", ToolCallState::Ok, "retried once, then worked"),
+                    call("read_file", ToolCallState::Error, "no such file"),
+                    call("search", ToolCallState::Running, ""),
+                    call("edit_file", ToolCallState::Error, ""),
+                ],
+            )
+            .expect("record calls");
+
+        let failures = store.failed_tool_calls_for_execution(id).expect("read");
+
+        assert_eq!(
+            failures,
+            vec![("read_file".to_string(), "no such file".to_string())],
+            "a success (however noisy), an in-flight call, and an empty error are all excluded"
+        );
+    }
+
+    /// Failures come back in call order, and only for the execution asked
+    /// for.
+    #[test]
+    fn failures_are_ordered_by_call_and_scoped_to_one_execution() {
+        let store = store();
+        let mine = finished(&store, "mine");
+        let other = finished(&store, "someone else's");
+        store
+            .record_tool_calls(
+                mine,
+                &[
+                    call("first", ToolCallState::Error, "one"),
+                    call("second", ToolCallState::Error, "two"),
+                    call("third", ToolCallState::Error, "three"),
+                ],
+            )
+            .expect("record mine");
+        store
+            .record_tool_calls(other, &[call("theirs", ToolCallState::Error, "not mine")])
+            .expect("record theirs");
+
+        let names: Vec<String> = store
+            .failed_tool_calls_for_execution(mine)
+            .expect("read")
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+
+        assert_eq!(
+            names,
+            vec!["first", "second", "third"],
+            "seq ASC, no leakage"
+        );
+    }
+
+    /// Citations replay in insert order (`rowid ASC`), so a replay derives
+    /// identical record ids — and only this execution's citations come back.
+    #[test]
+    fn citations_replay_in_insert_order_for_one_execution() {
+        let store = store();
+        let mine = finished(&store, "mine");
+        let other = finished(&store, "someone else's");
+        // Deliberately not sorted by memory id: insert order is the contract,
+        // and an id-sorted read would pass on an already-sorted fixture.
+        store
+            .record_memory_citations(
+                mine,
+                &[
+                    citation("nod_c", "third by id, first written"),
+                    citation("nod_a", "second"),
+                    citation("nod_b", "third"),
+                ],
+            )
+            .expect("record mine");
+        store
+            .record_memory_citations(other, &[citation("nod_z", "not mine")])
+            .expect("record theirs");
+
+        let ids: Vec<String> = store
+            .memory_citations_for_execution(mine)
+            .expect("read")
+            .into_iter()
+            .map(|row| row.memory_id)
+            .collect();
+
+        assert_eq!(ids, vec!["nod_c", "nod_a", "nod_b"]);
+    }
+}

--- a/crates/stella-store/src/enterprise_telemetry.rs
+++ b/crates/stella-store/src/enterprise_telemetry.rs
@@ -141,9 +141,10 @@ pub fn load_or_create_installation_uuid(data_dir: &Path) -> Result<String> {
             return create_installation_uuid(&path);
         }
         Err(error) => {
-            return Err(StoreError(format!(
-                "cannot inspect installation identity: {error}"
-            )));
+            return Err(StoreError::io(
+                "cannot inspect installation identity",
+                error,
+            ));
         }
     }
     let value = crate::read_private_to_string(&path)?;
@@ -151,7 +152,7 @@ pub fn load_or_create_installation_uuid(data_dir: &Path) -> Result<String> {
     if valid_uuid(&value) {
         Ok(value)
     } else {
-        Err(StoreError(
+        Err(StoreError::Other(
             "invalid enterprise installation identity".into(),
         ))
     }
@@ -165,14 +166,12 @@ pub fn ensure_trusted_host_data_dir(data_dir: &Path) -> Result<()> {
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
         let metadata = std::fs::symlink_metadata(data_dir).map_err(|error| {
-            StoreError(format!(
-                "cannot inspect enterprise host data directory: {error}"
-            ))
+            StoreError::io("cannot inspect enterprise host data directory", error)
         })?;
         if metadata.uid() != unsafe { libc::geteuid() }
             || metadata.permissions().mode() & 0o077 != 0
         {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise host data directory is not owner-controlled".into(),
             ));
         }
@@ -187,12 +186,10 @@ fn create_installation_uuid(path: &Path) -> Result<String> {
     options.write(true).create_new(true);
     match crate::private::open_private_file(path, options) {
         Ok(mut file) => {
-            file.write_all(generated.as_bytes()).map_err(|error| {
-                StoreError(format!("cannot write installation identity: {error}"))
-            })?;
-            file.sync_data().map_err(|error| {
-                StoreError(format!("cannot sync installation identity: {error}"))
-            })?;
+            file.write_all(generated.as_bytes())
+                .map_err(|error| StoreError::io("cannot write installation identity", error))?;
+            file.sync_data()
+                .map_err(|error| StoreError::io("cannot sync installation identity", error))?;
             Ok(generated)
         }
         Err(_) => {
@@ -201,7 +198,7 @@ fn create_installation_uuid(path: &Path) -> Result<String> {
             if valid_uuid(&value) {
                 Ok(value)
             } else {
-                Err(StoreError(
+                Err(StoreError::Other(
                     "invalid enterprise installation identity".into(),
                 ))
             }
@@ -222,7 +219,7 @@ impl BoundedIdentifier {
                 byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':')
             });
         if !valid {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "enterprise telemetry identifier must be 1..={IDENTIFIER_MAX_BYTES} ASCII bytes from [A-Za-z0-9._:-]"
             )));
         }
@@ -260,7 +257,7 @@ impl TryFrom<String> for EventId {
         if valid {
             Ok(Self(value))
         } else {
-            Err(StoreError("invalid operational event id".into()))
+            Err(StoreError::Other("invalid operational event id".into()))
         }
     }
 }
@@ -286,7 +283,9 @@ impl ModelDimension {
         if valid {
             Ok(Self(value.to_string()))
         } else {
-            Err(StoreError("invalid operational model dimension".into()))
+            Err(StoreError::Other(
+                "invalid operational model dimension".into(),
+            ))
         }
     }
 }
@@ -324,7 +323,9 @@ impl ProviderDimension {
         if valid_dimension_segment(value) {
             Ok(Self(value.to_string()))
         } else {
-            Err(StoreError("invalid operational provider dimension".into()))
+            Err(StoreError::Other(
+                "invalid operational provider dimension".into(),
+            ))
         }
     }
 }
@@ -378,7 +379,7 @@ pub struct OperationalIdentity {
 impl OperationalIdentity {
     pub fn new(installation_uuid: &str, store_uuid: &str) -> Result<Self> {
         if !valid_uuid(installation_uuid) || !valid_uuid(store_uuid) {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry identities must be lowercase UUIDs".into(),
             ));
         }
@@ -436,10 +437,10 @@ impl OperationalOutcome {
             "verification_failed" => Ok(Self::VerificationFailed),
             "goal_met" => Ok(Self::GoalMet),
             "goal_unmet" => Ok(Self::GoalUnmet),
-            "" => Err(StoreError(
+            "" => Err(StoreError::Other(
                 "enterprise telemetry requires a finalized execution rollup".into(),
             )),
-            other => Err(StoreError(format!(
+            other => Err(StoreError::Other(format!(
                 "unsupported finalized execution outcome `{other}`"
             ))),
         }
@@ -475,7 +476,7 @@ impl OperationalEventContext {
                 .bytes()
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
         {
-            return Err(StoreError("invalid enterprise export nonce".into()));
+            return Err(StoreError::Other("invalid enterprise export nonce".into()));
         }
         Ok(Self {
             enrollment_id: BoundedIdentifier::parse(enrollment_id)?,
@@ -517,7 +518,7 @@ impl StellaOperationalEventV1 {
         rollup: &ExecutionRollupRow,
     ) -> Result<Self> {
         if !rollup.usage_complete {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry requires complete paid-call accounting".into(),
             ));
         }
@@ -556,7 +557,7 @@ impl StellaOperationalEventV1 {
         let mut event_id = String::from("evt_");
         for byte in hash.finalize() {
             write!(&mut event_id, "{byte:02x}")
-                .map_err(|_| StoreError("cannot format operational event id".into()))?;
+                .map_err(|_| StoreError::Other("cannot format operational event id".into()))?;
         }
         let event_id = EventId(event_id);
 
@@ -593,13 +594,13 @@ fn hash_part(hash: &mut Sha256, bytes: &[u8]) {
 
 fn nonnegative_u64(name: &str, value: i64) -> Result<u64> {
     u64::try_from(value)
-        .map_err(|_| StoreError(format!("enterprise telemetry {name} must be non-negative")))
+        .map_err(|_| StoreError::Other(format!("enterprise telemetry {name} must be non-negative")))
 }
 
 fn finite_nonnegative_microusd(value: f64) -> Result<u64> {
     let scaled = value * 1_000_000.0;
     if !scaled.is_finite() || scaled < 0.0 || scaled >= u64::MAX as f64 {
-        return Err(StoreError(
+        return Err(StoreError::Other(
             "enterprise telemetry cost must be finite and non-negative".into(),
         ));
     }
@@ -673,7 +674,7 @@ impl EnterpriseTelemetrySpool {
     /// Open a host-owned spool at an already policy-checked path.
     pub fn open_at(path: &Path, limits: SpoolLimits) -> Result<Self> {
         if limits.max_rows == 0 || limits.max_bytes == 0 {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry spool limits must be non-zero".into(),
             ));
         }
@@ -745,14 +746,14 @@ impl EnterpriseTelemetrySpool {
     ) -> Result<EnqueueOutcome> {
         validate_sink_fingerprint(sink_fingerprint)?;
         if created_at_ms < 0 {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry enqueue time must be non-negative".into(),
             ));
         }
         let payload = serde_json::to_vec(event)
-            .map_err(|error| StoreError(format!("cannot serialize operational event: {error}")))?;
+            .map_err(|error| StoreError::serde("cannot serialize operational event", error))?;
         let payload_bytes = i64::try_from(payload.len())
-            .map_err(|_| StoreError("operational event is too large".into()))?;
+            .map_err(|_| StoreError::Other("operational event is too large".into()))?;
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let inserted = tx.execute(
@@ -794,7 +795,7 @@ impl EnterpriseTelemetrySpool {
     ) -> Result<ObservedClaimClock> {
         validate_sink_fingerprint(sink_fingerprint)?;
         if now_ms < 0 {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry claim time must be non-negative".into(),
             ));
         }
@@ -870,7 +871,7 @@ impl EnterpriseTelemetrySpool {
             || max_payload_bytes == 0
             || max_payload_bytes > MAX_CLAIM_PAYLOAD_BYTES
         {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "invalid enterprise telemetry claim limits".into(),
             ));
         }
@@ -878,7 +879,7 @@ impl EnterpriseTelemetrySpool {
             .saturating_add(MAX_CORRUPT_SCAN_ROWS)
             .min(MAX_CLAIM_SCAN_ROWS);
         let sql_limit = i64::try_from(scan_limit)
-            .map_err(|_| StoreError("invalid enterprise telemetry claim limits".into()))?;
+            .map_err(|_| StoreError::Other("invalid enterprise telemetry claim limits".into()))?;
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let current_clock: Option<(i64, i64)> = tx
@@ -949,7 +950,7 @@ impl EnterpriseTelemetrySpool {
                     continue;
                 }
                 let event = decoded.map_err(|error| {
-                    StoreError(format!("invalid operational event in spool: {error}"))
+                    StoreError::serde("invalid operational event in spool", error)
                 })?;
                 let size = payload.len();
                 if bytes.saturating_add(size) > max_payload_bytes {
@@ -981,7 +982,7 @@ impl EnterpriseTelemetrySpool {
                 params![owner, lease_until_ms, sink_fingerprint, id],
             )?;
             if changed != 1 {
-                return Err(StoreError(
+                return Err(StoreError::Other(
                     "operational telemetry claim does not match its exact sink row".into(),
                 ));
             }
@@ -1011,7 +1012,9 @@ impl EnterpriseTelemetrySpool {
             .iter()
             .any(|item| item.sink_fingerprint != sink_fingerprint)
         {
-            return Err(StoreError("claimed event belongs to another sink".into()));
+            return Err(StoreError::Other(
+                "claimed event belongs to another sink".into(),
+            ));
         }
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -1022,7 +1025,7 @@ impl EnterpriseTelemetrySpool {
                 params![sink_fingerprint, item.event.event_id(), owner],
             )?;
             if changed != 1 {
-                return Err(StoreError(
+                return Err(StoreError::Other(
                     "operational telemetry acknowledgement does not match its exact lease".into(),
                 ));
             }
@@ -1044,10 +1047,12 @@ impl EnterpriseTelemetrySpool {
             .iter()
             .any(|item| item.sink_fingerprint != sink_fingerprint)
         {
-            return Err(StoreError("claimed event belongs to another sink".into()));
+            return Err(StoreError::Other(
+                "claimed event belongs to another sink".into(),
+            ));
         }
         if now_ms < 0 {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise telemetry retry time must be non-negative".into(),
             ));
         }
@@ -1066,7 +1071,7 @@ impl EnterpriseTelemetrySpool {
             .iter()
             .any(|item| item.clock_generation != claimed_generation)
         {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "operational telemetry retry mixes clock generations".into(),
             ));
         }
@@ -1118,7 +1123,7 @@ impl EnterpriseTelemetrySpool {
                 ],
             )?;
             if changed != 1 {
-                return Err(StoreError(
+                return Err(StoreError::Other(
                     "operational telemetry retry does not match its exact lease".into(),
                 ));
             }
@@ -1213,7 +1218,7 @@ impl EnterpriseTelemetrySpool {
         )?;
         tx.commit()?;
         u64::try_from(discarded)
-            .map_err(|_| StoreError("rollover discard count exceeds u64".into()))
+            .map_err(|_| StoreError::Other("rollover discard count exceeds u64".into()))
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
@@ -1232,7 +1237,7 @@ pub(crate) fn validate_sink_fingerprint(value: &str) -> Result<()> {
     if valid {
         Ok(())
     } else {
-        Err(StoreError(
+        Err(StoreError::Other(
             "invalid enterprise telemetry sink fingerprint".into(),
         ))
     }

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -298,13 +298,13 @@ impl crate::Store {
     ) -> Result<Vec<PendingEnterpriseExport>> {
         validate_sink_fingerprint(sink_fingerprint)?;
         if limit == 0 || limit > MAX_EXPORT_PAGE_ROWS {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise export page limit must be 1..=256".into(),
             ));
         }
         let after = after_execution_id.unwrap_or(0);
         let sql_limit = i64::try_from(limit)
-            .map_err(|_| StoreError("invalid enterprise export page limit".into()))?;
+            .map_err(|_| StoreError::Other("invalid enterprise export page limit".into()))?;
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let mut pending = {
@@ -399,7 +399,7 @@ impl crate::Store {
                 params![sink_fingerprint, execution_id],
             )?;
             if deleted != 1 {
-                return Err(StoreError(
+                return Err(StoreError::Other(
                     "enterprise export skip did not consume exactly one pending row".into(),
                 ));
             }
@@ -470,12 +470,12 @@ impl crate::Store {
     ) -> Result<u64> {
         validate_sink_fingerprint(sink_fingerprint)?;
         if retain_completed == 0 || retain_completed > 10_000 {
-            return Err(StoreError(
+            return Err(StoreError::Other(
                 "enterprise export retention must be 1..=10000 rows".into(),
             ));
         }
         let offset = i64::try_from(retain_completed)
-            .map_err(|_| StoreError("invalid enterprise export retention".into()))?;
+            .map_err(|_| StoreError::Other("invalid enterprise export retention".into()))?;
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let cutoff: Option<i64> = tx
@@ -514,17 +514,17 @@ impl crate::Store {
             params![sink_fingerprint, cutoff],
         )?;
         tx.commit()?;
-        let deleted = deleted_ledger
-            .checked_add(deleted_skips)
-            .ok_or_else(|| StoreError("enterprise export compaction count exceeds usize".into()))?;
+        let deleted = deleted_ledger.checked_add(deleted_skips).ok_or_else(|| {
+            StoreError::Other("enterprise export compaction count exceeds usize".into())
+        })?;
         u64::try_from(deleted)
-            .map_err(|_| StoreError("enterprise export compaction count exceeds u64".into()))
+            .map_err(|_| StoreError::Other("enterprise export compaction count exceeds u64".into()))
     }
 }
 
 fn checked_ledger_counter(label: &str, value: i64) -> Result<u64> {
     u64::try_from(value)
-        .map_err(|_| StoreError(format!("enterprise export {label} counter is negative")))
+        .map_err(|_| StoreError::Other(format!("enterprise export {label} counter is negative")))
 }
 
 /// One execution this store still owes a sink: which execution, and the nonce

--- a/crates/stella-store/src/error.rs
+++ b/crates/stella-store/src/error.rs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! [`StoreError`] — everything this crate can fail with, as named variants.
+//!
+//! Its own module rather than more lines in the already-oversized `lib.rs`,
+//! per the crate's working rule: new code goes in a new module instead of
+//! raising a grandfathered ceiling.
+//!
+//! The type used to be `pub struct StoreError(pub String)`, which meant a
+//! caller could only tell a corrupt database from a stale binary from an
+//! ordinary `SQLITE_BUSY` by reading prose (#3735) — a breach of invariant #5
+//! ("typed errors, no panics"), and one the `typed-errors` gate cannot see
+//! because it only flags the literal `Result<_, String>` shape.
+//!
+//! # What earns a variant
+//!
+//! A failure gets its own variant when a caller can *act* differently on it —
+//! the four the crate already distinguished internally do:
+//! [`StoreError::NegativeSchemaVersion`] and [`StoreError::SchemaTooNew`] tell
+//! "move the file aside" from "upgrade your binary", and
+//! [`StoreError::Corrupt`] tells a malformed file (run `stella doctor`) from
+//! the plain [`StoreError::Sqlite`] failure it otherwise arrives as.
+//! [`StoreError::Io`] and [`StoreError::Serde`] keep the underlying
+//! `std::io::Error` / `serde_json::Error` reachable through
+//! [`std::error::Error::source`], so a caller can branch on
+//! [`std::io::ErrorKind`] rather than on the word "permission".
+//!
+//! Everything else is a one-off invariant check — a count that overflowed a
+//! column, a spool row that failed validation — where no caller has a second
+//! branch to take. Those stay in [`StoreError::Other`], which is the deliberate
+//! narrow catch-all, not a place to put a failure someone will later want to
+//! match on.
+
+/// Everything the store can fail with.
+///
+/// `Display` renders the failure and nothing else. The old wrapper prefixed
+/// every message with `store: `, which every caller then said again — the CLI
+/// printed `cannot open store: store: …` and the runtime
+/// `local store unavailable (store: …)`. Naming the subject is the caller's
+/// job; the four actionable variants carry their own full sentence, because
+/// that sentence is the remedy the user has to follow.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StoreError {
+    /// `PRAGMA user_version` is negative, so the file header is not one this
+    /// crate wrote (or was overwritten). Not recoverable in place — the file
+    /// has to be moved aside.
+    ///
+    /// Refused rather than indexed: a negative stamp would index `MIGRATIONS`
+    /// with a wrapped `usize` and panic, taking the session down with it.
+    #[error(
+        "store.db carries a negative schema version ({version}), so it is not a \
+         stella store or its header was overwritten. Move .stella/private/store.db aside \
+         and reopen this workspace to start a fresh one."
+    )]
+    NegativeSchemaVersion {
+        /// The stamp read out of the file header.
+        version: i64,
+    },
+
+    /// The file was written by a newer build than this one. A downgrade guard,
+    /// not a formality: older code writing into a newer shape would silently
+    /// violate whatever invariants the newer schema added.
+    #[error(
+        "store.db is at schema version {file_version}, but this build only knows \
+         {build_version} — your stella binary is out of date, not the workspace. Upgrade \
+         with `brew upgrade stella`, re-run install.sh, or grab a newer build from \
+         https://github.com/macanderson/stella/releases, then reopen this workspace."
+    )]
+    SchemaTooNew {
+        /// The version stamped in the file.
+        file_version: i64,
+        /// The version this binary understands (`migrations::SCHEMA_VERSION`).
+        build_version: i64,
+    },
+
+    /// SQLite cannot read the file as a database at all.
+    ///
+    /// Separated from [`StoreError::Sqlite`] because the remedy is different
+    /// and because it is otherwise invisible: without this the failure reaches
+    /// the caller as the raw rusqlite string ("database disk image is
+    /// malformed"), every later session repeats the same warning, and nothing
+    /// ever tells the user to move the file aside. See
+    /// `integrity::corrupt_store_error`.
+    #[error(
+        "store.db cannot be read as a SQLite database ({source}), so it is corrupt \
+         or was overwritten. Run `stella doctor` to confirm, then `stella doctor --repair` \
+         to salvage what is readable and move {path} aside (it is renamed, never deleted) \
+         — it holds local telemetry and session replay, never your source."
+    )]
+    Corrupt {
+        /// The file named in the remedy, as the caller located it.
+        path: String,
+        /// The corruption SQLite reported.
+        source: rusqlite::Error,
+    },
+
+    /// An ordinary SQLite failure — a busy database, a constraint, a query
+    /// against a schema this build did not expect.
+    #[error("{0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    /// A filesystem operation failed. `context` names the operation and the
+    /// path in the crate's established wording ("cannot read /…"); the kind is
+    /// on `source`, which is where a caller should read it from.
+    #[error("{context}: {source}")]
+    Io {
+        /// What was being attempted, path included.
+        context: String,
+        /// The underlying failure.
+        source: std::io::Error,
+    },
+
+    /// A JSON payload could not be serialized or parsed. Same split as
+    /// [`StoreError::Io`]: prose in `context`, the typed cause on `source`.
+    #[error("{context}: {source}")]
+    Serde {
+        /// What was being encoded or decoded.
+        context: String,
+        /// The underlying failure.
+        source: serde_json::Error,
+    },
+
+    /// A one-off invariant check with no second branch for a caller to take —
+    /// a value that overflowed its column, a spool row that failed validation,
+    /// a table name this build does not know.
+    ///
+    /// Deliberately narrow: a failure a caller will want to *match* on belongs
+    /// in a variant of its own, not here.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl StoreError {
+    /// A filesystem failure, with the operation and path as context.
+    pub(crate) fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// A JSON encode/decode failure, with what was being handled as context.
+    pub(crate) fn serde(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Self::Serde {
+            context: context.into(),
+            source,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rusqlite::Connection;
+
+    use super::StoreError;
+    use crate::{Store, migrations::SCHEMA_VERSION};
+
+    /// A workspace whose store exists on disk, plus the file itself.
+    fn opened_workspace() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path()).expect("store");
+        let path = store
+            .workspace_root()
+            .map(Path::to_path_buf)
+            .expect("a workspace store has a root")
+            .join(".stella/private/store.db");
+        drop(store);
+        assert!(path.exists(), "the store file must exist to be re-stamped");
+        (dir, path)
+    }
+
+    fn stamp_user_version(db_path: &Path, version: i64) {
+        let conn = Connection::open(db_path).expect("open");
+        conn.pragma_update(None, "user_version", version)
+            .expect("stamp");
+    }
+
+    /// The two schema-version refusals have opposite remedies — move the file
+    /// aside vs. upgrade the binary — and a caller must be able to tell them
+    /// apart without reading the sentence. Under the old
+    /// `StoreError(pub String)` this could only be spelled as a substring
+    /// search over prose.
+    #[test]
+    fn a_negative_schema_version_is_matchable_as_itself() {
+        let (dir, db_path) = opened_workspace();
+        stamp_user_version(&db_path, -4);
+
+        match Store::open(dir.path()) {
+            Ok(_) => panic!("a negative stamp must fail closed"),
+            Err(StoreError::NegativeSchemaVersion { version }) => assert_eq!(version, -4),
+            Err(other) => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_newer_schema_version_is_matchable_as_itself() {
+        let (dir, db_path) = opened_workspace();
+        stamp_user_version(&db_path, SCHEMA_VERSION + 1);
+
+        match Store::open(dir.path()) {
+            Ok(_) => panic!("a newer-versioned file must refuse to open"),
+            Err(StoreError::SchemaTooNew {
+                file_version,
+                build_version,
+            }) => {
+                assert_eq!(file_version, SCHEMA_VERSION + 1);
+                assert_eq!(build_version, SCHEMA_VERSION);
+            }
+            Err(other) => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    /// The remedy for a corrupt file (`stella doctor`) is not the remedy for a
+    /// busy or malformed *statement*, and both used to arrive as the same
+    /// stringly-typed error.
+    #[test]
+    fn a_corrupt_file_is_matchable_apart_from_an_ordinary_sqlite_failure() {
+        let (dir, db_path) = opened_workspace();
+        std::fs::write(&db_path, [0x7f; 4096]).expect("overwrite the header");
+
+        match Store::open(dir.path()) {
+            Ok(_) => panic!("a corrupt store must not open"),
+            Err(error @ StoreError::Corrupt { .. }) => assert!(
+                error.to_string().contains("stella doctor"),
+                "the corrupt variant carries the remedy: {error}"
+            ),
+            Err(other) => panic!("wrong variant: {other:?}"),
+        }
+
+        let store = Store::in_memory().expect("in-memory store");
+        let ordinary = store
+            .lock()
+            .execute_batch("SELECT * FROM no_such_table")
+            .map_err(StoreError::from)
+            .expect_err("a query against a missing table must fail");
+        assert!(
+            matches!(ordinary, StoreError::Sqlite(_)),
+            "an ordinary statement failure is not corruption: {ordinary:?}"
+        );
+    }
+
+    /// A filesystem failure keeps its `ErrorKind` reachable through
+    /// [`std::error::Error::source`], so a caller branches on the kind rather
+    /// than on the word "permission" appearing in a sentence.
+    #[test]
+    fn a_filesystem_failure_keeps_its_kind_on_the_source() {
+        let missing = std::fs::read("/nonexistent/stella/store-error-witness")
+            .expect_err("reading a missing path must fail");
+        let error = StoreError::io("cannot read /nonexistent", missing);
+
+        let source = std::error::Error::source(&error).expect("io errors carry their cause");
+        let io = source
+            .downcast_ref::<std::io::Error>()
+            .expect("the cause is the std::io::Error itself, not a rendering of it");
+        assert_eq!(io.kind(), std::io::ErrorKind::NotFound);
+        assert!(
+            error.to_string().starts_with("cannot read /nonexistent"),
+            "the context still leads the message: {error}"
+        );
+    }
+}

--- a/crates/stella-store/src/identity.rs
+++ b/crates/stella-store/src/identity.rs
@@ -215,7 +215,7 @@ fn save_cloud_registration_at(path: &Path, reg: &CloudRegistration) -> Result<()
         crate::ensure_private_dir(parent)?;
     }
     let body = serde_json::to_string_pretty(reg)
-        .map_err(|e| StoreError(format!("cannot render cloud registration: {e}")))?
+        .map_err(|e| StoreError::serde("cannot render cloud registration", e))?
         + "\n";
     crate::write_sensitive_file_atomic(path, body.as_bytes())
 }
@@ -265,7 +265,7 @@ pub fn register_workspace(workspace_root: &Path, id: Option<&str>) -> Result<Str
         _ => crate::enterprise_telemetry::random_uuid_v4(),
     };
     let dot = workspace_root.join(".stella");
-    std::fs::create_dir_all(&dot).map_err(|e| StoreError(format!("cannot create .stella: {e}")))?;
+    std::fs::create_dir_all(&dot).map_err(|e| StoreError::io("cannot create .stella", e))?;
     let path = dot.join("workspace.json");
     let body = serde_json::json!({ "workspace_id": minted }).to_string() + "\n";
     // create_new: if a sibling process registered first, its id wins.
@@ -277,9 +277,9 @@ pub fn register_workspace(workspace_root: &Path, id: Option<&str>) -> Result<Str
         Ok(mut file) => {
             use std::io::Write as _;
             file.write_all(body.as_bytes())
-                .map_err(|e| StoreError(format!("cannot write workspace identity: {e}")))?;
+                .map_err(|e| StoreError::io("cannot write workspace identity", e))?;
             file.sync_data()
-                .map_err(|e| StoreError(format!("cannot sync workspace identity: {e}")))?;
+                .map_err(|e| StoreError::io("cannot sync workspace identity", e))?;
             drop(file);
             crate::private::sync_directory(&dot)?;
             Ok(minted)
@@ -290,7 +290,7 @@ pub fn register_workspace(workspace_root: &Path, id: Option<&str>) -> Result<Str
         // and a file we cannot read may still hold one — so it names the exact
         // path and the remedy instead.
         Err(_) => workspace_id(workspace_root).ok_or_else(|| {
-            StoreError(format!(
+            StoreError::Other(format!(
                 "{} exists but carries no readable workspace_id. Inspect it, then \
                  delete it and re-run `stella cloud register` to mint a fresh one.",
                 path.display()

--- a/crates/stella-store/src/integrity.rs
+++ b/crates/stella-store/src/integrity.rs
@@ -81,12 +81,10 @@ pub(crate) fn corrupt_store_error(error: rusqlite::Error, db_path: Option<&Path>
         || ".stella/private/store.db".to_string(),
         |path| path.display().to_string(),
     );
-    StoreError(format!(
-        "store.db cannot be read as a SQLite database ({error}), so it is corrupt or \
-         was overwritten. Run `stella doctor` to confirm, then `stella doctor --repair` \
-         to salvage what is readable and move {path} aside (it is renamed, never \
-         deleted) — it holds local telemetry and session replay, never your source."
-    ))
+    StoreError::Corrupt {
+        path,
+        source: error,
+    }
 }
 
 /// How many problem rows a report keeps. `PRAGMA integrity_check` stops at 100
@@ -279,9 +277,8 @@ pub fn check_file(db_path: &Path) -> Result<IntegrityReport> {
             // Both doors failed: lead with the session-shaped attempt (the one
             // that matters) and keep the first failure, since whichever wording
             // the user recognizes is the useful one.
-            Err(first) => StoreError(format!(
-                "{} (an immutable read-only probe first failed with: {})",
-                error.0, first.0
+            Err(first) => StoreError::Other(format!(
+                "{error} (an immutable read-only probe first failed with: {first})"
             )),
             Ok(_) => error,
         }),
@@ -356,7 +353,9 @@ impl PragmaRun {
     /// the same distinction on the session path, through the same predicate.)
     fn refuse_if_not_corruption(&self) -> Result<()> {
         match &self.stopped_by {
-            Some(error) if !is_sqlite_corruption(error) => Err(StoreError(error.to_string())),
+            Some(error) if !is_sqlite_corruption(error) => {
+                Err(StoreError::Other(error.to_string()))
+            }
             _ => Ok(()),
         }
     }
@@ -464,9 +463,9 @@ pub struct StoreQuarantine {
 /// corrupt" and "may I move it" are different questions.
 pub fn quarantine_corrupt_store(db_path: &Path) -> Result<StoreQuarantine> {
     let metadata = std::fs::symlink_metadata(db_path)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", db_path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", db_path.display()), e))?;
     if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "{} is not a regular file — refusing to quarantine an ambiguous path",
             db_path.display()
         )));
@@ -507,7 +506,7 @@ pub fn quarantine_corrupt_store(db_path: &Path) -> Result<StoreQuarantine> {
 fn salvage(source: &Path, original: &Path, stamp: &str) -> (Option<PathBuf>, Option<String>) {
     let target = match unique_sibling(original, &format!("salvaged-{stamp}")) {
         Ok(target) => target,
-        Err(error) => return (None, Some(error.0)),
+        Err(error) => return (None, Some(error.to_string())),
     };
     // `VACUUM INTO` takes an expression, so the path binds as a parameter — no
     // quoting of a path that may contain apostrophes.
@@ -522,7 +521,7 @@ fn salvage(source: &Path, original: &Path, stamp: &str) -> (Option<PathBuf>, Opt
     };
     let attempt = open_private_sqlite_read_only(source).and_then(|conn| {
         conn.execute("VACUUM INTO ?1", [target_str])
-            .map_err(|e| StoreError(format!("VACUUM INTO failed: {e}")))
+            .map_err(|e| StoreError::Other(format!("VACUUM INTO failed: {e}")))
     });
     match attempt {
         Ok(_) => {
@@ -532,7 +531,7 @@ fn salvage(source: &Path, original: &Path, stamp: &str) -> (Option<PathBuf>, Opt
             // copy and report it.
             if let Err(error) = restrict_to_owner(&target) {
                 let _ = std::fs::remove_file(&target);
-                return (None, Some(error.0));
+                return (None, Some(error.to_string()));
             }
             (Some(target), None)
         }
@@ -540,7 +539,7 @@ fn salvage(source: &Path, original: &Path, stamp: &str) -> (Option<PathBuf>, Opt
             // A failed VACUUM can leave a partial file behind; it is this
             // function's own output path, never anything the user had.
             let _ = std::fs::remove_file(&target);
-            (None, Some(error.0))
+            (None, Some(error.to_string()))
         }
     }
 }
@@ -549,7 +548,7 @@ fn salvage(source: &Path, original: &Path, stamp: &str) -> (Option<PathBuf>, Opt
 fn restrict_to_owner(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| StoreError(format!("cannot restrict {}: {e}", path.display())))
+        .map_err(|e| StoreError::io(format!("cannot restrict {}", path.display()), e))
 }
 
 #[cfg(not(unix))]
@@ -559,11 +558,10 @@ fn restrict_to_owner(_path: &Path) -> Result<()> {
 
 fn rename(from: &Path, to: &Path) -> Result<()> {
     std::fs::rename(from, to).map_err(|e| {
-        StoreError(format!(
-            "cannot move {} to {}: {e}",
-            from.display(),
-            to.display()
-        ))
+        StoreError::io(
+            format!("cannot move {} to {}", from.display(), to.display()),
+            e,
+        )
     })
 }
 
@@ -571,7 +569,7 @@ fn rename(from: &Path, to: &Path) -> Result<()> {
 fn sibling_with_suffix(db_path: &Path, suffix: &str) -> Result<PathBuf> {
     let name = db_path
         .file_name()
-        .ok_or_else(|| StoreError(format!("{} has no filename", db_path.display())))?;
+        .ok_or_else(|| StoreError::Other(format!("{} has no filename", db_path.display())))?;
     let mut with_suffix = name.to_os_string();
     with_suffix.push(suffix);
     Ok(db_path.with_file_name(with_suffix))
@@ -584,7 +582,7 @@ fn sibling_with_suffix(db_path: &Path, suffix: &str) -> Result<PathBuf> {
 fn unique_sibling(path: &Path, tag: &str) -> Result<PathBuf> {
     let name = path
         .file_name()
-        .ok_or_else(|| StoreError(format!("{} has no filename", path.display())))?;
+        .ok_or_else(|| StoreError::Other(format!("{} has no filename", path.display())))?;
     for attempt in 1..=64u32 {
         let mut candidate = name.to_os_string();
         candidate.push(".");
@@ -597,7 +595,7 @@ fn unique_sibling(path: &Path, tag: &str) -> Result<PathBuf> {
             return Ok(candidate);
         }
     }
-    Err(StoreError(format!(
+    Err(StoreError::Other(format!(
         "cannot find a free `{tag}` name beside {} after 64 tries",
         path.display()
     )))

--- a/crates/stella-store/src/journal.rs
+++ b/crates/stella-store/src/journal.rs
@@ -193,7 +193,7 @@ impl SessionJournal {
         // the interruption tore, corrupting BOTH.
         if unterminated_tail(&mut file) {
             file.write_all(b"\n")
-                .map_err(|e| StoreError(format!("cannot heal {}: {e}", path.display())))?;
+                .map_err(|e| StoreError::io(format!("cannot heal {}", path.display()), e))?;
         }
         Ok(Self {
             file,
@@ -267,18 +267,18 @@ impl SessionJournal {
         if record.is_transition() {
             self.file
                 .sync_data()
-                .map_err(|e| StoreError(format!("journal fsync failed: {e}")))?;
+                .map_err(|e| StoreError::io("journal fsync failed", e))?;
         }
         Ok(())
     }
 
     fn write_line_unsynced(&mut self, record: &JournalRecord) -> Result<()> {
         let mut line = serde_json::to_string(record)
-            .map_err(|e| StoreError(format!("cannot serialize journal record: {e}")))?;
+            .map_err(|e| StoreError::serde("cannot serialize journal record", e))?;
         line.push('\n');
         self.file
             .write_all(line.as_bytes())
-            .map_err(|e| StoreError(format!("journal write failed: {e}")))
+            .map_err(|e| StoreError::io("journal write failed", e))
     }
 
     /// Drain any pending run and fsync — the clean-shutdown / handoff barrier
@@ -287,7 +287,7 @@ impl SessionJournal {
         self.flush_pending()?;
         self.file
             .sync_data()
-            .map_err(|e| StoreError(format!("journal fsync failed: {e}")))
+            .map_err(|e| StoreError::io("journal fsync failed", e))
     }
 }
 
@@ -373,7 +373,7 @@ pub fn has_state(dir: &Path) -> bool {
 fn write_snapshot<T: Serialize + ?Sized>(dir: &Path, name: &str, value: &T) -> Result<()> {
     crate::ensure_private_dir(dir)?;
     let json = serde_json::to_string(value)
-        .map_err(|e| StoreError(format!("cannot serialize {name}: {e}")))?;
+        .map_err(|e| StoreError::serde(format!("cannot serialize {name}"), e))?;
     let path = dir.join(name);
     crate::private::write_private_atomic(&path, json.as_bytes())
 }

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -112,6 +112,8 @@ use stella_protocol::{AgentEvent, TaskStatus};
 //   enterprise_telemetry
 //               the closed operational event schema, its bounded at-least-once
 //               spool, and the per-store export ledger
+//   error       (crate-private module, `StoreError` re-exported) every
+//               failure this crate returns, as named variants
 //   export      the `/export` telemetry dump and `stella stats`' usage
 //               aggregate, plus the `ExportScope` that decides whether either
 //               covers one session or the whole workspace (#2558)
@@ -130,6 +132,7 @@ use stella_protocol::{AgentEvent, TaskStatus};
 //               execution-level paid-call accounting gate
 //   usage       `usage.db` — user-tier cross-project telemetry aggregate
 mod ddl;
+mod error;
 mod migrations;
 mod private;
 mod receipts;
@@ -185,6 +188,7 @@ pub use drain::{
     RejectionClass, drain_org, schema_version_supported,
 };
 pub use efficacy::FinishedExecution;
+pub use error::StoreError;
 pub use export::ExportExclusions;
 pub use forget::{ContextSurface, SurfaceSuppression, is_restatement, is_suppressed};
 pub use foundry::{AdoptedTool, FoundryReuse};
@@ -233,27 +237,11 @@ pub(crate) fn fnv_hex(s: &str) -> String {
     format!("{hash:016x}")
 }
 
-/// Wrapper error: everything the store can fail with, rendered.
-#[derive(Debug)]
-pub struct StoreError(pub String);
-
-impl std::fmt::Display for StoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "store: {}", self.0)
-    }
-}
-impl std::error::Error for StoreError {}
-
-impl From<rusqlite::Error> for StoreError {
-    fn from(e: rusqlite::Error) -> Self {
-        StoreError(e.to_string())
-    }
-}
-
 type Result<T> = std::result::Result<T, StoreError>;
 
 fn sqlite_i64(name: &str, value: u64) -> Result<i64> {
-    i64::try_from(value).map_err(|_| StoreError(format!("{name} exceeds SQLite INTEGER range")))
+    i64::try_from(value)
+        .map_err(|_| StoreError::Other(format!("{name} exceeds SQLite INTEGER range")))
 }
 
 /// One session-level file-touch record, ready to persist: the normalized
@@ -514,10 +502,10 @@ pub struct SessionJournal {
 fn task_status_to_string(status: TaskStatus) -> Result<String> {
     match serde_json::to_value(status) {
         Ok(serde_json::Value::String(s)) => Ok(s),
-        Ok(other) => Err(StoreError(format!(
+        Ok(other) => Err(StoreError::Other(format!(
             "task status serialized to non-string JSON: {other}"
         ))),
-        Err(e) => Err(StoreError(format!("cannot serialize task status: {e}"))),
+        Err(e) => Err(StoreError::serde("cannot serialize task status", e)),
     }
 }
 
@@ -525,7 +513,7 @@ fn task_status_to_string(status: TaskStatus) -> Result<String> {
 /// back into the protocol enum.
 fn task_status_from_string(s: &str) -> Result<TaskStatus> {
     serde_json::from_value(serde_json::Value::String(s.to_string()))
-        .map_err(|e| StoreError(format!("unknown task status `{s}`: {e}")))
+        .map_err(|e| StoreError::serde(format!("unknown task status `{s}`"), e))
 }
 
 /// One aggregated analytics row per (provider, model): the numbers behind
@@ -598,9 +586,9 @@ impl UsageStatsRow {
 ///   away from publishing a session's transcripts.
 fn harden_workspace_dir(dir: &Path, created: bool) -> Result<()> {
     let metadata = std::fs::symlink_metadata(dir)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", dir.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", dir.display()), e))?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "workspace state path {} is not a real directory",
             dir.display()
         )));
@@ -609,10 +597,10 @@ fn harden_workspace_dir(dir: &Path, created: bool) -> Result<()> {
     if created {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
-            StoreError(format!(
-                "could not restrict freshly created {}: {e}",
-                dir.display()
-            ))
+            StoreError::io(
+                format!("could not restrict freshly created {}", dir.display()),
+                e,
+            )
         })?;
     }
     ensure_workspace_generated_ignore(dir)?;
@@ -754,25 +742,16 @@ impl Store {
             // with a wrapped `usize` and panic, taking the session down with
             // it. Persistence failing is observability loss (the CLI warns and
             // runs on); persistence PANICKING is a work stoppage.
-            return Err(StoreError(format!(
-                "store.db carries a negative schema version ({version}), so it is not a \
-                 stella store or its header was overwritten. Move \
-                 .stella/private/store.db aside and reopen this workspace to start a \
-                 fresh one."
-            )));
+            return Err(StoreError::NegativeSchemaVersion { version });
         }
         if version > SCHEMA_VERSION {
             // A downgrade guard, not a formality: older code writing into a
             // newer shape would silently violate whatever invariants the
             // newer schema added.
-            return Err(StoreError(format!(
-                "store.db is at schema version {version}, but this build only \
-                 knows {SCHEMA_VERSION} — your stella binary is out of date, not \
-                 the workspace. Upgrade with `brew upgrade stella`, re-run \
-                 install.sh, or grab a newer build from \
-                 https://github.com/macanderson/stella/releases, then reopen \
-                 this workspace."
-            )));
+            return Err(StoreError::SchemaTooNew {
+                file_version: version,
+                build_version: SCHEMA_VERSION,
+            });
         }
         if version == 0 && !any_store_table_exists(&bootstrap)? {
             create_latest_schema(&bootstrap)?;
@@ -864,7 +843,7 @@ impl Store {
     /// now the repair path rather than the only writer, for the full account.
     pub fn record_event(&self, execution_id: i64, seq: u64, event: &AgentEvent) -> Result<()> {
         let seq = sqlite_i64("event sequence", seq)?;
-        let payload = serde_json::to_string(event).map_err(|e| StoreError(e.to_string()))?;
+        let payload = serde_json::to_string(event).map_err(|e| StoreError::Other(e.to_string()))?;
         // Read the internally-tagged `type` by DESERIALIZING it, never by
         // string-scanning for the first `"type":"` literal — the scan silently
         // yields the wrong tag (or "unknown") if serialization is ever
@@ -1638,7 +1617,7 @@ impl Store {
     pub fn count(&self, table: &str) -> Result<i64> {
         // Table names can't be bound parameters; allowlist them.
         if !TABLES.contains(&table) {
-            return Err(StoreError(format!("unknown table `{table}`")));
+            return Err(StoreError::Other(format!("unknown table `{table}`")));
         }
         let count: i64 =
             self.lock()

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -371,7 +371,7 @@ pub(crate) fn apply_migration(
             row.get(0)
         })?;
     if violations > 0 {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "migration to schema version {target} would leave {violations} \
              foreign-key violation(s); rolling back"
         )));
@@ -394,7 +394,7 @@ mod tests {
         conn.pragma_update(None, "user_version", 7).expect("stamp");
 
         fn must_not_run(_: &rusqlite::Transaction<'_>) -> Result<()> {
-            Err(StoreError(
+            Err(StoreError::Other(
                 "the migration body ran even though the version was already stamped".into(),
             ))
         }

--- a/crates/stella-store/src/notify.rs
+++ b/crates/stella-store/src/notify.rs
@@ -114,7 +114,7 @@ impl NotificationStore {
     pub fn push(&self, notification: &Notification) -> Result<()> {
         crate::ensure_private_dir(&self.dir)?;
         let json = serde_json::to_string_pretty(notification)
-            .map_err(|e| StoreError(format!("cannot serialize notification: {e}")))?;
+            .map_err(|e| StoreError::serde("cannot serialize notification", e))?;
         let path = self.path_for(&notification.id);
         // sync = true: without it the rename can publish a file whose bytes
         // are still only in the page cache, and a power cut surfaces a
@@ -183,7 +183,7 @@ impl NotificationStore {
                 match std::fs::remove_file(self.path_for(&notification.id)) {
                     Ok(()) => removed += 1,
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(StoreError(format!("cannot prune notification: {e}"))),
+                    Err(e) => return Err(StoreError::io("cannot prune notification", e)),
                 }
             }
         }

--- a/crates/stella-store/src/private.rs
+++ b/crates/stella-store/src/private.rs
@@ -46,15 +46,15 @@ fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
         // publisher as the `nlink() == 0` arm below, seen one instant earlier.
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
-            return Err(StoreError(format!(
-                "cannot open committable file {}: {e}",
-                path.display()
-            )));
+            return Err(StoreError::io(
+                format!("cannot open committable file {}", path.display()),
+                e,
+            ));
         }
     };
     let metadata = file
         .metadata()
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", path.display()), e))?;
     // `nlink() == 0` is the one benign member of this family, and it must be
     // split out before the assertion below rather than folded into it: it says
     // the inode we are holding open was unlinked while we held it, which is
@@ -72,7 +72,7 @@ fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
     }
     if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "committable file {} must be an owner-controlled single-link regular file",
             path.display()
         )));
@@ -80,7 +80,7 @@ fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
     let mode = metadata.permissions().mode() & 0o7777;
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
-        .map_err(|e| StoreError(format!("cannot read {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot read {}", path.display()), e))?;
     Ok(Some((bytes, mode)))
 }
 
@@ -102,20 +102,20 @@ fn read_committable_file(path: &Path) -> Result<Option<(Vec<u8>, u32)>> {
         // judge yet, so the caller settles rather than concluding anything.
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
-            return Err(StoreError(format!(
-                "cannot inspect {}: {e}",
-                path.display()
-            )));
+            return Err(StoreError::io(
+                format!("cannot inspect {}", path.display()),
+                e,
+            ));
         }
     };
     if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "committable file {} must be a regular file",
             path.display()
         )));
     }
     let bytes = std::fs::read(path)
-        .map_err(|e| StoreError(format!("cannot read {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot read {}", path.display()), e))?;
     Ok(Some((bytes, MODE_SHARED)))
 }
 
@@ -149,14 +149,14 @@ fn create_generated_ignore_exclusively(path: &Path) -> Result<bool> {
         Ok(mut file) => {
             file.write_all(WORKSPACE_GENERATED_IGNORE)
                 .and_then(|_| file.sync_all())
-                .map_err(|e| StoreError(format!("cannot write {}: {e}", path.display())))?;
+                .map_err(|e| StoreError::io(format!("cannot write {}", path.display()), e))?;
             Ok(true)
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
-        Err(error) => Err(StoreError(format!(
-            "cannot create generated ignore {}: {error}",
-            path.display()
-        ))),
+        Err(error) => Err(StoreError::io(
+            format!("cannot create generated ignore {}", path.display()),
+            error,
+        )),
     }
 }
 
@@ -249,7 +249,7 @@ fn settled_generated_ignore(path: &Path) -> Result<(Vec<u8>, u32)> {
     // The budget is spent. An empty file we saw the whole way through is one
     // nobody is publishing, so it is ours to repair.
     last.ok_or_else(|| {
-        StoreError(format!(
+        StoreError::Other(format!(
             "generated ignore {} never settled: it was still being replaced \
              after {IGNORE_SETTLE_ATTEMPTS} attempts",
             path.display()
@@ -262,7 +262,7 @@ pub(crate) fn ensure_workspace_state_dir(workspace_root: &Path) -> Result<(PathB
     let created = match std::fs::symlink_metadata(&dir) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() || !metadata.is_dir() {
-                return Err(StoreError(format!(
+                return Err(StoreError::Other(format!(
                     "workspace state path {} is not a real directory",
                     dir.display()
                 )));
@@ -279,14 +279,14 @@ pub(crate) fn ensure_workspace_state_dir(workspace_root: &Path) -> Result<(PathB
             }
             builder
                 .create(&dir)
-                .map_err(|e| StoreError(format!("cannot create {}: {e}", dir.display())))?;
+                .map_err(|e| StoreError::io(format!("cannot create {}", dir.display()), e))?;
             true
         }
         Err(error) => {
-            return Err(StoreError(format!(
-                "cannot inspect workspace state directory {}: {error}",
-                dir.display()
-            )));
+            return Err(StoreError::io(
+                format!("cannot inspect workspace state directory {}", dir.display()),
+                error,
+            ));
         }
     };
     Ok((dir, created))
@@ -297,7 +297,7 @@ fn validate_state_name(name: &str) -> Result<()> {
     if !matches!(components.next(), Some(std::path::Component::Normal(_)))
         || components.next().is_some()
     {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "private state name must be one filename, got {name:?}"
         )));
     }
@@ -308,10 +308,10 @@ fn path_entry_exists(path: &Path) -> Result<bool> {
     match std::fs::symlink_metadata(path) {
         Ok(_) => Ok(true),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(StoreError(format!(
-            "cannot inspect {}: {error}",
-            path.display()
-        ))),
+        Err(error) => Err(StoreError::io(
+            format!("cannot inspect {}", path.display()),
+            error,
+        )),
     }
 }
 
@@ -320,10 +320,7 @@ fn validate_safe_legacy(path: &Path, directory: bool) -> Result<()> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let metadata = std::fs::symlink_metadata(path).map_err(|e| {
-        StoreError(format!(
-            "cannot inspect legacy state {}: {e}",
-            path.display()
-        ))
+        StoreError::io(format!("cannot inspect legacy state {}", path.display()), e)
     })?;
     let expected_type = if directory {
         metadata.is_dir()
@@ -337,7 +334,7 @@ fn validate_safe_legacy(path: &Path, directory: bool) -> Result<()> {
     let owner_only = metadata.uid() == unsafe { libc::geteuid() }
         && (!directory || metadata.permissions().mode() & 0o077 == 0);
     if metadata.file_type().is_symlink() || !expected_type || !owner_only {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "legacy private state {} is not owner-only; left untouched. Restrict its parent to \
              0700 and file to 0600, then retry, or move it aside to create fresh private state",
             path.display()
@@ -348,7 +345,7 @@ fn validate_safe_legacy(path: &Path, directory: bool) -> Result<()> {
 
 #[cfg(not(unix))]
 fn validate_safe_legacy(path: &Path, _directory: bool) -> Result<()> {
-    Err(StoreError(format!(
+    Err(StoreError::Other(format!(
         "legacy private state migration is unsupported on this platform; left untouched: {}",
         path.display()
     )))
@@ -369,7 +366,7 @@ fn migrate_legacy_files(dot: &Path, private: &Path, names: &[String]) -> Result<
         let legacy = dot.join(name.as_str());
         validate_safe_legacy(&legacy, false)?;
         if path_entry_exists(&private.join(name.as_str()))? {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "both legacy {} and private {} exist; refusing to choose or overwrite either",
                 legacy.display(),
                 private.join(name.as_str()).display()
@@ -381,11 +378,14 @@ fn migrate_legacy_files(dot: &Path, private: &Path, names: &[String]) -> Result<
         let legacy = dot.join(name.as_str());
         let target = private.join(name.as_str());
         std::fs::rename(&legacy, &target).map_err(|e| {
-            StoreError(format!(
-                "cannot migrate legacy private state {} to {}: {e}",
-                legacy.display(),
-                target.display()
-            ))
+            StoreError::io(
+                format!(
+                    "cannot migrate legacy private state {} to {}",
+                    legacy.display(),
+                    target.display()
+                ),
+                e,
+            )
         })?;
     }
     sync_directory(private)?;
@@ -419,7 +419,7 @@ pub fn append_workspace_private_line(
     options.create(true).append(true);
     let mut file = open_private_file(&path, options)?;
     writeln!(file, "{line}")
-        .map_err(|e| StoreError(format!("cannot append {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot append {}", path.display()), e))?;
     Ok(path)
 }
 
@@ -445,7 +445,7 @@ pub fn workspace_private_sqlite_path(workspace_root: &Path, name: &str) -> Resul
         if path_entry_exists(&dot.join(name))? {
             validate_safe_legacy(&dot.join(name), false)?;
         }
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "legacy SQLite state for {} has active WAL/SHM sidecars and was left untouched; \
              close and checkpoint the database, then retry migration into {}",
             dot.join(name).display(),
@@ -513,7 +513,7 @@ pub(crate) fn ensure_private_dir(dir: &Path) -> Result<()> {
     match std::fs::symlink_metadata(dir) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() || !metadata.is_dir() {
-                return Err(StoreError(format!(
+                return Err(StoreError::Other(format!(
                     "private state directory {} is not a real directory",
                     dir.display()
                 )));
@@ -529,19 +529,19 @@ pub(crate) fn ensure_private_dir(dir: &Path) -> Result<()> {
             }
             builder
                 .create(dir)
-                .map_err(|e| StoreError(format!("cannot create {}: {e}", dir.display())))?;
+                .map_err(|e| StoreError::io(format!("cannot create {}", dir.display()), e))?;
         }
         Err(error) => {
-            return Err(StoreError(format!(
-                "cannot inspect private state directory {}: {error}",
-                dir.display()
-            )));
+            return Err(StoreError::io(
+                format!("cannot inspect private state directory {}", dir.display()),
+                error,
+            ));
         }
     }
     let metadata = std::fs::symlink_metadata(dir)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", dir.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", dir.display()), e))?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "private state directory {} changed while opening",
             dir.display()
         )));
@@ -550,10 +550,10 @@ pub(crate) fn ensure_private_dir(dir: &Path) -> Result<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
-            StoreError(format!(
-                "cannot restrict private directory {}: {e}",
-                dir.display()
-            ))
+            StoreError::io(
+                format!("cannot restrict private directory {}", dir.display()),
+                e,
+            )
         })?;
     }
     Ok(())
@@ -572,15 +572,12 @@ pub(crate) fn open_private_file(
     }
     let file = options
         .open(path)
-        .map_err(|e| StoreError(format!("cannot open private file {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot open private file {}", path.display()), e))?;
     let metadata = file.metadata().map_err(|e| {
-        StoreError(format!(
-            "cannot inspect private file {}: {e}",
-            path.display()
-        ))
+        StoreError::io(format!("cannot inspect private file {}", path.display()), e)
     })?;
     if !metadata.is_file() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "private state path {} is not a regular file",
             path.display()
         )));
@@ -588,7 +585,7 @@ pub(crate) fn open_private_file(
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
         if metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1 {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "private state file {} is not an owner-controlled single-link file (links: {}); \
                  refusing ambiguous ownership",
                 path.display(),
@@ -597,10 +594,10 @@ pub(crate) fn open_private_file(
         }
         file.set_permissions(std::fs::Permissions::from_mode(0o600))
             .map_err(|e| {
-                StoreError(format!(
-                    "cannot restrict private file {}: {e}",
-                    path.display()
-                ))
+                StoreError::io(
+                    format!("cannot restrict private file {}", path.display()),
+                    e,
+                )
             })?;
     }
     Ok(file)
@@ -623,15 +620,12 @@ pub(crate) fn open_private_file(
 ) -> Result<std::fs::File> {
     let file = options
         .open(path)
-        .map_err(|e| StoreError(format!("cannot open private file {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot open private file {}", path.display()), e))?;
     let metadata = file.metadata().map_err(|e| {
-        StoreError(format!(
-            "cannot inspect private file {}: {e}",
-            path.display()
-        ))
+        StoreError::io(format!("cannot inspect private file {}", path.display()), e)
     })?;
     if !metadata.is_file() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "private state path {} is not a regular file",
             path.display()
         )));
@@ -646,24 +640,24 @@ pub(crate) fn read_private_to_string(path: &Path) -> Result<String> {
     let mut file = open_private_file(path, options)?;
     let mut text = String::new();
     file.read_to_string(&mut text)
-        .map_err(|e| StoreError(format!("cannot read {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot read {}", path.display()), e))?;
     Ok(text)
 }
 
 #[cfg(unix)]
 fn validate_owner_controlled_parent(path: &Path) -> Result<&Path> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
-    let parent = path
-        .parent()
-        .ok_or_else(|| StoreError(format!("private file {} has no parent", path.display())))?;
+    let parent = path.parent().ok_or_else(|| {
+        StoreError::Other(format!("private file {} has no parent", path.display()))
+    })?;
     let metadata = std::fs::symlink_metadata(parent)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", parent.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", parent.display()), e))?;
     if metadata.file_type().is_symlink()
         || !metadata.is_dir()
         || metadata.uid() != unsafe { libc::geteuid() }
         || metadata.permissions().mode() & 0o022 != 0
     {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "sensitive file parent {} must be a real owner-controlled directory with no \
              group/other write permission",
             parent.display()
@@ -685,13 +679,13 @@ fn validate_owner_controlled_parent(path: &Path) -> Result<&Path> {
 /// somewhere Stella cannot protect at all (#617).
 #[cfg(not(unix))]
 fn validate_owner_controlled_parent(path: &Path) -> Result<&Path> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| StoreError(format!("private file {} has no parent", path.display())))?;
+    let parent = path.parent().ok_or_else(|| {
+        StoreError::Other(format!("private file {} has no parent", path.display()))
+    })?;
     let metadata = std::fs::symlink_metadata(parent)
-        .map_err(|e| StoreError(format!("cannot inspect {}: {e}", parent.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", parent.display()), e))?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "sensitive file parent {} must be a real directory",
             parent.display()
         )));
@@ -724,7 +718,7 @@ pub(crate) fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Ok(metadata) = std::fs::symlink_metadata(path)
         && (metadata.file_type().is_symlink() || !metadata.is_file())
     {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "private state target {} is not a regular file",
             path.display()
         )));
@@ -737,12 +731,14 @@ pub(crate) fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 pub(crate) fn prepare_private_sqlite_path(path: &Path) -> Result<PathBuf> {
     let parent = path
         .parent()
-        .ok_or_else(|| StoreError(format!("database path {} has no parent", path.display())))?
+        .ok_or_else(|| {
+            StoreError::Other(format!("database path {} has no parent", path.display()))
+        })?
         .canonicalize()
-        .map_err(|e| StoreError(format!("cannot canonicalize {}: {e}", path.display())))?;
-    let name = path
-        .file_name()
-        .ok_or_else(|| StoreError(format!("database path {} has no filename", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot canonicalize {}", path.display()), e))?;
+    let name = path.file_name().ok_or_else(|| {
+        StoreError::Other(format!("database path {} has no filename", path.display()))
+    })?;
     let path = parent.join(name);
     let mut options = std::fs::OpenOptions::new();
     options.read(true).write(true).create(true);
@@ -809,9 +805,9 @@ pub(crate) fn open_private_sqlite_read_only(path: &Path) -> Result<Connection> {
 /// spaces and non-ASCII included, is passed through as SQLite expects.
 fn immutable_uri(path: &Path) -> Result<String> {
     let absolute = std::path::absolute(path)
-        .map_err(|e| StoreError(format!("cannot absolutize {}: {e}", path.display())))?;
+        .map_err(|e| StoreError::io(format!("cannot absolutize {}", path.display()), e))?;
     let text = absolute.to_str().ok_or_else(|| {
-        StoreError(format!(
+        StoreError::Other(format!(
             "cannot read {} through a SQLite URI: the path is not valid UTF-8",
             absolute.display()
         ))

--- a/crates/stella-store/src/private/tests.rs
+++ b/crates/stella-store/src/private/tests.rs
@@ -32,7 +32,7 @@ fn race_generated_ignore(racers: usize, rounds: usize) -> Vec<String> {
 
         for handle in handles {
             if let Err(error) = handle.join().expect("racer panicked") {
-                failures.push(error.0);
+                failures.push(error.to_string());
             }
         }
 

--- a/crates/stella-store/src/sessions.rs
+++ b/crates/stella-store/src/sessions.rs
@@ -301,7 +301,7 @@ impl SessionRegistry {
         let mut stamped = record.clone();
         stamped.updated_at_ms = now_ms();
         let json = serde_json::to_string_pretty(&stamped)
-            .map_err(|e| StoreError(format!("cannot serialize session record: {e}")))?;
+            .map_err(|e| StoreError::serde("cannot serialize session record", e))?;
         let path = self.path_for(&record.id);
         // sync = true: an unfsynced rename can publish a directory entry whose
         // bytes never left the page cache, so a power cut leaves a
@@ -429,10 +429,10 @@ impl SessionRegistry {
                 continue;
             }
             std::fs::remove_dir_all(&dir).map_err(|error| {
-                StoreError(format!(
-                    "cannot remove orphan session sidecar {}: {error}",
-                    dir.display()
-                ))
+                StoreError::io(
+                    format!("cannot remove orphan session sidecar {}", dir.display()),
+                    error,
+                )
             })?;
             removed.push(id);
         }
@@ -463,12 +463,12 @@ impl SessionRegistry {
         let existed = match std::fs::remove_file(self.path_for(id)) {
             Ok(()) => true,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
-            Err(e) => return Err(StoreError(format!("cannot remove session record: {e}"))),
+            Err(e) => return Err(StoreError::io("cannot remove session record", e)),
         };
         if let Err(e) = std::fs::remove_dir_all(self.sidecar_dir(id))
             && e.kind() != std::io::ErrorKind::NotFound
         {
-            return Err(StoreError(format!("cannot remove session state: {e}")));
+            return Err(StoreError::io("cannot remove session state", e));
         }
         Ok(existed)
     }

--- a/crates/stella-store/src/usage/schema.rs
+++ b/crates/stella-store/src/usage/schema.rs
@@ -165,8 +165,9 @@ pub(super) fn apply(conn: &mut Connection) -> Result<()> {
 
     let mut version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     while version < HUB_SCHEMA_VERSION {
-        let index = usize::try_from(version)
-            .map_err(|_| crate::StoreError(format!("hub schema version is negative: {version}")))?;
+        let index = usize::try_from(version).map_err(|_| {
+            crate::StoreError::Other(format!("hub schema version is negative: {version}"))
+        })?;
         let step = HUB_MIGRATIONS[index];
         let tx = conn.transaction()?;
         step(&tx)?;

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -241,7 +241,7 @@ impl WorkJournal {
         let identity = crate::workspace_local::resolve(workspace_root)?;
         let root = store_root.to_path_buf();
         std::fs::create_dir_all(&root)
-            .map_err(|e| StoreError(format!("cannot create work-journal root: {e}")))?;
+            .map_err(|e| StoreError::io("cannot create work-journal root", e))?;
         let journal = Self {
             git_dir: root.join(format!("{}.git", identity.id)),
             work_tree: identity.path,
@@ -415,19 +415,19 @@ impl WorkJournal {
             .stderr(std::process::Stdio::piped());
         let mut child = cmd
             .spawn()
-            .map_err(|e| StoreError(format!("cannot run git hash-object: {e}")))?;
+            .map_err(|e| StoreError::io("cannot run git hash-object", e))?;
         {
             use std::io::Write as _;
             let stdin = child.stdin.as_mut().expect("piped");
             stdin
                 .write_all(content.as_bytes())
-                .map_err(|e| StoreError(format!("cannot write blob: {e}")))?;
+                .map_err(|e| StoreError::io("cannot write blob", e))?;
         }
         let out = child
             .wait_with_output()
-            .map_err(|e| StoreError(format!("git hash-object failed: {e}")))?;
+            .map_err(|e| StoreError::io("git hash-object failed", e))?;
         if !out.status.success() {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "git hash-object failed: {}",
                 String::from_utf8_lossy(&out.stderr).trim()
             )));
@@ -844,19 +844,19 @@ impl WorkJournal {
             .stderr(Stdio::piped());
         let mut child = cmd
             .spawn()
-            .map_err(|e| StoreError(format!("cannot run git update-ref: {e}")))?;
+            .map_err(|e| StoreError::io("cannot run git update-ref", e))?;
         {
             use std::io::Write as _;
             let stdin = child.stdin.as_mut().expect("piped");
             stdin
                 .write_all(input.as_bytes())
-                .map_err(|e| StoreError(format!("cannot write ref deletions: {e}")))?;
+                .map_err(|e| StoreError::io("cannot write ref deletions", e))?;
         }
         let out = child
             .wait_with_output()
-            .map_err(|e| StoreError(format!("git update-ref failed: {e}")))?;
+            .map_err(|e| StoreError::io("git update-ref failed", e))?;
         if !out.status.success() {
-            return Err(StoreError(format!(
+            return Err(StoreError::Other(format!(
                 "git update-ref failed: {}",
                 String::from_utf8_lossy(&out.stderr).trim()
             )));
@@ -877,9 +877,9 @@ fn unix_now() -> i64 {
 fn run(cmd: &mut Command) -> Result<String> {
     let out = cmd
         .output()
-        .map_err(|e| StoreError(format!("cannot run git: {e}")))?;
+        .map_err(|e| StoreError::io("cannot run git", e))?;
     if !out.status.success() {
-        return Err(StoreError(format!(
+        return Err(StoreError::Other(format!(
             "git {:?} failed: {}",
             cmd.get_args().collect::<Vec<_>>(),
             String::from_utf8_lossy(&out.stderr).trim()

--- a/crates/stella-store/src/work_journal/snapshot.rs
+++ b/crates/stella-store/src/work_journal/snapshot.rs
@@ -119,7 +119,7 @@ impl WorkJournal {
         self.git_snapshot(&["add", "-A", "--"])?;
         let tree = self.git_snapshot(&["write-tree"])?.trim().to_string();
         if tree.is_empty() {
-            return Err(StoreError("git write-tree named no tree".into()));
+            return Err(StoreError::Other("git write-tree named no tree".into()));
         }
 
         let parent_tree = parent

--- a/crates/stella-store/src/workspace_local.rs
+++ b/crates/stella-store/src/workspace_local.rs
@@ -119,7 +119,7 @@ fn write_marker(workspace_root: &Path, marker: &Marker) -> Result<()> {
         .join(crate::private::WORKSPACE_PRIVATE_DIR);
     crate::ensure_private_dir(&dir)?;
     let body = serde_json::to_string(marker)
-        .map_err(|e| crate::StoreError(format!("cannot serialize {LOCAL_ID_FILE}: {e}")))?;
+        .map_err(|e| crate::StoreError::serde(format!("cannot serialize {LOCAL_ID_FILE}"), e))?;
     crate::private::write_private_atomic(&dir.join(LOCAL_ID_FILE), body.as_bytes())
 }
 


### PR DESCRIPTION
## What & why

Two `stella-store` issues, one crate, two commits.

**1. `StoreError` becomes a `thiserror` enum (#3735).** It was
`pub struct StoreError(pub String)` and the return error of nearly every public
function in the crate, so a caller could only tell a corrupt database from a
stale binary from an ordinary `SQLITE_BUSY` by matching on prose — invariant
#5's exact prohibition, and one `scripts/check-typed-errors.py` cannot see,
because it only flags the literal `Result<_, String>` shape.

The type moved to its own module (`lib.rs` is a grandfathered god file, so it
lost lines rather than gaining them) with these variants:

| Variant | Why it earns one |
|---|---|
| `NegativeSchemaVersion { version }` | remedy: move the file aside |
| `SchemaTooNew { file_version, build_version }` | remedy: upgrade the binary |
| `Corrupt { path, source }` | remedy: run `stella doctor` — was `integrity::corrupt_store_error`'s hand-formatted string |
| `Sqlite(#[from] rusqlite::Error)` | the ordinary failure the three above were indistinguishable from |
| `Io { context, source }` | keeps the `std::io::Error` on `Error::source`, so a caller branches on `ErrorKind`, not on the word "permission" |
| `Serde { context, source }` | same split for `serde_json::Error` |
| `Other(String)` | the deliberately narrow catch-all: a count that overflowed its column, a spool row that failed validation — failures with no second branch for a caller to take |

How coarse to cut was the open question in the issue. The rule I applied, and
wrote into the module header so the next person applies the same one: **a
failure earns a variant when a caller can act differently on it.** The ~85
filesystem/JSON sites became `Io`/`Serde` (their prose is now `context`, their
cause is a typed `source`); the ~80 genuine one-offs stayed `Other`.

Messages are byte-identical except for the `store: ` prefix, which is dropped —
every caller already names the subject, so the CLI was printing
`cannot open store: store: …`. Exemplar for the shape: `rusqlite::Error` and
`stella-serve`'s `CheckpointStoreError`, the nearest in-tree enum of the same
kind.

**2. `efficacy.rs` gets a test module (#3736).** Its three public reads are the
context-use extractor's whole source of truth and had no coverage anywhere in
the workspace.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

**For the error typing** — the four tests in `crates/stella-store/src/error.rs`
match on variants (`Err(StoreError::SchemaTooNew { file_version, .. })`), which
does not compile against `StoreError(pub String)`. That is the fail→pass flip:
the distinction they assert is not expressible on the old type.

**For the efficacy tests** — six tests, each checked by mutation rather than by
assertion that they pass. Removing one clause turns exactly one test red:

| Mutation | Killed by |
|---|---|
| drop `outcome IS NOT NULL` | `an_unfinished_execution_is_never_attributed` |
| drop `ok = 0` | `only_calls_that_failed_with_a_message_are_mined` |
| drop `error <> ''` | `only_calls_that_failed_with_a_message_are_mined` |
| neuter `LIMIT ?` | `paging_by_the_watermark_walks_every_row_once_in_order` |
| `ORDER BY seq DESC` | `failures_are_ordered_by_call_and_scoped_to_one_execution` |
| `ORDER BY memory_id ASC` | `citations_replay_in_insert_order_for_one_execution` |

`ok = 0` initially survived: with only successes carrying an empty `error`, the
`error <> ''` clause covers for a missing `ok` clause. The fixture now includes
a succeeded call with text in its `error` column, which separates them.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — one pre-existing failure, see below
- [x] Docs updated: `crates/stella-store/README.md` gains the `src/error.rs`
      row; `lib.rs`'s module map gains its line
- [x] `Closes #N` appears both here and as a commit trailer
- Also run green: `invariants`, `doc-links`, `typed-errors`, `file-size`,
  `god-files`, `left-behind`, `no-scratch`, `wire-schema`, `doc-warnings`,
  `tool-docs`, `lockfile-sync`, `self-driving-test`. `shellcheck` could not run
  (not installed in this container) and touches nothing here.

`cargo test --workspace` fails one test:
`stella-cli daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period`
("the child was killed after 81ms, before its 8s to shut down cleanly"). I ran
the cheap control — `git stash -u` and the same test on the unmodified tree —
and it fails identically there, so it is this container's process/signal
handling, not this change. Everything else passes (1832 in that binary, 399 in
`stella-store`).

## Nothing left behind

- [x] There is nothing new: everything I noticed is fixed here.

Two things worth a reviewer's judgement rather than an issue:

- `#3735`'s definition of done is met, but the `typed-errors` gate is blind to
  this shape both before and after — a named struct wrapping a `String` slips
  past a check that only matches `Result<_, String>`. Widening the guard to
  catch single-`String` newtype errors is a real follow-up; I did not file it
  because it is a decision about the guard's scope (it would also flag
  deliberate newtypes elsewhere), and it belongs to whoever owns
  `scripts/check-typed-errors.py`. Say the word and I will file it.
- `integrity.rs`'s `salvage` reports failures as `Option<String>` for a user
  report, so it renders the error rather than matching it. That is the right
  shape for a report and is unchanged here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (`thiserror` was already a
      `stella-store` dependency)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**The two commits would ideally have been two PRs.** #3735 asks to land the
error typing on its own, and it is the first commit, standalone and
self-contained. The session's designated branch covers both issues, so they
share one branch and therefore one PR; the commits are separable if you would
rather land them apart.

The bulk of the diff (~170 call sites) is mechanical and was applied by script,
then compiled: every site the compiler could not type-check was hand-resolved,
which is how the five `serde`-vs-`io` mix-ups were caught. Worth a skim rather
than a line-by-line read, with the attention spent on
`crates/stella-store/src/error.rs` — the variant set is the reviewable decision.

Closes #3735
Closes #3736

---
_Generated by [Claude Code](https://claude.ai/code/session_01JknvAdioxB5F95dhupY3ek)_

## Summary by Sourcery

Replace string-based stella-store errors with actionable typed variants and strengthen efficacy query coverage.

New Features:
- Add typed, matchable error variants for schema incompatibility, database corruption, SQLite, filesystem, serialization, and other store failures.
- Add comprehensive efficacy query tests covering execution filtering, pagination, failure extraction, ordering, and citation scoping.

Bug Fixes:
- Preserve underlying I/O and JSON error causes so callers can branch on typed error details instead of formatted messages.
- Distinguish corrupt stores and incompatible schema versions from ordinary SQLite failures.

Enhancements:
- Refactor stella-store error handling around a dedicated non-exhaustive `StoreError` enum and update call sites across the crate.
- Remove redundant store error message prefixes while retaining actionable context.

Documentation:
- Document the new error module and variant-based error handling in the stella-store module map and README.

Tests:
- Add witness tests validating typed StoreError matching and source preservation.
- Add efficacy tests for completed executions, watermark paging, failed tool-call filtering, ordering, and execution isolation.