### PR TITLE
fix(stella-transcript): drop the unused `word::Span` import that reddens clippy on every PR

### DIFF
--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -23,7 +23,6 @@ use crate::digest::{self, Chip};
 use crate::file_diff::{FileDiff, RowKind};
 use crate::fold::FoldState;
 use crate::model::{Call, FileStatus, NodeId, Run, Status, Step, ToolKind, Turn};
-use crate::word::Span;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Width of the elapsed-offset gutter, including its trailing space.


### PR DESCRIPTION
## What & why

`main` does not pass `cargo clippy --workspace --all-targets -- -D warnings`, so
the required `fmt + clippy + test` check is red on **every** open PR regardless
of what that PR changes — the check builds the PR merged with `main`.

```
error: unused import: `crate::word::Span`
  --> crates/stella-transcript/src/grid.rs:26:5
```

One line deleted, nothing else.

**Where it came from** (I traced this after filing the issue, and the issue's
first account of it was wrong — corrected in a comment there): #3755 removed
`grid.rs`'s `row_spans` **and** its `use crate::word::Span;` together, which was
correct. #3772 branched before that landed, and its `grid.rs` rewrite reinstated
the import line without a user. So this is an orphaned import, not a caller that
went missing — `row_spans` exists nowhere in the workspace today. `Span` itself
is still live in `file_diff.rs` and `html.rs`; only `grid.rs`'s import of it is
dead.

Plain `cargo build` only *warns* on an unused import, which is why the release
smoke build stayed green and nothing before the clippy step noticed.

Closes #3786

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the gate itself
      is the witness. `cargo clippy -p stella-transcript --all-targets -- -D
      warnings` fails on `main` and passes here; the workspace-wide run is green
      after. There is no behavior to test — the import had no user.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green (red on
      `main` before this)
- [x] `cargo test -p stella-transcript` — 46 passed
- [x] `file-size`, `god-files`, `left-behind`, `no-scratch`,
      `module-reachability`, `lockfile-sync` all green
- [x] Docs updated where behavior/flags changed — n/a, no behavior change

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

Reproduced on a clean `origin/main` worktree before fixing, so this was not a
merge artifact of any one branch.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Branched fresh from `main` at `2307391` (the merge of #3775), so the diff is
exactly the one line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JknvAdioxB5F95dhupY3ek)_

## Summary by Sourcery

Bug Fixes:
- Remove the unused `Span` import from `stella-transcript` so workspace Clippy checks pass with warnings treated as errors.