### PR TITLE
docs: phase 6 scrub remainder — spec status corrections (continued)

### DIFF
--- a/docs/playbooks/pipeline-as-plugins-execution.md
+++ b/docs/playbooks/pipeline-as-plugins-execution.md
@@ -46,16 +46,15 @@ this is the phase-level rollup the execution order below promises.
   (`before_turn` + `recall`, read-only, no worktree — exactly the "safest
   possible first real plugin" this phase named), graded against committed
   vectors in `crates/stella-runtime/tests/research_plugin_*.rs` and driven
-  end-to-end by `WrapperDispatch`. **One gap the plan did not anticipate**:
-  a plugin run through the raw loop does not yet write its variant id to
-  `executions.pipeline_variant` (`crates/stella-cli/src/agent/goal.rs`'s
-  `run_raw_one_shot` opens a bare `TurnDoor::new("run")` with no
-  `.wrapped_by(..)`), so the side-by-side comparison this phase's bar depends
-  on cannot yet distinguish a `stella-research` run from an unwrapped one in
-  the store — see `doc:pipeline-as-plugins` §7. `stella-plan`, `vera`,
-  `stella-candidates` and `stella-goal` remain unstarted; the dependency cut
-  (the phase's stated last slice) has not started either — the reference
-  count grew, not shrank, in the same work (§7 of the plan).
+  end-to-end by `WrapperDispatch`. Its runs write their variant id to
+  `executions.pipeline_variant` via `crates/stella-cli/src/wrapper_plugin.rs`'s
+  `RawTurnDriver::run_turn` (`TurnDoor::new("run").wrapped_by(self.variant)`),
+  so the side-by-side comparison this phase's bar depends on can already
+  distinguish a `stella-research` run from an unwrapped one in the store — see
+  `doc:pipeline-as-plugins` §7. `stella-plan`, `vera`, `stella-candidates` and
+  `stella-goal` remain unstarted; the dependency cut (the phase's stated last
+  slice) has not started either — the reference count grew, not shrank, in
+  the same work (§7 of the plan).
 - **Phase 5 (Track D, self-driving as a plugin).** Started, not finished.
   `plugins/stella-selfdriving/plugin.toml` exists as the settled D-3 consent
   declaration — the widest grant self-driving needs, written out and provable

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -641,31 +641,29 @@ corrected, path-scoped wording.
 
 ## 7. Track B — extraction order
 
-**The flag inversion of #3381 shipped (PR #3694).** `--pipeline <variant>`
-replaced `--no-pipeline` as the sole opt-in on every door: the raw loop is
-the default, and `--no-pipeline` is a deprecated no-op. What has not fully
-shipped is the other half of this paragraph's plan — the wrapper id recorded
-on the executions row so two variants can be compared. That column and
-migration shipped (`crates/stella-store/src/ddl.rs:115`, `migrations.rs:29`),
-and the `classic` path writes it (`crates/stella-cli/src/agent/persistence.rs:26`,
-via `begin_pipeline_execution`) — but the raw loop's plugin path
-(`crates/stella-cli/src/agent/goal.rs`'s `run_raw_one_shot`, which handles
-both `PipelineChoice::Raw` and `PipelineChoice::Plugin`) still opens its
-execution row through a bare `TurnDoor::new("run")` with no `.wrapped_by(..)`
-call, so a `--pipeline <variant>` naming an installed plugin runs and is
-recorded exactly like the unwrapped raw loop. Wiring the resolved plugin's
-`Wrapper::id` onto that door is still a Track A tail item — without it the
-A/B comparison this whole plan is justified by cannot distinguish a plugin
-run from a raw one in the store.
+**The flag inversion of #3381 shipped (PR #3694), and so did the other half
+of this paragraph's plan.** `--pipeline <variant>` replaced `--no-pipeline`
+as the sole opt-in on every door: the raw loop is the default, and
+`--no-pipeline` is a deprecated no-op. The wrapper id recorded on the
+executions row so two variants can be compared shipped too: the column and
+migration (`crates/stella-store/src/ddl.rs:115`, `migrations.rs:29`), the
+`classic` path writing it (`crates/stella-cli/src/agent/persistence.rs:26`,
+via `begin_pipeline_execution`), and — landed alongside the wrapper-plugin
+driver (#3494) — the raw loop's named-plugin path writing it too:
+`crates/stella-cli/src/wrapper_plugin.rs`'s `RawTurnDriver::run_turn` opens
+its execution row through `TurnDoor::new("run").wrapped_by(self.variant)`,
+where `self.variant` is the resolved plugin's declared `[wrapper] id`
+(`bound.variant()`), so a `--pipeline <variant>` run is distinguishable from
+an unwrapped raw run by a `GROUP BY pipeline_variant` today.
 
 Order, easiest and least risky first:
 
 1. **stella-research** — `before_turn` only, read-only, no worktree. The safest
    possible first real plugin. **Landed** — `plugins/stella-research`
    (`doc:pipeline-as-plugins-execution` Phase 4), driven end-to-end by
-   `WrapperDispatch` and graded against committed vectors in
-   `crates/stella-runtime/tests/research_plugin_*.rs`. See the note above:
-   its runs are not yet distinguishable from a raw run in `pipeline_variant`.
+   `WrapperDispatch`, graded against committed vectors in
+   `crates/stella-runtime/tests/research_plugin_*.rs`, and distinguishable in
+   the store per the paragraph above.
 2. **stella-plan** — `before_turn`, needs the triage signals A8 publishes.
 3. **vera** — `after_turn` + `judge`. Needs A10 (worktrees) and A6 (structured
    verdicts). Ported, not copied: see §8.

--- a/docs/spec/turn-loop-wrappers.md
+++ b/docs/spec/turn-loop-wrappers.md
@@ -454,8 +454,17 @@ Two things make that enforceable rather than aspirational:
 
 ### 9.4 The manifest needs two properties the sketch does not yet have
 
-§5's TOML sketch is the right shape. Two additions, both so that "a new variant
-is a manifest file" fails at load with a reason rather than at round three:
+**Landed (#3380/#3408), re-verified 2026-08-18.** Both additions below exist
+in `crates/stella-plugin/src/{manifest,wrapper,program}.rs`: the stage graph is
+load-checked on both axes (a condition reading a signal only a later stage
+publishes, or one only a conditionally-run earlier stage publishes, is a load
+error — `stella-plugin`'s README §"the stage graph is load-checked" states
+the rule this subsection asked for), and `if` is the closed grammar this
+subsection specified — `[no-]<boolean-signal>` or `<count-signal> <op>
+<number>` over a published `Signal`, never an expression language. The
+heading is kept as written, describing the gap at the commit this document
+was verified against; §5's TOML sketch is the right shape, and the two
+additions below are what closed it:
 
 - **Typed stage input/output, checked as a graph at load.** A stage whose input
   no prior stage produces is a load error. §5 already says each stage has a


### PR DESCRIPTION
## What & why

**Status: in progress — the tail of the Phase 6 docs scrub plus its adversarial-audit fixes land here.** This line will be removed when the branch is complete.

Continuation of #3787 (merged): residual spec-status corrections in `doc:pipeline-as-plugins`, `doc:turn-loop-wrappers`, and the execution playbook, plus whatever the docs-scrub audit round (running) requires — including settling the `pipeline_variant` question for plugin-driven raw runs (fix or file, with code evidence).

Refs #3381

## The witness

- [x] No witness needed (docs) — verified by the doc guard suite plus a two-lens adversarial audit of rewritten claims against the code they describe.

## The gate

- [ ] Boxes checked when the final validated push lands.

## Nothing left behind

- [ ] Filed issues linked before review.

## Ground-rule check

- [x] Prose-only unless the audit round requires a small code fix (which will be named here).

## Anything reviewers should know?

- Head commits are phase checkpoints; hold review until the status line is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTfq37g7bM6efEE5Pkx1k5)_

## Summary by Sourcery

Bring Phase 6 plugin documentation in line with the implemented pipeline variant tracking and manifest validation behavior.

Enhancements:
- Correct spec and execution-playbook status claims to reflect that named raw-loop plugins now record their variant identifiers for store-side comparisons.
- Document that plugin manifest stage-graph validation and closed conditional grammar have landed and were re-verified.

Documentation:
- Update pipeline plugin and turn-loop wrapper documentation to remove obsolete implementation gaps and accurately describe the shipped behavior.