### PR TITLE
feat(stella-cli): a wrapper plugin's child turn runs on the session's own dispatcher

### DIFF
--- a/crates/stella-cli/README.md
+++ b/crates/stella-cli/README.md
@@ -68,6 +68,15 @@ Specific changes this crate is the far end of:
   wrapper driver yet and refuse a named plugin variant rather than silently
   ignoring it (#3695) — see [`stella-runtime`](../stella-runtime)'s README
   for exactly which doors call `WrapperDispatch` today.
+- **Resolving a wrapper and serving it are two moments, deliberately.**
+  `bind_installed` finds the plugin and declares its transport *before* the
+  provider is built, so `--pipeline` naming nothing installed fails as a typo
+  rather than after a paid run; `ResolvedWrapper::serving` builds the
+  `HostCallGate` afterwards, because a plugin's `child_turn` is spent by this
+  session's own `SubAgentDispatcher` and that needs the provider (#3576).
+  `HostPlanes` is consumed by value at `HostCallGate::declare`, so a plane
+  cannot be added to a gate later — collapsing the two halves back into one
+  function is what would break, not merely untidy.
 
 ## Boundary — does this change belong here?
 

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -119,7 +119,7 @@ pub(crate) async fn run_raw_one_shot(
     // the run it was meant to shape. The grant is minted in the same breath and
     // for the same reason — a `--test-command` the host's parser refuses must
     // stop the run here, not after it is paid for.
-    let bound = match pipeline.plugin() {
+    let resolved = match pipeline.plugin() {
         Some(variant) => Some(
             crate::wrapper_plugin::resolve(&cfg.workspace_root, variant, &mut |line| {
                 eprintln!("  ! {line}");
@@ -130,7 +130,7 @@ pub(crate) async fn run_raw_one_shot(
     };
     // Pinned *before* the turn runs, which is the whole content of the tamper
     // claim: an identity snapshotted afterwards vouches for nothing.
-    let candidate = match &bound {
+    let candidate = match &resolved {
         Some(_) => Some(
             crate::wrapper_candidate::grant_shared_tree(&cfg.workspace_root, test_command)
                 .map_err(crate::failure::CliFailure::from)?,
@@ -144,7 +144,27 @@ pub(crate) async fn run_raw_one_shot(
     let registry: std::sync::Arc<ToolRegistry> =
         std::sync::Arc::new(crate::write_dirs::registry_for(cfg));
 
-    crate::subagent::install_for_session(cfg, &registry)?;
+    let sub_agents = crate::subagent::install_for_session(cfg, &registry)?;
+    // The gate is built *here*, not beside `resolve` above, and the ordering is
+    // the whole reason the two halves are separate: a `--pipeline` naming
+    // nothing installed must fail as a typo before a paid call, while a
+    // plugin's `child_turn` needs this session's dispatcher, which needs the
+    // provider built two lines up (#3576).
+    let bound = match resolved {
+        Some(resolved) => {
+            let host = crate::wrapper_plugin::session_host(
+                &cfg.workspace_root,
+                resolved.manifest(),
+                sub_agents,
+            );
+            Some(
+                resolved
+                    .serving(host)
+                    .map_err(crate::failure::CliFailure::from)?,
+            )
+        }
+        None => None,
+    };
     // The one derivation of "a human is here to answer" — the #2676 approval
     // responder and the rules-enforcement prompt both read this value.
     let ask = human_is_present(format == OutputFormat::Text);

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -55,6 +55,30 @@
 //!    with no plane still attaches the gate and answers with no frames: an
 //!    empty answer is something a plugin can degrade on, and an absent gate is
 //!    the one thing it cannot be told about.
+//! 4. **A child-turn plane** (#3576). A plugin that declares
+//!    `[loop] calls = ["child_turn"]` and a `[roles.<name>]` gets a real model
+//!    call at that role intent — spent by **this session's own**
+//!    `SubAgentDispatcher`, the one `task_assign` runs on, so the plugin never
+//!    holds a provider, an `Engine` or a credential (invariant 3,
+//!    `doc:turn-loop-wrappers` §9.3). The seat it resolves to is the receipt's
+//!    attribution, the child is read-only, the allowance is the host's, and
+//!    what it spent is printed beside what it was refused. Two limits stated
+//!    rather than implied: the `verifier` tier is bound to no seat here, so a
+//!    plugin naming it is answered `Unavailable`
+//!    ([`child_turn_plane`] argues why); and a point runs between the parent's
+//!    turns, where the tool registry's event slot is empty — so the spend
+//!    reaches the session's guard and this run's report, but not the store's
+//!    receipt (#3802). The turn's boundary controls are the third
+//!    (#3803): this door publishes none, so a child inherits none, which is
+//!    a no-op until a surface that *has* controls can drive a wrapped turn.
+//!
+//! The ordering that makes 4 possible is worth naming, because it is the shape
+//! of the split between [`bind_installed`] and [`ResolvedWrapper::serving`]: a
+//! `--pipeline` naming nothing installed must fail as a typo before a paid
+//! call, while a child-turn plane needs a dispatcher, which needs the provider.
+//! [`HostPlanes`] is consumed by value at [`HostCallGate::declare`], so a plane
+//! cannot be added to a gate afterwards — the two halves are therefore separate
+//! moments, not one function with an `Option` in it.
 //!
 //! And two scope limits: `--pipeline` is on `stella run` alone and a plugin's
 //! `Unmet` does not fail the process (#3554), and only this driver of
@@ -67,12 +91,13 @@ use stella_core::budget::BudgetGuard;
 use stella_core::estimator::CalibrationMap;
 use stella_core::ports::ToolExecutor;
 use stella_core::router::Router;
+use stella_core::subagent::SubAgentDispatcher;
 use stella_model::provider::Provider;
 use stella_plugin::{SignalValues, TurnOutcome as WrapperTurnOutcome};
 use stella_protocol::{AgentEvent, CompletionMessage};
 use stella_runtime::wrapper::{
-    DEFAULT_HOST_MAX_CALLS, DispatchReport, DrivenTurn, HostCallGate, HostPlanes, RoundInput,
-    SubprocessWrapper, TurnDriver, TurnPrelude, WrapperDispatch,
+    ChildTurnSpend, ChildTurns, DEFAULT_HOST_MAX_CALLS, DispatchReport, DrivenTurn, HostCallGate,
+    HostPlanes, RoundInput, SubprocessWrapper, TurnDriver, TurnPrelude, WrapperDispatch,
 };
 use stella_store::Store;
 use stella_tools::ToolRegistry;
@@ -282,6 +307,11 @@ pub(crate) struct BoundWrapper {
     /// The host-call gate this plugin's conversations run through, kept so
     /// [`HostCallGate::refusals`] reaches a surface after the run.
     gate: Arc<HostCallGate>,
+    /// The child-turn plane this host installed, kept for the same reason as
+    /// the gate beside it: the plane is the only thing that knows what a
+    /// plugin spent, and a driver that installed one and could not report on
+    /// it would be silent about money (#3576).
+    child_turns: Option<Arc<SessionChildTurns>>,
 }
 
 impl BoundWrapper {
@@ -289,14 +319,183 @@ impl BoundWrapper {
     pub(crate) fn variant(&self) -> &str {
         self.dispatch.variant()
     }
+
+    /// Every child turn this host ran on the plugin's behalf, in order.
+    ///
+    /// Empty both when the plugin never asked and when no plane was installed;
+    /// the two are told apart by [`HostCallGate::refusals`], which records the
+    /// `Unavailable` the second case answers with.
+    pub(crate) fn child_spends(&self) -> Vec<ChildTurnSpend> {
+        self.child_turns
+            .as_ref()
+            .map_or_else(Vec::new, |plane| plane.spends())
+    }
 }
 
-/// Read what is installed and bind the wrapper `variant` names.
+/// The child-turn plane a `stella run` session installs: the plugin's declared
+/// role intents over **this session's own** sub-agent dispatcher.
 ///
-/// The impure half — it reads the two plugin tiers, the settings that retract
-/// them, and this workspace's context plane — kept apart from
-/// [`bind_installed`], which is the decision and is therefore the half the tests
-/// drive.
+/// `Arc<dyn SubAgentDispatcher>` rather than the concrete
+/// [`crate::subagent::SessionSubAgents`] because that is what
+/// [`crate::subagent::install_for_session`] hands back, and a session installs
+/// exactly one dispatcher — a second would be a second pool, a second carve
+/// and a second ledger over one session's money.
+pub(crate) type SessionChildTurns = ChildTurns<Arc<dyn SubAgentDispatcher>>;
+
+/// The receipt turn slot a plugin's child turns are recorded under.
+///
+/// Not the parent's. A raw `stella run` turn is built from
+/// [`crate::agent::engine_config_for_kind`], which leaves `turn_instance` at
+/// its default of 0, and context receipts key on
+/// `(execution_id, turn_instance, step, call_seq)` with `step` restarting at 0
+/// every turn — so a child sharing slot 0 could overwrite the parent's step
+/// manifests. One slot along is enough to keep them apart, and it is a
+/// constant rather than a per-round bump because a plugin's points run
+/// *between* the rounds they are about: each round opens its own execution
+/// row, so the key is already unique across rounds without this moving.
+const PLUGIN_CHILD_TURN_SLOT: u32 = 1;
+
+/// This host's child-turn plane for one installed plugin.
+///
+/// Three deliberate decisions live here rather than at the call site, because
+/// each is a claim about the user's money or the receipt it lands on (#3576):
+///
+/// - **No `verifier` seat is bound.** [`ChildTurns`] serves `worker`,
+///   `triage`, `research` and `plan` by default and deliberately not
+///   `verifier`, whose seats are `WitnessAuthor` and `Verdict` — the model
+///   verdict #2584 removed *structurally*. Binding one here would put a call
+///   on the receipt attributed to a role this host did not make, so a plugin
+///   naming a `verifier` tier is told `Unavailable` and this driver does not
+///   pretend otherwise.
+/// - **No per-turn USD carve is requested.** `None` asks for the parent's
+///   whole remaining headroom, which `BudgetGuard::carve` clamps — and the
+///   dispatcher behind it carves from the session's sub-agent pool
+///   ([`crate::subagent::session_pool_limit_usd`]), so "unbounded ask" is
+///   still a bounded spend.
+/// - **The host's own ceiling stands.** `[loop] max_calls` is the plugin's ask
+///   and [`stella_runtime::wrapper::DEFAULT_HOST_MAX_CHILD_TURNS`] the
+///   authority; neither is overridden here.
+pub(crate) fn child_turn_plane(
+    manifest: &stella_plugin::PluginManifest,
+    dispatcher: Arc<dyn SubAgentDispatcher>,
+) -> SessionChildTurns {
+    ChildTurns::declare(manifest, dispatcher).with_turn_instance(PLUGIN_CHILD_TURN_SLOT)
+}
+
+/// What this host will do for a plugin, assembled after the resources exist.
+///
+/// Separate from [`ResolvedWrapper`] because the two are built at different
+/// moments and cannot be merged without losing one of the properties: the
+/// wrapper is resolved *before* the provider is built, so a `--pipeline` that
+/// names nothing installed fails as a typo rather than after a paid run, while
+/// a child-turn plane needs the session's dispatcher, which needs the
+/// provider. [`HostPlanes`] is consumed by value at
+/// [`HostCallGate::declare`], so a plane cannot be added to a gate afterwards
+/// — the host is therefore assembled whole, once, here.
+pub(crate) struct WrapperHost {
+    recall: Box<dyn stella_runtime::wrapper::RecallHost>,
+    child_turns: Option<Arc<SessionChildTurns>>,
+}
+
+impl WrapperHost {
+    /// A host serving `recall` from this workspace's context plane and nothing
+    /// else — what a driver with no dispatcher of its own can offer.
+    pub(crate) fn recalling(recall: Box<dyn stella_runtime::wrapper::RecallHost>) -> Self {
+        Self {
+            recall,
+            child_turns: None,
+        }
+    }
+
+    /// Also serve `child_turn` from this plane.
+    #[must_use]
+    pub(crate) fn with_child_turns(mut self, plane: Arc<SessionChildTurns>) -> Self {
+        self.child_turns = Some(plane);
+        self
+    }
+}
+
+/// Everything a `stella run` session can do for the plugin wrapping it.
+///
+/// The one place both planes are named together, so a driver cannot install
+/// half of them by accident.
+pub(crate) fn session_host(
+    workspace_root: &std::path::Path,
+    manifest: &stella_plugin::PluginManifest,
+    dispatcher: Arc<dyn SubAgentDispatcher>,
+) -> WrapperHost {
+    WrapperHost::recalling(Box::new(crate::wrapper_recall::SessionRecallHost::open(
+        workspace_root,
+    )))
+    .with_child_turns(Arc::new(child_turn_plane(manifest, dispatcher)))
+}
+
+/// An installed wrapper plugin, found and start-able, before this host has
+/// anything to serve it with.
+///
+/// The half of binding that needs no provider, no registry and no dispatcher,
+/// so it can run first — see [`WrapperHost`] for why the split exists.
+pub(crate) struct ResolvedWrapper {
+    manifest: stella_plugin::PluginManifest,
+    wrapper: SubprocessWrapper,
+    variant: String,
+}
+
+impl std::fmt::Debug for ResolvedWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedWrapper")
+            .field("plugin", &self.manifest.name)
+            .field("variant", &self.variant)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvedWrapper {
+    /// The manifest a human consented to at install — read by a caller
+    /// assembling this host's planes for it.
+    pub(crate) fn manifest(&self) -> &stella_plugin::PluginManifest {
+        &self.manifest
+    }
+
+    /// Bind the plugin's process to what this host will do for it.
+    ///
+    /// # Errors
+    ///
+    /// A wrapper whose declared stage order cannot be resolved — which a
+    /// validated manifest cannot hit, since the variant was found by its
+    /// `[wrapper] id`.
+    pub(crate) fn serving(self, host: WrapperHost) -> Result<BoundWrapper, String> {
+        let mut planes = HostPlanes::recalling(crate::wrapper_recall::BoxedRecall(host.recall));
+        if let Some(plane) = &host.child_turns {
+            planes = planes.with_child_turns(Arc::clone(plane));
+        }
+        // The manifest's own `[loop]` grant is the authoritative filter — an
+        // undeclared capability is refused before this host performs anything —
+        // and `DEFAULT_HOST_MAX_CALLS` clamps whatever allowance it asked for.
+        let gate = Arc::new(HostCallGate::declare(
+            self.manifest.loop_grant.clone(),
+            DEFAULT_HOST_MAX_CALLS,
+            Box::new(planes),
+        ));
+        let variant = self.variant;
+        let dispatch = WrapperDispatch::bind(
+            self.manifest,
+            Arc::new(self.wrapper.serving(Arc::clone(&gate))),
+        )
+        .map_err(|error| format!("wrapper \"{variant}\" cannot be driven: {error}"))?;
+        Ok(BoundWrapper {
+            dispatch,
+            gate,
+            child_turns: host.child_turns,
+        })
+    }
+}
+
+/// Read what is installed and resolve the wrapper `variant` names.
+///
+/// The impure half — it reads the two plugin tiers and the settings that
+/// retract them — kept apart from [`bind_installed`], which is the decision and
+/// is therefore the half the tests drive.
 ///
 /// # Errors
 ///
@@ -305,7 +504,7 @@ pub(crate) fn resolve(
     workspace_root: &std::path::Path,
     variant: &str,
     warn: &mut dyn FnMut(String),
-) -> Result<BoundWrapper, String> {
+) -> Result<ResolvedWrapper, String> {
     let settings = crate::settings::Settings::load(workspace_root).unwrap_or_default();
     let (roster, notices) = PluginRoster::load(workspace_root, &settings);
     // A plugin that did not load must never vanish silently: "I installed it
@@ -313,14 +512,7 @@ pub(crate) fn resolve(
     for notice in notices {
         warn(notice.trim_start_matches(" ! ").to_string());
     }
-    bind_installed(
-        &roster,
-        variant,
-        Box::new(crate::wrapper_recall::SessionRecallHost::open(
-            workspace_root,
-        )),
-        warn,
-    )
+    bind_installed(&roster, variant, warn)
 }
 
 /// Find the installed wrapper plugin that declares `variant`, and bind it to
@@ -337,18 +529,16 @@ pub(crate) fn resolve(
 /// every driver (#3512), and a plugin author whose manifest asked for one can
 /// only stop asking if they are told.
 ///
-/// `recall` is this host's context plane, taken as a parameter rather than
-/// opened here so the decision stays testable without a workspace on disk. It
-/// is always bound into a [`HostCallGate`], even when the plane behind it is
-/// empty: a plugin that asks and is answered "no frames" degrades honestly,
-/// while a plugin that asks through a transport with *no* gate has its stdin
-/// shut and waits for an answer that never comes (#3561).
+/// It stops short of the [`HostCallGate`]: this half runs before the provider
+/// exists, so it cannot yet build the child-turn plane that needs a
+/// dispatcher. [`ResolvedWrapper::serving`] is the other half, and every
+/// wrapper reaches it — a plugin that asks through a transport with *no* gate
+/// has its stdin shut and waits for an answer that never comes (#3561).
 pub(crate) fn bind_installed(
     roster: &PluginRoster,
     variant: &str,
-    recall: Box<dyn stella_runtime::wrapper::RecallHost>,
     warn: &mut dyn FnMut(String),
-) -> Result<BoundWrapper, String> {
+) -> Result<ResolvedWrapper, String> {
     let installed = roster
         .plugins()
         .iter()
@@ -414,22 +604,11 @@ pub(crate) fn bind_installed(
              receives a model credential; declare a [roles] tier instead"
         ));
     }
-    // The manifest's own `[loop]` grant is the authoritative filter — an
-    // undeclared capability is refused before this host performs anything —
-    // and `DEFAULT_HOST_MAX_CALLS` clamps whatever allowance it asked for.
-    let gate = Arc::new(HostCallGate::declare(
-        installed.manifest.loop_grant.clone(),
-        DEFAULT_HOST_MAX_CALLS,
-        Box::new(HostPlanes::recalling(crate::wrapper_recall::BoxedRecall(
-            recall,
-        ))),
-    ));
-    let dispatch = WrapperDispatch::bind(
-        installed.manifest.clone(),
-        Arc::new(admitted.wrapper.serving(Arc::clone(&gate))),
-    )
-    .map_err(|error| format!("wrapper \"{variant}\" cannot be driven: {error}"))?;
-    Ok(BoundWrapper { dispatch, gate })
+    Ok(ResolvedWrapper {
+        manifest: installed.manifest.clone(),
+        wrapper: admitted.wrapper,
+        variant: variant.to_string(),
+    })
 }
 
 /// This host's published signal values, as they stand **before** the turn.
@@ -615,10 +794,13 @@ pub(crate) async fn run_wrapped(
         candidate,
     };
     let report = bound.dispatch.run(input, &mut driver).await;
+    // Whatever a plugin's last point spent has no turn left to fold it in, so
+    // this driver folds it (#3576). See `settle_plugin_child_spend`.
+    settle_plugin_child_spend(driver.registry, &mut *driver.budget);
     let last = driver.results.pop();
     match report {
         Ok(report) => {
-            report_to(format, &report, &bound.gate);
+            report_to(format, &report, &bound.gate, &bound.child_spends());
             // A round always runs, so `results` always has an entry; an empty
             // one would mean the dispatcher returned without driving anything,
             // which is a report about the wrapper and not about the work.
@@ -639,431 +821,77 @@ pub(crate) async fn run_wrapped(
 ///
 /// stderr in every format: stdout may be machine-readable JSON, and a wrapper's
 /// commentary is not part of either summary contract.
-fn report_to(format: OutputFormat, report: &DispatchReport, gate: &HostCallGate) {
+fn report_to(
+    format: OutputFormat,
+    report: &DispatchReport,
+    gate: &HostCallGate,
+    spends: &[ChildTurnSpend],
+) {
     for fault in &report.faults {
         eprintln!("  ! wrapper: {fault}");
     }
     for refused in gate.refusals() {
         eprintln!("  ! wrapper: {refused}");
     }
+    for line in spend_lines(spends) {
+        eprintln!("  ! wrapper: {line}");
+    }
     if format == OutputFormat::Text || !report.met() {
         eprintln!("  ◇ {}", report.summary());
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-    use std::path::PathBuf;
-
-    use super::*;
-    use crate::plugin_cmd::roster::{InstalledPlugin, PluginScope};
-    use stella_plugin::PluginManifest;
-
-    const WRAPPER_MANIFEST: &str = r#"
-name = "budget-keeper"
-[loop]
-participation = "steering"
-points = ["before_turn", "after_turn"]
-[runtime]
-argv = ["/bin/sh", "${plugin_dir}/main.sh"]
-timeout_secs = 30
-env = ["PATH", "ANTHROPIC_API_KEY"]
-[wrapper]
-id = "budget-v1"
-[[wrapper.stages]]
-name = "execute"
-"#;
-
-    fn installed(text: &str, dir: &str) -> InstalledPlugin {
-        InstalledPlugin {
-            manifest: PluginManifest::from_toml_str(text).expect("fixture must load"),
-            dir: PathBuf::from(dir),
-            scope: PluginScope::User,
-        }
-    }
-
-    fn roster(plugins: Vec<InstalledPlugin>) -> PluginRoster {
-        PluginRoster::compose(plugins, Vec::new(), &BTreeMap::new())
-    }
-
-    /// A context plane that answers every ask with one frame, so a test can
-    /// tell "the gate reached the plane" from "the gate refused".
-    struct OneFrame;
-
-    #[async_trait]
-    impl stella_runtime::wrapper::RecallHost for OneFrame {
-        async fn recall(&self, goal: &str) -> Vec<stella_plugin::RecallFrame> {
-            vec![stella_plugin::RecallFrame {
-                label: "the last run".to_string(),
-                kind: "memory".to_string(),
-                source: "context.db".to_string(),
-                uri: None,
-                content: format!("about {goal}"),
-            }]
-        }
-    }
-
-    fn no_recall() -> Box<dyn stella_runtime::wrapper::RecallHost> {
-        Box::new(crate::wrapper_recall::SessionRecallHost::none())
-    }
-
-    fn bound(
-        roster: &PluginRoster,
-        variant: &str,
-        warn: &mut dyn FnMut(String),
-    ) -> Result<BoundWrapper, String> {
-        bind_installed(roster, variant, no_recall(), warn)
-    }
-
-    /// **Witness (#3381 "Flip the default").** No flag at all used to mean
-    /// `Classic` — the staged pipeline was the default. This assertion fails
-    /// on the pre-#3381 code (which resolves `(false, None)` to `Classic`)
-    /// and passes on this one: the raw loop is the default now, with or
-    /// without `--no-pipeline`.
-    #[test]
-    fn no_flag_at_all_resolves_to_the_raw_loop() {
-        assert_eq!(PipelineChoice::resolve(false, None), PipelineChoice::Raw);
-        assert_eq!(
-            PipelineChoice::resolve(true, None),
-            PipelineChoice::Raw,
-            "--no-pipeline is a deprecated no-op: it names the same choice as no flag at all"
-        );
-    }
-
-    /// `classic` is still selectable by the id it records, and an unknown
-    /// variant still binds a plugin lookup rather than the built-in.
-    #[test]
-    fn pipeline_variant_selects_classic_or_a_plugin_by_name() {
-        assert_eq!(
-            PipelineChoice::resolve(false, Some("classic")),
-            PipelineChoice::Classic,
-            "the built-in is selectable by the id it records"
-        );
-        assert_eq!(
-            PipelineChoice::resolve(false, Some("budget-v1")),
-            PipelineChoice::Plugin("budget-v1")
-        );
-    }
-
-    /// **Witness (#3381).** `--no-pipeline` together with `--pipeline` used to
-    /// be a hard error (`conflicts_with` in clap, then an `Err` from
-    /// `resolve`). This assertion fails on the pre-#3381 code (which returns
-    /// `Err` here) and passes on this one: a deprecated no-op flag must not
-    /// veto an explicit `--pipeline` opt-in, on either variant arm.
-    #[test]
-    fn no_pipeline_no_longer_vetoes_an_explicit_pipeline_choice() {
-        assert_eq!(
-            PipelineChoice::resolve(true, Some("budget-v1")),
-            PipelineChoice::Plugin("budget-v1"),
-            "--pipeline wins outright; the deprecated flag has nothing left to veto"
-        );
-        assert_eq!(
-            PipelineChoice::resolve(true, Some("classic")),
-            PipelineChoice::Classic
-        );
-    }
-
-    /// The notice fires exactly when `--no-pipeline` was passed, regardless of
-    /// what `--pipeline` said alongside it, and says nothing when it was not.
-    #[test]
-    fn the_deprecation_notice_fires_only_when_no_pipeline_was_passed() {
-        assert!(no_pipeline_deprecation_notice(false).is_none());
-        let notice = no_pipeline_deprecation_notice(true).expect("flag was passed");
-        assert!(notice.contains("--no-pipeline"), "{notice}");
-        assert!(notice.contains("--pipeline"), "{notice}");
-    }
-
-    /// **Witness (#3695).** `stella goal`/`stella fleet` cannot drive a
-    /// wrapper plugin today — only `stella run` implements [`TurnDriver`] over
-    /// one — so a named `--pipeline <variant>` must be refused on those doors
-    /// rather than silently downgraded to raw or promoted to classic. This
-    /// assertion fails on code that has no such gate at all (every door would
-    /// accept-and-ignore the variant) and passes on this one.
-    #[test]
-    fn a_named_plugin_variant_is_refused_on_a_door_that_cannot_drive_one() {
-        let err = reject_plugin_variant_for_door("goal", PipelineChoice::Plugin("budget-v1"))
-            .expect_err("goal has no wrapper driver");
-        assert!(err.contains("budget-v1"), "{err}");
-        assert!(err.contains("stella goal"), "{err}");
-        assert!(
-            err.contains("stella run --pipeline budget-v1"),
-            "the refusal must name the door that CAN run it: {err}"
-        );
-
-        let err = reject_plugin_variant_for_door("fleet", PipelineChoice::Plugin("budget-v1"))
-            .expect_err("fleet has no wrapper driver either");
-        assert!(err.contains("stella fleet"), "{err}");
-    }
-
-    /// `classic` and no flag at all both resolve away from `Plugin` before
-    /// reaching the gate, so neither is refused on a door with no wrapper
-    /// driver — only a *named* variant is out of reach there.
-    #[test]
-    fn classic_and_raw_are_never_refused_on_a_door_with_no_wrapper_driver() {
-        reject_plugin_variant_for_door("goal", PipelineChoice::Classic)
-            .expect("classic has no plugin to drive — nothing to refuse");
-        reject_plugin_variant_for_door("goal", PipelineChoice::Raw)
-            .expect("raw has no plugin to drive — nothing to refuse");
-    }
-
-    /// **Witness (#3696).** `--keep-witness`, `--require-verified`, and
-    /// `--test-command` used to reach `run_one_shot` on the `Raw` arm and be
-    /// silently dropped there (`run_raw_one_shot` takes no `keep_witness`/
-    /// `require_verified` parameter at all). This assertion fails against
-    /// that code (which has no such gate, so every call below returns `Ok`)
-    /// and passes on this one: each flag alone against `Raw` is refused, and
-    /// the message names the remedy.
-    #[test]
-    fn each_verification_flag_alone_is_refused_against_the_raw_loop() {
-        let err = reject_verification_flags_without_pipeline(
-            PipelineChoice::Raw,
-            Some("pytest"),
-            false,
-            false,
-        )
-        .expect_err("--test-command does nothing on the raw loop");
-        assert!(err.contains("--test-command"), "{err}");
-        assert!(err.contains("--pipeline classic"), "{err}");
-
-        let err =
-            reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, true, false)
-                .expect_err("--keep-witness does nothing on the raw loop");
-        assert!(err.contains("--keep-witness"), "{err}");
-
-        let err =
-            reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, true)
-                .expect_err("--require-verified does nothing on the raw loop");
-        assert!(err.contains("--require-verified"), "{err}");
-    }
-
-    /// The same three flags are accepted once `--pipeline classic` selects
-    /// the staged pipeline — the refusal only fires against a resolution
-    /// that cannot honor the flag, never against `Classic` itself.
-    #[test]
-    fn verification_flags_are_accepted_with_pipeline_classic() {
-        reject_verification_flags_without_pipeline(
-            PipelineChoice::Classic,
-            Some("pytest"),
-            true,
-            true,
-        )
-        .expect("classic runs the verification machinery these flags belong to");
-    }
-
-    /// A bare raw run with none of the three flags is unaffected — the gate
-    /// only fires when a flag was actually passed.
-    #[test]
-    fn a_bare_raw_run_with_no_verification_flags_is_unaffected() {
-        reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, false)
-            .expect("no verification flag was passed — nothing to refuse");
-    }
-
-    /// `--test-command` is meaningful on a named plugin variant too — it arms
-    /// the wrapper's own oracle (#3553) — so it is accepted there, while
-    /// `--keep-witness`/`--require-verified` remain pipeline-only and are
-    /// still refused, naming `classic` as the remedy.
-    #[test]
-    fn plugin_variant_accepts_test_command_but_still_refuses_witness_flags() {
-        reject_verification_flags_without_pipeline(
-            PipelineChoice::Plugin("budget-v1"),
-            Some("pytest"),
-            false,
-            false,
-        )
-        .expect("test-command arms the bound wrapper's own oracle");
-
-        let err = reject_verification_flags_without_pipeline(
-            PipelineChoice::Plugin("budget-v1"),
-            None,
-            true,
-            false,
-        )
-        .expect_err("keep-witness is pipeline-only, even under a named variant");
-        assert!(err.contains("--keep-witness"), "{err}");
-        assert!(err.contains("--pipeline classic"), "{err}");
-    }
-
-    /// A wrapper plugin is a child process the host starts, so the enterprise
-    /// process-free authority must refuse it exactly as it refuses the staged
-    /// pipeline — and `--pipeline <variant>` must not read as "raw" merely
-    /// because it is not `classic`.
-    #[test]
-    fn a_wrapper_plugin_is_not_the_process_free_surface() {
-        assert!(PipelineChoice::Raw.is_raw());
-        assert!(!PipelineChoice::Classic.is_raw());
-        assert!(
-            !PipelineChoice::Plugin("budget-v1").is_raw(),
-            "a plugin spawns a process, so it is not the surface that spawns none"
-        );
-        assert!(
-            crate::enterprise_telemetry::authorize_execution_surface_with(
-                crate::enterprise_telemetry::ExecutionSurface::PipelineOneShot,
-                true,
+/// One line per child turn this host ran for the plugin, naming the seat it
+/// was attributed to and what it cost.
+///
+/// The money half of "a refusal is reported, never silent": a plugin's child
+/// turn is a model call the *user* pays for and never asked for directly, so
+/// the run says so in the same place it says what the plugin was refused.
+/// Pure, so the wording is testable without a run — and empty for the
+/// overwhelmingly common case of a plugin that spent nothing, which keeps a
+/// silent run silent.
+fn spend_lines(spends: &[ChildTurnSpend]) -> Vec<String> {
+    spends
+        .iter()
+        .map(|spend| {
+            format!(
+                "spent a child turn at \"{}\" (seat {:?}, {} step(s), ${:.4}){}",
+                spend.role,
+                spend.seat,
+                spend.steps,
+                spend.cost_usd,
+                if spend.completed {
+                    ""
+                } else {
+                    " — it did not finish"
+                }
             )
-            .is_err(),
-            "and that surface is the one process-free authority refuses"
-        );
-    }
-
-    /// **Witness (selection).** A plugin installed on disk is found by the
-    /// variant id `--pipeline` names, its `${plugin_dir}` is interpolated, and
-    /// the credential its manifest asked for is refused *out loud*.
-    #[test]
-    fn an_installed_wrapper_is_bound_by_its_variant_id() {
-        // The manifest asks for a credential, so the parent must be carrying
-        // one — otherwise an empty `refused` list would prove nothing about the
-        // refusal and everything about the fixture.
-        let _guard = crate::test_env::lock();
-        let _restore = crate::test_env::EnvRestore::capture(&["ANTHROPIC_API_KEY"]);
-        // SAFETY: the env lock above is held for the whole mutate-read-restore
-        // window, which is what makes this single-threaded with respect to
-        // every other env-mutating test in this binary.
-        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-not-a-real-key") };
-
-        let roster = roster(vec![installed(
-            WRAPPER_MANIFEST,
-            "/home/dev/.stella/plugins/budget-keeper",
-        )]);
-        let mut warnings = Vec::new();
-        let wrapper = bound(&roster, "budget-v1", &mut |line| warnings.push(line))
-            .expect("the installed plugin declares this variant");
-        assert_eq!(wrapper.variant(), "budget-v1");
-        assert_eq!(wrapper.dispatch.manifest().name, "budget-keeper");
-        assert_eq!(
-            warnings.len(),
-            1,
-            "the refused credential is reported, never silently dropped: {warnings:?}"
-        );
-        assert!(warnings[0].contains("ANTHROPIC_API_KEY"), "{warnings:?}");
-    }
-
-    /// An unknown variant names what *is* installed rather than failing blank.
-    #[test]
-    fn an_unknown_variant_names_the_installed_ones() {
-        let roster = roster(vec![installed(WRAPPER_MANIFEST, "/plugins/budget-keeper")]);
-        let error =
-            bound(&roster, "vera-v2", &mut |_| {}).expect_err("nothing installed declares it");
-        assert!(error.contains("vera-v2"), "{error}");
-        assert!(error.contains("budget-v1"), "{error}");
-
-        let nothing = PluginRoster::default();
-        let empty = bound(&nothing, "vera-v2", &mut |_| {}).expect_err("none at all");
-        assert!(empty.contains("stella plugin list"), "{empty}");
-    }
-
-    /// A manifest that declares `[loop] calls = ["recall"]`.
-    const RECALLING_MANIFEST: &str = r#"
-name = "researcher"
-[loop]
-participation = "steering"
-points = ["before_turn"]
-calls = ["recall"]
-[runtime]
-argv = ["/bin/sh", "${plugin_dir}/main.sh"]
-timeout_secs = 30
-[wrapper]
-id = "research-v1"
-[[wrapper.stages]]
-name = "recall"
-"#;
-
-    /// **Witness (#3561).** Binding an installed wrapper attaches a host-call
-    /// gate, and a declared `recall` reaches this host's real context plane.
-    ///
-    /// Before this, `stella-cli` built its transport with
-    /// `SubprocessWrapper::declare` and bound it straight into the dispatch —
-    /// no `.serving(..)`, no `HostCallGate` anywhere in the crate — so the
-    /// plugin's `{"call":"recall",…}` had nowhere to go and `converse` answered
-    /// `UnannouncedCall`. There was no gate to open, so this test could not be
-    /// written.
-    #[tokio::test]
-    async fn a_declared_recall_reaches_this_hosts_context_plane() {
-        use stella_plugin::{HostCallArgs, HostCallOk, HostCallOutcome, RecallArgs};
-        use stella_runtime::wrapper::HostCallChannel;
-
-        let roster = roster(vec![installed(RECALLING_MANIFEST, "/plugins/researcher")]);
-        let wrapper = bind_installed(&roster, "research-v1", Box::new(OneFrame), &mut |_| {})
-            .expect("the installed plugin declares this variant");
-
-        let channel = wrapper.gate.open();
-        let outcome = channel
-            .call(HostCallArgs::Recall(RecallArgs {
-                goal: "the parser".to_string(),
-                limit: None,
-            }))
-            .await;
-        match outcome {
-            HostCallOutcome::Ok(HostCallOk::Recall(result)) => {
-                assert_eq!(result.frames.len(), 1);
-                assert_eq!(result.frames[0].content, "about the parser");
-            }
-            other => panic!("a declared recall must reach the plane, got {other:?}"),
-        }
-        assert!(
-            wrapper.gate.refusals().is_empty(),
-            "nothing was refused, so nothing is reported"
-        );
-    }
-
-    /// The gate is attached even when this workspace has no context plane, and
-    /// an undeclared capability is still refused — *and reported*, which is the
-    /// half a user can see. An absent gate is the one answer a plugin cannot be
-    /// given: its call would hang until the point timeout.
-    #[tokio::test]
-    async fn a_host_with_no_plane_still_gates_and_reports_what_it_refused() {
-        use stella_plugin::{ChildTurnArgs, HostCallArgs, HostCallOutcome, HostCallRefusal};
-        use stella_runtime::wrapper::HostCallChannel;
-
-        let roster = roster(vec![installed(RECALLING_MANIFEST, "/plugins/researcher")]);
-        let wrapper = bound(&roster, "research-v1", &mut |_| {}).expect("it binds");
-
-        let channel = wrapper.gate.open();
-        let undeclared = channel
-            .call(HostCallArgs::ChildTurn(ChildTurnArgs {
-                role: "verifier".to_string(),
-                instruction: "check it".to_string(),
-            }))
-            .await;
-        assert!(
-            matches!(
-                undeclared,
-                HostCallOutcome::Err(ref failure) if failure.refusal == HostCallRefusal::Undeclared
-            ),
-            "the manifest declares only recall, got {undeclared:?}"
-        );
-        assert_eq!(
-            wrapper.gate.refusals().len(),
-            1,
-            "a refusal only the plugin learns about is half of \"never silent\""
-        );
-    }
-
-    /// A wrapper declaration with no process to ask is refused by name, not
-    /// driven with an invented default.
-    #[test]
-    fn a_wrapper_without_a_runtime_block_is_refused() {
-        let no_process = WRAPPER_MANIFEST
-            .replace("argv = [\"/bin/sh\", \"${plugin_dir}/main.sh\"]\n", "")
-            .replace("timeout_secs = 30\n", "")
-            .replace("env = [\"PATH\", \"ANTHROPIC_API_KEY\"]\n", "")
-            .replace("[runtime]\n", "");
-        let roster = roster(vec![installed(&no_process, "/plugins/budget-keeper")]);
-        let error = bound(&roster, "budget-v1", &mut |_| {}).expect_err("no [runtime] block");
-        assert!(error.contains("no [runtime] block"), "{error}");
-    }
-
-    /// The pre-turn snapshot answers every signal, and answers the post-turn
-    /// ones with what is true before anything has run.
-    #[test]
-    fn the_pre_turn_snapshot_states_only_what_is_true_yet() {
-        let signals = pre_turn_signals(true, false);
-        assert!(signals.test_command);
-        assert!(!signals.budget_metered);
-        assert_eq!(signals.candidates, 1);
-        assert_eq!(signals.mutating_actions, 0);
-        assert_eq!(signals.diff_lines, 0);
-        assert!(!signals.flip_achieved);
-        assert!(!signals.tests_red && !signals.tests_green);
-    }
+        })
+        .collect()
 }
+
+/// Fold what a plugin's child turns spent into the session's own guard.
+///
+/// The dispatcher settles every child onto the registry's
+/// [`SubAgentSpendLedger`](stella_core::subagent::SubAgentSpendLedger) the
+/// moment it ends, and an engine turn drains that ledger into the parent's
+/// guard at its next step boundary — which is why a `before_turn` spend needs
+/// nothing from this function: the round's own turn folds it in. The last
+/// point of the last round has no next boundary, so without this the user
+/// would pay for a child turn that never reached the guard bounding
+/// `--spend-limit`, and the reflection call after the run would size its
+/// headroom against money already gone.
+///
+/// Draining is destructive by contract, so this is exactly-once even though it
+/// runs after turns that already drained: what it takes is only what no turn
+/// did.
+fn settle_plugin_child_spend(registry: &dyn ToolExecutor, budget: &mut BudgetGuard) -> f64 {
+    let residual = registry.drain_sub_agent_spend_usd();
+    if residual > 0.0 {
+        budget.record_spend(residual);
+    }
+    residual
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -1,0 +1,783 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for [`crate::wrapper_plugin`] — the CLI as a driver of the wrapper
+//! socket.
+//!
+//! A sibling file rather than an inline `mod tests`, for the reason AGENTS.md
+//! § "God files" gives: the parent carries the module doc, the flag decisions,
+//! the host assembly and the driver, and this suite grew past what the same
+//! file can hold under the 1500-line ratchet.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use stella_core::subagent::{SubAgentDispatcher, SubAgentOutcome, SubAgentReport, SubAgentSpec};
+use stella_plugin::PluginManifest;
+use stella_runtime::wrapper::TurnDriver;
+
+use super::*;
+use crate::plugin_cmd::roster::{InstalledPlugin, PluginScope};
+
+const WRAPPER_MANIFEST: &str = r#"
+name = "budget-keeper"
+[loop]
+participation = "steering"
+points = ["before_turn", "after_turn"]
+[runtime]
+argv = ["/bin/sh", "${plugin_dir}/main.sh"]
+timeout_secs = 30
+env = ["PATH", "ANTHROPIC_API_KEY"]
+[wrapper]
+id = "budget-v1"
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+fn installed(text: &str, dir: &str) -> InstalledPlugin {
+    InstalledPlugin {
+        manifest: PluginManifest::from_toml_str(text).expect("fixture must load"),
+        dir: PathBuf::from(dir),
+        scope: PluginScope::User,
+    }
+}
+
+fn roster(plugins: Vec<InstalledPlugin>) -> PluginRoster {
+    PluginRoster::compose(plugins, Vec::new(), &BTreeMap::new())
+}
+
+/// A context plane that answers every ask with one frame, so a test can
+/// tell "the gate reached the plane" from "the gate refused".
+struct OneFrame;
+
+#[async_trait]
+impl stella_runtime::wrapper::RecallHost for OneFrame {
+    async fn recall(&self, goal: &str) -> Vec<stella_plugin::RecallFrame> {
+        vec![stella_plugin::RecallFrame {
+            label: "the last run".to_string(),
+            kind: "memory".to_string(),
+            source: "context.db".to_string(),
+            uri: None,
+            content: format!("about {goal}"),
+        }]
+    }
+}
+
+fn no_recall() -> Box<dyn stella_runtime::wrapper::RecallHost> {
+    Box::new(crate::wrapper_recall::SessionRecallHost::none())
+}
+
+fn bound(
+    roster: &PluginRoster,
+    variant: &str,
+    warn: &mut dyn FnMut(String),
+) -> Result<BoundWrapper, String> {
+    bind_installed(roster, variant, warn)?.serving(WrapperHost::recalling(no_recall()))
+}
+
+/// **Witness (#3381 "Flip the default").** No flag at all used to mean
+/// `Classic` — the staged pipeline was the default. This assertion fails
+/// on the pre-#3381 code (which resolves `(false, None)` to `Classic`)
+/// and passes on this one: the raw loop is the default now, with or
+/// without `--no-pipeline`.
+#[test]
+fn no_flag_at_all_resolves_to_the_raw_loop() {
+    assert_eq!(PipelineChoice::resolve(false, None), PipelineChoice::Raw);
+    assert_eq!(
+        PipelineChoice::resolve(true, None),
+        PipelineChoice::Raw,
+        "--no-pipeline is a deprecated no-op: it names the same choice as no flag at all"
+    );
+}
+
+/// `classic` is still selectable by the id it records, and an unknown
+/// variant still binds a plugin lookup rather than the built-in.
+#[test]
+fn pipeline_variant_selects_classic_or_a_plugin_by_name() {
+    assert_eq!(
+        PipelineChoice::resolve(false, Some("classic")),
+        PipelineChoice::Classic,
+        "the built-in is selectable by the id it records"
+    );
+    assert_eq!(
+        PipelineChoice::resolve(false, Some("budget-v1")),
+        PipelineChoice::Plugin("budget-v1")
+    );
+}
+
+/// **Witness (#3381).** `--no-pipeline` together with `--pipeline` used to
+/// be a hard error (`conflicts_with` in clap, then an `Err` from
+/// `resolve`). This assertion fails on the pre-#3381 code (which returns
+/// `Err` here) and passes on this one: a deprecated no-op flag must not
+/// veto an explicit `--pipeline` opt-in, on either variant arm.
+#[test]
+fn no_pipeline_no_longer_vetoes_an_explicit_pipeline_choice() {
+    assert_eq!(
+        PipelineChoice::resolve(true, Some("budget-v1")),
+        PipelineChoice::Plugin("budget-v1"),
+        "--pipeline wins outright; the deprecated flag has nothing left to veto"
+    );
+    assert_eq!(
+        PipelineChoice::resolve(true, Some("classic")),
+        PipelineChoice::Classic
+    );
+}
+
+/// The notice fires exactly when `--no-pipeline` was passed, regardless of
+/// what `--pipeline` said alongside it, and says nothing when it was not.
+#[test]
+fn the_deprecation_notice_fires_only_when_no_pipeline_was_passed() {
+    assert!(no_pipeline_deprecation_notice(false).is_none());
+    let notice = no_pipeline_deprecation_notice(true).expect("flag was passed");
+    assert!(notice.contains("--no-pipeline"), "{notice}");
+    assert!(notice.contains("--pipeline"), "{notice}");
+}
+
+/// **Witness (#3695).** `stella goal`/`stella fleet` cannot drive a
+/// wrapper plugin today — only `stella run` implements [`TurnDriver`] over
+/// one — so a named `--pipeline <variant>` must be refused on those doors
+/// rather than silently downgraded to raw or promoted to classic. This
+/// assertion fails on code that has no such gate at all (every door would
+/// accept-and-ignore the variant) and passes on this one.
+#[test]
+fn a_named_plugin_variant_is_refused_on_a_door_that_cannot_drive_one() {
+    let err = reject_plugin_variant_for_door("goal", PipelineChoice::Plugin("budget-v1"))
+        .expect_err("goal has no wrapper driver");
+    assert!(err.contains("budget-v1"), "{err}");
+    assert!(err.contains("stella goal"), "{err}");
+    assert!(
+        err.contains("stella run --pipeline budget-v1"),
+        "the refusal must name the door that CAN run it: {err}"
+    );
+
+    let err = reject_plugin_variant_for_door("fleet", PipelineChoice::Plugin("budget-v1"))
+        .expect_err("fleet has no wrapper driver either");
+    assert!(err.contains("stella fleet"), "{err}");
+}
+
+/// `classic` and no flag at all both resolve away from `Plugin` before
+/// reaching the gate, so neither is refused on a door with no wrapper
+/// driver — only a *named* variant is out of reach there.
+#[test]
+fn classic_and_raw_are_never_refused_on_a_door_with_no_wrapper_driver() {
+    reject_plugin_variant_for_door("goal", PipelineChoice::Classic)
+        .expect("classic has no plugin to drive — nothing to refuse");
+    reject_plugin_variant_for_door("goal", PipelineChoice::Raw)
+        .expect("raw has no plugin to drive — nothing to refuse");
+}
+
+/// **Witness (#3696).** `--keep-witness`, `--require-verified`, and
+/// `--test-command` used to reach `run_one_shot` on the `Raw` arm and be
+/// silently dropped there (`run_raw_one_shot` takes no `keep_witness`/
+/// `require_verified` parameter at all). This assertion fails against
+/// that code (which has no such gate, so every call below returns `Ok`)
+/// and passes on this one: each flag alone against `Raw` is refused, and
+/// the message names the remedy.
+#[test]
+fn each_verification_flag_alone_is_refused_against_the_raw_loop() {
+    let err = reject_verification_flags_without_pipeline(
+        PipelineChoice::Raw,
+        Some("pytest"),
+        false,
+        false,
+    )
+    .expect_err("--test-command does nothing on the raw loop");
+    assert!(err.contains("--test-command"), "{err}");
+    assert!(err.contains("--pipeline classic"), "{err}");
+
+    let err = reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, true, false)
+        .expect_err("--keep-witness does nothing on the raw loop");
+    assert!(err.contains("--keep-witness"), "{err}");
+
+    let err = reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, true)
+        .expect_err("--require-verified does nothing on the raw loop");
+    assert!(err.contains("--require-verified"), "{err}");
+}
+
+/// The same three flags are accepted once `--pipeline classic` selects
+/// the staged pipeline — the refusal only fires against a resolution
+/// that cannot honor the flag, never against `Classic` itself.
+#[test]
+fn verification_flags_are_accepted_with_pipeline_classic() {
+    reject_verification_flags_without_pipeline(PipelineChoice::Classic, Some("pytest"), true, true)
+        .expect("classic runs the verification machinery these flags belong to");
+}
+
+/// A bare raw run with none of the three flags is unaffected — the gate
+/// only fires when a flag was actually passed.
+#[test]
+fn a_bare_raw_run_with_no_verification_flags_is_unaffected() {
+    reject_verification_flags_without_pipeline(PipelineChoice::Raw, None, false, false)
+        .expect("no verification flag was passed — nothing to refuse");
+}
+
+/// `--test-command` is meaningful on a named plugin variant too — it arms
+/// the wrapper's own oracle (#3553) — so it is accepted there, while
+/// `--keep-witness`/`--require-verified` remain pipeline-only and are
+/// still refused, naming `classic` as the remedy.
+#[test]
+fn plugin_variant_accepts_test_command_but_still_refuses_witness_flags() {
+    reject_verification_flags_without_pipeline(
+        PipelineChoice::Plugin("budget-v1"),
+        Some("pytest"),
+        false,
+        false,
+    )
+    .expect("test-command arms the bound wrapper's own oracle");
+
+    let err = reject_verification_flags_without_pipeline(
+        PipelineChoice::Plugin("budget-v1"),
+        None,
+        true,
+        false,
+    )
+    .expect_err("keep-witness is pipeline-only, even under a named variant");
+    assert!(err.contains("--keep-witness"), "{err}");
+    assert!(err.contains("--pipeline classic"), "{err}");
+}
+
+/// A wrapper plugin is a child process the host starts, so the enterprise
+/// process-free authority must refuse it exactly as it refuses the staged
+/// pipeline — and `--pipeline <variant>` must not read as "raw" merely
+/// because it is not `classic`.
+#[test]
+fn a_wrapper_plugin_is_not_the_process_free_surface() {
+    assert!(PipelineChoice::Raw.is_raw());
+    assert!(!PipelineChoice::Classic.is_raw());
+    assert!(
+        !PipelineChoice::Plugin("budget-v1").is_raw(),
+        "a plugin spawns a process, so it is not the surface that spawns none"
+    );
+    assert!(
+        crate::enterprise_telemetry::authorize_execution_surface_with(
+            crate::enterprise_telemetry::ExecutionSurface::PipelineOneShot,
+            true,
+        )
+        .is_err(),
+        "and that surface is the one process-free authority refuses"
+    );
+}
+
+/// **Witness (selection).** A plugin installed on disk is found by the
+/// variant id `--pipeline` names, its `${plugin_dir}` is interpolated, and
+/// the credential its manifest asked for is refused *out loud*.
+#[test]
+fn an_installed_wrapper_is_bound_by_its_variant_id() {
+    // The manifest asks for a credential, so the parent must be carrying
+    // one — otherwise an empty `refused` list would prove nothing about the
+    // refusal and everything about the fixture.
+    let _guard = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["ANTHROPIC_API_KEY"]);
+    // SAFETY: the env lock above is held for the whole mutate-read-restore
+    // window, which is what makes this single-threaded with respect to
+    // every other env-mutating test in this binary.
+    unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-not-a-real-key") };
+
+    let roster = roster(vec![installed(
+        WRAPPER_MANIFEST,
+        "/home/dev/.stella/plugins/budget-keeper",
+    )]);
+    let mut warnings = Vec::new();
+    let wrapper = bound(&roster, "budget-v1", &mut |line| warnings.push(line))
+        .expect("the installed plugin declares this variant");
+    assert_eq!(wrapper.variant(), "budget-v1");
+    assert_eq!(wrapper.dispatch.manifest().name, "budget-keeper");
+    assert_eq!(
+        warnings.len(),
+        1,
+        "the refused credential is reported, never silently dropped: {warnings:?}"
+    );
+    assert!(warnings[0].contains("ANTHROPIC_API_KEY"), "{warnings:?}");
+}
+
+/// An unknown variant names what *is* installed rather than failing blank.
+#[test]
+fn an_unknown_variant_names_the_installed_ones() {
+    let roster = roster(vec![installed(WRAPPER_MANIFEST, "/plugins/budget-keeper")]);
+    let error = bound(&roster, "vera-v2", &mut |_| {}).expect_err("nothing installed declares it");
+    assert!(error.contains("vera-v2"), "{error}");
+    assert!(error.contains("budget-v1"), "{error}");
+
+    let nothing = PluginRoster::default();
+    let empty = bound(&nothing, "vera-v2", &mut |_| {}).expect_err("none at all");
+    assert!(empty.contains("stella plugin list"), "{empty}");
+}
+
+/// A manifest that declares `[loop] calls = ["recall"]`.
+const RECALLING_MANIFEST: &str = r#"
+name = "researcher"
+[loop]
+participation = "steering"
+points = ["before_turn"]
+calls = ["recall"]
+[runtime]
+argv = ["/bin/sh", "${plugin_dir}/main.sh"]
+timeout_secs = 30
+[wrapper]
+id = "research-v1"
+[[wrapper.stages]]
+name = "recall"
+"#;
+
+/// **Witness (#3561).** Binding an installed wrapper attaches a host-call
+/// gate, and a declared `recall` reaches this host's real context plane.
+///
+/// Before this, `stella-cli` built its transport with
+/// `SubprocessWrapper::declare` and bound it straight into the dispatch —
+/// no `.serving(..)`, no `HostCallGate` anywhere in the crate — so the
+/// plugin's `{"call":"recall",…}` had nowhere to go and `converse` answered
+/// `UnannouncedCall`. There was no gate to open, so this test could not be
+/// written.
+#[tokio::test]
+async fn a_declared_recall_reaches_this_hosts_context_plane() {
+    use stella_plugin::{HostCallArgs, HostCallOk, HostCallOutcome, RecallArgs};
+    use stella_runtime::wrapper::HostCallChannel;
+
+    let roster = roster(vec![installed(RECALLING_MANIFEST, "/plugins/researcher")]);
+    let wrapper = bind_installed(&roster, "research-v1", &mut |_| {})
+        .expect("the installed plugin declares this variant")
+        .serving(WrapperHost::recalling(Box::new(OneFrame)))
+        .expect("a found variant binds");
+
+    let channel = wrapper.gate.open();
+    let outcome = channel
+        .call(HostCallArgs::Recall(RecallArgs {
+            goal: "the parser".to_string(),
+            limit: None,
+        }))
+        .await;
+    match outcome {
+        HostCallOutcome::Ok(HostCallOk::Recall(result)) => {
+            assert_eq!(result.frames.len(), 1);
+            assert_eq!(result.frames[0].content, "about the parser");
+        }
+        other => panic!("a declared recall must reach the plane, got {other:?}"),
+    }
+    assert!(
+        wrapper.gate.refusals().is_empty(),
+        "nothing was refused, so nothing is reported"
+    );
+}
+
+/// The gate is attached even when this workspace has no context plane, and
+/// an undeclared capability is still refused — *and reported*, which is the
+/// half a user can see. An absent gate is the one answer a plugin cannot be
+/// given: its call would hang until the point timeout.
+#[tokio::test]
+async fn a_host_with_no_plane_still_gates_and_reports_what_it_refused() {
+    use stella_plugin::{ChildTurnArgs, HostCallArgs, HostCallOutcome, HostCallRefusal};
+    use stella_runtime::wrapper::HostCallChannel;
+
+    let roster = roster(vec![installed(RECALLING_MANIFEST, "/plugins/researcher")]);
+    let wrapper = bound(&roster, "research-v1", &mut |_| {}).expect("it binds");
+
+    let channel = wrapper.gate.open();
+    let undeclared = channel
+        .call(HostCallArgs::ChildTurn(ChildTurnArgs {
+            role: "verifier".to_string(),
+            instruction: "check it".to_string(),
+        }))
+        .await;
+    assert!(
+        matches!(
+            undeclared,
+            HostCallOutcome::Err(ref failure) if failure.refusal == HostCallRefusal::Undeclared
+        ),
+        "the manifest declares only recall, got {undeclared:?}"
+    );
+    assert_eq!(
+        wrapper.gate.refusals().len(),
+        1,
+        "a refusal only the plugin learns about is half of \"never silent\""
+    );
+}
+
+/// A wrapper declaration with no process to ask is refused by name, not
+/// driven with an invented default.
+#[test]
+fn a_wrapper_without_a_runtime_block_is_refused() {
+    let no_process = WRAPPER_MANIFEST
+        .replace("argv = [\"/bin/sh\", \"${plugin_dir}/main.sh\"]\n", "")
+        .replace("timeout_secs = 30\n", "")
+        .replace("env = [\"PATH\", \"ANTHROPIC_API_KEY\"]\n", "")
+        .replace("[runtime]\n", "");
+    let roster = roster(vec![installed(&no_process, "/plugins/budget-keeper")]);
+    let error = bound(&roster, "budget-v1", &mut |_| {}).expect_err("no [runtime] block");
+    assert!(error.contains("no [runtime] block"), "{error}");
+}
+
+/// A manifest that declares `[loop] calls = ["child_turn"]` and two role
+/// intents: one resolving to a research seat, one pointed straight at the
+/// worker.
+///
+/// `grader` is declared deliberately. The independence rule has to be
+/// tested against a role the *manifest permits*, or it proves only that
+/// the manifest check works.
+const GRADING_MANIFEST: &str = r#"
+name = "grading-wrapper"
+[loop]
+participation = "steering"
+points = ["before_turn"]
+calls = ["child_turn"]
+[subloop]
+stages = ["research"]
+[roles.reviewer]
+tier = "research"
+[roles.grader]
+tier = "worker"
+[runtime]
+argv = ["/bin/sh", "${plugin_dir}/main.sh"]
+timeout_secs = 30
+[wrapper]
+id = "grading-v1"
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+/// This session's sub-agent dispatcher, standing in for
+/// [`crate::subagent::SessionSubAgents`] and recording every
+/// [`SubAgentSpec`] it was handed.
+///
+/// The recording is how these tests answer the question that matters:
+/// **who made the model call?** A plugin that had reached for a provider
+/// itself would leave nothing here.
+#[derive(Default, Clone)]
+struct RecordingDispatcher {
+    specs: Arc<std::sync::Mutex<Vec<SubAgentSpec>>>,
+}
+
+impl RecordingDispatcher {
+    fn specs(&self) -> Vec<SubAgentSpec> {
+        self.specs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+#[async_trait]
+impl SubAgentDispatcher for RecordingDispatcher {
+    async fn dispatch(&self, spec: SubAgentSpec) -> SubAgentOutcome {
+        let summary = format!("read it; asked: {}", spec.instruction);
+        self.specs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(spec);
+        SubAgentOutcome::Completed(SubAgentReport {
+            summary,
+            truncated: false,
+            cost_usd: 0.02,
+            steps: 3,
+            absorbed_messages: 7,
+        })
+    }
+}
+
+/// The plugin, this host's dispatcher, and the plane between them — what
+/// [`session_host`] assembles on the live path, with a recording
+/// dispatcher in place of the session's own.
+fn grading_host() -> (BoundWrapper, RecordingDispatcher) {
+    let roster = roster(vec![installed(
+        GRADING_MANIFEST,
+        "/plugins/grading-wrapper",
+    )]);
+    let manifest = PluginManifest::from_toml_str(GRADING_MANIFEST).expect("fixture must load");
+    let dispatcher = RecordingDispatcher::default();
+    let plane = Arc::new(child_turn_plane(
+        &manifest,
+        Arc::new(dispatcher.clone()) as Arc<dyn SubAgentDispatcher>,
+    ));
+    let wrapper = bind_installed(&roster, "grading-v1", &mut |_| {})
+        .expect("the installed plugin declares this variant")
+        .serving(WrapperHost::recalling(no_recall()).with_child_turns(plane))
+        .expect("a found variant binds");
+    (wrapper, dispatcher)
+}
+
+fn child_turn(role: &str) -> stella_plugin::HostCallArgs {
+    stella_plugin::HostCallArgs::ChildTurn(stella_plugin::ChildTurnArgs {
+        role: role.to_string(),
+        instruction: "read the diff and say whether the retry survived".to_string(),
+    })
+}
+
+/// **Witness (#3576).** A declared `child_turn` reaches this host's own
+/// sub-agent dispatcher, and the *host* — not the plugin — makes the call.
+///
+/// Fails before this change for one reason: `stella-cli` assembled its
+/// capabilities as `HostPlanes::recalling(..)` and installed no
+/// child-turn plane at all, so the only answer this call could get was
+/// `Unavailable` (the companion assertion below still proves that is what
+/// a host without a plane says). There was no parameter to pass a plane
+/// through and no handle to read a spend back from, so this test could not
+/// be written.
+#[tokio::test]
+async fn a_declared_child_turn_runs_on_this_hosts_dispatcher() {
+    use stella_plugin::{HostCallOk, HostCallOutcome};
+    use stella_runtime::wrapper::HostCallChannel;
+
+    let (wrapper, dispatcher) = grading_host();
+    let outcome = wrapper.gate.open().call(child_turn("reviewer")).await;
+    match outcome {
+        HostCallOutcome::Ok(HostCallOk::ChildTurn(result)) => {
+            assert_eq!(result.role, "reviewer");
+            assert_eq!(result.seat, "research", "the seat the host resolved it to");
+            assert!(result.completed);
+            assert!(
+                result.report.contains("read the diff"),
+                "the child answers the plugin's own instruction: {}",
+                result.report
+            );
+        }
+        other => panic!("a declared child turn must reach the plane, got {other:?}"),
+    }
+
+    let specs = dispatcher.specs();
+    assert_eq!(
+        specs.len(),
+        1,
+        "the host's dispatcher ran the turn — the plugin has no way to run one itself"
+    );
+    assert_eq!(
+        specs[0].role,
+        stella_protocol::event::ModelCallRole::Research
+    );
+    assert!(
+        !specs[0].write_access,
+        "a plugin's child turn gathers evidence; it does not get a write arm"
+    );
+    assert_eq!(
+        specs[0].turn_instance, PLUGIN_CHILD_TURN_SLOT,
+        "not the parent's receipt slot"
+    );
+
+    let spends = wrapper.child_spends();
+    assert_eq!(
+        spends.len(),
+        1,
+        "what a plugin spent is readable after the run"
+    );
+    assert_eq!(
+        spends[0].seat,
+        stella_protocol::event::ModelCallRole::Research
+    );
+    let line = spend_lines(&spends).remove(0);
+    assert!(line.contains("reviewer"), "{line}");
+    assert!(
+        line.contains("0.02"),
+        "the user is told what it cost: {line}"
+    );
+}
+
+/// The independence rule survives the wiring: a role intent the manifest
+/// declares but that resolves to the **worker's** seat is refused, and
+/// refused as `Forbidden` — "you may not have this" — rather than as the
+/// weaker `Unavailable` that would read as a configuration accident.
+#[tokio::test]
+async fn a_role_intent_pointing_at_the_worker_is_still_forbidden() {
+    use stella_plugin::{HostCallOutcome, HostCallRefusal};
+    use stella_runtime::wrapper::HostCallChannel;
+
+    let (wrapper, dispatcher) = grading_host();
+    let outcome = wrapper.gate.open().call(child_turn("grader")).await;
+    assert!(
+        matches!(
+            outcome,
+            HostCallOutcome::Err(ref failure)
+                if failure.refusal == HostCallRefusal::Forbidden
+        ),
+        "a plugin may not spend the model whose work it judges, got {outcome:?}"
+    );
+    assert!(
+        dispatcher.specs().is_empty(),
+        "a refusal costs no model call"
+    );
+    assert_eq!(
+        wrapper.gate.refusals().len(),
+        1,
+        "and the user is told, not only the plugin"
+    );
+    assert!(wrapper.child_spends().is_empty());
+}
+
+/// The same plugin against a host that installs no plane is answered
+/// `Unavailable` — the state every driver was in before this change, and
+/// the one a driver with no dispatcher of its own is still in.
+#[tokio::test]
+async fn a_host_with_no_child_turn_plane_answers_unavailable() {
+    use stella_plugin::{HostCallOutcome, HostCallRefusal};
+    use stella_runtime::wrapper::HostCallChannel;
+
+    let roster = roster(vec![installed(
+        GRADING_MANIFEST,
+        "/plugins/grading-wrapper",
+    )]);
+    let wrapper = bound(&roster, "grading-v1", &mut |_| {}).expect("it binds");
+    let outcome = wrapper.gate.open().call(child_turn("reviewer")).await;
+    assert!(
+        matches!(
+            outcome,
+            HostCallOutcome::Err(ref failure)
+                if failure.refusal == HostCallRefusal::Unavailable
+        ),
+        "no plane means a told gap, never a silence: {outcome:?}"
+    );
+    assert!(wrapper.child_spends().is_empty());
+}
+
+/// **The end-to-end witness (#3576).** A real `sh` plugin, started by this
+/// driver from what is installed on disk, asks the host for a model call at
+/// a role intent it declared — and the host's own dispatcher makes it,
+/// through the whole sequence a `stella run --pipeline <variant>` drives.
+///
+/// The plugin is a shell script with no JSON library, for
+/// `stella-runtime`'s reason: a capability only Rust can reach is a Rust
+/// API with extra steps (`doc:pipeline-as-plugins` §5 commitment 2). The
+/// one thing stubbed is the engine — [`TurnDriver`] is the seam the socket
+/// is designed around, and `run_raw_one_shot` supplies the real one — so
+/// everything between the plugin's stdout and the dispatcher's spec is the
+/// shipping path.
+///
+/// `cfg(unix)` is the same declared gap the runtime's own socket suite
+/// carries (#3497).
+#[cfg(unix)]
+#[tokio::test]
+async fn an_installed_sh_plugin_spends_a_child_turn_through_this_driver() {
+    use stella_plugin::{TamperFinding, TurnOutcome};
+    use stella_runtime::wrapper::{DrivenTurn, TurnPrelude};
+
+    /// The engine, stubbed: it records what the wrapper contributed and
+    /// reports a completed turn.
+    #[derive(Default)]
+    struct StubTurn {
+        contributed: Vec<String>,
+    }
+
+    #[async_trait(?Send)]
+    impl TurnDriver for StubTurn {
+        async fn run_turn(&mut self, prelude: TurnPrelude) -> DrivenTurn {
+            self.contributed.extend(
+                prelude
+                    .into_messages()
+                    .into_iter()
+                    .map(|message| message.content),
+            );
+            DrivenTurn {
+                outcome: TurnOutcome {
+                    completed: true,
+                    answer: "the retry is back".to_string(),
+                    tools: Some(Vec::new()),
+                    changed_files: Some(Vec::new()),
+                },
+                tamper: TamperFinding::NotChecked,
+            }
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("a temp dir for the installed plugin");
+    std::fs::write(
+        dir.path().join("main.sh"),
+        r#"
+read -r request
+printf '%s\n' '{"call":"child_turn","id":7,"args":{"role":"reviewer","instruction":"does the diff drop the retry?"}}'
+read -r answer
+case "$answer" in
+  *'"seat":"research"'*) finding="the reviewer read it at the research seat" ;;
+  *) finding="no assessment was available" ;;
+esac
+printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"reviewer","text":"%s"}]}}\n' "$finding"
+"#,
+    )
+    .expect("the plugin script is written");
+
+    let manifest = PluginManifest::from_toml_str(GRADING_MANIFEST).expect("fixture must load");
+    let dispatcher = RecordingDispatcher::default();
+    let plane = Arc::new(child_turn_plane(
+        &manifest,
+        Arc::new(dispatcher.clone()) as Arc<dyn SubAgentDispatcher>,
+    ));
+    let roster = roster(vec![installed(
+        GRADING_MANIFEST,
+        &dir.path().to_string_lossy(),
+    )]);
+    let wrapper = bind_installed(&roster, "grading-v1", &mut |_| {})
+        .expect("the installed plugin declares this variant")
+        .serving(WrapperHost::recalling(no_recall()).with_child_turns(plane))
+        .expect("it binds");
+
+    let mut driver = StubTurn::default();
+    let report = wrapper
+        .dispatch
+        .run(
+            RoundInput {
+                goal: "put the retry back".to_string(),
+                signals: pre_turn_signals(false, false),
+                candidate: None,
+            },
+            &mut driver,
+        )
+        .await
+        .expect("the declared stage program resolves");
+
+    assert_eq!(report.variant, "grading-v1");
+    assert!(
+        report.faults.is_empty(),
+        "the plugin answered every point it declared: {:?}",
+        report.faults
+    );
+    assert_eq!(
+        driver.contributed,
+        vec!["the reviewer read it at the research seat".to_string()],
+        "a real turn's result reached the plugin and became the turn's context"
+    );
+
+    let specs = dispatcher.specs();
+    assert_eq!(specs.len(), 1, "the host made the call, not the plugin");
+    assert_eq!(
+        specs[0].role,
+        stella_protocol::event::ModelCallRole::Research
+    );
+    assert_eq!(specs[0].instruction, "does the diff drop the retry?");
+    assert!(!specs[0].write_access);
+    assert_eq!(wrapper.child_spends().len(), 1);
+}
+
+/// **Witness (#3576, requirement 3).** What a plugin's last point spent
+/// lands on the session's guard.
+///
+/// The dispatcher settles every child onto the registry's ledger and an
+/// engine turn drains it at its next step boundary — but the last point of
+/// the last round has no next boundary, so before this change those
+/// dollars reached no guard at all. Draining is destructive, so the second
+/// call proves it folds exactly once.
+#[test]
+fn a_plugins_residual_child_spend_folds_into_the_sessions_guard() {
+    let registry = stella_tools::ToolRegistry::new(PathBuf::from("."));
+    stella_core::subagent::push_sub_agent_spend(&registry.sub_agent_spend_ledger(), 0.25);
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Enforced, None, Some(10.0));
+
+    let folded = settle_plugin_child_spend(&registry, &mut budget);
+    assert!((folded - 0.25).abs() < f64::EPSILON, "{folded}");
+    assert!((budget.session_spent_usd() - 0.25).abs() < f64::EPSILON);
+    assert_eq!(
+        settle_plugin_child_spend(&registry, &mut budget),
+        0.0,
+        "the ledger is drained, so a second fold charges nothing twice"
+    );
+}
+
+/// The pre-turn snapshot answers every signal, and answers the post-turn
+/// ones with what is true before anything has run.
+#[test]
+fn the_pre_turn_snapshot_states_only_what_is_true_yet() {
+    let signals = pre_turn_signals(true, false);
+    assert!(signals.test_command);
+    assert!(!signals.budget_metered);
+    assert_eq!(signals.candidates, 1);
+    assert_eq!(signals.mutating_actions, 0);
+    assert_eq!(signals.diff_lines, 0);
+    assert!(!signals.flip_achieved);
+    assert!(!signals.tests_red && !signals.tests_green);
+}

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -166,6 +166,22 @@ pub trait SubAgentDispatcher: Send + Sync {
     async fn dispatch(&self, spec: SubAgentSpec) -> SubAgentOutcome;
 }
 
+/// Dispatching through a handle a host still holds.
+///
+/// A session installs exactly one dispatcher and keeps an `Arc` to it, because
+/// two of them would be two pools, two carves and two ledgers over the same
+/// session. Anything else that wants to spend a child turn — the plugin
+/// host's child-turn plane is the standing example — therefore has an
+/// `Arc<dyn SubAgentDispatcher>` in hand and nothing to convert it into.
+/// Without this impl each such caller writes the same one-method forwarding
+/// newtype, which is a second place for the contract above to drift.
+#[async_trait]
+impl<D: SubAgentDispatcher + ?Sized> SubAgentDispatcher for std::sync::Arc<D> {
+    async fn dispatch(&self, spec: SubAgentSpec) -> SubAgentOutcome {
+        (**self).dispatch(spec).await
+    }
+}
+
 impl<'a> Engine<'a> {
     /// Attach a turn's boundary controls in their owned form.
     ///

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -92,18 +92,28 @@ crate's `TurnWrapper` socket, not this socket wearing a new caller.
 Candidate-workspace grants on the CLI path landed (#3553,
 `crates/stella-cli/src/wrapper_candidate.rs`): `RoundInput::candidate` now
 carries a real grant over the shared work tree a `flip = "required"` oracle
-can observe. A wrapper is also meant to be handed a child-turn **port** that
+can observe. A wrapper is also handed a child-turn **port** that
 names a role intent (`triage`, `planner`, `witness_author`) — never a
 provider, an `Engine`, or a credential; the host resolves the intent against
 the user's BYOK providers, carves the budget, attaches gate/steering/hooks,
-and settles once. That port now has a name and a type in this crate —
+and settles once. That port is
 [`ChildTurnPlane`](src/wrapper/child_turn.rs), implemented by
 [`ChildTurns`](src/wrapper/child_turn.rs) over the host's own sub-agent
-dispatcher, taking `ChildTurnArgs` on the wire — built and tested
-end-to-end in `child_turn.rs`'s own suite. What remains is attaching it at a
-live call site: no host builds a `HostCallGate` with `.with_child_turns(..)`
-yet, so a real plugin cannot reach it today even though the port itself is
-no longer design (`doc:pipeline-as-plugins` §9.3) but code.
+dispatcher, taking `ChildTurnArgs` on the wire. It is now attached at a live
+call site (#3576): `stella run --pipeline <variant>` builds its
+`HostCallGate` with `.with_child_turns(..)` over the session's own
+`SubAgentDispatcher` — the one `task_assign` runs on — so an installed plugin
+declaring `[loop] calls = ["child_turn"]` and a `[roles.<name>]` gets a real
+turn, read-only, attributed to the seat its tier resolves to, with what it
+spent printed beside what it was refused
+(`crates/stella-cli/src/wrapper_plugin.rs`). Two limits stand: the `verifier`
+tier is deliberately bound to no seat, so a plugin naming it is answered
+`Unavailable` rather than having its call attributed to a role the host never
+made (`ChildTurns::with_seat` is how a driver that wants it owns the claim);
+and a plugin's points run *between* the parent's turns, where the tool
+registry's event sender is a sink — so the child's `step_usage` reaches the
+run's report and the session's budget guard, but not the store's receipt
+(#3802).
 
 **The driver channel now moves bytes, and still has no production caller.**
 `SubprocessDriver` (#3634) is the transport between the wire

--- a/crates/stella-runtime/src/wrapper/child_turn.rs
+++ b/crates/stella-runtime/src/wrapper/child_turn.rs
@@ -104,13 +104,12 @@ pub const DEFAULT_HOST_MAX_CHILD_TURNS: u32 = 4;
 /// `doc:turn-loop-wrappers` §9.2 prefers a declared role to a `judge`: a
 /// verifier-tier call hidden inside a plugin is a call nobody can audit.
 ///
-/// **Consumer, stated honestly** (invariant 10's discipline, pointed at a host
-/// report rather than an event): today the only reader is a test, and the
-/// intended one is the driver that installs the plane — beside
-/// [`RefusedCall`](super::RefusedCall), which is exactly where a user looks to
-/// learn what a plugin did on their money. No shipping driver installs a plane
-/// yet, so no shipping driver reads this; that is #3576, declared here rather
-/// than implied. The receipt carries the same seat independently under
+/// **Consumer** (invariant 10's discipline, pointed at a host report rather
+/// than an event): `stella-cli`'s wrapper driver reads it after a run and
+/// prints one line per child turn beside
+/// [`RefusedCall`](super::RefusedCall) — `wrapper_plugin::spend_lines`, which
+/// is exactly where a user looks to learn what a plugin did on their money
+/// (#3576). The receipt carries the same seat independently under
 /// [`Self::seat`], because that is the `ModelCallRole` the child's model calls
 /// were attributed with — so the audit trail does not depend on this struct
 /// being read.

--- a/crates/stella-runtime/src/wrapper/host_call.rs
+++ b/crates/stella-runtime/src/wrapper/host_call.rs
@@ -147,11 +147,12 @@ pub trait HostCapabilities: Send + Sync {
 /// [`HostCall::RunTest`] answers [`HostCallRefusal::Unsupported`] from every
 /// host, because nothing in this tree performs it at all (#3580).
 ///
-/// `stella-cli` assembles one with a context plane on the `stella run` path
-/// (`src/wrapper_plugin.rs::bind_installed`, #3561). It installs **no**
-/// child-turn plane, so a plugin asking for one there is answered
-/// `Unavailable` — a declared gap the plugin is told about, tracked as #3576 —
-/// and the other two drivers §6 asks for assemble nothing yet (#3551).
+/// `stella-cli` assembles one on the `stella run` path
+/// (`src/wrapper_plugin.rs::ResolvedWrapper::serving`) with both planes: a
+/// context plane (#3561) and a child-turn plane over the session's own
+/// sub-agent dispatcher (#3576). A driver that installs neither still answers
+/// `Unavailable` rather than falling silent, which is what the other two
+/// drivers §6 asks for do today, having no assembly at all yet (#3551).
 pub struct HostPlanes {
     recall: Option<Box<dyn RecallHost>>,
     max_frames: u32,

--- a/crates/stella-runtime/tests/wrapper_host_call.rs
+++ b/crates/stella-runtime/tests/wrapper_host_call.rs
@@ -342,23 +342,28 @@ async fn a_dead_writer_mid_conversation_is_not_reported_as_a_missing_gate() {
     let gate = gate(generous, DEFAULT_HOST_MAX_CALLS);
 
     // Closing stdin immediately after the request is read guarantees the
-    // host's very first answer write lands on an already-closed pipe: no
-    // race against the host's own scheduling is needed for this test to be
-    // reliable. Three asks follow with no read in between — pipelining ahead
-    // rather than a round trip — with a short pause between each so the
-    // writer task, once it fails, has had time to exit and drop its receiver
-    // before the next ask's guard is checked.
+    // host's very first answer write lands on an already-closed pipe. What it
+    // does *not* guarantee is when the writer task notices: the host has to
+    // answer one ask, have that write fail, and have the failed task drop its
+    // receiver before a later ask's guard is checked. A fixed pause between a
+    // fixed number of asks bets on that happening inside the window — a bet
+    // this test lost on a loaded machine, reporting the child's exit instead
+    // of the fault. So the plugin keeps asking, with no read in between
+    // (pipelining ahead rather than a round trip), until the host stops the
+    // conversation. The bound only has to outlast the writer's scheduling,
+    // not match it, and the point timeout below is the backstop.
     let script = r#"
 read -r request
 exec 0<&-
-printf '%s\n' '{"call":"recall","id":1,"args":{"goal":"first"}}'
-sleep 0.2
-printf '%s\n' '{"call":"recall","id":2,"args":{"goal":"second"}}'
-sleep 0.2
-printf '%s\n' '{"call":"recall","id":3,"args":{"goal":"third"}}'
+id=1
+while [ "$id" -le 200 ]; do
+  printf '%s\n' "{\"call\":\"recall\",\"id\":$id,\"args\":{\"goal\":\"ask\"}}"
+  sleep 0.05
+  id=$((id + 1))
+done
 "#;
 
-    let error = plugin(script, Arc::clone(&gate), Duration::from_secs(10))
+    let error = plugin(script, Arc::clone(&gate), Duration::from_secs(30))
         .before_turn(before())
         .await
         .expect_err("a channel that died mid-conversation cannot answer a further ask");

--- a/plugins/stella-research/README.md
+++ b/plugins/stella-research/README.md
@@ -41,11 +41,12 @@ The built-in stage is two files:
 
 **This plugin cannot do that, and the difference is the point of the honest
 part of this README.** A plugin gets no engine, no provider and no credential
-(`doc:wrapper-socket` §7). The host-call channel now carries a `child_turn`
-capability — the shape that would let a plugin *ask* for one bounded turn at a
-declared role intent — but no shipped host performs it (`RecallOnly` answers
-`unsupported`, #3555), and this plugin declares neither it nor a `[roles]`
-entry to name (#3541). It also never receives the questions triage named — the
+(`doc:wrapper-socket` §7). The host-call channel carries a `child_turn`
+capability — the shape that lets a plugin *ask* for one bounded turn at a
+declared role intent — and `stella run --pipeline <variant>` now performs it,
+over the session's own sub-agent dispatcher (#3576). **This plugin still
+cannot use it**: it declares neither the capability nor a `[roles]` entry to
+name, so every ask it could make would be refused as undeclared (#3541). It also never receives the questions triage named — the
 request carries `Signal::Questions`, a *count* (#3539).
 
 So it does the half that is checkable without a model: a deterministic literal


### PR DESCRIPTION
## What & why

`stella run --pipeline <variant>` assembled its host capabilities as
`HostPlanes::recalling(..)` and installed **no** child-turn plane, so a plugin
declaring `[loop] calls = ["child_turn"]` plus a `[roles.<name>]` was answered
`Unavailable` on the only door that drives a wrapper. The port itself was built
and proven end-to-end against an `sh` plugin (`stella_runtime::wrapper::ChildTurns`,
#3564) — nothing in the tree installed one. This attaches it at the live call
site, which is the clause of #3380's contract that says a wrapper is handed a
`ChildTurn` port naming a **role intent**, never a provider, an `Engine`, or a
credential (`doc:turn-loop-wrappers` §9.3).

The plane runs over the session's **existing** `SubAgentDispatcher` — the one
`task_assign` runs on — rather than a second one, so the budget carve, the
read-only tool surface, the report clamp and the turn-controls read all come
from the sub-agent contract instead of a second copy of it that could drift.
(#3576's requirement 1 asked for a turn-scoped dispatcher; `SessionSubAgents`
is already session-scoped by object and turn-scoped by wiring — it reads the
registry's current `TurnControls` and event sender at dispatch time — so no new
dispatcher type was needed. That correction is recorded on the issue.)

Three decisions are stated where they are made rather than left to a reader:

- **No `verifier` seat is bound.** Its seats are `WitnessAuthor` and `Verdict`,
  and `Verdict` is the model verdict #2584 removed *structurally* — attributing
  a plugin's call to it would put a call on the receipt the pipeline did not
  make. A plugin naming that tier is told `Unavailable`; a driver that wants it
  says so with `ChildTurns::with_seat` and owns the claim.
- **Receipt slot 1, never the parent's 0.** A raw `stella run` turn leaves
  `EngineConfig::turn_instance` at its default 0 and `step` restarts per turn,
  so a child sharing the slot could overwrite the parent's step manifests.
- **No per-turn USD carve is requested.** `None` asks for the remaining
  headroom, which `BudgetGuard::carve` clamps against the session's sub-agent
  pool — an unbounded *ask* that is still a bounded spend.

Two supporting changes:

- **Resolve and serve are two moments now.** `bind_installed` finds the plugin
  and declares its transport *before* the provider is built, so a `--pipeline`
  naming nothing installed still fails as a typo rather than after a paid run;
  `ResolvedWrapper::serving` builds the `HostCallGate` afterwards, once the
  dispatcher exists. `HostPlanes` is consumed by value at
  `HostCallGate::declare`, so a plane genuinely cannot be added to a gate later
  — the split is required by the types, not tidying.
- **The residual spend folds back.** The dispatcher settles each child onto the
  registry's `SubAgentSpendLedger` and an engine turn drains it at its next step
  boundary — but the last point of the last round has no next boundary, so
  `run_wrapped` drains what is left into the session's guard, and `spend_lines`
  prints one line per child turn beside what the plugin was refused.

**Exemplar followed:** `stella_runtime::wrapper::ChildTurns`' own host assembly
in `crates/stella-runtime/tests/wrapper_child_turn.rs` — the plane, the gate and
the `Arc` handle kept for `spends()` are assembled here in the same order and
for the same reasons, so the shipping driver and the reference test are one
shape rather than two.

**No new dependencies.** The one addition to `stella-core` is a blanket
`impl SubAgentDispatcher for Arc<D>` (no I/O, no logic) so a host holding the
`Arc` its session installed can spend through it without a forwarding newtype
per caller — the same shape as the existing `ChildTurnPlane for Arc<P>`.

Closes #3576

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

In `crates/stella-cli/src/wrapper_plugin/tests.rs` (split out of the parent
module in this PR to stay under the 1500-line ratchet — the parent is not
grandfathered and no baseline entry was added):

| Test | What it proves |
|---|---|
| `an_installed_sh_plugin_spends_a_child_turn_through_this_driver` | The end-to-end one: a real `/bin/sh` plugin installed on disk, resolved and started by this driver, driven through `WrapperDispatch` with a stubbed `TurnDriver` — it asks for a child turn mid-`before_turn`, **the host's dispatcher makes the call** (the spec is recorded: `ModelCallRole::Research`, `write_access: false`), and the child's answer comes back as the turn's context. |
| `a_declared_child_turn_runs_on_this_hosts_dispatcher` | Same claim at the gate, plus the receipt slot (1, not the parent's 0) and the spend line the user is shown. |
| `a_role_intent_pointing_at_the_worker_is_still_forbidden` | Independence survives the wiring: a *declared* role that resolves to the worker's seat is `Forbidden`, costs no model call, and is reported to the host — not the weaker `Unavailable` that reads as a misconfiguration. |
| `a_host_with_no_child_turn_plane_answers_unavailable` | The state before this change, kept as an assertion: a driver with no plane still tells the plugin, never falls silent. |
| `a_plugins_residual_child_spend_folds_into_the_sessions_guard` | The last point's spend reaches the session's guard, and draining is exactly once. |

Why they fail on `main`: there was no way to install a plane from `stella-cli`
at all — `bind_installed` took no parameter for one and `BoundWrapper` held no
handle to read a spend back from — so the capability's only possible answer was
`Unavailable`, which the fourth row still asserts for a host that installs
nothing.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings` — run over `-p stella-cli -p stella-core -p stella-runtime` (the touched crates and their dependents through `CARGO_SCOPE`), plus `cargo check --workspace --all-targets` clean
- [ ] `cargo test --workspace` — **not run to completion locally**: the session's disk allowance filled while linking the workspace's test binaries. What did run green: `stella-core`, `stella-runtime`, `stella-tools`, `stella-cli` (1852 + integration tests), and `stella-serve`/`stella-fleet`/`stella-pipeline` as the consumers of the changed `stella-core` surface, plus `cargo check --workspace --all-targets`. CI runs the full suite.
- [x] Every other `make gate` guard run individually and green: `no-scratch`, `no-secrets`, `design-refs`, `action-pins`, `cargo-install-pins`, `license-allowlist-parity`, `repro-wiring`, `invariants`, `doc-links`, `command-docs`, `brand-case`, `file-size`, `god-files`, `gate-parity`, `left-behind`, `role-names`, `stat-portability`, `module-reachability`, `typed-errors`, `diagnostic-codes`, `tool-docs`, `lockfile-sync`, `doc-warnings`. (`shellcheck` is not installed in this environment; no shell script changed.)
- [x] Docs updated: `crates/stella-runtime/README.md` (the "no host builds a `HostCallGate` with `.with_child_turns(..)` yet" paragraph is now false and says what landed instead), `crates/stella-cli/README.md`, `crates/stella-runtime/src/wrapper/host_call.rs` and `child_turn.rs` (whose `ChildTurnSpend` consumer note declared "no shipping driver reads this"), `plugins/stella-research/README.md` (which said no shipped host performs `child_turn`), and this module's own header.
- [x] `Closes #3576` appears above **and** as a commit trailer

## Nothing left behind

- [x] Filed: **#3802**, **#3803**

- **#3802** — a plugin's points run *between* the parent's turns, where the tool
  registry's event slot is empty, so the child's `step_usage` rides a sink: the
  spend reaches this run's report and the session's budget guard, but **not the
  store's receipt**. That is the one clause of #3576's definition of done this
  PR does not deliver, and it is named here rather than implied: fixing it means
  deciding which execution row a between-turns child belongs to, which is a
  design decision about what a multi-round wrapped run *is*.
- **#3803** — this door publishes no `TurnControls`, so a plugin's child
  inherits none. Latent today (the wrapped path is headless: no pause gate, no
  steering tap) and load-bearing the moment a surface that *has* controls can
  drive a wrapped turn (#3554). Attaching `TurnControls::none()` now would be a
  no-op and unwitnessable, so it is filed as a clause of that change.

## Ground-rule check

- [x] No I/O added to `stella-core` — the only change there is a blanket trait
      impl that forwards through an `Arc`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types (the wire shapes were already in
      `stella-plugin` and are unchanged)

## Anything reviewers should know?

- **This is one slice of #3380, not #3380.** The epic's remaining work is
  unchanged: `stella-pipeline` is still not ported onto the socket (Track B),
  the other two drivers §6 asks for do not exist (#3551), and goal mode's round
  loop and `VerifierScopedTools` are still a second implementation (#2819).
  Only #3576 closes here.
- **The resolve/serve split is the shape of the diff**, and it is load-bearing
  rather than cosmetic — see the second bullet under "What & why". A reviewer
  who wants to collapse it back should check `HostCallGate::declare`'s by-value
  `HostPlanes` first.
- **The plane is installed unconditionally**, even for a plugin that declares no
  `calls` and no `[roles]`. The manifest's `[loop]` grant is still the
  authoritative filter (`LoopGrant::permits_call` refuses before the host does
  anything), and `ChildTurns::resolve` answers `Undeclared` naming what the
  manifest *did* declare — so an always-installed plane grants nothing extra and
  keeps the refusal specific.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW2njMqPvPuB2XEZxUxN3x)_

## Summary by Sourcery

Attach the child-turn host plane to the live CLI wrapper driver so plugins can make bounded role-intent calls through the session dispatcher while preserving budget, attribution, and refusal reporting.

New Features:
- Enable `stella run --pipeline <variant>` wrapper plugins to execute declared, read-only child turns through the session’s existing sub-agent dispatcher.
- Report wrapper child-turn spending alongside refusals and fold residual child spending into the session budget guard.

Bug Fixes:
- Prevent wrapper plugin resolution from triggering provider-dependent setup before invalid pipeline variants are rejected.
- Preserve independent receipt attribution for child turns by recording them in a dedicated turn slot.

Enhancements:
- Split wrapper resolution from resource-dependent serving so host capabilities are assembled only after the session dispatcher and provider exist.
- Keep verifier-tier and worker-seat child-turn requests unavailable or forbidden according to the host’s role policy.

Documentation:
- Update runtime, CLI, and plugin documentation to describe the live child-turn capability and its remaining limitations.

Tests:
- Add unit, integration, and end-to-end coverage for child-turn dispatch, role restrictions, spend reporting, residual budget settlement, and hosts without a child-turn plane.
- Harden the wrapper host-call test against scheduling variance when the plugin writer exits mid-conversation.

Chores:
- Move wrapper-plugin tests into a dedicated module file to remain within the project’s file-size limits.
- Add blanket dispatcher support for `Arc` handles without introducing new dependencies or core I/O.