### PR TITLE
fix(stella-tools,stella-cli): three silent-loss defects from a session export audit

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1694,7 +1694,7 @@ pub(crate) async fn run_turn(
     // boundary and emitted *before* the close below: these are the turn's own
     // events and a consumer folding the stream must see them inside the turn
     // they describe. See `crate::turn_files` for why a measurement, not a hook.
-    crate::turn_files::emit_shared_tree_changes(cfg, &tx);
+    crate::turn_files::emit_shared_tree_changes(cfg, &tx, execution.as_ref());
     // This path owns its run — one raw engine turn, no pipeline above it — so
     // it owes the run's terminator (#3379). The engine ends the turn with
     // `TurnComplete` and deliberately says nothing about the run, and every

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -132,8 +132,10 @@ fn file_touch_row(change: &JournalChange) -> FileTouchRow {
 /// The `ops` alphabet is CRUD letters, fixed by the reader rather than by
 /// preference — `Store::execution_rollup` and `finalize_execution_reflection`
 /// both match `ops LIKE '%C%' OR '%U%' OR '%D%'`, so a row spelled any other
-/// way is a row those queries cannot see. Same alphabet as
-/// [`crate::candidate_ws::adoption_ledger`], deliberately.
+/// way is a row those queries cannot see. Same alphabet as the adoption
+/// ledger's `ops_letter` (`candidate_ws/adoption_ledger.rs`), deliberately —
+/// named in prose rather than linked because that module is private, and an
+/// intra-doc link to it does not resolve.
 fn ops_letter(kind: JournalChangeKind) -> &'static str {
     match kind {
         JournalChangeKind::Created => "C",

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -57,26 +57,88 @@
 //! grandfathered god file, closed to growth (AGENTS.md § "God files — plan
 //! around them, never into them").
 
+use std::sync::Arc;
+
 use stella_core::EventSender;
 use stella_protocol::event::{AgentEvent, FileChangeKind};
 use stella_store::work_journal::{JournalChange, JournalChangeKind};
+use stella_store::{FileTouchRow, Store};
 
 use crate::config::Config;
 
-/// Measure the shared work tree and emit one [`AgentEvent::FileChange`] per
-/// path this turn changed.
+/// Measure the shared work tree once, then write both of this turn's file
+/// projections from that one reading: the [`AgentEvent::FileChange`] stream
+/// and the durable `files_touched` rows.
 ///
 /// Call **before** the turn's event channel closes — these are the turn's
 /// events, and a consumer folding the stream must see them inside the turn
 /// they describe.
 ///
+/// The measurement is taken exactly once and both projections are derived from
+/// it. Snapshotting twice would not merely cost a second `--numstat`: the
+/// journal's snapshot advances its own baseline, so the second reading would
+/// report an unchanged tree and the two projections would disagree about the
+/// same turn.
+///
 /// Best-effort and silent, like every other turn-boundary write: a turn that
 /// ended is not made less ended by an unmeasurable tree. A send failure means
 /// the renderer is already gone, which is not this function's problem to
 /// report.
-pub(crate) fn emit_shared_tree_changes(cfg: &Config, tx: &EventSender) {
-    for change in cfg.durability.snapshot_worktree() {
+pub(crate) fn emit_shared_tree_changes(
+    cfg: &Config,
+    tx: &EventSender,
+    execution: Option<&(Arc<Store>, i64)>,
+) {
+    let measured = cfg.durability.snapshot_worktree();
+    if measured.is_empty() {
+        return;
+    }
+    if let Some((store, execution_id)) = execution {
+        let rows: Vec<FileTouchRow> = measured.iter().map(file_touch_row).collect();
+        // Best-effort for the same reason `AdoptionLedger::record` is: this is
+        // observability, not evidence (#2882). A telemetry write must never
+        // fail a turn whose bytes are already on disk.
+        let _ = store.record_files_touched(*execution_id, &rows);
+    }
+    for change in measured {
         let _ = tx.send(file_change(change));
+    }
+}
+
+/// One measured delta as a durable row.
+///
+/// The durable half of #3413. That change gave the engine path a `FileChange`
+/// producer but no `files_touched` producer, leaving adoption as the table's
+/// only writer — so every direct-edit turn recorded zero touched files however
+/// many it wrote. `Store::finalize_execution_reflection` reads exactly this
+/// table for its `wrote_files` flag, so the empty table also told the
+/// reflection loop that a turn which edited dozens of files had written none.
+fn file_touch_row(change: &JournalChange) -> FileTouchRow {
+    FileTouchRow {
+        path: change.path.clone(),
+        ops: ops_letter(change.kind).to_string(),
+        lines_added: u64::from(change.added),
+        lines_removed: u64::from(change.removed),
+        events_json: serde_json::json!([{
+            "event": "measured",
+            "reason": "turn-boundary work-tree measurement",
+            "lines_added": change.added,
+            "lines_removed": change.removed,
+        }])
+        .to_string(),
+    }
+}
+
+/// The `ops` alphabet is CRUD letters, fixed by the reader rather than by
+/// preference — `Store::execution_rollup` and `finalize_execution_reflection`
+/// both match `ops LIKE '%C%' OR '%U%' OR '%D%'`, so a row spelled any other
+/// way is a row those queries cannot see. Same alphabet as
+/// [`crate::candidate_ws::adoption_ledger`], deliberately.
+fn ops_letter(kind: JournalChangeKind) -> &'static str {
+    match kind {
+        JournalChangeKind::Created => "C",
+        JournalChangeKind::Modified => "U",
+        JournalChangeKind::Deleted => "D",
     }
 }
 
@@ -110,6 +172,42 @@ mod tests {
             removed: 3,
             diff: Some("@@ -1 +1,2 @@\n+new\n".into()),
         }
+    }
+
+    /// The letters the two readers grep for. `execution_rollup`'s
+    /// `files_written` and `finalize_execution_reflection`'s `wrote_files`
+    /// both match `ops LIKE '%C%' OR '%U%' OR '%D%'`, so a row spelled any
+    /// other way fills the table while both queries answer zero.
+    #[test]
+    fn durable_rows_use_the_crud_letters_both_reader_queries_match() {
+        for (kind, expected) in [
+            (JournalChangeKind::Created, "C"),
+            (JournalChangeKind::Modified, "U"),
+            (JournalChangeKind::Deleted, "D"),
+        ] {
+            assert_eq!(ops_letter(kind), expected);
+        }
+    }
+
+    /// The durable projection carries the same measurement as the stream one,
+    /// from the same reading. Before this existed, a direct-edit turn emitted
+    /// `FileChange` events and wrote no `files_touched` row at all.
+    #[test]
+    fn a_measured_change_becomes_a_durable_row_carrying_the_same_counts() {
+        let row = file_touch_row(&measured(JournalChangeKind::Modified));
+        assert_eq!(row.path, "src/lib.rs");
+        assert_eq!(row.ops, "U");
+        assert_eq!((row.lines_added, row.lines_removed), (12, 3));
+
+        let events: serde_json::Value = serde_json::from_str(&row.events_json).expect("json");
+        let entries = events.as_array().expect("an array");
+        assert_eq!(entries.len(), 1, "one measurement is one audit entry");
+        assert_eq!(entries[0]["event"], "measured");
+        assert_eq!(entries[0]["lines_added"], 12);
+        assert!(
+            !row.events_json.contains("@@"),
+            "files_touched indexes paths; the diff rides the FileChange event"
+        );
     }
 
     #[test]

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -84,6 +84,66 @@ pub(crate) fn crlf_promoted(content: &str, old: &str, new: &str) -> Option<(Stri
     Some((promoted_old, promoted_new))
 }
 
+/// Lines of a needle that missed, but whose only difference from the file is
+/// leading whitespace — returned as the file's own bytes for that span.
+///
+/// The most common shape of an "unchanged file, still no match" miss, and the
+/// one the generic message cannot resolve without a ranged re-read: a needle
+/// copied out of a nested context and re-indented by a few spaces, or copied
+/// from a `read_file` render whose line prefix was trimmed off unevenly. The
+/// literal comparison is right to fail — an edit must be byte-exact — but the
+/// tool knows *why* it failed and can say so.
+///
+/// Deliberately narrow, so this can never claim a match the real edit would
+/// not have made:
+///
+/// - Every line must be equal after stripping leading whitespace **only**.
+///   Trailing whitespace still counts, because it is a real difference the
+///   model must reproduce and one that a "check whitespace" message covers.
+/// - The first matching window wins and a second one yields `None`. An
+///   ambiguous span would send the model to re-issue against the wrong copy,
+///   which is worse than the generic message.
+/// - Bounded by [`INDENT_HINT_MAX_LINES`]: this is a hint inside an error, not
+///   a file echo, and a huge needle is not the confusion this diagnoses.
+fn indentation_only_match(content: &str, needle: &str) -> Option<String> {
+    let needle_lines: Vec<&str> = needle.lines().collect();
+    if needle_lines.is_empty() || needle_lines.len() > INDENT_HINT_MAX_LINES {
+        return None;
+    }
+    // A single line with no leading whitespace of its own cannot be an
+    // indentation miss: there is nothing to have got wrong.
+    let trimmed: Vec<&str> = needle_lines
+        .iter()
+        .map(|l| l.trim_start_matches([' ', '\t']))
+        .collect();
+    if trimmed.iter().all(|l| l.is_empty()) {
+        return None;
+    }
+
+    let content_lines: Vec<&str> = content.lines().collect();
+    let mut found: Option<String> = None;
+    for window in content_lines.windows(needle_lines.len()) {
+        let matches = window
+            .iter()
+            .zip(&trimmed)
+            .all(|(actual, want)| actual.trim_start_matches([' ', '\t']) == *want);
+        if !matches {
+            continue;
+        }
+        if found.is_some() {
+            // Ambiguous — say nothing rather than point at the wrong span.
+            return None;
+        }
+        found = Some(window.join("\n"));
+    }
+    found
+}
+
+/// Ceiling on the needle this hint will diagnose. A long needle that misses is
+/// unlikely to be a pure indentation slip, and the hint has to stay small
+/// enough to belong inside an error message.
+const INDENT_HINT_MAX_LINES: usize = 40;
+
 #[derive(Default)]
 pub struct EditFile {
     ledger: Arc<ReadLedger>,
@@ -269,11 +329,23 @@ impl Tool for EditFile {
                         drift_echo(&content)
                     ))
                 }
-                Some(_) => ToolOutput::error(format!(
-                    "old_string not found in `{path}` — the file is unchanged since you last \
-                         saw it, so the copy in your context matches disk; check for exact \
-                         whitespace/newline differences"
-                )),
+                Some(_) => match indentation_only_match(&content, old_string) {
+                    // The needle is right and only its indentation is wrong.
+                    // The generic message below is accurate but costs a ranged
+                    // re-read to act on; naming the cause and echoing the
+                    // file's own bytes for the span removes that round trip.
+                    Some(actual) => ToolOutput::error(format!(
+                        "old_string not found in `{path}` — but the same text IS present with \
+                         different leading whitespace, so the needle was re-indented. The file \
+                         is unchanged since you last saw it. Copy this span byte-exact:\n\n--- \
+                         {path} (actual indentation) ---\n{actual}"
+                    )),
+                    None => ToolOutput::error(format!(
+                        "old_string not found in `{path}` — the file is unchanged since you last \
+                             saw it, so the copy in your context matches disk; check for exact \
+                             whitespace/newline differences"
+                    )),
+                },
                 None => ToolOutput::error(format!(
                     "old_string not found in `{path}` — no read of this file is recorded \
                          this session; read it first and copy old_string byte-exact"
@@ -334,6 +406,30 @@ mod tests {
         crate::ctx::ToolCtx::bare(root.as_ref().to_path_buf())
     }
     use crate::read::ReadFile;
+
+    /// The observed failure this diagnoses: a needle that is byte-correct
+    /// except for a missing list indent. The generic "check for exact
+    /// whitespace" message is true but costs a ranged re-read to act on.
+    #[test]
+    fn an_indentation_only_miss_hands_back_the_files_own_bytes() {
+        let content = "prose\n   - one\n   - two\nmore\n";
+        let hit = indentation_only_match(content, "- one\n- two").expect("the span");
+        assert_eq!(hit, "   - one\n   - two", "the file's indentation, verbatim");
+    }
+
+    /// The hint must never claim a match the real edit would not have made.
+    #[test]
+    fn the_hint_declines_when_it_would_be_a_guess() {
+        // Genuinely absent text is not an indentation problem.
+        assert_eq!(indentation_only_match("a\nb\n", "- nope"), None);
+        // Two candidate spans: pointing at either one could be wrong.
+        assert_eq!(indentation_only_match("  x\nsep\n    x\n", "x"), None);
+        // Trailing whitespace is a real difference the model must reproduce,
+        // and the generic message already covers it.
+        assert_eq!(indentation_only_match("  keep  \n", "keep"), None);
+        // Nothing to have mis-indented.
+        assert_eq!(indentation_only_match("\n\n", "   "), None);
+    }
 
     #[tokio::test]
     async fn replaces_unique_substring() {

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -414,7 +414,10 @@ mod tests {
     fn an_indentation_only_miss_hands_back_the_files_own_bytes() {
         let content = "prose\n   - one\n   - two\nmore\n";
         let hit = indentation_only_match(content, "- one\n- two").expect("the span");
-        assert_eq!(hit, "   - one\n   - two", "the file's indentation, verbatim");
+        assert_eq!(
+            hit, "   - one\n   - two",
+            "the file's indentation, verbatim"
+        );
     }
 
     /// The hint must never claim a match the real edit would not have made.

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -330,8 +330,21 @@ impl Tool for SpawnSubAgent {
 /// the salvaged text is real evidence the parent paid for, and burying it in
 /// an error message invites the model to discard it and redo the work.
 /// A child that never ran IS an error, because there is nothing to use.
+///
+/// A child that *completed* and said nothing is the same error wearing a
+/// success label, and is reported as one. The `Incomplete` arms below already
+/// split on an empty summary; `Completed` did not, so a child whose report was
+/// blank returned `ok` with no findings and the parent had to notice the
+/// thinness itself — which, in a real session, it did only after paying for
+/// the sweep twice.
 fn render(outcome: &SubAgentOutcome) -> ToolOutput {
     match outcome {
+        SubAgentOutcome::Completed(report) if report.summary.trim().is_empty() => {
+            ToolOutput::error(
+                "the sub-agent finished without reporting anything — its answer was empty. \
+                 Do the work directly, or re-ask with a narrower, self-contained question.",
+            )
+        }
         SubAgentOutcome::Completed(report) => ToolOutput::Ok {
             content: if report.truncated {
                 format!(

--- a/crates/stella-tools/src/subagent/tests.rs
+++ b/crates/stella-tools/src/subagent/tests.rs
@@ -160,6 +160,28 @@ async fn a_child_that_produced_nothing_is_an_error() {
     assert!(matches!(out, ToolOutput::Error { .. }), "{out:?}");
 }
 
+/// The silent-loss shape: a child that *completed* and reported nothing used
+/// to render as a plain `ok` with empty content, indistinguishable from a
+/// sweep that genuinely found nothing to say. The parent could only recover by
+/// noticing the thinness itself and paying for the whole delegation again.
+#[tokio::test]
+async fn a_completed_child_with_an_empty_report_is_an_error_not_a_silent_ok() {
+    for blank in ["", "   \n\t "] {
+        let (tool, _) = tool_with(SubAgentOutcome::Completed(report(blank, 0.42, false)));
+
+        let out = tool
+            .execute(
+                &call("x", "y"),
+                &crate::ctx::ToolCtx::bare(std::path::PathBuf::from(".")),
+            )
+            .await;
+        assert!(
+            matches!(out, ToolOutput::Error { .. }),
+            "a completed child that said nothing must not read as success: {out:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn a_truncated_report_says_so_to_the_model() {
     let (tool, _) = tool_with(SubAgentOutcome::Completed(report(


### PR DESCRIPTION
Three silent-loss defects found by an export audit of a real session
(`ses-1787092335250-47513`, execution 157: 66 edits across 35 files, cancelled
after the build passed). Each one made a failure look like a success.

## 1. A sub-agent's empty report read as `ok`

`render` in `crates/stella-tools/src/subagent.rs` split on an empty summary in
both `Incomplete` arms but not in `Completed`, so a child that finished and said
nothing returned a plain `ok` with no content — indistinguishable from a sweep
that genuinely found nothing to report. In the audited session one sweep covering
39 pages came back at 354 bytes against ~8 KB for its three siblings; the parent
recovered only by noticing the thinness itself and paying for the whole
delegation a second time (~5 minutes).

## 2. `files_touched` had no producer on the engine path

#3413 gave that path an `AgentEvent::FileChange` producer but no durable one,
leaving candidate adoption as the table's only writer
(`crates/stella-cli/src/candidate_ws/adoption_ledger.rs`). Every direct-edit turn
therefore recorded zero touched files however many it wrote.

This also explains a second symptom that looked unrelated:
`Store::finalize_execution_reflection` derives `wrote_files` from exactly that
table, so the reflection loop was told a turn that edited 35 files had written
none.

The turn-boundary measurement is now taken **once** and both projections derive
from it. Snapshotting twice would not merely cost a second `--numstat` — the
journal's snapshot advances its own baseline, so the second reading would report
an unchanged tree and the two projections would disagree about the same turn.

Both writes stay best-effort: observability, not evidence (#2882).

## 3. An indentation-only `edit_file` miss got a generic nudge

The unchanged-file arm of the #331 attribution is accurate but not actionable —
"check for exact whitespace/newline differences" costs a ranged re-read to act
on, which is what it cost in the audited session (a needle missing a three-space
list indent, twenty tool calls to recover). When the needle's lines match the
file's after stripping leading whitespace only, the tool now says so and echoes
the file's own bytes for the span.

Deliberately narrow, so it can never claim a match the literal edit would not
have made: trailing whitespace still counts as a real difference, an ambiguous
second window declines rather than guessing, and the needle is bounded — this is
a hint inside an error, not a file echo.

## Witnesses

- `a_completed_child_with_an_empty_report_is_an_error_not_a_silent_ok` —
  verified by removing the fix: FAILED without it, passes with it.
- `a_measured_change_becomes_a_durable_row_carrying_the_same_counts` and
  `durable_rows_use_the_crud_letters_both_reader_queries_match` — the second
  pins the `ops` alphabet both reader queries (`execution_rollup`'s
  `files_written`, `finalize_execution_reflection`'s `wrote_files`) grep for, so
  a row spelled any other way fills the table while both answer zero.
- `an_indentation_only_miss_hands_back_the_files_own_bytes` and
  `the_hint_declines_when_it_would_be_a_guess`. The pre-existing
  `unchanged_file_failure_is_not_drift_attributed` still passes, so the new
  branch does not hijack the generic path.

No test was deleted or renamed.

## Two audit findings I did NOT act on, because the premises are false

Recorded so the next reader does not re-derive them:

- *"Context drops are invisible to the agent."* They are not. Every compaction
  pass writes a model-visible stub (`EVICTION_STUB`, `DEDUP_STUB`,
  `SUPERSESSION_STUB`, `AGE_ELISION_MARKER`), and the last of those literally
  says "re-run the tool for the full output". The re-reads the audit called
  redundant are that stub's instructed recovery working as designed.
- *"`edit_file`'s staleness error is indistinguishable from never-existed."*
  `crates/stella-tools/src/edit.rs` already attributes all three causes —
  drifted (with a fresh-content echo), unchanged, and no-read-recorded — to
  three different messages with three different recoveries. Only the
  actionability of the *unchanged* arm was a real gap, which is item 3 above.

## Filed rather than fixed

- #3807 — `task` delegations record no `agent_uses` rows; the tool cannot reach
  the ledger without a new seam (`ToolCtx` has no handle, and the tool cannot
  hold the registry that owns it).
- #3808 — a cancelled execution's reflection is a silent stub. Note the
  `wrote_files = 0` half of that symptom is fixed here; the empty critique and
  null rating are a separate design call.
- #3690 already covers the prompt-cache finding (0 cache writes across 3.03M
  input tokens) — linked, not duplicated.

## Summary by Sourcery

Prevent successful-looking session outcomes from hiding empty sub-agent reports, missing file-change records, and recoverable indentation-only edit failures.

New Features:
- Provide actionable guidance when an `edit_file` replacement differs only by leading indentation.

Bug Fixes:
- Treat completed sub-agents with empty reports as errors instead of silent successes.
- Persist turn-boundary worktree changes to `files_touched` so direct edits contribute accurate file and reflection metrics.

Enhancements:
- Derive event and durable file-change projections from a single worktree measurement while keeping both writes best-effort.

Tests:
- Add coverage for empty completed sub-agent reports, durable file-touch projections and CRUD operation markers, and safe indentation-only edit hints.