### PR TITLE
feat(stella-tools): carry a delegation's cost and answer size back as structured data

### DIFF
--- a/crates/stella-tools/src/contracts.rs
+++ b/crates/stella-tools/src/contracts.rs
@@ -86,6 +86,22 @@ fn declared_output_schema(name: &str) -> Option<serde_json::Value> {
             },
             "required": ["entries"]
         })),
+        // What a delegation cost and how much answer came back. Declared
+        // because the prose alone cannot distinguish a lost or truncated
+        // child result from a cheap one, so nothing downstream could mark an
+        // anomalous delegation; `crate::subagent::render` documents why these
+        // values ride `data` rather than the model-visible content.
+        "task" => Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": { "type": "string", "enum": ["completed", "partial"] },
+                "steps": { "type": "integer", "minimum": 0 },
+                "cost_usd": { "type": "number", "minimum": 0 },
+                "report_chars": { "type": "integer", "minimum": 0 },
+                "truncated": { "type": "boolean" }
+            },
+            "required": ["status", "steps", "cost_usd", "report_chars", "truncated"]
+        })),
         _ => None,
     }
 }

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -76,7 +76,7 @@ use std::sync::{Arc, RwLock};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use stella_core::ports::TurnControls;
-use stella_core::subagent::{SubAgentDispatcher, SubAgentOutcome, SubAgentSpec};
+use stella_core::subagent::{SubAgentDispatcher, SubAgentOutcome, SubAgentReport, SubAgentSpec};
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 
 use crate::registry::Tool;
@@ -330,6 +330,24 @@ impl Tool for SpawnSubAgent {
 /// the salvaged text is real evidence the parent paid for, and burying it in
 /// an error message invites the model to discard it and redo the work.
 /// A child that never ran IS an error, because there is nothing to use.
+///
+/// # Why the metrics ride `data` and never the content
+///
+/// A delegation that spent minutes and several model calls to return two
+/// sentences is indistinguishable, in the prose alone, from one that answered
+/// cheaply — so a lost or truncated child result reads downstream as an
+/// unremarkable success, and nothing in a run export can mark it as anomalous.
+/// The facts that separate the two (how many steps it took, what it cost, how
+/// much report came back) are already on [`SubAgentReport`]; what was missing
+/// was a channel to carry them.
+///
+/// That channel is [`ToolOutput::Ok`]'s `data`, which is specified to leave the
+/// content bytes the model reads untouched. That property is load-bearing here
+/// rather than incidental: these values move on every call, and the loop
+/// detector compares tool-output bytes, so putting a step count or a cost in
+/// `content` would make two identical delegations look different to it. It is
+/// the same reason the dispatch heartbeat above is a progress event and not a
+/// line of output.
 fn render(outcome: &SubAgentOutcome) -> ToolOutput {
     match outcome {
         SubAgentOutcome::Completed(report) => ToolOutput::Ok {
@@ -342,7 +360,7 @@ fn render(outcome: &SubAgentOutcome) -> ToolOutput {
             } else {
                 report.summary.clone()
             },
-            data: None,
+            data: Some(metrics("completed", report)),
         },
         SubAgentOutcome::Incomplete { report, reason } if !report.summary.is_empty() => {
             ToolOutput::Ok {
@@ -351,7 +369,7 @@ fn render(outcome: &SubAgentOutcome) -> ToolOutput {
                      the above as incomplete evidence, not a final answer.]",
                     report.summary
                 ),
-                data: None,
+                data: Some(metrics("partial", report)),
             }
         }
         SubAgentOutcome::Incomplete { reason, .. } => ToolOutput::error(format!(
@@ -363,6 +381,27 @@ fn render(outcome: &SubAgentOutcome) -> ToolOutput {
                  own tools"
         )),
     }
+}
+
+/// The structured half of a delegation's result: what the child cost and how
+/// much came back, keyed to the schema `task` declares in
+/// `crate::contracts::declared_output_schema`.
+///
+/// `report_chars` is the answer's size in UTF-8 bytes rather than a verdict on
+/// it. There is deliberately no "this looks too thin" threshold: a two-sentence
+/// answer to a narrow question is correct, and a rule that called it a failure
+/// would be wrong more often than the loss it caught. Reporting the size beside
+/// the steps and the spend is what lets a reader — or a surface that ranks
+/// delegations by cost-per-byte — reach that judgement with the evidence in
+/// hand, which is the half that did not exist.
+fn metrics(status: &str, report: &SubAgentReport) -> Value {
+    json!({
+        "status": status,
+        "steps": report.steps,
+        "cost_usd": report.cost_usd,
+        "report_chars": report.summary.len(),
+        "truncated": report.truncated,
+    })
 }
 
 /// A short, stable, filesystem-safe id from the model's description, for

--- a/crates/stella-tools/src/subagent/tests.rs
+++ b/crates/stella-tools/src/subagent/tests.rs
@@ -445,3 +445,66 @@ async fn dispatching_a_child_emits_declared_progress_on_the_bus() {
     assert_eq!(events[0]["stage"], "dispatched");
     assert_eq!(events[0]["agent_id"], "find-retry-policy");
 }
+
+/// A delegation's cost and answer size cross back as structured `data`, so a
+/// thin or truncated child result can be recognised downstream instead of
+/// reading as an unremarkable success.
+///
+/// Before this, `render` returned `data: None` on both `Ok` arms: the only
+/// thing that crossed back was prose, and a child that spent minutes and
+/// several model calls to return two sentences was indistinguishable from one
+/// that answered cheaply. Nothing in a run export could mark it.
+#[tokio::test]
+async fn a_finding_carries_the_delegations_cost_and_size_as_data() {
+    let (tool, _dispatcher) = tool_with(SubAgentOutcome::Completed(report("thin", 0.42, false)));
+
+    let out = tool
+        .execute(
+            &call("sweep", "sweep the prose"),
+            &crate::ctx::ToolCtx::bare(std::path::PathBuf::from(".")),
+        )
+        .await;
+
+    let ToolOutput::Ok { content, data } = out else {
+        panic!("a completed child is an Ok");
+    };
+    assert_eq!(
+        content, "thin",
+        "the model-visible bytes are the report alone"
+    );
+    let data = data.expect("the structured half is present");
+    assert_eq!(data["status"], "completed");
+    assert_eq!(data["steps"], 4);
+    assert_eq!(data["cost_usd"], 0.42);
+    assert_eq!(
+        data["report_chars"], 4,
+        "the answer's size, so cost-per-byte is computable"
+    );
+    assert_eq!(data["truncated"], false);
+}
+
+/// The same for a salvaged partial, which is where a lost result most often
+/// lands — and the one case where knowing the spend behind an empty-looking
+/// answer matters most.
+#[tokio::test]
+async fn a_partial_finding_is_marked_partial_in_its_data() {
+    let (tool, _dispatcher) = tool_with(SubAgentOutcome::Incomplete {
+        report: report("half an answer", 0.9, true),
+        reason: "it ran out of steps".to_string(),
+    });
+
+    let out = tool
+        .execute(
+            &call("sweep", "sweep the prose"),
+            &crate::ctx::ToolCtx::bare(std::path::PathBuf::from(".")),
+        )
+        .await;
+
+    let ToolOutput::Ok { data, .. } = out else {
+        panic!("a salvaged partial is an Ok");
+    };
+    let data = data.expect("the structured half is present");
+    assert_eq!(data["status"], "partial");
+    assert_eq!(data["truncated"], true);
+    assert_eq!(data["cost_usd"], 0.9);
+}


### PR DESCRIPTION
`render` returned `data: None` on both `Ok` arms, so the only thing crossing back from a sub-agent was prose. A child that spent minutes and several model calls to return two sentences was indistinguishable from one that answered cheaply, and nothing downstream — a run export, a surface, a reviewer — could mark an anomalous delegation. Observed in a trace: a 419-second delegation returning a 354-byte report beside siblings returning ~8 KB, with nothing in the export flagging it as truncated, timed out, or anomalous.

The facts that separate the two were already on `SubAgentReport`; what was missing was a channel. `ToolOutput::Ok`'s `data` is that channel, and its specified property — content bytes the model reads are never perturbed by structure — is load-bearing here rather than incidental: these values move on every call and the loop detector compares tool-output bytes, so a step count in `content` would make two identical delegations look different to it. It is the same reason the dispatch heartbeat is a progress event and not a line of output.

`task` declares the matching output schema beside `list_state`, so the structured half is a reviewed contract rather than an undeclared payload.

Deliberately **no** "this looks too thin" threshold: a two-sentence answer to a narrow question is correct, and a rule calling it a failure would be wrong more often than the loss it caught. The size is reported, not judged.

## What this does not do, and why

The first attempt fixed a different, non-existent defect: classifying an empty child report as incomplete instead of completed. The witness test disproved it. Stella already catches that shape in `driver/confident_zero.rs` (the empty-response abort, plus the #1477 confident-zero check), and the one path skipping the empty guard — `out_of_time` — appends a "⚠ Stopped at the output-token limit" note, so `Completed` text is never empty. That branch would have been unreachable code, so it was reverted rather than shipped as an inert guard.

## Witness

`a_finding_carries_the_delegations_cost_and_size_as_data` and `a_partial_finding_is_marked_partial_in_its_data`. Both fail on the old code with `the structured half is present` (verified by reverting `data` to `None` and re-running) and pass with the change.

## Related

Refs #3806 — the second half of the same trace review (compaction leaves no "files already read" digest, so the model re-derives state from disk after every pass) is filed rather than fixed: it needs a volatile post-prefix digest under invariant 7, computed from the transcript under invariant 2, and invalidated by any write to the same path.

## Summary by Sourcery

Carry delegation outcome metrics alongside task results as structured data without altering the model-visible report.

New Features:
- Expose delegation status, step count, cost, report size, and truncation state as structured task output data.
- Declare the task tool's structured output schema for downstream consumers.

Enhancements:
- Preserve model-visible report content while making delegation metrics available for exports, surfaces, and review workflows.

Tests:
- Add coverage for structured metrics on completed and partial delegation results.