### PR TITLE
fix(stella-tools): record an agent_uses row for every `task` delegation

### DIFF
--- a/crates/stella-tools/src/agent_use.rs
+++ b/crates/stella-tools/src/agent_use.rs
@@ -14,7 +14,18 @@
 //! `stella-cli::agents_installed` for the on-disk versioning scheme), so the
 //! telemetry can attribute outcomes to the exact definition text that ran.
 
+use std::sync::{Arc, Mutex};
+
 use serde::{Deserialize, Serialize};
+
+/// A shared handle on the session's ledger.
+///
+/// The registry owns one and hands clones out — to
+/// [`crate::ctx::ToolCtx`] per call, so a tool can attribute its own
+/// delegations (#3807). Shared rather than borrowed because the context
+/// crosses an `async_trait` boundary on every dispatch, exactly like the
+/// hook bus beside it.
+pub type AgentUseLedgerHandle = Arc<Mutex<AgentUseLedger>>;
 
 /// One invocation of an installed agent definition.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/stella-tools/src/ctx.rs
+++ b/crates/stella-tools/src/ctx.rs
@@ -21,6 +21,31 @@
 //! failing the call over it would let an observability bug break a working
 //! tool.
 //!
+//! # Why attribution lives here and not on the tool (#3807)
+//!
+//! The `task` tool mints an agent id per delegation and recorded it nowhere:
+//! `agent_uses` had exactly one writer, the deck's named-agent path, so a
+//! session that delegated eight children exported zero rows and sub-agent
+//! health had no audit trail at all.
+//!
+//! Two seams were available. The first — a late-attached ledger handle on
+//! `SpawnSubAgent`, mirroring
+//! [`DispatcherSlot`](crate::subagent::DispatcherSlot) — was **not** taken:
+//! that slot exists to break a genuine reference cycle (the dispatcher owns
+//! the registry that owns the tool), and the ledger has no such cycle to
+//! break. Paying a slot's cost — a nullable handle, an attach call every host
+//! must remember, and a tool that silently records nothing when one forgets —
+//! buys nothing here, and the next tool that wants to attribute would need its
+//! own copy of it.
+//!
+//! The second is this: the registry already builds one context per call and
+//! already owns the ledger, so a clone rides along beside the bus with no new
+//! host step at all, and [`ToolCtx::record_agent_use`] serves any future tool.
+//! Attribution is not the contract-gated vocabulary `emit` is — a row names
+//! its own recorder and is drained per execution either way — so it needs no
+//! allowlist. A [`ToolCtx::bare`] context has no ledger and records nothing,
+//! the same shape `emit` already has.
+//!
 //! # Events never ride the output
 //!
 //! The loop detector keys on output bytes, so a timing or progress marker in
@@ -55,6 +80,9 @@ pub struct ToolCtx {
     /// root, so a context built before an operator widened anything confines
     /// to the workspace — the safe direction.
     scope: SessionScope,
+    /// The session's agent-invocation ledger, when this context came from a
+    /// registry (see the module docs, "Why attribution lives here").
+    agent_uses: Option<crate::agent_use::AgentUseLedgerHandle>,
 }
 
 impl ToolCtx {
@@ -75,6 +103,7 @@ impl ToolCtx {
             bus,
             allowed,
             scope,
+            agent_uses: None,
         }
     }
 
@@ -84,6 +113,15 @@ impl ToolCtx {
     #[must_use]
     pub fn with_scope(mut self, scope: SessionScope) -> Self {
         self.scope = scope;
+        self
+    }
+
+    /// The same context, able to attribute an invocation to the session's
+    /// agent-use ledger — what
+    /// [`crate::registry::ToolRegistry::execute`] attaches on every call.
+    #[must_use]
+    pub fn with_agent_ledger(mut self, ledger: crate::agent_use::AgentUseLedgerHandle) -> Self {
+        self.agent_uses = Some(ledger);
         self
     }
 
@@ -99,6 +137,7 @@ impl ToolCtx {
             bus: None,
             allowed: Vec::new(),
             scope,
+            agent_uses: None,
         }
     }
 
@@ -378,6 +417,29 @@ impl ToolCtx {
         };
         fields.insert("tool".into(), Value::String(self.tool.clone()));
         bus.emit_named(event, Value::Object(fields));
+        true
+    }
+
+    /// Record one agent invocation this call is responsible for, against the
+    /// session ledger the persistence layer drains per execution.
+    ///
+    /// Returns whether it was recorded — `false` only for a context with no
+    /// ledger ([`Self::bare`]), the same reported-drop shape as
+    /// [`Self::emit`]. A tool that mints a child agent should call this
+    /// **before** the dispatch it describes, so a turn cancelled mid-child
+    /// still carries the evidence that the child existed.
+    pub fn record_agent_use(&self, agent: &str, version: u32, reason: &str) -> bool {
+        let Some(ledger) = &self.agent_uses else {
+            return false;
+        };
+        ledger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .record(crate::agent_use::AgentUseEvent {
+                agent: agent.to_string(),
+                version,
+                reason: reason.to_string(),
+            });
         true
     }
 

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -80,7 +80,12 @@ pub struct ToolRegistry {
     /// Per-session agent-invocation ledger (see [`crate::agent_use`]) —
     /// drained once per execution by the persistence layer, as an event log,
     /// never aggregated.
-    agent_uses: std::sync::Mutex<crate::agent_use::AgentUseLedger>,
+    ///
+    /// A shared handle rather than an owned mutex because a clone rides every
+    /// [`crate::ctx::ToolCtx`], which is how a tool that mints its own child
+    /// (`task`) reaches the ledger without holding the registry that owns it
+    /// (#3807).
+    agent_uses: crate::agent_use::AgentUseLedgerHandle,
     /// The session's MCP tool-usage ledger. External MCP tools bypass this
     /// registry (they run through `stella-mcp`'s `McpToolSet`), so nothing here
     /// writes to it — the CLI hands a clone ([`ToolRegistry::mcp_usage_ledger`])
@@ -210,7 +215,7 @@ impl ToolRegistry {
         Self {
             tools,
             root,
-            agent_uses: std::sync::Mutex::new(crate::agent_use::AgentUseLedger::default()),
+            agent_uses: crate::agent_use::AgentUseLedgerHandle::default(),
             mcp_usage: Arc::default(),
             task_board,
             spawn_queue,
@@ -510,7 +515,8 @@ impl ToolRegistry {
                 let contract = crate::contracts::contract_for(&tool.schema());
                 let ctx =
                     crate::ctx::ToolCtx::new(self.root.clone(), name, bus.clone(), contract.events)
-                        .with_scope(self.write_scope());
+                        .with_scope(self.write_scope())
+                        .with_agent_ledger(self.agent_uses.clone());
                 tool.execute(input, &ctx).await
             }
             None => ToolOutput::classified_error(

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -257,3 +257,58 @@ async fn get_environment_reports_the_registrys_scratch_directory() {
         "the registry-owned scratch dir must be reported by path: {content}"
     );
 }
+
+/// A `task` delegation dispatched through the registry lands one `agent_uses`
+/// row carrying the child's minted agent id (#3807).
+///
+/// The witness: before the [`crate::ctx::ToolCtx`] attribution seam the tool
+/// had no reach into the ledger at all, so eight delegations drained zero
+/// rows and sub-agent health had no audit trail. Written against
+/// `execute` + `drain_agent_uses` — the same two calls the session driver
+/// makes — so it measures the wiring rather than the new method.
+#[tokio::test]
+async fn a_task_delegation_records_an_agent_use_row() {
+    use stella_core::subagent::{SubAgentOutcome, SubAgentReport};
+
+    struct StubDispatcher;
+
+    #[async_trait::async_trait]
+    impl stella_core::subagent::SubAgentDispatcher for StubDispatcher {
+        async fn dispatch(&self, _spec: stella_core::subagent::SubAgentSpec) -> SubAgentOutcome {
+            SubAgentOutcome::Completed(SubAgentReport {
+                summary: "the retry policy is in stella-core/src/retry.rs".into(),
+                truncated: false,
+                cost_usd: 0.004,
+                steps: 3,
+                absorbed_messages: 7,
+            })
+        }
+    }
+
+    let (_root, reg) = bare_registry();
+    reg.attach_sub_agent_dispatcher(Arc::new(StubDispatcher));
+
+    let out = reg
+        .execute(
+            "task",
+            &serde_json::json!({
+                "description": "find retry policy",
+                "prompt": "Which file defines the retry policy?",
+            }),
+        )
+        .await;
+    assert!(!out.is_error(), "the stub child completes: {out:?}");
+
+    let uses = reg.drain_agent_uses();
+    assert_eq!(uses.len(), 1, "one delegation, one row: {uses:?}");
+    assert_eq!(
+        uses[0].agent, "find-retry-policy",
+        "the row carries the child's minted agent id"
+    );
+    assert_eq!(uses[0].version, 1, "a minted child is un-versioned");
+    assert_eq!(uses[0].reason, "find retry policy");
+    assert!(
+        reg.drain_agent_uses().is_empty(),
+        "the drain discipline holds — a second drain has nothing"
+    );
+}

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -314,6 +314,19 @@ impl Tool for SpawnSubAgent {
             "description": description,
         }));
 
+        // The durable half of that announcement (#3807): the progress event is
+        // live telemetry nobody stores, so before this change a session that
+        // delegated eight children exported zero `agent_uses` rows and no
+        // reader could tell afterwards that any child had run. Recorded
+        // *before* the await for the same reason the dispatcher settles spend
+        // from the child's own thread — a hard cancel means the line after it
+        // never executes, and a delegation that vanished is exactly what this
+        // row exists to make visible. Version 1: a `task` child is minted here
+        // rather than loaded from a versioned definition on disk, so there is
+        // no pinned version to carry and the un-versioned agent's 1 is the
+        // ledger's own convention.
+        ctx.record_agent_use(&spec.agent_id, 1, description);
+
         // Already settled by the time this resolves — the dispatcher charges
         // the ledger from the child's own thread, which is the only place
         // that still runs when a hard cancel means this `await` never


### PR DESCRIPTION
## Problem

`ToolRegistry::record_agent_use` had exactly one production caller in the workspace — `crates/stella-cli/src/command_deck.rs`, the deck's named-agent path. The `task` sub-agent tool never called it, so a session that delegated through `task` recorded **zero** `agent_uses` rows however many children it spawned (8 delegations → 0 rows in the audited session), leaving no audit trail of sub-agent health.

## The seam, and why this one

The issue offered two: a late-attached ledger handle on the tool mirroring `DispatcherSlot`, or a `ToolCtx` method.

**`ToolCtx` wins.** `DispatcherSlot` exists to break a genuine reference cycle — the dispatcher owns the registry that owns the tool. The ledger has no such cycle to break, so a slot would buy only a nullable handle, an attach call every host must remember, and a tool that silently records nothing when one forgets. The registry already builds one context per call and already owns the ledger, so a clone rides along beside the bus with no new host step, and `ToolCtx::record_agent_use` serves any future tool that needs to attribute. Attribution is not the contract-gated vocabulary `emit` is (a row names its own recorder and drains per execution either way), so it needs no allowlist; a `ToolCtx::bare` context has no ledger and records nothing — the same reported-drop shape `emit` already has. This is stated in `ctx.rs`'s module docs, per the issue's "Done".

The row is recorded **before** the dispatch await, for the same reason the dispatcher settles spend from the child's own thread: a hard cancel means the line after it never executes, and a delegation that vanished is exactly what the row exists to make visible. `version` is 1 — a `task` child is minted here rather than loaded from a versioned on-disk definition, and 1 is the ledger's own un-versioned convention.

## Witness

`registry::tests::a_task_delegation_records_an_agent_use_row` dispatches `task` through `ToolRegistry::execute` with a stub dispatcher and then calls `drain_agent_uses` — the same two calls the session driver makes, so it measures the wiring rather than the new method.

Verified both directions: with the `ctx.record_agent_use` call disabled it fails with `assertion left == right failed: one delegation, one row: []`; with it, 417/417 `stella-tools` tests pass.

## Gate

`make gate CARGO_SCOPE="-p stella-tools"` green (29 steps, incl. clippy `-D warnings`, rustdoc, fmt, file-size, god-files). `cargo check -p stella-cli -p stella-observatory` clean — `record_agent_use`/`drain_agent_uses` signatures are unchanged, only the registry's field type (now the shared `AgentUseLedgerHandle`).

No tests deleted. No new dependencies.

Closes #3807

## Summary by Sourcery

Record every `task` delegation in the session agent-use ledger for reliable sub-agent auditing.

New Features:
- Record an `agent_uses` event for each child agent delegated through the `task` tool, including its identifier, version, and delegation reason.

Bug Fixes:
- Restore the missing audit trail for `task` sub-agent delegations so delegated children are visible to session persistence and health reporting.

Enhancements:
- Propagate the session agent-use ledger through `ToolCtx`, allowing tools to attribute delegations without additional host-side setup.

Documentation:
- Document why agent-use attribution is provided through `ToolCtx` and how missing ledgers are handled.

Tests:
- Add an end-to-end registry test verifying that a `task` delegation produces exactly one drainable agent-use record.