### PR TITLE
fix(stella-cli): publish a wrapped turn's controls to the children its plugin asks for

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -288,6 +288,13 @@ pub(crate) async fn run_raw_one_shot(
                     recall_event,
                     memory: memory.as_mut(),
                     watch: &candidate.watch,
+                    // Real ones the day a controlled surface drives a wrapped
+                    // turn (#3554). This door is headless — it publishes no
+                    // pause gate and installs no steering tap, the same reason
+                    // its goal rounds pass `steering: None` — so there is
+                    // nothing here to honour, and `none()` is the honest
+                    // answer rather than a placeholder.
+                    controls: stella_core::ports::TurnControls::none(),
                     results: Vec::new(),
                 },
             )

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -131,7 +131,12 @@
 //! has: the deck's lead and pipeline turns publish both a steering tap and a
 //! `WatchGate` (#1219 — `p` on the lead row parks the turn and, through this
 //! dispatcher, every child it dispatched), and deck worker lanes and fleet
-//! workers publish their own `WatchGate`. A driver that publishes nothing is
+//! workers publish their own `WatchGate`, and the wrapped one-shot path
+//! publishes whatever its caller supplied for the span of the wrapper's whole
+//! dispatch rather than for one round, because a plugin spends its children
+//! from the points *between* the rounds (#3803,
+//! `crate::wrapper_plugin::dispatch_under_turn_controls`). A driver that
+//! publishes nothing is
 //! still not a failure state — a child then runs bounded by its step cap and
 //! its carve, exactly as before.
 //!

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -68,9 +68,13 @@
 //!    ([`child_turn_plane`] argues why); and a point runs between the parent's
 //!    turns, where the tool registry's event slot is empty — so the spend
 //!    reaches the session's guard and this run's report, but not the store's
-//!    receipt (#3802). The turn's boundary controls are the third
-//!    (#3803): this door publishes none, so a child inherits none, which is
-//!    a no-op until a surface that *has* controls can drive a wrapped turn.
+//!    receipt (#3802). The turn's boundary controls **do** cross (#3803):
+//!    [`dispatch_under_turn_controls`] publishes them for the span of the
+//!    dispatch — every round and every point between them — so a plugin's
+//!    child parks with a paused parent and stops with a stopped one. What
+//!    this door supplies is [`TurnControls::none`], because it is headless
+//!    and has no pause gate or steering tap to publish; the seam is what
+//!    #3554 needs, and a controlled surface fills it by passing its own.
 //!
 //! The ordering that makes 4 possible is worth naming, because it is the shape
 //! of the split between [`bind_installed`] and [`ResolvedWrapper::serving`]: a
@@ -89,7 +93,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use stella_core::budget::BudgetGuard;
 use stella_core::estimator::CalibrationMap;
-use stella_core::ports::ToolExecutor;
+use stella_core::ports::{ToolExecutor, TurnControls};
 use stella_core::router::Router;
 use stella_core::subagent::SubAgentDispatcher;
 use stella_model::provider::Provider;
@@ -697,6 +701,19 @@ pub(crate) struct RawTurnDriver<'a> {
     /// The artifacts this host pinned before the run, and the finding it
     /// reports about them after each turn (#3553).
     pub(crate) watch: &'a crate::wrapper_candidate::TamperWatch,
+    /// This turn's boundary controls — the pause gate and the soft stop that
+    /// govern it — published on the registry for the span of the dispatch so
+    /// every child dispatched underneath honours them (#3803).
+    ///
+    /// A field rather than something this driver derives, because a driver
+    /// cannot invent the seam: it belongs to whichever surface has a human
+    /// behind it. `crate::agent::goal::run_raw_one_shot` supplies
+    /// [`TurnControls::none`] — that path is headless, publishes no pause gate
+    /// and installs no steering tap, so there is nothing there to honour. A
+    /// controlled surface driving a wrapped turn (the deck, #3554) supplies its
+    /// own, exactly as `command_deck::lead_control::turn_controls` already does
+    /// for the turns it drives directly.
+    pub(crate) controls: TurnControls,
     /// What each round's turn returned, in order — the caller's own view of a
     /// loop the dispatcher owns.
     pub(crate) results: Vec<Result<(), CliFailure>>,
@@ -793,7 +810,13 @@ pub(crate) async fn run_wrapped(
         // for why that is the shared work tree and not an isolated worktree.
         candidate,
     };
-    let report = bound.dispatch.run(input, &mut driver).await;
+    // Copied out of the driver before it is borrowed mutably — both are shared
+    // handles, so this costs nothing and keeps the publication above the
+    // dispatch rather than inside a round.
+    let registry = driver.registry;
+    let controls = driver.controls.clone();
+    let report =
+        dispatch_under_turn_controls(&bound.dispatch, input, registry, controls, &mut driver).await;
     // Whatever a plugin's last point spent has no turn left to fold it in, so
     // this driver folds it (#3576). See `settle_plugin_child_spend`.
     settle_plugin_child_spend(driver.registry, &mut *driver.budget);
@@ -808,6 +831,40 @@ pub(crate) async fn run_wrapped(
         }
         Err(error) => Err(CliFailure::from(error.to_string())),
     }
+}
+
+/// Run a wrapper's whole dispatch with `controls` published on `registry`.
+///
+/// [`SubAgentDispatcher`]'s contract requires the driver of a turn to hand the
+/// engine it builds the *current* turn's controls, and a session-scoped
+/// dispatcher can only get them by reading them off the registry at dispatch
+/// time ([`ToolRegistry::attach_turn_controls`]). Every other driver in this
+/// crate publishes them; the wrapped path did not, so every child it dispatched
+/// ran with [`TurnControls::none`] — a paused session that kept spending inside
+/// the child, and a soft stop that ended the parent while the child ran on
+/// (#3803, the #922 shape one layer out).
+///
+/// **The span is the dispatch, not the round.** Scoping the guard to
+/// `RawTurnDriver::run_turn` would look right and be wrong: a plugin spends its
+/// child turns from a *point* — `before_turn`, `after_turn` — and those run
+/// between the rounds (#3576), which is precisely when a round-scoped guard has
+/// already dropped. So the guard is held here, across every round and every
+/// point, and comes down when this function returns — including on an unwind,
+/// which is the reason [`stella_tools::subagent::TurnControlsGuard`] clears on
+/// drop rather than on an explicit detach.
+///
+/// Takes `&mut dyn TurnDriver` rather than the concrete [`RawTurnDriver`] so
+/// the property is witnessable against a stubbed engine: what the witness needs
+/// to observe is what a *child* sees, and that is the same on either driver.
+async fn dispatch_under_turn_controls(
+    dispatch: &WrapperDispatch,
+    input: RoundInput,
+    registry: &ToolRegistry,
+    controls: TurnControls,
+    driver: &mut dyn TurnDriver,
+) -> Result<DispatchReport, stella_runtime::wrapper::WrapperError> {
+    let _controls = registry.attach_turn_controls(controls);
+    dispatch.run(input, driver).await
 }
 
 /// Print what the wrapper concluded, every point that abstained, and every

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -744,6 +744,168 @@ printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":
     assert_eq!(wrapper.child_spends().len(), 1);
 }
 
+/// A dispatcher that answers a child the way [`crate::subagent::SessionSubAgents`]
+/// does — by reading the *current* turn's controls off the registry at dispatch
+/// time and refusing to spend when the turn it belongs to has already been
+/// stopped.
+///
+/// It reads the same slot through the same accessor as the shipping dispatcher
+/// (`ToolRegistry::turn_controls`), so what it observes is exactly what the
+/// real one observes; what it does with a latched stop is a two-line stand-in
+/// for the child engine, whose own honouring of these seams is witnessed in
+/// `crate::subagent::tests`.
+struct StopAwareDispatcher {
+    registry: Arc<stella_tools::ToolRegistry>,
+}
+
+#[async_trait]
+impl SubAgentDispatcher for StopAwareDispatcher {
+    async fn dispatch(&self, _spec: SubAgentSpec) -> SubAgentOutcome {
+        let controls = self.registry.turn_controls();
+        let stopped = controls
+            .steering
+            .as_ref()
+            .is_some_and(|tap| tap.soft_stop_requested());
+        if stopped {
+            return SubAgentOutcome::Incomplete {
+                report: SubAgentReport {
+                    summary: String::new(),
+                    truncated: false,
+                    cost_usd: 0.0,
+                    steps: 0,
+                    absorbed_messages: 0,
+                },
+                reason: stella_core::driver::SOFT_STOP_REASON.to_string(),
+            };
+        }
+        SubAgentOutcome::Completed(SubAgentReport {
+            summary: "spent the model on a stopped turn".to_string(),
+            truncated: false,
+            cost_usd: 0.02,
+            steps: 3,
+            absorbed_messages: 7,
+        })
+    }
+}
+
+/// **Witness (#3803).** A wrapped turn publishes its controls for the span of
+/// the dispatch, so the child a *plugin* asks for honours the stop that governs
+/// the parent.
+///
+/// Fails before this change with the child reporting `Completed`: `RawTurnDriver`
+/// attached nothing, so `ToolRegistry::turn_controls` answered
+/// `TurnControls::none()` and the dispatcher had no stop to see —
+/// [`SubAgentDispatcher`]'s contract broken at the one driver that never held up
+/// its end. It is the #922 shape one layer out: the parent is stopped, and the
+/// plugin's child runs on.
+///
+/// The plugin issues its `child_turn` from `before_turn` — a point, which runs
+/// *between* the rounds — which is why the guard is held across the dispatch and
+/// not merely across `run_turn`. A round-scoped guard passes nothing here.
+///
+/// The engine is the one thing stubbed, exactly as in the sibling witness above
+/// and for the same reason: [`TurnDriver`] is the seam the socket is designed
+/// around, and everything between the plugin's stdout and what the dispatcher
+/// reads is the shipping path.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_stopped_wrapped_turn_stops_the_child_its_plugin_asked_for() {
+    use stella_plugin::{TamperFinding, TurnOutcome};
+    use stella_runtime::wrapper::{DrivenTurn, TurnPrelude};
+
+    /// The engine, stubbed — this witness is about what the child sees, not
+    /// about what the turn answered.
+    struct StubTurn;
+
+    #[async_trait(?Send)]
+    impl TurnDriver for StubTurn {
+        async fn run_turn(&mut self, _prelude: TurnPrelude) -> DrivenTurn {
+            DrivenTurn {
+                outcome: TurnOutcome {
+                    completed: true,
+                    answer: "done".to_string(),
+                    tools: Some(Vec::new()),
+                    changed_files: Some(Vec::new()),
+                },
+                tamper: TamperFinding::NotChecked,
+            }
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("a temp dir for the installed plugin");
+    // The plugin asks for a child and reports back whether it ran, so the
+    // assertion below reads the plugin's own view rather than the host's.
+    std::fs::write(
+        dir.path().join("main.sh"),
+        r#"
+read -r request
+printf '%s\n' '{"call":"child_turn","id":7,"args":{"role":"reviewer","instruction":"read the diff"}}'
+read -r answer
+case "$answer" in
+  *'"completed":false'*) finding="the child stopped with its parent" ;;
+  *) finding="the child ran on" ;;
+esac
+printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"reviewer","text":"%s"}]}}\n' "$finding"
+"#,
+    )
+    .expect("the plugin script is written");
+
+    let registry = Arc::new(stella_tools::ToolRegistry::new(PathBuf::from(".")));
+    let manifest = PluginManifest::from_toml_str(GRADING_MANIFEST).expect("fixture must load");
+    let plane = Arc::new(child_turn_plane(
+        &manifest,
+        Arc::new(StopAwareDispatcher {
+            registry: Arc::clone(&registry),
+        }) as Arc<dyn SubAgentDispatcher>,
+    ));
+    let roster = roster(vec![installed(
+        GRADING_MANIFEST,
+        &dir.path().to_string_lossy(),
+    )]);
+    let wrapper = bind_installed(&roster, "grading-v1", &mut |_| {})
+        .expect("the installed plugin declares this variant")
+        .serving(WrapperHost::recalling(no_recall()).with_child_turns(plane))
+        .expect("it binds");
+
+    // The turn is stopped before it is driven — the state a user leaves behind
+    // by pressing Esc, latched by contract so every boundary after it sees it.
+    let tap: Arc<crate::subsession::SteeringTap> = Arc::default();
+    tap.request_soft_stop();
+    let controls = stella_core::ports::TurnControls::none().with_steering(tap);
+
+    let mut driver = StubTurn;
+    let report = super::dispatch_under_turn_controls(
+        &wrapper.dispatch,
+        RoundInput {
+            goal: "put the retry back".to_string(),
+            signals: pre_turn_signals(false, false),
+            candidate: None,
+        },
+        &registry,
+        controls,
+        &mut driver,
+    )
+    .await
+    .expect("the declared stage program resolves");
+
+    assert!(report.faults.is_empty(), "{:?}", report.faults);
+    assert_eq!(
+        wrapper.child_spends().len(),
+        1,
+        "the child was dispatched — this is about what it did, not whether it ran"
+    );
+    assert!(
+        !wrapper.child_spends()[0].completed,
+        "a stopped parent must not keep spending inside the child its plugin asked for"
+    );
+
+    assert!(
+        registry.turn_controls().is_empty(),
+        "and the guard comes down with the dispatch, so the stop cannot latch \
+         onto the children of a turn that has not started yet"
+    );
+}
+
 /// **Witness (#3576, requirement 3).** What a plugin's last point spent
 /// lands on the session's guard.
 ///


### PR DESCRIPTION
fix(stella-cli): publish a wrapped turn's controls to the children its plugin asks for

`SubAgentDispatcher`'s contract requires the driver of a turn to hand the
engine it builds the *current* turn's controls, and a session-scoped
dispatcher can only get them by reading the registry at dispatch time.
Every driver in this crate published them except `RawTurnDriver` — the one
behind `stella run --pipeline <variant>`, and since #3576 the one whose
`ChildTurns` plane spends a plugin's child turns. So every child it
dispatched ran with `TurnControls::none()`: a paused session that kept
spending inside the child, and a soft stop that ended the parent while the
child ran on. The #922 shape one layer out.

`RawTurnDriver` now carries the turn's `TurnControls` as a required field,
and `dispatch_under_turn_controls` publishes them for the span of the
wrapper's **whole dispatch** rather than for one round. That span is the
load-bearing part: a plugin spends its children from a *point*
(`before_turn`, `after_turn`), which runs between the rounds, exactly when
a round-scoped guard has already dropped.

`run_raw_one_shot` supplies `TurnControls::none()` — that door is headless,
publishes no pause gate and installs no steering tap, so there is nothing
there to honour and `none()` is the honest answer rather than a
placeholder. The seam is what #3554 needs: a controlled surface driving a
wrapped turn passes its own, exactly as the deck's `lead_control` already
does for the turns it drives directly.

Witness: `a_stopped_wrapped_turn_stops_the_child_its_plugin_asked_for`
drives a real installed `sh` plugin through the shipping dispatch with a
latched soft stop, and asserts the child the plugin asked for did not
complete. Verified artisanally by neutering the attach — it fails with
"a stopped parent must not keep spending inside the child its plugin asked
for" — and by the closing assertion that the guard comes down with the
dispatch. The engine is the one thing stubbed, as in the sibling #3576
witness. The dispatcher stand-in reads the same slot through the same
accessor as `SessionSubAgents`; that the real child engine honours these
seams is already witnessed in `crate::subagent::tests`.

Closes #3803

## Summary by Sourcery

Propagate turn controls across the full wrapped dispatch so plugin-requested child turns honor the parent turn’s pause and stop state.

Bug Fixes:
- Propagate a wrapped turn’s pause and soft-stop controls to plugin-dispatched child turns throughout the entire wrapper dispatch.
- Ensure children requested by plugins stop or pause consistently with their parent turn instead of continuing with empty controls.

Enhancements:
- Make wrapped-turn control publication explicit and allow controlled callers to supply their own turn controls while preserving headless one-shot behavior.

Tests:
- Add an integration-style witness verifying that a stopped wrapped turn prevents a plugin-requested child from completing and clears the controls after dispatch.