### PR TITLE
feat(stella-protocol,stella-cli): the issue port — GitHub becomes an adapter (#3599 B1)

### DIFF
--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -1,0 +1,254 @@
+//! The GitHub adapter behind [`IssueProvider`], and the one mapping from a
+//! tracker's shape into the ranker's.
+//!
+//! `doc:backlog-self-driving` B1. Until this module existed, `gh` was invoked
+//! literally inside `self_driving_cmd::queue` and the ranker's input type
+//! carried `#[serde(rename = "createdAt")]` — a `gh --json` field name, in a
+//! leaf crate that depends on nothing. "Which tracker" was therefore not a
+//! decision anything could express; it was spelled into the reader.
+//!
+//! What moved here is the I/O half only. The port and the kernel are
+//! [`stella_protocol::issue`]; the ranking stays in `stella_autonomy`, on its
+//! own input type, because that crate depends on no other workspace crate and
+//! that property is what lets the Observatory link it.
+//!
+//! # `gh`, not the REST API — for now, and for a reason
+//!
+//! The adapter shells out to `gh` rather than speaking HTTP. That is what the
+//! loop already did, so this slice is a relocation rather than a rewrite, and
+//! it keeps the one property a token-holding client would have to re-earn:
+//! **Stella never holds a GitHub credential.** `gh` owns the auth, the token
+//! never enters this process, and `stella auth` has nothing new to store.
+//! `doc:agent-native-delivery` §4.4's `kind = "exec"` is the general form of
+//! exactly this shape, and a manifest-driven provider is the next slice.
+
+use std::process::Command;
+
+use async_trait::async_trait;
+use stella_protocol::issue::{
+    Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
+};
+
+/// The provider id this adapter answers to, and the one an error names.
+pub(crate) const GITHUB: &str = "github";
+
+/// Reads the workspace's GitHub issues through the `gh` CLI.
+pub(crate) struct GhIssueProvider;
+
+/// What `gh issue list --json …` writes, named separately from [`Issue`] on
+/// purpose.
+///
+/// This is the **only** type in the tree allowed to carry GitHub's field
+/// spellings, and it is private to this module. Before B1 the same
+/// `createdAt` rename lived on the ranker's public input type in a leaf crate,
+/// which is how a tracker's wire format became the loop's vocabulary.
+#[derive(serde::Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+    #[serde(rename = "createdAt", default)]
+    created_at: String,
+    #[serde(default)]
+    url: String,
+}
+
+#[derive(serde::Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+impl GhIssue {
+    /// GitHub has no issue *type* on a plain repository, so the class is read
+    /// off the labels this repository actually uses.
+    ///
+    /// [`IssueClass::Other`] is the honest answer for an issue labelled
+    /// neither, and it is deliberately not `Task`: a wrong class silently
+    /// applies the wrong completion policy, which is worse than a visible
+    /// unmapped one (`doc:agent-native-delivery` §12.6 leaves whether `Other`
+    /// is workable open, and this adapter does not pre-empt it).
+    fn class(&self) -> IssueClass {
+        let has = |name: &str| self.labels.iter().any(|label| label.name == name);
+        if has("bug") {
+            IssueClass::Bug
+        } else if has("feature") {
+            IssueClass::Feature
+        } else if has("chore") || has("task") || has("refactor") {
+            IssueClass::Task
+        } else {
+            IssueClass::Other
+        }
+    }
+
+    fn into_issue(self) -> Issue {
+        let class = self.class();
+        Issue {
+            key: IssueKey(self.number.to_string()),
+            title: self.title,
+            body: self.body,
+            // `list_open` asks `gh` for open issues only, so every row it
+            // returns is open by construction. This adapter does not invent a
+            // status map because the query already is one.
+            state: IssueState::Open,
+            class,
+            labels: self
+                .labels
+                .into_iter()
+                .map(|label| IssueLabel { name: label.name })
+                .collect(),
+            created_at: self.created_at,
+            url: self.url,
+            // GitHub's parent edge needs a second (GraphQL) call per issue,
+            // which the queue read does not need and should not pay for.
+            // Absent here is "not fetched", and the write half fetches it when
+            // something reads it (#3599).
+            parent: None,
+        }
+    }
+}
+
+#[async_trait]
+impl IssueProvider for GhIssueProvider {
+    fn id(&self) -> &str {
+        GITHUB
+    }
+
+    async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError> {
+        let limit = limit.to_string();
+        let raw = gh_json(&[
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            &limit,
+            "--json",
+            "number,title,body,labels,createdAt,url",
+        ])?;
+        let rows: Vec<GhIssue> =
+            serde_json::from_str(&raw).map_err(|error| IssueError::Malformed {
+                provider: GITHUB.into(),
+                reason: error.to_string(),
+            })?;
+        Ok(rows.into_iter().map(GhIssue::into_issue).collect())
+    }
+}
+
+/// Run a `gh` subcommand whose stdout is parsed, with colour forced off.
+///
+/// The colour handling is not cosmetic and is inherited from the shell driver:
+/// ANSI escapes inside a JSON payload are invisible in a terminal and fatal to
+/// every parser, so a `gh` call whose output is read goes through here and one
+/// whose output a human reads does not.
+fn gh_json(args: &[&str]) -> Result<String, IssueError> {
+    let output = Command::new("gh")
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR_FORCE", "0")
+        .output()
+        .map_err(|error| IssueError::Unavailable {
+            provider: GITHUB.into(),
+            reason: format!("could not run `gh`: {error} — is the GitHub CLI installed?"),
+        })?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The two failures a caller must tell apart: installing a tool and logging
+    // into it are different instructions, and the loop can act on neither
+    // itself — so it must at least say which one a human needs to do.
+    let reason = stderr.trim().to_owned();
+    if stderr.contains("gh auth login") || stderr.contains("authentication") {
+        Err(IssueError::Unauthenticated {
+            provider: GITHUB.into(),
+            reason,
+        })
+    } else {
+        Err(IssueError::Failed {
+            provider: GITHUB.into(),
+            reason,
+        })
+    }
+}
+
+/// Map the kernel's [`Issue`] into the ranker's input.
+///
+/// The one place a tracker's shape meets the loop's, and it is a function
+/// rather than a trait impl because neither type's crate may depend on the
+/// other's: `stella-autonomy` takes no workspace dependency at all, and
+/// `stella-protocol` holds no logic. `stella-cli` is where both are already
+/// linked, so the mapping lands here and nowhere else.
+///
+/// `number` is parsed from the key and falls back to `0`. That is lossy for a
+/// non-numeric tracker (`STELLA-42`), and deliberately so at this slice: the
+/// ranker's field is a `u64` today, the loss shows up only in the display
+/// column, and widening a leaf crate's public type is a change that should be
+/// made when a non-numeric provider actually exists rather than in advance.
+/// Tracked in #3599 with B1's second slice.
+pub(crate) fn to_queue_issue(issue: &Issue) -> stella_autonomy::QueueIssue {
+    stella_autonomy::QueueIssue {
+        number: issue.key.as_str().parse().unwrap_or(0),
+        title: issue.title.clone(),
+        labels: issue
+            .labels
+            .iter()
+            .map(|label| stella_autonomy::IssueLabel {
+                name: label.name.clone(),
+            })
+            .collect(),
+        created_at: issue.created_at.clone(),
+        url: issue.url.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gh_payload() -> &'static str {
+        r#"[
+          {"number":1234,"title":"retry counter survives a round boundary",
+           "body":"keyed per turn","labels":[{"name":"bug"},{"name":"P1"}],
+           "createdAt":"2026-08-19T05:00:00Z","url":"https://example.test/1234"},
+          {"number":7,"title":"add a mistral adapter","body":"",
+           "labels":[{"name":"feature"}],"createdAt":"2026-08-01T00:00:00Z",
+           "url":"https://example.test/7"},
+          {"number":9,"title":"unlabelled","body":"","labels":[],
+           "createdAt":"2026-08-02T00:00:00Z","url":"https://example.test/9"}
+        ]"#
+    }
+
+    /// The GitHub wire shape decodes, and every field lands where the kernel
+    /// says it does.
+    #[test]
+    fn the_gh_payload_maps_onto_the_kernel() {
+        let rows: Vec<GhIssue> = serde_json::from_str(gh_payload()).expect("decode");
+        let issues: Vec<Issue> = rows.into_iter().map(GhIssue::into_issue).collect();
+
+        assert_eq!(issues[0].key, IssueKey::from("1234"));
+        assert_eq!(issues[0].class, IssueClass::Bug);
+        assert_eq!(issues[0].state, IssueState::Open);
+        assert_eq!(issues[0].created_at, "2026-08-19T05:00:00Z");
+        assert_eq!(issues[1].class, IssueClass::Feature);
+        // Unlabelled is `Other`, visibly — never silently `Task`.
+        assert_eq!(issues[2].class, IssueClass::Other);
+    }
+
+    /// The mapping into the ranker keeps exactly what ranking reads: the
+    /// labels it sorts on and the stamp it breaks ties with.
+    #[test]
+    fn the_ranker_mapping_keeps_what_ranking_reads() {
+        let rows: Vec<GhIssue> = serde_json::from_str(gh_payload()).expect("decode");
+        let issues: Vec<Issue> = rows.into_iter().map(GhIssue::into_issue).collect();
+        let mapped = to_queue_issue(&issues[0]);
+
+        assert_eq!(mapped.number, 1234);
+        assert_eq!(mapped.created_at, "2026-08-19T05:00:00Z");
+        assert!(mapped.labels.iter().any(|label| label.name == "P1"));
+    }
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -69,6 +69,7 @@ mod fleet_warmth;
 mod ingest_cmd;
 mod inspect;
 mod interactive;
+mod issue_provider;
 mod mcp_cmd;
 mod memory;
 mod memory_cmd;

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -13,6 +13,7 @@
 //! harness (`make self-driving-test`) drives those delegations end-to-end, so the
 //! two surfaces cannot drift.
 
+mod backlog;
 pub(crate) mod probes;
 pub(crate) mod state;
 mod surface;
@@ -397,22 +398,9 @@ fn gh_plain(args: &[&str]) -> Option<String> {
         .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
+/// The demand half of the governor, read through the issue port.
 fn demand() -> Demand {
-    if !gh_available() {
-        return Demand::default();
-    }
-    let count = |extra: &[&str]| -> u32 {
-        let mut args = vec!["issue", "list", "--state", "open", "--label", "bug"];
-        args.extend_from_slice(extra);
-        args.extend_from_slice(&["--json", "number", "--jq", "length"]);
-        gh_plain(&args)
-            .and_then(|s| s.trim().parse().ok())
-            .unwrap_or(0)
-    };
-    Demand {
-        open_defects: count(&[]),
-        p0: count(&["--label", "P0"]),
-    }
+    backlog::demand_from(&crate::issue_provider::GhIssueProvider)
 }
 
 fn plan(st: &LoopState, explain: bool) -> Result<(), String> {
@@ -875,52 +863,9 @@ fn calibrate_cmd(st: &LoopState, ok: bool, resource_fail: bool, show: bool) -> R
     Ok(())
 }
 
-fn queue(_st: &LoopState, limit: usize, format: QueryFormat) -> Result<(), String> {
-    let raw = gh_plain(&[
-        "issue",
-        "list",
-        "--state",
-        "open",
-        "--limit",
-        "200",
-        "--json",
-        "number,title,labels,createdAt,url",
-    ])
-    .ok_or_else(|| "gh issue list failed (is gh installed and authenticated?)".to_string())?;
-    let issues: Vec<stella_autonomy::QueueIssue> =
-        serde_json::from_str(&raw).map_err(|e| format!("gh issue list payload: {e}"))?;
-    let total_issues = issues.len();
-
-    let defects = stella_autonomy::rank_defects(issues);
-    let picked = &defects[..limit.min(defects.len())];
-
-    if format == QueryFormat::Json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&Rows::new(picked)).map_err(|e| e.to_string())?
-        );
-        return Ok(());
-    }
-    for i in picked {
-        let prio = ["P0", "P1", "P2"]
-            .into_iter()
-            .find(|p| i.labels.iter().any(|l| l.name == *p))
-            .unwrap_or("--");
-        let area = i
-            .labels
-            .iter()
-            .find(|l| l.name.starts_with("area:"))
-            .map(|l| l.name.as_str())
-            .unwrap_or("");
-        println!("{prio:>2}  #{:<6} {area:<18} {}", i.number, i.title);
-    }
-    eprintln!(
-        "\n{} of {} open defects ({} open issues total)",
-        picked.len(),
-        defects.len(),
-        total_issues
-    );
-    Ok(())
+/// The queue verb: the ranked defect batch this cycle draws from.
+fn queue(st: &LoopState, limit: usize, format: QueryFormat) -> Result<(), String> {
+    backlog::render_queue(st, &crate::issue_provider::GhIssueProvider, limit, format)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -1,0 +1,235 @@
+//! The backlog half of the self-driving verbs, read through the issue port.
+//!
+//! `doc:backlog-self-driving` B1. Split out of `self_driving_cmd.rs` rather
+//! than added to it: that file is 1005 lines and #3599 records it as closed to
+//! growth, with new logic landing in siblings here (AGENTS.md § *God files* —
+//! plan around them, never into them).
+//!
+//! The parent keeps the two verb entry points, which name the concrete
+//! provider. Everything below takes a `&dyn IssueProvider` and has never heard
+//! of GitHub — which is what makes "GitHub is an adapter, not the answer" a
+//! property a test can falsify rather than a claim about the code's shape.
+//!
+//! # Why these two verbs are one module
+//!
+//! `queue` and the governor's `demand` are the same read. Before B1 they were
+//! three separate `gh` invocations carrying **two** definitions of the word
+//! "defect" — `rank_defects`'s label filter, and a `--label bug` flag written
+//! into `demand`'s argv — which could disagree with each other about the very
+//! backlog one cycle drew its batch from. One read, one definition, folded two
+//! ways.
+
+use stella_autonomy::Demand;
+use stella_protocol::issue::IssueProvider;
+
+use crate::query_format::{QueryFormat, Rows};
+
+use super::state::LoopState;
+
+/// How many open issues cross the port to produce one cycle's batch.
+///
+/// A ceiling rather than "all of them": ranking is deterministic and a batch is
+/// single digits, so reading a ten-thousand-issue backlog to pick five is spend
+/// with no effect on the answer. 200 is what the shell driver asked `gh` for,
+/// kept unchanged so the picked batch cannot move in the change that relocates
+/// the read.
+pub(super) const QUEUE_READ_LIMIT: usize = 200;
+
+/// Read the tracker once and rank it, or explain why it could not be read.
+///
+/// The port is async because a tracker is a network service. These callers are
+/// short-lived CLI verbs with no runtime of their own, so each blocks on one
+/// current-thread runtime rather than making every self-driving verb async for
+/// a single awaited call.
+fn ranked(
+    provider: &dyn IssueProvider,
+) -> Result<(Vec<stella_autonomy::QueueIssue>, usize), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    let issues = runtime
+        .block_on(provider.list_open(QUEUE_READ_LIMIT))
+        .map_err(|error| error.to_string())?;
+    let total = issues.len();
+    let defects = stella_autonomy::rank_defects(
+        issues
+            .iter()
+            .map(crate::issue_provider::to_queue_issue)
+            .collect(),
+    );
+    Ok((defects, total))
+}
+
+/// The ranked defect batch this cycle draws from.
+pub(super) fn render_queue(
+    _st: &LoopState,
+    provider: &dyn IssueProvider,
+    limit: usize,
+    format: QueryFormat,
+) -> Result<(), String> {
+    let (defects, total_issues) = ranked(provider)?;
+    let picked = &defects[..limit.min(defects.len())];
+
+    if format == QueryFormat::Json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&Rows::new(picked)).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+    for i in picked {
+        let prio = ["P0", "P1", "P2"]
+            .into_iter()
+            .find(|p| i.labels.iter().any(|l| l.name == *p))
+            .unwrap_or("--");
+        let area = i
+            .labels
+            .iter()
+            .find(|l| l.name.starts_with("area:"))
+            .map(|l| l.name.as_str())
+            .unwrap_or("");
+        println!("{prio:>2}  #{:<6} {area:<18} {}", i.number, i.title);
+    }
+    eprintln!(
+        "\n{} of {} open defects ({} open issues total)",
+        picked.len(),
+        defects.len(),
+        total_issues
+    );
+    Ok(())
+}
+
+/// Size the demand half of the governor from the same read.
+///
+/// A tracker that cannot be reached yields [`Demand::default`] rather than an
+/// error: the governor's job is to size a cycle, and a cycle sized as though
+/// the backlog were empty is a survivable answer where a refusal to plan is
+/// not. That degradation is inherited from the `gh_available()` check this
+/// replaces, not introduced here.
+pub(super) fn demand_from(provider: &dyn IssueProvider) -> Demand {
+    let Ok((defects, _)) = ranked(provider) else {
+        return Demand::default();
+    };
+    let p0 = defects
+        .iter()
+        .filter(|issue| issue.labels.iter().any(|label| label.name == "P0"))
+        .count();
+    Demand {
+        open_defects: u32::try_from(defects.len()).unwrap_or(u32::MAX),
+        p0: u32::try_from(p0).unwrap_or(u32::MAX),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use stella_protocol::issue::{Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueState};
+
+    use super::*;
+
+    /// A tracker that is not GitHub and is not a process.
+    struct FixtureProvider(Vec<Issue>);
+
+    #[async_trait]
+    impl IssueProvider for FixtureProvider {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(self.0.iter().take(limit).cloned().collect())
+        }
+    }
+
+    /// A tracker that is not reachable — the degradation path.
+    struct DeadProvider;
+
+    #[async_trait]
+    impl IssueProvider for DeadProvider {
+        fn id(&self) -> &str {
+            "dead"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Err(IssueError::Unavailable {
+                provider: "dead".into(),
+                reason: "no tracker here".into(),
+            })
+        }
+    }
+
+    fn issue(key: &str, labels: &[&str], created: &str) -> Issue {
+        Issue {
+            key: IssueKey::from(key),
+            title: format!("issue {key}"),
+            body: String::new(),
+            state: IssueState::Open,
+            class: IssueClass::Bug,
+            labels: labels.iter().copied().map(IssueLabel::from).collect(),
+            created_at: created.into(),
+            url: String::new(),
+            parent: None,
+        }
+    }
+
+    fn backlog() -> FixtureProvider {
+        FixtureProvider(vec![
+            issue("7", &["bug", "P1"], "2026-08-19T00:00:00Z"),
+            issue("9", &["triage"], "2026-08-01T00:00:00Z"),
+            issue("3", &["bug", "P0"], "2026-08-18T00:00:00Z"),
+            issue("5", &["bug", "P1"], "2026-08-02T00:00:00Z"),
+            // Feature work is deliberately not a defect: this loop closes
+            // defects, and a mixed batch is unreviewable.
+            issue("11", &["feature", "P0"], "2026-07-01T00:00:00Z"),
+        ])
+    }
+
+    /// **The B1 witness.** A ranked defect queue is produced end to end — read,
+    /// mapped, ranked — from a provider that is not GitHub, holds no
+    /// credential, and runs no subprocess.
+    ///
+    /// It cannot compile on `main`: there is no `IssueProvider` to implement
+    /// there, because the queue read *is* the `gh` call. That is the property
+    /// under test — not that ranking works, which it already did, but that
+    /// ranking no longer requires GitHub to exist.
+    #[test]
+    fn a_ranked_queue_needs_no_github_at_all() {
+        let (defects, total) = ranked(&backlog()).expect("fixture read");
+        let order: Vec<u64> = defects.iter().map(|issue| issue.number).collect();
+        assert_eq!(
+            order,
+            vec![3, 5, 7, 9],
+            "P0 first, then P1 aged-before-fresh, then triage — and no feature"
+        );
+        assert_eq!(total, 5, "the total counts every open issue, defect or not");
+    }
+
+    /// The governor's two numbers are folds of that one ranking, so they cannot
+    /// disagree with the batch the same cycle draws.
+    #[test]
+    fn demand_is_a_fold_of_the_same_ranking() {
+        let demand = demand_from(&backlog());
+        assert_eq!(demand.open_defects, 4, "the feature is not a defect");
+        assert_eq!(demand.p0, 1, "and its P0 label does not make it one");
+    }
+
+    /// An unreachable tracker sizes a cycle as though the backlog were empty,
+    /// rather than refusing to plan.
+    #[test]
+    fn an_unreachable_tracker_degrades_rather_than_failing() {
+        assert_eq!(demand_from(&DeadProvider), Demand::default());
+    }
+
+    /// The limit bounds what crosses the port, not what the ranker discards
+    /// afterwards.
+    #[test]
+    fn the_read_limit_bounds_the_crossing() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let got = runtime.block_on(backlog().list_open(2)).expect("read");
+        assert_eq!(got.len(), 2);
+    }
+}

--- a/crates/stella-cli/tests/self_driving_consent.rs
+++ b/crates/stella-cli/tests/self_driving_consent.rs
@@ -140,11 +140,20 @@ fn the_declared_grant_and_the_loop_name_the_same_powers() {
     let root = repo_root();
 
     let powers = [
+        // The power did not change; where it lives did (#3599 B1). It used to
+        // be a `gh` argv built inline in `self_driving_cmd.rs`; it is now the
+        // GitHub adapter behind `IssueProvider`, which is the only place in the
+        // tree that reads issues from GitHub.
+        //
+        // The anchor is the impl rather than the argv on purpose. An argv
+        // string fires spuriously the first time someone adds a `--json` field,
+        // which teaches a reader that this guard cries wolf; the impl
+        // disappears only if the capability really does.
         (
             "reading the GitHub defect queue",
             "`gh` — read the defect queue",
-            "crates/stella-cli/src/self_driving_cmd.rs",
-            r#"vec!["issue", "list", "--state", "open", "--label", "bug"]"#,
+            "crates/stella-cli/src/issue_provider.rs",
+            "impl IssueProvider for GhIssueProvider",
         ),
         (
             "filing findings as GitHub issues",

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -1,0 +1,367 @@
+//! The issue kernel, and the port a tracker is reached through.
+//!
+//! `doc:backlog-self-driving` B1, over `doc:agent-native-delivery` §3–§4's
+//! model. The self-driving loop's defect queue is read by shelling out to `gh`
+//! literally, in the shipping binary
+//! (`crates/stella-cli/src/self_driving_cmd.rs`), and the type the ranker
+//! consumes is GitHub's wire shape — `stella_autonomy::QueueIssue` carries a
+//! `#[serde(rename = "createdAt")]`, which is a `gh --json` field name sitting
+//! in a leaf crate that depends on nothing. So "which tracker" is not a
+//! decision anything in the tree can express: it is spelled into the reader.
+//!
+//! This module is the seam. A tracker becomes an implementation of
+//! [`IssueProvider`], the loop reads [`Issue`] values, and GitHub stops being
+//! the only answer without becoming a special one — invariant 1, for the
+//! backlog plane.
+//!
+//! # The model is deliberately tiny
+//!
+//! Four states, four classes, a key, a title, a body, labels, a created stamp
+//! and a parent edge. That is the whole kernel, and it is
+//! `doc:agent-native-delivery` §3's argument rather than a shortcut: everything
+//! richer — a Jira workflow scheme, a Linear cycle, a GitHub project field — is
+//! the *customer's* vocabulary, and modelling it here would make Stella learn
+//! one tracker's data model and then fail to hold the next one. What crosses
+//! this boundary is what the loop actually decides on.
+//!
+//! Two consequences worth stating, because both were tempting:
+//!
+//! - **There is no `assignee`.** A tracker's assignee field is not a lock — it
+//!   has no compare-and-swap and no lease — and treating it as one is how two
+//!   workers take the same issue. Claims live in the fleet ledger
+//!   (`doc:agent-native-delivery` §10.4), which already has the primitive.
+//! - **There is no `priority` field.** Priority is expressed as a label here,
+//!   because that is how the trackers this must span actually carry it, and a
+//!   dedicated field would force every provider to invent a mapping into it.
+//!   Ranking reads labels (`stella_autonomy::rank_defects`).
+//!
+//! # Why the kernel is here and the ranking is not
+//!
+//! [`stella_autonomy`] is a leaf that depends on no other workspace crate —
+//! that is what lets `stella-cli` and `stella-observatory` share its folds
+//! without the observatory linking the machinery it observes. Moving the
+//! ranker onto [`Issue`] would cost it that property for no gain, so the
+//! ranker keeps its own input type and a caller maps into it. The mapping is
+//! one function in the CLI, and it is the *only* place a tracker's shape meets
+//! the loop's.
+//!
+//! [`stella_autonomy`]: https://docs.rs/stella-autonomy
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A tracker-scoped identifier for one issue, as the tracker spells it.
+///
+/// A string rather than a number, and that is the load-bearing choice: GitHub
+/// counts (`1234`), Jira does not (`STELLA-1234`), Linear does not
+/// (`ENG-42`). A numeric key would fit exactly one tracker and force every
+/// other provider to fabricate one — and a fabricated key cannot be handed
+/// back to the tracker it came from.
+///
+/// Opaque to Stella: it is produced by a provider, stored, compared for
+/// equality, and handed back. Nothing here parses it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct IssueKey(pub String);
+
+impl IssueKey {
+    /// The key as the tracker spells it.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for IssueKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for IssueKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+/// Where an issue is in its life, collapsed to what the loop decides on.
+///
+/// Three buckets, not a workflow. `doc:agent-native-delivery` §4.1 is explicit
+/// that a provider maps *every* reachable tracker status into one of these and
+/// that a status mapping to none of them is a load error rather than a guess —
+/// modelling the workflow itself is a stated non-goal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueState {
+    /// Nobody is working it. This is the queue the loop draws from.
+    Open,
+    /// Somebody or something holds it. Not a lock — see the module docs.
+    InProgress,
+    /// Finished, abandoned, or declined. The loop does not draw from here,
+    /// but `sweep regress` re-reads it: a closed issue is a claim with an
+    /// expiry (`doc:backlog-self-driving` §4.3).
+    Closed,
+}
+
+/// What kind of work an issue is, which decides what must exist before it can
+/// be called done.
+///
+/// Four, matching `doc:agent-native-delivery` §3. [`IssueClass::Other`] is the
+/// honest bucket for a type a provider's manifest does not map, and it exists
+/// so that an unmapped type is *visible* rather than silently filed as a
+/// feature and given the wrong policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueClass {
+    /// Something is broken. A fix wants a regression witness.
+    Bug,
+    /// Something should exist that does not.
+    Feature,
+    /// Work that is neither — a migration, a cleanup, a chore.
+    Task,
+    /// The provider's vocabulary had no mapping for this one.
+    Other,
+}
+
+/// One label, as the tracker spells it.
+///
+/// Deliberately a struct with a single `name` rather than a bare `String`:
+/// every tracker this must span carries more per label (a colour, a
+/// description, an id), and a caller that wants one later should find a field
+/// added here rather than a `Vec<String>` widened everywhere it is passed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IssueLabel {
+    /// The label text — `"P1"`, `"area:core"`, `"bug"`.
+    pub name: String,
+}
+
+impl From<&str> for IssueLabel {
+    fn from(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+        }
+    }
+}
+
+/// One issue, in the only shape that crosses this boundary.
+///
+/// Round-trips through `serde_json` byte-for-byte (invariant 4); the test is
+/// beside the type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Issue {
+    /// The tracker's own identifier.
+    pub key: IssueKey,
+    /// One line. Never empty in practice; not enforced here, because a
+    /// provider faithfully reporting an empty title is more useful than one
+    /// that refuses to.
+    pub title: String,
+    /// The body, as the tracker holds it.
+    ///
+    /// **Untrusted input, always.** Issue text is written by whoever can file
+    /// an issue, and it reaches a prompt as *data, never instruction*
+    /// (`doc:agent-native-delivery` §10.2). Of the context-record kinds only
+    /// `directive` carries instruction authority, and issue text is never one.
+    #[serde(default)]
+    pub body: String,
+    /// Which of the three buckets the tracker's status maps to.
+    pub state: IssueState,
+    /// Which policy applies to it.
+    pub class: IssueClass,
+    /// Labels, verbatim. Priority and area live here — see the module docs.
+    #[serde(default)]
+    pub labels: Vec<IssueLabel>,
+    /// When the tracker says it was created, RFC3339.
+    ///
+    /// A string rather than a timestamp type: this crate holds no clock and no
+    /// date dependency, the value is compared lexically for age ordering
+    /// (RFC3339 sorts correctly as text), and a provider that cannot produce
+    /// one supplies an empty string rather than a fabricated instant.
+    #[serde(default)]
+    pub created_at: String,
+    /// Where a human would go to read it.
+    #[serde(default)]
+    pub url: String,
+    /// The epic or parent this hangs off, when the tracker has one.
+    ///
+    /// One edge, not a tree: `doc:agent-native-delivery` §5 resolves a spec by
+    /// walking *up* this edge, and nothing in the loop needs to walk down.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<IssueKey>,
+}
+
+/// Why a tracker read or write did not happen.
+///
+/// Typed rather than a `String` (invariant 5), and the variants are chosen by
+/// what a **caller has to do differently**, which is the test that rule states:
+/// an unavailable tracker is retried or degraded, an unauthenticated one needs
+/// a human, a missing issue is a permanent answer, and a malformed payload is
+/// a bug in the provider.
+#[derive(Debug, thiserror::Error)]
+pub enum IssueError {
+    /// The provider's transport is not installed or not on `PATH`.
+    #[error("issue provider `{provider}` is unavailable: {reason}")]
+    Unavailable {
+        /// The provider id that could not be reached.
+        provider: String,
+        /// What was missing, in terms a human can act on.
+        reason: String,
+    },
+    /// The transport is present but the caller is not authenticated to it.
+    ///
+    /// Distinct from [`IssueError::Unavailable`] because the remedy differs and
+    /// a caller should say which: installing a tool and logging into it are
+    /// different instructions, and the loop cannot fix either itself.
+    #[error("issue provider `{provider}` is not authenticated: {reason}")]
+    Unauthenticated {
+        /// The provider id that refused.
+        provider: String,
+        /// What the tracker said.
+        reason: String,
+    },
+    /// No issue with that key.
+    #[error("no such issue: {key}")]
+    NotFound {
+        /// The key that resolved to nothing.
+        key: IssueKey,
+    },
+    /// The tracker answered, and the answer did not parse.
+    #[error("issue provider `{provider}` returned a payload this build cannot read: {reason}")]
+    Malformed {
+        /// The provider id whose payload was rejected.
+        provider: String,
+        /// The parse failure.
+        reason: String,
+    },
+    /// The tracker answered with a failure of its own.
+    #[error("issue provider `{provider}` failed: {reason}")]
+    Failed {
+        /// The provider id that failed.
+        provider: String,
+        /// What it said.
+        reason: String,
+    },
+}
+
+/// The port every tracker is reached through — invariant 1 for the backlog
+/// plane.
+///
+/// A new tracker is an adapter, never a change to the loop. Nothing above this
+/// trait knows whether the issues came from GitHub, Jira, a TOML fixture, or a
+/// local journal, which is exactly the property the witness test asserts by
+/// ranking a real queue with no `gh` on `PATH` at all.
+///
+/// # Read-only, on purpose, at this slice
+///
+/// Filing, claiming and closing are `doc:backlog-self-driving` §3.1's other
+/// four `backlog` calls, and they are deliberately not here yet: a write path
+/// with nothing calling it is the unwired code AGENTS.md's "nothing left
+/// behind" rule exists to prevent. This trait grows the write half in the
+/// slice that serves those calls, and #3599 tracks it.
+#[async_trait]
+pub trait IssueProvider: Send + Sync {
+    /// Stable id for this provider, e.g. `"github"` — what an error names and
+    /// what a workspace binds to.
+    fn id(&self) -> &str;
+
+    /// Every issue currently in [`IssueState::Open`], newest-first or in
+    /// whatever order the tracker returns them.
+    ///
+    /// **Ordering is not part of the contract**: ranking is the loop's job and
+    /// is deterministic (`stella_autonomy::rank_defects`), so a provider that
+    /// sorted differently could not change which issues a cycle picks. `limit`
+    /// bounds the read, because a tracker with ten thousand open issues should
+    /// not have all of them cross this boundary to produce a batch of five.
+    async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Issue {
+        Issue {
+            key: IssueKey::from("1234"),
+            title: "the retry counter survives a goal-round boundary".into(),
+            body: "`RetryHistory` is keyed per turn.".into(),
+            state: IssueState::Open,
+            class: IssueClass::Bug,
+            labels: vec![IssueLabel::from("P1"), IssueLabel::from("area:core")],
+            created_at: "2026-08-19T05:00:00Z".into(),
+            url: "https://github.com/macanderson/stella/issues/1234".into(),
+            parent: Some(IssueKey::from("1200")),
+        }
+    }
+
+    /// Invariant 4: every type crossing a crate boundary round-trips through
+    /// `serde_json` byte-for-byte.
+    #[test]
+    fn an_issue_round_trips_byte_for_byte() {
+        let issue = fixture();
+        let json = serde_json::to_string(&issue).expect("serialize");
+        let back: Issue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, issue);
+        assert_eq!(serde_json::to_string(&back).expect("re-serialize"), json);
+    }
+
+    /// The optional half round-trips too — a `parent`-less issue must not
+    /// serialize a null that a stricter reader would reject.
+    #[test]
+    fn an_issue_with_no_parent_omits_the_field() {
+        let issue = Issue {
+            parent: None,
+            ..fixture()
+        };
+        let json = serde_json::to_string(&issue).expect("serialize");
+        assert!(!json.contains("parent"), "{json}");
+        let back: Issue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, issue);
+    }
+
+    /// The wire spellings are pinned. These cross a process boundary into
+    /// provider manifests and stored records, so a rename is a breaking change
+    /// and should have to edit this test to happen.
+    #[test]
+    fn every_closed_vocabulary_is_pinned_on_the_wire() {
+        let states = [
+            (IssueState::Open, "\"open\""),
+            (IssueState::InProgress, "\"in_progress\""),
+            (IssueState::Closed, "\"closed\""),
+        ];
+        for (state, wire) in states {
+            assert_eq!(serde_json::to_string(&state).expect("serialize"), wire);
+        }
+
+        let classes = [
+            (IssueClass::Bug, "\"bug\""),
+            (IssueClass::Feature, "\"feature\""),
+            (IssueClass::Task, "\"task\""),
+            (IssueClass::Other, "\"other\""),
+        ];
+        for (class, wire) in classes {
+            assert_eq!(serde_json::to_string(&class).expect("serialize"), wire);
+        }
+    }
+
+    /// A key is transparent on the wire — a bare string, not `{"0": "..."}`.
+    /// A provider in another language writes the tracker's own identifier and
+    /// nothing around it.
+    #[test]
+    fn a_key_is_a_bare_string_on_the_wire() {
+        let json = serde_json::to_string(&IssueKey::from("STELLA-42")).expect("serialize");
+        assert_eq!(json, "\"STELLA-42\"");
+    }
+
+    /// A body absent from the payload is empty, never a parse failure: a
+    /// provider that lists issues without fetching each body is doing the
+    /// cheap correct thing, and the queue read does not need one.
+    #[test]
+    fn the_optional_fields_default_rather_than_refuse() {
+        let minimal = r#"{"key":"7","title":"t","state":"open","class":"task"}"#;
+        let issue: Issue = serde_json::from_str(minimal).expect("deserialize");
+        assert_eq!(issue.body, "");
+        assert_eq!(issue.created_at, "");
+        assert_eq!(issue.url, "");
+        assert!(issue.labels.is_empty());
+        assert_eq!(issue.parent, None);
+    }
+}

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -64,6 +64,7 @@ pub mod denial;
 pub mod error;
 pub mod event;
 pub mod hook;
+pub mod issue;
 pub mod journal;
 pub mod ladder;
 pub mod lane;
@@ -119,6 +120,7 @@ pub use journal::{StampedEvent, stamped_line};
 pub use lane::{BuiltinLane, LaneId, TurnLane};
 // The ladder vocabulary moved out of `event` when the rung joined it (#1043);
 // re-exported here so `stella_protocol::LadderSnapshot` never moved.
+pub use issue::{Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState};
 pub use ladder::{FlipOutcome, LadderRung, LadderSnapshot, OracleObservation, ProofTree};
 pub use provider::{Provider, ToolCallObserver};
 pub use role::{ModelRef, Role};

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -660,13 +660,31 @@ its witness — a test that fails on `main` and passes with the change.
 | Phase | Deliverable | Witness | Unblocks |
 |---|---|---|---|
 | **B0** — **built** | **The driver channel** (§3.0). A second dispatch context for the existing host-call machinery, opened by a driver session rather than a wrapper point; a `[driver]` block with its own `calls` list and its own `permits_call`, *without* touching the `Participation` ladder; the grant rendered at install consent. `stella-plugin/src/driver.rs` is the wire half and `stella-runtime/src/wrapper/driver_call.rs` the host half. **A call carries no arguments and returns no payload yet** — no verb is implemented, so no argument or result table can be written honestly; each lands with the verb that needs it. `plugins/stella-selfdriving` declares its `[driver]` grant but is still not a program the host runs, which is B2. | `an_undeclared_call_is_refused_and_the_session_keeps_running` (`stella-runtime/src/wrapper/driver_call.rs`): a driver whose manifest omits a call is refused it with a `HostCallRefusal` code, is not charged for it, and **keeps running**; a declared one is served. Both directions, because either alone is half a gate. Plus `a_driver_holds_capabilities_without_a_participation_grade` (`stella-plugin/src/manifest.rs`) — the defect itself, that `participation = "none"` made every capability unreachable. | everything below |
-| **B1** | **The issue port.** `Issue` kernel in `stella-protocol`; `IssueProvider` port; GitHub as a shipped manifest under `.stella/issues/`; the `backlog` calls on the channel; the CLI's `queue` row reshaped, `HOST_SURFACE_VERSION` → 2. | The ranked queue is produced against a fixture provider with **no `gh` on `PATH`**. | "any issue provider" |
+| **B1** — *port landed* | **The issue port.** `Issue` kernel in `stella-protocol`; `IssueProvider` port; GitHub as a shipped manifest under `.stella/issues/`; the `backlog` calls on the channel; the CLI's `queue` row reshaped, `HOST_SURFACE_VERSION` → 2. | The ranked queue is produced against a fixture provider with **no `gh` on `PATH`**. | "any issue provider" |
 | **B2** | **`work` + the loop step machine.** `LoopStep`/`step` pure in `stella-autonomy`; `work_start`/`work_status`/`work_abandon` served over the channel from `stella-cli`, built on the existing `child_turn` dispatcher rather than a second one; the plugin becomes a policy loop over declared calls; the eight slash commands and `scripts/self-driving.sh` retire **only after** `scripts/test-self-driving.sh` is green against the new path with every assertion intact. | One issue goes from `backlog next` to a verified diff with no Claude Code and no human. | the headline |
 | **B3** | **`deliver`.** `PrState` pure; open/observe/next/merge; `Escalated` reachable and terminal; `CiRed` vs `BaseBroken` distinguished. | A PR whose CI is red *on its base branch* transitions to `BaseBroken`, and the loop does not push a fix. |  PR rhythm (#2374's named weakness) |
 | **B4** | **Supply.** Ladder re-arm on baseline delta; `sweep regress` over closed-issue receipts; `sweep meta`. Per-supply switch, default queue-only. | A lens dry at `HEAD` re-opens after the declared baseline delta and yields **only** digests absent from `seen.txt`. | never runs out |
 | **B5** | **The residue gate** ([`doc:agent-native-delivery`](../design/agent-native-delivery.md) §7) in `warn`, plus fingerprint dedup and decay. | A run stating a follow-up in prose and claiming `done` fails the gate; the same run with the item `filed` passes. | filing is a guarantee |
 | **B6** | **`curate`.** Proposals from ledger evidence; acceptance gated on declared authority; `regulated` keeps the human on context records. | A skill proposal reaching the recurrence threshold is *proposed* and, under `regulated`, **not** applied. | self-curation |
 | **B7** | **`release`,** opt-in, gated on green `main` + quiet canary + derivable changelog. | Deliberately deferred — see §6.4. | shipping |
+
+**B1's first slice has landed**: the [`Issue`] kernel and the
+[`IssueProvider`] port (`crates/stella-protocol/src/issue.rs`), the GitHub
+adapter behind it (`crates/stella-cli/src/issue_provider.rs`), and both backlog
+readers moved onto the port
+(`crates/stella-cli/src/self_driving_cmd/backlog.rs`). GitHub is now an adapter
+rather than the answer, and the witness ranks a real defect queue from a fixture
+provider that runs no subprocess and holds no credential. The remaining
+`backlog` calls — `claim`, `file`, `close`, `link` — are the write half and are
+deliberately absent: a write path nothing calls is the unwired code AGENTS.md's
+"nothing left behind" rule exists to prevent.
+
+One thing the slice found that the design did not anticipate: **`demand` carried
+a second definition of "defect".** The governor counted its open-defect and P0
+numbers with two extra `gh issue list --jq length` calls whose `--label bug`
+filter was a rival to `rank_defects`'s own label rule — two definitions of one
+word, in two languages, able to disagree about the very backlog the same cycle
+drew its batch from. Both numbers are now folds of one ranking of one read.
 
 **Landing map** (each crate's boundary decides, not convenience):
 


### PR DESCRIPTION
## What & why

B1's first slice of #3599: the backlog plane gets a port, so GitHub stops being
the only tracker without becoming a special one — invariant 1, for issues.

The loop read its defect queue by shelling out to `gh` literally, in the
shipping binary, and the type the ranker consumed **was** GitHub's wire shape:
`stella_autonomy::QueueIssue` carries `#[serde(rename = "createdAt")]`, a
`gh --json` field name sitting in a leaf crate that depends on nothing. "Which
tracker" was not a decision anything in the tree could express; it was spelled
into the reader.

- `crates/stella-protocol/src/issue.rs` — the `Issue` kernel and the
  `IssueProvider` port, following `provider.rs`'s precedent for a port in that
  crate.
- `crates/stella-cli/src/issue_provider.rs` — the GitHub adapter, and the only
  place in the tree carrying GitHub's field spellings.
- `crates/stella-cli/src/self_driving_cmd/backlog.rs` — both backlog readers,
  over `&dyn IssueProvider`.

The kernel is deliberately tiny (`doc:agent-native-delivery` §3). **No
`assignee`** — a tracker's assignee field is not a lock, and treating it as one
is how two workers take the same issue; claims belong in the fleet ledger.
**No `priority` field** — every tracker this must span carries priority as a
label, and a dedicated field would force each provider to invent a mapping into
it.

`stella_autonomy` keeps its own ranker input type rather than moving onto
`Issue`: it takes no workspace dependency at all, that is what lets
`stella-observatory` link its folds without linking the machinery it observes,
and the mapping is one function in the CLI.

Refs #3599

## Two things found by building it, beyond the design's scope

**`demand` carried a second definition of "defect".** The governor counted its
open-defect and P0 numbers with two extra `gh issue list --jq length` calls
whose `--label bug` filter was a rival to `rank_defects`'s own label rule — two
definitions of one word, in two languages, able to disagree about the very
backlog the same cycle drew its batch from. Both numbers are now folds of one
ranking of one read, which also drops two subprocess round-trips per plan.

**New logic landed in a sibling.** #3599 records `self_driving_cmd.rs` as closed
to growth. I grew it by 56 lines first, noticed, and split: the parent is now
950 lines, down from 1005.

## Deliberately absent

The write half — `backlog claim` / `file` / `close` / `link` — is not here. A
write path nothing calls is the unwired code AGENTS.md's "nothing left behind"
rule exists to prevent; it lands with the slice that serves those calls. Same
reasoning as B0's: the `DriverCall` variants for them already exist on `main`
and answer `unsupported`.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`self_driving_cmd::backlog::tests::a_ranked_queue_needs_no_github_at_all` ranks
a real defect queue — priority order, age breaking ties, feature work excluded —
from a fixture provider that runs no subprocess and holds no credential.

**It cannot compile on `main`**: there is no `IssueProvider` to implement there,
because the queue read *is* the `gh` call. That is the property under test — not
that ranking works, which it already did, but that ranking no longer requires
GitHub to exist. Verified absent: `git show origin/main:crates/stella-protocol/src/issue.rs`
returns nothing.

Three more pin what the crossing must preserve: `demand_is_a_fold_of_the_same_ranking`,
`an_unreachable_tracker_degrades_rather_than_failing` (a tracker that cannot be
reached sizes a cycle as though the backlog were empty rather than refusing to
plan — inherited from the `gh_available()` check it replaces), and
`the_read_limit_bounds_the_crossing`. Plus five serde/mapping tests on the
kernel and adapter, including invariant 4's byte-for-byte round trip.

One test caught me rather than the code: my first fixture had `P0`/`P1` labels
but no `bug` label, and `rank_defects` correctly returned nothing.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-protocol --all-targets -- -D warnings`
- [x] `cargo test -p stella-protocol -p stella-cli`
- [x] `wire-schema`, `doc-warnings`, `file-size`, `god-files`, `design-refs`,
      `invariants`, `doc-links`, `brand-case`, `left-behind`, `typed-errors`,
      `module-reachability`, `no-scratch`, `format-check`

`shellcheck` is not installed in this container; this PR touches no shell.

### CI round 1 caught a real thing

`crates/stella-cli/tests/self_driving_consent.rs` asserts, in **both**
directions, that every capability the install prompt declares is one the code
actually exercises — and it fired:

> the grant declares `reading the GitHub defect queue` but
> `crates/stella-cli/src/self_driving_cmd.rs` no longer does it … Narrow the
> grant rather than leaving a capability declared that nothing needs, or repoint
> this row if the power moved.

The power moved rather than went, so the row is repointed at
`crates/stella-cli/src/issue_provider.rs` (`4e9a48d`). The new anchor is
`impl IssueProvider for GhIssueProvider` rather than another argv string: an
argv anchor fires spuriously the first time someone adds a `--json` field, which
teaches a reader that this guard cries wolf, while the impl disappears only if
the capability really does.

### Correction to an earlier claim in this description

An earlier revision of this body reported
`daemon::tests::a_run_that_ignores_term_is_killed_after_the_grace_period` as a
pre-existing failure. It fails in *this* container — and does so on clean
`origin/main` with my changes stashed, which is why I read it as pre-existing —
but **CI runs it green**, on this branch. So the honest statement is narrower
than what I wrote: it is an environment-sensitive failure local to a
disk-constrained sandbox, not a failure of `main`. The test's own comment
documents that flake mode and attributes it to #1721.

## Nothing left behind

- [x] Filed: nothing new. The write half and the non-numeric-key limitation are
      both recorded in #3599 and noted in the code where they bite
      (`to_queue_issue`'s doc comment states the `u64` key loss and why widening
      a leaf crate's public type should wait for a provider that needs it).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (`async-trait` was already a
      `stella-protocol` dependency)
- [x] No new outbound network calls — the adapter shells to `gh` exactly as the
      code it replaces did, which is also what keeps **Stella holding no GitHub
      credential**: `gh` owns the auth and the token never enters this process
- [x] New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

**The design's landing map said providers land in `stella-tools`; this puts the
port in `stella-protocol` and the adapter in `stella-cli`.** Reasoning: the port
is a trait crossing a crate boundary, which is `provider.rs`'s precedent
exactly, and `stella-tools` is where a *tool* lives — the issue port is not a
tool the model calls. If the intent was for the agent to have an issue *tool*,
that is a separate surface and this port would sit underneath it. Worth
confirming before B1's second slice builds on the choice.

**`IssueClass` for GitHub is read off labels**, since a plain repository has no
issue type. Unlabelled maps to `Other`, deliberately not `Task`: a wrong class
silently applies the wrong completion policy, and `doc:agent-native-delivery`
§12.6 leaves whether `Other` is workable open — this adapter does not pre-empt
it.

**`parent` is always `None` from GitHub here.** The parent edge needs a second
GraphQL call per issue that the queue read does not need and should not pay for.
Absent means "not fetched", and the write half fetches it when something reads
it.