### PR TITLE
fix(workspace): three call sites that outlived what they called — main does not compile

### DIFF
--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -231,15 +231,13 @@ fn a_steering_wrapper_is_not_refused_by_the_arbiter_gate() {
         .expect("a steering-grade wrapper can never hold a round open — nothing to refuse");
 }
 
-/// The resolved `Raw` choice bypasses this gate entirely on every door — only
-/// a *named* plugin variant is ever in reach of it, and only on `fleet`.
-#[test]
-fn a_resolved_raw_choice_is_never_refused_on_any_door() {
-    reject_plugin_variant_for_door("goal", PipelineChoice::Raw)
-        .expect("raw has no plugin to drive — nothing to refuse");
-    reject_plugin_variant_for_door("fleet", PipelineChoice::Raw)
-        .expect("raw has no plugin to drive — nothing to refuse");
-}
+// `a_resolved_raw_choice_is_never_refused_on_any_door` lived here, pinning
+// `reject_plugin_variant_for_door`: the gate that refused a named plugin
+// variant on `stella fleet`, the one door with no `TurnDriver` over its round
+// loop. #3896 gave fleet workers that driver — one plugin per attempt — so the
+// door it guarded no longer exists and the function was deleted with it. The
+// test outlived its subject by three merges because nothing compiled the two
+// together until now.
 
 /// **Witness (#3696).** `--keep-witness`, `--require-verified`, and
 /// `--test-command` used to reach `run_one_shot` on the `Raw` arm and be

--- a/crates/stella-plugin/tests/wire_contract.rs
+++ b/crates/stella-plugin/tests/wire_contract.rs
@@ -27,9 +27,9 @@ use serde::de::DeserializeOwned;
 use stella_plugin::{
     AdoptCandidateArgs, AdoptCandidateResult, AfterTurnRequest, AfterTurnResponse,
     BeforeTurnRequest, BeforeTurnResponse, CandidateFanoutArgs, CandidateFanoutResult,
-    CandidateGrant, ChildTurnResult, Continuation, Correction, EvidenceSet, FanoutCandidate,
-    FlipObservation, HostCall, HostCallOk, HostCallResponse, ObservedEvidence, Outcome,
-    PROTOCOL_VERSION, PluginManifest, PublishedSignal, RecallResult, RoundState, Signal,
+    CandidateGrant, ChildTurnResult, Continuation, Correction, EvidenceProvenance, EvidenceSet,
+    FanoutCandidate, FlipObservation, HostCall, HostCallOk, HostCallResponse, ObservedEvidence,
+    Outcome, PROTOCOL_VERSION, PluginManifest, PublishedSignal, RecallResult, RoundState, Signal,
     SignalValue, StageName, StopReason, TamperFinding, TestBaseline, TestPlan, TurnOutcome,
     UndecidedReason, UnmetBecause, UnmetRequirement, Verdict, VerdictRule, VolatileContext,
     WrapperPoint, WrapperRequest, WrapperResponse,

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -98,18 +98,13 @@ pub const DANGER: Color = palette::DANGER;
 /// Danger (bright — legible removed-line / error text on the dark backdrop).
 pub const DANGER_BRIGHT: Color = palette::DANGER;
 
-/// The oracle's **pre-flip** state — the one place red carries meaning in the
-/// deck (D6). A healthy, *expected* state ("the test fails before the patch —
-/// good"), so it deliberately does not share a value with [`DANGER`]: a failure
-/// hue on the very state a verification run is supposed to produce would teach
-/// readers to ignore the failure hue. Nothing else may take this role.
-///
-/// **No renderer claims it today.** Its only consumer was the witness panel,
-/// removed ahead of the staged pipeline's extraction (#3511); that crate was
-/// then deleted outright (#3865). The token is kept
-/// because [`palette`] mirrors the brand kit at `docs/brand/` and the contrast
-/// tables below are checked against it; retiring it is #3790.
-pub const ORACLE_PRE_FLIP: Color = palette::ORACLE_RED;
+// `ORACLE_PRE_FLIP` deliberately does not exist. #3890 retired it along with
+// its `palette::ORACLE_RED`/`ORACLE_RED_INK` values, and
+// `docs/design/verification-surface.md` § "Decision 3" is the standing
+// argument: the token's only consumer was the witness panel removed in #3791,
+// the brand kit at `docs/brand/` never carried an oracle token, and the
+// contrast-table case for keeping it was circular. A pre-flip red returns when
+// a panel paints one — a token earns its place by being painted.
 
 // ── Categorical hues (deliberately NOT brand) ───────────────────────────────
 //


### PR DESCRIPTION
## What & why

**`main` does not compile, and has not since #3896.** This PR makes it compile
again. It is three edits — a deleted const, a missing `use`, and a test whose
subject no longer exists — and no behaviour changes.

This started as "fix the conflicts on #3902". #3902 has since been merged
(`e921d378c`) and PR #3915 opened to revert it. **The revert would not have
helped:** the required `fmt + clippy + test` check was already `failure` on
`85b7e07ee`, the merge before #3902, and on `93eec5a50` before that. #3902 is
not what broke `main`.

Three separate PRs each removed a symbol and left a caller behind. Because one
compile error stops the build before the next crate is reached, each breakage
hid the one after it — they had to be found one rebuild at a time.

### 1. `crates/stella-tui/src/theme.rs` — `ORACLE_PRE_FLIP`

`pub const ORACLE_PRE_FLIP: Color = palette::ORACLE_RED;` referenced a token
that does not exist. #3890 deleted `ORACLE_RED`/`ORACLE_RED_INK` from
`palette.rs` and shrank `ALL` from 39 to 37; #3897, branched earlier, then
added this const.

Removed rather than resurrected, because the decision was already taken and
written down. `docs/design/verification-surface.md` § "Decision 3 —
`ORACLE_PRE_FLIP` is gone":

> The theme token's only consumer was the witness panel, removed in #3791. The
> brand kit at `docs/brand/` never carried an oracle token, so nothing mirrored
> it; the contrast-table argument for keeping it was circular (the tables
> existed to check a token nothing rendered). […] a token earns its place by
> being painted, not by waiting.

Resurrecting `ORACLE_RED` to satisfy the const would have reversed that
decision silently. A comment holds the place and cites the doc, so the next
reader does not add it a third time.

### 2. `crates/stella-plugin/tests/wire_contract.rs` — missing import

The file uses `EvidenceProvenance::PluginReported` in two round-trip
assertions but does not import the type. #3874 added the usages *and* the
import together, correctly; #3900 rewrote the `use stella_plugin::{…}` block to
add the fanout types and dropped `EvidenceProvenance` out of it. The field
names are right — `Verdict::Met` and `Outcome::Met` both take
`evidence: EvidenceProvenance` — so this is only the `use`.

This one is a **single-PR** break: it would have been caught on #3900's own
branch if red had still meant anything by then. See #3917.

### 3. `crates/stella-cli/src/wrapper_plugin/tests.rs` — orphaned test

`a_resolved_raw_choice_is_never_refused_on_any_door` called
`reject_plugin_variant_for_door`, which #3896 deleted. The deletion was right:
that gate refused a named plugin variant on `stella fleet`, the one door with
no `TurnDriver` over its round loop, and #3896 is the PR that gave fleet
workers exactly that driver. The door it guarded stopped existing.

The test is **removed, not repaired** — see "Anything reviewers should know?"
below.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: **the witness is
      the build itself.** Each of the three is a name that does not resolve, so
      `cargo clippy --workspace --all-targets` fails on the old code and passes
      on the new. A test asserting "the workspace type-checks" is the compiler.

Verified the artisanal way — the errors were found by rebuilding after each
fix, because each one masked the next:

```
$ cargo clippy --workspace --all-targets -- -D warnings   # before
error[E0425]: cannot find value `ORACLE_RED` in module `palette`
              --> crates/stella-tui/src/theme.rs:112:45
error[E0433]: cannot find type `EvidenceProvenance` in this scope
              --> crates/stella-plugin/tests/wire_contract.rs:154:19

$ # after fixing those two, a third appears:
error[E0425]: cannot find function `reject_plugin_variant_for_door` in this scope
              --> crates/stella-cli/src/wrapper_plugin/tests.rs:238:5

$ cargo clippy --workspace --all-targets -- -D warnings   # after
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — reaches
      `Finished` with no diagnostics, the first time the workspace has
      type-checked since #3896
- [x] `cargo test --workspace` — green, but **run in three parts on purpose**;
      see below
- [x] Docs updated where behavior/flags changed — n/a, no behaviour change
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Refs #N` appears both above and as a commit trailer

### Why the test run is split

A plain `cargo test --workspace` on a machine with a configured Stella **spends
real money**: `goal_wrapped_dispatch_cli` reached `zai/glm-5.2` for $0.1076
over 164.6s, then failed on the round cap. That is #3876, already open and
naming that exact file — it sets `STELLA_DATA_DIR` but not `STELLA_HOME`, and
`credentials.toml` is in the config tier, which only `STELLA_HOME` moves.
Nothing to do with this PR, but it is why the numbers below are three runs
rather than one:

| Run | Result |
| --- | --- |
| `--workspace --exclude stella-cli` | 157 suites, **0 failures**, exit 0 |
| `-p stella-cli --bins` | **1733 passed, 0 failed** |
| `-p stella-cli --tests` with `STELLA_HOME` isolated | all **17** integration targets pass, **no model spend** |

Two `stella-cli` bin unit tests
(`settings::tests::untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt`,
`tool_switches::tests::a_saved_switch_round_trips_through_the_settings_chain_under_the_managed_ceiling`)
pass in run 2 and fail in run 3 — they currently pass *because of* something in
the developer's real `~/.stella`. Causation verified both directions; both are
pre-existing and now recorded on #3876, along with the fact that seven files in
`crates/stella-cli/tests/` share the missing-`STELLA_HOME` gap, not one.

CI has no ambient credentials, so its own `fmt + clippy + test` run is the
single-command version of the same thing.

## Nothing left behind

- [x] Filed: #3916, #3917

- **#3917** — the dynamic, not the errors. Four PRs merged onto a `main` that
  did not compile, because once it was red every PR was red and red stopped
  distinguishing "your change is broken" from "the base is". `main-canary.yml`
  *did* fire on both `85b7e07ee` and `e921d378c`; nothing made the next merge
  wait for it. Same class as #3661, still open from 2026-08-18. The issue lays
  out three candidate mechanisms and asks for an executable acceptance
  criterion.
- **#3916** — `stella_core::router::FallbackInfo` has no consumer anywhere in
  the workspace. Found while resolving #3902's conflicts: both candidate
  wordings for that module doc named a host that turns it into an
  `AgentEvent::ProviderFallback`, and the only producer of that event
  (`driver/model_fallback.rs:158`) never touches the type. Since the doc rests
  it on L-M7 ("fallback is always visible, never silent"), an unread carrier is
  the exact thing L-M7 forbids. Not fixed here — wire-it-or-retire-it is a
  design call, not a compile fix.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

**A test was deleted**, which `check-deleted-tests` reports on:
`a_resolved_raw_choice_is_never_refused_on_any_door` in
`crates/stella-cli/src/wrapper_plugin/tests.rs`. It is removed rather than
repaired because there is nothing left to point it at — the function it called
was deleted by #3896 along with the door restriction it enforced. A comment
stands in its place recording what it pinned and why that is gone, so the
deletion reads as a decision rather than an omission. If a reviewer would
rather keep a test on this ground, the honest replacement asserts that
`stella fleet` now *accepts* a named variant, which is #3896's behaviour and
belongs in #3896's own coverage.

**What I did not do:** I did not touch #3915. On the evidence above the revert
addresses a cause that is not the cause, and #3902's content — the
`no_policy_crate_edge.rs` guard rename, the self-driving lens `rg` path fix,
and the `run_complete` consumer-site repoint — is work that would have to be
re-landed. That is a maintainer's call, not mine; this PR is written so it can
merge whether or not #3915 does.

**Scope.** Deliberately only the three compile errors. `main` being red is the
kind of thing that invites folding in unrelated cleanups, and a PR that fixes
the build should be reviewable in one sitting.

Refs #3917

---

## Update — two more failures, and what CI proved about the first three

The first CI run on this branch is the useful artifact, because it separates
what was broken from what I broke. Its step list:

| Step | Result |
| --- | --- |
| `cargo clippy -D warnings` | **success** |
| `cargo test` | **success** |
| `cargo doc -D warnings` | **success** |
| `cargo build` (release smoke, thin LTO) | **success** |
| `shellcheck` | failure |
| `check-design-refs` | failure |

So the three compile fixes work — clippy, the full workspace test suite and
rustdoc all pass in CI, with no ambient credentials, on the first try. The
job still went red because `fmt + clippy + test` is **one job running thirty
guards**, and two of them were failing for reasons unrelated to compilation.
That is the same masking this PR's description already describes, one layer
out: a single red job was reporting its first failure and hiding the rest.

The second commit fixes both:

- **`shellcheck`** — `scripts/test-install-zsh-completions.sh:112` had
  `cat "$path" | indent`, which trips SC2002; the step runs under `-e`, so
  that one style lint fails the whole gate. It landed with **#3889** and has
  been red on `main` ever since — a **fourth** independent breakage of this
  job, alongside the three compile errors. Now `indent < "$path"`.
- **`check-design-refs`** — **mine.** My replacement comment in `theme.rs`
  cited `docs/design/verification-surface.md`, and that guard forbids citing
  `docs/design/` at all: the directory is work-in-flight, and its stated
  remedy is promoting the document, not citing it from code. The comment now
  carries the argument itself and cites #3890/#3791 instead, which is more
  durable than a path anyway.

### Swept locally this time, not one CI round per failure

- `make guards` — all green, including `design-refs`, `shellcheck`,
  `wire-schema`, `lockfile-sync`, `fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `make doc-warnings` — `Finished`, no rustdoc warnings
- `check-typed-errors`, `check-tool-docs`, `file-size`, `god-files`,
  `gate-parity`, `left-behind`, `invariants`, `doc-links` — all pass

### One gate step still red, deliberately not fixed here

`make self-driving-test` reports **57 passed, 3 failed**. The three are
demand-rung assertions:

```
✗ the queue clamps the batch — 3 open defects never earn a batch of 20
✗ a P0 on a light tier buys a minimal fast cycle, not a skipped one
✗ a P0 on a healthy box changes nothing — the rescue is light-only
```

Pre-existing, unrelated to this branch (which touches four files, none of them
the demand or queue logic), and already tracked twice: **#3877** and **#3891**,
the latter naming the cause — the assertions test `GH_FIX_BUGS`/`GH_FIX_P0`,
"which nothing implements". That is an implementation gap needing a decision,
not a typo, so it is not folded in here.

It does not block: `self-driving-test` is a `make gate` step but is **not**
among the steps `ci.yml`'s required job runs (confirmed against the job's own
step list above). Worth knowing that the local gate and the required check
disagree here.
