### PR TITLE
fix(scripts): unbreak main's shellcheck — a useless cat in the zsh-completions harness

### DIFF
--- a/scripts/test-install-zsh-completions.sh
+++ b/scripts/test-install-zsh-completions.sh
@@ -109,7 +109,7 @@ assert_file() { # <name> <path> <want-substring>
     *)
       fail=$((fail + 1))
       echo "FAIL $name — ${path} does not contain '${want}':"
-      cat "$path" | indent
+      indent <"$path"
       ;;
   esac
 }


### PR DESCRIPTION
## What

One line. `scripts/test-install-zsh-completions.sh:112` becomes `indent <"$path"`
instead of `cat "$path" | indent`.

## Why

CI's `shellcheck` step runs `shellcheck install.sh scripts/*.sh scripts/lib/*.sh
.githooks/*`. That harness arrived with #3889 (`7971cbefb`) carrying a useless
cat on its failure branch, so the step has exited 1 on every commit since:

```
In scripts/test-install-zsh-completions.sh line 112:
      cat "$path" | indent
          ^-----^ SC2002 (style): Useless cat.
```

It went unnoticed because #3889 merged onto the already-red `main` #3917
describes — `fmt + clippy + test` was failing on the `ORACLE_RED` compile error,
which masks every step after it (the shape recorded in #3095), so the shellcheck
failure never distinguished itself. #3918 fixed the compile errors; this is what
was underneath them. Verified `7971cbefb`'s own `fmt + clippy + test` conclusion
is `failure`.

## Evidence

- `shellcheck install.sh scripts/*.sh scripts/lib/*.sh .githooks/*` — the exact
  CI invocation — is clean on this branch and reports SC2002 without it.
- `indent` is `while IFS= read -r line; do printf '       %s\n' "$line"; done`,
  i.e. a stdin filter, so the redirect is a substitution and not a rewrite.
  Checked directly: `cat f | indent` and `indent <f` emit byte-identical bytes.
- `bash scripts/test-install-zsh-completions.sh` → `17 passed, 0 failed`.

## Witness

None, and deliberately: the change is a shellcheck-clean rewrite of one line with
no behaviour to witness, and the gate step itself is the test — it fails on the
old line and passes on the new. No test was deleted.

## Scope

The one line. `main` being red invites folding in unrelated cleanups; #3918 made
the same call for the three compile errors and this follows it.

Refs #3917

## Summary by Sourcery

Bug Fixes:
- Replace the redundant `cat` pipeline in the zsh-completions installation test harness to resolve the ShellCheck SC2002 failure.