### PR TITLE
fix(scripts): the demand rungs assert through the read the governor makes (#3877, #3891)

### DIFF
--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -98,31 +98,70 @@ export PATH
 # A stub `gh` first on PATH keeps the demand half of `plan` and the whole of
 # `queue` off the network — the real `gh` is installed on the dev box, and
 # without the stub those cases would make live API calls and float with the
-# actual issue tracker. It answers `plan`'s two count queries from
-# $GH_FIX_P0 / $GH_FIX_BUGS and serves `queue` its raw payload from
-# $GH_FIX_QUEUE. The `:?` on the queue fixture is a tripwire: a case that
-# reaches it without declaring a fixture is a case that thought it was not
-# touching gh at all.
+# actual issue tracker. It serves one query, `issue list`, from $GH_FIX_QUEUE.
+# The `:?` is a tripwire: a case that reaches it without declaring a fixture is
+# a case that thought it was not touching gh at all.
 #
-# The `--version` arm answers a PROBE, not a query: `demand()` gates every
-# count behind `gh_available()`, which shells out to `gh --version` and reads
-# the exit status. Without this arm the stub fell through to its catch-all and
-# exited 1, so `plan` saw an empty queue and skipped the clamp entirely — the
-# three demand-rung cases below were red for that reason alone, and neither
-# the clamp nor the P0 rescue they name was ever actually exercised.
+# **One query, because the product now makes one read.** This stub used to
+# answer two more — `--label bug` and `--label bug --label P0`, counted out of
+# $GH_FIX_BUGS / $GH_FIX_P0 — because `demand()` shelled out for its two
+# numbers separately from the list `queue` ranked. #3854 (B1) folded all three
+# into a single read behind the issue port: `backlog::demand_from` now derives
+# both counts from the same ranked list, which is what stops the governor and
+# the queue holding two definitions of the word "defect" (that module's own
+# doc makes the argument). Those two arms therefore answered a question
+# nothing asks any more, and the cases that set the variables were driving a
+# retired code path — the reason three of them were red (#3877, #3891).
+# Demand is expressed as a *backlog fixture* below, which is the one input the
+# governor actually reads.
+#
+# The `--version` arm answers a PROBE, not a query: `gh_available()` shells out
+# to `gh --version` and reads the exit status. `demand()` no longer gates on it
+# (that is the degradation `demand_from` inherited and made explicit), but
+# `doctor` still probes, so the arm stays.
 STUB_BIN="$ROOT/bin"
 mkdir -p "$STUB_BIN"
 cat > "$STUB_BIN/gh" <<'SH'
 #!/bin/sh
 case "$*" in
-  *"--version"*)              echo "gh version 2.0.0 (stub)" ;;
-  *"--label bug --label P0"*) printf '%s\n' "${GH_FIX_P0:-0}" ;;
-  *"--label bug"*)            printf '%s\n' "${GH_FIX_BUGS:-0}" ;;
-  *"issue list"*)             cat "${GH_FIX_QUEUE:?stub gh: no queue fixture declared}" ;;
+  *"--version"*)  echo "gh version 2.0.0 (stub)" ;;
+  *"issue list"*) cat "${GH_FIX_QUEUE:?stub gh: no queue fixture declared}" ;;
   *) echo "stub gh: unexpected args: $*" >&2; exit 1 ;;
 esac
 SH
 chmod +x "$STUB_BIN/gh"
+
+# A backlog holding $1 defects, of which $2 carry P0, written to $3.
+#
+# `rank_defects` counts an issue as a defect when it is labelled `bug` or
+# `triage`, and `demand_from` counts P0 off the same list — so a fixture is
+# the honest way to say "the queue holds N, M of them urgent". Numbers are
+# what the governor derives, never what it is told.
+make_backlog() { # make_backlog <defects> <p0> <path>
+  local defects="$1" p0="$2" path="$3" i sep=""
+  : > "$path"
+  printf '[' >> "$path"
+  for i in $(seq 1 "$defects"); do
+    if [ "$i" -le "$p0" ]; then
+      printf '%s{"number":%d,"title":"defect %d","createdAt":"2026-08-0%dT00:00:00Z","url":"u","labels":[{"name":"bug"},{"name":"P0"}]}' \
+        "$sep" "$((900 + i))" "$i" "$(( (i % 9) + 1 ))" >> "$path"
+    else
+      printf '%s{"number":%d,"title":"defect %d","createdAt":"2026-08-0%dT00:00:00Z","url":"u","labels":[{"name":"bug"},{"name":"P2"}]}' \
+        "$sep" "$((900 + i))" "$i" "$(( (i % 9) + 1 ))" >> "$path"
+    fi
+    sep=","
+  done
+  printf ']\n' >> "$path"
+}
+
+# The supply rungs assert what the machine alone decides, so their backlog must
+# be genuinely EMPTY rather than merely unreadable. Both yield `Demand::default`
+# and both therefore skip the clamp — which is exactly why the empty fixture is
+# declared rather than left off: without it every supply case below would pass
+# whether the read worked or not, and a green that survives its own stub
+# breaking is the false green this file exists to prevent.
+EMPTY_BACKLOG="$ROOT/backlog-empty.json"
+printf '[]\n' > "$EMPTY_BACKLOG"
 
 # ---------------------------------------------------------------------------
 head_ "digest — the dedup key the termination oracle rests on"
@@ -291,7 +330,8 @@ want_plan() { # want_plan <name> <case_dir> "<tier build par scope bench batch a
       SELF_DRIVING_PROBE_CPU=8 SELF_DRIVING_PROBE_LOAD1=1 \
       SELF_DRIVING_PROBE_MEM_TOTAL_GB=16 SELF_DRIVING_PROBE_MEM_FREE_GB=8 \
       SELF_DRIVING_PROBE_DISK_FREE_GB=50 SELF_DRIVING_PROBE_ON_BATTERY=0 \
-      SELF_DRIVING_PROBE_CONTENTION=0 "$@" "$SD_SH" plan \
+      SELF_DRIVING_PROBE_CONTENTION=0 GH_FIX_QUEUE="$EMPTY_BACKLOG" \
+      "$@" "$SD_SH" plan \
     | awk -F= '
         $1 == "SELF_DRIVING_TIER"        { t = $2 }
         $1 == "SELF_DRIVING_LOCAL_BUILD" { b = $2 }
@@ -332,15 +372,28 @@ want_plan "a saturated box narrows concurrency and sheds the bench arm" \
 
 # Demand rungs: the queue can shrink the batch, and a P0 can rescue a light
 # cycle — but demand never upgrades the tier and never widens the batch.
+#
+# Each case declares the backlog it plans against, because that list is the
+# governor's actual input: `demand_from` ranks it once and folds it into an
+# open-defect count and a P0 count. Saying "3 defects, 2 of them P0" as a
+# fixture rather than as two environment counters is what keeps this ladder
+# honest about the single read #3854 unified — and is why these three were red
+# (#3877, #3891): they were setting counters for `gh` queries the product
+# stopped making.
+BACKLOG_3="$ROOT/backlog-3.json";      make_backlog 3 0 "$BACKLOG_3"
+BACKLOG_3P0="$ROOT/backlog-3p0.json";  make_backlog 3 2 "$BACKLOG_3P0"
+BACKLOG_9="$ROOT/backlog-9.json";      make_backlog 9 0 "$BACKLOG_9"
+
 want_plan "the queue clamps the batch — 3 open defects never earn a batch of 20" \
-  g-q1 "normal 1 2 impacted loop 3 deep" GH_FIX_BUGS=3
+  g-q1 "normal 1 2 impacted loop 3 deep" GH_FIX_QUEUE="$BACKLOG_3"
 want_plan "a P0 on a light tier buys a minimal fast cycle, not a skipped one" \
   g-q2 "light 1 1 impacted off 2 fast" \
-  SELF_DRIVING_PROBE_ON_BATTERY=1 GH_FIX_BUGS=3 GH_FIX_P0=2
+  SELF_DRIVING_PROBE_ON_BATTERY=1 GH_FIX_QUEUE="$BACKLOG_3P0"
 want_plan "a P0 on a healthy box changes nothing — the rescue is light-only" \
-  g-q3 "normal 1 2 impacted loop 3 deep" GH_FIX_BUGS=3 GH_FIX_P0=2
+  g-q3 "normal 1 2 impacted loop 3 deep" GH_FIX_QUEUE="$BACKLOG_3P0"
 want_plan "the light tier caps the batch at 5 whatever the queue holds" \
-  g-q4 "light 1 1 impacted off 5 deep" SELF_DRIVING_PROBE_ON_BATTERY=1 GH_FIX_BUGS=9
+  g-q4 "light 1 1 impacted off 5 deep" \
+  SELF_DRIVING_PROBE_ON_BATTERY=1 GH_FIX_QUEUE="$BACKLOG_9"
 
 # ---------------------------------------------------------------------------
 head_ "queue — ranked P0 > P1 > P2, oldest first inside a rank"


### PR DESCRIPTION
## What & why

`make self-driving-test` is **57 passed / 3 failed** on `main`. It is a
`make gate` step, so every push that reaches the full rung fails for a reason
the author did not cause. This makes it **60 passed**, exit 0.

The three red cases assert the governor's *demand rungs* — an open-defect
queue shrinks the batch, and a P0 buys a light tier a minimal fast cycle
rather than a skipped one.

### The feature is not missing

`stella_autonomy::plan_cycle` implements every rung the four cases describe,
and computes all four expected tuples correctly. I checked each by hand
against the code before changing anything. What rotted is how the harness
feeds it.

### What actually broke

The cases set `GH_FIX_BUGS`/`GH_FIX_P0`, which the stub `gh` served as answers
to two count queries: `--label bug` and `--label bug --label P0`.

**#3854 (B1) deleted those queries on purpose.**
`crates/stella-cli/src/self_driving_cmd/backlog.rs`'s module doc makes the
argument:

> Before B1 they were three separate `gh` invocations carrying **two**
> definitions of the word "defect" — `rank_defects`'s label filter, and a
> `--label bug` flag written into `demand`'s argv — which could disagree with
> each other about the very backlog one cycle drew its batch from. One read,
> one definition, folded two ways.

So `demand_from` derives both counts from the single ranked list that `queue`
also reads. The stub's two count arms answered a question nothing asks, and
each demand case fell through to `issue list` with no fixture — the `:?`
tripwire failed, `ranked` errored, and `Demand::default()` skipped the clamp.
Every "got" in the failure output was the bare tier default.

The harness was driving a retired code path. That is what this fixes.

## The change

- **Demand is a backlog fixture, not two counters.** `make_backlog <defects>
  <p0>` writes an issue list; a defect is whatever `rank_defects` says it is
  (labelled `bug` or `triage`), and P0 is a label on the same issues. The
  counts are *derived by the code under test*, never handed to it — which is
  the property B1 folded three `gh` calls into one to get.
- **The stub `gh` loses both count arms**, and serves the one query the
  product makes.
- **`want_plan` defaults `GH_FIX_QUEUE` to an empty backlog.** This is the
  half worth reviewing. An unreadable tracker and an empty one both yield
  `Demand::default()`, so before this change *every supply-rung case passed
  whether the read worked or not*. They now assert against a queue that is
  genuinely empty — the difference between a green and a green that survives
  its own stub breaking.

### Not chosen

#3891 offered a second option: delete the three assertions. They describe
implemented, correct behaviour, and deleting a live test to turn a gate green
is the expedient CLAUDE.md forbids. The rungs are real; only the plumbing to
them was stale.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The three assertions themselves are the witness: they fail on `main` and pass
here, and this branch changes no product code, so the flip is entirely about
whether the harness reaches the governor.

**Checked that the evidence can distinguish the claim from its opposite.** A
fixture that is merely *present* would make the cases pass without proving the
clamp runs, so I falsified it — changing `BACKLOG_3` from 3 defects to 7 moves
the observed batch to **7**:

```
✗ the queue clamps the batch — 3 open defects never earn a batch of 20
    (want 'normal 1 2 impacted loop 3 deep', got 'normal 1 2 impacted loop 7 deep')
```

Not 3 (which would mean the expectation was hard-coded) and not 20 (which
would mean the clamp never ran). So the fixture demonstrably drives the batch
through `gh issue list` → `GhIssueProvider` → `rank_defects` → `demand_from`
→ `plan_cycle`. Reverted before committing.

## The gate

- [x] `cargo fmt --check` — n/a, no Rust changed; runs clean regardless
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `make self-driving-test` — **60 checks passed**, exit 0
- [x] `shellcheck scripts/test-self-driving.sh` — clean
- [x] Docs updated where behavior/flags changed — n/a, no behaviour change
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears both above and as a commit trailer

One file changes, `scripts/test-self-driving.sh`. No product code, so the
compile-and-test tiers are unaffected by construction.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

The stale comment block above the stub — which claimed `demand()` gates its
counts behind `gh_available()`, no longer true after B1 — is corrected in the
same diff rather than left for someone to trip over.

## Anything reviewers should know?

**The empty-backlog default is a real behaviour change to the suite**, not
tidying. Twelve supply-rung cases previously ran with a stub that *failed*,
and passed because a failed read and an empty queue are indistinguishable to
the governor. If you want to see it, point `GH_FIX_QUEUE` at a non-empty
fixture and watch cases like `g-n1` start clamping — they were never asserting
what they appeared to assert.

**Closes both tracking issues.** #3877 named the cause correctly ("the demand
rungs' stub `gh` is no longer the path the plan reads"); #3891 documented the
symptom and the two options. Neither needs to stay open once this lands.

Closes #3877
Closes #3891

## Summary by Sourcery

Align the self-driving test harness with the governor's unified backlog input so demand-rung assertions exercise the implemented behavior and the gate passes reliably.

Bug Fixes:
- Update self-driving demand-rung fixtures so tests exercise the governor through the current single backlog-read path.

Enhancements:
- Replace retired defect and P0 counter fixtures with generated backlog issue fixtures whose counts are derived by the code under test.
- Default plan tests to an explicit empty backlog so supply-rung checks verify successful empty reads rather than silently passing after stub failures.
- Simplify the stub GitHub CLI to support the issue-list query and retain version probing.

Tests:
- Restore coverage for queue batch clamping and light-tier P0 rescue scenarios while keeping the self-driving test suite aligned with current backlog behavior.