### PR TITLE
fix(arenabench): resolve Stella sources through the published seam, not parents[2]

### DIFF
--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -323,10 +323,15 @@ class RoleConfig:
         return self.model is None and self.reasoning is None and self.effort is None
 
 
-#: The pipeline responsibilities an arm may ablate or reassign, matching
-#: ``stella_pipeline::roster`` (#2381). Names are Stella's ``ModelCallRole``
-#: wire tokens, so a match template and the engine it configures spell each job
-#: identically — the same agreement :data:`ROLES` has with the settings keys.
+#: The pipeline responsibilities an arm may ablate or reassign (#2381). Names
+#: are Stella's ``ModelCallRole`` wire tokens, so a match template and the
+#: engine it configures spell each job identically — the same agreement
+#: :data:`ROLES` has with the settings keys.
+#:
+#: These matched ``stella_pipeline::roster`` when that crate existed; it has
+#: since been deleted from the Stella workspace (#3865), so no Rust list in
+#: that tree pins this tuple today. Whether a declared roster still reaches a
+#: live engine is open — see #3879.
 #:
 #: This is what makes a single-stage ablation expressible at all. ``bare_loop``
 #: settles triage, plan, witness and verify together because all four ARE the
@@ -342,20 +347,26 @@ RESPONSIBILITIES: tuple[str, ...] = (
     "verdict",
 )
 
-#: The agents a responsibility may be reassigned *to* — Stella's
-#: ``AgentId::BUILTIN`` (``crates/stella-pipeline/src/roster.rs``). Anything else
-#: is a ``RosterError::UnknownAgent`` that fails the run inside the container,
-#: after the image is built and the clock is running, so an authoring surface
-#: that offers free text charges a container build for a typo.
+#: The agents a responsibility may be reassigned *to*. An unresolvable name
+#: fails the run inside the container, after the image is built and the clock
+#: is running, so an authoring surface that offers free text charges a
+#: container build for a typo.
+#:
+#: This named Stella's ``AgentId::BUILTIN``
+#: (``crates/stella-pipeline/src/roster.rs``) until that crate was deleted
+#: (#3865). The vocabulary's surviving normative home is ``role_key()`` in
+#: ``crates/stella-cli/src/config_wiring.rs``, which is what the test below
+#: reads.
 #:
 #: **Derived, not copied.** It is :data:`ROLES` without ``default``, because
 #: ``default`` is the interactive step loop and owns no pipeline responsibility.
 #: A fourth hand-maintained spelling of a Rust vocabulary is precisely the drift
 #: ``scripts/check-role-names.sh`` was written for (#1449) — deriving from a set
 #: that guard already pins inherits the guard instead of needing a new one. The
-#: premise (that Stella's bindable agents are exactly its configurable non-default
-#: roles) is an inference, so it is asserted against the Rust source itself in
-#: ``tests/test_responsibilities.py::TestReassignmentTargets``.
+#: derivation — that ``default`` is the one role owning no responsibility — is
+#: asserted against the Rust source itself in
+#: ``tests/test_responsibilities.py::TestReassignmentTargets``, which skips
+#: when no Stella checkout is configured.
 RESPONSIBILITY_AGENTS: tuple[str, ...] = tuple(
     role for role in ROLES if role != "default"
 )

--- a/arenabench/arenabench/proof.py
+++ b/arenabench/arenabench/proof.py
@@ -110,10 +110,12 @@ def flip_outcome(ladder: Mapping[str, Any]) -> str:
 
 #: Verdict-summary prefixes the pipeline stamps when it is telling you the
 #: result is *not* backed by proof. Ordered most- to least-specific; the first
-#: match wins. Sourced from ``crates/stella-pipeline/src/verify.rs`` — the
-#: constructors that build each summary — and deliberately matched against the
-#: head of the string rather than anywhere in it, because a model's own prose
-#: quotes these words often enough to matter.
+#: match wins. Sourced from the summary constructors in the staged pipeline's
+#: ``verify.rs``, before that crate was deleted from the Stella workspace
+#: (#3865); the strings live on in recorded runs and in whatever verification
+#: plugin ports the ladder, which is what this reader parses. Deliberately
+#: matched against the head of the string rather than anywhere in it, because
+#: a model's own prose quotes these words often enough to matter.
 _HONESTY_MARKERS: tuple[tuple[str, str], ...] = (
     ("WITNESS UNSATISFIABLE", "witness_unsatisfiable"),
     ("NO WORK ATTEMPTED", "nothing_attempted"),
@@ -212,8 +214,10 @@ class TrialProof:
     #: execute.
     warranted: bool | None = None
     #: Why no proof was demanded, when it was not. One of six fixed sentences
-    #: from ``crates/stella-pipeline/src/witness/warrant.rs`` — "documentation
-    #: only; prose has no runtime behavior to flip" and its siblings.
+    #: from the staged pipeline's ``witness/warrant.rs`` — "documentation
+    #: only; prose has no runtime behavior to flip" and its siblings. That
+    #: crate is deleted from the Stella workspace (#3865); the sentences are
+    #: what recorded runs carry.
     warrant_reason: str = ""
     #: Diff size the warrant saw. Its budget lives on the ladder.
     diff_lines: int | None = None

--- a/arenabench/tests/conftest.py
+++ b/arenabench/tests/conftest.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import pytest
 
+from arenabench import sut
 from arenabench.snapshot import load_capture_status, load_manifest
 
 MATCHES = Path(__file__).parent / "fixtures" / "matches"
@@ -86,6 +87,86 @@ def _isolate_dataset_corpus(config) -> None:
     (empty / "harbor").mkdir(parents=True, exist_ok=True)
     os.environ["ARENABENCH_DATASETS"] = str(empty / "datasets")
     os.environ["HARBOR_CACHE_DIR"] = str(empty / "harbor")
+
+
+# ---------------------------------------------------------------------------
+# The Stella checkout the cross-language ratchets read
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stella_checkout() -> Path:
+    """The Stella checkout to read Rust sources from, or skip the test.
+
+    A handful of tests are *ratchets across the language boundary*: they read
+    a file in Stella's tree and assert that a constant here still agrees with
+    it. They are the reason a Rust rename cannot silently leave ArenaBench
+    spelling a role the engine no longer resolves (#1449).
+
+    They used to reach that tree as ``Path(__file__).parents[2]`` — true only
+    while this folder sits inside the Stella monorepo. That is a hard-coded
+    layout, and it fails two ways: it went stale in place when
+    ``crates/stella-pipeline`` was deleted (#3865, filed as #3919), and it
+    becomes meaningless the moment this folder is its own repository, where
+    ``parents[2]`` is whatever directory happens to be above the checkout.
+
+    So the checkout is resolved through the seam ArenaBench already publishes
+    for exactly this question — ``ARENABENCH_STELLA_REPO``, then
+    ``ARENABENCH_STELLA_ADAPTER``, then the walk-up from this package
+    (:func:`arenabench.sut.stella_repo`) — and a run with no checkout skips
+    rather than fails. That asymmetry is the whole design:
+
+    * **No checkout: skip.** ArenaBench is agent-agnostic and its own gate
+      installs no Rust tree. A ratchet against a file that is not there is not
+      a failure of this repository.
+    * **A checkout, but the file is gone or unreadable: FAIL.** That is the
+      ratchet doing its job — the authority moved and nobody told the reader.
+      Repoint the test in the same change; never soften it to a skip, which is
+      how #3919 stayed invisible for as long as it did.
+    """
+    repo = sut.stella_repo()
+    if repo is None:
+        pytest.skip(
+            "no Stella checkout to read: "
+            f"{sut.repo_problem()} These assertions are a cross-language "
+            "ratchet against Stella's Rust sources; point "
+            "ARENABENCH_STELLA_REPO at a checkout to run them."
+        )
+    return repo
+
+
+@pytest.fixture
+def stella_adapter(tmp_path_factory, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A synthetic ``stella_harbor`` source tree, wired as this rig's adapter.
+
+    Building a seat's environment goes through
+    :func:`arenabench.adapter.seat_import_roots`, which stages the adapter and
+    raises :class:`~arenabench.adapter.AdapterUnavailableError` when neither
+    ``ARENABENCH_STELLA_ADAPTER`` nor a Stella checkout names one. The tests
+    that request this fixture are not about *finding* the adapter — they are
+    about what the seat's environment contains once one exists (lineage opt-in,
+    tool-set closure, credential screening, the launch command) — so they
+    supply one instead of borrowing whatever happens to sit beside the
+    checkout.
+
+    That is a strict improvement even inside the monorepo: their outcome stops
+    depending on whether the developer's `bench/harbor_adapter` is present and
+    intact. It is what makes them run at all once this folder is its own
+    repository, where there is no Stella tree to borrow from (#3919). The
+    tests that genuinely assert discovery and refusal — `test_adapter.py`'s
+    unconfigured cases — deliberately do not take this fixture.
+
+    The package holds one empty ``__init__.py`` and nothing else: staging
+    digests the files under it and refuses an empty directory, and no test
+    here imports it. The seat subprocess that would is never launched.
+    """
+    root = tmp_path_factory.mktemp("stella-adapter")
+    package = root / "stella_harbor"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setenv("ARENABENCH_STELLA_ADAPTER", str(root))
+    monkeypatch.setenv("ARENABENCH_HOME", str(root / "home"))
+    return root
 
 
 # ---------------------------------------------------------------------------

--- a/arenabench/tests/test_adapter.py
+++ b/arenabench/tests/test_adapter.py
@@ -245,7 +245,9 @@ class TestTheRigMustBeAbleToRunTheSeatItAccepts:
     def _passes(self, _interpreter: str, _roots: list[str]) -> tuple[int, str]:
         return 0, ""
 
-    def test_an_interpreter_that_cannot_import_the_seat_is_a_refusal(self) -> None:
+    def test_an_interpreter_that_cannot_import_the_seat_is_a_refusal(
+        self, stella_adapter: Path
+    ) -> None:
         problem = adapter.stella_seat_problem("/venv/bin/harbor", probe=self._fails)
         assert problem
         assert "No module named 'harbor'" in problem
@@ -254,11 +256,11 @@ class TestTheRigMustBeAbleToRunTheSeatItAccepts:
         assert "bench/harbor_adapter" in problem
         assert "uv sync" in problem
 
-    def test_a_working_interpreter_is_no_refusal(self) -> None:
+    def test_a_working_interpreter_is_no_refusal(self, stella_adapter: Path) -> None:
         assert adapter.stella_seat_problem("/venv/bin/harbor", probe=self._passes) is None
 
     def test_the_interpreter_asked_is_the_one_behind_the_harbor_script(
-        self, tmp_path: Path
+        self, tmp_path: Path, stella_adapter: Path
     ) -> None:
         """A console script's shebang is what the kernel will exec.
 
@@ -285,7 +287,7 @@ class TestTheRigMustBeAbleToRunTheSeatItAccepts:
         assert asked == [str(interpreter)]
 
     def test_a_uv_shell_wrapper_resolves_to_the_python_beside_it(
-        self, tmp_path: Path
+        self, tmp_path: Path, stella_adapter: Path
     ) -> None:
         """``uv`` writes a ``#!/bin/sh`` re-exec stub, not a Python shebang.
 
@@ -428,7 +430,7 @@ class TestTheHealthProbeStaysCheap:
     """
 
     def test_a_second_call_spends_no_subprocess(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, stella_adapter: Path
     ) -> None:
         monkeypatch.setattr(adapter, "_verdicts", {})
         calls: list[str] = []

--- a/arenabench/tests/test_arena.py
+++ b/arenabench/tests/test_arena.py
@@ -969,7 +969,9 @@ class TestOfflineTaskSource:
         runner._launch(match, spec.contestants[0], runner.resolve_harbor(match))
         return seen["command"]
 
-    def test_an_export_is_filtered_by_bare_task_name(self, tmp_path: Path, monkeypatch):
+    def test_an_export_is_filtered_by_bare_task_name(
+        self, tmp_path: Path, monkeypatch, stella_adapter
+    ):
         """Names are namespaced by the registry, not by the task. An export on
         disk is just directories and answers to the bare name — sending the
         qualified form matches nothing and ends the match at once."""
@@ -978,7 +980,7 @@ class TestOfflineTaskSource:
         assert command[command.index("--include-task-name") + 1] == "alpha"
 
     def test_a_registry_ref_is_filtered_by_qualified_task_name(
-        self, tmp_path: Path, monkeypatch
+        self, tmp_path: Path, monkeypatch, stella_adapter
     ):
         command = self._launched_command(tmp_path, monkeypatch, export=False)
         assert "--dataset" in command and "--path" not in command

--- a/arenabench/tests/test_catalog.py
+++ b/arenabench/tests/test_catalog.py
@@ -5,8 +5,10 @@ honest-degradation contract.
 
 The synthetic-source tests pin the parser's blind spots (the same ones the
 harbor adapter's ``TestCatalogCeilingParser`` learned the hard way); the
-live tests read the real files in this repository, so a catalog.rs or
-posture.py shape change fails here before it ships a broken select.
+live tests read the real files in a *configured Stella checkout*, so a
+catalog.rs or posture.py shape change fails here before it ships a broken
+select. With no checkout configured they skip — ArenaBench is agent-agnostic
+and its own gate installs no Rust tree (#3919).
 """
 
 from __future__ import annotations
@@ -17,8 +19,6 @@ import pytest
 
 from arenabench import catalog as cat
 from arenabench import sut
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 _SYNTHETIC = """
 impl Catalog {
@@ -89,23 +89,35 @@ class TestParser:
 
 
 class TestLiveSources:
-    """Against the real files in this repository — the shape ratchet."""
+    """Against the real files in a Stella checkout — the shape ratchet.
 
-    def test_the_real_catalog_parses_to_entries(self) -> None:
-        source = (_REPO_ROOT / cat._CATALOG_REL).read_text(encoding="utf-8")
+    The checkout comes from the `stella_checkout` fixture, which resolves it
+    through `ARENABENCH_STELLA_REPO` / `ARENABENCH_STELLA_ADAPTER` / the
+    walk-up and skips when there is none. These reached Stella's tree as
+    `parents[2]` until #3919 — a hard-coded monorepo layout, which stops
+    meaning anything the moment this folder is its own repository.
+
+    A missing checkout skips; a checkout whose files have moved still FAILS,
+    because that is the drift this class exists to catch.
+    """
+
+    def test_the_real_catalog_parses_to_entries(self, stella_checkout: Path) -> None:
+        source = (stella_checkout / cat._CATALOG_REL).read_text(encoding="utf-8")
         entries = cat.parse_catalog(source)
         assert entries, "the shipping catalog parsed to zero entries"
         assert all(e["slug"] and e["provider"] for e in entries)
 
-    def test_the_real_posture_yields_benchmarked_slugs(self) -> None:
-        source = (_REPO_ROOT / cat._POSTURE_REL).read_text(encoding="utf-8")
+    def test_the_real_posture_yields_benchmarked_slugs(
+        self, stella_checkout: Path
+    ) -> None:
+        source = (stella_checkout / cat._POSTURE_REL).read_text(encoding="utf-8")
         benchmarked = cat.parse_benchmarked_slugs(source)
         assert "claude-sonnet-5" in benchmarked
 
     def test_payload_groups_by_provider_and_flags_benchmarked(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, stella_checkout: Path
     ) -> None:
-        monkeypatch.setenv("ARENABENCH_STELLA_REPO", str(_REPO_ROOT))
+        monkeypatch.setenv("ARENABENCH_STELLA_REPO", str(stella_checkout))
         payload = cat.models_payload()
         providers = payload["providers"]
         assert providers, "no providers in the payload"
@@ -124,6 +136,14 @@ class TestLiveSources:
         itself running out of and nothing looked there."""
         monkeypatch.delenv("ARENABENCH_STELLA_REPO", raising=False)
         monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
+        if sut.stella_repo() is None:
+            pytest.skip(
+                "this arena is not running out of a Stella checkout, so the "
+                "walk-up this pins has nothing to find. It is the fallback "
+                "for a dev launch from inside the monorepo; configure "
+                "ARENABENCH_STELLA_REPO to exercise the configured path "
+                "instead."
+            )
         assert cat.models_payload()["providers"]
 
     def test_no_checkout_degrades_with_the_env_name(

--- a/arenabench/tests/test_lineage.py
+++ b/arenabench/tests/test_lineage.py
@@ -107,12 +107,16 @@ class TestSeatEnvironment:
         )
         return runner._agent_environment(spec, seat, run), run.notes
 
-    def test_a_clean_match_exports_nothing(self, tmp_path: Path) -> None:
+    def test_a_clean_match_exports_nothing(
+        self, tmp_path: Path, stella_adapter: Path
+    ) -> None:
         env, notes = self._env(match_from_toml(_toml_dict()), tmp_path)
         assert LINEAGE_ENV not in env
         assert not any("lineage" in note for note in notes)
 
-    def test_a_seeded_match_exports_the_id_and_says_so(self, tmp_path: Path) -> None:
+    def test_a_seeded_match_exports_the_id_and_says_so(
+        self, tmp_path: Path, stella_adapter: Path
+    ) -> None:
         env, notes = self._env(match_from_toml(_toml_dict(lineage="lin")), tmp_path)
         assert env[LINEAGE_ENV] == "lin"
         assert any("SEEDED from lineage lin" in note for note in notes)

--- a/arenabench/tests/test_responsibilities.py
+++ b/arenabench/tests/test_responsibilities.py
@@ -29,18 +29,35 @@ from arenabench.config import MatchTemplateError, dump_match, match_from_toml
 from arenabench.harbor_agent import arena_posture
 from arenabench.model import (
     RESPONSIBILITY_AGENTS,
+    ROLES,
     Engine,
     MatchSpec,
     ResponsibilityConfig,
 )
 
-_ROSTER_RS = (
-    Path(__file__).resolve().parents[2]
-    / "crates"
-    / "stella-pipeline"
-    / "src"
-    / "roster.rs"
-)
+#: Stella's normative home for the role vocabulary, relative to a checkout.
+#: ``scripts/check-role-names.sh`` names this same function as "the truth" and
+#: reads its match arms the same way, so the two halves of the contract are
+#: anchored to one file rather than to each other.
+_ROLE_KEY_RS = Path("crates") / "stella-cli" / "src" / "config_wiring.rs"
+
+#: One match arm of ``role_key()``: ``EngineAgentKind::Verifier => "verifier",``
+_ROLE_ARM = re.compile(r'EngineAgentKind::\w+\s*=>\s*"([a-z_]+)"')
+
+
+def _role_key_names(source: str) -> frozenset[str]:
+    """Every role spelling ``role_key()`` returns, read out of the Rust.
+
+    Scoped to that function's body — a bare sweep for the arm shape would also
+    collect every other ``match kind`` in the file, and those are legitimately
+    partial (``model_source`` skips ``Default``). The body ends at the first
+    column-zero ``}``, which is how ``check-role-names.sh``'s awk delimits it.
+    """
+    body = re.search(r"pub fn role_key\b.*?\n\}", source, re.DOTALL)
+    if body is None:
+        return frozenset()
+    return frozenset(_ROLE_ARM.findall(body.group()))
+
 
 HEADER = """
 [match]
@@ -255,31 +272,57 @@ class TestReassignmentTargets:
     """`RESPONSIBILITY_AGENTS` is derived, so the derivation gets asserted.
 
     The list an authoring surface offers as reassignment targets is Stella's
-    `AgentId::BUILTIN`, and ArenaBench derives it as `ROLES` minus `default`
+    role vocabulary, and ArenaBench derives it as `ROLES` minus `default`
     rather than keeping a fourth hand-maintained copy of a Rust vocabulary —
     the drift `scripts/check-role-names.sh` exists for (#1449).
 
-    The premise, that Stella's bindable agents are exactly its configurable
-    non-default roles, is an *inference*. It holds today, and this reads the
-    Rust source to say so out loud: an unresolvable name is a
-    `RosterError::UnknownAgent` raised inside the container after the image is
-    built, so a select offering one spends a container build on a typo and
-    reports it as the seat failing.
+    **What this reads, and why it changed.** It used to read
+    `AgentId::BUILTIN` out of `crates/stella-pipeline/src/roster.rs`. That
+    crate was deleted (#3865), and because the file simply vanished the test
+    became a `FileNotFoundError` that nothing surfaced — Stella's bench
+    workflow gates this suite behind a path filter, so only a PR touching
+    `bench/` or `arenabench/` ever saw it (#3919). The surviving normative
+    home for the vocabulary is `role_key()` in
+    `crates/stella-cli/src/config_wiring.rs`, which is the same file
+    `check-role-names.sh` calls "the truth", so both halves of the contract
+    now anchor to it.
+
+    That swap narrows the claim, and the narrowing is deliberate rather than
+    incidental. The old assertion was about the *bindable* set — the names a
+    roster would resolve — and inferred that it equals the configurable
+    non-default roles. With the roster gone there is no Rust list of bindable
+    agents left in the workspace to check that inference against, so it is no
+    longer asserted here and must not be read as if it were. What remains
+    assertable is the part that still has an authority: the spellings agree,
+    and the derivation drops exactly `default`. Whether `responsibilities`
+    reaches a live engine at all is a separate open question (#3879).
     """
 
-    def test_the_derived_list_is_stellas_builtin_agent_set(self) -> None:
-        source = _ROSTER_RS.read_text(encoding="utf-8")
-        match = re.search(
-            r"BUILTIN:\s*&'static\s*\[&'static\s*str\]\s*=\s*&\[(?P<names>[^\]]*)\]",
-            source,
+    def test_the_derived_list_is_stellas_configurable_role_set(
+        self, stella_checkout: Path
+    ) -> None:
+        path = stella_checkout / _ROLE_KEY_RS
+        assert path.is_file(), (
+            f"{path} does not exist. `role_key()` is Stella's normative home "
+            "for the role vocabulary; if it moved, repoint `_ROLE_KEY_RS` "
+            "here and in `scripts/check-role-names.sh` in the same change. "
+            "Do not delete this test — the last time this file's target "
+            "vanished, the failure sat unread behind a path filter (#3919)."
         )
-        assert match, f"could not find AgentId::BUILTIN in {_ROSTER_RS}"
-        builtin = tuple(re.findall(r'"([^"]+)"', match.group("names")))
-        assert builtin, "AgentId::BUILTIN parsed to zero names"
-        assert set(RESPONSIBILITY_AGENTS) == set(builtin), (
-            "the reassignment targets ArenaBench offers and the agents Stella "
-            f"resolves have diverged: {sorted(RESPONSIBILITY_AGENTS)} vs "
-            f"{sorted(builtin)}"
+        roles = _role_key_names(path.read_text(encoding="utf-8"))
+        assert roles, (
+            f"could not read any role from `role_key()` in {path}. The "
+            "function changed shape; repoint `_role_key_names`, which "
+            "deliberately fails rather than returning a silently empty set."
+        )
+        assert set(ROLES) == roles, (
+            "ArenaBench's ROLES and Stella's role_key() have diverged: "
+            f"{sorted(ROLES)} vs {sorted(roles)}"
+        )
+        assert set(RESPONSIBILITY_AGENTS) == roles - {"default"}, (
+            "the reassignment targets ArenaBench offers and the roles Stella "
+            f"configures have diverged: {sorted(RESPONSIBILITY_AGENTS)} vs "
+            f"{sorted(roles - {'default'})}"
         )
 
     def test_the_interactive_default_is_not_a_reassignment_target(self) -> None:

--- a/arenabench/tests/test_security.py
+++ b/arenabench/tests/test_security.py
@@ -91,7 +91,9 @@ class TestSeatEnvironmentIsScreened:
         assert seat.ignored_env == ("PATH", "STELLA_BINARY")
         assert seat.redacted()["ignored_env_keys"] == ["PATH", "STELLA_BINARY"]
 
-    def test_nothing_rejected_reaches_the_subprocess(self, tmp_path: Path, monkeypatch):
+    def test_nothing_rejected_reaches_the_subprocess(
+        self, tmp_path: Path, monkeypatch, stella_adapter
+    ):
         """The screen at the launch line, not only at the parser: a seat built
         by any other path must not be able to hand `Popen` a `PATH`."""
         # Stubbed at the `arenabench.harbor` seam: `_launch` resolves the

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -284,7 +284,30 @@ class TestCheckoutDiscovery:
         monkeypatch.delenv(sut.STELLA_REPO_ENV, raising=False)
         monkeypatch.delenv("ARENABENCH_STELLA_ADAPTER", raising=False)
 
-    def test_the_checkout_this_arena_runs_from_needs_no_configuration(self) -> None:
+    @pytest.fixture
+    def nested_in_a_checkout(self) -> Path:
+        """The checkout this package sits inside, or skip.
+
+        Three tests below assert the walk-up *succeeds*, and their premise is
+        that this package ships inside the repository it measures. That is a
+        fact about the layout, not about the code: it holds in the Stella
+        monorepo and stops holding the moment this folder is its own
+        repository (#3919). The other tests in this class assert the walk-up
+        correctly *declines* — an unrelated checkout, a misconfigured env —
+        and hold either way, so they take no fixture and keep running.
+        """
+        repo = sut.stella_repo()
+        if repo is None:
+            pytest.skip(
+                "this package is not nested inside a Stella checkout, so "
+                "there is no walk-up to succeed: "
+                f"{sut.repo_problem()}"
+            )
+        return repo
+
+    def test_the_checkout_this_arena_runs_from_needs_no_configuration(
+        self, nested_in_a_checkout: Path
+    ) -> None:
         found = sut.stella_repo()
         assert found is not None, (
             "the arena refused to name the checkout it is executing out of"
@@ -359,7 +382,7 @@ class TestCheckoutDiscovery:
         )
 
     def test_a_pinned_seat_launches_with_nothing_configured(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, nested_in_a_checkout: Path
     ) -> None:
         """The whole point, end to end: a staged binary for the pinned commit
         is enough to launch, with no arena-specific environment at all."""
@@ -367,7 +390,7 @@ class TestCheckoutDiscovery:
         assert sut.sut_problem_for(self._spec(head)) is None
 
     def test_the_launch_wires_the_adapter_from_that_same_checkout(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, nested_in_a_checkout: Path
     ) -> None:
         """Launching is not enough if the seat then runs nothing.
 

--- a/arenabench/tests/test_tool_set.py
+++ b/arenabench/tests/test_tool_set.py
@@ -154,10 +154,14 @@ class TestSeatEnvironment:
         )
         return runner._agent_environment(spec, seat, run)
 
-    def test_an_undeclared_match_exports_nothing(self, tmp_path) -> None:
+    def test_an_undeclared_match_exports_nothing(
+        self, tmp_path, stella_adapter
+    ) -> None:
         assert "STELLA_LEAN_TOOLS" not in self._env(_spec({}), tmp_path)
 
-    def test_a_declared_set_reaches_the_seat_as_a_closed_set(self, tmp_path) -> None:
+    def test_a_declared_set_reaches_the_seat_as_a_closed_set(
+        self, tmp_path, stella_adapter
+    ) -> None:
         # `only:` and not the bare list — the bare form adds the discovery
         # tools on top, and a four-tool arm that advertises seven is not the
         # arm the template declared or provenance records.


### PR DESCRIPTION
## What & why

Sixteen tests in `arenabench/tests/` reached the Stella tree by hard-coded monorepo layout — either `Path(__file__).parents[2]` for a Rust source, or an ambient checkout for the harbor adapter. Both are assumptions about where this folder happens to sit, not about the code, and both had already started failing:

- **`test_responsibilities.py` is red on `main` today.** It read `AgentId::BUILTIN` out of `crates/stella-pipeline/src/roster.rs`, deleted with that crate (#3865), and became a bare `FileNotFoundError`. `bench.yml` gates this suite behind a path filter, so only a PR touching `bench/` or `arenabench/` ever saw it.
- **Twelve more raise `AdapterUnavailableError`** the moment no Stella checkout sits above this folder — invisible in the monorepo, fatal the day `arenabench/` becomes its own repository, where `arenabench/.github/workflows/ci.yml` is the whole gate.

Three changes:

1. **The Rust-source ratchets resolve their checkout through the seam ArenaBench already publishes** — `arenabench.sut.stella_repo` (`ARENABENCH_STELLA_REPO` → `ARENABENCH_STELLA_ADAPTER` → the walk-up) — via a `stella_checkout` fixture. No checkout: **skip**. A checkout whose files have moved: still **FAIL**. That asymmetry is the design, not a convenience: a ratchet against a tree that is not there is not this repository's failure, but an authority that moved must never degrade to a skip — which is exactly how the roster breakage stayed invisible.

2. **`test_the_derived_list_is_stellas_builtin_agent_set` is renamed and re-anchored.** It is now `test_the_derived_list_is_stellas_configurable_role_set`, reading `role_key()` in `crates/stella-cli/src/config_wiring.rs` — the vocabulary's surviving normative home, and the same function `scripts/check-role-names.sh` calls "the truth", so both halves of the contract anchor to one file. **The claim narrows, deliberately:** the old assertion was about the *bindable* set and inferred it equals the configurable non-default roles. With the roster gone there is no Rust list of bindable agents left in the workspace to check that inference against, so it is no longer asserted and must not be read as if it were. What remains has an authority — the spellings agree, and the derivation drops exactly `default`. Whether `responsibilities` reaches a live engine at all is a separate open question (#3879), untouched here.

3. **The twelve seat-environment and probe tests take a `stella_adapter` fixture** that stages a synthetic `stella_harbor` package instead of borrowing the checkout's. They are about what a seat's environment contains (lineage opt-in, tool-set closure, credential screening, the launch command) and never about *finding* the adapter, so this makes them hermetic — a strict improvement inside the monorepo too, where their outcome used to depend on the developer's `bench/harbor_adapter` being present and intact. The tests that genuinely assert discovery and refusal deliberately take neither fixture. `test_sut.py::TestCheckoutDiscovery`'s three success cases skip instead: their premise is that this package ships *inside* the repository it measures, which is a fact about layout that ejection ends.

Also chases the deleted crate through the comments that cite it (`arenabench/model.py`, `arenabench/proof.py`), per this repo's rule that a stale comment is a bug in review.

Closes #3919

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Same tests, two conditions. **Ejected condition** = the folder copied outside the workspace, `git init`, both `ARENABENCH_STELLA_*` unset — the new repo's CI exactly.

| | before | after |
|---|---|---|
| monorepo (`cd arenabench && uv run --with pytest --no-project pytest`) | **1 failed**, 1089 passed, 6 skipped | 1090 passed, 6 skipped |
| ejected condition | **15 failed**, 1067 passed, 14 skipped | 1082 passed, 14 skipped |

The 15 → 0 was measured by reverting this diff inside the copied tree (`git apply -R`) and re-running, so the two rows are the same tests under the same interpreter.

The six new skips in the ejected condition are all checkout-dependent and say so by name (`tests/test_catalog.py` ×2, `tests/test_responsibilities.py` ×1, `tests/test_sut.py` ×3); the other eight are the pre-existing docker/corpus skips.

**Renamed test, named per the deleted-test guard:** `TestReassignmentTargets::test_the_derived_list_is_stellas_builtin_agent_set` → `test_the_derived_list_is_stellas_configurable_role_set`. Nothing is deleted.

## The gate

- [x] `cargo fmt --check` — no Rust changed; toolchain-free guards run green (`role-names`, `bench-suites`, `file-size`, `god-files`, `gate-parity`, `left-behind`, `invariants`, `doc-links`, `command-docs`, `brand-case`, `stat-portability`)
- [x] `cargo clippy` — n/a, no Rust changed
- [x] `cargo test --workspace` — n/a, no Rust changed; the Python suite this PR is about is in the table above
- [x] Docs updated where behavior changed — the changed contracts are documented in the fixtures' and tests' own docstrings, which is where this suite states them
- [x] CLA signed
- [x] `Closes #3919` appears both here and as a commit trailer

`ruff` reports two findings in touched files (`arenabench/proof.py` E501, `tests/test_sut.py` RUF012). Both were verified pre-existing by linting the `HEAD` version of each file; ruff is not gated here yet (#2193), but it **is** a job in `arenabench/.github/workflows/ci.yml`, so the new repo's first CI run will be red on the 34 findings already in the tree. That is worth clearing before the split, and is not this PR's scope.

## Nothing left behind

- [x] Filed: #3919 is what this closes. Everything found while fixing it is fixed here — the twelve adapter-dependent tests were discovered mid-change and are handled rather than deferred, which is why this PR is larger than #3919's original two-file description.

Two things noticed and deliberately **not** changed, both already tracked:
- `responsibilities` being emitted and hard-refused at launch — #3879.
- ruff's 34 pre-existing findings — #2193.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**This is one slice of the ejection cleanup, not all of it.** It fixes the arenabench-side monorepo assumptions only. The Stella-side re-pointing (the `bench.yml` step and scope filter, `check-bench-suites.sh`'s `arenabench/tests/x.py` probe, `check-role-names.sh`'s producers, `design_token_parity.rs`, `diff-view-parity.yml`, the `arena-*.sh` scripts, the file-size baseline) is untouched here and still red-on-removal.

The narrowed assertion in change 2 is the one judgement call worth a second opinion: it is a real reduction in what the test proves, made because the thing it used to prove no longer has an authority to prove it against. Restoring the stronger claim needs a Rust list of bindable agents to exist again, not a change here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZwV4HyAKFuYas5uSQeu2i)_

## Summary by Sourcery

Remove ArenaBench's hard-coded Stella checkout assumptions and make its cross-repository tests reliable both in the monorepo and as an independent repository.

Bug Fixes:
- Resolve cross-language source checks through configured Stella checkout discovery instead of assuming a monorepo directory layout.
- Make adapter-dependent tests hermetic by staging a synthetic Stella Harbor adapter, preventing failures when no checkout or local adapter is available.

Enhancements:
- Re-anchor the responsibility-role consistency test to Stella's current role vocabulary and explicitly skip only when no checkout is configured, while preserving failures for moved or changed source files.
- Skip checkout-layout-specific discovery tests when ArenaBench is not nested in a Stella repository and update stale references to the deleted pipeline roster.

Tests:
- Update catalog, responsibility, adapter, lineage, tool-set, arena, security, and SUT tests to use explicit checkout or adapter fixtures where appropriate.