### PR TITLE
fix(stella-core,stella-protocol): FallbackInfo is consumed — correct the record and audit the row (#3916)

### DIFF
--- a/crates/stella-core/src/router.rs
+++ b/crates/stella-core/src/router.rs
@@ -10,11 +10,21 @@
 //! over a caller-supplied abstraction (`ProviderProfile`) instead of any
 //! concrete catalog type, and has no I/O of its own: `resolve` is a plain
 //! synchronous function over owned data. It returns *data* describing what
-//! happened (a `ModelRef` plus an optional `FallbackInfo`); the host above
-//! this crate is what turns a `FallbackInfo` into an
-//! `AgentEvent::ProviderFallback` and pushes it onto the event channel —
-//! there is no event channel here. (That host was `stella-pipeline` when this
-//! was written; that crate was deleted in #3865.)
+//! happened (a `ModelRef` plus an optional [`FallbackInfo`]); the host above
+//! this crate is what turns that into an `AgentEvent::ProviderFallback` and
+//! pushes it onto the event channel — there is no event channel here.
+//!
+//! That host is `stella-cli`, and the whole chain is worth naming because the
+//! type's own name appears at only one end of it: `SessionFallback::
+//! resolve_fallback` (`stella-cli/src/agent/engine.rs`) reads
+//! [`RouterDecision::fallback`] and carries [`FallbackInfo::reason`] into a
+//! `ports::ResolvedFallback`, which `attempt_provider_fallback`
+//! (`stella-core/src/driver/model_fallback.rs`) sends as the event. Every step
+//! after the first destructures the value, so a search for the *type* finds
+//! the definition and nothing else — which is exactly how a reader concludes
+//! this type is unconsumed and that L-M7's "never a silent fallback" is
+//! unbacked here. It is backed; grep for `decision.fallback`, not for
+//! `FallbackInfo` (#3916).
 //!
 //! Binding lessons this module exists to satisfy: L-M3 (no `"auto"` string
 //! sentinel anywhere — absence of a pin is `Option::None`), L-M6 (role-based
@@ -275,8 +285,11 @@ impl CircuitBreaker {
 
 /// A breaker-forced provider substitution — maps directly onto
 /// `AgentEvent::ProviderFallback`'s fields. `stella-core` has no event
-/// channel; the host above it is what turns this into the real event (see
-/// the module docs). Never constructed for an intentional routing choice (e.g. verifier's
+/// channel; the host above it is what turns this into the real event —
+/// `stella-cli`'s `SessionFallback::resolve_fallback` reads it and
+/// [`Self::reason`] reaches the wire from there (the module docs name the
+/// full chain, and why grepping this type's *name* will not find it).
+/// Never constructed for an intentional routing choice (e.g. verifier's
 /// cross-family preference) — only when the originally preferred provider
 /// was unavailable (L-M7: fallback is always visible, never silent).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/stella-protocol/src/event/consumers.rs
+++ b/crates/stella-protocol/src/event/consumers.rs
@@ -184,7 +184,7 @@ pub use super::tags::SIGNAL_CONSUMERS;
 /// show up as a diff; raising it means a new variant was filed away unread,
 /// which is the exact move the ledger exists to prevent. #2703 drives it to
 /// zero, after which a new variant cannot reach `Unclassified` at all.
-pub const MAX_UNCLASSIFIED: usize = 34;
+pub const MAX_UNCLASSIFIED: usize = 33;
 
 /// What the audit found wrong with one ledger row.
 ///

--- a/crates/stella-protocol/src/event/tags.rs
+++ b/crates/stella-protocol/src/event/tags.rs
@@ -196,9 +196,19 @@ agent_event_tags! {
     GoalVerdict => "goal_verdict",
         ConsumerPosture::Unclassified { issue: "#2703" },
         &[];
+    // Audited out of the #2703 backlog by #3916. `Surfaced` rather than
+    // `Behavioral`: the swap has already happened in
+    // `stella-core/src/driver/model_fallback.rs::attempt_provider_fallback`
+    // by the time this is sent — the event announces the decision, it does
+    // not carry it, so deleting every consumer would change what a human
+    // sees and nothing the engine does. The Observatory is a genuinely
+    // selecting surface: `sessions.rs`'s journal query names
+    // `provider_fallback` in its explicit `event_type` list, counts it, and
+    // renders it as a warn chip. `stella-cli/src/diag_bridge.rs` also
+    // branches to a diagnostic record, which is recording, not deciding.
     ProviderFallback => "provider_fallback",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory];
     FileChange => "file_change",
         ConsumerPosture::Unclassified { issue: "#2703" },
         &[];


### PR DESCRIPTION
## What & why

**#3916 is wrong, and I filed it.** This corrects the record and pays back what
the false claim cost.

The issue said `stella_core::router::FallbackInfo` has no consumer anywhere in
the workspace, and that L-M7's "fallback is always visible, never silent" was
therefore unbacked on this path. The chain is complete, and always was:

```
router::resolve
  -> RouterDecision.fallback: Option<FallbackInfo>
  -> stella-cli/src/agent/engine.rs, SessionFallback::resolve_fallback
     reads `decision.fallback`, carries `fallback.reason`
  -> ports::ResolvedFallback { reason }
  -> stella-core/src/driver/model_fallback.rs::attempt_provider_fallback
     sends AgentEvent::ProviderFallback { from, to, reason }
```

### How the false claim happened

The evidence was `rg 'FallbackInfo'`, which finds the type's **name**. Every
consumer after the first destructures the *value* — `decision.fallback`, then
`fallback.reason` — so the name appears at one end of the chain only. That
search returns the same result whether the type is dead or is read through
three hops, which makes it not evidence at all. It is exactly the failure
CLAUDE.md names: check that the evidence can distinguish the claim from its
opposite.

### What it cost

While resolving #3902's merge conflicts I used this finding to **override
main's wording**. Main said "`stella-cli` is where the conversion lives now" —
accurate. I replaced it with a vaguer phrasing on the grounds that naming
`stella-cli` was a false claim. Main was right; my resolution was the
regression. This restores the naming and makes it specific enough to check.

## The change

Two edits, both aimed at the next reader rather than the compiler:

- **`router.rs`** names the full chain in the module doc — including *why the
  type's own name will not find it*, and that `decision.fallback` is the thing
  to grep. `FallbackInfo`'s own doc names its first consumer.
- **`AgentEvent::ProviderFallback` leaves the #2703 `Unclassified` backlog.**
  Having traced its consumers I can classify it honestly, which is what that
  ledger is for.

  It is **`Surfaced`, not `Behavioral`**. The posture doc's test is "whether
  removing the consumer would change what the engine *does*, not what a human
  sees" — and the provider swap has already happened inside
  `attempt_provider_fallback` before the event is sent. The event announces
  the decision; it does not carry it. `stella-cli/src/diag_bridge.rs` does
  branch on it, but into a diagnostic record, which is recording rather than
  deciding.

  `MAX_UNCLASSIFIED` drops 34 → 33. The ledger asserts equality precisely so
  that shows up as a diff.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the behaviour
      is unchanged. What changed is a doc that described the code wrongly, and
      a ledger row that said "unaudited" about something I then audited.

**The ratchet is the executable half, and I falsified it.** Restoring
`MAX_UNCLASSIFIED = 34` fails:

```
assertion `left == right` failed: 33 rows are Unclassified but
MAX_UNCLASSIFIED is 34. If you classified a signal, lower the constant in the
same commit.
```

So the lowered number is enforced, not decorative.

**Stating one limit plainly.** The `&[Surface::Observatory]` claim is verified
by *me reading* `stella-observatory/src/sessions.rs`, whose journal query names
`provider_fallback` in its explicit `event_type` list, counts it, and renders
it as a warn chip. That is a human reading, not a machine check:
`the_observatory_view_of_the_ledger_is_a_strict_subset` currently pins only
that the claim is non-empty and its tags are real, and its own comment names
**#2707** as the PR that would make it two-sided parity against the
observatory's whitelist. I am not claiming more than the harness proves.

## The gate

- [x] `cargo test -p stella-protocol` — 185 passed
- [x] `cargo clippy -p stella-protocol -p stella-core --all-targets -- -D warnings`
- [x] `make wire-schema` — OK. The tags.rs edit is `//` comments, not `///` doc
      comments on `AgentEvent` variants, so the generated wire contract is
      untouched
- [x] `cargo test -p stella-core --lib router` (19 passed), all
      `stella-observatory` suites green
- [ ] CLA signed (the bot prompts on your first PR)
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

#2707 already tracks the two-sided observatory parity this row would benefit
from; it is referenced above rather than duplicated.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The posture call is the reviewable judgement.** If you read
`diag_bridge.rs`'s branch as behavioral rather than as recording, the row
should be `Behavioral { site: "stella-cli/src/diag_bridge.rs::DomainBridge::observe" }`
instead — same ratchet drop either way. I chose `Surfaced` because the swap is
already committed by the time the event exists, so no consumer of the *event*
can change what the engine did.

**Why correct the doc rather than just close the issue.** The wrong conclusion
was reachable from an honest search, and it will be reached again by the next
person who greps for the type. The module doc now says what to grep instead.

Closes #3916

## Summary by Sourcery

Correct the fallback-consumption record and audit ProviderFallback's event classification without changing runtime behavior.

Bug Fixes:
- Correct the router documentation to accurately identify the complete fallback-consumption chain and clarify how to trace it.

Enhancements:
- Classify ProviderFallback as a surfaced Observatory signal after auditing its consumers.
- Reduce the unclassified event-consumer backlog threshold from 34 to 33.

Documentation:
- Document the stella-cli fallback consumer and the value-based search needed to find the fallback path.