### PR TITLE
feat(ci): the canary's signal reaches the merge decision — hold PRs while main is red (#3917)

### DIFF
--- a/.github/workflows/main-red-hold.yml
+++ b/.github/workflows/main-red-hold.yml
@@ -1,0 +1,65 @@
+name: main-red-hold
+
+# While `main` is known-broken, say so on the pull request (#3917).
+#
+# `main-canary.yml` asks "does main still compose?" after every merge and files
+# one labelled issue when the answer is no. On 2026-08-19 it did exactly that
+# — and four more PRs merged onto the broken tree over the next 35 minutes,
+# the first of them twelve seconds after the issue was filed. The detector was
+# never the problem. The signal had no consumer at the one place a decision
+# was still being made, which is invariant #10's shape pointed at CI.
+#
+# This job is that consumer. It compiles nothing and checks out only the
+# scripts it runs: one question to the issue tracker, seconds, on every PR.
+#
+# ── Why a separate workflow ──────────────────────────────────────────────────
+#
+# Same disjoint-trigger reasoning that gave wire-schema.yml and empty-diff.yml
+# their own files. The canary runs on `push` to main and must judge the merged
+# tree; this runs on `pull_request` and must reach a human while there is
+# still a decision to make. Folding it into ci.yml would also hide it behind
+# that workflow's `paths-ignore`, and "main does not compile" is not a fact
+# about which paths a PR touched.
+#
+# Deliberately NOT wired into `merge_group`: a queue builds the merged result,
+# which is a different and better question, and one this check does not need
+# to duplicate.
+#
+# ── Making it blocking ───────────────────────────────────────────────────────
+#
+# As shipped this reports; branch protection is what makes a report a hold,
+# and that is a repository setting rather than a file in this tree. Adding
+# "main is not known-broken" to main's required checks is the one-line change
+# that turns this from advice into the mechanism #3917 asks for. It is written
+# to be safe to require: it fails open on an unreachable tracker, and the
+# `unblocks-main` label exists so the repair is never the thing it blocks.
+
+on:
+  pull_request:
+
+# Reads the tracker and the PR's labels. Nothing here writes.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: main-red-hold-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main-red-hold:
+    name: main is not known-broken
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Hold if the canary says main is red
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Via env rather than inlined into the shell, so a PR number can
+          # never be read as script (the standard `${{ }}` injection shape in
+          # a `run:` block).
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/check-main-red-hold.sh --pr "$PR_NUMBER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,23 @@ silent failure costs here). `make main-canary` runs the same check locally
 without filing anything; `scripts/main-canary.sh`'s header carries the full
 argument, including why it deliberately does not open a fix PR (#3332).
 
+A sixth, `main-red-hold.yml`, is the canary's other half: the canary *detects*,
+and this is what consumes the detection at the point a merge is still a
+decision. It runs on `pull_request`, asks the tracker whether a `main-red`
+issue is open, and fails if one is — naming it. On 2026-08-19 the canary
+worked exactly as designed and it did not help: it filed its issue at 16:57:01,
+and four more PRs merged onto the non-compiling tree over the next 35 minutes,
+the first of them **twelve seconds later** (#3917). Once `main` is red every
+PR's checks are red too, so red stops distinguishing "your change is broken"
+from "the base is" — which is how one composition break became four breaks in
+three crates, each hiding the next. The `unblocks-main` label is the designed
+way through, so the hold never blocks its own repair, and an unreachable
+tracker fails **open** because this is the second line of defence and the
+canary's issue is the first. Compiles nothing. `make main-red-hold` asks by
+hand; `make main-red-hold-test` covers it, blocking branch included. Reporting
+becomes holding only when a maintainer adds it to main's required checks —
+a repository setting, not a file in this tree.
+
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
 id — `doc:context-reuse §4`. Moving the file cannot break it. A document with no

--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,18 @@ main-canary: ## Ask whether main still composes green (check only; no issue is f
 main-canary-test: ## Test the post-merge canary, announcements included (hermetic; not part of `gate`)
 	./scripts/test-main-canary.sh
 
+# The canary's other half: it detects, this is what consumes the detection at
+# the point a merge is still a decision (#3917). Not a gate step for the same
+# reason the canary is not — it asks the issue tracker a question, and `gate`
+# is hermetic and offline by contract.
+.PHONY: main-red-hold
+main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads the tracker)
+	@./scripts/check-main-red-hold.sh
+
+.PHONY: main-red-hold-test
+main-red-hold-test: ## Test the red-main hold, blocking branch included (hermetic; not part of `gate`)
+	./scripts/test-main-red-hold.sh
+
 .PHONY: check
 check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
 

--- a/scripts/check-main-red-hold.sh
+++ b/scripts/check-main-red-hold.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Guard: while `main` is known-broken, a pull request says so before it merges
+# onto the breakage. See #3917, filed from the incident.
+#
+# `main-canary.yml` already answers "does main still compose?" after every
+# merge, and files one labelled issue when the answer is no. On 2026-08-19 it
+# worked exactly as designed and it did not help:
+#
+#   16:55:59  #3897 merges — the composition break (it added a theme const
+#             naming a palette token #3890 had just deleted, and a test
+#             calling a function #3896 had just deleted; neither branch was
+#             wrong on its own)
+#   16:57:01  the canary files #3904, "main is red: compile fails on the
+#             merged tree"
+#   16:57:13  #3898 merges — twelve seconds later
+#   16:57:50  #3900 merges — and lands a second, unrelated break of its own
+#   17:08:54  #3902 merges
+#   17:30:56  the first fix merges
+#   17:32:07  the canary closes #3904
+#
+# Four PRs merged onto a tree that did not compile, over 35 minutes, with the
+# issue open the whole time. The detector was never the problem: the signal
+# had no consumer at the one place a decision was still being made.
+#
+# That is invariant #10's shape — "every emitted signal names its consumer" —
+# pointed at CI instead of at `AgentEvent`. This file is the consumer.
+#
+# ## Why piling on is the expensive part, not just untidy
+#
+# Once `main` is red, every PR's own checks are red too, so red stops
+# distinguishing "your change is broken" from "the base is". #3900's missing
+# import was a single-PR defect that its own CI would have caught on any other
+# day; it landed because by then nobody could tell its red apart from the red
+# everyone already had. One composition break became four breaks in three
+# crates, and each one hid the next behind it — a compile error stops the
+# build before the next crate is reached, so they had to be found one rebuild
+# at a time.
+#
+# ## What this is NOT
+#
+# Not a second `ci.yml`, and not a second canary. It compiles nothing, checks
+# out nothing, and asks one question of the issue tracker. The canary's own
+# header warns against growing it into a duplicate gate; the same warning
+# applies here with more force, because this one runs per pull request.
+#
+# ## The escape hatch, which is the whole design
+#
+# A hold that also blocks the repair is a deadlock, so the PR that unblocks
+# `main` carries the `unblocks-main` label and passes. The label is deliberate
+# rather than inferred: parsing a body for a closing keyword would guess, and
+# a human labelling a PR "this is the fix" is a statement someone made on
+# purpose and a reviewer can audit afterwards.
+#
+# ## Fail-open, deliberately, and said out loud
+#
+# If the tracker cannot be reached, this reports the failure loudly and
+# **passes**. It is the second line of defence — the canary's issue is the
+# first, and it is the one a human reads — so a GitHub API blip must not halt
+# every merge in the repository. The cost of that choice is real and is
+# stated rather than hidden: an unreachable tracker during a red `main` gets
+# the old behaviour, which is the behaviour this guard exists to improve on.
+#
+# Usage:
+#   scripts/check-main-red-hold.sh [--pr <number>]
+#   scripts/check-main-red-hold.sh --fixture-open-issues "3904" \
+#                                  --fixture-labels "bug,area:ci"
+#
+# Uses portable POSIX tools plus `gh` so it runs on a bare CI runner.
+set -uo pipefail
+
+label="main-red"
+escape_label="unblocks-main"
+pr=""
+fixture_open_issues=""
+fixture_labels=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --pr)
+    [ $# -ge 2 ] || {
+      echo "check-main-red-hold: --pr needs a number" >&2
+      exit 2
+    }
+    pr="$2"
+    shift 2
+    ;;
+  # Test-only seams. Both must be supplied together: a test that stubbed the
+  # tracker but let the label lookup reach the network would pass or fail for
+  # a reason the test did not choose.
+  --fixture-open-issues)
+    [ $# -ge 2 ] || {
+      echo "check-main-red-hold: --fixture-open-issues needs a value" >&2
+      exit 2
+    }
+    fixture_open_issues="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-labels)
+    [ $# -ge 2 ] || {
+      echo "check-main-red-hold: --fixture-labels needs a value" >&2
+      exit 2
+    }
+    fixture_labels="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    # The whole comment block after the shebang, bounded by its first
+    # non-comment line — hardcoded line numbers truncate silently the first
+    # time the header grows. Same reader as main-canary.sh's --help.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "check-main-red-hold: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+# Which issues, if any, say main is currently broken.
+if [ "$use_fixture" -eq 1 ]; then
+  open_issues="$fixture_open_issues"
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "note: gh is not installed, so this run could not ask whether main is" >&2
+    echo "      red. Passing: this guard is the second line of defence and must" >&2
+    echo "      not halt every merge when it cannot evaluate. See #3917." >&2
+    exit 0
+  fi
+  if ! open_issues="$(gh issue list --label "$label" --state open \
+    --limit 20 --json number --jq '.[].number' 2>/dev/null)"; then
+    echo "note: could not reach the issue tracker, so this run could not ask" >&2
+    echo "      whether main is red. Passing deliberately (fail-open); the" >&2
+    echo "      canary's own issue remains the primary signal. See #3917." >&2
+    exit 0
+  fi
+fi
+
+open_issues="$(printf '%s' "$open_issues" | tr -d ' ' | tr '\n' ' ')"
+open_issues="${open_issues% }"
+
+if [ -z "$open_issues" ]; then
+  # SIGPIPE ignored and the write discarded, so a reader that closed the pipe
+  # cannot turn a green verdict into a failure (the #1815 shape).
+  trap '' PIPE
+  echo "ok  no open \`$label\` issue — main is not known-broken." || true
+  exit 0
+fi
+
+# Main is red. The only question left is whether this PR is the repair.
+if [ "$use_fixture" -eq 1 ]; then
+  labels="$fixture_labels"
+elif [ -n "$pr" ]; then
+  if ! labels="$(gh pr view "$pr" --json labels --jq '.labels[].name' 2>/dev/null)"; then
+    echo "note: main is red (see $open_issues) but this run could not read PR" >&2
+    echo "      #$pr's labels, so it cannot tell a repair from a pile-on." >&2
+    echo "      Passing deliberately (fail-open). See #3917." >&2
+    exit 0
+  fi
+else
+  labels=""
+fi
+
+if printf '%s\n' "$labels" | tr ',' '\n' | grep -qx "$escape_label"; then
+  trap '' PIPE
+  echo "ok  main is red ($open_issues), and this PR is labelled \`$escape_label\`." || true
+  exit 0
+fi
+
+echo "FAIL main is red, and merging onto it is how one break becomes four." >&2
+echo "" >&2
+echo "     open \`$label\` issue(s): $open_issues" >&2
+echo "" >&2
+echo "     \`main-canary\` found the merged tree broken and filed the issue" >&2
+echo "     above. Until it closes, every PR's own checks are red for a reason" >&2
+echo "     that has nothing to do with the PR — which is exactly when a real" >&2
+echo "     defect merges unnoticed, because nobody can tell the two reds" >&2
+echo "     apart. That is not hypothetical: it is what happened on" >&2
+echo "     2026-08-19, four times in 35 minutes (#3917)." >&2
+echo "" >&2
+echo "     What to do:" >&2
+echo "       - Fixing main? Add the \`$escape_label\` label to this PR and" >&2
+echo "         re-run. That is the designed way through, not a workaround." >&2
+echo "       - Otherwise: wait. The canary closes its issue by itself the" >&2
+echo "         moment main composes again, and this check goes green with no" >&2
+echo "         action from you." >&2
+exit 1

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for scripts/check-main-red-hold.sh.
+#
+#   ./scripts/test-main-red-hold.sh     (or: make main-red-hold-test)
+#
+# No network and no `gh`: every case drives the fixture seams, so the suite is
+# the same on a bare runner as on a dev box with a live tracker.
+#
+# The case that matters most is the negative control. A hold that cannot be
+# shown to *block* is a claim rather than a guard — and this one spends its
+# life passing, because main is usually green, so nothing else would ever
+# exercise the branch it exists for.
+#
+# Deliberately not a `make gate` step, matching `main-canary-test`: the thing
+# under test is a CI-only guard that asks the issue tracker a question, and
+# the gate is hermetic and offline by contract.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-main-red-hold.sh"
+
+pass=0
+fail=0
+
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+# One assertion shape: run with both fixture seams pinned and compare the exit
+# code. An expected failure must also name its reason, because "exit 1" is
+# satisfied by a typo in the script just as well as by the defect the case is
+# about — the same discipline test-install-zsh-completions.sh applies.
+want() { # want <name> <expect-pass|expect-block> <want-substring> <issues> <labels>
+  local name="$1" expect="$2" want_text="$3" issues="$4" labels="$5"
+  local out rc
+  out="$("$SCRIPT" --fixture-open-issues "$issues" --fixture-labels "$labels" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
+    bad "$name — expected pass, got exit $rc: $out"
+    return
+  fi
+  if [ "$expect" = "expect-block" ] && [ "$rc" -eq 0 ]; then
+    bad "$name — expected the hold to BLOCK, but it passed: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — wrong reason (wanted '$want_text'): $out" ;;
+  esac
+}
+
+printf '\033[1mmain-red-hold — the canary'"'"'s signal reaches the merge decision\033[0m\n'
+
+# The ordinary day: nothing open, nothing to say.
+want "a green main lets every PR through" \
+  expect-pass "main is not known-broken" "" ""
+
+# The negative control. Without this the suite would be green on a script that
+# never blocks anything at all.
+want "an open main-red issue holds an ordinary PR" \
+  expect-block "merging onto it is how one break becomes four" "3904" ""
+
+want "the block names the issue so the reader can go read it" \
+  expect-block "3904" "3904" ""
+
+# The escape hatch: the repair must be able to land, or the hold is a deadlock.
+want "the labelled repair PR is let through" \
+  expect-pass "labelled \`unblocks-main\`" "3904" "unblocks-main"
+
+# A near-miss label must NOT open the gate — the check is exact, not a
+# substring, or `unblocks-main-later` would silently be a bypass.
+want "a label that merely contains the escape name does not bypass" \
+  expect-block "merging onto it" "3904" "unblocks-main-later"
+
+want "an unrelated label does not bypass" \
+  expect-block "merging onto it" "3904" "bug,area:ci"
+
+# Several open issues are one state, not several: main is red, once.
+want "multiple open issues still name them all" \
+  expect-block "3904 3905" "3904
+3905" ""
+
+want "the escape hatch works with several issues open too" \
+  expect-pass "labelled" "3904
+3905" "area:ci,unblocks-main"
+
+# Argument handling: a caller mistake must be a loud exit 2, never a silent
+# pass that looks like a green check.
+out="$("$SCRIPT" --pr 2>&1)"
+if [ $? -eq 2 ]; then ok "a flag missing its value exits 2, not 0"; else bad "a flag missing its value did not exit 2"; fi
+
+out="$("$SCRIPT" --nonsense 2>&1)"
+if [ $? -eq 2 ]; then ok "an unknown flag exits 2, not 0"; else bad "an unknown flag did not exit 2"; fi
+
+printf '\n'
+if [ "$fail" -eq 0 ]; then
+  printf '\033[32mmain-red-hold-test: OK\033[0m — %d checks passed\n' "$pass"
+  exit 0
+fi
+printf '\033[31mmain-red-hold-test: FAILED\033[0m — %d passed, %d failed\n' "$pass" "$fail"
+exit 1


### PR DESCRIPTION
## What & why

`main-canary.yml` detects a broken `main` and files one labelled issue. On
2026-08-19 it worked **exactly as designed**, and it did not help:

| time | event |
|---|---|
| 16:55:59 | #3897 merges — the composition break (a theme const naming a palette token #3890 had just deleted; a test calling a function #3896 had just deleted) |
| **16:57:01** | **the canary files #3904, "main is red: compile fails on the merged tree"** |
| 16:57:13 | #3898 merges — **twelve seconds later** |
| 16:57:50 | #3900 merges — and lands a second, unrelated break of its own |
| 17:08:54 | #3902 merges |
| 17:30:56 | the first fix merges |
| 17:32:07 | the canary closes #3904 |

Four PRs onto a non-compiling tree in 35 minutes, with the issue open
throughout. **Detection was never the problem.** The signal had no consumer at
the one place a decision was still being made — which is invariant #10's shape
("every emitted signal names its consumer") pointed at CI instead of at
`AgentEvent`. This PR adds the consumer.

### Why piling on is the expensive part, not just untidy

Once `main` is red, every PR's own checks are red too, so red stops
distinguishing "your change is broken" from "the base is". #3900's missing
import was a single-PR defect that its own CI would have caught on any other
day; it landed because by then nobody could tell its red from the red everyone
already had. One composition break became four breaks across three crates, and
each hid the next behind it — a compile error stops the build before the next
crate is reached, so they had to be found one rebuild at a time.

## The change

- **`scripts/check-main-red-hold.sh`** asks the tracker for an open `main-red`
  issue and fails, naming it, if one is open.
- **`.github/workflows/main-red-hold.yml`** runs it on `pull_request`.
  Compiles nothing, checks out only the script, seconds per PR. Its own file
  rather than a job in `ci.yml`, for the disjoint-trigger reason
  `wire-schema.yml` and `empty-diff.yml` have theirs — and because "main does
  not compile" is not a fact about which paths a PR touched, so it must not
  sit behind that workflow's `paths-ignore`.
- **`make main-red-hold` / `make main-red-hold-test`.** Neither is a gate step,
  matching `main-canary`: this asks the tracker a question and `gate` is
  hermetic and offline by contract.
- **AGENTS.md** gains it as the sixth workflow, beside the canary it completes.

### Two judgement calls, cheap to overrule

**The escape hatch is a label, not inference.** A hold that blocks its own
repair is a deadlock, so a PR labelled `unblocks-main` passes. Deliberate
rather than parsed out of the body for a closing keyword: a human labelling a
PR "this is the fix" is a statement someone made on purpose and a reviewer can
audit afterwards, where body-parsing guesses. The match is exact, and that is
tested — `unblocks-main-later` does **not** bypass.

**It fails open, and says so out loud.** An unreachable tracker reports loudly
and passes. This is the second line of defence — the canary's issue is the
first, and is the one a human reads — so a GitHub API blip must not halt every
merge in the repository. The cost is real and is stated rather than hidden: an
unreachable tracker during a red `main` gets today's behaviour back.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`./scripts/test-main-red-hold.sh` — **10 checks passed**, hermetic, no network,
both fixture seams pinned.

The case that matters is the **negative control**, because this guard spends
its life passing (main is usually green), so nothing else would ever exercise
the branch it exists for:

```
✓ a green main lets every PR through
✓ an open main-red issue holds an ordinary PR
✓ the block names the issue so the reader can go read it
✓ the labelled repair PR is let through
✓ a label that merely contains the escape name does not bypass
✓ an unrelated label does not bypass
✓ multiple open issues still name them all
✓ the escape hatch works with several issues open too
✓ a flag missing its value exits 2, not 0
✓ an unknown flag exits 2, not 0
```

**Run live against the real tracker** it reports `ok  no open main-red issue`.
That green is genuine rather than a broken query returning nothing: the same
query shape returns **5 rows** for `--state all` and **0** for `--state open`.

## The gate

- [x] `make guards` — exit 0, all 30 steps (`action-pins` at 75 `uses:`
      references and `gate-parity` at 30 steps both included)
- [x] `shellcheck` — clean on both new scripts
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` — unaffected; this
      compiles nothing
- [ ] CLA signed (the bot prompts on your first PR)
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #3932

**Reporting becomes holding only when a maintainer adds "main is not
known-broken" to main's required checks** — a repository setting, not a file
in this tree, so I cannot land it here. #3932 tracks that one toggle. Until
then the check still appears on every PR, red and naming the issue, at exactly
the moment the merge decision is made; what it cannot do yet is *stop* the
merge. It is written to be safe to require: fail-open plus the label.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls from the product (this is CI-only, and it
      reads the repository's own issue tracker)

## Anything reviewers should know?

**This deliberately does not touch `main-canary.yml`.** That file's header
warns against growing it into a second `ci.yml`, and the warning applies here
with more force since this runs per pull request. The canary detects; this
consumes. Keeping them separate is what keeps either from becoming the thing
that gets muted (#1464).

**A merge queue would be strictly better for the composition case** — it
builds the merged result, which is the question no pre-merge check can
otherwise answer, and would have caught #3890+#3897 before either landed. This
is not a substitute for that decision; it is the part that needs no repository
reconfiguration to be useful, and it also covers the *second* failure this
incident showed, which a queue does not: that once main is red, the next
author cannot tell their own break apart from the inherited one.

Closes #3917

## Summary by Sourcery

Add a pull-request safeguard that warns when `main` is known-broken while preserving a deliberate path for repair changes to merge.

New Features:
- Add a pull-request workflow that checks for open `main-red` issues and reports when the base branch is known-broken.
- Provide an `unblocks-main` label-based escape hatch for repair pull requests and fail-open behavior when the issue tracker cannot be queried.

Enhancements:
- Connect the post-merge canary's failure signal to pull-request merge decisions without adding compilation or product runtime changes.

Build:
- Add Makefile targets for running the main-red hold check and its hermetic test suite.

CI:
- Add read-only, pull-request-triggered CI coverage for detecting and communicating a broken `main` branch.

Documentation:
- Document the main-red hold workflow and its relationship to the main canary in AGENTS.md.

Tests:
- Add hermetic witness tests covering green, blocked, repair, label-matching, multiple-issue, and argument-validation cases.