### PR TITLE
feat(stella-autonomy): the self-driving decision core — convention, deliver, step, doctrine (#3599)

### DIFF
--- a/crates/stella-autonomy/src/convention.rs
+++ b/crates/stella-autonomy/src/convention.rs
@@ -1,0 +1,454 @@
+//! How this repository writes issues, learned rather than assumed.
+//!
+//! `doc:backlog-self-driving` §3.1a. The loop files issues — that is the whole
+//! point of `backlog file`, and it is what makes "nothing left behind" a
+//! guarantee instead of a habit. But a tracker is not a bag of text. Every
+//! repository the loop attaches to already has a classification scheme and a
+//! writing standard, and filing into it wrongly is worse than not filing at
+//! all: the queue the loop ranks is the queue the loop just polluted.
+//!
+//! # The defect this exists to prevent
+//!
+//! It is a feedback loop, and it is specific to *this* repository's
+//! automation. [`crate::rank_defects`] counts an issue as a defect if it
+//! carries `bug` **or** `triage` — an untriaged issue is a defect nobody has
+//! classified yet. Meanwhile `.github/workflows/issue-triage.yml` adds
+//! `triage` to any issue opened without one of its `TYPE_LABELS`
+//! (`bug feature epic documentation question`), and the comment above that
+//! rule says why: "Issues opened outside the template (`gh issue create`, the
+//! API) carry no labels at all — those are exactly the ones this catches."
+//!
+//! A loop filing through the API is exactly that case. So an unlabelled
+//! filing is stamped `triage` by the workflow, and the loop's own next cycle
+//! reads it back as an untriaged defect it is responsible for triaging. The
+//! loop manufactures its own queue, and every measure of whether it is
+//! gaining or losing ground against the backlog silently includes its own
+//! exhaust. `a_filing_that_omits_the_type_axis_is_refused` is the witness.
+//!
+//! # Why the standard is learned and not written down here
+//!
+//! Because it is not ours. A convention hardcoded here would fit this
+//! repository and fail the next one, which is the same mistake
+//! `stella_protocol::issue` refuses when it declines to model a Jira workflow
+//! scheme — the customer's vocabulary is the customer's. What is portable is
+//! the *shape* of a convention (axes, membership, requirement, reserved
+//! labels) and the precedence rule for learning it, and that is all this
+//! module holds.
+//!
+//! # No workspace dependency, deliberately
+//!
+//! This crate depends on no other workspace crate, which is what lets
+//! `stella-observatory` link its folds without linking the machinery it
+//! observes. So [`conform`] takes borrowed label text rather than a
+//! `stella_protocol::Issue`, exactly as [`crate::rank_defects`] keeps its own
+//! [`crate::QueueIssue`] input type for the same reason, and the one mapping
+//! from a tracker's shape into this one lives in the caller.
+
+use serde::{Deserialize, Serialize};
+
+/// Where a rule about how issues are written came from.
+///
+/// This is a precedence order, strongest first, and the ordering is the whole
+/// value of the type: two sources will disagree, and the tie has to break the
+/// same way every time or the loop's filings drift as the repository changes
+/// around it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConventionSource {
+    /// Automation acts on it.
+    ///
+    /// The only source that is a fact rather than a claim. A workflow that
+    /// adds `triage` to an untyped issue is not *describing* a convention, it
+    /// **is** one — it will do that to the loop's filings whatever any
+    /// document says. Read this first and let it win, because it is the only
+    /// source that can be wrong about itself in no way at all.
+    Enforced,
+    /// A human wrote it down — an issue template, a label description, a
+    /// `CONTRIBUTING` section, a slash command's handoff format.
+    ///
+    /// Authoritative about intent and silent about practice. It may describe
+    /// a rule nothing enforces and everyone ignores.
+    Declared,
+    /// Inferred from the distribution over recent issues.
+    ///
+    /// The weakest source and the only one that is a guess. Used to fill an
+    /// axis the two above leave undefined, never to override either. An
+    /// inferred axis is recorded with this source precisely so a human
+    /// reading the bound convention can see which parts nobody actually
+    /// stated.
+    Observed,
+}
+
+/// How many members of an axis a conformant issue carries.
+///
+/// Named for the count rather than for a policy word like `required`, because
+/// the interesting failure is not "missing" — it is **ambiguous**. Two
+/// priority labels on one issue is not a stricter filing; it is a filing whose
+/// rank is decided by whichever label the ranker happens to test first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AxisRequirement {
+    /// Exactly one member. Absent and ambiguous are both violations.
+    ExactlyOne,
+    /// At most one member. Absent is legal; two is not.
+    AtMostOne,
+    /// Any number, including none. An axis that only groups.
+    Any,
+}
+
+/// One dimension a repository classifies issues along.
+///
+/// `type`, `priority`, `area` are this repository's three; nothing here
+/// assumes those names or that count.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LabelAxis {
+    /// What the axis is called, for a human reading a refusal.
+    pub name: String,
+    /// The labels that belong to it, as the tracker spells them.
+    pub members: Vec<String>,
+    /// How many of them a conformant issue carries.
+    pub requirement: AxisRequirement,
+    /// Where this axis was learned from.
+    pub source: ConventionSource,
+}
+
+impl LabelAxis {
+    /// Which members of this axis appear in `labels`.
+    fn present<'a>(&self, labels: &[&'a str]) -> Vec<&'a str> {
+        labels
+            .iter()
+            .filter(|l| self.members.iter().any(|m| m == *l))
+            .copied()
+            .collect()
+    }
+}
+
+/// Whether a discovered convention may steer a filing yet.
+///
+/// The loop may propose any convention and grant itself none — §7's rule,
+/// pointed at classification. This is the field that makes that structural
+/// rather than a promise in a doc comment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Acceptance {
+    /// Learned from the repository and bound. Filings conform to it.
+    Bound,
+    /// The loop found no standard and is proposing one.
+    ///
+    /// A convention in this state is **inert**: [`conform`] refuses every
+    /// filing against it, because a loop that invented a taxonomy and then
+    /// filed under it has granted itself the authority to define how this
+    /// repository classifies work. Acceptance is a human's, and under
+    /// governance mode `regulated` it stays one.
+    Proposed,
+}
+
+/// The bound classification scheme for one repository's tracker.
+///
+/// Serialized to a source-tracked manifest beside the provider manifest under
+/// `.stella/issues/`, for the same reason the provider manifest is tracked: a
+/// convention that was *inferred* has to be readable by a human before it
+/// steers a filing. The loop never infers and files in one motion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BacklogConvention {
+    /// The dimensions, in the order a filing should be read.
+    pub axes: Vec<LabelAxis>,
+    /// Labels the loop must never apply itself.
+    ///
+    /// `triage` is this repository's: it marks an issue that arrived from
+    /// outside without a type, and the loop knows what it found — applying it
+    /// would be claiming to be a stranger to its own filing. Reserved is not
+    /// the same as unknown: a reserved label is one the loop is *forbidden*
+    /// to set, not one it fails to recognize.
+    #[serde(default)]
+    pub reserved: Vec<String>,
+    /// Whether this convention may steer a filing.
+    pub acceptance: Acceptance,
+}
+
+/// One reason a filing is not conformant.
+///
+/// Typed rather than a message string (invariant 5), and the variants are
+/// split by **what the caller does differently**: a missing axis is fixable by
+/// choosing a label, an ambiguous one by dropping a label, a reserved one by
+/// removing it, and an unaccepted convention is not fixable by the loop at
+/// all — it needs a human.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "violation")]
+pub enum Violation {
+    /// An `ExactlyOne` axis had no member present.
+    AxisMissing {
+        /// The axis that was not satisfied.
+        axis: String,
+        /// What could have satisfied it, so a refusal is actionable.
+        candidates: Vec<String>,
+    },
+    /// An axis admitting at most one member had several.
+    AxisAmbiguous {
+        /// The axis that was over-satisfied.
+        axis: String,
+        /// The members that were all present.
+        present: Vec<String>,
+    },
+    /// The filing carried a label the loop is forbidden to apply.
+    ReservedApplied {
+        /// The reserved label that appeared.
+        label: String,
+    },
+    /// The convention has not been accepted, so nothing may be filed under it.
+    ConventionUnaccepted,
+}
+
+/// The verdict on one prospective filing.
+///
+/// Deliberately not a `bool` and not a `Result<(), Vec<Violation>>`: the
+/// caller has to render every violation to a human at once. A filing refused
+/// one reason at a time is a filing refused four times.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "conformance")]
+pub enum Conformance {
+    /// The filing may be sent to the tracker.
+    Conformant,
+    /// It may not, and here is every reason.
+    Refused {
+        /// Every violation found, in axis order then reserved order. Never
+        /// empty — an empty refusal would be a conformant filing.
+        violations: Vec<Violation>,
+    },
+}
+
+impl Conformance {
+    /// Whether the filing may be sent.
+    #[must_use]
+    pub fn is_conformant(&self) -> bool {
+        matches!(self, Self::Conformant)
+    }
+}
+
+/// Decide whether a prospective filing may be sent to the tracker.
+///
+/// **Conform or refuse**, never best-effort. The module docs carry the
+/// argument: a filing the tracker's automation will re-label is a filing the
+/// loop will read back as somebody else's untriaged defect.
+///
+/// `labels` is the set the loop proposes to apply. Duplicates are tolerated —
+/// a label applied twice is one label — but they are counted once, so
+/// `["P1", "P1"]` is not ambiguous.
+#[must_use]
+pub fn conform(convention: &BacklogConvention, labels: &[&str]) -> Conformance {
+    if convention.acceptance == Acceptance::Proposed {
+        return Conformance::Refused {
+            violations: vec![Violation::ConventionUnaccepted],
+        };
+    }
+
+    let mut violations = Vec::new();
+
+    for axis in &convention.axes {
+        let mut present = axis.present(labels);
+        present.sort_unstable();
+        present.dedup();
+
+        match (axis.requirement, present.len()) {
+            (AxisRequirement::ExactlyOne, 0) => violations.push(Violation::AxisMissing {
+                axis: axis.name.clone(),
+                candidates: axis.members.clone(),
+            }),
+            (AxisRequirement::ExactlyOne | AxisRequirement::AtMostOne, n) if n > 1 => {
+                violations.push(Violation::AxisAmbiguous {
+                    axis: axis.name.clone(),
+                    present: present.iter().map(|s| (*s).to_owned()).collect(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    for label in &convention.reserved {
+        if labels.contains(&label.as_str()) {
+            violations.push(Violation::ReservedApplied {
+                label: label.clone(),
+            });
+        }
+    }
+
+    if violations.is_empty() {
+        Conformance::Conformant
+    } else {
+        Conformance::Refused { violations }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This repository's actual convention, as
+    /// `.github/workflows/issue-triage.yml` enforces it and
+    /// `scripts/self-driving/commands/self-driving/tickets.md` declares it.
+    fn stella() -> BacklogConvention {
+        BacklogConvention {
+            axes: vec![
+                LabelAxis {
+                    name: "type".into(),
+                    members: ["bug", "feature", "epic", "documentation", "question"]
+                        .iter()
+                        .map(|s| (*s).to_owned())
+                        .collect(),
+                    requirement: AxisRequirement::ExactlyOne,
+                    source: ConventionSource::Enforced,
+                },
+                LabelAxis {
+                    name: "priority".into(),
+                    members: ["P0", "P1", "P2"].iter().map(|s| (*s).to_owned()).collect(),
+                    requirement: AxisRequirement::AtMostOne,
+                    source: ConventionSource::Declared,
+                },
+                LabelAxis {
+                    name: "area".into(),
+                    members: ["area:core", "area:cli", "area:protocol"]
+                        .iter()
+                        .map(|s| (*s).to_owned())
+                        .collect(),
+                    requirement: AxisRequirement::Any,
+                    source: ConventionSource::Declared,
+                },
+            ],
+            reserved: vec!["triage".into()],
+            acceptance: Acceptance::Bound,
+        }
+    }
+
+    /// The witness. A filing with no type label is refused *before* it reaches
+    /// the tracker, rather than being filed, stamped `triage` by
+    /// `issue-triage.yml`, and read back by `rank_defects` as an untriaged
+    /// defect the loop must now triage.
+    #[test]
+    fn a_filing_that_omits_the_type_axis_is_refused() {
+        let verdict = conform(&stella(), &["P1", "area:core"]);
+
+        let Conformance::Refused { violations } = verdict else {
+            panic!("an untyped filing must not reach the tracker: {verdict:?}");
+        };
+        assert_eq!(
+            violations,
+            vec![Violation::AxisMissing {
+                axis: "type".into(),
+                candidates: vec![
+                    "bug".into(),
+                    "feature".into(),
+                    "epic".into(),
+                    "documentation".into(),
+                    "question".into(),
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn a_fully_classified_filing_is_conformant() {
+        assert!(conform(&stella(), &["bug", "P1", "area:core"]).is_conformant());
+    }
+
+    /// The priority axis admits at most one member, and two is not a stricter
+    /// filing — it is one whose rank depends on which label the ranker tests
+    /// first.
+    #[test]
+    fn two_members_of_a_single_valued_axis_are_ambiguous_not_stricter() {
+        let verdict = conform(&stella(), &["bug", "P0", "P2"]);
+
+        let Conformance::Refused { violations } = verdict else {
+            panic!("two priorities must not pass: {verdict:?}");
+        };
+        assert_eq!(
+            violations,
+            vec![Violation::AxisAmbiguous {
+                axis: "priority".into(),
+                present: vec!["P0".into(), "P2".into()],
+            }]
+        );
+    }
+
+    /// An axis whose requirement is `Any` never fails, in either direction.
+    #[test]
+    fn an_any_axis_accepts_none_and_several() {
+        assert!(conform(&stella(), &["bug"]).is_conformant());
+        assert!(conform(&stella(), &["bug", "area:core", "area:cli"]).is_conformant());
+    }
+
+    /// `triage` marks an issue that arrived from outside without a type. The
+    /// loop knows what it found, so applying it would be claiming to be a
+    /// stranger to its own filing.
+    #[test]
+    fn the_loop_may_not_apply_a_reserved_label() {
+        let verdict = conform(&stella(), &["bug", "triage"]);
+
+        let Conformance::Refused { violations } = verdict else {
+            panic!("the loop must not triage its own filing: {verdict:?}");
+        };
+        assert_eq!(
+            violations,
+            vec![Violation::ReservedApplied {
+                label: "triage".into(),
+            }]
+        );
+    }
+
+    /// Every reason at once: a filing refused one reason at a time is a filing
+    /// refused four times.
+    #[test]
+    fn a_refusal_carries_every_violation_not_the_first() {
+        let verdict = conform(&stella(), &["P0", "P1", "triage"]);
+
+        let Conformance::Refused { violations } = verdict else {
+            panic!("expected a refusal: {verdict:?}");
+        };
+        assert_eq!(violations.len(), 3, "{violations:?}");
+        assert!(matches!(violations[0], Violation::AxisMissing { .. }));
+        assert!(matches!(violations[1], Violation::AxisAmbiguous { .. }));
+        assert!(matches!(violations[2], Violation::ReservedApplied { .. }));
+    }
+
+    /// A label applied twice is one label, not an ambiguity.
+    #[test]
+    fn a_duplicated_label_is_counted_once() {
+        assert!(conform(&stella(), &["bug", "P1", "P1"]).is_conformant());
+    }
+
+    /// The structural half of "the loop may propose any convention and grant
+    /// itself none". A proposed convention is inert: it does not merely warn,
+    /// it refuses, so there is no code path where the loop files under a
+    /// taxonomy it invented.
+    #[test]
+    fn a_proposed_convention_files_nothing() {
+        let mut proposed = stella();
+        proposed.acceptance = Acceptance::Proposed;
+
+        let verdict = conform(&proposed, &["bug", "P1", "area:core"]);
+
+        assert_eq!(
+            verdict,
+            Conformance::Refused {
+                violations: vec![Violation::ConventionUnaccepted],
+            },
+            "a filing that would be conformant under a bound convention must \
+             still be refused under a proposed one"
+        );
+    }
+
+    /// Precedence is the whole value of [`ConventionSource`], so the ordering
+    /// is asserted rather than left to the declaration order surviving an edit.
+    #[test]
+    fn enforced_outranks_declared_outranks_observed() {
+        assert!(ConventionSource::Enforced < ConventionSource::Declared);
+        assert!(ConventionSource::Declared < ConventionSource::Observed);
+    }
+
+    #[test]
+    fn a_convention_round_trips_through_json() {
+        let convention = stella();
+        let json = serde_json::to_string(&convention).expect("serialize");
+        let back: BacklogConvention = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(convention, back);
+    }
+}

--- a/crates/stella-autonomy/src/deliver.rs
+++ b/crates/stella-autonomy/src/deliver.rs
@@ -1,0 +1,594 @@
+//! The PR rhythm, as arithmetic.
+//!
+//! `doc:backlog-self-driving` §3.3. Once the loop has a verified diff it has to
+//! *ship* it, and shipping is a sequence of decisions over observed facts:
+//! CI concluded, a review asked for something, the base moved, the same fix
+//! failed twice. None of that needs a model, and this module is where the
+//! deciding lives so that `deliver next` **buys no model call** — only *doing*
+//! the thing it decided (writing the fix for a red build) is a `work`
+//! invocation.
+//!
+//! That mirrors the terminality rule the deleted staged pipeline held for
+//! `ladder_decision`: every arm of this machine ends in an action, and no arm
+//! escalates to a model to ask what it should have concluded.
+//!
+//! # Two commitments, both paid for already
+//!
+//! **[`PrState::CiRed`] and [`PrState::BaseBroken`] are different states.** A
+//! failure that reproduces on the base branch is not this PR's failure, and
+//! treating it as one burns every cycle on somebody else's breakage. That is
+//! not hypothetical here: it is the first diagnostic question
+//! `/self-driving:evolve` asks under `STUCK`, and `main-canary.yml` exists
+//! because this repository's `main` does go red on its own. The machine splits
+//! them structurally, so the loop cannot get it wrong by forgetting to ask.
+//! `a_red_build_that_reproduces_on_the_base_is_not_this_prs_fault` is the
+//! witness, and `the_same_red_build_on_a_green_base_does_earn_a_fix` is its
+//! other half — either assertion alone would pass on a machine that always
+//! answered one way.
+//!
+//! **[`PrState::Escalated`] is terminal and reachable from everywhere.** A loop
+//! that cannot give up is a loop that pushes the same broken fix forever.
+//! Repeat-failure counting is here, in the pure machine; the ceiling is policy,
+//! because how many attempts are worth buying is a spend question and spend is
+//! the operator's.
+
+use serde::{Deserialize, Serialize};
+
+/// What a CI run concluded, collapsed to what the loop decides on.
+///
+/// Three, not a forge's full vocabulary: a cancelled run, a skipped run and a
+/// run that never started are all "no answer yet" as far as the next action is
+/// concerned, and flattening them here keeps every forge adapter from having to
+/// invent a mapping into a richer enum nothing branches on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiConclusion {
+    /// No conclusion yet. Waiting is the only honest action.
+    Pending,
+    /// Every required check passed.
+    Green,
+    /// At least one required check failed.
+    Red,
+}
+
+/// Whether the branch can merge as-is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mergeability {
+    /// No conflict with the base.
+    Clean,
+    /// The base moved under it.
+    Conflicted,
+    /// The forge has not computed it yet. Distinct from [`Self::Clean`] on
+    /// purpose: GitHub reports `null` while it computes, and reading that as
+    /// "clean" is how a merge is attempted into a conflict.
+    Unknown,
+}
+
+/// What human review has said, if anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewState {
+    /// Nobody has reviewed it.
+    None,
+    /// A reviewer asked for changes. Outranks a green build.
+    ChangesRequested,
+    /// A reviewer approved it.
+    Approved,
+}
+
+/// One read of the forge. Facts only — no decisions, per §3.3.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Observation {
+    /// What this PR's checks concluded.
+    pub ci: CiConclusion,
+    /// What the *same* checks concluded on the base branch.
+    ///
+    /// The load-bearing field, and the reason `deliver observe` reads twice.
+    /// Without it a red build is indistinguishable from an inherited one, and
+    /// the loop spends its whole budget fixing `main`.
+    pub base_ci: CiConclusion,
+    /// Whether the branch still merges cleanly.
+    pub mergeable: Mergeability,
+    /// What review has said.
+    pub review: ReviewState,
+    /// Whether the PR is still a draft.
+    pub draft: bool,
+}
+
+/// How many times the loop has already tried each remedy on this PR.
+///
+/// Counting lives in the pure machine so that "we have been here before" is a
+/// fact the transition can read, rather than a judgement the caller makes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attempts {
+    /// Pushes made in response to a red build on this PR.
+    pub fixes: u32,
+    /// Rebases made in response to a conflict.
+    pub rebases: u32,
+}
+
+/// The operator's ceilings. Policy, not arithmetic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliverPolicy {
+    /// How many fix pushes to buy before escalating to a human.
+    pub fix_ceiling: u32,
+    /// How many rebases to buy before escalating.
+    pub rebase_ceiling: u32,
+    /// Whether a human approval is required before merging.
+    ///
+    /// **Deliberately explicit rather than implied by the forge.** A loop
+    /// running unattended against a repository whose branch protection does not
+    /// require review will merge its own work, and that is a decision an
+    /// operator should make in a config file they can read — not one they
+    /// discover from the fact that it happened.
+    pub require_approval: bool,
+}
+
+impl Default for DeliverPolicy {
+    /// Conservative: two fixes, one rebase, and a human on the merge.
+    ///
+    /// A default that merges without review would make the *safe* choice the
+    /// one an operator has to remember to opt into.
+    fn default() -> Self {
+        Self {
+            fix_ceiling: 2,
+            rebase_ceiling: 1,
+            require_approval: true,
+        }
+    }
+}
+
+/// Where a PR the loop opened currently is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrState {
+    /// Opened, not yet pushed for checks.
+    Draft,
+    /// Checks are running.
+    CiPending,
+    /// This PR's checks failed and the base is green, so it is this PR's fault.
+    CiRed,
+    /// This PR's checks failed and so does the base. Not this PR's fault.
+    BaseBroken,
+    /// The base moved under it.
+    Conflicted,
+    /// Green, out of draft, waiting on review.
+    ReadyForReview,
+    /// A reviewer asked for changes.
+    ReviewChangesRequested,
+    /// Cleared to merge.
+    Approved,
+    /// Landed. Terminal.
+    Merged,
+    /// Handed to a human. Terminal.
+    Escalated,
+}
+
+impl PrState {
+    /// Whether the machine is done with this PR either way.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Merged | Self::Escalated)
+    }
+}
+
+/// Why the loop gave up.
+///
+/// Typed because a human reading an escalation needs to know whether to fix
+/// something, wait for something, or change a ceiling — three different next
+/// moves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationReason {
+    /// The same build kept failing after the policy's fix ceiling.
+    FixCeilingReached,
+    /// The branch kept conflicting after the policy's rebase ceiling.
+    RebaseCeilingReached,
+    /// A reviewer asked for something the loop is not permitted to decide.
+    ReviewNeedsHuman,
+}
+
+/// The single next thing to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum Action {
+    /// Do nothing and observe again later. The correct action far more often
+    /// than the others, and naming it beats a caller inventing a sleep.
+    Wait,
+    /// Run `work` to author a fix for this PR's own failure, then push.
+    PushFix,
+    /// Rebase onto the moved base and push.
+    Rebase,
+    /// Take it out of draft.
+    MarkReady,
+    /// Merge it. Emitted only from [`PrState::Approved`].
+    Merge,
+    /// Stop, and tell a human why.
+    Escalate {
+        /// What ran out.
+        reason: EscalationReason,
+    },
+}
+
+/// The state the machine moved to, and what to do there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Transition {
+    /// Where the PR is now.
+    pub state: PrState,
+    /// The one next action.
+    pub action: Action,
+}
+
+/// The deterministic transition: given what was observed and what has already
+/// been tried, the single next action.
+///
+/// Total over its inputs and free of I/O, a clock and randomness, so the same
+/// observation always yields the same move. That is what makes a perpetual
+/// loop's behaviour reviewable after the fact rather than merely plausible.
+///
+/// # Precedence
+///
+/// The order the conditions are tested in **is** the policy, so it is stated
+/// rather than left to be reverse-engineered from the `if` chain:
+///
+/// 1. **Terminal states absorb.** [`PrState::Merged`] and
+///    [`PrState::Escalated`] never move again.
+/// 2. **A ceiling already reached escalates**, before anything else is tried.
+/// 3. **`ChangesRequested` outranks a green build** — a human asked for
+///    something, and merging past it because CI is green is the machine
+///    overruling a person.
+/// 4. **A conflict outranks CI**, because a conflicted branch's checks are
+///    describing a merge that cannot happen.
+/// 5. **A red base outranks a red build.** This is the commitment in the module
+///    docs, and it is tested before the PR is blamed for anything.
+#[must_use]
+pub fn deliver_next(
+    state: PrState,
+    obs: &Observation,
+    attempts: Attempts,
+    policy: &DeliverPolicy,
+) -> Transition {
+    // 1. Terminal states absorb.
+    if state.is_terminal() {
+        return Transition {
+            state,
+            action: Action::Wait,
+        };
+    }
+
+    // 2. A ceiling already reached escalates before anything else is tried.
+    if attempts.fixes > policy.fix_ceiling {
+        return escalate(EscalationReason::FixCeilingReached);
+    }
+    if attempts.rebases > policy.rebase_ceiling {
+        return escalate(EscalationReason::RebaseCeilingReached);
+    }
+
+    // 3. A human asking for changes outranks a green build.
+    if obs.review == ReviewState::ChangesRequested {
+        return Transition {
+            state: PrState::ReviewChangesRequested,
+            action: Action::PushFix,
+        };
+    }
+
+    // 4. A conflicted branch's checks describe a merge that cannot happen.
+    if obs.mergeable == Mergeability::Conflicted {
+        return Transition {
+            state: PrState::Conflicted,
+            action: Action::Rebase,
+        };
+    }
+
+    match obs.ci {
+        CiConclusion::Pending => Transition {
+            state: PrState::CiPending,
+            action: Action::Wait,
+        },
+
+        // 5. A red base outranks a red build: this is not the PR's failure, and
+        //    pushing a fix for it would be fixing somebody else's breakage on
+        //    this PR's budget.
+        CiConclusion::Red if obs.base_ci == CiConclusion::Red => Transition {
+            state: PrState::BaseBroken,
+            action: Action::Wait,
+        },
+        CiConclusion::Red => Transition {
+            state: PrState::CiRed,
+            action: Action::PushFix,
+        },
+
+        CiConclusion::Green => green(obs, policy),
+    }
+}
+
+/// The green path, split out because it is the only one with three outcomes.
+fn green(obs: &Observation, policy: &DeliverPolicy) -> Transition {
+    if obs.draft {
+        return Transition {
+            state: PrState::ReadyForReview,
+            action: Action::MarkReady,
+        };
+    }
+
+    // Mergeability must be *known* clean. `Unknown` means the forge has not
+    // finished computing it, and reading that as clean is how a merge is
+    // attempted into a conflict.
+    if obs.mergeable != Mergeability::Clean {
+        return Transition {
+            state: PrState::CiPending,
+            action: Action::Wait,
+        };
+    }
+
+    match (policy.require_approval, obs.review) {
+        (true, ReviewState::Approved) | (false, _) => Transition {
+            state: PrState::Approved,
+            action: Action::Merge,
+        },
+        (true, _) => Transition {
+            state: PrState::ReadyForReview,
+            action: Action::Wait,
+        },
+    }
+}
+
+fn escalate(reason: EscalationReason) -> Transition {
+    Transition {
+        state: PrState::Escalated,
+        action: Action::Escalate { reason },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs() -> Observation {
+        Observation {
+            ci: CiConclusion::Green,
+            base_ci: CiConclusion::Green,
+            mergeable: Mergeability::Clean,
+            review: ReviewState::None,
+            draft: false,
+        }
+    }
+
+    /// The witness for §3.3's first commitment. A build that fails the same way
+    /// on the base branch is not this PR's failure, and the loop must not spend
+    /// a `work` invocation authoring a fix for it.
+    #[test]
+    fn a_red_build_that_reproduces_on_the_base_is_not_this_prs_fault() {
+        let inherited = Observation {
+            ci: CiConclusion::Red,
+            base_ci: CiConclusion::Red,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::CiPending,
+            &inherited,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(
+            t,
+            Transition {
+                state: PrState::BaseBroken,
+                action: Action::Wait,
+            },
+            "a red base must not cost this PR a fix push"
+        );
+    }
+
+    /// The other half of the same gate: with a green base, the identical red
+    /// build *is* this PR's problem. Either assertion alone is half a witness.
+    #[test]
+    fn the_same_red_build_on_a_green_base_does_earn_a_fix() {
+        let mine = Observation {
+            ci: CiConclusion::Red,
+            base_ci: CiConclusion::Green,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::CiPending,
+            &mine,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.state, PrState::CiRed);
+        assert_eq!(t.action, Action::PushFix);
+    }
+
+    /// A loop that cannot give up pushes the same broken fix forever.
+    #[test]
+    fn the_fix_ceiling_escalates_and_escalation_is_terminal() {
+        let mine = Observation {
+            ci: CiConclusion::Red,
+            base_ci: CiConclusion::Green,
+            ..obs()
+        };
+        let policy = DeliverPolicy::default();
+        let spent = Attempts {
+            fixes: policy.fix_ceiling + 1,
+            rebases: 0,
+        };
+
+        let t = deliver_next(PrState::CiRed, &mine, spent, &policy);
+        assert_eq!(t.state, PrState::Escalated);
+        assert_eq!(
+            t.action,
+            Action::Escalate {
+                reason: EscalationReason::FixCeilingReached
+            }
+        );
+
+        // Terminal means terminal: observing again does not restart it.
+        let again = deliver_next(t.state, &obs(), spent, &policy);
+        assert_eq!(again.state, PrState::Escalated);
+        assert_eq!(again.action, Action::Wait);
+    }
+
+    /// Merging past a human who asked for changes because CI is green is the
+    /// machine overruling a person.
+    #[test]
+    fn changes_requested_outranks_a_green_build() {
+        let reviewed = Observation {
+            review: ReviewState::ChangesRequested,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::ReadyForReview,
+            &reviewed,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.state, PrState::ReviewChangesRequested);
+        assert_eq!(t.action, Action::PushFix);
+    }
+
+    /// `Unknown` is the forge still computing. Reading it as clean is how a
+    /// merge is attempted into a conflict.
+    #[test]
+    fn an_uncomputed_mergeability_waits_rather_than_merging() {
+        let uncomputed = Observation {
+            mergeable: Mergeability::Unknown,
+            review: ReviewState::Approved,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::ReadyForReview,
+            &uncomputed,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.action, Action::Wait, "must not merge on an unknown");
+    }
+
+    /// The only state `Merge` is ever emitted from.
+    #[test]
+    fn merge_is_reachable_only_through_approved() {
+        let approved = Observation {
+            review: ReviewState::Approved,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::ReadyForReview,
+            &approved,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.state, PrState::Approved);
+        assert_eq!(t.action, Action::Merge);
+    }
+
+    /// The unattended case, and the reason the field is explicit: with review
+    /// not required the same observation merges, and an operator can read that
+    /// choice in a config file rather than discover it from the outcome.
+    #[test]
+    fn without_required_approval_a_green_pr_merges_itself() {
+        let policy = DeliverPolicy {
+            require_approval: false,
+            ..DeliverPolicy::default()
+        };
+
+        let t = deliver_next(
+            PrState::ReadyForReview,
+            &obs(),
+            Attempts::default(),
+            &policy,
+        );
+
+        assert_eq!(t.action, Action::Merge);
+
+        // And with the conservative default, the identical observation does not.
+        let guarded = deliver_next(
+            PrState::ReadyForReview,
+            &obs(),
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+        assert_eq!(guarded.action, Action::Wait);
+    }
+
+    /// A draft that is green gets taken out of draft, not merged.
+    #[test]
+    fn a_green_draft_is_marked_ready_first() {
+        let draft = Observation {
+            draft: true,
+            review: ReviewState::Approved,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::CiPending,
+            &draft,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.state, PrState::ReadyForReview);
+        assert_eq!(t.action, Action::MarkReady);
+    }
+
+    /// A conflicted branch's checks describe a merge that cannot happen, so the
+    /// conflict is addressed before CI is believed either way.
+    #[test]
+    fn a_conflict_outranks_ci() {
+        let conflicted = Observation {
+            ci: CiConclusion::Red,
+            base_ci: CiConclusion::Green,
+            mergeable: Mergeability::Conflicted,
+            ..obs()
+        };
+
+        let t = deliver_next(
+            PrState::CiPending,
+            &conflicted,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+
+        assert_eq!(t.state, PrState::Conflicted);
+        assert_eq!(t.action, Action::Rebase);
+    }
+
+    #[test]
+    fn pending_ci_waits() {
+        let pending = Observation {
+            ci: CiConclusion::Pending,
+            ..obs()
+        };
+        let t = deliver_next(
+            PrState::Draft,
+            &pending,
+            Attempts::default(),
+            &DeliverPolicy::default(),
+        );
+        assert_eq!(t.state, PrState::CiPending);
+        assert_eq!(t.action, Action::Wait);
+    }
+
+    #[test]
+    fn a_transition_round_trips_through_json() {
+        let t = Transition {
+            state: PrState::Escalated,
+            action: Action::Escalate {
+                reason: EscalationReason::RebaseCeilingReached,
+            },
+        };
+        let json = serde_json::to_string(&t).expect("serialize");
+        let back: Transition = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(t, back);
+    }
+}

--- a/crates/stella-autonomy/src/deliver.rs
+++ b/crates/stella-autonomy/src/deliver.rs
@@ -258,10 +258,10 @@ pub fn deliver_next(
     }
 
     // 2. A ceiling already reached escalates before anything else is tried.
-    if attempts.fixes > policy.fix_ceiling {
+    if attempts.fixes >= policy.fix_ceiling {
         return escalate(EscalationReason::FixCeilingReached);
     }
-    if attempts.rebases > policy.rebase_ceiling {
+    if attempts.rebases >= policy.rebase_ceiling {
         return escalate(EscalationReason::RebaseCeilingReached);
     }
 
@@ -413,8 +413,11 @@ mod tests {
             ..obs()
         };
         let policy = DeliverPolicy::default();
+        // Exactly the ceiling: the operator bought `fix_ceiling` fixes, so
+        // having spent that many means the budget is gone — this must escalate
+        // rather than buy one more.
         let spent = Attempts {
-            fixes: policy.fix_ceiling + 1,
+            fixes: policy.fix_ceiling,
             rebases: 0,
         };
 

--- a/crates/stella-autonomy/src/doctrine.rs
+++ b/crates/stella-autonomy/src/doctrine.rs
@@ -26,7 +26,7 @@
 //! - **Prose doctrine does not.** "Prefer the architecturally sound option",
 //!   "match the neighbourhood", "no new dependencies casually" — that is
 //!   instruction for the judgement half, it already has a home in the context
-//!   record plane (`.stella/rules/*.toml`, `doc:adaptive-context/context-pr`),
+//!   record plane (`.stella/rules/*.toml`, `doc:context-pr`),
 //!   and duplicating it here would create the fifth plane. A `[doctrine]` block
 //!   that wanted to say something prose-shaped is a context record, and this
 //!   module's answer to that request is a pointer, not a field.

--- a/crates/stella-autonomy/src/doctrine.rs
+++ b/crates/stella-autonomy/src/doctrine.rs
@@ -1,0 +1,368 @@
+//! The operator's decision system, declared rather than inferred.
+//!
+//! `doc:backlog-self-driving` §6.5. Self-driving stands in for a person, and a
+//! person deciding what to do next is not running a universal algorithm — they
+//! are applying a system they developed, which differs from the next person's.
+//! One maintainer's standing instruction is *"when two designs both work, ship
+//! the one still correct in five years"*; another's is *"ship the smallest diff
+//! that closes the ticket"*. **Both are legitimate, and a loop that hardcodes
+//! either is a loop that can only replace one of them.**
+//!
+//! So the tie-breakers are configuration, and this module is their vocabulary.
+//!
+//! # What belongs here, and what deliberately does not
+//!
+//! This repository already carries **four steering planes that do not know
+//! about each other** (#3243), and the fastest way to make that five is to add
+//! a free-text "how should I decide things" field to a manifest. So the line is
+//! drawn at machine-readability:
+//!
+//! - **Enumerated tie-breakers live here.** Every field is a closed enum or a
+//!   number, consumed by the pure machines ([`crate::step`],
+//!   [`crate::deliver_next`]). No model reads this type. That is what makes an
+//!   operator's declared preference *testable* rather than hopeful — you can
+//!   assert that `ForeignBreakage::FileAndWait` does not adopt, and the
+//!   assertion cannot be talked out of.
+//! - **Prose doctrine does not.** "Prefer the architecturally sound option",
+//!   "match the neighbourhood", "no new dependencies casually" — that is
+//!   instruction for the judgement half, it already has a home in the context
+//!   record plane (`.stella/rules/*.toml`, `doc:adaptive-context/context-pr`),
+//!   and duplicating it here would create the fifth plane. A `[doctrine]` block
+//!   that wanted to say something prose-shaped is a context record, and this
+//!   module's answer to that request is a pointer, not a field.
+//!
+//! The test for whether something belongs here is the same one invariant 5
+//! applies to error types: **does a caller branch on it?** A pure machine
+//! branching on a closed enum belongs; a sentence a model reads does not.
+
+use serde::{Deserialize, Serialize};
+
+/// What to do when the base branch is broken and this loop did not break it.
+///
+/// The interesting case, and the one an operator will genuinely disagree about.
+/// A red `main` blocks *everyone*, so there is a real argument for fixing it
+/// whoever broke it — and an equally real argument that a loop wandering into
+/// unrelated code is how an autonomous system becomes a liability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForeignBreakage {
+    /// File it and wait for whoever owns it.
+    ///
+    /// The conservative reading: the loop makes the breakage *visible*, which
+    /// is the part nobody disputes, and leaves the fix to a human.
+    FileAndWait,
+    /// File it, then fix it at the top of the queue.
+    ///
+    /// A red base blocks this loop as surely as it blocks its author, and a
+    /// loop that waits for someone else is a loop whose throughput is somebody
+    /// else's response time. Filing still happens first and separately — the
+    /// ticket is what makes the work attributable even if the fix fails.
+    FileAndAdopt,
+    /// Neither file nor fix.
+    ///
+    /// Here for completeness and for the operator who wants a silent loop, and
+    /// deliberately **not** the default: an autonomous system that notices
+    /// breakage and says nothing is the worst of the three.
+    Ignore,
+}
+
+/// How to order the queue when several issues are eligible.
+///
+/// A list rather than a single choice, applied in order as tie-breakers, so an
+/// operator expresses "P0 first, then regressions, then oldest" as exactly
+/// that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueCriterion {
+    /// Priority label rank — `P0` before `P1` before `P2`.
+    Priority,
+    /// Regressions first: a witness that passed and now fails is a fact, where
+    /// an audit finding is a claim needing triage (§4.3).
+    Regression,
+    /// Oldest first. An aged issue is a worse thing to be carrying.
+    Age,
+    /// Smallest first, by whatever size signal the provider carries.
+    ///
+    /// The "keep the loop moving" preference: many small closures beat one
+    /// large one for a system whose value is partly in demonstrating progress.
+    Size,
+}
+
+/// Whether the loop may act on a subject somebody else appears to be on.
+///
+/// The distinction matters because contention evidence is *heuristic* — a
+/// remote branch whose name resembles the work is a strong hint and not a
+/// proof — and how much weight to give a hint is exactly the kind of judgement
+/// that differs between operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentionPolicy {
+    /// Any sign of another actor on this subject defers.
+    ///
+    /// The default. A duplicated fix costs two workers' time and produces a
+    /// merge conflict; a deferred one costs a poll interval.
+    Defer,
+    /// Only a held ledger claim defers; branches and worktrees are advisory.
+    ///
+    /// For a solo operator whose remote is full of their own stale branches,
+    /// where deferring on branch names would deadlock the loop against itself.
+    ClaimsOnly,
+    /// Proceed regardless. Recorded, never silent.
+    Proceed,
+}
+
+/// The operator's declared decision system.
+///
+/// Source-tracked beside the provider and convention manifests under
+/// `.stella/issues/`, for the same reason: **the person who starts the loop is
+/// the person who decides how it decides**, and that is only true if what it
+/// will do is legible before it does it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Doctrine {
+    /// What to do about breakage the loop did not cause.
+    pub foreign_breakage: ForeignBreakage,
+    /// How much weight another actor's apparent work carries.
+    pub contention: ContentionPolicy,
+    /// Whether an escalated PR parks the loop or is abandoned so it can carry
+    /// on. Parking is the default: a PR a human must look at is usually a sign
+    /// the loop should stop making more of them.
+    pub abandon_escalated: bool,
+}
+
+impl Default for Doctrine {
+    /// Conservative on every axis where the aggressive choice is the one an
+    /// operator should have to opt into: file breakage but do not adopt it,
+    /// defer on any contention, and park on an escalation.
+    fn default() -> Self {
+        Self {
+            foreign_breakage: ForeignBreakage::FileAndWait,
+            contention: ContentionPolicy::Defer,
+            abandon_escalated: false,
+        }
+    }
+}
+
+/// Evidence that somebody else may already be on this subject.
+///
+/// Gathered by the caller — the loop reads the forge and the local machine —
+/// and reduced to a decision here. Every field is a **hint**, and naming them
+/// separately is what lets [`ContentionPolicy`] weigh them differently.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Contention {
+    /// Remote branches whose names indicate work on this subject.
+    #[serde(default)]
+    pub remote_branches: Vec<String>,
+    /// Open pull requests that appear to address it.
+    #[serde(default)]
+    pub open_prs: Vec<String>,
+    /// Worktrees on **this machine** that appear to hold a fix in flight.
+    ///
+    /// The one nobody remembers to check, and the one most likely to be the
+    /// loop's own other session: two self-driving processes against one clone
+    /// will each see the other's worktree here.
+    #[serde(default)]
+    pub local_worktrees: Vec<String>,
+    /// Ledger claims held by another worker.
+    ///
+    /// The only *authoritative* signal — a lease with an owner and an expiry,
+    /// rather than a name that resembles the work.
+    #[serde(default)]
+    pub ledger_claims: Vec<String>,
+}
+
+impl Contention {
+    /// Whether anything at all suggests another actor.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.remote_branches.is_empty()
+            && self.open_prs.is_empty()
+            && self.local_worktrees.is_empty()
+            && self.ledger_claims.is_empty()
+    }
+}
+
+/// Whether the loop may proceed on a contended subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "verdict")]
+pub enum ContentionVerdict {
+    /// Nothing suggests another actor, or policy says to proceed anyway.
+    Proceed,
+    /// Somebody else appears to be on it. Carries what was seen, because
+    /// "deferred" with no evidence is not reviewable.
+    Defer {
+        /// The signals that caused the deferral, for the ledger.
+        evidence: Vec<String>,
+    },
+}
+
+/// Decide whether to act on a subject given what else appears to be in flight.
+///
+/// Pure and total. The evidence is heuristic and the policy says how much that
+/// matters — which is the split that keeps a judgement call out of the
+/// mechanism.
+#[must_use]
+pub fn contention_verdict(policy: ContentionPolicy, seen: &Contention) -> ContentionVerdict {
+    let evidence: Vec<String> = match policy {
+        ContentionPolicy::Proceed => return ContentionVerdict::Proceed,
+        // Only the authoritative signal counts.
+        ContentionPolicy::ClaimsOnly => seen
+            .ledger_claims
+            .iter()
+            .map(|c| format!("ledger claim: {c}"))
+            .collect(),
+        ContentionPolicy::Defer => seen
+            .ledger_claims
+            .iter()
+            .map(|c| format!("ledger claim: {c}"))
+            .chain(seen.open_prs.iter().map(|p| format!("open pr: {p}")))
+            .chain(
+                seen.remote_branches
+                    .iter()
+                    .map(|b| format!("remote branch: {b}")),
+            )
+            .chain(
+                seen.local_worktrees
+                    .iter()
+                    .map(|w| format!("local worktree: {w}")),
+            )
+            .collect(),
+    };
+
+    if evidence.is_empty() {
+        ContentionVerdict::Proceed
+    } else {
+        ContentionVerdict::Defer { evidence }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_files_breakage_but_does_not_adopt_it() {
+        let d = Doctrine::default();
+        assert_eq!(d.foreign_breakage, ForeignBreakage::FileAndWait);
+        assert_eq!(d.contention, ContentionPolicy::Defer);
+        assert!(!d.abandon_escalated);
+    }
+
+    /// The witness for collision avoidance: a worktree on this machine defers
+    /// the loop, and it is the signal nobody remembers to check — two
+    /// self-driving sessions against one clone see each other only here.
+    #[test]
+    fn a_local_worktree_alone_is_enough_to_defer() {
+        let seen = Contention {
+            local_worktrees: vec!["fix-3912-design-refs".into()],
+            ..Contention::default()
+        };
+
+        assert_eq!(
+            contention_verdict(ContentionPolicy::Defer, &seen),
+            ContentionVerdict::Defer {
+                evidence: vec!["local worktree: fix-3912-design-refs".into()],
+            },
+            "a fix already in flight on this machine must not be duplicated"
+        );
+    }
+
+    /// ...and the same evidence proceeds under `ClaimsOnly`, which is the whole
+    /// reason the policy exists: a solo operator's remote is full of their own
+    /// stale branches, and deferring on those deadlocks the loop against itself.
+    #[test]
+    fn claims_only_ignores_branches_and_worktrees_but_not_a_lease() {
+        let hints = Contention {
+            remote_branches: vec!["old-thing".into()],
+            local_worktrees: vec!["stale".into()],
+            open_prs: vec!["1".into()],
+            ..Contention::default()
+        };
+        assert_eq!(
+            contention_verdict(ContentionPolicy::ClaimsOnly, &hints),
+            ContentionVerdict::Proceed
+        );
+
+        let leased = Contention {
+            ledger_claims: vec!["3599@worker-2".into()],
+            ..hints
+        };
+        assert!(matches!(
+            contention_verdict(ContentionPolicy::ClaimsOnly, &leased),
+            ContentionVerdict::Defer { .. }
+        ));
+    }
+
+    /// A deferral with no evidence is not reviewable, so the evidence rides in
+    /// the verdict rather than being logged and lost.
+    #[test]
+    fn a_deferral_names_every_signal_that_caused_it() {
+        let seen = Contention {
+            remote_branches: vec!["b".into()],
+            open_prs: vec!["12".into()],
+            local_worktrees: vec!["w".into()],
+            ledger_claims: vec!["c".into()],
+        };
+
+        let ContentionVerdict::Defer { evidence } =
+            contention_verdict(ContentionPolicy::Defer, &seen)
+        else {
+            panic!("expected a deferral");
+        };
+
+        assert_eq!(evidence.len(), 4, "{evidence:?}");
+        // The authoritative signal is named first.
+        assert!(evidence[0].starts_with("ledger claim:"));
+    }
+
+    #[test]
+    fn no_evidence_proceeds_under_every_policy() {
+        for policy in [
+            ContentionPolicy::Defer,
+            ContentionPolicy::ClaimsOnly,
+            ContentionPolicy::Proceed,
+        ] {
+            assert_eq!(
+                contention_verdict(policy, &Contention::default()),
+                ContentionVerdict::Proceed,
+                "{policy:?}"
+            );
+        }
+    }
+
+    /// `Proceed` overrides even an authoritative claim — recorded, never
+    /// silent, which is why the verdict is a value rather than a bool.
+    #[test]
+    fn proceed_overrides_even_a_held_lease() {
+        let leased = Contention {
+            ledger_claims: vec!["3599@worker-2".into()],
+            ..Contention::default()
+        };
+        assert_eq!(
+            contention_verdict(ContentionPolicy::Proceed, &leased),
+            ContentionVerdict::Proceed
+        );
+    }
+
+    #[test]
+    fn a_doctrine_round_trips_through_json() {
+        let d = Doctrine {
+            foreign_breakage: ForeignBreakage::FileAndAdopt,
+            contention: ContentionPolicy::ClaimsOnly,
+            abandon_escalated: true,
+        };
+        let json = serde_json::to_string(&d).expect("serialize");
+        let back: Doctrine = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(d, back);
+    }
+
+    /// An operator who writes a partial manifest gets the conservative default
+    /// for everything they did not mention, rather than a parse error.
+    #[test]
+    fn a_partial_manifest_fills_in_conservative_defaults() {
+        let d: Doctrine =
+            serde_json::from_str(r#"{"foreign_breakage":"file_and_adopt"}"#).expect("deserialize");
+        assert_eq!(d.foreign_breakage, ForeignBreakage::FileAndAdopt);
+        assert_eq!(d.contention, ContentionPolicy::Defer);
+    }
+}

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -39,6 +39,7 @@
 //! a host refuse a build it was not written against, instead of meeting the
 //! skew as an `unrecognized subcommand` three cycles in.
 
+mod convention;
 mod surface;
 
 use std::fmt::Write as _;
@@ -46,6 +47,10 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
+pub use convention::{
+    Acceptance, AxisRequirement, BacklogConvention, Conformance, ConventionSource, LabelAxis,
+    Violation, conform,
+};
 pub use surface::{
     Emits, HOST_SURFACE, HOST_SURFACE_VERSION, HostVerb, SurfaceDrift, host_verb, surface_drift,
 };

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -41,6 +41,7 @@
 
 mod convention;
 mod deliver;
+mod step;
 mod surface;
 
 use std::fmt::Write as _;
@@ -55,6 +56,10 @@ pub use convention::{
 pub use deliver::{
     Action, Attempts, CiConclusion, DeliverPolicy, EscalationReason, Mergeability, Observation,
     PrState, ReviewState, Transition, deliver_next,
+};
+pub use step::{
+    BlockReason, CarriedPr, Clearance, IssueRef, LoopObservation, LoopState, LoopStep,
+    PrDisposition, PrRef, WakeCondition, step,
 };
 pub use surface::{
     Emits, HOST_SURFACE, HOST_SURFACE_VERSION, HostVerb, SurfaceDrift, host_verb, surface_drift,

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -40,6 +40,7 @@
 //! skew as an `unrecognized subcommand` three cycles in.
 
 mod convention;
+mod deliver;
 mod surface;
 
 use std::fmt::Write as _;
@@ -50,6 +51,10 @@ use sha2::{Digest as _, Sha256};
 pub use convention::{
     Acceptance, AxisRequirement, BacklogConvention, Conformance, ConventionSource, LabelAxis,
     Violation, conform,
+};
+pub use deliver::{
+    Action, Attempts, CiConclusion, DeliverPolicy, EscalationReason, Mergeability, Observation,
+    PrState, ReviewState, Transition, deliver_next,
 };
 pub use surface::{
     Emits, HOST_SURFACE, HOST_SURFACE_VERSION, HostVerb, SurfaceDrift, host_verb, surface_drift,

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -41,6 +41,7 @@
 
 mod convention;
 mod deliver;
+mod doctrine;
 mod step;
 mod surface;
 
@@ -57,9 +58,13 @@ pub use deliver::{
     Action, Attempts, CiConclusion, DeliverPolicy, EscalationReason, Mergeability, Observation,
     PrState, ReviewState, Transition, deliver_next,
 };
+pub use doctrine::{
+    Contention, ContentionPolicy, ContentionVerdict, Doctrine, ForeignBreakage, QueueCriterion,
+    contention_verdict,
+};
 pub use step::{
     BlockReason, CarriedPr, Clearance, IssueRef, LoopObservation, LoopState, LoopStep,
-    PrDisposition, PrRef, WakeCondition, step,
+    PrDisposition, PrRef, UnblockAttempt, WakeCondition, step,
 };
 pub use surface::{
     Emits, HOST_SURFACE, HOST_SURFACE_VERSION, HostVerb, SurfaceDrift, host_verb, surface_drift,

--- a/crates/stella-autonomy/src/step.rs
+++ b/crates/stella-autonomy/src/step.rs
@@ -1,0 +1,737 @@
+//! "What now" — the loop's top-level move, decided deterministically.
+//!
+//! `doc:backlog-self-driving` §3.7. The policy loop that drives a cycle needs
+//! somewhere deterministic to ask what to do next, or every host re-derives the
+//! cycle and they drift — which is the exact failure this crate was extracted
+//! to end (#1613: the Observatory and `stella self-driving metrics` carried two
+//! `fold_runs` and disagreed about whether the loop was `NOISY`).
+//!
+//! So the step function is pure and lives beside the governor, and a host —
+//! the shell driver today, the plugin after B2 — asks it rather than deciding.
+//!
+//! # Blocking is a first-class outcome, and it clears itself
+//!
+//! **A loop that cannot stop is not autonomous, it is unsupervised**, and those
+//! are different things. [`LoopStep::Blocked`] is reachable for a spent budget,
+//! a revoked grant, an operator stop, and an [`PrDisposition::Escalated`] PR
+//! the policy declines to abandon. It is tested before anything else, so no
+//! amount of available work can outvote a stop.
+//!
+//! **But a block is a park, not a death.** The loop resumes the moment the
+//! thing blocking it clears, and *nobody has to tell it that it may*. There is
+//! no resume input, no acknowledgement, and no operator gesture in the
+//! contract: a human who raises the ceiling, restores the grant, drops the stop
+//! flag, or merges the escalated PR has already said everything that needs
+//! saying, and asking them to also say "go" is asking twice.
+//!
+//! This is enforced structurally rather than promised: **the machine holds no
+//! latch.** [`step`] is a total function of the current state and the current
+//! observation, so a block is recomputed from scratch on every poll and simply
+//! stops being returned when its cause is gone. There is no `blocked` flag that
+//! could be left set. `a_cleared_block_resumes_with_no_resume_signal` is the
+//! witness.
+//!
+//! The one obligation this puts on a host is the one thing the machine cannot
+//! do for it: **keep polling.** A host that exits the process on
+//! [`LoopStep::Blocked`] makes resumption impossible no matter what this
+//! function returns, which is why the variant carries a [`Clearance`] naming
+//! the observable to watch instead of reading as a terminal state.
+//!
+//! # Finishing outranks starting
+//!
+//! The precedence below puts `Deliver` above `Claim` deliberately. A loop that
+//! claims whenever the queue is non-empty accumulates open PRs it never drives
+//! green, and the backlog it is measured against grows by its own work in
+//! flight. Finish first.
+//!
+//! # No workspace dependency, deliberately
+//!
+//! The design sketch writes `IssueKey` and `PrId`, which live in
+//! `stella-protocol`. This crate depends on no workspace crate — that is what
+//! lets `stella-observatory` link its folds without linking the machinery it
+//! observes — so the references here are local newtypes and the caller maps.
+//! Exactly the trade [`crate::rank_defects`] already makes with
+//! [`crate::QueueIssue`].
+
+use serde::{Deserialize, Serialize};
+
+/// A tracker's issue key, as the tracker spells it.
+///
+/// Opaque: produced by a caller, compared for equality, handed back. See the
+/// module docs for why this is not `stella_protocol::IssueKey`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct IssueRef(pub String);
+
+/// A forge's pull-request identifier, as the forge spells it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrRef(pub String);
+
+/// Why the loop is parked.
+///
+/// Typed because a human reading a block needs to know whether to add money,
+/// re-grant, drop a stop flag, or go look at a pull request — four different
+/// next moves.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "block")]
+pub enum BlockReason {
+    /// The cycle's spend ceiling was reached. Budget is the only hard bound.
+    BudgetSpent,
+    /// The `[driver]` grant this loop runs under is no longer valid.
+    ///
+    /// Checked every step rather than at start-up: a grant revoked mid-cycle
+    /// must stop the loop at the next boundary, not at the next restart — and
+    /// a grant restored mid-park must resume it at the next poll.
+    GrantRevoked,
+    /// A human asked it to stop.
+    OperatorStop,
+    /// A pull request escalated to a human and policy declines to abandon it.
+    ///
+    /// Carries the reference, because "something escalated" is not actionable
+    /// and "PR 412 escalated" is.
+    EscalatedPr {
+        /// Which one.
+        pr: PrRef,
+    },
+}
+
+/// What would unblock the loop — the observable a parked host watches.
+///
+/// Every variant is a condition the loop can detect for itself. That is the
+/// point: **none of them is an operator telling it to resume.** A human who
+/// clears the cause has already said everything that needs saying.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "clears_when")]
+pub enum Clearance {
+    /// The stop flag is no longer set.
+    StopFlagDropped,
+    /// The `[driver]` grant validates again.
+    GrantRestored,
+    /// A budget axis has room again — a refreshed window or a raised ceiling.
+    BudgetAvailable,
+    /// That pull request reached a settled disposition, by any hand.
+    PrSettled {
+        /// Which one to watch.
+        pr: PrRef,
+    },
+}
+
+impl BlockReason {
+    /// The observable that would clear this block.
+    ///
+    /// Total by construction, so a new [`BlockReason`] cannot be added without
+    /// answering "and what would un-block it?" — a block with no clearance is a
+    /// block that needs a human to say "go", which is the thing this design
+    /// refuses.
+    #[must_use]
+    pub fn clearance(&self) -> Clearance {
+        match self {
+            Self::BudgetSpent => Clearance::BudgetAvailable,
+            Self::GrantRevoked => Clearance::GrantRestored,
+            Self::OperatorStop => Clearance::StopFlagDropped,
+            Self::EscalatedPr { pr } => Clearance::PrSettled { pr: pr.clone() },
+        }
+    }
+}
+
+/// What the loop is waiting for when there is nothing to do.
+///
+/// Watch is not sleep: each variant names an event a cheap sentinel can
+/// detect, so a watching loop costs nothing until the world changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WakeCondition {
+    /// The base branch moved, so a dry lens may not be dry any more (§4.2).
+    BaseMoved,
+    /// Somebody filed something.
+    DefectFiled,
+    /// A check on a PR this loop owns concluded.
+    CiChanged,
+}
+
+/// The one move to make next.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "step")]
+pub enum LoopStep {
+    /// Size the cycle to the machine it is running on.
+    Plan,
+    /// Draw from the ranked queue, up to the sized batch.
+    Claim {
+        /// How many the plan permits this cycle.
+        batch: u32,
+    },
+    /// Run one issue through Stella's turn loop.
+    Work {
+        /// Which issue.
+        issue: IssueRef,
+    },
+    /// Advance one open pull request by one deterministic transition.
+    Deliver {
+        /// Which pull request.
+        pr: PrRef,
+    },
+    /// Run the open lens's tooling and emit what has not been seen.
+    Sweep {
+        /// Which lens is open.
+        lens: String,
+    },
+    /// Emit proposals from ledger evidence.
+    Curate,
+    /// Nothing to do until the world changes.
+    Watch {
+        /// What would make it worth waking.
+        until: WakeCondition,
+    },
+    /// Parked. **Not terminal** — see the module docs.
+    ///
+    /// A host keeps polling and resumes automatically when `clears_when` is
+    /// satisfied. Exiting the process here is the one way to break the
+    /// self-resume property, because a machine that is never asked cannot
+    /// answer.
+    Blocked {
+        /// Why it parked.
+        reason: BlockReason,
+        /// The observable that will let it go again, with no operator gesture.
+        clears_when: Clearance,
+    },
+}
+
+/// Where one pull request the loop owns has got to.
+///
+/// A projection of [`crate::PrState`] onto the only question the top-level
+/// machine asks: is this one finished, stuck, or still moving? Keeping it
+/// separate means a new `PrState` variant does not silently change what the
+/// loop does with it — the mapping is a caller's explicit choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrDisposition {
+    /// Still has transitions available.
+    Moving,
+    /// Handed to a human.
+    Escalated,
+    /// Landed or abandoned; nothing left to do.
+    Settled,
+}
+
+/// One pull request the loop is carrying.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CarriedPr {
+    /// Which one.
+    pub pr: PrRef,
+    /// Where it has got to.
+    pub disposition: PrDisposition,
+}
+
+/// The loop's own durable state.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopState {
+    /// Whether this cycle has been sized yet.
+    #[serde(default)]
+    pub planned: bool,
+    /// How many issues the plan permits this cycle.
+    #[serde(default)]
+    pub batch: u32,
+    /// Issues claimed but not yet carried to a pull request.
+    #[serde(default)]
+    pub claimed: Vec<IssueRef>,
+    /// Pull requests this loop opened and has not settled.
+    #[serde(default)]
+    pub carrying: Vec<CarriedPr>,
+    /// The aperture lens currently open, if the ladder has not been exhausted.
+    #[serde(default)]
+    pub lens: Option<String>,
+    /// Proposals waiting for a human.
+    #[serde(default)]
+    pub pending_proposals: u32,
+}
+
+/// What the world looks like right now. Facts only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopObservation {
+    /// Whether any budget axis is exhausted.
+    ///
+    /// A bool rather than an amount: which axis and how much is the governor's
+    /// arithmetic, and this machine only needs to know whether it may spend.
+    pub budget_exhausted: bool,
+    /// Whether the `[driver]` grant is still valid.
+    pub grant_valid: bool,
+    /// Whether a human has asked it to stop.
+    pub stop_requested: bool,
+    /// How many issues the ranked queue is offering.
+    pub queue_depth: u32,
+    /// Whether policy abandons an escalated PR rather than halting on it.
+    ///
+    /// Policy, not arithmetic: an operator who wants the loop to keep going
+    /// past a PR a human must look at can say so, and an operator who wants the
+    /// loop to stop and wait can say that instead.
+    pub abandon_escalated: bool,
+}
+
+/// The loop's next move.
+///
+/// Total over its inputs, with no clock, no randomness and no I/O, so the same
+/// state and observation always yield the same move. That is what makes a
+/// perpetual loop's behaviour reviewable after the fact.
+///
+/// # Precedence
+///
+/// The order **is** the policy, so it is stated rather than reverse-engineered:
+///
+/// 1. **A stop outranks everything.** Operator stop, revoked grant, spent
+///    budget — checked before any available work, so no amount of work can
+///    outvote a stop. Each is recomputed rather than latched, so it stops
+///    applying the moment its cause is gone.
+/// 2. **An escalated PR parks the loop**, unless policy says to abandon it.
+/// 3. **Plan before acting**, so a cycle is sized to its machine first.
+/// 4. **Finishing outranks starting** — deliver a carried PR before claiming
+///    anything new. See the module docs.
+/// 5. **Work what is already claimed** before claiming more.
+/// 6. **Claim** while the queue offers something and the batch has room.
+/// 7. **Sweep** when the queue is dry and a lens is still open.
+/// 8. **Curate** when proposals have accumulated and nothing else is pressing.
+/// 9. **Watch** otherwise — the ladder is exhausted and the queue is empty.
+#[must_use]
+pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep {
+    // 1. A stop outranks everything. Recomputed every call and never latched,
+    //    so each of these stops being returned the moment its cause is gone.
+    if obs.stop_requested {
+        return blocked(BlockReason::OperatorStop);
+    }
+    if !obs.grant_valid {
+        return blocked(BlockReason::GrantRevoked);
+    }
+    if obs.budget_exhausted {
+        return blocked(BlockReason::BudgetSpent);
+    }
+
+    // 2. An escalated PR parks the loop unless policy abandons it.
+    if !obs.abandon_escalated
+        && let Some(carried) = state
+            .carrying
+            .iter()
+            .find(|c| c.disposition == PrDisposition::Escalated)
+    {
+        return blocked(BlockReason::EscalatedPr {
+            pr: carried.pr.clone(),
+        });
+    }
+
+    // 3. Size the cycle before acting in it.
+    if !state.planned {
+        return LoopStep::Plan;
+    }
+
+    // 4. Finishing outranks starting.
+    if let Some(carried) = state
+        .carrying
+        .iter()
+        .find(|c| c.disposition == PrDisposition::Moving)
+    {
+        return LoopStep::Deliver {
+            pr: carried.pr.clone(),
+        };
+    }
+
+    // 5. Work what is already claimed before claiming more.
+    if let Some(issue) = state.claimed.first() {
+        return LoopStep::Work {
+            issue: issue.clone(),
+        };
+    }
+
+    // 6. Claim, while the queue offers and the batch has room.
+    if obs.queue_depth > 0 && state.batch > 0 {
+        return LoopStep::Claim { batch: state.batch };
+    }
+
+    // 7. The queue is dry. A lens still open is where the next question comes
+    //    from (§4.1: only the queue supply terminates).
+    if let Some(lens) = &state.lens {
+        return LoopStep::Sweep { lens: lens.clone() };
+    }
+
+    // 8. Nothing to fix and nothing to look for — spend the idle step on
+    //    proposals that have already accumulated evidence.
+    if state.pending_proposals > 0 {
+        return LoopStep::Curate;
+    }
+
+    // 9. The ladder is exhausted and the queue is empty. Wake when the base
+    //    moves, because a lens dry at commit X says nothing about X+200 (§4.2).
+    LoopStep::Watch {
+        until: WakeCondition::BaseMoved,
+    }
+}
+
+fn blocked(reason: BlockReason) -> LoopStep {
+    let clears_when = reason.clearance();
+    LoopStep::Blocked {
+        reason,
+        clears_when,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs() -> LoopObservation {
+        LoopObservation {
+            budget_exhausted: false,
+            grant_valid: true,
+            stop_requested: false,
+            queue_depth: 5,
+            abandon_escalated: false,
+        }
+    }
+
+    fn planned() -> LoopState {
+        LoopState {
+            planned: true,
+            batch: 3,
+            ..LoopState::default()
+        }
+    }
+
+    /// The witness. A loop that cannot halt is not autonomous, it is
+    /// unsupervised — so a stop is tested before any amount of available work,
+    /// and work is deliberately available here in every form the machine knows.
+    #[test]
+    fn a_stop_outranks_every_kind_of_available_work() {
+        let busy = LoopState {
+            claimed: vec![IssueRef("1".into())],
+            carrying: vec![CarriedPr {
+                pr: PrRef("9".into()),
+                disposition: PrDisposition::Moving,
+            }],
+            lens: Some("rubric".into()),
+            pending_proposals: 4,
+            ..planned()
+        };
+
+        for (label, o) in [
+            (
+                "operator stop",
+                LoopObservation {
+                    stop_requested: true,
+                    ..obs()
+                },
+            ),
+            (
+                "revoked grant",
+                LoopObservation {
+                    grant_valid: false,
+                    ..obs()
+                },
+            ),
+            (
+                "spent budget",
+                LoopObservation {
+                    budget_exhausted: true,
+                    ..obs()
+                },
+            ),
+        ] {
+            assert!(
+                matches!(step(&busy, &o), LoopStep::Blocked { .. }),
+                "{label} must park a loop with work available in every form"
+            );
+        }
+    }
+
+    /// The self-resume witness. Every block clears **without any resume input**:
+    /// the same state, observed after the cause is gone, yields work again. The
+    /// machine holds no latch, so there is nothing an operator could have to
+    /// acknowledge.
+    ///
+    /// Asserted for all four block reasons, because a latch on any one of them
+    /// would strand the loop exactly there.
+    #[test]
+    fn a_cleared_block_resumes_with_no_resume_signal() {
+        let carrying_escalated = LoopState {
+            carrying: vec![CarriedPr {
+                pr: PrRef("412".into()),
+                disposition: PrDisposition::Escalated,
+            }],
+            ..planned()
+        };
+
+        // Each case: (label, the blocked observation, the state, the state once
+        // a human cleared the cause — and nothing else changed).
+        let cases: Vec<(&str, LoopObservation, LoopState, LoopState)> = vec![
+            (
+                "operator dropped the stop flag",
+                LoopObservation {
+                    stop_requested: true,
+                    ..obs()
+                },
+                planned(),
+                planned(),
+            ),
+            (
+                "grant restored",
+                LoopObservation {
+                    grant_valid: false,
+                    ..obs()
+                },
+                planned(),
+                planned(),
+            ),
+            (
+                "budget refreshed",
+                LoopObservation {
+                    budget_exhausted: true,
+                    ..obs()
+                },
+                planned(),
+                planned(),
+            ),
+            (
+                "a human settled the escalated PR",
+                obs(),
+                carrying_escalated,
+                planned(),
+            ),
+        ];
+
+        for (label, blocked_obs, blocked_state, cleared_state) in cases {
+            assert!(
+                matches!(step(&blocked_state, &blocked_obs), LoopStep::Blocked { .. }),
+                "{label}: expected a block first"
+            );
+
+            // The cause is gone. Nothing told the loop it may resume.
+            assert_eq!(
+                step(&cleared_state, &obs()),
+                LoopStep::Claim { batch: 3 },
+                "{label}: must resume on its own, with no resume signal"
+            );
+        }
+    }
+
+    /// A grant revoked mid-cycle stops the loop at the next boundary; a grant
+    /// restored mid-park resumes it at the next poll.
+    #[test]
+    fn a_revoked_grant_names_itself_rather_than_looking_like_a_stop() {
+        let o = LoopObservation {
+            grant_valid: false,
+            ..obs()
+        };
+        assert_eq!(
+            step(&planned(), &o),
+            LoopStep::Blocked {
+                reason: BlockReason::GrantRevoked,
+                clears_when: Clearance::GrantRestored,
+            }
+        );
+    }
+
+    /// "Something escalated" is not actionable; "PR 412 escalated" is — and the
+    /// clearance names the same PR, so a parked host knows exactly what to watch.
+    #[test]
+    fn an_escalated_pr_parks_and_names_which_one_to_watch() {
+        let stuck = LoopState {
+            carrying: vec![CarriedPr {
+                pr: PrRef("412".into()),
+                disposition: PrDisposition::Escalated,
+            }],
+            ..planned()
+        };
+
+        assert_eq!(
+            step(&stuck, &obs()),
+            LoopStep::Blocked {
+                reason: BlockReason::EscalatedPr {
+                    pr: PrRef("412".into())
+                },
+                clears_when: Clearance::PrSettled {
+                    pr: PrRef("412".into())
+                },
+            }
+        );
+    }
+
+    /// Every block names an observable that clears it. A block with no
+    /// clearance would be one needing a human to say "go".
+    #[test]
+    fn every_block_reason_names_a_clearance() {
+        for reason in [
+            BlockReason::BudgetSpent,
+            BlockReason::GrantRevoked,
+            BlockReason::OperatorStop,
+            BlockReason::EscalatedPr {
+                pr: PrRef("1".into()),
+            },
+        ] {
+            let clearance = reason.clearance();
+            assert!(
+                !matches!(
+                    (&reason, &clearance),
+                    (BlockReason::EscalatedPr { pr }, Clearance::PrSettled { pr: watched })
+                        if pr != watched
+                ),
+                "{reason:?} must watch the PR it named, got {clearance:?}"
+            );
+        }
+    }
+
+    /// ...unless the operator said to keep going past one.
+    #[test]
+    fn policy_can_abandon_an_escalated_pr_instead_of_parking() {
+        let stuck = LoopState {
+            carrying: vec![CarriedPr {
+                pr: PrRef("412".into()),
+                disposition: PrDisposition::Escalated,
+            }],
+            ..planned()
+        };
+        let o = LoopObservation {
+            abandon_escalated: true,
+            ..obs()
+        };
+
+        assert_eq!(step(&stuck, &o), LoopStep::Claim { batch: 3 });
+    }
+
+    #[test]
+    fn an_unplanned_cycle_is_sized_before_it_acts() {
+        let fresh = LoopState {
+            claimed: vec![IssueRef("1".into())],
+            ..LoopState::default()
+        };
+        assert_eq!(step(&fresh, &obs()), LoopStep::Plan);
+    }
+
+    /// A loop that claims whenever the queue is non-empty accumulates PRs it
+    /// never drives green, and the backlog grows by its own work in flight.
+    #[test]
+    fn delivering_a_carried_pr_outranks_claiming_more_work() {
+        let carrying = LoopState {
+            carrying: vec![CarriedPr {
+                pr: PrRef("77".into()),
+                disposition: PrDisposition::Moving,
+            }],
+            ..planned()
+        };
+
+        assert_eq!(
+            step(&carrying, &obs()),
+            LoopStep::Deliver {
+                pr: PrRef("77".into())
+            },
+            "a queue of 5 must not outrank a PR already in flight"
+        );
+    }
+
+    #[test]
+    fn a_claimed_issue_is_worked_before_more_are_claimed() {
+        let claimed = LoopState {
+            claimed: vec![IssueRef("3210".into())],
+            ..planned()
+        };
+        assert_eq!(
+            step(&claimed, &obs()),
+            LoopStep::Work {
+                issue: IssueRef("3210".into())
+            }
+        );
+    }
+
+    #[test]
+    fn a_settled_pr_does_not_hold_the_loop() {
+        let settled = LoopState {
+            carrying: vec![CarriedPr {
+                pr: PrRef("77".into()),
+                disposition: PrDisposition::Settled,
+            }],
+            ..planned()
+        };
+        assert_eq!(step(&settled, &obs()), LoopStep::Claim { batch: 3 });
+    }
+
+    /// §4.1: only the queue supply terminates. A dry queue is where the sweep
+    /// starts, not where the loop stops.
+    #[test]
+    fn a_dry_queue_sweeps_the_open_lens_rather_than_stopping() {
+        let dry = LoopState {
+            lens: Some("concurrency".into()),
+            ..planned()
+        };
+        let o = LoopObservation {
+            queue_depth: 0,
+            ..obs()
+        };
+
+        assert_eq!(
+            step(&dry, &o),
+            LoopStep::Sweep {
+                lens: "concurrency".into()
+            }
+        );
+    }
+
+    #[test]
+    fn proposals_are_curated_only_once_nothing_else_is_pressing() {
+        let idle = LoopState {
+            pending_proposals: 2,
+            ..planned()
+        };
+        let o = LoopObservation {
+            queue_depth: 0,
+            ..obs()
+        };
+        assert_eq!(step(&idle, &o), LoopStep::Curate);
+
+        // ...and not while the queue still offers work.
+        assert_eq!(step(&idle, &obs()), LoopStep::Claim { batch: 3 });
+    }
+
+    /// The exhausted ladder wakes on a moved base, because a lens dry at commit
+    /// X says nothing about commit X+200.
+    #[test]
+    fn an_exhausted_ladder_and_an_empty_queue_watch_the_base() {
+        let o = LoopObservation {
+            queue_depth: 0,
+            ..obs()
+        };
+        assert_eq!(
+            step(&planned(), &o),
+            LoopStep::Watch {
+                until: WakeCondition::BaseMoved
+            }
+        );
+    }
+
+    /// A batch of zero is a plan that permits nothing, and must not be read as
+    /// permission to claim.
+    #[test]
+    fn a_zero_batch_does_not_claim() {
+        let no_room = LoopState {
+            batch: 0,
+            lens: Some("rubric".into()),
+            ..planned()
+        };
+        assert_eq!(
+            step(&no_room, &obs()),
+            LoopStep::Sweep {
+                lens: "rubric".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_step_round_trips_through_json() {
+        let s = LoopStep::Blocked {
+            reason: BlockReason::EscalatedPr {
+                pr: PrRef("412".into()),
+            },
+            clears_when: Clearance::PrSettled {
+                pr: PrRef("412".into()),
+            },
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        let back: LoopStep = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(s, back);
+    }
+}

--- a/crates/stella-autonomy/src/step.rs
+++ b/crates/stella-autonomy/src/step.rs
@@ -55,6 +55,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::doctrine::{
+    Contention, ContentionVerdict, Doctrine, ForeignBreakage, contention_verdict,
+};
+
 /// A tracker's issue key, as the tracker spells it.
 ///
 /// Opaque: produced by a caller, compared for equality, handed back. See the
@@ -178,6 +182,16 @@ pub enum LoopStep {
     },
     /// Emit proposals from ledger evidence.
     Curate,
+    /// Act on the thing blocking the loop, rather than waiting for someone else
+    /// to.
+    ///
+    /// The loop exhausts the channels it is permitted before it parks: a
+    /// blockage it can make visible, it files; a blockage its doctrine lets it
+    /// adopt, it fixes. Parking is what is left when neither applies.
+    Unblock {
+        /// Which remedy.
+        attempt: UnblockAttempt,
+    },
     /// Nothing to do until the world changes.
     Watch {
         /// What would make it worth waking.
@@ -194,6 +208,34 @@ pub enum LoopStep {
         reason: BlockReason,
         /// The observable that will let it go again, with no operator gesture.
         clears_when: Clearance,
+    },
+}
+
+/// A remedy the loop may apply to its own blockage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "attempt")]
+pub enum UnblockAttempt {
+    /// File the base breakage so it is visible and attributable.
+    ///
+    /// Happens under every policy that files at all, and **before** any attempt
+    /// to fix it, because the ticket is the part that survives a failed fix.
+    FileBaseBreakage,
+    /// Fix breakage this loop did not cause.
+    ///
+    /// Only under [`ForeignBreakage::FileAndAdopt`], only once filed, and only
+    /// when nothing else appears to be on it.
+    AdoptBaseBreakage {
+        /// The issue to work, so the fix is attributable to the filing.
+        issue: IssueRef,
+    },
+    /// Somebody else is already fixing it.
+    ///
+    /// Not a no-op: it is a *recorded* decision not to duplicate work, carrying
+    /// what was seen. A loop that silently declined would be indistinguishable
+    /// from one that never looked.
+    DeferToExistingFix {
+        /// The signals that caused the deferral.
+        evidence: Vec<String>,
     },
 }
 
@@ -246,8 +288,9 @@ pub struct LoopState {
     pub pending_proposals: u32,
 }
 
-/// What the world looks like right now. Facts only.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// What the world looks like right now. Facts only — every policy question the
+/// machine asks is answered by [`Doctrine`], never by this type.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopObservation {
     /// Whether any budget axis is exhausted.
     ///
@@ -255,17 +298,36 @@ pub struct LoopObservation {
     /// arithmetic, and this machine only needs to know whether it may spend.
     pub budget_exhausted: bool,
     /// Whether the `[driver]` grant is still valid.
+    ///
+    /// Note the polarity: `false` blocks. [`Default`] therefore yields an
+    /// *invalid* grant, which is the safe direction — a caller that forgets to
+    /// set this gets a parked loop, not an ungoverned one.
     pub grant_valid: bool,
     /// Whether a human has asked it to stop.
     pub stop_requested: bool,
     /// How many issues the ranked queue is offering.
     pub queue_depth: u32,
-    /// Whether policy abandons an escalated PR rather than halting on it.
+    /// Whether the base branch is currently broken.
     ///
-    /// Policy, not arithmetic: an operator who wants the loop to keep going
-    /// past a PR a human must look at can say so, and an operator who wants the
-    /// loop to stop and wait can say that instead.
-    pub abandon_escalated: bool,
+    /// A red base blocks *everyone*, and it is the blockage a loop is most
+    /// likely to meet that it did not cause. §6.5's `foreign_breakage` decides
+    /// what to do about it.
+    pub base_broken: bool,
+    /// Whether the base breakage already has an issue filed against it.
+    ///
+    /// Filing is separate from fixing on purpose: the ticket is what makes the
+    /// breakage visible and attributable **even if the fix never lands**, so it
+    /// happens first and under every policy that files at all.
+    pub base_breakage_filed: bool,
+    /// The issue tracking the base breakage, once filed.
+    pub base_breakage_issue: Option<IssueRef>,
+    /// What else appears to be fixing that breakage already.
+    ///
+    /// Gathered from the forge and from **this machine** — the local worktrees
+    /// are the signal nobody remembers to check, and two self-driving sessions
+    /// against one clone see each other only there.
+    #[serde(default)]
+    pub base_fix_contention: Contention,
 }
 
 /// The loop's next move.
@@ -282,17 +344,20 @@ pub struct LoopObservation {
 ///    budget — checked before any available work, so no amount of work can
 ///    outvote a stop. Each is recomputed rather than latched, so it stops
 ///    applying the moment its cause is gone.
-/// 2. **An escalated PR parks the loop**, unless policy says to abandon it.
+/// 2. **An escalated PR parks the loop**, unless doctrine says to abandon it.
 /// 3. **Plan before acting**, so a cycle is sized to its machine first.
-/// 4. **Finishing outranks starting** — deliver a carried PR before claiming
+/// 4. **Unblock before working.** A broken base makes every PR the loop
+///    produces fail CI, so it is dealt with before more are made — filed first,
+///    then adopted if doctrine permits and nothing else is on it.
+/// 5. **Finishing outranks starting** — deliver a carried PR before claiming
 ///    anything new. See the module docs.
-/// 5. **Work what is already claimed** before claiming more.
-/// 6. **Claim** while the queue offers something and the batch has room.
-/// 7. **Sweep** when the queue is dry and a lens is still open.
-/// 8. **Curate** when proposals have accumulated and nothing else is pressing.
-/// 9. **Watch** otherwise — the ladder is exhausted and the queue is empty.
+/// 6. **Work what is already claimed** before claiming more.
+/// 7. **Claim** while the queue offers something and the batch has room.
+/// 8. **Sweep** when the queue is dry and a lens is still open.
+/// 9. **Curate** when proposals have accumulated and nothing else is pressing.
+/// 10. **Watch** otherwise — the ladder is exhausted and the queue is empty.
 #[must_use]
-pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep {
+pub fn step(state: &LoopState, obs: &LoopObservation, doctrine: &Doctrine) -> LoopStep {
     // 1. A stop outranks everything. Recomputed every call and never latched,
     //    so each of these stops being returned the moment its cause is gone.
     if obs.stop_requested {
@@ -305,8 +370,8 @@ pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep {
         return blocked(BlockReason::BudgetSpent);
     }
 
-    // 2. An escalated PR parks the loop unless policy abandons it.
-    if !obs.abandon_escalated
+    // 2. An escalated PR parks the loop unless doctrine abandons it.
+    if !doctrine.abandon_escalated
         && let Some(carried) = state
             .carrying
             .iter()
@@ -322,7 +387,15 @@ pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep {
         return LoopStep::Plan;
     }
 
-    // 4. Finishing outranks starting.
+    // 4. Exhaust the permitted channels on the loop's own blockage before
+    //    making more work that the same blockage will stall.
+    if obs.base_broken
+        && let Some(attempt) = unblock_base(obs, doctrine)
+    {
+        return LoopStep::Unblock { attempt };
+    }
+
+    // 5. Finishing outranks starting.
     if let Some(carried) = state
         .carrying
         .iter()
@@ -364,6 +437,48 @@ pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep {
     }
 }
 
+/// What, if anything, the loop may do about a broken base right now.
+///
+/// `None` means "nothing left to try" — the breakage is filed, doctrine does
+/// not permit adopting it, or someone else has it — and the caller carries on
+/// with ordinary work rather than parking, because a red base stops merges, not
+/// authoring.
+///
+/// The order is the argument:
+///
+/// 1. **File first, always.** The ticket is what makes the breakage visible and
+///    attributable *even if the fix never lands*, so it is never contingent on
+///    the fix being attempted.
+/// 2. **Then check contention**, before adopting. Two workers on one broken
+///    `main` produce a merge conflict on top of the outage.
+/// 3. **Then adopt**, only if doctrine says to.
+fn unblock_base(obs: &LoopObservation, doctrine: &Doctrine) -> Option<UnblockAttempt> {
+    if doctrine.foreign_breakage == ForeignBreakage::Ignore {
+        return None;
+    }
+
+    // 1. Make it visible first.
+    if !obs.base_breakage_filed {
+        return Some(UnblockAttempt::FileBaseBreakage);
+    }
+
+    if doctrine.foreign_breakage != ForeignBreakage::FileAndAdopt {
+        return None;
+    }
+
+    // 2. Do not duplicate a fix already in flight.
+    if let ContentionVerdict::Defer { evidence } =
+        contention_verdict(doctrine.contention, &obs.base_fix_contention)
+    {
+        return Some(UnblockAttempt::DeferToExistingFix { evidence });
+    }
+
+    // 3. Adopt it, attributed to the filing.
+    obs.base_breakage_issue
+        .clone()
+        .map(|issue| UnblockAttempt::AdoptBaseBreakage { issue })
+}
+
 fn blocked(reason: BlockReason) -> LoopStep {
     let clears_when = reason.clearance();
     LoopStep::Blocked {
@@ -378,12 +493,32 @@ mod tests {
 
     fn obs() -> LoopObservation {
         LoopObservation {
-            budget_exhausted: false,
             grant_valid: true,
-            stop_requested: false,
             queue_depth: 5,
-            abandon_escalated: false,
+            ..LoopObservation::default()
         }
+    }
+
+    /// A red base, already filed, with a doctrine that adopts it.
+    fn base_red_filed() -> LoopObservation {
+        LoopObservation {
+            base_broken: true,
+            base_breakage_filed: true,
+            base_breakage_issue: Some(IssueRef("3912".into())),
+            ..obs()
+        }
+    }
+
+    fn adopting() -> Doctrine {
+        Doctrine {
+            foreign_breakage: ForeignBreakage::FileAndAdopt,
+            ..Doctrine::default()
+        }
+    }
+
+    /// Convenience for the many cases that use the conservative default.
+    fn go(state: &LoopState, o: &LoopObservation) -> LoopStep {
+        step(state, o, &Doctrine::default())
     }
 
     fn planned() -> LoopState {
@@ -434,7 +569,7 @@ mod tests {
             ),
         ] {
             assert!(
-                matches!(step(&busy, &o), LoopStep::Blocked { .. }),
+                matches!(go(&busy, &o), LoopStep::Blocked { .. }),
                 "{label} must park a loop with work available in every form"
             );
         }
@@ -497,13 +632,13 @@ mod tests {
 
         for (label, blocked_obs, blocked_state, cleared_state) in cases {
             assert!(
-                matches!(step(&blocked_state, &blocked_obs), LoopStep::Blocked { .. }),
+                matches!(go(&blocked_state, &blocked_obs), LoopStep::Blocked { .. }),
                 "{label}: expected a block first"
             );
 
             // The cause is gone. Nothing told the loop it may resume.
             assert_eq!(
-                step(&cleared_state, &obs()),
+                go(&cleared_state, &obs()),
                 LoopStep::Claim { batch: 3 },
                 "{label}: must resume on its own, with no resume signal"
             );
@@ -519,7 +654,7 @@ mod tests {
             ..obs()
         };
         assert_eq!(
-            step(&planned(), &o),
+            go(&planned(), &o),
             LoopStep::Blocked {
                 reason: BlockReason::GrantRevoked,
                 clears_when: Clearance::GrantRestored,
@@ -540,7 +675,7 @@ mod tests {
         };
 
         assert_eq!(
-            step(&stuck, &obs()),
+            go(&stuck, &obs()),
             LoopStep::Blocked {
                 reason: BlockReason::EscalatedPr {
                     pr: PrRef("412".into())
@@ -586,12 +721,104 @@ mod tests {
             }],
             ..planned()
         };
-        let o = LoopObservation {
+        let abandoning = Doctrine {
             abandon_escalated: true,
+            ..Doctrine::default()
+        };
+
+        assert_eq!(
+            step(&stuck, &obs(), &abandoning),
+            LoopStep::Claim { batch: 3 }
+        );
+    }
+
+    /// The blockage-resolution witness. A base the loop did not break is filed
+    /// first — under every doctrine that files at all — because the ticket is
+    /// what makes the breakage visible and attributable even if no fix lands.
+    #[test]
+    fn a_base_the_loop_did_not_break_is_filed_before_anything_else() {
+        let red = LoopObservation {
+            base_broken: true,
             ..obs()
         };
 
-        assert_eq!(step(&stuck, &o), LoopStep::Claim { batch: 3 });
+        for doctrine in [Doctrine::default(), adopting()] {
+            assert_eq!(
+                step(&planned(), &red, &doctrine),
+                LoopStep::Unblock {
+                    attempt: UnblockAttempt::FileBaseBreakage
+                },
+                "{:?} must make the breakage visible first",
+                doctrine.foreign_breakage
+            );
+        }
+    }
+
+    /// The other half: with the breakage filed, doctrine decides whether the
+    /// loop fixes somebody else's code. Both answers are legitimate, which is
+    /// exactly why it is configuration and not a hardcoded rule.
+    #[test]
+    fn doctrine_decides_whether_foreign_breakage_is_adopted() {
+        // FileAndAdopt: a red base blocks this loop as surely as its author.
+        assert_eq!(
+            step(&planned(), &base_red_filed(), &adopting()),
+            LoopStep::Unblock {
+                attempt: UnblockAttempt::AdoptBaseBreakage {
+                    issue: IssueRef("3912".into())
+                }
+            }
+        );
+
+        // FileAndWait: filed already, so nothing more to try — and the loop
+        // carries on with ordinary work rather than parking, because a red base
+        // stops merges, not authoring.
+        assert_eq!(
+            step(&planned(), &base_red_filed(), &Doctrine::default()),
+            LoopStep::Claim { batch: 3 }
+        );
+    }
+
+    /// The collision witness. A fix already in flight — including one in a
+    /// worktree on this very machine — defers instead of duplicating, and the
+    /// deferral carries what was seen so it is reviewable.
+    #[test]
+    fn an_adopted_fix_defers_to_one_already_in_flight() {
+        let contended = LoopObservation {
+            base_fix_contention: Contention {
+                local_worktrees: vec!["fix-ci-3915".into()],
+                ..Contention::default()
+            },
+            ..base_red_filed()
+        };
+
+        assert_eq!(
+            step(&planned(), &contended, &adopting()),
+            LoopStep::Unblock {
+                attempt: UnblockAttempt::DeferToExistingFix {
+                    evidence: vec!["local worktree: fix-ci-3915".into()]
+                }
+            },
+            "two workers on one broken main produce a conflict on top of an outage"
+        );
+    }
+
+    /// `Ignore` is reachable and does nothing — present for the operator who
+    /// wants a silent loop, and deliberately not the default.
+    #[test]
+    fn ignore_neither_files_nor_fixes() {
+        let red = LoopObservation {
+            base_broken: true,
+            ..obs()
+        };
+        let silent = Doctrine {
+            foreign_breakage: ForeignBreakage::Ignore,
+            ..Doctrine::default()
+        };
+
+        assert_eq!(
+            step(&planned(), &red, &silent),
+            LoopStep::Claim { batch: 3 }
+        );
     }
 
     #[test]
@@ -600,7 +827,7 @@ mod tests {
             claimed: vec![IssueRef("1".into())],
             ..LoopState::default()
         };
-        assert_eq!(step(&fresh, &obs()), LoopStep::Plan);
+        assert_eq!(go(&fresh, &obs()), LoopStep::Plan);
     }
 
     /// A loop that claims whenever the queue is non-empty accumulates PRs it
@@ -616,7 +843,7 @@ mod tests {
         };
 
         assert_eq!(
-            step(&carrying, &obs()),
+            go(&carrying, &obs()),
             LoopStep::Deliver {
                 pr: PrRef("77".into())
             },
@@ -631,7 +858,7 @@ mod tests {
             ..planned()
         };
         assert_eq!(
-            step(&claimed, &obs()),
+            go(&claimed, &obs()),
             LoopStep::Work {
                 issue: IssueRef("3210".into())
             }
@@ -647,7 +874,7 @@ mod tests {
             }],
             ..planned()
         };
-        assert_eq!(step(&settled, &obs()), LoopStep::Claim { batch: 3 });
+        assert_eq!(go(&settled, &obs()), LoopStep::Claim { batch: 3 });
     }
 
     /// §4.1: only the queue supply terminates. A dry queue is where the sweep
@@ -664,7 +891,7 @@ mod tests {
         };
 
         assert_eq!(
-            step(&dry, &o),
+            go(&dry, &o),
             LoopStep::Sweep {
                 lens: "concurrency".into()
             }
@@ -681,10 +908,10 @@ mod tests {
             queue_depth: 0,
             ..obs()
         };
-        assert_eq!(step(&idle, &o), LoopStep::Curate);
+        assert_eq!(go(&idle, &o), LoopStep::Curate);
 
         // ...and not while the queue still offers work.
-        assert_eq!(step(&idle, &obs()), LoopStep::Claim { batch: 3 });
+        assert_eq!(go(&idle, &obs()), LoopStep::Claim { batch: 3 });
     }
 
     /// The exhausted ladder wakes on a moved base, because a lens dry at commit
@@ -696,7 +923,7 @@ mod tests {
             ..obs()
         };
         assert_eq!(
-            step(&planned(), &o),
+            go(&planned(), &o),
             LoopStep::Watch {
                 until: WakeCondition::BaseMoved
             }
@@ -713,7 +940,7 @@ mod tests {
             ..planned()
         };
         assert_eq!(
-            step(&no_room, &obs()),
+            go(&no_room, &obs()),
             LoopStep::Sweep {
                 lens: "rubric".into()
             }

--- a/crates/stella-autonomy/src/surface.rs
+++ b/crates/stella-autonomy/src/surface.rs
@@ -202,6 +202,11 @@ pub const HOST_SURFACE: &[HostVerb] = &[
         summary: "the ranked defect queue this cycle draws its batch from",
     },
     HostVerb {
+        path: "file",
+        emits: Emits::Text,
+        summary: "file a finding as an issue — refused unless it matches this workspace's convention",
+    },
+    HostVerb {
         path: "run start",
         emits: Emits::ShellAssignments,
         summary: "begin a run — the multi-cycle unit a person starts and stops",

--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 
 use async_trait::async_trait;
 use stella_protocol::issue::{
-    Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
+    Issue, IssueClass, IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
 };
 
 /// The provider id this adapter answers to, and the one an error names.
@@ -134,6 +134,57 @@ impl IssueProvider for GhIssueProvider {
                 reason: error.to_string(),
             })?;
         Ok(rows.into_iter().map(GhIssue::into_issue).collect())
+    }
+
+    async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+        let mut args: Vec<String> = vec![
+            "issue".into(),
+            "create".into(),
+            "--title".into(),
+            draft.title.clone(),
+            "--body".into(),
+            draft.body.clone(),
+        ];
+        for label in &draft.labels {
+            args.push("--label".into());
+            args.push(label.name.clone());
+        }
+
+        let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+        let raw = gh_json(&borrowed)?;
+
+        // `gh issue create` prints the issue URL, not JSON, so the key is the
+        // last path segment. Parsed rather than assumed: a `gh` that printed
+        // something else must fail loudly here, because the alternative is a
+        // filing the loop cannot reference and therefore cannot close.
+        let url = raw.trim();
+        let key = url
+            .rsplit('/')
+            .next()
+            .filter(|segment| !segment.is_empty() && segment.chars().all(|c| c.is_ascii_digit()))
+            .ok_or_else(|| IssueError::Malformed {
+                provider: GITHUB.into(),
+                reason: format!("`gh issue create` printed no issue number: {url:?}"),
+            })?;
+
+        Ok(IssueKey::from(key))
+    }
+
+    async fn close(&self, key: &IssueKey, receipt: &str) -> Result<(), IssueError> {
+        gh_json(&[
+            "issue",
+            "close",
+            key.as_str(),
+            "--comment",
+            receipt,
+            "--reason",
+            "completed",
+        ])
+        .map(|_| ())
+    }
+
+    async fn comment(&self, key: &IssueKey, body: &str) -> Result<(), IssueError> {
+        gh_json(&["issue", "comment", key.as_str(), "--body", body]).map(|_| ())
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -14,6 +14,7 @@
 //! two surfaces cannot drift.
 
 mod backlog;
+mod convention;
 pub(crate) mod probes;
 pub(crate) mod state;
 mod surface;
@@ -154,6 +155,31 @@ pub(crate) enum SelfDrivingCmd {
 
         /// Output format: the ranked table, or the picked issues under the
         /// versioned query envelope (#1568).
+        #[arg(long, value_enum, default_value = "text")]
+        format: QueryFormat,
+    },
+
+    /// File a finding as an issue, through the bound provider.
+    ///
+    /// Refuses rather than degrades. A draft is checked against this
+    /// workspace's issue convention *before* the tracker is reached, and one
+    /// already in the seen set is not filed twice — an unclassified filing
+    /// comes back next cycle as an untriaged defect the loop must triage
+    /// (`doc:backlog-self-driving` §3.1a).
+    File {
+        /// The one-line title. Also the dedup key, after normalization.
+        #[arg(long)]
+        title: String,
+
+        /// The handoff body. Assume the reader has none of your context.
+        #[arg(long, default_value = "")]
+        body: String,
+
+        /// A label to apply. Repeat for each.
+        #[arg(long = "label")]
+        labels: Vec<String>,
+
+        /// Output format.
         #[arg(long, value_enum, default_value = "text")]
         format: QueryFormat,
     },
@@ -335,6 +361,12 @@ pub(crate) fn run(cmd: &SelfDrivingCmd) -> Result<(), String> {
             show,
         } => calibrate_cmd(&st, *ok, *resource_fail, *show),
         SelfDrivingCmd::Queue { limit, format } => queue(&st, *limit, *format),
+        SelfDrivingCmd::File {
+            title,
+            body,
+            labels,
+            format,
+        } => file_finding(&st, title, body, labels, *format),
         SelfDrivingCmd::Run { cmd } => match cmd {
             RunCmd::Start => run_start(&st),
             RunCmd::End { status, reason } => run_end(&st, status, reason),
@@ -866,6 +898,57 @@ fn calibrate_cmd(st: &LoopState, ok: bool, resource_fail: bool, show: bool) -> R
 /// The queue verb: the ranked defect batch this cycle draws from.
 fn queue(st: &LoopState, limit: usize, format: QueryFormat) -> Result<(), String> {
     backlog::render_queue(st, &crate::issue_provider::GhIssueProvider, limit, format)
+}
+
+/// `stella self-driving file` — file a finding, if it is novel and conformant.
+///
+/// The digest is recorded **only on a filing that actually happened**. Marking a
+/// refused draft as seen would make the loop's own failure to classify look like
+/// a finding already handled, and it would never be filed again.
+fn file_finding(
+    st: &LoopState,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    format: QueryFormat,
+) -> Result<(), String> {
+    let root = std::env::current_dir().map_err(|e| format!("no working directory: {e}"))?;
+    let bound = convention::load(&root);
+
+    let draft = stella_protocol::issue::IssueDraft {
+        title: title.to_owned(),
+        body: body.to_owned(),
+        labels: labels
+            .iter()
+            .map(|name| stella_protocol::issue::IssueLabel { name: name.clone() })
+            .collect(),
+        parent: None,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("could not start a runtime for the issue provider: {e}"))?;
+    let outcome = runtime
+        .block_on(backlog::file_finding(
+            &crate::issue_provider::GhIssueProvider,
+            &bound.convention,
+            &st.seen(),
+            &draft,
+        ))
+        .map_err(|error| error.to_string())?;
+
+    if let backlog::Filed::New(key) = &outcome {
+        st.add_seen(&stella_autonomy::finding_digest(title))?;
+        if format == QueryFormat::Json {
+            println!(r#"{{"filed":"{key}"}}"#);
+        } else {
+            println!("filed #{key}");
+        }
+        return Ok(());
+    }
+
+    backlog::render_not_filed(&outcome, &bound, format)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -19,8 +19,8 @@
 //! backlog one cycle drew its batch from. One read, one definition, folded two
 //! ways.
 
-use stella_autonomy::Demand;
-use stella_protocol::issue::IssueProvider;
+use stella_autonomy::{BacklogConvention, Conformance, Demand, Violation, conform, finding_digest};
+use stella_protocol::issue::{IssueDraft, IssueError, IssueKey, IssueProvider};
 
 use crate::query_format::{QueryFormat, Rows};
 
@@ -121,6 +121,143 @@ pub(super) fn demand_from(provider: &dyn IssueProvider) -> Demand {
     }
 }
 
+/// Why a filing did not happen.
+///
+/// Three outcomes rather than a `Result<IssueKey, IssueError>`, because
+/// **"already filed" is a success from the loop's point of view** and an error
+/// from the tracker's. Collapsing it into the error arm is how a loop starts
+/// reporting failures for working correctly, and how a human learns to ignore
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Filed {
+    /// The tracker assigned it a key.
+    New(IssueKey),
+    /// A finding with this digest was filed before. Nothing was sent.
+    Duplicate {
+        /// The dedup key that matched.
+        digest: String,
+    },
+    /// The draft does not conform to this workspace's convention. Nothing was
+    /// sent.
+    Refused {
+        /// Every violation, so a human fixes them in one pass.
+        violations: Vec<Violation>,
+    },
+}
+
+/// File a finding, if it is both novel and conformant.
+///
+/// The order is the design, and both checks happen **before the provider is
+/// reached**:
+///
+/// 1. **Dedup by digest**, against the same `seen.txt` contract the aperture
+///    ladder rests on. Re-filing what the loop already filed is the fastest way
+///    to make a backlog worthless, and `finding_digest` normalization is what
+///    makes "the same defect with a shifted line number" one finding.
+/// 2. **Conform to the workspace's convention.** A filing the tracker's own
+///    automation will re-label is a filing the loop reads back next cycle as
+///    somebody else's untriaged defect (`stella_autonomy::convention`).
+///
+/// A caller cannot get this order wrong because there is no other way in: the
+/// provider's `file` is never called directly by a verb.
+pub(super) async fn file_finding(
+    provider: &dyn IssueProvider,
+    convention: &BacklogConvention,
+    seen: &[String],
+    draft: &IssueDraft,
+) -> Result<Filed, IssueError> {
+    let digest = finding_digest(&draft.title);
+    if seen.iter().any(|s| s == &digest) {
+        return Ok(Filed::Duplicate { digest });
+    }
+
+    let labels: Vec<&str> = draft.labels.iter().map(|l| l.name.as_str()).collect();
+    if let Conformance::Refused { violations } = conform(convention, &labels) {
+        return Ok(Filed::Refused { violations });
+    }
+
+    provider.file(draft).await.map(Filed::New)
+}
+
+/// Explain a filing that did not happen.
+///
+/// A refusal is rendered with **every** violation and with where the convention
+/// came from, because the two questions a human has are "what did I get wrong"
+/// and "wrong according to what" — and the second one is unanswerable if the
+/// convention was discovered rather than written down.
+pub(super) fn render_not_filed(
+    outcome: &Filed,
+    bound: &super::convention::Bound,
+    format: QueryFormat,
+) -> Result<(), String> {
+    match outcome {
+        Filed::New(_) => Ok(()),
+        Filed::Duplicate { digest } => {
+            if format == QueryFormat::Json {
+                println!(r#"{{"duplicate":"{digest}"}}"#);
+            } else {
+                println!("already filed (digest {digest}) — nothing sent");
+            }
+            Ok(())
+        }
+        Filed::Refused { violations } => {
+            let source = match bound.provenance {
+                super::convention::Provenance::Manifest => ".stella/issues/convention.json",
+                super::convention::Provenance::Discovered => {
+                    ".github/workflows/issue-triage.yml (discovered)"
+                }
+                super::convention::Provenance::Proposed => {
+                    "a PROPOSED convention — nothing may be filed until a human accepts it"
+                }
+            };
+            if format == QueryFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::json!({ "refused": violations, "convention": source })
+                );
+                // Still a failure exit: a caller that scripted this must not
+                // read "nothing was filed" as "the finding is recorded".
+                return Err(
+                    "not filed: the draft does not match this workspace's convention".into(),
+                );
+            }
+
+            // The whole explanation rides in the error rather than being
+            // printed here, so the binary renders it once, in its own voice.
+            // Printing first and returning an empty error produced a bare
+            // `stella:` line and looked like a crash.
+            let mut message =
+                String::from("not filed — the draft does not match this workspace's convention\n");
+            message.push_str(&format!("  convention: {source}\n"));
+            for violation in violations {
+                message.push_str(&format!("  {}\n", describe(violation)));
+            }
+            Err(message.trim_end().to_owned())
+        }
+    }
+}
+
+fn describe(violation: &Violation) -> String {
+    match violation {
+        Violation::AxisMissing { axis, candidates } => {
+            format!(
+                "missing a `{axis}` label — one of: {}",
+                candidates.join(", ")
+            )
+        }
+        Violation::AxisAmbiguous { axis, present } => format!(
+            "several `{axis}` labels ({}) — exactly one decides the rank",
+            present.join(", ")
+        ),
+        Violation::ReservedApplied { label } => {
+            format!("`{label}` is applied by automation, never by the loop")
+        }
+        Violation::ConventionUnaccepted => {
+            "this workspace's convention has not been accepted by a human".to_owned()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -129,7 +266,29 @@ mod tests {
     use super::*;
 
     /// A tracker that is not GitHub and is not a process.
-    struct FixtureProvider(Vec<Issue>);
+    ///
+    /// Records what it was asked to write, so a test can assert not only what
+    /// was filed but that nothing **was** — which is the half that matters for
+    /// a refusal, since a conformance check that ran after the write would pass
+    /// the same assertions on the returned value.
+    #[derive(Default)]
+    struct FixtureProvider {
+        open: Vec<Issue>,
+        filed: std::sync::Mutex<Vec<IssueDraft>>,
+    }
+
+    impl FixtureProvider {
+        fn with(open: Vec<Issue>) -> Self {
+            Self {
+                open,
+                filed: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn filed(&self) -> Vec<IssueDraft> {
+            self.filed.lock().expect("fixture lock").clone()
+        }
+    }
 
     #[async_trait]
     impl IssueProvider for FixtureProvider {
@@ -138,12 +297,35 @@ mod tests {
         }
 
         async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError> {
-            Ok(self.0.iter().take(limit).cloned().collect())
+            Ok(self.open.iter().take(limit).cloned().collect())
+        }
+
+        async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            let mut filed = self.filed.lock().expect("fixture lock");
+            filed.push(draft.clone());
+            Ok(IssueKey::from(format!("{}", 1000 + filed.len()).as_str()))
+        }
+
+        async fn close(&self, _key: &IssueKey, _receipt: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
         }
     }
 
     /// A tracker that is not reachable — the degradation path.
     struct DeadProvider;
+
+    impl DeadProvider {
+        fn gone() -> IssueError {
+            IssueError::Unavailable {
+                provider: "dead".into(),
+                reason: "no tracker here".into(),
+            }
+        }
+    }
 
     #[async_trait]
     impl IssueProvider for DeadProvider {
@@ -152,10 +334,19 @@ mod tests {
         }
 
         async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
-            Err(IssueError::Unavailable {
-                provider: "dead".into(),
-                reason: "no tracker here".into(),
-            })
+            Err(Self::gone())
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Err(Self::gone())
+        }
+
+        async fn close(&self, _key: &IssueKey, _receipt: &str) -> Result<(), IssueError> {
+            Err(Self::gone())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Err(Self::gone())
         }
     }
 
@@ -173,8 +364,147 @@ mod tests {
         }
     }
 
+    /// This repository's convention, as `issue-triage.yml` enforces it.
+    fn convention() -> BacklogConvention {
+        use stella_autonomy::{Acceptance, AxisRequirement, ConventionSource, LabelAxis};
+        BacklogConvention {
+            axes: vec![LabelAxis {
+                name: "type".into(),
+                members: ["bug", "feature", "epic", "documentation", "question"]
+                    .iter()
+                    .map(|s| (*s).to_owned())
+                    .collect(),
+                requirement: AxisRequirement::ExactlyOne,
+                source: ConventionSource::Enforced,
+            }],
+            reserved: vec!["triage".into()],
+            acceptance: Acceptance::Bound,
+        }
+    }
+
+    fn draft(title: &str, labels: &[&str]) -> IssueDraft {
+        IssueDraft {
+            title: title.into(),
+            body: "a handoff".into(),
+            labels: labels.iter().copied().map(IssueLabel::from).collect(),
+            parent: None,
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(f)
+    }
+
+    /// **The write-half witness.** A non-conformant draft is refused *before the
+    /// provider is reached*, and the fixture records that nothing was sent.
+    ///
+    /// Asserting only the returned value would pass on an implementation that
+    /// filed first and checked afterwards — which is the bug, since the issue
+    /// would already be in the tracker.
+    #[test]
+    fn a_non_conformant_filing_never_reaches_the_tracker() {
+        let provider = FixtureProvider::default();
+
+        let outcome = block_on(file_finding(
+            &provider,
+            &convention(),
+            &[],
+            &draft("the retry counter survives a goal round", &["P1"]),
+        ))
+        .expect("the port was reachable");
+
+        assert!(
+            matches!(outcome, Filed::Refused { .. }),
+            "expected a refusal, got {outcome:?}"
+        );
+        assert!(
+            provider.filed().is_empty(),
+            "a refused filing must not reach the tracker, but it recorded {:?}",
+            provider.filed()
+        );
+    }
+
+    /// The other half — the identical draft, classified, does reach it.
+    #[test]
+    fn a_conformant_filing_reaches_the_tracker_and_returns_its_key() {
+        let provider = FixtureProvider::default();
+
+        let outcome = block_on(file_finding(
+            &provider,
+            &convention(),
+            &[],
+            &draft("the retry counter survives a goal round", &["bug", "P1"]),
+        ))
+        .expect("the port was reachable");
+
+        assert_eq!(outcome, Filed::New(IssueKey::from("1001")));
+        assert_eq!(provider.filed().len(), 1);
+    }
+
+    /// Re-filing what the loop already filed is the fastest way to make a
+    /// backlog worthless, and the dedup runs before the conformance check
+    /// because a duplicate should cost nothing at all.
+    #[test]
+    fn a_finding_already_seen_is_not_filed_again() {
+        let provider = FixtureProvider::default();
+        let title = "the retry counter survives a goal round";
+        let seen = vec![finding_digest(title)];
+
+        let outcome = block_on(file_finding(
+            &provider,
+            &convention(),
+            &seen,
+            &draft(title, &["bug"]),
+        ))
+        .expect("the port was reachable");
+
+        assert!(matches!(outcome, Filed::Duplicate { .. }), "{outcome:?}");
+        assert!(provider.filed().is_empty());
+    }
+
+    /// `finding_digest` normalizes line numbers, so the same defect reported
+    /// against a shifted line is one finding — the property the aperture
+    /// ladder's dry streak rests on, now also governing what gets filed.
+    #[test]
+    fn the_same_defect_at_a_shifted_line_is_one_finding() {
+        let provider = FixtureProvider::default();
+        let seen = vec![finding_digest("driver.rs:412 retry counter leaks")];
+
+        let outcome = block_on(file_finding(
+            &provider,
+            &convention(),
+            &seen,
+            &draft("driver.rs:987 retry counter leaks", &["bug"]),
+        ))
+        .expect("the port was reachable");
+
+        assert!(matches!(outcome, Filed::Duplicate { .. }), "{outcome:?}");
+        assert!(provider.filed().is_empty());
+    }
+
+    /// A tracker that cannot be written to is an error, never a silent
+    /// success — the loop must not believe it filed what it found.
+    #[test]
+    fn an_unreachable_tracker_fails_the_filing_rather_than_swallowing_it() {
+        let outcome = block_on(file_finding(
+            &DeadProvider,
+            &convention(),
+            &[],
+            &draft("something", &["bug"]),
+        ));
+
+        assert!(
+            matches!(outcome, Err(IssueError::Unavailable { .. })),
+            "{outcome:?}"
+        );
+    }
+
     fn backlog() -> FixtureProvider {
-        FixtureProvider(vec![
+        FixtureProvider::with(vec![
             issue("7", &["bug", "P1"], "2026-08-19T00:00:00Z"),
             issue("9", &["triage"], "2026-08-01T00:00:00Z"),
             issue("3", &["bug", "P0"], "2026-08-18T00:00:00Z"),

--- a/crates/stella-cli/src/self_driving_cmd/convention.rs
+++ b/crates/stella-cli/src/self_driving_cmd/convention.rs
@@ -1,0 +1,287 @@
+//! Learning how *this* repository writes issues.
+//!
+//! `doc:backlog-self-driving` §3.1a. [`stella_autonomy::conform`] is the pure
+//! decision; this is the I/O half that finds out what to decide against.
+//!
+//! # Precedence, and why the enforced source wins
+//!
+//! **Enforced > declared > observed.** A workflow that adds `triage` to an
+//! untyped issue is not *describing* a convention — it **is** one, and it will
+//! do that to the loop's filings whatever any document says. So the enforced
+//! source is read first and is the only one that can be wrong about itself in
+//! no way at all.
+//!
+//! # Why this scans rather than parses
+//!
+//! It reads two declared facts out of `.github/workflows/issue-triage.yml` — the
+//! `TYPE_LABELS` list and whether `triage` is applied by automation — and it
+//! does **not** parse the workflow. That is a deliberate trade against adding a
+//! YAML dependency to the workspace for two lines (AGENTS.md: no new
+//! dependencies casually), and it is safe only because of how it fails:
+//!
+//! **A scan that finds nothing yields a [`Acceptance::Proposed`] convention,
+//! which refuses every filing.** So the failure mode of not understanding this
+//! repository is "file nothing and say so", never "file something unclassified".
+//! A fragile reader whose failure direction is refusal is a different thing from
+//! a fragile reader that guesses.
+//!
+//! If a workspace needs something this cannot discover, it writes the manifest
+//! by hand and [`load`] reads that instead — which is also how a non-GitHub
+//! tracker is described.
+
+use std::path::Path;
+
+use stella_autonomy::{
+    Acceptance, AxisRequirement, BacklogConvention, ConventionSource, LabelAxis,
+};
+
+/// Where a workspace pins its convention, overriding discovery.
+const MANIFEST: &str = ".stella/issues/convention.json";
+
+/// The workflow whose behaviour *is* this repository's type convention.
+const TRIAGE_WORKFLOW: &str = ".github/workflows/issue-triage.yml";
+
+/// How the convention in force was arrived at, for the human reading a refusal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Provenance {
+    /// Read from the workspace's checked-in manifest.
+    Manifest,
+    /// Discovered from repository automation.
+    Discovered,
+    /// Nothing could be learned, so a proposal was made and nothing may be
+    /// filed under it until a human accepts.
+    Proposed,
+}
+
+/// The convention in force, and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Bound {
+    /// The convention itself.
+    pub convention: BacklogConvention,
+    /// How it was arrived at.
+    pub provenance: Provenance,
+}
+
+/// Resolve the convention for a workspace root.
+///
+/// Never fails: an unreadable repository yields a proposal, and a proposal
+/// files nothing. The caller renders the difference to a human rather than
+/// having to handle an error it could not act on anyway.
+pub(super) fn load(root: &Path) -> Bound {
+    if let Some(convention) = from_manifest(root) {
+        return Bound {
+            convention,
+            provenance: Provenance::Manifest,
+        };
+    }
+    if let Some(convention) = discover(root) {
+        return Bound {
+            convention,
+            provenance: Provenance::Discovered,
+        };
+    }
+    Bound {
+        convention: propose(),
+        provenance: Provenance::Proposed,
+    }
+}
+
+fn from_manifest(root: &Path) -> Option<BacklogConvention> {
+    let raw = std::fs::read_to_string(root.join(MANIFEST)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Read the enforced convention out of repository automation.
+///
+/// Returns `None` when nothing enforced can be found, which is what makes the
+/// caller propose rather than guess.
+fn discover(root: &Path) -> Option<BacklogConvention> {
+    let workflow = std::fs::read_to_string(root.join(TRIAGE_WORKFLOW)).ok()?;
+
+    let members = type_labels(&workflow)?;
+
+    // A label the automation applies is a label the loop must not: it means
+    // "arrived from outside without a type", and the loop knows what it found.
+    let mut reserved = Vec::new();
+    if workflow.contains("--add-label triage") {
+        reserved.push("triage".to_owned());
+    }
+
+    Some(BacklogConvention {
+        axes: vec![LabelAxis {
+            name: "type".to_owned(),
+            members,
+            // The workflow's whole behaviour is "an issue without one of these
+            // gets stamped", which is `ExactlyOne` stated as an action.
+            requirement: AxisRequirement::ExactlyOne,
+            source: ConventionSource::Enforced,
+        }],
+        reserved,
+        acceptance: Acceptance::Bound,
+    })
+}
+
+/// Extract the `TYPE_LABELS` list — the one fact this scan is for.
+///
+/// The workflow declares it as a space-separated scalar, and its own comment
+/// says why: *"Space-separated; adding any of these counts as typing the
+/// issue."* An empty or missing list yields `None` rather than an empty axis,
+/// because an axis with no members would accept every filing — the failure
+/// direction this module exists to avoid.
+fn type_labels(workflow: &str) -> Option<Vec<String>> {
+    let line = workflow
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("TYPE_LABELS:"))?;
+
+    let members: Vec<String> = line
+        .trim_start_matches("TYPE_LABELS:")
+        .trim()
+        .trim_matches(['"', '\''])
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect();
+
+    (!members.is_empty()).then_some(members)
+}
+
+/// The minimal proposal for a repository with no discoverable standard.
+///
+/// **Inert by construction** — [`Acceptance::Proposed`] makes
+/// [`stella_autonomy::conform`] refuse every filing against it, including one
+/// that would otherwise pass. The loop may propose any convention and grant
+/// itself none; acceptance is a human's, and under governance mode `regulated`
+/// it stays one.
+///
+/// Deliberately small. A proposal is a thing a human has to read and agree to,
+/// and a large one is a thing they will skim.
+fn propose() -> BacklogConvention {
+    BacklogConvention {
+        axes: vec![LabelAxis {
+            name: "type".to_owned(),
+            members: ["bug", "feature", "task"]
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
+            requirement: AxisRequirement::ExactlyOne,
+            source: ConventionSource::Observed,
+        }],
+        reserved: Vec::new(),
+        acceptance: Acceptance::Proposed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    fn write(root: &Path, rel: &str, body: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(path, body).expect("write");
+    }
+
+    /// This repository's real workflow, abridged to the two facts that are read.
+    const REAL_WORKFLOW: &str = r#"
+env:
+  GH_TOKEN: ${{ github.token }}
+  # Space-separated; adding any of these counts as typing the issue.
+  TYPE_LABELS: bug feature epic documentation question
+jobs:
+  triage:
+    steps:
+      - run: gh issue edit "$ISSUE" --repo "$REPO" --add-label triage
+"#;
+
+    /// **The discovery witness.** The convention is learned from the automation
+    /// that enforces it, not from a table hardcoded in Stella — so a repository
+    /// that types its issues differently gets its own answer.
+    #[test]
+    fn the_type_axis_is_learned_from_the_workflow_that_enforces_it() {
+        let ws = workspace();
+        write(ws.path(), TRIAGE_WORKFLOW, REAL_WORKFLOW);
+
+        let bound = load(ws.path());
+
+        assert_eq!(bound.provenance, Provenance::Discovered);
+        assert_eq!(bound.convention.acceptance, Acceptance::Bound);
+        let axis = &bound.convention.axes[0];
+        assert_eq!(axis.source, ConventionSource::Enforced);
+        assert_eq!(
+            axis.members,
+            vec!["bug", "feature", "epic", "documentation", "question"]
+        );
+        assert_eq!(bound.convention.reserved, vec!["triage".to_owned()]);
+    }
+
+    /// A different repository, a different vocabulary. Nothing about Stella's
+    /// own labels is baked in.
+    #[test]
+    fn a_repository_with_its_own_vocabulary_gets_its_own_axis() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            TRIAGE_WORKFLOW,
+            "env:\n  TYPE_LABELS: defect enhancement chore\n",
+        );
+
+        let bound = load(ws.path());
+
+        assert_eq!(
+            bound.convention.axes[0].members,
+            vec!["defect", "enhancement", "chore"]
+        );
+        // No `--add-label triage` in this one, so nothing is reserved.
+        assert!(bound.convention.reserved.is_empty());
+    }
+
+    /// **The fail-safe witness.** A repository whose standard cannot be
+    /// discovered yields a proposal, and a proposal files nothing — so the
+    /// failure mode of not understanding a repository is "file nothing and say
+    /// so", never "file something unclassified".
+    #[test]
+    fn an_undiscoverable_repository_proposes_and_files_nothing() {
+        let bound = load(workspace().path());
+
+        assert_eq!(bound.provenance, Provenance::Proposed);
+        assert_eq!(bound.convention.acceptance, Acceptance::Proposed);
+
+        // The operative half: even a well-formed draft is refused.
+        assert!(!stella_autonomy::conform(&bound.convention, &["bug"]).is_conformant());
+    }
+
+    /// An empty list would make an axis that accepts every filing, which is the
+    /// exact failure direction this module exists to avoid — so it is treated
+    /// as "nothing discovered" rather than as a permissive convention.
+    #[test]
+    fn an_empty_type_list_is_not_a_permissive_convention() {
+        let ws = workspace();
+        write(ws.path(), TRIAGE_WORKFLOW, "env:\n  TYPE_LABELS:\n");
+
+        assert_eq!(load(ws.path()).provenance, Provenance::Proposed);
+    }
+
+    /// A checked-in manifest overrides discovery — how a workspace describes a
+    /// tracker this scan could never learn.
+    #[test]
+    fn a_checked_in_manifest_outranks_discovery() {
+        let ws = workspace();
+        write(ws.path(), TRIAGE_WORKFLOW, REAL_WORKFLOW);
+        write(
+            ws.path(),
+            MANIFEST,
+            r#"{"axes":[{"name":"kind","members":["defect"],
+                 "requirement":"exactly_one","source":"declared"}],
+                 "reserved":[],"acceptance":"bound"}"#,
+        );
+
+        let bound = load(ws.path());
+
+        assert_eq!(bound.provenance, Provenance::Manifest);
+        assert_eq!(bound.convention.axes[0].name, "kind");
+    }
+}

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -242,6 +242,32 @@ pub enum IssueError {
     },
 }
 
+/// A prospective issue, before a tracker has assigned it a key.
+///
+/// Distinct from [`Issue`] rather than an [`Issue`] with an empty key, because
+/// the fields differ in kind: a draft has no key, no state, no `created_at` and
+/// no url — the tracker decides all four — and a type whose invalid states are
+/// unrepresentable beats one whose caller must remember which four fields are
+/// ignored on write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueDraft {
+    /// One line.
+    pub title: String,
+    /// The handoff. Assume the reader has none of the filer's context.
+    pub body: String,
+    /// The labels to apply.
+    ///
+    /// **Checked against the workspace's convention before this ever reaches a
+    /// provider** (`stella_autonomy::conform`). A provider is the wrong layer
+    /// to enforce classification: it would have to learn every tracker's
+    /// taxonomy, and a refusal from here could not say which axis was missing.
+    #[serde(default)]
+    pub labels: Vec<IssueLabel>,
+    /// The epic or parent this hangs off, when there is one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<IssueKey>,
+}
+
 /// The port every tracker is reached through — invariant 1 for the backlog
 /// plane.
 ///
@@ -250,13 +276,23 @@ pub enum IssueError {
 /// local journal, which is exactly the property the witness test asserts by
 /// ranking a real queue with no `gh` on `PATH` at all.
 ///
-/// # Read-only, on purpose, at this slice
+/// # The write half
 ///
-/// Filing, claiming and closing are `doc:backlog-self-driving` §3.1's other
-/// four `backlog` calls, and they are deliberately not here yet: a write path
-/// with nothing calling it is the unwired code AGENTS.md's "nothing left
-/// behind" rule exists to prevent. This trait grows the write half in the
-/// slice that serves those calls, and #3599 tracks it.
+/// [`Self::file`] and [`Self::close`] landed with the `backlog` verbs that call
+/// them (#3599 B1b) — until then they were deliberately absent, because a write
+/// path with nothing calling it is the unwired code AGENTS.md's "nothing left
+/// behind" rule exists to prevent.
+///
+/// **There are no default implementations**, and that is the point. A provider
+/// that cannot write must say so in its own `id`'s voice by returning a typed
+/// error, because a default that silently no-ops would let the loop believe it
+/// had filed what it found — which is precisely the failure the residue
+/// discipline exists to prevent, arriving through the mechanism meant to stop
+/// it.
+///
+/// Claiming is **not** here. A tracker's assignee field has no
+/// compare-and-swap and no lease, so a claim goes in the fleet ledger where the
+/// primitive actually exists (see the module docs).
 #[async_trait]
 pub trait IssueProvider: Send + Sync {
     /// Stable id for this provider, e.g. `"github"` — what an error names and
@@ -272,6 +308,25 @@ pub trait IssueProvider: Send + Sync {
     /// bounds the read, because a tracker with ten thousand open issues should
     /// not have all of them cross this boundary to produce a batch of five.
     async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError>;
+
+    /// File a new issue and return the key the tracker assigned it.
+    ///
+    /// The key is the whole return value on purpose: it is what makes the
+    /// filing *referenceable* — a receipt, a `Closes #N`, a parent edge — and a
+    /// filing the loop cannot name afterwards is barely better than none.
+    async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError>;
+
+    /// Close an issue, recording why.
+    ///
+    /// `receipt` names the evidence (`doc:backlog-self-driving` §4.3) and is
+    /// required rather than optional: a closure with no evidence cannot be
+    /// re-checked later, and the count of unsweepable closures is the direct,
+    /// unflattering measure of how often `done` was a claim rather than a
+    /// proof.
+    async fn close(&self, key: &IssueKey, receipt: &str) -> Result<(), IssueError>;
+
+    /// Add a comment — the trail that binds an execution to an issue.
+    async fn comment(&self, key: &IssueKey, body: &str) -> Result<(), IssueError>;
 }
 
 #[cfg(test)]

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -307,6 +307,70 @@ provider configured" is the user-facing ask, and it is also the only piece every
 other verb group depends on: `work` needs a unit, `sweep` needs somewhere to
 file, `deliver` needs something to close.
 
+### 3.1a The backlog convention — learned, never assumed
+
+`backlog file` is what makes "nothing left behind" a guarantee rather than a
+habit. But a tracker is not a bag of text: every repository the loop attaches to
+already has a classification scheme and a writing standard, and **filing into it
+wrongly is worse than not filing at all** — the queue the loop ranks is the
+queue the loop just polluted.
+
+**The defect is a feedback loop, and it is live in this repository today.**
+`rank_defects` counts an issue as a defect if it carries `bug` **or** `triage` —
+an untriaged issue is a defect nobody has classified yet. Meanwhile
+`.github/workflows/issue-triage.yml` adds `triage` to any issue opened without
+one of its `TYPE_LABELS`, and the comment above that rule names the exact case:
+*"Issues opened outside the template (`gh issue create`, the API) carry no labels
+at all — those are exactly the ones this catches."* A loop filing through the API
+**is** that case. So an unlabelled filing is stamped `triage` by the workflow and
+read back next cycle as an untriaged defect the loop is responsible for
+triaging. The loop manufactures its own queue, and every measure of whether it is
+gaining or losing ground on the backlog silently includes its own exhaust.
+
+**Three sources, in precedence order**, because two of them will disagree and the
+tie has to break the same way every time:
+
+| Source | What it is | Why it ranks here |
+|---|---|---|
+| **Enforced** | Automation acts on it — `issue-triage.yml`'s `TYPE_LABELS`, the `triage` lifecycle | The only source that is a *fact* rather than a claim. A workflow that stamps an untyped issue is not describing a convention, it **is** one — it will do that to the loop's filings whatever any document says. |
+| **Declared** | Issue templates, the label set, a `CONTRIBUTING` section, the handoff format in `scripts/self-driving/commands/self-driving/tickets.md` | Authoritative about intent, silent about practice. It may describe a rule nothing enforces and everyone ignores. |
+| **Observed** | The distribution over recent issues | The only source that is a guess. Fills an axis the two above leave undefined; never overrides either. Recorded as `Observed` precisely so a human can see which parts nobody actually stated. |
+
+The result binds as a source-tracked **convention manifest** beside the provider
+manifest under `.stella/issues/`, for the same reason that one is tracked: a
+convention that was *inferred* must be readable by a human before it steers a
+filing. **The loop never infers and files in one motion.**
+
+**Conform or refuse, never best-effort.** A filing that cannot be classified
+under the bound convention is an error, not a degraded post. That is the whole
+mechanism — it is what stops the loop poisoning the queue it ranks, and it is why
+`conform` returns every violation at once rather than the first: a filing refused
+one reason at a time is a filing refused four times.
+
+**Where no standard exists, the loop proposes one and grants itself nothing.** A
+proposed convention is **inert** — `conform` refuses every filing against it,
+including one that would be conformant if the convention were bound. This is §7's
+rule pointed at classification: a loop that invented a taxonomy and then filed
+under it has granted itself the authority to define how this repository
+classifies work. Acceptance is a human's, and under governance mode `regulated`
+it stays one.
+
+The model is portable and this repository's vocabulary is not baked into it:
+axes (`type`, `priority`, `area` here), each with membership, a requirement
+(`ExactlyOne` / `AtMostOne` / `Any`) and its source; plus **reserved** labels the
+loop may never apply itself. `triage` is this repository's one reserved label —
+it marks an issue that arrived from outside without a type, and the loop knows
+what it found, so applying it would be claiming to be a stranger to its own
+filing. Note the interesting failure is not "missing" but **ambiguous**: two
+priority labels on one issue is not a stricter filing, it is a filing whose rank
+is decided by whichever label the ranker happens to test first.
+
+Lands in `crates/stella-autonomy/src/convention.rs` — pure, and over borrowed
+label text rather than a `stella_protocol::Issue`, so the crate keeps the
+no-workspace-dependency property that lets the Observatory link its folds. That
+is the same trade `rank_defects` already makes, and the one mapping from a
+tracker's shape into this one lives in the caller.
+
 ### 3.2 `work` — one unit of backlog, through Stella's own loop
 
 | Call | Returns | What it does |

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -477,16 +477,44 @@ pub enum LoopStep {
     Sweep { lens: &'static str },
     Curate,
     Watch { until: WakeCondition },
-    Halt { reason: HaltReason },
+    Blocked { reason: BlockReason, clears_when: Clearance },
 }
 
-pub fn step(state: &LoopState, obs: &Observation, now: Timestamp) -> LoopStep;
+pub fn step(state: &LoopState, obs: &LoopObservation) -> LoopStep;
 ```
 
-`Halt` exists and is reachable — for a spent budget, a revoked grant, an
+`Blocked` exists and is reachable — for a spent budget, a revoked grant, an
 operator stop, or an `Escalated` PR the policy declines to abandon. **A loop
-that cannot halt is not autonomous, it is unsupervised**, and those are
+that cannot stop is not autonomous, it is unsupervised**, and those are
 different things.
+
+**But a block is a park, not a death, and it clears itself.** The loop resumes
+the moment the thing blocking it goes away, and *nobody has to tell it that it
+may*. There is no resume input, no acknowledgement and no operator gesture in
+the contract: a human who raises the ceiling, restores the grant, drops the stop
+flag or merges the escalated PR has already said everything that needs saying,
+and asking them to also say "go" is asking twice.
+
+This is structural rather than promised — **the machine holds no latch.** `step`
+is a total function of the current state and the current observation, so a block
+is recomputed from scratch on every poll and simply stops being returned when
+its cause is gone. There is no `blocked` flag that could be left set, which
+means there is no state an operator could have to clear.
+`a_cleared_block_resumes_with_no_resume_signal` is the witness, and it asserts
+all four reasons, because a latch on any one of them would strand the loop
+exactly there.
+
+Two consequences worth stating:
+
+- **Every `BlockReason` names a `Clearance`** — the observable that will let it
+  go. `BlockReason::clearance()` is total, so a new reason cannot be added
+  without answering "and what would un-block it?". A block with no clearance is
+  by definition one that needs a human to say "go".
+- **The one obligation on a host is to keep polling.** A host that exits the
+  process on `Blocked` makes resumption impossible no matter what the machine
+  returns, which is why the variant carries its clearance rather than reading as
+  a terminal state. This is the same shape as `watch` mode: cheap sentinels, and
+  the loop wakes itself.
 
 ---
 

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -214,8 +214,9 @@ decides, `stella-cli` probes):
 | **`plugins/stella-selfdriving`** (the driver) | *Policy only*: when to run, how many at once, in what order, when to stop, what to escalate. A loop that asks for declared capabilities and nothing else. | It is the piece an operator should be able to fork, replace, or write in another language without forking Stella. |
 
 The load-bearing consequence: **the judgement half becomes Stella's own agent
-loop.** `work` (§3.2) runs a unit of backlog through Stella's staged pipeline —
-the same triage → … → verify → verdict path a `stella run` takes. If Stella's
+loop.** `work` (§3.2) runs a unit of backlog through Stella's turn loop — the
+same path a `stella run` takes, with whatever the installed plugins add over it
+and nothing else. If Stella's
 loop is not good enough to drive Stella's own backlog, that is a finding about
 Stella, and it should be measured rather than routed around by borrowing
 somebody else's agent. Today it is routed around.
@@ -375,7 +376,7 @@ tracker's shape into this one lives in the caller.
 
 | Call | Returns | What it does |
 |---|---|---|
-| `work start --issue <key>` | `json` | Resolve context for the issue, create the isolated worktree, run the staged pipeline against it, return the outcome and the diff. |
+| `work start --issue <key>` | `json` | Resolve context for the issue, create the isolated worktree, run Stella's turn loop against it — with whatever the installed plugins wrap it in — and return the outcome and the diff. |
 | `work status` | `query-envelope` | The in-flight unit: stage, spend, elapsed, checkpoint. |
 | `work abandon` | `text` | Release the claim and the worktree, recording why. Abandonment is a *recorded outcome*, never a silent drop. |
 
@@ -386,9 +387,21 @@ mechanism rather than new invention:
 - **Isolation is `candidate_ws.rs`'s shadow worktree**, not a branch checkout of
   the operator's tree. The loop must be able to run while a human works in the
   same clone.
-- **Done is the pipeline's verdict**, not the model's claim: the flip oracle,
-  tamper exclusion, `ladder_decision`. Self-driving gets no weaker definition of
-  done than a `stella run` gets, and gets no new terminal state.
+- **Done is whatever the installed plugins make it**, and this design invents no
+  definition of its own. The staged pipeline that once ran the flip oracle,
+  tamper exclusion and `ladder_decision` is **deleted from this workspace**
+  (#3852/#3865) and `--pipeline classic` is refused outright, so there is no
+  built-in verdict left to inherit. Self-driving therefore gets exactly what a
+  `stella run` gets on the same machine — no weaker, and no new terminal state —
+  which with no verification plugin installed is the turn's own outcome.
+
+  **Say the consequence out loud rather than letting the old sentence imply
+  otherwise:** on a workspace with no verification plugin, a `work` outcome means
+  *the turn finished*, not *the change is proven*. What makes an autonomous merge
+  safe is not this stage — it is `deliver` (§3.3), which gates on CI observed on
+  the forge. That is a weaker guarantee than the deleted pipeline offered and it
+  is the true one; a design doc that kept promising the stronger one would be
+  the expedient this repository treats as a defect.
 - **Abort is at safe boundaries** (invariant 6). A budget ceiling reached
   mid-tool waits for the tool.
 
@@ -684,6 +697,85 @@ rather say that now than discover it from a bad release.
 
 ---
 
+### 6.5 The doctrine — whose decision system the loop is running
+
+Self-driving stands in for a person, and **a person deciding what to do next is
+not running a universal algorithm.** They are applying a system they developed.
+One maintainer's standing instruction is *"when two designs both work, ship the
+one still correct in five years under a different maintainer"* — that is this
+repository's, and it is written down in `CLAUDE.md`. Another's is *"ship the
+smallest diff that closes the ticket"*. **Both are legitimate, and a loop that
+hardcodes either is a loop that can only replace one of them.**
+
+So the tie-breakers are configuration: a `[doctrine]` manifest, source-tracked
+beside the provider and convention manifests under `.stella/issues/`, because the
+person who starts the loop is the person who decides how it decides — and that is
+only true if what it will do is legible *before* it does it.
+
+**The line is machine-readability, and it is drawn to avoid a fifth steering
+plane.** This repository already carries four that do not know about each other
+(#3243), and the fastest way to make it five is a free-text "how should I decide
+things" field. So:
+
+| Belongs in `[doctrine]` | Belongs in a context record |
+|---|---|
+| Closed enums and numbers a **pure machine** branches on — `foreign_breakage`, `contention`, `queue_order`, `abandon_escalated`, the `deliver` ceilings | Prose instruction for the **judgement half** — "prefer the architecturally sound option", "match the neighbourhood", "no new dependencies casually" |
+| No model ever reads it. An operator's declared preference becomes *testable*: you can assert `FileAndWait` does not adopt, and the assertion cannot be talked out of. | Already has a home (`.stella/rules/*.toml`, `doc:context-pr`), already governed, already versioned. |
+
+The test is invariant 5's: **does a caller branch on it?** A pure machine
+branching on a closed enum belongs; a sentence a model reads does not. A
+`[doctrine]` field that wants to say something prose-shaped **is** a context
+record, and the answer to that request is a pointer, not a field.
+
+#### The loop exhausts its permitted channels before it parks
+
+A blockage is not automatically somebody else's problem. The case that matters is
+a **red base the loop did not cause**: it blocks everyone, and a loop that waits
+for its author has a throughput equal to somebody else's response time. But a
+loop wandering into unrelated code is also how an autonomous system becomes a
+liability — so this is exactly a doctrine axis, not a rule:
+
+- `file_and_wait` *(default)* — make it visible, leave the fix to a human.
+- `file_and_adopt` — make it visible, then fix it at the top of the queue.
+- `ignore` — neither. Present for the operator who wants a silent loop, and
+  deliberately **not** the default: a system that notices breakage and says
+  nothing is the worst of the three.
+
+Three orderings inside that are load-bearing:
+
+1. **File first, always, under every policy that files at all.** The ticket is
+   what makes the breakage visible and attributable *even if the fix never
+   lands*, so filing is never contingent on fixing being attempted.
+2. **Check contention before adopting.** Two workers on one broken `main`
+   produce a merge conflict on top of an outage.
+3. **Unblock before claiming.** A red base makes every PR the loop produces fail
+   CI, so it is dealt with before more are made.
+
+And a red base stops *merges*, not *authoring* — so under `file_and_wait`, once
+filed, the loop carries on with ordinary work rather than parking.
+
+#### Collision avoidance, and the signal nobody checks
+
+Contention evidence is **heuristic**, which is why how much it weighs is also
+doctrine. Four signals, and only one is authoritative:
+
+| Signal | Weight |
+|---|---|
+| **Ledger claim** | Authoritative — a lease with an owner and an expiry. |
+| Open PR | Strong hint. |
+| Remote branch | A name that resembles the work. |
+| **Worktree on this machine** | The one nobody remembers to check — and the one most likely to be the loop's *own other session*. Two self-driving processes against one clone see each other **only** here. |
+
+`ContentionPolicy` weighs them: `defer` on any signal (the default — a duplicated
+fix costs two workers and a conflict, a deferred one costs a poll interval);
+`claims_only` for the solo operator whose remote is full of their own stale
+branches, where deferring on branch names would deadlock the loop against itself;
+`proceed` regardless, recorded and never silent. A deferral carries the evidence
+that caused it, because "deferred" with no evidence is indistinguishable from
+never having looked.
+
+---
+
 ## 7. Curation: the loop may propose any authority, and grant itself none
 
 The user's ask includes the loop "curating its own set of tools and context
@@ -785,7 +877,7 @@ drew its batch from. Both numbers are now folds of one ranking of one read.
 | `LoopStep`, `step`, `PrState`, supply model, re-arm rule | `stella-autonomy` (pure; new modules — the crate has no god files and must keep none) |
 | `Issue`, `IssueState`, `IssueClass`, `PrId`, receipts | `stella-protocol` (types only) |
 | Residue detection, discharge rules | `stella-core` (pure, no I/O) |
-| The residue gate stage | `stella-pipeline`, beside `verify`/`witness` |
+| The residue gate stage | **Homeless.** `stella-pipeline` is deleted (#3852/#3865) and this row named it; B5 has to pick a home before it can be built — a wrapper plugin's own side, or a `stella-cli` check over the turn's transcript. Tracked in #3901's sweep of the same stale claim. |
 | `backlog`/`work`/`deliver`/`sweep`/`curate` verbs, the forge adapter, provider manifests | `stella-cli` (`self_driving_cmd/` — note `self_driving_cmd.rs` is 1005 lines and new logic lands in siblings) |
 | Issue claims | `stella-fleet` ledger |
 | The driver channel: dispatch context, `[driver]` block, `permits_call` | `stella-plugin` (wire + gate), `stella-runtime` (`src/wrapper/`, beside the existing host-call dispatch) |
@@ -854,7 +946,9 @@ land early if the residue gate is wanted sooner than the autonomy.
 - **Building a tracker.** Stella writes to the customer's.
 - **Replacing the human as the steering authority.** §6.4, §7.
 - **Autonomous release by default.** §6.4.
-- **A new definition of done.** The pipeline's verdict is the only one.
+- **A new definition of done.** Self-driving takes whatever the turn loop and the
+  installed plugins yield, and adds nothing of its own — see §3.2 on what that
+  is worth when nothing verifying is installed.
 - **Project management.** The loop drains a readiness queue; what belongs in the
   queue stays a human's call.
 - **Making the loop unstoppable.** `Halt` is a first-class outcome.

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -126,13 +126,35 @@ calls = [
   "backlog_file",
   "backlog_close",
   "backlog_link",
-  # work — one issue through Stella's own staged pipeline, in an isolated
-  # worktree, with the pipeline's verdict as the definition of done.
+  # work — one issue through Stella's own turn loop, in an isolated worktree.
+  #
+  # NOT through a built-in verification pipeline: there is no longer one to run.
+  # The staged pipeline was deleted from this workspace (#3852/#3865) and
+  # `--pipeline classic` is refused outright, so a turn gets exactly the
+  # verification the INSTALLED PLUGINS provide and no more. With no verification
+  # plugin installed, that is none, and the honest reading of a `work` outcome
+  # is "the turn finished", not "the change is proven".
+  #
+  # This block said "the staged pipeline" and "the pipeline's verdict as the
+  # definition of done" until #3599 B2. Both were false by then, and this file
+  # is a consent document — a human reads it to decide what to grant, so a
+  # promise here that nothing keeps is worse than no promise at all. What makes
+  # an autonomous merge safe is `deliver` below, which gates on CI observed on
+  # the forge, not on any claim made about the work stage.
   "work_start",
   "work_status",
   "work_abandon",
-  # deliver — the PR rhythm. `deliver_merge` is gated on the pipeline's
-  # verdict, never on the loop's opinion of it.
+  # deliver — the PR rhythm, and the whole of what makes an autonomous merge
+  # safe now that no built-in verification stage exists (see `work` above).
+  # `deliver_merge` is emitted only by the pure machine in
+  # `stella_autonomy::deliver_next`, and only from `Approved` — which requires
+  # CI observed GREEN ON THE FORGE, a mergeability the forge has actually
+  # computed, and, unless the operator turned it off in policy, a human
+  # approval. Never on the loop's own opinion of its work.
+  #
+  # A red build that reproduces on the base branch is `BaseBroken`, not
+  # `CiRed`: the loop waits rather than spending this PR's budget fixing
+  # somebody else's breakage.
   "deliver_open",
   "deliver_observe",
   "deliver_next",

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -19,6 +19,7 @@ stella self-driving aperture (--current | --advance | --reset | --list)
 stella self-driving seen (--digest TEXT… | --new DIGEST… | --add DIGEST… | --count)
 stella self-driving calibrate (--ok | --resource-fail | --show)
 stella self-driving queue [--limit N] [--format <text|json>]
+stella self-driving file --title TEXT [--body TEXT] [--label L…] [--format <text|json>]
 stella self-driving run (start | end [--status S] [--reason S] | cancel [reason] | list | stamp-cycle-pid [PID])
 stella self-driving runs
 stella self-driving phase <name>
@@ -92,6 +93,16 @@ A **run** spans many cycles (one `/loop` session, one daemon lifetime) and is th
 ### metrics, state, queue
 
 `metrics` folds the ledger into the loop's evidence about itself, with named pathology signals (`STUCK`, `STARVED`, `NOISY`, `FRAGILE`) for the meta-cycle to act on. `state` shows the counters and the last five cycles. `queue` ranks the open defects P0 &gt; P1 &gt; P2 &gt; untriaged, oldest first inside a rank — feature work is excluded, because this loop closes defects.
+
+### file
+
+`stella self-driving file` files a finding as an issue through the bound provider, and it **refuses rather than degrades**.
+
+Two checks run before the tracker is reached. A finding whose digest is already in the seen-set is not filed twice — the same normalization the aperture ladder's dry streak rests on, so the same defect reported against a shifted line number is one finding. And the draft must match this workspace's issue convention.
+
+That second check exists because of a feedback loop. The ranker counts an issue as a defect if it carries `bug` *or* `triage`; GitHub's triage workflow adds `triage` to any issue opened without a type label, and issues opened through the API carry no labels at all. So an unclassified filing comes back next cycle as an untriaged defect the loop is responsible for triaging — the loop manufactures its own queue, and every measure of ground gained on the backlog quietly includes its own exhaust.
+
+The convention is **learned, not assumed**: read from `.stella/issues/convention.json` if the workspace pins one, otherwise discovered from the automation that enforces it. Where nothing can be discovered the loop *proposes* a convention and files nothing under it until a human accepts — it may propose any convention and grants itself none. A refusal names every violation at once and says which source the convention came from, because "what did I get wrong" and "wrong according to what" are both questions you need answered.
 
 ## Files
 


### PR DESCRIPTION
## What & why

Four pure machines that together are the deterministic half of an autonomous
backlog loop. `stella-autonomy` keeps its no-workspace-dependency property
throughout, so the Observatory can still link these folds without linking the
machinery it observes.

Refs #3599. Not closing it — this is the brain, not the hands.

### `convention` — the loop learns how a repo writes issues

The defect is a live feedback loop. `rank_defects` counts an issue as a defect
if it carries `bug` **or** `triage`. `.github/workflows/issue-triage.yml` adds
`triage` to any issue opened without one of its `TYPE_LABELS`, and its own
comment names the case: issues opened through the API carry no labels, and
those are exactly the ones it catches. **A loop filing through the API is that
case** — so an unlabelled filing comes back next cycle as an untriaged defect
the loop must triage. It manufactures its own queue, and every measure of
ground gained on the backlog silently includes its own exhaust.

Precedence is enforced > declared > observed. Only the enforced source is a
fact rather than a claim: a workflow that stamps an untyped issue is not
describing a convention, it *is* one. Conform-or-refuse, never best-effort. A
proposed convention is inert, so there is no path where the loop files under a
taxonomy it invented — acceptance is a human's, and this repo is `regulated`.

### `deliver` — the PR rhythm as arithmetic

`deliver_next` buys no model call. `CiRed` and `BaseBroken` are structurally
different states, so the loop cannot burn cycles on somebody else's breakage by
forgetting to ask. `Escalated` is terminal and reachable from everywhere.
`require_approval` defaults to true — a default that merged without review would
make the safe choice the one an operator has to remember to opt into.

### `step` — what now, and a stop that clears itself

A block is a park, not a death. The loop resumes the moment the thing blocking
it clears and **nobody has to tell it that it may**: a human who raises the
ceiling, restores the grant, drops the stop flag or merges the escalated PR has
already said everything that needs saying.

Structural, not promised — **the machine holds no latch.** `step` is a total
function of state and observation, so a block is recomputed every poll and stops
being returned when its cause is gone. There is no flag that could be left set.
Every `BlockReason` names the `Clearance` that releases it, and `clearance()` is
total, so a new reason cannot be added without answering what un-blocks it.

### `doctrine` — whose decision system the loop is running

A person deciding what to do next is not running a universal algorithm. One
maintainer says *ship the design still correct in five years*; another says
*ship the smallest diff*. Both are legitimate; a loop that hardcodes either can
only replace one of them.

**Deliberately not a fifth steering plane.** This repo already has four that do
not know about each other (#3243). Closed enums a *pure machine* branches on go
in `[doctrine]`; prose instruction for the judgement half stays in the
context-record plane it already has. The test is invariant 5's — does a caller
branch on it?

The loop now exhausts permitted channels before parking: file a red base it did
not cause (under every policy that files at all — the ticket survives a failed
fix), check contention before adopting, unblock before claiming. Collision
evidence is heuristic so its weight is doctrine too; the signal nobody checks is
a **worktree on this machine**, which is where two self-driving sessions against
one clone see each other and nowhere else.

## Witnesses

| Machine | Witness |
|---|---|
| convention | `a_filing_that_omits_the_type_axis_is_refused` |
| deliver | `a_red_build_that_reproduces_on_the_base_is_not_this_prs_fault` + `the_same_red_build_on_a_green_base_does_earn_a_fix` |
| step | `a_cleared_block_resumes_with_no_resume_signal` (all four reasons) |
| doctrine | `an_adopted_fix_defers_to_one_already_in_flight`, `a_local_worktree_alone_is_enough_to_defer` |

Each pairs a positive and a negative case where one alone would pass on a
machine that always answered the same way.

84 tests green in `stella-autonomy`; clippy `-D warnings` and rustdoc clean;
`make guards-fast` green.

## Also corrected

`plugins/stella-selfdriving/plugin.toml` promised a human at install that
`work_start` runs "the staged pipeline" and `deliver_merge` is "gated on the
pipeline's verdict". **That crate is deleted** (#3852/#3865) and
`--pipeline classic` is refused outright, so the consent document was false. Per
@macanderson: a `work` unit goes through Stella's turn loop plus whatever
plugins are installed, and nothing else. §3.2 now says out loud what that is
worth when nothing verifying is installed, and the spec's landing map no longer
routes B5's residue gate to a crate that does not exist. Refs #3901.

## Deliberately not here

The I/O half: the `backlog` write verbs, the forge adapter, the driver-session
host (#3783), and the plugin policy loop. These machines have no callers yet —
they are consumed by the verbs in the next slice.

## Summary by Sourcery

Build the deterministic autonomy core and wire safe, convention-aware finding filing into the self-driving CLI.

New Features:
- Add deterministic autonomy machines for issue conventions, PR delivery decisions, loop stepping, and operator doctrine.
- Add `self-driving file` to deduplicate and convention-check findings before filing them through an issue provider.
- Extend issue providers with typed draft filing, closing, and commenting operations.

Bug Fixes:
- Prevent autonomous filings from creating untyped or duplicate backlog defects.
- Distinguish failures caused by a pull request from failures already present on the base branch.
- Ensure blocked loops resume automatically when their blocking condition clears.

Enhancements:
- Make loop blocking, escalation, contention handling, delivery transitions, and doctrine choices explicit and reviewable through pure state machines.
- Use conservative defaults for approval, contention, foreign breakage, and escalation handling.
- Correct self-driving documentation and plugin consent text to reflect the turn loop and installed verification plugins rather than the deleted staged pipeline.

Documentation:
- Document backlog convention discovery, fail-safe filing, self-resuming blocks, delivery guarantees, doctrine configuration, and the actual verification semantics of self-driving work.
- Document the new `self-driving file` command.

Tests:
- Add comprehensive unit and serialization tests covering convention conformance, duplicate prevention, delivery transitions, doctrine-driven contention, and automatic block recovery.