### PR TITLE
fix(stella-cli): unbreak main — delete verifier_engine_config_for, which names an enum #3944 removed

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -270,35 +270,6 @@ pub(crate) fn engine_config_for_kind(cfg: &Config, kind: &str) -> EngineConfig {
     engine
 }
 
-/// EngineConfig for the goal loop's standalone verifier engine — the VERIFIER
-/// agent's tuning.
-///
-/// Its production caller (`run_goal_pipeline_turn`, `agent/goal.rs`) was
-/// deleted along with the staged pipeline's goal arm (#3865) — `stella goal`'s
-/// surviving `Raw`/`Plugin` arms route their verifier through
-/// `stella_core::Engine::run_goal` directly rather than building a separate
-/// tuned config for it.
-///
-/// **Test-gated (#3872), not deleted.** `agent/tests/engine_wiring.rs`'s
-/// cross-role invariant tests (`checkpoint_sink_reaches_every_role`,
-/// `every_role_shares_one_session_view_of_affordable_output_ceilings`, the
-/// turn-timeout/max-output-tokens propagation tests) assert that
-/// `tuned_engine_config`'s session-wide plumbing (checkpoint sink, budget
-/// ceiling, flag propagation) reaches every `EngineAgentKind`, VERIFIER
-/// included; deleting this wrapper would either lose that coverage or force
-/// four tests to re-derive the config inline for no behavioral gain. `cfg(test)`
-/// keeps it out of the shipped binary while saying plainly that its only
-/// callers are tests — which the roleless-core work (#3903) will settle
-/// properly by retiring the VERIFIER kind from this crate's vocabulary.
-#[cfg(test)]
-pub(crate) fn verifier_engine_config_for(cfg: &Config) -> EngineConfig {
-    tuned_engine_config(
-        cfg,
-        crate::settings::EngineAgentKind::Verifier,
-        (cfg.provider.id, &cfg.model_id),
-    )
-}
-
 /// Fire `SessionStart` hooks once and return their stdout — the additional
 /// session context `stella_core::hooks` documents. `None` when no hooks are
 /// configured or they printed nothing. Called once per session by each


### PR DESCRIPTION
`main` does not compile. `cargo check -p stella-cli --all-targets` fails at `crates/stella-cli/src/agent/engine.rs:295` with `E0433` (cannot find `EngineAgentKind` in `settings`) and `E0061` (function takes 2 arguments but 3 were supplied). Canary issue: #3955.

## How two green PRs composed to a red tree

- **#3951** test-gated `verifier_engine_config_for` with `#[cfg(test)]` instead of deleting it, because `agent/tests/engine_wiring.rs` still asserted cross-role plumbing through that name. It kept calling `tuned_engine_config(cfg, EngineAgentKind::Verifier, (provider, model))`.
- **#3944** (the config collapse, `doc:roleless-core` §6 slice 4, epic #3903) retired `EngineAgentKind` entirely, narrowed `tuned_engine_config` to `(cfg, catalog_ref)`, and removed the engine-wiring tests that were this function's only callers.

Neither branch was wrong on its own, and neither could see the other — the exact shape AGENTS.md describes for a shared cell, and why `main-canary.yml` re-asks the question after the merge. It only bites `--all-targets`, because the function is `cfg(test)`; a plain `cargo build` stays green, which is why it reads as "tests are broken" rather than "the binary is broken".

## The fix

Delete it. After #3944 the function has **zero callers** and names a type that no longer exists.

This is what #3951's own doc comment predicted, one merge earlier than it expected:

> `cfg(test)` keeps it out of the shipped binary while saying plainly that its only callers are tests — which the roleless-core work (#3903) will settle properly by retiring the VERIFIER kind from this crate's vocabulary.

Nothing replaces it. With one role there is no second kind whose plumbing could diverge from the default's, which is the entire point of the collapse — so there is no coverage to preserve, only a wrapper for a distinction that no longer exists.

## Verification

| Check | Result |
|---|---|
| `cargo check -p stella-cli --all-targets` | clean (was 2 errors on `main`) |
| `cargo clippy -p stella-cli --all-targets -- -D warnings` | green |
| `cargo test -p stella-cli --bin stella` | 1753 passed, 0 failed |

No witness test: this is a deletion of unreachable code that does not compile, and the compiler is the witness — `main` fails and this tree does not.

Closes #3955

## Summary by Sourcery

Bug Fixes:
- Remove the obsolete verifier engine configuration helper so `stella-cli` compiles successfully with all targets after the verifier agent kind was retired.