### PR TITLE
feat(stella-protocol,stella-tui): the stage vocabulary opens — a plugin's stage gets a name and a colour

### DIFF
--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -216,7 +216,7 @@ pub(crate) async fn run_goal_wrapped_turn(
             let round_offset = stella_core::goal::goal_round_turn_offset(round);
             let round_engine = engine.with_turn_instance(round_offset);
             let _ = tx.send(AgentEvent::Stage {
-                name: stella_protocol::StageKind::Execute,
+                name: stella_protocol::StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Turn,
             });
 
@@ -292,7 +292,7 @@ pub(crate) async fn run_goal_wrapped_turn(
             }
 
             let _ = tx.send(AgentEvent::Stage {
-                name: stella_protocol::StageKind::Verdict,
+                name: stella_protocol::StageKind::Verdict.into(),
                 scope: stella_protocol::StageScope::Turn,
             });
             let (verdict, verifier_cost) = match round_engine

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -174,7 +174,7 @@ pub(super) fn open_raw_turn(events: &EventSender, recall_event: Option<AgentEven
         let _ = events.send(event);
     }
     let _ = events.send(AgentEvent::Stage {
-        name: stella_protocol::StageKind::Execute,
+        name: stella_protocol::StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
 }
@@ -374,7 +374,7 @@ mod durable_stream_tests {
 
         sender
             .send(AgentEvent::Stage {
-                name: stella_protocol::StageKind::Execute,
+                name: stella_protocol::StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             })
             .unwrap();
@@ -399,7 +399,7 @@ mod durable_stream_tests {
         let (raw_tx, mut paused_renderer) = mpsc::unbounded_channel();
         let sender = ordered_durable_event_sender(raw_tx, path.clone(), Arc::new(FixedClock(7)));
         let stage = AgentEvent::Stage {
-            name: stella_protocol::StageKind::Execute,
+            name: stella_protocol::StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         };
         let usage = AgentEvent::StepUsage {

--- a/crates/stella-cli/src/agent/persistence/stream_tests.rs
+++ b/crates/stella-cli/src/agent/persistence/stream_tests.rs
@@ -22,7 +22,7 @@ fn run_complete_is_final_even_when_later_events_arrive() {
             cost_usd: 1.25,
         },
         AgentEvent::Stage {
-            name: stella_protocol::StageKind::Reflect,
+            name: stella_protocol::StageKind::Reflect.into(),
             scope: stella_protocol::StageScope::Run,
         },
     ];
@@ -87,7 +87,7 @@ async fn stream_renderer_persists_reflection_before_the_run_terminator() {
     })
     .unwrap();
     tx.send(AgentEvent::Stage {
-        name: stella_protocol::StageKind::Reflect,
+        name: stella_protocol::StageKind::Reflect.into(),
         scope: stella_protocol::StageScope::Run,
     })
     .unwrap();
@@ -107,9 +107,9 @@ async fn stream_renderer_persists_reflection_before_the_run_terminator() {
     assert!(matches!(
         journal.events.get(1).map(|record| &record.event),
         Some(AgentEvent::Stage {
-            name: stella_protocol::StageKind::Reflect,
+            name,
             scope: stella_protocol::StageScope::Run
-        })
+        }) if name.kind() == Some(stella_protocol::StageKind::Reflect)
     ));
     // The run terminator is the final durable line.
     assert!(matches!(

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -323,7 +323,7 @@ pub(crate) async fn drive_resumed_turn(
     // render `hud.stage` cannot tell one from a fresh one.
     let events = events.pairing_stage_complete();
     let _ = events.send(stella_protocol::AgentEvent::Stage {
-        name: stella_protocol::StageKind::Execute,
+        name: stella_protocol::StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     engine.drive(&mut state, &events).await
@@ -528,9 +528,9 @@ mod tests {
         assert!(matches!(
             first,
             AgentEvent::Stage {
-                name: stella_protocol::StageKind::Execute,
+                name,
                 scope: stella_protocol::StageScope::Run
-            }
+            } if name.kind() == Some(stella_protocol::StageKind::Execute)
         ));
     }
 

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -147,14 +147,14 @@ pub(crate) fn spawn_forwarder(
                 owes_stage_execute = false;
                 held = Some(event);
                 AgentEvent::Stage {
-                    name: stella_protocol::StageKind::Execute,
+                    name: stella_protocol::StageKind::Execute.into(),
                     scope: stella_protocol::StageScope::Run,
                 }
             } else if owes_stage_complete && matches!(event, AgentEvent::TurnComplete { .. }) {
                 owes_stage_complete = false;
                 held = Some(event);
                 AgentEvent::Stage {
-                    name: stella_protocol::StageKind::Complete,
+                    name: stella_protocol::StageKind::Complete.into(),
                     scope: stella_protocol::StageScope::Run,
                 }
             } else {
@@ -364,11 +364,11 @@ mod tests {
         events
     }
 
-    fn stages(events: &[AgentEvent]) -> Vec<stella_protocol::StageKind> {
+    fn stages(events: &[AgentEvent]) -> Vec<stella_protocol::StageName> {
         events
             .iter()
             .filter_map(|event| match event {
-                AgentEvent::Stage { name, .. } => Some(*name),
+                AgentEvent::Stage { name, .. } => Some(name.clone()),
                 _ => None,
             })
             .collect()
@@ -414,8 +414,8 @@ mod tests {
         assert_eq!(
             stages(&events),
             vec![
-                stella_protocol::StageKind::Execute,
-                stella_protocol::StageKind::Complete
+                stella_protocol::StageName::from(stella_protocol::StageKind::Execute),
+                stella_protocol::StageName::from(stella_protocol::StageKind::Complete)
             ],
             "a raw lane frames its turn: {events:?}"
         );
@@ -428,10 +428,8 @@ mod tests {
             .position(|event| {
                 matches!(
                     event,
-                    AgentEvent::Stage {
-                        name: stella_protocol::StageKind::Complete,
-                        ..
-                    }
+                    AgentEvent::Stage { name, .. }
+                        if name.kind() == Some(stella_protocol::StageKind::Complete)
                 )
             })
             .expect("the closing boundary is emitted");
@@ -495,10 +493,8 @@ mod tests {
             .position(|event| {
                 matches!(
                     event,
-                    AgentEvent::Stage {
-                        name: stella_protocol::StageKind::Execute,
-                        ..
-                    }
+                    AgentEvent::Stage { name, .. }
+                        if name.kind() == Some(stella_protocol::StageKind::Execute)
                 )
             })
             .expect("the opening boundary is emitted");

--- a/crates/stella-cli/src/diag_bridge.rs
+++ b/crates/stella-cli/src/diag_bridge.rs
@@ -486,11 +486,19 @@ impl DomainBridge {
 
             // ---- Stage / turn shape. ------------------------------------
             AgentEvent::Stage { name, .. } => {
-                self.emit(
-                    Level::Info,
-                    "agent.stage",
-                    self.at_seq().with("stage", stage_name(*name)),
-                );
+                // Two shapes, deliberately kept apart. A host boundary is one
+                // of a closed set and rides as the `&'static str` the
+                // exhaustive match below produces. A *contributed* stage's name
+                // is runtime text, which a diagnostic field may not hold
+                // unreviewed — so it takes the reviewed path, the same one
+                // `operator_id` takes and for the same reason: the word was
+                // chosen by whoever installed the plugin, and is never model
+                // output, file content or a path.
+                let field = match name.kind() {
+                    Some(kind) => self.at_seq().with("stage", stage_name(kind)),
+                    None => self.at_seq().with("stage", contributed_stage(name.as_str())),
+                };
+                self.emit(Level::Info, "agent.stage", field);
             }
             AgentEvent::TurnComplete { model, cost_usd } => {
                 // A turn terminator: any call still awaiting a result will
@@ -745,6 +753,27 @@ impl DomainBridge {
     pub(crate) fn finish(&self) {
         self.emit(Level::Info, "agent.stream.tally", self.tally.fields());
     }
+}
+
+/// The name of a stage a **plugin** contributed (`doc:roleless-core`).
+///
+/// Through the same reviewed hatch (§5.5) as [`operator_id`], for the same
+/// reason: a stage name is declared in the manifest of a plugin the operator
+/// chose to install, so it is configuration, not content. It cannot be model
+/// output — nothing in a turn authors it — and it is never a path.
+///
+/// Dropping it instead was the alternative, and it is the worse one: a log
+/// saying only that "some stage happened" cannot answer which stage a run
+/// spent its time in, which is the whole question `agent.stage` exists for.
+fn contributed_stage(name: &str) -> Redacted<String> {
+    Redacted::reviewed(
+        name.to_owned(),
+        note!(
+            "a stage name declared by an installed plugin's manifest and chosen by whoever wrote \
+             that plugin; never model output, file content, or a path — and without it a wrapped \
+             run's stage log cannot say which stage it was in"
+        ),
+    )
 }
 
 /// A provider or model identifier the **operator** configured.

--- a/crates/stella-cli/src/diag_bridge.rs
+++ b/crates/stella-cli/src/diag_bridge.rs
@@ -494,11 +494,22 @@ impl DomainBridge {
                 // `operator_id` takes and for the same reason: the word was
                 // chosen by whoever installed the plugin, and is never model
                 // output, file content or a path.
-                let field = match name.kind() {
-                    Some(kind) => self.at_seq().with("stage", stage_name(kind)),
-                    None => self.at_seq().with("stage", contributed_stage(name.as_str())),
-                };
-                self.emit(Level::Info, "agent.stage", field);
+                //
+                // Inlined into the `emit` call rather than bound to a local
+                // first: the reference generator (`scripts/diagnostic-codes.py`)
+                // reads the field chain out of the emit site's own text, and a
+                // local turns `seq`/`stage` into "built at runtime" — a
+                // documented record losing the names of its fields.
+                self.emit(
+                    Level::Info,
+                    "agent.stage",
+                    match name.kind() {
+                        Some(kind) => self.at_seq().with("stage", stage_name(kind)),
+                        None => self
+                            .at_seq()
+                            .with("stage", contributed_stage(name.as_str())),
+                    },
+                );
             }
             AgentEvent::TurnComplete { model, cost_usd } => {
                 // A turn terminator: any call still awaiting a result will

--- a/crates/stella-cli/src/export/transcript/tests.rs
+++ b/crates/stella-cli/src/export/transcript/tests.rs
@@ -281,7 +281,7 @@ fn the_elapsed_column_counts_whole_seconds_and_invents_no_precision() {
             (
                 "2026-08-09 12:00:00",
                 AgentEvent::Stage {
-                    name: StageKind::Triage,
+                    name: StageKind::Triage.into(),
                     scope: stella_protocol::StageScope::Run,
                 },
             ),

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -899,7 +899,7 @@ async fn run_task(
             // closer rides `worker_event_sender` below, ahead of the
             // engine's `TurnComplete` (#3428).
             let _ = tx.send(AgentEvent::Stage {
-                name: stella_protocol::StageKind::Execute,
+                name: stella_protocol::StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             });
             match &wrapped {

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -406,11 +406,11 @@ fn a_raw_worker_closes_the_stage_it_opened() {
             seen.as_slice(),
             [
                 AgentEvent::Stage {
-                    name: stella_protocol::StageKind::Complete,
+                    name,
                     scope: stella_protocol::StageScope::Run,
                 },
                 AgentEvent::TurnComplete { .. },
-            ]
+            ] if name.kind() == Some(stella_protocol::StageKind::Complete)
         ),
         "the closing boundary rides ahead of the terminal event it annotates: {seen:?}"
     );

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -56,9 +56,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use colored::{Color, ColoredString, Colorize};
-use stella_protocol::{AgentEvent, BudgetMode, FileChangeKind, StageName};
 #[cfg(test)]
 use stella_protocol::StageKind;
+use stella_protocol::{AgentEvent, BudgetMode, FileChangeKind, StageName};
 use stella_tui::ansi::AnsiPalette;
 use stella_tui::render::{INLINE_DIFF_CAP, THINKING_ROWS};
 use stella_tui::textline::{self, EventLine, Tone, fmt_cost};

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -56,7 +56,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use colored::{Color, ColoredString, Colorize};
-use stella_protocol::{AgentEvent, BudgetMode, FileChangeKind, StageKind};
+use stella_protocol::{AgentEvent, BudgetMode, FileChangeKind, StageName};
+#[cfg(test)]
+use stella_protocol::StageKind;
 use stella_tui::ansi::AnsiPalette;
 use stella_tui::render::{INLINE_DIFF_CAP, THINKING_ROWS};
 use stella_tui::textline::{self, EventLine, Tone, fmt_cost};
@@ -324,14 +326,14 @@ pub fn welcome_banner(provider: &str, model: &str, workspace: &str) {
 ///
 /// The label alone, without the word "stage": the divider already says what
 /// kind of thing this is.
-pub fn stage_rule(stage: StageKind) {
+pub fn stage_rule(stage: &StageName) {
     println!("\n{}", stage_rule_line(stage));
 }
 
 /// [`stage_rule`]'s composition, kept pure so the layout is testable without
 /// capturing stdout — the same split [`crate::term_policy`] uses for its
 /// decisions, and for the same reason.
-fn stage_rule_line(stage: StageKind) -> String {
+fn stage_rule_line(stage: &StageName) -> String {
     let label = textline::stage_label(stage);
     // "  " + "──" + " " + label + " " — what the trailing rule has to clear.
     let used = label.chars().count() + 5;
@@ -510,7 +512,7 @@ pub fn render_event(event: &AgentEvent) {
         flush_reasoning();
     }
     match event {
-        AgentEvent::Stage { name, .. } => stage_rule(*name),
+        AgentEvent::Stage { name, .. } => stage_rule(name),
         AgentEvent::ToolStart { .. } | AgentEvent::ToolResult { .. } => {
             // Handled inline at the call site, which holds the `call_id ->
             // name` correlation this event pair needs (see the module doc).
@@ -767,13 +769,14 @@ mod tests {
             (StageKind::Execute, "execute"),
             (StageKind::Verdict, "verdict"),
         ] {
-            let line = strip_ansi(&stage_rule_line(stage)).into_owned();
+            let stage = StageName::from(stage);
+            let line = strip_ansi(&stage_rule_line(&stage)).into_owned();
             assert!(line.contains(label), "stage rule lost its label: {line:?}");
             assert!(line.contains('─'), "stage rule drew no rule: {line:?}");
             // The vocabulary is `textline`'s, not a local copy — #1465 was
             // five surfaces disagreeing about one stage's name.
             assert!(
-                line.contains(textline::stage_label(stage)),
+                line.contains(textline::stage_label(&stage)),
                 "stage rule stopped using the shared label: {line:?}"
             );
         }

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -1203,7 +1203,7 @@ mod tests {
             Inbound::Event {
                 agent: "lead".into(),
                 event: AgentEvent::Stage {
-                    name: stella_protocol::StageKind::Execute,
+                    name: stella_protocol::StageKind::Execute.into(),
                     scope: stella_protocol::StageScope::Run,
                 },
             },

--- a/crates/stella-core/src/event_sender.rs
+++ b/crates/stella-core/src/event_sender.rs
@@ -75,7 +75,7 @@ impl EventSender {
         Self::from_fn(move |event| {
             if matches!(event, AgentEvent::TurnComplete { .. }) {
                 inner.send(AgentEvent::Stage {
-                    name: stella_protocol::StageKind::Complete,
+                    name: stella_protocol::StageKind::Complete.into(),
                     // The owner's vocabulary spans the whole run, not the turn
                     // that happened to trigger it (#3398's `StageScope`).
                     scope: stella_protocol::StageScope::Run,

--- a/crates/stella-core/src/goal.rs
+++ b/crates/stella-core/src/goal.rs
@@ -244,7 +244,7 @@ impl Engine<'_> {
             // of its own (#3416), so a round that skipped this would leave the
             // HUD showing the previous round's verdict while work was running.
             let _ = events.send(AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 // Matches its `Verdict` sibling below: these are the round's
                 // own phases, and a HUD reading the pair must see one scope.
                 scope: stella_protocol::StageScope::Turn,
@@ -262,7 +262,7 @@ impl Engine<'_> {
             }
 
             let _ = events.send(AgentEvent::Stage {
-                name: StageKind::Verdict,
+                name: StageKind::Verdict.into(),
                 scope: stella_protocol::StageScope::Turn,
             });
             let (verdict, verifier_cost) = match round_engine

--- a/crates/stella-core/src/subagent/tests.rs
+++ b/crates/stella-core/src/subagent/tests.rs
@@ -821,7 +821,7 @@ fn the_forward_filter_fails_toward_visible() {
         tasks: vec![]
     }));
     assert!(!forwards_to_parent(&AgentEvent::Stage {
-        name: stella_protocol::StageKind::Execute,
+        name: stella_protocol::StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Turn
     }));
 }

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -74,6 +74,13 @@
 //! and [`CacheZone`] carry a `serde(other)` catch-all today. Adding a variant
 //! to a nested vocabulary is therefore still a one-directional change, and
 //! the reader that meets it drops the whole event, not just the field.
+//!
+//! One field is deliberately outside that rule: [`AgentEvent::Stage`]'s `name`
+//! is a [`crate::StageName`], an open vocabulary, because a stage a plugin
+//! contributed has a name this crate cannot enumerate ahead of time
+//! (`doc:roleless-core`). It is not a `serde(other)` catch-all — a catch-all
+//! variant is unit-only and *discards* the name, which for a stage is the one
+//! piece of information a reader needs. It carries the word instead.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -110,9 +117,6 @@ pub use payload::{
     ProposedHunk, ScopeProposal, TaskItem, TaskStatus, VerdictEvidence,
 };
 
-/// A named point in the turn's data flow. Exactly one stage vocabulary
-/// exists in this workspace — never duplicated per-crate (the TS-era
-/// `StageKind` duplication this structurally forbids, L-E1).
 /// Whose stage boundary an [`AgentEvent::Stage`] reports (#3398).
 ///
 /// Deliberately **not** `#[serde(default)]`. A default would silently claim
@@ -131,6 +135,17 @@ pub enum StageScope {
     Run,
 }
 
+/// A named point in the turn's data flow — **the boundaries this host emits**,
+/// and only those. Exactly one such vocabulary exists in this workspace, never
+/// duplicated per-crate (the TS-era `StageKind` duplication this structurally
+/// forbids, L-E1).
+///
+/// This is deliberately no longer the same thing as "every stage a turn can
+/// have". [`crate::StageName`] is what [`AgentEvent::Stage`] carries, and it is
+/// open: a stage a plugin contributed has a name here that this enum does not
+/// and should not know (`doc:roleless-core`). Staying closed is what keeps this
+/// type useful to the consumers that genuinely need a fixed set — the
+/// diagnostics bridge, whose field values cannot hold a runtime string at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
@@ -319,7 +334,14 @@ pub enum AgentEvent {
             description = "A stage boundary was crossed. `scope` says whose stage it is, and it is not decoration: two disjoint authorities emit stages. The engine emits its own, once per turn, with scope `turn`. A wrapper -- the staged pipeline, a goal loop -- emits its own vocabulary once per run, with scope `run`. A consumer that branches on stage transitions must select on `scope` first, or it will see two interleaved vocabularies as one and read a wrapper's backwards-looking boundary as an engine regression."
         )
     )]
-    Stage { name: StageKind, scope: StageScope },
+    Stage {
+        /// Which stage. An **open** vocabulary ([`crate::StageName`]): one of
+        /// [`StageKind`]'s twelve when this host emitted the boundary, or a
+        /// contributed stage's own word. On the wire it is a plain string
+        /// either way, so the twelve encode exactly as they always have.
+        name: crate::StageName,
+        scope: StageScope,
+    },
     /// The step's answer text, in full — the authoritative, durable record.
     /// Not a fragment, despite the live preview sibling
     /// [`AgentEvent::TextDelta`]: consumers must REPLACE any accumulated

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -339,6 +339,12 @@ pub enum AgentEvent {
         /// [`StageKind`]'s twelve when this host emitted the boundary, or a
         /// contributed stage's own word. On the wire it is a plain string
         /// either way, so the twelve encode exactly as they always have.
+        #[cfg_attr(
+            feature = "schema",
+            schemars(
+                description = "Which stage the boundary belongs to, as a plain string. An OPEN vocabulary: the host's own boundaries take the names listed in this field's type examples, and a stage contributed by an installed plugin takes whatever name that plugin declared. Every one of the host's own names encodes exactly as it always has, so an existing consumer keeps reading; a consumer must branch on the names it knows and keep a default arm, because a name it has never seen is now reachable."
+            )
+        )]
         name: crate::StageName,
         scope: StageScope,
     },

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -848,7 +848,7 @@ fn research_stage_and_role_roundtrip_with_snake_case_tokens() {
 fn stream_json_is_one_line_per_event() {
     let events = [
         AgentEvent::Stage {
-            name: StageKind::Triage,
+            name: StageKind::Triage.into(),
             scope: crate::StageScope::Run,
         },
         AgentEvent::Text { text: "hi".into() },

--- a/crates/stella-protocol/src/event/tests/tag_table.rs
+++ b/crates/stella-protocol/src/event/tests/tag_table.rs
@@ -20,7 +20,7 @@ fn type_tag_matches_the_serde_type_wire_tag() {
     // the recently added variants most prone to a copy-paste tag.
     let sample = vec![
         AgentEvent::Stage {
-            name: StageKind::Triage,
+            name: StageKind::Triage.into(),
             scope: crate::StageScope::Run,
         },
         AgentEvent::Text { text: "hi".into() },

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -75,6 +75,7 @@ pub mod receipt;
 pub mod role;
 #[cfg(feature = "schema")]
 pub mod schema_export;
+pub mod stage;
 pub mod subagent_event;
 pub mod tokens;
 pub mod tool;
@@ -110,6 +111,10 @@ pub use event::{
     PolicyKind, PrStatus, ProofStep, ProposedHunk, ProviderShare, ScopeProposal, StageKind,
     StageScope, TaskItem, TaskStatus, UNKNOWN_MODEL, UsageIncompleteReason, VerdictEvidence,
 };
+// The *open* stage vocabulary (`doc:roleless-core`). `StageKind` above stays
+// the closed set of boundaries this host emits; `StageName` is what the wire
+// carries, so a stage a plugin contributed can be named at all.
+pub use stage::StageName;
 // The journal line is the event plus the wall-clock stamp its sink adds
 // (#2111). Deliberately a separate type from `AgentEvent`: a stamp is a fact
 // about a write, and the engine that produces events owns no clock.

--- a/crates/stella-protocol/src/stage.rs
+++ b/crates/stella-protocol/src/stage.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The name of a stage boundary — **an open vocabulary** (`doc:roleless-core`).
+//!
+//! # What was closed, and what that cost
+//!
+//! [`StageKind`] is the twelve boundaries the host itself emits, and until now
+//! it was also the only thing [`AgentEvent::Stage`] could say. That made the
+//! stage vocabulary a closed set compiled into the host, which is the exact
+//! shape `doc:roleless-core` exists to remove: the moment core enumerates the
+//! stages, the set of turn shapes a plugin can express is capped at the set
+//! core anticipated, and "a plugin can fundamentally change how a turn runs"
+//! degrades into "a plugin can rearrange the stages we already shipped".
+//!
+//! It failed in the direction that misleads, too. A stage a plugin contributed
+//! could not be spelled on the wire at all, so it did not render as an unknown
+//! stage — it could not be emitted, and the surface whose whole job is to say
+//! what the turn is doing would show the turn skipping from one host stage to
+//! the next with the contributed work invisible between them.
+//!
+//! # What is open now, and what stays closed
+//!
+//! [`StageName`] is either one of [`StageKind`]'s twelve or a contributed name
+//! carried as the plugin's own word. On the wire it is a plain string in both
+//! cases, so every one of the twelve encodes exactly the byte it always did
+//! and every recorded session still reads.
+//!
+//! [`StageKind`] itself stays closed and is deliberately untouched. It is not
+//! the stage vocabulary any more; it is the set of boundaries *this host*
+//! emits, which is a smaller and honest claim — and the one the exhaustive
+//! matches that must stay exhaustive (the diagnostics bridge, the wire corpus)
+//! are actually about.
+//!
+//! # Normalization is what makes the round-trip exact
+//!
+//! [`StageName::new`] resolves a name that [`StageKind`] knows into
+//! [`StageName::Known`], so [`StageName::Contributed`] can never hold a string
+//! that a known kind would also answer to. Without that, `Contributed("judge")`
+//! would decode as [`StageKind::Verdict`] and re-encode as `"verdict"` — a
+//! value that does not survive its own round trip, which invariant 4 forbids.
+//!
+//! # This module does not learn what a plugin is
+//!
+//! Nothing here names one. A contributed name arrives as text and leaves as
+//! text; whether it exists because of a plugin, a wrapper manifest or a host
+//! that grew a thirteenth boundary is a question this type cannot ask and does
+//! not need to.
+//!
+//! [`AgentEvent::Stage`]: crate::AgentEvent::Stage
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::event::StageKind;
+
+impl StageKind {
+    /// Every boundary this host emits, in the turn order they occur in.
+    ///
+    /// Ordered rather than declaration-ordered by accident: a renderer that
+    /// needs a stable reading order for the host's own stages takes it from
+    /// here instead of writing a second list that can drift from this one.
+    pub const ALL: [Self; 12] = [
+        Self::Triage,
+        Self::ContextRecall,
+        Self::Research,
+        Self::Plan,
+        Self::ScopeReview,
+        Self::Witness,
+        Self::Execute,
+        Self::Verify,
+        Self::Verdict,
+        Self::Reflect,
+        Self::ContextWrite,
+        Self::Complete,
+    ];
+
+    /// The exact string this kind encodes as on the wire.
+    ///
+    /// Hand-written rather than derived because [`StageName`] has to compare
+    /// an arbitrary string against the vocabulary without routing every
+    /// comparison through `serde_json`. `the_wire_table_matches_serde` pins
+    /// the two together, so the table cannot drift from the derive that is
+    /// actually authoritative.
+    #[must_use]
+    pub const fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Triage => "triage",
+            Self::ContextRecall => "context_recall",
+            Self::Research => "research",
+            Self::Plan => "plan",
+            Self::ScopeReview => "scope_review",
+            Self::Witness => "witness",
+            Self::Execute => "execute",
+            Self::Verify => "verify",
+            Self::Verdict => "verdict",
+            Self::Reflect => "reflect",
+            Self::ContextWrite => "context_write",
+            Self::Complete => "complete",
+        }
+    }
+
+    /// The kind a wire string names, including the historical aliases.
+    ///
+    /// `judge` and `verifier` are [`StageKind::Verdict`]'s previous spellings
+    /// and are accepted here for the same reason the `serde` derive accepts
+    /// them: replay, the observatory and the golden fixtures all parse stored
+    /// streams, and a stream recorded against those builds must still read.
+    #[must_use]
+    pub fn from_wire_str(text: &str) -> Option<Self> {
+        match text {
+            "judge" | "verifier" => Some(Self::Verdict),
+            other => Self::ALL
+                .into_iter()
+                .find(|kind| kind.as_wire_str() == other),
+        }
+    }
+}
+
+/// The name of a stage boundary: one of the host's own, or a contributed word.
+///
+/// Encodes as a plain string either way — see the module docs for why the
+/// contributed arm cannot hold a name the host already answers to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageName {
+    /// A boundary this host emits.
+    Known(StageKind),
+    /// A stage something outside the host contributed, under its own word.
+    ///
+    /// Never a name [`StageKind::from_wire_str`] resolves — [`StageName::new`]
+    /// is the only constructor that can produce this arm, and it normalizes.
+    Contributed(String),
+}
+
+impl StageName {
+    /// The stage a name refers to, resolving the host's own vocabulary first.
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        StageKind::from_wire_str(name).map_or_else(
+            || Self::Contributed(name.to_owned()),
+            Self::Known,
+        )
+    }
+
+    /// The host boundary this is, or `None` for a contributed stage.
+    ///
+    /// The accessor the exhaustive matches use: a consumer that genuinely
+    /// needs the closed vocabulary (the diagnostics bridge, whose field values
+    /// cannot hold a runtime string at all) asks for it here and handles the
+    /// `None` explicitly, rather than being handed a guess.
+    #[must_use]
+    pub const fn kind(&self) -> Option<StageKind> {
+        match self {
+            Self::Known(kind) => Some(*kind),
+            Self::Contributed(_) => None,
+        }
+    }
+
+    /// The name as it appears on the wire and on screen.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Known(kind) => kind.as_wire_str(),
+            Self::Contributed(name) => name.as_str(),
+        }
+    }
+
+    /// Whether this stage came from outside the host.
+    #[must_use]
+    pub const fn is_contributed(&self) -> bool {
+        matches!(self, Self::Contributed(_))
+    }
+}
+
+impl From<StageKind> for StageName {
+    fn from(kind: StageKind) -> Self {
+        Self::Known(kind)
+    }
+}
+
+impl fmt::Display for StageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for StageName {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for StageName {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        Ok(Self::new(&text))
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for StageName {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "StageName".into()
+    }
+
+    /// Deliberately a bare string rather than an enum of the twelve.
+    ///
+    /// The schema is the contract a non-Rust reader validates against, and a
+    /// closed enum there would make a contributed stage a schema violation —
+    /// re-closing on the wire exactly the vocabulary this type opened.
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ALL` is a hand-written array, and it became load-bearing the moment
+    /// the schema stopped enumerating the twelve: the wire-contract corpus
+    /// samples stage kinds *from it*, so a kind missing here is a kind nothing
+    /// proves against the committed schema.
+    ///
+    /// The `slot` match is exhaustive, so a thirteenth variant does not compile
+    /// until it is given a slot — and then this test fails on an out-of-range
+    /// index until `ALL` grows too. That is the pair of failures that makes the
+    /// omission impossible to land quietly.
+    #[test]
+    fn all_lists_every_kind_exactly_once() {
+        fn slot(kind: StageKind) -> usize {
+            match kind {
+                StageKind::Triage => 0,
+                StageKind::ContextRecall => 1,
+                StageKind::Research => 2,
+                StageKind::Plan => 3,
+                StageKind::ScopeReview => 4,
+                StageKind::Witness => 5,
+                StageKind::Execute => 6,
+                StageKind::Verify => 7,
+                StageKind::Verdict => 8,
+                StageKind::Reflect => 9,
+                StageKind::ContextWrite => 10,
+                StageKind::Complete => 11,
+            }
+        }
+
+        let mut seen = vec![false; StageKind::ALL.len()];
+        for kind in StageKind::ALL {
+            let slot = slot(kind);
+            assert!(
+                !std::mem::replace(&mut seen[slot], true),
+                "{kind:?} appears in StageKind::ALL more than once"
+            );
+        }
+        assert!(
+            seen.iter().all(|hit| *hit),
+            "StageKind::ALL is missing a kind the vocabulary declares"
+        );
+    }
+
+    /// The hand-written wire table is only safe because this test pins it to
+    /// the `serde` derive that actually governs the bytes. A variant renamed
+    /// in `event.rs` and not here fails right here.
+    #[test]
+    fn the_wire_table_matches_serde() {
+        for kind in StageKind::ALL {
+            let encoded = serde_json::to_string(&kind).unwrap();
+            assert_eq!(
+                encoded,
+                format!("\"{}\"", kind.as_wire_str()),
+                "{kind:?} encodes differently than as_wire_str claims"
+            );
+            assert_eq!(StageKind::from_wire_str(kind.as_wire_str()), Some(kind));
+        }
+    }
+
+    /// **The witness.** A stage the host has never heard of survives the wire
+    /// under its own word — the thing that could not be expressed at all
+    /// before, and the whole reason a renderer can now show it.
+    #[test]
+    fn a_contributed_stage_round_trips_under_its_own_name() {
+        let name = StageName::new("triage-lite");
+        assert_eq!(name, StageName::Contributed("triage-lite".to_owned()));
+        assert_eq!(name.kind(), None);
+        assert!(name.is_contributed());
+
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, "\"triage-lite\"");
+        assert_eq!(serde_json::from_str::<StageName>(&json).unwrap(), name);
+    }
+
+    /// Every host boundary encodes as the byte it always did, so a recorded
+    /// session written before this type existed still reads.
+    #[test]
+    fn a_host_stage_encodes_exactly_as_it_always_did() {
+        for kind in StageKind::ALL {
+            let was = serde_json::to_string(&kind).unwrap();
+            let now = serde_json::to_string(&StageName::from(kind)).unwrap();
+            assert_eq!(was, now, "{kind:?} changed its encoding");
+            assert_eq!(
+                serde_json::from_str::<StageName>(&was).unwrap(),
+                StageName::Known(kind)
+            );
+        }
+    }
+
+    /// Normalization, from both directions: the constructor resolves a known
+    /// name rather than wrapping it, and the historical aliases resolve too.
+    ///
+    /// Load-bearing because `Contributed` holding a name the host answers to
+    /// would be a value that does not survive its own round trip — it would
+    /// decode as `Verdict` and re-encode as `"verdict"`.
+    #[test]
+    fn a_known_name_never_becomes_a_contributed_one() {
+        assert_eq!(StageName::new("execute"), StageName::Known(StageKind::Execute));
+        for alias in ["judge", "verifier"] {
+            let name = StageName::new(alias);
+            assert_eq!(name, StageName::Known(StageKind::Verdict));
+            assert_eq!(
+                serde_json::to_string(&name).unwrap(),
+                "\"verdict\"",
+                "an alias must re-encode as the canonical spelling"
+            );
+        }
+    }
+
+    /// A contributed name is compared, never parsed: case and separators carry
+    /// no meaning to the host, so two spellings are two stages.
+    #[test]
+    fn a_contributed_name_is_opaque() {
+        assert_ne!(StageName::new("Execute"), StageName::new("execute"));
+        assert_eq!(StageName::new("Execute").as_str(), "Execute");
+    }
+}

--- a/crates/stella-protocol/src/stage.rs
+++ b/crates/stella-protocol/src/stage.rs
@@ -362,3 +362,42 @@ mod tests {
         assert_eq!(StageName::new("Execute").as_str(), "Execute");
     }
 }
+
+#[cfg(test)]
+mod event_decode_tests {
+    use crate::AgentEvent;
+
+    /// **The regression this fixes on a stream that exists today.**
+    ///
+    /// `AgentEvent`'s tolerance stops at its own tag: an unknown *tag* becomes
+    /// `AgentEvent::Unknown`, but a known tag whose body does not fit is a hard
+    /// error and the reader loses the whole event. A stage name outside the
+    /// host's twelve used to be exactly that — so a journal or `stream-json`
+    /// feed from any emitter with one extra stage did not render that stage
+    /// badly, it failed to decode the line at all.
+    ///
+    /// This is not scaffolding for a producer that does not exist yet:
+    /// `stella resume` replays journals, the observatory parses stored streams,
+    /// and a `stella-serve` host forwards events it did not author.
+    #[test]
+    fn an_unknown_stage_name_no_longer_kills_the_event() {
+        let line = r#"{"type":"stage","name":"triage-lite","scope":"run"}"#;
+        let decoded: AgentEvent =
+            serde_json::from_str(line).expect("a contributed stage must decode");
+        match &decoded {
+            AgentEvent::Stage { name, scope } => {
+                assert_eq!(name.as_str(), "triage-lite");
+                assert!(name.is_contributed());
+                assert_eq!(*scope, crate::StageScope::Run);
+            }
+            other => panic!("decoded as {other:?}, not a stage"),
+        }
+        // And it decodes as a `stage`, not as the catch-all: the reader knows
+        // what kind of thing happened, which is the half `Unknown` cannot give.
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            line,
+            "a contributed stage must survive the round trip byte-for-byte"
+        );
+    }
+}

--- a/crates/stella-protocol/src/stage.rs
+++ b/crates/stella-protocol/src/stage.rs
@@ -137,10 +137,8 @@ impl StageName {
     /// The stage a name refers to, resolving the host's own vocabulary first.
     #[must_use]
     pub fn new(name: &str) -> Self {
-        StageKind::from_wire_str(name).map_or_else(
-            || Self::Contributed(name.to_owned()),
-            Self::Known,
-        )
+        StageKind::from_wire_str(name)
+            .map_or_else(|| Self::Contributed(name.to_owned()), Self::Known)
     }
 
     /// The host boundary this is, or `None` for a contributed stage.
@@ -204,13 +202,40 @@ impl schemars::JsonSchema for StageName {
         "StageName".into()
     }
 
-    /// Deliberately a bare string rather than an enum of the twelve.
+    /// A string, **not** an enum of the twelve.
     ///
     /// The schema is the contract a non-Rust reader validates against, and a
     /// closed enum there would make a contributed stage a schema violation —
     /// re-closing on the wire exactly the vocabulary this type opened.
+    ///
+    /// The twelve still ride along as `examples`, which documents without
+    /// constraining. That is the half a consumer actually loses when a closed
+    /// enum becomes a string: not validation (it never wanted to reject a
+    /// stage), but the list of names worth writing a branch for. A reader
+    /// should switch on these and keep a default arm — which is the shape it
+    /// needed anyway, since a stage it has never heard of is now reachable.
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+        let mut schema = String::json_schema(generator);
+        schema.insert(
+            "description".to_owned(),
+            serde_json::Value::String(
+                "The name of a stage boundary — an OPEN vocabulary. The host's own boundaries \
+                 are listed in `examples`; an installed plugin may contribute a stage under any \
+                 other name, so a consumer must branch on the names it knows and keep a default \
+                 arm rather than treating an unlisted value as invalid."
+                    .to_owned(),
+            ),
+        );
+        schema.insert(
+            "examples".to_owned(),
+            serde_json::Value::Array(
+                StageKind::ALL
+                    .iter()
+                    .map(|kind| serde_json::Value::String(kind.as_wire_str().to_owned()))
+                    .collect(),
+            ),
+        );
+        schema
     }
 }
 
@@ -314,7 +339,10 @@ mod tests {
     /// decode as `Verdict` and re-encode as `"verdict"`.
     #[test]
     fn a_known_name_never_becomes_a_contributed_one() {
-        assert_eq!(StageName::new("execute"), StageName::Known(StageKind::Execute));
+        assert_eq!(
+            StageName::new("execute"),
+            StageName::Known(StageKind::Execute)
+        );
         for alias in ["judge", "verifier"] {
             let name = StageName::new(alias);
             assert_eq!(name, StageName::Known(StageKind::Verdict));

--- a/crates/stella-protocol/tests/wire_contract.rs
+++ b/crates/stella-protocol/tests/wire_contract.rs
@@ -437,8 +437,14 @@ fn every_nested_vocabulary_is_fully_sampled() {
             .len()
     };
 
+    // `StageKind` is deliberately absent. It stopped being a nested *wire*
+    // vocabulary when `AgentEvent::Stage::name` became an open string
+    // (`doc:roleless-core`): the schema has no `$defs/StageKind` to count arms
+    // in, because nothing on the wire is constrained to the twelve any more.
+    // Its totality is proved at the source instead — `stella_protocol::stage`'s
+    // `all_lists_every_kind_exactly_once` — and `all_stage_kinds()` reads that
+    // array, so this corpus still samples every one of them.
     let counts: BTreeMap<&str, usize> = BTreeMap::from([
-        ("StageKind", all_stage_kinds().len()),
         ("StageScope", all_stage_scopes().len()),
         ("BudgetMode", all_budget_modes().len()),
         ("BudgetScope", all_budget_scopes().len()),
@@ -489,8 +495,10 @@ fn every_nested_vocabulary_is_fully_sampled() {
         .filter(|(_, def)| def.get("oneOf").is_some())
         .map(|(name, _)| name.as_str())
         .collect();
+    // No `StageKind` — see the comment on `counts` above: it left the schema
+    // when the stage field became an open string, so it is no longer an enum
+    // in the payload graph at all.
     let rows: BTreeSet<&str> = BTreeSet::from([
-        "StageKind",
         "StageScope",
         "BudgetMode",
         "BudgetScope",

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -33,22 +33,18 @@ pub(crate) fn all_stage_scopes() -> Vec<StageScope> {
     vec![StageScope::Turn, StageScope::Run]
 }
 
+/// Sourced from [`StageKind::ALL`] rather than restated here.
+///
+/// It used to be a second hand-written list, which was safe only while the
+/// committed schema also enumerated the twelve — the arm-count check in
+/// `every_nested_vocabulary_is_fully_sampled` caught a list that had fallen
+/// behind. The stage field is an open string now (`doc:roleless-core`), so the
+/// schema no longer enumerates anything and that check cannot cover this
+/// vocabulary. Reading the canonical array closes the hole at the source
+/// instead: `stella_protocol::stage`'s `all_lists_every_kind_exactly_once`
+/// proves the array is total, and this corpus inherits that.
 pub(crate) fn all_stage_kinds() -> Vec<StageKind> {
-    use StageKind::*;
-    vec![
-        Triage,
-        ContextRecall,
-        Research,
-        Plan,
-        ScopeReview,
-        Witness,
-        Execute,
-        Verify,
-        Verdict,
-        Reflect,
-        ContextWrite,
-        Complete,
-    ]
+    StageKind::ALL.to_vec()
 }
 
 pub(crate) fn all_budget_modes() -> Vec<BudgetMode> {
@@ -647,8 +643,19 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
         events.extend(
             all_stage_kinds()
                 .into_iter()
-                .map(move |name| AgentEvent::Stage { name, scope }),
+                .map(move |kind| AgentEvent::Stage {
+                    name: kind.into(),
+                    scope,
+                }),
         );
+        // A contributed stage is pinned beside the host's own, because the
+        // vocabulary is open (`doc:roleless-core`) and an open field's whole
+        // risk is that only the closed half is ever exercised. This sample is
+        // what proves a plugin's own word survives the wire unchanged.
+        events.push(AgentEvent::Stage {
+            name: stella_protocol::StageName::new("triage-lite"),
+            scope,
+        });
     }
     events.extend(
         all_tool_outputs()

--- a/crates/stella-serve/src/goal.rs
+++ b/crates/stella-serve/src/goal.rs
@@ -138,7 +138,7 @@ pub(crate) async fn drive_goal(
         }
 
         let _ = sender.send(AgentEvent::Stage {
-            name: StageKind::Verdict,
+            name: StageKind::Verdict.into(),
             scope: stella_protocol::StageScope::Run,
         });
         let (verdict, verifier_cost) = match round_engine

--- a/crates/stella-serve/src/observe/tally.rs
+++ b/crates/stella-serve/src/observe/tally.rs
@@ -137,11 +137,11 @@ mod tests {
     fn the_fold_counts_the_signals_that_distinguish_wedged_from_slow() {
         let mut fold = TallyFold::default();
         fold.observe(&AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         });
         fold.observe(&AgentEvent::Stage {
-            name: StageKind::Verify,
+            name: StageKind::Verify.into(),
             scope: stella_protocol::StageScope::Run,
         });
         fold.observe(&AgentEvent::Retry {
@@ -234,13 +234,13 @@ mod tests {
     fn a_parked_turn_is_distinguishable_from_a_wedged_one() {
         let mut wedged = TallyFold::default();
         wedged.observe(&AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         });
 
         let mut waiting = TallyFold::default();
         waiting.observe(&AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         });
         waiting.observe(&parked("CI for branch main settles", 1800));
@@ -312,7 +312,7 @@ mod tests {
         let mut fold = TallyFold::default();
         fold.tally.stages = u32::MAX;
         fold.observe(&AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         });
         assert_eq!(fold.finish().stages, u32::MAX);

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -546,7 +546,7 @@ pub(crate) async fn drive_turn(
     // `Stage(Execute)` goes out below.
     let events = RunEnding::sealing(EventSender::new(events.clone()).pairing_stage_complete());
     let _ = events.send(AgentEvent::Stage {
-        name: stella_protocol::StageKind::Execute,
+        name: stella_protocol::StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     let mut state = engine.new_turn(messages, budget).with_cancel_token(cancel);

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -376,11 +376,11 @@ async fn mini_run(tx: &mpsc::UnboundedSender<Inbound>, id: &str) {
     };
     let steps = vec![
         ev(AgentEvent::Stage {
-            name: StageKind::Triage,
+            name: StageKind::Triage.into(),
             scope: stella_protocol::StageScope::Run,
         }),
         ev(AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         }),
         ev(AgentEvent::ToolStart {

--- a/crates/stella-tui/src/accessible/tests.rs
+++ b/crates/stella-tui/src/accessible/tests.rs
@@ -26,7 +26,7 @@ fn stage(agent: &str) -> Inbound {
     Inbound::Event {
         agent: agent.into(),
         event: AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     }

--- a/crates/stella-tui/src/cache_panel.rs
+++ b/crates/stella-tui/src/cache_panel.rs
@@ -474,7 +474,7 @@ mod tests {
         m.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/src/debug_log.rs
+++ b/crates/stella-tui/src/debug_log.rs
@@ -128,7 +128,7 @@ mod tests {
         let log = DebugLog::new(Some(path.clone()));
         assert!(log.is_active());
         log.event(&AgentEvent::Stage {
-            name: stella_protocol::StageKind::Execute,
+            name: stella_protocol::StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         });
         log.input(&UserInput::Prompt {

--- a/crates/stella-tui/src/deck/classify.rs
+++ b/crates/stella-tui/src/deck/classify.rs
@@ -105,7 +105,15 @@ pub(super) fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
         AgentEvent::Unknown { event_type, .. } => {
             (TraceKind::Other, format!("unrecognized `{event_type}`"))
         }
-        AgentEvent::Stage { name, .. } => (TraceKind::Stage, format!("{name:?}").to_lowercase()),
+        // The shared label, not a `Debug` rendering of the enum. `Debug` used
+        // to spell the variant and happened to read like the stage word; once
+        // the vocabulary opened it spells the *wrapper* too (`Known(Triage)`),
+        // and a contributed stage would print `Contributed("triage-lite")`.
+        // `stage_label` is the one place a stage is worded (#1465).
+        AgentEvent::Stage { name, .. } => (
+            TraceKind::Stage,
+            crate::textline::stage_label(name).to_string(),
+        ),
         AgentEvent::Text { text } => (TraceKind::Text, snip(text)),
         // Mapped for completeness; `apply_event` never traces deltas (one
         // row per token would churn the capped ring — see the guard there).

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -132,7 +132,7 @@ fn prompt_started_flips_a_finished_agent_back_to_running() {
     w.apply_inbound(&reg("lead"));
     if let Some(a) = w.agents.first_mut() {
         a.status = AgentStatus::Done;
-        a.model.hud.stage = Some(StageKind::Complete);
+        a.model.hud.stage = Some(StageKind::Complete.into());
         a.model.hud.complete = true;
     }
     w.apply_inbound(&prompt_started("lead", "next"));
@@ -306,7 +306,7 @@ fn stray_event_auto_registers_its_agent() {
     w.apply_inbound(&ev(
         "ghost",
         AgentEvent::Stage {
-            name: StageKind::Plan,
+            name: StageKind::Plan.into(),
             scope: stella_protocol::StageScope::Run,
         },
     ));
@@ -559,7 +559,7 @@ fn trace_captures_every_agent_and_filters_by_agent() {
     w.apply_inbound(&ev(
         "a",
         AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     ));

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -192,7 +192,7 @@ fn running_model_with_queue() -> WorkspaceModel {
     m.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     });

--- a/crates/stella-tui/src/deck_ui/cards.rs
+++ b/crates/stella-tui/src/deck_ui/cards.rs
@@ -363,7 +363,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: stella_protocol::StageKind::Execute,
+                name: stella_protocol::StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -20,7 +20,7 @@
 use crate::ansi::strip_ansi;
 use stella_protocol::{
     AgentEvent, BudgetMode, CiStatus, FileChangeKind, HunkProposal, MediaJobState, MediaKind,
-    PrStatus, ScopeProposal, StageKind, StageScope, SubAgentPhase, SubAgentStatus, TaskItem,
+    PrStatus, ScopeProposal, StageKind, StageName, StageScope, SubAgentPhase, SubAgentStatus, TaskItem,
     TaskStatus, ToolOutput,
 };
 
@@ -241,8 +241,10 @@ pub enum TranscriptEntry {
     /// this when `PromptStarted` arrives so the user's message is visible
     /// inline in the transcript, matching the Crush-style conversational layout.
     User(String),
-    /// A stage boundary marker (`triage`, `plan`, `execute`, …).
-    Stage(StageKind),
+    /// A stage boundary marker (`triage`, `plan`, `execute`, …) — or a stage a
+    /// plugin contributed, under its own word. Open vocabulary, so the deck
+    /// renders a stage it has never heard of instead of dropping it.
+    Stage(StageName),
     /// Accumulated assistant natural-language output.
     Text(String),
     /// Accumulated model reasoning (rendered dimmed).
@@ -483,7 +485,24 @@ pub struct Hud {
     /// (`AgentEvent::BudgetTick::deadline_remaining_ms`), and this struct is a
     /// fold of the stream, not a reinterpretation of it.
     pub deadline_remaining_ms: Option<u64>,
-    pub stage: Option<StageKind>,
+    /// The stage the turn is in. [`StageName`], not [`StageKind`]: a
+    /// contributed stage is what the statline must be able to name.
+    pub stage: Option<StageName>,
+    /// The most recent stage that was one of **this host's own** boundaries.
+    ///
+    /// Separate from [`Hud::stage`] because the two answer different questions,
+    /// and one field cannot answer both once the vocabulary is open. `stage` is
+    /// "what is happening right now", which is what the statline says out loud.
+    /// This is "how far through its own shape the turn has got", which is what
+    /// the three-segment progress bar draws — and the bar has only the host's
+    /// three phases to draw with.
+    ///
+    /// Keeping it is what stops a contributed stage reading as a regression: a
+    /// plugin stage arriving after `execute` leaves this at `Execute`, so the
+    /// bar holds. Folding the contributed stage into the same field would make
+    /// it phase-less, and a phase-less stage falls back to phase 0 — the bar
+    /// would snap back to "plan" and claim the run had gone backwards.
+    pub host_stage: Option<StageKind>,
     pub model: Option<String>,
     /// [`Hud::spent_usd`] as it stood when the current turn began, so live turn
     /// cost is the difference. Snapshotted in [`SessionModel::push_user_prompt`]
@@ -583,7 +602,13 @@ impl SessionModel {
                 }
                 self.hud.complete = false;
                 self.hud.final_cost_usd = None;
-                self.hud.stage = Some(*name);
+                self.hud.stage = Some(name.clone());
+                // Only a host boundary moves the progress bar — see
+                // `Hud::host_stage` for why a contributed stage must leave it
+                // where it stands rather than resetting it.
+                if let Some(kind) = name.kind() {
+                    self.hud.host_stage = Some(kind);
+                }
                 // Any stage that isn't the scope-review gate itself means the
                 // engine has moved past a pending gate (approved → execute,
                 // or a later plan/verify stage) — retire it. Kept event-driven
@@ -600,7 +625,7 @@ impl SessionModel {
                 // event the human never saw. A turn-scoped stage is never an
                 // approval signal, because nobody was asked.
                 if *scope == StageScope::Run
-                    && *name != StageKind::ScopeReview
+                    && name.kind() != Some(StageKind::ScopeReview)
                     && let Some(approved) = self.pending_scope_review.take()
                 {
                     self.approved_scope = Some(approved);
@@ -609,7 +634,7 @@ impl SessionModel {
                     // and does so from the event, so replay reconstructs it.
                     self.plan.approve();
                 }
-                self.transcript.push(TranscriptEntry::Stage(*name));
+                self.transcript.push(TranscriptEntry::Stage(name.clone()));
             }
             AgentEvent::Text { text } => {
                 // The authoritative step text replaces any streamed preview
@@ -1074,7 +1099,8 @@ impl SessionModel {
             // The RUN ended — the only event that means nothing more is
             // coming, and so the only one that may settle terminal state.
             AgentEvent::RunComplete { model, cost_usd } => {
-                self.hud.stage = Some(StageKind::Complete);
+                self.hud.stage = Some(StageKind::Complete.into());
+                self.hud.host_stage = Some(StageKind::Complete);
                 self.hud.model = Some(model.clone());
                 self.hud.final_cost_usd = Some(*cost_usd);
                 self.hud.complete = true;

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -1240,6 +1240,11 @@ impl SessionModel {
         // at the new turn's beginning. A model turn's first `Stage` event resets
         // this anyway; a driver command (which emits no stages) relies on it.
         self.hud.stage = None;
+        // Both stage fields, or the bar would restart at the *previous* turn's
+        // phase: `host_stage` is exactly the field that survives a contributed
+        // stage on purpose, so it is also the one that has to be cleared
+        // deliberately when the turn it described is over.
+        self.hud.host_stage = None;
         self.transcript
             .push(TranscriptEntry::User(text.to_string()));
         self.evict_transcript_overflow();

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -20,8 +20,8 @@
 use crate::ansi::strip_ansi;
 use stella_protocol::{
     AgentEvent, BudgetMode, CiStatus, FileChangeKind, HunkProposal, MediaJobState, MediaKind,
-    PrStatus, ScopeProposal, StageKind, StageName, StageScope, SubAgentPhase, SubAgentStatus, TaskItem,
-    TaskStatus, ToolOutput,
+    PrStatus, ScopeProposal, StageKind, StageName, StageScope, SubAgentPhase, SubAgentStatus,
+    TaskItem, TaskStatus, ToolOutput,
 };
 
 use std::collections::VecDeque;

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -160,7 +160,7 @@ fn a_stage_between_text_deltas_breaks_coalescing() {
     let mut model = SessionModel::new();
     model.apply(&text("a"));
     model.apply(&AgentEvent::Stage {
-        name: StageKind::Verify,
+        name: StageKind::Verify.into(),
         scope: stella_protocol::StageScope::Run,
     });
     model.apply(&text("b"));
@@ -403,13 +403,13 @@ fn scope_review_sets_then_clears_on_next_stage() {
     assert!(model.pending_scope_review.is_some());
     // The scope-review stage marker itself must NOT clear it.
     model.apply(&AgentEvent::Stage {
-        name: StageKind::ScopeReview,
+        name: StageKind::ScopeReview.into(),
         scope: stella_protocol::StageScope::Run,
     });
     assert!(model.pending_scope_review.is_some());
     // The engine moving on to execute clears it.
     model.apply(&AgentEvent::Stage {
-        name: StageKind::Execute,
+        name: StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     assert!(model.pending_scope_review.is_none());
@@ -436,7 +436,7 @@ fn an_approved_plan_outlives_the_gate_that_carried_it() {
         },
     });
     model.apply(&AgentEvent::Stage {
-        name: StageKind::Execute,
+        name: StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     model.apply(&AgentEvent::RunComplete {
@@ -453,7 +453,7 @@ fn an_approved_plan_outlives_the_gate_that_carried_it() {
     // And it belongs to *that* turn: the next one starts unapproved rather
     // than inheriting consent it was never given.
     model.apply(&AgentEvent::Stage {
-        name: StageKind::Execute,
+        name: StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     assert!(
@@ -556,7 +556,7 @@ fn complete_populates_hud() {
     assert_eq!(model.hud.model.as_deref(), Some("glm-5.2"));
     assert_eq!(model.hud.final_cost_usd, Some(0.033));
     assert!(model.hud.complete);
-    assert_eq!(model.hud.stage, Some(StageKind::Complete));
+    assert_eq!(model.hud.stage, Some(StageKind::Complete.into()));
 }
 
 #[test]
@@ -1090,7 +1090,7 @@ fn replay_past_the_cap_stays_deterministic() {
 fn replay_of_the_same_log_yields_identical_models() {
     let log = vec![
         AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
         text("hi "),
@@ -1167,7 +1167,7 @@ fn a_settled_progress_line_is_never_overwritten_by_a_later_pass() {
     let mut model = SessionModel::new();
     model.set_progress_line("· semantic index: 12 files embedded…");
     model.apply(&AgentEvent::Stage {
-        name: StageKind::Execute,
+        name: StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     });
     model.set_progress_line("· chunk index: 4 files embedded…");

--- a/crates/stella-tui/src/progress.rs
+++ b/crates/stella-tui/src/progress.rs
@@ -583,6 +583,46 @@ mod tests {
         m.agents.first()
     }
 
+    /// **The witness that a contributed stage is not a regression.**
+    ///
+    /// The bar draws the host's three phases. A stage a plugin contributed
+    /// belongs to none of them, so it must leave the bar exactly where the last
+    /// host stage put it.
+    ///
+    /// The failure this pins is specific and ugly: fold the contributed stage
+    /// into the same field the bar reads and it becomes phase-less, phase-less
+    /// falls back to phase 0, and a plugin stage running *after* `execute`
+    /// would drag the bar backwards to "plan" — the deck telling the user the
+    /// run had regressed when nothing had.
+    #[test]
+    fn a_contributed_stage_leaves_the_bar_where_the_last_host_stage_put_it() {
+        let mut m = agent_running(StageKind::Execute);
+        let before = ProgressState::derive(focused(&m), m.now_ms, false);
+        assert_eq!(before.segments[1], SegState::Active, "execute is phase 1");
+
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Stage {
+                name: stella_protocol::StageName::new("triage-lite"),
+                scope: stella_protocol::StageScope::Run,
+            },
+        });
+        let after = ProgressState::derive(focused(&m), m.now_ms, false);
+        assert_eq!(
+            after.fill, before.fill,
+            "a contributed stage moved the bar; it has no phase to move it to"
+        );
+        assert_eq!(after.segments, before.segments);
+
+        // And the statline still says what is happening — the bar holding
+        // still is not the deck going quiet about the stage.
+        let hud_stage = focused(&m).unwrap().model.hud.stage.clone();
+        assert_eq!(
+            hud_stage.as_ref().map(stella_protocol::StageName::as_str),
+            Some("triage-lite")
+        );
+    }
+
     #[test]
     fn no_agent_is_idle() {
         let s = ProgressState::derive(None, 0, false);

--- a/crates/stella-tui/src/progress.rs
+++ b/crates/stella-tui/src/progress.rs
@@ -170,7 +170,11 @@ impl ProgressState {
             return Self::idle();
         }
 
-        let active = hud.stage.map(stage_phase);
+        // From `host_stage`, not `stage`: the bar draws the host's own three
+        // phases, and a contributed stage has none of them (see
+        // `model::Hud::host_stage`). Reading `stage` would make a plugin's
+        // stage phase-less and snap the bar back to "plan".
+        let active = hud.host_stage.map(stage_phase);
 
         if complete {
             return Self {
@@ -568,7 +572,7 @@ mod tests {
         m.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: stage,
+                name: stage.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -88,7 +88,7 @@ pub(crate) fn render_hud(
     let mut spans: Vec<Span<'static>> = vec![
         Span::styled("stage ", label),
         Span::styled(
-            hud.stage.map(stage_label).unwrap_or("—").to_string(),
+            hud.stage.as_ref().map_or("—", |s| stage_label(s)).to_string(),
             Style::new().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
         ),
         Span::styled("   model ", label),

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -88,7 +88,10 @@ pub(crate) fn render_hud(
     let mut spans: Vec<Span<'static>> = vec![
         Span::styled("stage ", label),
         Span::styled(
-            hud.stage.as_ref().map_or("—", |s| stage_label(s)).to_string(),
+            hud.stage
+                .as_ref()
+                .map_or("—", |s| stage_label(s))
+                .to_string(),
             Style::new().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
         ),
         Span::styled("   model ", label),

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -264,9 +264,9 @@ fn entry_body(
             // stage dot already uses, so the rule and the dot agree about
             // which phase this is.
             push_rule(
-                stage_label(*name),
+                stage_label(name),
                 Style::new()
-                    .fg(theme::stage_rule_color(*name))
+                    .fg(theme::stage_rule_color(name))
                     .add_modifier(Modifier::BOLD),
                 width,
                 out,

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -88,7 +88,7 @@ fn transcript_lines(
 fn sample_entries() -> Vec<TranscriptEntry> {
     vec![
         TranscriptEntry::User("hi".into()),
-        TranscriptEntry::Stage(StageKind::Execute),
+        TranscriptEntry::Stage(StageKind::Execute.into()),
         TranscriptEntry::Text("ok".into()),
         TranscriptEntry::Reasoning("hmm".into()),
         TranscriptEntry::ToolStart {

--- a/crates/stella-tui/src/render/tests/palette.rs
+++ b/crates/stella-tui/src/render/tests/palette.rs
@@ -168,7 +168,7 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
     // rule is precisely the transcript's coarsest structure, and at that
     // contrast neither the line nor the label set into it could be read.
     assert_eq!(
-        prefix_fg(&TranscriptEntry::Stage(StageKind::Execute)),
+        prefix_fg(&TranscriptEntry::Stage(StageKind::Execute.into())),
         Some(theme::HAIRLINE_STRONG),
         "a stage opens a section rule on the louder seam",
     );

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -188,7 +188,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             lead,
             AgentEvent::Stage {
-                name: StageKind::Triage,
+                name: StageKind::Triage.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ),
@@ -223,7 +223,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             lead,
             AgentEvent::Stage {
-                name: StageKind::Plan,
+                name: StageKind::Plan.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ),
@@ -291,7 +291,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             lead,
             AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ),
@@ -392,7 +392,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             auth,
             AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ),
@@ -456,7 +456,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
         ev(
             ci,
             AgentEvent::Stage {
-                name: StageKind::Verify,
+                name: StageKind::Verify.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ),

--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -68,6 +68,8 @@
 //! `SPEND`). [`statline_items`] is the single decision function,
 //! unit-testable without a buffer.
 
+use std::borrow::Cow;
+
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -98,7 +100,10 @@ const ETHOS: &str = "↝ deterministic-first ";
 #[derive(Clone, Debug)]
 pub struct StatItem {
     pub key: &'static str,
-    pub label: &'static str,
+    /// The column's heading. `Cow` rather than `&'static str` because the
+    /// stage cell's heading *is* the live stage word, and a stage a plugin
+    /// contributed is runtime text that no literal can cover.
+    pub label: Cow<'static, str>,
     pub priority: u8,
     pub spans: Vec<Span<'static>>,
     /// Overrides the label row's dim for this one cell. `None` for every
@@ -110,13 +115,13 @@ pub struct StatItem {
 impl StatItem {
     fn new(
         key: &'static str,
-        label: &'static str,
+        label: impl Into<Cow<'static, str>>,
         priority: u8,
         spans: Vec<Span<'static>>,
     ) -> Self {
         Self {
             key,
-            label,
+            label: label.into(),
             priority,
             spans,
             label_color: None,
@@ -160,7 +165,7 @@ pub fn statline_items(model: &WorkspaceModel, ui: &DeckUi) -> Vec<StatItem> {
     // The stage box: the stage NAME is the label (top row), so the row above
     // stops repeating a constant word and starts carrying live state; the
     // value below is how far through the task board this stage has gotten.
-    let stage_kind = focused.and_then(|a| a.model.hud.stage);
+    let stage_kind = focused.and_then(|a| a.model.hud.stage.as_ref());
     let stage = StatItem::new(
         "stage",
         stage_label_upper(stage_kind),
@@ -433,23 +438,32 @@ fn vendor_slug(pin: &crate::deck::RolePin) -> String {
 
 /// The stage name, uppercased for the label row it now heads. `None` — no
 /// stage observed yet — reads `IDLE`.
-fn stage_label_upper(stage: Option<stella_protocol::StageKind>) -> &'static str {
+fn stage_label_upper(stage: Option<&stella_protocol::StageName>) -> Cow<'static, str> {
     use stella_protocol::StageKind as S;
-    match stage {
-        None => "IDLE",
-        Some(S::Triage) => "TRIAGE",
-        Some(S::ContextRecall) => "CONTEXT RECALL",
-        Some(S::Research) => "RESEARCH",
-        Some(S::Plan) => "PLAN",
-        Some(S::ScopeReview) => "SCOPE REVIEW",
-        Some(S::Witness) => "WITNESS",
-        Some(S::Execute) => "EXECUTE",
-        Some(S::Verify) => "VERIFY",
-        Some(S::Verdict) => "VERDICT",
-        Some(S::Reflect) => "REFLECT",
-        Some(S::ContextWrite) => "CONTEXT WRITE",
-        Some(S::Complete) => "COMPLETE",
-    }
+    let Some(stage) = stage else {
+        return Cow::Borrowed("IDLE");
+    };
+    let Some(kind) = stage.kind() else {
+        // A contributed stage, in the plugin's own word — uppercased like every
+        // other heading on this row, because the statline's headings are chrome
+        // and a lowercase cell would read as a different kind of thing rather
+        // than as the same cell holding a different stage.
+        return Cow::Owned(stage.as_str().to_uppercase());
+    };
+    Cow::Borrowed(match kind {
+        S::Triage => "TRIAGE",
+        S::ContextRecall => "CONTEXT RECALL",
+        S::Research => "RESEARCH",
+        S::Plan => "PLAN",
+        S::ScopeReview => "SCOPE REVIEW",
+        S::Witness => "WITNESS",
+        S::Execute => "EXECUTE",
+        S::Verify => "VERIFY",
+        S::Verdict => "VERDICT",
+        S::Reflect => "REFLECT",
+        S::ContextWrite => "CONTEXT WRITE",
+        S::Complete => "COMPLETE",
+    })
 }
 
 /// How far through the task board the session has gotten: `Step 4 of 5`.
@@ -814,7 +828,7 @@ mod tests {
         m.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -957,6 +957,43 @@ mod tests {
         assert_eq!(stage.spans[0].content.as_ref(), "—");
     }
 
+    /// **The witness on the surface a user actually watches.** A stage a
+    /// plugin contributed heads the statline's stage box under its own word,
+    /// in its own colour.
+    ///
+    /// Before the vocabulary opened this could not happen at all: the wire had
+    /// no way to carry the name, so a wrapped run's contributed stages were
+    /// invisible and the box went on displaying whichever host stage had last
+    /// gone past — a live cell reporting stale state.
+    #[test]
+    fn the_stage_box_heads_itself_with_a_contributed_stage_too() {
+        let mut model = WorkspaceModel::new();
+        model.now_ms = 10_000;
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("lead", "goal", 0).with_role("lead"),
+        ));
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Stage {
+                name: stella_protocol::StageName::new("triage-lite"),
+                scope: stella_protocol::StageScope::Run,
+            },
+        });
+
+        let items = statline_items(&model, &DeckUi::default());
+        let stage = items.iter().find(|i| i.key == "stage").expect("stage");
+        assert_eq!(
+            stage.label, "TRIAGE-LITE",
+            "the plugin's own word heads the cell — not IDLE, and not the host \
+             stage whose name it happens to contain"
+        );
+        assert_eq!(
+            stage.label_color,
+            Some(theme::contributed_stage_color("triage-lite")),
+            "a contributed stage carries its own colour, not the row's dim"
+        );
+    }
+
     #[test]
     fn the_step_counter_reads_the_board_position_not_the_done_count() {
         use stella_protocol::{TaskItem, TaskStatus};

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1061,6 +1061,22 @@ mod tests {
         assert_eq!(crud_letter(FileChangeKind::Deleted), "D");
     }
 
+    /// **The witness for a contributed stage's word.** The deck says the
+    /// plugin's own name back, verbatim — not a category like "plugin", and
+    /// not the nearest host stage it happens to resemble.
+    ///
+    /// `triage-lite` is the load-bearing case: it *contains* a host stage's
+    /// name, so anything that resolved by prefix or substring would silently
+    /// relabel it `triage` and claim the turn ran a stage it never ran.
+    #[test]
+    fn a_contributed_stage_is_labelled_with_its_own_word() {
+        for word in ["triage-lite", "vera/witness", "sast", "spec-check"] {
+            let stage = StageName::new(word);
+            assert!(stage.kind().is_none(), "{word} must be contributed");
+            assert_eq!(stage_label(&stage), word);
+        }
+    }
+
     /// The stage after `verify` is `verdict` — never `verifier`, which is the
     /// *model* that produces it. Naming the stage after its model recreates the
     /// `verify → verifier` adjacency #1394's rename existed to remove, and it

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -27,7 +27,7 @@
 
 use stella_protocol::{
     AgentEvent, BudgetMode, CiStatus, FileChangeKind, MediaJobState, MediaKind, PrStatus,
-    ProviderShare, StageKind, TaskItem, TaskStatus,
+    ProviderShare, StageKind, StageName, TaskItem, TaskStatus,
 };
 
 /// Semantic weight of an annotation line. Each surface owns the mapping to
@@ -764,8 +764,22 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
 
 // ── Enum label tables ────────────────────────────────────────────────────────
 
-pub fn stage_label(stage: StageKind) -> &'static str {
-    match stage {
+/// The word the deck says out loud for a stage.
+///
+/// For one of the host's own boundaries this is the deck's phrasing, which is
+/// not always the wire spelling — `context_recall` reads "context recall",
+/// because the underscore is a wire detail and the deck writes prose.
+///
+/// For a **contributed** stage it is the plugin's own word, verbatim. That is
+/// the honest fallback and the same one the `/models` role table settled on
+/// (`envelope::roles`): the deck has no word for a stage it has never heard of,
+/// and inventing one — "plugin", "custom", "other" — would name the row after a
+/// category instead of after itself.
+pub fn stage_label(stage: &StageName) -> &str {
+    let Some(kind) = stage.kind() else {
+        return stage.as_str();
+    };
+    match kind {
         StageKind::Triage => "triage",
         StageKind::ContextRecall => "context recall",
         StageKind::Research => "research",
@@ -1035,7 +1049,7 @@ mod tests {
 
     #[test]
     fn label_tables_cover_every_variant() {
-        assert_eq!(stage_label(StageKind::ContextRecall), "context recall");
+        assert_eq!(stage_label(&StageKind::ContextRecall.into()), "context recall");
         assert_eq!(budget_mode_label(BudgetMode::Enforced), "enforced");
         assert_eq!(media_kind_label(MediaKind::Svg), "svg");
         assert_eq!(pr_status_label(PrStatus::Merged), "merged");
@@ -1054,8 +1068,8 @@ mod tests {
     /// `VERDICT` (#1465).
     #[test]
     fn the_verdict_stage_is_never_labelled_after_the_model_that_runs_it() {
-        assert_eq!(stage_label(StageKind::Verify), "verify");
-        assert_eq!(stage_label(StageKind::Verdict), "verdict");
+        assert_eq!(stage_label(&StageKind::Verify.into()), "verify");
+        assert_eq!(stage_label(&StageKind::Verdict.into()), "verdict");
     }
 
     // ── Dispatch coverage ────────────────────────────────────────────────
@@ -1252,7 +1266,7 @@ mod tests {
         use stella_protocol::{ToolCall, ToolOutput};
         let structural: Vec<AgentEvent> = vec![
             AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
             AgentEvent::Text { text: "t".into() },

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1049,7 +1049,10 @@ mod tests {
 
     #[test]
     fn label_tables_cover_every_variant() {
-        assert_eq!(stage_label(&StageKind::ContextRecall.into()), "context recall");
+        assert_eq!(
+            stage_label(&StageKind::ContextRecall.into()),
+            "context recall"
+        );
         assert_eq!(budget_mode_label(BudgetMode::Enforced), "enforced");
         assert_eq!(media_kind_label(MediaKind::Svg), "svg");
         assert_eq!(pr_status_label(PrStatus::Merged), "merged");

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -844,9 +844,16 @@ pub fn status_color(status: AgentStatus) -> Color {
 /// (checking is neither activity nor a verdict), and the wind-down stages
 /// dim. `Complete` is the sole outcome here and takes success — paired with
 /// the stage *word* beside the dot, so hue never carries the meaning alone.
-pub fn stage_color(stage: stella_protocol::StageKind) -> Color {
+///
+/// A **contributed** stage — one a plugin named, which this host has no phase
+/// family for — takes [`contributed_stage_color`] instead. See there for why it
+/// is a hash rather than a guess.
+pub fn stage_color(stage: &stella_protocol::StageName) -> Color {
     use stella_protocol::StageKind as S;
-    match stage {
+    let Some(kind) = stage.kind() else {
+        return contributed_stage_color(stage.as_str());
+    };
+    match kind {
         S::Triage | S::ContextRecall | S::Research | S::Plan | S::ScopeReview | S::Witness => RUN,
         S::Execute => ACCENT,
         S::Verify | S::Verdict => TEAL,
@@ -860,6 +867,33 @@ pub fn stage_color(stage: stella_protocol::StageKind) -> Color {
     }
 }
 
+/// The categorical hues a contributed stage is hashed into.
+///
+/// Excludes, deliberately: [`ACCENT`] (brand, and the one hue that means
+/// "active" — a plugin's stage is not the brand and is not a status), [`OK`],
+/// [`WARN`] and [`BAD`] (a contributed stage would read as a verdict it never
+/// reported), and [`AMBER`], which the palette stands down at 1.06:1 against
+/// the gold accent. What remains is five categorical hues that all clear AA on
+/// [`GROUND`] and none of which can be mistaken for an outcome.
+const CONTRIBUTED_STAGE_PALETTE: [Color; 5] = [VIOLET, TEAL, MAGENTA, CITRON, ORCHID];
+
+/// A deterministic colour for a stage this host did not define.
+///
+/// **The point is stability and distinctness, not per-colour meaning** — the
+/// same contract [`agent_color`] states, reached for the same reason. The deck
+/// cannot know whether a plugin's `triage-lite` is a planning stage or a
+/// verification one, so painting it violet because the name resembles `triage`
+/// would be a claim about the turn that nothing established. Hashing says only
+/// what is true: these are different stages, and each is always the same
+/// colour wherever it appears.
+///
+/// A contributed stage can therefore collide with a host stage's hue. That is
+/// acceptable for the reason [`stage_color`]'s own doc gives — the stage *word*
+/// renders beside the dot, so hue never carries the meaning alone.
+pub fn contributed_stage_color(name: &str) -> Color {
+    CONTRIBUTED_STAGE_PALETTE[(fnv1a(name) as usize) % CONTRIBUTED_STAGE_PALETTE.len()]
+}
+
 /// The stage colour a **transcript section rule** renders in — the same phase
 /// families [`stage_color`] uses, with one deliberate divergence.
 ///
@@ -871,10 +905,14 @@ pub fn stage_color(stage: stella_protocol::StageKind) -> Color {
 /// citron instead: the brightest categorical hue there is (11.08:1), 39° clear
 /// of gold, and — like the stage it marks — the one that says the workspace
 /// changed here.
-pub fn stage_rule_color(stage: stella_protocol::StageKind) -> Color {
-    match stage {
-        stella_protocol::StageKind::Execute => CITRON,
-        other => stage_color(other),
+///
+/// A contributed stage has no such divergence to make: it never takes the
+/// accent in the first place (see [`CONTRIBUTED_STAGE_PALETTE`]), so there is
+/// no gold to move off a settled thing, and it reads the same in both places.
+pub fn stage_rule_color(stage: &stella_protocol::StageName) -> Color {
+    match stage.kind() {
+        Some(stella_protocol::StageKind::Execute) => CITRON,
+        _ => stage_color(stage),
     }
 }
 

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -907,7 +907,7 @@ pub fn contributed_stage_color(name: &str) -> Color {
 /// changed here.
 ///
 /// A contributed stage has no such divergence to make: it never takes the
-/// accent in the first place (see [`CONTRIBUTED_STAGE_PALETTE`]), so there is
+/// accent in the first place (see [`contributed_stage_color`]), so there is
 /// no gold to move off a settled thing, and it reads the same in both places.
 pub fn stage_rule_color(stage: &stella_protocol::StageName) -> Color {
     match stage.kind() {

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -955,3 +955,77 @@ fn a_stage_rule_is_hued_by_phase_and_never_by_verdict() {
          status gold carries"
     );
 }
+
+/// **The witness for a plugin-contributed stage's styling.**
+///
+/// A stage the host has never heard of has to render as a stage — visible, in
+/// the kit, and never dressed as an outcome. Before the vocabulary opened it
+/// could not reach a renderer at all, so there was nothing to colour.
+///
+/// The bar it must clear is the same one every host stage clears above: not a
+/// verdict hue, not the brand, and not the neutral tier that made a boundary
+/// invisible.
+#[test]
+fn a_contributed_stage_is_visible_in_the_kit_and_never_reads_as_a_verdict() {
+    for word in [
+        "triage-lite",
+        "vera/witness",
+        "review",
+        "sast",
+        "spec-check",
+        "benchmark",
+        "x",
+    ] {
+        let stage = stella_protocol::StageName::new(word);
+        assert!(
+            stage.kind().is_none(),
+            "{word} must be a contributed stage for this test to mean anything"
+        );
+        let color = stage_color(&stage);
+        assert_ne!(color, BAD, "{word} must not read as a failure");
+        assert_ne!(color, OK, "{word} must not read as a settled success");
+        assert_ne!(color, WARN, "{word} must not read as a warning");
+        assert_ne!(
+            color, ACCENT,
+            "{word} must not take the brand accent — gold is 'active', and a \
+             plugin's stage is not the brand"
+        );
+        assert_ne!(
+            color, TEXT_SECONDARY,
+            "{word} must not fall back to the neutral tier — that is the exact \
+             invisibility the phase hues were introduced to end"
+        );
+        // The transcript rule and the statline dot agree for a contributed
+        // stage: it never takes the accent, so there is no gold to move off a
+        // settled thing (the one divergence `stage_rule_color` makes).
+        assert_eq!(
+            stage_rule_color(&stage),
+            color,
+            "{word} must read the same in the transcript and the statline"
+        );
+    }
+}
+
+/// The hash is an identity, not a decoration: the same stage is the same
+/// colour on every frame, in every process, forever. A colour that moved
+/// between renders would make the hue actively misleading — the reader would
+/// take a recolour for a change of stage.
+#[test]
+fn a_contributed_stage_keeps_one_colour() {
+    let once = contributed_stage_color("triage-lite");
+    for _ in 0..64 {
+        assert_eq!(contributed_stage_color("triage-lite"), once);
+    }
+    // And it is genuinely keyed on the name — two stages are allowed to
+    // collide, but they must not collide by construction.
+    let words = ["triage-lite", "review", "sast", "spec-check", "benchmark"];
+    let distinct: std::collections::BTreeSet<String> = words
+        .iter()
+        .map(|w| format!("{:?}", contributed_stage_color(w)))
+        .collect();
+    assert!(
+        distinct.len() > 1,
+        "every contributed stage landed on one colour — the hash is not keyed \
+         on the name at all"
+    );
+}

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -924,7 +924,8 @@ fn a_stage_rule_is_hued_by_phase_and_never_by_verdict() {
         S::Reflect,
         S::ContextWrite,
     ] {
-        let color = stage_rule_color(stage);
+        let stage = stella_protocol::StageName::from(stage);
+        let color = stage_rule_color(&stage);
         assert_ne!(color, BAD, "{stage:?} must not read as a failure");
         assert_ne!(color, OK, "{stage:?} must not read as a settled success");
         assert_ne!(
@@ -938,17 +939,17 @@ fn a_stage_rule_is_hued_by_phase_and_never_by_verdict() {
         );
         // The statline's live dot has the same job and answers separately —
         // but only `Execute` may differ, and only in that direction.
-        if !matches!(stage, S::Execute) {
+        if stage.kind() != Some(S::Execute) {
             assert_eq!(
                 color,
-                stage_color(stage),
+                stage_color(&stage),
                 "{stage:?} must read the same in the transcript and the statline"
             );
         }
     }
-    assert_eq!(stage_rule_color(S::Complete), OK);
+    assert_eq!(stage_rule_color(&S::Complete.into()), OK);
     assert_eq!(
-        stage_color(S::Execute),
+        stage_color(&S::Execute.into()),
         ACCENT,
         "the statline's LIVE execute dot keeps the accent — that is the one \
          status gold carries"

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -482,7 +482,7 @@ mod tests {
             assert_eq!(search_hits(&t, query), vec![0], "no hit for {query:?}");
         }
         assert!(
-            entry_fields(&TranscriptEntry::Stage(stella_protocol::StageKind::Verify)).is_empty()
+            entry_fields(&TranscriptEntry::Stage(stella_protocol::StageKind::Verify.into())).is_empty()
         );
     }
 

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -482,7 +482,10 @@ mod tests {
             assert_eq!(search_hits(&t, query), vec![0], "no hit for {query:?}");
         }
         assert!(
-            entry_fields(&TranscriptEntry::Stage(stella_protocol::StageKind::Verify.into())).is_empty()
+            entry_fields(&TranscriptEntry::Stage(
+                stella_protocol::StageKind::Verify.into()
+            ))
+            .is_empty()
         );
     }
 

--- a/crates/stella-tui/src/views/agents.rs
+++ b/crates/stella-tui/src/views/agents.rs
@@ -475,7 +475,7 @@ mod tests {
         model.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -240,7 +240,7 @@ mod tests {
         model.apply_inbound(&ev(
             "a",
             AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         ));

--- a/crates/stella-tui/tests/accessible_layout.rs
+++ b/crates/stella-tui/tests/accessible_layout.rs
@@ -190,7 +190,7 @@ fn scoped_session(accessible: bool) -> (WorkspaceModel, DeckUi) {
         },
     }));
     model.apply_inbound(&event(AgentEvent::Stage {
-        name: StageKind::Execute,
+        name: StageKind::Execute.into(),
         scope: stella_protocol::StageScope::Run,
     }));
     model.apply_inbound(&event(AgentEvent::Text {
@@ -260,7 +260,7 @@ fn the_live_pane_skips_whatever_is_already_in_scrollback() {
     for line in ["already flushed", "still live"] {
         for event in [
             AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
             AgentEvent::Text { text: line.into() },

--- a/crates/stella-tui/tests/accessible_tables.rs
+++ b/crates/stella-tui/tests/accessible_tables.rs
@@ -93,7 +93,7 @@ fn the_executions_dashboard_reads_as_labelled_records() {
     model.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     });

--- a/crates/stella-tui/tests/plan_card_grid.rs
+++ b/crates/stella-tui/tests/plan_card_grid.rs
@@ -40,7 +40,7 @@ fn scoped_model(approved: bool) -> WorkspaceModel {
         m.apply_inbound(&Inbound::Event {
             agent: "lead".into(),
             event: AgentEvent::Stage {
-                name: StageKind::Execute,
+                name: StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,
             },
         });

--- a/crates/stella-tui/tests/progress_brand_fill.rs
+++ b/crates/stella-tui/tests/progress_brand_fill.rs
@@ -30,7 +30,7 @@ fn running_model() -> WorkspaceModel {
     m.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     });

--- a/crates/stella-tui/tests/statline_cells.rs
+++ b/crates/stella-tui/tests/statline_cells.rs
@@ -39,7 +39,7 @@ fn running_model() -> WorkspaceModel {
     m.apply_inbound(&Inbound::Event {
         agent: "lead".into(),
         event: AgentEvent::Stage {
-            name: StageKind::Execute,
+            name: StageKind::Execute.into(),
             scope: stella_protocol::StageScope::Run,
         },
     });

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -265,7 +265,9 @@ A scope-level review decision crossed the event stream. Placement only; content 
 - **Fields:** `seq`, `stage`
 <!-- facts:end -->
 
-The pipeline entered a named `stage` (a closed enum). These records partition the timeline; the gap between consecutive ones is where a slow run spent its time.
+The run entered a named `stage`. These records partition the timeline; the gap between consecutive ones is where a slow run spent its time.
+
+`stage` is an **open** vocabulary (`doc:roleless-core`). One of the host's own twelve boundaries records as a plain closed-vocabulary value; a stage contributed by an installed plugin records its own name through the reviewed hatch (§5.5), justified there as configuration rather than content — it is declared in a manifest the operator chose to install, and nothing in a turn authors it. Dropping the name instead would leave the record unable to say which stage a run spent its time in, which is the question this code exists to answer.
 
 ### `agent.steered`
 

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -970,6 +970,9 @@ export interface ScopeProposal {
   write_globs?: string[];
 }
 
+/**
+ * The name of a stage boundary — an OPEN vocabulary. The host's own boundaries are listed in `examples`; an installed plugin may contribute a stage under any other name, so a consumer must branch on the names it knows and keep a default arm rather than treating an unlisted value as invalid.
+ */
 export type StageName = string;
 
 /**
@@ -1220,10 +1223,7 @@ export interface VerdictEvidence {
  */
 export type AgentEvent = {
   /**
-   * Which stage. An **open** vocabulary ([`crate::StageName`]): one of
-   * [`StageKind`]'s twelve when this host emitted the boundary, or a
-   * contributed stage's own word. On the wire it is a plain string
-   * either way, so the twelve encode exactly as they always have.
+   * Which stage the boundary belongs to, as a plain string. An OPEN vocabulary: the host's own boundaries take the names listed in this field's type examples, and a stage contributed by an installed plugin takes whatever name that plugin declared. Every one of the host's own names encodes exactly as it always has, so an existing consumer keeps reading; a consumer must branch on the names it knows and keep a default arm, because a name it has never seen is now reachable.
    */
   name: StageName;
   scope: StageScope;

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -970,12 +970,9 @@ export interface ScopeProposal {
   write_globs?: string[];
 }
 
-export type StageKind = "triage" | "context_recall" | "research" | "plan" | "scope_review" | "witness" | "execute" | "verify" | "verdict" | "reflect" | "context_write" | "complete";
+export type StageName = string;
 
 /**
- * A named point in the turn's data flow. Exactly one stage vocabulary
- * exists in this workspace — never duplicated per-crate (the TS-era
- * `StageKind` duplication this structurally forbids, L-E1).
  * Whose stage boundary an [`AgentEvent::Stage`] reports (#3398).
  *
  * Deliberately **not** `#[serde(default)]`. A default would silently claim
@@ -1222,7 +1219,13 @@ export interface VerdictEvidence {
  * compat fallback would mean hand-writing a visitor for every variant.
  */
 export type AgentEvent = {
-  name: StageKind;
+  /**
+   * Which stage. An **open** vocabulary ([`crate::StageName`]): one of
+   * [`StageKind`]'s twelve when this host emitted the boundary, or a
+   * contributed stage's own word. On the wire it is a plain string
+   * either way, so the twelve encode exactly as they always have.
+   */
+  name: StageName;
   scope: StageScope;
   /**
    * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1522,72 +1522,11 @@
       ],
       "type": "object"
     },
-    "StageKind": {
-      "oneOf": [
-        {
-          "const": "triage",
-          "description": "Prompt classification and routing: how hard is this turn, and which\ntier should serve it.",
-          "type": "string"
-        },
-        {
-          "const": "context_recall",
-          "description": "Context recall: the frames the context plane put in front of the model\nbefore it planned anything.",
-          "type": "string"
-        },
-        {
-          "const": "research",
-          "description": "Pre-plan research: triage named questions, and parallel read-only\nsub-agents answer them so the planner names files it has evidence for\nrather than guesses (#1778). Skipped whenever triage named none.",
-          "type": "string"
-        },
-        {
-          "const": "plan",
-          "description": "Planning: the ordered steps the worker is about to attempt.",
-          "type": "string"
-        },
-        {
-          "const": "scope_review",
-          "description": "The interactive approval gate a large plan passes through (L-E5).",
-          "type": "string"
-        },
-        {
-          "const": "witness",
-          "description": "Witness authoring: after the worker executes — once the warrant has\nread the diff and found something worth proving — an independent\nmodel (the verifier's resolution, never the worker's transcript)\nwrites the witness test in a pristine snapshot of the pre-execution\ntree: a test that FAILS there and will pass once the goal is met,\narming the deterministic flip oracle (L-E11). The witness is visible\nto the worker's revise turns (iterating against a failing test is\nwhere convergence comes from); integrity comes from tamper exclusion\nat verify time, not from hiding the test.",
-          "type": "string"
-        },
-        {
-          "const": "execute",
-          "description": "The worker's own tool-calling loop — the steps that actually change\nthe workspace.",
-          "type": "string"
-        },
-        {
-          "const": "verify",
-          "description": "The deterministic verification ladder: the flip oracle, the touched\ntests, the diff budget.",
-          "type": "string"
-        },
-        {
-          "const": "verdict",
-          "description": "The verifier's verdict, reached only when the deterministic ladder came\nback inconclusive (L-E11). Named for the output rather than the model:\na stage called `Verifier` sitting next to `Verify` hid which of the two\nwas proof and which was opinion.\n\nAliased for the same reason as the other renames in this pass: the\nstage shipped on the wire as `judge`, so every recorded session names\nit that way. Reading them is not optional — replay, the observatory and\nthe golden fixtures all parse stored streams. `verifier` is aliased too\nbecause it was this stage's name for the length of one commit on this\nbranch, and a stream recorded against that build must still read.",
-          "type": "string"
-        },
-        {
-          "const": "reflect",
-          "description": "Post-turn self-reflection: the agent reviews its own performance on\nthe completed turn and records improvement memories into the context\nplane, tagged with the workspace's inferred domains, for recall on\nfuture relevant turns.",
-          "type": "string"
-        },
-        {
-          "const": "context_write",
-          "description": "Context write-back: episode summaries and fact upserts landing in the\ncontext plane (close-not-delete, L-C3).",
-          "type": "string"
-        },
-        {
-          "const": "complete",
-          "description": "The turn is done. The last stage boundary a turn emits.",
-          "type": "string"
-        }
-      ]
+    "StageName": {
+      "type": "string"
     },
     "StageScope": {
-      "description": "A named point in the turn's data flow. Exactly one stage vocabulary\nexists in this workspace — never duplicated per-crate (the TS-era\n`StageKind` duplication this structurally forbids, L-E1).\nWhose stage boundary an [`AgentEvent::Stage`] reports (#3398).\n\nDeliberately **not** `#[serde(default)]`. A default would silently claim\none scope for every historical recording, and half of them are the other\none — a decode ambiguity that would live in the fixtures forever. A\nrecording written before this field existed decodes through\n[`AgentEvent::Unknown`] instead, which says \"I do not know what this is\"\nrather than guessing wrong.",
+      "description": "Whose stage boundary an [`AgentEvent::Stage`] reports (#3398).\n\nDeliberately **not** `#[serde(default)]`. A default would silently claim\none scope for every historical recording, and half of them are the other\none — a decode ambiguity that would live in the fixtures forever. A\nrecording written before this field existed decodes through\n[`AgentEvent::Unknown`] instead, which says \"I do not know what this is\"\nrather than guessing wrong.",
       "oneOf": [
         {
           "const": "turn",
@@ -1940,7 +1879,8 @@
       "description": "A stage boundary was crossed. `scope` says whose stage it is, and it is not decoration: two disjoint authorities emit stages. The engine emits its own, once per turn, with scope `turn`. A wrapper -- the staged pipeline, a goal loop -- emits its own vocabulary once per run, with scope `run`. A consumer that branches on stage transitions must select on `scope` first, or it will see two interleaved vocabularies as one and read a wrapper's backwards-looking boundary as an engine regression.",
       "properties": {
         "name": {
-          "$ref": "#/$defs/StageKind"
+          "$ref": "#/$defs/StageName",
+          "description": "Which stage. An **open** vocabulary ([`crate::StageName`]): one of\n[`StageKind`]'s twelve when this host emitted the boundary, or a\ncontributed stage's own word. On the wire it is a plain string\neither way, so the twelve encode exactly as they always have."
         },
         "scope": {
           "$ref": "#/$defs/StageScope"

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1523,6 +1523,21 @@
       "type": "object"
     },
     "StageName": {
+      "description": "The name of a stage boundary — an OPEN vocabulary. The host's own boundaries are listed in `examples`; an installed plugin may contribute a stage under any other name, so a consumer must branch on the names it knows and keep a default arm rather than treating an unlisted value as invalid.",
+      "examples": [
+        "triage",
+        "context_recall",
+        "research",
+        "plan",
+        "scope_review",
+        "witness",
+        "execute",
+        "verify",
+        "verdict",
+        "reflect",
+        "context_write",
+        "complete"
+      ],
       "type": "string"
     },
     "StageScope": {
@@ -1880,7 +1895,7 @@
       "properties": {
         "name": {
           "$ref": "#/$defs/StageName",
-          "description": "Which stage. An **open** vocabulary ([`crate::StageName`]): one of\n[`StageKind`]'s twelve when this host emitted the boundary, or a\ncontributed stage's own word. On the wire it is a plain string\neither way, so the twelve encode exactly as they always have."
+          "description": "Which stage the boundary belongs to, as a plain string. An OPEN vocabulary: the host's own boundaries take the names listed in this field's type examples, and a stage contributed by an installed plugin takes whatever name that plugin declared. Every one of the host's own names encodes exactly as it always has, so an existing consumer keeps reading; a consumer must branch on the names it knows and keep a default arm, because a name it has never seen is now reachable."
         },
         "scope": {
           "$ref": "#/$defs/StageScope"

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -22,7 +22,10 @@
  * compat fallback would mean hand-writing a visitor for every variant.
  */
 export type AgentEvent = {
-  name: StageKind;
+  /**
+   * Which stage the boundary belongs to, as a plain string. An OPEN vocabulary: the host's own boundaries take the names listed in this field's type examples, and a stage contributed by an installed plugin takes whatever name that plugin declared. Every one of the host's own names encodes exactly as it always has, so an existing consumer keeps reading; a consumer must branch on the names it knows and keep a default arm, because a name it has never seen is now reachable.
+   */
+  name: StageName;
   scope: StageScope;
   type: "stage";
 } | {
@@ -1769,12 +1772,12 @@ export interface ScopeProposal {
  */
 export type ServiceTier = "auto" | "default" | "flex" | "priority";
 
-export type StageKind = "triage" | "context_recall" | "research" | "plan" | "scope_review" | "witness" | "execute" | "verify" | "verdict" | "reflect" | "context_write" | "complete";
+/**
+ * The name of a stage boundary — an OPEN vocabulary. The host's own boundaries are listed in `examples`; an installed plugin may contribute a stage under any other name, so a consumer must branch on the names it knows and keep a default arm rather than treating an unlisted value as invalid.
+ */
+export type StageName = string;
 
 /**
- * A named point in the turn's data flow. Exactly one stage vocabulary
- * exists in this workspace — never duplicated per-crate (the TS-era
- * `StageKind` duplication this structurally forbids, L-E1).
  * Whose stage boundary an [`AgentEvent::Stage`] reports (#3398).
  *
  * Deliberately **not** `#[serde(default)]`. A default would silently claim

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -7,7 +7,8 @@
           "description": "A stage boundary was crossed. `scope` says whose stage it is, and it is not decoration: two disjoint authorities emit stages. The engine emits its own, once per turn, with scope `turn`. A wrapper -- the staged pipeline, a goal loop -- emits its own vocabulary once per run, with scope `run`. A consumer that branches on stage transitions must select on `scope` first, or it will see two interleaved vocabularies as one and read a wrapper's backwards-looking boundary as an engine regression.",
           "properties": {
             "name": {
-              "$ref": "#/$defs/StageKind"
+              "$ref": "#/$defs/StageName",
+              "description": "Which stage the boundary belongs to, as a plain string. An OPEN vocabulary: the host's own boundaries take the names listed in this field's type examples, and a stage contributed by an installed plugin takes whatever name that plugin declared. Every one of the host's own names encodes exactly as it always has, so an existing consumer keeps reading; a consumer must branch on the names it knows and keep a default arm, because a name it has never seen is now reachable."
             },
             "scope": {
               "$ref": "#/$defs/StageScope"
@@ -3255,72 +3256,26 @@
         }
       ]
     },
-    "StageKind": {
-      "oneOf": [
-        {
-          "const": "triage",
-          "description": "Prompt classification and routing: how hard is this turn, and which\ntier should serve it.",
-          "type": "string"
-        },
-        {
-          "const": "context_recall",
-          "description": "Context recall: the frames the context plane put in front of the model\nbefore it planned anything.",
-          "type": "string"
-        },
-        {
-          "const": "research",
-          "description": "Pre-plan research: triage named questions, and parallel read-only\nsub-agents answer them so the planner names files it has evidence for\nrather than guesses (#1778). Skipped whenever triage named none.",
-          "type": "string"
-        },
-        {
-          "const": "plan",
-          "description": "Planning: the ordered steps the worker is about to attempt.",
-          "type": "string"
-        },
-        {
-          "const": "scope_review",
-          "description": "The interactive approval gate a large plan passes through (L-E5).",
-          "type": "string"
-        },
-        {
-          "const": "witness",
-          "description": "Witness authoring: after the worker executes — once the warrant has\nread the diff and found something worth proving — an independent\nmodel (the verifier's resolution, never the worker's transcript)\nwrites the witness test in a pristine snapshot of the pre-execution\ntree: a test that FAILS there and will pass once the goal is met,\narming the deterministic flip oracle (L-E11). The witness is visible\nto the worker's revise turns (iterating against a failing test is\nwhere convergence comes from); integrity comes from tamper exclusion\nat verify time, not from hiding the test.",
-          "type": "string"
-        },
-        {
-          "const": "execute",
-          "description": "The worker's own tool-calling loop — the steps that actually change\nthe workspace.",
-          "type": "string"
-        },
-        {
-          "const": "verify",
-          "description": "The deterministic verification ladder: the flip oracle, the touched\ntests, the diff budget.",
-          "type": "string"
-        },
-        {
-          "const": "verdict",
-          "description": "The verifier's verdict, reached only when the deterministic ladder came\nback inconclusive (L-E11). Named for the output rather than the model:\na stage called `Verifier` sitting next to `Verify` hid which of the two\nwas proof and which was opinion.\n\nAliased for the same reason as the other renames in this pass: the\nstage shipped on the wire as `judge`, so every recorded session names\nit that way. Reading them is not optional — replay, the observatory and\nthe golden fixtures all parse stored streams. `verifier` is aliased too\nbecause it was this stage's name for the length of one commit on this\nbranch, and a stream recorded against that build must still read.",
-          "type": "string"
-        },
-        {
-          "const": "reflect",
-          "description": "Post-turn self-reflection: the agent reviews its own performance on\nthe completed turn and records improvement memories into the context\nplane, tagged with the workspace's inferred domains, for recall on\nfuture relevant turns.",
-          "type": "string"
-        },
-        {
-          "const": "context_write",
-          "description": "Context write-back: episode summaries and fact upserts landing in the\ncontext plane (close-not-delete, L-C3).",
-          "type": "string"
-        },
-        {
-          "const": "complete",
-          "description": "The turn is done. The last stage boundary a turn emits.",
-          "type": "string"
-        }
-      ]
+    "StageName": {
+      "description": "The name of a stage boundary — an OPEN vocabulary. The host's own boundaries are listed in `examples`; an installed plugin may contribute a stage under any other name, so a consumer must branch on the names it knows and keep a default arm rather than treating an unlisted value as invalid.",
+      "examples": [
+        "triage",
+        "context_recall",
+        "research",
+        "plan",
+        "scope_review",
+        "witness",
+        "execute",
+        "verify",
+        "verdict",
+        "reflect",
+        "context_write",
+        "complete"
+      ],
+      "type": "string"
     },
     "StageScope": {
-      "description": "A named point in the turn's data flow. Exactly one stage vocabulary\nexists in this workspace — never duplicated per-crate (the TS-era\n`StageKind` duplication this structurally forbids, L-E1).\nWhose stage boundary an [`AgentEvent::Stage`] reports (#3398).\n\nDeliberately **not** `#[serde(default)]`. A default would silently claim\none scope for every historical recording, and half of them are the other\none — a decode ambiguity that would live in the fixtures forever. A\nrecording written before this field existed decodes through\n[`AgentEvent::Unknown`] instead, which says \"I do not know what this is\"\nrather than guessing wrong.",
+      "description": "Whose stage boundary an [`AgentEvent::Stage`] reports (#3398).\n\nDeliberately **not** `#[serde(default)]`. A default would silently claim\none scope for every historical recording, and half of them are the other\none — a decode ambiguity that would live in the fixtures forever. A\nrecording written before this field existed decodes through\n[`AgentEvent::Unknown`] instead, which says \"I do not know what this is\"\nrather than guessing wrong.",
       "oneOf": [
         {
           "const": "turn",


### PR DESCRIPTION
`doc:roleless-core`. The stage vocabulary opens: a stage a plugin contributed
can be named on the wire, and every surface that renders a stage renders it —
with its own word and its own colour.

## What

`AgentEvent::Stage::name` was `StageKind`, a closed enum of the twelve
boundaries this host emits. It is now `StageName`
(`crates/stella-protocol/src/stage.rs`) — either one of the twelve or a
contributed name carried as the plugin's own word. On the wire it is a plain
string either way, so **every one of the twelve encodes exactly the byte it
always did**.

```
  MODEL                     │ TRIAGE-LITE │ CPU  …
  worker: zai/glm-5.2       │ —           │ …
```

## Why this is a bug fix, not only a feature

`AgentEvent`'s forward-compatibility stops at its own tag: an unknown *tag*
becomes `AgentEvent::Unknown`, but a known tag whose body does not fit is a hard
error and the reader loses the whole event. A stage name outside the twelve was
exactly that — so a journal or `stream-json` feed carrying one extra stage did
not render it badly, **the line failed to decode**. `stella resume` replays
journals, the observatory parses stored streams, and a `stella-serve` host
forwards events it did not author, so this was reachable today.

`stage::event_decode_tests::an_unknown_stage_name_no_longer_kills_the_event`
is the witness.

## Styling — the part that had a real choice in it

A contributed stage takes a deterministic hue from
`theme::contributed_stage_color`, hashed FNV-1a into five categorical values.
This is `theme::agent_color`'s contract and its stated reason: **stability and
distinctness, not per-colour meaning.** The deck cannot know whether a plugin's
`triage-lite` is a planning stage or a verification one, so painting it violet
because the name resembles `triage` would be a claim nothing established.

The palette excludes the brand accent (gold is "active"), `OK`/`WARN`/`BAD` (a
stage is not a verdict), and the stood-down amber. A contributed stage may
collide with a host stage's hue, which is acceptable for the reason
`stage_color`'s own doc already gives — the stage *word* renders beside it, so
hue never carries the meaning alone.

The **label** is the plugin's word verbatim. `envelope::roles` settled the same
question for the `/models` role table and its argument carries: inventing
"plugin" or "custom" would name the row after a category instead of after
itself. `triage-lite` is the load-bearing case — it *contains* a host stage's
name, so anything resolving by prefix would silently relabel it `triage`.

## Two real regressions the witnesses caught

- **`Hud::host_stage`.** The three-segment progress bar draws the host's phases,
  and a contributed stage has none of them. Folding it into the same field made
  it phase-less, phase-less falls back to phase 0, and a plugin stage running
  after `execute` dragged the bar back to "plan" — the deck reporting a
  regression that never happened. `host_stage` retains the last *host* boundary
  so the bar holds while the statline still names what is running.
- **The Traces tab worded a stage from `Debug`.** `format!("{name:?}")` used to
  spell the variant and happened to read like the stage word; it now spells the
  wrapper (`Known(Triage)`). A golden frame caught it. It reads through
  `textline::stage_label` now, which is the single wording home (#1465).

## Wire change — read this as a contract change

`StageKind` no longer appears in `docs/wire/*.schema.json` or `*.d.ts`; the
field is `StageName = string`. **A TypeScript consumer importing `StageKind`
from the generated `.d.ts`, or exhaustively switching on it, breaks.** Every
value it used to receive is still valid and still spelled identically — the
break is that new values are now reachable and the type no longer enumerates
them.

To keep what a consumer actually loses, the twelve ride along as JSON Schema
`examples` with a description telling readers to branch on the names they know
and keep a default arm. That documents without re-closing.

## Deliberately not here

A plugin manifest still cannot **declare** a contributed stage —
`stella_plugin::wrapper::StageName` stays closed, because that crate's own
argument holds: a manifest key that loads but dispatches nothing is worse than
one that refuses to load, and dispatch semantics are #3907's blocked decisions.
Filed as **#3963** with the seam, the files, and the verify steps.

## Witness tests

Each fails on `main` — several by not compiling, since the feature could not be
expressed there at all.

| Test | Proves |
|---|---|
| `stage::event_decode_tests::an_unknown_stage_name_no_longer_kills_the_event` | the decode failure this fixes |
| `stage::tests::a_contributed_stage_round_trips_under_its_own_name` | the name survives the wire |
| `stage::tests::a_host_stage_encodes_exactly_as_it_always_did` | no wire regression for the twelve |
| `stage::tests::a_known_name_never_becomes_a_contributed_one` | normalization; `judge`/`verifier` aliases still resolve |
| `theme::tests::a_contributed_stage_is_visible_in_the_kit_and_never_reads_as_a_verdict` | styling: visible, in-kit, never an outcome |
| `theme::tests::a_contributed_stage_keeps_one_colour` | the hue is an identity, not decoration |
| `textline::tests::a_contributed_stage_is_labelled_with_its_own_word` | the plugin's word, not a category |
| `statline::tests::the_stage_box_heads_itself_with_a_contributed_stage_too` | the surface a user watches |
| `progress::tests::a_contributed_stage_leaves_the_bar_where_the_last_host_stage_put_it` | no phantom regression |

Two guards also got tighter rather than looser: `StageKind::ALL` is now proved
total by `all_lists_every_kind_exactly_once` (the wire corpus samples from it,
so a missing kind is a coverage hole the schema can no longer catch), and the
wire corpus pins a contributed stage beside the twelve.

## Gate

`make gate` is green through every step except `test`, which fails only on
`goal_wrapped_dispatch_cli::a_goal_run_dispatches_each_round_through_the_bound_wrapper`
— **pre-existing**. I ran the control: it fails identically on a clean
`origin/main` worktree, at the same line, and its round count varies run to run
(1, 2, then 3), which matches the "reads the real `~/.stella` and bills a live
model call" diagnosis. Tracked as #3957, #3938, #3876. Not touched here.

No tests were deleted.

Refs #3907, #3903. Refs #3963.

## Summary by Sourcery

Open stage events to plugin-defined names while preserving host-stage compatibility and rendering contributed stages consistently across every surface.

New Features:
- Open the stage-event vocabulary so plugin-contributed stage names can be carried over the wire and rendered across the CLI, TUI, diagnostics, journals, and served streams.
- Assign contributed stages stable, deterministic categorical colours and display their names verbatim.

Bug Fixes:
- Allow unknown stage names to decode and round-trip instead of rejecting the entire event.
- Prevent contributed stages from resetting host progress indicators and ensure trace labels use the shared stage wording.

Enhancements:
- Preserve the existing wire encodings for all host-defined stages while exposing the stage field as a string to TypeScript consumers with documented known-name examples.
- Keep host progress tracking separate from the currently displayed stage and centralize stage naming and styling for open vocabulary support.

Documentation:
- Document the open stage vocabulary and its compatibility expectations in generated wire types and diagnostics reference documentation.

Tests:
- Add protocol, rendering, styling, progress, trace, and wire-contract coverage for contributed stages and host-stage compatibility.