### PR TITLE
fix(stella-cli): per-round friction ledgers for /goal, and the Command Deck stops reflecting blind (#3962)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -433,6 +433,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             let turn_start = messages.len();
             let started_unix = crate::memory::unix_now_secs();
             presence.update_prompt(goal);
+            // One ledger per round of the arc (#3962), filled by the goal loop
+            // from the journal its renderer drained.
+            let mut goal_rounds: Vec<TurnFriction> = Vec::new();
             let result = run_goal_turn(
                 &*provider,
                 base_tools,
@@ -447,6 +450,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 Some(presence.id()),
                 recall_event,
                 memory.as_mut(),
+                Some(&mut goal_rounds),
             )
             .await;
             presence.needs_input();
@@ -461,15 +465,11 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             if let Err(e) = &result {
                 eprintln!("  {} {}\n", "Error:".red().bold(), e);
             }
-            // `/goal` reflects with an empty ledger, deliberately and for now
-            // (#3946). `run_goal_turn` runs SEVERAL turns, each with its own
-            // event channel, while this reflection covers the whole goal's
-            // transcript — so there is no single turn whose friction describes
-            // it. Folding every round into one ledger is the mistake #3552
-            // named on the wrapper's `TurnFacts`: it reports the first round's
-            // tools as the third round's. Per-round ledgers threaded through
-            // the goal loop are the real answer and are their own change.
-            let goal_friction = TurnFriction::default();
+            // `/goal` reflects ONCE over an arc of several turns, so it hands
+            // reflection one ledger per round rather than one for the arc
+            // (#3962). The fold it is not allowed to make is the merged one:
+            // that is the mistake #3552 named on the wrapper's `TurnFacts`,
+            // where the first round's tools are reported as the third round's.
             reflect_on_interactive_turn(
                 &*provider,
                 cfg,
@@ -477,7 +477,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 reflect::InteractiveTurn {
                     messages: &messages,
                     turn_start,
-                    friction: &goal_friction,
+                    friction: &goal_rounds,
                 },
                 &result,
                 &mut budget,
@@ -563,7 +563,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             reflect::InteractiveTurn {
                 messages: &messages,
                 turn_start,
-                friction: &friction,
+                friction: std::slice::from_ref(&friction),
             },
             &result,
             &mut budget,

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -549,6 +549,11 @@ pub async fn run_goal_cmd(
     // Machine-wide presence: a goal run is exactly the long-lived headless
     // session the SESSIONS overlay + replay exist for.
     let mut presence = SessionPresence::announce(cfg, goal);
+    // This arc's friction, one ledger per round, filled by the raw arm below
+    // and read by the reflection further down (#3962). The wrapped arm leaves
+    // it empty for the same reason `run_raw_one_shot`'s does: those turns are
+    // the plugin's to observe through the wrapper socket.
+    let mut rounds: Vec<TurnFriction> = Vec::new();
     let outcome = if let Some(bound) = &bound {
         goal_wrapped::run_goal_wrapped_turn(
             &*provider,
@@ -583,6 +588,7 @@ pub async fn run_goal_cmd(
             Some(presence.id()),
             recall_event,
             memory.as_mut(),
+            Some(&mut rounds),
         )
         .await
     };
@@ -605,12 +611,14 @@ pub async fn run_goal_cmd(
         && turn_warrants_reflection(&messages)
         && let Some(m) = &mut memory
     {
-        // Transcript-only evidence, as on the raw one-shot above (#2483).
+        // One ledger per round (#3962): this reflection covers an arc of
+        // several turns, and a single fold over the whole stream would report
+        // round 1's tools as the round that ran last.
         let mut report = crate::memory::reflect_routed(
             m,
             cfg,
             &*provider,
-            crate::memory::TurnEvidence::from_transcript(&messages, outcome.is_ok()),
+            crate::memory::TurnEvidence::with_rounds(&messages, &rounds, outcome.is_ok()),
             false,
             crate::agent::remaining_budget(&budget),
         )
@@ -677,6 +685,12 @@ pub(crate) async fn run_goal_turn(
     // runs — reflection stores the self-review 1:1 with an execution, and an
     // unstamped round files an id-less row.
     session_memory: Option<&mut crate::memory::SessionMemory>,
+    // Where this arc's friction ledgers land, ONE PER ROUND, for a caller that
+    // reflects afterwards (#3962). An out-parameter for the same reason
+    // `run_turn`'s single-ledger slot is one: this function's return type says
+    // whether the goal was met, and reflection's evidence is not that. `None`
+    // for a caller that does not reflect.
+    rounds: Option<&mut Vec<TurnFriction>>,
 ) -> Result<(), crate::failure::CliFailure> {
     let turn_start = Instant::now();
     // This function is the RAW arm — `run_goal_cmd` calls it only for
@@ -753,7 +767,16 @@ pub(crate) async fn run_goal_turn(
     let (GoalOutcome::Met { cost_usd, .. } | GoalOutcome::Unmet { cost_usd, .. }) = &outcome;
     persistence::emit_run_complete_on_raw(&tx, &cfg.model_id, *cost_usd);
     drop(tx);
-    let persistence_complete = renderer.await.unwrap_or_default().persistence_complete;
+    let rendered = renderer.await.unwrap_or_default();
+    let persistence_complete = rendered.persistence_complete;
+    // The arc's friction, folded from the journal the renderer just finished
+    // draining — split at each round's own `GoalVerdict` so no round is
+    // credited with another's tools (#3962). Folded here for the same reason
+    // `run_turn` folds here: this is the first point at which the whole stream
+    // is both complete and still owned.
+    if let Some(slot) = rounds {
+        *slot = TurnFriction::per_goal_round(&rendered.events);
+    }
 
     let (outcome_label, cost) = match &outcome {
         GoalOutcome::Met { cost_usd, .. } => ("goal_met", *cost_usd),

--- a/crates/stella-cli/src/agent/reflect.rs
+++ b/crates/stella-cli/src/agent/reflect.rs
@@ -45,7 +45,13 @@ pub(super) struct InteractiveTurn<'a> {
     /// was said; only this records what it cost, how long it took, and whether
     /// the turn retried or looped — none of which a `CompletionMessage`
     /// carries.
-    pub(super) friction: &'a TurnFriction,
+    ///
+    /// A slice because the two doors that share this helper do not agree on
+    /// how many turns one reflection covers (#3962): a plain prompt hands one
+    /// ledger for its one turn, and `/goal` hands one per round of its arc.
+    /// Merging the arc's rounds into a single ledger is the one thing neither
+    /// may do — see this module's callers and `TurnFriction::per_goal_round`.
+    pub(super) friction: &'a [TurnFriction],
 }
 
 /// Post-turn reflection for one interactive REPL turn, shared by the plain
@@ -77,7 +83,7 @@ pub(super) async fn reflect_on_interactive_turn<T, E: std::fmt::Display>(
             m,
             cfg,
             provider,
-            TurnEvidence::with_friction(turn.messages, turn.friction, result.is_ok()),
+            TurnEvidence::with_rounds(turn.messages, turn.friction, result.is_ok()),
             false,
             remaining_budget(budget),
         )

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -105,7 +105,7 @@ mod task_tap;
 mod theme_cmd;
 use pr_observe::{ci_status_token, observe_pr, pr_status_token};
 
-use crate::memory::{SessionMemory, inject_recall_block};
+use crate::memory::{SessionMemory, TurnFriction, inject_recall_block};
 use crate::runtime::TokioSleeper;
 use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::{agents_list_creating, agents_list_inbound, handle_agent_create};
@@ -1514,6 +1514,7 @@ pub async fn run_deck_session(
         let steering: Arc<subsession::SteeringTap> = Arc::default();
         // The lead lane's pause seam — `p` on the lead row (#1219).
         let lead_pause = lead_control::LeadPause::new();
+        let mut friction = TurnFriction::default(); // #3962
         let end = {
             // Both arms return `Result<(), CliFailure>`, so one pinned future
             // drives either path through the same select loop.
@@ -1534,6 +1535,7 @@ pub async fn run_deck_session(
                 &lead_pause,
                 recall_event,
                 memory.as_ref(),
+                &mut friction,
             );
             tokio::pin!(turn);
             loop {
@@ -1998,6 +2000,7 @@ pub async fn run_deck_session(
                             started_unix,
                             &messages,
                             reflect_start,
+                            &friction,
                             &*provider,
                             cfg,
                             &mut budget,
@@ -3717,6 +3720,7 @@ async fn run_lead_turn(
     // because recall runs before this channel exists.
     recall_event: Option<AgentEvent>,
     session_memory: Option<&SessionMemory>, // #3243 Phase 3: behind the re-query
+    friction: &mut TurnFriction,            // #3962: filled from the lane's own stream
 ) -> Result<(), crate::failure::CliFailure> {
     budget.begin_turn();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
@@ -3791,7 +3795,9 @@ async fn run_lead_turn(
     // requires gone; otherwise the forwarder's `recv()` stays pending forever
     // and the turn future wedges after the deck painted the turn done (#2290).
     drop(requery);
-    let persistence_complete = close_turn_stream(registry, tx, forwarder).await;
+    let ended = close_turn_stream(registry, tx, forwarder).await;
+    let persistence_complete = ended.persistence_complete;
+    *friction = ended.friction; // this turn's reflection evidence (#3962)
     claims.release_all();
 
     if let Some((store, id)) = &execution {

--- a/crates/stella-cli/src/command_deck/authoring.rs
+++ b/crates/stella-cli/src/command_deck/authoring.rs
@@ -84,6 +84,7 @@ pub(super) async fn record_and_reflect_turn(
     started_unix: i64,
     messages: &[CompletionMessage],
     reflect_start: usize,
+    friction: &crate::memory::TurnFriction,
     provider: &dyn Provider,
     cfg: &Config,
     budget: &mut BudgetGuard,
@@ -101,15 +102,17 @@ pub(super) async fn record_and_reflect_turn(
         return;
     }
     let Some(memory) = memory else { return };
-    // Transcript-only evidence: the deck's driver events ride a bare
-    // `UnboundedSender` with no `EventSender` seam to wrap (#2483). Every tool
-    // call and its typed result are in `messages`, which is what the digest
-    // selects on.
+    // Transcript AND the lane's own folded ledger (#3962). The transcript
+    // carries every tool call and its typed result, which is what the digest
+    // selects on; only the ledger carries what the turn cost, how long each
+    // tool took, and whether it retried or looped — none of which any
+    // `CompletionMessage` records. It is one ledger because a lead turn is one
+    // turn: the several-turn case is `/goal`, and it passes a slice.
     let mut report = crate::memory::reflect_routed(
         memory,
         cfg,
         provider,
-        crate::memory::TurnEvidence::from_transcript(messages, true),
+        crate::memory::TurnEvidence::with_friction(messages, friction, true),
         true,
         crate::agent::remaining_budget(budget),
     )

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -11,6 +11,25 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::agent;
 use crate::cache_insight::{InsightScope, cache_insight_for};
+use crate::memory::TurnFriction;
+
+/// What a lane's closed turn stream leaves behind for its owner.
+///
+/// Two facts, not one, since #3962. `persistence_complete` was always the
+/// forwarder's answer; `friction` is the fold of the same stream that
+/// reflection reads — and it is folded HERE, in the one seam every deck lane
+/// shares, rather than in `command_deck.rs`, because that file is a god file
+/// closed to growth and because a lane that starts reflecting later should
+/// inherit the ledger rather than re-derive it.
+///
+/// [`Default`] is `persistence_complete: false` — the answer a forwarder that
+/// panicked or was cancelled owes, which is what its `unwrap_or(false)` said
+/// before this struct existed.
+#[derive(Default)]
+pub(crate) struct LaneStreamEnd {
+    pub(crate) persistence_complete: bool,
+    pub(crate) friction: TurnFriction,
+}
 
 /// Warn that execution closeout could not write its audit record (files
 /// touched / memory citations / outcome).
@@ -61,9 +80,14 @@ pub(crate) fn spawn_forwarder(
     inbound: UnboundedSender<Inbound>,
     lane: String,
     plan_board: Option<stella_tools::tasks::TaskBoardHandle>,
-) -> tokio::task::JoinHandle<bool> {
+) -> tokio::task::JoinHandle<LaneStreamEnd> {
     tokio::spawn(async move {
         let mut seq = 0u64;
+        // The lane's friction ledger (#3962), folded as the stream goes past
+        // rather than from a collected `Vec` the way `agent::run_turn` does:
+        // this task forwards each event and keeps none, and a ledger is bounded
+        // where a retained journal is not.
+        let mut friction = TurnFriction::default();
         // Two independent latches, not one. A single shared flag meant an
         // early usage gap — the benign, self-healing condition — silenced any
         // later store-write failure, which is the one that actually points at
@@ -168,6 +192,7 @@ pub(crate) fn spawn_forwarder(
                 _ => {}
             }
             bridge.observe(&event);
+            friction.observe(&event);
             // A plan that reached the gate is the plan whose progress the
             // board records, so this is where it becomes one. Seeded on the
             // proposal rather than on approval: the ids must already resolve
@@ -259,7 +284,10 @@ pub(crate) fn spawn_forwarder(
             }
         }
         bridge.finish();
-        persistence_complete
+        LaneStreamEnd {
+            persistence_complete,
+            friction,
+        }
     })
 }
 
@@ -289,11 +317,11 @@ pub(crate) fn spawn_forwarder(
 pub(crate) async fn close_turn_stream(
     registry: &stella_tools::ToolRegistry,
     tx: UnboundedSender<AgentEvent>,
-    forwarder: tokio::task::JoinHandle<bool>,
-) -> bool {
+    forwarder: tokio::task::JoinHandle<LaneStreamEnd>,
+) -> LaneStreamEnd {
     registry.detach_event_stream();
     drop(tx);
-    forwarder.await.unwrap_or(false)
+    forwarder.await.unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -337,10 +365,9 @@ mod tests {
         )
         .await;
 
-        let persistence_complete =
-            settled.expect("the registry-held sender must not wedge the turn tail");
+        let ended = settled.expect("the registry-held sender must not wedge the turn tail");
         assert!(
-            persistence_complete,
+            ended.persistence_complete,
             "an event-only stream persists cleanly"
         );
         // The forwarded event reached the deck lane before the stream closed.
@@ -351,7 +378,7 @@ mod tests {
     async fn lane_events(
         registry: &stella_tools::ToolRegistry,
         tx: UnboundedSender<AgentEvent>,
-        forwarder: tokio::task::JoinHandle<bool>,
+        forwarder: tokio::task::JoinHandle<LaneStreamEnd>,
         in_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Inbound>,
     ) -> Vec<AgentEvent> {
         close_turn_stream(registry, tx, forwarder).await;

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -168,6 +168,11 @@ pub struct TurnFriction {
     retries: Vec<String>,
     loops: Vec<String>,
     dropped: usize,
+    /// Which goal round this ledger covers, when it covers one — set only by
+    /// [`Self::per_goal_round`] (#3962). `None` on every single-turn door,
+    /// where "this turn" is the whole answer and a round number would be a
+    /// number invented to fill a field.
+    round: Option<usize>,
 }
 
 impl TurnFriction {
@@ -194,6 +199,45 @@ impl TurnFriction {
             friction.observe(event);
         }
         friction
+    }
+
+    /// Fold a **goal arc's** journal into one ledger *per round* (#3962).
+    ///
+    /// A goal run is several turns on one event channel
+    /// (`stella_core::goal::Engine::run_goal`), and [`Self::from_events`] over
+    /// that whole stream is not a smaller answer — it is a wrong one. It
+    /// reports round 1's failed `bash` as something the turn that ran third
+    /// did, which is exactly the misattribution #3552 named on the wrapper's
+    /// `TurnFacts`. Reflection is handed the rounds as a slice
+    /// ([`TurnEvidence::with_rounds`]) and renders them separately, so no
+    /// round can borrow another's friction.
+    ///
+    /// The split key is [`AgentEvent::GoalVerdict`], the round's own
+    /// terminator, which **carries its round number** — so a segment is
+    /// labelled from the stream rather than from its position in it. A
+    /// trailing segment with no verdict is the round that ended the arc
+    /// without being judged (an aborted working turn, the round cap): it takes
+    /// the next round number, because it ran.
+    pub fn per_goal_round(events: &[AgentEvent]) -> Vec<Self> {
+        let mut rounds: Vec<Self> = Vec::new();
+        let mut current = Self::default();
+        let mut judged = 0usize;
+        for event in events {
+            current.observe(event);
+            if let AgentEvent::GoalVerdict { round, .. } = event {
+                judged = *round;
+                current.round = Some(*round);
+                rounds.push(std::mem::take(&mut current));
+            }
+        }
+        // An empty tail is the ordinary shape of a goal that ended ON a
+        // verdict — the run's own terminator folds to nothing — and a round
+        // that ran nothing is not a round worth naming.
+        if !current.is_empty() {
+            current.round = Some(judged.saturating_add(1));
+            rounds.push(current);
+        }
+        rounds
     }
 
     /// Fold one event into the ledger.
@@ -334,13 +378,6 @@ impl TurnFriction {
             && self.loops.is_empty()
     }
 
-    /// A shared empty ledger, so [`TurnEvidence::from_transcript`] can hand out
-    /// a reference without every caller owning a `Default`.
-    fn empty() -> &'static Self {
-        static EMPTY: std::sync::OnceLock<TurnFriction> = std::sync::OnceLock::new();
-        EMPTY.get_or_init(TurnFriction::default)
-    }
-
     /// Tool names the event stream saw, by call id — the half of the
     /// call-id → name map the transcript cannot supply on the staged pipeline
     /// path, where the worker's tool turns are deliberately kept out of
@@ -393,11 +430,22 @@ impl TurnFriction {
     /// have reconstructed at any window size, and it is short — putting it
     /// behind several thousand characters of transcript would make it the first
     /// thing a narrating model skims past.
-    fn section(&self) -> String {
+    /// `total` is how many ledgers this one is being rendered among, which is
+    /// what lets the header name the round (#3962). The round label is written
+    /// only when there is more than one ledger to tell apart: a single-turn
+    /// door renders the byte-identical section it rendered before this
+    /// parameter existed, because "round 1 of 1" is a distinction with nothing
+    /// on the other side of it.
+    fn section(&self, total: usize) -> String {
         if self.is_empty() {
             return String::new();
         }
-        let mut out = String::from("Where this turn spent itself (from its event stream):\n");
+        let mut out = match self.round {
+            Some(round) if total > 1 => {
+                format!("Where round {round} of {total} spent itself (from its event stream):\n")
+            }
+            _ => String::from("Where this turn spent itself (from its event stream):\n"),
+        };
         if !self.steps.is_empty() {
             let calls = self.steps.len();
             let cost: f64 = self.steps.iter().map(|step| step.cost_usd).sum();
@@ -479,26 +527,41 @@ pub struct TurnEvidence<'a> {
     /// messages plus the final answer).
     pub transcript: &'a [CompletionMessage],
     /// What the turn's event stream said about cost, wall clock, retries and
-    /// loop firings.
-    pub friction: &'a TurnFriction,
+    /// loop firings — **one ledger per turn**, not one per reflection.
+    ///
+    /// A slice rather than a single ledger because `/goal` reflects once over
+    /// an arc of several turns (#3962), and the one thing that must not happen
+    /// there is a fold of every round into one ledger: it would report round
+    /// 1's tools as round 3's. Empty for a caller with no event stream, one
+    /// element for every single-turn door, one per round for a goal arc.
+    pub friction: &'a [TurnFriction],
     /// Whether the turn succeeded — which reflection prompt template applies.
     pub succeeded: bool,
 }
 
 impl<'a> TurnEvidence<'a> {
-    /// Evidence from a transcript alone: the shape a caller with no event
-    /// ledger uses, and the shape most tests use.
+    /// Evidence from a transcript alone: a permanently empty ledger, which
+    /// renders no friction section and leaves `Priority::Friction` with only
+    /// the transcript's own errored tool results to select on — no cost, no
+    /// wall clock, no retries, no loop firings, because no
+    /// `CompletionMessage` carries them.
     ///
-    /// Prefer [`Self::with_friction`] on any surface that owns its turn's
-    /// event stream. This constructor hands `build` a permanently empty
-    /// ledger, which renders no friction section at all and leaves
-    /// `Priority::Friction` with only the transcript's own errored tool
-    /// results to select on — it cannot see cost, wall clock, retries or
-    /// loop firings, because no `CompletionMessage` carries them.
+    /// **Test-gated as of #3962, because it finally can be.** Every shipping
+    /// door now owns its turn's event stream and hands over what it folded:
+    /// the single-turn doors through [`Self::with_friction`] (#3946) and
+    /// `/goal` through [`Self::with_rounds`]. What is left is the replay
+    /// harness (`memory/replay.rs`, itself `#[cfg(test)]`), which reflects
+    /// over a recorded transcript that never had an event stream, plus the
+    /// tests that build evidence by hand. `#[cfg(test)]` rather than an
+    /// `#[allow(dead_code)]` states which of those is true and makes a future
+    /// production caller a build error — the point being that a surface that
+    /// reaches for this is a surface that has quietly stopped reporting what
+    /// its turn cost.
+    #[cfg(test)]
     pub fn from_transcript(transcript: &'a [CompletionMessage], succeeded: bool) -> Self {
         Self {
             transcript,
-            friction: TurnFriction::empty(),
+            friction: &[],
             succeeded,
         }
     }
@@ -512,6 +575,22 @@ impl<'a> TurnEvidence<'a> {
     pub fn with_friction(
         transcript: &'a [CompletionMessage],
         friction: &'a TurnFriction,
+        succeeded: bool,
+    ) -> Self {
+        Self::with_rounds(transcript, std::slice::from_ref(friction), succeeded)
+    }
+
+    /// Evidence from a transcript plus **one ledger per round** — what a
+    /// surface that reflects over several turns at once builds (#3962), and
+    /// today that is `/goal` alone (`TurnFriction::per_goal_round`).
+    ///
+    /// Separate from [`Self::with_friction`] rather than that constructor
+    /// taking a slice, so the single-turn doors keep saying "this turn has one
+    /// ledger" in their own call and cannot pass a several-round slice by
+    /// accident.
+    pub fn with_rounds(
+        transcript: &'a [CompletionMessage],
+        friction: &'a [TurnFriction],
         succeeded: bool,
     ) -> Self {
         Self {
@@ -590,8 +669,8 @@ pub(crate) fn build(evidence: TurnEvidence<'_>) -> String {
 
 /// Join the kept renderings in transcript order, replacing each run of dropped
 /// messages with a marker saying how many went missing.
-fn stitch(kept: &[Option<String>], friction: &TurnFriction) -> String {
-    let mut out = friction.section();
+fn stitch(kept: &[Option<String>], friction: &[TurnFriction]) -> String {
+    let mut out = friction_sections(friction);
     let elided = kept.iter().filter(|body| body.is_none()).count();
     if elided > 0 {
         if !out.is_empty() {
@@ -633,6 +712,28 @@ fn stitch(kept: &[Option<String>], friction: &TurnFriction) -> String {
     out
 }
 
+/// Every ledger's friction section, in round order, blank-line separated.
+///
+/// One section per round rather than one merged section is the whole point of
+/// #3962: the merge is what attributed round 1's failed tool to round 3. A
+/// round that spent itself on nothing renders nothing at all and does not
+/// change what the others are numbered — the count in each header is the
+/// number of rounds the arc ran, not the number that had something to say.
+fn friction_sections(rounds: &[TurnFriction]) -> String {
+    let mut out = String::new();
+    for ledger in rounds {
+        let section = ledger.section(rounds.len());
+        if section.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&section);
+    }
+    out
+}
+
 /// `call_id` → tool name, from both sources that know one.
 ///
 /// The transcript knows it whenever the assistant's tool-calling message is in
@@ -641,7 +742,13 @@ fn stitch(kept: &[Option<String>], friction: &TurnFriction) -> String {
 /// messages — so the map is the union, transcript last so a name recorded in
 /// both resolves to the transcript's.
 fn call_names<'a>(evidence: TurnEvidence<'a>) -> HashMap<&'a str, &'a str> {
-    let mut names: HashMap<&str, &str> = evidence.friction.call_names().collect();
+    // Across every round: a `call_id` is unique to the call that carried it,
+    // so the union names calls without telling any round it made one.
+    let mut names: HashMap<&str, &str> = evidence
+        .friction
+        .iter()
+        .flat_map(TurnFriction::call_names)
+        .collect();
     for message in evidence.transcript {
         for call in &message.tool_calls {
             names.insert(call.call_id.as_str(), call.name.as_str());
@@ -658,7 +765,9 @@ fn classify(evidence: TurnEvidence<'_>) -> Vec<Priority> {
         .flat_map(|message| message.tool_results.iter())
         .filter(|result| result.output.is_error())
         .map(|result| result.call_id.as_str())
-        .chain(evidence.friction.flagged())
+        // Each round flags its own costliest calls, so a long arc's later
+        // rounds are not out-competed for the friction tier by round 1.
+        .chain(evidence.friction.iter().flat_map(TurnFriction::flagged))
         .collect();
     let outcome_from = transcript.len().saturating_sub(OUTCOME_TAIL_MESSAGES);
     let goal = transcript

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -122,7 +122,7 @@ const FRICTION_LIST_CAP: usize = 6;
 /// leak in a best-effort path.
 const FRICTION_ENTRY_CAP: usize = 512;
 
-/// One model call's metering record, as [`AgentEvent::StepUsage`](stella_protocol::AgentEvent::StepUsage) reported it.
+/// One model call's metering record, as [`AgentEvent::StepUsage`] reported it.
 #[derive(Debug, Clone)]
 struct StepCost {
     step: usize,
@@ -132,8 +132,8 @@ struct StepCost {
     tool_calls: usize,
 }
 
-/// One tool call's pass through the turn — opened by [`AgentEvent::ToolStart`](stella_protocol::AgentEvent::ToolStart),
-/// closed by its [`AgentEvent::ToolResult`](stella_protocol::AgentEvent::ToolResult).
+/// One tool call's pass through the turn — opened by [`AgentEvent::ToolStart`],
+/// closed by its [`AgentEvent::ToolResult`].
 #[derive(Debug, Clone)]
 struct ToolPass {
     call_id: String,
@@ -150,7 +150,7 @@ struct ToolPass {
 
 /// What a turn's event stream says about where its time and money went.
 ///
-/// Folded live by the surface that owns the turn's [`AgentEvent`](stella_protocol::AgentEvent) stream and
+/// Folded live by the surface that owns the turn's [`AgentEvent`] stream and
 /// handed to reflection as evidence the transcript does not carry: a
 /// `CompletionMessage` records what was said, never what it cost or how long it
 /// took, and a retry or a loop-detector firing leaves no message at all.
@@ -430,6 +430,7 @@ impl TurnFriction {
     /// have reconstructed at any window size, and it is short — putting it
     /// behind several thousand characters of transcript would make it the first
     /// thing a narrating model skims past.
+    ///
     /// `total` is how many ledgers this one is being rendered among, which is
     /// what lets the header name the round (#3962). The round label is written
     /// only when there is more than one ledger to tell apart: a single-turn
@@ -569,7 +570,7 @@ impl<'a> TurnEvidence<'a> {
     /// Evidence from a transcript plus the turn's folded event ledger — what
     /// a surface that owns its `AgentEvent` stream should build (#3946).
     ///
-    /// Separate from [`Self::from_transcript`] rather than an `Option`
+    /// Separate from `from_transcript` rather than an `Option`
     /// parameter on it, so a caller that *has* a ledger and forgets to pass
     /// it is a visibly different call rather than a `None` nobody reads.
     pub fn with_friction(

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -224,7 +224,7 @@ fn the_whole_rendering_reads_like_this() {
 
     let out = build(TurnEvidence {
         transcript: &transcript,
-        friction: &friction,
+        friction: std::slice::from_ref(&friction),
         succeeded: true,
     });
     // Ten messages under a 6k budget: nothing is elided, so there is no
@@ -468,7 +468,7 @@ fn the_friction_section_names_the_costliest_step_by_its_wire_role() {
     let mut friction = TurnFriction::default();
     friction.observe(&step_usage(1, ModelCallRole::Triage, 0.001, 900));
     friction.observe(&step_usage(7, ModelCallRole::WitnessAuthor, 0.31, 61_000));
-    let section = friction.section();
+    let section = friction.section(1);
     assert!(
         section.contains("step 7 (witness_author) $0.3100"),
         "the role is spelled as the wire spells it, so a reflection's account of \
@@ -510,7 +510,7 @@ fn the_friction_section_names_every_failed_tool_and_the_loop_detector() {
         evidence: "same two calls, three times".into(),
         aborted: true,
     });
-    let section = friction.section();
+    let section = friction.section(1);
     for expected in [
         "bash (c1): exit 101: could not compile stella-core",
         "slowest tool: bash (c1) took 1m36s",
@@ -536,7 +536,7 @@ fn a_result_without_its_start_is_recorded_under_its_call_id() {
         speculated: false,
     });
     assert!(
-        friction.section().contains("orphan: no such file"),
+        friction.section(1).contains("orphan: no such file"),
         "dropping it would lose a failure to bookkeeping"
     );
     let transcript = vec![
@@ -546,7 +546,7 @@ fn a_result_without_its_start_is_recorded_under_its_call_id() {
     ];
     let out = build(TurnEvidence {
         transcript: &transcript,
-        friction: &friction,
+        friction: std::slice::from_ref(&friction),
         succeeded: false,
     });
     assert!(
@@ -559,7 +559,7 @@ fn a_result_without_its_start_is_recorded_under_its_call_id() {
 /// a header promising evidence it has none of (#2483).
 #[test]
 fn an_empty_ledger_renders_no_friction_section() {
-    assert!(TurnFriction::default().section().is_empty());
+    assert!(TurnFriction::default().section(1).is_empty());
     let transcript = vec![user("hi"), assistant("hello")];
     let out = build(TurnEvidence::from_transcript(&transcript, true));
     assert!(
@@ -599,7 +599,7 @@ fn the_digest_is_a_function_of_the_turn() {
         let transcript = long_turn(30, 4, "boom");
         build(TurnEvidence {
             transcript: &transcript,
-            friction: &friction,
+            friction: std::slice::from_ref(&friction),
             succeeded: false,
         })
     };
@@ -653,9 +653,9 @@ fn the_ledger_is_bounded_and_reports_what_it_refused() {
     assert_eq!(friction.dropped, 25);
     assert!(
         friction
-            .section()
+            .section(1)
             .contains("25 further friction records were not retained"),
         "a silent truncation reads as \"this was everything\"\n\n{}",
-        friction.section()
+        friction.section(1)
     );
 }

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -661,10 +661,136 @@ async fn the_folded_journal_reaches_the_prompt_and_an_unfolded_turn_says_nothing
     );
 }
 
+/// One tool call's pass through a goal round, as the arc's journal carries it.
+fn round_tool(
+    call_id: &str,
+    name: &str,
+    command: &str,
+    error: Option<&str>,
+) -> Vec<stella_protocol::AgentEvent> {
+    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+    vec![
+        AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: call_id.into(),
+                name: name.into(),
+                input: serde_json::json!({ "command": command }),
+            },
+        },
+        AgentEvent::ToolResult {
+            call_id: call_id.into(),
+            output: match error {
+                Some(message) => ToolOutput::Error {
+                    message: message.into(),
+                    class: None,
+                },
+                None => ToolOutput::Ok {
+                    content: "ok".into(),
+                    data: None,
+                },
+            },
+            duration_ms: 4_000,
+            speculated: false,
+        },
+    ]
+}
+
+/// A three-round goal arc's journal, in the shape `run_goal_turn` hands to
+/// [`super::digest::TurnFriction::per_goal_round`]: every round calls a tool
+/// the other two never call, and each round is closed by its own `GoalVerdict`
+/// — the split key, carrying the round number.
+fn goal_journal() -> Vec<stella_protocol::AgentEvent> {
+    let verdict = |round: usize, met: bool| stella_protocol::AgentEvent::GoalVerdict {
+        round,
+        met,
+        reasoning: format!("round {round}"),
+        cost_usd: 0.01,
+    };
+    let mut events = round_tool("c1", "bash", "cargo test", Some("round one linker failure"));
+    events.push(verdict(1, false));
+    events.extend(round_tool("c2", "read_file", "src/lib.rs", None));
+    events.push(verdict(2, false));
+    events.extend(round_tool("c3", "edit_file", "src/leak.rs", None));
+    events.push(verdict(3, true));
+    events
+}
+
+/// **The #3962 witness.** A goal run is several turns reflected on ONCE, and
+/// the ledger it reflects with must be one per round.
+///
+/// Before this, `/goal` passed an explicitly-empty ledger, because the only
+/// alternative on offer — one fold over the whole arc — is not a smaller
+/// answer but a wrong one: it reports round 1's failed `bash` as something the
+/// round that ran last did. That is the misattribution #3552 named on the
+/// wrapper's `TurnFacts`, and the second half of this test is that wrong
+/// answer, executable, so the first half cannot be satisfied by producing it.
+#[tokio::test]
+async fn a_goal_arcs_rounds_reflect_separately_and_never_borrow_each_others_friction() {
+    let events = goal_journal();
+    let rounds = super::TurnFriction::per_goal_round(&events);
+    assert_eq!(
+        rounds.len(),
+        3,
+        "each `GoalVerdict` closes a round, so a three-round arc folds to three ledgers"
+    );
+    let transcript = vec![CompletionMessage::user("fix the leak and prove it")];
+
+    // Round 3 alone: the round that did NOT run `cargo test` must not be able
+    // to say it did, whatever else the arc contains.
+    let third_only = prompt_for_evidence(super::TurnEvidence::with_rounds(
+        &transcript,
+        &rounds[2..],
+        true,
+    ))
+    .await;
+    assert!(
+        !third_only.contains("round one linker failure"),
+        "round 3's ledger holds round 1's failure — the rounds were folded \
+         together.\n\nprompt was:\n{third_only}"
+    );
+
+    // The whole arc: each round renders its own section, labelled, in order.
+    let wired =
+        prompt_for_evidence(super::TurnEvidence::with_rounds(&transcript, &rounds, true)).await;
+    let first_at = wired
+        .find("Where round 1 of 3 spent itself")
+        .expect("round 1 must name itself as round 1 of 3");
+    let third_at = wired
+        .find("Where round 3 of 3 spent itself")
+        .expect("round 3 must name itself as round 3 of 3");
+    let failure_at = wired
+        .find("round one linker failure")
+        .expect("round 1's failure is the arc's friction and must survive selection");
+    assert!(
+        first_at < failure_at && failure_at < third_at,
+        "round 1's failure must be rendered inside round 1's section, ahead of \
+         round 3's.\n\nprompt was:\n{wired}"
+    );
+
+    // Anti-vacuity, and the wrong answer this issue exists to forbid: the same
+    // journal folded as ONE ledger puts every round's tools under a single
+    // heading that speaks for "this turn", where nothing tells a reader which
+    // round ran which — the third round inherits the first round's failure.
+    let merged = super::TurnFriction::from_events(&events);
+    let conflated = prompt_for_evidence(super::TurnEvidence::with_friction(
+        &transcript,
+        &merged,
+        true,
+    ))
+    .await;
+    assert!(
+        conflated.contains("Where this turn spent itself")
+            && conflated.contains("round one linker failure")
+            && !conflated.contains("Where round 1 of 3"),
+        "the merged fold must still render — this half is the regression, and a \
+         test that cannot produce it proves nothing.\n\nprompt was:\n{conflated}"
+    );
+}
+
 /// The other half of the #3946 witness: the test above builds its evidence by
 /// hand, so it would still pass with every production call site reverted. This
 /// asserts the wiring itself — that a ledger is folded and that reflection is
-/// handed it, at the two doors that reflect on a single turn.
+/// handed it, at every door that reflects.
 ///
 /// Source-level for the reason `every_recalling_driver_arms_the_control_first`
 /// (`memory/tests/ab_control.rs`) is: observing it otherwise means standing up a
@@ -676,6 +802,8 @@ fn the_reflecting_doors_fold_a_ledger_and_reflect_with_it() {
     const AGENT: &str = include_str!("../../agent.rs");
     const GOAL: &str = include_str!("../../agent/goal.rs");
     const REFLECT: &str = include_str!("../../agent/reflect.rs");
+    const DECK: &str = include_str!("../../command_deck/authoring.rs");
+    const FORWARDER: &str = include_str!("../../command_deck/forwarder.rs");
 
     assert!(
         AGENT.contains("TurnFriction::from_events(&collected)"),
@@ -696,10 +824,40 @@ fn the_reflecting_doors_fold_a_ledger_and_reflect_with_it() {
          from_transcript's empty one"
     );
 
-    // The interactive door.
+    // The interactive door — one ledger for a plain prompt, a slice of them
+    // for `/goal`, so the shared helper takes the slice shape.
     assert!(
-        REFLECT.contains("TurnEvidence::with_friction("),
+        REFLECT.contains("TurnEvidence::with_rounds("),
         "reflect_on_interactive_turn must reflect with the turn's ledger"
+    );
+
+    // The `/goal` doors (#3962), both of which reflect ONCE over an arc of
+    // several turns: the fold is per round, and the reflection takes the slice.
+    assert!(
+        GOAL.contains("TurnFriction::per_goal_round(&rendered.events)"),
+        "run_goal_turn must split its journal at each round's own verdict; one \
+         fold over the whole arc reports round 1's tools as the last round's"
+    );
+    assert!(
+        GOAL.contains("TurnEvidence::with_rounds("),
+        "the headless `stella goal` door must reflect with its per-round ledgers"
+    );
+    assert!(
+        AGENT.contains("friction: &goal_rounds"),
+        "the REPL's `/goal` handler must hand reflection the arc's per-round \
+         ledgers, not the empty one it passed while this was unwired"
+    );
+
+    // The Command Deck, which #3946 did not touch at all.
+    assert!(
+        DECK.contains("TurnEvidence::with_friction("),
+        "the deck's lead turn must reflect with the ledger its lane forwarder \
+         folded, not a transcript-only digest"
+    );
+    assert!(
+        FORWARDER.contains("friction.observe(&event)"),
+        "the lane forwarder is where a deck turn's ledger is folded — it is the \
+         one seam every lane shares"
     );
 }
 
@@ -740,7 +898,7 @@ async fn the_prompt_names_where_the_turn_spent_itself() {
     let transcript = vec![CompletionMessage::user("fix it")];
     let prompt = prompt_for_evidence(super::TurnEvidence {
         transcript: &transcript,
-        friction: &friction,
+        friction: std::slice::from_ref(&friction),
         succeeded: false,
     })
     .await;

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -771,7 +771,9 @@ async fn run_worker(
             _ = stop_wait => RacedTurn::Stopped,
         }
     };
-    let persistence_complete = close_turn_stream(&registry, tx, forwarder).await;
+    let persistence_complete = close_turn_stream(&registry, tx, forwarder)
+        .await
+        .persistence_complete;
     // Release the worker's whole claim set — the stop path included (the
     // dropped turn future cannot release for itself).
     claims.release_all();


### PR DESCRIPTION
Closes #3962.

`/goal` reflects **once** over an arc of several turns. #3946 wired the friction ledger at the two doors that reflect on a single turn and deliberately left `/goal` passing an explicitly-empty one, because the obvious alternative — one fold over the whole arc — is not a smaller answer but a wrong one: it reports round 1's failed `bash` as something the round that ran last did. That is the misattribution #3552 named on the wrapper's `TurnFacts`. The Command Deck was not touched at all.

## The choice, made deliberately

The issue offers two shapes. This is **(a)**: reflection stays one paid call per goal run and is handed **one ledger per round**. **(b)** — reflecting inside the goal loop, once per round — changes how many paid reflection calls a goal run makes and needs its own cost read, which this PR does not do and does not pretend to.

## One correction to the issue's premise

The issue says `run_goal_turn` runs several turns "each with its own event channel". It does not: `Engine::run_goal` runs every round on **one** channel (`crates/stella-core/src/goal.rs`), and each round is closed by its own `AgentEvent::GoalVerdict`, which **carries the round number**. So segmentation is a fold over one journal split at a key that names the round from the stream, not from its position in it — which is what makes this a contained change rather than a channel-plumbing one.

## What changed

- **`TurnFriction::per_goal_round`** splits an arc's journal at each `GoalVerdict`. A trailing segment with no verdict is the round that ended the arc unjudged (aborted working turn, round cap) and takes the next round number, because it ran.
- **`TurnEvidence.friction` grows from one ledger to a slice.** `with_rounds` is the goal doors' constructor; `with_friction` stays the single-turn one and forwards through `slice::from_ref`, so a single-turn door cannot pass a several-round slice by accident. Each round renders its own headed section — "Where round 2 of 4 spent itself" — and a single ledger renders byte-identically to before. `call_names`/`flagged` union across rounds: a `call_id` is unique to its call, so naming one tells no round it made it, and per-round flagging stops round 1 out-competing later rounds for the friction tier.
- **Both `/goal` doors are wired**: the REPL handler (`agent.rs`) and headless `run_goal_cmd`. The issue named only the first; they share `run_goal_turn` and leaving one behind would be exactly the drift this repo treats as a bug.
- **The Command Deck** folds its ledger in `spawn_forwarder` — the one seam every deck lane shares — and returns it in a new `LaneStreamEnd`. Folded there rather than in `command_deck.rs` for two reasons: that file is a god file closed to growth (this PR adds 6 lines to it, against 10 of headroom), and a lane that starts reflecting later inherits the ledger instead of re-deriving it.
- **`TurnEvidence::from_transcript` is now `#[cfg(test)]`**, because it finally can be: every shipping door hands over a real ledger, and what is left is the `#[cfg(test)]` replay harness plus tests. `#[cfg(test)]` rather than `#[allow(dead_code)]` per AGENTS.md — it makes a future production caller a build error rather than a silent re-justification, and a surface reaching for it is a surface that has quietly stopped reporting what its turn cost.

## Second commit: main's rustdoc is red, and this unbreaks it

`make doc-warnings` fails on `main` today. #3951 wrote an explicit link target on `AgentEvent::ToolStart` and three siblings while `digest.rs` imported `AgentEvent` only under `#[cfg(test)]`, so in the non-test doc build the label did not resolve and the explicit target was load-bearing. #3961 made that import unconditional and every one of those labels started resolving to its own target, tripping `rustdoc::redundant_explicit_links` at `-D warnings`.

**Verified, not inferred**: with `origin/main`'s `crates/stella-cli/src` checked out into this worktree, `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps --document-private-items` reports 4 `redundant explicit link target` errors. #3961's own `fmt + clippy + test` check was red at merge (11m58s, failed) and it landed anyway.

It is fixed here rather than filed because it is four doc lines in a file this PR is already editing, and because leaving `main` red reds every other PR.

**Third commit: the same lint in `stella-core`, and how the local gate missed it.** CI's first run of this PR failed on `[`BudgetGuard`](crate::budget::BudgetGuard)` (`crates/stella-core/src/driver/config.rs:79`), which arrived with #3966 — also landed today. The local gate did not catch it because `make gate CARGO_SCOPE="-p stella-cli"` documents one crate and `rustdoc::redundant_explicit_links` is per-crate: a scoped run cannot see a red crate it was not asked to document. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going` reported exactly that one error and nothing else, and finishes clean with this commit.

So `main`'s rustdoc was red from **two independent commits landed the same day**, in two crates, each invisible to a gate run scoped to the other.

## Witnesses

`a_goal_arcs_rounds_reflect_separately_and_never_borrow_each_others_friction` (`crates/stella-cli/src/memory/reflection/tests.rs`) — the shape #3962 asks for. A three-round arc whose round 1 fails a tool rounds 2 and 3 never call:

- round 3's ledger, rendered alone, must not contain round 1's failure;
- across the arc, each round names itself ("round 1 of 3", "round 3 of 3") and round 1's failure is rendered *inside* round 1's section, ahead of round 3's;
- and the same journal folded as **one** ledger is asserted in the same test to produce the wrong answer — one heading speaking for "this turn", carrying round 1's failure with nothing to say which round ran it. That half is the regression, executable, so the first half cannot be satisfied by producing it.

`the_reflecting_doors_fold_a_ledger_and_reflect_with_it` gains four wiring assertions (per-round fold, both `/goal` doors, the deck, the lane forwarder). Each was checked absent on `origin/main` — `git show origin/main:<file>` finds none of the four patterns — so the guard genuinely fails on the old code.

No test was deleted. `.section()` → `.section(1)` is a signature change at 6 existing call sites, not a removal.

## Verification run — and the two failures that are not this change

`make gate CARGO_SCOPE="-p stella-cli"`: every guard green (21 of them), plus `lockfile-sync`, `cargo fmt --check`, `doc-warnings` (green because of the second commit — it is the step that failed before it), and `clippy -p stella-cli --all-targets -D warnings`. The `test` step hit **two** failures, both environment-dependent and neither reachable from this diff. They pull in opposite directions, which is why no single environment runs this crate's suite green today:

- `goal_wrapped_dispatch_cli::a_goal_run_dispatches_each_round_through_the_bound_wrapper` fails **with** the developer's real `~/.stella` — this is **#3876**, already open and naming this exact test. Its banner says it: `cross-family verifier: zai worker · openrouter verifier`. The worker went to the wiremock server as designed; the verifier was routed to real OpenRouter out of `~/.stella/credentials.toml`, which is CONFIG tier and untouched by the test's `STELLA_DATA_DIR` isolation. It then failed because a live model returned a real "not yet met" on a fixture goal. Evidence added to #3876.
- `settings::tests::untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt` fails **without** it — filed as **#3982**. It establishes its user tier by overriding `HOME` alone, and `STELLA_HOME` is documented to win over `HOME`, so under an isolated home the user-tier "bash: off" it is testing against was never loaded.

Run each half in the environment its tests assume and both are green:

- `cargo test -p stella-cli --bin stella` → **1759 passed, 0 failed**
- `STELLA_HOME=$(mktemp -d) cargo test -p stella-cli --no-fail-fast` → all **17** integration targets pass, `goal_wrapped_dispatch_cli` included

Also `cargo test -p stella-cli --bin stella memory::reflection` → 34 passed.

That the variable is the environment and not this branch is distinguishable, not assumed: the settings test passes **with this branch applied** under a real home and fails **with the same branch** under an isolated one, and this diff touches no settings, trust, or `stella-home` code.

## Remaining work filed

- #3976 — the **wrapped** (`--pipeline`) arms of both one-shot and goal still reflect with an empty ledger. Left as-is here on purpose: those turns' events are the plugin's to observe through the wrapper socket, and a host-side fold would describe a turn the door did not drive. The issue asks for that to be a decision rather than a comment.
- #3982 — `untrusted_project_cannot_enable_tools_…` passes only because it reads the real `~/.stella`; it overrides `HOME` but not `STELLA_HOME`. The mirror of #3876, and the two are one missing test helper seen from opposite sides.
- #3977 — `goal_verdict`'s consumer-ledger row is still `Unclassified { issue: "#2703" }` and now has a genuinely *behavioral* consumer (`per_goal_round`). Not promoted here because promoting the row means doing the full consumer census, and a ledger claim that has not been checked is worse than none.

Refs #3946, #3552, #2483, #3961, #3951
