### PR TITLE
fix(stella-cli,stella-core): drop five redundant explicit doc-link targets, unblocking main

### DIFF
--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -122,7 +122,7 @@ const FRICTION_LIST_CAP: usize = 6;
 /// leak in a best-effort path.
 const FRICTION_ENTRY_CAP: usize = 512;
 
-/// One model call's metering record, as [`AgentEvent::StepUsage`](stella_protocol::AgentEvent::StepUsage) reported it.
+/// One model call's metering record, as [`AgentEvent::StepUsage`] reported it.
 #[derive(Debug, Clone)]
 struct StepCost {
     step: usize,
@@ -132,8 +132,8 @@ struct StepCost {
     tool_calls: usize,
 }
 
-/// One tool call's pass through the turn — opened by [`AgentEvent::ToolStart`](stella_protocol::AgentEvent::ToolStart),
-/// closed by its [`AgentEvent::ToolResult`](stella_protocol::AgentEvent::ToolResult).
+/// One tool call's pass through the turn — opened by [`AgentEvent::ToolStart`],
+/// closed by its [`AgentEvent::ToolResult`].
 #[derive(Debug, Clone)]
 struct ToolPass {
     call_id: String,
@@ -150,7 +150,7 @@ struct ToolPass {
 
 /// What a turn's event stream says about where its time and money went.
 ///
-/// Folded live by the surface that owns the turn's [`AgentEvent`](stella_protocol::AgentEvent) stream and
+/// Folded live by the surface that owns the turn's [`AgentEvent`] stream and
 /// handed to reflection as evidence the transcript does not carry: a
 /// `CompletionMessage` records what was said, never what it cost or how long it
 /// took, and a retry or a loop-detector firing leaves no message at all.

--- a/crates/stella-core/src/driver/config.rs
+++ b/crates/stella-core/src/driver/config.rs
@@ -76,7 +76,7 @@ pub struct EngineConfig {
     /// stubbed), replace the oldest span of the conversation with a
     /// model-written summary instead of letting the next call overflow the
     /// provider's context window. Costs one cheap completion, metered into
-    /// the same [`BudgetGuard`](crate::budget::BudgetGuard) as every other call.
+    /// the same [`BudgetGuard`] as every other call.
     pub summarize_overflow: bool,
     /// Messages at the conversation tail the summarizer never touches —
     /// the recent work the model is actively reasoning over.


### PR DESCRIPTION
`main` is red on `cargo doc -D warnings` and has been for several commits — CI run 32295835836 on e47b3b7b1, in the required "fmt + clippy + test" job. Every PR's checks are red underneath it, which is exactly the state `main-red-hold.yml` exists to stop compounding.

## The defect

Five doc links spell their target twice:

```rust
/// One model call's metering record, as [`AgentEvent::StepUsage`](stella_protocol::AgentEvent::StepUsage) reported it.
```

rustdoc's `redundant_explicit_links` rejects a label that already resolves on its own, and the gate runs rustdoc at `-D warnings`. Four sites are in `crates/stella-cli/src/memory/reflection/digest.rs` (from #3951), the fifth in `crates/stella-core/src/driver/config.rs`.

Removing the explicit target is the fix rustdoc itself suggests. The rendered link is unchanged — that is precisely why the lint fires.

## Evidence

Verified against the base rather than inferred: `cargo doc -p stella-cli --no-deps` at e47b3b7b1 with no change applied reproduces all four stella-cli warnings; CI's failing log shows the same five errors and no others. `make doc-warnings` is green across the workspace with this applied, rebased onto 6477f227c.

## Witness

None, deliberately: rustdoc under `-D warnings` **is** the test here, and it is a `make gate` step (`doc-warnings`) and a CI step. A test asserting the absence of a lint would be a second, weaker copy of the gate.

No tests were deleted.

Found while working on #3956, kept separate from it so the repair is not held up behind a feature review.

## Summary by Sourcery

Bug Fixes:
- Fix rustdoc warnings caused by five redundant explicit documentation link targets.