### PR TITLE
feat(stella-cli): reinstate stella calibration standalone — the answer key comes back (#3866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ each row links to its reference page on [stella.oxagen.sh](https://stella.oxagen
 | [`stats`](https://stella.oxagen.sh/docs/commands/stats)                     | Cost, tokens, and $/resolved task for **this** workspace                                                          |
 | [`usage <cmd>`](https://stella.oxagen.sh/docs/commands/usage)               | The same numbers across **every** project, from the hub at `~/.stella/usage.db`                                   |
 | [`scoreboard`](https://stella.oxagen.sh/docs/commands/scoreboard)           | What the work cost, and whether a merged or closed PR implies anyone called it good                               |
-| [`calibration`](https://stella.oxagen.sh/docs/commands/calibration)         | Verifier calibration: how often a pass verdict later failed CI                                                    |
+| [`calibration`](https://stella.oxagen.sh/docs/commands/calibration)         | Pass calibration: how often a pass verdict later failed CI, or was reverted                                       |
 | [`inspect`](https://stella.oxagen.sh/docs/commands/inspect)                 | Replay the exact context a past model call was sent, verified against its digests                                 |
 | [`observe`](https://stella.oxagen.sh/docs/commands/observe)                 | Serve the Observatory dashboard over local telemetry — loopback-only, read-only                                   |
 | [`cloud <cmd>`](https://stella.oxagen.sh/docs/commands/cloud)               | Show or set the org/workspace identity that scopes replicated telemetry                                           |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,15 +163,18 @@ Lint/typecheck are rightly excluded from the flip oracle. But they can still
   lint sample, never a log dump.
 - **Verifier verdict calibration telemetry.** *Done (#871), first slice.*
   Everything needed was already persisted (verdicts with snapshots, PR/CI
-  observations in the same stream), so `replay::calibration` folds it and
-  `stella calibration` reports the verifier's measured false-positive rate
-  beside the deterministic cohort's — unmeasured stays unmeasured, never 0%.
+  observations in the same stream), so `stella_cli::calibration` folds it and
+  `stella calibration` reports the unproven cohort's measured false-positive
+  rate beside the deterministic cohort's — unmeasured stays unmeasured, never
+  0%. (The fold lived in `stella_pipeline::replay` until that crate was
+  deleted, #3865; it was reinstated standalone in the CLI in #3866, with the
+  measurement unchanged.)
 - **An answer key: reverts, and verdicts that arrive late.** *Done (#1293).*
-  Two gaps in the first slice are closed. `replay::ground_truth` reads git's
-  own `This reverts commit <sha>` marker, so a human undoing Stella's work is
-  a ground-truth source — counted apart from red CI, because a revert is a
-  later and better-informed statement. And `calibration_pending` carries a
-  session's unsettled passes out of the fold with the commits and PRs they
+  Two gaps in the first slice are closed. `calibration::ground_truth` reads
+  git's own `This reverts commit <sha>` marker, so a human undoing Stella's
+  work is a ground-truth source — counted apart from red CI, because a revert
+  is a later and better-informed statement. And the fold carries a
+  session's unsettled passes out with the commits and PRs they
   cover, so a terminal verdict recorded in *another* session (or a revert
   landing weeks later) still reconciles them. The asymmetry is deliberate and
   enforced: a revert settles a pass as a false positive, while the ABSENCE of

--- a/crates/stella-cli/src/calibration.rs
+++ b/crates/stella-cli/src/calibration.rs
@@ -1,0 +1,444 @@
+//! `stella calibration`'s measurement model (#871, #1293, #3866): fold the
+//! pass verdicts a recorded event stream holds against the evidence that later
+//! confirmed or contradicted them, and report each cohort's measured
+//! false-positive rate.
+//!
+//! Pure functions over borrowed events — no I/O, no store, no git. The
+//! command's I/O half (enumerating sessions, reading the journal, shelling out
+//! to `git log`) lives in [`crate::inspect`] and hands its bytes here.
+//!
+//! # Why this is a module and not a crate (#3866)
+//!
+//! The model this replaces lived in `stella_pipeline::replay`, and went out of
+//! the tree with that crate (#3865). Reinstating it had two homes to choose
+//! between: a leaf crate on the `stella-diff`/`stella-embed` pattern, or a
+//! module of the binary that asks the question.
+//!
+//! It is a module because a crate boundary is a public API commitment, and
+//! there is exactly one consumer. The logic is pure and independence-testable,
+//! which is the argument *for* a crate — but that argument buys a second
+//! consumer's isolation, and no second consumer exists: nothing else in this
+//! workspace measures verdicts, and a verification plugin lives in another
+//! repository behind the wrapper socket rather than linking this. The day one
+//! appears, promoting this directory to a leaf crate is a move, not a rewrite;
+//! promoting it *now* would ship a README, an AGENTS.md row, and a stable
+//! surface for nobody.
+//!
+//! # What produces the verdicts this reads
+//!
+//! Nothing in this workspace, any more. The built-in staged pipeline was the
+//! only in-tree emitter of [`AgentEvent::Verdict`] and was deleted in #3865;
+//! `Verdict` stays on the wire as `RecordedOnly` because it is the natural
+//! event a verification plugin re-emits (`stella-protocol`'s consumer ledger,
+//! #3790). So this instrument reads two populations and no third: sessions
+//! recorded while the built-in ladder still ran, and streams an installed
+//! verification plugin writes now.
+//!
+//! That is why [`render_calibration`] says so out loud when it folds no
+//! verdict at all. A report of "0 passes, 0 false positives" reads exactly
+//! like a flawless verifier to anyone who does not already know that no
+//! verifier ran, and an instrument whose measured failure mode is leniency
+//! must never be readable as flattery.
+
+pub(crate) mod ground_truth;
+pub(crate) mod independence;
+
+use ground_truth::PendingPass;
+use independence::GraderCohorts;
+use stella_protocol::{AgentEvent, CiStatus, LadderSnapshot};
+
+/// Calibration tallies folded from recorded event streams (#871).
+///
+/// The event store already persists every verdict (with the ladder snapshot it
+/// was decided from, #865) and every PR/CI observation — so calibration is a
+/// *reading* of what exists, not a new write path. A `Verdict` with
+/// `deterministic: false, passed: true` is an **unproven** pass; the next
+/// **terminal** CI verdict in the same stream (`Pr { ci: Some(Passing |
+/// Failing) }`) reconciles every unreconciled pass before it. Deterministic
+/// passes are tallied identically, because a false-positive *rate* means
+/// nothing without the cohort it should be compared against.
+///
+/// # Why the cohort is not called "model verifier" (#2635)
+///
+/// It was, and the name was exact while the only way to emit
+/// `passed: true, deterministic: false` was a model verifier ruling on
+/// inconclusive evidence. #2584 removed that call, and the same flag was then
+/// set by the ladder's own non-determinate outcomes — `unverified_evidence`,
+/// `unverifiable_evidence`, and `waived_completion` for a triage waiver. So on
+/// any session recorded after #2584 the cohort counts **unproven passes, not
+/// judged ones**, and no model was involved in a single one of them.
+///
+/// The rate itself was always a real number — the false-positive rate of passes
+/// nothing proved, which is worth knowing. What was wrong was the label, and a
+/// misnamed measurement is worse than a missing one. The fields state the
+/// property they actually select on.
+///
+/// Sessions spanning #2584 still mix both populations under one heading, and
+/// nothing in the record distinguishes them. That is a fact about the old data,
+/// not something a rename can repair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct CalibrationReport {
+    /// Every `Verdict` event folded, pass or fail, snapshot or not.
+    ///
+    /// The denominator of nothing — it exists so a report can tell "no verdict
+    /// was ever recorded" from "verdicts were recorded and none of them
+    /// passed". Those render identically in every other field, and the first
+    /// is now the ordinary state of a workspace with no verification plugin
+    /// installed (#3866).
+    pub verdicts_observed: u32,
+    /// Passes observed with no deterministic evidence behind them.
+    pub unproven_passes: u32,
+    /// …of which later evidence — terminal CI, or a revert — reconciled.
+    pub unproven_reconciled: u32,
+    /// …reconciled as WRONG: the run reported a pass that CI rejected or a
+    /// human reverted.
+    pub unproven_false_positives: u32,
+    /// Deterministic (ladder) passes observed — the comparison cohort.
+    pub deterministic_passes: u32,
+    pub deterministic_reconciled: u32,
+    pub deterministic_false_positives: u32,
+    /// Verdicts carrying a ladder snapshot — the denominator for the
+    /// uncorroborated rate below (#1295). Verdicts recorded before snapshots
+    /// existed (#865) are excluded rather than assumed either way.
+    pub snapshotted_verdicts: u32,
+    /// …of which NOTHING mechanical corroborated the result: no achieved flip,
+    /// no touched-test run observed green, and no worker-run `verify_done`
+    /// confirmation.
+    ///
+    /// This is [`stands_alone`] read back off the record. Counted over every
+    /// snapshotted verdict, not only over passes, because the question is how
+    /// often the *condition* holds — which is what decides whether a policy
+    /// gated on it taxes every turn or only the suspicious minority.
+    pub uncorroborated_verdicts: u32,
+    /// Unproven passes where that condition held: a pass with nothing
+    /// mechanical behind it at all.
+    ///
+    /// Kept beside the cohort rather than folded into it: it is a near-subset
+    /// of [`Self::unproven_passes`], but the two are folded from different
+    /// sources — this one from the ladder snapshot, the cohort from the
+    /// verdict's own `deterministic` flag — so a divergence between them is a
+    /// real signal that one of the two projections has drifted.
+    pub unproven_passes_standing_alone: u32,
+    /// …of the reconciled unproven passes, how many were settled by a **revert**
+    /// rather than by CI (#1293).
+    ///
+    /// Counted apart because it is a different and stronger claim. CI failing
+    /// can mean a flake, a neighbouring change, or an infrastructure day; a
+    /// human reverting a commit is a person deciding, later and with more
+    /// information, that the work should not have landed. A cohort whose false
+    /// positives are mostly reverts is failing differently from one whose false
+    /// positives are mostly red CI, and a single number would hide it.
+    pub unproven_reverted: u32,
+    /// The same, for the deterministic cohort.
+    pub deterministic_reverted: u32,
+    /// The unproven cohort above, partitioned by who graded it (#1865):
+    /// self-graded / independent / unknown, with unknown never assumed into
+    /// either measured cohort. The three partitions sum to the unpartitioned
+    /// cohort tallies.
+    pub by_grader: GraderCohorts,
+}
+
+impl CalibrationReport {
+    /// Combine per-session reports into a workspace total.
+    pub fn merge(mut self, other: Self) -> Self {
+        self.verdicts_observed += other.verdicts_observed;
+        self.unproven_passes += other.unproven_passes;
+        self.unproven_reconciled += other.unproven_reconciled;
+        self.unproven_false_positives += other.unproven_false_positives;
+        self.deterministic_passes += other.deterministic_passes;
+        self.deterministic_reconciled += other.deterministic_reconciled;
+        self.deterministic_false_positives += other.deterministic_false_positives;
+        self.snapshotted_verdicts += other.snapshotted_verdicts;
+        self.uncorroborated_verdicts += other.uncorroborated_verdicts;
+        self.unproven_passes_standing_alone += other.unproven_passes_standing_alone;
+        self.unproven_reverted += other.unproven_reverted;
+        self.deterministic_reverted += other.deterministic_reverted;
+        self.by_grader = self.by_grader.merge(other.by_grader);
+        self
+    }
+
+    /// How often a verdict had no mechanical corroboration behind it, over the
+    /// verdicts that recorded enough to say (#1295).
+    ///
+    /// The number an **evidence-demand policy** is set from: "the ladder
+    /// settled nothing, so spend one more turn asking the worker for evidence"
+    /// is worth its turn only where this is the suspicious minority. A majority
+    /// reproduces the Terminal-Bench measurement that switched the built-in
+    /// version of that policy off (#1211 §1): the condition held on most turns
+    /// precisely because most turns had no tracked command, so the ask could
+    /// not be satisfied by any worker and the turn it cost was pure loss.
+    ///
+    /// The policy itself left the tree with the staged pipeline (#3865); the
+    /// rate did not stop being the right input for the plugin-side one that
+    /// replaces it.
+    #[must_use]
+    pub fn uncorroborated_rate(&self) -> Option<f64> {
+        rate(self.uncorroborated_verdicts, self.snapshotted_verdicts)
+    }
+
+    /// The measured false-positive rate over RECONCILED unproven passes, or
+    /// `None` when nothing was reconciled — an unmeasured rate is reported as
+    /// unmeasured, never as zero.
+    #[must_use]
+    pub fn unproven_false_positive_rate(&self) -> Option<f64> {
+        rate(self.unproven_false_positives, self.unproven_reconciled)
+    }
+
+    /// Same rate for the deterministic cohort.
+    #[must_use]
+    pub fn deterministic_false_positive_rate(&self) -> Option<f64> {
+        rate(
+            self.deterministic_false_positives,
+            self.deterministic_reconciled,
+        )
+    }
+}
+
+/// A measured proportion, or `None` when the denominator is empty.
+///
+/// Every rate in this module goes through here so that "unmeasured" is one
+/// decision made once. A zero denominator rendering as `0%` is the single
+/// mistake this instrument cannot afford: it reports a verifier that was never
+/// measured as a verifier that never erred.
+#[must_use]
+pub(crate) fn rate(numerator: u32, denominator: u32) -> Option<f64> {
+    (denominator > 0).then(|| f64::from(numerator) / f64::from(denominator))
+}
+
+/// Render a [`CalibrationReport`] for a human — the `stella calibration` body.
+/// States unmeasured rates as unmeasured and names the cohort sizes, so a rate
+/// is never read without its denominator.
+pub(crate) fn render_calibration(report: &CalibrationReport) -> String {
+    use independence::cohort_line as cohort;
+
+    // The state a workspace with no verification plugin installed is now in,
+    // and the one reading that is most easily misread (#3866). Said first and
+    // instead of the tallies, because every tally below it would be a zero,
+    // and a page of zeros reads as a clean bill of health.
+    if report.verdicts_observed == 0 {
+        return "pass calibration (#871) — nothing to calibrate\n  \
+                No recorded session holds a verification verdict.\n  \
+                Since #3865 this workspace ships no built-in verification path, so nothing\n  \
+                emits one: `stella run` is the raw step loop, and verdicts come only from an\n  \
+                installed verification plugin (`stella plugin install`, then\n  \
+                `stella run --pipeline <plugin-id>`) or from sessions recorded before that\n  \
+                deletion.\n  \
+                This is NOT a measured result — an empty record is not a perfect verifier."
+            .to_string();
+    }
+
+    // #1293: reverts are counted apart from CI, because they are a different
+    // and stronger statement — a human deciding later that the work should not
+    // have landed. Stated only when there are any: a zero here would read as
+    // "no work was reverted", when the ordinary case is that the caller
+    // gathered no revert evidence at all.
+    let reverts = match (report.unproven_reverted, report.deterministic_reverted) {
+        (0, 0) => String::new(),
+        (unproven, deterministic) => format!(
+            "\n  of those, settled by a REVERT (a human said it was wrong, not CI): \
+             {unproven} unproven, {deterministic} deterministic"
+        ),
+    };
+    // #1865: the unproven line above, partitioned by who graded it. Rendered
+    // only once there is an unproven pass to partition — the section answers a
+    // question about recorded unproven verdicts, and with none recorded there
+    // is no cohort to compare.
+    let grader = if report.unproven_passes > 0 {
+        format!(
+            "\n{}",
+            independence::render_grader_cohorts(&report.by_grader)
+        )
+    } else {
+        String::new()
+    };
+    // #1295: the rate an evidence-demand policy is set from. Rendered beside
+    // the calibration cohorts because it is read for the same reason — to
+    // replace an argument about the verifier with a number — and stated with
+    // its denominator, like every other rate here.
+    let uncorroborated = match report.uncorroborated_rate() {
+        Some(rate) => format!(
+            "  uncorroborated rate: {:.0}% of {} snapshotted verdict(s) had no flip, no green \
+             touched test and no verify_done confirmation ({} of them were reported as passes)\n  \
+             → a MINORITY is the condition an evidence-demand send-back is worth a turn for; \
+             a majority reproduces the measurement that switched the built-in one off (#1295, \
+             #1211 §1)",
+            100.0 * rate,
+            report.snapshotted_verdicts,
+            report.unproven_passes_standing_alone,
+        ),
+        None => "  uncorroborated rate: unmeasured (no verdict carried a ladder snapshot yet)"
+            .to_string(),
+    };
+    format!(
+        "pass calibration (#871) — passes reconciled against later CI verdicts and reverts\n  \
+         {} verdict(s) folded\n{}\n{}{reverts}{grader}\n\
+         note: a pass is reconciled by a terminal CI verdict or by a revert of\n\
+         a commit it covers, from any session or from the git history (#1293).\n\
+         A pass no evidence reaches stays UNRECONCILED and out of every\n\
+         denominator — absence of a revert is never a confirmation.\n\
+         the `unproven` cohort is every pass the ladder could not settle —\n\
+         unverified, unverifiable, or waived. No model judged any of them\n\
+         (#2584, #2635).\n\
+         {uncorroborated}",
+        report.verdicts_observed,
+        cohort(
+            "  unproven      ",
+            report.unproven_passes,
+            report.unproven_reconciled,
+            report.unproven_false_positives
+        ),
+        cohort(
+            "  deterministic",
+            report.deterministic_passes,
+            report.deterministic_reconciled,
+            report.deterministic_false_positives
+        ),
+    )
+}
+
+/// Fold one event stream into a [`CalibrationReport`] (#871), returning the
+/// pass verdicts the stream could not settle itself (#1293).
+///
+/// Reconciliation here is stream-local and forward-only: a terminal CI verdict
+/// covers the passes that PRECEDED it (the PR carries the session's adopted
+/// work), and passes after the last terminal CI observation stay unreconciled.
+/// `Pending`/`Running` reconcile nothing — absence of a verdict is not a
+/// verdict.
+///
+/// The returned [`PendingPass`] values are what makes a *late* verdict usable:
+/// a CI run that finishes after the session, a revert that lands next week, a
+/// terminal verdict recorded in some other session's stream. Feed them to
+/// [`ground_truth::reconcile`] with whatever evidence exists.
+///
+/// The attribution rule for artifacts mirrors the CI one already in place: a
+/// commit or PR recorded at index *i* covers every unsettled pass before it.
+/// That is deliberately generous, and it is the only rule available — a
+/// session's events do not carry which verdict a given commit implements. The
+/// consequence is stated rather than hidden: a session that produced two passes
+/// and one commit attributes that commit's fate to both, so a revert there
+/// counts two false positives. Sessions that adopt one change are the ordinary
+/// case, and over-attributing a revert errs toward reporting the verifier as
+/// *worse* than it is — the safe direction for an instrument whose measured
+/// failure is leniency.
+pub(crate) fn calibration(events: &[AgentEvent]) -> (CalibrationReport, Vec<PendingPass>) {
+    let mut report = CalibrationReport::default();
+    // Unsettled pass verdicts, in order, with the artifacts recorded since
+    // each one. `verifier` distinguishes the two cohorts.
+    let mut pending: Vec<PendingPass> = Vec::new();
+    for event in events {
+        match event {
+            // Every verdict — pass or fail — contributes to the uncorroborated
+            // denominator (#1295): the question is how often verification
+            // reaches a verdict with nothing mechanical behind it, and a
+            // failing turn is as much a part of that population as a passing
+            // one. The pass cohorts below are counted separately, on the same
+            // pass.
+            AgentEvent::Verdict { passed, evidence } => {
+                report.verdicts_observed += 1;
+                if let Some(snapshot) = evidence.ladder.as_deref() {
+                    report.snapshotted_verdicts += 1;
+                    if stands_alone(snapshot) {
+                        report.uncorroborated_verdicts += 1;
+                        if *passed && !evidence.deterministic {
+                            report.unproven_passes_standing_alone += 1;
+                        }
+                    }
+                }
+                if !*passed {
+                    continue;
+                }
+                // #1865: which model graded a verdict rides the ladder snapshot
+                // (#1795); absent — pre-#1795, worker-unresolvable, or no
+                // snapshot at all — stays UNKNOWN, never assumed.
+                let grader_independent = evidence
+                    .ladder
+                    .as_deref()
+                    .and_then(|snapshot| snapshot.verifier_independent);
+                if evidence.deterministic {
+                    report.deterministic_passes += 1;
+                } else {
+                    report.unproven_passes += 1;
+                    report.by_grader.tally_mut(grader_independent).passes += 1;
+                }
+                pending.push(PendingPass {
+                    verifier: !evidence.deterministic,
+                    grader_independent,
+                    commits: Vec::new(),
+                    prs: Vec::new(),
+                });
+            }
+            // Every commit and PR the session records after a pass is an
+            // artifact that pass covers — the handle a late verdict is keyed
+            // on. Attached to the unsettled passes only: one already reconciled
+            // in-stream has had its answer.
+            AgentEvent::Commit { sha, .. } => {
+                for pass in &mut pending {
+                    pass.commits.push(sha.clone());
+                }
+            }
+            AgentEvent::Pr { url, ci, .. } => {
+                for pass in &mut pending {
+                    pass.prs.push(url.clone());
+                }
+                let failing = match ci {
+                    Some(CiStatus::Passing) => false,
+                    Some(CiStatus::Failing) => true,
+                    // Absence of a verdict is not a verdict — the PR is still
+                    // recorded above, so a terminal result arriving later (this
+                    // session or another) can still settle these.
+                    Some(CiStatus::Pending | CiStatus::Running) | None => continue,
+                };
+                for pass in pending.drain(..) {
+                    if pass.verifier {
+                        report.unproven_reconciled += 1;
+                        report.unproven_false_positives += u32::from(failing);
+                        let tally = report.by_grader.tally_mut(pass.grader_independent);
+                        tally.reconciled += 1;
+                        tally.false_positives += u32::from(failing);
+                    } else {
+                        report.deterministic_reconciled += 1;
+                        report.deterministic_false_positives += u32::from(failing);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    (report, pending)
+}
+
+/// Whether a recorded verdict had no mechanical corroboration behind it
+/// (#1295): no achieved flip, no touched-test run observed green, and no
+/// worker-run `verify_done` confirmation.
+///
+/// # This is now the definition, and that is a change worth naming (#3866)
+///
+/// It used to *call* `LadderInputs::verifier_pass_stands_alone` rather than
+/// restate it, and the doc comment on it said why in some detail: for a while
+/// it restated the predicate in two conjuncts, and when #2191 taught the live
+/// one a third channel (`verify_done_flip`) the copy here stayed at two — so
+/// [`CalibrationReport::uncorroborated_verdicts`] counted verdicts as
+/// uncorroborated over runs where the engine, at decision time, held
+/// corroboration (#2194).
+///
+/// That predicate went out of the tree with `stella-pipeline` (#3865), so
+/// calling it is no longer an option and this restatement is the only copy
+/// there is. The old hazard — two copies drifting apart — is therefore gone by
+/// construction. The one that replaces it is different and should not be
+/// mistaken for it: a verification plugin implements its own ladder on the far
+/// side of the wrapper socket, and may credit corroboration through a channel
+/// [`LadderSnapshot`] has no field for. This can only ever report what the
+/// snapshot recorded, which is why the rendered line names the three channels
+/// it reads instead of claiming to be exhaustive.
+///
+/// A readable diff or a recorded file touch is deliberately not among them:
+/// they prove the tree **changed**, never that the change is **correct**, and
+/// only the second claim is what a pass makes.
+fn stands_alone(snapshot: &LadderSnapshot) -> bool {
+    !snapshot.flip.is_achieved()
+        && snapshot.touched_tests_passed != Some(true)
+        && !snapshot.verify_done_flip
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/calibration/ground_truth.rs
+++ b/crates/stella-cli/src/calibration/ground_truth.rs
@@ -1,0 +1,376 @@
+//! The verifier's answer key (#1293): cases where we know for certain whether
+//! the work was actually good, and the machinery that connects them back to the
+//! judgement made at the time.
+//!
+//! # Why an answer key is the blocking problem
+//!
+//! Verification's weakest channel has always been a judgement about whether the
+//! work *looks* correct, and that judgement has been measured badly lenient —
+//! 46% agreement with a benchmark's own grader. Every threshold built on top of
+//! it was a guess, and it *stays* a guess until something independent says
+//! which verdicts were wrong. Tuning without that is not tuning; it is changing
+//! numbers.
+//!
+//! #871 built the first source: a terminal CI verdict recorded in the same
+//! session stream. Two gaps remained, and this module closes both.
+//!
+//! # Gap 1: reverts were not a source at all
+//!
+//! When a human reverts a commit, that is a person saying "this was wrong",
+//! usually long after a verifier said it was fine — the exact ground truth the
+//! verifier is missing. It was never collected. [`parse_revert_targets`] reads
+//! it out of git's own revert message.
+//!
+//! # Gap 2: reconciliation ended when the session did
+//!
+//! [`super::calibration`] reconciles forward within one stream, so a pass
+//! recorded after that session's last CI observation stayed unreconciled
+//! forever — and the verdict that would have settled it (a CI run finishing
+//! minutes later, a revert landing next week) had nowhere to go. [`PendingPass`]
+//! carries those passes out of the fold with the commits and PRs they cover,
+//! and [`reconcile`] settles them against evidence gathered from anywhere:
+//! another session's stream, the git history, a caller's own source.
+//!
+//! # The asymmetry, stated once
+//!
+//! A revert is evidence of **wrongness** only. A commit that was never reverted
+//! is not evidence that the work was good — nobody may have looked, and most
+//! correct work is never reverted for the same reason most correct work is
+//! never mentioned. So a revert reconciles a pass as a false positive, while
+//! the absence of one leaves it unreconciled and OUT of the denominator.
+//! Counting un-reverted commits as confirmations would improve every measured
+//! rate by construction, which is the one direction a calibration instrument
+//! must never drift.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use stella_protocol::{AgentEvent, CiStatus};
+
+use super::CalibrationReport;
+
+/// A pass verdict that no in-stream verdict settled — carried out of the fold
+/// so evidence arriving after the session ended can still reach it.
+///
+/// The `commits` and `prs` are what the pass is *about*: everything the session
+/// recorded after it, on the same "a later observation covers the passes before
+/// it" rule the in-stream CI reconciliation already uses. A session that
+/// recorded neither leaves a pass that nothing can ever settle, which is honest
+/// — there is no artifact to observe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingPass {
+    /// Whether the pass was unproven (`true`) or a deterministic ladder pass
+    /// (`false`, the comparison cohort).
+    pub verifier: bool,
+    /// The grader-independence fact the pass's ladder snapshot recorded
+    /// (#1795), carried out of the fold so a late verdict settles the right
+    /// grader cohort (#1865). `None` — no snapshot, or a snapshot from before
+    /// the fact existed — stays the unknown cohort, never assumed. Meaningless
+    /// when `verifier` is `false`: nothing graded.
+    pub grader_independent: Option<bool>,
+    /// Commit SHAs the session recorded after this pass.
+    pub commits: Vec<String>,
+    /// PR URLs the session recorded after this pass.
+    pub prs: Vec<String>,
+}
+
+/// Evidence about work Stella produced, gathered from wherever it exists.
+///
+/// Deliberately keyed on artifacts (a commit SHA, a PR URL) rather than on
+/// sessions: that is what lets a verdict recorded in one session — or in no
+/// session at all, like a revert in the git log — settle a pass recorded in
+/// another. Session-keyed reconciliation is precisely what left the record
+/// stream-local.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct GroundTruth {
+    /// Commits a later commit reverted. Membership means "a human said this was
+    /// wrong"; absence means nothing at all (see the module docs).
+    pub reverted_commits: BTreeSet<String>,
+    /// PR URL → whether its terminal CI verdict was FAILING.
+    pub pr_ci_failing: BTreeMap<String, bool>,
+}
+
+impl GroundTruth {
+    /// Fold every terminal CI observation in one recorded stream into the
+    /// PR-keyed map — the half of the answer key that already exists in the
+    /// event journal, read across sessions instead of within one.
+    ///
+    /// A later terminal verdict for the same PR overwrites an earlier one: CI
+    /// is re-run, and the last word about a PR is the one that stands.
+    #[must_use]
+    pub fn with_stream(mut self, events: &[AgentEvent]) -> Self {
+        for event in events {
+            let AgentEvent::Pr {
+                url, ci: Some(ci), ..
+            } = event
+            else {
+                continue;
+            };
+            let failing = match ci {
+                CiStatus::Passing => false,
+                CiStatus::Failing => true,
+                // Absence of a verdict is not a verdict.
+                CiStatus::Pending | CiStatus::Running => continue,
+            };
+            self.pr_ci_failing.insert(url.clone(), failing);
+        }
+        self
+    }
+
+    /// Add reverted commit SHAs — from [`parse_revert_targets`], or from any
+    /// other source a host trusts.
+    #[must_use]
+    pub fn with_reverts(mut self, shas: impl IntoIterator<Item = String>) -> Self {
+        self.reverted_commits.extend(shas);
+        self
+    }
+
+    /// What this says about one pending pass, or `None` when it says nothing.
+    fn verdict_for(&self, pass: &PendingPass) -> Option<Settled> {
+        // Reverts first: a revert is a human's considered statement about the
+        // merged result, made later than CI and knowing more. A commit that
+        // passed CI and was then reverted is exactly the false positive this
+        // whole instrument exists to count, and taking CI's word first would
+        // record it as a success.
+        if pass
+            .commits
+            .iter()
+            .any(|sha| self.reverted_commits.contains(sha))
+        {
+            return Some(Settled::Reverted);
+        }
+        for pr in &pass.prs {
+            if let Some(failing) = self.pr_ci_failing.get(pr) {
+                return Some(if *failing {
+                    Settled::CiFailing
+                } else {
+                    Settled::CiPassing
+                });
+            }
+        }
+        None
+    }
+}
+
+/// How a late verdict settled one pending pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Settled {
+    Reverted,
+    CiFailing,
+    CiPassing,
+}
+
+impl Settled {
+    fn is_false_positive(self) -> bool {
+        matches!(self, Settled::Reverted | Settled::CiFailing)
+    }
+}
+
+/// Settle `pending` against `truth`, folding the results into `report` (#1293).
+///
+/// Every settled pass joins the reconciled cohort it belongs to, so the measured
+/// false-positive rates finally include the verdicts that used to fall off the
+/// end of their session. A pass nothing can settle is left alone: it stays
+/// unreconciled, out of every denominator, exactly as before.
+///
+/// Returns how many passes were settled — the number a caller reports as "late
+/// evidence reached N earlier verdicts", which is the thing that was silently
+/// zero before.
+pub(crate) fn reconcile(
+    report: &mut CalibrationReport,
+    pending: &[PendingPass],
+    truth: &GroundTruth,
+) -> u32 {
+    let mut settled = 0;
+    for pass in pending {
+        let Some(verdict) = truth.verdict_for(pass) else {
+            continue;
+        };
+        settled += 1;
+        let false_positive = u32::from(verdict.is_false_positive());
+        let reverted = u32::from(verdict == Settled::Reverted);
+        if pass.verifier {
+            report.unproven_reconciled += 1;
+            report.unproven_false_positives += false_positive;
+            report.unproven_reverted += reverted;
+            let tally = report.by_grader.tally_mut(pass.grader_independent);
+            tally.reconciled += 1;
+            tally.false_positives += false_positive;
+        } else {
+            report.deterministic_reconciled += 1;
+            report.deterministic_false_positives += false_positive;
+            report.deterministic_reverted += reverted;
+        }
+    }
+    settled
+}
+
+/// The commit SHAs a `git log` body says were reverted (#1293).
+///
+/// Reads git's own revert message — `git revert` writes `This reverts commit
+/// <sha>.` into the body, and has since 2005 — rather than guessing from a
+/// `Revert "…"` subject. The subject line is a convention a human can retype or
+/// a tool can rewrite; the body line is generated, carries the full SHA, and is
+/// what makes the link machine-checkable.
+///
+/// Deliberately tolerant of what surrounds it: the caller may pass a whole `git
+/// log` output, one commit body, or several concatenated. Anything that is not
+/// the marker is skipped, and a marker whose SHA is not hex is skipped too — a
+/// wrong link here would attribute a human's "this was wrong" to a verdict that
+/// never made the claim, which is worse than missing the signal.
+#[must_use]
+pub(crate) fn parse_revert_targets(log: &str) -> BTreeSet<String> {
+    const MARKER: &str = "This reverts commit ";
+    let mut out = BTreeSet::new();
+    for line in log.lines() {
+        let Some(rest) = line.trim().strip_prefix(MARKER) else {
+            continue;
+        };
+        let sha: String = rest
+            .chars()
+            .take_while(char::is_ascii_hexdigit)
+            .flat_map(char::to_lowercase)
+            .collect();
+        // Git abbreviates to at least 7 characters and writes the full 40 (or
+        // 64, for a sha256 repository) in its own revert message. Below 7 is
+        // not a commit id, whatever else it might be.
+        if sha.len() >= 7 {
+            out.insert(sha);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_protocol::PrStatus;
+
+    fn pass(verifier: bool, commits: &[&str], prs: &[&str]) -> PendingPass {
+        PendingPass {
+            verifier,
+            grader_independent: None,
+            commits: commits.iter().map(|s| (*s).to_string()).collect(),
+            prs: prs.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// The revert marker git itself writes, in the shapes it actually appears
+    /// in — indented inside a `git log` body, with the trailing period, and
+    /// beside a subject line that must NOT be parsed.
+    #[test]
+    fn revert_targets_come_from_gits_own_marker() {
+        let log = "\
+commit ffff1111
+    Revert \"feat: add the widget\"
+
+    This reverts commit 0A1B2C3D4E5F60718293A4B5C6D7E8F901234567.
+
+commit eeee2222
+    feat: add the widget
+
+commit dddd3333
+    Revert \"something\" (no body marker, so nothing to link)
+";
+        let targets = parse_revert_targets(log);
+        assert_eq!(
+            targets.iter().collect::<Vec<_>>(),
+            vec!["0a1b2c3d4e5f60718293a4b5c6d7e8f901234567"],
+            "only the generated marker links a revert, and the SHA is normalized"
+        );
+    }
+
+    /// Nothing that is not a commit id may become one: a short or non-hex tail
+    /// is skipped rather than recorded as a link.
+    #[test]
+    fn a_malformed_marker_links_nothing() {
+        assert!(parse_revert_targets("This reverts commit abc.").is_empty());
+        assert!(parse_revert_targets("This reverts commit zzzzzzzzzz.").is_empty());
+        assert!(parse_revert_targets("nothing here").is_empty());
+    }
+
+    /// #1293's first half: a revert reaches back to the judgement it
+    /// contradicts, and is counted as a false positive of the cohort that
+    /// produced it.
+    #[test]
+    fn a_revert_settles_the_pass_that_approved_the_commit() {
+        let mut report = CalibrationReport::default();
+        let pending = vec![
+            pass(true, &["aaaa1111aaaa"], &[]),
+            pass(false, &["bbbb2222bbbb"], &[]),
+        ];
+        let truth = GroundTruth::default().with_reverts(["aaaa1111aaaa".to_string()]);
+        assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+        assert_eq!(report.unproven_reconciled, 1);
+        assert_eq!(report.unproven_false_positives, 1);
+        assert_eq!(report.unproven_reverted, 1);
+        assert_eq!(
+            report.deterministic_reconciled, 0,
+            "an un-reverted commit settles nothing: absence of a revert is not a confirmation"
+        );
+    }
+
+    /// #1293's second half: a terminal CI verdict recorded in a DIFFERENT
+    /// session settles a pass its own session never saw one for.
+    #[test]
+    fn a_verdict_from_another_session_still_reaches_an_earlier_pass() {
+        let later_session = vec![AgentEvent::Pr {
+            url: "https://example.test/pr/7".into(),
+            status: PrStatus::Open,
+            number: Some(7),
+            ci: Some(CiStatus::Failing),
+        }];
+        let truth = GroundTruth::default().with_stream(&later_session);
+        let pending = vec![pass(true, &[], &["https://example.test/pr/7"])];
+        let mut report = CalibrationReport::default();
+        assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+        assert_eq!(report.unproven_reconciled, 1);
+        assert_eq!(report.unproven_false_positives, 1);
+        assert_eq!(
+            report.unproven_reverted, 0,
+            "CI failing is not a revert — the two are counted apart"
+        );
+    }
+
+    /// A pass CI approved and a human then reverted is a FALSE POSITIVE, not a
+    /// success: the revert is the later and better-informed statement, so it is
+    /// consulted first.
+    #[test]
+    fn a_revert_outranks_a_green_ci_verdict() {
+        let truth = GroundTruth::default()
+            .with_stream(&[AgentEvent::Pr {
+                url: "https://example.test/pr/9".into(),
+                status: PrStatus::Merged,
+                number: Some(9),
+                ci: Some(CiStatus::Passing),
+            }])
+            .with_reverts(["cccc3333cccc".to_string()]);
+        let mut report = CalibrationReport::default();
+        let pending = vec![pass(
+            true,
+            &["cccc3333cccc"],
+            &["https://example.test/pr/9"],
+        )];
+        assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+        assert_eq!(report.unproven_false_positives, 1);
+        assert_eq!(report.unproven_reverted, 1);
+    }
+
+    /// Non-terminal CI contributes nothing, and a pass with no artifact at all
+    /// stays unreconciled rather than being assumed either way.
+    #[test]
+    fn nothing_settles_a_pass_with_no_evidence() {
+        let truth = GroundTruth::default().with_stream(&[AgentEvent::Pr {
+            url: "https://example.test/pr/11".into(),
+            status: PrStatus::Open,
+            number: Some(11),
+            ci: Some(CiStatus::Running),
+        }]);
+        let mut report = CalibrationReport::default();
+        let pending = vec![
+            pass(true, &[], &["https://example.test/pr/11"]),
+            pass(true, &[], &[]),
+        ];
+        assert_eq!(reconcile(&mut report, &pending, &truth), 0);
+        assert_eq!(report.unproven_reconciled, 0);
+    }
+}

--- a/crates/stella-cli/src/calibration/independence.rs
+++ b/crates/stella-cli/src/calibration/independence.rs
@@ -1,0 +1,129 @@
+//! The unproven cohort partitioned by who graded it (#1865).
+//!
+//! #1795 stamps `LadderSnapshot::verifier_independent` on every graded verdict:
+//! `Some(false)` means the verdict call resolved to the worker's own model. The
+//! 46%-agreement measurement this whole instrument exists to replace was made
+//! under exactly that self-graded condition, and the question this partition
+//! answers is whether it was a self-grading artifact: is a self-graded PASS
+//! measurably less trustworthy than an independent one? One folded cohort
+//! cannot say; three can.
+
+use super::rate;
+
+/// The unproven tallies of a [`super::CalibrationReport`], partitioned by the
+/// grader-independence fact (#1865).
+///
+/// Only the unproven cohort is partitioned: a deterministic pass buys no
+/// grader, so independence is not a fact about it (see
+/// `LadderSnapshot::verifier_independent`). Each pass lands in exactly one
+/// cohort, so the three `passes` fields sum to the report's `unproven_passes` —
+/// and the same holds for `reconciled` and `false_positives`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct GraderCohorts {
+    /// Verdicts the worker's own model graded (`verifier_independent ==
+    /// Some(false)`) — the condition the 46%-agreement number was measured
+    /// under.
+    pub self_graded: GraderTally,
+    /// Verdicts a distinct model graded (`Some(true)`).
+    pub independent: GraderTally,
+    /// Verdicts that recorded no grader fact: pre-#1795 snapshots,
+    /// worker-unresolvable runs, and verdicts with no snapshot at all. Kept
+    /// apart and OUT of both rates — never assumed either way.
+    pub unknown: GraderTally,
+}
+
+impl GraderCohorts {
+    /// The cohort a recorded grader fact belongs to.
+    pub(super) fn tally_mut(&mut self, grader_independent: Option<bool>) -> &mut GraderTally {
+        match grader_independent {
+            Some(false) => &mut self.self_graded,
+            Some(true) => &mut self.independent,
+            None => &mut self.unknown,
+        }
+    }
+
+    /// Combine per-session cohorts into a workspace total.
+    pub(super) fn merge(mut self, other: Self) -> Self {
+        self.self_graded = self.self_graded.merge(other.self_graded);
+        self.independent = self.independent.merge(other.independent);
+        self.unknown = self.unknown.merge(other.unknown);
+        self
+    }
+}
+
+/// One grader cohort's tallies — the same three counters the report keeps for
+/// the whole unproven cohort, so the two rates read identically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct GraderTally {
+    /// Unproven PASS verdicts observed in this cohort.
+    pub passes: u32,
+    /// …of which a later terminal verdict (CI or revert) reconciled.
+    pub reconciled: u32,
+    /// …reconciled as wrong: the grader approved work that was rejected.
+    pub false_positives: u32,
+}
+
+impl GraderTally {
+    fn merge(mut self, other: Self) -> Self {
+        self.passes += other.passes;
+        self.reconciled += other.reconciled;
+        self.false_positives += other.false_positives;
+        self
+    }
+
+    /// The measured false-positive rate over RECONCILED passes, or `None` when
+    /// nothing was reconciled — an unmeasured rate is reported as unmeasured,
+    /// never as zero.
+    #[must_use]
+    pub fn false_positive_rate(&self) -> Option<f64> {
+        rate(self.false_positives, self.reconciled)
+    }
+}
+
+/// One cohort line of the calibration render — shared with
+/// [`super::render_calibration`] so the partitioned and unpartitioned cohorts
+/// read in exactly one voice.
+pub(super) fn cohort_line(
+    label: &str,
+    passes: u32,
+    reconciled: u32,
+    false_positives: u32,
+) -> String {
+    let measured = match rate(false_positives, reconciled) {
+        Some(rate) => format!("{:.0}% false-positive rate", 100.0 * rate),
+        None => "rate unmeasured (no CI ground truth recorded yet)".to_string(),
+    };
+    format!(
+        "{label}: {passes} pass(es), {reconciled} reconciled against CI, \
+         {false_positives} CI-failed — {measured}"
+    )
+}
+
+/// The grader-independence section of the calibration render (#1865): the
+/// self-graded and independent false-positive rates side by side, with the
+/// unknown cohort stated apart and excluded from both.
+pub(super) fn render_grader_cohorts(cohorts: &GraderCohorts) -> String {
+    let unknown = match cohorts.unknown.passes {
+        0 => String::new(),
+        n => format!(
+            "\n    ({n} pass(es) recorded no grader fact — pre-#1795 or worker-unresolvable — \
+             and are excluded from both rates)"
+        ),
+    };
+    format!(
+        "  grader independence (#1795) — was the 46%-agreement number a self-grading artifact?\n  \
+         {}\n  {}{unknown}",
+        cohort_line(
+            "  self-graded ",
+            cohorts.self_graded.passes,
+            cohorts.self_graded.reconciled,
+            cohorts.self_graded.false_positives,
+        ),
+        cohort_line(
+            "  independent ",
+            cohorts.independent.passes,
+            cohorts.independent.reconciled,
+            cohorts.independent.false_positives,
+        ),
+    )
+}

--- a/crates/stella-cli/src/calibration/tests.rs
+++ b/crates/stella-cli/src/calibration/tests.rs
@@ -1,0 +1,561 @@
+//! The calibration fold's tests: the pass cohorts, the uncorroborated rate an
+//! evidence-demand policy is set from, the grader partition, and the late
+//! reconciliation that reaches a verdict after its session ended.
+//!
+//! A child module so `stands_alone` — private, and deliberately so — stays
+//! reachable, in its own file so neither it nor `calibration.rs` approaches the
+//! file-size ceiling.
+
+use super::ground_truth::{GroundTruth, reconcile};
+use super::*;
+use stella_protocol::{FlipOutcome, LadderRung, PrStatus, VerdictEvidence};
+
+/// The in-stream reading alone, for the tests that do not exercise the late
+/// path. `calibration` returns the unsettled passes beside the report (#1293);
+/// most assertions here are about the report.
+fn fold(events: &[AgentEvent]) -> CalibrationReport {
+    calibration(events).0
+}
+
+fn verdict(passed: bool, deterministic: bool) -> AgentEvent {
+    AgentEvent::Verdict {
+        passed,
+        evidence: VerdictEvidence {
+            summary: String::new(),
+            deterministic,
+            evidence_refs: vec![],
+            ladder: None,
+        },
+    }
+}
+
+fn ci(status: CiStatus) -> AgentEvent {
+    pr("https://example.test/pr/1", Some(status))
+}
+
+fn pr(url: &str, ci: Option<CiStatus>) -> AgentEvent {
+    AgentEvent::Pr {
+        url: url.into(),
+        status: PrStatus::Open,
+        number: Some(1),
+        ci,
+    }
+}
+
+fn commit(sha: &str) -> AgentEvent {
+    AgentEvent::Commit {
+        sha: sha.into(),
+        message: "feat: the work".into(),
+    }
+}
+
+/// A snapshot observing nothing, for tests that set only the channels they
+/// exercise. The diff fields are non-zero because "the tree changed" is never
+/// corroboration here — a literal that looked all-dark would suggest it might
+/// be.
+///
+/// Written out field by field rather than spread from a `Default`: a channel
+/// added to [`LadderSnapshot`] must make someone here decide whether
+/// [`stands_alone`] reads it, and a compile error is the only way to force that
+/// question.
+fn bare_snapshot() -> LadderSnapshot {
+    LadderSnapshot {
+        rung: None,
+        tracked_command: None,
+        oracle_trace: vec![],
+        flip: FlipOutcome::NotAchieved,
+        unstable_flip: false,
+        flip_refused_different_failure: false,
+        touched_tests_passed: None,
+        test_infra: None,
+        diff_lines: 4,
+        diff_budget: 400,
+        diff_available: true,
+        mutating_actions: 2,
+        new_diag_errors: 0,
+        new_diag_warnings: 0,
+        witness_intact: None,
+        witness_mutation: None,
+        diff_coverage: None,
+        verify_done_flip: false,
+        no_test_surface: false,
+        errored_commands: 0,
+        verifier_independent: None,
+    }
+}
+
+/// A verdict carrying its ladder snapshot, so the uncorroborated fold has
+/// something to read. `corroborated` decides whether the recorded turn had a
+/// flip behind it.
+fn snapshotted(passed: bool, deterministic: bool, corroborated: bool) -> AgentEvent {
+    let snapshot = LadderSnapshot {
+        flip: if corroborated {
+            FlipOutcome::Achieved
+        } else {
+            FlipOutcome::NotAchieved
+        },
+        touched_tests_passed: corroborated.then_some(true),
+        ..bare_snapshot()
+    };
+    AgentEvent::Verdict {
+        passed,
+        evidence: VerdictEvidence {
+            summary: String::new(),
+            deterministic,
+            evidence_refs: vec![],
+            ladder: Some(Box::new(snapshot)),
+        },
+    }
+}
+
+/// An unproven PASS carrying the grader fact under test; `None` with
+/// `snapshot: false` is a verdict with no ladder snapshot at all — the pre-#865
+/// shape.
+fn graded_pass(grader_independent: Option<bool>, snapshot: bool) -> AgentEvent {
+    let ladder = snapshot.then(|| {
+        Box::new(LadderSnapshot {
+            verifier_independent: grader_independent,
+            ..bare_snapshot()
+        })
+    });
+    AgentEvent::Verdict {
+        passed: true,
+        evidence: VerdictEvidence {
+            summary: String::new(),
+            deterministic: false,
+            evidence_refs: vec![],
+            ladder,
+        },
+    }
+}
+
+/// The #871 acceptance: an unproven pass that later fails CI is recorded as a
+/// false positive; the deterministic cohort reconciles beside it.
+#[test]
+fn an_unproven_pass_that_fails_ci_is_a_false_positive() {
+    let events = vec![
+        verdict(true, false), // unproven PASS
+        verdict(true, true),  // deterministic pass
+        ci(CiStatus::Failing),
+    ];
+    let report = fold(&events);
+    assert_eq!(report.unproven_passes, 1);
+    assert_eq!(report.unproven_reconciled, 1);
+    assert_eq!(report.unproven_false_positives, 1);
+    assert_eq!(report.unproven_false_positive_rate(), Some(1.0));
+    assert_eq!(report.deterministic_false_positives, 1);
+}
+
+/// Pending/Running reconcile nothing, and passes after the last terminal CI
+/// verdict stay unreconciled — an unmeasured rate reads `None`.
+#[test]
+fn non_terminal_ci_and_trailing_passes_stay_unreconciled() {
+    let events = vec![
+        verdict(true, false),
+        ci(CiStatus::Running),
+        ci(CiStatus::Passing),
+        verdict(true, false), // after the last terminal verdict
+    ];
+    let report = fold(&events);
+    assert_eq!(report.unproven_passes, 2);
+    assert_eq!(
+        report.unproven_reconciled, 1,
+        "only the pass before the terminal verdict was settled in-stream"
+    );
+    assert_eq!(report.unproven_false_positives, 0);
+    assert_eq!(report.unproven_false_positive_rate(), Some(0.0));
+
+    let unmeasured = fold(&[verdict(true, false)]);
+    assert_eq!(unmeasured.unproven_false_positive_rate(), None);
+}
+
+/// Failed verdicts and revise-loop reds never enter the pass tallies — the
+/// question is the false-POSITIVE rate of passes — but they are still observed,
+/// because "no verdict was recorded" is a different fact from "no verdict
+/// passed" (#3866).
+#[test]
+fn failed_verdicts_are_observed_but_not_tallied_as_passes() {
+    let events = vec![
+        verdict(false, true),
+        verdict(false, false),
+        ci(CiStatus::Passing),
+    ];
+    let report = fold(&events);
+    assert_eq!(report.unproven_passes, 0);
+    assert_eq!(report.deterministic_passes, 0);
+    assert_eq!(report.verdicts_observed, 2);
+}
+
+#[test]
+fn merge_adds_componentwise() {
+    let a = fold(&[verdict(true, false), ci(CiStatus::Failing)]);
+    let b = fold(&[verdict(true, false), ci(CiStatus::Passing)]);
+    let merged = a.merge(b);
+    assert_eq!(merged.verdicts_observed, 2);
+    assert_eq!(merged.unproven_passes, 2);
+    assert_eq!(merged.unproven_reconciled, 2);
+    assert_eq!(merged.unproven_false_positives, 1);
+}
+
+/// #1295: the rate an evidence-demand policy is set from is measured off what
+/// is already recorded — every snapshotted verdict counts toward the
+/// denominator, and an unproven PASS with nothing behind it is separately
+/// identified as a turn such a policy would have sent back.
+#[test]
+fn the_uncorroborated_rate_is_measured_from_recorded_snapshots() {
+    let events = vec![
+        snapshotted(true, false, false),  // unproven PASS, nothing behind it
+        snapshotted(true, true, true),    // deterministic pass, flip achieved
+        snapshotted(false, false, false), // a FAILING verdict, also uncorroborated
+        snapshotted(true, false, true),   // unproven PASS with a flip behind it
+    ];
+    let report = fold(&events);
+    assert_eq!(report.snapshotted_verdicts, 4);
+    assert_eq!(
+        report.uncorroborated_verdicts, 2,
+        "the denominator is every verdict, not only the passing ones — the question is how \
+         often the CONDITION holds"
+    );
+    assert_eq!(report.uncorroborated_rate(), Some(0.5));
+    assert_eq!(
+        report.unproven_passes_standing_alone, 1,
+        "only the unproven PASS with no flip and no green test would be sent back"
+    );
+    // The pass cohorts are untouched by this fold.
+    assert_eq!(report.unproven_passes, 2);
+    assert_eq!(report.deterministic_passes, 1);
+}
+
+/// #2194, restated for a workspace where the live predicate no longer exists
+/// (#3866): every combination of the three channels [`stands_alone`] reads,
+/// through the wire, against the same rule written the other way round.
+///
+/// This is the assertion whose absence let the two copies drift the first time.
+/// `stands_alone` restated `LadderInputs::verifier_pass_stands_alone` in two
+/// conjuncts; #2191 taught the live predicate a third (`verify_done_flip`) and
+/// the copy stayed at two, so `uncorroborated_verdicts` over-counted every
+/// `verify_done`-rescued turn. That predicate left the tree with
+/// `stella-pipeline` (#3865), so there is nothing to agree WITH any more — what
+/// is pinned instead is the definition itself, expressed as a disjunction of
+/// positives here against the conjunction of negatives there, so dropping a
+/// conjunct fails rather than silently widening the tally.
+///
+/// The JSON round trip is not decoration: a replay reader meets a snapshot off
+/// disk, not from memory, so a channel that stops surviving serialization
+/// reproduces the same drift wearing a `Default` instead of a missing conjunct.
+#[test]
+fn stands_alone_reads_exactly_three_channels_and_they_survive_the_wire() {
+    for flip in [
+        FlipOutcome::Unobserved,
+        FlipOutcome::NotAchieved,
+        FlipOutcome::Achieved,
+    ] {
+        for touched_tests_passed in [None, Some(false), Some(true)] {
+            for verify_done_flip in [false, true] {
+                let snapshot = LadderSnapshot {
+                    flip,
+                    touched_tests_passed,
+                    verify_done_flip,
+                    ..bare_snapshot()
+                };
+                let json = serde_json::to_string(&snapshot).expect("snapshot serializes");
+                let recorded: LadderSnapshot =
+                    serde_json::from_str(&json).expect("snapshot round-trips");
+                let any_corroboration = flip == FlipOutcome::Achieved
+                    || touched_tests_passed == Some(true)
+                    || verify_done_flip;
+                assert_eq!(
+                    stands_alone(&recorded),
+                    !any_corroboration,
+                    "corroboration misread at flip={flip:?} \
+                     touched={touched_tests_passed:?} verify_done={verify_done_flip}"
+                );
+            }
+        }
+    }
+}
+
+/// The consequence, folded: a verdict rescued by a worker-run `verify_done`
+/// confirmation is corroborated, and must not land in the uncorroborated tally.
+#[test]
+fn a_verify_done_rescued_verdict_is_not_counted_uncorroborated() {
+    let rescued = AgentEvent::Verdict {
+        passed: true,
+        evidence: VerdictEvidence {
+            summary: "heuristic fallback passed on the worker's verify_done confirmation".into(),
+            deterministic: false,
+            evidence_refs: vec![],
+            ladder: Some(Box::new(LadderSnapshot {
+                verify_done_flip: true,
+                ..bare_snapshot()
+            })),
+        },
+    };
+    let report = fold(&[rescued]);
+    assert_eq!(report.snapshotted_verdicts, 1);
+    assert_eq!(
+        report.uncorroborated_verdicts, 0,
+        "a confirmed verify_done flip is deterministic corroboration, exactly as the \
+         engine weighed it at decision time"
+    );
+    assert_eq!(report.unproven_passes_standing_alone, 0);
+}
+
+/// A rate with no denominator is reported as unmeasured, never as 0% — the same
+/// discipline the false-positive rates already keep. Verdicts recorded before
+/// ladder snapshots existed (#865) contribute nothing rather than being assumed
+/// corroborated.
+#[test]
+fn a_stream_without_snapshots_leaves_the_uncorroborated_rate_unmeasured() {
+    let report = fold(&[verdict(true, false), verdict(false, true)]);
+    assert_eq!(report.snapshotted_verdicts, 0);
+    assert_eq!(report.uncorroborated_rate(), None);
+    assert!(
+        render_calibration(&report).contains("uncorroborated rate: unmeasured"),
+        "an unmeasured rate must say so: {}",
+        render_calibration(&report)
+    );
+}
+
+/// #3866: a workspace that recorded no verdict at all must not read as a
+/// verifier that never erred.
+///
+/// This is now the ordinary state — the built-in verification path was deleted
+/// (#3865), so nothing emits a `Verdict` unless a verification plugin is
+/// installed — which makes the all-zero render the single most likely thing
+/// anyone sees. It says what it is instead.
+#[test]
+fn an_empty_record_reports_itself_as_unmeasured_not_as_perfect() {
+    let rendered = render_calibration(&fold(&[commit("abc123abc123"), ci(CiStatus::Passing)]));
+    assert!(
+        rendered.contains("nothing to calibrate"),
+        "an empty record must name itself: {rendered}"
+    );
+    assert!(
+        rendered.contains("NOT a measured result"),
+        "and must refuse to be read as a clean bill of health: {rendered}"
+    );
+    assert!(
+        !rendered.contains("false-positive rate"),
+        "a rate over nothing must not be printed at all: {rendered}"
+    );
+    assert!(
+        rendered.contains("plugin"),
+        "and must point at the only thing that produces a verdict now: {rendered}"
+    );
+}
+
+/// #2635: the cohort names the property it selects on — a pass with no
+/// deterministic evidence — and nothing in the output claims a model judged it.
+///
+/// The predicate `passed && !deterministic` was exact while the only way to set
+/// it was a model verifier ruling on inconclusive evidence. #2584 removed that
+/// call, and the ladder's own non-determinate outcomes set the same flag:
+/// `unverified`, `unverifiable`, and a triage `waived`. So the cohort counts
+/// unproven passes, no model was involved in any of them, and the old label was
+/// a measurement artifact asserting a mechanism that no longer contributes to
+/// it — which is worse than a missing number, because a consumer parsing
+/// `--format json` read `verifier_*` and got something else.
+#[test]
+fn the_unproven_cohort_never_claims_a_model_verifier() {
+    // A pass the ladder could not settle, carrying the rung that says so.
+    let unsettled = AgentEvent::Verdict {
+        passed: true,
+        evidence: VerdictEvidence {
+            summary: "UNVERIFIED: nothing deterministic settled this turn".into(),
+            deterministic: false,
+            evidence_refs: vec![],
+            ladder: Some(Box::new(LadderSnapshot {
+                rung: Some(LadderRung::Unverified),
+                ..bare_snapshot()
+            })),
+        },
+    };
+    let report = fold(&[unsettled]);
+    assert_eq!(
+        report.unproven_passes, 1,
+        "a pass nothing proved belongs to the unproven cohort"
+    );
+
+    let rendered = render_calibration(&report);
+    for banned in ["model verifier", "model-verifier", "verifier calibration"] {
+        assert!(
+            !rendered.contains(banned),
+            "the calibration output still names `{banned}`, a mechanism #2584 \
+             removed and which contributes to none of these tallies:\n{rendered}"
+        );
+    }
+    assert!(
+        rendered.contains("unproven"),
+        "the cohort must name what it selects on:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Late reconciliation (#1293): evidence that arrives after the session ended.
+// ---------------------------------------------------------------------------
+
+/// #1293 acceptance: a pass recorded after its session's last CI observation
+/// used to be lost. It now leaves the fold carrying the commit it covers, and a
+/// revert discovered later settles it.
+#[test]
+fn a_pass_after_the_last_ci_verdict_survives_its_session_and_a_revert_settles_it() {
+    let events = vec![
+        verdict(true, false),
+        pr("https://example.test/pr/1", Some(CiStatus::Passing)),
+        // Everything below is after the session's last terminal verdict — the
+        // region that used to be unreachable.
+        verdict(true, false),
+        commit("abc123abc123"),
+    ];
+    let (mut report, pending) = calibration(&events);
+    assert_eq!(report.unproven_passes, 2);
+    assert_eq!(
+        report.unproven_reconciled, 1,
+        "only the first pass had an in-stream verdict"
+    );
+    assert_eq!(pending.len(), 1, "the trailing pass is carried out");
+    assert_eq!(pending[0].commits, vec!["abc123abc123".to_string()]);
+
+    let truth = GroundTruth::default().with_reverts(["abc123abc123".to_string()]);
+    assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+    assert_eq!(report.unproven_reconciled, 2);
+    assert_eq!(report.unproven_false_positives, 1);
+    assert_eq!(report.unproven_reverted, 1);
+    assert!(
+        render_calibration(&report).contains("settled by a REVERT"),
+        "the render must distinguish a human's revert from a red CI run: {}",
+        render_calibration(&report)
+    );
+}
+
+/// The cross-session half: session A's trailing pass is settled by a terminal
+/// CI verdict recorded in session B, for the PR they share.
+#[test]
+fn a_terminal_verdict_in_a_later_session_settles_an_earlier_ones_pass() {
+    let session_a = vec![verdict(true, false), pr("https://example.test/pr/4", None)];
+    let session_b = vec![pr("https://example.test/pr/4", Some(CiStatus::Failing))];
+    let (mut report, pending) = calibration(&session_a);
+    assert_eq!(
+        report.unproven_reconciled, 0,
+        "a PR with no terminal verdict reconciles nothing in its own stream"
+    );
+    let truth = GroundTruth::default()
+        .with_stream(&session_a)
+        .with_stream(&session_b);
+    assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+    assert_eq!(report.unproven_false_positives, 1);
+    assert_eq!(
+        report.unproven_reverted, 0,
+        "CI is not a revert, and the two must not merge into one number"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Grader independence (#1865).
+// ---------------------------------------------------------------------------
+
+/// The #1865 acceptance: a scripted stream carrying both polarities (and an
+/// unknown) folds each pass into exactly one cohort, and the in-stream CI
+/// reconciliation settles each into its own cohort's rate — unknown counted
+/// apart, never folded into either.
+#[test]
+fn the_fold_partitions_the_unproven_cohort_by_grader_independence() {
+    let events = vec![
+        graded_pass(Some(false), true), // self-graded
+        graded_pass(Some(true), true),  // independent
+        graded_pass(None, true),        // snapshotted, fact not recorded
+        graded_pass(None, false),       // no snapshot at all (pre-#865)
+        ci(CiStatus::Failing),
+    ];
+    let report = fold(&events);
+    assert_eq!(report.unproven_passes, 4);
+    assert_eq!(report.by_grader.self_graded.passes, 1);
+    assert_eq!(report.by_grader.independent.passes, 1);
+    assert_eq!(
+        report.by_grader.unknown.passes, 2,
+        "no snapshot and no recorded fact are both UNKNOWN — never assumed into a cohort"
+    );
+    assert_eq!(report.by_grader.self_graded.reconciled, 1);
+    assert_eq!(report.by_grader.self_graded.false_positives, 1);
+    assert_eq!(
+        report.by_grader.self_graded.false_positive_rate(),
+        Some(1.0)
+    );
+    assert_eq!(report.by_grader.independent.reconciled, 1);
+    assert_eq!(report.by_grader.independent.false_positives, 1);
+    assert_eq!(report.by_grader.unknown.reconciled, 2);
+    let total = report.by_grader.self_graded.passes
+        + report.by_grader.independent.passes
+        + report.by_grader.unknown.passes;
+    assert_eq!(
+        total, report.unproven_passes,
+        "the partition is exhaustive: every unproven pass lands in exactly one cohort"
+    );
+}
+
+/// The late path keeps the fact: a pass carried out of its session still knows
+/// who graded it, so a revert landing next week settles the right cohort — not
+/// a merged one.
+#[test]
+fn late_reconciliation_settles_the_cohort_the_pass_belongs_to() {
+    let events = vec![graded_pass(Some(false), true), commit("abc123abc123")];
+    let (mut report, pending) = calibration(&events);
+    assert_eq!(report.by_grader.self_graded.passes, 1);
+    assert_eq!(report.by_grader.self_graded.reconciled, 0);
+    let truth = GroundTruth::default().with_reverts(["abc123abc123".to_string()]);
+    assert_eq!(reconcile(&mut report, &pending, &truth), 1);
+    assert_eq!(report.by_grader.self_graded.reconciled, 1);
+    assert_eq!(report.by_grader.self_graded.false_positives, 1);
+    assert_eq!(
+        report.by_grader.independent.reconciled + report.by_grader.unknown.reconciled,
+        0,
+        "the revert reaches only the cohort that made the call"
+    );
+}
+
+/// Deterministic passes carry no grader — nothing graded, so they must not leak
+/// into any cohort, unknown included.
+#[test]
+fn deterministic_passes_join_no_grader_cohort() {
+    let report = fold(&[verdict(true, true), ci(CiStatus::Passing)]);
+    assert_eq!(report.deterministic_passes, 1);
+    assert_eq!(report.by_grader, GraderCohorts::default());
+}
+
+/// Workspace totals partition too: `merge` is componentwise across the cohorts,
+/// the same as every other tally in the report.
+#[test]
+fn merge_adds_grader_cohorts_componentwise() {
+    let a = fold(&[graded_pass(Some(false), true), ci(CiStatus::Failing)]);
+    let b = fold(&[graded_pass(Some(true), true), ci(CiStatus::Passing)]);
+    let merged = a.merge(b);
+    assert_eq!(merged.by_grader.self_graded.false_positives, 1);
+    assert_eq!(merged.by_grader.independent.reconciled, 1);
+    assert_eq!(merged.by_grader.independent.false_positives, 0);
+}
+
+/// The render answers the question side by side, and states the unknown cohort
+/// apart instead of folding it into either rate.
+#[test]
+fn the_render_shows_both_grader_rates_and_excludes_unknown() {
+    let events = vec![
+        graded_pass(Some(false), true),
+        graded_pass(Some(true), true),
+        graded_pass(None, false),
+        ci(CiStatus::Failing),
+    ];
+    let rendered = render_calibration(&fold(&events));
+    assert!(
+        rendered.contains("self-graded"),
+        "the self-graded cohort must be named: {rendered}"
+    );
+    assert!(
+        rendered.contains("independent"),
+        "the independent cohort must be named: {rendered}"
+    );
+    assert!(
+        rendered.contains("excluded from both rates"),
+        "the unknown cohort is stated apart, never folded in: {rendered}"
+    );
+}

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -1056,14 +1056,16 @@ pub(crate) enum Command {
         only: inspect::RoleFilter,
     },
 
-    /// Verifier calibration: false-positive rate vs CI ground truth
+    /// Pass calibration: false-positive rate vs CI and revert ground truth
     ///
-    /// Fold every recorded session's pass verdicts against the CI verdicts
-    /// observed after them (#871): how often did a model-verifier PASS — and,
-    /// as the comparison cohort, a deterministic ladder pass — later fail
-    /// CI? Rates are reported as unmeasured until CI ground truth exists.
-    /// Reads .stella/private/store.db only; needs no API key and never
-    /// writes.
+    /// Fold every recorded session's pass verdicts against the evidence
+    /// observed after them (#871, #1293): how often did an unproven PASS —
+    /// and, as the comparison cohort, a deterministic ladder pass — later
+    /// fail CI, or get reverted by a human? Rates are reported as unmeasured
+    /// until ground truth exists, and a workspace that recorded no verdict at
+    /// all says so rather than reporting zeroes. Reads
+    /// .stella/private/store.db and the git log only; needs no API key and
+    /// never writes.
     Calibration {
         /// Output format: text, or json under the versioned query envelope
         #[arg(long, value_enum, default_value = "text")]

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -1056,7 +1056,7 @@ pub(crate) enum Command {
         only: inspect::RoleFilter,
     },
 
-    /// Pass calibration: false-positive rate vs CI and revert ground truth
+    /// Pass calibration: false-positive rate vs CI and reverts
     ///
     /// Fold every recorded session's pass verdicts against the evidence
     /// observed after them (#871, #1293): how often did an unproven PASS —

--- a/crates/stella-cli/src/inspect.rs
+++ b/crates/stella-cli/src/inspect.rs
@@ -182,28 +182,156 @@ pub(crate) fn run_inspect(args: &InspectArgs) -> Result<(), String> {
     }
 }
 
-/// `stella calibration` (#871, #1293) folded every recorded session's pass
-/// verdicts against the evidence that later contradicted or confirmed them —
-/// `GroundTruth`, `CalibrationReport`, `calibration_pending`, and
-/// `render_calibration` all lived in `stella_pipeline::replay`, and that
-/// crate is gone (#3865). Unlike this file's other pipeline-era callers,
-/// that module was not a clean retarget: `replay::CalibrationReport` folds
-/// `LadderInputs` (`stella_pipeline::verify`) and
-/// `independence::GraderCohorts`, both pipeline-internal — pulling this
-/// command back would mean reconstructing a verify/independence model from
-/// scratch outside the crate that owned it, not moving a self-contained
-/// type. That is a real design decision, not a mechanical one, so it is
-/// left to a human rather than guessed at under a deletion slice's compile
-/// pressure (CLAUDE.md: "'now' vs. 'right' is the maintainer's call").
-/// Tracked in #3866; the command still parses so a script invoking it fails
-/// loudly with this text instead of "unknown subcommand".
-pub(crate) fn run_calibration(_format: QueryFormat) -> Result<(), String> {
-    Err("stella calibration no longer runs anything — it read \
-         stella_pipeline::replay's ground-truth/calibration model, which was \
-         removed along with the staged pipeline crate (#3865). \
-         Re-implementing it standalone is an open design decision, tracked \
-         in https://github.com/macanderson/stella/issues/3866."
-        .to_string())
+/// `stella calibration` (#871, #1293): fold every recorded session's pass
+/// verdicts against the evidence that later contradicted or confirmed them,
+/// and report the unproven cohort's measured false-positive rate beside the
+/// deterministic one's.
+///
+/// Three passes over what already exists — no new write path, no daemon:
+///
+/// 1. Fold each session, keeping the passes it could not settle itself.
+/// 2. Build the workspace's answer key: every terminal CI verdict from
+///    **every** session (so a verdict recorded after another session ended
+///    still reaches it), plus the reverts in the git history (a human saying
+///    "this was wrong", the source #1293 added).
+/// 3. Settle what the key can reach, and leave the rest unreconciled.
+///
+/// The measurement model itself is [`crate::calibration`] — pure functions
+/// over the events, reinstated there when `stella_pipeline::replay` left the
+/// tree with the staged pipeline (#3865, #3866). This function is its I/O
+/// half and nothing else.
+pub(crate) fn run_calibration(format: QueryFormat) -> Result<(), String> {
+    use crate::calibration::ground_truth::{GroundTruth, reconcile};
+    use crate::calibration::{CalibrationReport, calibration, render_calibration};
+
+    let store = open_readonly_store()?;
+    let sessions = store
+        .event_session_ids()
+        .map_err(|e| format!("cannot enumerate recorded sessions: {e}"))?;
+    let mut total = CalibrationReport::default();
+    let mut pending = Vec::new();
+    // Seeded with the git history's reverts before any stream is read: a
+    // revert is evidence about a commit, not about a session, so it belongs
+    // to the workspace rather than to whichever stream happens to mention it.
+    let mut truth = GroundTruth::default().with_reverts(revert_targets_from_git());
+    for session_id in &sessions {
+        let journal = store
+            .session_events(session_id)
+            .map_err(|e| format!("cannot read session {session_id}: {e}"))?;
+        let events: Vec<stella_protocol::AgentEvent> =
+            journal.events.into_iter().map(|r| r.event).collect();
+        let (report, unsettled) = calibration(&events);
+        total = total.merge(report);
+        pending.extend(unsettled);
+        // Every session contributes its CI observations to the key, including
+        // the ones that arrived too late for their own stream.
+        truth = truth.with_stream(&events);
+    }
+    let settled_late = reconcile(&mut total, &pending, &truth);
+    let unreconciled = pending.len() as u32 - settled_late;
+    if matches!(format, QueryFormat::Json) {
+        return print_json(&Versioned::new(serde_json::json!({
+            "sessions": sessions.len(),
+            // "no verdict was ever recorded" and "no verdict passed" render
+            // identically in every other field, and since #3865 the first is
+            // the ordinary state of a workspace with no verification plugin
+            // installed (#3866).
+            "verdicts_observed": total.verdicts_observed,
+            "unproven_passes": total.unproven_passes,
+            "unproven_reconciled": total.unproven_reconciled,
+            "unproven_false_positives": total.unproven_false_positives,
+            "unproven_false_positive_rate": total.unproven_false_positive_rate(),
+            "deterministic_passes": total.deterministic_passes,
+            "deterministic_reconciled": total.deterministic_reconciled,
+            "deterministic_false_positives": total.deterministic_false_positives,
+            "deterministic_false_positive_rate": total.deterministic_false_positive_rate(),
+            // #1295: the uncorroborated cohort, so a decision about demanding
+            // evidence can be taken from a measured number rather than from
+            // the last run someone remembers.
+            "snapshotted_verdicts": total.snapshotted_verdicts,
+            "uncorroborated_verdicts": total.uncorroborated_verdicts,
+            "uncorroborated_rate": total.uncorroborated_rate(),
+            "unproven_passes_standing_alone": total.unproven_passes_standing_alone,
+            // #1293: the answer key's own reach — how many earlier verdicts
+            // evidence arriving after their session settled, and how many of
+            // the reconciled ones a human revert (not CI) contradicted.
+            "settled_by_late_evidence": settled_late,
+            "unreconciled_passes": unreconciled,
+            "unproven_reverted": total.unproven_reverted,
+            "deterministic_reverted": total.deterministic_reverted,
+            // #1865: the unproven cohort partitioned by who graded it. The
+            // human report has shown this since #1865; the JSON did not, so
+            // anything scripting `--format json` could not ask the question
+            // the section exists to answer.
+            "by_grader": grader_cohorts_json(&total.by_grader),
+        })));
+    }
+    println!(
+        "{} session(s) with recorded events\n{}\n  \
+         late evidence settled {settled_late} verdict(s) their own session never resolved; \
+         {unreconciled} still unreconciled",
+        sessions.len(),
+        render_calibration(&total),
+    );
+    Ok(())
+}
+
+/// The grader partition as JSON (#1865), one object per cohort with the same
+/// three counters and the same unmeasured-is-`null` rate the top-level cohorts
+/// use — so the two read identically whichever surface asks.
+fn grader_cohorts_json(
+    cohorts: &crate::calibration::independence::GraderCohorts,
+) -> serde_json::Value {
+    fn tally(t: &crate::calibration::independence::GraderTally) -> serde_json::Value {
+        serde_json::json!({
+            "passes": t.passes,
+            "reconciled": t.reconciled,
+            "false_positives": t.false_positives,
+            "false_positive_rate": t.false_positive_rate(),
+        })
+    }
+    serde_json::json!({
+        "self_graded": tally(&cohorts.self_graded),
+        "independent": tally(&cohorts.independent),
+        // Never folded into either measured cohort — a verdict that recorded
+        // no grader fact is unknown, not assumed.
+        "unknown": tally(&cohorts.unknown),
+    })
+}
+
+/// The commits this repository's history says were reverted (#1293).
+///
+/// Read-only and best-effort, exactly like every other question `stella
+/// inspect` asks: a workspace that is not a git repository, or a `git` that is
+/// not installed, contributes no revert evidence and the calibration simply has
+/// one fewer source. It never fails the command — a missing answer key is the
+/// state this is trying to improve, not an error.
+///
+/// The window is deliberately bounded. A revert contradicts a judgement made
+/// *before* it, so history older than the recorded sessions cannot settle
+/// anything, and reading the whole log of a long-lived repository would cost
+/// seconds to learn nothing.
+fn revert_targets_from_git() -> std::collections::BTreeSet<String> {
+    use crate::calibration::ground_truth::parse_revert_targets;
+
+    let Ok(root) = std::env::current_dir() else {
+        return Default::default();
+    };
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["log", "--no-merges", "-n", "2000", "--format=%B"])
+        .current_dir(&root);
+    // The same discipline as every other git spawn in this crate: a
+    // hook-exported GIT_* var must not re-target the read at another repo.
+    for var in stella_tools::exec::GIT_REPO_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    let Ok(output) = cmd.output() else {
+        return Default::default();
+    };
+    if !output.status.success() {
+        return Default::default();
+    }
+    parse_revert_targets(&String::from_utf8_lossy(&output.stdout))
 }
 
 /// Open the workspace store without creating it. Mirrors `stella stats`: a

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -30,6 +30,7 @@ mod attachments;
 mod auth_cmd;
 mod build_info;
 mod cache_insight;
+mod calibration;
 mod candidate_workspaces;
 mod claims;
 mod cli;

--- a/crates/stella-cli/tests/calibration_cli.rs
+++ b/crates/stella-cli/tests/calibration_cli.rs
@@ -1,0 +1,292 @@
+//! End-to-end witness for `stella calibration` (#3866): drive the real binary
+//! against a real store and a real git history, and check that the measured
+//! false-positive rates come back out.
+//!
+//! This is the acceptance for reinstating the command. Its measurement model
+//! lived in `stella_pipeline::replay` and went out of the tree with that crate
+//! (#3865), leaving `run_calibration` a stub that returned an error naming the
+//! issue — so on `main` before this change, every assertion below fails at the
+//! `status.success()` check, whatever the fixture says.
+//!
+//! Two sources are exercised together because only the whole command joins
+//! them: the terminal CI verdicts recorded in the event journal (#871), and the
+//! reverts read out of `git log` (#1293). The unit tests in
+//! `stella-cli/src/calibration/` cover the fold itself; what is witnessed here
+//! is the wiring — the store enumeration, the git spawn, and the JSON shape a
+//! script parses.
+
+use std::process::Command;
+
+use stella_protocol::{
+    AgentEvent, CiStatus, FlipOutcome, LadderSnapshot, PrStatus, VerdictEvidence,
+};
+use stella_store::Store;
+
+/// A snapshot that observed no corroboration at all: no achieved flip, no green
+/// touched test, no `verify_done` confirmation. `verifier_independent` is
+/// recorded so the grader partition (#1865) has a fact to sort on.
+fn uncorroborated_snapshot() -> LadderSnapshot {
+    LadderSnapshot {
+        rung: None,
+        tracked_command: None,
+        oracle_trace: vec![],
+        flip: FlipOutcome::NotAchieved,
+        unstable_flip: false,
+        flip_refused_different_failure: false,
+        touched_tests_passed: None,
+        test_infra: None,
+        diff_lines: 4,
+        diff_budget: 400,
+        diff_available: true,
+        mutating_actions: 2,
+        new_diag_errors: 0,
+        new_diag_warnings: 0,
+        witness_intact: None,
+        witness_mutation: None,
+        diff_coverage: None,
+        verify_done_flip: false,
+        no_test_surface: false,
+        errored_commands: 0,
+        verifier_independent: Some(false),
+    }
+}
+
+/// A git repository holding one commit and a revert of it, returning the SHA
+/// the revert names — the ground truth #1293 added, in the only form the
+/// command reads it: git's own generated `This reverts commit <sha>.` body.
+fn repo_with_a_reverted_commit(dir: &std::path::Path) -> String {
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.test")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.test")
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    git(&["init", "--quiet", "--initial-branch", "main"]);
+    // A signing key configured globally would make every commit below fail on a
+    // developer's machine and pass in CI; pin the decision instead of
+    // inheriting it, the same discipline the colour tests keep.
+    git(&["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("widget.txt"), "the work\n").expect("write");
+    git(&["add", "widget.txt"]);
+    git(&["commit", "--quiet", "-m", "feat: add the widget"]);
+    let sha = git(&["rev-parse", "HEAD"]);
+    git(&["revert", "--no-edit", "--no-gpg-sign", &sha]);
+    sha
+}
+
+/// A workspace whose store holds one session: an unproven pass a failing CI run
+/// settled in-stream, and a deterministic pass settled only by the revert in
+/// the git history — the late path, which no single session could reach.
+fn seeded_workspace() -> (tempfile::TempDir, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = tempfile::tempdir().expect("home");
+    let reverted = repo_with_a_reverted_commit(dir.path());
+
+    let events = [
+        // An unproven pass, carrying the snapshot that says nothing
+        // corroborated it.
+        AgentEvent::Verdict {
+            passed: true,
+            evidence: VerdictEvidence {
+                summary: "UNVERIFIED: nothing deterministic settled this turn".into(),
+                deterministic: false,
+                evidence_refs: vec![],
+                ladder: Some(Box::new(uncorroborated_snapshot())),
+            },
+        },
+        // …which this terminal CI verdict reconciles, in-stream, as wrong.
+        AgentEvent::Pr {
+            url: "https://example.test/pr/1".into(),
+            status: PrStatus::Merged,
+            number: Some(1),
+            ci: Some(CiStatus::Failing),
+        },
+        // A deterministic pass with no CI observation after it: unreconciled
+        // when its session ends, and reachable only by the git history.
+        AgentEvent::Verdict {
+            passed: true,
+            evidence: VerdictEvidence {
+                summary: "flip achieved".into(),
+                deterministic: true,
+                evidence_refs: vec![],
+                ladder: None,
+            },
+        },
+        AgentEvent::Commit {
+            sha: reverted,
+            message: "feat: add the widget".into(),
+        },
+    ];
+
+    let store = Store::open(dir.path()).expect("store");
+    let execution = store
+        .begin_execution("run", "add the widget", "anthropic", "opus")
+        .expect("execution");
+    store
+        .set_execution_session(execution, "sess-a")
+        .expect("session");
+    for (seq, event) in events.iter().enumerate() {
+        store
+            .record_event(execution, seq as u64, event)
+            .expect("record event");
+    }
+    (dir, home)
+}
+
+fn calibration(dir: &tempfile::TempDir, home: &tempfile::TempDir, args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .arg("calibration")
+        .args(args)
+        .current_dir(dir.path())
+        // The whole user tier, not just the data dir: `credentials.toml` is
+        // config-tier, so a narrower override still lets a test read the
+        // developer's real home (#3876).
+        .env("STELLA_HOME", home.path())
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run stella calibration");
+    assert!(
+        output.status.success(),
+        "stella calibration {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The #3866 acceptance: `--format json` reports real tallies again, joining
+/// the in-stream CI verdict (#871) and the git revert (#1293) that no session
+/// could have settled by itself.
+#[test]
+fn calibration_json_reports_both_ground_truth_sources() {
+    let (dir, home) = seeded_workspace();
+    let report: serde_json::Value =
+        serde_json::from_str(&calibration(&dir, &home, &["--format", "json"])).expect("json");
+
+    assert_eq!(report["sessions"], 1);
+    assert_eq!(
+        report["verdicts_observed"], 2,
+        "both verdicts are observed, whichever cohort they land in"
+    );
+
+    // #871: the in-stream half.
+    assert_eq!(report["unproven_passes"], 1);
+    assert_eq!(report["unproven_reconciled"], 1);
+    assert_eq!(report["unproven_false_positives"], 1);
+    assert_eq!(report["unproven_false_positive_rate"], 1.0);
+
+    // #1293: the late half — the deterministic pass was settled by a revert
+    // read out of the git log, after its own session had ended.
+    assert_eq!(report["settled_by_late_evidence"], 1);
+    assert_eq!(report["unreconciled_passes"], 0);
+    assert_eq!(report["deterministic_passes"], 1);
+    assert_eq!(report["deterministic_reconciled"], 1);
+    assert_eq!(report["deterministic_false_positives"], 1);
+    assert_eq!(
+        report["deterministic_reverted"], 1,
+        "a revert is counted apart from CI: it is a human's later and stronger statement"
+    );
+    assert_eq!(report["unproven_reverted"], 0);
+
+    // #1295: the uncorroborated cohort, measured off the recorded snapshot.
+    assert_eq!(report["snapshotted_verdicts"], 1);
+    assert_eq!(report["uncorroborated_verdicts"], 1);
+    assert_eq!(report["uncorroborated_rate"], 1.0);
+    assert_eq!(report["unproven_passes_standing_alone"], 1);
+
+    // #1865: the grader partition, which the human report has shown since it
+    // landed and the JSON did not until now.
+    assert_eq!(report["by_grader"]["self_graded"]["passes"], 1);
+    assert_eq!(
+        report["by_grader"]["self_graded"]["false_positive_rate"],
+        1.0
+    );
+    assert_eq!(
+        report["by_grader"]["independent"]["false_positive_rate"],
+        serde_json::Value::Null,
+        "an unmeasured rate is null, never zero — the one direction this instrument must not drift"
+    );
+}
+
+/// The human report states the same measurement, with every rate beside the
+/// denominator it was computed over.
+#[test]
+fn calibration_text_names_the_cohorts_and_the_revert() {
+    let (dir, home) = seeded_workspace();
+    let rendered = calibration(&dir, &home, &[]);
+    assert!(
+        rendered.contains("1 session(s) with recorded events"),
+        "the session count leads: {rendered}"
+    );
+    assert!(
+        rendered.contains("unproven"),
+        "the unproven cohort is named: {rendered}"
+    );
+    assert!(
+        rendered.contains("settled by a REVERT"),
+        "a revert is distinguished from a red CI run: {rendered}"
+    );
+    assert!(
+        rendered.contains("late evidence settled 1 verdict(s)"),
+        "the late path reports its own reach: {rendered}"
+    );
+}
+
+/// #3866's second half: a workspace that recorded no verdict at all must say
+/// so, not print a page of zeroes that reads as a flawless verifier.
+///
+/// This is now the ordinary state — nothing in the workspace emits a `Verdict`
+/// since the built-in verification path was deleted (#3865), so it is the most
+/// likely thing anyone running the command sees.
+#[test]
+fn a_workspace_with_no_verdicts_says_so_instead_of_reporting_zeroes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = tempfile::tempdir().expect("home");
+    let store = Store::open(dir.path()).expect("store");
+    let execution = store
+        .begin_execution("run", "do the thing", "anthropic", "opus")
+        .expect("execution");
+    store
+        .set_execution_session(execution, "sess-quiet")
+        .expect("session");
+    store
+        .record_event(
+            execution,
+            0,
+            &AgentEvent::Commit {
+                sha: "abc123abc123abc123".into(),
+                message: "feat: the work".into(),
+            },
+        )
+        .expect("record event");
+
+    let rendered = calibration(&dir, &home, &[]);
+    assert!(
+        rendered.contains("nothing to calibrate"),
+        "an empty record names itself: {rendered}"
+    );
+    assert!(
+        !rendered.contains("false-positive rate"),
+        "and prints no rate over nothing: {rendered}"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_str(&calibration(&dir, &home, &["--format", "json"])).expect("json");
+    assert_eq!(report["verdicts_observed"], 0);
+    assert_eq!(
+        report["unproven_false_positive_rate"],
+        serde_json::Value::Null,
+        "unmeasured, not zero"
+    );
+}

--- a/website/content/docs/commands/calibration.mdx
+++ b/website/content/docs/commands/calibration.mdx
@@ -13,7 +13,7 @@ stella calibration --format json  # machine-readable tallies
 ```
 
 <Callout type="warn">
-**Nothing in Stella emits a verdict any more.** The built-in staged pipeline
+**Nothing in stella emits a verdict any more.** The built-in staged pipeline
 was the only in-tree producer of `Verdict` events and was deleted; a plain
 `stella run` is the raw step loop with no verification stage over it. Verdicts
 now come from an **installed verification plugin** (`stella plugin install`,

--- a/website/content/docs/commands/calibration.mdx
+++ b/website/content/docs/commands/calibration.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella calibration
-description: The verifier's measured false-positive rate — every recorded pass verdict reconciled against the CI results observed after it.
+description: The measured false-positive rate of a pass verdict — every recorded pass reconciled against the CI results and reverts observed after it.
 ---
 
-Answer "how often does the verifier approve work that CI later rejects?" from what the workspace has already recorded. Every verification verdict is persisted in the local event journal with the ladder snapshot it was decided from, and every PR/CI observation lands in the same stream — so calibration is a *reading*, not a new telemetry pipe. Entirely local; no API key, no network, and it never writes.
+Answer "how often was a pass wrong?" from what the workspace has already recorded. Every verification verdict is persisted in the local event journal with the ladder snapshot it was decided from, every PR/CI observation lands in the same stream, and every revert is already in the git log — so calibration is a *reading*, not a new telemetry pipe. Entirely local; no API key, no network, and it never writes.
 
 ## Synopsis
 
@@ -12,6 +12,17 @@ stella calibration                # human-readable report
 stella calibration --format json  # machine-readable tallies
 ```
 
+<Callout type="warn">
+**Nothing in Stella emits a verdict any more.** The built-in staged pipeline
+was the only in-tree producer of `Verdict` events and was deleted; a plain
+`stella run` is the raw step loop with no verification stage over it. Verdicts
+now come from an **installed verification plugin** (`stella plugin install`,
+then `stella run --pipeline <plugin-id>`), or from sessions recorded before
+that deletion. A workspace with neither has nothing to calibrate — and the
+command says exactly that, rather than printing a page of zeroes that reads
+like a flawless verifier.
+</Callout>
+
 ## What it reports
 
 Two cohorts, deliberately side by side — a false-positive rate means nothing without the cohort it should be compared against:
@@ -19,37 +30,48 @@ Two cohorts, deliberately side by side — a false-positive rate means nothing w
 - **unproven** — `Verdict` events with `passed: true` and `deterministic: false`: a pass the ladder could not settle. Three different outcomes land here — *unverified* (the probes looked and did not settle it), *unverifiable* (no probe could look), and a triage-*waived* pass — and no model judged any of them.
 - **deterministic** — passes the ladder credited itself (fail→pass flip, green tests, budget, and every pre-submit audit).
 
-<Callout type="warn">
-**Sessions recorded before the model verdict call was removed mix two
-populations under the `unproven` heading.** The cohort used to be labelled
-*model verifier*, and that name was exact while a `deterministic: false` pass
-could only have come from a model ruling on inconclusive evidence. Removing that
-call left the same flag being set by the ladder's own non-determinate outcomes,
-so the label named a mechanism that had stopped contributing to it — and the
-JSON keys spelled `verifier_*`, so anything scripting `--format json` read
-"verifier" and got something else. The fields are now `unproven_*`, which is
-what they always selected on. Nothing in an old record distinguishes the two
-populations, so a report spanning the change cannot separate them.
-</Callout>
+For each: how many passes were recorded, how many were **reconciled**, and how many of those turned out to be wrong. The rate is printed only over reconciled passes; with no ground truth yet, it is reported as **unmeasured**, never as zero.
 
-<Callout type="warn">
-**Breaking change to `--format json`.** `verifier_passes`,
-`verifier_reconciled`, `verifier_false_positives`,
-`verifier_false_positive_rate`, `verifier_passes_standing_alone` and
-`verifier_reverted` are renamed to `unproven_*`. The old spellings are **not**
-emitted alongside the new ones: they named a mechanism that contributes nothing
-to the tallies, so keeping them would have kept serving the wrong answer to a
-consumer who never noticed. The human report's `verifier-alone rate` line is
-likewise now `uncorroborated rate`.
-</Callout>
+Three further readings ride along:
 
-For each: how many passes were recorded, how many were **reconciled** — a terminal CI verdict (`Passing`/`Failing`) was observed later in the same session's stream — and how many of those reconciled passes failed CI. The rate is printed only over reconciled passes; with no CI ground truth yet, it is reported as **unmeasured**, never as zero.
+- **the uncorroborated rate** — over the verdicts that carried a ladder snapshot, how often *nothing* mechanical stood behind the result: no achieved fail→pass flip, no touched-test run observed green, no worker-run `verify_done` confirmation. This is the number an evidence-demand policy ("spend one more turn asking the worker to prove it") should be set from: a minority is the condition such a send-back is worth a turn for; a majority reproduces the benchmark measurement that switched the built-in one off.
+- **reverted, counted apart** — how many reconciled passes a human revert settled rather than CI. A cohort whose false positives are mostly reverts is failing differently from one whose false positives are mostly red CI, and a single number would hide it.
+- **grader independence** — the unproven cohort split by whether the worker's own model graded the verdict or a distinct one did. Verdicts that recorded no grader fact are kept apart and excluded from both rates, never assumed into either.
+
+## Ground truth: two sources, one asymmetry
+
+A pass is reconciled by either:
+
+1. a **terminal CI verdict** (`Passing`/`Failing`) for a PR the pass covers — read from **every** recorded session, so a verdict that arrived after one session ended still reaches back to it; or
+2. a **revert** of a commit the pass covers, read out of `git log` from git's own generated `This reverts commit <sha>.` body.
+
+The asymmetry is deliberate and enforced: **a revert settles a pass as a false positive, while the absence of one confirms nothing.** Most correct work is never reverted for the same reason most correct work is never mentioned, so an un-reverted commit leaves its pass unreconciled and out of every denominator. Counting un-reverted commits as confirmations would improve every measured rate by construction — the one direction a calibration instrument must never drift.
+
+A revert also outranks a green CI run for the same pass: it is the later and better-informed statement.
 
 ## Honest limits
 
-- Reconciliation is stream-local and forward-only: a session's terminal CI verdict covers the passes recorded before it, and passes after the last CI observation stay unreconciled.
 - `Pending`/`Running` CI states reconcile nothing — absence of a verdict is not a verdict.
-- Reverts and rollbacks are not yet a ground-truth source; the report says so rather than approximating.
+- A session's events do not record which verdict a given commit implements, so a commit is attributed to every unsettled pass before it. A session that produced two passes and one commit counts a revert twice. This errs toward reporting the verifier as *worse* than it is, which is the safe direction here.
+- The git log is read best-effort and bounded: a workspace that is not a git repository simply contributes one fewer source.
+- Sessions recorded before the model verdict call was removed mix two populations under the `unproven` heading. The cohort used to be labelled *model verifier*, and that name was exact while a `deterministic: false` pass could only have come from a model ruling on inconclusive evidence. Removing that call left the same flag being set by the ladder's own non-determinate outcomes. Nothing in an old record distinguishes the two, so a report spanning the change cannot separate them.
+
+## `--format json`
+
+Under the versioned query envelope. Every rate is `null` when unmeasured, never `0`. Keys: `sessions`, `verdicts_observed`, the `unproven_*` and `deterministic_*` cohorts with their `*_false_positive_rate`, `snapshotted_verdicts` / `uncorroborated_verdicts` / `uncorroborated_rate` / `unproven_passes_standing_alone`, `settled_by_late_evidence` / `unreconciled_passes`, `unproven_reverted` / `deterministic_reverted`, and `by_grader` (`self_graded`, `independent`, `unknown`).
+
+`verdicts_observed` is the field that separates "no verdict was ever recorded" from "no verdict passed" — they are identical in every other tally, and since the pipeline's deletion the first is the ordinary state.
+
+<Callout type="warn">
+**Earlier rename.** `verifier_passes`, `verifier_reconciled`,
+`verifier_false_positives`, `verifier_false_positive_rate`,
+`verifier_passes_standing_alone` and `verifier_reverted` were renamed to
+`unproven_*`, and the human report's `verifier-alone rate` line to
+`uncorroborated rate`. The old spellings are **not** emitted alongside the new
+ones: they named a mechanism that contributes nothing to the tallies, so
+keeping them would have kept serving the wrong answer to a consumer who never
+noticed.
+</Callout>
 
 ## See also
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -109,7 +109,7 @@ here and the index your terminal shows can never drift apart.
     Show the exact context a past model call was sent
   </SpecCard>
   <SpecCard title="stella calibration" href="/docs/commands/calibration">
-    Pass calibration: false-positive rate vs CI and revert ground truth
+    Pass calibration: false-positive rate vs CI and reverts
   </SpecCard>
   <SpecCard title="stella usage" href="/docs/commands/usage">
     Cross-project telemetry hub (~/.stella/usage.db)

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -109,7 +109,7 @@ here and the index your terminal shows can never drift apart.
     Show the exact context a past model call was sent
   </SpecCard>
   <SpecCard title="stella calibration" href="/docs/commands/calibration">
-    Verifier calibration: false-positive rate vs CI ground truth
+    Pass calibration: false-positive rate vs CI and revert ground truth
   </SpecCard>
   <SpecCard title="stella usage" href="/docs/commands/usage">
     Cross-project telemetry hub (~/.stella/usage.db)


### PR DESCRIPTION
## What

`stella calibration` (#871, #1293) read its entire measurement model from
`stella_pipeline::replay`, and went out of the tree with that crate (#3865).
What was left was a stub: the command still parsed, and returned an error
naming #3866. That issue asked a maintainer to choose between reimplementing
the model standalone and retiring the command. **This is direction 1 —
reimplement.**

Closes #3866

## Where it lives, and why not a crate

`crates/stella-cli/src/calibration/` — a module, not a new leaf crate.

The issue offered a leaf crate on the `stella-diff`/`stella-embed` pattern
"if the logic is judged independence-testable". It is: the fold is pure
functions over borrowed `AgentEvent`s with no I/O. But that argument buys a
*second consumer's* isolation, and there is no second consumer — nothing else
in this workspace measures verdicts, and a verification plugin lives on the
far side of the wrapper socket rather than linking this. A crate boundary is
a public API commitment; shipping a README, an AGENTS.md row and a stable
surface for one caller is cost with no buyer. Promoting the directory the day
a second consumer appears is a move, not a rewrite.

The command's I/O half (session enumeration, the `git log` spawn, the JSON
envelope) stays in `inspect.rs` where it always was.

## Ported unchanged in substance

- `CalibrationReport` and the two-cohort fold — unproven vs deterministic
  passes, reconciled forward within a stream by terminal CI only.
- `GroundTruth` — the artifact-keyed answer key: terminal CI verdicts from
  *every* recorded session, plus reverts read from git's own generated
  `This reverts commit <sha>.` body. The asymmetry is intact: a revert settles
  a pass as a false positive, absence of one confirms nothing.
- `GraderCohorts` — the unproven cohort split self-graded / independent /
  unknown, unknown excluded from both rates.

## Three things that are deliberately not copies

1. **`stands_alone` restates the predicate instead of calling it.** It used to
   call `LadderInputs::verifier_pass_stands_alone` precisely *because* an
   earlier restatement had drifted: #2191 taught the live predicate a third
   channel (`verify_done_flip`), the copy stayed at two conjuncts, and the
   uncorroborated tally over-counted every `verify_done`-rescued turn (#2194).
   That predicate no longer exists, so calling it is not an option and this is
   now the only copy — the old two-copies hazard is gone by construction. The
   test that pinned agreement is replaced by an exhaustive truth table over
   all 18 combinations of the three channels, through a JSON round trip,
   written as the De Morgan dual of the implementation so dropping a conjunct
   fails rather than silently widening the tally. The new hazard is named in
   the doc comment rather than papered over: a plugin's own ladder may credit
   corroboration through a channel `LadderSnapshot` has no field for, and this
   can only ever report what the snapshot recorded.

2. **Every citation of deleted machinery is retargeted.** The uncorroborated
   rate no longer claims to tune `PipelineConfig::verifier_evidence_demand`,
   a type that left with the pipeline; it is stated as the input for whatever
   evidence-demand policy a verification plugin implements, with #1211 §1's
   measurement kept as the reason a majority rate is the switch-it-off case.

3. **`verdicts_observed`, and an empty-record render.** Nothing in this
   workspace emits a `Verdict` any more — the built-in pipeline was its only
   in-tree producer — so "0 passes, 0 false positives" is now the most likely
   thing anyone sees, and it reads exactly like a flawless verifier. The
   report refuses that reading: it names itself as unmeasured, says why, and
   points at `stella plugin install` as the only remaining producer. This is
   the same discipline the unmeasured-vs-zero rule already keeps, applied one
   level up.

`--format json` also gains `by_grader`, which the human report has shown since
#1865 and the JSON never did — so anything scripting the command could not ask
the question that section exists to answer.

## Witness

`crates/stella-cli/tests/calibration_cli.rs` drives the real binary against a
real store and a real git repository containing a real revert, and asserts the
joined result of both ground-truth sources.

Demonstrated, not asserted: with `crates/stella-cli/src/inspect.rs` checked
out from the base commit and everything else unchanged, all three tests fail
at the `status.success()` check with the stub's error text; restored, all
three pass. 23 unit tests cover the fold itself.

## Gate

`make gate CARGO_SCOPE="-p stella-cli"` is green through every guard.

Two failures are **pre-existing on the base commit** and reproduce there with
this branch's code reverted — neither is caused by this change, and both are
already tracked:

- `doc-warnings` — four `redundant_explicit_links` errors in
  `crates/stella-cli/src/memory/reflection/digest.rs`, untouched here. #3979.
- `settings::tests::untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt`
  — fails whenever `STELLA_HOME` is isolated, which is exactly #3880.

## Docs

`website/content/docs/commands/calibration.mdx` was stale in two ways beyond
this change (it still said reverts were not a ground-truth source, closed by
#1293) and is rewritten to the post-#3865 reality. README's command row,
the website command index card, the clap help, and ROADMAP's now-dangling
`replay::*` module paths are updated in step.

## Deleted tests

None.

## Summary by Sourcery

Reinstate standalone `stella calibration` with cross-session CI and git-revert ground truth, richer cohort reporting, and honest empty-state metrics.

New Features:
- Restore the `stella calibration` command with standalone pass-verdict measurement against CI results and git reverts.
- Add late evidence reconciliation across sessions and an artifact-keyed ground-truth answer key.
- Expose grader-independence cohorts and additional calibration metrics in human-readable and JSON output.

Bug Fixes:
- Prevent empty workspaces from appearing to have a perfect verifier by explicitly reporting that no verdicts were observed.
- Count worker `verify_done` corroboration correctly when calculating uncorroborated verdict rates.

Enhancements:
- Keep calibration logic as a pure CLI module while retaining session, store, and git integration in inspection code.
- Preserve unmeasured rates as unmeasured and distinguish CI failures from human reverts in calibration results.

Documentation:
- Update calibration command documentation, CLI help, README, website command index, and roadmap references for CI and revert-based calibration.

Tests:
- Add unit coverage for calibration cohorts, ground-truth reconciliation, corroboration channels, grader partitions, and unmeasured output.
- Add end-to-end CLI coverage using a real event store and git repository with a reverted commit.