### PR TITLE
feat(stella-cli): a fleet attempt mines its own turn, into the invocation root (#3956)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -69,6 +69,7 @@ use graph::{GraphSummary, format_graph_stats, index_workspace_graph_blocking};
 pub use init::run_init;
 pub(crate) use init::{InitIo, InitLine, deck_narrator, deck_notice_narrator, init_workspace};
 pub(crate) use outcome::settled_cost_since;
+pub(crate) use output::reflection_explicitly_disabled;
 use output::*;
 pub(crate) use persistence::{
     PersistOutcome, ReasoningRun, begin_execution, close_event_stream, flush_reasoning_tail,

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -272,7 +272,14 @@ pub(crate) fn one_shot_reflection_enabled(format: OutputFormat) -> bool {
     supported_format && !reflection_explicitly_disabled()
 }
 
-fn reflection_explicitly_disabled() -> bool {
+/// The reflection opt-out itself, separated from the one-shot format question
+/// above because it is neither about one-shots nor about formats: it is the
+/// workspace-wide "do not spend the extra provider call" switch, and every door
+/// that spends one owes it. The fleet door reads it directly (#3956) — a wave
+/// of attempts is the largest batch of reflection calls Stella can make, so an
+/// automation that opted out would otherwise have opted out of the cheapest
+/// door and kept the dearest.
+pub(crate) fn reflection_explicitly_disabled() -> bool {
     std::env::var(DISABLE_REFLECTION_ENV).is_ok_and(|value| is_truthy_env_value(&value))
 }
 

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -25,6 +25,12 @@
 //! reason rather than a token one; an unattended lane is precisely where the
 //! repository's published steering should still apply.
 //!
+//! The lane steers **out** as well as in (#3956): an attempt mines its own turn
+//! like every other door, into the *invocation* root's memory rather than the
+//! disposable tree it ran in — see [`mine_attempt_lesson`] for why those two
+//! roots differ, what an unattended lane is and is not allowed to teach, and
+//! how the extra call stays inside the `--spend-limit` below.
+//!
 //! The
 //! parent `--spend-limit` is enforced twice, per the fleet's contract: each child
 //! runs under its own enforced guard, and the fleet stops launching new
@@ -747,13 +753,112 @@ async fn worker_recall_block(
     memory.arm_recall_control();
     let recalled = memory.recall_block_reported(prompt).await;
     let event = recalled.telemetry_event();
-    // `memory` is dropped here: this wires the steering that reaches a worker,
-    // not the reflection that would come back out of one. A fleet attempt still
-    // mines no lessons from its own turn, unlike `stella run` and the REPL —
-    // tracked as its own change rather than smuggled into this one (#3956),
-    // because where the lesson lands is a real decision in a disposable
-    // worktree, not a wiring detail.
+    // `memory` is dropped here, and deliberately not carried to the reflection
+    // below: this handle is rooted at the attempt's own tree, and a lesson
+    // written through it would land in a database that is deleted with the
+    // worktree. [`mine_attempt_lesson`] opens its own, at the invocation root.
     (recalled.text, event)
+}
+
+/// Mine one fleet attempt's turn into the workspace's memory — the steering
+/// *out* of an unattended lane, where [`worker_recall_block`] is the steering
+/// in (#3956).
+///
+/// Every other door does this: `stella run`, `/goal` and the REPL all keep
+/// their `SessionMemory` alive past the turn and reflect on it. A fleet attempt
+/// did not, which made the fan-out asymmetric in the direction that compounds —
+/// it consumed the skills and records other doors' reflections produced and
+/// contributed none, so every fleet run left the corpus relatively staler. A
+/// wave is also the largest batch of turns a workspace ever runs and the one
+/// nobody is watching, which is where a mined lesson is worth the most.
+///
+/// **Where the lesson lands is the decision, not the wiring.** Recall is rooted
+/// at the attempt's own tree; this is rooted at `invocation_root`, and the two
+/// are genuinely different for an isolated task. Both choices are correct for
+/// their half: recall must see the tree the work happens in, while a lesson
+/// written into a linked worktree's `.stella/private/context.db` — a fresh
+/// empty file, because `.stella/private/` is gitignored and does not travel
+/// with `git worktree add` — would be deleted along with the worktree that
+/// taught it. It is the same split, for the same reason, that
+/// [`agent::open_store`] is called against `cfg.workspace_root` for the
+/// coordination store while the attempt's own telemetry store is rooted in the
+/// task tree.
+///
+/// **What an unattended lane may teach.** Opened through
+/// [`crate::memory::SessionMemory::open`] rather than `open_for_session`, so
+/// `include_workspace_skills` is false: the lesson reaches `context.db` and the
+/// proposal ledger, where recall and `stella proposals list` find it, but a
+/// worker never publishes a `SKILL.md` or a rule FILE into the operator's
+/// workspace. Promotion to something that steers every later turn stays an
+/// attended decision — and the file writes are the half that would have N
+/// concurrent workers racing one no-clobber check. The store itself takes
+/// concurrent writers by construction (WAL, `busy_timeout`), which is the same
+/// property `ab_control`'s durable counter already relies on and names a fleet
+/// among its cases; a wave that did contend past the timeout loses that
+/// lesson and nothing else, on the best-effort contract the whole learning
+/// loop already runs under — never a failed attempt.
+///
+/// **What it costs.** One model call per attempt that warrants one, on the same
+/// terms as every other door: gated by `turn_warrants_reflection` so a tool-free
+/// turn spends nothing, bounded by this child's remaining headroom, and settled
+/// back into its `BudgetGuard` — so the reflection lands inside the
+/// `--spend-limit` the fleet enforces twice (the child's own cap here, and the
+/// metered total the parent stops new waves on), rather than beside it.
+/// `STELLA_DISABLE_REFLECTION` turns it off, the same switch the one-shot door
+/// reads.
+///
+/// The report's own accounting events are dropped rather than emitted: this
+/// runs after the attempt's event channel has closed and its renderer has
+/// drained (the friction fold needs the finished journal), and a second,
+/// unframed event sequence after a stream's terminal frame is exactly what
+/// `surface_reflection` refuses to write on every machine surface. The *cost*
+/// is not dropped — it is in the guard, and from there in the attempt's
+/// execution row and the fleet ledger.
+async fn mine_attempt_lesson(
+    invocation_root: &Path,
+    cfg: &Config,
+    provider: &dyn stella_protocol::Provider,
+    evidence: crate::memory::TurnEvidence<'_>,
+    execution_id: Option<i64>,
+    budget: &mut stella_core::BudgetGuard,
+) -> Option<crate::memory::ReflectionReport> {
+    let mut memory = crate::memory::SessionMemory::open(invocation_root, false)?;
+    if let Some(id) = execution_id {
+        memory.set_execution_id(id);
+    }
+    // `quiet`, for the Command Deck's reason: with `--watch` a live grid owns
+    // the terminal, and a per-worker reflection line would be N-fold noise
+    // painted over it.
+    let mut report = crate::memory::reflect_routed(
+        &mut memory,
+        cfg,
+        provider,
+        evidence,
+        true,
+        agent::remaining_budget(budget),
+    )
+    .await;
+    agent::settle_reflection_budget(&mut report, budget);
+    Some(report)
+}
+
+/// Whether `attempt_root` and `invocation_root` are the same tree, so a row id
+/// minted in one is meaningful in the other.
+///
+/// The question is never cosmetic: execution ids are per-database autoincrement
+/// keys, so stamping an isolated attempt's id (minted in its worktree's
+/// `store.db`) onto a reflection writing into the invocation root's store would
+/// file that turn's self-review against whatever unrelated execution happens to
+/// hold the same number. Canonicalized so a shared task is recognised as one
+/// through a symlinked or non-normalized path, and falling back to plain
+/// equality when a path cannot be resolved — a false negative only drops the
+/// self-review, which is the documented `None` degradation, while a false
+/// positive would write a wrong row.
+fn same_tree(attempt_root: &Path, invocation_root: &Path) -> bool {
+    match (attempt_root.canonicalize(), invocation_root.canonicalize()) {
+        (Ok(attempt), Ok(invocation)) => attempt == invocation,
+        _ => attempt_root == invocation_root,
+    }
 }
 
 /// One worker turn in `root`, on the calling thread's runtime — the
@@ -801,6 +906,11 @@ async fn run_task(
         None => None,
     };
 
+    // Where `stella fleet` was invoked, captured before the per-worker override
+    // below takes `cfg.workspace_root` away. It is where this attempt's mined
+    // lesson lands (`mine_attempt_lesson`) — the one durable tree in a run whose
+    // task trees may not outlive it.
+    let invocation_root = cfg.workspace_root.clone();
     let mut cfg = cfg.clone();
     cfg.workspace_root = root.to_path_buf();
     let provider = agent::build_provider(&cfg)?;
@@ -883,6 +993,10 @@ async fn run_task(
     let (recall_text, recall_event) =
         worker_recall_block(root, &cfg, &active_rules, &task.prompt).await;
     crate::memory::inject_recall_block(&mut messages, recall_text);
+    // Everything the engine appends past here is this attempt's own work; the
+    // reflection gate reads only that slice, so a turn that called no tool
+    // spends no model call on being mined (`turn_warrants_reflection`).
+    let turn_start = messages.len();
     // Each child runs under its own enforced guard at the full cap; the
     // parent fleet guard additionally stops new waves on the metered sum.
     let mut budget = agent::build_budget_guard(budget_limit);
@@ -1052,6 +1166,39 @@ async fn run_task(
     drop(tx);
     let rendered = renderer.await.unwrap_or_default();
     claims.release_all();
+
+    // The steering out of this lane (#3956). Placed here, after the renderer has
+    // drained and before the spend is read: the friction fold needs the finished
+    // journal, and the guard has to have absorbed the reflection call before
+    // `spent` becomes this attempt's cost in the execution row, the fleet ledger
+    // and the parent's metered total.
+    //
+    // A stopped attempt is not mined, on the same rule the other doors apply
+    // (`should_reflect_on`): an operator's soft stop is the one outcome that is
+    // not a learning signal — nothing concluded, and the transcript ends
+    // mid-thought.
+    if !force_incomplete
+        && !agent::reflection_explicitly_disabled()
+        && crate::memory::turn_warrants_reflection(&messages[turn_start..])
+    {
+        // Folded from the journal the renderer just finished draining (#3946) —
+        // what the turn cost, how long it took, and whether it retried or
+        // looped, none of which the transcript records.
+        let friction = crate::memory::TurnFriction::from_events(&rendered.events);
+        mine_attempt_lesson(
+            &invocation_root,
+            &cfg,
+            &*provider,
+            crate::memory::TurnEvidence::with_friction(&messages, &friction, success),
+            // Only when this attempt's execution was minted in the very store
+            // the lesson is being written into — see `same_tree`.
+            same_tree(root, &invocation_root)
+                .then(|| execution.as_ref().map(|(_, id)| *id))
+                .flatten(),
+            &mut budget,
+        )
+        .await;
+    }
 
     let spent = budget.session_spent_usd();
     let _ = finalize_fleet_execution(

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -596,3 +596,207 @@ async fn a_fleet_worker_receives_skills_records_and_todays_date() {
          operand without this line (#2901):\n{block}"
     );
 }
+
+/// Answers one reflection call with a single lesson, at a known price.
+///
+/// The price is the point of the `cost_usd` field: a reflection that is not
+/// settled back into the attempt's guard is a call the `--spend-limit` never
+/// saw, and only a non-zero cost can tell that apart from a settled one.
+struct OneLesson;
+
+#[async_trait::async_trait]
+impl stella_protocol::Provider for OneLesson {
+    fn id(&self) -> &str {
+        "one-lesson"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<stella_protocol::CompletionResult, stella_protocol::ProviderError> {
+        Ok(stella_protocol::CompletionResult {
+            upstream_provider: None,
+            text: r#"{"lessons": [
+                {"lesson": "the billing migration must be run with the ledger writer stopped",
+                 "trigger": "a task touches the billing migration",
+                 "saves": "a corrupted ledger",
+                 "kind": "domain", "domains": []}
+            ]}"#
+            .into(),
+            tool_calls: vec![],
+            usage: stella_protocol::CompletionUsage {
+                reported: true,
+                input_tokens: 1,
+                ..stella_protocol::CompletionUsage::default()
+            },
+            model: "one-lesson".into(),
+            cost_usd: 0.02,
+            finish_reason: None,
+        })
+    }
+}
+
+/// A transcript that warrants reflection — a tool call, which is what
+/// `turn_warrants_reflection` gates the whole mining call on.
+fn mined_transcript() -> Vec<CompletionMessage> {
+    let mut worked = CompletionMessage::assistant("running it");
+    worked.tool_calls = vec![stella_protocol::ToolCall {
+        call_id: "c1".into(),
+        name: "bash".into(),
+        input: serde_json::json!({"command": "make migrate"}),
+    }];
+    vec![
+        CompletionMessage::user("run the billing migration"),
+        worked,
+        CompletionMessage::assistant("migration applied"),
+    ]
+}
+
+/// **Witness (#3956).** A lesson mined by a fleet worker is readable from the
+/// primary workspace after the run — and is not written into the disposable
+/// tree the attempt ran in.
+///
+/// Fails on base, where `mine_attempt_lesson` does not exist because a fleet
+/// attempt mined nothing at all: `worker_recall_block` opened a `SessionMemory`,
+/// recalled through it and dropped it before the turn ran, so the fan-out read
+/// the workspace's accumulated lessons and contributed none back.
+///
+/// The two roots are the substance of the test, not scenery. An isolated task
+/// runs in a linked worktree whose `.stella/private/` is gitignored and
+/// therefore absent, so mining into the attempt's own root would write every
+/// lesson a wave produced into databases that are deleted with their worktrees —
+/// a learning loop that runs, costs money, and forgets. Asserting only that a
+/// lesson was recorded would pass in exactly that broken arrangement, which is
+/// why the negative half below is what makes this a witness.
+#[tokio::test]
+async fn a_worker_mines_its_lesson_into_the_invocation_root_not_its_worktree() {
+    let (td, _guard, invocation_root) = steered_workspace();
+    // The attempt's own tree — a sibling of the invocation root, standing in for
+    // the linked worktree an isolated task runs in.
+    let attempt_root = td.path().join("worktree");
+    std::fs::create_dir_all(&attempt_root).expect("attempt tree");
+    let cfg = steered_config(attempt_root.clone());
+
+    let messages = mined_transcript();
+    let friction = crate::memory::TurnFriction::default();
+    let mut budget = agent::build_budget_guard(Some(10.0));
+    budget.begin_turn();
+
+    let report = super::mine_attempt_lesson(
+        &invocation_root,
+        &cfg,
+        &OneLesson,
+        crate::memory::TurnEvidence::with_friction(&messages, &friction, true),
+        None,
+        &mut budget,
+    )
+    .await
+    .expect("the invocation root's memory opens");
+
+    assert_eq!(
+        report.recorded, 1,
+        "the scripted lesson must reach a store: {report:?}"
+    );
+
+    // The DoD's question, asked the way an operator would ask it: open the
+    // primary workspace fresh, as a later session does, and recall.
+    let after_the_run =
+        crate::memory::SessionMemory::open(&invocation_root, false).expect("primary workspace");
+    let recalled = after_the_run
+        .recall_block_reported("a task touches the billing migration")
+        .await
+        .text
+        .unwrap_or_default();
+    assert!(
+        recalled.contains("ledger writer stopped"),
+        "a lesson a worker mined must be readable from the primary workspace \
+         after the run — this is the block a later session would receive:\n{recalled}"
+    );
+
+    // The negative half: nothing was written into the tree that gets deleted.
+    let stranded = attempt_root
+        .join(".stella")
+        .join("private")
+        .join("context.db");
+    assert!(
+        !stranded.exists(),
+        "the attempt's own tree must hold no mined lesson — a worktree's context \
+         store dies with the worktree, so a lesson written there is a call the \
+         operator paid for and can never read back: {}",
+        stranded.display()
+    );
+
+    // And the call is inside the fleet's spend contract rather than beside it.
+    assert!(
+        (budget.session_spent_usd() - 0.02).abs() < f64::EPSILON,
+        "the reflection call must settle into the attempt's guard, which is what \
+         puts it inside the `--spend-limit` the fleet enforces twice: {}",
+        budget.session_spent_usd()
+    );
+}
+
+/// The guard on the cross-store hazard (#3956): an execution id means something
+/// only in the database that minted it.
+///
+/// An isolated attempt's execution is opened in its worktree's `store.db` while
+/// its lesson is written into the invocation root's, and both are
+/// autoincrement keys — so a stamped id would file the turn's self-review
+/// against whatever unrelated execution happens to hold that number. The
+/// non-normalized form is the case worth pinning: it must still be recognised
+/// as the same tree, because a false negative here silently drops the
+/// self-review of every shared-tree attempt.
+#[test]
+fn only_a_shared_tree_attempt_shares_the_invocation_root_s_row_ids() {
+    let td = tempfile::tempdir().unwrap();
+    let invocation = td.path().join("repo");
+    let worktree = td.path().join("worktrees").join("t1");
+    std::fs::create_dir_all(&invocation).unwrap();
+    std::fs::create_dir_all(&worktree).unwrap();
+
+    assert!(
+        same_tree(&invocation, &invocation),
+        "a shared-tree task runs in the invocation root itself"
+    );
+    assert!(
+        same_tree(&invocation.join("."), &invocation),
+        "a non-normalized path to the same tree must not read as a different \
+         store — that would drop the self-review it is safe to write"
+    );
+    assert!(
+        !same_tree(&worktree, &invocation),
+        "an isolated attempt's worktree is a different database; stamping its \
+         execution id into the invocation root's store writes a wrong row"
+    );
+}
+
+/// The other half of the #3956 witness: the first test calls the seam directly,
+/// so it would still pass with the production call site reverted. This asserts
+/// the wiring — that the attempt reflects, and that it does so where the cost
+/// can still reach the ledger.
+///
+/// Source-level for the reason `the_reflecting_doors_fold_a_ledger_and_reflect_with_it`
+/// (`memory/reflection/tests.rs`) is: observing it otherwise means standing up a
+/// provider, a git worktree, a store and a renderer task to watch one call. The
+/// names asserted on are real items, so a rename breaks the compile too.
+#[test]
+fn a_fleet_attempt_reflects_before_its_spend_is_read() {
+    const FLEET: &str = include_str!("../fleet_cmd.rs");
+
+    let call = FLEET
+        .find("mine_attempt_lesson(\n")
+        .expect("run_task must mine the attempt's turn (#3956)");
+    let spend = FLEET
+        .find("let spent = budget.session_spent_usd();")
+        .expect("run_task must still read the attempt's spend");
+    assert!(
+        call < spend,
+        "the reflection has to settle into the guard BEFORE the spend is read — \
+         after it, the call is real money the execution row, the fleet ledger and \
+         the parent's metered total never see"
+    );
+    assert!(
+        FLEET.contains("&invocation_root,"),
+        "the lesson must be mined against the invocation root; against the \
+         attempt's root it dies with the worktree"
+    );
+}

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -782,8 +782,11 @@ fn only_a_shared_tree_attempt_shares_the_invocation_root_s_row_ids() {
 fn a_fleet_attempt_reflects_before_its_spend_is_read() {
     const FLEET: &str = include_str!("../fleet_cmd.rs");
 
+    // `rfind` so we anchor on the call site, not the `async fn` definition —
+    // the definition also matches `mine_attempt_lesson(\n` but sits above both
+    // the call and the spend read, which would make the ordering assert vacuous.
     let call = FLEET
-        .find("mine_attempt_lesson(\n")
+        .rfind("mine_attempt_lesson(\n")
         .expect("run_task must mine the attempt's turn (#3956)");
     let spend = FLEET
         .find("let spent = budget.session_spent_usd();")


### PR DESCRIPTION
Closes #3956. Refs #3947.

Answers #3956 with **(a)**: a fleet attempt now mines a lesson like every other door.

## The defect

`stella run`, the REPL and `/goal` all keep their `SessionMemory` alive past the turn and reflect on it. A fleet attempt did not — `worker_recall_block` opened one, recalled through it, and dropped it before the turn ran. So the fan-out read the workspace's accumulated lessons and contributed none back.

That is asymmetric in the direction that compounds: fleet *consumes* the skills and records other doors' reflections produced, and produces none, so every fleet run left the corpus relatively staler. A wave is also the largest batch of turns a workspace ever runs, and the one nobody is watching.

## The three things #3956 said had to be decided, not wired

**Where the lesson lands.** Recall stays rooted at the attempt's own tree; mining is rooted at the invocation root. An isolated task's `.stella/private/` is gitignored and does not travel with `git worktree add`, so its `context.db` is a fresh empty file — a lesson written there is deleted with the worktree that taught it. Both roots are correct for their half, and the split is now stated at both ends (`worker_recall_block` says why it does *not* carry its handle forward; `mine_attempt_lesson` says why it opens its own). It is the same split `agent::open_store` already makes for the coordination store.

**What an unattended lane may teach.** Opened through `SessionMemory::open` rather than `open_for_session`, so `include_workspace_skills` is false. The lesson reaches `context.db` and the proposal ledger — where recall and `stella proposals list` find it — but a worker publishes no `SKILL.md` and no rule FILE into the operator's workspace. Promotion to something that steers every later turn stays an attended decision, and the file writes are exactly the half that would have N concurrent workers racing one no-clobber check.

**Cost.** One call per attempt that warrants one: gated by `turn_warrants_reflection` (a tool-free turn spends nothing), bounded by the child's remaining headroom, and settled back into its `BudgetGuard` **before** `spent` is read — so it lands inside the `--spend-limit` the fleet enforces twice rather than beside it, and reaches the execution row and the fleet ledger. `STELLA_DISABLE_REFLECTION` turns it off, which is why that opt-out moved out of the one-shot door's private scope; an automation that opted out would otherwise have opted out of the cheapest door and kept the dearest. A stopped attempt is not mined, on the rule `should_reflect_on` already applies.

**Write contention**, the fourth question the issue raised: the store takes concurrent writers by construction (WAL, `busy_timeout`) — the property `ab_control`'s durable counter already relies on, and whose docs name a fleet among its cases. A wave that contends past the timeout loses that lesson and nothing else, on the best-effort contract the learning loop already runs under.

## A cross-store hazard this had to avoid

Execution ids are per-database autoincrement keys. An isolated attempt's execution is minted in its **worktree's** `store.db`, while the reflection writes into the **invocation root's** — so stamping that id would file the turn's self-review against whatever unrelated execution happens to hold the same number. `same_tree` stamps it only when the two are one tree (a shared-tree task); otherwise the self-review is dropped, which is the documented `None` degradation.

## Witness

`a_worker_mines_its_lesson_into_the_invocation_root_not_its_worktree` mines through the seam with a scripted provider and asserts three things: the lesson is readable from the primary workspace opened fresh afterwards, the attempt's tree holds no context store, and the guard absorbed the call's $0.02.

**Checked against its opposite**, per the rule that evidence must distinguish a claim from its negation: pointing the mine at `attempt_root` instead fails it on the recall assertion, exactly as predicted — asserting only "a lesson was recorded" would have passed in the broken arrangement.

`a_fleet_attempt_reflects_before_its_spend_is_read` pins the wiring and the placement (source-level, the pattern `the_reflecting_doors_fold_a_ledger_and_reflect_with_it` established).

No tests were deleted.

## Gate

`guards-fast`, `clippy -D warnings`, `cargo doc -D warnings` (my own links included — one unresolved `SessionMemory::open` was caught and fixed) and the full `stella-cli` suite are green.

**`main` is independently red** on `cargo doc -D warnings` (five pre-existing `redundant explicit link target` errors; CI run 32295835836), so this PR's checks will be red until **#3981** lands — that repair is split out rather than folded in here.

## Summary by Sourcery

Make fleet attempts reflect on eligible turns and persist their lessons in the invocation workspace within the fleet's spending contract.

New Features:
- Mine lessons from fleet attempts into the invocation workspace so unattended runs contribute to future recall and proposals.

Bug Fixes:
- Include fleet reflection costs in each attempt's budget and fleet spend accounting.
- Avoid associating isolated worktree execution IDs with reflections stored in the invocation workspace.

Enhancements:
- Respect reflection eligibility, cancellation, concurrency, and workspace-wide opt-out behavior for fleet attempts while keeping unattended mining from publishing workspace skill or rule files.

Documentation:
- Document the fleet reflection behavior, workspace-root storage choice, budget handling, and execution-ID safeguards.

Tests:
- Add coverage proving fleet lessons are persisted in the invocation workspace, excluded from disposable worktrees, budgeted correctly, and wired before spend accounting.