### PR TITLE
fix(stella-cli): restore the deck forwarder's friction binding — main does not compile

### DIFF
--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -88,6 +88,11 @@ pub(crate) fn spawn_forwarder(
         // forwarder, and a forwarder is one lane — every lane has a registry
         // and a channel of its own, so two lanes' thoughts cannot fuse.
         let mut reasoning = agent::ReasoningRun::default();
+        // The lane's friction ledger (#3962), folded as the stream goes past
+        // rather than from a collected `Vec` the way `agent::run_turn` does:
+        // this task forwards each event and keeps none, and a ledger is bounded
+        // where a retained journal is not.
+        let mut friction = TurnFriction::default();
         // Two independent latches, not one. A single shared flag meant an
         // early usage gap — the benign, self-healing condition — silenced any
         // later store-write failure, which is the one that actually points at


### PR DESCRIPTION
`origin/main` at e26208db7 fails to build `stella-cli`:

```
error[E0425]: cannot find value `friction` in this scope
  --> crates/stella-cli/src/command_deck/forwarder.rs:195:13
  --> crates/stella-cli/src/command_deck/forwarder.rs:309:13
```

`LaneStreamEnd::friction` and both of its uses are still there; only the
`let mut friction = TurnFriction::default();` that fed them is gone.

## Two green PRs, one red tree

This is the composition break AGENTS.md's `main-canary.yml` section describes,
in its purest form. #3978 introduced the binding with its comment at the top of
the spawned forwarder task; #3980 rewrote that same span to introduce
`ReasoningRun` and, having branched before #3978 landed, wrote its lines where
the other's had been. Textually clean, no conflict for git to report, and
neither author's tree was wrong — the composed one is.

Restoring the binding is the whole fix; the comment comes back with it because
it explains why the ledger is folded here rather than collected.

## Evidence

- `cargo check -p stella-cli --all-targets` on a detached `origin/main`
  (e26208db7), clean tree: **fails** with the two errors above.
- The same command with this commit: **passes**.

## Witness

None, and deliberately: this restores a deleted line rather than changing
behaviour, and every existing test that exercises the deck forwarder was
already unable to compile. The compiler is the witness — `cargo check` is red
before and green after.

While main is red, every PR's checks are red too, which is exactly the state
`main-red-hold.yml` exists to stop compounding.

The post-merge canary caught this and filed #3990 — the machinery worked. What
it cannot do is repair the tree, which is what this PR is for.

Closes #3990

## Summary by Sourcery

Bug Fixes:
- Restore the deck forwarder’s friction ledger binding so `stella-cli` builds successfully again.