### PR TITLE
fix(stella-cli): main does not compile — restore the friction binding #3962 and #3969 composed away

### DIFF
--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -83,6 +83,18 @@ pub(crate) fn spawn_forwarder(
 ) -> tokio::task::JoinHandle<LaneStreamEnd> {
     tokio::spawn(async move {
         let mut seq = 0u64;
+        // The lane's friction ledger (#3962), folded as the stream goes past
+        // rather than from a collected `Vec` the way `agent::run_turn` does:
+        // this task forwards each event and keeps none, and a ledger is bounded
+        // where a retained journal is not.
+        //
+        // This declaration is the one #3962 and #3969 composed away between
+        // them: both PRs were green, and the textual merge took #3969's version
+        // of the hunk that opened this task — which carried its own `reasoning`
+        // binding and not this one — while keeping #3962's two *uses* below.
+        // Neither author's tree was wrong, which is why no pre-merge check
+        // could see it (AGENTS.md, `main-canary.yml`).
+        let mut friction = TurnFriction::default();
         // This lane's open run of streamed reasoning fragments, joined into one
         // row per thought rather than one per few tokens (#3969). One run per
         // forwarder, and a forwarder is one lane — every lane has a registry


### PR DESCRIPTION
**`main` does not compile.** At `e26208db7`, `cargo check -p stella-cli` fails with two errors:

```
error[E0425]: cannot find value `friction` in this scope
  --> crates/stella-cli/src/command_deck/forwarder.rs:195:13
error[E0425]: cannot find value `friction` in this scope
  --> crates/stella-cli/src/command_deck/forwarder.rs:309:13
```

Every PR opened against `main` right now is red for this reason and not its own, which is the condition `main-red-hold.yml` exists for.

## Neither PR was wrong

- **#3962 (#3978)** added `let mut friction = TurnFriction::default();` at the top of `spawn_forwarder`'s spawned task, folded each event into it (`friction.observe(&event)`), and returned it in the new `LaneStreamEnd`.
- **#3969 (#3980)** then rewrote the *same opening hunk* to introduce its own `ReasoningRun` binding.

The textual merge took #3969's version of that hunk — which carries `reasoning` and not `friction` — while keeping #3962's two **uses**, which sit in hunks #3969 never touched. Git had no conflict to report: one side simply does not contain the other's line. Both branches were green on their own; the composition is not.

This is exactly the shape AGENTS.md names for `main-canary.yml` — "a guard enforced against a shared cell can be satisfied correctly by two branches that still compose into a broken tree once both land. No pre-merge run can catch that: neither author's tree is wrong." The shared cell here is not a baseline file but a **function preamble** two PRs both had to extend.

## The fix

Restore the binding with its original comment, plus a short note recording how it was lost, so the next person editing this task's preamble knows there are now two bindings that have to survive it.

Deleting the two uses would also compile, and would be the wrong repair: it would silently un-wire the Command Deck's reflection evidence that #3962 landed, with the witnesses in `crates/stella-cli/src/memory/reflection/tests.rs` still passing — they assert on `forwarder.rs` containing `friction.observe(&event)`, which is the half that survived.

## Verified

- `cargo check -p stella-cli --all-targets` — clean (fails with the two errors above without this commit).
- `cargo test -p stella-cli --bin stella memory::reflection` — 34 passed, including `a_goal_arcs_rounds_reflect_separately_and_never_borrow_each_others_friction` and `the_reflecting_doors_fold_a_ledger_and_reflect_with_it`.

Refs #3962, #3978, #3969, #3980

## Summary by Sourcery

Bug Fixes:
- Restore the missing friction ledger binding so stella-cli compiles and preserves streamed event reflection tracking.