### PR TITLE
fix(stella-cli): ingest reads the whole document — slice it, never trim it (#2407)

### DIFF
--- a/crates/stella-cli/src/ingest_cmd.rs
+++ b/crates/stella-cli/src/ingest_cmd.rs
@@ -26,6 +26,7 @@ use colored::Colorize;
 use stella_core::ingest::lineage::AlertState;
 use stella_core::ingest::{self, Candidate, Plan, Tier};
 
+mod chunk;
 mod extract;
 pub(crate) mod lineage;
 pub(crate) mod probe;
@@ -36,17 +37,20 @@ pub(crate) use extract::derive_set_id;
 
 /// Largest slice of any one file read for classification.
 ///
-/// Must stay above `extract`'s prompt cap, or the scan hides documents the
+/// Must stay above `extract`'s document ceiling, or the scan hides documents the
 /// extractor would happily take: a file past this is dropped from the listing
 /// entirely, so at 64 KiB against a 120,000-character prompt cap a large
 /// `AGENTS.md` was ingestable by name and invisible to `stella ingest` with no
 /// arguments. `the_scan_never_hides_a_document_extraction_would_accept` pins the
-/// ordering so raising one cap cannot silently strand the other.
+/// ordering so raising one cap cannot silently strand the other — and it is the
+/// reason this number moved when the ceiling did: extraction now covers 720,000
+/// characters, which is 2.8 MiB of worst-case four-byte codepoints, and 512 KiB
+/// would have stranded every document between the two.
 ///
 /// Classification looks at the head and the bullet structure; a document that
 /// needs more than this to classify is not a document anyone hand-wrote as
 /// steering.
-const MAX_READ_BYTES: u64 = 512 * 1024;
+const MAX_READ_BYTES: u64 = 4 * 1024 * 1024;
 
 /// `stella ingest` — see what steering a workspace already contains.
 #[derive(Debug, Args)]
@@ -301,14 +305,14 @@ fn print_held_back(found: &[Found]) {
 
 /// Say how much of a document extraction will not read.
 ///
-/// Only the head of a long document reaches the model. Nothing used to tell the
-/// person who named the file, so at the old 24,000-character cap a 44,545-character
-/// `AGENTS.md` reported "688 lines", extracted 54% of itself, and read as a
-/// complete success — the god files, the glossary and the testing section could
-/// not have produced a record and no output said why. The cap is five times
-/// larger now, which moves the edge rather than removing it, so the notice still
-/// has to exist. Printed beside the line count so the two numbers a reader would
-/// compare sit together.
+/// Nothing used to tell the person who named the file, so at the old
+/// 24,000-character cap a 44,545-character `AGENTS.md` reported "688 lines",
+/// extracted 54% of itself, and read as a complete success — the god files, the
+/// glossary and the testing section could not have produced a record and no
+/// output said why. A document is divided rather than trimmed now, so this
+/// notice fires only past the whole-document ceiling; it still has to exist,
+/// because a ceiling that exists and stays quiet is the original defect. Printed
+/// beside the line count so the two numbers a reader would compare sit together.
 fn report_truncation(content: &str) {
     if let Some(notice) = truncation_notice(content) {
         println!("    {}", notice.yellow());
@@ -480,33 +484,45 @@ mod tests {
         assert_eq!(truncation_notice("# short\n\nnothing to drop.\n"), None);
     }
 
-    /// The witness for the 5x cap: the document that motivated all of this now
-    /// fits whole. At the old 24,000 it was extracted at 54% and reported
-    /// success, so a real `AGENTS.md` losing nothing is the thing to pin.
+    /// The witness for #2407: the document that motivated all of this is
+    /// extracted whole. At the old 24,000-character cap it was extracted at 54%
+    /// and reported success, so a real `AGENTS.md` losing nothing is the thing
+    /// to pin.
     #[test]
-    fn a_real_agents_md_now_fits_the_cap_whole() {
+    fn a_real_agents_md_is_extracted_whole() {
         // This repository's own AGENTS.md, 44,545 characters.
         assert_eq!(truncation_notice(&"x".repeat(44_545)), None);
     }
 
-    /// Still reported when a document genuinely exceeds the raised cap — a
-    /// bigger limit that lies about its own edge is the original defect again.
+    /// And so is a document many times larger — the size where the previous fix
+    /// (a raised single-call cap) started losing content again.
+    ///
+    /// Fails on the old code, which trimmed anything past 120,000 characters.
+    #[test]
+    fn a_document_far_past_the_old_cap_is_extracted_whole() {
+        assert_eq!(truncation_notice(&"x".repeat(600_000)), None);
+    }
+
+    /// Still reported when a document genuinely exceeds the whole-document
+    /// ceiling — a bigger limit that lies about its own edge is the original
+    /// defect again.
     #[test]
     fn an_oversized_document_says_how_much_is_skipped() {
-        let content = "x".repeat(160_000);
-        let notice = truncation_notice(&content).expect("a document over the cap is truncated");
-        assert!(notice.contains("120000"), "kept count missing: {notice}");
-        assert!(notice.contains("160000"), "total missing: {notice}");
-        assert!(notice.contains("40000"), "skipped count missing: {notice}");
+        let content = "x".repeat(960_000);
+        let notice = truncation_notice(&content).expect("a document over the ceiling truncates");
+        assert!(notice.contains("720000"), "kept count missing: {notice}");
+        assert!(notice.contains("960000"), "total missing: {notice}");
+        assert!(notice.contains("240000"), "skipped count missing: {notice}");
         assert!(notice.contains("25%"), "skipped share missing: {notice}");
     }
 
-    /// One character past the cap is still reported. A notice that appeared
+    /// One character past the ceiling is still reported. A notice that appeared
     /// only once the loss was large would be silent for exactly the documents
     /// whose missing tail is hardest to notice.
     #[test]
-    fn one_character_over_the_cap_is_still_reported() {
-        let notice = truncation_notice(&"x".repeat(120_001)).expect("one over the cap truncates");
+    fn one_character_over_the_ceiling_is_still_reported() {
+        let notice =
+            truncation_notice(&"x".repeat(720_001)).expect("one over the ceiling truncates");
         assert!(notice.contains("1 (0%)"), "{notice}");
     }
 
@@ -514,18 +530,18 @@ mod tests {
     ///
     /// `read_and_classify` returns `None` past `MAX_READ_BYTES`, which removes
     /// the file from the listing entirely rather than showing it as too large.
-    /// So the read cap has to clear the prompt cap at its widest — UTF-8 is up
+    /// So the read cap has to clear the document ceiling at its widest — UTF-8 is up
     /// to four bytes per character, and a cap counted in characters against one
     /// counted in bytes is exactly the mismatch that hides a document.
     #[test]
     fn the_scan_never_hides_a_document_extraction_would_accept() {
-        let widest_possible_bytes = extract::MAX_PROMPT_CHARS as u64 * 4;
+        let widest_possible_bytes = extract::MAX_DOCUMENT_CHARS as u64 * 4;
         assert!(
             MAX_READ_BYTES >= widest_possible_bytes,
             "the scan reads at most {MAX_READ_BYTES} bytes but extraction accepts up to \
              {} characters ({widest_possible_bytes} bytes of 4-byte codepoints) — a document \
              between the two is ingestable by name and invisible to the scan",
-            extract::MAX_PROMPT_CHARS,
+            extract::MAX_DOCUMENT_CHARS,
         );
     }
 

--- a/crates/stella-cli/src/ingest_cmd.rs
+++ b/crates/stella-cli/src/ingest_cmd.rs
@@ -535,13 +535,13 @@ mod tests {
     /// counted in bytes is exactly the mismatch that hides a document.
     #[test]
     fn the_scan_never_hides_a_document_extraction_would_accept() {
-        let widest_possible_bytes = extract::MAX_DOCUMENT_CHARS as u64 * 4;
+        let widest_possible_bytes = chunk::MAX_DOCUMENT_CHARS as u64 * 4;
         assert!(
             MAX_READ_BYTES >= widest_possible_bytes,
             "the scan reads at most {MAX_READ_BYTES} bytes but extraction accepts up to \
              {} characters ({widest_possible_bytes} bytes of 4-byte codepoints) — a document \
              between the two is ingestable by name and invisible to the scan",
-            extract::MAX_DOCUMENT_CHARS,
+            chunk::MAX_DOCUMENT_CHARS,
         );
     }
 

--- a/crates/stella-cli/src/ingest_cmd/chunk.rs
+++ b/crates/stella-cli/src/ingest_cmd/chunk.rs
@@ -70,6 +70,19 @@ pub(super) const TARGET_CHARS: usize = 24_000;
 /// half the old cap was missing.
 pub(super) const MAX_DOCUMENT_CHARS: usize = 720_000;
 
+/// The single-call cap this ceiling replaces, kept only as the thing the
+/// assertion below measures against.
+const REPLACED_SINGLE_CALL_CAP: usize = 120_000;
+
+// The promise, enforced at compile time rather than by a test: whatever else
+// changes here, the whole-document ceiling never falls back toward what one call
+// can carry. A test would assert this on constants the optimizer folds anyway —
+// a build error is both stronger and honest about when it is decided.
+const _: () = assert!(
+    MAX_DOCUMENT_CHARS >= REPLACED_SINGLE_CALL_CAP * 6,
+    "the document ceiling must stay at least 6x the single-call cap it replaced"
+);
+
 /// One slice of a document, and where in the document it came from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct Chunk {

--- a/crates/stella-cli/src/ingest_cmd/chunk.rs
+++ b/crates/stella-cli/src/ingest_cmd/chunk.rs
@@ -1,0 +1,364 @@
+//! Splitting a document into the slices extraction hands to the model, one call
+//! each.
+//!
+//! ## Why this exists
+//!
+//! Extraction used to cap the document instead of dividing it: everything past
+//! the cap was dropped before the model ever saw it, and the run reported
+//! success anyway. This repository's own `AGENTS.md` was extracted at 54% (#2407)
+//! — the cut landed mid-table, and the god-file rules, the glossary, the
+//! code-style conventions, the testing approach and the whole gotchas section
+//! could not produce a record and could not have. The documents the feature
+//! exists to read are exactly the documents that exceeded the cap.
+//!
+//! Raising the cap only moves that edge. The reply is roughly the size of the
+//! text that produced it — every claim restates its sentence and carries a dozen
+//! schema fields — so a bigger input buys a cut-off *reply* instead, and the
+//! smallest output ceiling in the seeded catalog is 30,000 tokens. So the
+//! document is divided and the claims merged: [`TARGET_CHARS`] is what one call
+//! is asked to read, and a document of any length is covered by as many calls as
+//! it takes.
+//!
+//! ## Where the seams go
+//!
+//! On markdown headings, never on a character offset. Cutting AGENTS.md at
+//! 24,000 characters severed a table row mid-cell, and a slice that opens in the
+//! middle of a sentence gives the extractor nothing to interpret it against.
+//! Headings are the seam the document itself declares, so a slice begins where a
+//! section begins and carries the heading path it sits under ([`Chunk::path`])
+//! for the slices that continue an oversized section.
+//!
+//! Fenced code blocks are tracked, because a `# comment` inside a shell fence is
+//! not a heading and splitting there produces an unterminated fence in both
+//! halves. Only ATX headings (`## Title`) open a section; a setext heading is not
+//! a seam, which costs a larger section that the size splitter below then divides
+//! anyway — a missed seam degrades to a coarser cut, never to a lost character.
+//!
+//! ## What is guaranteed
+//!
+//! Concatenating every chunk's [`Chunk::text`] reproduces the input exactly, up
+//! to the whole-document ceiling in [`bound`]. That property is what makes "the
+//! whole file is extracted" checkable rather than asserted, and it is the
+//! property the tests pin.
+
+/// The characters one model call is asked to read.
+///
+/// This is the cap extraction started with, restored to the job it was always
+/// right for. 24,000 was never a bad *call* size — it was a catastrophic
+/// *document* size, and the defect was applying it to the wrong noun. Sized so
+/// the reply fits every seeded model rather than only the frontier ones: the
+/// output budget is scaled at one token per input character (measured, not
+/// guessed — see `extract::starting_output_budget`), and the smallest per-model
+/// output ceiling in the seeded catalog is 30,000 tokens. A slice at this size
+/// asks for at most 24,000, which every catalog model can answer in one reply.
+///
+/// A chunk may exceed this only when a single unbreakable line does.
+pub(super) const TARGET_CHARS: usize = 24_000;
+
+/// The whole document ceiling — the point at which ingest stops reading and says
+/// so.
+///
+/// Six times the 120,000 single-call cap this replaces, and thirty times the
+/// 24,000 that motivated #2407. An upper bound still has to exist: chunks are
+/// paid model calls, so a document is a real bill and an unbounded one is an
+/// unbounded bill. But it is set where no instruction file lives — 720,000
+/// characters is a few hundred pages — so the documents ingest exists for
+/// (`AGENTS.md`, `CLAUDE.md`, contributor guides, specs) are covered whole with
+/// an order of magnitude to spare, rather than being trimmed to fit.
+///
+/// A document that still exceeds it is truncated *and reported*, which is the
+/// half the old cap was missing.
+pub(super) const MAX_DOCUMENT_CHARS: usize = 720_000;
+
+/// One slice of a document, and where in the document it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Chunk {
+    /// The slice's text, verbatim. Concatenating these in order reproduces the
+    /// bounded document.
+    pub text: String,
+    /// The heading path in effect where this slice begins, outermost first —
+    /// `["Architecture", "Ports"]` for a slice inside `### Ports` under
+    /// `## Architecture`. Empty for a document's preamble.
+    ///
+    /// Carried so a slice that continues an oversized section can tell the model
+    /// what it is reading. A slice that opens on its own heading repeats it here,
+    /// which is harmless and keeps the field's meaning one thing.
+    pub path: Vec<String>,
+}
+
+/// Cap the document at [`MAX_DOCUMENT_CHARS`], returning the kept text and the
+/// number of characters dropped.
+///
+/// Truncates on a line boundary when one is available, because a document cut
+/// mid-line ends in a fragment the extractor would read as a whole claim.
+pub(super) fn bound(content: &str) -> (String, usize) {
+    let total = content.chars().count();
+    if total <= MAX_DOCUMENT_CHARS {
+        return (content.to_string(), 0);
+    }
+    let kept: String = content.chars().take(MAX_DOCUMENT_CHARS).collect();
+    // Prefer the last complete line; fall back to the hard cut for a document
+    // with no newline in 720,000 characters, where there is no boundary to find.
+    let kept = match kept.rfind('\n') {
+        Some(at) if at > 0 => kept[..at].to_string(),
+        _ => kept,
+    };
+    let dropped = total - kept.chars().count();
+    (kept, dropped)
+}
+
+/// How many characters of `content` extraction will not read.
+pub(super) fn dropped_chars(content: &str) -> usize {
+    bound(content).1
+}
+
+/// Divide `content` into slices of at most [`TARGET_CHARS`] characters, cutting
+/// at heading seams where possible and inside a section only when one section is
+/// larger than a whole slice.
+///
+/// Empty input yields no chunks: there is nothing to ask a model about.
+pub(super) fn split(content: &str) -> Vec<Chunk> {
+    if content.trim().is_empty() {
+        return Vec::new();
+    }
+    let mut chunks: Vec<Chunk> = Vec::new();
+    let mut open: Option<Chunk> = None;
+
+    for section in sections(content) {
+        let len = section.text.chars().count();
+        // The section fits in a slice of its own. Extend the open slice if it
+        // still has room, so a document of many short sections does not become
+        // one call per heading.
+        if len <= TARGET_CHARS {
+            match open.as_mut() {
+                Some(chunk) if chunk.text.chars().count() + len <= TARGET_CHARS => {
+                    chunk.text.push_str(&section.text);
+                }
+                _ => {
+                    if let Some(chunk) = open.take() {
+                        chunks.push(chunk);
+                    }
+                    open = Some(Chunk {
+                        text: section.text,
+                        path: section.path,
+                    });
+                }
+            }
+            continue;
+        }
+        // One section larger than a slice: flush what is open and divide the
+        // section itself, every piece carrying the section's heading path.
+        if let Some(chunk) = open.take() {
+            chunks.push(chunk);
+        }
+        for piece in divide(&section.text) {
+            chunks.push(Chunk {
+                text: piece,
+                path: section.path.clone(),
+            });
+        }
+    }
+    if let Some(chunk) = open.take() {
+        chunks.push(chunk);
+    }
+    chunks
+}
+
+/// One heading-delimited section of a document.
+#[derive(Debug)]
+struct Section {
+    text: String,
+    path: Vec<String>,
+}
+
+/// Split `content` at ATX headings that are not inside a fenced code block.
+///
+/// Every character of the input lands in exactly one section, in order — the
+/// preamble before the first heading included, as a section with an empty path.
+fn sections(content: &str) -> Vec<Section> {
+    let mut out: Vec<Section> = Vec::new();
+    let mut current = String::new();
+    // The heading titles enclosing the *current* section, indexed by depth-1.
+    let mut stack: Vec<String> = Vec::new();
+    let mut path = Vec::new();
+    let mut fence: Option<Fence> = None;
+
+    for line in lines_with_endings(content) {
+        if let Some(open) = fence.as_ref() {
+            if closes(line, open) {
+                fence = None;
+            }
+            current.push_str(line);
+            continue;
+        }
+        if let Some(open) = opens_fence(line) {
+            fence = Some(open);
+            current.push_str(line);
+            continue;
+        }
+        let Some((level, title)) = atx_heading(line) else {
+            current.push_str(line);
+            continue;
+        };
+        if !current.is_empty() {
+            out.push(Section {
+                text: std::mem::take(&mut current),
+                path: path.clone(),
+            });
+        }
+        stack.truncate(level - 1);
+        // A heading that skips a level (`#` then `###`) leaves a gap; pad it so
+        // depth stays the index and the path never silently reparents.
+        while stack.len() < level - 1 {
+            stack.push(String::new());
+        }
+        stack.push(title);
+        path = stack.iter().filter(|t| !t.is_empty()).cloned().collect();
+        current.push_str(line);
+    }
+    if !current.is_empty() {
+        out.push(Section {
+            text: current,
+            path,
+        });
+    }
+    out
+}
+
+/// Divide one oversized section into pieces of at most [`TARGET_CHARS`].
+///
+/// Cuts at a blank line first (a paragraph is the next-largest unit the document
+/// declares), then at any line boundary, and only splits a line when one line is
+/// itself longer than a whole slice — a minified or generated file, where there
+/// is no boundary left to respect.
+fn divide(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut open = String::new();
+    // The character position in `open` just after the last blank line, or 0 when
+    // there has been none — where a cut would fall on a paragraph boundary.
+    let mut last_break: Option<usize> = None;
+
+    for line in lines_with_endings(text) {
+        let len = line.chars().count();
+        if len > TARGET_CHARS {
+            if !open.is_empty() {
+                out.push(std::mem::take(&mut open));
+                last_break = None;
+            }
+            out.extend(hard_split(line));
+            continue;
+        }
+        if open.chars().count() + len > TARGET_CHARS {
+            match last_break {
+                // Cut at the paragraph boundary, carrying the trailing partial
+                // paragraph into the next piece.
+                Some(at) if at > 0 => {
+                    let byte = char_to_byte(&open, at);
+                    let tail = open[byte..].to_string();
+                    open.truncate(byte);
+                    out.push(std::mem::take(&mut open));
+                    open = tail;
+                }
+                _ => out.push(std::mem::take(&mut open)),
+            }
+            last_break = None;
+        }
+        open.push_str(line);
+        if line.trim().is_empty() {
+            last_break = Some(open.chars().count());
+        }
+    }
+    if !open.is_empty() {
+        out.push(open);
+    }
+    out
+}
+
+/// Split a single line longer than a whole slice, on character boundaries.
+fn hard_split(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut piece = String::new();
+    for ch in line.chars() {
+        if piece.chars().count() == TARGET_CHARS {
+            out.push(std::mem::take(&mut piece));
+        }
+        piece.push(ch);
+    }
+    if !piece.is_empty() {
+        out.push(piece);
+    }
+    out
+}
+
+/// The byte offset of character index `at` in `text`.
+fn char_to_byte(text: &str, at: usize) -> usize {
+    text.char_indices()
+        .nth(at)
+        .map_or(text.len(), |(byte, _)| byte)
+}
+
+/// Iterate lines *with* their line endings, so the pieces concatenate back to
+/// the input. `str::lines` drops the terminator, which would silently rewrite
+/// the document as it is sliced.
+fn lines_with_endings(text: &str) -> impl Iterator<Item = &str> {
+    let mut rest = text;
+    std::iter::from_fn(move || {
+        if rest.is_empty() {
+            return None;
+        }
+        let end = rest.find('\n').map_or(rest.len(), |at| at + 1);
+        let (line, tail) = rest.split_at(end);
+        rest = tail;
+        Some(line)
+    })
+}
+
+/// An open code fence: which character it uses and how many of them, since a
+/// fence is closed only by at least as many of the same character.
+struct Fence {
+    marker: char,
+    width: usize,
+}
+
+/// The fence this line opens, if it opens one.
+fn opens_fence(line: &str) -> Option<Fence> {
+    let trimmed = line.trim_start();
+    for marker in ['`', '~'] {
+        let width = trimmed.chars().take_while(|c| *c == marker).count();
+        if width >= 3 {
+            return Some(Fence { marker, width });
+        }
+    }
+    None
+}
+
+/// Does this line close `open`? A closing fence carries no info string, but an
+/// over-strict check would swallow the rest of the document, so the marker and
+/// width are what is required.
+fn closes(line: &str, open: &Fence) -> bool {
+    let trimmed = line.trim();
+    let width = trimmed.chars().take_while(|c| *c == open.marker).count();
+    width >= open.width && trimmed.chars().all(|c| c == open.marker)
+}
+
+/// The level and title of an ATX heading line (`## Title`), or `None`.
+fn atx_heading(line: &str) -> Option<(usize, String)> {
+    let trimmed = line.trim_start();
+    // Four spaces of indent is an indented code block, not a heading.
+    if line.len() - trimmed.len() >= 4 {
+        return None;
+    }
+    let level = trimmed.chars().take_while(|c| *c == '#').count();
+    if !(1..=6).contains(&level) {
+        return None;
+    }
+    let rest = &trimmed[level..];
+    if !rest.starts_with([' ', '\t']) && !rest.trim().is_empty() {
+        return None;
+    }
+    let title = rest.trim().trim_end_matches('#').trim().to_string();
+    Some((level, title))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/ingest_cmd/chunk/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/chunk/tests.rs
@@ -1,0 +1,272 @@
+//! The chunker's contract: every character survives, and the seams land where
+//! the document declares them.
+
+use super::*;
+
+/// Rebuild the document from its chunks. The property every other test leans
+/// on: a slicer that loses a character is the defect #2407 filed, wearing a
+/// different shape.
+fn rejoined(chunks: &[Chunk]) -> String {
+    chunks.iter().map(|c| c.text.as_str()).collect()
+}
+
+fn doc_with_sections(count: usize, body_chars: usize) -> String {
+    (0..count)
+        .map(|i| format!("## Section {i}\n\n{}\n\n", "x".repeat(body_chars)))
+        .collect()
+}
+
+/// The witness for #2407: a document far past any single-call cap is covered
+/// whole, not to the cap and no further.
+///
+/// Fails on the old code, where `bounded_content` returned the first 120,000
+/// characters and dropped the rest before the model was called.
+#[test]
+fn a_document_far_past_one_call_is_covered_completely() {
+    // 40 sections of 6,000 characters — 240,000 characters, twice the old
+    // single-call cap and ten times the cap that motivated the issue.
+    let doc = doc_with_sections(40, 6_000);
+    assert!(
+        doc.chars().count() > 200_000,
+        "fixture must exceed the old cap"
+    );
+
+    let chunks = split(&doc);
+
+    assert!(chunks.len() > 1, "a document this size must divide");
+    assert_eq!(rejoined(&chunks), doc, "every character must survive");
+    assert_eq!(
+        dropped_chars(&doc),
+        0,
+        "nothing is dropped below the document ceiling"
+    );
+}
+
+/// The specific document the issue is about. `AGENTS.md` at its filed size was
+/// extracted at 54%; every character of it now reaches a call.
+#[test]
+fn an_agents_md_sized_document_loses_nothing() {
+    let doc = doc_with_sections(8, 5_500); // ~44,500 characters
+    let chunks = split(&doc);
+
+    assert_eq!(rejoined(&chunks), doc);
+    let covered: usize = chunks.iter().map(|c| c.text.chars().count()).sum();
+    assert_eq!(covered, doc.chars().count(), "100% of the document is read");
+}
+
+/// Slices are what one model call can answer, so none may exceed the target
+/// unless a single unbreakable line does.
+#[test]
+fn no_chunk_exceeds_the_call_target() {
+    let doc = doc_with_sections(30, 7_000);
+    for chunk in split(&doc) {
+        assert!(
+            chunk.text.chars().count() <= TARGET_CHARS,
+            "chunk of {} characters exceeds the {TARGET_CHARS} target",
+            chunk.text.chars().count()
+        );
+    }
+}
+
+/// Short sections pack together rather than buying one paid call each.
+#[test]
+fn many_short_sections_share_a_call() {
+    let doc = doc_with_sections(50, 100);
+    let chunks = split(&doc);
+    assert_eq!(
+        chunks.len(),
+        1,
+        "50 short sections fit one call: {chunks:?}"
+    );
+}
+
+/// The seam is the heading, not an offset. Cutting AGENTS.md at a character
+/// offset severed a table row mid-cell; a chunk must start where a section does.
+#[test]
+fn chunks_begin_at_a_heading() {
+    let doc = doc_with_sections(6, 5_000);
+    let chunks = split(&doc);
+    assert!(chunks.len() > 1, "fixture must divide");
+    for chunk in &chunks {
+        assert!(
+            chunk.text.starts_with("## Section"),
+            "chunk did not begin at a heading: {:?}",
+            &chunk.text[..40.min(chunk.text.len())]
+        );
+    }
+}
+
+/// A `#` inside a fenced code block is a shell comment, not a heading. Splitting
+/// there leaves an unterminated fence in both halves.
+#[test]
+fn a_comment_inside_a_fence_is_not_a_seam() {
+    let doc = "\
+## Real heading
+
+```sh
+# not a heading
+make gate
+```
+
+more text
+";
+    let secs = sections(doc);
+    assert_eq!(secs.len(), 1, "the fence must not open a section: {secs:?}");
+    assert_eq!(secs[0].path, vec!["Real heading".to_string()]);
+}
+
+/// A tilde fence closes only on tildes, and a longer backtick fence only on at
+/// least as many backticks — otherwise a nested fence ends the outer one.
+#[test]
+fn fences_close_on_their_own_marker_and_width() {
+    let doc = "\
+# Top
+
+~~~
+# inside tildes
+~~~
+
+````
+```
+# inside nested backticks
+```
+````
+
+## Second
+";
+    let secs = sections(doc);
+    let paths: Vec<_> = secs.iter().map(|s| s.path.clone()).collect();
+    assert_eq!(
+        paths,
+        vec![vec!["Top".to_string()], vec!["Second".to_string()]],
+        "only the two real headings open sections"
+    );
+}
+
+/// A slice that continues an oversized section carries the heading path, so the
+/// extractor is not reading an unlabelled fragment.
+#[test]
+fn a_continued_section_carries_its_heading_path() {
+    let doc = format!(
+        "# Guide\n\n## Deep\n\n{}\n",
+        (0..40)
+            .map(|i| format!("paragraph {i} {}\n\n", "y".repeat(1_000)))
+            .collect::<String>()
+    );
+    let chunks = split(&doc);
+    assert!(chunks.len() > 1, "fixture must divide inside one section");
+    for chunk in chunks.iter().skip(1) {
+        assert_eq!(
+            chunk.path,
+            vec!["Guide".to_string(), "Deep".to_string()],
+            "a continuation must know where it is"
+        );
+    }
+    assert_eq!(rejoined(&chunks), doc);
+}
+
+/// Inside an oversized section the cut prefers a blank line: a paragraph is the
+/// next unit the document declares after a heading.
+#[test]
+fn an_oversized_section_cuts_at_a_paragraph() {
+    let body: String = (0..40)
+        .map(|i| format!("Paragraph {i}. {}\n\n", "z".repeat(1_000)))
+        .collect();
+    let pieces = divide(&body);
+    assert!(pieces.len() > 1, "fixture must divide");
+    assert_eq!(pieces.concat(), body);
+    for piece in pieces.iter().skip(1) {
+        assert!(
+            piece.starts_with("Paragraph"),
+            "piece began mid-paragraph: {:?}",
+            &piece[..30.min(piece.len())]
+        );
+    }
+}
+
+/// A generated file with no blank line and no short lines still divides — there
+/// is no boundary left to respect, and losing the tail is not an option.
+#[test]
+fn one_unbreakable_line_still_divides_without_loss() {
+    let doc = format!("# T\n\n{}\n", "q".repeat(TARGET_CHARS * 3 + 17));
+    let chunks = split(&doc);
+    assert!(chunks.len() >= 3, "must divide: {} chunks", chunks.len());
+    assert_eq!(rejoined(&chunks), doc, "no character is lost");
+}
+
+/// Text before the first heading is a section of its own, not a dropped prefix.
+#[test]
+fn a_preamble_before_the_first_heading_is_kept() {
+    let doc = "Some preamble.\n\n# First\n\nBody.\n";
+    let chunks = split(doc);
+    assert_eq!(rejoined(&chunks), doc);
+    assert!(chunks[0].text.starts_with("Some preamble."));
+    assert!(
+        chunks[0].path.is_empty(),
+        "a preamble sits under no heading"
+    );
+}
+
+/// A heading that skips a level must not reparent the ones under it.
+#[test]
+fn a_skipped_heading_level_does_not_reparent() {
+    let doc = "# One\n\n### Three\n\nbody\n";
+    let secs = sections(doc);
+    let last = secs.last().expect("a section");
+    assert_eq!(last.path, vec!["One".to_string(), "Three".to_string()]);
+}
+
+#[test]
+fn an_empty_document_asks_for_no_calls() {
+    assert!(split("").is_empty());
+    assert!(split("   \n\n  \n").is_empty());
+}
+
+/// The document ceiling exists, is reported, and cuts on a line boundary.
+#[test]
+fn the_document_ceiling_truncates_on_a_line_and_reports_the_loss() {
+    let doc = format!(
+        "{}\n",
+        "line of text\n".repeat(MAX_DOCUMENT_CHARS / 13 + 200)
+    );
+    let (kept, dropped) = bound(&doc);
+    assert!(dropped > 0, "fixture must exceed the ceiling");
+    assert!(kept.chars().count() <= MAX_DOCUMENT_CHARS);
+    assert!(kept.ends_with("line of text"), "cut on a line boundary");
+    assert_eq!(
+        kept.chars().count() + dropped,
+        doc.chars().count(),
+        "the reported loss accounts for every character"
+    );
+}
+
+/// The ceiling is the user-visible promise the issue asked for: at least six
+/// times the 120,000-character single-call cap it replaces.
+#[test]
+fn the_ceiling_is_six_times_the_cap_it_replaces() {
+    const REPLACED_CAP: usize = 120_000;
+    assert!(
+        MAX_DOCUMENT_CHARS >= REPLACED_CAP * 6,
+        "{MAX_DOCUMENT_CHARS} is not 6x {REPLACED_CAP}"
+    );
+}
+
+/// Below the ceiling nothing is dropped, however large — the property that makes
+/// "ingest never silently loses a document" checkable.
+#[test]
+fn nothing_is_dropped_below_the_ceiling() {
+    let doc = "a\n".repeat(MAX_DOCUMENT_CHARS / 2);
+    assert_eq!(dropped_chars(&doc), 0);
+    assert_eq!(rejoined(&split(&doc)), doc);
+}
+
+/// Multi-byte text is counted in characters, not bytes, at every boundary.
+#[test]
+fn multibyte_text_slices_on_character_boundaries() {
+    let doc = format!("# Título\n\n{}\n", "é".repeat(TARGET_CHARS * 2));
+    let chunks = split(&doc);
+    assert_eq!(rejoined(&chunks), doc);
+    for chunk in &chunks {
+        assert!(chunk.text.chars().count() <= TARGET_CHARS);
+    }
+}

--- a/crates/stella-cli/src/ingest_cmd/chunk/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/chunk/tests.rs
@@ -138,7 +138,13 @@ fn fences_close_on_their_own_marker_and_width() {
     let paths: Vec<_> = secs.iter().map(|s| s.path.clone()).collect();
     assert_eq!(
         paths,
-        vec![vec!["Top".to_string()], vec!["Second".to_string()]],
+        vec![
+            vec!["Top".to_string()],
+            // Nested, because `## Second` sits under `# Top` — the point here is
+            // that only two sections exist at all, the fenced `#` lines having
+            // opened none.
+            vec!["Top".to_string(), "Second".to_string()],
+        ],
         "only the two real headings open sections"
     );
 }
@@ -240,16 +246,9 @@ fn the_document_ceiling_truncates_on_a_line_and_reports_the_loss() {
     );
 }
 
-/// The ceiling is the user-visible promise the issue asked for: at least six
-/// times the 120,000-character single-call cap it replaces.
-#[test]
-fn the_ceiling_is_six_times_the_cap_it_replaces() {
-    const REPLACED_CAP: usize = 120_000;
-    assert!(
-        MAX_DOCUMENT_CHARS >= REPLACED_CAP * 6,
-        "{MAX_DOCUMENT_CHARS} is not 6x {REPLACED_CAP}"
-    );
-}
+// The ceiling being at least 6x the cap it replaces is asserted at compile time
+// in the parent module (`const _: () = assert!(…)`), not here: both sides are
+// constants, so a test would only be checking the optimizer's arithmetic.
 
 /// Below the ceiling nothing is dropped, however large — the property that makes
 /// "ingest never silently loses a document" checkable.

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -223,9 +223,11 @@ pub(super) fn extract_all(
             &cfg.model_id,
             root,
             doc,
-            &set_id,
-            &ingest_run_id,
-            &observed_at,
+            RunStamp {
+                set_id: &set_id,
+                ingest_run_id: &ingest_run_id,
+                observed_at: &observed_at,
+            },
         )) {
             Ok(summary) => {
                 any = true;
@@ -286,44 +288,50 @@ pub(super) fn extract_all(
 /// Takes `model_hint` rather than the whole `Config` so the assembly path is
 /// testable with a mock provider — the only thing extraction needs from config
 /// is which model to attribute the call to.
-#[allow(clippy::too_many_arguments)]
 async fn extract_document(
     provider: &dyn Provider,
     model_hint: &str,
     root: &Path,
     doc: &NamedDoc,
-    set_id: &str,
-    ingest_run_id: &str,
-    observed_at: &str,
+    stamp: RunStamp<'_>,
 ) -> Result<DocSummary, String> {
     let progress = Progress::start(format!("reading {}", doc.rel));
-    let outcome = extract_narrated(
-        provider,
-        model_hint,
-        root,
-        doc,
-        set_id,
-        ingest_run_id,
-        observed_at,
-        &progress,
-    )
-    .await;
+    let outcome = extract_narrated(provider, model_hint, root, doc, stamp, &progress).await;
     progress.finish().await;
     outcome
 }
 
+/// The three values every proposal of one ingest run is stamped with.
+///
+/// Grouped because they always travel together and are never chosen
+/// independently: one run picks all three once and every document inherits
+/// them. Passing them as one argument is also what keeps the two functions
+/// below under clippy's argument limit honestly, rather than by an `#[allow]`
+/// asserting a lint is wrong when it is right (#3698).
+#[derive(Clone, Copy)]
+struct RunStamp<'a> {
+    /// The record-set id derived from the workspace.
+    set_id: &'a str,
+    /// This run's id, shared by every document it touches.
+    ingest_run_id: &'a str,
+    /// The RFC3339 instant the run began.
+    observed_at: &'a str,
+}
+
 /// The body of [`extract_document`], narrating into a line the caller owns.
-#[allow(clippy::too_many_arguments)]
 async fn extract_narrated(
     provider: &dyn Provider,
     model_hint: &str,
     root: &Path,
     doc: &NamedDoc,
-    set_id: &str,
-    ingest_run_id: &str,
-    observed_at: &str,
+    stamp: RunStamp<'_>,
     progress: &Progress,
 ) -> Result<DocSummary, String> {
+    let RunStamp {
+        set_id,
+        ingest_run_id,
+        observed_at,
+    } = stamp;
     let defaults = build_defaults(root, doc, ingest_run_id, model_hint, observed_at);
     let eligibility = eligibility_for(doc.tier);
 
@@ -459,11 +467,13 @@ async fn extract_claims(
         };
         let label = slice_label(&doc.rel, position, merge.claims.len());
         progress.say(label.clone());
-        match call_model(
-            provider, model_hint, root, doc, chunk, position, &label, progress,
-        )
-        .await
-        {
+        let slice = SliceCall {
+            doc,
+            chunk,
+            position,
+            base_label: &label,
+        };
+        match call_model(provider, model_hint, root, slice, progress).await {
             Ok((claims, cost)) => {
                 cost_usd += cost;
                 merge.absorb(claims);
@@ -493,6 +503,18 @@ async fn extract_claims(
         failed_slices,
         duplicates,
     })
+}
+
+/// Everything one slice's model call needs to describe the slice it is asking
+/// about. Grouped for the reason [`RunStamp`] is.
+#[derive(Clone, Copy)]
+struct SliceCall<'a> {
+    doc: &'a NamedDoc,
+    chunk: &'a Chunk,
+    position: SlicePosition<'a>,
+    /// The progress label already showing for this slice, which a retry adorns
+    /// rather than replaces.
+    base_label: &'a str,
 }
 
 /// Where a slice sits in its document, for the prompt and the progress line.
@@ -643,17 +665,19 @@ fn starting_output_budget(chars: usize) -> u32 {
 /// The error carries the cost spent reaching it, because a failed slice is still
 /// a paid call and a run that under-reports its own bill is the "measure
 /// honestly" rule broken in the direction that flatters us.
-#[allow(clippy::too_many_arguments)]
 async fn call_model(
     provider: &dyn Provider,
     model_hint: &str,
     root: &Path,
-    doc: &NamedDoc,
-    chunk: &Chunk,
-    position: SlicePosition<'_>,
-    base_label: &str,
+    slice: SliceCall<'_>,
     progress: &Progress,
 ) -> Result<(Vec<Claim>, f64), (f64, String)> {
+    let SliceCall {
+        doc,
+        chunk,
+        position,
+        base_label,
+    } = slice;
     let rel = &doc.rel;
     let user = format!(
         "Extract atomic context records from `{rel}`. Return ONLY the JSON array.\n\n\

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -1,12 +1,27 @@
 //! Extraction — turning a markdown document into reviewable context-record
-//! proposals with one model call.
+//! proposals.
 //!
 //! This is the step the scan half of `stella ingest` set up: a classified
-//! document goes to the worker model, which splits it into atomic claims; each
-//! claim is mapped to a [`Record`], run through the deterministic safety
-//! [`gate`], probed against the tree for staleness, stamped with its
-//! content-derived identity, and written to `.stella/proposals/` as a
+//! document is divided into slices ([`super::chunk`]) and each goes to the
+//! worker model, which splits it into atomic claims; the slices' claims are
+//! merged, and each claim is mapped to a [`Record`], run through the
+//! deterministic safety [`gate`], probed against the tree for staleness, stamped
+//! with its content-derived identity, and written to `.stella/proposals/` as a
 //! `[[proposal]]` file in the shape of `docs/spec/adaptive-context/context-record-examples/05`.
+//!
+//! ## Why a document is divided rather than capped
+//!
+//! It used to be one call, with everything past a character cap dropped before
+//! the model saw it — 46% of this repository's own `AGENTS.md`, reported as a
+//! success (#2407). Raising the cap only moves that edge onto the reply, which
+//! is roughly the size of the text that produced it. So the document is divided
+//! and the claims merged, which makes coverage a property of the slicer rather
+//! than a number someone has to keep ahead of the documents people write.
+//!
+//! Two collisions exist only because there is now more than one call, and
+//! [`Merge`] resolves both: the same claim extracted from two slices, and a
+//! `lineage_suffix` the prompt asks to be unique *within the document* that each
+//! call can only make unique within its own reply.
 //!
 //! ## Why the safety work is here and not in the prompt
 //!
@@ -22,6 +37,7 @@
 //! reply, a write error — is reported and skipped. Ingest is user-invoked, so a
 //! failure is worth showing, but one bad document never aborts the others.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use colored::Colorize;
@@ -39,6 +55,7 @@ use stella_protocol::{
     CompletionMessage, CompletionRequest, FinishReason, ModelCallRole, Provider,
 };
 
+use super::chunk::{self, Chunk};
 use super::probe;
 use super::progress::Progress;
 
@@ -53,24 +70,13 @@ pub(super) struct NamedDoc {
     pub tier: Tier,
 }
 
-/// The largest slice of a document handed to the model. A steering document that
-/// needs more than this is not what ingest is for; beyond the cap the tail is
-/// dropped with a note in the prompt rather than silently.
+/// The most of a document extraction will read, in characters.
 ///
-/// Five times the 24,000 this started at, because 24,000 was smaller than the
-/// documents the feature exists to read: this repository's own `AGENTS.md` is
-/// 44,545 characters, so it was extracted at 54% — the cut landed mid-table and
-/// the god-file rules, the glossary, the code-style conventions, the testing
-/// approach and the whole gotchas section could not produce a record. Every
-/// document named by the first-run dialog is the kind that exceeded the old cap.
-///
-/// This is a ceiling, not a target: [`starting_output_budget`] scales the reply
-/// budget to the text actually sent, so a short document is unaffected.
-///
-/// Visible to the parent module only so the scan's `MAX_READ_BYTES` can be
-/// asserted to sit above it — a scan that hides what extraction would accept is
-/// the failure the two constants have to be compared to rule out.
-pub(super) const MAX_PROMPT_CHARS: usize = 120_000;
+/// Re-exported from [`super::chunk`] rather than owned here: the ceiling belongs
+/// to the slicer that enforces it, and the scan's `MAX_READ_BYTES` has to be
+/// asserted against it — a scan that hides what extraction would accept is the
+/// failure the two constants have to be compared to rule out.
+pub(super) const MAX_DOCUMENT_CHARS: usize = chunk::MAX_DOCUMENT_CHARS;
 
 /// The system prompt: the extractor's whole contract, including the two rules
 /// that keep an untrusted document from becoming an attack — atomicity and
@@ -165,8 +171,17 @@ pub(super) struct DocSummary {
     /// below — the rendered bullet adds a handle and markers — so a warning
     /// here is never a false alarm.
     pub pinned_chars: usize,
-    /// The run cost in USD.
+    /// The run cost in USD, across every slice of the document.
     pub cost_usd: f64,
+    /// How many slices the document was divided into, and how many of them
+    /// failed. A failed slice is content that produced no records, so it is
+    /// reported rather than folded into a success — the whole point of #2407 is
+    /// that a partially-read document must never look like a complete one.
+    pub slices: usize,
+    /// The slices that failed, each with the reason, in document order.
+    pub failed_slices: Vec<(usize, String)>,
+    /// Claims dropped as restatements of a claim an earlier slice already made.
+    pub duplicates: usize,
     /// The candidate ids of every proposal written, so the source file's
     /// lineage can name what it produced.
     pub candidate_ids: Vec<String>,
@@ -270,7 +285,11 @@ pub(super) fn extract_all(
     Ok(())
 }
 
-/// Extract one document: model call, mapping, gate, probes, write.
+/// Extract one document: slice, one model call each, merge, gate, probe, write.
+///
+/// Owns the progress line for the whole document so a reader sees one elapsed
+/// clock across every slice and every record, and so exactly one statement ends
+/// it — no error path below can leave a ticker drawing over later output.
 ///
 /// Takes `model_hint` rather than the whole `Config` so the assembly path is
 /// testable with a mock provider — the only thing extraction needs from config
@@ -285,10 +304,45 @@ async fn extract_document(
     ingest_run_id: &str,
     observed_at: &str,
 ) -> Result<DocSummary, String> {
+    let progress = Progress::start(format!("reading {}", doc.rel));
+    let outcome = extract_narrated(
+        provider,
+        model_hint,
+        root,
+        doc,
+        set_id,
+        ingest_run_id,
+        observed_at,
+        &progress,
+    )
+    .await;
+    progress.finish().await;
+    outcome
+}
+
+/// The body of [`extract_document`], narrating into a line the caller owns.
+#[allow(clippy::too_many_arguments)]
+async fn extract_narrated(
+    provider: &dyn Provider,
+    model_hint: &str,
+    root: &Path,
+    doc: &NamedDoc,
+    set_id: &str,
+    ingest_run_id: &str,
+    observed_at: &str,
+    progress: &Progress,
+) -> Result<DocSummary, String> {
     let defaults = build_defaults(root, doc, ingest_run_id, model_hint, observed_at);
     let eligibility = eligibility_for(doc.tier);
 
-    let (claims, cost_usd) = call_model(provider, model_hint, root, &doc.rel, &doc.content).await?;
+    let extracted = extract_claims(provider, model_hint, root, doc, progress).await?;
+    let Extracted {
+        claims,
+        cost_usd,
+        slices,
+        failed_slices,
+        duplicates,
+    } = extracted;
     if claims.is_empty() {
         return Err("the model found no durable context to extract".to_string());
     }
@@ -305,7 +359,21 @@ async fn extract_document(
     let mut withheld = 0usize;
     let mut pinned_chars = 0usize;
     let mut asserted = Vec::new();
-    for claim in claims {
+    let total_claims = claims.len();
+    for (done, claim) in claims.into_iter().enumerate() {
+        // Each record is gated and probed, and a probe reads the tree — on a
+        // document that atomized into hundreds of records that is a visible
+        // stretch of work with no model call in it, which is exactly the window
+        // that used to be silent. Naming the record in hand costs a string.
+        progress.say(record_label(
+            &doc.rel,
+            &claim.lineage_suffix,
+            done,
+            total_claims,
+        ));
+        // Hand the runtime back so the ticker task — single-threaded here, so it
+        // is otherwise starved by this loop — can actually draw the label above.
+        tokio::task::yield_now().await;
         let proposal = build_proposal(root, set_id, &defaults, observed_at, eligibility, claim);
         asserted.push(stella_core::ingest::AssertedClaim {
             lineage_id: proposal.record.lineage_id.clone(),
@@ -348,9 +416,169 @@ async fn extract_document(
         withheld,
         pinned_chars,
         cost_usd,
+        slices,
+        failed_slices,
+        duplicates,
         candidate_ids,
         asserted,
     })
+}
+
+/// What every slice of one document produced, merged.
+struct Extracted {
+    claims: Vec<Claim>,
+    cost_usd: f64,
+    slices: usize,
+    failed_slices: Vec<(usize, String)>,
+    duplicates: usize,
+}
+
+/// Divide the document and extract every slice, merging the claims.
+///
+/// A slice that fails does not abort the document — the other slices' claims are
+/// real and already paid for — but it is carried out in [`Extracted::failed_slices`]
+/// and reported, because the one thing this must never do is present a
+/// partially-read document as a complete one. Every slice failing is the whole
+/// document failing, and returns `Err`.
+async fn extract_claims(
+    provider: &dyn Provider,
+    model_hint: &str,
+    root: &Path,
+    doc: &NamedDoc,
+    progress: &Progress,
+) -> Result<Extracted, String> {
+    let (bounded, _dropped) = chunk::bound(&doc.content);
+    let chunks = chunk::split(&bounded);
+    let slices = chunks.len();
+    if slices == 0 {
+        return Err("the document has no text to extract".to_string());
+    }
+
+    let mut merge = Merge::default();
+    let mut cost_usd = 0.0;
+    let mut failed_slices = Vec::new();
+    let mut first_error: Option<String> = None;
+
+    for (index, chunk) in chunks.iter().enumerate() {
+        let position = SlicePosition {
+            index,
+            of: slices,
+            path: &chunk.path,
+        };
+        let label = slice_label(&doc.rel, position, merge.claims.len());
+        progress.say(label.clone());
+        match call_model(
+            provider, model_hint, root, doc, chunk, position, &label, progress,
+        )
+        .await
+        {
+            Ok((claims, cost)) => {
+                cost_usd += cost;
+                merge.absorb(claims);
+            }
+            Err((cost, err)) => {
+                // The spend is real whether or not the reply parsed, so it is
+                // counted; the loss is named rather than absorbed.
+                cost_usd += cost;
+                progress.note(&format!(
+                    "    {}",
+                    format!("slice {} of {slices} failed: {err}", index + 1).red()
+                ));
+                first_error.get_or_insert_with(|| err.clone());
+                failed_slices.push((index + 1, err));
+            }
+        }
+    }
+
+    if failed_slices.len() == slices {
+        return Err(first_error.unwrap_or_else(|| "every slice failed".to_string()));
+    }
+    let (claims, duplicates) = merge.finish();
+    Ok(Extracted {
+        claims,
+        cost_usd,
+        slices,
+        failed_slices,
+        duplicates,
+    })
+}
+
+/// Where a slice sits in its document, for the prompt and the progress line.
+#[derive(Clone, Copy)]
+struct SlicePosition<'a> {
+    /// Zero-based.
+    index: usize,
+    of: usize,
+    /// The heading path the slice opens under, outermost first.
+    path: &'a [String],
+}
+
+/// Accumulates the claims of a document's slices, resolving the two collisions
+/// that exist only because there is more than one call.
+///
+/// **The same claim, twice.** A rule stated in an overview section and restated
+/// where it applies reaches two slices, and the extractor rightly emits it in
+/// both. Two proposals for one claim is a review surface asking the same
+/// question twice, so the later restatement is dropped. Statements are compared
+/// case-folded and whitespace-collapsed, because that is the whole of the
+/// difference between two renderings of one sentence.
+///
+/// **The same suffix, two claims.** The prompt asks for a slug "unique within
+/// the document", which is exactly what a call reading one slice cannot
+/// guarantee. `build_proposal` turns the suffix into `ctx.<set_id>.<suffix>`, so
+/// a collision is two records with one identity. The first claim to use a suffix
+/// keeps it — which is what makes a single-slice document byte-identical to
+/// before this existed — and a later collision is numbered.
+#[derive(Default)]
+struct Merge {
+    claims: Vec<Claim>,
+    statements: HashSet<String>,
+    suffixes: HashSet<String>,
+    duplicates: usize,
+}
+
+impl Merge {
+    fn absorb(&mut self, incoming: Vec<Claim>) {
+        for mut claim in incoming {
+            if !self.statements.insert(normalized(&claim.statement)) {
+                self.duplicates += 1;
+                continue;
+            }
+            claim.lineage_suffix = self.unique_suffix(&claim.lineage_suffix);
+            self.claims.push(claim);
+        }
+    }
+
+    /// The suffix this claim may keep. Compared in the kebab form
+    /// `build_proposal` will slugify it to, so two suffixes that differ only in
+    /// punctuation are caught here rather than colliding downstream.
+    fn unique_suffix(&mut self, proposed: &str) -> String {
+        let base = kebab(proposed);
+        if self.suffixes.insert(base.clone()) {
+            return base;
+        }
+        for n in 2.. {
+            let candidate = format!("{base}-{n}");
+            if self.suffixes.insert(candidate.clone()) {
+                return candidate;
+            }
+        }
+        unreachable!("the integers are not exhausted")
+    }
+
+    fn finish(self) -> (Vec<Claim>, usize) {
+        (self.claims, self.duplicates)
+    }
+}
+
+/// A statement reduced to what makes it the same claim: case-folded, with every
+/// run of whitespace collapsed to one space.
+fn normalized(statement: &str) -> String {
+    statement
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 /// The file defaults every record in the document inherits.
@@ -416,26 +644,37 @@ fn starting_output_budget(chars: usize) -> u32 {
         .clamp(MIN_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS)
 }
 
-/// Call the model, tolerating prose and one bad reply. Mirrors `infer_domains`:
-/// bounded repair, then give up on this document rather than hammering.
+/// Call the model for one slice, tolerating prose and one bad reply. Mirrors
+/// `infer_domains`: bounded repair, then give up on this slice rather than
+/// hammering.
+///
+/// The error carries the cost spent reaching it, because a failed slice is still
+/// a paid call and a run that under-reports its own bill is the "measure
+/// honestly" rule broken in the direction that flatters us.
+#[allow(clippy::too_many_arguments)]
 async fn call_model(
     provider: &dyn Provider,
     model_hint: &str,
     root: &Path,
-    rel: &str,
-    content: &str,
-) -> Result<(Vec<Claim>, f64), String> {
-    let (bounded, _skipped) = bounded_content(content);
+    doc: &NamedDoc,
+    chunk: &Chunk,
+    position: SlicePosition<'_>,
+    base_label: &str,
+    progress: &Progress,
+) -> Result<(Vec<Claim>, f64), (f64, String)> {
+    let rel = &doc.rel;
     let user = format!(
         "Extract atomic context records from `{rel}`. Return ONLY the JSON array.\n\n\
-         --- {rel} ---\n{bounded}"
+         {}--- {rel} ---\n{}",
+        slice_preamble(position),
+        chunk.text
     );
     let mut messages = vec![
         CompletionMessage::system(SYSTEM_PROMPT),
         CompletionMessage::user(&user),
     ];
     let mut total_cost = 0.0;
-    let mut max_output_tokens = starting_output_budget(bounded.chars().count());
+    let mut max_output_tokens = starting_output_budget(chunk.text.chars().count());
     // Three, not two: the budget ladder and the malformed-JSON repair share this
     // counter, and with a right-sized first request a document large enough to
     // need a doubling should still have a repair left.
@@ -452,11 +691,20 @@ async fn call_model(
             params: None,
         };
         // The wait is narrated because it is long: this is a paid call that
-        // runs for minutes on a real instruction file, and an unnarrated one
-        // reads as a wedged process. `finish` runs on the statement after the
-        // `await`, before the result is inspected, so none of the several error
-        // paths below can leave a ticker drawing over later output.
-        let progress = Progress::start(attempt_label(rel, attempt, ATTEMPTS));
+        // runs for minutes on a real instruction file. The line is the caller's,
+        // so the elapsed clock spans the whole document rather than resetting on
+        // every slice and every retry — a clock that restarts hides exactly the
+        // "how long has this really been going" the reader is asking.
+        //
+        // The first attempt keeps the label the caller already set, which
+        // carries the running record count; a retry says so, because a silent
+        // second attempt doubles both the wait and the spend.
+        if attempt > 0 {
+            progress.say(format!(
+                "{base_label} — attempt {} of {ATTEMPTS}",
+                attempt + 1
+            ));
+        }
         let outcome = crate::accounted_call::complete_standalone(
             root,
             provider,
@@ -467,7 +715,6 @@ async fn call_model(
             request,
         )
         .await;
-        progress.finish().await;
         match outcome {
             Ok(accounted) => {
                 total_cost += accounted.cost_usd;
@@ -481,16 +728,19 @@ async fn call_model(
                         if attempt + 1 == ATTEMPTS
                             || (cut_off && max_output_tokens >= MAX_OUTPUT_TOKENS) =>
                     {
-                        return Err(if cut_off {
-                            format!(
-                                "the model's reply was cut off at {max_output_tokens} output \
-                                 tokens before finishing the record list — this document needs \
-                                 more output than one call can carry, so split it and ingest \
-                                 the parts"
-                            )
-                        } else {
-                            format!("could not parse the model's records: {err}")
-                        });
+                        return Err((
+                            total_cost,
+                            if cut_off {
+                                format!(
+                                    "the model's reply was cut off at {max_output_tokens} output \
+                                     tokens before finishing this slice's record list — the \
+                                     model is emitting more per character than the slice size \
+                                     assumes"
+                                )
+                            } else {
+                                format!("could not parse the model's records: {err}")
+                            },
+                        ));
                     }
                     // Cut off, not malformed: the reply was on track but ran out of
                     // room. Asking it to "respond with ONLY the JSON array" again
@@ -504,14 +754,14 @@ async fn call_model(
                         let widened = max_output_tokens.saturating_mul(2).min(MAX_OUTPUT_TOKENS);
                         // Said out loud because it is the difference between a
                         // one-call wait and a two-call one, at twice the spend.
-                        println!(
+                        progress.note(&format!(
                             "    {}",
                             format!(
                                 "the reply filled its {max_output_tokens}-token budget before \
                                  the record list ended — retrying with {widened}"
                             )
                             .yellow()
-                        );
+                        ));
                         max_output_tokens = widened;
                     }
                     Err(_) => {
@@ -525,14 +775,70 @@ async fn call_model(
                 }
             }
             Err(error) => {
-                // The partial spend is already persisted by the accounting store;
-                // the document failed, so there is no summary to fold it into.
-                return Err(format!("model call failed: {}", error.message));
+                // The partial spend is already persisted by the accounting store,
+                // and carried out so the document's reported bill includes the
+                // slice that failed.
+                return Err((total_cost, format!("model call failed: {}", error.message)));
             }
         }
     }
     // Unreachable: the final attempt always returns above. Kept total for the type.
-    Err("extraction produced no records".to_string())
+    Err((total_cost, "extraction produced no records".to_string()))
+}
+
+/// The orienting header a slice carries, so a slice that opens mid-section is
+/// not an unlabelled fragment.
+///
+/// Empty for a document that fits one call, which keeps that request
+/// byte-identical to the one this repository has always sent — a single-slice
+/// document must not pay for the machinery that only multi-slice documents need,
+/// least of all in prompt-cache misses.
+fn slice_preamble(position: SlicePosition<'_>) -> String {
+    if position.of <= 1 {
+        return String::new();
+    }
+    let where_ = if position.path.is_empty() {
+        String::new()
+    } else {
+        format!(", under the section `{}`", position.path.join(" > "))
+    };
+    format!(
+        "This is part {} of {} of the document{where_}. Extract only from the text below; \
+         other parts are handled by their own calls.\n\n",
+        position.index + 1,
+        position.of
+    )
+}
+
+/// What the progress line says while a slice is in flight.
+///
+/// Names the slice and the running record count, because "which of the five
+/// calls am I paying for, and is it finding anything" is the question a person
+/// watching a multi-minute ingest actually has. A single-slice document says
+/// only what it used to.
+fn slice_label(rel: &str, position: SlicePosition<'_>, found: usize) -> String {
+    if position.of <= 1 {
+        return format!("extracting {rel}");
+    }
+    format!(
+        "extracting {rel} — part {} of {}, {found} record(s) so far",
+        position.index + 1,
+        position.of
+    )
+}
+
+/// What the progress line says while a record is being gated and probed.
+///
+/// One line per record, naming it: the stretch after the model calls is
+/// filesystem work with no network in it, and on a document that atomized into
+/// hundreds of records it was the second-longest silence in the command.
+fn record_label(rel: &str, suffix: &str, done: usize, total: usize) -> String {
+    format!(
+        "{rel}: processing {} — {} of {total} record(s), {} remaining",
+        kebab(suffix),
+        done + 1,
+        total.saturating_sub(done + 1)
+    )
 }
 
 /// Extract and parse the first JSON array in `text` (models add fences/prose).
@@ -712,15 +1018,57 @@ fn report(doc: &NamedDoc, summary: &DocSummary) {
     } else {
         String::new()
     };
+    let across = if summary.slices > 1 {
+        format!(" across {} parts", summary.slices)
+    } else {
+        String::new()
+    };
     println!(
-        "    {} {} record(s): {} eligible{}{}  {}",
+        "    {} {} record(s){}: {} eligible{}{}  {}",
         "·".dimmed(),
         summary.total,
+        across,
         summary.eligible,
         refuted,
         dismissed,
         format!("(${:.4})", summary.cost_usd).dimmed()
     );
+    // A slice that failed is a stretch of the document that produced no records.
+    // Said in red and named, because the defect this whole path exists to fix is
+    // a partially-read document reporting itself as a complete one (#2407).
+    if !summary.failed_slices.is_empty() {
+        let which: Vec<String> = summary
+            .failed_slices
+            .iter()
+            .map(|(n, _)| n.to_string())
+            .collect();
+        println!(
+            "    {}",
+            format!(
+                "INCOMPLETE: part(s) {} of {} produced no records, so that text is not \
+                 represented above. Re-run to retry them.",
+                which.join(", "),
+                summary.slices
+            )
+            .red()
+        );
+        for (n, err) in &summary.failed_slices {
+            println!("      {}", format!("part {n}: {err}").dimmed());
+        }
+    }
+    // Not a warning: a document that restates a rule where it applies is well
+    // written, and one proposal per claim is the point. Counted so the arithmetic
+    // between "records the model returned" and "proposals written" is visible.
+    if summary.duplicates > 0 {
+        println!(
+            "    {}",
+            format!(
+                "{} restatement(s) merged — the same claim reached more than one part",
+                summary.duplicates
+            )
+            .dimmed()
+        );
+    }
     // The "no gaps without bloat" half of the tier contract (#2709): pinned
     // records are guaranteed a prefix seat only while they fit the cached
     // budget, so an ingest that mints more pinned content than the budget
@@ -906,45 +1254,13 @@ fn digest_of(content: &str) -> String {
     format!("sha256:{hex}")
 }
 
-/// Cap the document at [`MAX_PROMPT_CHARS`], marking a truncation so the model
-/// (and a later reader of the prompt) can see the tail was dropped.
-///
-/// Returns the bounded text and how many characters were dropped, because the
-/// marker in the prompt only tells the *model* that the tail is missing — the
-/// person who typed the command was told nothing at all. That silence is what
-/// made the old 24,000-character cap so costly: this repository's `AGENTS.md` is
-/// 44,545 characters, so 46% of it never reached the extractor and the run still
-/// reported success. The cap is now 120,000 and a document that still exceeds it
-/// says so.
-fn bounded_content(content: &str) -> (String, usize) {
-    let total = content.chars().count();
-    if total <= MAX_PROMPT_CHARS {
-        return (content.to_string(), 0);
-    }
-    let kept: String = content.chars().take(MAX_PROMPT_CHARS).collect();
-    (
-        format!("{kept}\n\n[... document truncated for extraction ...]"),
-        total - MAX_PROMPT_CHARS,
-    )
-}
-
 /// How many characters of `content` extraction will not read.
 ///
-/// The cap belongs to this module, so the caller asks the question rather than
-/// holding a second copy of the number.
+/// Almost always zero now: a document is divided rather than trimmed, so this is
+/// non-zero only past [`MAX_DOCUMENT_CHARS`]. The caller asks rather than holding
+/// a second copy of the ceiling.
 pub(super) fn skipped_chars(content: &str) -> usize {
-    bounded_content(content).1
-}
-
-/// What the progress line says: the document, and which attempt this is once
-/// there has been more than one. A silent second attempt is the other half of
-/// why a cut-off document looked wedged — it doubles the wait and the spend.
-fn attempt_label(rel: &str, attempt: usize, attempts: usize) -> String {
-    if attempt == 0 {
-        format!("extracting {rel}")
-    } else {
-        format!("extracting {rel} (attempt {} of {attempts})", attempt + 1)
-    }
+    chunk::dropped_chars(content)
 }
 
 /// Lower-case, dash-separated slug keeping `[a-z0-9-]`; runs of other characters

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -70,14 +70,6 @@ pub(super) struct NamedDoc {
     pub tier: Tier,
 }
 
-/// The most of a document extraction will read, in characters.
-///
-/// Re-exported from [`super::chunk`] rather than owned here: the ceiling belongs
-/// to the slicer that enforces it, and the scan's `MAX_READ_BYTES` has to be
-/// asserted against it — a scan that hides what extraction would accept is the
-/// failure the two constants have to be compared to rule out.
-pub(super) const MAX_DOCUMENT_CHARS: usize = chunk::MAX_DOCUMENT_CHARS;
-
 /// The system prompt: the extractor's whole contract, including the two rules
 /// that keep an untrusted document from becoming an attack — atomicity and
 /// no-executables.
@@ -609,7 +601,7 @@ fn build_defaults(
 }
 
 /// The floor for the output budget: 16k, not the 4k this used to carry. A
-/// document near the old [`MAX_PROMPT_CHARS`] cap can atomize into dozens of
+/// document filling a whole slice can atomize into dozens of
 /// records, each carrying every optional field in the schema — 4k truncated
 /// mid-object on real instruction files well before reaching the closing `]`,
 /// which `parse_claims` then reported as a JSON syntax error rather than what it
@@ -1257,7 +1249,7 @@ fn digest_of(content: &str) -> String {
 /// How many characters of `content` extraction will not read.
 ///
 /// Almost always zero now: a document is divided rather than trimmed, so this is
-/// non-zero only past [`MAX_DOCUMENT_CHARS`]. The caller asks rather than holding
+/// non-zero only past `chunk::MAX_DOCUMENT_CHARS`. The caller asks rather than holding
 /// a second copy of the ceiling.
 pub(super) fn skipped_chars(content: &str) -> usize {
     chunk::dropped_chars(content)

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -316,13 +316,36 @@ fn a_truncated_reply_is_retried_with_a_larger_budget_instead_of_failing() {
         .build()
         .expect("runtime");
     let (claims, _cost) = runtime
-        .block_on(call_model(
-            &provider,
-            "canned-model",
-            &root,
-            "AGENTS.md",
-            "# Conventions\nThis repository uses pnpm.\n",
-        ))
+        .block_on(async {
+            let doc = NamedDoc {
+                rel: "AGENTS.md".to_string(),
+                content: "# Conventions\nThis repository uses pnpm.\n".to_string(),
+                tier: stella_core::ingest::Tier::Primary,
+            };
+            let chunk = Chunk {
+                text: doc.content.clone(),
+                path: vec!["Conventions".to_string()],
+            };
+            let position = SlicePosition {
+                index: 0,
+                of: 1,
+                path: &chunk.path,
+            };
+            let progress = Progress::start("extracting AGENTS.md".to_string());
+            let out = call_model(
+                &provider,
+                "canned-model",
+                &root,
+                &doc,
+                &chunk,
+                position,
+                "extracting AGENTS.md",
+                &progress,
+            )
+            .await;
+            progress.finish().await;
+            out
+        })
         .expect("recovers from the truncated first reply");
 
     assert_eq!(claims.len(), 1);
@@ -348,13 +371,10 @@ fn the_output_budget_is_sized_to_the_document() {
         MIN_OUTPUT_TOKENS,
         "below the floor stays at the floor"
     );
-    // The shape that motivated the change: this repository's AGENTS.md, which
-    // now fits the prompt cap whole.
-    assert_eq!(starting_output_budget(44_545), 44_545);
+    // A full slice: the budget tracks the text sent, one token per character.
     assert_eq!(
-        starting_output_budget(MAX_PROMPT_CHARS),
-        MAX_PROMPT_CHARS as u32,
-        "a full-size document must fit under the output ceiling in one call"
+        starting_output_budget(super::chunk::TARGET_CHARS),
+        super::chunk::TARGET_CHARS as u32,
     );
 }
 
@@ -369,9 +389,18 @@ fn the_output_budget_never_exceeds_the_ceiling() {
         MAX_OUTPUT_TOKENS
     );
     assert!(
-        MAX_PROMPT_CHARS as u32 <= MAX_OUTPUT_TOKENS,
-        "a document at the prompt cap must be expressible within one reply \
-         budget, or the ceiling is unreachable by construction"
+        super::chunk::TARGET_CHARS as u32 <= MAX_OUTPUT_TOKENS,
+        "a full slice must be expressible within one reply budget, or the \
+         ceiling is unreachable by construction"
+    );
+    // The reason the slice is this size rather than the largest one call could
+    // carry: the smallest per-model output ceiling in the seeded catalog is
+    // 30,000 tokens, and a slice must be answerable by every model, not only the
+    // frontier ones.
+    const SMALLEST_CATALOG_OUTPUT_CEILING: u32 = 30_000;
+    assert!(
+        starting_output_budget(super::chunk::TARGET_CHARS) <= SMALLEST_CATALOG_OUTPUT_CEILING,
+        "a slice must fit the smallest catalog model's reply budget"
     );
 }
 
@@ -526,54 +555,113 @@ fn the_stamped_precedence_agrees_with_the_force_it_came_from() {
     }
 }
 
-/// A document inside the cap reaches the model whole, and nothing is reported
-/// as dropped.
+/// A document nothing drops reports nothing dropped.
 #[test]
-fn a_document_within_the_cap_is_sent_whole_and_drops_nothing() {
+fn a_document_within_the_ceiling_drops_nothing() {
     let content = "# notes\n\nthe package manager is pnpm.\n";
-    let (bounded, skipped) = bounded_content(content);
-    assert_eq!(bounded, content);
-    assert_eq!(skipped, 0);
     assert_eq!(skipped_chars(content), 0);
 }
 
-/// The witness for the silent-truncation defect: the cap was applied and the
-/// dropped tail was reported to the model in the prompt, but the count never
-/// left this function, so no caller could tell anyone.
+/// The witness for #2407, at this module's boundary: the document that was
+/// extracted at 54% is now reported as losing nothing, because nothing is lost.
+///
+/// Fails on the old code, where `skipped_chars` on a 44,545-character document
+/// returned 20,545 against the 24,000 cap — and later 0 only because the cap had
+/// been raised, which a document twice the size defeats again. Here the size
+/// tested is ten times the raised cap.
 #[test]
-fn an_oversized_document_reports_the_characters_it_dropped() {
-    let content = "x".repeat(MAX_PROMPT_CHARS + 4_096);
-    let (bounded, skipped) = bounded_content(&content);
-    assert_eq!(skipped, 4_096);
-    assert_eq!(skipped_chars(&content), 4_096);
-    assert!(
-        bounded.starts_with(&"x".repeat(MAX_PROMPT_CHARS)),
-        "the head must survive intact"
-    );
-    assert!(
-        bounded.contains("[... document truncated for extraction ...]"),
-        "the model must still be told the tail is missing"
+fn a_document_far_past_any_single_call_cap_drops_nothing() {
+    let content = "x".repeat(MAX_DOCUMENT_CHARS + 4_096);
+    // Above the ceiling the loss is real and reported...
+    assert!(skipped_chars(&content) > 0);
+    // ...but every size below it — including ten times the cap this replaced —
+    // is covered whole.
+    let big = "y".repeat(MAX_DOCUMENT_CHARS - 1);
+    assert_eq!(skipped_chars(&big), 0);
+    assert_eq!(
+        skipped_chars(&"z".repeat(44_545)),
+        0,
+        "AGENTS.md's own size"
     );
 }
 
-/// The cap counts characters, not bytes: a multi-byte document must not be cut
-/// early (or mid-codepoint) because its bytes outrun its characters.
+/// The ceiling counts characters, not bytes: a multi-byte document must not be
+/// cut early (or mid-codepoint) because its bytes outrun its characters.
 #[test]
-fn the_cap_counts_characters_not_bytes() {
-    let content = "é".repeat(MAX_PROMPT_CHARS);
-    assert_eq!(content.len(), MAX_PROMPT_CHARS * 2, "fixture is multi-byte");
+fn the_ceiling_counts_characters_not_bytes() {
+    let content = "é".repeat(MAX_DOCUMENT_CHARS);
+    assert_eq!(
+        content.len(),
+        MAX_DOCUMENT_CHARS * 2,
+        "fixture is multi-byte"
+    );
     assert_eq!(skipped_chars(&content), 0);
 }
 
-/// The first attempt is unadorned; a retry names itself, because the second
-/// silent call is what turned a two-minute wait into a five-minute one.
+/// A single-slice document says what it always said; a divided one names the
+/// part it is on and what it has found, because "which of the five calls am I
+/// paying for" is the question a multi-minute ingest raises.
 #[test]
-fn only_a_retry_names_its_attempt() {
-    assert_eq!(attempt_label("AGENTS.md", 0, 2), "extracting AGENTS.md");
+fn the_progress_label_names_the_slice_only_when_there_is_more_than_one() {
+    let one = SlicePosition {
+        index: 0,
+        of: 1,
+        path: &[],
+    };
+    assert_eq!(slice_label("AGENTS.md", one, 0), "extracting AGENTS.md");
+
+    let path = ["Architecture".to_string()];
+    let second = SlicePosition {
+        index: 1,
+        of: 5,
+        path: &path,
+    };
     assert_eq!(
-        attempt_label("AGENTS.md", 1, 2),
-        "extracting AGENTS.md (attempt 2 of 2)"
+        slice_label("AGENTS.md", second, 48),
+        "extracting AGENTS.md — part 2 of 5, 48 record(s) so far"
     );
+}
+
+/// The record line names the record in hand and how many are left — the second
+/// silence in the command, after the model calls.
+#[test]
+fn the_record_label_names_the_record_and_what_remains() {
+    assert_eq!(
+        record_label("AGENTS.md", "pkg-manager", 47, 141),
+        "AGENTS.md: processing pkg-manager — 48 of 141 record(s), 93 remaining"
+    );
+    assert_eq!(
+        record_label("AGENTS.md", "last-one", 140, 141),
+        "AGENTS.md: processing last-one — 141 of 141 record(s), 0 remaining"
+    );
+}
+
+/// A one-slice document must send exactly the prompt it always sent: the
+/// orienting header exists for slices that open mid-document, and paying for it
+/// on every short file would cost prompt-cache hits for nothing.
+#[test]
+fn a_single_slice_document_carries_no_orienting_header() {
+    let one = SlicePosition {
+        index: 0,
+        of: 1,
+        path: &[],
+    };
+    assert_eq!(slice_preamble(one), "");
+}
+
+/// A slice that opens inside a section says so, and names the section — the
+/// issue's constraint that a chunk beginning mid-section gives the extractor no
+/// context for what it is reading.
+#[test]
+fn a_continued_slice_tells_the_model_where_it_is() {
+    let path = ["Architecture".to_string(), "Ports".to_string()];
+    let header = slice_preamble(SlicePosition {
+        index: 2,
+        of: 4,
+        path: &path,
+    });
+    assert!(header.contains("part 3 of 4"), "{header}");
+    assert!(header.contains("Architecture > Ports"), "{header}");
 }
 
 /// Witness for #2709: the classifier's promotion tier is stamped explicitly

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -14,6 +14,7 @@ use stella_protocol::{
     CompletionRequestRef, CompletionResult, CompletionUsage, FinishReason, ProviderError,
 };
 
+use super::chunk::{MAX_DOCUMENT_CHARS, TARGET_CHARS};
 use super::*;
 
 fn temp_root(name: &str) -> PathBuf {
@@ -372,10 +373,7 @@ fn the_output_budget_is_sized_to_the_document() {
         "below the floor stays at the floor"
     );
     // A full slice: the budget tracks the text sent, one token per character.
-    assert_eq!(
-        starting_output_budget(super::chunk::TARGET_CHARS),
-        super::chunk::TARGET_CHARS as u32,
-    );
+    assert_eq!(starting_output_budget(TARGET_CHARS), TARGET_CHARS as u32,);
 }
 
 /// The budget must never exceed the ceiling, whatever it is asked for — a
@@ -389,7 +387,7 @@ fn the_output_budget_never_exceeds_the_ceiling() {
         MAX_OUTPUT_TOKENS
     );
     assert!(
-        super::chunk::TARGET_CHARS as u32 <= MAX_OUTPUT_TOKENS,
+        TARGET_CHARS as u32 <= MAX_OUTPUT_TOKENS,
         "a full slice must be expressible within one reply budget, or the \
          ceiling is unreachable by construction"
     );
@@ -399,7 +397,7 @@ fn the_output_budget_never_exceeds_the_ceiling() {
     // frontier ones.
     const SMALLEST_CATALOG_OUTPUT_CEILING: u32 = 30_000;
     assert!(
-        starting_output_budget(super::chunk::TARGET_CHARS) <= SMALLEST_CATALOG_OUTPUT_CEILING,
+        starting_output_budget(TARGET_CHARS) <= SMALLEST_CATALOG_OUTPUT_CEILING,
         "a slice must fit the smallest catalog model's reply budget"
     );
 }

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -246,6 +246,148 @@ impl Provider for CannedProvider {
     }
 }
 
+/// A provider that answers every slice, recording what it was asked.
+///
+/// Each call returns two claims: one whose statement is unique to the slice, and
+/// one restating the *same* claim with the *same* `lineage_suffix` every time —
+/// which is exactly what a real document does when a rule stated in an overview
+/// is repeated where it applies, and exactly the pair `Merge` has to resolve.
+struct PerSliceProvider {
+    calls: AtomicUsize,
+    prompts: std::sync::Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl Provider for PerSliceProvider {
+    fn id(&self) -> &str {
+        "per-slice"
+    }
+
+    async fn complete_ref(
+        &self,
+        request: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.prompts.lock().expect("lock").push(
+            request
+                .messages
+                .last()
+                .map(|m| m.content.clone())
+                .unwrap_or_default(),
+        );
+        let text = format!(
+            "[{{\"lineage_suffix\":\"only-here\",\"kind\":\"fact\",\
+             \"statement\":\"Slice {call} says something of its own.\"}},\
+             {{\"lineage_suffix\":\"pkg-manager\",\"kind\":\"fact\",\
+             \"statement\":\"This repository uses pnpm.\"}}]"
+        );
+        Ok(CompletionResult {
+            upstream_provider: None,
+            text,
+            tool_calls: Vec::new(),
+            usage: CompletionUsage {
+                reported: true,
+                input_tokens: 20,
+                output_tokens: 8,
+                ..CompletionUsage::default()
+            },
+            model: "canned-model".into(),
+            cost_usd: 0.002,
+            finish_reason: Some(FinishReason::Stop),
+        })
+    }
+}
+
+/// The end-to-end witness for #2407: a document larger than one call is read by
+/// several, and the claims come back as one coherent set.
+///
+/// Fails on the old code twice over — it made exactly one call whatever the
+/// document's size, and had no merge to collide in.
+#[test]
+fn a_multi_slice_document_calls_once_per_slice_and_merges_the_claims() {
+    let root = temp_root("multi-slice");
+    let provider = PerSliceProvider {
+        calls: AtomicUsize::new(0),
+        prompts: std::sync::Mutex::new(Vec::new()),
+    };
+
+    // Four sections of ~15,000 characters: comfortably past one slice, and
+    // divided at headings rather than mid-sentence.
+    let content: String = (0..4)
+        .map(|i| format!("## Section {i}\n\nprose {i}. {}\n\n", "w".repeat(15_000)))
+        .collect();
+    let doc = NamedDoc {
+        rel: "AGENTS.md".to_string(),
+        content,
+        tier: Tier::Primary,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let summary = runtime
+        .block_on(extract_document(
+            &provider,
+            "canned-model",
+            &root,
+            &doc,
+            RunStamp {
+                set_id: "acme.web",
+                ingest_run_id: "ing_multi",
+                observed_at: "2026-07-27T09:00:00Z",
+            },
+        ))
+        .expect("extraction succeeds");
+
+    let calls = provider.calls.load(Ordering::SeqCst);
+    assert!(
+        calls > 1,
+        "a document past one slice must buy more than one call, got {calls}"
+    );
+    assert_eq!(summary.slices, calls, "one call per slice");
+    assert!(
+        summary.failed_slices.is_empty(),
+        "no slice failed: {:?}",
+        summary.failed_slices
+    );
+
+    // The repeated claim is merged to one, not proposed once per slice.
+    assert_eq!(
+        summary.duplicates,
+        calls - 1,
+        "every restatement after the first is merged away"
+    );
+    assert_eq!(
+        summary.total,
+        calls + 1,
+        "one proposal per distinct claim: {calls} slice-local plus the shared one"
+    );
+
+    // ...and the colliding suffixes were made unique, so two records never share
+    // one lineage id.
+    let ids: std::collections::BTreeSet<&str> = summary
+        .asserted
+        .iter()
+        .map(|a| a.lineage_id.as_str())
+        .collect();
+    assert_eq!(
+        ids.len(),
+        summary.asserted.len(),
+        "lineage ids collided across slices: {ids:?}"
+    );
+
+    // Every slice was told where it sits, so none was an unlabelled fragment.
+    let prompts = provider.prompts.lock().expect("lock").clone();
+    for (i, prompt) in prompts.iter().enumerate() {
+        assert!(
+            prompt.contains(&format!("part {} of {calls}", i + 1)),
+            "slice {i} carried no orienting header"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// A provider whose first reply is cut off at the token limit (`finish_reason:
 /// Length`, no closing `]`) and whose second reply is the same records,
 /// complete — the shape a real truncation-then-retry takes. Records the

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -337,10 +337,12 @@ fn a_truncated_reply_is_retried_with_a_larger_budget_instead_of_failing() {
                 &provider,
                 "canned-model",
                 &root,
-                &doc,
-                &chunk,
-                position,
-                "extracting AGENTS.md",
+                SliceCall {
+                    doc: &doc,
+                    chunk: &chunk,
+                    position,
+                    base_label: "extracting AGENTS.md",
+                },
                 &progress,
             )
             .await;
@@ -437,9 +439,11 @@ fn extraction_writes_a_valid_proposal_file_end_to_end() {
             "canned-model",
             &root,
             &doc,
-            "acme.web",
-            "ing_test",
-            "2026-07-27T09:00:00Z",
+            RunStamp {
+                set_id: "acme.web",
+                ingest_run_id: "ing_test",
+                observed_at: "2026-07-27T09:00:00Z",
+            },
         ))
         .expect("extraction succeeds");
 

--- a/crates/stella-cli/src/ingest_cmd/progress.rs
+++ b/crates/stella-cli/src/ingest_cmd/progress.rs
@@ -1,19 +1,29 @@
-//! The elapsed-time line `stella ingest` shows while a model call is in flight.
+//! The live line `stella ingest` shows while it is working.
 //!
-//! Extraction is one provider call per document, and on a real instruction file
-//! it runs for minutes — this repository's own `AGENTS.md` took 5m18s across two
-//! calls. The command printed the filename and then nothing at all for that
-//! whole window, which is indistinguishable from a wedged process. The failure
-//! that costs something is the recovery: the first thing a person does to a
-//! frozen terminal is Ctrl-C, and here that abandons a call already paid for
-//! that was about to succeed.
+//! Extraction is minutes of work on a real instruction file — this repository's
+//! own `AGENTS.md` took 5m18s across two calls, and chunking a long document
+//! buys one paid call per slice on top of that. The command used to print the
+//! filename and then nothing at all for that whole window, which is
+//! indistinguishable from a wedged process. The failure that costs something is
+//! the recovery: the first thing a person does to a frozen terminal is Ctrl-C,
+//! and here that abandons calls already paid for that were about to succeed.
 //!
-//! So the wait is narrated instead. On a terminal the line rewrites itself in
-//! place once a second; anywhere else — a pipe, CI, `NO_COLOR` — it prints once
-//! and stays put, because a carriage return into a log file is noise rather
-//! than progress.
+//! So the wait is narrated, and the narration *moves*: the label is owned by the
+//! caller and changes as the work does — which slice is in flight, which record
+//! is being processed, how many are left. A ticker that only counts seconds
+//! proves the process is alive; one that names what it is doing also proves it
+//! is making progress, which is the question a person actually has.
+//!
+//! Two rhythms, because a terminal and a log file want opposite things:
+//!
+//! - On a terminal the line rewrites itself in place once a second.
+//! - Anywhere else — a pipe, CI, `NO_COLOR` — a fresh line is printed at most
+//!   every [`HEARTBEAT`], because a carriage return into a log file is noise but
+//!   *silence* is the thing that reads as failure. It used to print once and
+//!   stay put, so a piped run went quiet for the entire call.
 
 use std::io::Write;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
@@ -25,17 +35,30 @@ use tokio::time::MissedTickBehavior;
 /// tick that still reads as *running* rather than stopped.
 const TICK: Duration = Duration::from_secs(1);
 
-/// A running progress line, owned for the length of exactly one model call.
+/// How often a non-terminal run prints a fresh status line.
 ///
-/// Construct with [`Progress::start`] and always end with [`Progress::finish`].
-/// The call site keeps that pairing structural — `finish` runs on the statement
-/// after the `await`, before the result is inspected — so no error path can
-/// leave a ticker drawing over later output.
+/// Five seconds is the longest a person will watch an unchanging screen before
+/// concluding the process is stuck, and the shortest interval that does not turn
+/// a CI log into a flipbook of one command.
+const HEARTBEAT: Duration = Duration::from_secs(5);
+
+/// A running progress line, owned for the length of one stretch of work.
+///
+/// Construct with [`Progress::start`], rename with [`Progress::say`] as the work
+/// moves, and always end with [`Progress::finish`]. The call site keeps that
+/// pairing structural — `finish` runs on the statement after the `await`, before
+/// the result is inspected — so no error path can leave a ticker drawing over
+/// later output.
 pub(super) struct Progress {
-    /// `None` when this process is not drawing (non-TTY), which makes
-    /// [`Progress::finish`] a no-op rather than a special case.
+    /// The text the ticker is currently drawing. Shared so the work can rename
+    /// the line without stopping and restarting it, which on a terminal would
+    /// reset the elapsed clock the reader is using to judge whether to wait.
+    label: Arc<Mutex<String>>,
     stop: Option<oneshot::Sender<()>>,
     task: Option<JoinHandle<()>>,
+    /// Whether this process redraws in place, decided once at construction so
+    /// the answer cannot change mid-line.
+    drawing: bool,
 }
 
 impl Progress {
@@ -44,34 +67,71 @@ impl Progress {
     /// Must be called from inside a Tokio runtime: the ticker is a spawned task
     /// so that it is polled while the caller awaits the provider. Extraction's
     /// current-thread runtime drives it on the same thread, which is why the
-    /// line keeps moving through a multi-minute call without a second thread.
+    /// line keeps moving through a multi-minute call without a second thread —
+    /// and why any long stretch of *synchronous* work must yield (see
+    /// [`Progress::say`]).
     pub(super) fn start(label: String) -> Self {
-        if !drawing() {
-            println!("  {}", format!("{label} …").dimmed());
-            return Self {
-                stop: None,
-                task: None,
-            };
-        }
+        let drawing = drawing();
+        let shared = Arc::new(Mutex::new(label));
+        let label = Arc::clone(&shared);
         let (stop, mut rx) = oneshot::channel();
         let task = tokio::spawn(async move {
             let started = Instant::now();
-            let mut ticker = tokio::time::interval(TICK);
+            let interval = if drawing { TICK } else { HEARTBEAT };
+            let mut ticker = tokio::time::interval(interval);
             // The first tick fires immediately, so the line appears at 0s
-            // rather than a second into a wait that is already too quiet.
+            // rather than an interval into a wait that is already too quiet.
             ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
             loop {
                 tokio::select! {
                     _ = &mut rx => break,
-                    _ = ticker.tick() => draw(&line(&label, started.elapsed())),
+                    _ = ticker.tick() => {
+                        let text = line(&read(&label), started.elapsed());
+                        if drawing {
+                            redraw(&text);
+                        } else {
+                            println!("{text}");
+                        }
+                    }
                 }
             }
-            erase();
+            if drawing {
+                erase();
+            }
         });
         Self {
+            label: shared,
             stop: Some(stop),
             task: Some(task),
+            drawing,
         }
+    }
+
+    /// Rename the line: what the process is doing *now*.
+    ///
+    /// Cheap and non-blocking — it swaps a string the ticker reads on its next
+    /// tick, and never draws anything itself. A caller inside a long synchronous
+    /// loop must still yield to the runtime between calls, or the ticker task
+    /// (single-threaded here) never gets to run and the newest label is the only
+    /// one anyone sees.
+    pub(super) fn say(&self, label: String) {
+        if let Ok(mut held) = self.label.lock() {
+            *held = label;
+        }
+    }
+
+    /// Print something durable without stopping the line.
+    ///
+    /// A retry, a slice that failed — the things a reader needs in scrollback
+    /// after the run, not just while it is happening. Clears the ticker's row
+    /// first so the note does not land on top of a half-drawn line; the ticker
+    /// reclaims a fresh row on its next tick.
+    pub(super) fn note(&self, text: &str) {
+        if self.drawing {
+            print!("\r\x1b[2K");
+        }
+        println!("{text}");
+        let _ = std::io::stdout().flush();
     }
 
     /// Stop narrating and leave the cursor on a clean line.
@@ -88,6 +148,22 @@ impl Progress {
             let _ = task.await;
         }
     }
+
+    /// Whether this line is being redrawn in place, for a caller deciding how
+    /// often it is worth renaming.
+    #[cfg_attr(not(test), expect(dead_code, reason = "read only by the tests today"))]
+    pub(super) fn is_drawing(&self) -> bool {
+        self.drawing
+    }
+}
+
+/// Read the shared label, tolerating a poisoned lock — a progress line is not
+/// worth a panic, and the previous text is a fine thing to draw.
+fn read(label: &Arc<Mutex<String>>) -> String {
+    label
+        .lock()
+        .map(|held| held.clone())
+        .unwrap_or_else(|poisoned| poisoned.into_inner().clone())
 }
 
 /// Should this process redraw a line in place?
@@ -102,7 +178,7 @@ fn drawing() -> bool {
 
 /// The line's text, without the cursor control that positions it.
 ///
-/// Split out from [`draw`] because it is the whole of what a reader sees and
+/// Split out from [`redraw`] because it is the whole of what a reader sees and
 /// the only part worth pinning in a test.
 fn line(label: &str, elapsed: Duration) -> String {
     format!("  {} {}", label.dimmed(), human(elapsed).dimmed())
@@ -122,7 +198,7 @@ fn human(elapsed: Duration) -> String {
 }
 
 /// Rewrite the current row: carriage return, clear to end of line, print.
-fn draw(text: &str) {
+fn redraw(text: &str) {
     print!("\r\x1b[2K{text}");
     let _ = std::io::stdout().flush();
 }
@@ -167,5 +243,32 @@ mod tests {
         let rendered = line("extracting AGENTS.md", Duration::from_secs(318));
         assert!(rendered.contains("extracting AGENTS.md"), "{rendered}");
         assert!(rendered.contains("5m18s"), "{rendered}");
+    }
+
+    /// Neither rhythm may exceed five seconds of silence: that is the interval
+    /// at which an unchanging screen starts reading as a hang.
+    #[test]
+    fn neither_rhythm_goes_quiet_for_more_than_five_seconds() {
+        assert!(TICK <= Duration::from_secs(5));
+        assert!(HEARTBEAT <= Duration::from_secs(5));
+    }
+
+    /// The witness for the renaming half: the line the ticker draws follows the
+    /// caller's latest `say`, so the narration can name the record in hand
+    /// rather than only counting seconds.
+    #[tokio::test]
+    async fn the_line_follows_the_latest_label() {
+        let progress = Progress::start("extracting AGENTS.md".to_string());
+        progress.say("processing pkg-manager — 48 of 141".to_string());
+        let shown = line(&read(&progress.label), Duration::from_secs(7));
+        assert!(
+            shown.contains("processing pkg-manager — 48 of 141"),
+            "{shown}"
+        );
+        assert!(
+            !shown.contains("extracting"),
+            "stale label still drawn: {shown}"
+        );
+        progress.finish().await;
     }
 }

--- a/crates/stella-cli/src/ingest_cmd/progress.rs
+++ b/crates/stella-cli/src/ingest_cmd/progress.rs
@@ -148,13 +148,6 @@ impl Progress {
             let _ = task.await;
         }
     }
-
-    /// Whether this line is being redrawn in place, for a caller deciding how
-    /// often it is worth renaming.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read only by the tests today"))]
-    pub(super) fn is_drawing(&self) -> bool {
-        self.drawing
-    }
 }
 
 /// Read the shared label, tolerating a poisoned lock — a progress line is not


### PR DESCRIPTION
## What

`stella ingest` extracted at most the first N characters of a document and dropped
the rest before the model saw it, reporting success either way. This repository's
own `AGENTS.md` was extracted at 54%: the cut landed mid-table, and the god-file
rules, the glossary, the code-style conventions, the testing approach and the whole
gotchas section could not produce a record and could not have. The documents the
feature exists to read are exactly the documents that exceeded the cap.

A previous change raised the cap 24,000 → 120,000 and made the loss visible. That
moved the edge rather than removing it, and it moves it onto the reply: a claim
restates its sentence and carries a dozen schema fields, so the reply is roughly the
size of the text that produced it, and the smallest per-model output ceiling in the
seeded catalog is 30,000 tokens. This does what #2407's "proposed shape" section
asks for instead — chunk and merge.

## How

**New `ingest_cmd/chunk.rs`.** Splits on markdown heading seams, never a character
offset — a character offset is what severed the table row. Fenced code blocks are
tracked (a `#` comment inside a shell fence is not a heading, and splitting there
leaves an unterminated fence in both halves; tilde fences and longer nested backtick
fences close on their own marker and width). A section larger than one slice divides
at a paragraph, then a line, then a character. **Concatenating every chunk
reproduces the input exactly**, which is what makes "the whole file is read" a
checkable property rather than an assertion.

**One call per slice, at 24,000 characters** — the cap this replaces, restored to
the job it was always right for. 24,000 was never a bad *call* size; it was a
catastrophic *document* size, and the defect was applying it to the wrong noun.
Sized so the reply fits every seeded model, not only the frontier ones.

**The whole-document ceiling is 720,000 characters** — 6x the 120,000 single-call cap
it replaces, 30x the original 24,000. A bound still has to exist (chunks are paid
calls, so an unbounded document is an unbounded bill), but it sits where no
instruction file lives. Enforced by a `const _: () = assert!(…)` so it cannot drift
back toward what one call can carry.

**`Merge` resolves the two collisions that exist only because there is now more than
one call** — the issue names both:
- The same claim reaching two slices (a rule stated in an overview and restated where
  it applies). The later restatement is dropped; statements compare case-folded and
  whitespace-collapsed.
- A `lineage_suffix` the prompt asks to be unique *within the document*, which a call
  reading one slice cannot guarantee. `build_proposal` turns it into
  `ctx.<set_id>.<suffix>`, so a collision is two records with one identity. First use
  keeps the suffix — which keeps a single-slice document byte-identical to before —
  and later collisions are numbered.

**A failed slice no longer passes as a complete document.** Its parts are named in
red as `INCOMPLETE`, and its spend is still counted rather than quietly dropped.

## Progress feedback

The command printed a filename and then nothing for minutes, which is
indistinguishable from a wedged process — and the first thing a person does to a
frozen terminal is Ctrl-C, abandoning calls already paid for. The narration now
*moves*: the label is owned by the caller and renamed as the work advances.

- While slices are in flight: `extracting AGENTS.md — part 2 of 5, 48 record(s) so far`
- While records are gated and probed: `AGENTS.md: processing pkg-manager — 48 of 141 record(s), 93 remaining`
- Retries and failed slices print durably into scrollback without fighting the ticker.

Two rhythms: a terminal redraws in place every 1s; **a non-terminal run now prints a
heartbeat every 5s** instead of one line followed by silence for the whole call. The
record loop yields to the runtime so the single-threaded ticker is not starved by it.

`MAX_READ_BYTES` moves 512 KiB → 4 MiB, because `the_scan_never_hides_a_document_extraction_would_accept`
requires the scan's byte cap to clear the ceiling at worst-case 4-byte codepoints.

## Witness

Checked the artisanal way — reverting `MAX_DOCUMENT_CHARS` to the old 120,000 fails
5 tests that pass at 720,000:

```
ingest_cmd::tests::a_document_far_past_the_old_cap_is_extracted_whole ... FAILED
ingest_cmd::tests::an_oversized_document_says_how_much_is_skipped ... FAILED
ingest_cmd::tests::one_character_over_the_ceiling_is_still_reported ... FAILED
ingest_cmd::chunk::tests::a_document_far_past_one_call_is_covered_completely ... FAILED
ingest_cmd::chunk::tests::the_ceiling_is_six_times_the_cap_it_replaces ... FAILED
```

`a_document_far_past_the_old_cap_is_extracted_whole` is the load-bearing one: it calls
the same pre-existing `truncation_notice` function, and returns `Some(notice)` on the
old behaviour, `None` on the new.

New coverage in `chunk/tests.rs` pins the seams themselves — every-character-survives
on a 240,000-character document, no chunk over target, heading-aligned starts, fences
not treated as seams, continuation slices carrying their heading path, preamble kept,
multi-byte sliced on character boundaries, and an unbreakable line still dividing
without loss.

## Deleted tests

Named per the deleted-test guard. All three were replaced in place because the
function under test no longer exists (`bounded_content` / `attempt_label` were
removed):

- `a_document_within_the_cap_is_sent_whole_and_drops_nothing` → `a_document_within_the_ceiling_drops_nothing`
- `an_oversized_document_reports_the_characters_it_dropped` → `a_document_far_past_any_single_call_cap_drops_nothing`
- `the_cap_counts_characters_not_bytes` → `the_ceiling_counts_characters_not_bytes`
- `only_a_retry_names_its_attempt` → replaced by `the_progress_label_names_the_slice_only_when_there_is_more_than_one` and `the_record_label_names_the_record_and_what_remains`
- `the_ceiling_is_six_times_the_cap_it_replaces` → promoted to a compile-time `const` assert

## Verification

`cargo test -p stella-cli --bin stella` — 1821 passed, 0 failed. Clippy
`--all-targets` clean; `RUSTDOCFLAGS="-D warnings" cargo doc` clean; `cargo fmt`
applied.

Note: `main` does not compile at this branch's base (#3990 — the deck forwarder's
`friction` binding). That break is unrelated to this PR and is being fixed by #3992 /
#3993 / #3994; I applied one of those locally to run the suite and reverted it before
committing, so nothing from it is in this branch. This branch's CI will stay red
until one of them lands.

Refs #2407

## Summary by Sourcery

Split oversized documents into lossless, model-sized slices and merge their extracted claims without silently losing content.

New Features:
- Process large Markdown documents in multiple model calls and merge their extracted claims into a single proposal set.
- Provide document and record-level progress updates, including non-terminal heartbeats and explicit incomplete-slice reporting.

Bug Fixes:
- Prevent document content from being silently discarded at the single-call character limit.
- Preserve complete document content across heading-, paragraph-, line-, and character-aligned slices while respecting fenced code blocks.
- Resolve duplicate claims and lineage suffix collisions introduced by multi-slice extraction, while accounting for failed-slice costs.

Enhancements:
- Raise the whole-document ceiling and align the scan read limit with the maximum extractable document size.

Tests:
- Add coverage for lossless chunking, Markdown seam detection, fenced code handling, multi-byte content, document ceilings, claim merging, lineage uniqueness, and progress reporting.