### PR TITLE
fix(stella-cli): drop the duplicated friction ledger declaration — main's lint gate is red

### DIFF
--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -93,11 +93,6 @@ pub(crate) fn spawn_forwarder(
         // forwarder, and a forwarder is one lane — every lane has a registry
         // and a channel of its own, so two lanes' thoughts cannot fuse.
         let mut reasoning = agent::ReasoningRun::default();
-        // The lane's friction ledger (#3962), folded as the stream goes past
-        // rather than from a collected `Vec` the way `agent::run_turn` does:
-        // this task forwards each event and keeps none, and a ledger is bounded
-        // where a retained journal is not.
-        let mut friction = TurnFriction::default();
         // Two independent latches, not one. A single shared flag meant an
         // early usage gap — the benign, self-healing condition — silenced any
         // later store-write failure, which is the one that actually points at


### PR DESCRIPTION
Third composition break in `command_deck/forwarder.rs` today, same shape each time.

## What happened

- **#3978** (merged 20:36:11Z) added the forwarder's friction ledger: a `let mut friction = TurnFriction::default();` plus two uses.
- **#3980** (merged 20:36:48Z — **37 seconds later**) rewrote the same block to add the reasoning run, and dropped the binding while keeping both uses. `main` stopped compiling. The canary caught this: the `main-canary` run at 20:37:50Z failed.
- **#3994** restored the binding — and so did a concurrent fix. Both landed. The file now declares the identical 5-line comment and binding **twice in one scope**.

## Why it still matters after #3994

It compiles: the second declaration shadows the first. But the first is then never read, so:

```
warning: unused variable: `friction`
warning: variable does not need to be mutable
```

The gate's lint step is `clippy --all-targets -- -D warnings`, so **main builds and fails lint** — the half a plain `cargo build` does not show, which is likely why the latest canary run went green.

No `main-red` issue is currently open.

## The fix

Delete the second declaration. The surviving one is the earlier, where #3978 originally put it — immediately after `seq` and ahead of the `reasoning` run #3980 added. **No behaviour changes**: the shadowed binding was dead.

## Evidence

No witness test — the change deletes a dead binding, and the thing that goes from failing to passing is the gate step itself:

```
$ cargo clippy -p stella-cli --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.51s
```

Before this commit the same command reports the two warnings above.

Refs #3332

## Summary by Sourcery

Bug Fixes:
- Remove the duplicate `friction` declaration in the forwarder to eliminate unused-variable and unnecessary-mutability lint failures.