### PR TITLE
fix(stella-cli,stella-autonomy): repair main — duplicated `resolve` and an unformatted closure, both from #4001 (#4010)

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -231,42 +231,6 @@ pub(super) async fn escalate(
     comment(provider, key, &body, signature).await
 }
 
-/// Resolve one issue by key, through the port.
-///
-/// Reads the open queue and finds the key rather than asking the tracker for
-/// one issue, and that is a deliberate limit rather than an oversight: the port
-/// has no single-issue read, and adding one to serve a caller that only ever
-/// works **open** issues would widen a trait for a case that does not exist
-/// yet. The loop works what it drew from the ranked queue, and a claim lives in
-/// the fleet ledger rather than in the tracker's assignee field — so an issue
-/// being worked is still `Open` and still in this read.
-///
-/// A key that is not in the open queue is a typed refusal naming the two
-/// reasons a caller can act on: it is closed, or it does not exist.
-pub(super) fn resolve(
-    provider: &dyn IssueProvider,
-    key: &str,
-) -> Result<stella_protocol::issue::Issue, String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
-    let issues = runtime
-        .block_on(provider.list_open(QUEUE_READ_LIMIT))
-        .map_err(|error| error.to_string())?;
-
-    issues
-        .into_iter()
-        .find(|issue| issue.key.as_str() == key)
-        .ok_or_else(|| {
-            format!(
-                "#{key} is not in the open queue — it is closed, or it does not exist \
-                 (read {QUEUE_READ_LIMIT} open issues from `{}`)",
-                provider.id()
-            )
-        })
-}
-
 /// Close an issue with a receipt naming the evidence, signed.
 ///
 /// The receipt is an issue comment, so it takes the `issue_comment` signature


### PR DESCRIPTION
## What

`main` does not compile, and its gate is red for a second, independent reason. Both come from the same commit, `9304d3341` (#4001).

**1. `stella-cli` fails name resolution.** #4001 re-inserted `backlog::resolve` alongside its new issue-lifecycle block, byte-for-byte identical (doc comment included) to the copy already in the file:

```
error[E0428]: the name `resolve` is defined multiple times
   --> crates/stella-cli/src/self_driving_cmd/backlog.rs:350:1
```

Nothing downstream of `stella-cli` builds, so `make build-release` dies on every clone of `main`. The canary filed #4010.

**2. `format-check` fails.** The same commit introduced `rank_defects`'s filter closure in a shape the pinned rustfmt collapses to one line. This matters beyond tidiness: `format-check` runs *before* clippy, rustdoc and the tests, so while it is red the compile fix cannot be shown green at all (#3095 — one red gate step masks the next). Folded in here rather than filed, because it is the same commit's breakage and blocks demonstrating fix 1.

## Which `resolve` copy this removes, and why

Pre-merge (`c44d8b943`) the file held `render_queue`, `demand_from`, `resolve`, `render_not_filed` — one `resolve`, immediately before `render_not_filed`. That is the position of the **second** copy on `main`. So the copy at line 246 is the one #4001 added, and this removes that one: the diff is exactly the accidental duplication, and the surviving definition keeps its original position and its callers.

Both blocks were verified identical before choosing (`diff` over the two line ranges — no difference, body or doc comment), so the choice is about diff minimality and placement, not behaviour.

## Evidence

- **The compiler is the witness for fix 1.** `cargo check -p stella-cli` fails on the old tree with `E0428` and passes here. A behavioural witness test is not available for a duplicate-definition error — a second definition is not something a test can observe, because the crate carrying the test cannot be built. **This PR deletes no test.**
- `cargo check --workspace --all-targets` is **clean**. Worth stating explicitly: name resolution stops a crate at its first `E0428`, so the reported error could have been masking further breakage. It was not.
- Fix 2 is pure `cargo fmt --all` output on the pinned 1.97.0 toolchain — one hunk, one file, and `cargo fmt --all -- --check` reported no other drift anywhere in the workspace.
- `make gate` result reported in a comment below.

## How this reached `main`, and where that is tracked

Not filed as new — it is a recurrence of **#3887**, commented there with the timeline. In short: #4001's own required check `fmt + clippy + test` was **FAILURE** before the merge, and `cargo check on the declared MSRV` failed in 1m20s naming this exact `E0428`. It was merged anyway; the canary filed #4010 87 seconds later. The pre-merge signal was fast, fresh and unambiguous — nothing consumed it.

Note this is a gap #3932 cannot close: the `main is not known-broken` hold covers PRs merging *onto* an already-red `main` (and correctly passed on #4001, since no `main-red` issue existed yet). It structurally cannot catch the PR that *causes* the break.

Closes #4010
