### PR TITLE
style(stella-autonomy): rustfmt the closure #4001 left unformatted — main's format-check is red

### DIFF
--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -824,9 +824,7 @@ impl QueueIssue {
 pub fn rank_defects(issues: Vec<QueueIssue>) -> Vec<QueueIssue> {
     let mut defects: Vec<QueueIssue> = issues
         .into_iter()
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
         .collect();
     defects.sort_by(|a, b| {
         a.priority_rank()


### PR DESCRIPTION
## What

`main`'s gate stops at `format-check`. `9304d3341` (#4001) introduced `rank_defects`'s filter closure in a shape the pinned rustfmt collapses to one line:

```
Diff in crates/stella-autonomy/src/lib.rs:824
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
```

This is the second of the two breaks #4001 left. The first — the duplicated `backlog::resolve` that made `stella-cli` fail name resolution — landed in #4011 (`f9789df17`, closing #4010). This is the remainder.

## Why it is worth its own PR rather than a footnote

`format-check` runs **before** clippy, rustdoc and the tests in `GATE_STEPS`, so while it is red every step behind it is masked and never reports (#3095). `main`'s gate currently cannot get far enough to tell anyone anything else. It is a three-line diff with an outsized blast radius.

It was originally committed on #4011's branch, but that PR merged at its first commit while this one was still in flight, so it never reached the merged head. Rebased onto `f9789df17` and re-proposed here.

## Evidence

- Pure `cargo fmt --all` output on the pinned 1.97.0 toolchain — no hand-formatting.
- `cargo fmt --all -- --check` reports **zero** diffs on this branch, and reported exactly this one file before the change. No other drift anywhere in the workspace.
- Blamed to `9304d3341` via `git log -L 820,828:crates/stella-autonomy/src/lib.rs`, confirming it is #4001's line and not inherited from further back.
- No behaviour change: the closure is identical, only its line breaks differ. No witness test — this is a formatting-only change, and **no test is deleted**.

## Known-red beyond this, and not addressed here

With this applied, `make gate` locally clears fmt, clippy and rustdoc and then fails in `test` on `goal_wrapped_dispatch_cli` — which is **#3957**, filed 2026-08-19T19:17:17Z, hours before #4001 merged and before this branch existed. It is unrelated to this diff and deliberately not fixed here. Worth flagging from #3957's own title: that test bills a live model call on every run, so it should not be re-run casually to "check".

Refs #3957

## Summary by Sourcery

Enhancements:
- Apply pinned rustfmt formatting to the defect-ranking filter closure so the workspace passes format checks.