### PR TITLE
stella-autonomy: sign() has no doctest, so its exactly-one-line-break contract is only prose (#4006)

### DIFF
--- a/crates/stella-autonomy/src/attribution.rs
+++ b/crates/stella-autonomy/src/attribution.rs
@@ -95,6 +95,19 @@ impl Attribution {
 /// An empty signature returns the body untouched — including its own trailing
 /// whitespace, because a caller that signs nothing has not asked for its text
 /// to be reformatted.
+///
+/// # Examples
+///
+/// The join is exactly one line break, whatever the body ended with — so two
+/// callers that differ only in trailing whitespace produce the identical
+/// result:
+///
+/// ```
+/// use stella_autonomy::sign;
+///
+/// assert_eq!(sign("body", "Created by stella."), "body\nCreated by stella.");
+/// assert_eq!(sign("body\n\n", "Created by stella."), "body\nCreated by stella.");
+/// ```
 #[must_use]
 pub fn sign(body: &str, signature: &str) -> String {
     if signature.trim().is_empty() {


### PR DESCRIPTION
Autonomous fix for #4006.

Closes #4006

---
created by stella*

## Summary by Sourcery

Document and test the exact line-break behavior of `sign()`.

Enhancements:
- Add a doctest documenting and validating that `sign()` joins non-empty signatures to the body with exactly one line break while normalizing trailing body whitespace.

Tests:
- Cover the `sign()` trailing-whitespace and exact-one-line-break contract with executable examples.