### PR TITLE
fix(stella-autonomy): unbreak main's fmt gate

### DIFF
--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -824,9 +824,7 @@ impl QueueIssue {
 pub fn rank_defects(issues: Vec<QueueIssue>) -> Vec<QueueIssue> {
     let mut defects: Vec<QueueIssue> = issues
         .into_iter()
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
         .collect();
     defects.sort_by(|a, b| {
         a.priority_rank()


### PR DESCRIPTION
main is red on `cargo fmt --check`, which fails the required `fmt + clippy + test` check for **every pull request in the repository** — including ones whose own diff is clean.

`rank_defects` grew the escalation-label filter without a formatting pass:

```
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
```

One line, no behaviour change — `cargo fmt --all` produced exactly this and nothing else.

## Why it is urgent rather than tidy

The self-driving loop is running against this repository right now and has opened #4014 autonomously. Its delivery machine reads CI, compares each failing check against the **same check on the base branch**, and correctly classifies an inherited failure as `BaseBroken` rather than as its own — so it waits instead of pushing a fix for somebody else’s breakage.

That is the right behaviour and it means **nothing can merge until main is green**. The loop is currently parked on exactly this.

`harbor_adapter + analyzer pytest` is also failing on main and is tracked separately as #3967.

Refs #3599

## Summary by Sourcery

Bug Fixes:
- Restore formatting compliance in `stella-autonomy` so the repository’s required `cargo fmt --check` gate passes.