### PR TITLE
feat: PreIssueWork and PostIssueWork — let a person hold an agent off an issue (#3599)

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/roster.rs
+++ b/crates/stella-cli/src/plugin_cmd/roster.rs
@@ -60,10 +60,22 @@ use crate::settings::{Settings, Toggle};
 /// the file and `the_manifest_filename_is_the_specified_one` pins it here.
 pub(crate) const MANIFEST_FILE: &str = "plugin.toml";
 
-/// Every hook event, in the fixed order routes are emitted in. Exhaustive by
-/// construction: [`HookEvent`] is `stella-protocol`'s, and a sixth event
-/// added there without a line here would be silently unroutable, so the
-/// `event_order_is_exhaustive` test destructures the enum against this list.
+/// Every hook event a **plugin** can be routed at, in the fixed order routes
+/// are emitted in.
+///
+/// Deliberately not every [`HookEvent`]. The loop-lifecycle pair
+/// (`PreIssueWork`/`PostIssueWork`, #3599) is dispatched by the self-driving
+/// loop from the user's own `hooks` settings, outside any turn and through a
+/// different transport than this table feeds — so a route here would be one
+/// nothing dispatches, the silent half of "an undeclared hook is never
+/// invoked" wearing the other face. A plugin manifest that declares one is
+/// refused by name (`ManifestError::HookNotAvailableToPlugins`) rather than
+/// left to discover it at run time.
+///
+/// Exhaustive by construction for the events it does cover: the
+/// `event_order_is_exhaustive` test destructures the enum against this list,
+/// so a new in-turn event added to `stella-protocol` without a line here
+/// stops it compiling.
 const EVENT_ORDER: [HookEvent; 5] = [
     HookEvent::SessionStart,
     HookEvent::PreToolUse,
@@ -532,15 +544,21 @@ mod tests {
             HookEvent::PostToolUse,
             HookEvent::Stop,
             HookEvent::PreCompact,
+            HookEvent::PreIssueWork,
+            HookEvent::PostIssueWork,
         ] {
-            // The match is the assertion: adding a sixth variant to
-            // `HookEvent` stops this compiling until it is added above too.
+            // The match is the assertion: adding an in-turn variant to
+            // `HookEvent` stops this compiling until it is placed here too.
+            // The loop-lifecycle pair is routed by the self-driving loop
+            // rather than by this table, and is refused in a plugin manifest —
+            // so it is named here as excluded, not forgotten.
             let named = match event {
                 HookEvent::SessionStart
                 | HookEvent::PreToolUse
                 | HookEvent::PostToolUse
                 | HookEvent::Stop
                 | HookEvent::PreCompact => EVENT_ORDER.contains(&event),
+                HookEvent::PreIssueWork | HookEvent::PostIssueWork => !EVENT_ORDER.contains(&event),
             };
             assert!(named, "{event} is declarable but unroutable");
         }

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -18,6 +18,7 @@ mod config;
 mod convention;
 mod deliver;
 mod drive;
+mod hooks;
 mod lifecycle;
 pub(crate) mod probes;
 pub(crate) mod state;
@@ -32,6 +33,7 @@ use serde_json::Value;
 use stella_autonomy::{CycleOutcome, CycleRecord, Demand, Tooling};
 
 use crate::query_format::{QueryFormat, Rows};
+use crate::settings::Settings;
 use crate::timefmt::{now_unix, rfc3339_utc_now};
 use state::LoopState;
 
@@ -1260,7 +1262,34 @@ fn work_issue(
     let issue = backlog::resolve(&crate::issue_provider::GhIssueProvider, key)?;
 
     let attribution = config::load(&root).attribution;
+
+    // The `PreIssueWork` gate (#3599), before the worktree exists and before
+    // any model call — so a skip costs nothing and leaves nothing behind.
+    let settings = Settings::load(&root).unwrap_or_default();
+    let hook_issue = hooks::HookIssueInfo {
+        number: key.to_string(),
+        title: Some(issue.title.clone()),
+        branch: None,
+    };
+    if let hooks::WorkGate::Skip { reason } =
+        hooks::before_issue_work(&root, &settings, &hook_issue)
+    {
+        // Exit 0: a held issue is the loop being steered, not the loop
+        // failing, and a driver that treated it as an error would stop the
+        // sweep at the first fenced-off item.
+        if format == QueryFormat::Json {
+            println!(
+                "{}",
+                serde_json::json!({ "outcome": "skipped", "why": reason })
+            );
+        } else {
+            println!("skipped #{key} — {reason}");
+        }
+        return Ok(());
+    }
+
     let outcome = work::start(&root, &issue, spend_limit, &attribution)?;
+    hooks::after_issue_work(&root, &settings, &hook_issue, hook_outcome(&outcome));
 
     match &outcome {
         work::WorkOutcome::Changed { branch, stat, .. } => {
@@ -1289,6 +1318,23 @@ fn work_issue(
         // A failure exits non-zero: a caller that scripted this must not read
         // "the command returned" as "the issue was worked".
         work::WorkOutcome::Failed { reason } => Err(format!("#{key} was not worked: {reason}")),
+    }
+}
+
+/// The work unit's outcome, in the vocabulary a `PostIssueWork` hook reads.
+///
+/// Three arms rather than a boolean, and the mapping is total by `match` so a
+/// fourth `WorkOutcome` cannot silently become "no change" — which is the arm
+/// a subscriber acts on least and would notice missing last.
+fn hook_outcome(outcome: &work::WorkOutcome) -> hooks::HookIssueOutcome {
+    match outcome {
+        work::WorkOutcome::Changed { stat, .. } => hooks::HookIssueOutcome::Changed {
+            summary: stat.clone(),
+        },
+        work::WorkOutcome::NoChange { .. } => hooks::HookIssueOutcome::NoChange,
+        work::WorkOutcome::Failed { reason } => hooks::HookIssueOutcome::Failed {
+            reason: reason.clone(),
+        },
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd/hooks.rs
+++ b/crates/stella-cli/src/self_driving_cmd/hooks.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The loop's own hook dispatch — `PreIssueWork` and `PostIssueWork` (#3599).
+//!
+//! Every other hook point in this workspace is dispatched by the engine's
+//! driver, from inside a turn. These two are dispatched from here, because
+//! they bracket a turn rather than sitting inside one: `PreIssueWork` fires
+//! before the worktree exists and before any model call, and `PostIssueWork`
+//! fires after the whole work unit is done.
+//!
+//! # Why `PreIssueWork` can veto, and why the veto is a *skip*
+//!
+//! A person needs a way to keep an agent off work they have not finished
+//! thinking about — an issue that is still being specified, one a colleague has
+//! started, a release freeze — and the tracker is where that intent already
+//! lives (a label, an assignee, a milestone). Without a gate here the only
+//! options are editing the backlog query in Rust or stopping the loop
+//! entirely.
+//!
+//! A `deny` therefore skips **this issue** and lets the loop continue to the
+//! next. It is not an error and not a stop: the loop working through a backlog
+//! and stepping over one held item is the behaviour being asked for. A hook
+//! that means "stop everything" has to say so to its operator, because nothing
+//! here can tell the two intents apart from a `deny` alone.
+//!
+//! # It fails closed, which is the opposite of the usual choice
+//!
+//! A hook that could not be evaluated — it never ran, timed out, or exited
+//! non-zero — **skips the issue**. Most gates in this codebase fail open, so
+//! this is worth the sentence:
+//!
+//! The purpose of this hook is to withhold work. If it cannot run, the one
+//! thing we know is that we do not know whether this issue is held — and the
+//! two outcomes are not symmetric. Skipping an issue that was in fact free
+//! costs one cycle and is corrected by the next run. Working an issue that was
+//! in fact held is unrecoverable in the way that matters: a branch, a pull
+//! request, and a comment on an issue somebody deliberately fenced off.
+//!
+//! This mirrors `PreToolUse`, where a non-zero exit blocks the tool rather
+//! than waving it through.
+//!
+//! # `require_approval` is a skip, not a prompt
+//!
+//! The loop is the unattended path by construction; there is no human at the
+//! keyboard to answer. Rendering a prompt nobody sees and then proceeding
+//! would be strictly worse than declining, so the reason is reported and the
+//! issue is skipped — an operator reading the loop's output learns the same
+//! thing they would have been asked.
+
+use std::path::Path;
+
+use stella_core::bus::HookDecision;
+use stella_core::hooks::{HookEvent, HookPayload, decision::run_decision_hooks};
+pub(super) use stella_core::hooks::{HookIssueInfo, HookIssueOutcome};
+use stella_tools::hook_runner::ShellHookRunner;
+
+use crate::settings::Settings;
+
+/// Whether the loop may work this issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum WorkGate {
+    /// No hook objected — or none is registered, which is the common case.
+    Allow,
+    /// Skip this issue and move to the next one, for this reason.
+    Skip {
+        /// What to tell the operator. Always non-empty: a skip with no stated
+        /// reason is indistinguishable from a bug in the loop.
+        reason: String,
+    },
+}
+
+/// Run the `PreIssueWork` chain and fold it into a gate.
+///
+/// Returns [`WorkGate::Allow`] immediately when nothing is registered, so a
+/// workspace with no hooks pays no runtime at all — not even a runtime start.
+pub(super) fn before_issue_work(
+    root: &Path,
+    settings: &Settings,
+    issue: &HookIssueInfo,
+) -> WorkGate {
+    let Some(hooks) = registered(settings, HookEvent::PreIssueWork) else {
+        return WorkGate::Allow;
+    };
+    let payload = HookPayload::pre_issue_work(root.display().to_string(), issue.clone());
+
+    let run = match dispatch(&payload, hooks) {
+        Ok(run) => run,
+        // The runtime itself could not be started. Fails closed with the rest,
+        // per this module's header: the hook exists to withhold work, so "we
+        // could not ask" is not "go ahead".
+        Err(reason) => {
+            return WorkGate::Skip {
+                reason: format!("the PreIssueWork hook could not be evaluated: {reason}"),
+            };
+        }
+    };
+
+    for diagnostic in &run.diagnostics {
+        eprintln!("  ! PreIssueWork: {diagnostic}");
+    }
+    if !run.output.trim().is_empty() {
+        eprintln!("{}", run.output.trim_end());
+    }
+
+    match run.evaluation {
+        // A chain that only modified ends `Allow`. There is nothing here for a
+        // `modify` to rewrite — the payload is not a tool input — so it is
+        // reported as a diagnostic above and otherwise carries no effect.
+        Ok(HookDecision::Allow | HookDecision::Modify { .. }) => WorkGate::Allow,
+        Ok(HookDecision::Deny(denial)) => WorkGate::Skip {
+            reason: reason_or(denial.to_string(), "a PreIssueWork hook denied it"),
+        },
+        Ok(HookDecision::RequireApproval { reason }) => WorkGate::Skip {
+            reason: reason_or(
+                reason,
+                "a PreIssueWork hook asked for approval, and no human is driving this loop",
+            ),
+        },
+        Err(failure) => WorkGate::Skip {
+            reason: format!("the PreIssueWork hook could not be evaluated: {failure}"),
+        },
+    }
+}
+
+/// Run the `PostIssueWork` chain. Reports; never blocks.
+///
+/// The outcome has already happened, so there is no decision to fold and a
+/// failure here is a warning rather than a gate. It is still *reported* — a
+/// notifier that silently stopped notifying is the shape invariant #10 exists
+/// to prevent, on the consumption side.
+pub(super) fn after_issue_work(
+    root: &Path,
+    settings: &Settings,
+    issue: &HookIssueInfo,
+    outcome: HookIssueOutcome,
+) {
+    let Some(hooks) = registered(settings, HookEvent::PostIssueWork) else {
+        return;
+    };
+    let payload = HookPayload::post_issue_work(root.display().to_string(), issue.clone(), outcome);
+
+    match dispatch(&payload, hooks) {
+        Ok(run) => {
+            for diagnostic in &run.diagnostics {
+                eprintln!("  ! PostIssueWork: {diagnostic}");
+            }
+            if !run.output.trim().is_empty() {
+                eprintln!("{}", run.output.trim_end());
+            }
+            if let Err(failure) = run.evaluation {
+                eprintln!("  ! PostIssueWork hook failed: {failure}");
+            }
+        }
+        Err(reason) => eprintln!("  ! PostIssueWork hook could not be run: {reason}"),
+    }
+}
+
+/// The workspace's hooks, but only when something is registered for `event`.
+///
+/// The `None` arm is what keeps an unhooked workspace free: no runtime is
+/// built and no payload is serialized. Project-scope hooks are already gated
+/// by [`Settings::load`] on `STELLA_TRUST_PROJECT`, so a cloned repository
+/// cannot make the loop run its commands — this reads the merged result rather
+/// than re-deriving that gate, which would be a second copy of it.
+fn registered(settings: &Settings, event: HookEvent) -> Option<&stella_core::hooks::Hooks> {
+    let hooks = settings.hooks.as_ref()?;
+    (!hooks.matchers_for(event).is_empty()).then_some(hooks)
+}
+
+/// Run one chain on a runtime of its own.
+///
+/// A `current_thread` runtime built per dispatch, matching
+/// `self_driving_cmd`'s issue-provider call: these verbs are otherwise
+/// synchronous, and a hook chain is a handful of bounded subprocesses rather
+/// than something that needs the multi-threaded scheduler.
+fn dispatch(
+    payload: &HookPayload,
+    hooks: &stella_core::hooks::Hooks,
+) -> Result<stella_core::hooks::decision::DecisionRun, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the hook: {error}"))?;
+    Ok(runtime.block_on(run_decision_hooks(&ShellHookRunner, Some(hooks), payload)))
+}
+
+/// A hook's own words when it gave any, and a description of what happened
+/// when it did not.
+///
+/// A blank reason is the one thing this must not pass through: the operator
+/// reads it to decide whether the skip was intended.
+fn reason_or(reason: String, fallback: &str) -> String {
+    if reason.trim().is_empty() {
+        fallback.to_string()
+    } else {
+        reason
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/self_driving_cmd/hooks/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/hooks/tests.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `PreIssueWork` gate, over the real shell runner.
+//!
+//! These spawn actual `bash -c` hooks rather than a fake runner, because the
+//! thing worth proving is the whole path a user's `settings.json` takes: the
+//! matcher selection, the payload on stdin, the decision parsed off stdout,
+//! and the fold into a skip. A fake runner would assert the fold and leave
+//! the three steps a user actually writes untested.
+
+use std::path::PathBuf;
+
+use stella_core::hooks::{HookAction, HookMatcher, Hooks};
+
+use super::*;
+
+/// A temp root whose path is safe to interpolate into a shell command.
+///
+/// A thread id renders as `ThreadId(9)` — parentheses, which `bash -c` reads
+/// as syntax. These tests run real shell hooks against real paths, so the name
+/// is reduced to characters a shell has no opinion about rather than quoted at
+/// every use site.
+fn temp_root(label: &str) -> PathBuf {
+    let thread: String = format!("{:?}", std::thread::current().id())
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect();
+    let root = std::env::temp_dir().join(format!(
+        "stella-sd-hooks-{label}-{}-{thread}",
+        std::process::id(),
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("temp root");
+    root
+}
+
+/// Settings carrying one `PreIssueWork` hook running `command`.
+fn settings_with(event: &str, command: &str) -> Settings {
+    let matchers = vec![HookMatcher {
+        matcher: None,
+        hooks: vec![HookAction::new(command)],
+    }];
+    let mut hooks = Hooks::default();
+    match event {
+        "PreIssueWork" => hooks.pre_issue_work = Some(matchers),
+        "PostIssueWork" => hooks.post_issue_work = Some(matchers),
+        other => panic!("unhandled event {other}"),
+    }
+    // Built by mutation rather than by struct update: `Settings` has private
+    // fields, and a test that could name them all would be a test coupled to
+    // every future one.
+    let mut settings = Settings::default();
+    settings.hooks = Some(hooks);
+    settings
+}
+
+fn issue(number: &str) -> HookIssueInfo {
+    HookIssueInfo::new(number)
+}
+
+/// **The witness for the whole feature.** A hook can hold the loop off one
+/// issue, and the reason it gives reaches the operator.
+///
+/// This is the `agent-hold` shape: a real hook reads the issue number off the
+/// payload, decides, and prints a `deny`. Here the decision is unconditional;
+/// what is being proved is that a `deny` becomes a skip carrying the hook's
+/// own words.
+#[test]
+fn a_deny_skips_the_issue_and_carries_the_hook_s_reason() {
+    let root = temp_root("deny");
+    let settings = settings_with(
+        "PreIssueWork",
+        r#"echo '{"action":"deny","reason":"labelled agent-hold"}'"#,
+    );
+    assert_eq!(
+        before_issue_work(&root, &settings, &issue("42")),
+        WorkGate::Skip {
+            reason: "labelled agent-hold".into()
+        }
+    );
+}
+
+/// The payload reaches the hook on stdin, carrying the issue it is being asked
+/// about — without which a hook could only ever answer the same way for every
+/// issue, which is not a gate.
+#[test]
+fn the_hook_receives_the_issue_number_on_stdin() {
+    let root = temp_root("payload");
+    let seen = root.join("payload.json");
+    let settings = settings_with("PreIssueWork", &format!("cat > {}", seen.display()));
+
+    assert_eq!(
+        before_issue_work(&root, &settings, &issue("4000")),
+        WorkGate::Allow,
+        "a hook that decides nothing allows"
+    );
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&seen).expect("the hook was run"))
+            .expect("the payload is JSON");
+    assert_eq!(payload["event"], "PreIssueWork");
+    assert_eq!(payload["issue"]["number"], "4000");
+    assert_eq!(payload["cwd"], root.display().to_string());
+}
+
+/// **Fails closed.** A hook that exits non-zero has not said "go ahead" — it
+/// has said nothing, and this gate exists to withhold work. See the module
+/// header for why the two outcomes are not symmetric.
+#[test]
+fn a_hook_that_cannot_be_evaluated_skips_rather_than_proceeds() {
+    let root = temp_root("failclosed");
+    let settings = settings_with("PreIssueWork", "exit 3");
+    let gate = before_issue_work(&root, &settings, &issue("1"));
+    let WorkGate::Skip { reason } = gate else {
+        panic!("a failed hook must skip, not allow: {gate:?}");
+    };
+    assert!(reason.contains("could not be evaluated"), "{reason}");
+}
+
+/// No human is driving an unattended loop, so an approval request is declined
+/// rather than rendered to nobody.
+#[test]
+fn require_approval_skips_because_no_one_is_there_to_answer() {
+    let root = temp_root("approval");
+    let settings = settings_with(
+        "PreIssueWork",
+        r#"echo '{"action":"require_approval","reason":"ask me first"}'"#,
+    );
+    assert_eq!(
+        before_issue_work(&root, &settings, &issue("7")),
+        WorkGate::Skip {
+            reason: "ask me first".into()
+        }
+    );
+}
+
+/// An explicit allow is an allow, so a hook that inspects and approves does
+/// not cost the issue.
+#[test]
+fn an_explicit_allow_lets_the_work_proceed() {
+    let root = temp_root("allow");
+    let settings = settings_with("PreIssueWork", r#"echo '{"action":"allow"}'"#);
+    assert_eq!(
+        before_issue_work(&root, &settings, &issue("9")),
+        WorkGate::Allow
+    );
+}
+
+/// The overwhelmingly common case: nothing registered, nothing run, no
+/// runtime built. A loop in a workspace with no hooks must pay nothing for
+/// this feature existing.
+#[test]
+fn a_workspace_with_no_hook_registered_allows_without_running_anything() {
+    let root = temp_root("none");
+    assert_eq!(
+        before_issue_work(&root, &Settings::default(), &issue("1")),
+        WorkGate::Allow
+    );
+    // A hook registered for the *other* event must not be selected for this
+    // one — the matcher table is keyed per event, and reading the wrong key
+    // would run a reporting hook as a gate.
+    let elsewhere = settings_with("PostIssueWork", "exit 1");
+    assert_eq!(
+        before_issue_work(&root, &elsewhere, &issue("1")),
+        WorkGate::Allow,
+        "a PostIssueWork hook must not gate PreIssueWork"
+    );
+}
+
+/// `PostIssueWork` reports and cannot block: it runs after the work, so there
+/// is nothing left to veto. A failing one must not panic or propagate.
+#[test]
+fn post_issue_work_reports_the_outcome_and_never_blocks() {
+    let root = temp_root("post");
+    let seen = root.join("outcome.json");
+    let settings = settings_with("PostIssueWork", &format!("cat > {}", seen.display()));
+
+    after_issue_work(
+        &root,
+        &settings,
+        &issue("4000"),
+        HookIssueOutcome::Changed {
+            summary: "3 files changed".into(),
+        },
+    );
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&seen).expect("the hook was run"))
+            .expect("the payload is JSON");
+    assert_eq!(payload["event"], "PostIssueWork");
+    assert_eq!(payload["issueOutcome"]["status"], "changed");
+    assert_eq!(payload["issueOutcome"]["summary"], "3 files changed");
+
+    // A hook that fails is a warning, not a propagated error — the work is
+    // already done and there is nothing to undo.
+    after_issue_work(
+        &root,
+        &settings_with("PostIssueWork", "exit 9"),
+        &issue("1"),
+        HookIssueOutcome::NoChange,
+    );
+}
+
+/// A failed work unit reports as `failed`, not as `no_change`. The two are
+/// the arms a dashboard most needs apart: one is a loop with nothing to do,
+/// the other is a loop that needs a human.
+#[test]
+fn a_failure_is_reported_as_its_own_outcome() {
+    let root = temp_root("failed");
+    let seen = root.join("outcome.json");
+    let settings = settings_with("PostIssueWork", &format!("cat > {}", seen.display()));
+    after_issue_work(
+        &root,
+        &settings,
+        &issue("5"),
+        HookIssueOutcome::Failed {
+            reason: "the turn exited 1".into(),
+        },
+    );
+    let payload: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&seen).expect("the hook was run")).unwrap();
+    assert_eq!(payload["issueOutcome"]["status"], "failed");
+    assert_eq!(payload["issueOutcome"]["reason"], "the turn exited 1");
+}

--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -165,8 +165,10 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
 }
 
 /// One row per field of [`Hooks`]. Every event concatenates across scopes —
-/// any scope may add a gate, none may remove another's — so all five are
-/// [`Posture::Merged`].
+/// any scope may add a gate, none may remove another's — so all of them are
+/// [`Posture::Merged`], the loop-lifecycle pair included: a gate that holds an
+/// agent off an issue is exactly the kind a project should be able to add to
+/// one an operator already set.
 fn hooks_ledger(h: &Hooks) -> Vec<Field> {
     let d = Hooks::default();
     let Hooks {
@@ -175,6 +177,8 @@ fn hooks_ledger(h: &Hooks) -> Vec<Field> {
         post_tool_use,
         stop,
         pre_compact,
+        pre_issue_work,
+        post_issue_work,
     } = h;
     vec![
         keyed(
@@ -194,6 +198,16 @@ fn hooks_ledger(h: &Hooks) -> Vec<Field> {
         ),
         keyed("Stop", Posture::Merged, stop != &d.stop),
         keyed("PreCompact", Posture::Merged, pre_compact != &d.pre_compact),
+        keyed(
+            "PreIssueWork",
+            Posture::Merged,
+            pre_issue_work != &d.pre_issue_work,
+        ),
+        keyed(
+            "PostIssueWork",
+            Posture::Merged,
+            post_issue_work != &d.post_issue_work,
+        ),
     ]
 }
 
@@ -265,7 +279,9 @@ const EVERY_KEY: &str = r#"{
     "PreToolUse":   [ { "hooks": [{ "command": "pre-tool-use" }] } ],
     "PostToolUse":  [ { "hooks": [{ "command": "post-tool-use" }] } ],
     "Stop":         [ { "hooks": [{ "command": "stop" }] } ],
-    "PreCompact":   [ { "hooks": [{ "command": "pre-compact" }] } ]
+    "PreCompact":   [ { "hooks": [{ "command": "pre-compact" }] } ],
+    "PreIssueWork":  [ { "hooks": [{ "command": "pre-issue-work" }] } ],
+    "PostIssueWork": [ { "hooks": [{ "command": "post-issue-work" }] } ]
   },
   "mcp": { "registry_url": "https://registry.test/v0.1" },
   "agent_engine_config": { "default_model": "acme/acme-large" },
@@ -336,7 +352,7 @@ fn every_merged_settings_field_survives_the_scope_merge() {
     }
 }
 
-/// All five hook events concatenate across scopes.
+/// Every hook event concatenates across scopes.
 ///
 /// **Witness.** Fails on the base commit at `Stop` and `PreCompact`.
 /// Separate from the ledger test above because `hooks` is one row there:

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -56,6 +56,8 @@ fn concat_hooks(base: &mut Option<Hooks>, extra: &Hooks) {
     join(&mut target.post_tool_use, &extra.post_tool_use);
     join(&mut target.stop, &extra.stop);
     join(&mut target.pre_compact, &extra.pre_compact);
+    join(&mut target.pre_issue_work, &extra.pre_issue_work);
+    join(&mut target.post_issue_work, &extra.post_issue_work);
 }
 
 impl Settings {

--- a/crates/stella-core/src/hooks.rs
+++ b/crates/stella-core/src/hooks.rs
@@ -3,7 +3,7 @@
 //!
 //! Hooks are shell commands declared in workspace settings that fire on
 //! agent lifecycle events, receiving the event payload as JSON on stdin
-//! (Claude Code parity). Five events are wired, each with distinct,
+//! (Claude Code parity). Seven events are wired, each with distinct,
 //! load-bearing behavior:
 //!
 //!   - [`HookEvent::SessionStart`] — runs once before the turn. Anything a
@@ -23,10 +23,24 @@
 //!   - [`HookEvent::PreCompact`] — runs before an overflow-summarization
 //!     round. A `deny` decision vetoes the round; a `modify` decision may
 //!     inject summarization instructions.
+//!   - [`HookEvent::PreIssueWork`] — runs before the self-driving loop works
+//!     an issue, and outside any turn. A `deny` decision makes the loop skip
+//!     that issue and move on, which is how a person holds an agent off work
+//!     they are not ready to hand over (#3599).
+//!   - [`HookEvent::PostIssueWork`] — runs after that work unit, whatever the
+//!     outcome. Never blocks: the work is already done.
 //!
 //! Matchers are globs over the tool name for `PreToolUse`/`PostToolUse`;
-//! the non-tool-scoped events (`SessionStart`, `Stop`, `PreCompact`)
-//! ignore the matcher and run every action.
+//! every other event ignores the matcher and runs every action.
+//!
+//! # Two families, and why the second is here rather than in its own engine
+//!
+//! The first five name points *inside* a turn and are dispatched by the
+//! driver. The issue-work pair names points *around* a turn and is dispatched
+//! by the self-driving loop in `stella-cli`, which is a different caller
+//! entirely. They share this module because they share a settings file, a
+//! payload shape, and the `allow`/`deny` fold — see [`stella_protocol::hook`]
+//! for the argument against a second vocabulary.
 //!
 //! `PreToolUse` payloads carry the tool's advertised metadata — today the
 //! [`ToolSchema::read_only`](stella_protocol::ToolSchema) bit, so an
@@ -63,11 +77,11 @@ pub mod decision;
 /// plus the #2684 additions `Stop` and `PreCompact`).
 ///
 /// Defined in [`stella_protocol::hook`] and re-exported here, so this path
-/// keeps resolving. A plugin manifest grants the same five points
+/// keeps resolving. A plugin manifest grants the same points
 /// (`stella-plugin::manifest`), and before #3310 that was a second hand-kept
 /// copy of this enum: the engine may not depend on `stella-plugin` (#3245
 /// open question 3) and `stella-plugin` may not depend on the engine, so the
-/// vocabulary lives in the crate underneath both. A sixth event is now one
+/// vocabulary lives in the crate underneath both. Another event is now one
 /// edit; it used to be two, with nothing red if you made only one.
 pub use stella_protocol::hook::HookEvent;
 
@@ -117,8 +131,8 @@ impl HookAction {
 
 /// Groups hook actions under a tool-name pattern (TS: `HookMatcher`). For
 /// `PreToolUse`/`PostToolUse`, `matcher` is a glob over the tool name
-/// (e.g. `"task_create"`, `"mcp__*"`, `"*"`). The non-tool-scoped events
-/// (`SessionStart`, `Stop`, `PreCompact`) ignore it — every action runs.
+/// (e.g. `"task_create"`, `"mcp__*"`, `"*"`). Every other event ignores it —
+/// every action runs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HookMatcher {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -158,6 +172,18 @@ pub struct Hooks {
         skip_serializing_if = "Option::is_none"
     )]
     pub pre_compact: Option<Vec<HookMatcher>>,
+    #[serde(
+        rename = "PreIssueWork",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pre_issue_work: Option<Vec<HookMatcher>>,
+    #[serde(
+        rename = "PostIssueWork",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub post_issue_work: Option<Vec<HookMatcher>>,
 }
 
 impl Hooks {
@@ -170,6 +196,8 @@ impl Hooks {
             HookEvent::PostToolUse => &self.post_tool_use,
             HookEvent::Stop => &self.stop,
             HookEvent::PreCompact => &self.pre_compact,
+            HookEvent::PreIssueWork => &self.pre_issue_work,
+            HookEvent::PostIssueWork => &self.post_issue_work,
         };
         field.as_deref().unwrap_or(&[])
     }
@@ -211,6 +239,17 @@ pub struct HookPayload {
     /// same reason: what a hook can afford to read is the hook's call.
     #[serde(rename = "finalText", default, skip_serializing_if = "Option::is_none")]
     pub final_text: Option<String>,
+    /// Present for `PreIssueWork` / `PostIssueWork`: which issue the
+    /// self-driving loop is about to work, or has just worked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<HookIssueInfo>,
+    /// Present for `PostIssueWork`: how the work unit ended.
+    #[serde(
+        rename = "issueOutcome",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub issue_outcome: Option<HookIssueOutcome>,
 }
 
 impl HookPayload {
@@ -223,6 +262,8 @@ impl HookPayload {
             tool: None,
             tool_result: None,
             final_text: None,
+            issue: None,
+            issue_outcome: None,
         }
     }
 
@@ -281,6 +322,92 @@ impl HookPayload {
     pub fn pre_compact(cwd: impl Into<String>) -> Self {
         Self::bare(HookEvent::PreCompact, cwd.into())
     }
+
+    /// A `PreIssueWork` payload — the issue the loop is about to work.
+    ///
+    /// No outcome, because nothing has happened yet: this is the payload a
+    /// hook reads to decide whether the work should happen at all.
+    pub fn pre_issue_work(cwd: impl Into<String>, issue: HookIssueInfo) -> Self {
+        Self {
+            issue: Some(issue),
+            ..Self::bare(HookEvent::PreIssueWork, cwd.into())
+        }
+    }
+
+    /// A `PostIssueWork` payload — the same issue, plus how it went.
+    pub fn post_issue_work(
+        cwd: impl Into<String>,
+        issue: HookIssueInfo,
+        outcome: HookIssueOutcome,
+    ) -> Self {
+        Self {
+            issue: Some(issue),
+            issue_outcome: Some(outcome),
+            ..Self::bare(HookEvent::PostIssueWork, cwd.into())
+        }
+    }
+}
+
+/// The issue a self-driving work unit is about, as a hook sees it.
+///
+/// # Why the identifier and nothing else is guaranteed
+///
+/// Only [`Self::number`] is always present. The rest is what the loop happened
+/// to have already read, and the loop reads the tracker lazily — so a hook that
+/// needs a field this does not carry should fetch it itself (`gh issue view`
+/// is one line in a shell hook) rather than have Stella fetch it on every
+/// dispatch for the hooks that do not.
+///
+/// That is a deliberate cost split: an extra tracker round trip per issue,
+/// paid by the hooks that want it, beats one paid by every loop whether a hook
+/// is registered or not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookIssueInfo {
+    /// The issue number, as the tracker spells it. Always present — it is the
+    /// identity everything else about the work unit hangs off.
+    pub number: String,
+    /// The issue's title, when the loop already had it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// The branch the work would land on, when it is already decided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+}
+
+impl HookIssueInfo {
+    /// The identifier alone — the shape a caller that has read nothing else
+    /// can always build.
+    pub fn new(number: impl Into<String>) -> Self {
+        Self {
+            number: number.into(),
+            title: None,
+            branch: None,
+        }
+    }
+}
+
+/// How a work unit ended, for [`HookEvent::PostIssueWork`].
+///
+/// Three arms rather than a boolean, because a consumer's next move differs
+/// for each: `Changed` means there is a branch to review, `NoChange` means the
+/// issue is still open and untouched, and `Failed` means something needs a
+/// human. Collapsing the last two into "not successful" is what makes a
+/// dashboard unable to tell a starved loop from a broken one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum HookIssueOutcome {
+    /// The turn ran and left committed or uncommitted work behind.
+    Changed {
+        /// What changed, as the loop summarized it.
+        summary: String,
+    },
+    /// The turn ran and changed nothing.
+    NoChange,
+    /// The work unit could not complete.
+    Failed {
+        /// Why, in the loop's own words.
+        reason: String,
+    },
 }
 
 /// One hook command's raw execution result — returned even on non-zero

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -47,6 +47,25 @@ pub enum ManifestError {
         participation: Participation,
     },
 
+    /// `[loop] hooks` named a hook a plugin cannot be routed at.
+    ///
+    /// The loop-lifecycle events (`PreIssueWork`, `PostIssueWork`, #3599) are
+    /// dispatched by the self-driving loop from the operator's own `hooks`
+    /// settings, outside any turn — a different caller and a different
+    /// transport than the plugin routing table feeds. A manifest may spell
+    /// them, because they are one vocabulary; it may not yet be routed at
+    /// them, and this is that refusal said out loud rather than discovered as
+    /// a grant that quietly does nothing.
+    #[error(
+        "[loop] hooks names {hook}, which a plugin cannot be routed at: it is a \
+         self-driving loop event dispatched outside any turn, from the \
+         operator's own hooks settings. Register it there instead."
+    )]
+    HookNotAvailableToPlugins {
+        /// The event a plugin may not be routed at.
+        hook: HookEvent,
+    },
+
     /// `[loop] points` listed the same wrapper point twice — the
     /// [`ManifestError::DuplicateHook`] rule, for the socket's points.
     #[error("[loop] points declares {point} more than once")]

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -609,6 +609,12 @@ impl PluginManifest {
             if !seen_hooks.insert(*hook) {
                 return Err(ManifestError::DuplicateHook { hook: *hook });
             }
+            // The loop-lifecycle pair is spellable here — it is one vocabulary
+            // — and not routable to a plugin, so it is refused by name rather
+            // than granted and never dispatched (#3599).
+            if matches!(hook, HookEvent::PreIssueWork | HookEvent::PostIssueWork) {
+                return Err(ManifestError::HookNotAvailableToPlugins { hook: *hook });
+            }
         }
         if !grant.hooks.is_empty() && !participation.includes(Participation::Steering) {
             return Err(ManifestError::HooksRequireSteering { participation });
@@ -873,6 +879,29 @@ mod tests {
                 hook: HookEvent::PreToolUse
             }
         ));
+    }
+
+    /// **The other half of "an undeclared hook is never invoked".** A plugin
+    /// may spell the loop-lifecycle events — they are one vocabulary — and may
+    /// not be routed at them: they are dispatched by the self-driving loop
+    /// from the operator's own hooks settings, outside any turn. Refused by
+    /// name, so an author learns it here rather than from a grant that
+    /// silently never fires (#3599).
+    #[test]
+    fn a_plugin_may_not_be_routed_at_a_loop_lifecycle_hook() {
+        for hook in ["PreIssueWork", "PostIssueWork"] {
+            let err = parse(&format!(
+                "name = \"x\"\n[loop]\nparticipation = \"steering\"\nhooks = [\"{hook}\"]"
+            ))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::HookNotAvailableToPlugins { .. }),
+                "{hook} must be refused: {err:?}"
+            );
+            let text = err.to_string();
+            assert!(text.contains(hook), "{text}");
+            assert!(text.contains("outside any turn"), "{text}");
+        }
     }
 
     /// The set-based duplicate checks must name the same offender the prefix

--- a/crates/stella-protocol/src/hook.rs
+++ b/crates/stella-protocol/src/hook.rs
@@ -15,18 +15,38 @@
 //! `stella-plugin` must never pull in the engine. So the vocabulary moves
 //! *down* to the crate both may depend on, exactly as invariant #1 says a
 //! shared contract should. `stella-core::hooks` and `stella-plugin::manifest`
-//! re-export this type, so every existing path still resolves and a sixth
+//! re-export this type, so every existing path still resolves and another
 //! event is now one edit rather than two — the drift shape #3310 was filed
 //! against is no longer expressible.
 //!
 //! # Wire shape
 //!
-//! PascalCase, with no `rename_all`, because these five strings are not this
+//! PascalCase, with no `rename_all`, because these strings are not this
 //! crate's to choose: `"PreToolUse"` is already what a user types in
 //! `.stella/settings.json`. Per invariant #4 the type round-trips through
 //! `serde_json` byte-for-byte, and this module's `WIRE_STRINGS` test constant
 //! pins each spelling so a rename that would break a shipped settings file
 //! fails a test instead of a user's session.
+//!
+//! # Two families, one vocabulary
+//!
+//! The original five events name points **inside a turn**. [`HookEvent::PreIssueWork`]
+//! and [`HookEvent::PostIssueWork`] name points **around a turn**: the
+//! self-driving loop deciding to work an issue, and the outcome when it is
+//! done (#3599). They share this enum rather than getting one of their own for
+//! the reason this module exists at all — a user registers both in the same
+//! `hooks` block of the same settings file, and a plugin declares both in the
+//! same `[loop] hooks` list. A second enum would be a second vocabulary to
+//! keep identical, which is the drift shape #3310 removed.
+//!
+//! The naming rule for anything added here, so the set stays readable as one:
+//! **`Pre`/`Post` for a pair that brackets something, a past participle for a
+//! thing that happened, and no `ON_`/`BEFORE_` prefixes** — the tense lives in
+//! the name. The rest of the self-driving vocabulary (the tracker, pull-request
+//! and check events) is designed and deliberately **not** declared here yet:
+//! it needs the `deliver` verbs to have somewhere to fire from, and a hook
+//! point nothing dispatches is a declaration that quietly does nothing. See
+//! the issue tracking it.
 
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +68,32 @@ pub enum HookEvent {
     /// An overflow-summarization round is about to run
     /// (`driver::user_hooks`). Not tool-scoped: the matcher is ignored.
     PreCompact,
+    /// The self-driving loop is about to work an issue, before the worktree
+    /// exists and before any model call (#3599). Not tool-scoped.
+    ///
+    /// **A veto point**, on [`HookEvent::PreToolUse`]'s contract: a `deny`
+    /// decision means the loop skips this issue and moves to the next one. That
+    /// is the point of the event rather than a side effect of it — it is how a
+    /// person keeps an agent off work they have not finished thinking about
+    /// (an `agent-hold` label, an unresolved question, a release freeze), and
+    /// how two agents working one backlog avoid taking the same issue.
+    ///
+    /// A skip is not a failure: the loop continues. A hook that means "stop the
+    /// whole loop" should say so in its reason and let the operator act, since
+    /// nothing here can distinguish the two intents.
+    PreIssueWork,
+    /// The self-driving loop has finished working an issue, whatever the
+    /// outcome. Not tool-scoped, and **cannot veto** — the work is done.
+    ///
+    /// Fires for a failed attempt as well as a successful one, because the
+    /// consumers that most want it (a dashboard, a notifier, a second agent
+    /// waiting for the branch) need the failure at least as much.
+    ///
+    /// Does **not** fire when [`HookEvent::PreIssueWork`] denied: nothing was
+    /// worked, so there is no outcome to report, and a `Post` that fired
+    /// without its `Pre` having been allowed would make the pair useless for
+    /// exactly the bookkeeping it exists for.
+    PostIssueWork,
 }
 
 impl HookEvent {
@@ -57,12 +103,14 @@ impl HookEvent {
     /// variant without adding it here fails this module's
     /// `every_variant_is_listed` test, which is what makes "the whole
     /// vocabulary" a value a caller can iterate instead of a set it re-types.
-    pub const ALL: [HookEvent; 5] = [
+    pub const ALL: [HookEvent; 7] = [
         HookEvent::SessionStart,
         HookEvent::PreToolUse,
         HookEvent::PostToolUse,
         HookEvent::Stop,
         HookEvent::PreCompact,
+        HookEvent::PreIssueWork,
+        HookEvent::PostIssueWork,
     ];
 
     /// Whether this event fires for one specific tool call — the events
@@ -81,6 +129,8 @@ impl HookEvent {
             HookEvent::PostToolUse => "PostToolUse",
             HookEvent::Stop => "Stop",
             HookEvent::PreCompact => "PreCompact",
+            HookEvent::PreIssueWork => "PreIssueWork",
+            HookEvent::PostIssueWork => "PostIssueWork",
         }
     }
 }
@@ -98,16 +148,18 @@ mod tests {
     /// The pinned wire strings. A rename here is a break of every shipped
     /// `.stella/settings.json` and every plugin manifest, so it has to be a
     /// deliberate edit to this list.
-    const WIRE_STRINGS: [&str; 5] = [
+    const WIRE_STRINGS: [&str; 7] = [
         "SessionStart",
         "PreToolUse",
         "PostToolUse",
         "Stop",
         "PreCompact",
+        "PreIssueWork",
+        "PostIssueWork",
     ];
 
     /// Its position in [`HookEvent::ALL`], derived by a match so the compiler
-    /// forces a sixth variant to be placed rather than silently omitted.
+    /// forces a new variant to be placed rather than silently omitted.
     fn declared_index(event: HookEvent) -> usize {
         match event {
             HookEvent::SessionStart => 0,
@@ -115,6 +167,8 @@ mod tests {
             HookEvent::PostToolUse => 2,
             HookEvent::Stop => 3,
             HookEvent::PreCompact => 4,
+            HookEvent::PreIssueWork => 5,
+            HookEvent::PostIssueWork => 6,
         }
     }
 

--- a/website/content/docs/agent-tools/hooks.mdx
+++ b/website/content/docs/agent-tools/hooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hooks
-description: Run shell commands on stella's agent lifecycle events — SessionStart, PreToolUse, PostToolUse, Stop, and PreCompact — configured under the hooks key in settings.json.
+description: Run shell commands on stella's agent lifecycle events — SessionStart, PreToolUse, PostToolUse, Stop, PreCompact, PreIssueWork, and PostIssueWork — configured under the hooks key in settings.json.
 ---
 
 Hooks are shell commands that fire on agent lifecycle events. They are configured under the `hooks` key in your `settings.json` and follow Claude Code parity, so existing hook knowledge carries over.
@@ -16,7 +16,9 @@ Each hook receives the event payload as **JSON on stdin**, so your command can r
 
 ## Events
 
-stella fires hooks on five lifecycle events. Each behaves differently, and each has its own rules for matching and blocking.
+stella fires hooks on seven lifecycle events. Each behaves differently, and each has its own rules for matching and blocking.
+
+Five of them name points **inside a turn**. The last two name points **around a work unit of the [self-driving loop](/docs/self-improvement)** — the loop deciding to work an issue, and the outcome once it has. They live in the same `hooks` block and speak the same decision vocabulary.
 
 <HookLifecycleDiagram />
 
@@ -40,6 +42,14 @@ stella fires hooks on five lifecycle events. Each behaves differently, and each 
   <OptionCard name="PreCompact">
     Runs before an overflow-summarization round. A `deny` decision vetoes the round; a
     `modify` decision can steer the summarizer. The matcher is ignored.
+  </OptionCard>
+  <OptionCard name="PreIssueWork">
+    Runs before the self-driving loop works an issue. **Blocking**: a `deny` makes the
+    loop skip that issue and move on. The matcher is ignored.
+  </OptionCard>
+  <OptionCard name="PostIssueWork">
+    Runs after that work unit, whatever the outcome. **Never blocks** — the work is done.
+    The matcher is ignored.
   </OptionCard>
 </CardGrid>
 
@@ -65,6 +75,27 @@ Runs when a turn is about to complete, with the would-be final text in the paylo
 
 Runs before each overflow-summarization round (the model-written summary that replaces the oldest span when the conversation outgrows its context budget). Printing `{"action":"deny","reason":"…"}` vetoes the round — the transcript is left intact, at the risk of a later hard overflow — and `{"action":"modify","payload":{"instructions":"…"}}` appends your instructions to the summarizer's prompt (for example, "keep every file path verbatim"). A failing `PreCompact` hook proceeds un-vetoed, so a broken hook cannot starve compaction. The matcher is **ignored**.
 
+### `PreIssueWork`
+
+Runs before the self-driving loop works an issue — **before the worktree exists and before any model call**, so a skip costs nothing and leaves nothing behind. The payload carries the issue under `issue`. Printing `{"action":"deny","reason":"…"}` makes the loop **skip that issue and continue to the next one**; the reason is printed for the operator. The matcher is **ignored**.
+
+This is the hook to reach for when you want a person to be able to hold an agent off specific work — an issue that is still being specified, one a colleague has started, or anything under a release freeze. See [Holding an agent off an issue](#holding-an-agent-off-an-issue).
+
+A skip is **not a failure**: the verb exits 0, because a driver working through a backlog should step over a held item rather than stop at it. Nothing distinguishes "skip this one" from "stop everything" in a `deny` alone, so a hook that means the latter has to say so to its operator.
+
+<Callout type="warn">
+  **`PreIssueWork` fails closed**, unlike most gates here. A hook that never ran, timed out,
+  or exited non-zero **skips the issue**. The two outcomes are not symmetric: skipping an
+  issue that was in fact free costs one cycle and corrects itself next run, while working an
+  issue that was in fact held leaves a branch, a pull request, and a comment on something
+  somebody deliberately fenced off. `require_approval` also skips — an unattended loop has
+  nobody at the keyboard to answer it.
+</Callout>
+
+### `PostIssueWork`
+
+Runs after the loop has finished a work unit, whatever happened. **Never blocks**: the work is already done and there is nothing left to veto. The payload carries the same `issue` plus an `issueOutcome`. It fires for a failed attempt as well as a successful one — a dashboard, a notifier, or a second agent waiting on the branch needs the failure at least as much. It does **not** fire when `PreIssueWork` denied, because nothing was worked. The matcher is **ignored**.
+
 ## The stdin payload
 
 Every hook receives one JSON document on stdin. Its shape:
@@ -83,8 +114,9 @@ Every hook receives one JSON document on stdin. Its shape:
 
 <CardGrid size="md">
   <OptionCard name="event">
-    String, always present. `"SessionStart"`, `"PreToolUse"`, `"PostToolUse"`, `"Stop"`, or
-    `"PreCompact"` — the same PascalCase names as the config keys.
+    String, always present. `"SessionStart"`, `"PreToolUse"`, `"PostToolUse"`, `"Stop"`,
+    `"PreCompact"`, `"PreIssueWork"`, or `"PostIssueWork"` — the same PascalCase names as
+    the config keys.
   </OptionCard>
   <OptionCard name="cwd">
     String, always present. The workspace root — also the hook's working directory.
@@ -104,6 +136,18 @@ Every hook receives one JSON document on stdin. Its shape:
   <OptionCard name="finalText">
     String, on `Stop` only. The text the turn is about to complete with — whole, same
     unclipped posture as `toolResult`.
+  </OptionCard>
+  <OptionCard name="issue">
+    Object, on `PreIssueWork` and `PostIssueWork`. `{ "number": …, "title": …, "branch": … }`.
+    Only `number` is guaranteed — the rest is whatever the loop had already read. A hook
+    that needs more should fetch it itself (`gh issue view` is one line), rather than have
+    every loop pay a tracker round trip for the hooks that do not.
+  </OptionCard>
+  <OptionCard name="issueOutcome">
+    Object, on `PostIssueWork` only. `{"status":"changed","summary":…}`,
+    `{"status":"no_change"}`, or `{"status":"failed","reason":…}`. Three states rather
+    than a boolean: *nothing to do* and *needs a human* are the two a dashboard most needs
+    to tell apart.
   </OptionCard>
 </CardGrid>
 
@@ -227,6 +271,63 @@ Wire it to every tool with a `"*"` matcher:
   }
 }
 ```
+
+### Holding an agent off an issue
+
+The self-driving loop works whatever the backlog hands it. `PreIssueWork` is where a person gets a say — and the cleanest way to express that is a label on the issue itself, because the tracker is where the intent already lives and anyone on the team can set it without touching a config file.
+
+This hook holds the loop off any issue labelled `agent-hold`:
+
+```bash title="scripts/agent-hold.sh"
+#!/usr/bin/env bash
+# PreIssueWork gate: refuse any issue labelled `agent-hold`.
+# The event payload arrives as one JSON document on stdin.
+set -euo pipefail
+
+payload=$(cat)
+number=$(printf '%s' "$payload" | jq -r '.issue.number')
+
+labels=$(gh issue view "$number" --json labels --jq '.labels[].name')
+
+if grep -qx 'agent-hold' <<<"$labels"; then
+  printf '{"action":"deny","reason":"issue #%s is labelled agent-hold"}\n' "$number"
+  exit 0
+fi
+
+echo '{"action":"allow"}'
+```
+
+Register it in your user-scope settings:
+
+```json title="~/.stella/settings.json"
+{
+  "hooks": {
+    "PreIssueWork": [
+      {
+        "hooks": [
+          { "type": "command", "command": "./scripts/agent-hold.sh", "timeoutMs": 10000 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Now `gh issue edit 123 --add-label agent-hold` is all it takes to fence an issue off, and removing the label hands it back. The loop prints `skipped #123 — issue #123 is labelled agent-hold` and moves on to the next item.
+
+<Callout type="warn">
+  Note the exit status: the script exits **0** and expresses its decision on stdout. A
+  non-zero exit also skips the issue — `PreIssueWork` fails closed — but it reports as
+  *"the hook could not be evaluated"* rather than as your reason, which is much harder to
+  read six issues later. Decide on stdout; reserve a non-zero exit for genuinely broken.
+</Callout>
+
+The same shape gives you several other things, with no change to stella:
+
+- **Two agents, one backlog.** Have the hook claim the issue (assign it, or add an `agent-claimed-$HOSTNAME` label) and deny when it is already claimed by someone else.
+- **A release freeze.** Deny everything while a `freeze` milestone is open.
+- **Working hours.** Deny outside a window, so an unattended loop does not open pull requests at 3am.
+- **Scope limits.** Deny anything not labelled `good-first-issue`, or anything whose estimate exceeds what you want an agent attempting unattended.
 
 <Callout type="warn">
 **Project-scope hooks are a trust boundary.** Hooks declared in a repository's project-scope file (`<workspace>/.stella/settings.json`) do **not** load unless the repo is trusted — set `STELLA_TRUST_PROJECT=1`, or the legacy hooks-scoped `STELLA_PROJECT_HOOKS=1`. Either flag unlocks them; without one, the merged hook set is rebuilt from the user and org-managed scopes alone and a stderr notice names what was skipped. This stops a cloned repo from running arbitrary commands on your machine. Hooks in the user scope (`~/.stella/settings.json`) always load. See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -826,7 +826,10 @@ org settings snapshot always win; changing the file takes effect on the next set
 ## Lifecycle hooks
 
 `settings.json` also carries `hooks` — shell commands that fire on agent lifecycle events.
-That schema is documented on the [Hooks](/docs/agent-tools/hooks) page.
+That schema is documented on the [Hooks](/docs/agent-tools/hooks) page. Two of the seven
+events bracket a [self-driving](/docs/self-improvement) work unit rather than a turn:
+`PreIssueWork` can hold the loop off an issue entirely, and `PostIssueWork` reports how one
+went.
 
 Unlike `providers`, hooks **concatenate** across scopes — every scope can add matchers and
 none replaces another's. Hooks from the user and org-managed scopes always load, but hooks


### PR DESCRIPTION
Refs #3599

## The problem

The self-driving loop works whatever the backlog hands it, and nothing outside it could act on that. A person who wants to keep an agent off work they have not finished thinking about — an issue still being specified, one a colleague has started, anything under a release freeze — had two options: edit the backlog query in Rust, or stop the loop.

## Two events, in the vocabulary that already exists

`PreIssueWork` and `PostIssueWork` join `HookEvent` alongside the five that ship today. They name points **around** a turn rather than inside one, and are dispatched by the loop rather than by the driver — but they go in the same enum, the same `hooks` block of the same settings file, and speak the same `allow`/`deny` vocabulary. A second enum would be a second thing to keep identical, which is the drift shape #3310 removed.

Naming rule, written into the module doc so the set stays readable as one: **`Pre`/`Post` for a pair that brackets something, a past participle for a thing that happened, and no `ON_`/`BEFORE_` prefixes** — the tense lives in the name.

## The decisions worth reviewing

**`PreIssueWork` fails closed**, which is the opposite of the usual choice here. A hook that never ran, timed out, or exited non-zero **skips the issue**. The asymmetry is the whole argument: skipping an issue that was in fact free costs one cycle and corrects itself next run; working an issue that was in fact held leaves a branch, a pull request, and a comment on something somebody deliberately fenced off. `require_approval` also skips — an unattended loop has nobody at the keyboard.

**A skip exits 0.** A held issue is the loop being steered, not the loop failing; a driver that treated it as an error would stop its sweep at the first fenced-off item.

**`PostIssueWork` carries three outcomes, not a boolean** — `changed` / `no_change` / `failed`. *Nothing to do* and *needs a human* are the two states a dashboard most needs to tell apart.

## Three things the existing guards caught, rather than review

1. **`concat_hooks` joins per event.** Without a line there, a `PreIssueWork` matcher would be parsed from every settings scope and then dropped — the `enable_recap` defect the completeness ledger exists to prevent, whose own doc comment apologises for the last two instances. The completeness test failed until both `join` lines and both `EVERY_KEY` fixture entries landed.
2. **`EVENT_ORDER` in the plugin roster is the routing table for *in-turn* dispatch.** Adding these to it would have created plugin routes that nothing dispatches. They stay out, the split is stated where the table is defined, and a plugin manifest that declares one is refused by name (`ManifestError::HookNotAvailableToPlugins`) rather than granted a hook that silently never fires.
3. **Two exhaustive matches went `E0004`** and had to place the new variants. That is the design working.

## Witness tests

`self_driving_cmd::hooks::tests` drives **real `bash -c` hooks** rather than a fake runner, because what is worth proving is the whole path a user's `settings.json` takes: matcher selection, payload on stdin, decision parsed off stdout, fold into a skip. Eight tests, including:

- `a_deny_skips_the_issue_and_carries_the_hook_s_reason` — the feature.
- `a_hook_that_cannot_be_evaluated_skips_rather_than_proceeds` — fails closed.
- `the_hook_receives_the_issue_number_on_stdin` — without which a hook could only answer the same way for every issue, which is not a gate.
- `a_workspace_with_no_hook_registered_allows_without_running_anything` — no runtime is built and no payload serialized when nothing is registered.

Plus `a_plugin_may_not_be_routed_at_a_loop_lifecycle_hook` in `stella-plugin`.

## Docs

`/docs/agent-tools/hooks` gains both events and the worked **`agent-hold`** example — a label on the issue holds the loop off it, because the tracker is where that intent already lives and anyone on the team can set it without touching a config file. It also calls out the trap in the shape: decide on stdout and exit 0, because a non-zero exit skips too but reports *"the hook could not be evaluated"* rather than your reason.

## Scope — what is deliberately not here

The rest of the approved vocabulary (tracker, pull-request and check events — `IssueCreated`, `PullRequestOpened`, `ChecksFailed`/`BaseBroken`, …) is designed and **not declared**, because a hook point nothing dispatches is a declaration that quietly does nothing. #4001 landed the `deliver` verbs while this was open, so they now have somewhere to fire from; I am filing that as its own issue rather than growing this PR.

`make guards-fast` and `make wire-schema` are green; `stella-protocol`, `stella-core`, `stella-plugin` and `stella-cli` test suites pass (1853 in the CLI).

## Summary by Sourcery

Add lifecycle hooks that let operators hold the self-driving loop off selected issues and observe each work unit's outcome.

New Features:
- Add `PreIssueWork` and `PostIssueWork` lifecycle hooks for controlling and observing self-driving issue work.
- Expose issue details and three-way work outcomes in hook payloads, including changed, no-change, and failed states.
- Allow `PreIssueWork` hooks to skip individual issues, including fail-closed behavior for unavailable or unattended approvals.

Enhancements:
- Keep issue-work hooks in the shared hook vocabulary while preventing unsupported plugin routing.
- Merge the new hook settings across configuration scopes and preserve behavior when no hooks are registered.

Documentation:
- Document the new lifecycle events, payloads, failure semantics, and an `agent-hold` label example.

Tests:
- Add end-to-end shell-hook coverage for issue gating, payloads, failure handling, approvals, outcomes, and plugin restrictions.