### PR TITLE
style(stella-autonomy): rustfmt rank_defects — main's fmt gate is red

### DIFF
--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -824,9 +824,7 @@ impl QueueIssue {
 pub fn rank_defects(issues: Vec<QueueIssue>) -> Vec<QueueIssue> {
     let mut defects: Vec<QueueIssue> = issues
         .into_iter()
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
         .collect();
     defects.sort_by(|a, b| {
         a.priority_rank()


### PR DESCRIPTION
`cargo fmt --check` fails on `main` (`f9789df17`) at `crates/stella-autonomy/src/lib.rs:824`. That is a required gate step and a required CI job, so every PR opened against main inherits the failure.

## The fix

```diff
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL)
-        })
+        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
```

The closure fits on one line once `ESCALATION_LABEL` replaced the literal it was written against, and the multi-line form it kept is not what rustfmt emits. Pure `cargo fmt --all` output — **no behaviour change**.

## Evidence

No witness test; the thing that goes from failing to passing is the gate step itself:

```
$ cargo fmt --all --check      # on f9789df17
Diff in crates/stella-autonomy/src/lib.rs:824
…
$ cargo fmt --all --check      # with this commit
(silent)
```

## Context worth recording

This is the **third live main-red condition** in one session, and none of the three had a `main-red` issue open:

1. #3978 / #3980 merged 37 seconds apart; the second dropped a `let` binding the first added, so main did not compile. The canary caught it.
2. Two independent fixes for that both landed, duplicating the binding — build green, **clippy red**. Fixed in #4009.
3. The same duplicated-fix shape recurred for `resolve` (#4010 / #4011).
4. This one.

Worth noting for whoever tunes the canary: a **fmt-only** failure is invisible to `cargo build` *and* to `cargo clippy`. It survives every local check short of the fmt step itself, which is exactly why it sat.

Refs #3332

## Summary by Sourcery

Enhancements:
- Apply rustfmt’s formatting to the defect-ranking filter closure without changing behavior.