### PR TITLE
fix(stella-tui): a delivered steer leaves the prompt queue

### DIFF
--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -759,6 +759,35 @@ impl WorkspaceModel {
         }
     }
 
+    /// Remove the queued prompt an [`AgentEvent::Steered`] ack settles.
+    ///
+    /// The row holds what the user typed (`> fix the tests`); the ack carries
+    /// what the driver injected (`fix the tests`), because the marker is the
+    /// routing instruction and is stripped once it has been obeyed. The
+    /// comparison is on that normalized form, and strips exactly one `>` for
+    /// the same reason the driver does — a deliberate `>> literal` steer keeps
+    /// its second marker on both sides and still matches.
+    ///
+    /// Matched rather than popped from the front, because a steer is consumed
+    /// **out of order**: prompts queued before it are still waiting, and it is
+    /// the one that left. Oldest match first, so two identical steers claim
+    /// two rows rather than one row twice.
+    ///
+    /// No match is the ordinary case, not a failure: `Steered` is also how the
+    /// engine narrates its OWN injections — the loop-escalation nudge — which
+    /// were never in anyone's queue and must leave the backlog untouched. That
+    /// is the same guard `PromptStarted` applies to a driver-side prompt.
+    fn claim_steered(&mut self, text: &str) {
+        let steered = text.trim();
+        let position = self.queue.items.iter().position(|queued| {
+            let head = queued.text.trim_start();
+            head.strip_prefix('>').unwrap_or(head).trim() == steered
+        });
+        if let Some(i) = position {
+            self.queue.remove(i);
+        }
+    }
+
     fn apply_event(&mut self, agent: &AgentId, event: &AgentEvent) {
         // Auto-register an agent we've never seen so a stray event is never
         // dropped — the dashboard row appears with what we know.
@@ -777,6 +806,17 @@ impl WorkspaceModel {
 
         // Per-agent pure fold — untouched.
         self.agents[idx].model.apply(event);
+
+        // A steer landed at the running turn's step boundary. The prompt
+        // carrying it never entered the dispatch backlog — the driver's
+        // mid-turn arm reads `> …` straight off the input channel and hands
+        // it to the steering tap — so no `PromptStarted` will ever pop the
+        // queue mirror of it, and the row would sit there as "waiting"
+        // forever while the words it holds were long since delivered. This
+        // ack is the only signal that says they were.
+        if let AgentEvent::Steered { text } = event {
+            self.claim_steered(text);
+        }
 
         // Derived counters.
         {

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -676,6 +676,77 @@ fn prompt_requeued_returns_the_prompt_to_the_front_of_the_queue() {
     assert!(row.summary.contains("first"), "{}", row.summary);
 }
 
+/// The bug this file's `claim_steered` exists for: a `>`-prefixed prompt is
+/// consumed off the input channel by the driver's mid-turn arm and handed
+/// straight to the steering tap, so it never enters the dispatch backlog and
+/// no `PromptStarted` is ever emitted for it. Before the ack claimed the row,
+/// the queue popup showed the steer as still waiting for the rest of the
+/// session — after the words had already been delivered mid-turn.
+#[test]
+fn a_steered_ack_claims_the_prompt_that_carried_it() {
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    // The shell mirrors every submission, marker and all.
+    w.queue.enqueue("first".into(), 1);
+    w.queue.enqueue("> fix the tests".into(), 2);
+    w.queue.enqueue("last".into(), 3);
+    // The engine drained the tap at a step boundary and acked with the text
+    // it injected — the marker stripped, because it has been obeyed.
+    w.apply_inbound(&ev(
+        "lead",
+        AgentEvent::Steered {
+            text: "fix the tests".into(),
+        },
+    ));
+    assert_eq!(w.queue.pending(), 2, "the steer's own row is gone");
+    let waiting: Vec<&str> = w.queue.items.iter().map(|q| q.text.as_str()).collect();
+    assert_eq!(
+        waiting,
+        vec!["first", "last"],
+        "a steer is consumed out of order — the prompts queued around it wait on"
+    );
+}
+
+/// `Steered` is also how the engine narrates its own mid-turn injections (the
+/// loop-escalation nudge). Those were never queued by anyone, so an ack that
+/// matches no row must leave the backlog exactly as it found it — the same
+/// guard `prompt_started_with_an_unseen_text_never_drops_someone_elses_entry`
+/// puts on the dispatch path.
+#[test]
+fn an_engine_authored_steer_never_claims_someone_elses_prompt() {
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    w.queue.enqueue("> fix the tests".into(), 1);
+    w.apply_inbound(&ev(
+        "lead",
+        AgentEvent::Steered {
+            text: "you have repeated the same tool call three times".into(),
+        },
+    ));
+    assert_eq!(w.queue.pending(), 1);
+}
+
+/// Two identical steers are two prompts the user typed twice, so the first
+/// ack claims one row and the second claims the other — never one row twice,
+/// which would leave a delivered steer on display forever.
+#[test]
+fn identical_steers_claim_one_row_each() {
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    w.queue.enqueue("> again".into(), 1);
+    w.queue.enqueue("> again".into(), 2);
+    let ack = ev(
+        "lead",
+        AgentEvent::Steered {
+            text: "again".into(),
+        },
+    );
+    w.apply_inbound(&ack);
+    assert_eq!(w.queue.pending(), 1);
+    w.apply_inbound(&ack);
+    assert_eq!(w.queue.pending(), 0);
+}
+
 #[test]
 fn front_inserts_stack_so_the_newest_front_insert_runs_first() {
     // Double-Esc requeues the interrupted prompt at the front; the user's


### PR DESCRIPTION
## The bug

Steering an agent from the deck delivers the words correctly — they land at the running turn's next step boundary — but the prompt that carried them stays in the queue popup, reading "waiting", for the rest of the session.

## Why

The backlog mirror is drained by exactly one signal, and that signal never arrives for a steer:

1. A `>`-prefixed submission is sent as `WorkspaceInput::Enqueue { text: "> …" }` (`deck_ui/dispatch.rs:55` — the dispatch card's `Steer` route deliberately re-adds the marker rather than inventing a message type), and `deck_shell.rs:677` mirrors every `Enqueue` into `model.queue`.
2. Driver-side, the mid-turn arm routes it through `subsession::route_mid_turn` → `MidTurnRoute::Steer(note)` → `steering.push(note)` (`command_deck.rs:1587`). It is consumed straight off the input channel: it never enters the `DurableQueue`, and it is never dispatched.
3. `Inbound::PromptStarted` is the only thing that pops the deck's mirror (`deck.rs:623`). Nothing dispatches a steer, so nothing ever emits it.

The row outlives the words it held.

## The fix

`AgentEvent::Steered` is the engine's ack, emitted at the step boundary where the tap is drained (`stella-core/src/driver/step_boundary.rs:35`). That is the signal that says the words were delivered, so that is what claims the row — folded in `WorkspaceModel::apply_event`, the same one-mutation-site discipline `PromptStarted` follows.

Two properties the implementation is built around:

- **Matched on text, not popped from the front.** A steer is consumed *out of order*: prompts queued before it are still waiting, and it is the one that left. The row holds `> fix the tests`; the ack carries `fix the tests`, because the marker is the routing instruction and is stripped once obeyed — so the comparison strips exactly one `>`, for the same reason the driver does.
- **No match is the ordinary case, not a failure.** `Steered` is also how the engine narrates its own mid-turn injections (the loop-escalation nudge). Those were never in anyone's queue and must leave the backlog untouched — the same guard `prompt_started_with_an_unseen_text_never_drops_someone_elses_entry` already puts on the dispatch path.

## Witness

`a_steered_ack_claims_the_prompt_that_carried_it` and `identical_steers_claim_one_row_each` both **fail on `main`** (checked with the patch reverted: the queue keeps 3 rows where 2 should be waiting) and pass here. `an_engine_authored_steer_never_claims_someone_elses_prompt` covers the no-match case and passes on both sides by design — it is a guard, not a witness.

No test was deleted or renamed.

## Verification

`cargo test -p stella-tui` — 865 lib + 58 integration, all green. `cargo clippy -p stella-tui --all-targets -- -D warnings` clean. `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` clean. Every `make gate` guard step up to `format-check` passes.

**`make gate`'s `format-check` step is red on `main`, not on this branch** — `crates/stella-autonomy/src/lib.rs:824` has a rustfmt drift that landed with #4001 and is untouched here (`cargo fmt --check -p stella-tui` is clean). Filed separately rather than folded in; see the issues below.

## Remaining work filed

- The Esc-steer path (`WorkspaceInput::Steer`) never actually steers — it routes every text to a sidecar sub-session.
- The driver's `DurableQueue` is not drained of the texts an Esc-steer delivers, so a prompt can dispatch twice.
- The `main` rustfmt drift above.

No new dependencies.

## Summary by Sourcery

Clear delivered steer prompts from the workspace queue when the engine acknowledges them.

Bug Fixes:
- Remove delivered steer prompts from the TUI queue mirror when their engine acknowledgement is received, preventing them from remaining displayed as waiting after delivery.

Enhancements:
- Match steer acknowledgements against queued prompts by normalized text, preserving out-of-order delivery and correctly handling duplicate steers without affecting unrelated engine-authored injections.

Tests:
- Add coverage for claiming delivered steers, preserving unmatched queue entries, and processing identical steers independently.