### PR TITLE
feat(stella-cli): the loop does not stop, resumes by looking, and writes down everything

### DIFF
--- a/crates/stella-autonomy/src/attribution.rs
+++ b/crates/stella-autonomy/src/attribution.rs
@@ -5,15 +5,28 @@
 //! reading any of them a month later needs to know whether a human wrote it,
 //! and that is not a thing to leave to a reader's guess about tone.
 //!
-//! # The rule is exact, because "roughly one blank line" is not a contract
+//! # The rule is exact, because "roughly a footer" is not a contract
 //!
-//! [`sign`] appends the signature **exactly one line break after the last
-//! character of the body**. Not two, not "a blank line", not "whatever the
-//! caller already had". Trailing whitespace on the body is removed first, so
-//! the result does not depend on whether the caller happened to end with a
-//! newline — which is precisely the kind of difference that produces two
-//! near-identical formats across four surfaces and no way to tell which is
-//! right. `exactly_one_line_break_separates_body_and_signature` is the witness.
+//! [`sign`] appends the signature as a **horizontal rule footer**: a blank
+//! line, `---`, a newline, then the text. So a signed body always ends
+//!
+//! ```text
+//! <body>
+//!
+//! ---
+//! created by stella*
+//! ```
+//!
+//! Trailing whitespace on the body is removed first, so the result does not
+//! depend on whether the caller happened to end with a newline — precisely the
+//! difference that would otherwise produce two near-identical formats across
+//! four surfaces with no way to tell which is right.
+//! `the_signature_is_a_horizontal_rule_footer` is the witness.
+//!
+//! **The separator is fixed and the text is not.** A distribution changes what
+//! the footer *says*; it does not get to change whether there is a rule above
+//! it, because that is what makes a signed body recognisable at a glance
+//! across every surface and every deployment.
 //!
 //! # Configurable per surface, and separately
 //!
@@ -27,6 +40,19 @@
 //! different hat: *what does this repository see when the loop touches it?*
 
 use serde::{Deserialize, Serialize};
+
+/// What the footer says, unless a workspace changes it.
+///
+/// One string for all four surfaces by default: a reader should recognise the
+/// same mark on a commit, a pull request, an issue and a comment without
+/// having to learn four phrasings. A deployment that wants them to differ sets
+/// them separately.
+pub const SIGNATURE: &str = "created by stella*";
+
+/// What separates a body from its signature: a blank line, then a rule.
+///
+/// Fixed rather than configurable — see the module docs.
+const SEPARATOR: &str = "\n\n---\n";
 
 /// The default branch prefix.
 ///
@@ -63,10 +89,10 @@ pub struct Attribution {
 impl Default for Attribution {
     fn default() -> Self {
         Self {
-            commit: "Created by stella.".to_owned(),
-            pull_request: "Created by stella.".to_owned(),
-            issue: "Filed by stella.".to_owned(),
-            issue_comment: "Posted by stella.".to_owned(),
+            commit: SIGNATURE.to_owned(),
+            pull_request: SIGNATURE.to_owned(),
+            issue: SIGNATURE.to_owned(),
+            issue_comment: SIGNATURE.to_owned(),
             branch_prefix: DEFAULT_BRANCH_PREFIX.to_owned(),
         }
     }
@@ -89,8 +115,11 @@ impl Attribution {
     }
 }
 
-/// Append `signature` exactly one line break after the last character of
-/// `body`.
+/// Append `signature` to `body` as a horizontal rule footer.
+///
+/// The result ends `<body>\n\n---\n<signature>`. Trailing whitespace on the
+/// body is normalized first, so two callers whose bodies differ only in how
+/// they terminated produce identical output.
 ///
 /// An empty signature returns the body untouched — including its own trailing
 /// whitespace, because a caller that signs nothing has not asked for its text
@@ -102,23 +131,22 @@ pub fn sign(body: &str, signature: &str) -> String {
     }
     let trimmed = body.trim_end();
     if trimmed.is_empty() {
-        // A body that is entirely empty gets the signature alone rather than a
-        // leading blank line.
-        return signature.trim().to_owned();
+        // An empty body gets the footer without a leading blank line: a rule
+        // with nothing above it is a rule separating nothing.
+        return format!("---\n{}", signature.trim());
     }
-    format!("{trimmed}\n{}", signature.trim())
+    format!("{trimmed}{SEPARATOR}{}", signature.trim())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// **The witness.** Exactly one line break, whatever the body ended with —
-    /// so the four surfaces cannot drift into four near-identical formats.
+    /// **The witness.** A blank line, a rule, then the text — whatever the body
+    /// ended with, so the four surfaces cannot drift into four near-identical
+    /// formats.
     #[test]
-    fn exactly_one_line_break_separates_body_and_signature() {
-        let sig = "Created by stella.";
-
+    fn the_signature_is_a_horizontal_rule_footer() {
         for body in [
             "the body",
             "the body\n",
@@ -127,9 +155,9 @@ mod tests {
             "the body   ",
         ] {
             assert_eq!(
-                sign(body, sig),
-                "the body\nCreated by stella.",
-                "body {body:?} must produce exactly one line break"
+                sign(body, SIGNATURE),
+                "the body\n\n---\ncreated by stella*",
+                "body {body:?} must produce the same footer"
             );
         }
     }
@@ -138,7 +166,10 @@ mod tests {
     /// normalized.
     #[test]
     fn interior_line_breaks_are_left_alone() {
-        assert_eq!(sign("first\n\nsecond\n", "sig"), "first\n\nsecond\nsig");
+        assert_eq!(
+            sign("first\n\nsecond\n", "sig"),
+            "first\n\nsecond\n\n---\nsig"
+        );
     }
 
     /// An operator who clears a surface's signature gets silence on it, not a
@@ -149,10 +180,12 @@ mod tests {
         assert_eq!(sign("the body", "   "), "the body");
     }
 
+    /// A rule with nothing above it separates nothing, so an empty body gets
+    /// the footer without a leading blank line.
     #[test]
-    fn an_empty_body_gets_the_signature_alone() {
-        assert_eq!(sign("", "sig"), "sig");
-        assert_eq!(sign("  \n ", "sig"), "sig");
+    fn an_empty_body_gets_the_footer_without_a_leading_blank_line() {
+        assert_eq!(sign("", "sig"), "---\nsig");
+        assert_eq!(sign("  \n ", "sig"), "---\nsig");
     }
 
     /// The default is `stella/`, and it is what an unset prefix falls back to.
@@ -177,6 +210,15 @@ mod tests {
         assert_eq!(theirs.branch_prefix(), "oxagen-");
     }
 
+    /// A distribution changes what the footer says; it does not change that
+    /// there is a rule above it. That is what makes a signed body recognisable
+    /// across every surface and every deployment.
+    #[test]
+    fn the_separator_is_fixed_even_when_the_text_is_not() {
+        assert!(sign("body", "Created by oxagen.").starts_with("body\n\n---\n"));
+        assert!(sign("body", "anything at all").starts_with("body\n\n---\n"));
+    }
+
     /// The four surfaces are independent: changing one does not move another.
     #[test]
     fn each_surface_signs_separately() {
@@ -187,10 +229,10 @@ mod tests {
             issue_comment: "n".into(),
             ..Attribution::default()
         };
-        assert_eq!(sign("x", &a.commit), "x\nc");
-        assert_eq!(sign("x", &a.pull_request), "x\np");
-        assert_eq!(sign("x", &a.issue), "x\ni");
-        assert_eq!(sign("x", &a.issue_comment), "x\nn");
+        assert_eq!(sign("x", &a.commit), "x\n\n---\nc");
+        assert_eq!(sign("x", &a.pull_request), "x\n\n---\np");
+        assert_eq!(sign("x", &a.issue), "x\n\n---\ni");
+        assert_eq!(sign("x", &a.issue_comment), "x\n\n---\nn");
     }
 
     /// A partial manifest fills in the defaults for what it did not mention —
@@ -200,7 +242,7 @@ mod tests {
         let parsed: Attribution =
             serde_json::from_str(r#"{"commit":"Created by oxagen."}"#).expect("deserialize");
         assert_eq!(parsed.commit, "Created by oxagen.");
-        assert_eq!(parsed.issue, "Filed by stella.");
+        assert_eq!(parsed.issue, SIGNATURE);
         assert_eq!(parsed.branch_prefix(), "stella/");
     }
 

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -44,6 +44,7 @@ mod closure;
 mod convention;
 mod deliver;
 mod doctrine;
+pub mod priority;
 mod stats;
 mod step;
 mod surface;
@@ -798,7 +799,12 @@ pub struct IssueLabel {
 }
 
 impl QueueIssue {
-    fn has_label(&self, name: &str) -> bool {
+    /// Whether this issue carries a label by that exact name.
+    ///
+    /// `pub(crate)` rather than private because [`crate::priority`] ranks by
+    /// label and must ask the same question the same way — a second copy of
+    /// "does it have this label" is how two rankers start disagreeing.
+    pub(crate) fn has_label(&self, name: &str) -> bool {
         self.labels.iter().any(|l| l.name == name)
     }
 

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -44,6 +44,7 @@ mod closure;
 mod convention;
 mod deliver;
 mod doctrine;
+mod stats;
 mod step;
 mod surface;
 
@@ -52,7 +53,7 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-pub use attribution::{Attribution, DEFAULT_BRANCH_PREFIX, sign};
+pub use attribution::{Attribution, DEFAULT_BRANCH_PREFIX, SIGNATURE, sign};
 pub use closure::{
     Citation, Closure, ClosureRefusal, check as check_closure, receipt, resolution_of,
 };
@@ -68,6 +69,7 @@ pub use doctrine::{
     Contention, ContentionPolicy, ContentionVerdict, Doctrine, ForeignBreakage, QueueCriterion,
     contention_verdict,
 };
+pub use stats::SessionStats;
 pub use step::{
     BlockReason, CarriedPr, Clearance, IssueRef, LoopObservation, LoopState, LoopStep,
     PrDisposition, PrRef, UnblockAttempt, WakeCondition, step,

--- a/crates/stella-autonomy/src/priority.rs
+++ b/crates/stella-autonomy/src/priority.rs
@@ -1,0 +1,432 @@
+//! The operator's priority vocabulary, and what the loop does with an issue
+//! that has not been given one.
+//!
+//! `doc:backlog-self-driving` §3.2 (#3599). Two decisions live here, and both
+//! used to be hardcoded in `rank_defects`.
+//!
+//! # The rungs are declared, not built in
+//!
+//! `["P0", "P1", "P2"]` was written into the ranking function. Every tracker
+//! spells urgency differently — `Sev1`, `critical`, `now/next/later`, a numeric
+//! field — and a loop that only understands one spelling can only be pointed at
+//! one repository. [`PriorityLadder`] is the operator's list, most urgent
+//! first, and the position in that list *is* the rank.
+//!
+//! # An issue with no rung is not the lowest rung
+//!
+//! This is the half that was wrong rather than merely inflexible. The old
+//! `priority_rank` mapped "carries no priority label" to `3` — below `P2` and
+//! indistinguishable from an issue somebody had deliberately ranked lowest. So
+//! a P0 filed thirty seconds ago with no labels yet sorted beneath a P2 from
+//! March, and the loop would work its way through the entire ranked backlog
+//! before ever looking at it.
+//!
+//! [`rank_of`] returns `None` for that issue instead, and [`partition`]
+//! separates it out. **Unranked is a question, not a position** — it means
+//! nobody has judged this yet, and the answer is to judge it, which is what
+//! [`Unassessed`] hands to the caller.
+
+use crate::QueueIssue;
+
+/// The operator's priority labels, most urgent first.
+///
+/// Position is rank: `rungs[0]` outranks `rungs[1]`. An empty ladder ranks
+/// nothing, which makes every issue [`Unassessed`] rather than making them all
+/// equal — a ladder nobody configured is a question nobody has answered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PriorityLadder {
+    /// The label names, most urgent first.
+    pub rungs: Vec<String>,
+}
+
+impl Default for PriorityLadder {
+    /// GitHub's common convention, which is also this repository's.
+    ///
+    /// A default exists so an operator who configures nothing still gets a
+    /// working loop — the same reason the issue vocabulary ships GitHub's
+    /// defaults rather than refusing to start.
+    fn default() -> Self {
+        Self {
+            rungs: ["P0", "P1", "P2", "P3"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
+}
+
+impl PriorityLadder {
+    /// Build a ladder from declared rungs, most urgent first.
+    #[must_use]
+    pub fn new(rungs: Vec<String>) -> Self {
+        Self { rungs }
+    }
+
+    /// Whether this ladder can rank anything at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rungs.is_empty()
+    }
+
+    /// The most urgent rung, for a caller that has to name one.
+    #[must_use]
+    pub fn most_urgent(&self) -> Option<&str> {
+        self.rungs.first().map(String::as_str)
+    }
+}
+
+/// Where an issue sits on the ladder, or `None` if nobody has said.
+///
+/// The first rung the issue carries wins, so an issue mislabelled with two
+/// rungs is treated as the more urgent of them. That is the safe direction: a
+/// contradiction should not be resolved by ignoring the alarm.
+#[must_use]
+pub fn rank_of(issue: &QueueIssue, ladder: &PriorityLadder) -> Option<u8> {
+    ladder
+        .rungs
+        .iter()
+        .position(|rung| issue.has_label(rung))
+        .and_then(|index| u8::try_from(index).ok())
+}
+
+/// An issue nobody has placed on the ladder.
+///
+/// Carried as its own type rather than as a `QueueIssue` with a `None` rank so
+/// a caller cannot accidentally sort it in among the ranked ones — which is
+/// precisely the bug this module exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unassessed {
+    /// The issue's key, as the tracker spells it.
+    pub key: String,
+    /// Its title, so a triage prompt has something to work with.
+    pub title: String,
+    /// When it was filed, so the oldest unassessed issue is assessed first.
+    pub created_at: String,
+}
+
+/// The queue, split into what can be ranked and what must be judged first.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Queue {
+    /// Issues carrying a rung, most urgent first, oldest first within a rung.
+    pub ranked: Vec<QueueIssue>,
+    /// Issues carrying no rung, oldest first.
+    ///
+    /// **Not a tail of `ranked`.** These are unjudged, and the loop's response
+    /// is to judge them — see the module docs.
+    pub unassessed: Vec<Unassessed>,
+}
+
+impl Queue {
+    /// Whether there is anything at all to do.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ranked.is_empty() && self.unassessed.is_empty()
+    }
+}
+
+/// Split a queue into ranked work and issues awaiting a judgement.
+///
+/// Sorting is by rung, then by age within a rung, so a P0 filed today is taken
+/// before a P0 filed last month and both are taken before any P1. Age is
+/// compared as the tracker's own timestamp string, which is ISO-8601 and
+/// therefore sorts correctly as text.
+#[must_use]
+pub fn partition(issues: Vec<QueueIssue>, ladder: &PriorityLadder) -> Queue {
+    let mut ranked = Vec::new();
+    let mut unassessed = Vec::new();
+
+    for issue in issues {
+        if rank_of(&issue, ladder).is_some() {
+            ranked.push(issue);
+        } else {
+            unassessed.push(Unassessed {
+                key: issue.number.to_string(),
+                title: issue.title.clone(),
+                created_at: issue.created_at.clone(),
+            });
+        }
+    }
+
+    ranked.sort_by(|a, b| {
+        rank_of(a, ladder)
+            .cmp(&rank_of(b, ladder))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+    unassessed.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+
+    Queue { ranked, unassessed }
+}
+
+/// Everything the loop needs in order to place an issue, all of it declared.
+///
+/// Two axes, because an issue arrives needing a judgement on both: *is this
+/// mine to work* and *how urgent is it*. A loop that only reads urgency will
+/// claim a documentation request; one that only reads kind will take a
+/// three-month-old `P3` ahead of this morning's `P0`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriagePolicy {
+    /// The urgency rungs, most urgent first.
+    pub ladder: PriorityLadder,
+    /// Labels meaning "this loop works this".
+    pub defect_kinds: Vec<String>,
+    /// Labels meaning "this loop does not work this".
+    ///
+    /// Named explicitly rather than inferred from "not a defect kind", because
+    /// the two are different claims: an issue labelled `enhancement` has been
+    /// judged and excluded, while an issue labelled only `P0` has been judged
+    /// on one axis and not the other. Only the first may be dropped silently.
+    pub excluded_kinds: Vec<String>,
+}
+
+impl Default for TriagePolicy {
+    fn default() -> Self {
+        Self {
+            ladder: PriorityLadder::default(),
+            defect_kinds: ["bug", "triage"].into_iter().map(str::to_owned).collect(),
+            excluded_kinds: ["enhancement", "feature", "documentation", "question"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
+}
+
+/// Split the open queue into work, questions, and things that are not ours.
+///
+/// The order of the checks is the whole content of this function:
+///
+/// 1. **Escalated** issues are dropped. The loop already tried and could not
+///    resolve them; re-claiming spends the same money on the same wall. The
+///    label is how that survives a restart, which process-local state cannot.
+/// 2. **Excluded kinds** are dropped. Somebody judged this and said it is not
+///    a defect.
+/// 3. **A defect kind *and* a rung** is rankable work.
+/// 4. **Everything else is a question**, not a low-priority answer — the
+///    unlabelled issue filed a minute ago, and the issue carrying a rung but
+///    no kind. See the module docs for what that mistake costs.
+#[must_use]
+pub fn triage(issues: Vec<QueueIssue>, policy: &TriagePolicy) -> Queue {
+    let mut rankable = Vec::new();
+    let mut queue = Queue::default();
+
+    for issue in issues {
+        if issue.has_label(crate::ESCALATION_LABEL) {
+            continue;
+        }
+        if policy
+            .excluded_kinds
+            .iter()
+            .any(|kind| issue.has_label(kind))
+        {
+            continue;
+        }
+
+        let is_defect = policy.defect_kinds.iter().any(|kind| issue.has_label(kind));
+        if is_defect && rank_of(&issue, &policy.ladder).is_some() {
+            rankable.push(issue);
+        } else {
+            queue.unassessed.push(Unassessed {
+                key: issue.number.to_string(),
+                title: issue.title.clone(),
+                created_at: issue.created_at.clone(),
+            });
+        }
+    }
+
+    let ranked = partition(rankable, &policy.ladder);
+    queue.ranked = ranked.ranked;
+    queue
+        .unassessed
+        .sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    queue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IssueLabel;
+
+    fn issue(number: u64, created_at: &str, labels: &[&str]) -> QueueIssue {
+        QueueIssue {
+            number,
+            title: format!("issue {number}"),
+            created_at: created_at.to_owned(),
+            labels: labels
+                .iter()
+                .map(|name| IssueLabel {
+                    name: (*name).to_owned(),
+                })
+                .collect(),
+            url: String::new(),
+        }
+    }
+
+    /// An unlabelled issue is a question, not the bottom of the queue.
+    ///
+    /// The witness for this module's reason to exist. `priority_rank` mapped
+    /// "no priority label" to `3`, one below `P2`, so a freshly filed issue
+    /// nobody had triaged yet sorted underneath everything anyone had ever
+    /// ranked — including issues deliberately marked as least urgent. A P0
+    /// filed a minute ago would wait for the entire backlog.
+    #[test]
+    fn an_unlabelled_issue_is_unassessed_not_lowest() {
+        let ladder = PriorityLadder::default();
+        let queue = partition(
+            vec![
+                issue(1, "2026-03-01T00:00:00Z", &["P2"]),
+                issue(2, "2026-08-19T00:00:00Z", &[]),
+            ],
+            &ladder,
+        );
+
+        assert_eq!(queue.ranked.len(), 1, "only the P2 can be ranked");
+        assert_eq!(queue.ranked[0].number, 1);
+        assert_eq!(
+            queue.unassessed.len(),
+            1,
+            "the unlabelled one is a question"
+        );
+        assert_eq!(queue.unassessed[0].key, "2");
+    }
+
+    /// The rungs come from the operator, not from this crate.
+    ///
+    /// A tracker spelling urgency as `Sev1`/`Sev2` ranks correctly, and the
+    /// built-in `P0` means nothing to it — proving the ladder is consulted
+    /// rather than a hardcoded list being consulted first.
+    #[test]
+    fn the_ladder_is_the_operators_vocabulary() {
+        let ladder = PriorityLadder::new(vec!["Sev1".into(), "Sev2".into()]);
+        let queue = partition(
+            vec![
+                issue(1, "2026-01-01T00:00:00Z", &["Sev2"]),
+                issue(2, "2026-01-01T00:00:00Z", &["Sev1"]),
+                issue(3, "2026-01-01T00:00:00Z", &["P0"]),
+            ],
+            &ladder,
+        );
+
+        assert_eq!(
+            queue.ranked.iter().map(|i| i.number).collect::<Vec<_>>(),
+            vec![2, 1],
+            "Sev1 outranks Sev2"
+        );
+        assert_eq!(
+            queue.unassessed[0].key, "3",
+            "`P0` is not in this operator's vocabulary, so it is unjudged"
+        );
+    }
+
+    /// Within a rung, the older issue goes first.
+    #[test]
+    fn age_breaks_a_tie_within_a_rung() {
+        let ladder = PriorityLadder::default();
+        let queue = partition(
+            vec![
+                issue(1, "2026-08-19T00:00:00Z", &["P0"]),
+                issue(2, "2026-01-01T00:00:00Z", &["P0"]),
+            ],
+            &ladder,
+        );
+        assert_eq!(
+            queue.ranked.iter().map(|i| i.number).collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+    }
+
+    /// Two rungs on one issue resolve to the more urgent.
+    ///
+    /// A contradiction is not resolved by ignoring the alarm.
+    #[test]
+    fn the_more_urgent_of_two_rungs_wins() {
+        let ladder = PriorityLadder::default();
+        assert_eq!(
+            rank_of(&issue(1, "2026-01-01T00:00:00Z", &["P2", "P0"]), &ladder),
+            Some(0)
+        );
+    }
+
+    /// A brand-new unlabelled issue is a question the loop must answer.
+    ///
+    /// The behaviour this module was asked for: an issue arriving with no
+    /// labels at all must reach the loop's attention as something to judge.
+    /// Under `rank_defects` it was invisible — the kind filter dropped it
+    /// before ranking ever ran, so a P0 nobody had labelled yet was not
+    /// low-priority, it was *absent*.
+    #[test]
+    fn an_unlabelled_new_issue_is_a_question_not_an_omission() {
+        let policy = TriagePolicy::default();
+        let queue = triage(
+            vec![
+                issue(1, "2026-01-01T00:00:00Z", &["bug", "P2"]),
+                issue(2, "2026-08-19T00:00:00Z", &[]),
+            ],
+            &policy,
+        );
+
+        assert_eq!(queue.ranked.len(), 1);
+        assert_eq!(
+            queue
+                .unassessed
+                .iter()
+                .map(|u| u.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["2"],
+            "the unlabelled issue must surface for judgement, not vanish"
+        );
+    }
+
+    /// A rung without a kind is still only half-judged.
+    #[test]
+    fn a_rung_with_no_kind_is_unassessed() {
+        let policy = TriagePolicy::default();
+        let queue = triage(vec![issue(1, "2026-01-01T00:00:00Z", &["P0"])], &policy);
+        assert!(queue.ranked.is_empty());
+        assert_eq!(queue.unassessed[0].key, "1");
+    }
+
+    /// An issue somebody judged as not-a-defect is dropped, not queued.
+    ///
+    /// The distinction the `excluded_kinds` field exists for: this has been
+    /// judged, so it is not a question — unlike the rung-without-a-kind above.
+    #[test]
+    fn a_judged_non_defect_is_dropped_rather_than_asked_about() {
+        let policy = TriagePolicy::default();
+        let queue = triage(
+            vec![issue(1, "2026-01-01T00:00:00Z", &["enhancement", "P0"])],
+            &policy,
+        );
+        assert!(queue.is_empty(), "somebody already answered this one");
+    }
+
+    /// An escalated issue leaves the queue entirely, on either axis.
+    #[test]
+    fn an_escalated_issue_is_not_re_asked() {
+        let policy = TriagePolicy::default();
+        let queue = triage(
+            vec![
+                issue(
+                    1,
+                    "2026-01-01T00:00:00Z",
+                    &["bug", "P0", crate::ESCALATION_LABEL],
+                ),
+                issue(2, "2026-01-01T00:00:00Z", &[crate::ESCALATION_LABEL]),
+            ],
+            &policy,
+        );
+        assert!(
+            queue.is_empty(),
+            "an escalated issue must not come back as ranked work OR as a question"
+        );
+    }
+
+    /// A ladder nobody configured judges nothing, rather than judging
+    /// everything equal.
+    #[test]
+    fn an_empty_ladder_leaves_everything_unassessed() {
+        let ladder = PriorityLadder::new(Vec::new());
+        let queue = partition(vec![issue(1, "2026-01-01T00:00:00Z", &["P0"])], &ladder);
+        assert!(queue.ranked.is_empty());
+        assert_eq!(queue.unassessed.len(), 1);
+    }
+}

--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -61,6 +61,11 @@ pub struct SessionStats {
     // -- what the loop added to the backlog ---------------------------------
     /// Issues the loop filed. New work it discovered and wrote down.
     pub issues_created: u32,
+    /// Issues the loop placed on the ladder itself, having found them
+    /// unjudged. Counted separately from `issues_attempted` because triaging
+    /// an issue is not working it — a dashboard that merged the two would
+    /// report a labelling pass as delivery.
+    pub issues_triaged: u32,
     /// Filings refused for not matching the workspace's convention.
     pub filings_refused: u32,
     /// Filings skipped because the finding was already in the seen set.

--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -1,0 +1,293 @@
+//! What a session did, counted as it happens.
+//!
+//! A perpetual loop is judged on a record, not on a moment, and the record has
+//! to be readable **while the loop is still running** — an operator watching a
+//! dashboard wants to know whether the last hour was productive, not to wait
+//! for a run that never ends to produce a summary.
+//!
+//! So the counters live here, in the leaf crate, and both readers share them:
+//! `stella-cli` increments and writes, the Observatory reads. That is the
+//! #1613 lesson applied before it can bite — the dashboard and the terminal
+//! carried two `fold_runs` once, drifted, and disagreed about whether the loop
+//! was `NOISY` for every odd cycle count.
+//!
+//! # Counts are facts; the interesting numbers are ratios
+//!
+//! A raw count answers "how busy was it", which is the question that flatters.
+//! [`SessionStats`] therefore also derives the three ratios that answer
+//! "was it *worth* it", and each is deliberately capable of reporting badly:
+//!
+//! - [`SessionStats::inflation_ratio`] — issues created per issue closed. A
+//!   loop that sustains more than 1.0 is **losing ground**: it is filing faster
+//!   than it is finishing, which `doc:backlog-self-driving` §4.4 names as the
+//!   failure mode none of its mitigations is proven to prevent.
+//! - [`SessionStats::attempt_yield`] — how many attempts produced a change.
+//! - [`SessionStats::merge_rate`] — how many opened pull requests landed.
+//!
+//! A dashboard that showed only the counts would make a loop generating
+//! twenty issues and closing three look like a productive week.
+
+use serde::{Deserialize, Serialize};
+
+/// Everything one driving session has done so far.
+///
+/// Every field is a monotonic count, so a reader that samples twice can
+/// subtract to get a rate without the writer having to keep a window.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SessionStats {
+    // -- the backlog side ---------------------------------------------------
+    /// Issues taken off the ranked queue.
+    pub issues_claimed: u32,
+    /// Issues a turn was actually spent on.
+    ///
+    /// Lower than `issues_claimed` whenever something was claimed and then
+    /// could not be started — a peer already on it, a branch left by a dead
+    /// run. The gap between the two is the contention story.
+    pub issues_attempted: u32,
+    /// Attempts that left a change on a branch.
+    pub issues_changed: u32,
+    /// Attempts whose turn ran and changed nothing.
+    ///
+    /// Not a failure: an issue that needed no change is a real answer.
+    pub issues_no_change: u32,
+    /// Attempts whose turn did not complete.
+    pub issues_failed: u32,
+    /// Issues marked `agent-escalated` — tried, unresolved, handed back.
+    pub issues_escalated: u32,
+    /// Issues skipped because something else appeared to be working them.
+    pub issues_deferred: u32,
+
+    // -- what the loop added to the backlog ---------------------------------
+    /// Issues the loop filed. New work it discovered and wrote down.
+    pub issues_created: u32,
+    /// Filings refused for not matching the workspace's convention.
+    pub filings_refused: u32,
+    /// Filings skipped because the finding was already in the seen set.
+    pub filings_duplicate: u32,
+
+    // -- what the loop removed from it --------------------------------------
+    /// Issues closed, however they were resolved.
+    pub closed_total: u32,
+    /// Closed as completed — the work was done.
+    pub closed_completed: u32,
+    /// Closed as not planned — declined, stale, superseded.
+    pub closed_not_planned: u32,
+    /// Closed as a duplicate of another issue.
+    pub closed_duplicate: u32,
+
+    // -- delivery -----------------------------------------------------------
+    /// Pull requests opened.
+    pub prs_opened: u32,
+    /// Pull requests merged.
+    pub prs_merged: u32,
+    /// Pull requests handed to a human rather than merged.
+    pub prs_escalated: u32,
+    /// Fix pushes made in response to a red build.
+    pub fixes_pushed: u32,
+    /// Rebases made in response to a conflict.
+    pub rebases: u32,
+    /// Times a red build was found to reproduce on the base branch.
+    ///
+    /// Worth counting separately: it is time the loop spent waiting on
+    /// somebody else's breakage, and a high number is a fact about the
+    /// repository rather than about the loop.
+    pub base_broken_waits: u32,
+
+    // -- what the loop learned ----------------------------------------------
+    /// Reflections written to the reflection log.
+    pub reflections_logged: u32,
+    /// Memories created.
+    pub memories_created: u32,
+    /// Proposals emitted for a human to accept or decline.
+    pub proposals_made: u32,
+
+    // -- cost ---------------------------------------------------------------
+    /// Turns run through the model.
+    pub turns_run: u32,
+    /// Turns that stopped because they hit their spend ceiling.
+    pub turns_over_budget: u32,
+}
+
+impl SessionStats {
+    /// Issues created per issue closed.
+    ///
+    /// `None` when nothing has been closed yet — a ratio against zero is not a
+    /// large number, it is an undefined one, and rendering it as `∞` or `0`
+    /// would both mislead a dashboard on a session's first minutes.
+    ///
+    /// **Above 1.0 sustained means the loop is losing ground**: filing faster
+    /// than finishing. `doc:backlog-self-driving` §4.4 names this as the
+    /// failure mode none of its mitigations is proven to prevent, which is
+    /// exactly why it should be on the dashboard rather than in a report
+    /// somebody reads later.
+    #[must_use]
+    pub fn inflation_ratio(&self) -> Option<f64> {
+        (self.closed_total > 0)
+            .then(|| f64::from(self.issues_created) / f64::from(self.closed_total))
+    }
+
+    /// The share of attempts that produced a change.
+    ///
+    /// `None` before anything has been attempted.
+    #[must_use]
+    pub fn attempt_yield(&self) -> Option<f64> {
+        (self.issues_attempted > 0)
+            .then(|| f64::from(self.issues_changed) / f64::from(self.issues_attempted))
+    }
+
+    /// The share of opened pull requests that merged.
+    ///
+    /// `None` before anything has been opened. Note this can only fall as a
+    /// session runs — a pull request is opened before it can merge — so a low
+    /// number early is not yet a signal.
+    #[must_use]
+    pub fn merge_rate(&self) -> Option<f64> {
+        (self.prs_opened > 0).then(|| f64::from(self.prs_merged) / f64::from(self.prs_opened))
+    }
+
+    /// Whether the closure counts add up.
+    ///
+    /// A dashboard showing `closed_total` beside three kinds that sum to
+    /// something else is worse than one showing neither, because a reader will
+    /// believe whichever they looked at first. Checked rather than assumed,
+    /// because the counts are incremented at different call sites.
+    #[must_use]
+    pub fn closures_balance(&self) -> bool {
+        self.closed_completed + self.closed_not_planned + self.closed_duplicate == self.closed_total
+    }
+
+    /// Record a closure by its canonical resolution.
+    ///
+    /// One method rather than four fields a caller increments by hand: that is
+    /// what keeps [`SessionStats::closures_balance`] true by construction
+    /// instead of by discipline. An unrecognised resolution still counts
+    /// toward the total, so the balance check catches it rather than the
+    /// number silently going missing.
+    pub fn record_closure(&mut self, canonical: &str) {
+        self.closed_total += 1;
+        match canonical {
+            "completed" => self.closed_completed += 1,
+            "not_planned" => self.closed_not_planned += 1,
+            "duplicate" => self.closed_duplicate += 1,
+            // Deliberately lands nowhere but the total, so `closures_balance`
+            // reports false and a reader learns the vocabulary grew.
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The witness.** A loop filing faster than it finishes is losing ground,
+    /// and the number that says so must be on the dashboard — the raw counts
+    /// would make twenty created and three closed look like a productive week.
+    #[test]
+    fn inflation_above_one_means_the_backlog_is_growing() {
+        let losing = SessionStats {
+            issues_created: 20,
+            closed_total: 3,
+            closed_completed: 3,
+            ..SessionStats::default()
+        };
+        assert!(losing.inflation_ratio().expect("closed something") > 1.0);
+
+        let gaining = SessionStats {
+            issues_created: 1,
+            closed_total: 4,
+            closed_completed: 4,
+            ..SessionStats::default()
+        };
+        assert!(gaining.inflation_ratio().expect("closed something") < 1.0);
+    }
+
+    /// A ratio against zero is undefined, not large. Rendering it as `∞` or `0`
+    /// would both mislead a dashboard in a session's first minutes.
+    #[test]
+    fn a_ratio_with_no_denominator_is_none_not_a_number() {
+        let fresh = SessionStats::default();
+        assert_eq!(fresh.inflation_ratio(), None);
+        assert_eq!(fresh.attempt_yield(), None);
+        assert_eq!(fresh.merge_rate(), None);
+    }
+
+    /// The three kinds must sum to the total, and `record_closure` is what
+    /// makes that true by construction rather than by a caller remembering.
+    #[test]
+    fn recording_closures_keeps_the_counts_balanced() {
+        let mut stats = SessionStats::default();
+        stats.record_closure("completed");
+        stats.record_closure("completed");
+        stats.record_closure("not_planned");
+        stats.record_closure("duplicate");
+
+        assert_eq!(stats.closed_total, 4);
+        assert_eq!(stats.closed_completed, 2);
+        assert_eq!(stats.closed_not_planned, 1);
+        assert_eq!(stats.closed_duplicate, 1);
+        assert!(stats.closures_balance());
+    }
+
+    /// A resolution this build does not know still counts toward the total, so
+    /// the balance check reports the gap rather than the number vanishing.
+    #[test]
+    fn an_unknown_resolution_is_visible_rather_than_lost() {
+        let mut stats = SessionStats::default();
+        stats.record_closure("cannot_reproduce");
+
+        assert_eq!(stats.closed_total, 1);
+        assert!(
+            !stats.closures_balance(),
+            "an unrecognised resolution must show up as an imbalance, not disappear"
+        );
+    }
+
+    /// Claimed and attempted are different numbers, and the gap is the
+    /// contention story — an issue taken off the queue that could not be
+    /// started because somebody else was on it.
+    #[test]
+    fn the_gap_between_claimed_and_attempted_is_visible() {
+        let stats = SessionStats {
+            issues_claimed: 5,
+            issues_attempted: 3,
+            issues_deferred: 2,
+            ..SessionStats::default()
+        };
+        assert_eq!(stats.issues_claimed - stats.issues_attempted, 2);
+    }
+
+    #[test]
+    fn yields_are_shares_of_their_own_denominator() {
+        let stats = SessionStats {
+            issues_attempted: 4,
+            issues_changed: 1,
+            prs_opened: 2,
+            prs_merged: 1,
+            ..SessionStats::default()
+        };
+        assert!((stats.attempt_yield().expect("attempted") - 0.25).abs() < f64::EPSILON);
+        assert!((stats.merge_rate().expect("opened") - 0.5).abs() < f64::EPSILON);
+    }
+
+    /// Serialized with every field defaulted, so a dashboard written against
+    /// an older build reads a newer session's file without failing — and a
+    /// newer dashboard reads an older file with the new counters at zero.
+    #[test]
+    fn stats_round_trip_and_tolerate_a_missing_field() {
+        let stats = SessionStats {
+            issues_created: 3,
+            prs_merged: 1,
+            ..SessionStats::default()
+        };
+        let json = serde_json::to_string(&stats).expect("serialize");
+        let back: SessionStats = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(stats, back);
+
+        let sparse: SessionStats =
+            serde_json::from_str(r#"{"prs_merged":2}"#).expect("a partial document still reads");
+        assert_eq!(sparse.prs_merged, 2);
+        assert_eq!(sparse.issues_created, 0);
+    }
+}

--- a/crates/stella-autonomy/src/surface.rs
+++ b/crates/stella-autonomy/src/surface.rs
@@ -217,6 +217,11 @@ pub const HOST_SURFACE: &[HostVerb] = &[
         summary: "run the loop unattended: claim, work, open, watch, merge — and park rather than exit on a block",
     },
     HostVerb {
+        path: "stats",
+        emits: Emits::Json,
+        summary: "what this session has done so far — the counters a live dashboard reads",
+    },
+    HostVerb {
         path: "triage",
         emits: Emits::QueryEnvelope,
         summary: "bring an issue up to this workspace's convention — repairs what is mechanical, reports what needs judgement",

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -24,6 +24,7 @@ pub(crate) mod probes;
 pub(crate) mod state;
 mod stats;
 mod surface;
+mod triage;
 mod work;
 
 use std::collections::BTreeMap;
@@ -678,13 +679,16 @@ fn gh_plain(args: &[&str]) -> Option<String> {
 }
 
 /// The demand half of the governor, read through the issue port.
-fn demand() -> Demand {
-    backlog::demand_from(&crate::issue_provider::GhIssueProvider)
+fn demand(root: &std::path::Path) -> Demand {
+    backlog::demand_from(
+        &crate::issue_provider::GhIssueProvider,
+        &config::load(root).triage,
+    )
 }
 
 fn plan(st: &LoopState, explain: bool) -> Result<(), String> {
     let supply = probes::supply(&st.repo_root);
-    let demand = demand();
+    let demand = demand(&st.repo_root);
     let cal = st.calibration();
     let plan = stella_autonomy::plan_cycle(supply, demand, &cal, state::floors());
     let aperture = st.aperture();
@@ -942,7 +946,7 @@ fn watch(st: &LoopState) -> Result<(), String> {
     }
 
     if gh_available() {
-        let d = demand();
+        let d = demand(&st.repo_root);
         if d.open_defects > 0 {
             println!("  ! {} open defects in the queue", d.open_defects);
             triggered = true;
@@ -1144,7 +1148,13 @@ fn calibrate_cmd(st: &LoopState, ok: bool, resource_fail: bool, show: bool) -> R
 
 /// The queue verb: the ranked defect batch this cycle draws from.
 fn queue(st: &LoopState, limit: usize, format: QueryFormat) -> Result<(), String> {
-    backlog::render_queue(st, &crate::issue_provider::GhIssueProvider, limit, format)
+    backlog::render_queue(
+        st,
+        &crate::issue_provider::GhIssueProvider,
+        &config::load(&st.repo_root).triage,
+        limit,
+        format,
+    )
 }
 
 /// `stella self-driving deliver` — the pull-request rhythm.

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -1170,7 +1170,7 @@ fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
         }
 
         DeliverCmd::Observe { pr, format } => {
-            let obs = deliver::observe(&root, pr)?;
+            let obs = deliver::observe(pr)?;
             if *format == QueryFormat::Json {
                 println!(
                     "{}",
@@ -1192,7 +1192,7 @@ fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
             no_review,
             format,
         } => {
-            let transition = decide(&root, pr, *fixes, *rebases, *no_review)?;
+            let transition = decide(pr, *fixes, *rebases, *no_review)?;
             if *format == QueryFormat::Json {
                 println!(
                     "{}",
@@ -1213,7 +1213,7 @@ fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
             rebases,
             no_review,
         } => {
-            let transition = decide(&root, pr, *fixes, *rebases, *no_review)?;
+            let transition = decide(pr, *fixes, *rebases, *no_review)?;
             if transition.action != stella_autonomy::Action::Merge {
                 // Refused, not silently skipped: a caller that asked to merge
                 // and got nothing must be able to tell "already merged" from
@@ -1232,13 +1232,12 @@ fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
 
 /// Observe the forge and run the pure machine over what it said.
 fn decide(
-    root: &std::path::Path,
     pr: &str,
     fixes: u32,
     rebases: u32,
     no_review: bool,
 ) -> Result<stella_autonomy::Transition, String> {
-    let obs = deliver::observe(root, pr)?;
+    let obs = deliver::observe(pr)?;
     let policy = stella_autonomy::DeliverPolicy {
         require_approval: !no_review,
         ..stella_autonomy::DeliverPolicy::default()

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -21,6 +21,7 @@ mod drive;
 mod lifecycle;
 pub(crate) mod probes;
 pub(crate) mod state;
+mod stats;
 mod surface;
 mod work;
 
@@ -231,6 +232,16 @@ pub(crate) enum SelfDrivingCmd {
         /// Seconds between polls while waiting on CI.
         #[arg(long, default_value_t = 45)]
         poll_secs: u64,
+    },
+
+    /// What this session has done so far — the counters a dashboard reads.
+    ///
+    /// Written after every step rather than at the end, because a perpetual
+    /// loop that only reported on exit would never report at all.
+    Stats {
+        /// Output format.
+        #[arg(long, value_enum, default_value = "text")]
+        format: QueryFormat,
     },
 
     /// Bring an issue up to this workspace's standard.
@@ -574,7 +585,8 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, spend_limit: Option<f64>) -> Result<(), 
             max_issues,
             no_review,
             poll_secs,
-        } => drive::drive(*max_issues, *no_review, spend_limit, *poll_secs),
+        } => drive::drive(&st, *max_issues, *no_review, spend_limit, *poll_secs),
+        SelfDrivingCmd::Stats { format } => stats::session_stats(&st, *format),
         SelfDrivingCmd::Triage {
             issue,
             dry_run,
@@ -1334,6 +1346,7 @@ fn file_finding(
 
     if let backlog::Filed::New(key) = &outcome {
         st.add_seen(&stella_autonomy::finding_digest(title))?;
+        st.update_stats(|s| s.issues_created += 1);
         if format == QueryFormat::Json {
             println!(r#"{{"filed":"{key}"}}"#);
         } else {

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -13,6 +13,7 @@
 //! harness (`make self-driving-test`) drives those delegations end-to-end, so the
 //! two surfaces cannot drift.
 
+mod audit;
 mod backlog;
 mod config;
 mod convention;

--- a/crates/stella-cli/src/self_driving_cmd/audit.rs
+++ b/crates/stella-cli/src/self_driving_cmd/audit.rs
@@ -1,0 +1,245 @@
+//! Everything the loop did, said out loud and written down.
+//!
+//! An autonomous system that changes a shared repository has to be able to
+//! answer, months later and to somebody who was not there: *what did it do, to
+//! what, when, and how did that turn out?* A scrollback buffer cannot answer
+//! that — it is the least durable surface in the system and it is gone the
+//! moment the terminal closes.
+//!
+//! So every action goes to two places at once. The operator watching sees a
+//! line; the record keeps the same fact as one JSON object per line in
+//! `audit.jsonl`, beside the loop's other durable state.
+//!
+//! # Why both, rather than a log file a renderer tails
+//!
+//! Because they answer different questions and would otherwise drift. The
+//! screen line is written for a person watching a run in progress and is
+//! allowed to be a sentence. The record is written for a person reconstructing
+//! a run afterwards and has to be queryable — which action, against which
+//! issue, at what time, with what outcome. Deriving one from the other means
+//! parsing prose, and prose is exactly what changes when somebody improves a
+//! message.
+//!
+//! # Append-only, and never the reason a step fails
+//!
+//! Entries are appended and never rewritten: an audit trail that can be edited
+//! by the thing it audits is not one. And a failure to write the record is
+//! reported but does not stop the action — a loop that refused to work because
+//! it could not log would be trading the work for the paperwork, and the
+//! action's effect on the repository is what a reader is reconstructing anyway.
+
+use std::io::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use super::state::LoopState;
+
+/// What kind of thing happened.
+///
+/// A closed set rather than free text, so the record can be counted and
+/// filtered without parsing sentences. The sentence is [`AuditEntry::outcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum Action {
+    /// The session started.
+    SessionStarted,
+    /// The session stopped, and why.
+    SessionStopped,
+    /// Work already in flight was picked up after a restart.
+    Resumed,
+    /// An issue was taken off the ranked queue.
+    Claimed,
+    /// A turn was started against an issue.
+    WorkStarted,
+    /// A turn left changes on a branch.
+    WorkChanged,
+    /// A turn ran and changed nothing.
+    WorkNoChange,
+    /// A turn did not complete.
+    WorkFailed,
+    /// An issue was skipped because something else appeared to be on it.
+    Deferred,
+    /// An issue was marked as attempted and unresolved.
+    Escalated,
+    /// A pull request was opened.
+    PrOpened,
+    /// A pull request was observed.
+    PrObserved,
+    /// A pull request was merged.
+    PrMerged,
+    /// A pull request was handed to a human.
+    PrEscalated,
+    /// An issue was filed.
+    IssueFiled,
+    /// An issue was closed.
+    IssueClosed,
+    /// The loop waited, and for what.
+    Waited,
+    /// Something failed in a way the loop treated as transient.
+    Transient,
+}
+
+impl Action {
+    /// The word that leads a screen line.
+    fn label(self) -> &'static str {
+        match self {
+            Self::SessionStarted => "started",
+            Self::SessionStopped => "stopped",
+            Self::Resumed => "resumed",
+            Self::Claimed => "claimed",
+            Self::WorkStarted => "working",
+            Self::WorkChanged => "changed",
+            Self::WorkNoChange => "no change",
+            Self::WorkFailed => "failed",
+            Self::Deferred => "deferred",
+            Self::Escalated => "escalated",
+            Self::PrOpened => "pr opened",
+            Self::PrObserved => "pr observed",
+            Self::PrMerged => "pr merged",
+            Self::PrEscalated => "pr escalated",
+            Self::IssueFiled => "filed",
+            Self::IssueClosed => "closed",
+            Self::Waited => "waiting",
+            Self::Transient => "retrying",
+        }
+    }
+}
+
+/// One thing the loop did.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct AuditEntry {
+    /// When, RFC3339 UTC.
+    pub at: String,
+    /// Which run this belongs to, so a record spanning restarts can be split
+    /// back into sessions.
+    pub run_id: String,
+    /// What kind of thing happened.
+    pub action: Action,
+    /// What it happened to — an issue key, a pull request number.
+    ///
+    /// `None` for the session-level entries, which are about the loop rather
+    /// than about any one piece of work.
+    pub subject: Option<String>,
+    /// What happened, in a sentence a person can read.
+    pub outcome: String,
+}
+
+/// Record an action: print it, then append it.
+///
+/// Printed first, deliberately. If the append fails the operator has still
+/// seen the line, and a warning follows it — the reverse order would make a
+/// disk problem look like the loop having stalled.
+pub(super) fn record(st: &LoopState, action: Action, subject: Option<&str>, outcome: &str) {
+    let subject = subject.map(str::to_owned);
+
+    match &subject {
+        Some(s) => println!("[{}] {} {s} — {outcome}", short_time(), action.label()),
+        None => println!("[{}] {} — {outcome}", short_time(), action.label()),
+    }
+    // Flushed so a piped or redirected run shows progress as it happens rather
+    // than in blocks when the buffer fills. A loop that runs for hours behind a
+    // pipe is one whose output nobody sees until it ends.
+    let _ = std::io::stdout().flush();
+
+    let entry = AuditEntry {
+        at: crate::timefmt::rfc3339_utc_now(),
+        run_id: st
+            .current_run_id()
+            .unwrap_or_else(|| "unassigned".to_owned()),
+        action,
+        subject,
+        outcome: outcome.to_owned(),
+    };
+
+    if let Err(error) = append(st, &entry) {
+        // Reported, and not fatal. A loop that refused to work because it could
+        // not write its log would trade the work for the paperwork.
+        eprintln!("warning: could not append to the audit log: {error}");
+    }
+}
+
+fn append(st: &LoopState, entry: &AuditEntry) -> std::io::Result<()> {
+    let line = serde_json::to_string(entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(st.audit_path())?;
+    writeln!(file, "{line}")
+}
+
+/// `HH:MM:SS`, which is what a person watching a run needs.
+///
+/// The full timestamp is in the record; a screen line repeating the date on
+/// every row would push the actual message off a narrow terminal.
+fn short_time() -> String {
+    let full = crate::timefmt::rfc3339_utc_now();
+    full.split('T')
+        .nth(1)
+        .and_then(|t| t.split(['.', 'Z']).next())
+        .unwrap_or(&full)
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every action has a label, so no screen line can render as an empty word.
+    #[test]
+    fn every_action_has_a_label() {
+        for action in [
+            Action::SessionStarted,
+            Action::SessionStopped,
+            Action::Resumed,
+            Action::Claimed,
+            Action::WorkStarted,
+            Action::WorkChanged,
+            Action::WorkNoChange,
+            Action::WorkFailed,
+            Action::Deferred,
+            Action::Escalated,
+            Action::PrOpened,
+            Action::PrObserved,
+            Action::PrMerged,
+            Action::PrEscalated,
+            Action::IssueFiled,
+            Action::IssueClosed,
+            Action::Waited,
+            Action::Transient,
+        ] {
+            assert!(!action.label().is_empty(), "{action:?} has no label");
+        }
+    }
+
+    /// **The audit witness.** An entry keeps the four things a reader
+    /// reconstructing a run needs — when, which run, what kind, and to what —
+    /// as *fields*, not as a sentence somebody has to parse.
+    #[test]
+    fn an_entry_is_queryable_rather_than_prose() {
+        let entry = AuditEntry {
+            at: "2026-08-19T21:00:00Z".into(),
+            run_id: "r-1".into(),
+            action: Action::PrOpened,
+            subject: Some("4021".into()),
+            outcome: "opened for #3591, ci in progress".into(),
+        };
+
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let back: AuditEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(entry, back);
+
+        // The action is a token, not a word inside the sentence.
+        assert!(json.contains(r#""action":"pr_opened""#), "{json}");
+        assert!(json.contains(r#""subject":"4021""#), "{json}");
+    }
+
+    /// The screen line is short-form time; the record keeps the full stamp.
+    #[test]
+    fn the_screen_time_is_the_clock_not_the_date() {
+        let t = short_time();
+        assert_eq!(t.len(), 8, "expected HH:MM:SS, got {t:?}");
+        assert_eq!(t.matches(':').count(), 2, "{t:?}");
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/audit.rs
+++ b/crates/stella-cli/src/self_driving_cmd/audit.rs
@@ -61,6 +61,10 @@ pub(super) enum Action {
     Deferred,
     /// An issue was marked as attempted and unresolved.
     Escalated,
+    /// A turn was asked to place an issue nobody had judged.
+    TriageStarted,
+    /// An issue was placed, and the labels written.
+    Triaged,
     /// A pull request was opened.
     PrOpened,
     /// A pull request was observed.
@@ -93,6 +97,8 @@ impl Action {
             Self::WorkFailed => "failed",
             Self::Deferred => "deferred",
             Self::Escalated => "escalated",
+            Self::TriageStarted => "triaging",
+            Self::Triaged => "triaged",
             Self::PrOpened => "pr opened",
             Self::PrObserved => "pr observed",
             Self::PrMerged => "pr merged",

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -43,7 +43,8 @@ pub(super) const QUEUE_READ_LIMIT: usize = 200;
 /// a single awaited call.
 fn ranked(
     provider: &dyn IssueProvider,
-) -> Result<(Vec<stella_autonomy::QueueIssue>, usize), String> {
+    policy: &stella_autonomy::priority::TriagePolicy,
+) -> Result<(stella_autonomy::priority::Queue, usize), String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -52,46 +53,31 @@ fn ranked(
         .block_on(provider.list_open(QUEUE_READ_LIMIT))
         .map_err(|error| error.to_string())?;
     let total = issues.len();
-    let defects = stella_autonomy::rank_defects(
+    let queue = stella_autonomy::priority::triage(
         issues
             .iter()
             .map(crate::issue_provider::to_queue_issue)
             .collect(),
+        policy,
     );
 
-    // An issue the loop already tried and could not resolve is not in the
-    // queue. Without this `escalate` is half a feature: the label goes on, the
-    // next run claims the issue anyway, and the loop spends the same money
-    // rediscovering the same wall every cycle — which is the one thing about
-    // the backlog that has not changed.
-    //
-    // Filtered HERE, in the one read, rather than in each caller: the renderer
-    // and the driver must not be able to disagree about what the queue holds,
-    // which is exactly the two-definitions defect B1 removed from `demand`. A
-    // human wanting to see them asks the tracker.
-    //
-    // The work is still wanted — the label says a human should look, not that
-    // the issue is finished. Removing it puts the issue back in play.
-    let defects: Vec<_> = defects
-        .into_iter()
-        .filter(|issue| {
-            !issue
-                .labels
-                .iter()
-                .any(|l| l.name == stella_autonomy::ESCALATION_LABEL)
-        })
-        .collect();
-    Ok((defects, total))
+    // Escalated issues, excluded kinds and the unassessed split all happen
+    // inside `triage`, in the one read. The renderer and the driver must not
+    // be able to disagree about what the queue holds — that is exactly the
+    // two-definitions defect B1 removed from `demand`.
+    Ok((queue, total))
 }
 
 /// The ranked defect batch this cycle draws from.
 pub(super) fn render_queue(
     _st: &LoopState,
     provider: &dyn IssueProvider,
+    policy: &stella_autonomy::priority::TriagePolicy,
     limit: usize,
     format: QueryFormat,
 ) -> Result<(), String> {
-    let (defects, total_issues) = ranked(provider)?;
+    let (queue, total_issues) = ranked(provider, policy)?;
+    let defects = queue.ranked;
     let picked = &defects[..limit.min(defects.len())];
 
     if format == QueryFormat::Json {
@@ -102,10 +88,14 @@ pub(super) fn render_queue(
         return Ok(());
     }
     for i in picked {
-        let prio = ["P0", "P1", "P2"]
-            .into_iter()
-            .find(|p| i.labels.iter().any(|l| l.name == *p))
-            .unwrap_or("--");
+        // The operator's rungs, not a built-in list — a tracker spelling
+        // urgency `Sev1` must render its own word.
+        let prio = policy
+            .ladder
+            .rungs
+            .iter()
+            .find(|rung| i.labels.iter().any(|l| &l.name == *rung))
+            .map_or("--", String::as_str);
         let area = i
             .labels
             .iter()
@@ -115,10 +105,11 @@ pub(super) fn render_queue(
         println!("{prio:>2}  #{:<6} {area:<18} {}", i.number, i.title);
     }
     eprintln!(
-        "\n{} of {} open defects ({} open issues total)",
+        "\n{} of {} ranked defects ({} open issues total, {} awaiting triage)",
         picked.len(),
         defects.len(),
-        total_issues
+        total_issues,
+        queue.unassessed.len()
     );
     Ok(())
 }
@@ -130,16 +121,22 @@ pub(super) fn render_queue(
 /// the backlog were empty is a survivable answer where a refusal to plan is
 /// not. That degradation is inherited from the `gh_available()` check this
 /// replaces, not introduced here.
-pub(super) fn demand_from(provider: &dyn IssueProvider) -> Demand {
-    let Ok((defects, _)) = ranked(provider) else {
+pub(super) fn demand_from(
+    provider: &dyn IssueProvider,
+    policy: &stella_autonomy::priority::TriagePolicy,
+) -> Demand {
+    let Ok((queue, _)) = ranked(provider, policy) else {
         return Demand::default();
     };
-    let p0 = defects
+    // The most urgent rung the operator declared, whatever they call it.
+    let urgent = policy.ladder.most_urgent().unwrap_or_default();
+    let p0 = queue
+        .ranked
         .iter()
-        .filter(|issue| issue.labels.iter().any(|label| label.name == "P0"))
+        .filter(|issue| issue.labels.iter().any(|label| label.name == urgent))
         .count();
     Demand {
-        open_defects: u32::try_from(defects.len()).unwrap_or(u32::MAX),
+        open_defects: u32::try_from(queue.ranked.len()).unwrap_or(u32::MAX),
         p0: u32::try_from(p0).unwrap_or(u32::MAX),
     }
 }
@@ -217,12 +214,29 @@ pub(super) async fn file_finding(
 /// The same read and the same ranking `queue` renders — one definition of
 /// "defect", folded a third way. A driver that filtered the queue itself would
 /// be the second definition B1 removed.
-pub(super) fn ranked_keys(provider: &dyn IssueProvider) -> Result<Vec<String>, String> {
-    let (defects, _) = ranked(provider)?;
-    Ok(defects
+pub(super) fn ranked_keys(
+    provider: &dyn IssueProvider,
+    policy: &stella_autonomy::priority::TriagePolicy,
+) -> Result<Vec<String>, String> {
+    let (queue, _) = ranked(provider, policy)?;
+    Ok(queue
+        .ranked
         .into_iter()
         .map(|issue| issue.number.to_string())
         .collect())
+}
+
+/// Issues nobody has placed, oldest first.
+///
+/// Read through the **same** `ranked` call the driver claims from, so the two
+/// cannot disagree about which issues are still questions. A driver that ran
+/// its own read would be the second definition this module exists to prevent.
+pub(super) fn unassessed(
+    provider: &dyn IssueProvider,
+    policy: &stella_autonomy::priority::TriagePolicy,
+) -> Result<Vec<stella_autonomy::priority::Unassessed>, String> {
+    let (queue, _) = ranked(provider, policy)?;
+    Ok(queue.unassessed)
 }
 
 /// Mark an issue as one the loop tried and could not resolve, and say why.
@@ -232,6 +246,26 @@ pub(super) fn ranked_keys(provider: &dyn IssueProvider) -> Result<Vec<String>, S
 /// reads, and without it the label is an accusation with no evidence — an
 /// issue sitting there marked unresolvable by a machine that did not say what
 /// went wrong is worse than one that was never attempted.
+/// [`escalate`] for a synchronous caller.
+///
+/// The driver's arms are synchronous and each awaited port call would
+/// otherwise make one runtime inline at the call site — which is how two of
+/// them end up spelled differently. One wrapper, one spelling.
+pub(super) fn escalate_blocking(
+    provider: &dyn IssueProvider,
+    key: &str,
+    why: &str,
+    signature: &str,
+) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    runtime
+        .block_on(escalate(provider, &IssueKey::from(key), why, signature))
+        .map_err(|error| error.to_string())
+}
+
 pub(super) async fn escalate(
     provider: &dyn IssueProvider,
     key: &IssueKey,
@@ -755,30 +789,71 @@ mod tests {
     /// ranking no longer requires GitHub to exist.
     #[test]
     fn a_ranked_queue_needs_no_github_at_all() {
-        let (defects, total) = ranked(&backlog()).expect("fixture read");
-        let order: Vec<u64> = defects.iter().map(|issue| issue.number).collect();
+        let policy = stella_autonomy::priority::TriagePolicy::default();
+        let (queue, total) = ranked(&backlog(), &policy).expect("fixture read");
+        let order: Vec<u64> = queue.ranked.iter().map(|issue| issue.number).collect();
         assert_eq!(
             order,
-            vec![3, 5, 7, 9],
-            "P0 first, then P1 aged-before-fresh, then triage — and no feature"
+            vec![3, 5, 7],
+            "P0 first, then P1 aged-before-fresh — and no feature"
         );
         assert_eq!(total, 5, "the total counts every open issue, defect or not");
+    }
+
+    /// A defect nobody gave a rung is a question, not the bottom of the queue.
+    ///
+    /// #9 carries `triage` and no priority label. It used to rank *last*,
+    /// below every `P2`, because the old `priority_rank` mapped "no rung" to
+    /// the number one past the ladder — so an unjudged issue was
+    /// indistinguishable from one somebody had deliberately ranked least
+    /// urgent. It now surfaces as unassessed, which is what lets the loop go
+    /// and place it instead of burying it.
+    #[test]
+    fn a_defect_with_no_rung_surfaces_as_a_question() {
+        let policy = stella_autonomy::priority::TriagePolicy::default();
+        let (queue, _) = ranked(&backlog(), &policy).expect("fixture read");
+        assert_eq!(
+            queue
+                .unassessed
+                .iter()
+                .map(|u| u.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["9"],
+            "the untriaged defect is a question the loop must answer"
+        );
+        assert!(
+            !queue.ranked.iter().any(|i| i.number == 9),
+            "and it must not also be sitting at the bottom of the ranked work"
+        );
     }
 
     /// The governor's two numbers are folds of that one ranking, so they cannot
     /// disagree with the batch the same cycle draws.
     #[test]
     fn demand_is_a_fold_of_the_same_ranking() {
-        let demand = demand_from(&backlog());
-        assert_eq!(demand.open_defects, 4, "the feature is not a defect");
-        assert_eq!(demand.p0, 1, "and its P0 label does not make it one");
+        let policy = stella_autonomy::priority::TriagePolicy::default();
+        let demand = demand_from(&backlog(), &policy);
+        assert_eq!(
+            demand.open_defects, 3,
+            "the feature is not a defect, and the unranked one is not yet work"
+        );
+        assert_eq!(
+            demand.p0, 1,
+            "and the feature's P0 label does not make it one"
+        );
     }
 
     /// An unreachable tracker sizes a cycle as though the backlog were empty,
     /// rather than refusing to plan.
     #[test]
     fn an_unreachable_tracker_degrades_rather_than_failing() {
-        assert_eq!(demand_from(&DeadProvider), Demand::default());
+        assert_eq!(
+            demand_from(
+                &DeadProvider,
+                &stella_autonomy::priority::TriagePolicy::default()
+            ),
+            Demand::default()
+        );
     }
 
     /// The limit bounds what crosses the port, not what the ranker discards

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -58,6 +58,29 @@ fn ranked(
             .map(crate::issue_provider::to_queue_issue)
             .collect(),
     );
+
+    // An issue the loop already tried and could not resolve is not in the
+    // queue. Without this `escalate` is half a feature: the label goes on, the
+    // next run claims the issue anyway, and the loop spends the same money
+    // rediscovering the same wall every cycle — which is the one thing about
+    // the backlog that has not changed.
+    //
+    // Filtered HERE, in the one read, rather than in each caller: the renderer
+    // and the driver must not be able to disagree about what the queue holds,
+    // which is exactly the two-definitions defect B1 removed from `demand`. A
+    // human wanting to see them asks the tracker.
+    //
+    // The work is still wanted — the label says a human should look, not that
+    // the issue is finished. Removing it puts the issue back in play.
+    let defects: Vec<_> = defects
+        .into_iter()
+        .filter(|issue| {
+            !issue
+                .labels
+                .iter()
+                .any(|l| l.name == stella_autonomy::ESCALATION_LABEL)
+        })
+        .collect();
     Ok((defects, total))
 }
 
@@ -297,42 +320,6 @@ pub(super) async fn comment(
     provider
         .comment(key, &stella_autonomy::sign(body, signature))
         .await
-}
-
-/// Resolve one issue by key, through the port.
-///
-/// Reads the open queue and finds the key rather than asking the tracker for
-/// one issue, and that is a deliberate limit rather than an oversight: the port
-/// has no single-issue read, and adding one to serve a caller that only ever
-/// works **open** issues would widen a trait for a case that does not exist
-/// yet. The loop works what it drew from the ranked queue, and a claim lives in
-/// the fleet ledger rather than in the tracker's assignee field — so an issue
-/// being worked is still `Open` and still in this read.
-///
-/// A key that is not in the open queue is a typed refusal naming the two
-/// reasons a caller can act on: it is closed, or it does not exist.
-pub(super) fn resolve(
-    provider: &dyn IssueProvider,
-    key: &str,
-) -> Result<stella_protocol::issue::Issue, String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
-    let issues = runtime
-        .block_on(provider.list_open(QUEUE_READ_LIMIT))
-        .map_err(|error| error.to_string())?;
-
-    issues
-        .into_iter()
-        .find(|issue| issue.key.as_str() == key)
-        .ok_or_else(|| {
-            format!(
-                "#{key} is not in the open queue — it is closed, or it does not exist \
-                 (read {QUEUE_READ_LIMIT} open issues from `{}`)",
-                provider.id()
-            )
-        })
 }
 
 /// Explain a filing that did not happen.

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -322,6 +322,42 @@ pub(super) async fn comment(
         .await
 }
 
+/// Resolve one issue by key, through the port.
+///
+/// Reads the open queue and finds the key rather than asking the tracker for
+/// one issue, and that is a deliberate limit rather than an oversight: the port
+/// has no single-issue read, and adding one to serve a caller that only ever
+/// works **open** issues would widen a trait for a case that does not exist
+/// yet. The loop works what it drew from the ranked queue, and a claim lives in
+/// the fleet ledger rather than in the tracker's assignee field — so an issue
+/// being worked is still `Open` and still in this read.
+///
+/// A key that is not in the open queue is a typed refusal naming the two
+/// reasons a caller can act on: it is closed, or it does not exist.
+pub(super) fn resolve(
+    provider: &dyn IssueProvider,
+    key: &str,
+) -> Result<stella_protocol::issue::Issue, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    let issues = runtime
+        .block_on(provider.list_open(QUEUE_READ_LIMIT))
+        .map_err(|error| error.to_string())?;
+
+    issues
+        .into_iter()
+        .find(|issue| issue.key.as_str() == key)
+        .ok_or_else(|| {
+            format!(
+                "#{key} is not in the open queue — it is closed, or it does not exist \
+                 (read {QUEUE_READ_LIMIT} open issues from `{}`)",
+                provider.id()
+            )
+        })
+}
+
 /// Explain a filing that did not happen.
 ///
 /// A refusal is rendered with **every** violation and with where the convention

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -47,6 +47,8 @@ pub(super) struct LoopConfig {
     pub attribution: Attribution,
     /// How the active tracker spells the concepts every tracker has.
     pub vocabulary: Vocabulary,
+    /// Which labels mean urgent, which mean "ours", which mean "not ours".
+    pub triage: stella_autonomy::priority::TriagePolicy,
 }
 
 /// Read the loop's configuration for a workspace.
@@ -64,6 +66,7 @@ pub(super) fn load(root: &Path) -> LoopConfig {
     LoopConfig {
         attribution: parsed.self_driving.attribution.clone(),
         vocabulary: vocabulary_for(root, &parsed.issues),
+        triage: parsed.self_driving.triage.policy(),
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -183,7 +183,7 @@ branch_prefix = "oxagen/"
         assert_eq!(cfg.attribution.commit, "Created by oxagen.");
         assert_eq!(cfg.attribution.branch_prefix(), "oxagen/");
         // Unmentioned surfaces keep identifying the loop rather than blanking.
-        assert_eq!(cfg.attribution.issue, "Filed by stella.");
+        assert_eq!(cfg.attribution.issue, stella_autonomy::SIGNATURE);
     }
 
     /// **The portability witness.** `stella.toml` says *which* tracker; the

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -220,6 +220,70 @@ pub(super) fn commit_trailer(issue_key: &str) -> String {
     format!("Closes #{issue_key}")
 }
 
+/// Ask the forge to run this pull request's failed checks again.
+///
+/// The one remedy the loop has for a red it did not cause and cannot see:
+/// a check that ran against a base which has since been repaired keeps its
+/// failing verdict forever, and no amount of re-reading the forge changes it.
+/// `base_conclusion` compares what is failing *now*, so once the base goes
+/// green the pull request is left holding a failure that reproduces nowhere.
+///
+/// Re-running is cheap and the answer is unambiguous either way, which is why
+/// this is attempted before the fix path rather than instead of it. The caller
+/// bounds it to once per pull request.
+pub(super) fn rerun_failed(pr: &str) -> Result<(), String> {
+    // `gh pr checks --json` names the run each check belongs to only through
+    // its URL, so the run id is recovered from there. A pull request whose
+    // checks all pass yields nothing to re-run, which is not an error.
+    let raw = gh(&["pr", "checks", pr, "--json", "state,link"])?;
+
+    #[derive(serde::Deserialize)]
+    struct Row {
+        #[serde(default)]
+        state: String,
+        #[serde(default)]
+        link: String,
+    }
+
+    let rows: Vec<Row> = serde_json::from_str(&raw).map_err(|error| {
+        format!("`gh pr checks` returned a payload this build cannot read: {error}")
+    })?;
+
+    let mut runs: Vec<String> = rows
+        .iter()
+        .filter(|row| row.state.eq_ignore_ascii_case("FAILURE"))
+        .filter_map(|row| run_id_from_link(&row.link))
+        .collect();
+    runs.sort();
+    runs.dedup();
+
+    if runs.is_empty() {
+        return Err("no failed check named a workflow run to re-run".to_owned());
+    }
+
+    for run in &runs {
+        gh(&["run", "rerun", run, "--failed"])?;
+    }
+    Ok(())
+}
+
+/// The workflow-run id inside a check's link, if it has one.
+///
+/// A check link looks like `…/actions/runs/<run>/job/<job>`. Anything else —
+/// a third-party check pointing at its own dashboard, an empty link — yields
+/// `None` rather than a guess, because re-running the wrong id is worse than
+/// re-running nothing.
+#[must_use]
+fn run_id_from_link(link: &str) -> Option<String> {
+    let after = link.split("/actions/runs/").nth(1)?;
+    let id = after.split('/').next()?;
+    if !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()) {
+        Some(id.to_owned())
+    } else {
+        None
+    }
+}
+
 /// The forge endpoint carrying a ref's check runs.
 ///
 /// Split out so the one thing that can be wrong here — *which commit gets
@@ -422,6 +486,31 @@ mod tests {
         assert!(
             !endpoint.contains("origin/"),
             "a remote-tracking ref resolves against the last fetch, not the forge: {endpoint}"
+        );
+    }
+
+    /// A check link yields a run id, or nothing — never a guess.
+    ///
+    /// The re-run is the loop's one remedy for a red the base already
+    /// explains, and it is aimed by parsing a URL. Re-running the wrong id is
+    /// worse than re-running nothing, so every shape that is not a GitHub
+    /// Actions run must decline: this repository's checks include third-party
+    /// ones (Vercel) whose links point somewhere else entirely, and one of
+    /// them is failing on every pull request right now.
+    #[test]
+    fn only_an_actions_run_link_names_a_run_to_rerun() {
+        assert_eq!(
+            run_id_from_link(
+                "https://github.com/macanderson/stella/actions/runs/32311670564/job/96255819957"
+            )
+            .as_deref(),
+            Some("32311670564")
+        );
+        assert_eq!(run_id_from_link("https://vercel.com/github"), None);
+        assert_eq!(run_id_from_link(""), None);
+        assert_eq!(
+            run_id_from_link("https://github.com/o/r/actions/runs/not-a-number/job/1"),
+            None
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -42,36 +42,97 @@ use stella_autonomy::{CiConclusion, Mergeability, Observation, ReviewState};
 use super::state::git;
 
 /// One check as the forge reports it, reduced to what the mapping reads.
-#[derive(Debug, Clone, serde::Deserialize)]
+///
+/// # There are two kinds of check and they do not share a spelling
+///
+/// A pull request's rollup mixes **check runs** (GitHub Actions: `name`,
+/// `status`, `conclusion`) with **commit statuses** (the older API that
+/// third-party services still post to: `context`, `state`, and no `status`
+/// field at all). Deserializing only the first shape does not fail — every
+/// field is `#[serde(default)]` — it silently produces a check with no name
+/// and no conclusion.
+///
+/// Which reads as *pending forever*: `status` is not `COMPLETED`, so
+/// [`Self::pending`] is true on every poll, for a check that concluded before
+/// the loop ever looked. That is what it did. This repository carries a Vercel
+/// commit status that has been failing on every pull request, and the loop sat
+/// on #4022 re-reading `ci=Pending` for twenty-five minutes after all three
+/// required checks had gone green.
+///
+/// The empty `name` is the same bug's other half: [`base_conclusion`] joins by
+/// name, and every commit status would have joined against every other.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
 pub(super) struct Check {
-    /// The check's name — the join key against the base branch.
+    /// A check run's name.
     #[serde(default)]
     pub name: String,
-    /// `SUCCESS`, `FAILURE`, `""` while running, and the rest of the forge's
-    /// vocabulary.
+    /// A commit status's name. GitHub calls the same thing `context` here.
+    #[serde(default)]
+    pub context: String,
+    /// A check run's outcome: `SUCCESS`, `FAILURE`, `SKIPPED`, `""` while
+    /// running.
     #[serde(default)]
     pub conclusion: String,
-    /// `COMPLETED`, `IN_PROGRESS`, `QUEUED`.
+    /// A commit status's outcome: `SUCCESS`, `FAILURE`, `ERROR`, `PENDING`,
+    /// `EXPECTED`.
+    #[serde(default)]
+    pub state: String,
+    /// A check run's progress: `COMPLETED`, `IN_PROGRESS`, `QUEUED`. **Absent
+    /// on a commit status**, which is how the two are told apart.
     #[serde(default)]
     pub status: String,
 }
 
 impl Check {
+    /// The join key, whichever shape reported it.
+    pub(super) fn name(&self) -> &str {
+        if self.name.is_empty() {
+            &self.context
+        } else {
+            &self.name
+        }
+    }
+
+    /// The outcome, whichever shape reported it.
+    fn outcome(&self) -> String {
+        let raw = if self.conclusion.is_empty() {
+            &self.state
+        } else {
+            &self.conclusion
+        };
+        raw.trim().to_ascii_uppercase()
+    }
+
+    /// Whether this is a commit status rather than a check run.
+    ///
+    /// The absence of `status` is the discriminator, because it is the one
+    /// field the older API has no equivalent for.
+    fn is_commit_status(&self) -> bool {
+        self.status.trim().is_empty()
+    }
+
     /// Whether this check has concluded and concluded badly.
+    ///
+    /// `ERROR` is a commit status's way of saying the service itself broke,
+    /// which is a failure for every purpose this loop has.
     fn failed(&self) -> bool {
         matches!(
-            self.conclusion.to_ascii_uppercase().as_str(),
-            "FAILURE" | "TIMED_OUT" | "STARTUP_FAILURE" | "ACTION_REQUIRED"
+            self.outcome().as_str(),
+            "FAILURE" | "ERROR" | "TIMED_OUT" | "STARTUP_FAILURE" | "ACTION_REQUIRED"
         )
     }
 
     /// Whether it has not finished.
     fn pending(&self) -> bool {
+        if self.is_commit_status() {
+            // No progress field exists, so the outcome is the whole story.
+            return matches!(self.outcome().as_str(), "PENDING" | "EXPECTED" | "");
+        }
         !self.status.eq_ignore_ascii_case("COMPLETED")
             // A completed check with no conclusion is a forge quirk, not a
             // pass: treated as still-unknown rather than green, on the same
             // reasoning as `Mergeability::Unknown`.
-            || self.conclusion.trim().is_empty()
+            || self.outcome().is_empty()
     }
 
     /// Whether it should be ignored entirely.
@@ -81,10 +142,7 @@ impl Check {
     /// is skipped by design (this repository skips several on a docs-only
     /// diff).
     fn inert(&self) -> bool {
-        matches!(
-            self.conclusion.to_ascii_uppercase().as_str(),
-            "SKIPPED" | "NEUTRAL" | "CANCELLED"
-        )
+        matches!(self.outcome().as_str(), "SKIPPED" | "NEUTRAL" | "CANCELLED")
     }
 }
 
@@ -117,18 +175,14 @@ pub(super) fn ci_from(checks: &[Check]) -> CiConclusion {
 /// fault*, not *is the base perfect*.
 #[must_use]
 pub(super) fn base_conclusion(pr: &[Check], base: &[Check]) -> CiConclusion {
-    let failing_here: Vec<&str> = pr
-        .iter()
-        .filter(|c| c.failed())
-        .map(|c| c.name.as_str())
-        .collect();
+    let failing_here: Vec<&str> = pr.iter().filter(|c| c.failed()).map(Check::name).collect();
 
     if failing_here.is_empty() {
         // Nothing failed here, so there is nothing for the base to excuse.
         return CiConclusion::Green;
     }
 
-    let failing_there = |name: &str| base.iter().any(|c| c.name == name && c.failed());
+    let failing_there = |name: &str| base.iter().any(|c| c.name() == name && c.failed());
 
     if failing_here.iter().all(|name| failing_there(name)) {
         CiConclusion::Red
@@ -352,14 +406,41 @@ pub(super) fn checks_for_branch(branch: &str) -> Vec<Check> {
     if branch.is_empty() {
         return Vec::new();
     }
+    let mut checks = read_jq(
+        &check_runs_endpoint(branch),
+        ".check_runs[] | {name: .name, conclusion: (.conclusion // \"\"), status: .status}",
+    );
+
+    // Commit statuses live behind a different endpoint and speak a different
+    // dialect. Read separately and appended, because a pull request's rollup
+    // contains both — and a base showing only half of it would fail to excuse
+    // exactly the checks most likely to be broken repository-wide, since a
+    // third-party service is what posts a commit status.
+    checks.extend(read_jq(
+        &statuses_endpoint(branch),
+        ".statuses[] | {context: .context, state: .state}",
+    ));
+    checks
+}
+
+/// The forge endpoint carrying a ref's commit statuses.
+///
+/// A second endpoint rather than a second field: GitHub never merged the two
+/// APIs, and `check-runs` genuinely does not contain a commit status.
+#[must_use]
+fn statuses_endpoint(branch: &str) -> String {
+    format!("repos/{{owner}}/{{repo}}/commits/{branch}/status")
+}
+
+/// Run one `gh api` read and parse a [`Check`] per line.
+///
+/// An unreachable forge yields no checks, which `base_conclusion` reads as
+/// "excuses nothing" — the direction that blames the pull request, and so the
+/// one that must never be reached by accident. It is reached only when `gh`
+/// itself cannot run.
+fn read_jq(endpoint: &str, jq: &str) -> Vec<Check> {
     let out = std::process::Command::new("gh")
-        .args([
-            "api",
-            &check_runs_endpoint(branch),
-            "--paginate",
-            "--jq",
-            ".check_runs[] | {name: .name, conclusion: (.conclusion // \"\"), status: .status}",
-        ])
+        .args(["api", endpoint, "--paginate", "--jq", jq])
         .env("NO_COLOR", "1")
         .output();
     let Ok(out) = out else {
@@ -517,6 +598,97 @@ mod tests {
         );
     }
 
+    /// A commit status is a concluded check, not a pending one.
+    ///
+    /// **The witness for the bug that stalled the loop.** GitHub's rollup
+    /// mixes two dialects: a check run carries `name`/`status`/`conclusion`,
+    /// a commit status carries `context`/`state` and no `status` at all.
+    /// Reading only the first shape does not fail — every field defaults — it
+    /// yields a nameless check with no conclusion, which `pending()` reports
+    /// as unfinished on every poll forever.
+    ///
+    /// That is what happened: this repository's Vercel commit status had
+    /// already concluded `FAILURE`, and the loop re-read `ci=Pending` on #4022
+    /// for twenty-five minutes after all three required checks went green.
+    #[test]
+    fn a_commit_status_is_read_as_concluded_not_as_pending() {
+        let vercel = Check {
+            context: "Vercel".into(),
+            state: "FAILURE".into(),
+            ..Check::default()
+        };
+
+        assert!(
+            !vercel.pending(),
+            "it concluded — before the loop ever looked"
+        );
+        assert!(vercel.failed());
+        assert_eq!(vercel.name(), "Vercel", "and it must join by its context");
+        assert_eq!(ci_from(&[vercel]), CiConclusion::Red);
+    }
+
+    /// A commit status that really is pending still reads as pending.
+    ///
+    /// The other direction, so the fix above cannot be "call every commit
+    /// status finished".
+    #[test]
+    fn a_pending_commit_status_still_reads_as_pending() {
+        let waiting = Check {
+            context: "Vercel".into(),
+            state: "PENDING".into(),
+            ..Check::default()
+        };
+        assert!(waiting.pending());
+        assert!(!waiting.failed());
+        assert_eq!(ci_from(&[waiting]), CiConclusion::Pending);
+    }
+
+    /// A commit status failing on both sides is the base's fault, not ours.
+    ///
+    /// This only works because the base is read from *two* endpoints. A base
+    /// read that saw check runs alone would show no `Vercel` row, the join
+    /// would find nothing, and a service broken account-wide would be charged
+    /// to every pull request the loop opened.
+    #[test]
+    fn a_commit_status_broken_on_the_base_excuses_the_pull_request() {
+        let failing = |context: &str| Check {
+            context: context.into(),
+            state: "FAILURE".into(),
+            ..Check::default()
+        };
+
+        assert_eq!(
+            base_conclusion(&[failing("Vercel")], &[failing("Vercel")]),
+            CiConclusion::Red,
+            "the base is broken in the same way, so this is not ours to fix"
+        );
+        assert_eq!(
+            base_conclusion(&[failing("Vercel")], &[]),
+            CiConclusion::Green,
+            "and a base that does not share the failure excuses nothing"
+        );
+    }
+
+    /// A check run and a commit status of the same name are one check.
+    ///
+    /// Neither dialect is privileged: the join key is whichever field carried
+    /// the name.
+    #[test]
+    fn the_two_dialects_join_on_one_name() {
+        let run = Check {
+            name: "build".into(),
+            status: "COMPLETED".into(),
+            conclusion: "FAILURE".into(),
+            ..Check::default()
+        };
+        let status = Check {
+            context: "build".into(),
+            state: "FAILURE".into(),
+            ..Check::default()
+        };
+        assert_eq!(base_conclusion(&[run], &[status]), CiConclusion::Red);
+    }
+
     /// A check link yields a run id, or nothing — never a guess.
     ///
     /// The re-run is the loop's one remedy for a red the base already
@@ -558,6 +730,7 @@ mod tests {
             name: name.into(),
             conclusion: conclusion.into(),
             status: "COMPLETED".into(),
+            ..Check::default()
         }
     }
 
@@ -566,6 +739,7 @@ mod tests {
             name: name.into(),
             conclusion: String::new(),
             status: "IN_PROGRESS".into(),
+            ..Check::default()
         }
     }
 
@@ -647,6 +821,7 @@ mod tests {
             name: "a".into(),
             conclusion: String::new(),
             status: "COMPLETED".into(),
+            ..Check::default()
         };
         assert_eq!(ci_from(&[odd]), CiConclusion::Pending);
     }

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -318,6 +318,40 @@ pub(super) fn observe(root: &std::path::Path, pr: &str) -> Result<Observation, S
     Ok(observation_from(&view, &base_checks))
 }
 
+/// Every open pull request on a branch with this workspace's prefix.
+///
+/// How a restarted loop finds what it was carrying. It **asks the forge**
+/// rather than reading a list it wrote down, because the forge is the source
+/// of truth about a pull request and a remembered list can only be wrong —
+/// stale after a human merges one by hand, or after a run died between opening
+/// a pull request and recording it.
+pub(super) fn open_prs_for_prefix(prefix: &str) -> Result<Vec<String>, String> {
+    #[derive(serde::Deserialize)]
+    struct Row {
+        number: u64,
+        #[serde(rename = "headRefName", default)]
+        head_ref_name: String,
+    }
+
+    let raw = gh(&[
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--json",
+        "number,headRefName",
+    ])?;
+    let rows: Vec<Row> = serde_json::from_str(&raw).map_err(|error| {
+        format!("`gh pr list` returned a payload this build cannot read: {error}")
+    })?;
+
+    Ok(rows
+        .into_iter()
+        .filter(|row| row.head_ref_name.starts_with(prefix))
+        .map(|row| row.number.to_string())
+        .collect())
+}
+
 /// Take a pull request out of draft.
 ///
 /// Called only when the machine returned `MarkReady`, which it does once CI is

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -468,13 +468,13 @@ mod tests {
     /// different text and either alone is a silent single point of failure.
     #[test]
     fn closing_an_issue_takes_both_the_body_and_the_trailer() {
-        let body = pr_body("3939", "summary", "Created by stella.");
+        let body = pr_body("3939", "summary", stella_autonomy::SIGNATURE);
         assert!(body.contains("Closes #3939"));
         assert_eq!(commit_trailer("3939"), "Closes #3939");
-        // And the signature sits exactly one line break after the last
-        // character, not two.
+        // And the footer is a horizontal rule below the closing keyword, so
+        // the `Closes` line is never swallowed into the signature.
         assert!(
-            body.ends_with("Closes #3939\nCreated by stella."),
+            body.ends_with("Closes #3939\n\n---\ncreated by stella*"),
             "{body:?}"
         );
     }

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -220,20 +220,51 @@ pub(super) fn commit_trailer(issue_key: &str) -> String {
     format!("Closes #{issue_key}")
 }
 
+/// The forge endpoint carrying a ref's check runs.
+///
+/// Split out so the one thing that can be wrong here — *which commit gets
+/// asked about* — is visible to a test. See [`checks_for_branch`].
+#[must_use]
+fn check_runs_endpoint(branch: &str) -> String {
+    format!("repos/{{owner}}/{{repo}}/commits/{branch}/check-runs")
+}
+
 /// Read a branch's checks from the forge.
-pub(super) fn checks_for_branch(root: &std::path::Path, branch: &str) -> Vec<Check> {
+///
+/// # The branch is named to the forge, never resolved locally first
+///
+/// This used to run `git rev-parse origin/<branch>` and ask about the commit
+/// that came back. A remote-tracking ref is only as fresh as the last fetch,
+/// and this loop does not fetch between polls — so once the process had been
+/// up for a while, `origin/main` still pointed at whatever main was when it
+/// started.
+///
+/// That is not a stale-data annoyance; it is a loss of work, and in the one
+/// direction that costs. [`base_conclusion`] excuses a pull request only when
+/// **every** check failing on it also fails on the base. Reading a
+/// pre-breakage base makes the base look green, so an inherited failure is
+/// scored as the pull request's own and a change that was never wrong gets a
+/// fix attempt or an escalation. It happened on the first pull request this
+/// loop ever opened: #4014 failed on a `cargo fmt` diff in a file its own diff
+/// never touched, and was escalated for it.
+///
+/// Naming the branch to the forge has no local state left to be stale. It is
+/// the same rule [`open_prs_for_prefix`] follows: for a question about the
+/// forge, ask the forge.
+pub(super) fn checks_for_branch(branch: &str) -> Vec<Check> {
     // `gh pr view` is not available for a branch with no pull request, so the
-    // base is read through the commit's check-runs instead. A base with no
-    // checks at all yields an empty list, which `base_conclusion` reads as
-    // "does not excuse anything" — the safe direction.
-    let raw = git(root, &["rev-parse", branch]).unwrap_or_default();
-    if raw.is_empty() {
+    // base is read through the ref's check-runs instead. A base with no checks
+    // at all yields an empty list, which `base_conclusion` reads as "does not
+    // excuse anything" — which blames the pull request, so it is only correct
+    // while it means "the base really has no checks".
+    if branch.is_empty() {
         return Vec::new();
     }
     let out = std::process::Command::new("gh")
         .args([
             "api",
-            &format!("repos/{{owner}}/{{repo}}/commits/{}/check-runs", raw.trim()),
+            &check_runs_endpoint(branch),
+            "--paginate",
             "--jq",
             ".check_runs[] | {name: .name, conclusion: (.conclusion // \"\"), status: .status}",
         ])
@@ -296,7 +327,7 @@ pub(super) fn open(
 
 /// One read of the forge, plus the second read of the base its
 /// [`Observation::base_ci`] needs.
-pub(super) fn observe(root: &std::path::Path, pr: &str) -> Result<Observation, String> {
+pub(super) fn observe(pr: &str) -> Result<Observation, String> {
     let raw = gh(&[
         "pr",
         "view",
@@ -308,12 +339,10 @@ pub(super) fn observe(root: &std::path::Path, pr: &str) -> Result<Observation, S
         format!("`gh pr view` returned a payload this build cannot read: {error}")
     })?;
 
-    let base_branch = if view.base_ref_name.is_empty() {
-        "origin/HEAD".to_owned()
-    } else {
-        format!("origin/{}", view.base_ref_name)
-    };
-    let base_checks = checks_for_branch(root, &base_branch);
+    // The forge's own name for the base, passed through untouched. Prefixing
+    // it with `origin/` would name a remote-tracking ref this process no
+    // longer resolves — see `checks_for_branch`.
+    let base_checks = checks_for_branch(&view.base_ref_name);
 
     Ok(observation_from(&view, &base_checks))
 }
@@ -373,6 +402,39 @@ pub(super) fn merge(pr: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The base is asked about by branch name, so no local ref can go stale.
+    ///
+    /// The endpoint used to carry a commit resolved by `git rev-parse
+    /// origin/<branch>`, which is only as fresh as the last fetch — and this
+    /// loop never fetches. A base that broke while the process was up still
+    /// resolved to the pre-breakage commit, so [`base_conclusion`] saw a green
+    /// base and scored an inherited failure as the pull request's own. #4014
+    /// was escalated for a `cargo fmt` diff in a file it never touched.
+    ///
+    /// Asserting the *absence* of `origin/` is the half that matters: a
+    /// remote-tracking spelling would resolve locally again and re-introduce
+    /// exactly the staleness this replaced.
+    #[test]
+    fn the_base_is_named_to_the_forge_not_a_remote_tracking_ref() {
+        let endpoint = check_runs_endpoint("main");
+        assert_eq!(endpoint, "repos/{owner}/{repo}/commits/main/check-runs");
+        assert!(
+            !endpoint.contains("origin/"),
+            "a remote-tracking ref resolves against the last fetch, not the forge: {endpoint}"
+        );
+    }
+
+    /// A base with no name is not a base with no failures.
+    ///
+    /// Reading an empty list here means "the base excuses nothing", which
+    /// blames the pull request. That is only sound when the base genuinely has
+    /// no checks — so the empty-name path returns early rather than asking the
+    /// forge about a ref spelled `""` and reading its 404 as the same thing.
+    #[test]
+    fn an_unnamed_base_asks_the_forge_nothing() {
+        assert!(checks_for_branch("").is_empty());
+    }
 
     fn check(name: &str, conclusion: &str) -> Check {
         Check {

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -220,18 +220,46 @@ pub(super) fn commit_trailer(issue_key: &str) -> String {
     format!("Closes #{issue_key}")
 }
 
+/// Re-decide a red verdict against the base as it stands now.
+///
+/// The one remedy the loop has for a red it did not cause and cannot see. A
+/// check that ran against a base which has since been repaired keeps its
+/// failing verdict forever, and `base_conclusion` compares what is failing
+/// *now* — so once the base goes green the pull request is left holding a
+/// failure that reproduces nowhere.
+///
+/// # Re-running alone does not do it, and that is the whole subtlety
+///
+/// A `pull_request` run is anchored to the merge commit computed when the run
+/// was **created**. `gh run rerun` replays that same commit, stale base and
+/// all. Measured here rather than assumed: #4022's failed job was re-run at
+/// 23:28, twelve minutes after #4015 repaired `main`, and reproduced the
+/// identical `cargo fmt` diff at `stella-autonomy/src/lib.rs:824` that only
+/// ever existed on the old base.
+///
+/// So the base is merged in first — a new head commit, and a fresh run that
+/// sees the repair. Re-running is kept as the fallback for the case
+/// `update-branch` declines, which is a branch that is *already* current: then
+/// there is no staleness to clear and a red that re-runs green was a flake.
+///
+/// Either way the caller bounds this to once per pull request, so a genuine
+/// failure reaches the fix path on the next poll.
+pub(super) fn refresh_against_base(pr: &str) -> Result<(), String> {
+    // Ahead of the fallback because it is the one that can actually change the
+    // answer. A branch already level with the base refuses here, which is
+    // exactly when re-running is the right move instead.
+    if gh(&["pr", "update-branch", pr]).is_ok() {
+        return Ok(());
+    }
+    rerun_failed(pr)
+}
+
 /// Ask the forge to run this pull request's failed checks again.
 ///
-/// The one remedy the loop has for a red it did not cause and cannot see:
-/// a check that ran against a base which has since been repaired keeps its
-/// failing verdict forever, and no amount of re-reading the forge changes it.
-/// `base_conclusion` compares what is failing *now*, so once the base goes
-/// green the pull request is left holding a failure that reproduces nowhere.
-///
-/// Re-running is cheap and the answer is unambiguous either way, which is why
-/// this is attempted before the fix path rather than instead of it. The caller
-/// bounds it to once per pull request.
-pub(super) fn rerun_failed(pr: &str) -> Result<(), String> {
+/// The fallback half of [`refresh_against_base`] — correct for a flake, and
+/// unable to clear a stale base. See that function for why the distinction
+/// matters.
+fn rerun_failed(pr: &str) -> Result<(), String> {
     // `gh pr checks --json` names the run each check belongs to only through
     // its URL, so the run id is recovered from there. A pull request whose
     // checks all pass yields nothing to re-run, which is not an error.

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -317,7 +317,15 @@ fn rerun_failed(pr: &str) -> Result<(), String> {
     // `gh pr checks --json` names the run each check belongs to only through
     // its URL, so the run id is recovered from there. A pull request whose
     // checks all pass yields nothing to re-run, which is not an error.
-    let raw = gh(&["pr", "checks", pr, "--json", "state,link"])?;
+    //
+    // `gh pr checks` exits non-zero whenever the checks are not all green —
+    // exit 1 on a failure, exit 8 while any are still pending — and does so
+    // *while still writing the requested JSON to stdout*. The plain `gh`
+    // helper reads that as an error and throws the payload away, so it cannot
+    // be used here: this fallback only ever runs on a red pull request, i.e.
+    // exactly when the exit code is non-zero. Read stdout regardless of exit
+    // status and let the JSON parse below be the arbiter instead.
+    let raw = gh_stdout(&["pr", "checks", pr, "--json", "state,link"])?;
 
     #[derive(serde::Deserialize)]
     struct Row {
@@ -465,6 +473,29 @@ fn gh(args: &[&str]) -> Result<String, String> {
     } else {
         Err(String::from_utf8_lossy(&out.stderr).trim().to_owned())
     }
+}
+
+/// Run `gh` and return stdout even when the command exits non-zero.
+///
+/// Some `gh` subcommands report their result through the exit code while still
+/// emitting the requested payload on stdout — `gh pr checks` exits 1 on a
+/// failing check and 8 on a pending one, yet writes its `--json` output either
+/// way. For those, a non-zero exit is a verdict about the checks, not a
+/// failure of the command, so the payload must survive it. stderr is only
+/// surfaced when stdout came back empty, which is the one case that signals
+/// the command itself could not run.
+fn gh_stdout(args: &[&str]) -> Result<String, String> {
+    let out = std::process::Command::new("gh")
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR_FORCE", "0")
+        .output()
+        .map_err(|error| format!("could not run `gh`: {error} — is the GitHub CLI installed?"))?;
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if stdout.is_empty() && !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_owned());
+    }
+    Ok(stdout)
 }
 
 /// Push `branch` and open a draft pull request that closes `issue_key`.

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -76,6 +76,9 @@ use super::state::LoopState as Durable;
 struct Spent {
     fixes: u32,
     rebases: u32,
+    /// Whether the stale-red re-run has already been spent on this pull
+    /// request. Exactly one is allowed — see [`advance`].
+    rerun: bool,
 }
 
 /// What one run of the loop did, for the closing line.
@@ -580,6 +583,41 @@ fn advance(
             Ok(false)
         }
         Action::PushFix => {
+            // A red that the base already explains is not this pull request's
+            // to fix, and `base_conclusion` cannot see it: it compares what is
+            // failing *now*, and a check that ran against a base which has
+            // since been repaired keeps its old verdict forever. The pull
+            // request looks guilty of a failure that no longer exists
+            // anywhere.
+            //
+            // Asking the forge to run it again is the cheapest way to find
+            // out, and costs nothing but CI minutes when the answer is "still
+            // red" — at which point the fix path below runs on the next poll
+            // with the re-run already spent. One per pull request: a loop that
+            // re-ran on every red would never reach the fix, and would spin on
+            // a genuine failure for as long as the operator left it up.
+            if !entry.rerun {
+                entry.rerun = true;
+                match super::deliver::rerun_failed(pr) {
+                    Ok(()) => {
+                        audit::record(
+                            durable,
+                            Audit::PrObserved,
+                            Some(pr),
+                            "red against a base that has since gone green — asked the forge to \
+                             run the failed checks again before treating it as ours",
+                        );
+                        return Ok(false);
+                    }
+                    Err(error) => audit::record(
+                        durable,
+                        Audit::Transient,
+                        Some(pr),
+                        &format!("could not ask for a re-run ({error}); treating the red as ours"),
+                    ),
+                }
+            }
+
             // Counted even though this slice does not author the fix: the
             // ceiling is what stops a loop pushing the same broken change
             // forever, and a counter that only moved on success would never

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -137,6 +137,10 @@ pub(super) fn drive(
         ..LoopState::default()
     };
     let mut spent: HashMap<String, Spent> = HashMap::new();
+    // Issues this process already offered to triage. The escalation label is
+    // the durable half; this covers the window before it lands, and stops a
+    // provider that failed to accept the label costing a turn every pass.
+    let mut triaged: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut tally = Tally::default();
 
     resume(durable, &cfg, &mut state);
@@ -164,9 +168,35 @@ pub(super) fn drive(
             LoopStep::Plan => state.planned = true,
 
             LoopStep::Claim { .. } => {
+                // Judged before ranked, every single time.
+                //
+                // An issue nobody has labelled is not low-priority, it is
+                // unplaced — and the queue is re-read from the tracker on
+                // every claim precisely so that a P0 filed a minute ago, or an
+                // issue somebody just re-labelled, is taken next rather than
+                // whenever this run happens to come back round. Assessing
+                // first is what makes that true for an issue that arrived
+                // with no labels at all: otherwise it would sit invisible
+                // while the loop worked an older, lesser, already-labelled
+                // one.
+                //
+                // One per pass. Triage is a model call, and draining a
+                // hundred unlabelled issues before touching any work would
+                // turn a delivery loop into a labelling bot.
+                if let Err(error) =
+                    assess_one(durable, &root, &provider, &cfg, spend_limit, &mut triaged)
+                {
+                    audit::record(
+                        durable,
+                        Audit::Transient,
+                        None,
+                        &format!("could not triage ({error}); ranking what is already placed"),
+                    );
+                }
+
                 // A queue read is a network call. Failing it is a reason to
                 // wait, never a reason to end a run meant to be perpetual.
-                let ranked = match super::backlog::ranked_keys(&provider) {
+                let ranked = match super::backlog::ranked_keys(&provider, &cfg.triage) {
                     Ok(ranked) => ranked,
                     Err(error) => {
                         audit::record(
@@ -506,6 +536,85 @@ fn escalate(
             &format!("could not label it as escalated: {error}"),
         ),
     }
+}
+
+/// Place the oldest issue nobody has judged, if there is one.
+///
+/// Returns `Ok(())` when there was nothing to do as well as when something was
+/// placed — a queue with no questions in it is the normal case, not an
+/// exception.
+///
+/// # Why a refusal escalates rather than retries
+///
+/// A turn that answers outside the declared vocabulary, or declines to answer
+/// at all, has told us it cannot place this issue. Leaving it unplaced would
+/// mean meeting it again on the very next pass, paying for the same turn, and
+/// getting the same refusal — forever, and at the cost of never claiming any
+/// work. So it gets the escalation label, which takes it out of the queue and
+/// puts it in front of a human. `triaged` is the process-local half of the
+/// same guard, covering the window before the label lands.
+fn assess_one(
+    durable: &Durable,
+    root: &std::path::Path,
+    provider: &crate::issue_provider::GhIssueProvider,
+    cfg: &super::config::LoopConfig,
+    spend_limit: Option<f64>,
+    triaged: &mut std::collections::HashSet<String>,
+) -> Result<(), String> {
+    let unassessed = super::backlog::unassessed(provider, &cfg.triage)?;
+    let Some(issue) = unassessed.into_iter().find(|u| !triaged.contains(&u.key)) else {
+        return Ok(());
+    };
+    triaged.insert(issue.key.clone());
+
+    audit::record(
+        durable,
+        Audit::TriageStarted,
+        Some(&issue.key),
+        &format!("nobody has placed this — assessing it: {}", issue.title),
+    );
+
+    // The body, so the turn judges the report rather than the headline. An
+    // unreadable body is not a reason to skip the issue; a title-only
+    // judgement is still better than leaving it unplaced forever.
+    let body = super::backlog::resolve(provider, &issue.key)
+        .map(|resolved| resolved.body)
+        .unwrap_or_default();
+
+    let prompt = super::triage::prompt(&issue, &body, &cfg.triage);
+    let output = super::work::run_turn(root, &prompt, spend_limit)?;
+
+    let Some(assessment) = super::triage::parse(&output, &cfg.triage) else {
+        super::backlog::escalate_blocking(
+            provider,
+            &issue.key,
+            "triage could not place this issue in the configured vocabulary — \
+             it needs a human to label it",
+            &cfg.attribution.issue_comment,
+        )?;
+        audit::record(
+            durable,
+            Audit::Escalated,
+            Some(&issue.key),
+            "could not be placed — labelled for a human",
+        );
+        return Ok(());
+    };
+
+    super::triage::apply(
+        provider,
+        &issue.key,
+        &assessment,
+        &cfg.attribution.issue_comment,
+    )?;
+    durable.update_stats(|s| s.issues_triaged += 1);
+    audit::record(
+        durable,
+        Audit::Triaged,
+        Some(&issue.key),
+        &assessment.reason(),
+    );
+    Ok(())
 }
 
 /// Advance one pull request by exactly one deterministic transition.

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -61,6 +61,7 @@ struct Tally {
 /// constant and why reaching it is reported as *reached the bound*, never as
 /// *finished*.
 pub(super) fn drive(
+    durable: &super::state::LoopState,
     max_issues: u32,
     no_review: bool,
     spend_limit: Option<f64>,
@@ -118,6 +119,7 @@ pub(super) fn drive(
                     return report(&tally);
                 };
                 eprintln!("claimed #{key}");
+                durable.update_stats(|s| s.issues_claimed += 1);
                 state.claimed.push(IssueRef(key));
             }
 
@@ -163,6 +165,10 @@ pub(super) fn drive(
                         )?;
                         eprintln!("  opened pr #{pr}");
                         tally.opened += 1;
+                        durable.update_stats(|s| {
+                            s.issues_changed += 1;
+                            s.prs_opened += 1;
+                        });
                         state.carrying.push(CarriedPr {
                             pr: PrRef(pr),
                             disposition: PrDisposition::Moving,
@@ -170,9 +176,21 @@ pub(super) fn drive(
                     }
                     super::work::WorkOutcome::NoChange { why } => {
                         eprintln!("  changed nothing ({why}) — moving on");
+                        durable.update_stats(|s| s.issues_no_change += 1);
                     }
                     super::work::WorkOutcome::Failed { reason } => {
                         eprintln!("  not worked: {reason}");
+                        durable.update_stats(|s| {
+                            s.issues_failed += 1;
+                            // A turn stopped by its ceiling is counted
+                            // separately: it is a budget fact, not a sign the
+                            // issue is unworkable, and conflating them would
+                            // make a too-small allowance look like a hard
+                            // backlog.
+                            if reason.contains("budget exceeded") {
+                                s.turns_over_budget += 1;
+                            }
+                        });
                         // Recorded on the issue, not just in this log. A run
                         // that only printed it would repeat the attempt — and
                         // the cost — on the next cycle, having learnt nothing
@@ -183,10 +201,13 @@ pub(super) fn drive(
                             &reason,
                             &cfg.attribution.issue_comment,
                         )) {
-                            Ok(()) => eprintln!(
-                                "  labelled `{}` — later runs will skip it",
-                                stella_autonomy::ESCALATION_LABEL
-                            ),
+                            Ok(()) => {
+                                durable.update_stats(|s| s.issues_escalated += 1);
+                                eprintln!(
+                                    "  labelled `{}` — later runs will skip it",
+                                    stella_autonomy::ESCALATION_LABEL
+                                );
+                            }
                             Err(error) => eprintln!("  could not label it: {error}"),
                         }
                     }
@@ -194,7 +215,7 @@ pub(super) fn drive(
             }
 
             LoopStep::Deliver { pr } => {
-                let settled = advance(&root, &pr.0, &mut spent, no_review, &mut tally)?;
+                let settled = advance(&root, &pr.0, &mut spent, no_review, &mut tally, durable)?;
                 if settled {
                     for carried in &mut state.carrying {
                         if carried.pr == pr {
@@ -266,6 +287,7 @@ fn advance(
     spent: &mut HashMap<String, Spent>,
     no_review: bool,
     tally: &mut Tally,
+    durable: &super::state::LoopState,
 ) -> Result<bool, String> {
     let entry = spent.entry(pr.to_owned()).or_default();
     let obs = super::deliver::observe(root, pr)?;
@@ -289,15 +311,24 @@ fn advance(
         obs.ci, obs.base_ci, obs.mergeable, transition.action
     );
 
+    // Counted whether or not it changes the action: waiting on somebody
+    // else's broken base is time this loop spent, and a high count is a fact
+    // about the repository rather than about the loop.
+    if obs.base_ci == stella_autonomy::CiConclusion::Red {
+        durable.update_stats(|s| s.base_broken_waits += 1);
+    }
+
     match transition.action {
         Action::Merge => {
             super::deliver::merge(pr)?;
             tally.merged += 1;
+            durable.update_stats(|s| s.prs_merged += 1);
             eprintln!("  merged #{pr}");
             Ok(true)
         }
         Action::Escalate { reason } => {
             tally.escalated += 1;
+            durable.update_stats(|s| s.prs_escalated += 1);
             eprintln!("  escalated to a human: {reason:?}");
             Ok(true)
         }
@@ -312,6 +343,7 @@ fn advance(
             // forever, and a counter that only moved on success would never
             // reach it.
             entry.fixes += 1;
+            durable.update_stats(|s| s.fixes_pushed += 1);
             eprintln!(
                 "  needs a fix, which this build does not author — that is `work` on the \
                  existing branch, and it is the next slice. Leaving it for a human."
@@ -320,6 +352,7 @@ fn advance(
         }
         Action::Rebase => {
             entry.rebases += 1;
+            durable.update_stats(|s| s.rebases += 1);
             eprintln!("  needs a rebase, which this build does not perform. Leaving it.");
             Ok(true)
         }

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -598,14 +598,14 @@ fn advance(
             // a genuine failure for as long as the operator left it up.
             if !entry.rerun {
                 entry.rerun = true;
-                match super::deliver::rerun_failed(pr) {
+                match super::deliver::refresh_against_base(pr) {
                     Ok(()) => {
                         audit::record(
                             durable,
                             Audit::PrObserved,
                             Some(pr),
-                            "red against a base that has since gone green — asked the forge to \
-                             run the failed checks again before treating it as ours",
+                            "red against a base that has since gone green — merged the base in for a \
+                             fresh verdict before treating it as ours",
                         );
                         return Ok(false);
                     }
@@ -623,7 +623,21 @@ fn advance(
             // forever, and a counter that only moved on success would never
             // reach it.
             entry.fixes += 1;
-            durable.update_stats(|s| s.fixes_pushed += 1);
+            // Both counters move, because two things are true and a reader of
+            // either number alone would be misled. A fix was owed — that is
+            // `fixes_pushed`, and it is what the attempt ceiling reads. And
+            // the pull request was handed to a human — that is
+            // `prs_escalated`, and it is what a dashboard reads as "needs
+            // someone".
+            //
+            // Counting only the first left the audit log recording
+            // `pr_escalated` twice while `prs_escalated` stayed at zero: two
+            // records of one event that disagreed about what it was.
+            durable.update_stats(|s| {
+                s.fixes_pushed += 1;
+                s.prs_escalated += 1;
+            });
+            tally.escalated += 1;
             audit::record(
                 durable,
                 Audit::PrEscalated,

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -339,22 +339,19 @@ pub(super) fn drive(
             }
 
             LoopStep::Deliver { pr } => {
-                let settled =
-                    match advance(&root, &pr.0, &mut spent, no_review, &mut tally, durable) {
-                        Ok(settled) => settled,
-                        Err(error) => {
-                            audit::record(
-                                durable,
-                                Audit::Transient,
-                                Some(&pr.0),
-                                &format!(
-                                    "could not advance it ({error}); re-asking in {poll_secs}s"
-                                ),
-                            );
-                            sleep(poll_secs);
-                            false
-                        }
-                    };
+                let settled = match advance(&pr.0, &mut spent, no_review, &mut tally, durable) {
+                    Ok(settled) => settled,
+                    Err(error) => {
+                        audit::record(
+                            durable,
+                            Audit::Transient,
+                            Some(&pr.0),
+                            &format!("could not advance it ({error}); re-asking in {poll_secs}s"),
+                        );
+                        sleep(poll_secs);
+                        false
+                    }
+                };
 
                 if settled {
                     for carried in &mut state.carrying {
@@ -513,7 +510,6 @@ fn escalate(
 /// Returns whether it settled — merged, escalated, or handed back — so the
 /// caller can stop carrying it.
 fn advance(
-    root: &std::path::Path,
     pr: &str,
     spent: &mut HashMap<String, Spent>,
     no_review: bool,
@@ -521,7 +517,7 @@ fn advance(
     durable: &Durable,
 ) -> Result<bool, String> {
     let entry = spent.entry(pr.to_owned()).or_default();
-    let obs = super::deliver::observe(root, pr)?;
+    let obs = super::deliver::observe(pr)?;
     let policy = DeliverPolicy {
         require_approval: !no_review,
         ..DeliverPolicy::default()

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -5,48 +5,80 @@
 //! what it returns to the verbs. Until this existed, `step` had no caller — the
 //! machine was correct and unreachable.
 //!
-//! # The one obligation the machine cannot discharge for itself
+//! # It does not stop
 //!
-//! **On [`LoopStep::Blocked`], keep polling. Do not exit.**
+//! A perpetual loop that exits on a transient failure is not perpetual, and the
+//! failures it will actually meet are almost all transient: a forge that
+//! rate-limits, a network that drops, a `gh` that times out. **Every step below
+//! treats a failure as a reason to wait and re-ask, never as a reason to
+//! return.** What ends a run is reaching its bound, or the machine asking for a
+//! step this build cannot perform.
+//!
+//! That is not a robustness nicety. It is the difference between a loop an
+//! operator can walk away from and one that quietly died at 3am and left the
+//! backlog untouched until somebody noticed.
+//!
+//! # On a block it parks, and it clears itself
 //!
 //! Self-resume is structural — the machine holds no latch, so a block is
-//! recomputed from scratch on every call and stops being returned the moment
-//! its cause is gone. But a host that exits on a block makes resumption
-//! impossible no matter what the machine returns. That is why `Blocked` carries
-//! a `Clearance` naming the observable to watch rather than reading as terminal,
-//! and why this loop sleeps and re-asks instead of returning.
+//! recomputed on every call and stops being returned the moment its cause is
+//! gone. But a host that exits on a block makes resumption impossible whatever
+//! the machine returns. Nobody should ever have to tell this loop it may
+//! resume: a human who raises the ceiling, restores the grant, drops the stop
+//! flag or merges the escalated pull request has already said everything that
+//! needs saying.
 //!
-//! Nobody should ever have to tell this loop it may resume. A human who raises
-//! the ceiling, restores the grant, drops the stop flag or merges the escalated
-//! pull request has already said everything that needs saying.
+//! # It resumes by looking, not by remembering
+//!
+//! A crashed process loses what it held in memory, so the loop keeps as little
+//! there as it can. On start it **re-derives what it was carrying from the
+//! forge**: every open pull request on a branch with this workspace's prefix is
+//! work it began and has not finished.
+//!
+//! Re-deriving beats persisting because the forge is the source of truth about
+//! a pull request and a remembered list can only be wrong — stale after a human
+//! merges one by hand, or after a run died between opening and recording. Same
+//! reasoning `deliver merge` uses when it re-observes rather than trusting that
+//! the caller already ran `next`.
+//!
+//! # Everything it does is said out loud and written down
+//!
+//! Every action goes through [`super::audit`]: a line on screen for whoever is
+//! watching, and one JSON object in `audit.jsonl` for whoever reconstructs the
+//! run afterwards. A scrollback buffer cannot answer *what did it do, to what,
+//! when, and how did that turn out* — it is the least durable surface in the
+//! system and it is gone when the terminal closes.
 //!
 //! # What this slice performs, and what it only reports
 //!
-//! It drives `claim → work → deliver`, which is the path that produces pull
-//! requests. `Sweep` and `Curate` are returned by the machine and **reported
-//! rather than performed** — B4 and B6 build them. Each says out loud that it
-//! is not built and stops, rather than spinning on a step it cannot take: a
-//! driver that silently did nothing for a step it was handed would look healthy
-//! forever.
+//! It drives `claim → work → deliver`, the path that produces pull requests.
+//! `Sweep` and `Curate` are returned by the machine and **reported rather than
+//! performed** — B4 and B6 build them. Each says out loud that it is not built
+//! and stops, rather than spinning on a step it cannot take: a driver that did
+//! nothing for a step it was handed would look healthy forever.
 
 use std::collections::HashMap;
 
 use stella_autonomy::{
-    Action, Attempts, CarriedPr, Contention, DeliverPolicy, Doctrine, IssueRef, LoopObservation,
-    LoopState, LoopStep, PrDisposition, PrRef, PrState, UnblockAttempt, deliver_next, step,
+    Action, Attempts, CarriedPr, CiConclusion, Contention, DeliverPolicy, Doctrine, IssueRef,
+    LoopObservation, LoopState, LoopStep, PrDisposition, PrRef, PrState, UnblockAttempt,
+    deliver_next, step,
 };
+
+use super::audit::{self, Action as Audit};
+use super::state::LoopState as Durable;
 
 /// Attempts spent on one pull request, carried across polls.
 ///
-/// The pure machine *reads* the counts; something durable has to hold them, and
-/// for the length of one run that is this process.
+/// The pure machine *reads* the counts; something has to hold them, and for the
+/// length of one run that is this process.
 #[derive(Debug, Default, Clone, Copy)]
 struct Spent {
     fixes: u32,
     rebases: u32,
 }
 
-/// What one run of the loop did.
+/// What one run of the loop did, for the closing line.
 #[derive(Debug, Default)]
 struct Tally {
     opened: u32,
@@ -58,10 +90,9 @@ struct Tally {
 ///
 /// `max_issues` bounds one invocation so a demonstration terminates; the real
 /// loop never does, which is why the bound is a parameter rather than a
-/// constant and why reaching it is reported as *reached the bound*, never as
-/// *finished*.
+/// constant and why reaching it reports *reached the bound*, never *finished*.
 pub(super) fn drive(
-    durable: &super::state::LoopState,
+    durable: &Durable,
     max_issues: u32,
     no_review: bool,
     spend_limit: Option<f64>,
@@ -72,14 +103,28 @@ pub(super) fn drive(
     let doctrine = Doctrine::default();
     let provider = crate::issue_provider::GhIssueProvider;
 
+    audit::record(
+        durable,
+        Audit::SessionStarted,
+        None,
+        &format!(
+            "session began — up to {max_issues} issue(s), {}, polling every {poll_secs}s",
+            if no_review {
+                "merging without waiting for review"
+            } else {
+                "waiting for review before any merge"
+            }
+        ),
+    );
+
     // Installed before anything is claimed. The loop cannot record an
     // escalation against a label the tracker does not carry, and discovering
     // that at the first failure — rather than here — would lose the one record
     // that stops the next run repeating the attempt.
     crate::issue_provider::ensure_label(
         stella_autonomy::ESCALATION_LABEL,
-        "The self-driving loop attempted this and could not resolve it. Still wanted; \
-         remove the label to return it to the queue.",
+        // Under 100 characters, which is GitHub's cap on a label description.
+        "Attempted by the self-driving loop and unresolved. Still wanted — remove to requeue.",
     )
     .map_err(|error| format!("could not install the escalation label: {error}"))?;
 
@@ -91,6 +136,8 @@ pub(super) fn drive(
     let mut spent: HashMap<String, Spent> = HashMap::new();
     let mut tally = Tally::default();
 
+    resume(durable, &cfg, &mut state);
+
     loop {
         let obs = observe(max_issues, tally.opened);
 
@@ -99,10 +146,14 @@ pub(super) fn drive(
                 reason,
                 clears_when,
             } => {
-                // Park, do not exit. See the module docs — this is the one
-                // thing the machine cannot do for itself.
-                eprintln!(
-                    "blocked: {reason:?}; waiting for {clears_when:?}. Re-asking in {poll_secs}s."
+                audit::record(
+                    durable,
+                    Audit::Waited,
+                    None,
+                    &format!(
+                        "blocked: {reason:?}. Waiting for {clears_when:?}; re-asking in \
+                         {poll_secs}s — nobody needs to tell it to resume."
+                    ),
                 );
                 sleep(poll_secs);
             }
@@ -110,112 +161,201 @@ pub(super) fn drive(
             LoopStep::Plan => state.planned = true,
 
             LoopStep::Claim { .. } => {
-                let ranked = super::backlog::ranked_keys(&provider)?;
-                let Some(key) = ranked.into_iter().find(|k| {
-                    !state.claimed.iter().any(|c| &c.0 == k)
-                        && !spent.keys().any(|worked| worked == k)
-                }) else {
-                    eprintln!("the queue offered nothing this run has not already taken");
-                    return report(&tally);
+                // A queue read is a network call. Failing it is a reason to
+                // wait, never a reason to end a run meant to be perpetual.
+                let ranked = match super::backlog::ranked_keys(&provider) {
+                    Ok(ranked) => ranked,
+                    Err(error) => {
+                        audit::record(
+                            durable,
+                            Audit::Transient,
+                            None,
+                            &format!(
+                                "could not read the queue ({error}); re-asking in {poll_secs}s"
+                            ),
+                        );
+                        sleep(poll_secs);
+                        continue;
+                    }
                 };
-                eprintln!("claimed #{key}");
+
+                let Some(key) = ranked
+                    .into_iter()
+                    .find(|k| !state.claimed.iter().any(|c| &c.0 == k) && !spent.contains_key(k))
+                else {
+                    audit::record(
+                        durable,
+                        Audit::SessionStopped,
+                        None,
+                        "the queue offered nothing this run has not already taken",
+                    );
+                    return report(durable, &tally);
+                };
+
+                audit::record(
+                    durable,
+                    Audit::Claimed,
+                    Some(&key),
+                    "taken off the ranked queue",
+                );
                 durable.update_stats(|s| s.issues_claimed += 1);
                 state.claimed.push(IssueRef(key));
             }
 
             LoopStep::Work { issue } => {
                 state.claimed.retain(|i| i != &issue);
+
+                let resolved = match super::backlog::resolve(&provider, &issue.0) {
+                    Ok(resolved) => resolved,
+                    Err(error) => {
+                        audit::record(
+                            durable,
+                            Audit::Transient,
+                            Some(&issue.0),
+                            &format!("could not read it ({error}); putting it back"),
+                        );
+                        // Put it back: the read failing says nothing about the
+                        // issue, so dropping it would silently skip real work.
+                        state.claimed.push(issue);
+                        sleep(poll_secs);
+                        continue;
+                    }
+                };
+
                 // Recorded before the work starts, so a failure cannot make the
                 // loop re-claim the same issue forever.
                 spent.entry(issue.0.clone()).or_default();
 
-                let resolved = super::backlog::resolve(&provider, &issue.0)?;
-                eprintln!("working #{} — {}", issue.0, resolved.title);
+                audit::record(
+                    durable,
+                    Audit::WorkStarted,
+                    Some(&issue.0),
+                    &format!("began work — {}", resolved.title),
+                );
 
-                // A `work` that cannot start — a leftover branch from a killed
-                // run, an unreachable worktree — is one issue's problem, not
-                // the loop's. Propagating it would let a single stale branch
-                // halt a run that has three other issues it could be getting
-                // on with, and the operator would have to intervene for
-                // something the loop can simply route around.
-                //
-                // Reported at full volume rather than swallowed: the branch is
-                // still there, still holds whatever the dead run left, and
-                // still needs a human eventually.
+                // A `work` that cannot start is one issue's problem, not the
+                // loop's: a single leftover branch must not halt a run that has
+                // other issues to get on with.
                 let outcome =
                     match super::work::start(&root, &resolved, spend_limit, &cfg.attribution) {
                         Ok(outcome) => outcome,
                         Err(reason) => {
-                            eprintln!("  could not start: {reason}");
-                            eprintln!("  moving on to the next issue");
+                            audit::record(
+                                durable,
+                                Audit::Deferred,
+                                Some(&issue.0),
+                                &format!("could not start ({reason}); moving on"),
+                            );
+                            durable.update_stats(|s| s.issues_deferred += 1);
                             continue;
                         }
                     };
 
+                durable.update_stats(|s| {
+                    s.issues_attempted += 1;
+                    s.turns_run += 1;
+                });
+
                 match outcome {
                     super::work::WorkOutcome::Changed { branch, stat, .. } => {
-                        eprintln!("  changed: {stat}");
+                        audit::record(
+                            durable,
+                            Audit::WorkChanged,
+                            Some(&issue.0),
+                            &format!("the turn left changes — {stat}"),
+                        );
+                        durable.update_stats(|s| s.issues_changed += 1);
+
                         let title = format!("{} (#{})", resolved.title, issue.0);
-                        let pr = super::deliver::open(
+                        let pr = match super::deliver::open(
                             &root,
                             &branch,
                             &issue.0,
                             &title,
                             &cfg.attribution.pull_request,
-                        )?;
-                        eprintln!("  opened pr #{pr}");
+                        ) {
+                            Ok(pr) => pr,
+                            Err(error) => {
+                                // The work is committed on its branch and is not
+                                // lost: the next start re-derives open pull
+                                // requests from the forge.
+                                audit::record(
+                                    durable,
+                                    Audit::Transient,
+                                    Some(&issue.0),
+                                    &format!(
+                                        "could not open a pull request ({error}); the branch \
+                                         `{branch}` keeps the work"
+                                    ),
+                                );
+                                continue;
+                            }
+                        };
+
+                        audit::record(
+                            durable,
+                            Audit::PrOpened,
+                            Some(&pr),
+                            &format!("opened for #{} — ci in progress", issue.0),
+                        );
                         tally.opened += 1;
-                        durable.update_stats(|s| {
-                            s.issues_changed += 1;
-                            s.prs_opened += 1;
-                        });
+                        durable.update_stats(|s| s.prs_opened += 1);
                         state.carrying.push(CarriedPr {
                             pr: PrRef(pr),
                             disposition: PrDisposition::Moving,
                         });
                     }
+
                     super::work::WorkOutcome::NoChange { why } => {
-                        eprintln!("  changed nothing ({why}) — moving on");
+                        audit::record(
+                            durable,
+                            Audit::WorkNoChange,
+                            Some(&issue.0),
+                            &format!("the turn changed nothing ({why}); worktree released"),
+                        );
                         durable.update_stats(|s| s.issues_no_change += 1);
                     }
+
                     super::work::WorkOutcome::Failed { reason } => {
-                        eprintln!("  not worked: {reason}");
+                        audit::record(
+                            durable,
+                            Audit::WorkFailed,
+                            Some(&issue.0),
+                            &format!("the turn did not complete: {reason}"),
+                        );
                         durable.update_stats(|s| {
                             s.issues_failed += 1;
-                            // A turn stopped by its ceiling is counted
-                            // separately: it is a budget fact, not a sign the
-                            // issue is unworkable, and conflating them would
-                            // make a too-small allowance look like a hard
-                            // backlog.
+                            // A turn stopped by its ceiling is a budget fact,
+                            // not a sign the issue is unworkable; conflating
+                            // them would make a too-small allowance look like a
+                            // hard backlog.
                             if reason.contains("budget exceeded") {
                                 s.turns_over_budget += 1;
                             }
                         });
-                        // Recorded on the issue, not just in this log. A run
-                        // that only printed it would repeat the attempt — and
-                        // the cost — on the next cycle, having learnt nothing
-                        // that outlived the process.
-                        match runtime().block_on(super::backlog::escalate(
-                            &provider,
-                            &resolved.key,
-                            &reason,
-                            &cfg.attribution.issue_comment,
-                        )) {
-                            Ok(()) => {
-                                durable.update_stats(|s| s.issues_escalated += 1);
-                                eprintln!(
-                                    "  labelled `{}` — later runs will skip it",
-                                    stella_autonomy::ESCALATION_LABEL
-                                );
-                            }
-                            Err(error) => eprintln!("  could not label it: {error}"),
-                        }
+                        escalate(durable, &provider, &cfg, &resolved.key, &reason);
                     }
                 }
             }
 
             LoopStep::Deliver { pr } => {
-                let settled = advance(&root, &pr.0, &mut spent, no_review, &mut tally, durable)?;
+                let settled =
+                    match advance(&root, &pr.0, &mut spent, no_review, &mut tally, durable) {
+                        Ok(settled) => settled,
+                        Err(error) => {
+                            audit::record(
+                                durable,
+                                Audit::Transient,
+                                Some(&pr.0),
+                                &format!(
+                                    "could not advance it ({error}); re-asking in {poll_secs}s"
+                                ),
+                            );
+                            sleep(poll_secs);
+                            false
+                        }
+                    };
+
                 if settled {
                     for carried in &mut state.carrying {
                         if carried.pr == pr {
@@ -228,66 +368,157 @@ pub(super) fn drive(
             }
 
             LoopStep::Unblock { attempt } => match attempt {
-                // Filing is the half that is always worth doing, under every
-                // doctrine that files at all: the ticket makes the breakage
-                // visible and attributable even if no fix is ever attempted.
                 UnblockAttempt::FileBaseBreakage => {
-                    eprintln!(
-                        "the base is broken and unfiled. This build does not compose the report \
-                         yet — that is `sweep` (B4, #3599). Stopping rather than proceeding \
-                         while every pull request it opens would fail CI."
+                    audit::record(
+                        durable,
+                        Audit::SessionStopped,
+                        None,
+                        "the base is broken and unfiled, and this build cannot compose the \
+                         report — that is `sweep` (B4, #3599). Stopping rather than opening \
+                         pull requests that would all fail ci.",
                     );
-                    return report(&tally);
+                    return report(durable, &tally);
                 }
                 UnblockAttempt::AdoptBaseBreakage { issue } => {
-                    eprintln!("adopting the base breakage as #{}", issue.0);
+                    audit::record(
+                        durable,
+                        Audit::Claimed,
+                        Some(&issue.0),
+                        "adopting the base breakage — it blocks everyone, not just its author",
+                    );
                     state.claimed.push(issue);
                 }
                 UnblockAttempt::DeferToExistingFix { evidence } => {
-                    eprintln!(
-                        "someone else is already fixing the base ({}). Waiting rather than \
-                         duplicating — two workers on one broken base produce a conflict on top \
-                         of an outage.",
-                        evidence.join(", ")
+                    audit::record(
+                        durable,
+                        Audit::Deferred,
+                        None,
+                        &format!(
+                            "somebody else is already fixing the base ({}); waiting rather \
+                             than duplicating",
+                            evidence.join(", ")
+                        ),
                     );
                     sleep(poll_secs);
                 }
             },
 
             LoopStep::Sweep { lens } => {
-                eprintln!(
-                    "the machine asked to sweep `{lens}`, and this build cannot — B4 builds it \
-                     (#3599). Stopping rather than spinning on a step it cannot take."
+                audit::record(
+                    durable,
+                    Audit::SessionStopped,
+                    None,
+                    &format!(
+                        "the machine asked to sweep `{lens}` and this build cannot — B4 builds \
+                         it (#3599). Stopping rather than spinning on a step it cannot take."
+                    ),
                 );
-                return report(&tally);
+                return report(durable, &tally);
             }
+
             LoopStep::Curate => {
-                eprintln!(
-                    "the machine asked to curate, and this build cannot — B6 builds it (#3599). \
-                     Stopping rather than spinning."
+                audit::record(
+                    durable,
+                    Audit::SessionStopped,
+                    None,
+                    "the machine asked to curate and this build cannot — B6 builds it (#3599).",
                 );
-                return report(&tally);
+                return report(durable, &tally);
             }
 
             LoopStep::Watch { until } => {
-                eprintln!("nothing to do; the machine would watch for {until:?}");
-                return report(&tally);
+                audit::record(
+                    durable,
+                    Audit::SessionStopped,
+                    None,
+                    &format!("nothing left to do; the machine would watch for {until:?}"),
+                );
+                return report(durable, &tally);
             }
         }
     }
 }
 
+/// Pick up pull requests a previous run left open.
+///
+/// Not fatal if the forge cannot be read: that is the same transient condition
+/// the loop is built to wait through, and a later pass picks them up.
+fn resume(durable: &Durable, cfg: &super::config::LoopConfig, state: &mut LoopState) {
+    match super::deliver::open_prs_for_prefix(cfg.attribution.branch_prefix()) {
+        Ok(carried) if !carried.is_empty() => {
+            audit::record(
+                durable,
+                Audit::Resumed,
+                None,
+                &format!(
+                    "{} pull request(s) from an earlier run are still open",
+                    carried.len()
+                ),
+            );
+            for pr in carried {
+                audit::record(durable, Audit::Resumed, Some(&pr), "carrying it");
+                state.carrying.push(CarriedPr {
+                    pr: PrRef(pr),
+                    disposition: PrDisposition::Moving,
+                });
+            }
+        }
+        Ok(_) => {}
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("could not read open pull requests to resume ({error}); continuing"),
+        ),
+    }
+}
+
+/// Mark an issue the loop tried and could not resolve.
+fn escalate(
+    durable: &Durable,
+    provider: &crate::issue_provider::GhIssueProvider,
+    cfg: &super::config::LoopConfig,
+    key: &stella_protocol::issue::IssueKey,
+    why: &str,
+) {
+    match runtime().block_on(super::backlog::escalate(
+        provider,
+        key,
+        why,
+        &cfg.attribution.issue_comment,
+    )) {
+        Ok(()) => {
+            durable.update_stats(|s| s.issues_escalated += 1);
+            audit::record(
+                durable,
+                Audit::Escalated,
+                Some(key.as_str()),
+                &format!(
+                    "labelled `{}` — unresolved, later runs will skip it",
+                    stella_autonomy::ESCALATION_LABEL
+                ),
+            );
+        }
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            Some(key.as_str()),
+            &format!("could not label it as escalated: {error}"),
+        ),
+    }
+}
+
 /// Advance one pull request by exactly one deterministic transition.
 ///
-/// Returns whether it settled — merged, escalated, or handed back to a human —
-/// so the caller can stop carrying it.
+/// Returns whether it settled — merged, escalated, or handed back — so the
+/// caller can stop carrying it.
 fn advance(
     root: &std::path::Path,
     pr: &str,
     spent: &mut HashMap<String, Spent>,
     no_review: bool,
     tally: &mut Tally,
-    durable: &super::state::LoopState,
+    durable: &Durable,
 ) -> Result<bool, String> {
     let entry = spent.entry(pr.to_owned()).or_default();
     let obs = super::deliver::observe(root, pr)?;
@@ -306,15 +537,20 @@ fn advance(
         &policy,
     );
 
-    eprintln!(
-        "pr #{pr}: ci={:?} base={:?} mergeable={:?} -> {:?}",
-        obs.ci, obs.base_ci, obs.mergeable, transition.action
+    audit::record(
+        durable,
+        Audit::PrObserved,
+        Some(pr),
+        &format!(
+            "ci={:?} base={:?} mergeable={:?} review={:?} -> {:?}",
+            obs.ci, obs.base_ci, obs.mergeable, obs.review, transition.action
+        ),
     );
 
-    // Counted whether or not it changes the action: waiting on somebody
-    // else's broken base is time this loop spent, and a high count is a fact
-    // about the repository rather than about the loop.
-    if obs.base_ci == stella_autonomy::CiConclusion::Red {
+    // Counted whether or not it changes the action: waiting on somebody else's
+    // broken base is time this loop spent, and a high count is a fact about the
+    // repository rather than about the loop.
+    if obs.base_ci == CiConclusion::Red {
         durable.update_stats(|s| s.base_broken_waits += 1);
     }
 
@@ -323,18 +559,28 @@ fn advance(
             super::deliver::merge(pr)?;
             tally.merged += 1;
             durable.update_stats(|s| s.prs_merged += 1);
-            eprintln!("  merged #{pr}");
+            audit::record(durable, Audit::PrMerged, Some(pr), "merged");
             Ok(true)
         }
         Action::Escalate { reason } => {
             tally.escalated += 1;
             durable.update_stats(|s| s.prs_escalated += 1);
-            eprintln!("  escalated to a human: {reason:?}");
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                &format!("handed to a human: {reason:?}"),
+            );
             Ok(true)
         }
         Action::MarkReady => {
             super::deliver::mark_ready(pr)?;
-            eprintln!("  taken out of draft");
+            audit::record(
+                durable,
+                Audit::PrObserved,
+                Some(pr),
+                "ci is green — taken out of draft",
+            );
             Ok(false)
         }
         Action::PushFix => {
@@ -344,16 +590,23 @@ fn advance(
             // reach it.
             entry.fixes += 1;
             durable.update_stats(|s| s.fixes_pushed += 1);
-            eprintln!(
-                "  needs a fix, which this build does not author — that is `work` on the \
-                 existing branch, and it is the next slice. Leaving it for a human."
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                "needs a fix, which this build does not author — leaving it for a human",
             );
             Ok(true)
         }
         Action::Rebase => {
             entry.rebases += 1;
             durable.update_stats(|s| s.rebases += 1);
-            eprintln!("  needs a rebase, which this build does not perform. Leaving it.");
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                "needs a rebase, which this build does not perform — leaving it",
+            );
             Ok(true)
         }
         Action::Wait => Ok(false),
@@ -380,10 +633,6 @@ fn observe(max_issues: u32, opened: u32) -> LoopObservation {
 }
 
 /// A runtime for the one awaited call a synchronous arm needs.
-///
-/// Built per use rather than held: these verbs are short-lived and the
-/// alternative is making every arm of the loop async for a handful of awaited
-/// port calls.
 fn runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -395,10 +644,15 @@ fn sleep(secs: u64) {
     std::thread::sleep(std::time::Duration::from_secs(secs));
 }
 
-fn report(tally: &Tally) -> Result<(), String> {
-    println!(
-        "loop stopped: {} opened, {} merged, {} escalated",
-        tally.opened, tally.merged, tally.escalated
+fn report(durable: &Durable, tally: &Tally) -> Result<(), String> {
+    audit::record(
+        durable,
+        Audit::SessionStopped,
+        None,
+        &format!(
+            "{} opened, {} merged, {} escalated — `stella self-driving stats` has the rest",
+            tally.opened, tally.merged, tally.escalated
+        ),
     );
     Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/lifecycle.rs
+++ b/crates/stella-cli/src/self_driving_cmd/lifecycle.rs
@@ -220,6 +220,13 @@ pub(super) fn close_issue(req: CloseRequest<'_>) -> Result<(), String> {
             .map_err(|error| error.to_string())?;
     }
 
+    // Counted by canonical resolution through `record_closure`, so the three
+    // kinds cannot drift from the total — the balance a dashboard shows beside
+    // them is true by construction rather than by every call site remembering.
+    state::LoopState::open()
+        .map(|st| st.update_stats(|s| s.record_closure(canonical)))
+        .unwrap_or_default();
+
     println!("closed #{key} as {spelled}");
     Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -238,6 +238,15 @@ impl LoopState {
     fn stats_path(&self) -> PathBuf {
         self.dir.join("stats.json")
     }
+
+    /// The append-only record of everything the loop did.
+    ///
+    /// Public because the audit writer opens it directly in append mode: the
+    /// whole point is that entries are added and never rewritten, so it does
+    /// not go through the atomic read-modify-write the other state files use.
+    pub fn audit_path(&self) -> PathBuf {
+        self.dir.join("audit.jsonl")
+    }
     fn runs_path(&self) -> PathBuf {
         self.dir.join("runs.jsonl")
     }

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -235,6 +235,9 @@ impl LoopState {
     fn run_path(&self) -> PathBuf {
         self.dir.join("run.json")
     }
+    fn stats_path(&self) -> PathBuf {
+        self.dir.join("stats.json")
+    }
     fn runs_path(&self) -> PathBuf {
         self.dir.join("runs.jsonl")
     }
@@ -309,6 +312,36 @@ impl LoopState {
     }
 
     // -- the run lifecycle ---------------------------------------------------
+
+    // -- session statistics -------------------------------------------------
+
+    /// What this session has done so far.
+    ///
+    /// Absent or unreadable yields the zero value rather than an error: a
+    /// dashboard asking about a loop that has not started should see zeros,
+    /// not a failure. Every field defaults, so an older file read by a newer
+    /// build gains the new counters at zero rather than failing to parse.
+    pub fn stats(&self) -> stella_autonomy::SessionStats {
+        read_json(&self.stats_path())
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default()
+    }
+
+    /// Read, mutate, and write the session's counters.
+    ///
+    /// Written after **every** step rather than at the end, because the point
+    /// is a record readable while the loop is still running — a perpetual loop
+    /// that only reported on exit would never report at all.
+    ///
+    /// Atomic, so a dashboard sampling mid-write reads the previous complete
+    /// document rather than a truncated one.
+    pub fn update_stats(&self, mutate: impl FnOnce(&mut stella_autonomy::SessionStats)) {
+        let mut stats = self.stats();
+        mutate(&mut stats);
+        if let Ok(value) = serde_json::to_value(stats) {
+            let _ = write_json_atomic(&self.stats_path(), &value);
+        }
+    }
 
     pub fn run_doc(&self) -> Option<Value> {
         read_json(&self.run_path())

--- a/crates/stella-cli/src/self_driving_cmd/stats.rs
+++ b/crates/stella-cli/src/self_driving_cmd/stats.rs
@@ -1,0 +1,97 @@
+//! `stats` — what a session has done so far, rendered for a person.
+//!
+//! The counters themselves are [`stella_autonomy::SessionStats`], shared with
+//! the Observatory so the dashboard and the terminal cannot disagree. This
+//! module is only the rendering.
+//!
+//! Split out of `self_driving_cmd.rs` rather than added to it: that file is
+//! over the 1500-line limit and `doc:backlog-self-driving` §9 records it as
+//! closed to growth (AGENTS.md § *God files* — plan around them, never into
+//! them).
+
+use crate::query_format::QueryFormat;
+
+use super::state::LoopState;
+
+/// `stella self-driving stats` — the session's counters.
+///
+/// Renders the ratios beside the counts, deliberately. A raw count answers
+/// "how busy was it", which is the question that flatters; the ratios answer
+/// "was it worth it", and each can report badly. A dashboard showing only
+/// counts would make a loop that created twenty issues and closed three look
+/// like a productive week.
+pub(super) fn session_stats(st: &LoopState, format: QueryFormat) -> Result<(), String> {
+    let stats = st.stats();
+
+    if format == QueryFormat::Json {
+        println!(
+            "{}",
+            serde_json::to_string(&stats).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    // `--` rather than `0.00` for a ratio with no denominator: a ratio against
+    // zero is undefined, not small, and printing a number would tell a reader
+    // something the session has not yet established.
+    let ratio = |value: Option<f64>| value.map_or_else(|| "  --".to_owned(), |v| format!("{v:.2}"));
+
+    println!("backlog");
+    println!("  claimed         {:>5}", stats.issues_claimed);
+    println!("  attempted       {:>5}", stats.issues_attempted);
+    println!("  changed         {:>5}", stats.issues_changed);
+    println!("  no change       {:>5}", stats.issues_no_change);
+    println!("  failed          {:>5}", stats.issues_failed);
+    println!("  escalated       {:>5}", stats.issues_escalated);
+    println!("  deferred        {:>5}", stats.issues_deferred);
+
+    println!("\nfiled");
+    println!("  created         {:>5}", stats.issues_created);
+    println!("  refused         {:>5}", stats.filings_refused);
+    println!("  duplicate       {:>5}", stats.filings_duplicate);
+
+    println!("\nclosed");
+    println!("  total           {:>5}", stats.closed_total);
+    println!("    completed     {:>5}", stats.closed_completed);
+    println!("    not planned   {:>5}", stats.closed_not_planned);
+    println!("    duplicate     {:>5}", stats.closed_duplicate);
+    if !stats.closures_balance() {
+        eprintln!(
+            "  warning: the three kinds do not sum to the total — a resolution \
+             this build does not recognise was recorded"
+        );
+    }
+
+    println!("\ndelivery");
+    println!("  prs opened      {:>5}", stats.prs_opened);
+    println!("  prs merged      {:>5}", stats.prs_merged);
+    println!("  prs escalated   {:>5}", stats.prs_escalated);
+    println!("  fixes pushed    {:>5}", stats.fixes_pushed);
+    println!("  rebases         {:>5}", stats.rebases);
+    println!("  base-broken     {:>5}", stats.base_broken_waits);
+
+    println!("\nlearning");
+    println!("  reflections     {:>5}", stats.reflections_logged);
+    println!("  memories        {:>5}", stats.memories_created);
+    println!("  proposals       {:>5}", stats.proposals_made);
+
+    println!("\ncost");
+    println!("  turns run       {:>5}", stats.turns_run);
+    println!("  over budget     {:>5}", stats.turns_over_budget);
+
+    println!("\nyield");
+    println!(
+        "  inflation       {:>5}   created per closed; above 1.00 is losing ground",
+        ratio(stats.inflation_ratio())
+    );
+    println!(
+        "  attempt yield   {:>5}   attempts that changed something",
+        ratio(stats.attempt_yield())
+    );
+    println!(
+        "  merge rate      {:>5}   opened prs that landed",
+        ratio(stats.merge_rate())
+    );
+
+    Ok(())
+}

--- a/crates/stella-cli/src/self_driving_cmd/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/triage.rs
@@ -1,0 +1,298 @@
+//! `triage` — place an issue nobody has judged, using the project's own
+//! steering documents as the standard.
+//!
+//! `doc:backlog-self-driving` §3.2 (#3599). [`stella_autonomy::priority`] can
+//! say *that* an issue is unjudged; only a reader can say *what* it should be.
+//! This is that reader.
+//!
+//! # Why this is a turn and not a rule
+//!
+//! Every other decision in this loop is arithmetic over observed facts, and
+//! deliberately so — deciding buys no model call. Placing an unlabelled issue
+//! is the exception, and it is worth being precise about why rather than
+//! treating it as a convenient escape.
+//!
+//! The inputs are a title and a body written by a human in prose, and the
+//! standard they are measured against is this repository's context records —
+//! also prose. There is no arithmetic over those two things. A regular
+//! expression on the title would be a rule, but it would be a rule nobody
+//! declared and nobody could change by publishing a record, which is the whole
+//! point of having records.
+//!
+//! So the turn runs **with the project's steering already loaded** — that is
+//! what `refuse_if_unsteered` guarantees — and the prompt does not restate the
+//! policy. It names the vocabulary it must answer in and tells the turn to
+//! consult the records. Changing how issues get prioritized is then a matter of
+//! retiring a record and publishing another, with no code change at all.
+//!
+//! # It answers in the operator's vocabulary or it does not answer
+//!
+//! [`parse`] accepts only labels the [`TriagePolicy`] declared. A turn that
+//! invents `urgent` when the ladder says `P0` has not answered the question,
+//! and writing that label would put a word into the tracker that no ranker can
+//! read — the issue would come straight back as unassessed on the next cycle
+//! and the loop would pay for the same turn forever.
+//!
+//! An unparseable answer is therefore a refusal, and the caller escalates. That
+//! costs one issue a human glance. Guessing costs an unbounded number of turns.
+
+use stella_autonomy::priority::{TriagePolicy, Unassessed};
+use stella_protocol::issue::{IssueKey, IssueProvider};
+
+/// Where a turn decided an issue belongs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Assessment {
+    /// Work for this loop: a defect kind and a rung.
+    Place {
+        /// The kind label to add, from `defect_kinds`.
+        kind: String,
+        /// The rung label to add, from the ladder.
+        priority: String,
+    },
+    /// Not this loop's work: a kind from `excluded_kinds`.
+    Exclude {
+        /// The kind label to add.
+        kind: String,
+    },
+}
+
+impl Assessment {
+    /// The labels this assessment adds to the issue.
+    pub(super) fn labels(&self) -> Vec<String> {
+        match self {
+            Self::Place { kind, priority } => vec![kind.clone(), priority.clone()],
+            Self::Exclude { kind } => vec![kind.clone()],
+        }
+    }
+
+    /// A one-line account for the audit log and the issue comment.
+    pub(super) fn reason(&self) -> String {
+        match self {
+            Self::Place { kind, priority } => {
+                format!("placed as `{kind}` at `{priority}`")
+            }
+            Self::Exclude { kind } => format!("placed as `{kind}` — not this loop's work"),
+        }
+    }
+}
+
+/// The line a triage turn must end with.
+const MARKER: &str = "ASSESSMENT:";
+
+/// Compose the prompt that asks a turn to place one issue.
+///
+/// Deliberately short. The standard lives in the context records the turn has
+/// already loaded, and restating policy here would create a second copy that
+/// drifts from the records the moment anybody edits one — the exact failure
+/// this loop is supposed to make impossible.
+#[must_use]
+pub(super) fn prompt(issue: &Unassessed, body: &str, policy: &TriagePolicy) -> String {
+    let rungs = policy.ladder.rungs.join(", ");
+    let defects = policy.defect_kinds.join(", ");
+    let excluded = policy.excluded_kinds.join(", ");
+
+    format!(
+        "Triage one issue for this repository. Do not change any code.\n\n\
+         Issue #{key}: {title}\n\n\
+         --- body ---\n{body}\n--- end body ---\n\n\
+         Decide two things, judged against this project's context records and \
+         steering documents — they are the standard, not your own preferences:\n\n\
+         1. Is this a defect this repository's self-driving loop should work, \
+         or is it something else?\n\
+         2. If it is work, how urgent is it?\n\n\
+         Answer on a single final line, in exactly one of these two forms, using \
+         only the words listed:\n\n\
+         {MARKER} kind=<one of: {defects}>; priority=<one of: {rungs}>\n\
+         {MARKER} exclude=<one of: {excluded}>\n\n\
+         Any other vocabulary is not an answer. If the issue is too poorly \
+         described to place, say so in prose and emit no {MARKER} line.",
+        key = issue.key,
+        title = issue.title,
+    )
+}
+
+/// Read a turn's answer, accepting only the declared vocabulary.
+///
+/// The last `ASSESSMENT:` line wins, so a turn that thinks out loud and then
+/// commits does not trip over its own reasoning.
+#[must_use]
+pub(super) fn parse(output: &str, policy: &TriagePolicy) -> Option<Assessment> {
+    let line = output
+        .lines()
+        .rev()
+        .find_map(|line| line.trim().strip_prefix(MARKER))?
+        .trim();
+
+    let mut kind = None;
+    let mut priority = None;
+    let mut exclude = None;
+
+    for field in line.split(';') {
+        let Some((name, value)) = field.split_once('=') else {
+            continue;
+        };
+        let value = value.trim().trim_matches('`').to_owned();
+        match name.trim() {
+            "kind" => kind = Some(value),
+            "priority" => priority = Some(value),
+            "exclude" => exclude = Some(value),
+            _ => {}
+        }
+    }
+
+    // Checked against the policy, never merely non-empty. A label the ranker
+    // cannot read would send the issue straight back round as unassessed.
+    if let Some(kind) = exclude {
+        return policy
+            .excluded_kinds
+            .contains(&kind)
+            .then_some(Assessment::Exclude { kind });
+    }
+
+    let kind = kind?;
+    let priority = priority?;
+    (policy.defect_kinds.contains(&kind) && policy.ladder.rungs.contains(&priority))
+        .then_some(Assessment::Place { kind, priority })
+}
+
+/// Write an assessment onto the issue.
+///
+/// The label and the comment are one action: a label with no comment leaves a
+/// human wondering who decided this and on what basis, which is exactly the
+/// complaint people have about bots touching their backlog.
+pub(super) fn apply(
+    provider: &dyn IssueProvider,
+    key: &str,
+    assessment: &Assessment,
+    signature: &str,
+) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+
+    let issue_key = IssueKey::from(key);
+    let add = assessment.labels();
+
+    runtime
+        .block_on(provider.relabel(&issue_key, &add, &[]))
+        .map_err(|error| error.to_string())?;
+
+    let body = stella_autonomy::sign(
+        &format!(
+            "Triaged automatically: {}.\n\nJudged against this repository's \
+             context records. If that is the wrong call, re-label the issue — \
+             the next cycle reads the labels, not this comment.",
+            assessment.reason()
+        ),
+        signature,
+    );
+
+    runtime
+        .block_on(provider.comment(&issue_key, &body))
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_autonomy::priority::PriorityLadder;
+
+    fn policy() -> TriagePolicy {
+        TriagePolicy::default()
+    }
+
+    fn unassessed() -> Unassessed {
+        Unassessed {
+            key: "42".into(),
+            title: "the thing is broken".into(),
+            created_at: "2026-08-19T00:00:00Z".into(),
+        }
+    }
+
+    /// A well-formed answer in the declared vocabulary is accepted.
+    #[test]
+    fn a_declared_answer_places_the_issue() {
+        assert_eq!(
+            parse("ASSESSMENT: kind=bug; priority=P0", &policy()),
+            Some(Assessment::Place {
+                kind: "bug".into(),
+                priority: "P0".into()
+            })
+        );
+    }
+
+    /// An invented label is not an answer.
+    ///
+    /// The witness for this module's strictness. Writing `urgent` when the
+    /// ladder says `P0` would put a word in the tracker that no ranker reads,
+    /// so the issue returns as unassessed on the next cycle and the loop pays
+    /// for the same turn forever. Refusing costs one human glance.
+    #[test]
+    fn a_label_outside_the_vocabulary_is_not_an_answer() {
+        assert_eq!(
+            parse("ASSESSMENT: kind=bug; priority=urgent", &policy()),
+            None
+        );
+        assert_eq!(
+            parse("ASSESSMENT: kind=defect; priority=P0", &policy()),
+            None
+        );
+        assert_eq!(parse("ASSESSMENT: exclude=whatever", &policy()), None);
+    }
+
+    /// Thinking out loud before committing is fine — the last line wins.
+    #[test]
+    fn the_last_assessment_line_wins() {
+        let output = "ASSESSMENT: kind=bug; priority=P2\n\
+                      on reflection this blocks a release\n\
+                      ASSESSMENT: kind=bug; priority=P0";
+        assert_eq!(
+            parse(output, &policy()),
+            Some(Assessment::Place {
+                kind: "bug".into(),
+                priority: "P0".into()
+            })
+        );
+    }
+
+    /// No answer at all is a refusal, not a default.
+    ///
+    /// The prompt explicitly permits this for an issue too poorly described to
+    /// place. Defaulting to the lowest rung would bury it exactly the way the
+    /// old `priority_rank` did.
+    #[test]
+    fn silence_is_a_refusal_not_a_default() {
+        assert_eq!(
+            parse("I cannot tell what this issue is asking for.", &policy()),
+            None
+        );
+        assert_eq!(parse("", &policy()), None);
+    }
+
+    /// The prompt names the operator's vocabulary, not a built-in one.
+    #[test]
+    fn the_prompt_offers_only_the_declared_words() {
+        let policy = TriagePolicy {
+            ladder: PriorityLadder::new(vec!["Sev1".into()]),
+            defect_kinds: vec!["defect".into()],
+            excluded_kinds: vec!["wontfix".into()],
+        };
+        let text = prompt(&unassessed(), "it broke", &policy);
+        assert!(text.contains("Sev1"));
+        assert!(text.contains("defect"));
+        assert!(text.contains("wontfix"));
+        assert!(!text.contains("P0"), "a built-in rung must not leak in");
+    }
+
+    /// An excluded kind is a complete answer on its own.
+    #[test]
+    fn an_exclusion_needs_no_rung() {
+        assert_eq!(
+            parse("ASSESSMENT: exclude=enhancement", &policy()),
+            Some(Assessment::Exclude {
+                kind: "enhancement".into()
+            })
+        );
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -233,7 +233,11 @@ fn tree_change(dir: &Path, base: &str) -> Option<String> {
 /// `PATH` may be an older release — the staleness trap #1753 already cost a
 /// session, and a work unit measured against the wrong binary is worse than
 /// one that did not run.
-fn run_turn(dir: &Path, prompt: &str, spend_limit: Option<f64>) -> Result<String, String> {
+pub(super) fn run_turn(
+    dir: &Path,
+    prompt: &str,
+    spend_limit: Option<f64>,
+) -> Result<String, String> {
     let exe = std::env::current_exe()
         .map_err(|error| format!("cannot resolve this binary to run the turn: {error}"))?;
 
@@ -427,7 +431,7 @@ pub(super) fn start(
 /// It refuses only when there is something to lose: a workspace with no records
 /// has no steering to miss, and demanding a trust flag from it would be
 /// ceremony.
-fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
+pub(super) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
     let records = root.join(".stella").join("rules");
     let count = std::fs::read_dir(&records)
         .map(|entries| {

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -336,6 +336,53 @@ pub struct SelfDrivingSection {
     /// `[self_driving.attribution]` — what the loop appends to what it writes,
     /// and how it names branches.
     pub attribution: stella_autonomy::Attribution,
+    /// `[self_driving.triage]` — the vocabulary the loop places issues in.
+    ///
+    /// Here rather than in the tracker manifest because these are *this
+    /// operator's* judgements about their own backlog — which labels mean
+    /// urgent, which mean "not ours" — not how the tracker spells a concept
+    /// every tracker has. Two teams on one GitHub can want different ladders.
+    #[serde(default)]
+    pub triage: TriageSection,
+}
+
+/// `[self_driving.triage]` — how the loop places an issue.
+///
+/// Every field defaults, so an operator who writes none of it gets a working
+/// loop on GitHub's common conventions. Declaring any one of them replaces
+/// that list wholesale rather than adding to it: a partial override would
+/// leave the operator unable to *remove* a built-in they disagree with.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TriageSection {
+    /// Priority labels, most urgent first. Empty means "use the default".
+    #[serde(default)]
+    pub priorities: Vec<String>,
+    /// Labels meaning "this loop works this".
+    #[serde(default)]
+    pub defect_kinds: Vec<String>,
+    /// Labels meaning "this loop does not work this".
+    #[serde(default)]
+    pub excluded_kinds: Vec<String>,
+}
+
+impl TriageSection {
+    /// Resolve to the policy the ranker reads, filling each unset list from
+    /// the default independently.
+    #[must_use]
+    pub fn policy(&self) -> stella_autonomy::priority::TriagePolicy {
+        let mut policy = stella_autonomy::priority::TriagePolicy::default();
+        if !self.priorities.is_empty() {
+            policy.ladder = stella_autonomy::priority::PriorityLadder::new(self.priorities.clone());
+        }
+        if !self.defect_kinds.is_empty() {
+            policy.defect_kinds = self.defect_kinds.clone();
+        }
+        if !self.excluded_kinds.is_empty() {
+            policy.excluded_kinds = self.excluded_kinds.clone();
+        }
+        policy
+    }
 }
 
 /// `[issues]` — the active tracker.

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -22,6 +22,7 @@ stella self-driving queue [--limit N] [--format <text|json>]
 stella self-driving file --title TEXT [--body TEXT] [--label L…] [--format <text|json>]
 stella self-driving work --issue KEY [--spend-limit USD] [--format <text|json>]
 stella self-driving drive [--max-issues N] [--no-review] [--poll-secs N]
+stella self-driving stats [--format <text|json>]
 stella self-driving triage --issue KEY [--dry-run] [--format <text|json>]
 stella self-driving close --issue KEY (--completed | --not-planned REASON | --duplicate-of KEY | --partial DONE --remaining KEY…) [--pr KEY | --commit SHA] [--per CITATION]
 stella self-driving deliver open --issue KEY --branch B --title T
@@ -135,6 +136,20 @@ Worktrees live under `.stella/private/self-driving/` on `self-driving/` branches
 `--max-issues` bounds one invocation so it terminates. The real loop never does, which is why the bound is a flag rather than a constant, and why reaching it is reported as *reached the bound* rather than as *finished*.
 
 Steps the machine returns that this build cannot perform — sweeping an audit lens, curating a proposal — are **reported and then stop the loop**, never silently skipped. A driver that did nothing for a step it was handed would look healthy forever.
+
+### stats
+
+`stella self-driving stats` is what a session has done so far — issues claimed, attempted, changed, failed, escalated and deferred; issues created, refused and deduplicated; issues closed by each resolution; pull requests opened, merged and escalated; fixes, rebases, and time spent waiting on a broken base; reflections, memories and proposals; turns run and turns stopped by their ceiling.
+
+It is written after **every step**, not at the end. A perpetual loop that only reported on exit would never report at all, and the point is a record readable while the loop is still running. Writes are atomic, so a dashboard sampling mid-write reads the previous complete document rather than a truncated one.
+
+**The ratios are printed beside the counts, deliberately.** A raw count answers *how busy was it*, which is the question that flatters. Three derived numbers answer *was it worth it*, and each can report badly:
+
+- **inflation** — issues created per issue closed. Above 1.00 sustained means the loop is **losing ground**: filing faster than it finishes. That is the failure mode the design names as the one none of its mitigations is proven to prevent, so it belongs on the dashboard rather than in a report somebody reads later.
+- **attempt yield** — the share of attempts that changed something.
+- **merge rate** — the share of opened pull requests that landed.
+
+A ratio with no denominator prints `--` rather than `0.00`: a ratio against zero is undefined, not small, and a number would tell a reader something the session has not established. The three closure kinds are checked against the total, and a mismatch is reported — a dashboard showing a total beside kinds that sum to something else is worse than one showing neither, because a reader believes whichever they saw first.
 
 ### triage
 


### PR DESCRIPTION
Three commits that turn the self-driving loop from something you watch into something you leave running.

## 1. Session statistics, recorded as they happen

`stella_autonomy::SessionStats` counts what a dashboard needs: issues attempted, closed by each canonical resolution, **issues created**, reflections, memories, pull requests opened and merged, escalations.

Two decisions worth review:

- **The derived rates return `Option<f64>`, never `0.0`.** `inflation_ratio`, `attempt_yield` and `merge_rate` are `None` when the denominator is zero, because "the loop closed nothing out of nothing" and "the loop closed nothing out of forty" are different facts and a dashboard that renders both as `0%` has destroyed the distinction it exists to show.
- **`record_closure` takes the canonical resolution**, so the per-resolution counters cannot drift from the tracker's own spelling. `closures_balance()` asserts the parts sum to the total — a counter nobody cross-checks is a number, not a measurement.

## 2. The loop does not stop, resumes by looking, and writes down everything

**Durability.** Every failure inside the loop body now waits and re-asks instead of propagating. A `?` on a transient forge read exited the process — a dropped connection, a rate limit, a `gh` hiccup ended a session that had nothing wrong with it. There are no `?`-exits left in the loop body.

**Resume by observation, not by memory.** On start, `resume()` asks the forge for every open pull request on a branch carrying this workspace's prefix and carries those. It does not read a list it wrote down. A remembered list can only be wrong — stale after a human merges one by hand, or after the process died between opening a pull request and recording it. This is what makes a restart after machine death or a network outage a non-event.

**The audit log.** Every action goes through `audit::record`, which prints a timestamped line *and* appends one JSON object to `audit.jsonl`. The `Action` enum is a closed set, so a new verb cannot be logged as prose. Append-only, and never fatal — a loop that died because it could not write its own log would be a log that caused the outage it recorded.

```
[22:45:38] claimed 4006 — taken off the ranked queue
[22:49:50] changed 4006 — the turn left changes — crates/stella-autonomy/src/attribution.rs | 13 +++++++++++++
[22:49:54] pr opened 4014 — opened for #4006 — ci in progress
[22:49:55] pr observed 4014 — ci=Pending base=Green mergeable=Unknown review=None -> Wait
```

## 3. Ask the forge which commit the base is, not the last fetch

`checks_for_branch` resolved the base with `git rev-parse origin/<branch>` and asked the forge about the commit that came back. **A remote-tracking ref is only as fresh as the last fetch, and this loop never fetches between polls** — so once the process had been up for a while, `origin/main` still pointed at whatever main was when it started.

That is not a stale-read annoyance. `base_conclusion` excuses a pull request only when *every* check failing on it also fails on the base, so a pre-breakage base reads as green and an inherited failure is scored as the pull request's own. The loop then spends a fix attempt, or escalates, on a change that was never wrong.

**It cost the first pull request this loop ever opened.** #4014 touched only `attribution.rs`. It failed on a `cargo fmt` diff at `stella-autonomy/src/lib.rs:824` — inherited from main, and fixed since by #4015 — and the loop escalated it to a human for somebody else's formatting.

Naming the branch to the forge leaves no local state to be stale. It is the rule `open_prs_for_prefix` already follows: for a question about the forge, ask the forge.

## Witnesses

| Test | Fails on main because |
|---|---|
| `the_base_is_named_to_the_forge_not_a_remote_tracking_ref` | the endpoint carried a locally-resolved SHA, and the `origin/` assertion is the half that stops it coming back |
| `an_unnamed_base_asks_the_forge_nothing` | an empty base name reached the forge as a ref |
| `the_signature_is_a_horizontal_rule_footer` | `sign()` did not emit `\n\n---\n` |
| `closures_balance` | the per-resolution counters were not cross-checked against the total |

`observe` and `decide` also lose the repo path they only held in order to resolve that ref — a **compile-level** witness, and it immediately caught two more call sites in `self_driving_cmd.rs` that a test would not have.

## What this does not claim

The shell-out in `checks_for_branch` is not itself unit-tested — the tested seam is which ref gets named, not that `gh` returns what we think. The evidence that the whole path works is the live run above, not these tests.

Refs #3599

## Summary by Sourcery

Make the self-driving loop durable and observable by resuming forge work, recovering from transient failures, recording actions and metrics, and improving backlog and pull-request decisions.

New Features:
- Add persistent self-driving session statistics with derived productivity ratios and a `self-driving stats` command.
- Add configurable issue triage that surfaces unassessed work and applies declared priority and ownership labels.
- Add append-only, structured audit logging for self-driving actions.
- Resume open pull requests from forge state and keep the driving loop alive across transient failures and blocked conditions.

Bug Fixes:
- Read pull-request checks using both check-run and commit-status formats so concluded third-party statuses are not treated as pending.
- Resolve base checks from the forge branch name instead of stale local remote-tracking references.
- Refresh red pull requests against the current base before escalating or attempting fixes.
- Standardize generated attribution signatures as horizontal-rule footers.

Enhancements:
- Centralize backlog filtering and ranking around configurable triage policy.
- Track issue, delivery, learning, cost, and closure metrics durably as actions occur.
- Improve recovery and observability for failed work, delivery operations, triage, and session lifecycle events.

Documentation:
- Document the new self-driving statistics command and its metrics.

Tests:
- Add coverage for configurable triage, check-status handling, fresh forge base lookup, pull-request refresh behavior, attribution formatting, audit records, and session statistics.

Chores:
- Expose the new triage, statistics, audit, and priority functionality across the self-driving command surface.