### PR TITLE
docs(spec): audit the nine plugins, spec the five that are missing, and design the marketplace

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -411,6 +411,38 @@
       "status": "living",
       "title": "The journey of a prompt \u2014 full pipeline mode, in plain language"
     },
+    "plugin-completion-plan": {
+      "path": "docs/spec/plugin-completion-plan.md",
+      "sections": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "status": "proposed",
+      "title": "The five plugins that did not get built: an audit, a spec, and where each one ships"
+    },
+    "plugin-marketplace": {
+      "path": "docs/spec/plugin-marketplace.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "status": "proposed",
+      "title": "The plugin marketplace: an index is a repository, not a service"
+    },
     "plugin-transport-spike": {
       "path": "docs/spec/plugin-transport-spike.md",
       "sections": [

--- a/docs/spec/plugin-completion-plan.md
+++ b/docs/spec/plugin-completion-plan.md
@@ -1,0 +1,512 @@
+---
+id: plugin-completion-plan
+title: "The five plugins that did not get built: an audit, a spec, and where each one ships"
+status: proposed
+---
+
+# The five plugins that did not get built
+
+**Status:** proposed, written 2026-08-19, against `main` at `f9789df17`.
+
+`doc:pipeline-as-plugins` §3 names **nine plugins** that replace one staged
+pipeline and one built-in autonomous loop. §7 states the bar plainly: *"a
+side-by-side benchmark holds before the built-in path is deleted."* The
+built-in path was deleted on 2026-08-19 (#3865). This document answers the
+question that deletion makes urgent — **which of the nine actually exist** —
+and specifies the work for the ones that do not.
+
+Everything asserted about today's tree was read out of it and is cited so it
+can be checked. Where a claim is an inference rather than an observation, it
+says so.
+
+---
+
+## 0. The one-sentence answer
+
+**Four of the nine are built and graded, one of those four cannot do its job on
+any host running today, three more exist but are ungated from this repository,
+and the single most important plugin in the plan — the one carrying the
+project's headline claim — is an empty repository with a README in it.**
+
+---
+
+## 1. The audit
+
+| # | Plugin (§3) | Where it should be | State | Evidence |
+|---|---|---|---|---|
+| 1 | **vera** | `oxageninc/vera`, private | **NOT BUILT** | `gh api repos/oxageninc/vera/contents` returns exactly one entry, `README.md`; repo size 3 KB; last push 2026-08-17 |
+| 2 | **stella-plan** | this repo, `plugins/` | **BUILT, graded** | `plugins/stella-plan/{plugin.toml,main.py}`; `crates/stella-runtime/tests/plan_plugin_{conformance,dispatch,hostcall}.rs` |
+| 3 | **stella-research** | this repo, `plugins/` | **BUILT, graded** | `plugins/stella-research/{plugin.toml,main.py}`; `crates/stella-runtime/tests/research_plugin_{conformance,dispatch,recall}.rs` |
+| 4 | **stella-candidates** | this repo, `plugins/` | **NOT BUILT** | no `plugins/stella-candidates` directory exists |
+| 5 | **stella-selfdriving** | this repo, `plugins/` | **DECLARATION ONLY** | `plugins/stella-selfdriving/` holds `plugin.toml` and `README.md` and nothing else — no program, no `[runtime]`, `participation = "none"`. Its own README says so: *"It is not the extraction."* |
+| 6 | **stella-goal** | this repo, `plugins/` | **BUILT, graded, INERT** | `plugins/stella-goal/{plugin.toml,main.py}` and three test harnesses exist; but `crates/stella-cli/src/wrapper_plugin.rs:519` documents *"No `verifier` seat is bound"*, which is #3838 — the plugin's one job degrades to `HostCallRefusal::Unavailable` on every shipping door |
+| 7 | **example-rs** | `stella-examples`, `plugins/verify-rs` | **BUILT, ungated here** | present in `macanderson/stella-examples`; workflow `plugins.yml`; **nothing in this repository references it** (`rg 'verify-rs' --glob '!docs/**'` returns no non-doc hit) |
+| 8 | **example-py** | `stella-examples`, `plugins/verify-py` | **BUILT, ungated here** | same |
+| 9 | **example-ts** | `stella-examples`, `plugins/verify-ts` | **BUILT, ungated here** | same |
+
+Two qualifications on that table, both of which make it worse rather than
+better.
+
+**The three examples are stale, not merely ungated.** #3523 is open and says
+so: *"Track C's three example plugins still carry the manifest redundancies
+#3499/#3501 removed."* So the artefacts that exist to prove the surface is a
+platform were written against a manifest grammar the host no longer requires.
+
+**`doc:pipeline-as-plugins` §9 rule 4 is unmet.** It asks that CI run all three
+*"in `stella-examples` **and as a smoke check in `stella` itself**, so a
+protocol change that breaks a non-Rust plugin fails the PR that made it rather
+than being discovered by a user."* The second half does not exist. This is the
+same argument `plugins/README.md` makes for keeping the first-party plugins
+in-tree — *"a vector living in another repository cannot fail the PR that broke
+it"* — applied to Track C and left undone.
+
+---
+
+## 2. What the audit means, stated plainly
+
+### 2.1 Stella ships no verification path today
+
+This is the finding that outranks the rest, and it is a composition of three
+facts each individually recorded as correct:
+
+1. `stella run --pipeline classic` is refused
+   (`crates/stella-cli/src/wrapper_plugin.rs:204`, `classic_removed_message`),
+   because the built-in staged pipeline was deleted (#3865).
+2. `AGENTS.md`'s opening states the only remaining verification path is an
+   installed verification plugin, and names Oxagen's Vera as the reference one.
+3. `oxageninc/vera` contains one file, `README.md`.
+
+**Inference, labelled:** from 1–3 it follows that no user of any build from
+this tree can obtain a witness-verified turn by any route, because the only
+route requires a plugin that does not exist. I verified each of the three
+premises directly; I did not exhaustively search for a fourth, unrecorded
+verification path, and none appears in `plugins/` or in the `--pipeline`
+resolver.
+
+`doc:pipeline-as-plugins` §7 anticipated exactly this and recorded it as a
+deliberate maintainer call — the built-in path *"had already stopped being the
+default (#3381) and stopped being reachable from most surfaces"* — so the
+remaining risk was judged to be *"carrying dead, unreferenced code rather than
+losing a working feature."* That judgement is defensible about the **code**. It
+is not a judgement about the **claim**, and the claim is what the project trades
+on. §7 itself says extraction *"is still real, open work — deleting the built-in
+path does not mark it done."*
+
+### 2.2 Three of the four "built" plugins are steering-grade toys, by design
+
+`stella-research` and `stella-plan` are `participation = "steering"`,
+`before_turn` only. They are the right first extractions and they work. But
+neither one is what the pipeline was *for*: no oracle, no verdict, no hold.
+Only `stella-goal` reaches `arbiter`, and #3838 means its `after_turn` cannot
+reach a verifier. So **no plugin in existence today exercises the `judge` /
+`again` half of the socket against a real measurement.** The half of the
+wrapper contract that the whole extraction was justified by is proven only by
+fixtures (`crates/stella-plugin/tests/fixtures/{arbiter,perf-budget}.toml`).
+
+### 2.3 Two epic children look stale-open, and one looks genuinely landed
+
+Reported as observations, not as closures — I did not run the gate to confirm:
+
+- **#3804** ("`wrapper_plugin.rs` is 1516 lines, 16 over the ceiling"): the file
+  is now **1233 lines** with the tests split into
+  `crates/stella-cli/src/wrapper_plugin/tests.rs`, and `rg 'wrapper_plugin'
+  scripts/file-size-baseline.txt` returns nothing — so it was fixed by a split
+  and not by a baseline entry, which is the outcome the issue asked for. It is
+  still open.
+- **#3844** ("wrapper socket has no capability for isolated, N-wide candidate
+  fan-out"): `crates/stella-runtime/src/wrapper/candidate_fanout.rs` (864
+  lines), `crates/stella-cli/src/candidate_workspaces.rs` (583 lines) and
+  `crates/stella-runtime/tests/wrapper_candidate_fanout.rs` all exist, and
+  `wrapper_plugin.rs` serves the `CandidateFanouts` plane on `stella run`'s
+  door (`:491`, `:577`, `:617`). `doc:pipeline-as-plugins` §7 already says this
+  landed as #3892. The issue is still open. **The capability appears present;
+  the consumer — `plugins/stella-candidates` — is what is absent.**
+
+Both want a maintainer verify-and-close rather than more work. Leaving them
+open makes epic #3848 read as further from done than it is, which is the
+direction that misleads in the opposite way to the usual: it hides that the
+remaining blocker is *writing a plugin*, not *building a capability*.
+
+---
+
+## 3. Prerequisites that block more than one plugin
+
+These are the items where the socket, not the plugin author, is the blocker.
+Each already has an issue; this section states which plugin each one gates, so
+the sequencing in §6 is derivable rather than asserted.
+
+| Prereq | Issue | Gates |
+|---|---|---|
+| A `ChildTurns` binding serving the `verifier` role intent | #3838 | stella-goal (its only job), vera (witness authoring) |
+| `stella run` raises `host_max_holds` / the `ChildTurns` ceiling to the manifest's ask | #3841 | stella-goal (`max_holds = 7`, capped at 3), vera |
+| `--pipeline <variant>` composes more than one plugin's contribution | #3801 | every realistic install — research + plan + vera is three plugins, not a choice of one |
+| `[loop] max_calls` separates per-point from whole-run budget | #3839 | vera, stella-candidates |
+| A verifier's free-text reasoning reaches the next round's worker | #3840 | stella-goal, vera |
+| The role table is plugin-populated (`EngineRole` closed at six) | #3472, #3492 | vera (contributes `worker` + independent `verifier`) |
+| `Principal::Plugin` is constructed and a `[[capabilities]]` entry binds to an `AuthzGate` rule | #3482 | stella-selfdriving — **hard** gate, see §4.3 |
+| A plugin-contributed tool can run a script the package ships (`${plugin_dir}` interpolation) | #3579 | vera, stella-candidates |
+
+Two of these deserve to be called out as more than a checklist row.
+
+**#3801 is the one that decides whether this is a platform.** A `--pipeline`
+selection binds one manifest (`WrapperDispatch::bind`). So today a user chooses
+grounding *or* planning *or* verification. The pipeline being replaced ran all
+of them in one turn. Until composition lands, the plugin path is strictly less
+capable than the thing it replaced, no matter how many plugins get written —
+and no benchmark against the deleted path can be honest, because the plugin arm
+cannot be assembled.
+
+**#3482 is the one that decides whether the marketplace is safe.**
+`doc:pipeline-as-plugins` §A1 says it without hedging: *"a marketplace shipped
+on top of a system that cannot distinguish an installed plugin from its
+operator grants every plugin the operator's authority."* `Principal::Plugin`
+exists as a variant (#A1, landed) and nothing constructs it for a capability
+binding. See `doc:plugin-marketplace` §7, which treats this as a hard
+precondition on distribution rather than a nice-to-have.
+
+---
+
+## 4. The five specs
+
+### 4.1 Verification: split it in two — `stella-witness` (open) and `vera` (commercial)
+
+**Recommendation, and it is the one substantive departure from
+`doc:pipeline-as-plugins` §8 in this document.** §8 plans a single private
+plugin. I recommend two:
+
+- **`plugins/stella-witness`** — first-party, AGPL, in this repository. Carries
+  the *nucleus* §8 already enumerates as portable: `FlipOracle`, `FlipState`,
+  `ladder_decision`, the evidence builders, `strip_witness_hunks`, the witness
+  prompt construction, `parse_test_invocation`, `runner_probe`, the three
+  acceptance validators, and `witness/airlock.rs`. Plus the property test §8
+  says to carry over first,
+  `flip_requires_a_prior_failing_observation`.
+- **`oxageninc/vera`** — private, commercial. The superset: verifier-independence
+  enforcement across a roster, tamper hardening beyond
+  `TamperPolicy::ArtifactIdentity`, multi-oracle composition, the durable flip
+  record feeding a fine-tuning corpus, org policy, and the paid support surface.
+
+**Three reasons this beats one private plugin, in descending order of how much
+they should matter:**
+
+1. **The code being extracted is already AGPL and already public.** It shipped
+   in `crates/stella-pipeline` in this repository's history until 2026-08-19.
+   Moving it, and only it, into a private repository is a relicense by
+   deletion. Nothing forbids the copyright holder from doing that; it is
+   nonetheless the kind of move that costs a reference implementation the
+   reputation it exists to build, and `CLAUDE.md` names spending that
+   reputation as the worst available trade.
+2. **The headline claim needs an open referent.** `AGENTS.md`'s first paragraph
+   defines "verified done, not claimed done" as *"a property of the path that
+   produced the evidence."* If the only such path is a paid private artefact,
+   the open-source project's central claim is unfalsifiable by anyone who has
+   not bought something. An open `stella-witness` makes the claim checkable,
+   which is the entire argument for the project existing.
+3. **It de-risks the deletion that already happened.** §7's bar — a side-by-side
+   benchmark before the built-in path is deleted — can still be met
+   *retroactively*, because the built-in path is readable at the commit before
+   `a6d3db4f6` and can be checked out and benchmarked against `stella-witness`.
+   That is the cheapest available repair of the one process failure this
+   extraction has on its record.
+
+**What the split costs:** Oxagen gives up the simple story "verification is the
+paid thing." What it gets instead is the story the project can actually
+defend — *verification is open; verification at organisational scale is paid* —
+which is the same line every successful open-core infrastructure project draws,
+and the only one compatible with §2.1 above.
+
+**This is a maintainer's call, per `CLAUDE.md`'s "now vs. right" rule, and I am
+naming it rather than deciding it.** If the answer is one private plugin, then
+§2.1 needs a corresponding correction in `README.md` and `AGENTS.md`: the open
+product does not verify, and should stop implying it does.
+
+**Manifest sketch for `stella-witness`:**
+
+```toml
+name = "stella-witness"
+description = "Author a failing witness test, watch it flip, and hold the turn open until it does."
+
+[loop]
+participation = "arbiter"
+hooks = ["Stop"]
+points = ["after_turn"]
+calls = ["child_turn", "candidate_fanout"]
+max_holds = 4
+
+[requirements]
+witness_flips = "A test that failed before the change passes after it."
+witness_untampered = "The worker did not modify the witness files."
+
+[oracle]
+flip = "required"
+tamper = "artifact-identity"
+
+[roles.verifier]
+# independent of the worker — the roster already refuses a responsibility whose
+# agent is the worker's (`roster.rs:656-660`)
+
+[runtime]
+argv = ["python3", "${plugin_dir}/main.py"]
+```
+
+**Witnesses this plugin owes:**
+- `flip_requires_a_prior_failing_observation`, ported unchanged (§8's own ask).
+- A tamper case: a worker that edits the witness file scores `Undecided`, never
+  a flip. `crates/stella-runtime/tests/host_owned_tamper.rs` is the host half
+  and already passes; this is the plugin half.
+- A conformance harness at `crates/stella-runtime/tests/witness_plugin_conformance.rs`,
+  matching the shape of the three that exist.
+
+**Blocked on:** #3838 (a verifier seat to author the witness in), #3841 (four
+holds, not three), #3579 (`${plugin_dir}` for the tools it ships).
+
+### 4.2 `plugins/stella-candidates` — best-of-N
+
+**The capability is built; the plugin is not** (§2.3). This is the cheapest
+remaining plugin relative to its value, and it is the one that proves the
+`again?` point, which nothing currently does.
+
+**Shape:** `participation = "arbiter"`, points `["before_turn", "again"]`,
+`calls = ["candidate_fanout"]`, `[loop] max_fanout_width = N`. `before_turn`
+asks for N isolated writable workspaces; each runs a full worker turn rooted in
+its own `git worktree`
+(`crates/stella-cli/src/candidate_workspaces.rs`); the plugin reports each
+candidate's measurements as `ObservedEvidence`; `judge` picks deterministically
+against declared `[[oracle.checks]]`; `again` either adopts the winner or asks
+for another round.
+
+**The design question that must be answered before it is written:** what
+decides "best"? The grammar carries *"a verdict over an aggregate the oracle
+computes, not a quantifier the host evaluates"* (§6.1). So the plugin must
+compute one number per candidate and the manifest must declare the comparison.
+The obvious first cut is *the candidate whose declared test command passes and
+whose diff is smallest*, which is expressible today. A model-scored ranking is
+**not** expressible and must not be smuggled in through the oracle process —
+that is §6's failure mode arriving through the side door, and it should be
+refused in review.
+
+**Blocked on:** nothing in the socket, per §2.3. Blocked on #3844 being
+verified and closed, which is bookkeeping.
+
+**Witness:** two candidates, one of which fails its test command; the plugin
+adopts the other and the losing worktree is discarded. Then the anti-vacuity
+half: both pass, and the smaller diff wins.
+
+### 4.3 `plugins/stella-selfdriving` — the program behind the declaration
+
+Today this directory is a consent document and says so. The host side is being
+built underneath it on a different track: #3599's B0 (the driver channel,
+`crates/stella-plugin/src/driver.rs`, `DriverCall` with 15 verbs), B2 (`work`,
+1f7c579b8) and B3 (`deliver`, 9304d3341) have landed as commits, though the
+epic's checkboxes are all still unticked.
+
+**So the remaining work for the plugin itself is narrower than
+`doc:pipeline-as-plugins` §10 makes it sound**, and it is exactly this: write
+the program, give the manifest a `[runtime]`, and delete `scripts/self-driving.sh`
+*only* when `make self-driving-test` is green with every assertion intact (§10
+D5 — an assertion relaxed to make the move pass is a bug in the move).
+
+**The hard gate remains #3482**, and it remains the right gate. §10 is correct
+that this plugin holds `gh`, the AWS CLI, `brew`, a line in `~/.zshrc`, a
+daemon, and the power to merge — and correct that packaging *relocates* rather
+than grants that authority. But relocation is exactly when the authority
+becomes installable by someone who did not write it, which is when a declared
+`[[capabilities]]` entry needs to bind to a real `AuthzGate` rule rather than
+print nicely. **Do not ship a runnable `stella-selfdriving` before #3482.** It
+is the most dangerous plugin anyone will install, which §10 already identifies
+as the reason it is the right forcing function for the authority work.
+
+**Witness:** the one #3599 B0 already names, pointed at this manifest — a
+driver whose manifest omits a call is refused it with a `HostCallRefusal` code
+and keeps running; a driver that declares it is served. Both directions.
+
+### 4.4 `plugins/stella-goal` — repair, not build
+
+The plugin is written. It cannot work. The repair is entirely host-side and
+entirely already-filed: #3838 (bind a `verifier` seat), #3841 (honour
+`max_holds = 7`), #3840 (carry the verifier's own words into the next round).
+
+**One additional thing this plugin owes that is not filed:** `plugins/README.md`
+and the plugin's own header both explain at length that its designed home is
+`stella run --pipeline goal-v1` and that `stella goal` refuses it (#3832). That
+is correct and well-documented. What is missing is the check that it *works* on
+its designed home — the three existing harnesses
+(`goal_plugin_{conformance,dispatch,hostcall}.rs`) grade the wire and the
+refusal; none of them can grade a completed supervision round, because #3838
+means none can happen. **The witness for #3838 should therefore be written
+against this plugin, not against a fixture**, or the fix lands with the plugin
+still inert and nobody notices.
+
+### 4.5 Track C — make the three examples fail the PR that breaks them
+
+Two pieces of work, both small, both overdue.
+
+**a. Refresh the three manifests** (#3523). They predate #3499 (tamper split)
+and #3501 (`[loop] points`, optional `[oracle] command`). `stella-examples`
+already ships `plugins/ci/generate-manifests.py` and
+`plugins/ci/check-manifests-identical.py`, so the regeneration path exists;
+what is missing is a run of it against the current grammar.
+
+**b. Add the smoke check §9 rule 4 asks for, in *this* repository.** The
+mechanism is already proven four times over: `crates/stella-runtime/tests/`
+spawns a plugin through the host's own `SubprocessWrapper` and grades it
+against committed vectors. Add a fifth harness that does the same for the three
+examples, resolving them from a **pinned `stella-examples` commit SHA** checked
+out by CI. A pinned SHA makes the bump a reviewable diff, which is the property
+that makes the check meaningful rather than a moving target.
+
+Rust and Python run in CI unconditionally. TypeScript needs a build step
+(`argv = ["node", "${plugin_dir}/dist/main.js"]`), so gate it on Node being
+present and **report the skip out loud** — a silently skipped language check is
+how "we support three languages" becomes false without any PR being red.
+
+---
+
+## 5. Where each plugin ships, and why
+
+`plugins/README.md` already states the governing rule, and it is the right one:
+a plugin that must **move in lockstep with this repository's wire contract**
+lives in this repository, because *"a vector living in another repository cannot
+fail the PR that broke it."* A plugin that exists to prove the surface is
+third-party-usable must **not** live here, or it proves nothing.
+
+| Plugin | Repository | Why |
+|---|---|---|
+| `stella-research`, `stella-plan`, `stella-goal` | **`macanderson/stella` — `plugins/`** (unchanged) | first-party stage extractions; graded by in-tree harnesses on every PR |
+| **`stella-witness`** | **`macanderson/stella` — `plugins/`** | §4.1: the open referent for the project's central claim; also the heaviest consumer of the wire contract, so it must break the PR that breaks it |
+| **`stella-candidates`** | **`macanderson/stella` — `plugins/`** | consumes `candidate_fanout`, a capability that lives here and is still moving |
+| **`stella-selfdriving`** | **`macanderson/stella` — `plugins/`** (unchanged) | consumes `DriverCall`, which is still growing verb by verb through #3599 |
+| **`vera`** | **`oxageninc/vera`, private** | commercial superset; depends on the published wire contract, not on this tree's internals |
+| `verify-rs`, `verify-py`, `verify-ts` | **`macanderson/stella-examples` — `plugins/`** (unchanged) | third-party-shaped by design; pinned by SHA from this repo's CI (§4.5b) |
+
+**The one rule that keeps this from rotting:** a plugin in this repository is
+graded by a harness in `crates/stella-runtime/tests/`; a plugin outside it is
+graded against the **published wire corpus** (`docs/wire/wrapper.wire.json`,
+already generated and gate-checked by `make wire-schema`). Those are two
+different contracts and they should stay that way. In-tree plugins may read the
+tree; out-of-tree plugins may read only the corpus. If Vera ever needs
+something the corpus does not carry, that is a bug in the corpus, and finding it
+is one of the things a private plugin is genuinely good for.
+
+**A prerequisite for the out-of-tree half that does not exist yet.** The wire
+carries `PROTOCOL_VERSION: u32 = 1` on every message
+(`crates/stella-plugin/src/wire.rs:79`), but **the manifest does not declare
+which protocol version a plugin speaks**, so an incompatible pair is discovered
+at first dispatch rather than refused at install. That is tolerable while every
+plugin ships in the same commit as the host. It is not tolerable the moment a
+plugin is distributed. See `doc:plugin-marketplace` §5, which treats this as
+prerequisite M-3.
+
+---
+
+## 6. The implementation plan
+
+Ordered by dependency, and deliberately not by size. Each slice names its
+witness, because `CLAUDE.md`'s rule is that correctness is demonstrated or it
+is not claimed.
+
+### Phase 0 — clear the bookkeeping (hours, not days)
+
+- **P0.1** Verify and close #3804 and #3844 (§2.3), or state why they are still
+  open. Nothing below is blocked on this; it is blocked on it being *legible*.
+- **P0.2** Tick #3599's landed phases (B0, B2, B3) or say why the commits do not
+  satisfy them. An epic whose body contradicts its own merge history is a
+  claim, not a tracker.
+
+### Phase 1 — unblock the arbiter half (the real critical path)
+
+Nothing that matters can be built until a plugin can spend a verifier call and
+hold a round.
+
+- **P1.1 — #3838.** Bind a `ChildTurns` seat serving the `verifier` role intent.
+  *Witness: `plugins/stella-goal` completes one supervision round end-to-end —
+  written against the plugin, not a fixture (§4.4).*
+- **P1.2 — #3841.** `stella run`'s door raises `host_max_holds` and the
+  `ChildTurns` ceiling to the installed manifest's ask, or reports the gap
+  before the run ends. *Witness: a manifest asking `max_holds = 7` gets seven,
+  and one asking for more than the ceiling is told so at bind time, not at
+  round four.*
+- **P1.3 — #3840.** A verifier's free-text reasoning reaches the next round's
+  worker. *Witness: the held-open round's prompt contains the verifier's own
+  sentence, not the manifest's `[requirements]` prose.*
+
+### Phase 2 — composition, which decides whether any of this is usable
+
+- **P2.1 — #3801.** `--pipeline <variant>` composes more than one plugin's
+  contribution. *Witness: `research-v1` + `plan-v1` bound together in one
+  selection, both stages observable in the trace fold, and a stage-graph
+  conflict between two manifests refused at bind time rather than resolved
+  silently.*
+
+This is one slice and it is the largest single piece of work in the plan.
+Everything downstream of it is a plugin; it is the last piece of *platform*.
+
+### Phase 3 — the plugins, in parallel once Phase 2 lands
+
+- **P3.1 — `plugins/stella-candidates`** (§4.2). Independent of Phase 1;
+  buildable as soon as P0.1 confirms the capability. *Witness: §4.2's two-case
+  pair.*
+- **P3.2 — `plugins/stella-witness`** (§4.1). Needs P1.1–P1.3 and #3579.
+  *Witnesses: the ported property test, the tamper case, a conformance harness.*
+- **P3.3 — Track C refresh + in-tree smoke check** (§4.5). Independent of
+  everything above. *Witness: a deliberate breaking change to the wire corpus
+  turns the new harness red in this repository, on the PR that made it.*
+- **P3.4 — benchmark, retroactively** (§4.1 reason 3). Check out the commit
+  before `a6d3db4f6`, and run the deleted built-in path against
+  `stella-witness` on Terminal-Bench 2.1 with repeats per task. Report the
+  unflattering number if that is the true one. *This closes §7's bar late
+  rather than never, and it is the only remaining repair of the one process
+  failure on this extraction's record.*
+
+### Phase 4 — the dangerous one, gated on authority
+
+- **P4.1 — #3482.** `Principal::Plugin` is constructed and a declared
+  `[[capabilities]]` entry binds to an `AuthzGate` rule. *Witness: an installed
+  plugin calling a capability its manifest did not declare is refused by the
+  gate, with the refusal naming the plugin — and one that declared it is
+  served.*
+- **P4.2 — `plugins/stella-selfdriving` becomes a program** (§4.3), and
+  `scripts/self-driving.sh` retires only when `make self-driving-test` is green
+  with every assertion intact.
+
+**P4.1 is also the precondition on distribution**, so it is where this plan and
+`doc:plugin-marketplace` join.
+
+---
+
+## 7. Definition of done for this document
+
+- All nine of §3's plugins exist, and each is graded by something that runs on
+  a PR — in-tree harness for the six that ship here, pinned-SHA smoke check for
+  the three that ship in `stella-examples`, published wire corpus for Vera.
+- One `--pipeline` selection can bind grounding, planning and verification
+  together, so the plugin path is not strictly less capable than the path it
+  replaced.
+- A verification plugin exists that anybody can read, install and check
+  (§4.1) — or `README.md` and `AGENTS.md` are corrected to stop implying one
+  does.
+- The retroactive side-by-side benchmark (§6 P3.4) is run and reported, whatever
+  it says.
+- No plugin holds a capability it declared and the gate does not enforce
+  (#3482).
+- `make gate` green throughout, and no entry added to
+  `scripts/file-size-baseline.txt` to accommodate any of it.
+
+---
+
+## 8. What this document did not verify
+
+Stated so it is not read as more thorough than it is.
+
+- **I did not run `make gate`, `cargo test`, or any benchmark.** Every claim
+  above is from reading the tree, the GitHub tracker, and `git log`. File sizes
+  are `wc -l`; test *existence* is `ls`; test *passing* is asserted nowhere.
+- **I did not read the three example plugins' source** in `stella-examples`,
+  only the directory listing and the workflow filename. The staleness claim in
+  §1 is #3523's, cited, not independently re-derived.
+- **I did not read `oxageninc/vera`'s README**, only the repository's file
+  listing and size. "Charter only" is an inference from a 3 KB repository whose
+  sole entry is `README.md`.
+- **I did not confirm that #3599's B0/B2/B3 commits fully satisfy their phase
+  definitions** — only that commits naming those phases are on `main`. P0.2
+  exists because that gap should be closed by whoever wrote them.

--- a/docs/spec/plugin-marketplace.md
+++ b/docs/spec/plugin-marketplace.md
@@ -1,0 +1,449 @@
+---
+id: plugin-marketplace
+title: "The plugin marketplace: an index is a repository, not a service"
+status: proposed
+---
+
+# The plugin marketplace
+
+**Status:** proposed, written 2026-08-19, against `main` at `f9789df17`.
+Companion to `doc:plugin-completion-plan`, which specifies the plugins
+themselves; this document specifies how anybody gets one.
+
+**The recommendation in one paragraph.** Do not build a registry service.
+Make the marketplace a **git repository containing an index of plugin
+listings**, resolve installs to **pinned commit SHAs with recomputable tree
+digests**, let anyone add their own index ("tap") so distribution needs
+nobody's permission, generate a **static discovery site** from the index at
+merge, and make the one genuinely novel thing a **grant diff on upgrade** — a
+plugin may never quietly widen what it asked for. This costs one repository and
+a static site build, breaks none of Stella's invariants, requires no accounts,
+works offline after the first fetch, and can grow a hosted API later without
+changing how anything resolves.
+
+---
+
+## 1. What exists today
+
+Read out of the tree, because the gap is the design input:
+
+- **`stella plugin` has exactly three subcommands** — `Install { dir, scope,
+  yes }`, `List`, `Remove { name }`
+  (`crates/stella-cli/src/plugin_cmd.rs:48-68`). `install` takes a **local
+  directory** and copies the tree (`stage_and_commit`, `copy_tree`, `:520`,
+  `:577`). There is no network path of any kind.
+- **The manifest carries no distribution identity.** `PluginManifest`
+  (`crates/stella-plugin/src/manifest.rs:449`) has fourteen fields: `name`,
+  `description`, `loop`, `driver`, `requirements`, `oracle`, `subloop`,
+  `roles`, `wrapper`, `runtime`, `capabilities`, `tools`, `skills`, `records`.
+  **No `version`. No `license`. No `publisher`. No `homepage`. No declaration of
+  which wire protocol it speaks.**
+- **The wire is versioned; the manifest is not.** `PROTOCOL_VERSION: u32 = 1`
+  rides on every message (`crates/stella-plugin/src/wire.rs:79`), so an
+  incompatible plugin is discovered at first dispatch rather than refused at
+  install.
+- **Install is already a consent transaction, and that is the asset.**
+  `plugin_cmd.rs`'s own header says so, and `stella_plugin::consent_text` is a
+  pure function over the manifest's bytes — one document, rendered by the crate
+  rather than by the CLI, precisely so *"`stella plugin install` was complete
+  and every embedding host was not"* stopped being true (#3565,
+  `doc:pipeline-as-plugins` §13.2).
+- **Retraction is already structural.** Nothing is copied into `.stella/tools`,
+  `.stella/skills` or `.stella/rules`; contributions are recomputed from
+  installed packages on every load, so `remove` deletes a directory and there is
+  nothing left to forget (§13.2). **Uninstall therefore survives any transport
+  we choose**, which is a large piece of the problem already solved.
+
+So: consent and retraction are done and done well. **Identity, integrity,
+versioning, discovery and distribution do not exist at all.**
+
+---
+
+## 2. The five constraints that decide the design
+
+These are not preferences. Each one eliminates at least one otherwise-reasonable
+option.
+
+**C1 — Zero telemetry egress by default (invariant 3).** *"Update checks and
+anonymous analytics remain prohibited."* A registry that is consulted in the
+background, that counts installs, or that must be reachable for Stella to
+function, breaks the invariant the project enforces with a reviewed allowlist
+and a gate. Any network call must be user-initiated, to a host the user can
+name.
+
+**C2 — The manifest is the product, and a human reads it before code runs.**
+Whatever the transport, the artefact a user consents to is the grant. A
+marketplace that surfaces stars and download counts more prominently than the
+grant is optimising the wrong thing for this product.
+
+**C3 — A plugin is code that runs with the operator's authority, today.**
+Nothing constructs `Principal::Plugin` for a capability binding (#3482), so a
+declared `[[capabilities]]` entry is a claim, not a fence.
+`doc:pipeline-as-plugins` §A1: *"a marketplace shipped on top of a system that
+cannot distinguish an installed plugin from its operator grants every plugin the
+operator's authority."* **This bounds how open distribution may be until #3482
+lands** (§7).
+
+**C4 — Stella has no accounts and should not grow them for this.**
+`~/.stella/cloud.json` reserves an `oauth_token` slot that nothing fills. A
+design requiring publisher accounts, sessions and password resets is a
+different product.
+
+**C5 — Offline and air-gapped use must keep working.** Stella is a local binary
+run by people on planes and inside networks that do not reach the public
+internet. Resolution that requires a live service is a regression for those
+users.
+
+---
+
+## 3. Four options, honestly compared
+
+| | **A. Registry service** (crates.io / npm) | **B. Git-native + index repo** (Homebrew tap / Go) | **C. OCI artifacts** (ghcr + cosign) | **D. B, plus a static discovery site** |
+|---|---|---|---|---|
+| Infrastructure to run | a service, a database, object storage, on-call | **none** | none (the OCI registry is somebody else's) | a static build, on the docs deploy that already exists |
+| Accounts needed | yes (C4 ✗) | no | no (uses registry auth) | no |
+| Works offline after first fetch | no (C5 ✗) | **yes** | partly | **yes** |
+| Background egress | typical (C1 ✗) | none | none | none |
+| Publish flow for an author writing `main.py` | `stella plugin publish` | `git tag` + one PR | `oras push` + cosign (a wall) | `git tag` + one PR |
+| Who reviews a new listing | whoever staffs the registry | **a PR, with a diff and a history** | nobody | a PR |
+| Discovery | strong | weak | none | **good** (static site + offline `search`) |
+| Content integrity | server-attested | pinned SHA + tree digest | content-addressed (best) | pinned SHA + tree digest |
+| Takedown / revocation | delete the crate | yank flag in the index | delete the tag | yank flag in the index |
+| Cost to Stella of getting it wrong | a 24/7 security duty | a bad PR merge | a Rust OCI client dependency | a bad PR merge |
+
+**A is rejected on C1, C4 and C5, and on a cost nobody mentions until they own
+one: a package registry is a permanent security obligation** — typosquatting,
+malware review, key rotation, abuse reports, legal takedowns — staffed
+continuously. Stella should acquire that obligation when the ecosystem's size
+forces it, not before.
+
+**C is technically the best of the four and rejected on adoption.** Content
+addressing and cosign signing are exactly right. But the plugin surface's whole
+argument (`doc:pipeline-as-plugins` §9 rule 3) is *"no SDK in the first cut… if
+a plugin cannot be written without an SDK, the protocol is too complicated."*
+Requiring `oras` and `cosign` to ship a Python file contradicts that argument at
+the distribution layer. Keep C in reserve: the index format in §4 can add an
+`oci` reference beside `commit` later without changing anything else.
+
+**B is the design; D is B finished.** Homebrew ran at enormous scale for years
+with no registry service, and Go removed the central index from module
+resolution entirely. Both worked for the same reason: **git already is a
+content-addressed distribution network with authentication, mirroring and
+history, and every plugin author already has one.**
+
+---
+
+## 4. The design
+
+### 4.1 An index is a repository
+
+The default index is `oxageninc/stella-registry` — public, one file per plugin
+under `plugins/<name>.toml`:
+
+```toml
+name = "stella-lint"
+description = "Hold the turn open until the linter is clean."
+publisher = "acme"
+repository = "https://github.com/acme/stella-lint"
+homepage = "https://acme.dev/stella-lint"
+license = "Apache-2.0"
+categories = ["verification", "code-quality"]
+
+[[releases]]
+version = "1.2.0"
+git_ref = "v1.2.0"
+commit = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+tree_digest = "sha256:9f86d0818…"
+protocol = 1
+yanked = false
+
+[[releases]]
+version = "1.1.0"
+git_ref = "v1.1.0"
+commit = "0f1e2d3c4b5a69788796a5b4c3d2e1f001234567"
+tree_digest = "sha256:2c26b46b6…"
+protocol = 1
+yanked = true
+yank_reason = "leaked an API key into the consent text"
+```
+
+Five properties, each load-bearing:
+
+1. **The index pins a commit SHA, never only a tag.** Tags move. This is Go's
+   lesson and it costs nothing to adopt.
+2. **`tree_digest` is recomputed by the host after copy and compared.** That is
+   integrity without any signing infrastructure at all: the trust event is the
+   index PR, and after it the bytes are pinned forever. A repository owner who
+   force-pushes over a tag cannot change what an installed plugin is.
+3. **`protocol` is the wire version the plugin speaks**, so an incompatible
+   plugin is refused **at install** rather than at first dispatch. This needs
+   prerequisite M-3 (§5).
+4. **`yanked` is the revocation channel** — the index cannot delete anything
+   from anyone's disk, and should not pretend to; what it can do is make
+   `stella plugin outdated` say so loudly and make new installs of that version
+   refuse.
+5. **Adding a plugin is a pull request.** Author, diff, review, history, revert.
+   Most registries reconstruct a worse version of this after the fact.
+
+### 4.2 Anyone may run an index — "taps"
+
+```bash
+stella plugin tap add acme https://github.com/acme/stella-taps
+stella plugin tap list
+stella plugin tap update            # explicit refresh; nothing polls
+stella plugin tap remove acme
+```
+
+A tap is a git repository with an `index/` directory in the §4.1 format,
+cloned to `~/.stella/taps/<name>/`. The default `oxagen` tap is **seeded and
+removable**. An enterprise adds a private tap and its people install internal
+plugins with no Oxagen involvement, no allowlist request and no egress outside
+their own network — which is not a concession to enterprises, it is the same
+property that makes the design honest for everyone: **nobody needs anybody's
+permission to distribute a Stella plugin.**
+
+Names resolve tap-first when ambiguous (`acme/stella-lint`), and a bare name
+that matches in two taps is an error naming both, never a silent pick.
+
+### 4.3 Resolution and the lockfile
+
+`stella plugin install <source>` takes one of three sources, which **scope** the
+verb rather than select a different one (invariant 9):
+
+| Source | Example | Meaning |
+|---|---|---|
+| a local path | `stella plugin install ./plugins/stella-research` | today's behaviour, unchanged |
+| a git reference | `stella plugin install git+https://github.com/acme/stella-lint@v1.2.0` | no index involved |
+| an index name | `stella plugin install stella-lint@1.2.0` | resolved through the taps |
+
+Every install writes a **lockfile** — `.stella/plugins.lock` for the project
+tier, `~/.stella/plugins.lock` for the user tier:
+
+```toml
+[[plugin]]
+name = "stella-lint"
+source = "tap:oxagen"
+version = "1.2.0"
+commit = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+tree_digest = "sha256:9f86d0818…"
+consented_grant = "sha256:60303ae22…"   # digest of the rendered consent_text
+installed_at = "2026-08-19T18:04:11Z"
+```
+
+One file, four jobs, and this is where most of the design's value is:
+
+- **Reproducible installs.** `stella plugin sync` installs exactly what the
+  lockfile says — how a teammate or a CI job gets the same plugins, and the
+  reason the lockfile belongs in git for a project-tier install (the same
+  reasoning that makes `.stella/rules/` tracked: *"a record only steers a
+  teammate's session if it travels with the repository."*)
+- **Integrity re-checking.** `stella plugin verify` recomputes every installed
+  tree's digest against the lockfile. A plugin edited in place after consent is
+  detectable.
+- **The upgrade base.** `consented_grant` is what §4.4 diffs against.
+- **Provenance in `stella plugin list`**, which today cannot say where a plugin
+  came from or what it configured (#4018).
+
+### 4.4 The grant diff on upgrade — the part that matters most
+
+**#3514 is open and says a plugin can widen its own grant by rewriting its
+manifest.** In a world of local directory installs that is a footgun. In a world
+of distributed, upgradable plugins it is the primary attack: version 1.2 asks
+for `Stop` and `bash`; version 1.3 quietly adds `deliver_merge` and a wider
+environment allowlist; the user typed `upgrade` and read nothing.
+
+So `stella plugin upgrade` is a **separate verb from `install`** — not a flag —
+because it has a gate `install` does not:
+
+1. Render `consent_text` for the new manifest.
+2. Diff it against the `consented_grant` recorded at install.
+3. **Unchanged or narrower → proceed, printing the one-line summary.**
+4. **Wider → print only what was added, and require an explicit yes.** With no
+   terminal attached, **refuse** — the same posture
+   `plugins/stella-selfdriving`'s README already describes for install: *"With
+   no terminal attached it prints the same text and refuses instead of assuming
+   an answer."*
+
+This converts consent from a one-time event into a maintained invariant, and it
+is nearly free: `consent_text` is already a pure function over manifest bytes,
+so the diff is a diff of two strings the crate already knows how to produce.
+`crates/stella-diff` is a leaf with no dependencies and renders exactly this
+shape.
+
+**Witness:** a plugin whose 1.3.0 manifest adds one `[[capabilities]]` entry
+upgrades only after an explicit yes, and refuses under `--yes` unless the flag
+is the narrower `--accept-widened-grant`; a 1.3.0 that *removes* a capability
+upgrades silently. Both directions, because either alone is half a gate.
+
+### 4.5 Discovery is a static site, not an API
+
+The index repository builds a static site at merge — the same Vercel deploy
+path the documentation site under `website/` already uses. One page per plugin,
+and the page's centrepiece is **the
+rendered consent text for the latest release**, so a person can read exactly
+what a plugin will ask for *before downloading anything at all*. That is the
+inversion this product should be known for: every other marketplace shows you
+the pitch and hides the permissions.
+
+In the CLI, discovery is **offline over the cached taps**:
+
+```bash
+stella plugin search lint          # substring/category match over cached indexes
+stella plugin info stella-lint     # the listing, the versions, and the grant
+```
+
+No search API, no server, no egress beyond the explicit `tap update`. This is
+the same posture `stella models` already takes toward the model catalog — ship
+the data, never phone home.
+
+### 4.6 Publisher identity, phased
+
+**v1 — the namespace is claimed in the index, and the PR is the identity.** A
+`publisher` value is owned by a GitHub org or user recorded in the index repo's
+`publishers/<name>.toml`, and `CODEOWNERS` rejects a PR touching another
+publisher's listings. This is cheap, real, reviewable, and requires no keys.
+
+**v2 — signed tags, once v1 exists.** The listing records an expected signing
+identity (a sigstore identity or an OpenPGP fingerprint) and the host verifies
+the tag signature at install. Deliberately **not** first: *a signature over an
+unclaimed name proves that somebody signed something.* The namespace claim is
+what makes the signature mean anything, and it is the cheaper half.
+
+### 4.7 Paid plugins with no payments infrastructure
+
+**The git remote is the paywall.** A listing may declare:
+
+```toml
+distribution = "licensed"
+license_url = "https://oxagen.com/vera"
+```
+
+The repository is private. The buyer receives read access — an org invitation,
+a deploy key, a token — and `stella plugin install vera` resolves the listing,
+sees `licensed`, and clones using the **user's existing git credentials**. If
+they have no access, the refusal names `license_url` instead of a 404.
+
+Oxagen builds zero payments infrastructure: Stripe plus a GitHub org invite is
+the entire fulfilment path, and Vera ships the day it is written. It generalises
+to third-party paid plugins later without Stella becoming a payment processor —
+a role that brings tax, chargeback, refund and compliance obligations that would
+dominate the roadmap of a team this size.
+
+---
+
+## 5. Prerequisites — none of the above is buildable without these
+
+| | Prerequisite | Why it blocks | Related |
+|---|---|---|---|
+| **M-1** | `version` (semver, required for a published plugin), `license` (SPDX), `publisher`, `homepage`, `repository` on `PluginManifest` | there is nothing to index, compare, upgrade or attribute without them | new |
+| **M-2** | A tree-digest function over an installed package, and `.stella/plugins.lock` | integrity, `sync`, `verify`, and the upgrade base (§4.3) | new |
+| **M-3** | A manifest declaration of the wire `PROTOCOL_VERSION` it speaks, and an install-time refusal on mismatch | today an incompatible plugin fails at first dispatch, which for a *distributed* plugin means after consent and after a paid model call | new |
+| **M-4** | `stella plugin list` reports source, version and what the package configured | provenance is unreadable today | #4018 |
+| **M-5** | `Principal::Plugin` constructed, `[[capabilities]]` bound to an `AuthzGate` rule | **gates how open distribution may be** (§7) | #3482 |
+| **M-6** | Uninstall removes a symlinked install | a distribution channel that can install what it cannot remove is not one | #3530 |
+
+M-1 through M-3 are additive manifest and CLI work with no architectural
+tension; they are the first thing to build and they are useful on their own,
+before any index exists. M-5 is the one that decides §7.
+
+---
+
+## 6. Phases
+
+Each phase is independently shippable and independently useful. Nothing here
+requires the index to exist until M-5's phase.
+
+- **P1 — identity.** M-1 + M-3. *Witness: a manifest missing `version` installs
+  from a local path (unchanged) and is refused a published listing; a manifest
+  declaring `protocol = 2` against a host at `PROTOCOL_VERSION = 1` is refused
+  at install, naming both numbers.*
+- **P2 — integrity and reproducibility.** M-2 + `stella plugin verify` +
+  `stella plugin sync`. *Witness: a byte edited inside an installed package
+  makes `verify` fail and name the file; `sync` on a clean checkout reproduces
+  the locked set exactly.*
+- **P3 — remote install, no index.** `git+<url>@<ref>`. Resolution pins the
+  SHA into the lockfile. *Witness: two installs of the same moving tag record
+  the same commit and refuse the second if the tree digest changed.*
+- **P4 — upgrade with the grant diff.** §4.4. Closes the distribution half of
+  #3514. *Witness: §4.4's pair.*
+- **P5 — taps and the index.** `tap add|list|remove|update`, `search`, `info`,
+  `outdated`, and the `oxageninc/stella-registry` repository with its schema
+  check in CI. *Witness: a listing whose `tree_digest` does not match its
+  `commit` fails the index repo's own gate, on the PR that added it.*
+- **P6 — the static discovery site**, built from the index at merge, rendering
+  the consent text per listing.
+- **P7 — licensed distribution.** §4.7, with Vera as its first and proving
+  listing.
+- **P8 — open the default tap to third-party submissions.** **Gated on M-5
+  (#3482)** — see §7.
+
+---
+
+## 7. The security position, stated in the terms it is actually true in
+
+A plugin is executable code that today runs with the operator's authority,
+because nothing binds a declared capability to a gate (#3482). Two consequences
+this document will not soften:
+
+**The default tap stays curated until #3482 lands.** First-party plugins and
+reviewed partners only. Third parties distribute through their own taps in the
+meantime, which is not a second-class path — it is the *honest* one, because
+adding a tap is a user explicitly choosing a source, whereas a public default
+index implies a safety property Stella cannot yet provide.
+
+**The install prompt says the true thing about review.** When a marketplace
+listing is involved, the consent text must not imply that listing means vetting.
+The index reviewed the **listing** — the name, the namespace claim, the pinned
+commit — and not the **behaviour**. `doc:pipeline-as-plugins` §13.3 already sets
+this standard for the manifest's own claims: *"printing an unverified command
+line is the 'claimed limit rendered as an enforced one' mistake in new
+clothes."* The same rule governs the word "verified" on a marketplace page.
+
+**After #3482, the position improves but does not become "safe."** A capability
+gate makes a declared grant enforceable; it does not sandbox a process that was
+granted `bash`. The honest ceiling for the foreseeable future is *"you can read
+exactly what it asked for, the host enforces exactly that, and the bytes are
+pinned."* That is a considerably better story than every incumbent tells, and
+overstating it by one word would forfeit the advantage.
+
+---
+
+## 8. What this design deliberately does not do
+
+- **No download counts, no popularity ranking.** Counting installs is
+  telemetry, and invariant 3 does not have an exception for flattering numbers.
+- **No ratings or reviews.** They need accounts (C4) and they are the part of
+  every marketplace that gets gamed first.
+- **No `stella plugin publish`.** Publishing is `git tag` plus a pull request.
+  A CLI verb would add a credential path and an upload surface to replace two
+  commands an author already knows.
+- **No inter-plugin dependency resolution.** Plugins are leaves. Two plugins
+  that need to compose is #3801's problem — one `--pipeline` selection binding
+  more than one manifest — and a version solver would be the wrong tool
+  answering the wrong question.
+- **No auto-update.** `outdated` reports; a human upgrades. An agent that
+  silently changed what it is allowed to do between two runs is the exact thing
+  the grant diff exists to prevent.
+
+---
+
+## 9. Risks
+
+- **A deleted upstream repository breaks reinstall.** Real, and mitigated only
+  partly: the lockfile pins digests so *existing* installs keep working and stay
+  verifiable, and a tap may optionally vendor a mirror. Not solved, and named
+  rather than hidden — it is the standing cost of choosing git over an
+  artifact store, and the point at which option C (§3) earns a second look.
+- **A tap is a trust root, and adding one is a security decision.**
+  `tap add` must print what it means in a sentence, the way install already
+  does.
+- **Discovery is weaker than a hosted registry's.** Accepted at the scale of
+  dozens to hundreds of plugins. The index stays canonical if a search API is
+  ever added, so this is a deferrable decision rather than a one-way door — the
+  property §3 selected B for in the first place.
+- **The grant diff is only as good as `consent_text`'s completeness.** It is
+  complete today because `PluginManifest::reconcile` refuses both an undeclared
+  directory and an undelivered declaration (§13.3). **A future manifest field
+  that `consent_text` does not render silently becomes un-diffable**, so a
+  test asserting that every manifest field reaches the consent document should
+  land with M-1, not after it.


### PR DESCRIPTION
## What this is

Two proposal documents, no code. They answer two questions that the deletion of
the built-in staged pipeline (#3865) made urgent:

1. **Have the plugins meant to replace the pipeline been built?**
2. **How is anyone supposed to obtain one?**

## `doc:plugin-completion-plan` — the audit and the spec

`doc:pipeline-as-plugins` §3 names nine plugins. Read out of the tree at
`f9789df17`:

| State | Plugins |
| --- | --- |
| Built and graded | `stella-research`, `stella-plan` |
| Built, graded, **inert on every shipping door** (#3838) | `stella-goal` |
| Built but **ungated from this repository** (§9 rule 4 unmet) and stale (#3523) | `verify-rs`, `verify-py`, `verify-ts` |
| **Declaration only** — no program, no `[runtime]` | `stella-selfdriving` |
| **Not built** | `stella-candidates` |
| **Not built** — `oxageninc/vera` is one `README.md`, 3 KB | `vera` |

The composite finding, with each premise cited: `--pipeline classic` is
refused, `AGENTS.md` says the only remaining verification path is an installed
verification plugin, and that plugin does not exist — so **no build from this
tree can obtain a witness-verified turn by any route**. `doc:pipeline-as-plugins`
§7 records the deletion as a deliberate call and says extraction "is still real,
open work"; this document says what is left of it.

The document then specs the five missing or incomplete plugins, recommends the
repository each ships in, and sequences the work behind the socket gaps that
block it (#3838, #3841, #3840 on the critical path; #3801 for composition;
#3482 gating `stella-selfdriving`).

**One substantive departure from §8, flagged as a maintainer's call rather than
decided:** split verification into an open `plugins/stella-witness` carrying the
nucleus §8 already lists as portable, and keep Vera as the commercial superset.
The code being extracted is already AGPL and already public — it shipped in
`crates/stella-pipeline` until 2026-08-19 — and the project's headline claim
needs a referent anyone can check.

## `doc:plugin-marketplace` — the design

**An index is a repository, not a service.** Four options compared (registry
service, git-native, OCI artifacts, git-native plus a static site); the
recommendation is the last.

- Installs resolve to a **pinned commit SHA** with a **recomputable tree
  digest** — integrity with no signing infrastructure.
- **Anyone may run an index ("tap")**, so distribution needs nobody's
  permission and an enterprise's internal plugins never leave its network.
- Discovery is a **static site** built from the index at merge, whose
  centrepiece is the rendered consent text — read the grant before downloading.
- The novel part: **`stella plugin upgrade` diffs the grant.** Wider than what
  was consented to requires an explicit yes and refuses with no terminal
  attached. This closes the distribution half of #3514 and turns consent from a
  one-time event into a maintained invariant.
- **Paid plugins need no payments backend:** the private git remote is the
  paywall, so Vera ships the day it is written.

Selected against five constraints read out of the tree — invariant 3's zero
egress, consent-as-the-product, `Principal::Plugin` not yet being enforced
(#3482), no accounts, and offline use. §7 states the security position without
softening it: **the default tap stays curated until #3482 lands**, because a
public default index implies a safety property Stella cannot yet provide.

Six prerequisites are named (§5), and the manifest carries **none** of them
today: `PluginManifest` has no `version`, `license`, `publisher`, `homepage`,
or declaration of the wire `PROTOCOL_VERSION` it speaks.

## Witness

Docs-only; no witness test, per `CONTRIBUTING.md`'s exemption. `make
guards-fast` is green (exit 0) — the correct rung for a change reaching no
crate and not touching `docs/wire/**`. `doc-links` passes at 686 citations
across 81 identified documents, and it caught one invented citation during
authoring, which is the guard doing its job.

Deleted tests: none.

## Deliberate limits, stated so this is not read as more thorough than it is

`doc:plugin-completion-plan` §8 lists them: no `make gate`, no `cargo test` and
no benchmark were run; test *existence* is asserted, test *passing* is not; the
three example plugins' source was not read, only their directory listing; and
"Vera is charter only" is an inference from a 3 KB repository whose sole entry
is `README.md`.

Two epic children look stale-open and want a maintainer verify-and-close rather
than more work — #3804 (the file is 1233 lines with no baseline entry) and
#3844 (the fan-out capability appears landed; the plugin consuming it is what is
absent). Both are commented on rather than closed here.

## Filed alongside

- #4029 — Epic: the five plugins that did not get built, and the verification path that ships nowhere
- #4030 — Epic: a plugin marketplace — an index is a repository, not a service
- #4031 — Track C is not smoke-checked in this repository

Commented rather than closed: #3804, #3844.

Refs #3380 #3848 #3599
