### PR TITLE
fix(stella-tui): a file read is source — colour it, and stop deleting its gutter tab (#4019, #4020)

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -269,6 +269,16 @@ pub enum TranscriptEntry {
         /// Resolved from the matching `ToolStart` at fold time so call and
         /// result rows read as one aligned pair.
         name: String,
+        /// The path the call targeted, resolved from the same `ToolStart` as
+        /// `name` and by the same lookup.
+        ///
+        /// Carried so the renderer can tell what *language* a result body is
+        /// written in: a `read_file` output is the named file's source, and
+        /// the extension is the only evidence of that on the entry. Without it
+        /// the deck could colour a body only when the body itself announced
+        /// its format — which is why a file read went uncoloured for every
+        /// language, JSON included (#4019).
+        path: Option<String>,
         ok: bool,
         summary: String,
         /// The output, capped at `OUTPUT_BUDGET` chars — the collapsed row
@@ -682,19 +692,25 @@ impl SessionModel {
                         )
                     }
                 };
-                // Resolve the tool's name from its start entry (results only
-                // carry the call id on the wire).
-                let name = self
+                // Resolve the tool's name and target path from its start entry
+                // (results only carry the call id on the wire). One lookup for
+                // both: they answer to the same entry, and two reverse scans
+                // could only differ by finding different `ToolStart`s for one
+                // call id, which would be worse than either answer.
+                let (name, path) = self
                     .transcript
                     .iter()
                     .rev()
                     .find_map(|e| match e {
                         TranscriptEntry::ToolStart {
-                            call_id: cid, name, ..
-                        } if cid == call_id => Some(name.clone()),
+                            call_id: cid,
+                            name,
+                            path,
+                            ..
+                        } if cid == call_id => Some((name.clone(), path.clone())),
                         _ => None,
                     })
-                    .unwrap_or_else(|| "tool".to_string());
+                    .unwrap_or_else(|| ("tool".to_string(), None));
                 // Only a *successful* mutation gets an inline-diff reference —
                 // a failed call produced no `FileChange`, and rendering the
                 // path's previous diff under its ✗ would attribute a change
@@ -717,6 +733,7 @@ impl SessionModel {
                 self.transcript.push(TranscriptEntry::ToolResult {
                     call_id: call_id.clone(),
                     name,
+                    path,
                     ok,
                     summary,
                     full,

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -70,21 +70,129 @@ fn reads_as_json(text: &str) -> bool {
     stella_transcript::syntax::reads_as_json(text)
 }
 
-/// Emit one body line, syntax-colored when `json`, at the detail column.
-fn push_body_line(line: &str, json: bool, width: usize, out: &mut Vec<Line<'static>>) {
-    if !json {
-        push_detail_line(line, width, out);
-        return;
+/// How a tool-result body is colored.
+///
+/// This used to be a bare `bool` meaning "is this JSON", which answered the
+/// question the deck could answer cheaply rather than the one it wanted: a
+/// body earned coloring only when the body itself opened with `{` or `[`. A
+/// `read_file` result never does — every line carries a right-aligned
+/// line-number gutter, so its first non-blank character is a digit — and the
+/// consequence was larger than "Rust is not highlighted": reading a `.json`
+/// file through `read_file` was not highlighted either, because the gutter
+/// defeated the same test (#4019). The lexers were all present and wired to
+/// diffs, markdown fences and the definition editors; nothing reached them
+/// from here.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BodyPaint {
+    /// No lexer applies — one flat muted tone, as every non-JSON body had.
+    Plain,
+    /// The body *is* a JSON document: every line lexes as JSON.
+    Json,
+    /// The body is a numbered file listing. Each line carrying the gutter has
+    /// it split off as chrome and the remainder lexed as this language;
+    /// anything else in the body — the read footer, a payload-cap notice —
+    /// stays plain, which is what it is.
+    Numbered(syntax::Lang),
+}
+
+impl BodyPaint {
+    /// Whether this body carries syntax color, and so must stay whole in the
+    /// body column.
+    ///
+    /// The collapsed fold otherwise promotes a body's first line onto the
+    /// result row, which renders in one flat style and would strip exactly the
+    /// coloring this exists to show. JSON already claimed that exemption; a
+    /// source listing has the identical claim on it.
+    fn colored(self) -> bool {
+        self != BodyPaint::Plain
     }
-    let spans: Vec<Span<'static>> = syntax::tokenize(line, syntax::Lang::Json)
-        .into_iter()
-        .map(|(text, tok)| match tok {
-            Some(t) => Span::styled(text, syntax::tok_style(t)),
-            // Punctuation and whitespace keep the body's muted base tone, so
-            // the colored tokens are what the eye lands on.
-            None => Span::styled(text, Style::new().fg(theme::MUTED)),
-        })
-        .collect();
+}
+
+/// Decide how to color a result body, from the call's target path and the body
+/// itself.
+///
+/// Order matters. A body that opens as a JSON document is JSON whatever tool
+/// produced it and whatever it was reading — that is a fact about the bytes.
+/// Only then does the path get a say, and only for a body that actually *is* a
+/// numbered listing: the same `read_file` can answer with
+/// `(file has 3 lines, offset 9 is past end)`, and lexing that as Rust because
+/// the path ended in `.rs` would color a sentence.
+///
+/// The first non-blank line decides, mirroring
+/// [`stella_transcript::syntax::body_reads_as_json`] — a numbered listing
+/// carries its gutter from its first line, so nothing later in the body can
+/// change the answer.
+fn body_paint(path: Option<&str>, full: &str) -> BodyPaint {
+    if reads_as_json(full) {
+        return BodyPaint::Json;
+    }
+    let numbered = full
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .is_some_and(|l| split_gutter(l).is_some());
+    match path.and_then(syntax::lang_from_path) {
+        Some(lang) if numbered => BodyPaint::Numbered(lang),
+        _ => BodyPaint::Plain,
+    }
+}
+
+/// Split `read_file`'s line-number gutter off a body line, as
+/// `(gutter_including_its_tab, source)`.
+///
+/// The shape is `stella-tools`' `{line_num:>6}\t{line}`: optional padding
+/// spaces, ASCII digits, one tab. Matched rather than assumed, so the lines of
+/// the same body that carry no gutter — the footer, a cap notice — say so by
+/// returning `None` instead of having six characters of their own text
+/// amputated.
+///
+/// The *first* tab is the separator; a source line may contain more, and those
+/// belong to the source.
+fn split_gutter(line: &str) -> Option<(&str, &str)> {
+    let tab = line.find('\t')?;
+    let digits = line[..tab].trim_start_matches(' ');
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(line.split_at(tab + 1))
+}
+
+/// Emit one body line at the detail column, colored per `paint`.
+fn push_body_line(line: &str, paint: BodyPaint, width: usize, out: &mut Vec<Line<'static>>) {
+    let (gutter, source, lang) = match paint {
+        BodyPaint::Plain => {
+            push_detail_line(line, width, out);
+            return;
+        }
+        BodyPaint::Json => ("", line, syntax::Lang::Json),
+        BodyPaint::Numbered(lang) => match split_gutter(line) {
+            Some((gutter, source)) => (gutter, source, lang),
+            // A line of this body that is not a numbered line — the footer.
+            None => {
+                push_detail_line(line, width, out);
+                return;
+            }
+        },
+    };
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    if !gutter.is_empty() {
+        // The gutter is chrome, not source: it wears the dimmest text tone so
+        // the eye reads down the code and not down the numbers. Lexing it with
+        // the rest would paint every line number as a literal.
+        spans.push(Span::styled(
+            gutter.to_owned(),
+            Style::new().fg(theme::TEXT_TERTIARY),
+        ));
+    }
+    spans.extend(
+        syntax::tokenize(source, lang)
+            .into_iter()
+            .map(|(text, tok)| match tok {
+                Some(t) => Span::styled(text, syntax::tok_style(t)),
+                // Punctuation and whitespace keep the body's muted base tone, so
+                // the colored tokens are what the eye lands on.
+                None => Span::styled(text, Style::new().fg(theme::MUTED)),
+            }),
+    );
     push_detail_spans(spans, width, out);
 }
 
@@ -392,12 +500,13 @@ fn entry_body(
                     .and_then(|v| serde_json::to_string_pretty(&v))
                     .unwrap_or_else(|_| raw.clone());
                 for l in pretty.lines() {
-                    push_body_line(l, true, width, out);
+                    push_body_line(l, BodyPaint::Json, width, out);
                 }
             }
         }
         TranscriptEntry::ToolResult {
             ok,
+            path,
             full,
             duration_ms,
             speculated,
@@ -453,16 +562,16 @@ fn entry_body(
                     width,
                     out,
                 );
-                let json = reads_as_json(full);
+                let paint = body_paint(path.as_deref(), full);
                 for l in full.lines() {
-                    push_body_line(l, json, width, out);
+                    push_body_line(l, paint, width, out);
                 }
             } else {
                 // With a diff below, a prose summary ("Applied edit to
                 // src/agent.rs") would restate the call row above it and the
                 // diff under it in the same breath. The row carries only its
                 // metrics and gets out of the way.
-                let json = reads_as_json(full);
+                let paint = body_paint(path.as_deref(), full);
                 let shown: Vec<&str> = if inline.is_some() {
                     Vec::new()
                 } else {
@@ -473,9 +582,13 @@ fn entry_body(
                     // gets the same window, for the reason on [`OK_PREVIEW`].
                     let budget = if *ok { OK_PREVIEW } else { FAIL_PREVIEW };
                     // `salient_line` skips a tool's preamble to the line worth
-                    // reading. A JSON body has no preamble — its first line is
-                    // the opening delimiter, and starting anywhere else shows
-                    // an object with its shape cut off.
+                    // reading. A *document* has no preamble — a JSON body's
+                    // first line is the opening delimiter, and starting
+                    // anywhere else shows an object with its shape cut off; a
+                    // numbered listing's first line is the line the caller
+                    // asked for by offset, and hunting inside it for the word
+                    // "error" would anchor a source file's preview on its own
+                    // error-handling code.
                     //
                     // Clamped so the window is never starved: anchoring on a
                     // salient line near the *end* of the output would otherwise
@@ -486,7 +599,7 @@ fn entry_body(
                     // the window back to fill keeps the salient line on screen
                     // (it is the last thing shown rather than the first) while
                     // honouring the shared preview budget.
-                    let skip = if json {
+                    let skip = if paint.colored() {
                         0
                     } else {
                         let total = full.lines().count();
@@ -494,12 +607,13 @@ fn entry_body(
                     };
                     full.lines().skip(skip).take(budget).collect()
                 };
-                // A JSON preview stays whole in the body column. Promoting its
-                // first line to the result row would strip that line's coloring
-                // (the row is one flat style) and split an object across two
+                // A colored preview stays whole in the body column. Promoting
+                // its first line to the result row would strip that line's
+                // coloring (the row is one flat style) and split an object —
+                // or a numbered listing's own gutter column — across two
                 // different columns.
                 let head: Vec<Span<'static>> = match shown.first() {
-                    Some(l) if !json => vec![Span::styled(
+                    Some(l) if !paint.colored() => vec![Span::styled(
                         l.trim_end().to_owned(),
                         if *ok {
                             dim
@@ -515,8 +629,8 @@ fn entry_body(
                     width,
                     out,
                 );
-                for l in shown.iter().skip(usize::from(!json)) {
-                    push_body_line(l.trim_end(), json, width, out);
+                for l in shown.iter().skip(usize::from(!paint.colored())) {
+                    push_body_line(l.trim_end(), paint, width, out);
                 }
                 // The "there is more" row, for a success as well as a failure —
                 // it is the only place the hidden count is stated now, and the

--- a/crates/stella-tui/src/render/row.rs
+++ b/crates/stella-tui/src/render/row.rs
@@ -105,15 +105,79 @@ impl Rail {
     }
 }
 
+/// The column a tab advances to: the next multiple of this from the current
+/// screen column.
+///
+/// Four rather than the terminal-conventional eight because the transcript
+/// pane is a fraction of the frame, and a tab-indented file three levels deep
+/// would spend half of a narrow pane on whitespace. Four still preserves the
+/// multiple-of-a-stop arithmetic every tab-using file assumes; it only makes
+/// each step cheaper.
+const TAB_STOP: usize = 4;
+
+/// Replace every tab in `line` with the spaces that reach the next tab stop.
+///
+/// ratatui does not render control characters — `Span::styled_graphemes`
+/// filters them out of the grapheme stream entirely — so a tab is not narrowed
+/// and not drawn zero-width, it is **deleted**. `read_file` separates its
+/// line-number gutter from the source with one (`stella-tools`'s
+/// `{line_num:>6}\t{line}`), which is why an unindented source line reached the
+/// screen as `780#[test]` with no gap at all, while an indented one looked
+/// right by accident — its own leading spaces stood in for the separator
+/// (#4020).
+///
+/// Expanded here rather than at the emitter because that payload is also read
+/// by the model and by the export surfaces, where a tab is the cheaper wire
+/// form; this is a fact about *drawing* a line, so it belongs to the drawing
+/// layer. Expanded before [`wrap_one_indent`] measures, because
+/// `UnicodeWidthChar` gives a tab width 0 as well: measuring first would
+/// inherit the very hole this closes, and the deck's wrap arithmetic would
+/// disagree with what ratatui finally draws.
+///
+/// The stop is counted from the true screen column — rail prefix and body
+/// indent included, since both are already spans on the line by the time this
+/// runs — so the expansion is the one a terminal would have performed. A file
+/// that uses tabs to *align* rather than to indent renders slightly off when
+/// its author's stop was not [`TAB_STOP`]; that is the same "degrades to
+/// slightly-off coloring, never a wrong render" contract [`crate::syntax`]
+/// already accepts for a line lexed out of context.
+fn expand_tabs(line: &mut Line<'static>) {
+    if !line.spans.iter().any(|s| s.content.contains('\t')) {
+        return;
+    }
+    let mut col = 0usize;
+    for span in &mut line.spans {
+        if !span.content.contains('\t') {
+            col += UnicodeWidthStr::width(span.content.as_ref());
+            continue;
+        }
+        let mut expanded = String::with_capacity(span.content.len());
+        for ch in span.content.chars() {
+            if ch == '\t' {
+                let pad = TAB_STOP - (col % TAB_STOP);
+                expanded.extend(std::iter::repeat_n(' ', pad));
+                col += pad;
+            } else {
+                expanded.push(ch);
+                col += UnicodeWidthChar::width(ch).unwrap_or(0);
+            }
+        }
+        span.content = expanded.into();
+    }
+}
+
 /// Wrap a single styled line into multiple lines of at most `max_width`,
 /// with continuation lines indented by `indent` spaces. The first line
 /// passes through unchanged (it already has its label prefix).
 pub(crate) fn wrap_one_indent(
-    line: Line<'static>,
+    mut line: Line<'static>,
     max_width: usize,
     indent: usize,
     out: &mut Vec<Line<'static>>,
 ) {
+    // Before the width is taken: see [`expand_tabs`] on why measuring a tab
+    // and drawing a tab are the same hole.
+    expand_tabs(&mut line);
     let line_width = line.width();
     // The last clause is the narrow-terminal guard: with `indent >= max_width`
     // the content column has zero width, and the loop below would then flush a
@@ -320,7 +384,12 @@ pub(crate) fn push_gap(out: &mut Vec<Line<'static>>) {
 pub(crate) fn push_diff_line(line: Line<'static>, out: &mut Vec<Line<'static>>) {
     let mut spans = vec![Span::raw(" ".repeat(BODY))];
     spans.extend(line.spans);
-    out.push(Line::from(spans));
+    // The one row that reaches the buffer without passing through
+    // [`wrap_one_indent`], and so the one that needs [`expand_tabs`] by name: a
+    // tab-indented file's diff would otherwise lose its indentation entirely.
+    let mut row = Line::from(spans);
+    expand_tabs(&mut row);
+    out.push(row);
 }
 
 /// Multi-line form of [`push_row`]: the rail glyph prefixes the first line and

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -101,6 +101,7 @@ fn sample_entries() -> Vec<TranscriptEntry> {
         TranscriptEntry::ToolResult {
             call_id: "c1".into(),
             name: "bash".into(),
+            path: None,
             ok: true,
             summary: "done".into(),
             full: "done".into(),

--- a/crates/stella-tui/src/render/tests/inline_diff.rs
+++ b/crates/stella-tui/src/render/tests/inline_diff.rs
@@ -28,6 +28,7 @@ fn mutation_entry_and_files() -> (TranscriptEntry, Vec<FileState>) {
     let entry = TranscriptEntry::ToolResult {
         call_id: "c1".into(),
         name: "edit_file".into(),
+        path: None,
         ok: true,
         summary: "ok".into(),
         full: "ok".into(),

--- a/crates/stella-tui/src/render/tests/palette.rs
+++ b/crates/stella-tui/src/render/tests/palette.rs
@@ -132,6 +132,7 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
         prefix_fg(&TranscriptEntry::ToolResult {
             call_id: "c1".into(),
             name: "read_file".into(),
+            path: None,
             ok: true,
             summary: "ok".into(),
             full: "ok".into(),
@@ -147,6 +148,7 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
         prefix_fg(&TranscriptEntry::ToolResult {
             call_id: "c2".into(),
             name: "read_file".into(),
+            path: None,
             ok: false,
             summary: "no".into(),
             full: "no".into(),

--- a/crates/stella-tui/src/render/tests/tool_output.rs
+++ b/crates/stella-tui/src/render/tests/tool_output.rs
@@ -14,9 +14,26 @@ use crate::theme;
 
 /// A successful, non-mutating tool result carrying `body`.
 fn result(body: &str) -> TranscriptEntry {
+    result_for(None, body)
+}
+
+/// [`result`] for a call that targeted `path` — a file read, whose body is
+/// that file's source and whose extension is the only evidence of its
+/// language.
+fn read_result(path: &str, body: &str) -> TranscriptEntry {
+    result_for(Some(path), body)
+}
+
+fn result_for(path: Option<&str>, body: &str) -> TranscriptEntry {
     TranscriptEntry::ToolResult {
         call_id: "c1".into(),
-        name: "search".into(),
+        name: if path.is_some() {
+            "read_file"
+        } else {
+            "search"
+        }
+        .into(),
+        path: path.map(str::to_owned),
         ok: true,
         summary: "ok".into(),
         full: body.into(),
@@ -24,6 +41,18 @@ fn result(body: &str) -> TranscriptEntry {
         speculated: false,
         diff: None,
     }
+}
+
+/// One line of `read_file`'s output: a right-aligned line number, a tab, the
+/// source. Built from the emitter's own format string
+/// (`stella-tools`' `{line_num:>6}\t{line}`) so a test cannot drift from the
+/// shape it is meant to be reading.
+fn numbered(first: usize, source: &[&str]) -> String {
+    source
+        .iter()
+        .enumerate()
+        .map(|(i, l)| format!("{:>6}\t{l}\n", first + i))
+        .collect()
 }
 
 fn collapsed(entry: &TranscriptEntry) -> Vec<Line<'static>> {
@@ -265,4 +294,169 @@ fn a_salient_line_near_the_end_still_shows_the_full_preview() {
             "the salient line at index {marker_at} fell outside the window it anchors"
         );
     }
+}
+
+// ── A file read is source, and now reads as source (#4019, #4020) ───────────
+
+/// A `read_file` result is coloured in the language of the file it read.
+///
+/// The witness: colouring used to be gated on `reads_as_json(full)` — does the
+/// body's first non-blank character open a JSON document — and a numbered
+/// listing's first character is a *digit*, so a file read fell through to one
+/// flat muted tone for every language. The lexer was present and wired to
+/// diffs, markdown fences and the definition editors the whole time; nothing
+/// reached it from a tool result.
+#[test]
+fn a_read_result_is_coloured_in_its_files_language() {
+    let body = numbered(
+        780,
+        &["#[test]", "fn a_verb_is_named() {", "    let x = 1;", "}"],
+    );
+    let spans = colors(&collapsed(&read_result(
+        "crates/stella-autonomy/src/tests.rs",
+        &body,
+    )));
+
+    let keyword = syntax::tok_style(syntax::Tok::Keyword).fg;
+    assert!(
+        spans.iter().any(|(t, c)| t == "fn" && *c == keyword),
+        "a Rust keyword in a read_file body was not coloured: {spans:?}"
+    );
+    assert!(
+        spans.iter().any(|(t, c)| t == "let" && *c == keyword),
+        "only the first line was coloured: {spans:?}"
+    );
+}
+
+/// The same read, of a JSON file, is coloured too.
+///
+/// Kept apart from the case above because it is the sharper half of the bug:
+/// the deck already *had* a JSON path, and the gutter defeated it just as
+/// thoroughly as it defeated everything else. A reader could reasonably have
+/// concluded the deck simply did not highlight source; it did not highlight
+/// the one format it was built to highlight either.
+#[test]
+fn a_read_of_a_json_file_is_coloured_despite_its_gutter() {
+    let body = numbered(1, &["{", "  \"name\": \"stella\",", "  \"count\": 12", "}"]);
+    let spans = colors(&collapsed(&read_result(".stella/settings.json", &body)));
+
+    assert!(
+        spans
+            .iter()
+            .any(|(t, c)| t == "\"name\"" && *c == syntax::tok_style(syntax::Tok::Keyword).fg),
+        "a JSON key read through read_file was not coloured: {spans:?}"
+    );
+    assert!(
+        spans
+            .iter()
+            .any(|(t, c)| t == "\"stella\"" && *c == syntax::tok_style(syntax::Tok::Str).fg),
+        "a JSON string read through read_file was not coloured: {spans:?}"
+    );
+}
+
+/// The line-number gutter is chrome, and is never lexed with the source.
+///
+/// Without the split it is the leading run of every line, so the lexer would
+/// take each line number for a numeric literal and paint the gutter in the hue
+/// that means "a value in this code" — the brightest column on screen, saying
+/// nothing.
+#[test]
+fn the_line_number_gutter_is_not_lexed_as_source() {
+    let body = numbered(780, &["fn f() {}"]);
+    let spans = colors(&collapsed(&read_result("src/lib.rs", &body)));
+
+    let number = syntax::tok_style(syntax::Tok::Number).fg;
+    assert!(
+        !spans.iter().any(|(t, c)| t.contains("780") && *c == number),
+        "the line number was coloured as a numeric literal: {spans:?}"
+    );
+    assert!(
+        spans
+            .iter()
+            .any(|(t, c)| t.contains("780") && *c == Some(theme::TEXT_TERTIARY)),
+        "the gutter lost its subordinate tone: {spans:?}"
+    );
+}
+
+/// A body line with no gutter — `read_file`'s own footer, a cap notice — is not
+/// source and is not lexed as any.
+#[test]
+fn a_body_line_without_a_gutter_stays_plain() {
+    let body = format!("{}(read 1/1 lines)", numbered(1, &["const X: u8 = 1;"]));
+    let spans = colors(&collapsed(&read_result("src/lib.rs", &body)));
+
+    // The source line still colours...
+    assert!(
+        spans
+            .iter()
+            .any(|(t, c)| t == "const" && *c == syntax::tok_style(syntax::Tok::Keyword).fg),
+        "the numbered line stopped colouring: {spans:?}"
+    );
+    // ...and the footer beside it carries no token hue at all.
+    let footer: Vec<_> = spans
+        .iter()
+        .filter(|(t, _)| t.contains("read 1/1 lines"))
+        .collect();
+    assert!(!footer.is_empty(), "the footer vanished: {spans:?}");
+    assert!(
+        footer.iter().all(|(_, c)| *c == Some(theme::MUTED)),
+        "the footer was lexed as source: {footer:?}"
+    );
+}
+
+/// An extension the deck has no lexer for renders exactly as it did before —
+/// plain, never wrong. [`crate::syntax`]'s contract is that an unknown language
+/// degrades to no colouring rather than to the wrong one.
+#[test]
+fn a_read_of_an_unknown_extension_stays_plain() {
+    let body = numbered(1, &["fn this is not any language we lex"]);
+    let spans = colors(&collapsed(&read_result("notes/scratch.xyz", &body)));
+    assert!(
+        !spans
+            .iter()
+            .any(|(_, c)| *c == syntax::tok_style(syntax::Tok::Keyword).fg),
+        "an unlexed extension picked up keyword colouring: {spans:?}"
+    );
+}
+
+/// No tab reaches a drawn span.
+///
+/// ratatui's `Span::styled_graphemes` filters control characters out of the
+/// grapheme stream, so a tab is not narrowed and not drawn zero-width — it is
+/// **deleted**. `read_file` separates its gutter from the source with one, so
+/// an unindented source line arrived on screen as `780#[test]`, while an
+/// indented one looked correct by accident: its own leading spaces stood in for
+/// the missing separator (#4020).
+///
+/// Asserted at the span layer rather than against a rendered buffer because
+/// that is also where the deck's own wrap arithmetic reads the width — a tab is
+/// width 0 to `UnicodeWidthChar` as well, so leaving it in place would have the
+/// deck measuring one thing and ratatui drawing another.
+#[test]
+fn no_tab_survives_into_a_drawn_span() {
+    let body = numbered(780, &["#[test]", "\tfn tab_indented() {}"]);
+    let lines = collapsed(&read_result("src/tests.rs", &body));
+
+    for line in &lines {
+        for span in &line.spans {
+            assert!(
+                !span.content.contains('\t'),
+                "a tab survived into a drawn span ({:?}); ratatui will delete it",
+                span.content
+            );
+        }
+    }
+
+    let rendered = text_of(&lines);
+    let row = rendered
+        .lines()
+        .find(|l| l.contains("#[test]"))
+        .unwrap_or_else(|| panic!("the source line was not rendered:\n{rendered}"));
+    let (_, after) = row
+        .split_once("780")
+        .unwrap_or_else(|| panic!("the gutter was not rendered: {row:?}"));
+    assert!(
+        after.starts_with(' '),
+        "the line number is glued to the source it numbers: {row:?}"
+    );
 }

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -346,6 +346,7 @@ mod tests {
         TranscriptEntry::ToolResult {
             call_id: "c".into(),
             name: "cmd".into(),
+            path: None,
             ok,
             summary: "s".into(),
             full: "f".into(),
@@ -359,6 +360,7 @@ mod tests {
         TranscriptEntry::ToolResult {
             call_id: "c".into(),
             name: "edit_file".into(),
+            path: None,
             ok: true,
             summary: "s".into(),
             full: "f".into(),
@@ -431,6 +433,7 @@ mod tests {
             TranscriptEntry::ToolResult {
                 call_id: "c".into(),
                 name: "cmd".into(),
+                path: None,
                 ok: true,
                 summary: "Compiling".into(),
                 full: "line one\nDEADLOCK detected\nline three".into(),


### PR DESCRIPTION
A `read_file` result rendered as flat muted text for every language, and its
line-number gutter arrived glued to the source (`780#[test]`). Two independent
defects with one symptom surface, reported from a screenshot of the deck.

## 1. Colouring was gated on a question the body could not answer (#4019)

`push_body_line` coloured only when `reads_as_json(full)` — does the body's first
non-blank character open a JSON document. `read_file` prefixes every line with a
right-aligned gutter (`stella-tools`' `{line_num:>6}\t{line}`), so that character
is always a **digit**, and the gate never opened.

The consequence was wider than "Rust is not highlighted": reading a `.json` file
through `read_file` was not highlighted either. The deck's one JSON path was
unreachable from the tool whose output most often *is* the answer.

The lexers were all present in `crates/stella-tui/src/syntax.rs` — `Rust`, `TsJs`,
`Python`, `Markdown`, `Toml`, `Json` — and wired to diff bodies, markdown fences,
and the skills/agents definition editors. Nothing reached them from a tool result,
because `TranscriptEntry::ToolResult` carried no path to ask `lang_from_path`
about; the path lives on the matching `ToolStart`.

`path` now travels from that `ToolStart` alongside `name`, resolved in the *same*
lookup — two reverse scans could only differ by finding different starts for one
call id, which would be worse than either answer. `BodyPaint` replaces the bool:

- `Plain` — no lexer applies, exactly as before
- `Json` — the body *is* a JSON document, whatever tool produced it
- `Numbered(Lang)` — a numbered listing; each gutter-carrying line has the gutter
  split off as chrome and the remainder lexed

Order matters and is documented: the bytes get the first say, the path only the
second, and only for a body that really is a listing — the same `read_file` can
answer `(file has 3 lines, offset 9 is past end)`, and lexing that as Rust because
the path ended in `.rs` would colour a sentence. The footer and cap notices carry
no gutter and stay plain, which is what they are.

`BodyPaint::colored()` also replaces the `json` flag on the two collapsed-fold
decisions that existed for the same reason — a coloured body stays whole in the
body column, because the result row is one flat style and would strip the colouring.

## 2. ratatui deletes tabs (#4020)

`Span::styled_graphemes` filters control characters out of the grapheme stream
(`ratatui-core-0.1.2/src/text/span.rs:314`), so a tab is not narrowed and not
drawn zero-width — it is **deleted**. An unindented source line therefore arrived
as `780#[test]`, while an indented one looked correct by accident: its own leading
spaces stood in for the missing separator.

`expand_tabs` runs at the row layer, before `wrap_one_indent` measures, because
`UnicodeWidthChar` gives a tab width 0 as well — measuring first would inherit the
same hole and have the deck's wrap arithmetic disagree with what ratatui draws.
The stop is counted from the true screen column (rail prefix and body indent
included), so the expansion is the one a terminal would perform.
`push_diff_line` is the one row that bypasses `wrap_one_indent`, so it calls
`expand_tabs` by name.

Expanded at the drawing layer rather than at the emitter: the payload is also read
by the model and by the export surfaces, where a tab is the cheaper wire form.

## Witnesses

Six tests in `render::tests::tool_output`, checked by ablation rather than by
assertion:

- ablating **both** fixes: 5 of the 6 fail, every pre-existing test still passes
- ablating **only** `expand_tabs`: exactly `no_tab_survives_into_a_drawn_span`
  fails — so the two fixes are independently witnessed

The sixth, `a_read_of_an_unknown_extension_stays_plain`, is a guard against
over-reach and correctly passes both ways.

`make gate CARGO_SCOPE="-p stella-tui"` exits 0, including the golden deck frames
(`deck_render_snapshots`), which are unchanged — the colouring lives in span
styles, and the tab expansion only affects bodies that contain one.

No new dependencies.

## Deleted tests

None.

## Remaining work, filed not skipped

The export and Observatory renderers in `stella-transcript` did **not** get either
fix, so the deck and an exported transcript now render the same result differently
— the divergence #3644 closed, one axis over. Filed as #4036 rather than bundled:
the colouring half is a crate-boundary move (five lexers from `stella-tui` down to
`stella-transcript`), which deserves its own review surface. The HTML renderer's
tab handling is already fine — it wraps output in `<pre>`; the grid renderer's is
an open question that issue states as a suspicion rather than a finding.

Closes #4019
Closes #4020
Refs #4036, #3644, #3764

## Summary by Sourcery

Render file-reading results as properly highlighted source while preserving their line-number gutters and indentation.

Bug Fixes:
- Highlight source returned by file-reading tools using the language inferred from the target file path, including JSON and supported programming languages.
- Preserve the file-read line-number gutter and render tab separators as visible spacing instead of dropping them.

Enhancements:
- Carry the target path on tool results and keep colored result bodies intact during collapsed previews.
- Keep non-source footers and files with unsupported extensions uncolored.

Tests:
- Add rendering coverage for language-specific file-read highlighting, gutter styling, plain footers and unknown extensions, and tab removal.