### PR TITLE
fix(arenabench): a tool call and its result are ONE row, named once

### DIFF
--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -14,6 +14,7 @@ import {
 import {
   erroredSeqs,
   indexByCallId,
+  mergeToolRows,
   rawExchange,
   type RawExchange,
 } from "@/lib/transcript-view";
@@ -320,9 +321,16 @@ function TranscriptView({
     Record<number, boolean>
   >({});
   const [openResults, setOpenResults] = React.useState<Record<number, boolean>>({});
+  // The call's raw-argument disclosure, kept apart from `openResults`: on a
+  // merged row the primary fold belongs to the OUTPUT, and `args` is a sub-fold
+  // of the call — the same two folds `crates/stella-transcript` gives a Call.
+  // One record for both would make opening a call's arguments also open its
+  // output, and neither control could then say what it does.
+  const [openArgs, setOpenArgs] = React.useState<Record<number, boolean>>({});
   React.useEffect(() => {
     setThinkingOverrides({});
     setOpenResults({});
+    setOpenArgs({});
   }, [seatId, task]);
 
   // Open by default, because it is the answer to the question that brought
@@ -368,6 +376,13 @@ function TranscriptView({
     });
   }, [entries, enabled, disabledTools, query, errorsOnly, errored]);
 
+  // A tool call and its result are ONE row. Folded after filtering, never
+  // before, so a reader who switched calls or results off gets the honest
+  // degradation (`mergeToolRows`) rather than a pairing that ignores the
+  // filter — and so pacing, scrolling and the empty-state all count rows the
+  // way the reader sees them.
+  const rows = React.useMemo(() => mergeToolRows(visible), [visible]);
+
   // -- playback (paced replay for a finished trial) -----------------------
   const [playing, setPlaying] = React.useState(true);
   const [speed, setSpeed] = React.useState<number>(1);
@@ -379,24 +394,27 @@ function TranscriptView({
   const paced = historical && !searching && !skipPacing;
 
   React.useEffect(() => {
-    setRevealed(paced ? 0 : visible.length);
+    setRevealed(paced ? 0 : rows.length);
     setPlaying(true);
-  }, [seatId, task, paced, visible.length]);
+  }, [seatId, task, paced, rows.length]);
 
   React.useEffect(() => {
     if (!paced || !playing) return;
-    if (revealed >= visible.length) return;
-    const previous = visible[revealed - 1]?.t ?? 0;
-    const current = visible[revealed]?.t ?? previous;
+    if (revealed >= rows.length) return;
+    // The clock is the row's anchor — the CALL's timestamp for a paired
+    // exchange — so a replay reveals a call when it was made and its output
+    // arrives with it, which is what one node means.
+    const previous = rows[revealed - 1]?.entry.t ?? 0;
+    const current = rows[revealed]?.entry.t ?? previous;
     const timer = window.setTimeout(
-      () => setRevealed((n) => Math.min(n + 1, visible.length)),
+      () => setRevealed((n) => Math.min(n + 1, rows.length)),
       pacedDelay(Math.max(0, current - previous), speed),
     );
     return () => window.clearTimeout(timer);
-  }, [paced, playing, revealed, visible, speed]);
+  }, [paced, playing, revealed, rows, speed]);
 
-  const shown = paced ? visible.slice(0, revealed) : visible;
-  const done = paced && revealed >= visible.length && visible.length > 0;
+  const shown = paced ? rows.slice(0, revealed) : rows;
+  const done = paced && revealed >= rows.length && rows.length > 0;
 
   const feedRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
@@ -736,13 +754,18 @@ function TranscriptView({
                   : "no transcript entries for this trial."}
             </div>
           ) : (
-            shown.map((entry) => {
+            shown.map(({ entry, result }) => {
               // The icon is offered only where there is genuinely an exchange
               // behind the row, which is what keeps it rare enough to notice.
               const callId =
                 typeof entry.meta?.call_id === "string" ? entry.meta.call_id : "";
               const hasExchange =
                 Boolean(callId) && rawExchange(entry, callIndex) !== null;
+              // The row's outcome is its RESULT's, not its call's — a call
+              // carries no error flag, and on a merged row the dot is the only
+              // margin signal a failure has.
+              const failed = Boolean((result ?? entry).meta?.error);
+              const cls = toolClassOf(entry.meta);
               return (
                 <div key={entry.seq} className="tx-row py-0.5">
                   <span className="tx-clock">{fmtClock(entry.t)}</span>
@@ -756,10 +779,8 @@ function TranscriptView({
                       <span
                         className={cn(
                           "tx-dot",
-                          entry.meta?.error
-                            ? "text-bad"
-                            : TOOL_CLASS_TEXT[toolClassOf(entry.meta)],
-                          toolClassOf(entry.meta) === "mutate" && "solid",
+                          failed ? "text-bad" : TOOL_CLASS_TEXT[cls],
+                          cls === "mutate" && "solid",
                         )}
                       />
                     )}
@@ -767,6 +788,7 @@ function TranscriptView({
                   <div className="min-w-0">
                     <Entry
                       entry={entry}
+                      result={result}
                       query={query.trim()}
                       thinkingOpen={thinkingOverrides[entry.seq] ?? thinkingDefault}
                       toggleThinking={() =>
@@ -778,6 +800,13 @@ function TranscriptView({
                       resultOpen={openResults[entry.seq] ?? false}
                       toggleResult={() =>
                         setOpenResults((state) => ({
+                          ...state,
+                          [entry.seq]: !state[entry.seq],
+                        }))
+                      }
+                      argsOpen={openArgs[entry.seq] ?? false}
+                      toggleArgs={() =>
+                        setOpenArgs((state) => ({
                           ...state,
                           [entry.seq]: !state[entry.seq],
                         }))

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -766,6 +766,13 @@ function TranscriptView({
               // margin signal a failure has.
               const failed = Boolean((result ?? entry).meta?.error);
               const cls = toolClassOf(entry.meta);
+              // Never returned, as opposed to merely not folded into this row:
+              // asked of the WHOLE transcript, so switching results off does
+              // not make every call on screen claim to be running.
+              const pending =
+                entry.kind === "tool" &&
+                Boolean(callId) &&
+                !callIndex.get(callId)?.result;
               return (
                 <div key={entry.seq} className="tx-row py-0.5">
                   <span className="tx-clock">{fmtClock(entry.t)}</span>
@@ -789,6 +796,7 @@ function TranscriptView({
                     <Entry
                       entry={entry}
                       result={result}
+                      pending={pending}
                       query={query.trim()}
                       thinkingOpen={thinkingOverrides[entry.seq] ?? thinkingDefault}
                       toggleThinking={() =>

--- a/arenabench/ui/components/arena/transcript/entry.tsx
+++ b/arenabench/ui/components/arena/transcript/entry.tsx
@@ -806,6 +806,7 @@ function ResultBody({
 export function Entry({
   entry,
   result,
+  pending,
   query,
   thinkingOpen,
   toggleThinking,
@@ -822,6 +823,10 @@ export function Entry({
    *  ONE row — see `mergeToolRows`. Absent for every non-tool entry, and for a
    *  call still running or whose result the reader filtered away. */
   result?: TranscriptEntry;
+  /** Whether this call has no result anywhere in the transcript — it never
+   *  returned. Decided by the page, which can see the whole stream; the absence
+   *  of `result` above only says it is not in the current filtered view. */
+  pending?: boolean;
   query: string;
   thinkingOpen: boolean;
   toggleThinking: () => void;
@@ -928,10 +933,17 @@ export function Entry({
             </span>
           )}
           {parts && <ResultChips parts={parts} />}
-          {/* A call with no result yet is said to be pending rather than left
-              looking like one that returned nothing — a killed run leaves calls
-              that genuinely never came back, and the two must not look alike. */}
-          {!result && <span className="tx-chips"><span className="tx-chip">running…</span></span>}
+          {/* A call that never returned says so rather than looking like one
+              that returned nothing — a killed run leaves calls that genuinely
+              never came back, and the two must not look alike. Driven by
+              `pending` (the whole transcript) rather than by the absence of
+              `result` (this filtered view), because a reader who switched
+              results off has not made every call on screen start running. */}
+          {pending && (
+            <span className="tx-chips">
+              <span className="tx-chip">running…</span>
+            </span>
+          )}
           {onInspect && <Inspect onOpen={onInspect} open={Boolean(inspecting)} />}
           {expandable && toggleArgs && (
             <button

--- a/arenabench/ui/components/arena/transcript/entry.tsx
+++ b/arenabench/ui/components/arena/transcript/entry.tsx
@@ -30,18 +30,25 @@
  *   error/warning marker — a build's first line is `Checking foo v0.1.0` and
  *   the line a reader came for is twenty lines down. A success shows one line
  *   from there; a failure shows six.
- * - **The rails are the deck's**: `●` opens a call, `⎿` its result, `✗` a
- *   failed one — a distinct glyph *and* column, so a failure is findable by
- *   margin-scan alone.
+ * - **A call and its result are ONE row.** The tool is named once, its output
+ *   nested under it — [`Call`] owns its `Output` in the shared model, and this
+ *   page reaches the same shape over the wire's flat stream via `mergeToolRows`.
+ *   The wire carries `tool` and `tool_result` as separate entries because that
+ *   is the *journal's* shape; rendering them as separate rows printed the tool's
+ *   name twice and the invocation up to three times down the whole transcript,
+ *   which is the defect `crates/stella-transcript` exists to end.
+ * - **The rails are the deck's**: `●` opens a call, `⎿` a result whose call is
+ *   not on screen, `✗` a failed one — a distinct glyph *and* column, so a
+ *   failure is findable by margin-scan alone.
  * - **Metadata rides as chips**, right-aligned and muted, never inline at the
  *   weight of the work it paid for.
  *
- * Two deliberate departures from the deck. It renders a call and its result as
- * one block nothing can split, so the result row need not repeat the tool's
- * name; here the kind filters can hide every call row, which would leave a
- * column of results naming nothing — so a result carries its tool's name,
- * subordinate to the call's. And every body on the wire here is
- * character-capped for the live stream's sake
+ * One deliberate departure from the deck, and one degradation. A result whose
+ * call is *not on screen* — filtered off by kind, or begun before the stream's
+ * cursor — renders alone and keeps its tool's name, because a column of outputs
+ * naming nothing is worse than a name that appears once; that is the orphan arm
+ * below, and it is not licence to print the name beside its own call. And every
+ * body on the wire here is character-capped for the live stream's sake
  * (`arenabench.transcript.TOOL_RESULT_BUDGET`) in a way the deck, reading a
  * session in memory, never has to be.
  */
@@ -566,24 +573,265 @@ function Inspect({ onOpen, open }: { onOpen: () => void; open: boolean }) {
   );
 }
 
+/**
+ * Everything a result contributes to the row it belongs to.
+ *
+ * Computed in one place because a merged call row and an orphan result row show
+ * the *same* result and must not be able to disagree about what it says — the
+ * shape of defect this whole change is about. The only thing that differs
+ * between the two is whether the row re-states the tool's name.
+ */
+type ResultParts = {
+  isError: boolean;
+  hasDiff: boolean;
+  diffAdded: number;
+  diffRemoved: number;
+  metrics: string[];
+  /** Output lines to print, already windowed on the salient line when folded. */
+  shown: string[];
+  diffShown: DiffRow[];
+  /** What the fold control says it is hiding. Empty means nothing is hidden. */
+  foldParts: string[];
+  /** Whether an expanded row has anything to collapse back down. */
+  collapsible: boolean;
+};
+
+function resultParts(result: TranscriptEntry, resultOpen: boolean): ResultParts {
+  const body = result.body || "";
+  const meta = (result.meta || {}) as Record<string, unknown>;
+  const isError = Boolean(meta.error);
+  const lines = body ? splitLines(body) : [];
+  const total = lines.length;
+  // The mutation's diff, inline under the result — correlated server-side
+  // (`arenabench.transcript`, the `tool_result` arm) and rendered in the deck's
+  // grammar (`crates/stella-tui/src/render/entry.rs`): the metric column states
+  // the emitter's own `+N −M` instead of a line count, the collapsed row
+  // suppresses the output preview (a prose "Applied edit to …" would restate
+  // the call row above it and the diff under it in the same breath), and the
+  // diff shows at most `INLINE_DIFF_CAP` lines until disclosed. Only a
+  // successful mutation carries one, so `isError` never coincides with a diff.
+  const diffText = typeof meta.diff === "string" ? meta.diff : "";
+  const hasDiff = diffText.length > 0;
+  const diffAll = hasDiff ? parseDiff(diffText) : [];
+  const diffPlan = resultOpen
+    ? { keep: diffAll.map(() => true), hidden: 0, foldBefore: -1 }
+    : selectDiffLines(
+        diffAll.map((row) => row.text),
+        INLINE_DIFF_CAP,
+      );
+  const diffKeep = diffPlan.keep;
+  // A lone hunk header is dropped (`diff.rs::body_lines_inline`): inline under
+  // a call row it restates what the gutter beside it already says, and a
+  // two-line change should not cost three rows. With several hunks the headers
+  // stay — there they are the boundary between two disjoint regions of the file.
+  const multiHunk = diffAll.filter((row) => row.tone === "hunk").length > 1;
+  const diffHidden = diffPlan.hidden;
+  // The elision is drawn WHERE the lines were, as a row of its own. Stated only
+  // in the fold summary below, a head-and-tail rendering would read as "the
+  // change continues past the bottom" under a row that is already the change's
+  // last line.
+  const elision = (): DiffRow => {
+    const text = `⋯ ${diffHidden} ${diffHidden === 1 ? "line" : "lines"} not shown`;
+    return { text, code: text, sign: "", tone: "meta", oldNo: null, newNo: null };
+  };
+  const diffShown: DiffRow[] = [];
+  diffAll.forEach((row, i) => {
+    if (i === diffPlan.foldBefore && diffHidden > 0) diffShown.push(elision());
+    if (diffKeep[i] && (multiHunk || row.tone !== "hunk")) diffShown.push(row);
+  });
+  if (diffPlan.foldBefore === diffAll.length && diffHidden > 0) {
+    diffShown.push(elision());
+  }
+  // The collapsed window anchors on the SALIENT line, not line 1 — see
+  // `salientLine`'s doc comment — and its size is the shared preview budget.
+  //
+  // The anchor is clamped so the window is never starved: a salient line near
+  // the *end* of the output would otherwise leave fewer than `budget` lines to
+  // take, and this surface would show one line where the deck and the export
+  // showed six. Sliding the window back keeps the salient line on screen as the
+  // last thing shown rather than the first. A port of the same clamp in
+  // `crates/stella-tui/src/render/entry.rs`.
+  const budget = isError ? FAIL_PREVIEW_LINES : OK_PREVIEW_LINES;
+  const anchor =
+    total > 0 ? Math.min(salientLine(body), Math.max(0, total - budget)) : 0;
+  const collapsedShown = hasDiff ? [] : lines.slice(anchor, anchor + budget);
+  const shown = resultOpen ? lines : collapsedShown;
+  const hidden = resultOpen ? 0 : total - collapsedShown.length;
+  const metrics = [
+    meta.duration_ms != null ? fmtDuration(meta.duration_ms) : null,
+    // A diff states its own size in `+N −M` — the honest unit for an edit;
+    // "12 lines" would describe the tool's chatter, not the change.
+    total > 1 && !hasDiff ? `${total} lines` : null,
+    // ⚡ marks a speculated result: its duration overlapped the model's own
+    // streaming instead of following it, so the number is not latency the run
+    // actually spent waiting.
+    meta.speculated ? "⚡ speculated" : null,
+    // The protocol grew a `ToolOutput` arm this page predates. Say so rather
+    // than presenting the JSON fallback as if it were output.
+    meta.unrecognized ? "unrecognized output shape" : null,
+  ].filter(Boolean) as string[];
+  const foldParts = [
+    // Not the diff's own hidden count: the `⋯ n lines not shown` row inside the
+    // diff already carries it, in the place it happened.
+    hidden > 0
+      ? hasDiff
+        ? `${hidden} output ${hidden === 1 ? "line" : "lines"}`
+        : `${hidden} more ${hidden === 1 ? "line" : "lines"}`
+      : null,
+  ].filter(Boolean) as string[];
+
+  return {
+    isError,
+    hasDiff,
+    diffAdded: Number(meta.diff_added ?? 0),
+    diffRemoved: Number(meta.diff_removed ?? 0),
+    metrics,
+    shown,
+    diffShown,
+    foldParts,
+    collapsible: total > budget || hasDiff,
+  };
+}
+
+/**
+ * A result's chips, for the header of whichever row carries it.
+ *
+ * `+N −M` first, from the counts the emitter measured
+ * (`meta.diff_added`/`diff_removed`) — never a recount of the rendered hunk,
+ * which is a bounded view of the changed region and reports a smaller number.
+ * Then the metrics, right-aligned and muted: the rule the transcript grammar is
+ * built on is that a duration and a cost are the accounting, and the output is
+ * the thing.
+ */
+function ResultChips({ parts }: { parts: ResultParts }) {
+  return (
+    <>
+      {parts.hasDiff && (
+        <span className="text-[10.5px] tabular-nums">
+          <span className="text-ok">+{parts.diffAdded}</span>{" "}
+          <span className="text-bad">−{parts.diffRemoved}</span>
+        </span>
+      )}
+      {parts.metrics.length > 0 && (
+        <span className="tx-chips">
+          {parts.metrics.map((metric) => (
+            <span
+              key={metric}
+              className={cn("tx-chip", parts.isError && "err")}
+            >
+              {metric}
+            </span>
+          ))}
+        </span>
+      )}
+    </>
+  );
+}
+
+/**
+ * A result's body: the output window, the inline diff, and the fold control.
+ *
+ * Indented onto the row's spine (`ml-5`), which is the character grid's `│`
+ * carrying a call's output under the call — the same relationship
+ * `crates/stella-transcript`'s two renderers draw, in a browser's units.
+ */
+function ResultBody({
+  parts,
+  query,
+  resultOpen,
+  toggleResult,
+}: {
+  parts: ResultParts;
+  query: string;
+  resultOpen: boolean;
+  toggleResult: () => void;
+}) {
+  return (
+    <>
+      {parts.shown.length > 0 && (
+        <pre
+          className={cn(
+            "ml-5 overflow-x-auto whitespace-pre-wrap break-words",
+            parts.isError ? "text-bad/90" : "text-muted",
+          )}
+        >
+          <Highlight text={parts.shown.join("\n")} query={query} />
+        </pre>
+      )}
+      {/* Dual gutters and word-level highlight, from the shared policy — see
+          `DiffTable`. The old rendering carried one number column, which for a
+          removed line had to show a new-side number it does not have. */}
+      {parts.diffShown.length > 0 && (
+        <div className="ml-5 overflow-x-auto">
+          <DiffTable
+            rows={parts.diffShown}
+            query={query}
+            highlightText={(text, q) => <Highlight text={text} query={q} />}
+          />
+        </div>
+      )}
+      {/* The deck only earns this row for a failure — a successful result
+          already states its size in the metric column above. A mouse-driven
+          page has no ctrl+o, though, so a folded SUCCESS still gets a quiet way
+          to see the rest; it just does not compete for attention the way the
+          failure's does. With a diff, the fold names both of the things it
+          hides: the diff's overflow and the output the collapsed row
+          suppressed entirely. */}
+      {!resultOpen && parts.foldParts.length > 0 && (
+        <button
+          type="button"
+          onClick={toggleResult}
+          className={cn(
+            "ml-5 cursor-pointer text-[10.5px] hover:text-muted",
+            parts.isError ? "text-dim" : "text-dim/70",
+          )}
+        >
+          ⋯ {parts.foldParts.join(" · ")}
+        </button>
+      )}
+      {resultOpen && parts.collapsible && (
+        <button
+          type="button"
+          onClick={toggleResult}
+          className="ml-5 cursor-pointer text-[10.5px] text-dim hover:text-muted"
+        >
+          ⏶ collapse
+        </button>
+      )}
+    </>
+  );
+}
+
 /** One transcript entry, rendered in the transcript grammar. */
 export function Entry({
   entry,
+  result,
   query,
   thinkingOpen,
   toggleThinking,
   resultOpen,
   toggleResult,
+  argsOpen,
+  toggleArgs,
   onInspect,
   inspecting,
   isAnswer,
 }: {
   entry: TranscriptEntry;
+  /** The `tool_result` folded into this call's row. A call and its result are
+   *  ONE row — see `mergeToolRows`. Absent for every non-tool entry, and for a
+   *  call still running or whose result the reader filtered away. */
+  result?: TranscriptEntry;
   query: string;
   thinkingOpen: boolean;
   toggleThinking: () => void;
   resultOpen: boolean;
   toggleResult: () => void;
+  /** The call's raw-argument disclosure, which is its own fold: the row's
+   *  primary fold belongs to the OUTPUT, exactly as `args` is a sub-fold of a
+   *  call in `crates/stella-transcript`. */
+  argsOpen?: boolean;
+  toggleArgs?: () => void;
   /** Absent for a row with no exchange behind it — which is how the icon
    *  stays rare enough to mean something. */
   onInspect?: () => void;
@@ -654,14 +902,22 @@ export function Entry({
     // rail here is undyed and the class colour is spent on the one place a
     // reader actually scans: the tool's own name.
     const cls = toolClassOf(meta);
+    // The result folded into this row. Its outcome outranks the call's class
+    // for the rail glyph and colour: a failure must be findable by margin-scan
+    // alone, the same precedence the deck gives an outcome over a category.
+    const parts = result ? resultParts(result, resultOpen) : null;
+    const failed = Boolean(parts?.isError);
+    const showArgs = Boolean(argsOpen);
     return (
       <div>
         <div className="flex items-baseline gap-2">
-          <span className="select-none text-dim">●</span>
+          <span className={cn("select-none", failed ? "text-bad" : "text-dim")}>
+            {failed ? "✗" : "●"}
+          </span>
           <span
             className={cn(
               "min-w-[8.5rem] shrink-0 font-semibold",
-              TOOL_CLASS_TEXT[cls],
+              failed ? "text-bad" : TOOL_CLASS_TEXT[cls],
             )}
           >
             <Highlight text={entry.title ?? "tool"} query={query} />
@@ -671,19 +927,24 @@ export function Entry({
               <Highlight text={body} query={query} />
             </span>
           )}
+          {parts && <ResultChips parts={parts} />}
+          {/* A call with no result yet is said to be pending rather than left
+              looking like one that returned nothing — a killed run leaves calls
+              that genuinely never came back, and the two must not look alike. */}
+          {!result && <span className="tx-chips"><span className="tx-chip">running…</span></span>}
           {onInspect && <Inspect onOpen={onInspect} open={Boolean(inspecting)} />}
-          {expandable && (
+          {expandable && toggleArgs && (
             <button
               type="button"
-              onClick={toggleResult}
-              aria-label={resultOpen ? "hide arguments" : "show arguments"}
+              onClick={toggleArgs}
+              aria-label={showArgs ? "hide arguments" : "show arguments"}
               className="shrink-0 cursor-pointer text-[10.5px] text-dim hover:text-muted"
             >
-              {resultOpen ? "⏶" : "⋯"}
+              {showArgs ? "⏶" : "⋯"}
             </button>
           )}
         </div>
-        {expandable && resultOpen &&
+        {expandable && showArgs &&
           (() => {
             // A file-mutating tool renders as a coloured diff; everything else
             // keeps the raw argument JSON. The diff is null-safe: a call whose
@@ -697,202 +958,57 @@ export function Entry({
               </pre>
             );
           })()}
+        {parts && (
+          <ResultBody
+            parts={parts}
+            query={query}
+            resultOpen={resultOpen}
+            toggleResult={toggleResult}
+          />
+        )}
       </div>
     );
   }
 
   if (entry.kind === "tool_result") {
-    // `⎿ name · 141ms · 12 lines`, then the body — the deck's result rail,
-    // subordinate to the call above it. A failure takes `✗` and its own
-    // colour so it is findable by margin-scan alone, overriding the class
-    // colour below: an outcome always outranks a category, the same
-    // precedence the deck gives a stage rule over its own hue.
+    // An ORPHAN result: one whose call is not on screen — it scrolled past the
+    // stream's cursor, or the reader filtered calls off. A paired result never
+    // reaches here; it is folded into its call's row by `mergeToolRows`, which
+    // is what stops the tool's name being printed twice down the transcript.
     //
-    // The name is on the row rather than left implicit in the call above,
-    // which is where this page departs from the deck on purpose: the deck
-    // renders a call and its result as one tight block that cannot be split,
-    // while here the kind filters can hide every call row and leave a column
-    // of results naming nothing. It carries the same class colour as its
-    // call for the same reason — a reader who has filtered down to "results"
-    // alone should not lose which kind of call produced each one.
-    const meta = (entry.meta || {}) as Record<string, unknown>;
-    const isError = Boolean(meta.error);
-    const cls = toolClassOf(meta);
-    const lines = body ? splitLines(body) : [];
-    const total = lines.length;
-    // The mutation's diff, inline under the result — correlated server-side
-    // (`arenabench.transcript`, the `tool_result` arm) and rendered in the
-    // deck's grammar (`crates/stella-tui/src/render/entry.rs`): the metric
-    // column states the emitter's own `+N −M` instead of a line count, the
-    // collapsed row suppresses the output preview (a prose "Applied edit to
-    // …" would restate the call row above it and the diff under it in the
-    // same breath), and the diff shows at most `INLINE_DIFF_CAP` lines until
-    // disclosed. Only a successful mutation carries one, so `isError` never
-    // coincides with a diff.
-    const diffText = typeof meta.diff === "string" ? meta.diff : "";
-    const hasDiff = diffText.length > 0;
-    const diffAll = hasDiff ? parseDiff(diffText) : [];
-    const diffPlan = resultOpen
-      ? { keep: diffAll.map(() => true), hidden: 0, foldBefore: -1 }
-      : selectDiffLines(
-          diffAll.map((row) => row.text),
-          INLINE_DIFF_CAP,
-        );
-    const diffKeep = diffPlan.keep;
-    // A lone hunk header is dropped (`diff.rs::body_lines_inline`): inline
-    // under a call row it restates what the gutter beside it already says,
-    // and a two-line change should not cost three rows. With several hunks
-    // the headers stay — there they are the boundary between two disjoint
-    // regions of the file.
-    const multiHunk = diffAll.filter((row) => row.tone === "hunk").length > 1;
-    const diffHidden = diffPlan.hidden;
-    // The elision is drawn WHERE the lines were, as a row of its own. Stated
-    // only in the fold summary below, a head-and-tail rendering would read as
-    // "the change continues past the bottom" under a row that is already the
-    // change's last line.
-    const elision = (): DiffRow => {
-      const text = `⋯ ${diffHidden} ${diffHidden === 1 ? "line" : "lines"} not shown`;
-      return { text, code: text, sign: "", tone: "meta", oldNo: null, newNo: null };
-    };
-    const diffShown: DiffRow[] = [];
-    diffAll.forEach((row, i) => {
-      if (i === diffPlan.foldBefore && diffHidden > 0) diffShown.push(elision());
-      if (diffKeep[i] && (multiHunk || row.tone !== "hunk")) diffShown.push(row);
-    });
-    if (diffPlan.foldBefore === diffAll.length && diffHidden > 0) {
-      diffShown.push(elision());
-    }
-    // The collapsed window anchors on the SALIENT line, not line 1 — see
-    // `salientLine`'s doc comment — and its size is the shared preview budget.
-    //
-    // The anchor is clamped so the window is never starved: a salient line near
-    // the *end* of the output would otherwise leave fewer than `budget` lines
-    // to take, and this surface would show one line where the deck and the
-    // export showed six. Sliding the window back keeps the salient line on
-    // screen as the last thing shown rather than the first. A port of the same
-    // clamp in `crates/stella-tui/src/render/entry.rs`.
-    const budget = isError ? FAIL_PREVIEW_LINES : OK_PREVIEW_LINES;
-    const anchor =
-      total > 0 ? Math.min(salientLine(body ?? ""), Math.max(0, total - budget)) : 0;
-    const collapsedShown = hasDiff ? [] : lines.slice(anchor, anchor + budget);
-    const shown = resultOpen ? lines : collapsedShown;
-    const hidden = resultOpen ? 0 : total - collapsedShown.length;
-    const metrics = [
-      meta.duration_ms != null ? fmtDuration(meta.duration_ms) : null,
-      // A diff states its own size in `+N −M` — the honest unit for an edit;
-      // "12 lines" would describe the tool's chatter, not the change.
-      total > 1 && !hasDiff ? `${total} lines` : null,
-      // ⚡ marks a speculated result: its duration overlapped the model's own
-      // streaming instead of following it, so the number is not latency the
-      // run actually spent waiting.
-      meta.speculated ? "⚡ speculated" : null,
-      // The protocol grew a `ToolOutput` arm this page predates. Say so
-      // rather than presenting the JSON fallback as if it were output.
-      meta.unrecognized ? "unrecognized output shape" : null,
-    ].filter(Boolean);
-    const foldParts = [
-      // Not the diff's own hidden count: the `⋯ n lines not shown` row inside
-      // the diff already carries it, in the place it happened.
-      null,
-      hidden > 0
-        ? hasDiff
-          ? `${hidden} output ${hidden === 1 ? "line" : "lines"}`
-          : `${hidden} more ${hidden === 1 ? "line" : "lines"}`
-        : null,
-    ].filter(Boolean);
+    // Here, and only here, the row keeps the tool's name: a bare column of
+    // outputs naming nothing is worse than a name that appears once. `⎿` marks
+    // it as the result half of a call whose header is elsewhere, and a failure
+    // takes `✗` and its own colour so it is findable by margin-scan alone —
+    // an outcome always outranks a category.
+    const parts = resultParts(entry, resultOpen);
+    const cls = toolClassOf(entry.meta || {});
     return (
       <div>
         <div className="flex items-baseline gap-2">
-          <span className={cn("select-none", isError ? "text-bad" : "text-dim")}>
-            {isError ? "✗" : "⎿"}
+          <span className={cn("select-none", parts.isError ? "text-bad" : "text-dim")}>
+            {parts.isError ? "✗" : "⎿"}
           </span>
           <span
-            className={cn("font-medium", isError ? "text-bad" : TOOL_CLASS_TEXT[cls])}
+            className={cn(
+              "font-medium",
+              parts.isError ? "text-bad" : TOOL_CLASS_TEXT[cls],
+            )}
           >
             <Highlight text={entry.title ?? "tool"} query={query} />
           </span>
-          {/* The deck's `+N −M`, first in the metric column, from the counts
-              the emitter measured (`meta.diff_added`/`diff_removed`) — never
-              a recount of the rendered hunk, which is a bounded view of the
-              changed region and reports a smaller number. */}
-          {hasDiff && (
-            <span className="text-[10.5px] tabular-nums">
-              <span className="text-ok">+{Number(meta.diff_added ?? 0)}</span>{" "}
-              <span className="text-bad">−{Number(meta.diff_removed ?? 0)}</span>
-            </span>
-          )}
-          {/* Metadata as chips, right-aligned and muted — never inline at the
-              weight of the work it paid for. The rule the transcript grammar
-              is built on: a duration and a cost are the accounting, and the
-              output is the thing. */}
-          {metrics.length > 0 && (
-            <span className="tx-chips">
-              {metrics.map((metric) => (
-                <span
-                  key={String(metric)}
-                  className={cn("tx-chip", isError && "err")}
-                >
-                  {metric}
-                </span>
-              ))}
-            </span>
-          )}
+          <ResultChips parts={parts} />
           {onInspect && <Inspect onOpen={onInspect} open={Boolean(inspecting)} />}
         </div>
-        {shown.length > 0 && (
-          <pre
-            className={cn(
-              "ml-5 overflow-x-auto whitespace-pre-wrap break-words",
-              isError ? "text-bad/90" : "text-muted",
-            )}
-          >
-            <Highlight text={shown.join("\n")} query={query} />
-          </pre>
-        )}
-        {/* Dual gutters and word-level highlight, from the shared policy — see
-            `DiffTable`. The old rendering carried one number column, which for
-            a removed line had to show a new-side number it does not have. */}
-        {diffShown.length > 0 && (
-          <div className="ml-5 overflow-x-auto">
-            <DiffTable
-              rows={diffShown}
-              query={query}
-              highlightText={(text, q) => <Highlight text={text} query={q} />}
-            />
-          </div>
-        )}
-        {/* The deck only earns this row for a failure — a successful result
-            already states its size in the metric column above. A mouse-driven
-            page has no ctrl+o, though, so a folded SUCCESS still gets a quiet
-            way to see the rest; it just does not compete for attention the
-            way the failure's does. With a diff, the fold names both of the
-            things it hides: the diff's overflow and the output the collapsed
-            row suppressed entirely. */}
-        {!resultOpen && foldParts.length > 0 && (
-          <button
-            type="button"
-            onClick={toggleResult}
-            className={cn(
-              "ml-5 cursor-pointer text-[10.5px] hover:text-muted",
-              isError ? "text-dim" : "text-dim/70",
-            )}
-          >
-            ⋯ {foldParts.join(" · ")}
-          </button>
-        )}
-        {resultOpen && (total > budget || hasDiff) && (
-          <button
-            type="button"
-            onClick={toggleResult}
-            className="ml-5 cursor-pointer text-[10.5px] text-dim hover:text-muted"
-          >
-            ⏶ collapse
-          </button>
-        )}
+        <ResultBody
+          parts={parts}
+          query={query}
+          resultOpen={resultOpen}
+          toggleResult={toggleResult}
+        />
       </div>
     );
   }
-
   if (entry.kind === "usage") {
     return <div className="text-[10.5px] text-dim">{usageLine(entry)}</div>;
   }

--- a/arenabench/ui/lib/transcript-view.ts
+++ b/arenabench/ui/lib/transcript-view.ts
@@ -140,6 +140,71 @@ export function rawExchange(
   };
 }
 
+/**
+ * One rendered row. A tool call and its result are ONE row, never two.
+ *
+ * This is `crates/stella-transcript`'s model expressed over the wire's flat
+ * stream: there a [`Call`] owns its `Output`, so there is no way to render one
+ * without the other and no second place for the tool's name to live. This page
+ * reads `tool` and `tool_result` as separate entries — the journal's shape, not
+ * the transcript's — and folding them here is what stops the name being printed
+ * twice down the whole transcript.
+ */
+export type TranscriptRow = {
+  /** The entry the row is anchored on — the CALL for a paired exchange, so the
+   *  clock reads when the call was made and the duration rides as a chip. */
+  entry: TranscriptEntry;
+  /** The result folded into this row. Absent for every non-tool row, and for a
+   *  call whose result has not arrived (or was filtered away). */
+  result?: TranscriptEntry;
+};
+
+/**
+ * Fold each `tool_result` into the `tool` row that produced it.
+ *
+ * Pairs strictly **within the list it is given**, which is what makes it
+ * composable with the page's filters rather than fighting them. Three cases,
+ * all of them honest:
+ *
+ * - **Call and result both present** — one row, the tool named once. The
+ *   overwhelmingly common case, and the defect this function exists to end.
+ * - **Call alone** (still running, or the reader filtered results off) — the
+ *   call row renders with no body, marked pending by the caller.
+ * - **Result alone** (the call scrolled past the stream's cursor, or the reader
+ *   filtered calls off) — it renders on its own and *keeps* its tool's name,
+ *   because a bare column of outputs naming nothing is worse than a name
+ *   appearing once. That fallback is the whole reason the name survives on
+ *   `tool_result` at all; it is not licence to print it beside its own call.
+ *
+ * Order is the anchor's: a result never moves a row, it only joins one.
+ */
+export function mergeToolRows(entries: readonly TranscriptEntry[]): TranscriptRow[] {
+  /** call_id → the result to fold in, for calls present in this same list. */
+  const results = new Map<string, TranscriptEntry>();
+  const callIds = new Set<string>();
+  for (const entry of entries) {
+    const callId = entry.meta?.call_id;
+    if (typeof callId !== "string" || !callId) continue;
+    if (entry.kind === "tool") callIds.add(callId);
+    else if (entry.kind === "tool_result") results.set(callId, entry);
+  }
+
+  const rows: TranscriptRow[] = [];
+  for (const entry of entries) {
+    const callId =
+      typeof entry.meta?.call_id === "string" ? entry.meta.call_id : "";
+    // A result whose call is in this list has already been rendered as part of
+    // that call's row. Without a call to join, it stands alone.
+    if (entry.kind === "tool_result" && callId && callIds.has(callId)) continue;
+    if (entry.kind === "tool" && callId) {
+      rows.push({ entry, result: results.get(callId) });
+      continue;
+    }
+    rows.push({ entry });
+  }
+  return rows;
+}
+
 /** Index every tool call and result by the `call_id` the two share. */
 export function indexByCallId(
   entries: readonly TranscriptEntry[],

--- a/arenabench/ui/scripts/check-transcript-view.mjs
+++ b/arenabench/ui/scripts/check-transcript-view.mjs
@@ -29,6 +29,7 @@ import {
   indexByCallId,
   isFailedResult,
   lineText,
+  mergeToolRows,
   rawExchange,
 } from "../lib/transcript-view.ts";
 
@@ -55,6 +56,78 @@ const entry = (seq, kind, extra = {}) => ({
   body: extra.body ?? "",
   meta: extra.meta ?? {},
 });
+
+// -- one row per call ------------------------------------------------------
+
+// The defect: a `tool` and its `tool_result` rendered as two rows, so the tool's
+// name was printed twice and the invocation up to three times, all the way down
+// the transcript. `crates/stella-transcript` makes this structurally impossible
+// by having a Call OWN its Output; over the wire's flat stream, this is where
+// the same shape is recovered.
+console.log("one row per call");
+{
+  const entries = [
+    entry(1, "text", { body: "planning" }),
+    entry(2, "tool", { title: "bash", body: "ls", meta: { call_id: "c1" } }),
+    entry(3, "tool_result", { title: "bash", body: "a.txt", meta: { call_id: "c1" } }),
+    entry(4, "tool", { title: "read_file", meta: { call_id: "c2" } }),
+    entry(5, "tool_result", { title: "read_file", meta: { call_id: "c2" } }),
+  ];
+
+  const rows = mergeToolRows(entries);
+  eq("two calls and a prose row make three rows, not five", rows.length, 3);
+  eq("the rows are anchored on the prose and the two CALLS", rows.map((r) => r.entry.seq), [1, 2, 4]);
+  check("no row is anchored on a result", rows.every((r) => r.entry.kind !== "tool_result"));
+  eq("each call carries its own result", rows.slice(1).map((r) => r.result?.seq), [3, 5]);
+  // The whole point, stated as the reader sees it: the tool's name appears once
+  // per exchange, on the call.
+  const named = rows.filter((r) => r.entry.title === "bash").length;
+  eq("the tool is named once per exchange", named, 1);
+}
+
+// A call still running has no result to fold, and must not be made to look like
+// one that returned nothing.
+{
+  const rows = mergeToolRows([entry(1, "tool", { title: "bash", meta: { call_id: "c1" } })]);
+  eq("a running call is one row", rows.length, 1);
+  check("with no result attached", rows[0].result === undefined);
+}
+
+// The orphan: a result whose call is not in the list — filtered off by kind, or
+// begun before the stream's cursor. It stands alone and keeps its name, which is
+// the one case where the name on a result is right.
+{
+  const rows = mergeToolRows([
+    entry(7, "tool_result", { title: "bash", body: "out", meta: { call_id: "gone" } }),
+  ]);
+  eq("an orphan result still renders", rows.length, 1);
+  eq("anchored on itself", rows[0].entry.seq, 7);
+  check("with nothing folded into it", rows[0].result === undefined);
+}
+
+// Pairing happens over the list it is GIVEN, so it composes with the page's
+// filters instead of fighting them: hiding calls must not silently hide results
+// too, and hiding results must leave the call rows intact.
+{
+  const call = entry(2, "tool", { title: "bash", meta: { call_id: "c1" } });
+  const result = entry(3, "tool_result", { title: "bash", meta: { call_id: "c1" } });
+  eq("results filtered off leaves the call alone", mergeToolRows([call]).length, 1);
+  const resultsOnly = mergeToolRows([result]);
+  eq("calls filtered off leaves the result alone", resultsOnly.length, 1);
+  eq("and it is still named", resultsOnly[0].entry.title, "bash");
+}
+
+// Order is the anchor's: a result joins a row, it never moves one.
+{
+  const rows = mergeToolRows([
+    entry(1, "tool", { title: "a", meta: { call_id: "c1" } }),
+    entry(2, "tool", { title: "b", meta: { call_id: "c2" } }),
+    entry(3, "tool_result", { title: "b", meta: { call_id: "c2" } }),
+    entry(4, "tool_result", { title: "a", meta: { call_id: "c1" } }),
+  ]);
+  eq("interleaved results do not reorder their calls", rows.map((r) => r.entry.seq), [1, 2]);
+  eq("each still finds its own result", rows.map((r) => r.result?.seq), [4, 3]);
+}
 
 // -- the errors-only filter ------------------------------------------------
 

--- a/crates/stella-cli/src/export/transcript/tests.rs
+++ b/crates/stella-cli/src/export/transcript/tests.rs
@@ -184,6 +184,19 @@ fn a_tool_result_is_named_by_its_call_and_takes_its_verdict_from_the_tag() {
         "named from its call:\n{}",
         out.body
     );
+    // And named ONCE. `rendered == 1` counts rows; this counts headers, which
+    // is what a reader actually sees — a result patched into its call's row but
+    // carrying a second `<b>bash</b>` would satisfy the row count and still
+    // print the tool's name twice per call all the way down the document. That
+    // is the defect the arena's transcript shipped
+    // (`arenabench/ui/lib/transcript-view.ts::mergeToolRows`), and the reason to
+    // pin the property here rather than trust the row count to imply it.
+    assert_eq!(
+        count(&out.body, "<b>bash</b>"),
+        1,
+        "the tool is named once per call:\n{}",
+        out.body
+    );
     assert!(
         out.body.contains("git status"),
         "arguments come from ToolCall::input:\n{}",

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -213,10 +213,7 @@ fn acceptance_tool_is_named_exactly_once_per_call() {
     );
 
     let plain = grid::to_plain(&grid::render(&run, &state, 120));
-    let header_rows = plain
-        .lines()
-        .filter(|line| line.contains("ls -la"))
-        .count();
+    let header_rows = plain.lines().filter(|line| line.contains("ls -la")).count();
     assert_eq!(header_rows, 1, "tool header rendered twice:\n{plain}");
 }
 

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -179,6 +179,47 @@ fn acceptance_command_appears_exactly_once_per_call() {
     );
 }
 
+/// A tool is NAMED exactly once per call, in either renderer.
+///
+/// The sibling of the command check above, and the half that was never pinned.
+/// A journal carries a call and its result as two events, and a surface that
+/// renders them as two rows prints the tool's name on both — so a reader
+/// scrolling a run sees `bash … bash … bash …`, twice per call, with the second
+/// one naming nothing the first did not. That is exactly what the arena's
+/// transcript did until `mergeToolRows`, and the reason it could not happen
+/// *here* is structural: a [`Call`] owns its [`Output`], so there is one header
+/// and no second place for the name to live.
+///
+/// Pinned anyway, because "structurally impossible" is a claim about today's
+/// shape: a later result row added to either renderer would reintroduce it
+/// silently, and the Observatory renders through this crate.
+#[test]
+fn acceptance_tool_is_named_exactly_once_per_call() {
+    // A body that repeats the tool's own name, so a renderer echoing the result
+    // under its own header cannot pass by accident.
+    let call = bash("ls -la", &["bash: command output", "a.txt"], Status::Ok);
+    let run = run_with(vec![step(call, 0)]);
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+
+    // The name as a *header* — `>bash<` in the markup's tool span, and the
+    // padded verb column in the grid — rather than the bare substring, which
+    // the output line above deliberately also contains.
+    let markup = html::render_run(&run, &state);
+    assert_eq!(
+        markup.matches("class=\"tool bash\">bash</span>").count(),
+        1,
+        "tool named more than once:\n{markup}"
+    );
+
+    let plain = grid::to_plain(&grid::render(&run, &state, 120));
+    let header_rows = plain
+        .lines()
+        .filter(|line| line.contains("ls -la"))
+        .count();
+    assert_eq!(header_rows, 1, "tool header rendered twice:\n{plain}");
+}
+
 /// Toggling any fold shifts zero columns: the gutters to the left of a step's
 /// tool name are byte-identical open and closed.
 #[test]


### PR DESCRIPTION
## The defect

The arena transcript rendered `tool` and `tool_result` as two rows, so every
call printed the tool's name **twice** down the whole transcript — `bash` at
19:43 for the call, `bash` again at 19:49 for its result, for one exchange.

That is the *journal's* shape, not the transcript's. `crates/stella-transcript`
exists to end exactly this defect, and its module doc names it: "a tool call and
its result were siblings in that stream, so every surface printed the tool's
name twice and the command up to three times. Here a `Call` owns its `Output` —
there is no way to render one without the other, and no second place for the
invocation string to live."

The arena page had this written down as a *deliberate departure*: the result row
carried the name because the kind filters can hide every call row and leave a
column of results naming nothing. That reason is real, but it justifies the
**orphan** case only — not printing the name beside its own call.

## The fix

`mergeToolRows` (`arenabench/ui/lib/transcript-view.ts`) recovers the shared
model's shape over the wire's flat stream. It pairs strictly **within the list
it is given**, so it composes with the page's filters rather than fighting them,
and the three cases stay honest:

| case | rendering |
|---|---|
| call + result | **one row**, tool named once, output nested under it |
| call, no result anywhere | one row, `running…` |
| result whose call is not on screen | stands alone and **keeps** its name |

The row's primary fold is now the OUTPUT, with `args` as a sub-fold of the call
— the same two folds the shared model gives a `Call`. One record for both would
make opening a call's arguments also open its output, and neither control could
then say what it does.

`running…` is decided from the **whole** transcript, not from the absence of a
result in the filtered view: a reader who switched the results group off has not
made every call on screen start running.

## Observatory and session export

Both already rendered one row per call, and I verified that rather than assuming
it:

- **Observatory** builds `stella_transcript::Call` (which owns its `Output`) in
  `crates/stella-observatory/src/transcript_view.rs`, and the shared HTML
  renderer emits one tool header per step.
- **Session export** patches the result into the call's row
  (`close_tool` in `crates/stella-cli/src/export/transcript.rs`), replacing the
  pending placeholder; its existing test already asserted `rendered == 1`.

So there was no rendering change to make in either. Both are now **pinned**:

- `acceptance_tool_is_named_exactly_once_per_call` (`stella-transcript`) covers
  both shared renderers, the sibling of the existing command-once check and the
  half that was never pinned.
- The export's one-row test additionally **counts headers** — a result patched
  into a row but carrying a second `<b>bash</b>` satisfies a row count and still
  prints the name twice per call.

These two are regression guards, not witnesses of a change: they pass on `main`.

## Witness

`node arenabench/ui/scripts/check-transcript-view.mjs` — the six `one row per
call` checks import `mergeToolRows`, which does not exist on `main`, so the
harness is **red there and green here** (48 checks pass).

## Checks run

- `node scripts/check-transcript-view.mjs` — 48 pass
- `node scripts/check-diff-view-parity.mjs` — 246 cases
- `node scripts/check-word-highlight-parity.mjs` — 64 rows
- `npx tsc --noEmit` — clean
- `cargo test -p stella-transcript -p stella-observatory` — all pass
- `cargo test -p stella-cli --bin stella export::transcript` — 20 pass
- `cargo clippy -p stella-transcript --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `make guards-fast` — all green

**Deferred, and saying so out loud:** the compiling gate tiers (`make gate`'s
workspace clippy, rustdoc and full test run) were **not** run — a live
benchmark match (`19f239f62acb`, GLM-5.2 vs Kimi-K3 over 10 Terminal-Bench 2.1
tasks) is executing on this machine under harbor/docker, and a workspace build
would compete with it for CPU and perturb the timings it exists to measure. The
Rust half of this PR is two test-file additions, both compiled and run above.
CI is the backstop.

## Notes

`arenabench/web/` is a separate control-plane app, not a mirror of `ui/` — no
hand-edit was needed there. No test was deleted.

## Summary by Sourcery

Render each visible tool call and result as one transcript row, keeping tool names only on paired calls while retaining names for orphaned results.

New Features:
- Render paired tool calls and results as a single transcript row while preserving standalone orphan results.

Bug Fixes:
- Prevent tool names and invocation details from being duplicated when displaying completed tool exchanges.
- Distinguish calls that are genuinely still running from calls whose results are hidden by filtering.

Enhancements:
- Separate output and argument expansion controls and consolidate result rendering across paired and orphan rows.
- Preserve transcript ordering and filter-aware pairing while maintaining result previews, diffs, metadata, errors, and failure indicators.

Tests:
- Add transcript-view checks covering paired, pending, orphan, filtered, and interleaved tool rows.
- Add regression coverage ensuring shared renderers and session export name each tool exactly once.