### PR TITLE
stella-autonomy: Citation::render has no doctest, so the four citation shapes are undocumented at the API (#4008)

### DIFF
--- a/crates/stella-autonomy/src/closure.rs
+++ b/crates/stella-autonomy/src/closure.rs
@@ -108,6 +108,25 @@ impl Citation {
     }
 
     /// How the citation reads in a comment.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stella_autonomy::Citation;
+    /// let pr = Citation::PullRequest { key: "3985".into() };
+    /// assert_eq!(pr.render(), "#3985");
+    ///
+    /// // A key already carrying its `#` renders the same — the leading
+    /// // `#` is stripped so it is never doubled.
+    /// let same = Citation::PullRequest { key: "#3985".into() };
+    /// assert_eq!(same.render(), "#3985");
+    ///
+    /// let commit = Citation::Commit { sha: "f8935f2".into() };
+    /// assert_eq!(commit.render(), "commit f8935f2");
+    ///
+    /// let record = Citation::ContextRecord { lineage_id: "lin-42".into() };
+    /// assert_eq!(record.render(), "context record `lin-42`");
+    /// ```
     #[must_use]
     pub fn render(&self) -> String {
         match self {


### PR DESCRIPTION
Autonomous fix for #4008.

Closes #4008

---
created by stella*

## Summary by Sourcery

Document citation rendering behavior with executable API examples.

Enhancements:
- Document the four citation rendering shapes with an API doctest covering pull requests, commits, and context records.

Documentation:
- Add executable examples to the `Citation::render` API documentation, including handling of keys that already contain a leading `#`.