### PR TITLE
fix: unblock main — public docs cannot link private items, and one file is unformatted

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/configure/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/configure/tests.rs
@@ -254,7 +254,10 @@ fn a_journal_naming_a_foreign_destination_writes_nothing_there() {
     // Removal re-derives the destination as the tier's own `stella.toml`, sees
     // the journal names something else, and refuses the whole replay.
     let reverted = revert(&plugin_dir, &manifest, Some(&config));
-    assert!(reverted.keys.is_empty(), "nothing was put back: {reverted:?}");
+    assert!(
+        reverted.keys.is_empty(),
+        "nothing was put back: {reverted:?}"
+    );
     assert_eq!(
         reverted.unaccounted,
         ["self_driving.attribution.commit"],

--- a/crates/stella-store/src/tool_calls.rs
+++ b/crates/stella-store/src/tool_calls.rs
@@ -679,8 +679,9 @@ impl Store {
     /// Rows are emitted in call order; a `tool_start` with no matching result
     /// (turn cut off mid-tool) is recorded as an abandoned, failed call so the
     /// count stays honest. Idempotent, and identical to what the live fold
-    /// wrote — both go through [`refold_tool_calls`]'s rule, keyed on the
-    /// announcing event's `seq`. Returns the count.
+    /// wrote — both go through `refold_tool_calls`'s rule, keyed on the
+    /// announcing event's `seq`. Returns the count. (Named, not linked: that
+    /// function is `pub(crate)`, and this doc is public.)
     pub fn materialize_tool_calls(&self, execution_id: i64) -> Result<usize> {
         let mut conn = self.lock();
         let tx = conn.transaction()?;

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -224,6 +224,7 @@ impl ReadLedger {
         if state.sha256 != sha256 {
             state.reads_since_change = 0;
         }
+
         state.reads_since_change += 1;
         state.sha256 = sha256;
         // Coverage is not known until the payload has been rendered, so it is
@@ -1080,9 +1081,22 @@ mod tests {
         let tool = ReadFile::default();
         let ctx = cx(dir.path());
         for pass in 0..40 {
-            std::fs::write(&path, format!("fn main() {{}} // pass {pass}\n")).unwrap();
+            // A file long enough that the read below is a *window*, and a
+            // window on purpose: a whole-file read is exempt from the ceiling
+            // (it returns identical bytes, so the loop verdicts already catch a
+            // spiral of them), which would make this test pass even with the
+            // reset deleted. The reset is the whole safety argument for the
+            // ceiling, so it has to be exercised by a read the ceiling can
+            // actually refuse.
+            let body: String = (0..200)
+                .map(|line| format!("fn f{line}() {{}} // pass {pass}\n"))
+                .collect();
+            std::fs::write(&path, body).unwrap();
             let out = tool
-                .execute(&serde_json::json!({"path": "a.rs"}), &ctx)
+                .execute(
+                    &serde_json::json!({"path": "a.rs", "offset": 1, "limit": 40}),
+                    &ctx,
+                )
                 .await;
             assert!(
                 matches!(out, ToolOutput::Ok { .. }),

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -202,7 +202,9 @@ pub struct ReadLedger {
 /// Two counts, not one, because they answer different questions: `reads` is
 /// the model-facing "you have looked at this file before" nudge that rides the
 /// footer, while `since_change` is the only one a *ceiling* may be measured
-/// against — see [`ReadState::reads_since_change`].
+/// against: it resets whenever the file's content changes, so a read → edit →
+/// read cycle can never accumulate against a ceiling. (`ReadState` holds it and
+/// is private, so this names it rather than linking to it.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReadTally {
     /// Reads of this path this session, under any spelling.


### PR DESCRIPTION
`main` is red on two of the three `fmt + clippy + test` steps. This fixes both. One of them is mine.

## 1. `cargo doc -D warnings` — mine, from #4041

```
error: public documentation for `materialize_tool_calls` links to private item `refold_tool_calls`
  --> crates/stella-store/src/tool_calls.rs:682:35
error: public documentation for `ReadTally` links to private item `ReadState::reads_since_change`
  --> crates/stella-tools/src/read.rs:205:21
```

rustdoc refuses a **public** item's intra-doc link to a private one. `refold_tool_calls` is `pub(crate)` and `ReadState` is private, so both links were hard errors. Both docs now *name* what they cannot link to and say why, which is the existing idiom in that module (`the_footer_a_read_writes_is_the_one_loop_comparison_strips` is named-not-linked for the same reason, being `#[cfg(test)]`).

I wrote this fix while #4041 was still open, but the PR merged at a head that did not carry it — so the error reached `main`. Apologies for the round-trip.

## 2. `cargo fmt --check` — from #4012

`crates/stella-cli/src/plugin_cmd/configure/tests.rs:254` has an `assert!` rustfmt wants wrapped. Verified against `origin/main` directly (`git show origin/main:… | rustfmt --check`), so it is on `main` rather than an artifact of this branch.

## 3. Still red after this: `file-size` (#4044)

`crates/stella-cli/src/self_driving_cmd.rs` is **1501 lines**, one over the limit and not grandfathered. Deliberately **not** fixed here: it needs a real split into a submodule, and AGENTS.md is explicit that an unrelated ratchet repair should land on its own from a fresh `main` rather than be folded into another PR. #4044 tracks it.

So this PR takes `main` from three red steps to one.

## Also included

`editing_the_file_resets_the_read_ceiling` now pages a 200-line file in 40-line windows instead of reading it whole.

This matters rather than being tidying: #4041's review fix exempted whole-file reads from the unchanged-read ceiling (correctly — a whole-file read returns identical bytes, so `ExactRepeat`/`Stagnant` already catch a spiral of them). But that exemption made this test **vacuous**: it read whole-file, so it passed even with the content-change reset deleted — and that reset is the entire reason the ceiling cannot fire on an ordinary read → edit → read cycle. A windowed read is one the ceiling can actually refuse.

Verified load-bearing the artisanal way: deleting the reset makes it fail at pass 24 with the refusal text, and restoring it makes it pass.

## Verification

`cargo fmt --all --check` clean; `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-store -p stella-tools --no-deps --document-private-items` clean; `cargo test -p stella-tools --lib read::tests` green (22).

No tests deleted or renamed.

## Summary by Sourcery

Restore clean documentation and formatting checks while making the read-ceiling regression test cover content-change resets.

Bug Fixes:
- Fix public rustdoc links to private items so documentation builds cleanly with warnings treated as errors.
- Exercise read-ceiling resets with windowed reads after file content changes.

Enhancements:
- Keep read-state documentation accurate while preserving the distinction between public and private implementation details.

Build:
- Format the previously unformatted assertion so the repository passes the formatting check.

Tests:
- Strengthen the read reset test to use a sufficiently large file and partial read windows.