### PR TITLE
fix(stella-cli): an advisory check is not a red build, and a merged pull request is done

### DIFF
--- a/crates/stella-autonomy/src/attribution.rs
+++ b/crates/stella-autonomy/src/attribution.rs
@@ -62,6 +62,13 @@ const SEPARATOR: &str = "\n\n---\n";
 /// it owned them.
 pub const DEFAULT_BRANCH_PREFIX: &str = "stella/";
 
+/// What a pull request the loop opens is titled with, unless configured.
+///
+/// Names the *thing that did it* rather than the crate it touched. A
+/// maintainer scanning a pull request list wants to know which entries nobody
+/// wrote by hand; which crate a change lands in is already in the diff.
+pub const DEFAULT_TITLE_PREFIX: &str = "stella self-driving:";
+
 /// What the loop appends to each thing it writes, and how it names branches.
 ///
 /// Source-tracked so it travels with the repository, and rewritable by an
@@ -84,6 +91,18 @@ pub struct Attribution {
     /// corrected: some teams namespace with `-`, and silently rewriting an
     /// operator's choice is worse than honouring an unusual one.
     pub branch_prefix: String,
+    /// Prefix for the title of every pull request it opens.
+    ///
+    /// The footer says who wrote a pull request once you open it; this says so
+    /// in the list, which is where a maintainer actually triages. Without it an
+    /// autonomous pull request inherits its issue's title verbatim and is
+    /// indistinguishable from a human's at a glance.
+    ///
+    /// Deliberately **not** applied to commit messages. Those follow
+    /// Conventional Commits (`fix(stella-cli): …`), the scope is load-bearing,
+    /// and a prefix in front of it would break the convention the repository
+    /// enforces. The commit identifies its author through the footer instead.
+    pub title_prefix: String,
 }
 
 impl Default for Attribution {
@@ -94,11 +113,30 @@ impl Default for Attribution {
             issue: SIGNATURE.to_owned(),
             issue_comment: SIGNATURE.to_owned(),
             branch_prefix: DEFAULT_BRANCH_PREFIX.to_owned(),
+            title_prefix: DEFAULT_TITLE_PREFIX.to_owned(),
         }
     }
 }
 
 impl Attribution {
+    /// Put the title prefix in front of a summary.
+    ///
+    /// An empty prefix is honoured as "no prefix" here, unlike
+    /// [`Self::branch_prefix`] — an unprefixed title is merely
+    /// indistinguishable, while an unprefixed branch collides with a human's
+    /// refs. One is cosmetic and one is operational.
+    ///
+    /// Already-prefixed titles are left alone, so re-opening a pull request
+    /// for the same issue cannot stack the prefix twice.
+    #[must_use]
+    pub fn title(&self, summary: &str) -> String {
+        let prefix = self.title_prefix.trim();
+        if prefix.is_empty() || summary.starts_with(prefix) {
+            return summary.to_owned();
+        }
+        format!("{prefix} {summary}")
+    }
+
     /// The branch prefix, falling back to the default when unset.
     ///
     /// An empty prefix is treated as unset rather than as "no prefix": an
@@ -168,6 +206,49 @@ pub fn sign(body: &str, signature: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A pull request the loop opened says so in the list, not just inside it.
+    ///
+    /// The footer identifies an autonomous pull request once it is open; the
+    /// title is what a maintainer reads while triaging twenty of them. Before
+    /// this, the title was the issue's verbatim — `stella-autonomy: sign() has
+    /// no doctest …` — indistinguishable from something a person wrote.
+    #[test]
+    fn a_title_says_what_opened_the_pull_request() {
+        let attribution = Attribution::default();
+        assert_eq!(
+            attribution.title("stella-autonomy: sign() has no doctest (#4006)"),
+            "stella self-driving: stella-autonomy: sign() has no doctest (#4006)"
+        );
+    }
+
+    /// Re-opening for the same issue cannot stack the prefix.
+    #[test]
+    fn an_already_prefixed_title_is_left_alone() {
+        let attribution = Attribution::default();
+        let once = attribution.title("fix the thing");
+        assert_eq!(attribution.title(&once), once);
+    }
+
+    /// The prefix is the operator's, and an empty one means none.
+    ///
+    /// Unlike `branch_prefix`, where empty falls back to the default: an
+    /// unprefixed title is merely indistinguishable, while an unprefixed
+    /// branch collides with a human's refs. Cosmetic versus operational.
+    #[test]
+    fn an_empty_title_prefix_is_honoured_as_no_prefix() {
+        let attribution = Attribution {
+            title_prefix: String::new(),
+            ..Attribution::default()
+        };
+        assert_eq!(attribution.title("fix the thing"), "fix the thing");
+
+        let oxagen = Attribution {
+            title_prefix: "oxagen:".to_owned(),
+            ..Attribution::default()
+        };
+        assert_eq!(oxagen.title("fix the thing"), "oxagen: fix the thing");
+    }
 
     /// **The witness.** A blank line, a rule, then the text — whatever the body
     /// ended with, so the four surfaces cannot drift into four near-identical

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -54,7 +54,7 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-pub use attribution::{Attribution, DEFAULT_BRANCH_PREFIX, SIGNATURE, sign};
+pub use attribution::{Attribution, DEFAULT_BRANCH_PREFIX, DEFAULT_TITLE_PREFIX, SIGNATURE, sign};
 pub use closure::{
     Citation, Closure, ClosureRefusal, check as check_closure, receipt, resolution_of,
 };

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -1187,7 +1187,7 @@ fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
         }
 
         DeliverCmd::Observe { pr, format } => {
-            let obs = deliver::observe(pr)?;
+            let obs = deliver::observe(pr)?.observation;
             if *format == QueryFormat::Json {
                 println!(
                     "{}",
@@ -1254,7 +1254,7 @@ fn decide(
     rebases: u32,
     no_review: bool,
 ) -> Result<stella_autonomy::Transition, String> {
-    let obs = deliver::observe(pr)?;
+    let obs = deliver::observe(pr)?.observation;
     let policy = stella_autonomy::DeliverPolicy {
         require_approval: !no_review,
         ..stella_autonomy::DeliverPolicy::default()

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -237,6 +237,14 @@ pub(super) struct PrView {
     /// branch it actually merges into rather than an assumed `main`.
     #[serde(default, rename = "baseRefName")]
     pub base_ref_name: String,
+    /// `OPEN`, `MERGED`, `CLOSED`.
+    ///
+    /// Read because a pull request that has already reached its destination
+    /// needs no further transition, and the observation the pure machine
+    /// decides over cannot express that: a merged pull request reports
+    /// `mergeable: UNKNOWN`, which is `Wait` — forever.
+    #[serde(default)]
+    pub state: String,
 }
 
 /// Assemble the observation the pure machine decides over.
@@ -590,15 +598,31 @@ pub(super) fn open(
         .ok_or_else(|| format!("`gh pr create` printed no pull request number: {url:?}"))
 }
 
+/// What one read of the forge said about a pull request.
+///
+/// `settled` is carried beside the observation rather than inside it because
+/// it is not something the pure machine decides over — it is the question of
+/// whether there is anything left to decide. A merged pull request reports
+/// `mergeable: UNKNOWN`, which the machine correctly reads as `Wait`; without
+/// this flag the loop waits on it for the rest of the run. It did, on #4022,
+/// after merging it successfully.
+#[derive(Debug, Clone)]
+pub(super) struct Reading {
+    /// What the pure machine decides over.
+    pub observation: Observation,
+    /// Whether the pull request has already reached a terminal state.
+    pub settled: bool,
+}
+
 /// One read of the forge, plus the second read of the base its
 /// [`Observation::base_ci`] needs.
-pub(super) fn observe(pr: &str) -> Result<Observation, String> {
+pub(super) fn observe(pr: &str) -> Result<Reading, String> {
     let raw = gh(&[
         "pr",
         "view",
         pr,
         "--json",
-        "isDraft,mergeable,reviewDecision,statusCheckRollup,baseRefName",
+        "isDraft,mergeable,reviewDecision,statusCheckRollup,baseRefName,state",
     ])?;
     let view: PrView = serde_json::from_str(&raw).map_err(|error| {
         format!("`gh pr view` returned a payload this build cannot read: {error}")
@@ -615,7 +639,15 @@ pub(super) fn observe(pr: &str) -> Result<Observation, String> {
     let mut view = view;
     view.status_check_rollup = only_required(view.status_check_rollup, &required);
 
-    Ok(observation_from(&view, &base_checks))
+    let settled = matches!(
+        view.state.to_ascii_uppercase().as_str(),
+        "MERGED" | "CLOSED"
+    );
+
+    Ok(Reading {
+        observation: observation_from(&view, &base_checks),
+        settled,
+    })
 }
 
 /// Every open pull request on a branch with this workspace's prefix.
@@ -667,7 +699,26 @@ pub(super) fn mark_ready(pr: &str) -> Result<(), String> {
 /// [`stella_autonomy::Action::Merge`]; the caller enforces that, and the
 /// machine emits it from exactly one state.
 pub(super) fn merge(pr: &str) -> Result<(), String> {
-    gh(&["pr", "merge", pr, "--squash", "--delete-branch"]).map(|_| ())
+    // No `--delete-branch`. It deletes the *local* branch too, and this loop
+    // works inside git worktrees that hold exactly those branches — so the
+    // delete fails, `gh` exits non-zero, and a merge that already succeeded is
+    // reported as a failure. That is what it did: #4022 merged at 00:32:54 and
+    // the loop went on re-observing a merged pull request because the branch
+    // cleanup after it had failed.
+    //
+    // Cleanup is a separate concern from delivery, and the forge's own
+    // "automatically delete head branches" setting does it without a local
+    // side effect. Losing a branch is recoverable; losing the record of a
+    // merge strands the pull request forever.
+    let outcome = gh(&["pr", "merge", pr, "--squash"]).map(|_| ());
+
+    // A pull request that is already merged is the state this asked for, so it
+    // is a success. Racing a human who merged it by hand, or re-observing
+    // after a partial failure, must not read as an error.
+    match outcome {
+        Err(error) if error.to_ascii_lowercase().contains("already merged") => Ok(()),
+        other => other,
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -374,6 +374,67 @@ fn run_id_from_link(link: &str) -> Option<String> {
     }
 }
 
+/// The checks this repository actually requires to merge into `branch`.
+///
+/// # Why "CI is red" cannot mean "any check is red"
+///
+/// A repository's rollup contains checks it requires and checks it merely
+/// runs. This one carries a Vercel commit status that has been failing on
+/// every pull request for as long as the account has been blocked — it is
+/// advisory, the forge merges past it, and a human ignores it. A loop that
+/// treats it as blocking never merges anything again, and cannot be argued
+/// out of it: the failure is real, it is red, and it will never go green.
+///
+/// GitHub agrees, and says so in its own vocabulary: #4022 reported
+/// `mergeStateStatus: UNSTABLE, mergeable: MERGEABLE` — advisory checks
+/// failing, merge permitted. Reading branch protection is how the loop learns
+/// the same thing without hardcoding which service to ignore.
+///
+/// An unreadable protection document (no permission, no protection
+/// configured) yields an empty list, and an empty list means **no filtering**:
+/// every check counts, which is what the loop did before it could ask. That is
+/// the conservative direction — it can refuse to merge something mergeable,
+/// but it can never merge something the repository would have blocked.
+fn required_contexts(branch: &str) -> Vec<String> {
+    let out = std::process::Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{{owner}}/{{repo}}/branches/{branch}/protection"),
+            "--jq",
+            ".required_status_checks.contexts[]?",
+        ])
+        .env("NO_COLOR", "1")
+        .output();
+    let Ok(out) = out else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Keep only the checks that can block a merge.
+///
+/// An empty `required` list leaves the rollup untouched — see
+/// [`required_contexts`] for why that is the safe reading rather than "nothing
+/// is required".
+#[must_use]
+fn only_required(checks: Vec<Check>, required: &[String]) -> Vec<Check> {
+    if required.is_empty() {
+        return checks;
+    }
+    checks
+        .into_iter()
+        .filter(|check| required.iter().any(|name| name == check.name()))
+        .collect()
+}
+
 /// The forge endpoint carrying a ref's check runs.
 ///
 /// Split out so the one thing that can be wrong here — *which commit gets
@@ -546,7 +607,13 @@ pub(super) fn observe(pr: &str) -> Result<Observation, String> {
     // The forge's own name for the base, passed through untouched. Prefixing
     // it with `origin/` would name a remote-tracking ref this process no
     // longer resolves — see `checks_for_branch`.
-    let base_checks = checks_for_branch(&view.base_ref_name);
+    let required = required_contexts(&view.base_ref_name);
+    let base_checks = only_required(checks_for_branch(&view.base_ref_name), &required);
+
+    // Both sides filtered by the same list, so the base can still excuse a
+    // required check — and an advisory one can no longer condemn.
+    let mut view = view;
+    view.status_check_rollup = only_required(view.status_check_rollup, &required);
 
     Ok(observation_from(&view, &base_checks))
 }
@@ -626,6 +693,78 @@ mod tests {
         assert!(
             !endpoint.contains("origin/"),
             "a remote-tracking ref resolves against the last fetch, not the forge: {endpoint}"
+        );
+    }
+
+    /// An advisory check that fails forever must not block forever.
+    ///
+    /// **The witness for the rule that "CI is red" means the *required*
+    /// checks are red.** This repository runs a Vercel commit status that has
+    /// failed on every pull request for as long as the account has been
+    /// blocked. It is not a required context, the forge merges past it
+    /// (#4022 reported `UNSTABLE / MERGEABLE`), and a human ignores it.
+    ///
+    /// Counting it made the loop escalate two pull requests whose every
+    /// required check was green — and no amount of waiting could have helped,
+    /// because that failure is never going to clear.
+    #[test]
+    fn an_advisory_check_does_not_block_a_merge() {
+        let required = vec!["fmt + clippy + test".to_owned()];
+        let rollup = vec![
+            check("fmt + clippy + test", "SUCCESS"),
+            Check {
+                context: "Vercel".into(),
+                state: "FAILURE".into(),
+                ..Check::default()
+            },
+        ];
+
+        assert_eq!(
+            ci_from(&rollup),
+            CiConclusion::Red,
+            "unfiltered, the advisory failure condemns the pull request"
+        );
+        assert_eq!(
+            ci_from(&only_required(rollup, &required)),
+            CiConclusion::Green,
+            "filtered to what the repository requires, it is green"
+        );
+    }
+
+    /// A repository with no declared requirements keeps every check.
+    ///
+    /// The conservative direction: unable to read protection, the loop can
+    /// still refuse to merge something mergeable, but can never merge
+    /// something the repository would have blocked.
+    #[test]
+    fn no_declared_requirements_filters_nothing() {
+        let rollup = vec![check("a", "FAILURE"), check("b", "SUCCESS")];
+        assert_eq!(only_required(rollup, &[]).len(), 2);
+    }
+
+    /// Filtering applies to the base too, so it can still excuse a required
+    /// check that is broken on both sides.
+    #[test]
+    fn the_base_is_filtered_by_the_same_list() {
+        let required = vec!["fmt + clippy + test".to_owned()];
+        let pr = only_required(
+            vec![
+                check("fmt + clippy + test", "FAILURE"),
+                check("noise", "FAILURE"),
+            ],
+            &required,
+        );
+        let base = only_required(
+            vec![
+                check("fmt + clippy + test", "FAILURE"),
+                check("other noise", "SUCCESS"),
+            ],
+            &required,
+        );
+        assert_eq!(
+            base_conclusion(&pr, &base),
+            CiConclusion::Red,
+            "the required check is broken on the base, so this is not ours"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -629,7 +629,20 @@ fn advance(
     durable: &Durable,
 ) -> Result<bool, String> {
     let entry = spent.entry(pr.to_owned()).or_default();
-    let obs = super::deliver::observe(pr)?;
+    let reading = super::deliver::observe(pr)?;
+    if reading.settled {
+        // Nothing left to decide. Reached either because the merge below
+        // succeeded and the cleanup after it did not, or because a human got
+        // there first — both are this pull request being done.
+        audit::record(
+            durable,
+            Audit::PrMerged,
+            Some(pr),
+            "already settled on the forge — carrying it no further",
+        );
+        return Ok(true);
+    }
+    let obs = reading.observation;
     let policy = DeliverPolicy {
         require_approval: !no_review,
         ..DeliverPolicy::default()

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -299,7 +299,9 @@ pub(super) fn drive(
                         );
                         durable.update_stats(|s| s.issues_changed += 1);
 
-                        let title = format!("{} (#{})", resolved.title, issue.0);
+                        let title = cfg
+                            .attribution
+                            .title(&format!("{} (#{})", resolved.title, issue.0));
                         let pr = match super::deliver::open(
                             &root,
                             &branch,

--- a/crates/stella-cli/src/self_driving_cmd/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/triage.rs
@@ -111,13 +111,58 @@ pub(super) fn prompt(issue: &Unassessed, body: &str, policy: &TriagePolicy) -> S
     )
 }
 
+/// Everything a turn said, whatever envelope it arrived in.
+///
+/// `work::run_turn` spawns `stella run --output-format json`, so the answer
+/// arrives **inside a JSON document** with its newlines escaped — no line of
+/// that text ever begins with `ASSESSMENT:`. Scanning it line by line found
+/// nothing, every assessment read as a refusal, and the first four issues the
+/// loop triaged were escalated to a human with the turn's actual answer sitting
+/// in the string it had just been handed.
+///
+/// Every string value is collected rather than one named field, because which
+/// field carries the answer is `stella run`'s business and a name copied here
+/// is a second definition waiting to drift. Non-JSON output is returned
+/// unchanged, so a plain-text turn still works.
+#[must_use]
+fn answer_text(output: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(output) else {
+        return output.to_owned();
+    };
+    let mut collected = String::new();
+    collect_strings(&value, &mut collected);
+    collected
+}
+
+/// Append every string in a JSON document, one per line.
+fn collect_strings(value: &serde_json::Value, out: &mut String) {
+    match value {
+        serde_json::Value::String(text) => {
+            out.push_str(text);
+            out.push('\n');
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_strings(item, out);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            for item in fields.values() {
+                collect_strings(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Read a turn's answer, accepting only the declared vocabulary.
 ///
 /// The last `ASSESSMENT:` line wins, so a turn that thinks out loud and then
 /// commits does not trip over its own reasoning.
 #[must_use]
 pub(super) fn parse(output: &str, policy: &TriagePolicy) -> Option<Assessment> {
-    let line = output
+    let text = answer_text(output);
+    let line = text
         .lines()
         .rev()
         .find_map(|line| line.trim().strip_prefix(MARKER))?
@@ -218,6 +263,48 @@ mod tests {
             Some(Assessment::Place {
                 kind: "bug".into(),
                 priority: "P0".into()
+            })
+        );
+    }
+
+    /// The answer survives the JSON envelope it arrives in.
+    ///
+    /// **The witness for a feature that was decorative without it.**
+    /// `run_turn` spawns `stella run --output-format json`, so the turn's text
+    /// arrives inside a JSON string with its newlines escaped. Scanning that
+    /// document line by line finds no `ASSESSMENT:` line, every answer reads
+    /// as a refusal, and the loop escalates issues it had in fact placed — it
+    /// did exactly that to the first four it triaged.
+    #[test]
+    fn an_answer_inside_the_json_envelope_is_still_an_answer() {
+        let envelope = serde_json::json!({
+            "status": "ok",
+            "result": "Looking at the context records, this blocks a release.\nASSESSMENT: kind=bug; priority=P0",
+        })
+        .to_string();
+
+        assert!(
+            !envelope
+                .lines()
+                .any(|l| l.trim().starts_with("ASSESSMENT:")),
+            "the envelope must genuinely hide the marker, or this proves nothing"
+        );
+        assert_eq!(
+            parse(&envelope, &policy()),
+            Some(Assessment::Place {
+                kind: "bug".into(),
+                priority: "P0".into()
+            })
+        );
+    }
+
+    /// Plain text still works, so the envelope handling is additive.
+    #[test]
+    fn a_plain_text_answer_still_parses() {
+        assert_eq!(
+            parse("ASSESSMENT: exclude=documentation", &policy()),
+            Some(Assessment::Exclude {
+                kind: "documentation".into()
             })
         );
     }


### PR DESCRIPTION
Three fixes found by running the loop against this repository, not by reading it. Each one stopped a pull request that was already finished from being recognised as finished.

## 1. Only a required check can block a merge

A repository's rollup mixes checks it *requires* with checks it merely *runs*. The loop counted both.

This repository carries a Vercel commit status that has failed on every pull request for as long as the account has been blocked. It is advisory, the forge merges past it, and a human ignores it — but the loop read it as a red build. That is unrecoverable rather than merely wrong: the failure is real, it is red, and it is never going to clear, so no amount of waiting or re-running helps.

**Both pull requests the loop opened were escalated to a human with every required check green, and both stayed stuck in draft** — `MarkReady` is downstream of the same green read.

GitHub already publishes the answer. #4022 reported `mergeStateStatus: UNSTABLE, mergeable: MERGEABLE` — advisory checks failing, merge permitted. `required_contexts` reads the same fact out of branch protection, so the loop learns which checks matter *here* rather than hardcoding which service to ignore.

Both sides are filtered by the same list, so the base can still excuse a required check broken on both. An unreadable protection document filters nothing — the loop can then refuse a merge the repository would have allowed, but can never allow one it would have blocked.

## 2. A merged pull request is done, and the cleanup after it is not the merge

`gh pr merge --delete-branch` deletes the **local** branch as well as the remote one, and this loop works inside git worktrees that hold exactly those branches. The delete fails, `gh` exits non-zero, and a merge that already succeeded is reported as a failure.

That is not hypothetical: **#4022 merged at 00:32:54 and the loop went on re-observing it**, because the branch cleanup afterwards had failed.

Cleanup is a separate concern from delivery, and the forge's own "automatically delete head branches" setting does it with no local side effect. Losing a branch is recoverable; losing the record of a merge strands the pull request forever.

A second bug outlived the first. A merged pull request reports `mergeable: UNKNOWN`, which the pure machine correctly reads as `Wait` — it has no way to say "there is nothing left to decide", because that is not a transition, it is the absence of one. `Reading` now carries `settled` beside the observation, read from the same `gh pr view` call, so it costs no extra request.

## 3. An autonomous pull request is titled as one

The attribution footer says who opened a pull request once you are looking at it. The title is what a maintainer reads while triaging a list of twenty, and there the loop's pull requests were indistinguishable from a person's — #4014 read `stella-autonomy: sign() has no doctest …` with nothing to say no human wrote it.

`Attribution::title_prefix` defaults to `stella self-driving:` and is set in `stella.toml` beside the other four surfaces, so a downstream distribution renames the loop without touching this crate.

Deliberately **not** applied to commit messages: those follow Conventional Commits, the scope is load-bearing, and a prefix in front of `fix(stella-cli):` would break the convention the gate enforces. A commit identifies its author through the footer instead.

## Witnesses

| Test | Fails without the change because |
|---|---|
| `an_advisory_check_does_not_block_a_merge` | the unfiltered rollup is `Red` and the filtered one is `Green`, asserted side by side |
| `no_declared_requirements_filters_nothing` | an unreadable protection document must not silently unblock everything |
| `the_base_is_filtered_by_the_same_list` | otherwise the base could no longer excuse a required check broken on both sides |
| `a_title_says_what_opened_the_pull_request` | the title was the issue's verbatim |
| `an_already_prefixed_title_is_left_alone` | re-opening for one issue would stack the prefix |
| `an_empty_title_prefix_is_honoured_as_no_prefix` | empty must mean none here, unlike `branch_prefix` where it falls back |

## Evidence this works

Both pull requests the loop had escalated went `ci=Green → MarkReady → out of draft → Merge` on the next poll after these landed locally, with no human touching either:

```
[00:31:48] pr observed 4022 — ci=Green base=Green mergeable=Unknown review=None -> MarkReady
[00:31:50] pr observed 4022 — ci is green — taken out of draft
[00:32:52] pr observed 4022 — ci=Green base=Green mergeable=Clean review=None -> Merge
[00:41:00] pr observed 4014 — ci=Green base=Green mergeable=Clean review=None -> MarkReady
[00:42:07] pr merged 4014 — merged
```

#4022 and #4014 are both merged into `main`.

## What this does not claim

`required_contexts` shells out to `gh api` and that call is not unit-tested — the tested seam is `only_required`, the pure filter it feeds. The evidence that the whole path works is the run above.

`cargo test -p stella-cli` is green apart from `a_goal_run_dispatches_each_round_through_the_bound_wrapper`, which fails on unmodified `main` and is tracked as #3957.

Refs #3599

## Summary by Sourcery

Make autonomous pull request delivery recognize repository merge semantics, completed work, and its own triage output reliably.

New Features:
- Add configurable attribution prefixes to autonomously created pull request titles, with a default marker and support for downstream customization.

Bug Fixes:
- Prevent advisory checks from blocking merges by evaluating only repository-required checks.
- Treat merged or closed pull requests as complete and avoid reporting successful merges as failures due to local branch cleanup.
- Parse triage assessments embedded in JSON-formatted command output.

Enhancements:
- Apply required-check filtering consistently to pull request and base-branch status evaluations.
- Separate merge delivery from local branch cleanup and handle already-merged pull requests safely.

Tests:
- Add coverage for advisory-check filtering, conservative handling of missing requirements, base-branch filtering, JSON-wrapped triage responses, and pull request title attribution.