### PR TITLE
fix(stella-autonomy): unbreak main — the sign() doctest asserts the footer sign() writes

### DIFF
--- a/crates/stella-autonomy/src/attribution.rs
+++ b/crates/stella-autonomy/src/attribution.rs
@@ -127,15 +127,29 @@ impl Attribution {
 ///
 /// # Examples
 ///
-/// The join is exactly one line break, whatever the body ended with — so two
-/// callers that differ only in trailing whitespace produce the identical
-/// result:
+/// The join is exactly one blank line and a horizontal rule, whatever the body
+/// ended with — so two callers that differ only in trailing whitespace produce
+/// the identical result:
 ///
 /// ```
 /// use stella_autonomy::sign;
 ///
-/// assert_eq!(sign("body", "Created by stella."), "body\nCreated by stella.");
-/// assert_eq!(sign("body\n\n", "Created by stella."), "body\nCreated by stella.");
+/// assert_eq!(
+///     sign("body", "created by stella*"),
+///     "body\n\n---\ncreated by stella*"
+/// );
+/// assert_eq!(
+///     sign("body\n\n", "created by stella*"),
+///     "body\n\n---\ncreated by stella*"
+/// );
+/// ```
+///
+/// An empty body gets the rule with nothing above it:
+///
+/// ```
+/// use stella_autonomy::sign;
+///
+/// assert_eq!(sign("", "created by stella*"), "---\ncreated by stella*");
 /// ```
 #[must_use]
 pub fn sign(body: &str, signature: &str) -> String {


### PR DESCRIPTION
`main` is red on `fmt + clippy + test`. The `sign()` doctest asserts `sign("body", sig) == "body\nsig"`; `sign` writes `body\n\n---\nsig`.

## Neither branch was wrong

The doctest arrived in **#4014** — a pull request the self-driving loop opened, worked and merged autonomously — written against the doc comment's prose, which still said *"the join is exactly one line break"*. The change to a horizontal-rule footer landed separately, updating `SEPARATOR` and the summary line, with no doctest existing yet to update.

Each was green on its own merge commit. `strict: false` branch protection means a pull request need not be up to date with `main`, so neither ever saw the other. The **shared cell is `sign()`'s contract**, not a file both edited, which is why git reported no conflict.

Same shape AGENTS.md documents for `Cargo.lock` and `scripts/file-size-baseline.txt`, and the reason `main-canary.yml` exists: no pre-merge run can catch it, because neither author's tree is wrong.

## The fix

The doctest now asserts the footer `sign` writes, and the prose above it is corrected in the same change — the prose is what the doctest was written from, and left stale it seeds the next one. A third example covers the empty-body arm, which had no example at all.

## Verify

```
cargo test -p stella-autonomy --doc
```

Fails on `main` (`attribution::sign (line 134) ... FAILED`), passes here — 3 passed, 0 failed.

Closes #4067

## Summary by Sourcery

Align the `sign()` documentation and doctests with its current footer format.

Bug Fixes:
- Update the `sign()` doctest to match the horizontal-rule footer produced by the function, restoring documentation test coverage on main.

Enhancements:
- Clarify the `sign()` contract for bodies with trailing whitespace and add coverage for empty bodies.

Tests:
- Expand the `sign()` documentation examples to cover normal, trailing-whitespace, and empty-body inputs.