### PR TITLE
fix(build): sync stella-tui-theme in Cargo.lock — main does not compile under --locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui-theme"
-version = "0.9.112"
+version = "0.9.114"
 dependencies = [
  "ratatui",
 ]


### PR DESCRIPTION
## What & why

`main` does not compile under `--locked` at `6f4a7cd22`, and one stale line is
the entire cause.

`stella-tui-theme` is the crate #4055 and #4066 each created. It arrived while
the release version sync was in flight, so its `Cargo.toml` reached **0.9.114**
(#4075) while `Cargo.lock` still records the package at **0.9.112**.

Nothing anyone runs day to day passes `--locked` — which is precisely why this
stayed invisible until the post-merge canary asked. Under `--locked`, cargo
refuses to update the lock and fails *before compiling anything*:

```
error: cannot update the lock file .../Cargo.lock because --locked was passed to prevent this
```

So the two canary rows at `6f4a7cd22` — **`lockfile-sync`** and **`compile`** —
are not two defects. They are one stale line, reported twice. Nothing is wrong
with any source file, and no crate needed a change.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

Checked the artisanal way rather than asserted, both directions on the same
tree:

| Lock | `cargo check --workspace --all-targets --locked` |
|---|---|
| as committed on `main` | fails with the error above, compiles nothing |
| with this one-line change | `Finished dev profile` — clean |

There is no test to add here: the assertion *is* `--locked`, and it already runs
in `main-canary.yml` (`compile`) and in `make lockfile-sync` on every gate rung
including `guards-fast`.

**What this does not claim.** It does not claim the canary's other rows are
fixed. `file-size` (#4044) is untouched and still red on the merged tree; it is
a genuine split and lands on its own.

## Why it lands alone

This is exactly the shared-cell shape AGENTS.md § *Gotchas* names: `Cargo.lock`
is one cell every version-bumping PR writes, two branches were each individually
correct, and they composed into a tree neither author could see. That section
also says the repair lands on its own from a fresh `main` rather than folded
into an unrelated change — so it is split out of the brand work that found it.

## The gate

- [x] `cargo check --workspace --all-targets --locked`
- [x] `make lockfile-sync`
- [x] `make file-size` — passes the ratchet (the 1501-line drift is inherited
      from the base and is #4044's, not this change's)

Not re-run for a one-line lockfile change that alters no source: clippy,
rustdoc, the test suite. CI runs them.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — no dependency added, removed,
      or re-resolved. The diff is one version string on an existing workspace
      member.
- [x] No new outbound network calls

Refs #4062

## Summary by Sourcery

Bug Fixes:
- Synchronize the `stella-tui-theme` version in `Cargo.lock` with the workspace manifest so locked Cargo checks can complete.