### PR TITLE
fix: main is red — the theme crate's generated palette is unreachable and the lock is stale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui-theme"
-version = "0.9.112"
+version = "0.9.114"
 dependencies = [
  "ratatui",
 ]

--- a/crates/stella-tui-theme/src/lib.rs
+++ b/crates/stella-tui-theme/src/lib.rs
@@ -47,6 +47,21 @@
 
 pub mod clamp;
 pub mod fallback;
+// The generated face of `design/tokens/stella-tokens.json`, emitted by
+// `scripts/gen-tokens.py` and kept in sync by `make tokens`. It carries a
+// second copy of the palette — `generated::ALL` against `token::ALL` —
+// because this crate was created twice, by #4066 (generator first) and #4055
+// (hand-written table first), and the two landed without a textual conflict.
+// This declaration is #4066's, restored: without it the generated artifact is
+// tracked but unreachable, so rustc, rustfmt and clippy all walk past it
+// while `make tokens` still checks it for staleness. Collapsing the two
+// palettes into one is #4058, under epic #4059.
+//
+// Deliberately not a doc comment: an outer `///` here is merged with the
+// module's own `//!` docs and resolves their intra-doc links in *this* file's
+// scope, where `Color`, `ALL` and `Clamp` do not exist — three rustdoc
+// errors under the gate's `-D warnings`.
+pub mod generated;
 pub mod glyph;
 pub mod token;
 pub mod wordmark;


### PR DESCRIPTION
## What is red

`ci.yml`'s required job fails on **two** guard steps on the current main tip
(`6f4a7cd22`), before clippy/test ever run — one red gate step masks the next:

| Step | Status on `6f4a7cd22` |
|---|---|
| `every src/ file is reachable from its crate root` | FAILED |
| `Cargo.lock is in sync with the manifests` | FAILED |

Both are shared-cell collisions: each side landed green on its own branch and
composed red on main, with no textual conflict for git to report.

## 1. The generated palette is unreachable

`crates/stella-tui-theme/src/generated.rs` is tracked, but no `mod`
declaration reaches it.

The crate was created **twice**:

- **#4066** landed first, as exactly `lib.rs` + `generated.rs`, whose `lib.rs`
  declared `pub mod generated;` and re-exported from it.
- **#4055** landed next and replaced `lib.rs` wholesale with its own
  five-module version (`clamp`, `fallback`, `glyph`, `token`, `wordmark`) —
  a branch that never contained a `mod generated;` line.

One side simply does not contain the other's lines, so the merge was clean and
the generated artifact went invisible to rustc, rustfmt **and** clippy at once,
while `make tokens` carried on checking it for staleness. Its four tests had
stopped running while the suite still reported `ok` — the #1750 shape.

Restoring the declaration is **#4066's own line, put back**, not a new design
decision. The crate now carries two copies of the palette (`generated::ALL`
against `token::ALL`); collapsing them into one is already tracked as **#4058**
under epic **#4059**, and is deliberately not folded in here.

### Why a plain `//` and not `///`

An outer doc comment on a `mod` declaration is merged with the module file's
own `//!` docs and resolves their intra-doc links in the **parent** file's
scope. With `///` the restored declaration produced three
`unresolved link` errors — `Color::Rgb`, `ALL`, `Clamp` — none of which exist
in `lib.rs`, failing `cargo doc -D warnings`. Verified both ways.

## 2. `Cargo.lock` is stale

The lock recorded `stella-tui-theme` at `0.9.112` while the crate inherits
`version.workspace = true` = `0.9.114`. The release bump and the new-crate PR
each wrote the lock correctly in isolation. One-line regeneration.

## Witness

Both guards go **FAIL to OK** on this branch, and the previously-dead tests run:

```
check-module-reachability: FAILED  ->  OK - 1028 source file(s) across 28 crate(s), all reachable
check-lockfile-sync:       FAIL    ->  OK - Cargo.lock resolves against the manifests
cargo test -p stella-tui-theme     ->  22 passed, including 4x generated::tests::*
                                        (they could not execute at all before)
cargo clippy -p stella-tui-theme --all-targets -- -D warnings  ->  clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui-theme       ->  clean
cargo fmt --all --check                                        ->  clean
```

No test was deleted in this change.

## Left behind, tracked not dropped

`make tokens` is **also** red on main — retired brand hexes in 7 places
(`export/tests.rs`, `observatory/src/assets/index.html`,
`stella-tui-theme/README.md`, `website/src/app/tokens.css`) plus 13 non-token
hex literals in `website/src/app/tokens.css`.

It does not gate this PR, and the reason is worth stating precisely because I
first got it wrong: `tokens` **is** a `make gate` step — the last entry of
`GATE_GUARDS_FAST` in the `Makefile`, so `make gate` and the pre-push hook both
run it — but it appears in **no** workflow under `.github/workflows/`. So it
blocks a local push and nothing server-side. That parity hole is filed
separately, along with the red itself; a brand-wide hex sweep does not belong
inside a red-main repair.

Refs #4058, #4059
