### PR TITLE
fix(stella-cli): split the loop's reporting verbs out of self_driving_cmd.rs

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -27,6 +27,7 @@ mod drive;
 mod hooks;
 mod lifecycle;
 pub(crate) mod probes;
+mod report;
 pub(crate) mod state;
 mod stats;
 mod surface;
@@ -562,8 +563,8 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, spend_limit: Option<f64>) -> Result<(), 
                 lens_tool.as_deref(),
             ),
         },
-        SelfDrivingCmd::Watch => watch(&st),
-        SelfDrivingCmd::Metrics => metrics(&st),
+        SelfDrivingCmd::Watch => report::watch(&st),
+        SelfDrivingCmd::Metrics => report::metrics(&st),
         SelfDrivingCmd::Aperture {
             current,
             advance,
@@ -924,130 +925,6 @@ fn advance_aperture(st: &LoopState, current: &str) -> Result<(), String> {
         println!("aperture {current} -> watch (every lens dry; the loop sleeps, it does not stop)");
     } else {
         println!("aperture {current} -> {next}");
-    }
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// watch / metrics
-// ---------------------------------------------------------------------------
-
-fn watch(st: &LoopState) -> Result<(), String> {
-    let mut triggered = false;
-    say("watch mode — checking what would invalidate the last clean sweep");
-
-    let head_now = state::git(&st.repo_root, &["rev-parse", "origin/main"])
-        .unwrap_or_else(|| "none".to_string());
-    let head_seen = st
-        .calibration()
-        .extra
-        .get("last_clean_head")
-        .and_then(Value::as_str)
-        .unwrap_or("none")
-        .to_string();
-    if head_now == head_seen {
-        println!("  ✓ main unchanged since the last clean sweep");
-    } else {
-        println!("  ! main moved ({head_seen} -> {head_now}) — new code has never been audited");
-        triggered = true;
-    }
-
-    if gh_available() {
-        let d = demand(&st.repo_root);
-        if d.open_defects > 0 {
-            println!("  ! {} open defects in the queue", d.open_defects);
-            triggered = true;
-        } else {
-            println!("  ✓ defect queue empty");
-        }
-
-        let ci = gh_plain(&[
-            "run",
-            "list",
-            "--branch",
-            "main",
-            "--limit",
-            "1",
-            "--json",
-            "conclusion",
-            "--jq",
-            ".[0].conclusion",
-        ])
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-        if ci == "failure" {
-            println!("  ! main is red in CI");
-            triggered = true;
-        } else {
-            println!("  ✓ main CI: {ci}");
-        }
-    }
-
-    println!();
-    if triggered {
-        st.set_aperture("rubric")?;
-        println!("WAKE — aperture reset to rubric; run a full cycle.");
-        return Ok(());
-    }
-    println!("SLEEP — nothing changed. Check again next interval; spend nothing.");
-    // The sleep verdict is an exit code, not an error: the driver loops on
-    // `watch || continue`, and an error envelope here would read as a broken
-    // sentinel rather than a quiet night.
-    std::process::exit(1);
-}
-
-fn metrics(st: &LoopState) -> Result<(), String> {
-    let rows = st.cycles();
-    if rows.is_empty() {
-        println!("no cycles recorded yet");
-        return Ok(());
-    }
-    let cal = st.calibration();
-    let m = stella_autonomy::metrics(&rows);
-    let n = m.cycles;
-
-    println!("cycles            {n}");
-    println!(
-        "fixed / cycle     {:.1}   ({} total)",
-        m.fixed as f64 / n as f64,
-        m.fixed
-    );
-    println!(
-        "filed / cycle     {:.1}   ({} total)",
-        m.filed as f64 / n as f64,
-        m.filed
-    );
-    println!(
-        "discovery / cycle {:.1}   (unseen findings)",
-        m.new_findings as f64 / n as f64
-    );
-    println!(
-        "zero-fix cycles   {} ({:.0}%)",
-        m.zero_fix_cycles,
-        100.0 * m.zero_fix_cycles as f64 / n as f64
-    );
-    println!(
-        "red-gate cycles   {} ({:.0}%)",
-        m.red_gate_cycles,
-        100.0 * m.red_gate_cycles as f64 / n as f64
-    );
-    println!(
-        "controller        batch<={} parallel<={} ({} clean runs) — {}",
-        cal.batch_ceiling, cal.parallel_ceiling, cal.clean_run, cal.note
-    );
-
-    let mut signals = m.signals;
-    if let Some(s) = stella_autonomy::starved(&cal) {
-        // Keep the shell driver's order: STARVED reported right after STUCK.
-        let at = usize::from(signals.first().is_some_and(|s| s.code == "STUCK"));
-        signals.insert(at, s);
-    }
-    if !signals.is_empty() {
-        println!("\nsignals for /self-driving:evolve");
-        for s in signals {
-            println!("  ! {}: {}", s.code, s.text);
-        }
     }
     Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/report.rs
+++ b/crates/stella-cli/src/self_driving_cmd/report.rs
@@ -1,0 +1,137 @@
+//! The loop's two read-only reporting verbs: `watch` and `metrics`.
+//!
+//! Both answer a question about the loop without moving it. `watch` asks
+//! whether anything has happened that would invalidate the last clean sweep;
+//! `metrics` folds the recorded cycles into the rates `/self-driving:evolve`
+//! reads. Neither files, fixes, or advances the aperture — `watch`'s one write
+//! is the aperture *reset* that a wake implies, which is the observation
+//! becoming the decision rather than a side effect of reporting.
+//!
+//! Split out of `self_driving_cmd.rs` when that file crossed the 1500-line
+//! ratchet (#4044). They were already one section behind a shared banner
+//! there, so the seam is the one the file had drawn for itself.
+
+use serde_json::Value;
+
+use super::state::{self, LoopState};
+use super::{demand, gh_available, gh_plain, say};
+
+pub(super) fn watch(st: &LoopState) -> Result<(), String> {
+    let mut triggered = false;
+    say("watch mode — checking what would invalidate the last clean sweep");
+
+    let head_now = state::git(&st.repo_root, &["rev-parse", "origin/main"])
+        .unwrap_or_else(|| "none".to_string());
+    let head_seen = st
+        .calibration()
+        .extra
+        .get("last_clean_head")
+        .and_then(Value::as_str)
+        .unwrap_or("none")
+        .to_string();
+    if head_now == head_seen {
+        println!("  ✓ main unchanged since the last clean sweep");
+    } else {
+        println!("  ! main moved ({head_seen} -> {head_now}) — new code has never been audited");
+        triggered = true;
+    }
+
+    if gh_available() {
+        let d = demand(&st.repo_root);
+        if d.open_defects > 0 {
+            println!("  ! {} open defects in the queue", d.open_defects);
+            triggered = true;
+        } else {
+            println!("  ✓ defect queue empty");
+        }
+
+        let ci = gh_plain(&[
+            "run",
+            "list",
+            "--branch",
+            "main",
+            "--limit",
+            "1",
+            "--json",
+            "conclusion",
+            "--jq",
+            ".[0].conclusion",
+        ])
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+        if ci == "failure" {
+            println!("  ! main is red in CI");
+            triggered = true;
+        } else {
+            println!("  ✓ main CI: {ci}");
+        }
+    }
+
+    println!();
+    if triggered {
+        st.set_aperture("rubric")?;
+        println!("WAKE — aperture reset to rubric; run a full cycle.");
+        return Ok(());
+    }
+    println!("SLEEP — nothing changed. Check again next interval; spend nothing.");
+    // The sleep verdict is an exit code, not an error: the driver loops on
+    // `watch || continue`, and an error envelope here would read as a broken
+    // sentinel rather than a quiet night.
+    std::process::exit(1);
+}
+
+pub(super) fn metrics(st: &LoopState) -> Result<(), String> {
+    let rows = st.cycles();
+    if rows.is_empty() {
+        println!("no cycles recorded yet");
+        return Ok(());
+    }
+    let cal = st.calibration();
+    let m = stella_autonomy::metrics(&rows);
+    let n = m.cycles;
+
+    println!("cycles            {n}");
+    println!(
+        "fixed / cycle     {:.1}   ({} total)",
+        m.fixed as f64 / n as f64,
+        m.fixed
+    );
+    println!(
+        "filed / cycle     {:.1}   ({} total)",
+        m.filed as f64 / n as f64,
+        m.filed
+    );
+    println!(
+        "discovery / cycle {:.1}   (unseen findings)",
+        m.new_findings as f64 / n as f64
+    );
+    println!(
+        "zero-fix cycles   {} ({:.0}%)",
+        m.zero_fix_cycles,
+        100.0 * m.zero_fix_cycles as f64 / n as f64
+    );
+    println!(
+        "red-gate cycles   {} ({:.0}%)",
+        m.red_gate_cycles,
+        100.0 * m.red_gate_cycles as f64 / n as f64
+    );
+    println!(
+        "controller        batch<={} parallel<={} ({} clean runs) — {}",
+        cal.batch_ceiling, cal.parallel_ceiling, cal.clean_run, cal.note
+    );
+
+    let mut signals = m.signals;
+    if let Some(s) = stella_autonomy::starved(&cal) {
+        // Keep the shell driver's order: STARVED reported right after STUCK.
+        let at = usize::from(signals.first().is_some_and(|s| s.code == "STUCK"));
+        signals.insert(at, s);
+    }
+    if !signals.is_empty() {
+        println!("\nsignals for /self-driving:evolve");
+        for s in signals {
+            println!("  ! {}: {}", s.code, s.text);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What & why

`crates/stella-cli/src/self_driving_cmd.rs` reached **1501 lines** and is not
grandfathered, so `file-size` fails on the merged tree — the failure #4044
records, and one of the three rows the post-merge canary is currently red on.

AGENTS.md is explicit about the remedy for a *first-time* crossing, and about
what it is not: split into a sibling submodule, and never add a baseline entry
(`--update` refuses to create one anyway, since #3441). This does the split.

`watch` and `metrics` move to `self_driving_cmd/report.rs`.

**The seam is the file's own.** Those two functions already sat together behind
a shared `// watch / metrics` section banner, so this is the cut the file had
already drawn rather than a boundary chosen to hit a line count. They are the
loop's two read-only reporting verbs — each answers a question about the loop
without moving it — which is what makes them a module rather than an arbitrary
123 lines. `watch`'s one write is the aperture reset a wake implies, i.e. the
observation becoming the decision rather than a side effect of reporting; the
new module's header says so, because that is the part a later reader would
otherwise have to re-derive.

**No visibility was widened.** A child module can already see its parent's
private items, so `say`, `gh_available`, `gh_plain` and `demand` stay `fn` and
are reached through `super::`. This is worth stating because widening four
helpers to `pub(super)` is the obvious way to do this split and would have been
a real (if small) loss of encapsulation for no reason.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

The guard *is* the witness, run exactly the way `main-canary.yml` runs it
(`./scripts/check-file-size.sh --absolute` — the strict whole-tree form, not
the ratchet-against-base form a PR normally gets):

| Tree | `./scripts/check-file-size.sh --absolute` |
|---|---|
| `main` | `crates/stella-cli/src/self_driving_cmd.rs is 1501 lines, over the 1500-line limit` — FAILED |
| here | `OK — 1496 Rust/Python/shell files, 23 grandfathered over 1500 lines` |

The file lands at **1378 lines**, so the headroom is real rather than one line
under the wire.

No behaviour test is added because there is no behaviour change: both functions
move verbatim, and their two call sites in the dispatch `match` are re-pointed
at `report::`. `make self-driving-test` drives `watch` and `metrics` through the
shell harness end-to-end and is unchanged.

## Why it lands alone

AGENTS.md § *God files* says a baseline/ratchet repair is landed on its own from
a fresh `main` and not folded into an unrelated PR. This is that, so it is split
out of the brand work that found it.

## The gate

- [x] `./scripts/check-file-size.sh --absolute`
- [x] `cargo check -p stella-cli --all-targets`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all`

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow]`, no `TODO`, no baseline entry added

Closes #4044

## Summary by Sourcery

Split the self-driving reporting commands into a sibling module to bring the main command file back under the size limit.

Enhancements:
- Extract the self-driving loop’s watch and metrics reporting commands into a dedicated report module without changing their behavior or visibility.

Chores:
- Reduce self_driving_cmd.rs below the file-size limit to resolve the god-file check failure without adding a baseline entry.