### PR TITLE
fix(stella-cli): split the run ledger out of self_driving_cmd.rs so main compiles its own ceiling

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -27,13 +27,13 @@ mod drive;
 mod hooks;
 mod lifecycle;
 pub(crate) mod probes;
+mod run_lifecycle;
 pub(crate) mod state;
 mod stats;
 mod surface;
 mod triage;
 mod work;
 
-use std::collections::BTreeMap;
 use std::process::Command;
 
 use clap::Subcommand;
@@ -623,14 +623,14 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, spend_limit: Option<f64>) -> Result<(), 
             remaining,
         }),
         SelfDrivingCmd::Run { cmd } => match cmd {
-            RunCmd::Start => run_start(&st),
-            RunCmd::End { status, reason } => run_end(&st, status, reason),
-            RunCmd::Cancel { reason } => run_end_as(
+            RunCmd::Start => run_lifecycle::run_start(&st),
+            RunCmd::End { status, reason } => run_lifecycle::run_end(&st, status, reason),
+            RunCmd::Cancel { reason } => run_lifecycle::run_end_as(
                 &st,
                 "cancelled",
                 reason.as_deref().unwrap_or("stopped by hand"),
             ),
-            RunCmd::List => runs_report(&st),
+            RunCmd::List => run_lifecycle::runs_report(&st),
             RunCmd::StampCyclePid { pid } => {
                 st.update_run_doc(|doc| match pid {
                     Some(p) => {
@@ -643,7 +643,7 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, spend_limit: Option<f64>) -> Result<(), 
                 Ok(())
             }
         },
-        SelfDrivingCmd::Runs => runs_report(&st),
+        SelfDrivingCmd::Runs => run_lifecycle::runs_report(&st),
         SelfDrivingCmd::Phase { name } => {
             st.run_write(name, None, None);
             println!("phase: {name}");
@@ -1417,85 +1417,4 @@ fn file_finding(
     }
 
     backlog::render_not_filed(&outcome, &bound, format)
-}
-
-// ---------------------------------------------------------------------------
-// run lifecycle
-// ---------------------------------------------------------------------------
-
-fn run_start(st: &LoopState) -> Result<(), String> {
-    let rid = state::new_run_id();
-    let driver = std::env::var("SELF_DRIVING_DRIVER").unwrap_or_else(|_| "interactive".to_string());
-    let mut fields = BTreeMap::new();
-    fields.insert("run_id".to_string(), Value::String(rid.clone()));
-    fields.insert("status".to_string(), Value::String("running".to_string()));
-    fields.insert("driver".to_string(), Value::String(driver));
-    fields.insert(
-        "slug".to_string(),
-        Value::String(state::repo_slug(&st.repo_root)),
-    );
-    fields.insert(
-        "workspace_root".to_string(),
-        Value::String(st.repo_root.to_string_lossy().into_owned()),
-    );
-    fields.insert("pid".to_string(), u64::from(std::process::id()).into());
-    st.append_run_record(fields)?;
-
-    let started = rfc3339_utc_now();
-    st.update_run_doc(|doc| {
-        doc.insert("run_id".into(), rid.clone().into());
-        doc.entry("started_at".to_string())
-            .or_insert_with(|| Value::String(started));
-    });
-    // Stamp the first heartbeat through the SAME writer every other phase
-    // uses — the record must be complete from its first byte, not completed
-    // by whatever happens next.
-    st.run_write("idle", None, None);
-
-    say(&format!("run {rid} started"));
-    println!("SELF_DRIVING_RUN_ID={rid}");
-    Ok(())
-}
-
-fn run_end(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
-    run_end_as(st, status, reason)
-}
-
-fn run_end_as(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
-    let rid = st
-        .current_run_id()
-        .ok_or_else(|| "run end: no run in progress".to_string())?;
-    let mut fields = BTreeMap::new();
-    fields.insert("run_id".to_string(), Value::String(rid.clone()));
-    fields.insert("status".to_string(), Value::String(status.to_string()));
-    fields.insert("reason".to_string(), Value::String(reason.to_string()));
-    st.append_run_record(fields)?;
-    st.clear_run_doc();
-    say(&format!("run {rid} -> {status}"));
-    Ok(())
-}
-
-fn runs_report(st: &LoopState) -> Result<(), String> {
-    let rows = stella_autonomy::fold_runs(
-        &st.run_records(),
-        &st.cycles(),
-        st.run_doc().as_ref(),
-        now_unix(),
-        state::stale_after_secs(),
-    );
-    if rows.is_empty() {
-        println!("no self-driving runs recorded yet");
-        return Ok(());
-    }
-    println!(
-        "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  phase",
-        "run", "status", "cyc", "fixed", "filed", "new"
-    );
-    for r in rows {
-        println!(
-            "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  {}",
-            r.run_id, r.status, r.cycles, r.fixed, r.filed, r.new_findings, r.phase
-        );
-    }
-    Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/run_lifecycle.rs
+++ b/crates/stella-cli/src/self_driving_cmd/run_lifecycle.rs
@@ -1,0 +1,96 @@
+//! The run ledger — one self-driving *run* opened, closed, and reported.
+//!
+//! A run is the outer bracket around the cycles `lifecycle` drives: `run_start`
+//! mints the id and stamps the first heartbeat, `run_end_as` closes it with a
+//! status and a reason, and `runs_report` folds the record stream into the
+//! table `stella self-driving runs` prints. The fold itself is
+//! `stella_autonomy::fold_runs` — pure and property-tested there, so everything
+//! in this file is the I/O half invariant 2 keeps out of the engine.
+//!
+//! Split out of `self_driving_cmd.rs` when that file reached the 1500-line
+//! ceiling (#4044), following `stella-core`'s `driver/settlement.rs`.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::state::LoopState;
+use super::{say, state};
+use crate::timefmt::{now_unix, rfc3339_utc_now};
+
+pub(super) fn run_start(st: &LoopState) -> Result<(), String> {
+    let rid = state::new_run_id();
+    let driver = std::env::var("SELF_DRIVING_DRIVER").unwrap_or_else(|_| "interactive".to_string());
+    let mut fields = BTreeMap::new();
+    fields.insert("run_id".to_string(), Value::String(rid.clone()));
+    fields.insert("status".to_string(), Value::String("running".to_string()));
+    fields.insert("driver".to_string(), Value::String(driver));
+    fields.insert(
+        "slug".to_string(),
+        Value::String(state::repo_slug(&st.repo_root)),
+    );
+    fields.insert(
+        "workspace_root".to_string(),
+        Value::String(st.repo_root.to_string_lossy().into_owned()),
+    );
+    fields.insert("pid".to_string(), u64::from(std::process::id()).into());
+    st.append_run_record(fields)?;
+
+    let started = rfc3339_utc_now();
+    st.update_run_doc(|doc| {
+        doc.insert("run_id".into(), rid.clone().into());
+        doc.entry("started_at".to_string())
+            .or_insert_with(|| Value::String(started));
+    });
+    // Stamp the first heartbeat through the SAME writer every other phase
+    // uses — the record must be complete from its first byte, not completed
+    // by whatever happens next.
+    st.run_write("idle", None, None);
+
+    say(&format!("run {rid} started"));
+    println!("SELF_DRIVING_RUN_ID={rid}");
+    Ok(())
+}
+
+pub(super) fn run_end(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
+    run_end_as(st, status, reason)
+}
+
+pub(super) fn run_end_as(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
+    let rid = st
+        .current_run_id()
+        .ok_or_else(|| "run end: no run in progress".to_string())?;
+    let mut fields = BTreeMap::new();
+    fields.insert("run_id".to_string(), Value::String(rid.clone()));
+    fields.insert("status".to_string(), Value::String(status.to_string()));
+    fields.insert("reason".to_string(), Value::String(reason.to_string()));
+    st.append_run_record(fields)?;
+    st.clear_run_doc();
+    say(&format!("run {rid} -> {status}"));
+    Ok(())
+}
+
+pub(super) fn runs_report(st: &LoopState) -> Result<(), String> {
+    let rows = stella_autonomy::fold_runs(
+        &st.run_records(),
+        &st.cycles(),
+        st.run_doc().as_ref(),
+        now_unix(),
+        state::stale_after_secs(),
+    );
+    if rows.is_empty() {
+        println!("no self-driving runs recorded yet");
+        return Ok(());
+    }
+    println!(
+        "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  phase",
+        "run", "status", "cyc", "fixed", "filed", "new"
+    );
+    for r in rows {
+        println!(
+            "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  {}",
+            r.run_id, r.status, r.cycles, r.fixed, r.filed, r.new_findings, r.phase
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## The defect

`file-size` fails on `main` itself. `crates/stella-cli/src/self_driving_cmd.rs`
is 1501 lines on the merged tree — one line over the limit — and carries no
baseline entry, so the guard fails outright:

```
crates/stella-cli/src/self_driving_cmd.rs is 1501 lines, over the 1500-line limit
```

Per AGENTS.md § `main-red-hold`, a red `main` reds every open PR, so this is
costing every contributor a failure they did not cause. Filed by the post-merge
canary as #4044.

## The fix

Not a raised ceiling. `run_start`, `run_end`, `run_end_as` and `runs_report`
are one cohesive unit — the run ledger, the outer bracket around the cycles
`lifecycle` drives. They share no state with the argument tree above them or
the cycle reporting beside them, and they are called from exactly four sites
inside a single `match` arm.

They move to `crates/stella-cli/src/self_driving_cmd/run_lifecycle.rs`, beside
the fourteen submodules already in that directory. **Exemplar:**
`crates/stella-core/src/driver/settlement.rs`, split out of `driver.rs` the
same way — the pattern AGENTS.md § "God files" names.

The move is mechanical. No function body changed. What changed:

- visibility: private → `pub(super)` on the four functions
- the four call sites gain a `run_lifecycle::` qualifier
- `use std::collections::BTreeMap;` left the parent's import list with them

Parent lands at **1421 lines**, 79 under the ceiling.

## What this deliberately does not do

**No entry added to `scripts/file-size-baseline.txt`.** The baseline covers
files that predate the guard; a first-time crossing bought with a raised
ceiling is the expedient CLAUDE.md forbids, and `--update` refuses to add a
new entry for exactly this reason (#3441).

`run_end` is a pure pass-through to `run_end_as` with an identical signature.
It moved as-is rather than being collapsed — this PR unblocks `main` and does
one thing.

## Witness

Not a behaviour change, so no witness test — this is a pure code move plus the
guard that was already failing. The guard **is** the evidence, and it flips:

```
$ ./scripts/check-file-size.sh          # on main
check-file-size: FAILED
  crates/stella-cli/src/self_driving_cmd.rs is 1501 lines, over the 1500-line limit

$ ./scripts/check-file-size.sh          # on this branch
check-file-size: OK — 1496 Rust/Python/shell files, 23 grandfathered over
1500 lines, and nothing went over by this change. Judged against 35f984c30.
```

No test was deleted.

Closes #4044

## Summary by Sourcery

Split the self-driving run ledger into its own module to restore compliance with the source file-size limit without changing runtime behavior.

Bug Fixes:
- Reduce `self_driving_cmd.rs` below the file-size limit so the main branch guard passes again.

Enhancements:
- Extract run lifecycle ledger operations into a dedicated `run_lifecycle` module without changing behavior.