### PR TITLE
fix(stella-tui-theme): the generated palette is tracked but unreachable — main is red on module-reachability

### DIFF
--- a/crates/stella-tui-theme/src/lib.rs
+++ b/crates/stella-tui-theme/src/lib.rs
@@ -47,6 +47,21 @@
 
 pub mod clamp;
 pub mod fallback;
+// The generated face of `design/tokens/stella-tokens.json`, emitted by
+// `scripts/gen-tokens.py` and kept in sync by `make tokens`. It carries a
+// second copy of the palette — `generated::ALL` against `token::ALL` —
+// because this crate was created twice, by #4066 (generator first) and #4055
+// (hand-written table first), and the two landed without a textual conflict.
+// This declaration is #4066's, restored: without it the generated artifact is
+// tracked but unreachable, so rustc, rustfmt and clippy all walk past it
+// while `make tokens` still checks it for staleness. Collapsing the two
+// palettes into one is #4058, under epic #4059.
+//
+// Deliberately not a doc comment: an outer `///` here is merged with the
+// module's own `//!` docs and resolves their intra-doc links in *this* file's
+// scope, where `Color`, `ALL` and `Clamp` do not exist — three rustdoc
+// errors under the gate's `-D warnings`.
+pub mod generated;
 pub mod glyph;
 pub mod token;
 pub mod wordmark;


### PR DESCRIPTION
Replaces #4079, which was cut before #4076/#4077 landed and conflicted on
`Cargo.lock`. The lockfile half of that PR is now redundant — #4076 fixed it —
so this carries **only** the half that is still red.

## What is red

`check-module-reachability` fails in `ci.yml`'s required job on the current
main tip (`04fc177be`):

```
$ python3 ./scripts/check-module-reachability.py
  crates/stella-tui-theme/src/generated.rs
check-module-reachability: FAILED
```

The file is tracked under a crate's `src/`, but no `mod` declaration reaches it
from the crate root.

## How it got that way

The crate was created **twice**, and the two creations composed cleanly into a
broken tree:

- **#4066** landed first, as exactly `lib.rs` + `generated.rs`. Its `lib.rs`
  declared `pub mod generated;` and re-exported from it.
- **#4055** landed next and replaced `lib.rs` wholesale with its own
  five-module version (`clamp`, `fallback`, `glyph`, `token`, `wordmark`) —
  a branch that had never contained a `mod generated;` line.

Git had no conflict to report, because one side simply does not contain the
other's lines. The result is the #1750 shape: rustc, rustfmt **and** clippy all
walk past the file at once, while `make tokens` carries on checking it for
staleness — and its four tests had stopped running while the suite still
reported `ok`.

## The fix

Restore the declaration. This is **#4066's own line put back**, not a new
design decision.

The crate consequently holds two copies of the palette — `generated::ALL`
against `token::ALL`. Collapsing them into one is already tracked as **#4058**
under epic **#4059**, and is deliberately not folded into a red-main repair.

### Why a plain `//` and not `///`

An outer doc comment on a `mod` declaration is merged with the module file's
own `//!` docs and resolves their intra-doc links in the **parent** file's
scope. With `///`, the restored declaration produced three `unresolved link`
errors — `Color::Rgb`, `ALL`, `Clamp` — none of which exist in `lib.rs`,
failing `cargo doc -D warnings`. Verified in both directions; the comment
records it so the next author does not re-discover it.

## Witness

```
check-module-reachability   FAILED -> OK (1028 files across 28 crates, all reachable)
cargo test -p stella-tui-theme     22 passed, including 4x generated::tests::*
                                   which could not execute at all before
cargo clippy -p stella-tui-theme --all-targets -- -D warnings   clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui-theme        clean
cargo fmt --all --check                                         clean
check-lockfile-sync                                             OK on this base
```

Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` and
`cargo doc --workspace -D warnings` were both run and are clean, since the two
guard failures had been masking every compile step behind them.

No test was deleted in this change.

## Left behind, tracked not dropped

`make tokens` is also red on main, and it is a `make gate` step
(`GATE_GUARDS_FAST`) that runs in **no** workflow — filed as **#4081** with the
full hex list and the gate-parity hole.

Refs #4058, #4059, #4081

## Summary by Sourcery

Bug Fixes:
- Restore the generated palette module to the stella-tui-theme crate so the tracked artifact is reachable and its tests and checks execute.