### PR TITLE
fix(stella-tui-theme): declare the generated palette, which nothing compiled

### DIFF
--- a/crates/stella-tui-theme/src/lib.rs
+++ b/crates/stella-tui-theme/src/lib.rs
@@ -47,6 +47,24 @@
 
 pub mod clamp;
 pub mod fallback;
+// The generated palette, emitted by `scripts/gen-tokens.py` from
+// `design/tokens/stella-tokens.json` and gate-checked by `make tokens`.
+//
+// It landed without this declaration, which made it invisible to rustc,
+// rustfmt and clippy at once while `make tokens` went on validating it — a
+// generated artifact that was checked and then compiled by nothing (#1750 is
+// the guard that caught it; `check-module-reachability` was failing on `main`).
+//
+// `pub` rather than private because every item in it is generated as `pub`:
+// declaring it privately would make the whole module dead code, and silencing
+// that with `#[allow(dead_code)]` is exactly the suppression AGENTS.md refuses
+// — the lint would not be wrong.
+//
+// It does **not** yet supersede [`token`], and the two are not interchangeable:
+// `generated::ALL` pairs each token with a [`clamp::Clamp`] while
+// `token::ALL` pairs it with a [`token::Role`]. Which table becomes
+// authoritative is a live design question, not something to settle by wiring.
+pub mod generated;
 pub mod glyph;
 pub mod token;
 pub mod wordmark;


### PR DESCRIPTION
## The defect

`check-module-reachability` fails on `main`:

```
These files are tracked under a crate's src/ but no `mod` declaration
reaches them from the crate root.
  crates/stella-tui-theme/src/generated.rs
```

`scripts/gen-tokens.py` writes that file (`RUST_OUT`) from
`design/tokens/stella-tokens.json`, and `make tokens` validates it on every gate
run:

```
$ python3 ./scripts/gen-tokens.py --check
tokens: 21 validated, 2 artifacts in sync
```

But `crates/stella-tui-theme/src/lib.rs` carried no `mod generated;`, and
`git grep generated -- crates/stella-tui-theme/` returned nothing. So rustc,
rustfmt and clippy all walked past it. **The generated palette was being
validated by one gate step and compiled by none** — the exact shape #1750 added
the reachability guard to catch, and the guard did catch it.

## The fix

One declaration, in `lib.rs`.

`pub mod generated;` rather than private: every item in the generated file is
emitted as `pub`, so a private module would make the entire thing dead code, and
silencing that with `#[allow(dead_code)]` is precisely the suppression AGENTS.md
refuses — the lint would not be wrong there.

## What this deliberately does not do

It does not migrate anything, and the two files are **not** a file and its copy:

- `generated::ALL` pairs each token with a `clamp::Clamp`
- `token::ALL` pairs each token with a `token::Role`

Different tables, different types, 25 constants against 18. Which becomes
authoritative is a real design decision that belongs to whoever finishes the
brand work — settling it as a side effect of a `mod` declaration would be the
wrong way to decide it. Filed separately as #4092 rather than resolved here.

So after this PR the crate has two palettes: the live one (`token`) and the
generated one (`generated`), both compiled, both tested, neither pretending to
be the other.

## Witness

The guard is the evidence, and it flips:

```
$ python3 ./scripts/check-module-reachability.py     # on main
check-module-reachability: FAILED
  crates/stella-tui-theme/src/generated.rs

$ python3 ./scripts/check-module-reachability.py     # on this branch
check-module-reachability: OK — 1028 source file(s) across 28 crate(s),
all reachable from a crate root.
```

`cargo test -p stella-tui-theme` — 22 passed, 0 failed. `cargo clippy
-p stella-tui-theme --all-targets -- -D warnings` clean. `cargo fmt --all
--check` clean. No test was deleted.

## Context: this is the third independent red-main break

A red `main` reds every open PR (AGENTS.md § `main-red-hold`), so these are
costing every contributor a failure they did not cause. Currently open and
distinct:

| Break | Issue | Fix |
| --- | --- | --- |
| `file-size` — `self_driving_cmd.rs` at 1501 lines | #4044 | PR #4082 |
| `doc-warnings` + `format-check` | #4062 | (doc-warnings verified already fixed at `04fc177be`) |
| `module-reachability` — this one | #4087 | this PR |

Each hid the next: `file-size` runs before `module-reachability`, so nobody saw
this until the earlier step's failure was read past.

Closes #4087

## Summary by Sourcery

Bug Fixes:
- Declare the generated theme palette module so it is compiled and included in module reachability checks.