### PR TITLE
fix(build): exclude .stella-examples from the workspace so the plugin grading can build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,13 @@ stella-bench-handoff/
 # results from aws hosted bench runs get dropped here
 arenabench/arenabench-cloud/
 
+# A checkout of macanderson/stella-examples, which `example-plugins.yml` clones
+# to this path to grade the three verify-{rs,py,ts} plugins. It is another
+# repository's tree living under this one for the length of a job, and
+# reproducing that job locally is the documented way to debug it — so the
+# directory has to be ignorable rather than merely absent.
+.stella-examples/
+
 # Private key material, anywhere in the tree. scripts/check-no-secrets.sh
 # enforces the same rule against what is already tracked, since .gitignore has
 # no opinion about a file that is staged explicitly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,20 @@ members = [
   "bench/loop-bench",
   "bench/request-bench",
 ]
+# `example-plugins.yml` clones macanderson/stella-examples into
+# `.stella-examples/` *inside this checkout* and builds `verify-rs` there. A
+# Cargo.toml anywhere under a workspace root is assumed to be a member, so
+# cargo refuses it outright:
+#
+#   error: current package believes it's in a workspace when it's not
+#
+# Excluding the path is the remedy cargo itself names, and it is the right one
+# here: those plugins are a separate repository's crates that happen to be
+# checked out under this one. They must not inherit this workspace's lockfile,
+# profiles or `[workspace.dependencies]` — a plugin is supposed to build the
+# way a third party's would, and silently linking it against our resolution
+# would make the grading run prove something about a tree nobody else has.
+exclude = [".stella-examples"]
 
 [workspace.package]
 version = "0.9.115"


### PR DESCRIPTION
## What & why

**`example plugins` is red on `main`**, at `ed74c3da0` — the merge commit of the
change that introduced it (#4096). It has never built anything:

```
error: current package believes it's in a workspace when it's not:
current:   .../stella/.stella-examples/plugins/verify-rs/Cargo.toml
workspace: .../stella/Cargo.toml
```

`.github/workflows/example-plugins.yml` clones `macanderson/stella-examples` to
`.stella-examples/` **inside this checkout** and runs `cargo build --release` in
`verify-rs`. Cargo treats any `Cargo.toml` under a workspace root as a member it
has not been told about, and refuses rather than guessing.

## Why `exclude`, and not the other two options

Cargo names three remedies. The other two are worse here:

- **Add it to `workspace.members`** — wrong outright. It would make another
  repository's crates members of this one, and they are not present in a normal
  checkout, so every `cargo` invocation would fail for everyone who has not run
  that workflow.
- **Add an empty `[workspace]` to the plugin's own manifest** — correct, but it
  lives in `macanderson/stella-examples`. Fixing it there leaves this repository
  able to break the same job again by moving the clone path, and needs a
  cross-repo change to unbreak `main` now.

`exclude` is also the choice that says the right thing about what those crates
*are*. As members they would inherit this workspace's `Cargo.lock`, profiles and
`[workspace.dependencies]` — so the grading run would be proving something about
a dependency resolution no third-party plugin author has. **A plugin has to
build the way someone else's would**, which is the entire point of grading the
examples against the published grammar.

`.gitignore` gets the path too. Reproducing this job locally is the documented
way to debug it, and doing so leaves another repository's working tree sitting
in this one — ignorable beats merely absent. `check-no-scratch` stays green
because nothing there is tracked.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

Run both ways on the same tree, with a stand-in `verify-rs` crate at the path
the workflow clones to:

| Tree | `cargo build --release` in `.stella-examples/plugins/verify-rs` |
|---|---|
| `main` | fails, naming **this repository's root** as the claiming workspace — the CI failure exactly |
| here | the root no longer claims the package |

One honest caveat about that second row: this was run from a git worktree nested
inside another checkout of the same repo, so once our root stops claiming the
package cargo keeps walking and finds the *outer* checkout's manifest. That
second error is an artifact of where I ran it and does not exist in CI, where
the checkout is top-level. The row that matters is the first one, and the
difference between the two — *which* manifest cargo names — is what proves the
`exclude` took effect.

No test is added: the assertion is the workflow itself, which is already
required to build these three plugins on every push touching them.

## The gate

- [x] `cargo metadata --locked` — still resolves 28 workspace members
- [x] `./scripts/check-lockfile-sync.sh`
- [x] `./scripts/check-no-scratch.sh`

No Rust source changes, so clippy/rustdoc/test are untouched by this diff.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow]`, no `TODO`, no baseline entry

Deliberately not written as `Closes #4096` — that PR is merged, and this fixes a
defect it shipped, so it is a follow-up rather than a completion.

## Summary by Sourcery

Exclude the separately cloned example plugins from the workspace so the example-plugin grading workflow can build successfully.

Bug Fixes:
- Fix example plugin builds by preventing Cargo from treating the cloned `.stella-examples` repository as part of the main workspace.

Build:
- Exclude `.stella-examples` from workspace discovery while preserving independent plugin dependency and build resolution.