### PR TITLE
fix(bench): the launcher vocabulary reader must read both halves of the seam

### DIFF
--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -928,8 +928,14 @@ _UNKNOWN_RS = _REPO_ROOT / "crates" / "stella-cli" / "src" / "settings" / "unkno
 
 def _parse_rust_str_slice(source: str, const_name: str) -> frozenset[str]:
     """Every string literal in a ``const NAME: &[&str] = &[ ... ];`` table."""
+    # `=\s*&\[` rather than `= &\[`: rustfmt wraps the initialiser onto the
+    # next line once the declaration is long enough, which is a formatting
+    # accident this reader must not be sensitive to. It was —
+    # `RETIRED_ENGINE_AGENT_NAMES` is wrapped that way, and a reader that
+    # cannot see a table reports it missing rather than empty, which reads as
+    # "the constant was renamed" and sends the next person to the wrong file.
     match = re.search(
-        rf"const {const_name}: &\[&str\] = &\[(.*?)\];", source, re.DOTALL
+        rf"const {const_name}: &\[&str\] =\s*&\[(.*?)\];", source, re.DOTALL
     )
     assert match is not None, (
         f"could not find `{const_name}` in {_UNKNOWN_RS} — the constant moved "
@@ -962,7 +968,26 @@ def _engine_root_fields() -> frozenset[str]:
         ) from exc
     fields = _parse_rust_str_slice(source, "ENGINE_ROOT_FIELDS")
     assert fields, "ENGINE_ROOT_FIELDS parsed to zero entries"
-    return fields
+    # `RETIRED_ENGINE_ROOT` is the other half of the seam's vocabulary, and
+    # leaving it out made this helper answer a different question than its
+    # callers ask. They assert "the trusted launcher would not refuse this
+    # posture"; the launcher recognizes both tables, so a posture naming a
+    # retired key passes the seam and failed here — the assertion was simply
+    # false about the code it names.
+    #
+    # #3908 retired those five keys and #3944 finished the collapse, and
+    # `unknown.rs` is explicit that they are *deliberately* still recognized
+    # rather than dropped: this file and `arenabench/harbor_agent.py` still
+    # write them into hashed postures, so refusing them would invalidate every
+    # digest registered in `bench/READINESS.md` §8.4 — a published-numbers
+    # decision #3870 reserves for a maintainer. Recognized, ignored, reported.
+    #
+    # So the union is not a loosening; it is this helper finally describing the
+    # seam. When the Python stops writing the retired keys (#3910 slice 6) the
+    # Rust table empties, and this union collapses back to one set on its own
+    # without anyone editing this line.
+    retired = _parse_rust_str_slice(source, "RETIRED_ENGINE_ROOT")
+    return fields | retired
 
 
 def _engine_agent_names() -> frozenset[str]:
@@ -985,7 +1010,16 @@ def _engine_agent_names() -> frozenset[str]:
         ) from exc
     names = _parse_rust_str_slice(source, "ENGINE_AGENT_NAMES")
     assert names, "ENGINE_AGENT_NAMES parsed to zero entries"
-    return names
+    # The same union, one level down, for the same stated reason: `unknown.rs`
+    # keeps `RETIRED_ENGINE_AGENT_NAMES` recognized rather than dropping it,
+    # explicitly citing `RETIRED_ENGINE_ROOT`'s argument. Core knows one role
+    # name now (`default`, #3903), but a hashed posture written before the
+    # collapse still carries the five personas, and the seam still accepts
+    # them — so a caller asking "would the launcher refuse this?" has to read
+    # both tables or it is asking a question about a stricter launcher than
+    # the one that exists.
+    retired = _parse_rust_str_slice(source, "RETIRED_ENGINE_AGENT_NAMES")
+    return names | retired
 
 
 def _parse_output_ceilings(source: str) -> dict[str, int]:


### PR DESCRIPTION
## What & why

`harbor_adapter + analyzer pytest` has been red on `main` since #3944 (#3967 has
the bisect). Four of its five failures are **one defect**, and it is a defect in
the tests rather than in the postures they check.

The tests ask *"would the trusted launcher refuse this posture?"* and answer it
from `ENGINE_ROOT_FIELDS` alone. The seam accepts **two** tables.

`crates/stella-cli/src/settings/unknown.rs` keeps `RETIRED_ENGINE_ROOT` and
`RETIRED_ENGINE_AGENT_NAMES` *recognized* rather than dropped, and says why in as
many words:

> Deliberately not simply dropped from `ENGINE_ROOT_FIELDS` … `posture.py` and
> `arenabench/harbor_agent.py` still *write* these keys into hashed benchmark
> postures. Dropping them here would refuse every benchmark launch and force a
> re-hash of every digest registered in `bench/READINESS.md` §8.4 — the
> published-numbers decision #3870 reserves for a maintainer.
>
> Recognized, ignored, reported — never silently accepted, and never silently
> dropped.

So a posture naming `pipeline_verifier_model` **passes the launcher** and failed
these tests. The assertion was simply false about the code it names.

Reading both tables is therefore not a loosening — it is the helper finally
describing the seam it claims to describe. And it is self-retiring: when the
Python stops writing the retired keys (#3910 slice 6), the Rust tables empty and
the union collapses back to one set with no edit here.

**No posture value changes, so no digest changes.** That is the constraint the
whole design above exists to protect, and this PR stays inside it.

### One character in the parser, which was hiding the second half

`_parse_rust_str_slice`'s regex required `= &[` on a single line. rustfmt wraps
the initialiser once a declaration gets long enough — which
`RETIRED_ENGINE_AGENT_NAMES` is:

```rust
pub(crate) const RETIRED_ENGINE_AGENT_NAMES: &[&str] =
    &["worker", "verifier", "triage", "research", "plan"];
```

A reader that cannot see a table reports it **missing**, and "the constant was
renamed or moved" sends the next person to the wrong file. `=\s*&\[` fixes it.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | `uv run --no-sync pytest -q` in `bench/harbor_adapter` |
|---|---|
| `main` | 7 failed / 710 passed |
| here | 3 failed / 714 passed |

**Two of the three remaining are this machine, not the tree.**
`tests/test_adapter.py` picks up a real `OPENROUTER_API_KEY` / `VOYAGE_API_KEY`
from the environment. Run with those unset, that file is **83 passed**, and CI —
which has neither — has never reported them: its run shows `5 failed, 713
passed`, and these two are not among the five.

So in CI this takes the job from **five failures to one**, which also unblocks
the six suites the fail-fast job currently skips behind it — including
`arenabench — pytest`, whose own fix (#3950) has been landed but unexercised.

## The fifth failure is deliberately left

`test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` is a
different kind of problem and I am not guessing at it.

It pins `resolve_posture_role_model` to `AgentEngineConfig::model_for`, and
`model_for` lost its middle rung in the collapse. It is now:

```rust
pub fn model_for(&self) -> Option<&str> {
    self.agent()
        .and_then(|a| a.model.as_deref())
        .or(self.default_model.as_deref())
}
```

— `agents.<…>.model` → `default_model`, with no flat per-role key and no `kind`
argument, because core knows one role now (#3903).

The Python mirror still resolves through three rungs plus a worker-inheritance
arm. Aligning them is not a test edit: `resolve_posture_role_model` is what
decides the **assurance tier** a run is characterised by (`witness-on` vs
`witness-off`, via the verifier-independence predicate). Changing its resolution
changes which runs count as witness-authored — a claim about published benchmark
numbers, which is the maintainer call #3870 reserves and CLAUDE.md tells me not
to make silently.

Filed with the options and the consequence rather than folded in here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No posture value, arm definition, or digest touched
- [x] No `#[allow]`, no `TODO`, no baseline entry

## Deleted tests, named as the guard requires

None. No test is removed, renamed, or skipped — two helper functions read one
more constant each.

Refs #3967

## Summary by Sourcery

Align posture test vocabulary checks with both active and retired launcher tables while supporting formatted Rust declarations.

Bug Fixes:
- Correct posture validation helpers to recognize retired engine root fields and agent names accepted by the trusted launcher.
- Make Rust constant parsing robust to rustfmt-wrapped slice initializers.

Tests:
- Update posture tests to reflect the launcher's complete vocabulary without changing posture values or benchmark digests.