### PR TITLE
fix: unblock main — an unused import and two private intra-doc links

### DIFF
--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -136,7 +136,7 @@ use stella_core::ports::{ToolExecutor, TurnControls};
 use stella_core::router::Router;
 use stella_core::subagent::SubAgentDispatcher;
 use stella_model::provider::Provider;
-use stella_plugin::{HostCall, SignalValues, TurnOutcome as WrapperTurnOutcome};
+use stella_plugin::{SignalValues, TurnOutcome as WrapperTurnOutcome};
 use stella_protocol::{AgentEvent, CompletionMessage};
 use stella_runtime::wrapper::{
     CandidateFanoutSpend, CandidateFanouts, ChildTurnSpend, ChildTurns, DEFAULT_HOST_MAX_CALLS,

--- a/crates/stella-runtime/src/wrapper/dispatch.rs
+++ b/crates/stella-runtime/src/wrapper/dispatch.rs
@@ -376,7 +376,7 @@ impl WrapperDispatch {
     /// is stating that grounding comes before planning, and nothing else in
     /// the system knows that. Within one stage their contributions concatenate
     /// in that order; across stages they follow the merged stage order
-    /// [`super::compose`] computed.
+    /// `super::compose` computed.
     ///
     /// Each member keeps its **own** grants. A member that did not declare
     /// `before_turn` is not asked it because another member did; composition
@@ -388,7 +388,7 @@ impl WrapperDispatch {
     /// block — a composition of a wrapper and a non-wrapper is a caller
     /// mistake, not a degraded composition. [`WrapperError::EmptyComposition`]
     /// for no members. Otherwise one of the four conflict variants
-    /// [`super::compose`] documents: contradictory stage order, two oracles,
+    /// `super::compose` documents: contradictory stage order, two oracles,
     /// two arbiters, or one requirement name meaning two things.
     pub fn bind_composed(
         members: Vec<(PluginManifest, Arc<dyn TurnWrapper>)>,


### PR DESCRIPTION
## What & why

**`main` is red at `ed74c3da0`** on the **required** `fmt + clippy + test` job,
at two separate steps. Both come from the wrapper-composition work in #4095, and
both are one-line problems.

```
cargo clippy -D warnings
  error: unused import: `HostCall`
  error: could not compile `stella-cli` (bin "stella")
  error: could not compile `stella-cli` (bin "stella" test)

cargo doc -D warnings
  error: public documentation for `bind_composed` links to private item `super::compose`
         --> crates/stella-runtime/src/wrapper/dispatch.rs:379:11
  error: public documentation for `bind_composed` links to private item `super::compose`
         --> crates/stella-runtime/src/wrapper/dispatch.rs:391:11
  error: could not document `stella-runtime`
```

While this is red, every open PR is red too, and red stops distinguishing "your
change is broken" from "the base is" — the situation `main-red-hold` exists for.

### `HostCall`

Imported in `crates/stella-cli/src/wrapper_plugin.rs` and used nowhere in it.
Every other reference in that file is to `HostCallGate`, which is a different
type and stays. No doc link names the bare `HostCall` either, so nothing breaks
by dropping it.

Dropped from the import rather than suppressed. `#[allow(unused_imports)]` is
specifically what `scripts/check-dead-code-allows.py` exists to keep out of this
tree, and it would be asserting the lint is wrong when the lint is right.

### `super::compose`

`compose` is `pub(crate)` (`crates/stella-runtime/src/wrapper/compose.rs:88`),
and `bind_composed`'s documentation is public — so the intra-doc link is an
error under `-D warnings`.

Both become plain code text rather than being made to resolve. AGENTS.md names
this as the usual right answer *when the reference is a reader's orientation
rather than a navigable API relationship*, and that is exactly the case here:
a reader of `bind_composed`'s public docs could not navigate to a crate-private
function whatever we write, so backticks say precisely what the link meant and
nothing it cannot deliver. Making `compose` public to satisfy a doc link would
be widening an API for a footnote.

This is the fourth and fifth instance of the shape #3981 records, where `main`
went red on five of them at once.

### Why both reached `main`

Neither is visible to a normal local build. `cargo check` does not run clippy,
and rustdoc's `private_intra_doc_links` lint only fires under
`--document-private-items` — which only `make doc-warnings` passes. The pre-push
hook runs both; a push that skipped it would see neither.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Step | `main` (`ed74c3da0`) | here |
|---|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | the `HostCall` error above — CI run `32336986408`, job `96328422005` | `Finished dev profile` |
| `make doc-warnings` | both `super::compose` errors, `could not document stella-runtime` | `Finished` / `Generated … and 28 other files` |

`cargo fmt --all -- --check` is clean; the diff is one import line and two
backtick pairs, so there is no behaviour to test.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow]`, no `TODO`, no baseline entry, no widened visibility

## Deleted tests, named as the guard requires

None.

## Summary by Sourcery

Bug Fixes:
- Fix clippy and documentation warnings that were blocking the main branch by removing an unused CLI import and correcting private intra-documentation references.