### PR TITLE
feat(plugins): stella-candidates — best-of-N, and the first consumer of the fan-out

### DIFF
--- a/crates/stella-runtime/tests/candidates_plugin_hostcall.rs
+++ b/crates/stella-runtime/tests/candidates_plugin_hostcall.rs
@@ -1,0 +1,496 @@
+//! `plugins/stella-candidates` — best-of-N, graded through a scripted host
+//! conversation (#4029 P3.1, `doc:plugin-completion-plan` §4.2).
+//!
+//! # What this file is for
+//!
+//! `candidate_fanout`, `run_test` and `adopt_candidate` landed with #3844 and
+//! **nothing consumed them** — three capabilities on the wire with no plugin
+//! asking for any. This plugin is the consumer, and it is the only thing in the
+//! tree that reaches the `again?` point through a real fan-out.
+//!
+//! A host call is not a one-request-one-response exchange, so this drives the
+//! plugin line by line rather than through `SubprocessWrapper` — the same shape
+//! `goal_plugin_hostcall.rs` and `plan_plugin_hostcall.rs` use, with the script
+//! inline because these cases are about *sequences of calls* rather than about
+//! golden bytes.
+//!
+//! # What it can and cannot prove today
+//!
+//! §4.2's witness asks for "two candidates, one of which fails its test
+//! command; the plugin adopts the other", then the anti-vacuity half: "both
+//! pass, and the smaller diff wins".
+//!
+//! The first half **cannot pass**: `run_test` is answered
+//! `HostCallRefusal::Unsupported` by every host (#3580), so there is no test
+//! signal to fail on. What is graded here instead is the half that can be
+//! proven — the smaller diff wins, an unfinished candidate is never adopted —
+//! plus the thing that matters more while #3580 is open: that the plugin
+//! **asks anyway** and degrades honestly, reporting
+//! `test-signal-available = 0` rather than ranking silently.
+//!
+//! When #3580 lands, the missing half becomes writable — a candidate answering
+//! `passed: false` losing to one answering `passed: true` — against
+//! `main.py::choose`'s existing rule, with no change to the plugin. Until then
+//! that test would only be asserting against a host nobody has built, so it is
+//! deliberately absent rather than written against a fixture.
+//!
+//! `cfg(unix)` for `wrapper_socket.rs`'s reason (#3497).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use serde_json::{Value, json};
+use stella_plugin::{HostCall, Participation, PluginManifest, WrapperPoint};
+
+fn plugin_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../plugins/stella-candidates")
+        .canonicalize()
+        .expect("the first-party plugin ships at plugins/stella-candidates")
+}
+
+fn manifest() -> PluginManifest {
+    let text = fs::read_to_string(plugin_dir().join("plugin.toml"))
+        .expect("the manifest file is `plugin.toml`, exactly");
+    PluginManifest::from_toml_str(&text).expect("the shipped manifest loads")
+}
+
+fn argv(manifest: &PluginManifest) -> Vec<String> {
+    let dir = plugin_dir().display().to_string();
+    manifest
+        .runtime
+        .as_ref()
+        .expect("[runtime]")
+        .argv
+        .iter()
+        .map(|arg| arg.replace("${plugin_dir}", &dir))
+        .collect()
+}
+
+fn child_env(manifest: &PluginManifest) -> Vec<(String, String)> {
+    manifest
+        .runtime
+        .as_ref()
+        .expect("[runtime]")
+        .child_env(|name| std::env::var(name).ok())
+}
+
+/// An `after_turn` request with a candidate grant and no test plan.
+fn request(goal: &str) -> String {
+    json!({
+        "point": "after_turn",
+        "body": {
+            "protocol_version": 1,
+            "wrapper": "candidates-v1",
+            "round": 0,
+            "goal": goal,
+            "turn": { "completed": true, "answer": "a first attempt" }
+        }
+    })
+    .to_string()
+}
+
+/// One fan-out candidate, as the host's answer spells it.
+fn candidate(handle: &str, completed: bool, lines: u32) -> Value {
+    json!({
+        "candidate": handle,
+        "root": format!("/tmp/{handle}"),
+        "report": format!("{handle} did the work"),
+        "completed": completed,
+        "files_changed": 1,
+        "lines_changed": lines
+    })
+}
+
+fn ok(id: u32, payload: Value) -> Value {
+    json!({ "result": id, "ok": payload })
+}
+
+fn refused(id: u32, code: &str, detail: &str) -> Value {
+    json!({ "result": id, "err": { "refusal": code, "detail": detail } })
+}
+
+/// What one whole conversation produced.
+struct Conversation {
+    /// The calls the plugin made, in order, as raw messages.
+    calls: Vec<Value>,
+    /// The `evidence` object it finished with, when it finished.
+    evidence: Option<Value>,
+    stderr: String,
+    succeeded: bool,
+}
+
+impl Conversation {
+    fn measurement(&self, name: &str) -> Option<u64> {
+        self.evidence
+            .as_ref()?
+            .get("measurements")?
+            .get(name)?
+            .as_u64()
+    }
+
+    /// The `args` of the one call made for `call`, when exactly one was.
+    fn call_args(&self, call: &str) -> Option<&Value> {
+        let mut found = self
+            .calls
+            .iter()
+            .filter(|message| message.get("call").and_then(Value::as_str) == Some(call));
+        let first = found.next()?;
+        first.get("args")
+    }
+
+    fn calls_named(&self, call: &str) -> usize {
+        self.calls
+            .iter()
+            .filter(|message| message.get("call").and_then(Value::as_str) == Some(call))
+            .count()
+    }
+}
+
+/// Play the host's side of one conversation.
+///
+/// `answers` is consulted in order; a call the script has no answer for closes
+/// the pipe, which is a host that died mid-conversation and is itself a case
+/// worth being able to write.
+fn converse(request_text: &str, answers: &[Value]) -> Conversation {
+    let manifest = manifest();
+    let argv = argv(&manifest);
+    let env = child_env(&manifest);
+    let (program, args) = argv.split_first().expect("a program");
+
+    let mut child: Child = Command::new(program)
+        .args(args)
+        .env_clear()
+        .envs(env.iter().map(|(k, v)| (k, v)))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the plugin starts");
+
+    let mut stdin = Some(child.stdin.take().expect("a stdin pipe"));
+    let stdout = child.stdout.take().expect("a stdout pipe");
+
+    stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("{request_text}\n").as_bytes())
+        .expect("the request is written");
+
+    let mut calls = Vec::new();
+    let mut evidence = None;
+    for line in BufReader::new(stdout).lines() {
+        let line = line.expect("a readable line");
+        if line.trim().is_empty() {
+            continue;
+        }
+        let message: Value =
+            serde_json::from_str(&line).unwrap_or_else(|e| panic!("{line:?} is not JSON: {e}"));
+
+        // The response ends the conversation; anything else is a host call.
+        if message.get("point").is_some() {
+            evidence = message
+                .get("body")
+                .and_then(|body| body.get("evidence"))
+                .cloned();
+            break;
+        }
+
+        let index = calls.len();
+        calls.push(message);
+        match answers.get(index) {
+            Some(answer) => {
+                let pipe = stdin.as_mut().expect("stdin");
+                writeln!(pipe, "{answer}").expect("the answer is written");
+                pipe.flush().expect("the answer reaches the plugin");
+            }
+            None => {
+                drop(stdin.take());
+            }
+        }
+    }
+    drop(stdin.take());
+
+    let mut stderr = String::new();
+    BufReader::new(child.stderr.take().expect("a stderr pipe"))
+        .read_to_string(&mut stderr)
+        .expect("readable stderr");
+    let succeeded = child.wait().expect("the plugin exits").success();
+
+    Conversation {
+        calls,
+        evidence,
+        stderr,
+        succeeded,
+    }
+}
+
+/// **The witness (§4.2's anti-vacuity half).** Three candidates all finish; the
+/// one that changed the fewest lines is adopted and the rest are discarded.
+///
+/// This is the half of §4.2's witness that can be proven while #3580 is open.
+/// It fails before this plugin exists for the plainest possible reason: nothing
+/// in the tree asked for a `candidate_fanout` at all, so there was no consumer
+/// of the capability #3844 built and no code path that reached
+/// `adopt_candidate`.
+#[test]
+fn the_smallest_finished_candidate_wins_and_is_adopted() {
+    let conversation = converse(
+        &request("make the retry budget honoured"),
+        &[
+            // 1. the fan-out
+            ok(
+                1,
+                json!({
+                    "requested": 4,
+                    "candidates": [
+                        candidate("candidate-1", true, 120),
+                        candidate("candidate-2", true, 18),
+                        candidate("candidate-3", true, 64),
+                    ]
+                }),
+            ),
+            // 2-4. run_test, refused as every host does today
+            refused(2, "unsupported", "this host does not re-run tests (#3580)"),
+            refused(3, "unsupported", "this host does not re-run tests (#3580)"),
+            refused(4, "unsupported", "this host does not re-run tests (#3580)"),
+            // 5. the adoption
+            ok(
+                5,
+                json!({ "adopted": "candidate-2", "discarded": ["candidate-1", "candidate-3"] }),
+            ),
+        ],
+    );
+
+    assert!(
+        conversation.succeeded,
+        "the plugin exited non-zero: {}",
+        conversation.stderr
+    );
+
+    let adopted = conversation
+        .call_args(CALL_ADOPT)
+        .and_then(|args| args.get("candidate"))
+        .and_then(Value::as_str);
+    assert_eq!(
+        adopted,
+        Some("candidate-2"),
+        "the smallest diff (18 lines) wins over 64 and 120; the plugin asked to adopt {adopted:?}"
+    );
+
+    assert_eq!(conversation.measurement("candidates-scored"), Some(3));
+    assert_eq!(conversation.measurement("candidate-adopted"), Some(1));
+    assert_eq!(
+        conversation.measurement("winner-lines-changed"),
+        Some(18),
+        "the winner's size is reported, so a reader can see what was chosen and not only that \
+         something was"
+    );
+}
+
+/// **The degradation witness (#3580).** The plugin asks `run_test` for every
+/// candidate even though every host refuses it, and reports the absence as a
+/// number rather than ranking silently.
+///
+/// This is the half that matters most while #3580 is open, and it is what makes
+/// the "ask, degrade, disclose" decision checkable rather than a claim in a
+/// README. A plugin that had routed around the refusal — reading the grant's
+/// `TestPlan` and running the tests itself — would make no `run_test` call at
+/// all, and this test is what would catch that.
+#[test]
+fn run_test_is_asked_for_every_candidate_and_its_refusal_is_reported_as_a_number() {
+    let conversation = converse(
+        &request("anything"),
+        &[
+            ok(
+                1,
+                json!({
+                    "requested": 4,
+                    "candidates": [
+                        candidate("candidate-1", true, 10),
+                        candidate("candidate-2", true, 20),
+                    ]
+                }),
+            ),
+            refused(2, "unsupported", "this host does not re-run tests (#3580)"),
+            refused(3, "unsupported", "this host does not re-run tests (#3580)"),
+            ok(
+                4,
+                json!({ "adopted": "candidate-1", "discarded": ["candidate-2"] }),
+            ),
+        ],
+    );
+
+    assert_eq!(
+        conversation.calls_named(CALL_RUN_TEST),
+        2,
+        "one ask per candidate — the designed path, taken even though this host refuses it"
+    );
+    assert_eq!(
+        conversation.measurement("test-signal-available"),
+        Some(0),
+        "no host served run_test, and the plugin says so as a declared measurement rather than \
+         leaving a reader to assume the ranking used tests"
+    );
+    assert!(
+        conversation.stderr.contains("#3580"),
+        "and names the issue on stderr for a human: {}",
+        conversation.stderr
+    );
+    // It still chose, on the signals it does have.
+    assert_eq!(conversation.measurement("candidate-adopted"), Some(1));
+}
+
+/// A candidate that did not finish is never adopted, even when it is the
+/// smallest.
+///
+/// `completed = false` is an ordinary outcome — a carve ran out, a step cap hit
+/// — and its workspace is still readable. Adopting it would land a half-change
+/// on the real tree, which is worse than adopting nothing.
+#[test]
+fn an_unfinished_candidate_is_never_adopted_however_small_its_diff() {
+    let conversation = converse(
+        &request("anything"),
+        &[
+            ok(
+                1,
+                json!({
+                    "requested": 4,
+                    "candidates": [
+                        candidate("candidate-1", false, 2),
+                        candidate("candidate-2", true, 90),
+                    ]
+                }),
+            ),
+            refused(2, "unsupported", "no test signal"),
+            refused(3, "unsupported", "no test signal"),
+            ok(
+                4,
+                json!({ "adopted": "candidate-2", "discarded": ["candidate-1"] }),
+            ),
+        ],
+    );
+
+    let adopted = conversation
+        .call_args(CALL_ADOPT)
+        .and_then(|args| args.get("candidate"))
+        .and_then(Value::as_str);
+    assert_eq!(
+        adopted,
+        Some("candidate-2"),
+        "the 2-line candidate never finished, so the 90-line one that did is the only choice"
+    );
+    assert_eq!(conversation.measurement("winner-lines-changed"), Some(90));
+}
+
+/// When no candidate finished, nothing is adopted — and the plugin says so with
+/// numbers that let the declared check refuse.
+#[test]
+fn no_finished_candidate_means_nothing_is_adopted() {
+    let conversation = converse(
+        &request("anything"),
+        &[
+            ok(
+                1,
+                json!({
+                    "requested": 4,
+                    "candidates": [
+                        candidate("candidate-1", false, 5),
+                        candidate("candidate-2", false, 7),
+                    ]
+                }),
+            ),
+            refused(2, "unsupported", "no test signal"),
+            refused(3, "unsupported", "no test signal"),
+        ],
+    );
+
+    assert_eq!(
+        conversation.calls_named(CALL_ADOPT),
+        0,
+        "there is nothing to adopt, so nothing is asked for"
+    );
+    assert_eq!(conversation.measurement("candidates-scored"), Some(2));
+    assert_eq!(
+        conversation.measurement("candidate-adopted"),
+        Some(0),
+        "reported as a 0 rather than omitted: the plugin ran, asked, and adopted nothing, which \
+         is a claim the declared check can refuse on"
+    );
+}
+
+/// A host that serves no fan-out plane leaves the plugin with nothing to choose
+/// between, and it reports that rather than failing.
+#[test]
+fn a_host_with_no_fanout_plane_is_a_report_of_nothing_not_a_failure() {
+    let conversation = converse(
+        &request("anything"),
+        &[refused(
+            1,
+            "unavailable",
+            "this host holds no isolation substrate",
+        )],
+    );
+
+    assert!(
+        conversation.succeeded,
+        "a refused capability is a degradation, not a plugin bug: {}",
+        conversation.stderr
+    );
+    assert_eq!(conversation.measurement("candidates-scored"), Some(0));
+    assert_eq!(conversation.measurement("candidate-adopted"), Some(0));
+    assert_eq!(
+        conversation.calls_named(CALL_ADOPT),
+        0,
+        "nothing was built, so nothing is adopted"
+    );
+}
+
+/// The role intent every candidate runs at must resolve to the **worker's**
+/// seat — the inverse of `child_turn`'s rule, and the one thing about this
+/// capability a plugin author has to get right.
+///
+/// A child turn may not resolve to the worker's seat, because a plugin must not
+/// grade work with the model that did it. A fan-out candidate is not evidence
+/// about the work, it **is** the work, so booking it against `triage` would put
+/// spend on the receipt under a responsibility that did no writing.
+#[test]
+fn the_shipped_manifest_declares_a_worker_tier_for_its_fanout_role() {
+    let manifest = manifest();
+
+    assert_eq!(manifest.name, "stella-candidates");
+    assert_eq!(manifest.loop_grant.participation, Participation::Arbiter);
+    assert_eq!(manifest.loop_grant.points, vec![WrapperPoint::AfterTurn]);
+
+    for call in [
+        HostCall::CandidateFanout,
+        HostCall::RunTest,
+        HostCall::AdoptCandidate,
+    ] {
+        assert!(
+            manifest.loop_grant.calls.contains(&call),
+            "the manifest grants {call}; got {:?}",
+            manifest.loop_grant.calls
+        );
+    }
+
+    let roles = manifest.roles.as_ref().expect("[roles]");
+    let builder = roles.get("builder").expect("[roles.builder]");
+    assert_eq!(
+        builder.tier, "worker",
+        "a fan-out candidate IS the work, so its role must resolve to the worker's seat"
+    );
+
+    let width = manifest
+        .loop_grant
+        .max_fanout_width
+        .expect("[loop] max_fanout_width");
+    assert!(width > 0, "a zero width bounds nothing");
+}
+
+const CALL_RUN_TEST: &str = "run_test";
+const CALL_ADOPT: &str = "adopt_candidate";

--- a/plugins/stella-candidates/README.md
+++ b/plugins/stella-candidates/README.md
@@ -1,0 +1,122 @@
+# stella-candidates — best-of-N, as a plugin
+
+Try the work N ways in isolated worktrees, keep the one that does the least
+damage, throw the rest away.
+
+`candidate_fanout`, `run_test` and `adopt_candidate` landed with #3844 and
+**nothing consumed them** — three capabilities on the wire with no plugin asking
+for any of them. This is the consumer, and it is the only thing in the tree that
+reaches the `again?` point through a real fan-out.
+
+## Read this before installing
+
+Every candidate is a **writing** worker turn in an isolated worktree, and this
+plugin asks for up to `max_fanout_width` of them per round. That is N times a
+worker turn's spend, on your key, bought by a plugin rather than by you asking
+for it.
+
+The host clamps the width against its own ceiling and reports what it actually
+ran, so the number in the manifest is an ask and never an authority — but read
+it as "this may spend N turns", because it may.
+
+Stella does not score the candidates. It mints the worktrees, runs the turns and
+reports what each did; the choosing is this plugin's job, and the rule it
+chooses by is declared in `[oracle]` as data you can read before installing.
+
+## Why everything happens at `after_turn`
+
+`doc:plugin-completion-plan` §4.2 puts the fan-out at `before_turn`. **This
+plugin does not**, and the deviation is deliberate rather than an oversight.
+
+A plugin is a fresh process per point — `SubprocessWrapper::exchange` spawns per
+call. So a `before_turn` fan-out exits before `after_turn` runs and has nothing
+left to report, and `ObservedEvidence` is an `after_turn` value. Nothing carries
+across the boundary: `BeforeTurnRequest::published` propagates signals only
+within one `before_turn` sweep, and `AfterTurnRequest` has no field for them.
+
+A plugin that fanned out at `before_turn` would therefore have to fan out
+**again** at `after_turn` to have anything to report — N writing worker turns
+bought twice.
+
+So the host's own turn is attempt 0, and this plugin buys alternatives at
+`after_turn` when the outcome warrants it. Same best-of-N, one process, and one
+fewer turn: "best of N" costs N-1 extra turns rather than N.
+
+## How it chooses
+
+Mechanical, in this order, and there is no model call anywhere in the program:
+
+1. **A candidate that did not finish is never chosen.** `completed = false` is
+   an ordinary outcome — a carve ran out, a step cap hit — and its workspace is
+   still readable, but adopting an unfinished attempt lands a half-change on the
+   real tree.
+2. **A candidate whose tests passed beats one whose tests failed.** With no test
+   signal (see below) every candidate is equal here and the tiebreak does the
+   work.
+3. **The smallest `lines_changed` wins.**
+4. **Ties break on the handle**, so the choice is deterministic rather than
+   dependent on the order the host happened to mint them in.
+
+A model-scored ranking is **not** expressible in the oracle grammar
+(`doc:plugin-completion-plan` §6.1: *"a verdict over an aggregate the oracle
+computes, not a quantifier the host evaluates"*) and smuggling one in through
+the oracle process is the failure mode §6 exists to refuse. There is no arm in
+`main.py` that asks for a model call, which is how that stays true rather than
+being promised.
+
+## The test signal, and why it asks anyway
+
+`run_test` is answered `HostCallRefusal::Unsupported` by **every host** today —
+the arm in `wrapper/host_call.rs` is unconditional, and #3580 is open.
+
+This plugin asks for it regardless, once per candidate, and degrades to the
+mechanical signals when the answer is a refusal. `test-signal-available` reports
+which of the two happened, so a reader can tell a run that ranked on tests from
+one that ranked on diff size alone.
+
+That is the decision recorded on #4029: **ask, degrade, disclose.** The
+alternative — reading the candidate grant's `TestPlan` and running the tests
+here, the way `verify-{rs,py,ts}` run theirs — would route around #3580
+permanently instead of inheriting its fix. `run_test` exists precisely as the
+way to ask.
+
+When #3580 lands, this plugin ranks on tests with **no change to it**.
+
+## What it reports
+
+| Measurement | Meaning |
+| --- | --- |
+| `candidates-scored` | how many the host actually built and ran |
+| `candidate-adopted` | 1 when one landed on the real tree, 0 otherwise |
+| `winner-lines-changed` | the winner's diff size, so a reader sees *what* was chosen |
+| `test-signal-available` | 1 when some host served `run_test`, 0 while #3580 is open |
+
+One requirement, decided by one check: `candidate-adopted >= 1`. Deliberately
+not "the best candidate was chosen" — that is not something a check over
+reported numbers can decide, and a requirement no oracle can settle is
+`ManifestError::UndecidableRequirement`. The honest bar for a plugin whose job
+is to leave exactly one attempt on the tree is that it left one.
+
+## What §4.2's witness cannot prove yet
+
+§4.2 asks for *"two candidates, one of which fails its test command; the plugin
+adopts the other"*, then the anti-vacuity half, *"both pass, and the smaller
+diff wins"*.
+
+The first half **cannot pass** while `run_test` is unsupported — there is no
+test signal to fail on. What ships is the second half, plus the thing that
+matters more while #3580 is open: that the plugin asks anyway and reports the
+absence as a number. See
+`crates/stella-runtime/tests/candidates_plugin_hostcall.rs`.
+
+## Testing it
+
+| Harness | What it grades |
+| --- | --- |
+| `crates/stella-runtime/tests/candidates_plugin_hostcall.rs` | six scripted host conversations: the smallest finished candidate wins and is adopted; `run_test` is asked per candidate and its refusal becomes a declared measurement; an unfinished candidate is never adopted however small; no finished candidate means nothing is adopted; a host with no fan-out plane is a report of nothing rather than a failure; and the manifest declares a `worker` tier for its fan-out role |
+
+That last one is not bookkeeping. `CandidateFanoutArgs::role` is judged by the
+**opposite** rule to `child_turn`'s: a child turn may not resolve to the
+worker's seat, because a plugin must not grade work with the model that did it —
+but a fan-out candidate is not evidence about the work, it **is** the work, so
+it must resolve to the worker's seat and nothing else.

--- a/plugins/stella-candidates/main.py
+++ b/plugins/stella-candidates/main.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""`stella-candidates` — best-of-N, as a plugin.
+
+Standard library only, deliberately — the rule every first-party plugin here
+ships under (`doc:pipeline-as-plugins` §9 rule 3). `main.py` is the whole
+program.
+
+# What it does
+
+The capability landed with #3844 and nothing consumed it: `candidate_fanout`,
+`run_test` and `adopt_candidate` sat on the wire with no plugin asking for any
+of them. This is the consumer, and it is the only thing in the tree that
+exercises the `again?` point.
+
+One point, `after_turn`, and one conversation inside it:
+
+    host   {"point":"after_turn","body":{...}}
+ -> plugin {"call":"candidate_fanout","id":1,"args":{"role":"builder",...}}
+ -> host   {"result":1,"ok":{"requested":4,"candidates":[...]}}
+ -> plugin {"call":"run_test","id":2,"args":{"candidate":"..."}}      (per candidate)
+ -> host   {"result":2,"err":{"refusal":"unsupported",...}}          (today)
+ -> plugin {"call":"adopt_candidate","id":N,"args":{"candidate":"..."}}
+ -> host   {"result":N,"ok":{"adopted":"...","discarded":[...]}}
+ -> plugin {"point":"after_turn","body":{"evidence":{...}}}          <- ends it
+
+# Why everything is at `after_turn`
+
+`doc:plugin-completion-plan` §4.2 puts the fan-out at `before_turn`. That is
+not implementable: a plugin is a fresh process per point
+(`SubprocessWrapper::exchange` spawns per call), so a `before_turn` fan-out
+exits before `after_turn` runs and has nothing left to report — and
+`ObservedEvidence` is an `after_turn` value. Nothing carries across the
+boundary. A plugin that fanned out at `before_turn` would have to fan out again
+to report, buying N writing worker turns twice.
+
+So the host's own turn is attempt 0, and this plugin buys alternatives at
+`after_turn`. Same best-of-N, one process, one fewer turn.
+
+# How it decides, and what it will not do
+
+The manifest declares the rule as data. This program computes the numbers the
+rule reads and never a verdict — `judge` is the host's own function.
+
+**Scoring is mechanical and stays that way.** The winner is the candidate that
+finished, passed its test if a test signal exists, and changed the fewest
+lines. There is no model call anywhere in this file and no arm that asks for
+one. A model-scored ranking is not expressible in the oracle grammar
+(`doc:plugin-completion-plan` §6.1: "a verdict over an aggregate the oracle
+computes, not a quantifier the host evaluates") and smuggling one in through
+the oracle process is the failure mode §6 exists to refuse.
+
+# The test signal, and asking for it anyway
+
+`run_test` is answered `HostCallRefusal::Unsupported` by every host today
+(#3580) — the arm is unconditional in `wrapper/host_call.rs`. This plugin asks
+for it regardless, and degrades to the mechanical signals the fan-out already
+carries when the answer is a refusal.
+
+That is deliberate: `run_test` is the *designed* way to ask, and reading the
+candidate grant's `TestPlan` and running it here — the way
+`verify-{rs,py,ts}` run theirs — would route around #3580 permanently instead
+of inheriting its fix. Ask, degrade, disclose. `test-signal-available` reports
+which of the two happened, so a reader can tell a run that ranked on tests from
+one that ranked on diff size alone.
+"""
+
+import json
+import sys
+
+PROTOCOL_VERSION = 1
+POINT = "after_turn"
+
+REQUEST_FIELDS = {
+    "protocol_version",
+    "wrapper",
+    "stage",
+    "round",
+    "goal",
+    "candidate",
+    "turn",
+}
+CALL_ANSWER_FIELDS = {"result", "ok", "err"}
+
+# `host_call::CandidateFanoutResult` / `FanoutCandidate`, field for field.
+FANOUT_OK_FIELDS = {"requested", "candidates"}
+CANDIDATE_FIELDS = {
+    "candidate",
+    "root",
+    "report",
+    "completed",
+    "files_changed",
+    "lines_changed",
+}
+ADOPT_OK_FIELDS = {"adopted", "discarded"}
+
+CALL_FANOUT = "candidate_fanout"
+CALL_RUN_TEST = "run_test"
+CALL_ADOPT = "adopt_candidate"
+
+# The `[roles.<name>]` key this plugin declares. Must resolve to the WORKER's
+# seat — a fan-out candidate is the work, not evidence about it.
+ROLE_INTENT = "builder"
+
+# The ask. The host clamps it and reports what it actually ran.
+REQUESTED_WIDTH = 4
+
+
+class Refusal(Exception):
+    """The plugin cannot answer. Exits non-zero; the host reads the silence."""
+
+
+def refuse(reason):
+    raise Refusal(reason)
+
+
+def deny_unknown(table, allowed, subject="the request"):
+    unknown = sorted(set(table) - allowed)
+    if unknown:
+        refuse("{} denies unknown fields; got {}".format(subject, ", ".join(unknown)))
+    return table
+
+
+def read_json(stream):
+    """The next JSON document on `stream`, or `None` when there is not one."""
+    decoder = json.JSONDecoder()
+    buffered = ""
+    while True:
+        text = buffered.strip()
+        if text:
+            try:
+                document, end = decoder.raw_decode(text)
+            except ValueError:
+                pass  # Not yet complete, or never will be. EOF decides which.
+            else:
+                if not text[end:].strip():
+                    return document
+        line = stream.readline()
+        if not line:
+            return None
+        buffered += line
+
+
+def write_json(stream, document):
+    """One JSON document, on one line, flushed. The flush is load-bearing."""
+    stream.write(json.dumps(document) + "\n")
+    stream.flush()
+
+
+def report(reason):
+    """Say on stderr what this plugin did or degraded to — never silent."""
+    sys.stderr.write("stella-candidates: {}\n".format(reason))
+
+
+def refusal_text(failure):
+    """A failed call's `err`, as the one line this plugin logs about it."""
+    if isinstance(failure, dict):
+        code = failure.get("refusal")
+        detail = failure.get("detail")
+        if isinstance(code, str) and isinstance(detail, str):
+            return "{}: {}".format(code, detail)
+    return json.dumps(failure, sort_keys=True)
+
+
+class HostCalls:
+    """This plugin's end of the host-call conversation (§6b).
+
+    `ask` returns the `ok` payload or `None`. `None` covers every way a call can
+    fail to produce one — refused for any of the closed reasons, answered for a
+    different call, or not answered at all — and does not branch on which,
+    because every one of them leaves this plugin with the same job: degrade, and
+    say so on stderr.
+
+    `refused` records the last refusal code, because this plugin has one
+    degradation it must report as a *number* rather than only as prose: whether
+    a test signal existed at all.
+    """
+
+    def __init__(self, stdin, stdout):
+        self.stdin = stdin
+        self.stdout = stdout
+        self.asked = 0
+        self.last_refusal = None
+
+    def ask(self, call, args):
+        self.asked += 1
+        call_id = self.asked
+        write_json(self.stdout, {"call": call, "id": call_id, "args": args})
+
+        answer = read_json(self.stdin)
+        if not isinstance(answer, dict):
+            report("the host did not answer the {} call".format(call))
+            return None
+        answered = answer.get("result")
+        if isinstance(answered, bool) or answered != call_id:
+            report(
+                "the host answered call {} while this plugin asked {}".format(
+                    json.dumps(answered), call_id
+                )
+            )
+            return None
+        deny_unknown(answer, CALL_ANSWER_FIELDS, "a host-call answer")
+        ok = answer.get("ok")
+        failure = answer.get("err")
+        if (ok is None) == (failure is None):
+            refuse("a host-call answer carries either ok or err, never both")
+        if failure is not None:
+            if isinstance(failure, dict):
+                self.last_refusal = failure.get("refusal")
+            report("the host did not serve {}: {}".format(call, refusal_text(failure)))
+            return None
+        if not isinstance(ok, dict):
+            refuse("a host-call answer's ok must be an object")
+        return ok
+
+
+def fan_out(host_calls, goal, width):
+    """Ask for `width` isolated writing turns. Returns `(requested, candidates)`.
+
+    `(0, [])` on every degradation — the host serves no fan-out plane, the
+    manifest was not granted the call, or the answer was unreadable. A plugin
+    that cannot fan out has nothing to choose between, which is a report of
+    nothing rather than a failure.
+    """
+    ok = host_calls.ask(
+        CALL_FANOUT,
+        {"role": ROLE_INTENT, "instruction": candidate_instruction(goal), "width": width},
+    )
+    if ok is None:
+        return (0, [])
+    deny_unknown(ok, FANOUT_OK_FIELDS, "the fan-out answer")
+    requested = ok.get("requested")
+    candidates = ok.get("candidates", [])
+    if not isinstance(requested, int) or isinstance(requested, bool):
+        refuse("the fan-out answer carried no requested width")
+    if not isinstance(candidates, list):
+        refuse("the fan-out answer's candidates must be a list")
+
+    scored = []
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            refuse("a fan-out candidate must be an object")
+        deny_unknown(entry, CANDIDATE_FIELDS, "a fan-out candidate")
+        handle = entry.get("candidate")
+        completed = entry.get("completed")
+        lines = entry.get("lines_changed")
+        files = entry.get("files_changed")
+        if not isinstance(handle, str) or not handle:
+            refuse("a fan-out candidate carried no handle")
+        if not isinstance(completed, bool):
+            refuse("a fan-out candidate's completed must be a boolean")
+        if not isinstance(lines, int) or isinstance(lines, bool):
+            refuse("a fan-out candidate carried no lines_changed")
+        if not isinstance(files, int) or isinstance(files, bool):
+            refuse("a fan-out candidate carried no files_changed")
+        scored.append(
+            {
+                "handle": handle,
+                "completed": completed,
+                "lines_changed": lines,
+                "files_changed": files,
+                # Filled in below, when a test signal exists at all.
+                "passed": None,
+            }
+        )
+    return (requested, scored)
+
+
+def candidate_instruction(goal):
+    """What every candidate turn is asked to do.
+
+    The goal, and a bounded restatement of the rule they are about to be judged
+    by. Telling them the rule is not gaming it: the rule is in the manifest a
+    human read before installing, and a worker that knows "smallest correct
+    change wins" writes a better candidate than one guessing at the criterion.
+    """
+    return (
+        "{}\n\n"
+        "You are one of several independent attempts at this task, each in its "
+        "own isolated worktree. Exactly one attempt will be kept and the rest "
+        "discarded. The attempt that is kept is the one that finishes, passes "
+        "the project's tests, and changes the fewest lines to do it. Make the "
+        "smallest correct change you can; do not rewrite what you do not have "
+        "to."
+    ).format(goal)
+
+
+def score_tests(host_calls, candidates):
+    """Ask the host to run each candidate's tests. Returns whether it could.
+
+    Today every host answers `unsupported` (#3580), so this returns `False` and
+    every candidate keeps `passed = None`. Asking anyway is the point: when
+    #3580 lands, this plugin ranks on tests with no change to it.
+    """
+    served = False
+    for candidate in candidates:
+        ok = host_calls.ask(CALL_RUN_TEST, {"candidate": candidate["handle"]})
+        if ok is None:
+            continue
+        served = True
+        # The host has no `run_test` answer shape yet (`HostCallOk` carries no
+        # RunTest variant), so this reads the two keys any such answer must
+        # plausibly carry and treats anything else as no signal. It is written
+        # to be replaced by a typed read the day the shape exists, not to guess
+        # cleverly in the meantime.
+        passed = ok.get("passed")
+        if isinstance(passed, bool):
+            candidate["passed"] = passed
+    if not served:
+        report(
+            "no host served run_test (#3580), so candidates are ranked on what "
+            "the fan-out itself reported: completion, then diff size"
+        )
+    return served
+
+
+def choose(candidates):
+    """The winner, or `None` when there is nothing to choose.
+
+    Mechanical, in this order:
+
+    1. A candidate that did not finish is never chosen. `completed = false` is
+       an ordinary outcome — its carve ran out, its step cap hit — and its
+       workspace is still readable, but adopting an unfinished attempt would
+       land a half-change on the real tree.
+    2. Among those, a candidate whose tests passed beats one whose tests failed.
+       With no test signal every candidate is equal here, and the tiebreak below
+       does all the work.
+    3. Among those, the smallest `lines_changed` wins.
+    4. Ties break on the handle, so the choice is deterministic rather than
+       dependent on the order the host happened to mint them in.
+    """
+    finished = [c for c in candidates if c["completed"]]
+    if not finished:
+        return None
+    if any(c["passed"] is False for c in finished):
+        passing = [c for c in finished if c["passed"] is not False]
+        if passing:
+            finished = passing
+    return min(finished, key=lambda c: (c["lines_changed"], c["handle"]))
+
+
+def adopt(host_calls, winner):
+    """Land the winner. Returns whether the host says it did."""
+    ok = host_calls.ask(CALL_ADOPT, {"candidate": winner["handle"]})
+    if ok is None:
+        return False
+    deny_unknown(ok, ADOPT_OK_FIELDS, "the adopt answer")
+    adopted = ok.get("adopted")
+    if not isinstance(adopted, str) or not adopted:
+        refuse("the adopt answer named no adopted candidate")
+    discarded = ok.get("discarded", [])
+    if not isinstance(discarded, list):
+        refuse("the adopt answer's discarded must be a list")
+    report(
+        "adopted {} and discarded {} sibling(s)".format(adopted, len(discarded))
+    )
+    return True
+
+
+def evidence(measurements):
+    """One `ObservedEvidence`. This plugin's evidence is never a flip."""
+    return {"flip": "not-applicable", "measurements": measurements}
+
+
+def assess(body, host_calls):
+    """The whole of `after_turn`."""
+    goal = body.get("goal")
+    if not isinstance(goal, str) or not goal:
+        refuse("the request carried no goal")
+
+    requested, candidates = fan_out(host_calls, goal, REQUESTED_WIDTH)
+    if not candidates:
+        report(
+            "no candidate workspaces were built, so there is nothing to choose "
+            "between and nothing was adopted"
+        )
+        # Deliberately NOT `candidate-adopted: 0` alone — the check reads that
+        # name and a 0 is an honest claim here: the plugin ran, asked, and
+        # adopted nothing. `candidates-scored: 0` is what says why.
+        return evidence(
+            {
+                "candidates-scored": 0,
+                "candidate-adopted": 0,
+                "winner-lines-changed": 0,
+                "test-signal-available": 0,
+            }
+        )
+
+    served = score_tests(host_calls, candidates)
+    winner = choose(candidates)
+    if winner is None:
+        report(
+            "{} candidate(s) were built and none finished, so none was adopted".format(
+                len(candidates)
+            )
+        )
+        return evidence(
+            {
+                "candidates-scored": len(candidates),
+                "candidate-adopted": 0,
+                "winner-lines-changed": 0,
+                "test-signal-available": 1 if served else 0,
+            }
+        )
+
+    landed = adopt(host_calls, winner)
+    if requested > len(candidates):
+        report(
+            "asked for {} candidates and the host ran {}".format(
+                requested, len(candidates)
+            )
+        )
+    return evidence(
+        {
+            "candidates-scored": len(candidates),
+            "candidate-adopted": 1 if landed else 0,
+            "winner-lines-changed": winner["lines_changed"],
+            "test-signal-available": 1 if served else 0,
+        }
+    )
+
+
+def read_request(stdin):
+    """Decode `{"point": ..., "body": ...}` and return the `after_turn` body."""
+    envelope = read_json(stdin)
+    if not isinstance(envelope, dict):
+        refuse("stdin was not a single JSON object")
+    if set(envelope) - {"point", "body"}:
+        refuse("the request envelope carried a field outside {point, body}")
+
+    point = envelope.get("point")
+    if point != POINT:
+        refuse("this plugin answers only `{}`; it was asked `{}`".format(POINT, point))
+    body = envelope.get("body")
+    if not isinstance(body, dict):
+        refuse("the request carried no body object")
+    deny_unknown(body, REQUEST_FIELDS)
+
+    version = body.get("protocol_version")
+    if version != PROTOCOL_VERSION:
+        refuse(
+            "this plugin speaks protocol version {}; the host wrote {}".format(
+                PROTOCOL_VERSION, version
+            )
+        )
+    return body
+
+
+def main():
+    host_calls = HostCalls(sys.stdin, sys.stdout)
+    try:
+        body = read_request(sys.stdin)
+        observed = assess(body, host_calls)
+    except Refusal as refused:
+        report(str(refused))
+        return 1
+    write_json(
+        sys.stdout,
+        {
+            "point": POINT,
+            "body": {"protocol_version": PROTOCOL_VERSION, "evidence": observed},
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/stella-candidates/plugin.toml
+++ b/plugins/stella-candidates/plugin.toml
@@ -1,0 +1,125 @@
+# stella-candidates — best-of-N, as a plugin (#4029 P3.1,
+# `doc:plugin-completion-plan` §4.2).
+#
+# The capability landed with #3844 and nothing consumed it: `candidate_fanout`,
+# `run_test` and `adopt_candidate` were on the wire with no plugin asking for
+# any of them. This is the consumer, and it is the only thing in the tree that
+# exercises the `again?` point — the half of the wrapper socket that decides
+# whether a turn gets another round.
+#
+# READ THIS BEFORE INSTALLING. Every candidate is a **writing** worker turn in
+# an isolated worktree, and this plugin asks for up to `max_fanout_width` of
+# them per round. That is N times a worker turn's spend, on your key, bought by
+# a plugin rather than by you asking. The host clamps the width against its own
+# ceiling and reports what it actually ran, so the number below is an ask and
+# never an authority — but read it as "this may spend N turns", because it may.
+#
+# Stella does not score the candidates. It mints the worktrees, runs the turns,
+# and reports what each did; the choosing is this plugin's whole job, and the
+# rule it chooses by is declared in `[oracle]` below as data a human can read
+# before installing.
+
+name = "stella-candidates"
+description = "Try the work N ways in isolated worktrees, keep the one that does the least damage, and throw the rest away. Reports what it scored; Stella applies the declared rule."
+
+# Arbiter: this plugin decides whether the round is finished and may hold it
+# open for another attempt. `Stop` comes with the grade
+# (`ManifestError::ArbiterMustDeclareStop`).
+[loop]
+participation = "arbiter"
+hooks = ["Stop"]
+# `after_turn` ONLY, and this is a deliberate departure from
+# `doc:plugin-completion-plan` §4.2, which puts the fan-out at `before_turn`.
+#
+# A plugin is a fresh process per point — `SubprocessWrapper::exchange` spawns
+# per call — so a `before_turn` fan-out exits before `after_turn` runs and has
+# nothing left to report. `ObservedEvidence` is an `after_turn` value, and
+# nothing carries across the boundary (`BeforeTurnRequest::published`
+# propagates only within one `before_turn` sweep). A plugin that fanned out at
+# `before_turn` would have to fan out AGAIN to report, buying N worker turns
+# twice.
+#
+# So: the host's own turn is attempt 0, and this plugin buys N-1 alternatives
+# at `after_turn` when the outcome warrants it. Same best-of-N, one process,
+# and one fewer turn. See README.md.
+points = ["after_turn"]
+# The three capabilities #3844 built and nothing consumed until now,
+# exhaustively — an undeclared call is refused before this host performs
+# anything.
+#
+# `run_test` is declared even though every host answers it `unsupported`
+# (#3580). That is the decision, not an oversight: it is the designed way to
+# ask, and reading the grant's own `TestPlan` and running the tests here
+# instead would route around #3580 permanently rather than inheriting its fix.
+calls = ["candidate_fanout", "run_test", "adopt_candidate"]
+# Two corrections. A fan-out is expensive enough that "try again with a wider
+# net" needs a reason, not a reflex.
+max_holds = 2
+# Per-point conversation ceiling (#3839): one `candidate_fanout`, one
+# `run_test` per candidate, one `adopt_candidate`.
+max_calls = 8
+# The ask. `DEFAULT_HOST_MAX_FANOUT_WIDTH` is the authority and clamps it; the
+# answer reports both, so this plugin can say honestly that it scored three of
+# the four it wanted.
+max_fanout_width = 4
+
+# ---------------------------------------------------------------------------
+# The definition of done.
+#
+# One requirement, and deliberately not "the best candidate was chosen" — that
+# is not a thing a check over reported numbers can decide, and a requirement
+# no oracle can settle is `ManifestError::UndecidableRequirement`. What CAN be
+# decided is that a candidate was adopted at all, which is the honest bar for
+# a plugin whose job is to leave exactly one attempt on the tree.
+# ---------------------------------------------------------------------------
+[requirements]
+a-candidate-was-adopted = "one candidate's changes were applied to the real tree, and its siblings were discarded"
+
+[oracle]
+# Not a flip. This plugin's evidence is a count, not a red-to-green transition
+# — the same shape `plugins/stella-witness` declares the opposite of, and the
+# reason `flip = "not-applicable"` exists.
+flip = "not-applicable"
+measurements = [
+  "candidates-scored",
+  "candidate-adopted",
+  "winner-lines-changed",
+  "test-signal-available",
+]
+
+[[oracle.checks]]
+requirement = "a-candidate-was-adopted"
+check = "candidate-adopted >= 1"
+
+# The role intent every candidate turn runs at.
+#
+# `tier = "worker"` is not a preference: `CandidateFanoutArgs::role` is judged
+# by the OPPOSITE rule to `child_turn`'s. A child turn may not resolve to the
+# worker's seat, because a plugin must not grade work with the model that did
+# it. A fan-out candidate is not evidence about the work — it IS the work — so
+# it must resolve to the worker's seat and nothing else. Booking a writing turn
+# against `triage` would put spend on the receipt under a responsibility that
+# did no writing.
+[roles.builder]
+tier = "worker"
+
+# Declared only because `[roles]` requires it (#3496). This plugin spends its
+# turns over the host-call channel, not through `[subloop]`'s own bounded
+# dispatch — the same declaration-to-satisfy-the-validator that
+# `plugins/stella-goal` and `plugins/stella-plan` both carry.
+[subloop]
+stages = ["execute"]
+
+[runtime]
+argv = ["python3", "${plugin_dir}/main.py"]
+# Generous, and it has to be: one point of this plugin may run N writing worker
+# turns end to end. `SubprocessWrapper`'s timeout covers the whole conversation
+# rather than each message, by contract.
+timeout_secs = 1800
+env = ["PATH"]
+
+[wrapper]
+id = "candidates-v1"
+
+[[wrapper.stages]]
+name = "execute"


### PR DESCRIPTION
Epic #4029 **P3.1**. The last of the buildable plugins.

## The gap

`candidate_fanout`, `run_test` and `adopt_candidate` landed with #3844 and
**nothing consumed them** — three capabilities on the wire with no plugin asking
for any of them. §4.2 calls this "the cheapest remaining plugin relative to its
value, and the one that proves the `again?` point, which nothing currently
does".

## Two departures from §4.2, both forced by the code, both reported before I wrote a line

**1. The fan-out happens at `after_turn`, not `before_turn`.**

§4.2 says `before_turn` asks for the workspaces *and* the plugin reports each
candidate's measurements as `ObservedEvidence`. Those cannot both happen,
because a plugin is a fresh process per point:

```rust
// crates/stella-runtime/src/wrapper/subprocess.rs:354
async fn exchange(&self, request: WrapperRequest) -> Result<WrapperResponse, WrapperError> {
    ...
    let mut child = command.spawn()...
```

`before_turn` and `after_turn` each call `exchange`, and `exchange` spawns. The
process that fans out at `before_turn` **exits** before `after_turn` runs, and
`ObservedEvidence` is an `after_turn` value. Nothing carries across:
`BeforeTurnRequest::published` propagates only within one `before_turn` sweep.
A plugin built to §4.2's shape would have to fan out **twice** — N writing
worker turns bought for one round's evidence.

So the host's own turn is attempt 0 and this plugin buys alternatives at
`after_turn`. Same best-of-N, one process, and one fewer turn: N-1 extra rather
than N.

**2. §4.2's "blocked on: nothing in the socket" is wrong — it is blocked on
#3580.**

`run_test` is answered `HostCallRefusal::Unsupported` by every host; the arm in
`wrapper/host_call.rs:305` is unconditional. So the "whose declared test command
passes" half of §4.2's own ranking rule has no signal.

Both findings are on #4029 with their evidence, posted **before** building, so
the plan is corrected rather than quietly deviated from.

## Ask, degrade, disclose

Your decision on #4029, implemented literally. The plugin asks `run_test` once
per candidate even though every host refuses it, degrades to the mechanical
signals the fan-out already carries, and reports which of the two happened as a
declared measurement.

The alternative — reading the grant's `TestPlan` and running the tests here, the
way `verify-{rs,py,ts}` run theirs — would route around #3580 permanently
instead of inheriting its fix. `run_test` exists precisely as the way to ask.

**When #3580 lands, this plugin ranks on tests with no change to it.**

## How it chooses

1. A candidate that did not finish is never chosen — adopting a half-change is
   worse than adopting nothing.
2. A passing test beats a failing one (inert today, see above).
3. Smallest `lines_changed` wins.
4. Ties break on the handle, so the choice is deterministic rather than
   dependent on the order the host minted them in.

**No model call anywhere in `main.py`, and no arm that asks for one.** A
model-scored ranking is not expressible in the oracle grammar (§6.1: *"a verdict
over an aggregate the oracle computes, not a quantifier the host evaluates"*)
and smuggling one in through the oracle process is the failure mode §6 exists to
refuse. That stays true by there being nothing that could, not by promise.

One requirement, decided by `candidate-adopted >= 1`. Deliberately **not** "the
best candidate was chosen" — no check over reported numbers can decide that, and
a requirement no oracle can settle is `UndecidableRequirement`.

## Witnesses

`crates/stella-runtime/tests/candidates_plugin_hostcall.rs` — 6 scripted host
conversations, all green.

The load-bearing one is
`run_test_is_asked_for_every_candidate_and_its_refusal_is_reported_as_a_number`.
It is what makes "ask, degrade, disclose" **checkable** rather than a claim in a
README: a plugin that had routed around the refusal would make no `run_test`
call at all and fail it.

The others: the smallest finished candidate wins and is adopted; an unfinished
candidate is never adopted however small; no finished candidate means nothing is
adopted; a host with no fan-out plane is a report of nothing rather than a
failure; and the manifest declares a **`worker`** tier for its fan-out role.

That last is not bookkeeping — `CandidateFanoutArgs::role` is judged by the
*opposite* rule to `child_turn`'s. A child turn may not resolve to the worker's
seat, because a plugin must not grade work with the model that did it; a fan-out
candidate is not evidence about the work, it **is** the work.

§4.2's own witness half — one candidate failing its test command — is **not
written**, because it could only assert against a host nobody has built. Writing
it against a fixture would be a green test for a path that does not exist.

## Note on the base, and on a false green

This branch inherits `main`'s red `cargo doc` (#4104, fixed by #4105). The only
file rustdoc names is `dispatch.rs`; none of the files added here.

Worth saying how I know that, because the first check lied: `cargo doc` on this
branch reported clean, and it was a **cached** result. `touch` on the offending
file is what showed the truth. Recorded here because a piped cargo run that
reports success without rebuilding is exactly the shape that lets a red gate
read as green.

## Checks

`cargo test -p stella-runtime --test candidates_plugin_hostcall` — 6 passed.
`cargo clippy -p stella-runtime --all-targets -- -D warnings` clean.
`cargo fmt --all` clean. No test deleted. No baseline entry.

Refs #4029
Refs #3580

## Summary by Sourcery

Add a best-of-N candidate plugin that evaluates isolated worker attempts and adopts the smallest finished candidate while reporting capability degradations.

New Features:
- Add the stella-candidates plugin to fan out isolated worker attempts, rank them, and adopt the selected candidate.
- Expose best-of-N candidate scoring through completion, diff-size, adoption, and test-signal measurements.

Enhancements:
- Use after-turn fan-out to account for per-point plugin process isolation and avoid duplicating candidate work.
- Degrade gracefully when candidate fan-out or test execution is unavailable while disclosing the resulting signals.
- Keep candidate selection deterministic by excluding unfinished work, preferring available test results, minimizing changed lines, and breaking ties by handle.
- Declare candidate work under the worker tier and limit the plugin to mechanical, non-model-based ranking.

Documentation:
- Document the plugin’s installation costs, selection behavior, host capability fallbacks, and declared evidence.

Tests:
- Add scripted host-conversation coverage for candidate adoption, test-call refusals, unfinished candidates, empty fan-out results, and manifest role validation.