### PR TITLE
fix(bench,arenabench,stella-autonomy): three defects reddening main, each hiding the next (#4110)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -79,8 +79,19 @@ jobs:
           # pinning that let #2182 through one level up — the sweep asserts
           # this pattern covers every caller it reads, so the next one cannot
           # land outside the filter unnoticed.
+          #
+          # `crates/stella-cli/src/settings/` is the second Rust path in scope
+          # for the catalog's reason, added after it cost a red `main`.
+          # `test_assurance_tiers.py` parses `AgentEngineConfig::model_for` and
+          # `RETIRED_ENGINE_ROOT` out of that module, because the posture
+          # module mirrors the engine's model-resolution ladder and a mirror
+          # that drifts is #2134. #3908 collapsed the ladder to one role,
+          # touched no path named here, and so ran none of these suites on its
+          # own PR — then reddened every push to `main` from the merge onward,
+          # since a push runs them unconditionally. The tests assert this
+          # pattern still names the module they read.
           if git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Eq '^(bench/|arenabench/|crates/stella-model/src/catalog\.rs$|\.github/workflows/bench\.yml$)'; then
+            | grep -Eq '^(bench/|arenabench/|crates/stella-model/src/catalog\.rs$|crates/stella-cli/src/settings(\.rs$|/)|\.github/workflows/bench\.yml$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/arenabench/tests/test_responsibilities.py
+++ b/arenabench/tests/test_responsibilities.py
@@ -33,28 +33,25 @@ from arenabench.model import (
     ResponsibilityConfig,
 )
 
-#: Stella's normative home for the role vocabulary, relative to a checkout.
-#: ``scripts/check-role-names.sh`` names this same function as "the truth" and
-#: reads its match arms the same way, so the two halves of the contract are
-#: anchored to one file rather than to each other.
-_ROLE_KEY_RS = Path("crates") / "stella-cli" / "src" / "config_wiring.rs"
-
-#: One match arm of ``role_key()``: ``EngineAgentKind::Verifier => "verifier",``
-_ROLE_ARM = re.compile(r'EngineAgentKind::\w+\s*=>\s*"([a-z_]+)"')
-
-
-def _role_key_names(source: str) -> frozenset[str]:
-    """Every role spelling ``role_key()`` returns, read out of the Rust.
-
-    Scoped to that function's body — a bare sweep for the arm shape would also
-    collect every other ``match kind`` in the file, and those are legitimately
-    partial (``model_source`` skips ``Default``). The body ends at the first
-    column-zero ``}``, which is how ``check-role-names.sh``'s awk delimits it.
-    """
-    body = re.search(r"pub fn role_key\b.*?\n\}", source, re.DOTALL)
-    if body is None:
-        return frozenset()
-    return frozenset(_ROLE_ARM.findall(body.group()))
+# The reader that used to live here — `_ROLE_KEY_RS`, `_ROLE_ARM` and
+# `_role_key_names()`, which parsed `role_key()`'s match arms out of
+# `crates/stella-cli/src/config_wiring.rs` — is deleted, finishing what #3950
+# started. That PR removed the assertion those three existed to serve and the
+# `re`/`pathlib` imports they needed, but left the three behind, so importing
+# this module raised `NameError: name 'Path' is not defined` and NOTHING in
+# `arenabench/tests/` could be collected. It went unseen because the bench
+# workflow's arenabench step never ran: the `harbor_adapter` step above it had
+# been failing since #3944, and one red step masks every step after it.
+#
+# They are deleted rather than repaired, for #3950's own two reasons plus a
+# third it could not have known. The property is still enforced by a gate step
+# (`scripts/check-role-names.sh`), so repointing would be a fourth copy of a
+# passing check; re-creating a role roster for core to publish pulls against
+# `doc:roleless-core` (#3903); and the subject itself is gone — #3908 deleted
+# `role_key()` and `EngineAgentKind`, and repointed that gate at
+# `ENGINE_AGENT_NAMES`/`RETIRED_ENGINE_AGENT_NAMES` in `settings::unknown`. A
+# repaired reader would parse a function that no longer exists and silently
+# return the empty set.
 
 
 HEADER = """

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -960,15 +960,28 @@ def resolve_posture_role_model(
 ) -> tuple[str, str]:
     """Resolve one role's model from a posture, and name the key it came from.
 
-    Mirrors ``AgentEngineConfig::model_for`` (``crates/stella-cli/src/settings.rs``)
-    key for key: ``agents.<role>.model`` outranks the flat ``pipeline_<role>_model``,
-    which outranks ``default_model`` — except for the two roles that inherit the
-    worker instead on that last rung (``_WORKER_INHERITING_ROLES``, which is the
-    engine's own split between ``model_spec_for`` and ``own_model_spec_for``, not
-    an approximation of it). Mirroring it *exactly* is the whole point —
-    a declaration that resolves roles by a different rule than the engine does is
-    free to disagree with the run it describes, which is the shape of #2134 and of
+    Mirrors ``AgentEngineConfig::model_for``
+    (``crates/stella-cli/src/settings/engine.rs``): ``agents.<role>.model``
+    outranks the flat ``pipeline_<role>_model``, which outranks
+    ``default_model`` — except for the two roles that inherit the worker
+    instead on that last rung (``_WORKER_INHERITING_ROLES``, which is the
+    engine's own split between ``model_spec_for`` and ``own_model_spec_for``,
+    not an approximation of it). Mirroring it is the whole point: a declaration
+    that resolves roles by a different rule than the engine does is free to
+    disagree with the run it describes, which is the shape of #2134 and of
     #1147 before it.
+
+    **The middle rung is knowingly ahead of the engine.** #3908 collapsed
+    ``agent_engine_config`` to the one role core has, so ``model_for`` now
+    reads ``agents.default.model`` > ``default_model`` and the five flat
+    ``pipeline_<role>_model`` keys are **retired** — recognized, ignored and
+    reported by name (``settings::unknown::RETIRED_ENGINE_ROOT``) rather than
+    removed, because this harness and ``arenabench`` still write them into
+    postures whose digests are registered in ``bench/READINESS.md`` §8.4.
+    Reading them here is therefore still correct for what this function
+    describes — the posture as written — and stops being correct when slice 6
+    (#3910) stops writing them. Both halves of that are pinned by
+    ``test_assurance_tiers.py``; do not narrow this ladder without it.
 
     Two of those rungs bit in the same match. ``cc00894779ff`` read only the
     host-side selector and so missed the flat key an ArenaBench roles config

--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -18,16 +18,27 @@ Two questions are covered here, and they are different:
   so every channel into it — the host selector, a harness's overridden builder —
   is honored by construction rather than one at a time.
 - **How a role resolves inside that posture.** The engine reads
-  `agents.<role>.model` > the flat `pipeline_<role>_model` > `default_model`
-  (`AgentEngineConfig::model_for`). A declaration that resolves roles by any
-  other rule is free to disagree with the run it describes, which is the whole
-  defect class.
+  `agents.default.model` > `default_model` (`AgentEngineConfig::model_for`). A
+  declaration that resolves roles by any other rule is free to disagree with
+  the run it describes, which is the whole defect class.
+
+  That ladder used to carry a middle rung — the flat `pipeline_<role>_model` —
+  and this module still reads it. The divergence is deliberate and bounded:
+  #3908 collapsed the engine to the one role core has and **retired** the five
+  flat keys rather than removing them, precisely because this harness and
+  `arenabench` still write them into hashed postures, and refusing them would
+  re-hash every digest registered in `bench/READINESS.md` §8.4. The Python
+  stops writing them in slice 6 (#3910). Until then the two sides are
+  knowingly out of step, so the mirror tests below pin the order of the rungs
+  that *survive* and assert the extra rung is exactly the retired set — a
+  named divergence rather than a drift nobody noticed.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -45,6 +56,7 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     assurance_tiers_from_posture,
 )
 from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    _FLAT_ROLE_MODEL_KEY,
     resolve_posture_role_model,
 )
 
@@ -330,7 +342,9 @@ _SETTINGS_MODULE = [
     _SETTINGS_SRC / "settings.rs",
     *sorted((_SETTINGS_SRC / "settings").glob("*.rs")),
 ]
+_BENCH_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "bench.yml"
 _MODEL_FOR_DECL = "pub fn model_for("
+_RETIRED_ROOT_DECL = "pub(crate) const RETIRED_ENGINE_ROOT: &[&str] = &["
 
 
 def _model_for_source() -> str:
@@ -357,25 +371,129 @@ def _model_for_source() -> str:
     return holders[0].read_text()
 
 
+def _model_for_body() -> str:
+    """The body of `AgentEngineConfig::model_for`, brace to matching brace."""
+    source = _model_for_source()
+    start = source.index(_MODEL_FOR_DECL)
+    return source[start : source.index("\n    }\n", start)]
+
+
+def _retired_engine_root() -> set[str]:
+    """The flat role keys the engine still *recognizes* after #3908.
+
+    Parsed rather than copied: a list duplicated into this file is a second
+    cell that drifts, and it would drift in exactly the direction that costs —
+    this harness still writing a key the trusted launcher has begun refusing,
+    discovered at launch with the posture already hashed.
+    """
+    holders = [
+        f for f in _SETTINGS_MODULE if f.exists() and _RETIRED_ROOT_DECL in f.read_text()
+    ]
+    assert len(holders) == 1, (
+        f"`RETIRED_ENGINE_ROOT` is declared in {len(holders)} settings files "
+        f"({[str(f) for f in holders]}); this mirror needs exactly one to name "
+        "the vocabulary the launcher still accepts"
+    )
+    source = holders[0].read_text()
+    start = source.index(_RETIRED_ROOT_DECL) + len(_RETIRED_ROOT_DECL)
+    return set(re.findall(r'"([^"]+)"', source[start : source.index("];", start)]))
+
+
 def test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors() -> None:
     """Pin the mirror to its original: `AgentEngineConfig::model_for`.
 
-    The declaration is only trustworthy while it resolves roles the way the
+    The declaration is only trustworthy while it resolves a role the way the
     engine does. Reordering `model_for` without reordering
     `resolve_posture_role_model` re-opens #2134 in a new place, and nothing
     else in either tree would notice — the two live in different languages,
     different test suites, and different CI jobs.
+
+    Only the rungs both sides still share are pinned here. #3908 removed the
+    engine's middle rung; that this module still reads it is asserted as a
+    named, tracked divergence by the test below, rather than silently
+    tolerated by weakening this one.
     """
-    source = _model_for_source()
-    start = source.index(_MODEL_FOR_DECL)
-    body = source[start : source.index("\n    }\n", start)]
+    body = _model_for_body()
     rungs = [
-        body.index("self.agent(kind).and_then(|a| a.model"),
-        body.index("pipeline_verifier_model"),
+        body.index(".and_then(|a| a.model"),
         body.index("self.default_model"),
     ]
     assert rungs == sorted(rungs), (
-        "`model_for` no longer reads `agents.<kind>.model` > the flat per-role "
-        "key > `default_model`; `resolve_posture_role_model` mirrors that order "
-        "and has to change with it (#2134)"
+        "`model_for` no longer reads `agents.default.model` > `default_model`; "
+        "`resolve_posture_role_model` mirrors that order and has to change "
+        "with it (#2134)"
+    )
+
+
+def test_the_flat_role_keys_this_module_reads_are_retired_by_the_engine() -> None:
+    """The one rung this mirror has and the engine does not is the retired set.
+
+    #3908 collapsed `agent_engine_config` to the one role core has and dropped
+    the flat `pipeline_<role>_model` keys out of `model_for`. It deliberately
+    did not drop them out of the settings *vocabulary*: they are recognized,
+    ignored and reported by name in `RETIRED_ENGINE_ROOT`, because this harness
+    and `arenabench` still write them into postures whose digests are
+    registered in `bench/READINESS.md` §8.4, and refusing them would re-hash
+    every one of those — the published-numbers call #3870 reserves for a
+    maintainer.
+
+    So the divergence is legitimate exactly while both halves hold: the engine
+    reads none of these keys, and it still recognizes all of them. Slice 6
+    (#3910) closes it from this side. If either half moves first, this is where
+    a maintainer finds out — rather than a benchmark launch being refused with
+    the posture already hashed, or a rung growing back under a mirror that no
+    longer checks it.
+    """
+    body = _model_for_body()
+    flat_keys = set(_FLAT_ROLE_MODEL_KEY.values())
+
+    read_again = sorted(key for key in flat_keys if key in body)
+    assert not read_again, (
+        f"`model_for` reads {read_again} again — the engine grew back a rung "
+        "this module mirrors, so `resolve_posture_role_model`'s order is no "
+        "longer a mirror of it but a guess (#2134)"
+    )
+
+    dropped = sorted(flat_keys - _retired_engine_root())
+    assert not dropped, (
+        f"{dropped} are still written into postures by this harness but are no "
+        "longer named in `RETIRED_ENGINE_ROOT`, so the trusted-launcher seam "
+        "refuses them and every digest in `bench/READINESS.md` §8.4 needs "
+        "re-hashing; slice 6 (#3910) has to land on this side first"
+    )
+
+
+def test_the_bench_workflow_runs_when_the_settings_module_changes() -> None:
+    """A ratchet that reads a file must be triggered by that file.
+
+    `test_posture.py`'s catalog assertion, made for the second Rust path a
+    bench suite reads. The two mirrors above parse
+    `crates/stella-cli/src/settings/` — the engine's ladder and its retired-key
+    vocabulary — and that directory was not named in `bench.yml`'s change
+    filter, so a PR touching only it set `changed=false` and skipped the whole
+    suite. #3908 was exactly that PR: green on its own branch, and red on
+    `main` from the merge onward, because a push to `main` runs the suites
+    unconditionally. The filter is a hand-written literal on both sides, so the
+    two are compared here rather than trusted to stay in step.
+
+    Matched against the filter *expression* rather than the file, deliberately:
+    the whole file includes the paragraph of comment explaining the pattern, so
+    a whole-file search goes green on prose alone — it would still pass for
+    someone who wrote the rationale and deleted the alternative.
+    """
+    relative = (_SETTINGS_SRC / "settings").relative_to(_REPO_ROOT).as_posix()
+    lines = _BENCH_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    filters = [line for line in lines if "grep -Eq" in line]
+    assert len(filters) == 1, (
+        f"expected exactly one `grep -Eq` change filter in "
+        f"{_BENCH_WORKFLOW.name}, found {len(filters)}; this assertion can no "
+        "longer name which one gates the suites"
+    )
+    # The filter is a POSIX ERE, so its literals carry escaped dots; compare
+    # against the unescaped text.
+    assert relative in filters[0].replace("\\", ""), (
+        f"{_BENCH_WORKFLOW.name}'s change filter does not name {relative}, so "
+        "a PR touching only the engine's settings module skips this suite — "
+        "including the two mirror checks above, whose only input is that "
+        "module."
     )

--- a/crates/stella-autonomy/src/gate.rs
+++ b/crates/stella-autonomy/src/gate.rs
@@ -1,8 +1,8 @@
 //! Which checks are allowed to block a merge, and which have stopped earning
 //! that right.
 //!
-//! `doc:backlog-self-driving` §3.3 (#3599). [`crate::deliver`] decides what to
-//! do about a red build; this decides *which reds count*. They are separate
+//! `doc:backlog-self-driving` §3.3 (#3599). [`deliver_next`](crate::deliver_next)
+//! decides what to do about a red build; this decides *which reds count*. They are separate
 //! questions and were previously the same one, which is how a loop ends up
 //! permanently blocked by something no pull request could ever fix.
 //!

--- a/scripts/bench-suites.sh
+++ b/scripts/bench-suites.sh
@@ -181,12 +181,22 @@ run_suites() {
     printf '\033[36m▸ bench suite: %s (%s)%s\033[0m\n' \
       "$workdir" "$mode" "${args:+ $args}" >&2
 
+    # `${argv[@]+"${argv[@]}"}` rather than a plain `"${argv[@]}"`: under
+    # `set -u`, bash 3.2 — which is the `/bin/bash` every macOS ships, and so
+    # the one the pre-push hook actually runs — treats an EMPTY array's `[@]`
+    # expansion as an unbound variable and kills the shell outright. Two of
+    # the seven suites take no extra pytest arguments, and the first of them
+    # is the first suite in the list, so `make bench-test` died on line one
+    # with `argv[@]: unbound variable` on every Mac. The guard reports the
+    # array as absent when it is empty and expands it normally otherwise,
+    # which is well-defined on 3.2 and on 5.x alike. Fixed in bash 4.4; the
+    # repository does not get to require it.
     case "$mode" in
     sync)
-      (cd "$workdir" && uv sync --locked --extra dev && uv run --no-sync pytest -q "${argv[@]}")
+      (cd "$workdir" && uv sync --locked --extra dev && uv run --no-sync pytest -q ${argv[@]+"${argv[@]}"})
       ;;
     no-project)
-      (cd "$workdir" && uv run --with pytest --no-project pytest -q "${argv[@]}")
+      (cd "$workdir" && uv run --with pytest --no-project pytest -q ${argv[@]+"${argv[@]}"})
       ;;
     *)
       die "unknown suite mode '$mode' — scripts/bench-suites.sh is out of date."


### PR DESCRIPTION
## What & why

`main` is red, on **three** independent defects in two required jobs. Each one hid the next, so they are fixed together and in the order they surfaced.

### 1. `harbor_adapter + analyzer pytest` — the role-model mirror outlived its original

Red on **every** push to `main` since #3944. #3908 collapsed `AgentEngineConfig::model_for` to the one role core has — `agents.default.model` > `default_model` — and `test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` looks for `pipeline_verifier_model` inside its body, so it raises `ValueError: substring not found` and asserts nothing at all.

This ships **#4103's option 2, and only that**: restate what the mirror mirrors, change no resolution behaviour. `posture.py`'s entire diff is its docstring — `resolve_posture_role_model` still resolves the same rungs for the same postures, so no recorded run is re-characterised and the published-numbers decision #3870 reserves for a maintainer is untouched. **Options 1 and 3 stay open, and so does #4103.** I am not the one who should choose between "collapse the mirror" and "retire the tier"; this only stops `main` being red while that is decided.

The mirror is repointed, not weakened:

- the surviving pin asserts the order of the two rungs both sides still share — the #2134 reorder hazard on everything that is left;
- a new test asserts the extra rung is *exactly* the retired set: `model_for` reads none of the five flat `pipeline_<role>_model` keys, **and** `RETIRED_ENGINE_ROOT` still names all five. The divergence is legitimate only while both halves hold, and slice 6 (#3910) closes it from the Python side. `RETIRED_ENGINE_ROOT` is parsed out of the Rust rather than copied, so it cannot drift in the direction that costs — this harness writing a key the launcher has begun refusing, discovered at launch with the posture already hashed.

**And the reason it reached `main` is closed.** `bench.yml`'s PR filter names `crates/stella-model/src/catalog.rs` because a suite reads it, but did not name `crates/stella-cli/src/settings/`, which these mirrors parse. #3908 touched no filtered path, so its PR skipped the suites and went green; a push to `main` runs them unconditionally, so it reddened from the merge onward. The filter now names the module and a third test asserts it does — matched against the `grep -Eq` expression rather than the whole file, because a whole-file search would pass on the rationale comment alone.

### 2. `make bench-test` could not start on a Mac — and was hiding a second red suite

Found by trying to *prove* (1) with the local command this PR claims. `scripts/bench-suites.sh` expands each suite's pytest arguments as `"${argv[@]}"` under `set -u`. In bash 3.2 — the `/bin/bash` every macOS ships, and the one the pre-push hook runs — an **empty** array's `[@]` expansion is a fatal unbound-variable error. Two of seven suites take no arguments and one is first, so the command died on line one. Same class as #2847 one level down: the local command existed and could not start.

With it running, `arenabench/tests/` turns out to fail **collection entirely**: `NameError: name 'Path' is not defined`. #3950 removed the assertion that `_ROLE_KEY_RS`, `_ROLE_ARM` and `_role_key_names()` served, and their `re`/`pathlib` imports, but left the three module-level orphans behind. Red since 2026-08-19, unseen because the bench job's steps are sequential — `harbor_adapter` fails first, so the arenabench step never ran. **One red step masks every step after it.**

The three are deleted, not repaired, for #3950's own two reasons plus a third it could not have known: #3908 deleted `role_key()` and `EngineAgentKind` and repointed `check-role-names.sh` at `ENGINE_AGENT_NAMES`/`RETIRED_ENGINE_AGENT_NAMES`. A repaired reader would parse a function that no longer exists and silently return the empty set — a green assertion over nothing.

### 3. `fmt + clippy + test` — `cargo doc -D warnings` fails on a private intra-doc link

Separate job, separate defect, surfaced by the `main-red-hold` check on this PR naming **#4110**. `crates/stella-autonomy/src/gate.rs:4` links `[`crate::deliver`]`; that module is private and its items are public only via the re-export at `lib.rs:66`. Introduced by #4097. Repointed at `[`deliver_next`](crate::deliver_next)`, which is both public and the accurate referent, and is exactly how `doctrine.rs:22` already spells the same item.

Closes #4110
Refs #4103
Refs #3910

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

| Witness | On `main` | Here |
|---|---|---|
| `test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` | `ValueError: substring not found` | passes |
| `test_the_bench_workflow_runs_when_the_settings_module_changes` | fails — `main`'s filter does not name the module | passes |
| `make bench-test` (macOS) | `bench-suites.sh: line 186: argv[@]: unbound variable` | runs all seven suites |
| `arenabench` collection | `NameError: name 'Path' is not defined` | collects to 100% |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-autonomy` | `could not document stella-autonomy` | `Documenting stella-autonomy` → `Finished` |

`test_the_flat_role_keys_this_module_reads_are_retired_by_the_engine` is not a witness for this change — it is the guard for the gap that let #3908 through, and would have failed *before* #3908 for the right reason.

The rustdoc witness was run the way #4110 prescribes — `touch` the file first, then read the output for `Documenting`, not for `Finished` — because `cargo doc` reports a cached success without rebuilding, and that false green is what let #4104 through after an explicit check.

```
bench/harbor_adapter:  719 passed, 2 skipped
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace:  exit 0, 29 crates
```

**Two local failures are the machine, not the code, and are named rather than hidden:** the two `test_adapter` failures on a box carrying a real `VOYAGE_API_KEY`/`OPENROUTER_API_KEY` are #3668; the five `arenabench/tests/test_sut.py` failures are `stella_seat_problem()` correctly refusing because `/usr/bin/python3` is 3.9.6 here and `tomllib` landed in 3.11. CI's ubuntu runner is 3.12. The refusal is the guard working. CI is the authority for those five and I did not run them green locally.

## The gate

- [x] `make guards-fast` (exit 0)
- [x] `make bench-test` — now that it can run
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` (exit 0)
- [x] `shellcheck scripts/bench-suites.sh` (exit 0)
- [x] Docs updated where behaviour changed — the two stale docstrings claiming a key-for-key mirror are corrected in the same diff
- [x] `Closes #4110` in this description **and** as a commit trailer

## Nothing left behind

- [x] There is nothing new: everything I noticed is already tracked.

Checked against existing issues rather than duplicated:

- the mirror-vs-engine decision itself — **#4103**, deliberately left open, because option 2 does not answer it
- the fail-closed tightening this unblocks — **#3910**
- the two adapter tests that read ambient provider credentials — **#3668**
- the red `main` this closes — **#4110**

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The judgement call worth reviewing is that I shipped #4103's option 2 without a maintainer.** #4103 explicitly reserves the choice, so the thing to check is that this really is behaviour-neutral: `git diff` on `posture.py` should be docstring-only. If it is, no arm changes and no digest re-hashes, and the maintainer question is exactly as open as it was.

**Three defects in one PR is a deliberate exception to one-logical-change.** They are causally chained — (2) is what let me prove (1), and fixing (2) is what revealed the arenabench half; (3) was surfaced by the hold check on this PR and blocks the same required job set. Splitting them would mean landing a fix whose evidence I could not run.

The ERE is worth a second pair of eyes: `crates/stella-cli/src/settings(\.rs$|/)` matches `settings.rs` and `settings/*.rs` and deliberately not `settings_other.rs`; verified against those three plus `agent.rs` and `catalog.rs` before committing.
