### PR TITLE
fix(stella-autonomy): gate.rs links a private module, and main is red

### DIFF
--- a/crates/stella-autonomy/src/gate.rs
+++ b/crates/stella-autonomy/src/gate.rs
@@ -1,8 +1,8 @@
 //! Which checks are allowed to block a merge, and which have stopped earning
 //! that right.
 //!
-//! `doc:backlog-self-driving` §3.3 (#3599). [`crate::deliver`] decides what to
-//! do about a red build; this decides *which reds count*. They are separate
+//! `doc:backlog-self-driving` §3.3 (#3599). [`deliver_next`](crate::deliver_next)
+//! decides what to do about a red build; this decides *which reds count*. They are separate
 //! questions and were previously the same one, which is how a loop ends up
 //! permanently blocked by something no pull request could ever fix.
 //!


### PR DESCRIPTION
## The defect

`main` is red. `cargo doc -D warnings`, a step of the required `fmt + clippy +
test` job, exits 101 at `29d1eb14d` and every commit since:

```
error: public documentation for `gate` links to private item `crate::deliver`
error: could not document `stella-autonomy`
```

`crates/stella-autonomy/src/gate.rs:4` links `[`crate::deliver`]`. That module
is private (`mod deliver;`, `lib.rs:45`); its items reach the public surface
only through the re-export at `lib.rs:66`.

Introduced by #4097. `f3d2cbe2e`, the commit before it, is green — so this is
the one change that flipped it.

**Not mine**, but a red `main` reds every open PR, and the repair is two words.

## The fix

Point the link at the public re-export:

```diff
-//! `doc:backlog-self-driving` §3.3 (#3599). [`crate::deliver`] decides what to
-//! do about a red build; this decides *which reds count*.
+//! `doc:backlog-self-driving` §3.3 (#3599). [`deliver_next`](crate::deliver_next)
+//! decides what to do about a red build; this decides *which reds count*.
```

`deliver_next` is also the **accurate** referent — it is the function that
decides what to do about a red build, and `crates/stella-autonomy/src/doctrine.rs:22`
already uses exactly this form for exactly this item. So the fix matches a
working pattern in the same crate rather than inventing one.

No `#[allow(rustdoc::private_intra_doc_links)]`. The lint is right.

## Fourth instance in two days, and the reason is not "somebody skipped a check"

#3981 was five at once. #4104 was four more, in
`crates/stella-runtime/src/wrapper/dispatch.rs`, two hours ago — mine. This is
the same lint again.

Two things conspire, and both are worth naming because the obvious remedy
("run `cargo doc` before pushing") does not work on its own:

1. **The rungs people actually run compile no rustdoc.** `make guards-fast` and
   `make check` don't touch it, so a doc-comment-only edit reaches CI unchecked.
2. **`cargo doc` reports success from cache without rebuilding.** A run right
   after an unrelated build prints `Finished` and nothing else, and looks
   exactly like a pass. That false green is what let #4104 through *after* I
   had explicitly checked it.

What actually catches it — and how this PR was verified:

```
$ touch crates/stella-autonomy/src/gate.rs
$ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-autonomy
   Documenting stella-autonomy v0.9.116        ← the line that matters
    Finished `dev` profile
```

**Read the output for `Documenting <crate>`, never for `Finished`.**

Whether `make check` should include `cargo doc` is a real trade — it costs a
documentation build on a rung chosen for speed — so I have left it as a note on
#4110 rather than folding a workflow change into a red-main repair. Four
instances in two days is the evidence for opening it as its own issue.

## Witness

The guard is the evidence, and it flips:

```
$ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-autonomy   # on main
error: public documentation for `gate` links to private item `crate::deliver`
error: could not document `stella-autonomy`

$ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stella-autonomy   # here
   Documenting stella-autonomy v0.9.116
    Finished
```

Doc comment only — no code changed, no test deleted, no baseline entry.

Closes #4110

## Summary by Sourcery

Bug Fixes:
- Fix the autonomy crate's documentation link to reference the public `deliver_next` API instead of the private `deliver` module, restoring documentation builds with warnings treated as errors.