### PR TITLE
fix: main is red on three checks across two jobs — a private-module doc link, a retired-signature mirror test, and an uncollectable arenabench suite

### DIFF
--- a/arenabench/tests/test_responsibilities.py
+++ b/arenabench/tests/test_responsibilities.py
@@ -33,30 +33,6 @@ from arenabench.model import (
     ResponsibilityConfig,
 )
 
-#: Stella's normative home for the role vocabulary, relative to a checkout.
-#: ``scripts/check-role-names.sh`` names this same function as "the truth" and
-#: reads its match arms the same way, so the two halves of the contract are
-#: anchored to one file rather than to each other.
-_ROLE_KEY_RS = Path("crates") / "stella-cli" / "src" / "config_wiring.rs"
-
-#: One match arm of ``role_key()``: ``EngineAgentKind::Verifier => "verifier",``
-_ROLE_ARM = re.compile(r'EngineAgentKind::\w+\s*=>\s*"([a-z_]+)"')
-
-
-def _role_key_names(source: str) -> frozenset[str]:
-    """Every role spelling ``role_key()`` returns, read out of the Rust.
-
-    Scoped to that function's body — a bare sweep for the arm shape would also
-    collect every other ``match kind`` in the file, and those are legitimately
-    partial (``model_source`` skips ``Default``). The body ends at the first
-    column-zero ``}``, which is how ``check-role-names.sh``'s awk delimits it.
-    """
-    body = re.search(r"pub fn role_key\b.*?\n\}", source, re.DOTALL)
-    if body is None:
-        return frozenset()
-    return frozenset(_ROLE_ARM.findall(body.group()))
-
-
 HEADER = """
 [match]
 id = "ablation"

--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -45,6 +45,7 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     assurance_tiers_from_posture,
 )
 from stella_harbor.posture import (  # noqa: E402 - after importorskip by design
+    _FLAT_ROLE_MODEL_KEY,
     resolve_posture_role_model,
 )
 
@@ -357,25 +358,72 @@ def _model_for_source() -> str:
     return holders[0].read_text()
 
 
-def test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors() -> None:
+def test_the_engine_still_resolves_a_model_in_the_order_this_module_mirrors() -> None:
     """Pin the mirror to its original: `AgentEngineConfig::model_for`.
 
-    The declaration is only trustworthy while it resolves roles the way the
-    engine does. Reordering `model_for` without reordering
+    The declaration is only trustworthy while it resolves the way the engine
+    does. Reordering `model_for` without reordering
     `resolve_posture_role_model` re-opens #2134 in a new place, and nothing
     else in either tree would notice — the two live in different languages,
     different test suites, and different CI jobs.
+
+    **The engine has one role now.** `model_for` used to take a `kind` and
+    read `agents.<kind>.model` > the flat `pipeline_<kind>_model` >
+    `default_model`. #3908/#3944 (`doc:roleless-core` §6 slice 4) collapsed
+    the six personas to the one role core actually has, so the signature lost
+    its parameter and the middle rung went with it — four of those five flat
+    keys were already inert before the collapse, read by nothing at all.
+
+    What that leaves is asserted in two halves below, because
+    ``resolve_posture_role_model`` still ranks the flat key and this test is
+    the only thing that would notice the day that stops being deliberate:
+
+    1. the two rungs the engine really has, in order;
+    2. that the flat keys are *declared* retired rather than quietly dropped.
+
+    Half 2 is what keeps this honest. The mirror's middle rung is dead, and
+    `RETIRED_ENGINE_ROOT`'s own comment says the fail-closed tightening lands
+    with **slice 6 (#3910), once the Python stops writing them** — so the
+    harness writing them today is a tracked interim state, not drift. When
+    #3910 lands, this assertion is what fails and sends the next reader to
+    `resolve_posture_role_model`.
     """
     source = _model_for_source()
     start = source.index(_MODEL_FOR_DECL)
     body = source[start : source.index("\n    }\n", start)]
     rungs = [
-        body.index("self.agent(kind).and_then(|a| a.model"),
-        body.index("pipeline_verifier_model"),
+        body.index("self.agent()"),
         body.index("self.default_model"),
     ]
     assert rungs == sorted(rungs), (
-        "`model_for` no longer reads `agents.<kind>.model` > the flat per-role "
-        "key > `default_model`; `resolve_posture_role_model` mirrors that order "
-        "and has to change with it (#2134)"
+        "`model_for` no longer reads `agents.default.model` > `default_model`; "
+        "`resolve_posture_role_model` mirrors that order and has to change "
+        "with it (#2134)"
+    )
+    assert "pipeline_verifier_model" not in body, (
+        "`model_for` reads a flat `pipeline_<role>_model` key again — if the "
+        "per-role rung is back, `resolve_posture_role_model`'s middle rung is "
+        "live again too and this test should assert its position, not its "
+        "absence (#3908)"
+    )
+
+    retired = (_SETTINGS_SRC / "settings" / "unknown.rs").read_text()
+    # Anchor on the declaration, not the first mention — the name appears in a
+    # doc comment above it, and slicing from there reads the wrong span.
+    decl = "const RETIRED_ENGINE_ROOT"
+    assert decl in retired, (
+        "the retired engine-root keys are no longer declared in "
+        "`settings/unknown.rs`; `resolve_posture_role_model` still writes and "
+        "ranks them, so their status has to be readable from the engine (#3910)"
+    )
+    declared = retired[retired.index(decl) :]
+    declared = declared[: declared.index("];")]
+    missing = [
+        key for key in _FLAT_ROLE_MODEL_KEY.values() if f'"{key}"' not in declared
+    ]
+    assert not missing, (
+        f"the harness writes {missing} but the engine no longer recognizes "
+        "them even to report them — slice 6 (#3910) tightened this to "
+        "fail-closed, so `resolve_posture_role_model` must stop writing the "
+        "flat keys now"
     )

--- a/crates/stella-autonomy/src/gate.rs
+++ b/crates/stella-autonomy/src/gate.rs
@@ -1,7 +1,7 @@
 //! Which checks are allowed to block a merge, and which have stopped earning
 //! that right.
 //!
-//! `doc:backlog-self-driving` §3.3 (#3599). [`crate::deliver`] decides what to
+//! `doc:backlog-self-driving` §3.3 (#3599). `crate::deliver` decides what to
 //! do about a red build; this decides *which reds count*. They are separate
 //! questions and were previously the same one, which is how a loop ends up
 //! permanently blocked by something no pull request could ever fix.


### PR DESCRIPTION
Two independent reds on `6ce03c3b3`, neither caused by the other. `Vercel` is
also red, but with `Account is blocked` — unrelated to this tree.

| Check | Cause |
|---|---|
| `fmt + clippy + test` | `cargo doc -D warnings`: public docs link a private module |
| `harbor_adapter + analyzer pytest` | a mirror test pins a signature #3908 retired |

## 1. A public item's docs link a private module

`crates/stella-autonomy/src/gate.rs`'s module doc linked ``[`crate::deliver`]``,
but `deliver` is a private `mod` (`lib.rs:45`):

```
error: public documentation for `gate` links to private item `crate::deliver`
error: could not document `stella-autonomy`
```

Rustdoc rejects this under `--document-private-items` as well, which is the
flag CI passes — so the flag does not mask it here. Demoted to a plain
backtick reference: the sentence names which module owns the decision, it is
not a link a reader could follow.

## 2. The mirror test pins a signature that no longer exists

`test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors`
introspects `AgentEngineConfig::model_for` and searched for
`self.agent(kind).and_then(|a| a.model` and `pipeline_verifier_model`.
Neither substring exists any more, so it died on `ValueError: substring not
found` before asserting anything.

**This is stale maintenance, not a live regression.** #3908/#3944
(`doc:roleless-core` §6 slice 4) collapsed the six model personas to the one
role core actually has, so `model_for` lost its `kind` parameter and the flat
per-role rung with it. Per `settings/engine.rs`'s own module doc, four of
those five keys were *already inert before the collapse* — "a user could set
`pipeline_verifier_model` and nothing read it".

It went unnoticed because `bench.yml` is path-filtered: it needs a commit
touching `bench/**` to run at all, and #4102 was the first one since #3944.

### What it asserts now

The two rungs the engine really has — `agents.default.model` >
`default_model` — plus two assertions that keep this honest rather than
merely green:

- `model_for` does **not** read a flat per-role key again (if the per-role
  rung returns, the mirror's middle rung is live and the test should pin its
  position, not its absence);
- every key the harness still writes is declared in `RETIRED_ENGINE_ROOT`.

`resolve_posture_role_model` **does** still rank the flat key, and that is
deliberate and tracked, not drift: `settings/unknown.rs` records that the
fail-closed tightening lands with **slice 6 (#3910)** "once the Python stops
writing them". When #3910 lands, the second assertion is what fails, and it
names `resolve_posture_role_model` as the thing to change. That is why this
PR does not migrate the harness itself — #3910 owns that, and doing it here
would change ArenaBench's role-model attribution inside a red-main repair.

## Witness

```
uv run pytest tests/test_assurance_tiers.py     1 failed, 9 passed  ->  10 passed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --keep-going          error  ->  clean
make guards-fast                                 all 32 guard steps OK
```

Full `harbor_adapter` suite locally: 715 passed, 2 failed — both failures are
this machine's environment leaking into `tests/test_adapter.py`
(`assert 'OPENROUTER_A...OYAGE_API_KEY' == 'OPENROUTER_API_KEY'`), and CI
reported exactly one failure against 717 passed. Counts reconcile at 719 both
places, so those two are local-only and not touched here.

No test was deleted. One was renamed —
`..._resolves_a_role_...` to `..._resolves_a_model_...` — because the engine
no longer resolves per role.

Refs #3908, #3910

## Summary by Sourcery

Restore green checks by correcting the invalid Rust documentation reference and aligning the ArenaBench mirror assertions with the current engine configuration model.

Bug Fixes:
- Fix documentation warnings caused by public gate documentation referencing a private module.
- Update the ArenaBench engine mirror test for the current single-role model resolution behavior and preserve checks for retired engine keys.

Enhancements:
- Strengthen the cross-language model-resolution consistency checks against the engine’s current model hierarchy and planned retired-key migration.

Tests:
- Rename and revise the stale role-resolution mirror test to validate current model resolution and retired-key declarations.