### PR TITLE
fix(bench): the model_for mirror asserts what is still true, and names what is not

### DIFF
--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -365,17 +365,40 @@ def test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors() -> 
     `resolve_posture_role_model` re-opens #2134 in a new place, and nothing
     else in either tree would notice — the two live in different languages,
     different test suites, and different CI jobs.
+
+    **The engine lost a rung, and this test now says so out loud.** `model_for`
+    read `agents.<kind>.model` > the flat `pipeline_<role>_model` > `default_model`
+    until the config collapse (#3944, #3903). It is two rungs now, with no
+    `kind` argument at all, because core knows one role. So the middle rung
+    below is asserted **absent** rather than ordered — a re-introduction of a
+    flat per-role key in the engine is exactly as interesting as a reorder, and
+    would otherwise land silently.
+
+    What this deliberately does NOT assert any more is that
+    `resolve_posture_role_model` matches rung for rung, because it does not:
+    it still resolves the flat key and still carries the worker-inheritance
+    arm. That divergence is real and is tracked in **#4103** — it cannot be
+    closed here, because that function decides the assurance tier a recorded
+    run is characterised by, so collapsing it re-characterises published
+    numbers (the decision #3870 reserves for a maintainer). Narrowing this
+    test to what is still true is the honest half; the other half is an open
+    issue rather than a passing assertion.
     """
     source = _model_for_source()
     start = source.index(_MODEL_FOR_DECL)
     body = source[start : source.index("\n    }\n", start)]
-    rungs = [
-        body.index("self.agent(kind).and_then(|a| a.model"),
-        body.index("pipeline_verifier_model"),
-        body.index("self.default_model"),
-    ]
-    assert rungs == sorted(rungs), (
-        "`model_for` no longer reads `agents.<kind>.model` > the flat per-role "
-        "key > `default_model`; `resolve_posture_role_model` mirrors that order "
-        "and has to change with it (#2134)"
+
+    agent_rung = body.index("self.agent()")
+    default_rung = body.index("self.default_model")
+    assert agent_rung < default_rung, (
+        "`model_for` no longer reads `agents.<…>.model` before `default_model`; "
+        "`resolve_posture_role_model` mirrors that order and has to change with "
+        "it (#2134)"
+    )
+
+    assert "pipeline_" not in body, (
+        "`model_for` reads a flat per-role key again. The collapse (#3944) "
+        "removed that rung and the bench mirror was left resolving it anyway "
+        "(#4103) — if the engine is bringing it back, the two have to be "
+        "reconciled deliberately rather than drifting back into agreement"
     )


### PR DESCRIPTION
## What & why

The **last** failure in `harbor_adapter + analyzer pytest`. On `main` right now that job reports `1 failed, 717 passed` — down from `5 failed, 713 passed` since #4102, and this is the one left.

`test_the_engine_still_resolves_a_role_in_the_order_this_module_mirrors` pins the Python mirror to `AgentEngineConfig::model_for`, and the engine lost a rung underneath it:

```rust
pub fn model_for(&self) -> Option<&str> {
    self.agent()
        .and_then(|a| a.model.as_deref())
        .or(self.default_model.as_deref())
}
```

Two rungs, no `kind` argument, no flat `pipeline_<role>_model` — the config collapse (#3944) and one role name in core (#3903). The test looked for the middle rung and raised `ValueError: substring not found`.

## What it asserts now

- the two surviving rungs, **in order** (`agents.<…>.model` before `default_model`);
- the middle rung is **absent** — `"pipeline_" not in body`.

That second assertion is the part worth reviewing. A flat per-role key reappearing in the engine is exactly as interesting as a reorder, and with the old assertion simply deleted it would land in silence. Its failure message names #4103 so whoever trips it lands on the reconciliation rather than on a puzzle.

## What it deliberately stops asserting, and why that is not a weakening in disguise

It no longer claims `resolve_posture_role_model` matches the engine rung for rung — **because it does not**. That function still resolves the flat key and still carries the `_WORKER_INHERITING_ROLES` arm.

I did not collapse the mirror to match, and that is a deliberate refusal rather than an oversight. `resolve_posture_role_model` is not descriptive: its production caller computes the **assurance tier** a run is characterised by (`witness-on` / `witness-off`, from whether the worker's and verifier's models differ). Changing its resolution changes which *already-recorded* runs count as witness-authored — a claim about published benchmark numbers, which is the decision #3870 reserves for a maintainer, and which CLAUDE.md tells me not to make silently.

So: the test narrows to what is still true, the divergence becomes a tracked issue (**#4103**, with three options costed) instead of a red test nobody can act on, and the docstring states both halves where the next reader hits them. A test that passed while claiming the mirror matched would have been worse than the red one.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | `uv run --no-sync pytest -q` in `bench/harbor_adapter` |
|---|---|
| `main` | `1 failed, 717 passed` — CI's own run on `6ce03c3b3` |
| here | **`717 passed, 2 skipped`** |

Run with the provider API keys unset. `tests/test_adapter.py` picks up a real `OPENROUTER_API_KEY`/`VOYAGE_API_KEY` from the environment and fails on any machine that has one; CI has neither, and its run confirms the same single failure. That environment sensitivity is its own defect, not this one.

## What this unblocks, and one thing to expect

`bench.yml`'s job is fail-fast, so six suites have been **skipped** behind this step ever since #3944 — including `arenabench — pytest`, whose own fix (#3950) has therefore never been exercised. They start running again with this.

I ran all six locally. Five are clean (`terminal_bench_analysis` 270 passed, `telemetry_store` 10, `evidence` 66, `trace_triage` 90, `frontier` 27). **`arenabench` was not** — it aborts during collection on two missing imports, which is #4104's sibling PR. Both need to land for `bench` to actually go green; flagging it here rather than letting the job go red again for a new reason and look like this change failed.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No production code touched — no posture value, no arm, no digest
- [x] No `#[allow]`, no `TODO`, no baseline entry, no skip or `xfail`

## Deleted tests, named as the guard requires

None. The test is rewritten in place under the same name.

Closes #3967

## Summary by Sourcery

Align the assurance-tier mirror test with the engine's current model resolution behavior while explicitly tracking the remaining resolver divergence.

Bug Fixes:
- Update the assurance-tier mirror test to reflect the engine's current two-level model resolution order and detect reintroduction of flat per-role model keys.

Enhancements:
- Document the intentional divergence between the engine model resolver and posture-role resolution without changing production behavior.

Tests:
- Rewrite the model resolution mirror test to verify agent-specific models precede the default model and that the removed pipeline key is absent.