### PR TITLE
fix(arenabench): two missing imports made test_responsibilities uncollectable

### DIFF
--- a/arenabench/tests/test_responsibilities.py
+++ b/arenabench/tests/test_responsibilities.py
@@ -19,7 +19,9 @@ No Docker, no network, no model key: every fixture is synthetic.
 
 from __future__ import annotations
 
+import re
 import tomllib
+from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## What & why

`arenabench/tests/test_responsibilities.py` uses `Path` at module scope (line 40) and `re` immediately after it, and imports neither. The suite does not fail a test — it **cannot be collected**:

```
NameError: name 'Path' is not defined
Interrupted: 1 error during collection
```

A collection error takes the whole project down rather than one test: pytest exits non-zero having run nothing in `arenabench/`.

## Why nobody has seen it

`bench.yml`'s job runs its suites as sequential fail-fast steps, and `harbor_adapter — sync (locked) + pytest` has been red since #3944 (#3967). So `arenabench — pytest (until ejection)` has been **skipped**, not failing, on every run since.

#3967 called this shape out explicitly — *"Why this is worth its own issue: it MASKS another fix"* — about #3950, whose arenabench fix has never actually been exercised. This is a second thing hiding behind the same step, and it only becomes reachable once the harbor_adapter failures clear. #4102 cleared four of them; #4114 clears the fifth. **Both of those plus this one are needed for `bench` to go green** — otherwise the job simply goes red at a later step and looks like #4114 failed.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | `uv run --with pytest --no-project pytest -q` in `arenabench/` |
|---|---|
| `main` | aborts during collection — `NameError: name 'Path' is not defined` |
| here | collects; `tests/test_responsibilities.py` runs and its tests pass |

I also checked the file has no *other* unbound module-scope names, by walking its AST for `Name` loads not bound by an import, assignment, def, class or argument — rather than fixing one `NameError`, re-running, and finding the next (which is how `re` turned up after `Path`). Clean.

The other five suites behind this step are green locally too: `terminal_bench_analysis` 270 passed, `telemetry_store` 10, `evidence` 66, `trace_triage` 90, `frontier` 27.

## One local-only failure, named so it is not mistaken for this

Five `tests/test_sut.py` tests fail on my machine and are neither this change's nor the tree's. They shell out to `/usr/bin/python3`, which on macOS is **3.9.6**, and the adapter needs `tomllib` — stdlib only since 3.11. The error says so itself:

```
AdapterUnavailableError: /usr/bin/python3 cannot build a Stella seat:
`import arenabench.harbor_agent` failed with ModuleNotFoundError: No module named 'tomllib'
```

`ubuntu-latest` ships 3.12 at that path, so CI does not see them. Excluding that one file, the suite is green here. I am flagging it rather than "fixing" it, because making those five pass on a 3.9 interpreter would mean changing what the adapter requires.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — both imports are stdlib
- [x] No new outbound network calls
- [x] No `#[allow]`, no `TODO`, no baseline entry, no skip or `xfail`

## Deleted tests, named as the guard requires

None. Two import lines added; nothing else in the file changes.

Refs #3967

## Summary by Sourcery

Bug Fixes:
- Restore test collection for the arenabench responsibilities suite by adding its missing standard-library imports.