### PR TITLE
fix(stella-autonomy): a public module doc cannot link a private one

### DIFF
--- a/crates/stella-autonomy/src/gate.rs
+++ b/crates/stella-autonomy/src/gate.rs
@@ -1,7 +1,7 @@
 //! Which checks are allowed to block a merge, and which have stopped earning
 //! that right.
 //!
-//! `doc:backlog-self-driving` §3.3 (#3599). [`crate::deliver`] decides what to
+//! `doc:backlog-self-driving` §3.3 (#3599). `crate::deliver` decides what to
 //! do about a red build; this decides *which reds count*. They are separate
 //! questions and were previously the same one, which is how a loop ends up
 //! permanently blocked by something no pull request could ever fix.


### PR DESCRIPTION
## What & why

**`main` is red** on the required `fmt + clippy + test` job, at `cargo doc`:

```
error: public documentation for `gate` links to private item `crate::deliver`
  --> crates/stella-autonomy/src/gate.rs:4
error: could not document `stella-autonomy`
```

`gate` is `pub mod`; `deliver` is `mod` (`crates/stella-autonomy/src/lib.rs:45`). Arrived with #4097.

While this is red every open PR is red too, and red stops distinguishing "your change is broken" from "the base is".

## The fix, and why not the other one

Plain code text rather than an intra-doc link — **not** making `deliver` public.

A reader of `gate`'s public documentation cannot navigate into a private module whatever we write there, so the backticks deliver exactly what the sentence meant and nothing it can't. AGENTS.md names this as the usual right answer when the reference is a reader's orientation rather than a navigable API relationship. Widening a module's visibility to satisfy a cross-reference would be changing the crate's surface to satisfy a footnote.

## Why it keeps happening

This is the **third** instance today — #4105 and #4106 fixed two in `crates/stella-runtime/src/wrapper/dispatch.rs` — and the fifth and sixth since #3981 recorded five at once.

The mechanism is always the same and worth naming: the lint is `rustdoc::private_intra_doc_links`, which only fires under `--document-private-items`. That flag is passed by `make doc-warnings` and **not** by a plain `cargo doc`, so the error is invisible to an ordinary local build and only appears in the pre-push hook or CI. Someone writing a doc comment next to a private sibling gets no feedback at all until the gate runs.

I'm not fixing that here — it's a guard/ergonomics question, not this PR's — but three in one day suggests it's worth one. #4089 (five gate guards that run in no workflow) is the neighbouring version of the same "the check exists but nothing routine runs it" problem.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | check |
|---|---|
| `main` | CI's own `cargo doc -D warnings` step emits the error above — run `32343348527`, job `96346787878` |
| here | `make doc-warnings` → `Finished` / `Generated … and 28 other files`, clean |

Also run here: `cargo clippy --workspace --all-targets -- -D warnings` — clean, so this is the only thing standing between `main` and a green required job.

No test is added because there is no behaviour: the diff is one pair of backticks in a `//!` comment.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow(rustdoc::private_intra_doc_links)]`, no widened visibility, no `TODO`

## Deleted tests, named as the guard requires

None.

## Summary by Sourcery

Bug Fixes:
- Fix the public module documentation so it no longer creates an invalid link to the private `deliver` module.