### PR TITLE
ci: run the five gate guards that ran in no workflow at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,47 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-gate-parity.sh
 
+      # The five below were in `GATE_GUARDS_FAST` and in no workflow at all
+      # (#4089). `gate-parity` above holds AGENTS.md and CONTRIBUTING.md to
+      # `GATE_STEPS`, which is a question about the prose — it says nothing
+      # about whether anything server-side runs a given step, and that is the
+      # gap these close.
+      #
+      # It is not theoretical. `tokens` was red on `main` from #4066 until
+      # #4086 — seven retired brand hexes and thirteen stray literals — and no
+      # workflow said so, on a tree whose every PR was otherwise green. The
+      # pre-push hook runs them, but it is advisory, per-clone, and bypassable
+      # (`SKIP_GATE=1`, `--no-verify`), and with `enforce_admins` off an
+      # auto-merge lands past it. AGENTS.md already says the hook "complements
+      # the required server-side checks rather than replacing them"; for these
+      # five there was no server-side check to complement.
+      #
+      # All toolchain-free (Python and shell over the tree), so they sit here
+      # with the other guards rather than after the cargo setup, and cost about
+      # a second each. Each carries the same `!cancelled()` as its neighbours,
+      # so a red one reports independently instead of masking the next.
+      - name: the colour system is the one in the tree
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: |
+          python3 ./scripts/gen-tokens.py --check
+          python3 ./scripts/check-tokens.py
+
+      - name: no library crate returns Result<_, String>
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-typed-errors.py
+
+      - name: every dead-code suppression says why
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-dead-code-allows.py
+
+      - name: every emitted diagnostic code is documented
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-diagnostic-codes.sh
+
+      - name: make bench-test runs every suite bench.yml runs
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-bench-suites.sh
+
       # Also toolchain-free (shellcheck ships preinstalled on ubuntu-latest).
       # install.sh is fetched over the network and piped into `sh` by
       # strangers before Stella is installed; the guard scripts are what the


### PR DESCRIPTION
## What & why

Five `make gate` guards ran **nowhere server-side**: `tokens`, `typed-errors`, `dead-code-allows`, `diagnostic-codes`, `bench-suites`. All are in `GATE_GUARDS_FAST`; none appeared in any workflow.

AGENTS.md already claims otherwise, in as many words:

> `/.github/workflows/ci.yml`'s required job runs everything except `invariants` and `doc-links`

That sentence was false for five steps. **This makes the sentence true rather than rewriting it** — the workflow drifted from the documented intent, not the other way round.

`gate-parity` does not cover this, and structurally never could: it holds AGENTS.md and CONTRIBUTING.md to `GATE_STEPS`, which is a question about *the prose*. It says nothing about whether a workflow runs a given step. That is the gap.

## The cost of the gap, measured

`tokens` — the colour-system guard — was **red on `main` from #4066 (2026-08-19) until #4086**: seven retired brand hexes and thirteen stray hex literals, for a day, while every PR's checks were otherwise green and nothing reported it. It was found by running `make gate` by hand.

The pre-push hook does run these. But AGENTS.md is explicit that the hook "complements the required server-side checks rather than replacing them" — it is advisory, per-clone, and bypassable (`SKIP_GATE=1`, `git push --no-verify`), and with `enforce_admins` off an admin or auto-merge lands past it entirely. For these five there was no server-side check to complement.

## Placement

All five are toolchain-free (Python and shell over the tree), so they sit with the other guards rather than after the cargo setup, and cost about a second each. Each carries the same `if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}` as its neighbours, so a red one **reports independently** instead of masking the next — the property the surrounding block's comment explains at length.

`tokens` is one step running both halves (`gen-tokens.py --check` then `check-tokens.py`), matching the Makefile target, because "the artifacts are stale" and "a retired hex shipped" are one question about one system.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

The witness is the workflow file itself, and it is checkable both directions:

```sh
# Before: the five are in the Makefile and in no workflow.
rg -n "run: .*scripts/" .github/workflows/*.yml | sed 's/.*scripts\///' | sort -u
```

Verified green on this tree **before** adding them, so this cannot turn `main` red on merge:

```
tokens: 32 validated, 2 artifacts in sync
tokens: no retired hex in the tree; 3 token-only path(s) clean, 3 path(s) still migrating
check-dead-code-allows: OK -- 9 suppression(s), each justified and within the ratchet.
check-diagnostic-codes: OK — 43 codes emitted, all documented.
check-bench-suites: OK — 7 suites in .github/workflows/bench.yml, all run by make bench-test.
```

(`check-typed-errors.py` is silent on success and exited 0 in the same chain.)

`make guards-fast` is clean with the edit in place, and the workflow parses — the `check` job carries 34 steps and all five new names are present.

## What a reviewer should weigh

**This widens what the required check covers**, which is visible in branch protection. That is the point, and it is a maintainer-facing consequence rather than an implementation detail, so it is stated rather than buried.

I did **not** take the other option in #4089 — having `ci.yml` invoke the Makefile target instead of re-listing scripts. That would stop the drift recurring, but it collapses the per-step reporting this job is deliberately built around (one red step masking the next is a failure mode this repo has recorded). The durable fix is a parity check asserting every `GATE_STEPS` entry is reachable from some workflow; that stays open on #4089's follow-up rather than being smuggled in here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new `uses:` (so `action-pins` is unaffected), no `#[allow]`, no `TODO`, no baseline entry

## Deleted tests, named as the guard requires

None. Five steps added; nothing removed.

Closes #4089

## Summary by Sourcery

Run all fast gate guards in the required CI workflow so previously unmonitored repository invariants are enforced server-side.

Bug Fixes:
- Run the five previously omitted fast gate guards in the required CI workflow, including token validation, typed-error checks, dead-code suppression checks, diagnostic-code documentation checks, and benchmark-suite coverage checks.

Enhancements:
- Expand server-side required-check coverage so the documented CI gate behavior matches the configured fast guards while preserving independent per-guard reporting.

CI:
- Add five toolchain-free guard steps to the CI check job with cancellation and checkout-success conditions.