### PR TITLE
fix(bench): restore _model_for_body — three PRs fixed one test and composed into a NameError

### DIFF
--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -342,7 +342,6 @@ _SETTINGS_MODULE = [
     _SETTINGS_SRC / "settings.rs",
     *sorted((_SETTINGS_SRC / "settings").glob("*.rs")),
 ]
-_BENCH_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "bench.yml"
 _MODEL_FOR_DECL = "pub fn model_for("
 _RETIRED_ROOT_DECL = "pub(crate) const RETIRED_ENGINE_ROOT: &[&str] = &["
 
@@ -369,6 +368,23 @@ def _model_for_source() -> str:
         "one the engine resolves through"
     )
     return holders[0].read_text()
+
+
+def _model_for_body() -> str:
+    """Just `model_for`'s body, sliced out of the file that declares it.
+
+    Scoped deliberately. The assertions below ask whether the *function*
+    reads a rung, and `settings/engine.rs` is a large file that mentions
+    `default_model` and the retired flat keys in several other places — a
+    whole-file search would answer a different question and pass for the
+    wrong reason.
+
+    The end anchor is the first column-4 `}`, which is where a method in an
+    `impl` block closes.
+    """
+    source = _model_for_source()
+    start = source.index(_MODEL_FOR_DECL)
+    return source[start : source.index("\n    }\n", start)]
 
 
 def test_the_engine_still_resolves_a_model_in_the_order_this_module_mirrors() -> None:
@@ -421,7 +437,7 @@ def test_the_engine_still_resolves_a_model_in_the_order_this_module_mirrors() ->
     retired = (_SETTINGS_SRC / "settings" / "unknown.rs").read_text()
     # Anchor on the declaration, not the first mention — the name appears in a
     # doc comment above it, and slicing from there reads the wrong span.
-    decl = "const RETIRED_ENGINE_ROOT"
+    decl = _RETIRED_ROOT_DECL
     assert decl in retired, (
         "the retired engine-root keys are no longer declared in "
         "`settings/unknown.rs`; `resolve_posture_role_model` still writes and "


### PR DESCRIPTION
## What & why

**`main` is red.** `harbor_adapter + analyzer pytest` fails at collection-adjacent runtime with:

```
NameError: name '_model_for_body' is not defined
1 failed, 716 passed
```

Nobody wrote that bug. It is what three individually-correct PRs **compose** into.

#4109, #4111 and #4113 all fixed the same red `main`, and all three merged. Two of them rewrote `bench/harbor_adapter/tests/test_assurance_tiers.py`, and they split the same helper differently:

- one kept `_model_for_source()`, returning the whole file;
- the other introduced `_model_for_body()`, returning just `model_for`'s span, and called it from the test.

Git merged them with **no conflict** — it took one side's definition and the other side's call site — and the result calls a function no file defines.

This is the shared-cell shape AGENTS.md names, arriving through a *seam* rather than a file (#3659's shape). Each author was right. Neither tree was wrong. No pre-merge check could see it, because no pre-merge check had both halves in front of it — which is exactly what `main-canary` exists to catch after the fact.

## The fix

`_model_for_body()` is restored, as the caller expects, and **its scoping is the point** rather than an implementation detail — so it is now stated:

> the assertions ask whether *the function* reads a rung, and `settings/engine.rs` mentions `default_model` and the retired flat keys in several other places — a whole-file search would answer a different question and pass for the wrong reason.

That is a real hazard, not a hypothetical: `_model_for_source()` returns the entire file, and `"pipeline_verifier_model" not in body` would have been trivially satisfiable — or trivially broken — depending on unrelated text elsewhere in it.

Two more orphans from the same merge, both defined and used by nothing:

- **`_BENCH_WORKFLOW`** — a duplicate. `tests/test_posture.py` carries its own copy and actually uses it (line 1267). This one is deleted rather than wired to anything.
- **`_RETIRED_ROOT_DECL`** — the precise declaration anchor. The test had separately grown a local `decl = "const RETIRED_ENGINE_ROOT"` doing the same job less precisely, so the constant is used where it belongs and the local goes.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | `uv run --no-sync pytest -q` in `bench/harbor_adapter` |
|---|---|
| `main` (`fc2167e91`) | `1 failed, 716 passed` — `NameError: name '_model_for_body' is not defined` |
| here | **`717 passed, 2 skipped`** |

I checked for further casualties by **parsing** rather than by re-running until the next `NameError`: walking the module's AST for `Name` loads bound by no import, assignment, `def`, `class` or argument. It reports nothing unbound. That matters here because this exact file lost a helper silently — finding the second one by running the suite again would have been luck.

(API keys unset for the run — `tests/test_adapter.py` picks up a real `OPENROUTER_API_KEY`/`VOYAGE_API_KEY` from the environment and fails on any machine that has one. CI has neither. Filed separately as #4131.)

## Also verified on `main` as it stands, so this is the only thing left

`make guards-fast` clean (incl. `tokens: no retired hex in the tree`), `make doc-warnings` clean, `arenabench` exit 0. This `NameError` is the sole remaining failure I can find.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow]`, no `TODO`, no baseline entry, no skip or `xfail`
- [x] No assertion weakened — the test does strictly more than before, since the flat-key check is now scoped to the function body

## Deleted tests, named as the guard requires

None. One helper added, one duplicate constant removed, one local replaced by the constant that already existed for it.

## Summary by Sourcery

Repair the assurance-tier tests so model-resolution checks use the intended scoped source span and all merged references are defined.

Bug Fixes:
- Restore the missing `_model_for_body()` test helper to eliminate the composed `NameError` and correctly scope model-resolution assertions to the target function body.

Enhancements:
- Reuse the existing retired-root declaration constant and remove an unused duplicate benchmark workflow constant.

Tests:
- Verify the assurance-tier test suite passes after repairing the merged helper and constant references.