### PR TITLE
fix(stella-tui): re-bless two deck goldens my own merge left stale — main is red

### DIFF
--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -29,7 +29,7 @@
 │                                           │          low · thinking off · from agents.triage.model               │   ││                                      │
 │── EXECUTE ────────────────────────────────│research  zai/glm-5.2-air                                             │───││                                      │
 │                                           │          low · thinking off · from default_model                     │   ││                                      │
-│● mcp__fs__read_file apps/app/automations/p│plan      zai/glm-5.2-air                                             │   ││                                      │
+│ │ ● apps/app/automations/page.tsx         │plan      zai/glm-5.2-air                                             │   ││                                      │
 │  ⎿ 312 lines                              │          medium · thinking on · from default_model                   │2ms││                                      │
 │                                           │work      zai/glm-5.2-air                                     served  │   ││                                      │
 │☰  plan  5/7  ·  Workflows canvas          │          medium · thinking on · from default_model                   │   ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -29,7 +29,7 @@
 │                                                   │▸ ○ 1. extract types                                  │           ││                                      │
 │── EXECUTE ────────────────────────────────────────│  ○ 2. move hooks                                     │───────────││                                      │
 │                                                   │  ○ 3. update 9 imports                               │           ││                                      │
-│● mcp__fs__read_file apps/app/automations/page.tsx │                                                      │           ││                                      │
+│ │ ● apps/app/automations/page.tsx                 │                                                      │           ││                                      │
 │  ⎿ 312 lines                                      │repo      macanderson/web-app ⎇ feat/automations-store│       42ms││                                      │
 │                                                   │write     packages/automations/** · apps/app/automatio│           ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                  │read      apps/** · packages/**  (2 globs)            │           ││                                      │


### PR DESCRIPTION
`card_plan.txt` and `card_models.txt` describe a tool row the code stopped drawing, so `deck_render_snapshots` fails on a clean checkout of main.

```
-│● mcp__fs__read_file apps/app/automations/page.tsx
+│ │ ● apps/app/automations/page.tsx
```

That is #4123's SPEC 6.2 rail form — a rail plus the path, instead of the raw tool name — which is what the code draws today.

## How it broke, and whose fault it is

Mine. #4123 landed the SPEC 6 rails and blessed these goldens for the new rendering. #4129 was cut from a base that predated it, re-blessed all nineteen deck goldens for the status-bar swap, and wrote the **old** tool row back over #4123's. Neither branch was wrong on its own and git reported no conflict: the goldens are one shared cell that every re-blessing PR writes, the same shape as `Cargo.lock` and `scripts/file-size-baseline.txt`.

The lesson is not "bless more carefully". It is that a PR re-blessing a whole golden suite must be re-blessed again against the merge base before landing, because between cutting and merging someone else's rendering change can enter the same files.

## Verification

`BLESS=1 cargo test -p stella-tui --test deck_render_snapshots` on clean main, diff read by eye (above — two lines, both the same change). `cargo test -p stella-tui` green. `check-file-size` green.

Landed on its own from a fresh main rather than folded into the palette work that found it, so the repair is reviewable as itself.

## Tests deleted

None.

## Summary by Sourcery

Refresh stale deck rendering goldens so they reflect the current rail-form tool rows.

Bug Fixes:
- Update the two stale deck rendering snapshots to match the current tool-row format and restore clean-checkout snapshot test passes.

Tests:
- Refresh the affected `card_models` and `card_plan` golden snapshots.