### PR TITLE
fix(stella-tui): unbreak main — #4123 and #4129 were each green and compose into a red tree

### DIFF
--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -21,8 +21,10 @@
 //! not want them and something still does:
 //!
 //! - [`CTX_WINDOW`], the divisor the context meter reads.
-//! - [`vendor_slug`], which answers "whose model is this" for the bar's worker
-//!   cell — the model's own vendor, not whoever proxied the call.
+//! - `vendor_slug`, which answers "whose model is this" for the bar's worker
+//!   cell — the model's own vendor, not whoever proxied the call. Named in
+//!   plain code font rather than linked: it is `pub(crate)`, and a public
+//!   module doc that links a private item is a `-D warnings` rustdoc error.
 //! - [`render_diagnosis`], the low-hit-rate sentence, which is prose and so has
 //!   nowhere to sit on a row of glanceable values.
 

--- a/crates/stella-tui/src/v2/status_bar.rs
+++ b/crates/stella-tui/src/v2/status_bar.rs
@@ -155,8 +155,9 @@ fn sep() -> Span<'static> {
 /// can drop from the right when the row is tight.
 ///
 /// Pure over [`Status`] — THE decision function, unit-testable without a
-/// buffer, the shape [`crate::statline::statline_items`] uses for the same
-/// reason.
+/// buffer. The v1 statline's `statline_items` had the same shape for the same
+/// reason; it was deleted with the two-row wall (#4129), so this is now the
+/// only cell list on the deck's bottom band.
 #[must_use]
 pub fn cells(status: &Status<'_>) -> Vec<Vec<Span<'static>>> {
     let text = Style::new().fg(token::TEXT);

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -29,7 +29,7 @@
 │                                           │          low · thinking off · from agents.triage.model               │   ││                                      │
 │── EXECUTE ────────────────────────────────│research  zai/glm-5.2-air                                             │───││                                      │
 │                                           │          low · thinking off · from default_model                     │   ││                                      │
-│● mcp__fs__read_file apps/app/automations/p│plan      zai/glm-5.2-air                                             │   ││                                      │
+│ │ ● apps/app/automations/page.tsx         │plan      zai/glm-5.2-air                                             │   ││                                      │
 │  ⎿ 312 lines                              │          medium · thinking on · from default_model                   │2ms││                                      │
 │                                           │work      zai/glm-5.2-air                                     served  │   ││                                      │
 │☰  plan  5/7  ·  Workflows canvas          │          medium · thinking on · from default_model                   │   ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -29,7 +29,7 @@
 │                                                   │▸ ○ 1. extract types                                  │           ││                                      │
 │── EXECUTE ────────────────────────────────────────│  ○ 2. move hooks                                     │───────────││                                      │
 │                                                   │  ○ 3. update 9 imports                               │           ││                                      │
-│● mcp__fs__read_file apps/app/automations/page.tsx │                                                      │           ││                                      │
+│ │ ● apps/app/automations/page.tsx                 │                                                      │           ││                                      │
 │  ⎿ 312 lines                                      │repo      macanderson/web-app ⎇ feat/automations-store│       42ms││                                      │
 │                                                   │write     packages/automations/** · apps/app/automatio│           ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                  │read      apps/** · packages/**  (2 globs)            │           ││                                      │


### PR DESCRIPTION
## main is red

`main` (a1b56da6a) fails both the rustdoc gate and `cargo test -p stella-tui`.
Neither #4123 nor #4129 is wrong alone — this is the shared-cell composition
hazard AGENTS.md describes, which no pre-merge run can catch because neither
author's tree contains the other's change.

## Three breaks, one cause

**1. `crates/stella-tui/src/statline.rs:24`** — the public module doc links
``[`vendor_slug`]``, which is `pub(crate)`. #4123 narrowed that function for the
v2 projection; #4129 rewrote the module doc around it and linked it. A public
doc linking a private item is a hard error under `-D warnings`
(`rustdoc::private_intra_doc_links`) — and it surfaces *only* with
`--document-private-items`, which is exactly what the gate passes and what a
casual local `cargo doc` does not.

Fixed by naming it in plain code font. The item stays `pub(crate)`: widening an
API to satisfy a doc link is the wrong direction.

**2. `crates/stella-tui/src/v2/status_bar.rs:158`** — links
`crate::statline::statline_items`, which #4129 deleted along with the two-row
wall. Rewritten to name it as history rather than as a live item.

**3. `tests/snapshots/deck/card_plan.txt` and `card_models.txt`** still hold the
v1 tool row where the code now emits #4123's v2 rail:

```
-│● mcp__fs__read_file apps/app/automations/page.tsx
+│ │ ● apps/app/automations/page.tsx
```

#4129's merge kept its own copies of these two goldens, which predate the
transcript router. Re-blessed — the diff is those two rows and nothing else, and
it was read, not blessed blind.

## Verify

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --keep-going
```
before: `error: public documentation for statline links to private item vendor_slug`,
`error: unresolved link to crate::statline::statline_items`, `could not document stella-tui`.
after: clean.

```
cargo test -p stella-tui
```
before: `deck_render_snapshots_pin_the_floating_cards FAILED`.
after: 858 lib tests green, every integration target green.

## Witness

The gate commands above are the witness: each fails on `main` at a1b56da6a and
passes on this branch. No behaviour changes — two doc comments and two golden
rows that were already stale relative to the code that generates them.

I am one of the two authors involved (#4123), so this is a break I helped cause
and am fixing rather than filing.

## Summary by Sourcery

Restore the stella-tui documentation and snapshot test gates after the combined statline changes.

Bug Fixes:
- Fix rustdoc failures caused by public documentation linking to private or deleted items.
- Update stale deck card snapshots to match the current v2 rendering output.

Documentation:
- Clarify documentation references to private and removed statline functionality without creating invalid links.