### PR TITLE
fix(stella-tui): two doc links the v2 split left behind, and main is red

### DIFF
--- a/crates/stella-tui/src/statline.rs
+++ b/crates/stella-tui/src/statline.rs
@@ -21,7 +21,7 @@
 //! not want them and something still does:
 //!
 //! - [`CTX_WINDOW`], the divisor the context meter reads.
-//! - [`vendor_slug`], which answers "whose model is this" for the bar's worker
+//! - `vendor_slug`, which answers "whose model is this" for the bar's worker
 //!   cell — the model's own vendor, not whoever proxied the call.
 //! - [`render_diagnosis`], the low-hit-rate sentence, which is prose and so has
 //!   nowhere to sit on a row of glanceable values.

--- a/crates/stella-tui/src/v2/status_bar.rs
+++ b/crates/stella-tui/src/v2/status_bar.rs
@@ -155,8 +155,9 @@ fn sep() -> Span<'static> {
 /// can drop from the right when the row is tight.
 ///
 /// Pure over [`Status`] — THE decision function, unit-testable without a
-/// buffer, the shape [`crate::statline::statline_items`] uses for the same
-/// reason.
+/// buffer. The v1 status line built its row the same way and for the same
+/// reason; that builder is gone now (`crate::statline` keeps only the two
+/// pieces the v2 bar does not replace), so this is the only one left.
 #[must_use]
 pub fn cells(status: &Status<'_>) -> Vec<Vec<Span<'static>>> {
     let text = Style::new().fg(token::TEXT);


### PR DESCRIPTION
## What & why

**`main` is red.** `cargo doc -D warnings` — a step of the required `fmt + clippy + test` job — fails at `a1b56da6a`, from the tui-v2 work in #4123/#4129:

```
error: public documentation for `statline` links to private item `vendor_slug`
  --> crates/stella-tui/src/statline.rs:24:9

error: unresolved link to `crate::statline::statline_items`
  --> crates/stella-tui/src/v2/status_bar.rs:158:25
      no item named `statline_items` in module `statline`

error: could not document `stella-tui`
```

Two different rustdoc failures with one cause: the v2 split moved most of the status line out of `statline.rs`, and the doc comments were not chased through it.

### `vendor_slug` — private

It is `pub(crate)`, and is literally one of the three items the module doc says *"stayed behind"* — while the module doc itself is public, so the link cannot resolve for the reader it is written for. Plain code text, the same treatment #4105 / #4106 / #4111 gave the identical shape earlier today. Its two neighbours, `CTX_WINDOW` and `render_diagnosis`, are `pub` and stay linked.

### `statline_items` — worse than private, it does not exist

The same work that wrote the reference deleted the function. `statline.rs` is now down to exactly two functions (`vendor_slug`, `render_diagnosis`).

So the sentence is **rewritten to say what is true** — the v1 row was built the same way, and that builder is gone — rather than re-pointed at a symbol nobody can follow. Putting the dead name in backticks would have satisfied rustdoc and left the prose lying, which this repo treats as a bug in its own right ("stale comments are treated as bugs in review").

## Why these keep reaching `main`

This is the **fourth and fifth** instance of the private/broken intra-doc shape today (#4105, #4106, #4111 were the first three), and the sixth and seventh since #3981 recorded five at once.

Both lints — `rustdoc::private_intra_doc_links` and `rustdoc::broken_intra_doc_links` — fire only under `--document-private-items`, which `make doc-warnings` passes and a plain `cargo doc` does **not**. So neither is visible to an ordinary local build; you see them in the pre-push hook or in CI, and nowhere else. That is the mechanism, and it is worth a separate look — five in a day is a pattern, not luck.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

| Tree | `make doc-warnings` |
|---|---|
| `main` (`a1b56da6a`) | exits 101 with both errors above |
| here | `Finished` / `Generated … and 28 other files` |

Also clean here: `cargo clippy -p stella-tui --all-targets -- -D warnings` and `cargo fmt --all -- --check`.

No test is added — the diff is two doc comments and no code.

## Note on the other red

`bench` is separately red on `main` with `NameError: name '_model_for_body' is not defined`, which #4132 fixes. That one came from merging three duplicate fixes for the same earlier breakage. Both PRs are needed for a green `main`; they touch disjoint files and do not conflict.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No `#[allow(rustdoc::…)]`, no widened visibility, no `TODO`

## Deleted tests, named as the guard requires

None.

## Summary by Sourcery

Fix stale stella-tui documentation references left behind by the status-bar v2 split.

Bug Fixes:
- Fix stale intra-documentation links in stella-tui so documentation builds pass with warnings treated as errors.

Enhancements:
- Update status-line documentation to accurately describe the v1 builder after the v2 split.

Documentation:
- Correct public module documentation and status-bar references that pointed to private or removed symbols.