### PR TITLE
docs(stella-tui): three v2 module claims that stopped being true

### DIFF
--- a/crates/stella-tui/src/v2.rs
+++ b/crates/stella-tui/src/v2.rs
@@ -1,12 +1,17 @@
 //! The TUI v2 command deck — the black-and-gold redesign.
 //!
-//! Built beside the v1 deck rather than on top of it. The two disagree about
-//! the palette at the root (v1 is warm-neutral by design; v2's hue clamp
-//! rejects a warm gray outright — see [`stella_tui_theme`]), so a gradual
-//! recolour of the existing widgets was never available: the first migrated
-//! widget would have had to sit next to eleven unmigrated ones in the opposite
-//! metal. Phases land whole surfaces here, and the v1 modules stay normative
-//! until the surface that replaces them ships.
+//! Built beside the v1 deck rather than on top of it, and landing one whole
+//! surface at a time: a v1 module stays normative until the thing that replaces
+//! it draws.
+//!
+//! It began as two palettes. v1 was warm-neutral by design and v2's hue clamp
+//! rejects a warm gray outright, so a gradual recolour was not available — the
+//! first migrated widget would have sat beside eleven unmigrated ones in the
+//! opposite metal. That is no longer the split: v5.0 put both on one gold, and
+//! [`crate::palette`]'s shared constants are re-exports of
+//! [`stella_tui_theme::token`] rather than copies of it. What still separates
+//! the two is *layout and event vocabulary*, not colour — which is why a v2
+//! surface can now replace a v1 one a band at a time, as the status bar did.
 //!
 //! Every colour in this module tree comes from [`stella_tui_theme::token`] and
 //! every state glyph from [`stella_tui_theme::glyph`]. A hex literal below

--- a/crates/stella-tui/src/v2/status_bar.rs
+++ b/crates/stella-tui/src/v2/status_bar.rs
@@ -6,12 +6,13 @@
 //!
 //! ## Why one row and not two
 //!
-//! The v1 statline ([`crate::statline`]) is two rows: a dim micro-label row
-//! stacked over its value row, ten cells wide, carrying MODEL, the stage box,
-//! CPU, CONTEXT, SPEND, CACHE, SAVED, WARMTH, ENGINE and INBOX. Its own module
-//! doc makes the case — stacking the label above the value spends free
-//! vertical space instead of scarce horizontal space — and the case is sound
-//! for the set of cells it was answering for.
+//! The v1 statline was two rows: a dim micro-label row stacked over its value
+//! row, ten cells wide, carrying MODEL, the stage box, CPU, CONTEXT, SPEND,
+//! CACHE, SAVED, WARMTH, ENGINE and INBOX. Its case — stacking the label above
+//! the value spends free vertical space instead of scarce horizontal space —
+//! was sound for the set of cells it was answering for, and
+//! [`crate::statline`]'s module doc keeps it, because a design decision this
+//! surface reversed is worth being able to read.
 //!
 //! v2 changes the set, and the argument does not survive the change. CPU, MEM,
 //! WARMTH and ENGINE move behind `?` and the AGENTS tab (SPEC 5) because none
@@ -37,14 +38,13 @@
 //! are booleans, not a computed ratio: a call either reached a model or it did
 //! not.
 //!
-//! ## What this module is not
+//! ## Where it draws
 //!
-//! Not wired to the live deck yet. Every value here has a live source — the v1
-//! statline already projects all six off `WorkspaceModel` — so this is a
-//! sequencing question, not a data one. The v2 shell that owns this row lands
-//! in P1; wiring a v2 bar under v1 chrome before then would put the only
-//! cool-gray element on a warm screen, and churn the deck's nineteen goldens
-//! twice.
+//! `render_deck`'s bottom band, through [`render_band`] — the deck's only
+//! status row since #4129 deleted the two-row wall. [`crate::v2::project`]
+//! turns the live `WorkspaceModel` into a [`Status`]; nothing in this module
+//! reads the fold itself, which is what keeps every golden below fixture data
+//! all the way down.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;


### PR DESCRIPTION
Stale comments are bugs in review here, and these three were mine.

| Claim | Reality |
|---|---|
| `status_bar.rs`: "Not wired to the live deck yet… the shell that owns this row lands in P1" | #4129 wired it — `deck_render` calls `render_band` every frame |
| `status_bar.rs`: "The v1 statline **is** two rows" | #4129 deleted that band |
| `v2.rs`: the two decks "disagree about the palette at the root", so a gradual recolour is unavailable | v5.0 put both on one gold, and #4135 made `palette.rs`'s shared constants re-exports of `stella_tui_theme::token` |

The third is the one worth reading. That paragraph was the stated reason for *not* wiring the status bar, and it outlived the reason twice over. What still separates v1 from v2 is layout and event vocabulary, not colour — which is exactly why a v2 surface can now replace a v1 band on its own, as the status bar did. The corrected text says that, so the next person planning a phase is not talked out of it by an argument that expired.

The second now also records *why* `statline`'s module doc keeps the two-row case: a design decision this surface reversed is worth being able to read.

## Verification

No behaviour change. `RUSTDOCFLAGS=-D warnings cargo doc` clean, `cargo clippy --all-targets -D warnings` clean, `make guards` green, `cargo test -p stella-tui` green with no re-blessing.

## Tests deleted

None.

## Summary by Sourcery

Correct stale Stella TUI v2 documentation to describe the current palette relationship, migration strategy, and status-bar implementation.

Enhancements:
- Update Stella TUI module documentation to reflect the current shared palette, incremental v2 surface migration, and live status-bar integration.
- Clarify the historical rationale for the v1 two-row statline while documenting the v2 status bar’s current rendering boundary.

Documentation:
- Correct stale v1/v2 architecture and status-bar documentation so it matches the current deck layout, palette, and rendering behavior.