### PR TITLE
docs(stella-tui): the status bar IS wired — delete the note saying it is not

### DIFF
--- a/crates/stella-tui/src/v2/status_bar.rs
+++ b/crates/stella-tui/src/v2/status_bar.rs
@@ -37,14 +37,18 @@
 //! are booleans, not a computed ratio: a call either reached a model or it did
 //! not.
 //!
-//! ## What this module is not
+//! ## Wiring
 //!
-//! Not wired to the live deck yet. Every value here has a live source — the v1
-//! statline already projects all six off `WorkspaceModel` — so this is a
-//! sequencing question, not a data one. The v2 shell that owns this row lands
-//! in P1; wiring a v2 bar under v1 chrome before then would put the only
-//! cool-gray element on a warm screen, and churn the deck's nineteen goldens
-//! twice.
+//! [`render_band`] is the deck's bottom band: `render_deck` reserves one row
+//! for it and two only when a cache diagnosis is showing.
+//!
+//! This section used to say the module was "not wired to the live deck yet",
+//! and give the reason — that a v2 bar under v1 chrome would be "the only
+//! cool-gray element on a warm screen". That argument was already spent when it
+//! was written: the recolour that made v1 cool landed four minutes after the
+//! module did, and the two palettes agree on every token this row uses. The
+//! note outlived the condition it described by a day, which is the whole reason
+//! this repo treats a stale comment as a defect rather than as harmless prose.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;


### PR DESCRIPTION
## The defect

`crates/stella-tui/src/v2/status_bar.rs` carries a section headed **"What this
module is not"**, opening with *"Not wired to the live deck yet."*

It has been wired since #4123/#4129. `render_deck` reserves the deck's bottom
band and calls `render_band` — the paragraph explaining why the work could not
be done sits directly above the code doing it.

## Why it is worth a PR on its own

The note's *reasoning* was already spent when it was written. It argued that
wiring a v2 bar under v1 chrome would put "the only cool-gray element on a warm
screen". But #4055 landed the module at 19:50 and #4073 recoloured v1 to cool
near-black at 19:54 — four minutes later. The two palettes now agree on all
seven tokens this row uses (`BG`/`GROUND` `#0A0A0C`, `GOLD`/`BRAND` `#EFC53F`,
`TEXT` `#E8E8EC`, `SILVER` `#A9AAB5`, `MUTED` `#777782`, `DIM` `#4B4B56`,
`BORDER` `#26262C`).

So the justification was stale on arrival, and the claim went false a day later.
That is not cosmetic: a reader who trusts a doc comment saying a module is
unreachable will not go looking for its call site — which is very close to how
this module sat unwired while a redesign was reported as landed.

Replaced with a `## Wiring` section naming the call site, plus one sentence
keeping the lesson, since AGENTS.md treats a stale comment as a bug in review.

## Verify

```
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps \
  --document-private-items --keep-going     # clean
cargo test -p stella-tui                    # 858 lib tests green
```

No behaviour change — doc comment only. No witness test is owed (docs change,
per CONTRIBUTING); the claim it corrects is checkable by reading
`render_deck`'s band list.

## Summary by Sourcery

Align the status bar documentation with its existing live deck wiring and remove the obsolete unwired-module note.

Bug Fixes:
- Correct documentation that falsely described the status bar as unwired despite its live deck integration.

Enhancements:
- Document the status bar’s current rendering path and preserve the rationale for treating stale comments as defects.

Documentation:
- Update the status bar module documentation to identify its deck wiring and remove obsolete palette-related guidance.