### PR TITLE
fix(brand): stella-tui leaves the migration ledger, and two stale claims go with it

### DIFF
--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -39,8 +39,14 @@
 //! - **`VOID` and `HAIRLINE_STRONG`,** derived steps either side of the
 //!   declared ramp.
 //!
-//! Until those land in the JSON, `scripts/check-tokens.py` keeps
-//! `crates/stella-tui/` on its migration ledger.
+//! Those are values the token system has no home for yet, and they are fine
+//! where they are: `scripts/check-tokens.py` only requires a hex to *be* a
+//! live token inside its `TOKEN_ONLY` paths, and this crate is not one. What
+//! it does require everywhere is that no **retired** hex appears, and this
+//! crate now meets that — so it has left the `MIGRATING` ledger, and a v4.0
+//! bronze reappearing here fails the gate like anywhere else. #4058 is still
+//! open for the rest of the alignment; leaving the ledger is not the same as
+//! finishing it.
 //!
 //! The identity is **Gold on a cool near-black**: one colour, owned. Gold
 //! `#EFC53F` is the signal -- the mark, the prompt, active/selected, focus --
@@ -69,13 +75,21 @@
 //! ember -> blue -> gold) and the name must outlive the value. Add a *value*
 //! here; name a *role* in `theme`.
 //!
-//! **This is the product palette, not the marketing brand kit.** It is held
-//! apart from `docs/brand/css/tokens.css` and `website/src/app/tokens.css`,
-//! which are still on kit v4.0's Bronze Gold `#C58A32` on Obsidian `#070B10`:
-//! the kit's ramp is byte-parity-checked against ~60 generated binary assets
-//! (logo PNGs, `favicon.ico`, PWA icons, wallpapers, spinner GIFs) that
-//! cannot be regenerated without `rsvg-convert` and `ffmpeg`, so moving it is
-//! a dedicated pass. The closest sibling this file *does* track is the
+//! **This is the product palette, not the marketing brand kit** — but the two
+//! agree by value now, which they did not when this paragraph was first
+//! written. It used to say the kit and `website/src/app/tokens.css` were "still
+//! on kit v4.0's Bronze Gold on Obsidian", and that was true right up until
+//! v5.0 moved them: `docs/brand/css/tokens.css`, the site, the Observatory and
+//! this file are one gold, all downstream of
+//! `design/tokens/stella-tokens.json`. The sentence survived being false
+//! because `crates/stella-tui/` sat in `check-tokens.py`'s `MIGRATING` ledger,
+//! so the hex ban skipped this file entirely; it does not any more. The kit
+//! still moves as its own pass — its ramp is byte-parity-checked against ~60
+//! generated binaries (logo PNGs, `favicon.ico`, PWA icons, wallpapers,
+//! spinner GIFs) needing `rsvg-convert` and `ffmpeg` — which is a statement
+//! about *cadence*, not about the values diverging.
+//!
+//! The closest sibling this file *does* track is the
 //! instrument palette shared by the Observatory
 //! (`crates/stella-observatory/src/assets/index.html`), the `/export`
 //! dashboard and the two arenabench UIs -- same grounds, same text ramp, same

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -91,11 +91,6 @@ MIGRATING: dict[str, str] = {
     # with new numbers. stella-tui-prompt.md is superseded outright by
     # SPEC-stella-tui-v2.md and still specifies the retired `✦ stella` lockup.
     "docs/brand/prompts/": "#4057",
-    # Phase 2 of the alignment, in flight in another worktree which already has
-    # an uncommitted stella-tui-theme. Editing these files from a second branch
-    # would create two authorities over one palette — the exact failure this
-    # change exists to end.
-    "crates/stella-tui/": "#4058",
 }
 
 HEX = re.compile(r"#[0-9A-Fa-f]{6}\b")


### PR DESCRIPTION
## What & why

`crates/stella-tui/` has sat in `scripts/check-tokens.py`'s `MIGRATING` ledger since #4066. The reason recorded there is now historical:

```python
# Phase 2 of the alignment, in flight in another worktree which already has
# an uncommitted stella-tui-theme. Editing these files from a second branch
# would create two authorities over one palette — the exact failure this
# change exists to end.
"crates/stella-tui/": "#4058",
```

There is no second worktree and no second authority any more: **#4101** consolidated the generated table into `token.rs`, and **#4135** turned the deck's sixteen duplicated colours into re-exports of it.

The ledger's own contract is that *"the only way a path leaves the ledger is by being migrated"* — and this one now has.

## The two banned hexes under it were a sentence that had gone false

The ledger governs the **ban** (no retired hex, anywhere). The only two hits under `crates/stella-tui/` were both on one line, and they could only stay there because the ledger entry made the guard skip the file:

> This is the product palette, not the marketing brand kit. It is held apart from `docs/brand/css/tokens.css` and `website/src/app/tokens.css`, **which are still on kit v4.0's Bronze Gold `#C58A32` on Obsidian `#070B10`**

They are not, and have not been since v5.0. The kit, the site, the Observatory and this file are one gold, all downstream of `design/tokens/stella-tokens.json`. The kit still moves on its own cadence — its ramp is byte-parity-checked against ~60 generated binaries needing `rsvg-convert` and `ffmpeg` — but that is a statement about **when**, not about the values diverging, and the rewrite says exactly that.

This is the fourth stale "the kit is still bronze" claim found and corrected (the Observatory's, `stella-tui-theme`'s README and `website/src/app/tokens.css` went in #4086). It is the one that survived longest, precisely because the ledger hid it.

## A second claim, conflating two different rules

> Until those land in the JSON, `scripts/check-tokens.py` keeps `crates/stella-tui/` on its migration ledger.

That reads as "this crate is on the ledger because it carries non-token hexes", which is not how the guard works. Two separate rules:

- **the ban** — no *retired* hex, in any tracked file; this is what `MIGRATING` suspends;
- **`TOKEN_ONLY`** — every hex must be a *live token*, and only inside three declared paths.

`crates/stella-tui/` is not a `TOKEN_ONLY` path. So the light theme, `WARNING`, the three status inks, `VOID` and `HAIRLINE_STRONG` may keep their own hex exactly where they are — which is what #4058 is open to reconsider, on design grounds rather than guard grounds.

**Leaving the ledger is not finishing #4058**, and the rewritten comment says so. What it means is that a v4.0 bronze reappearing in this crate now fails the gate like it would anywhere else, instead of being skipped.

## The witness

- [x] This PR includes a witness (fails on `main`, passes here)

Run both ways on the same tree, which is what separates "the prose was wrong" from "the ledger entry was load-bearing":

| Tree | `make tokens` |
|---|---|
| ledger entry dropped, prose left as-is | **fails** — `palette.rs:74: #C58A32` and `palette.rs:74: #070B10` |
| this PR (prose corrected, entry dropped) | `no retired hex in the tree; 3 token-only path(s) clean, **2** path(s) still migrating` |

The ledger goes from 3 entries to 2. It is meant to reach empty; the two left (`docs/brand/brand-guidelines.html` → #4056, `docs/brand/prompts/` → #4057) are documents where a retired hex is the subject matter, and each still carries its issue.

Also clean: `cargo fmt --all -- --check`, `make doc-warnings`, `cargo test -p stella-tui`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No colour value changed — comments and one ledger entry only
- [x] No `MIGRATING` entry **added** (the guard refuses that anyway), no `#[allow]`, no `TODO`

## Deleted tests, named as the guard requires

None.

Refs #4058

## Summary by Sourcery

Remove stella-tui from the token migration ledger and update its palette guidance to reflect the current shared colour values.

Bug Fixes:
- Remove the stale stella-tui migration exemption so retired colour values in the crate are checked by the token guard.

Enhancements:
- Correct palette documentation to reflect that the product palette and brand kit now share the same values while keeping their release cadences distinct.
- Clarify that leaving the migration ledger does not complete the broader palette alignment tracked by #4058.