### PR TITLE
feat(stella-tui): a turn closes on a rule and a receipt — SPEC 6.1 reaches the screen

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -74,6 +74,16 @@ const _: () =
 /// [`mod@crate::render`]).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SessionModel {
+    /// Turns this session has completed — the ordinal stamped on each
+    /// [`TranscriptEntry::Complete`] so a closing rule can name its turn
+    /// (SPEC 6.1).
+    ///
+    /// A counter rather than a derivation, because the two obvious derivations
+    /// both lie: counting `Complete` entries in the transcript renumbers
+    /// everything once front-eviction drops one, and `AgentEvent` carries a
+    /// `turn_instance` that is per-*run*, so a wrapped run restarts it while
+    /// the scrollback does not.
+    pub turns_completed: u32,
     /// The scrollback transcript, oldest first. Streaming `Text`/`Reasoning`
     /// deltas are accumulated into the trailing entry rather than producing
     /// one line per token.
@@ -454,7 +464,17 @@ pub enum TranscriptEntry {
     /// An error event.
     Error { message: String, retryable: bool },
     /// The turn completed.
-    Complete { model: String, cost_usd: f64 },
+    ///
+    /// `turn` is this turn's ordinal in the session, 1-based, so the closing
+    /// rule can name it (SPEC 6.1). Carried on the entry rather than counted at
+    /// render time: the renderer sees one entry at a time and front-eviction
+    /// shifts every index, so a position-derived number would renumber the
+    /// whole scrollback the first time the retention cap bit.
+    Complete {
+        model: String,
+        cost_usd: f64,
+        turn: u32,
+    },
 }
 
 /// A mutating tool result's handle on the diff it may render inline: the
@@ -1108,9 +1128,11 @@ impl SessionModel {
             AgentEvent::TurnComplete { model, cost_usd } => {
                 self.hud.model = Some(model.clone());
                 self.streaming_text.clear();
+                self.turns_completed += 1;
                 self.transcript.push(TranscriptEntry::Complete {
                     model: model.clone(),
                     cost_usd: *cost_usd,
+                    turn: self.turns_completed,
                 });
             }
             // The RUN ended — the only event that means nothing more is

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -19,7 +19,7 @@ use stella_protocol::{CiStatus, PrStatus, SubAgentStatus};
 use crate::model::{FileState, TranscriptEntry};
 use crate::render::row::*;
 use crate::textline::{
-    self, budget_mode_label, ci_status_label, media_kind_label, media_state_label, pr_status_label,
+    budget_mode_label, ci_status_label, media_kind_label, media_state_label, pr_status_label,
     stage_label,
 };
 // Still owned by the parent: `resolve_inline_diff` reads the draw-side file
@@ -216,6 +216,10 @@ fn v2_rows(entry: &TranscriptEntry, width: usize, out: &mut Vec<Line<'static>>) 
                 *evicted,
                 *deduped,
             ));
+            true
+        }
+        TranscriptEntry::Complete { cost_usd, turn, .. } => {
+            out.extend(v2::turn_end_rows(*turn, *cost_usd, width));
             true
         }
         _ => false,
@@ -1043,30 +1047,13 @@ fn entry_body(
                 out,
             );
         }
-        TranscriptEntry::Complete { model, cost_usd } => {
-            // The turn's receipt, and now the *only* spend line in the
-            // transcript — the per-call `BudgetTick` rows that used to print
-            // four or five running subtotals per turn are gauge-only (see
-            // `SessionModel::apply`). Because it is the one line, it can afford
-            // to be the definite one: green for a settled amount, and the model
-            // that actually answered spelled out beside it rather than left to
-            // the statline.
-            push_note(
-                "✓ cost",
-                loud(theme::SUCCESS_BRIGHT),
-                vec![
-                    Span::styled(
-                        textline::fmt_cost(*cost_usd),
-                        Style::new()
-                            .fg(theme::SUCCESS_BRIGHT)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(format!("  ·  {model}"), quiet()),
-                ],
-                width,
-                out,
-            );
-        }
+        // Owned by the v2 router above, which returns `true` for it and so
+        // never falls through to here — the closing rule and receipt of
+        // SPEC 6.1. The arm exists because the match must stay exhaustive, and
+        // it draws nothing rather than panicking: if the router is ever
+        // narrowed, a missing turn rule is a visible gap a reader can report,
+        // where an `unreachable!()` would take the session down mid-frame.
+        TranscriptEntry::Complete { .. } => {}
     }
 }
 

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -212,6 +212,7 @@ fn sample_entries() -> Vec<TranscriptEntry> {
         TranscriptEntry::Complete {
             model: "glm-5.2".into(),
             cost_usd: 0.1,
+            turn: 1,
         },
         // Both phases: the start and finish rows take different render
         // paths (quiet note vs. status-hued note), so one sample would
@@ -385,6 +386,86 @@ fn screenshot_recall() -> TranscriptEntry {
                 ("workspace-memory".into(), 1, 2, 812),
             ],
         }),
+    }
+}
+
+/// SPEC 6.1: a turn ends on a labelled rule and one receipt line.
+///
+/// The witness for the boundary landing. On the old renderer a completed turn
+/// was a single `✓ cost` note, so every assertion here fails on it: there was
+/// no rule, no `receipt` line, and no turn number anywhere in the transcript.
+#[test]
+fn a_completed_turn_closes_on_a_rule_and_a_receipt() {
+    let entry = TranscriptEntry::Complete {
+        model: "glm-5.2".into(),
+        cost_usd: 0.11,
+        turn: 14,
+    };
+    let text = recall_text(&entry, false, 100);
+
+    assert!(text.contains("turn 14 done"), "no closing rule:\n{text}");
+    assert!(
+        text.contains("──"),
+        "the rule does not reach the row:\n{text}"
+    );
+    assert!(text.contains("receipt"), "no receipt line:\n{text}");
+    assert!(
+        text.contains("$0.11"),
+        "the receipt lost the spend:\n{text}"
+    );
+    assert!(
+        text.contains("↵ audit"),
+        "the receipt lost its affordance:\n{text}"
+    );
+
+    // Nothing the deck cannot measure. `StepUsage` is deliberately unfolded,
+    // there is no per-turn clock, and no per-turn file/test/memory count — so a
+    // receipt claiming any of them would be reporting a measurement nobody
+    // took. They elide until something counts them.
+    for absent in ["tok", "det ", "tests", "file", "memory", "0:00"] {
+        assert!(
+            !text.contains(absent),
+            "the receipt invented {absent:?}:\n{text}"
+        );
+    }
+}
+
+/// SPEC 2: money is gold. The v1 row rendered a settled turn cost in
+/// `SUCCESS_BRIGHT` green, which spends the pass colour on an amount — and
+/// green is reserved for pass semantics, not for spending.
+#[test]
+fn the_turn_receipt_prices_in_gold_not_in_the_pass_colour() {
+    let mut out = Vec::new();
+    entry_lines(
+        &TranscriptEntry::Complete {
+            model: "glm-5.2".into(),
+            cost_usd: 0.11,
+            turn: 14,
+        },
+        &[],
+        false,
+        false,
+        false,
+        100,
+        &mut out,
+    );
+    let money = out
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .find(|s| s.content.contains("$0.11"))
+        .expect("the receipt renders the spend");
+    assert_eq!(
+        money.style.fg,
+        Some(stella_tui_theme::token::GOLD),
+        "money is gold (SPEC 2/5)"
+    );
+    for span in out.iter().flat_map(|l| l.spans.iter()) {
+        assert_ne!(
+            span.style.fg,
+            Some(stella_tui_theme::token::GREEN),
+            "green is pass semantics; a turn ending is not a pass: {:?}",
+            span.content
+        );
     }
 }
 

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -511,6 +511,7 @@ mod tests {
             TranscriptEntry::Complete {
                 model: "m".into(),
                 cost_usd: 0.1,
+                turn: 1,
             },
         ];
         let turns = turns(&t);

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -203,7 +203,14 @@ pub struct TurnHead {
 #[derive(Clone, Debug, Default)]
 pub struct Receipt {
     pub spend_usd: f64,
-    pub tokens: u64,
+    /// Tokens this turn spent. `None` when nothing has counted them.
+    ///
+    /// Optional for the same reason [`Receipt::det_pct`] is: `StepUsage` is a
+    /// metering record the deck deliberately does not fold (it would
+    /// double-count the spend the budget gauge already tracks), so a turn's
+    /// token total has no source in the session model today. A receipt that
+    /// printed `0 tok` would be stating a measurement nobody took.
+    pub tokens: Option<u64>,
     /// The deterministic share of the turn's work. This is `det %`'s home —
     /// SPEC 5 removed it from the status bar and named the receipt instead.
     pub det_pct: Option<u32>,
@@ -259,17 +266,20 @@ pub fn turn_begin(head: &TurnHead, width: usize) -> Line<'static> {
 /// The closing rule of a turn (SPEC 6.1). `elapsed` is pre-formatted — this
 /// module has no clock.
 #[must_use]
-pub fn turn_end(number: u32, elapsed: &str, width: usize) -> Line<'static> {
+pub fn turn_end(number: u32, elapsed: Option<&str>, width: usize) -> Line<'static> {
     let dim = Style::new().fg(token::DIM);
-    labelled_rule(
-        vec![
-            Span::styled("turn ", dim),
-            Span::styled(number.to_string(), Style::new().fg(token::GOLD)),
-            Span::styled(" done", Style::new().fg(token::TEXT)),
-            Span::styled(format!(" · {elapsed}"), dim),
-        ],
-        width,
-    )
+    let mut label = vec![
+        Span::styled("turn ", dim),
+        Span::styled(number.to_string(), Style::new().fg(token::GOLD)),
+        Span::styled(" done", Style::new().fg(token::TEXT)),
+    ];
+    // Elided rather than rendered as `0:00`, which is a duration nobody
+    // measured. The deck folds no per-turn clock today; when it does, this
+    // fills in without the rule changing shape.
+    if let Some(elapsed) = elapsed {
+        label.push(Span::styled(format!(" · {elapsed}"), dim));
+    }
+    labelled_rule(label, width)
 }
 
 /// The receipt line under a closing rule (SPEC 6.1).
@@ -284,10 +294,12 @@ pub fn receipt(r: &Receipt) -> Line<'static> {
     let mut spans = vec![
         Span::styled("   receipt ", dim),
         Span::styled(format!("${:.2}", r.spend_usd), Style::new().fg(token::GOLD)),
-        Span::styled(" · ", dim),
-        Span::styled(fmt_tokens(r.tokens), text),
-        Span::styled(" tok", dim),
     ];
+    if let Some(tokens) = r.tokens {
+        spans.push(Span::styled(" · ", dim));
+        spans.push(Span::styled(fmt_tokens(tokens), text));
+        spans.push(Span::styled(" tok", dim));
+    }
     if let Some(det) = r.det_pct {
         spans.push(Span::styled(" · det ", dim));
         spans.push(Span::styled(format!("{det}%"), text));

--- a/crates/stella-tui/src/v2/transcript/tests.rs
+++ b/crates/stella-tui/src/v2/transcript/tests.rs
@@ -48,7 +48,7 @@ fn scripted_turn() -> (TurnHead, Vec<Event>, Receipt) {
 
     let receipt = Receipt {
         spend_usd: 0.11,
-        tokens: 18_000,
+        tokens: Some(18_000),
         det_pct: Some(86),
         tests_passed: 4,
         tests_total: 4,
@@ -65,7 +65,7 @@ fn frame(head: &TurnHead, events: &[Event], r: &Receipt) -> (Buffer, String) {
     for e in events {
         lines.extend(event_rows(e, W));
     }
-    lines.push(turn_end(head.number, "0:42", W));
+    lines.push(turn_end(head.number, Some("0:42"), W));
     lines.push(receipt(r));
 
     let h = lines.len() as u16;
@@ -113,7 +113,9 @@ fn a_scripted_turn_renders_begin_events_and_receipt() {
 fn a_turn_rule_spans_the_full_width() {
     let (head, _, _) = scripted_turn();
     assert_eq!(turn_begin(&head, W).width(), W);
-    assert_eq!(turn_end(14, "0:42", W).width(), W);
+    assert_eq!(turn_end(14, Some("0:42"), W).width(), W);
+    // A turn with no measured clock still rules the full width.
+    assert_eq!(turn_end(14, None, W).width(), W);
 }
 
 /// SPEC 6.2: every event row carries a rail, and the rail is the kind's metal.

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -27,7 +27,7 @@
 
 use ratatui::text::Line;
 
-use super::transcript::{Event, EventKind, event_rows};
+use super::transcript::{Event, EventKind, Receipt, event_rows, receipt, turn_end};
 
 /// The metal-bearing head of a dispatched call (SPEC 6.2).
 ///
@@ -106,6 +106,29 @@ fn subject_for(name: &str, path: Option<&str>, input: &str) -> String {
 /// The first line of a blob, for a row that has exactly one.
 fn first_line(text: &str) -> &str {
     text.lines().next().unwrap_or("").trim_end()
+}
+
+/// A turn's closing rule and its receipt (SPEC 6.1).
+///
+/// Two rows, always: the boundary is the transcript's rhythm — SPEC 2 makes the
+/// turn its unit — so it renders whether or not the receipt has anything but
+/// money to say.
+///
+/// Everything the receipt cannot source is elided rather than zeroed. Only
+/// `spend_usd` is fed today: the deck does not fold `StepUsage` (it would
+/// double-count the spend the budget gauge tracks), keeps no per-turn clock,
+/// and counts no per-turn files, tests or memories. A receipt reading
+/// `0 tok · 0 files · 0/0 tests` would be four measurements nobody took, on the
+/// one line whose whole job is to be the settled account of a turn.
+#[must_use]
+pub fn turn_end_rows(turn: u32, cost_usd: f64, width: usize) -> Vec<Line<'static>> {
+    vec![
+        turn_end(turn, None, width),
+        receipt(&Receipt {
+            spend_usd: cost_usd,
+            ..Receipt::default()
+        }),
+    ]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`turn_end` and `receipt` were written in #4123 and never called. SPEC 2 makes the turn the unit of the transcript, and the transcript had no turn rhythm at all — a completed turn was one green `✓ cost` note in a flat run of events.

```
── turn 14 done ─────────────────────────────────────────────────────────
   receipt $0.11 · ↵ audit
```

## The receipt says only what something measured

Every field but the spend elides, and two of them became `Option` so they could:

| Field | Why it is absent |
|---|---|
| `tokens` | the deck deliberately does not fold `StepUsage` — it would double-count the spend the budget gauge tracks — so a turn's token total has no source. `0 tok` is a measurement nobody took |
| elapsed | there is no per-turn clock. `0:00` is a duration nobody timed |
| `det_pct`, tests, files, memories | already elided |

The receipt fills in as data arrives, without the rule changing shape. This is the same discipline that kept `det %` off the status bar: the one line whose whole job is to be the settled account of a turn cannot open by stating four numbers nobody counted.

## Money stops being green

The v1 row priced a settled turn in `SUCCESS_BRIGHT`. SPEC 2 reserves green for **pass semantics** and makes money **gold** — so that row was spending the pass colour on an amount, and a turn ending is not a turn passing. `the_turn_receipt_prices_in_gold_not_in_the_pass_colour` asserts both halves: the spend is gold, and no span on the row is green.

## The turn number is carried, not counted

`TranscriptEntry::Complete` gains `turn`, stamped from a new `SessionModel::turns_completed`. Both obvious derivations lie:

- counting `Complete` entries in the transcript renumbers the whole scrollback the first time front-eviction bites;
- `AgentEvent`'s `turn_instance` is per-**run**, so a wrapped run restarts it while the scrollback does not.

## Witness

`a_completed_turn_closes_on_a_rule_and_a_receipt`, verified by deleting the router arm — it then fails on `no closing rule`. (My first attempt at that check asserted nothing and "passed" against a disarm that never applied; the real one asserts the arm is present before removing it.) It also asserts the receipt invents none of `tok`, `det`, `tests`, `file`, `memory`, `0:00`.

## Tests deleted

None. The v1 `Complete` render arm is deleted — it was unreachable once the router claimed the entry — and the exhaustive arm replacing it draws nothing rather than panicking, so a narrowed router leaves a visible gap a reader can report instead of taking the session down mid-frame.

## Verification

`cargo test -p stella-tui` green, `cargo clippy --all-targets -D warnings` clean, `RUSTDOCFLAGS=-D warnings cargo doc` clean, `make guards` green. Deck goldens unchanged — no fixture holds a `Complete` entry, which is why the witness above is a unit test rather than a frame.

Refs #4053

## Summary by Sourcery

Add turn-level transcript closure with stable session numbering and measurement-based receipts.

New Features:
- Render completed turns with a numbered closing rule and receipt showing the measured spend.

Bug Fixes:
- Prevent completed-turn numbering from changing when transcript history is evicted or runs restart.

Enhancements:
- Elide unavailable receipt measurements instead of displaying fabricated zero values.
- Use gold for turn spending rather than the green pass-status color.
- Make completed-turn rendering resilient to routing changes without panicking.

Tests:
- Add coverage for the completed-turn boundary, receipt contents, and spending color semantics.