### PR TITLE
fix(stella-model): an aborted OpenRouter stream is transient, not terminal

### DIFF
--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -753,8 +753,8 @@ impl ZaiStreamError {
 
 /// Classify an in-band OpenAI-compatible error frame into a typed
 /// `ProviderError`. Transient/server-side conditions (overloaded, 5xx,
-/// unavailable, timeout) are **retryable** `Transport`; an explicit rate
-/// limit is `RateLimited`; everything else is `Terminal`. The gateways don't
+/// unavailable, timeout, aborted) are **retryable** `Transport`; an explicit
+/// rate limit is `RateLimited`; everything else is `Terminal`. The gateways don't
 /// share a stable machine code, so this matches on the human-readable
 /// `type`/`message` text — deliberately conservative: unknown ⇒ terminal, so
 /// a genuine failure is never retried into an infinite loop. `label` names
@@ -772,6 +772,14 @@ fn classify_zai_stream_error(err: &ZaiStreamError, label: &str) -> ProviderError
         || haystack.contains("server_error")
         || haystack.contains("unavailable")
         || haystack.contains("timeout")
+        // An abort is the upstream connection dropping mid-stream, not a
+        // decision about the request — so it is transient by construction and
+        // the identical retry can succeed. OpenRouter phrases it "The
+        // operation was aborted" and attaches NO `code`, so neither the words
+        // above nor the statuses below could catch it: the same shape as the
+        // `code: 502` frame this arm's sibling was added for, one rung further
+        // out, and it burned the turn on attempt 1 with all retries unused.
+        || haystack.contains("aborted")
         || code == "500"
         || code == "502"
         || code == "503"

--- a/crates/stella-model/src/zai/tests/openrouter_stream.rs
+++ b/crates/stella-model/src/zai/tests/openrouter_stream.rs
@@ -97,6 +97,89 @@ async fn openrouter_in_band_error_code_502_is_retryable() {
     );
 }
 
+/// The same shape as the 502 above, one rung further out: the frame carries
+/// NO `code` at all, and its prose is the gateway's own abort wording. An
+/// abort is the upstream connection dropping mid-stream — transient by
+/// construction, since nothing about the request was refused — but none of
+/// the classifier's transient words appear in it, so it fell through to
+/// non-retryable `Terminal` and killed the turn on attempt 1 with every
+/// configured retry unused.
+#[tokio::test]
+async fn openrouter_in_band_abort_without_a_code_is_retryable() {
+    let server = MockServer::start().await;
+    // The frame witnessed on a live OpenRouter stream: no `code`, and the
+    // message shares no substring with "overload"/"unavailable"/"timeout".
+    let sse_body = concat!(
+        "data: {\"error\":{\"message\":\"The operation was aborted\"}}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let err = provider.complete(req).await.expect_err("must be an error");
+    assert!(
+        err.is_retryable(),
+        "a dropped upstream connection must be retried, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("The operation was aborted"),
+        "surfaces the gateway's own text: {msg}"
+    );
+}
+
+/// The negative control for the abort arm: "aborted" must widen the transient
+/// set by exactly one word and no further. A refusal the gateway states
+/// plainly stays `Terminal`, because retrying it re-pays the prompt to be
+/// refused identically.
+#[tokio::test]
+async fn openrouter_in_band_refusal_stays_terminal() {
+    let server = MockServer::start().await;
+    let sse_body = concat!(
+        "data: {\"error\":{\"message\":\"This model is not available to your account\"}}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-fable-5")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    let req = CompletionRequest {
+        messages: vec![CompletionMessage::user("hi")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    };
+    let err = provider.complete(req).await.expect_err("must be an error");
+    assert!(
+        matches!(err, ProviderError::Terminal(_)),
+        "an account-level refusal is not transient, got {err:?}"
+    );
+    assert!(!err.is_retryable());
+}
+
 /// A `code: 429` frame whose prose never says "rate limit" must still
 /// classify as throttling rather than a permanent rejection.
 #[tokio::test]


### PR DESCRIPTION
## What & why

A live run died with every retry unused:

```
✗ error  terminal provider error: OpenRouter stream error: The operation was aborted
```

OpenRouter emits `{"error":{"message":"The operation was aborted"}}` as an in-band SSE frame when the upstream connection to the underlying model provider drops mid-stream. `classify_zai_stream_error` matches transient conditions on prose (`overload` / `server_error` / `unavailable` / `timeout`) plus a numeric `code`. This frame has **no `code` at all**, and its prose shares no substring with any of those words — so it fell through the conservative catch-all to non-retryable `Terminal` and burned the turn on attempt 1.

An abort is the connection dropping, not a decision about the request: nothing was refused, and the identical retry can succeed. This classifies it as `Transport`, which the retry ladder honours.

This is the same shape as the `code: 502` frame the sibling arm was added for, one rung further out. That one was invisible because the status lived in a field we were dropping; this one because the frame carries no status to read. The `code` fix made the classifier's numeric arms reachable — it could not help a frame with nothing numeric in it.

### Scope of the widening

Exactly one word, `aborted`, added to the transient prose set. Deliberately no further: the neighbouring connection-drop vocabulary a Node-based gateway can plausibly emit (`socket hang up`, `ECONNRESET`, `connection reset`) is **unwitnessed** here, and this repo does not classify on speculation. If one of those shows up in a trace it earns its own arm and its own witness.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`openrouter_in_band_abort_without_a_code_is_retryable` — drives the real frame through a wiremock SSE stream on the `openrouter` identity.

Checked the artisanal way. On the parent commit:

```
thread '...openrouter_in_band_abort_without_a_code_is_retryable' panicked at
crates/stella-model/src/zai/tests/openrouter_stream.rs:135:5:
a dropped upstream connection must be retried, got
Terminal("OpenRouter stream error: The operation was aborted")
```

That panic string is byte-identical to what the live run put on screen, so the test reproduces the reported failure rather than a lookalike. With the fix: 4 passed.

Paired with a **negative control**, `openrouter_in_band_refusal_stays_terminal` — an account-level refusal (`"This model is not available to your account"`) must stay `Terminal`, since retrying it re-pays the prompt to be refused identically. Without that control the witness would pass just as happily if the arm were widened to retry everything.

Full crate: `cargo test -p stella-model` → 419 + 1 + 28 passed, 0 failed.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior changed — the function's own doc comment now names `aborted` in the transient set, and the new arm carries the rationale inline
- [x] No `Closes #N`: there was no pre-existing issue for this defect; it was found from a live trace and is fixed here

## Nothing left behind

Two things I found in the same panel and did **not** fix here, both filed as handoffs:

- [x] #4146 — one model-call failure paints **two** `✗ error` rows (the host wraps the message the engine already emitted, and `repeats_the_last_row` demands verbatim equality). Same screenshot, different crate, different logical change.
- [x] #4147 — the no-final-usage warning asserts "the work itself is unaffected" on the call that just aborted the turn. Includes the verification step I could not complete from the reported screen alone.

## Ground-rule check

- [x] No I/O added to `stella-core` (this PR does not touch it); no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**Provider parity matrix**: no row change. This is general transient classification in the shared chat-completions adapter, not one of the five declared axes (`CachePosture` / `ReasoningPosture` / `StreamFallbackPosture` / `OverflowPosture` / `OutputBudgetPosture`). Worth a second opinion — the closest neighbour is `StreamFallbackPosture`, but that axis is about a stream that broke *before its first byte* or returned 200-with-nothing, whereas this is a frame arriving mid-stream and naming its own failure.

**Blast radius**: `classify_zai_stream_error` is shared by every OpenAI-compatible provider routed through this adapter (Z.ai, xAI, DeepSeek, OpenRouter, local endpoints), so the new arm applies to all of them. That is intended — an abort is transient wherever it comes from — but it does mean a provider that used the word "aborted" in a *permanent* rejection would now be retried. I found no such usage in the tree, and the negative control pins the general refusal case.

**Deleted tests**: none.

## Summary by Sourcery

Treat aborted upstream streams as transient failures so identical requests can be retried.

Bug Fixes:
- Classify OpenAI-compatible in-band stream errors containing "aborted" as retryable transport failures instead of terminal provider errors.

Enhancements:
- Document the expanded transient error classification and preserve terminal handling for account-level refusals.

Documentation:
- Update the stream error classifier documentation to include aborted operations among transient conditions.

Tests:
- Add OpenRouter SSE coverage proving abort frames without a code are retryable and account-level refusal frames remain terminal.