### PR TITLE
fix(stella-core): the lead's task lane is single-occupancy, so a skipped task_complete is caught

### DIFF
--- a/crates/stella-core/src/tasks.rs
+++ b/crates/stella-core/src/tasks.rs
@@ -24,6 +24,16 @@ pub enum TaskBoardError {
     UnknownTask { id: String },
     #[error("task {id} is already {status:?} — terminal tasks cannot change state")]
     Terminal { id: String, status: TaskStatus },
+    #[error(
+        "task {open_id} `{open_subject}` is still in_progress — you hold exactly one task at a \
+         time, so finish it with task_complete (or drop it with task_cancel) before starting \
+         task {id}"
+    )]
+    AnotherTaskInProgress {
+        id: String,
+        open_id: String,
+        open_subject: String,
+    },
 }
 
 /// One queued request to spawn a dedicated sub-agent for a task
@@ -122,12 +132,54 @@ impl TaskBoard {
     /// reject every transition; re-asserting the same open status is a no-op
     /// that succeeds (idempotent `task_complete` retries stay terminal-safe
     /// because terminality is checked first).
+    ///
+    /// # The lead holds one task at a time
+    ///
+    /// A move *into* `InProgress` is refused while another **unowned** task is
+    /// already in progress: that is the agent's own lane, and it is
+    /// single-occupancy. `task_start`'s and `task_complete`'s descriptions have
+    /// promised this since they were written ("keep exactly ONE task
+    /// in_progress at a time: complete the current task before starting the
+    /// next") and nothing enforced it, so a board could — and did — sit with a
+    /// step marked in progress that the agent had long since walked past, while
+    /// it edited files for a later step. An advisory board is a board that
+    /// misreports which step the work is on, which is the one thing it exists
+    /// to report.
+    ///
+    /// Refusal, not silent auto-completion: closing a card the agent never said
+    /// was finished would claim work was done on the board's own authority. The
+    /// error names the open task and both remedies, so the next call can be the
+    /// `task_complete` that should have come first.
+    ///
+    /// Only *unowned* tasks occupy the lane. [`Self::assign`] deliberately does
+    /// not route through here: delegated tasks carry an owner and run in
+    /// parallel by design, so N sub-agent lanes plus the lead's own task is a
+    /// legal board, not a violation.
     pub fn set_status(
         &mut self,
         id: &str,
         status: TaskStatus,
     ) -> Result<&TaskItem, TaskBoardError> {
+        // Scanned before the mutable borrow, but reported *after* the
+        // unknown/terminal check below: a task that can never start should be
+        // told why it can never start, not which lane it happened to collide
+        // with.
+        let occupant = (status == TaskStatus::InProgress)
+            .then(|| {
+                self.items
+                    .iter()
+                    .find(|t| t.id != id && t.owner.is_none() && t.status == TaskStatus::InProgress)
+            })
+            .flatten()
+            .map(|t| (t.id.clone(), t.subject.clone()));
         let item = Self::find(&mut self.items, id)?;
+        if let Some((open_id, open_subject)) = occupant {
+            return Err(TaskBoardError::AnotherTaskInProgress {
+                id: id.to_string(),
+                open_id,
+                open_subject,
+            });
+        }
         item.status = status;
         Ok(item)
     }
@@ -274,6 +326,118 @@ mod tests {
         assert_eq!(
             board.set_status("7", TaskStatus::Completed).unwrap_err(),
             TaskBoardError::UnknownTask { id: "7".into() }
+        );
+    }
+
+    /// Witness for the defect: a plan whose step 1 is never checked off.
+    ///
+    /// A three-step plan is seeded, step 1 is started, and the agent walks on
+    /// to step 2 without completing step 1. On main both starts succeeded and
+    /// the board carried two live steps — so the panel kept pointing at
+    /// "investigate" while the edits belonged to "implement". The refusal names
+    /// the step that has to be closed and both ways to close it.
+    #[test]
+    fn a_second_task_cannot_start_while_the_first_is_still_open() {
+        let mut board = TaskBoard::new();
+        assert!(board.seed_from_plan(&[
+            "Investigate chunk embedding pass",
+            "Implement cross-file batching",
+            "Add tests",
+        ]));
+        board.set_status("1", TaskStatus::InProgress).unwrap();
+
+        let refusal = board.set_status("2", TaskStatus::InProgress).unwrap_err();
+        assert_eq!(
+            refusal,
+            TaskBoardError::AnotherTaskInProgress {
+                id: "2".into(),
+                open_id: "1".into(),
+                open_subject: "Investigate chunk embedding pass".into(),
+            }
+        );
+        let rendered = refusal.to_string();
+        for remedy in ["task_complete", "task_cancel"] {
+            assert!(
+                rendered.contains(remedy),
+                "the refusal must name the way out: {rendered}"
+            );
+        }
+
+        // The board is untouched by a refused start — no second live step.
+        assert_eq!(board.items()[0].status, TaskStatus::InProgress);
+        assert_eq!(board.items()[1].status, TaskStatus::Pending);
+
+        // And closing step 1 is what unblocks step 2, which is the whole point.
+        board.set_status("1", TaskStatus::Completed).unwrap();
+        board.set_status("2", TaskStatus::InProgress).unwrap();
+        assert_eq!(board.items()[1].status, TaskStatus::InProgress);
+    }
+
+    /// Cancelling is the other way out, and a completed/cancelled step never
+    /// occupies the lane it has left.
+    #[test]
+    fn cancelling_the_open_task_also_frees_the_lane() {
+        let mut board = TaskBoard::new();
+        board.create("abandoned", None);
+        board.create("the real work", None);
+        board.set_status("1", TaskStatus::InProgress).unwrap();
+        board.set_status("1", TaskStatus::Cancelled).unwrap();
+        board.set_status("2", TaskStatus::InProgress).unwrap();
+        assert_eq!(board.items()[1].status, TaskStatus::InProgress);
+    }
+
+    /// Re-asserting in_progress on the task you already hold stays the
+    /// idempotent no-op it always was — the occupant check excludes the target
+    /// itself, so a repeated `task_start` is not a self-collision.
+    #[test]
+    fn restarting_the_task_you_already_hold_is_not_a_collision() {
+        let mut board = TaskBoard::new();
+        board.create("mine", None);
+        board.set_status("1", TaskStatus::InProgress).unwrap();
+        board.set_status("1", TaskStatus::InProgress).unwrap();
+        assert_eq!(board.items()[0].status, TaskStatus::InProgress);
+    }
+
+    /// Delegation is parallel by design: sub-agent lanes carry an owner and do
+    /// not occupy the lead's. Three workers running plus the lead's own step is
+    /// a legal board — the rule is one task *of yours*, not one task on the
+    /// board.
+    #[test]
+    fn delegated_lanes_do_not_occupy_the_leads_lane() {
+        let mut board = TaskBoard::new();
+        for subject in [
+            "port the parser",
+            "port the lexer",
+            "port the printer",
+            "review it all",
+        ] {
+            board.create(subject, None);
+        }
+        board.assign("1", "sub:1").unwrap();
+        board.assign("2", "sub:2").unwrap();
+        board.assign("3", "sub:3").unwrap();
+
+        board
+            .set_status("4", TaskStatus::InProgress)
+            .expect("the lead may work while sub-agents run");
+        assert_eq!(board.items()[3].status, TaskStatus::InProgress);
+    }
+
+    /// Terminality outranks the lane: a task that can never start is told why
+    /// it can never start, not which lane it collided with.
+    #[test]
+    fn a_terminal_target_reports_terminality_not_the_open_lane() {
+        let mut board = TaskBoard::new();
+        board.create("open", None);
+        board.create("done", None);
+        board.set_status("1", TaskStatus::InProgress).unwrap();
+        board.set_status("2", TaskStatus::Completed).unwrap();
+        assert_eq!(
+            board.set_status("2", TaskStatus::InProgress).unwrap_err(),
+            TaskBoardError::Terminal {
+                id: "2".into(),
+                status: TaskStatus::Completed
+            }
         );
     }
 

--- a/crates/stella-core/src/tasks.rs
+++ b/crates/stella-core/src/tasks.rs
@@ -26,8 +26,10 @@ pub enum TaskBoardError {
     Terminal { id: String, status: TaskStatus },
     #[error(
         "task {open_id} `{open_subject}` is still in_progress — you hold exactly one task at a \
-         time, so finish it with task_complete (or drop it with task_cancel) before starting \
-         task {id}"
+         time. Finish it with task_complete if its work is done; if you are changing order and \
+         it is not, task_cancel it with the reason (the row stays as an audit trail, and \
+         task_create can put the step back later — ids are never reused). Only then start \
+         task {id}. Do not complete a task whose work is unfinished."
     )]
     AnotherTaskInProgress {
         id: String,
@@ -148,8 +150,18 @@ impl TaskBoard {
     ///
     /// Refusal, not silent auto-completion: closing a card the agent never said
     /// was finished would claim work was done on the board's own authority. The
-    /// error names the open task and both remedies, so the next call can be the
+    /// error names the open task and every way out, so the next call can be the
     /// `task_complete` that should have come first.
+    ///
+    /// All three ways, deliberately. A refusal offering only "finish it" and
+    /// "drop it" is a trap for the agent that is merely re-ordering — it starts
+    /// a step, learns a later one must land first, and finds that the only exit
+    /// phrased as *keeping* the step is a `task_complete` that would be a lie.
+    /// So the message also names the honest reorder path (`task_cancel` with the
+    /// reason, which keeps the row as an audit trail, then `task_create` when the
+    /// step is reachable — ids are never reused, so nothing is corrupted) and
+    /// says outright not to complete unfinished work. A rule that makes the
+    /// board honest must not buy that by making the agent dishonest.
     ///
     /// Only *unowned* tasks occupy the lane. [`Self::assign`] deliberately does
     /// not route through here: delegated tasks carry an owner and run in
@@ -356,12 +368,22 @@ mod tests {
             }
         );
         let rendered = refusal.to_string();
-        for remedy in ["task_complete", "task_cancel"] {
+        // All three ways out, not just the two that are easy to reach for. A
+        // refusal offering only "complete it" and "drop it" pushes an agent
+        // that is merely re-ordering toward a false task_complete — the exact
+        // dishonesty this rule exists to prevent — so the reorder path
+        // (cancel with a reason, re-create the step later) is named too, along
+        // with the guard against taking the lying exit.
+        for remedy in ["task_complete", "task_cancel", "task_create"] {
             assert!(
                 rendered.contains(remedy),
                 "the refusal must name the way out: {rendered}"
             );
         }
+        assert!(
+            rendered.contains("Do not complete a task whose work is unfinished"),
+            "the refusal must not read as an invitation to lie: {rendered}"
+        );
 
         // The board is untouched by a refused start — no second live step.
         assert_eq!(board.items()[0].status, TaskStatus::InProgress);

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -706,6 +706,42 @@ mod tests {
         );
     }
 
+    /// The tool-level half of the single-lane rule: `task_start` on a second
+    /// task is refused, and the message the model reads names the task it must
+    /// close first. Without this, an agent that walked from "investigate" to
+    /// "implement" without a `task_complete` left the board pointing at the
+    /// wrong step for the rest of the session, and nothing ever said so.
+    #[tokio::test]
+    async fn task_start_refuses_a_second_task_and_names_the_open_one() {
+        let (board, _queue) = handles();
+        content(
+            exec(
+                &TaskCreate(board.clone()),
+                serde_json::json!({ "tasks": ["Investigate the pass", "Implement batching"] }),
+            )
+            .await,
+        );
+        content(exec(&TaskStart(board.clone()), serde_json::json!({"id": "1"})).await);
+
+        let msg = error(exec(&TaskStart(board.clone()), serde_json::json!({"id": "2"})).await);
+        assert!(msg.contains("Investigate the pass"), "{msg}");
+        assert!(msg.contains("task_complete"), "{msg}");
+        assert_eq!(
+            board.lock().unwrap().items()[1].status,
+            TaskStatus::Pending,
+            "a refused start must leave the second task claimable"
+        );
+
+        // Completing the first is what lets the second start — the correction
+        // the refusal asks for actually works.
+        content(exec(&TaskComplete(board.clone()), serde_json::json!({"id": "1"})).await);
+        content(exec(&TaskStart(board.clone()), serde_json::json!({"id": "2"})).await);
+        assert_eq!(
+            board.lock().unwrap().items()[1].status,
+            TaskStatus::InProgress
+        );
+    }
+
     #[tokio::test]
     async fn cancel_echoes_the_reason_in_the_confirmation() {
         let (board, _queue) = handles();


### PR DESCRIPTION
## The defect

A seeded three-step plan sat at `working 0/3` with step 1 ("Investigate chunk
embedding pass…") marked in progress, while the transcript below it was already
running `edit crates/stella-tools/src/search/engine.rs` and `cargo build` —
step 2's work. Step 1 was never checked off. The panel pointed at a step the
agent had walked past, for the rest of the session, and nothing said so.

## Why nothing caught it

`task_start`'s and `task_complete`'s descriptions have promised the rule since
they were written — *"Keep exactly ONE task in_progress at a time: complete the
current task before starting the next"* — and it was prose only.
`TaskBoard::set_status` checked terminality and nothing else, so two live lanes
were a legal board.

The pressure runs the other way, too: #2412 measured board bookkeeping at 12–16%
of the session budget and its fix put *"Board updates cost a full model round
trip when they travel alone"* into those same descriptions. With cost pressure
on one side and no enforcement on the other, skipping `task_complete` entirely
is the cheapest move available and is never corrected.

## The change

A move into `InProgress` is refused while another **unowned** task is open. The
error names the open task and both ways out:

```
task 1 `Investigate chunk embedding pass` is still in_progress — you hold
exactly one task at a time, so finish it with task_complete (or drop it with
task_cancel) before starting task 2
```

Three things this is deliberately not:

- **Not auto-completion.** Closing a card the agent never said was finished
  would claim work done on the board's own authority. The refusal makes the
  next call the `task_complete` that should have come first.
- **Not a tax on delegation.** Only *unowned* tasks occupy the lane, and
  `assign` does not route through `set_status`, so N sub-agent lanes plus the
  lead's own task stays legal. Covered by
  `delegated_lanes_do_not_occupy_the_leads_lane`.
- **Not a new round trip.** It fires only on the call that would have opened a
  second lane. A well-behaved session never sees it.

Terminality still outranks the lane, so a task that can never start is told why
it can never start rather than which lane it collided with
(`a_terminal_target_reports_terminality_not_the_open_lane`).

## Witness

`a_second_task_cannot_start_while_the_first_is_still_open` (stella-core) replays
the exact board from the report: seed three steps, start 1, try to start 2.

Checked by neutralising only the enforcement (`occupant` forced to `None`) with
the tests left in place — the witness **FAILED**, the other 14 board tests
passed; restored, all 15 pass. `task_start_refuses_a_second_task_and_names_the_open_one`
is the tool-level half.

Ran: `cargo clippy -p stella-core -p stella-tools --all-targets -- -D warnings`
(clean), `cargo test -p stella-core -p stella-tools` (1350 + 457 + integration,
all pass), `make guards-fast` (all 32 gate-parity guards + fmt, clean). Not the
full workspace gate — the change is confined to these two crates, and the only
other `set_status` caller (`session_clear.rs:217`) writes `Completed`, which is
ungated.

No tests deleted.

## What this does not fix

The refusal fires when the agent finally starts the *next* task. In the reported
session it never did — it went straight to editing. Nothing detects "file
mutations are happening while the in-progress card is stale," and that is not
mechanically decidable from the board alone; it needs a reinforcement signal
(a periodic board reminder in context, or an end-of-turn diagnostic). Filed
separately, along with the fact that the lifecycle rule appears nowhere in the
system prompt — `prompt.rs:68` names the six tools and stops — because putting
it there tensions directly against #2412's measured cost finding and is a
maintainer's call, not mine.

Refs #2412

## Summary by Sourcery

Enforce single-occupancy for the lead's task lane so skipped task completion is surfaced before subsequent work starts.

Bug Fixes:
- Prevent starting a second unowned task while another lead task is still in progress, ensuring the task board cannot silently point to stale work.
- Provide actionable errors that identify the open task and explain how to complete, cancel, or reorder it before starting another task.

Enhancements:
- Preserve parallel delegated work by excluding owned tasks from the lead's single-occupancy lane and retain terminal-state precedence and idempotent status updates.

Tests:
- Add core task-board coverage for lane occupancy, cancellation, repeated starts, delegation, and terminal-state precedence.
- Add tool-level coverage confirming that refused task starts leave the target pending and become valid after the current task is completed.

---

## Follow-up in this PR: the refusal must not steer toward a lie

Second commit. The refusal originally named two exits — finish it, or drop it —
and neither fits an agent that is merely **re-ordering**: it starts a step,
learns a later one has to land first, and finds the only exit phrased as
*keeping* the step is a `task_complete` that would claim unfinished work was
done. A rule that makes the board honest must not buy that by making the agent
dishonest, and as written it pushed exactly that way.

The honest reorder path already existed and simply was not named: `task_cancel`
with the reason keeps the row as an audit trail (`task_cancel`'s own description
says so), and `task_create` puts the step back when it is reachable — ids are
never reused, so nothing is corrupted. The message now names all three ways out
and ends "Do not complete a task whose work is unfinished."

Both the reorder path and that guard are asserted in the witness, so a future
reword cannot quietly drop them.
