### PR TITLE
fix(stella-tui): the v2 transcript head stated +0 -0 over every real edit

### DIFF
--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -38,13 +38,6 @@ use stella_tui_theme::{glyph, token};
 /// Cells the coloured rail occupies at the head of every event row (SPEC 6.2).
 pub const RAIL_W: usize = 2;
 
-/// What kind of thing happened — the sole input to an event's glyph and metal.
-///
-/// A *visual* taxonomy, not a mirror of the engine's event enum, for the reason
-/// [`stella_transcript::ToolKind`] gives: the engine gains event kinds every
-/// release and a renderer that needs an arm per kind silently drops the ones it
-/// has not heard of. Anything unrecognised is [`EventKind::Other`] and renders
-/// as a plain muted row, which is the correct degradation.
 /// A file event's size, as **measured**.
 ///
 /// Every field here is an `Option` for one reason: a head row renders the
@@ -93,6 +86,13 @@ impl Extent {
     }
 }
 
+/// What kind of thing happened — the sole input to an event's glyph and metal.
+///
+/// A *visual* taxonomy, not a mirror of the engine's event enum, for the reason
+/// [`stella_transcript::ToolKind`] gives: the engine gains event kinds every
+/// release and a renderer that needs an arm per kind silently drops the ones it
+/// has not heard of. Anything unrecognised is [`EventKind::Other`] and renders
+/// as a plain muted row, which is the correct degradation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventKind {
     /// `▸ read <path> · <n> lines` — folded by default. The count rides

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -46,8 +46,14 @@ pub const RAIL_W: usize = 2;
 /// that the edit changed nothing, which is a louder and entirely different
 /// claim than "not measured yet", and the same substitution already shipped
 /// once as a defect in the files panel (see [`crate::deck::FileLedger`], whose
-/// counts stopped being re-derived for exactly this reason). `None` renders as
-/// no column at all.
+/// counts stopped being re-derived for exactly this reason — #2290). `None`
+/// renders as no column at all.
+///
+/// Nothing constructs a measured `Extent` from a live session yet: the head
+/// draws at dispatch and there is no pass that revisits the row once the
+/// turn-boundary `FileChange` lands. That backfill is the other half of #4150
+/// and is tracked separately; until it exists an edit head is honestly silent
+/// about its size, and the measured numbers stay on the v1 result row.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Extent {
     /// Lines added, for an edit or a new file.

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -45,16 +45,66 @@ pub const RAIL_W: usize = 2;
 /// release and a renderer that needs an arm per kind silently drops the ones it
 /// has not heard of. Anything unrecognised is [`EventKind::Other`] and renders
 /// as a plain muted row, which is the correct degradation.
+/// A file event's size, as **measured**.
+///
+/// Every field here is an `Option` for one reason: a head row renders the
+/// moment its call dispatches, and nothing has been measured yet at that
+/// moment. A zero is not the honest stand-in — `+0 -0` beside a path asserts
+/// that the edit changed nothing, which is a louder and entirely different
+/// claim than "not measured yet", and the same substitution already shipped
+/// once as a defect in the files panel (see [`crate::deck::FileLedger`], whose
+/// counts stopped being re-derived for exactly this reason). `None` renders as
+/// no column at all.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Extent {
+    /// Lines added, for an edit or a new file.
+    pub added: Option<u32>,
+    /// Lines removed, for an edit or a deletion.
+    pub removed: Option<u32>,
+}
+
+impl Extent {
+    /// A measured `(added, removed)` pair.
+    #[must_use]
+    pub fn delta(added: u32, removed: u32) -> Self {
+        Self {
+            added: Some(added),
+            removed: Some(removed),
+        }
+    }
+
+    /// A measured one-sided count — a read's or a new file's line count on the
+    /// `added` side, a deletion's on the `removed` side.
+    #[must_use]
+    pub fn added(lines: u32) -> Self {
+        Self {
+            added: Some(lines),
+            removed: None,
+        }
+    }
+
+    /// The removed-side counterpart of [`Extent::added`].
+    #[must_use]
+    pub fn removed(lines: u32) -> Self {
+        Self {
+            added: None,
+            removed: Some(lines),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventKind {
-    /// `▸ read <path> · <n> lines` — folded by default.
-    Read { lines: u32 },
-    /// `● edit <path> +a -b`.
-    Edit { added: u32, removed: u32 },
-    /// `＋ write <path> · new file · n lines`.
-    Write { lines: u32 },
-    /// `✗ delete <path> · -n lines · git-backed · u undo`.
-    Delete { lines: u32 },
+    /// `▸ read <path> · <n> lines` — folded by default. The count rides
+    /// `Extent::added`, and is absent until the read returns.
+    Read { extent: Extent },
+    /// `● edit <path> +a -b`, the counts absent until the edit returns.
+    Edit { extent: Extent },
+    /// `＋ write <path> · new file · n lines`, the count on `Extent::added`.
+    Write { extent: Extent },
+    /// `✗ delete <path> · -n lines · git-backed · u undo`, the count on
+    /// `Extent::removed`.
+    Delete { extent: Extent },
     /// `● run <cmd>`.
     Run,
     /// `✦ skill <name> · auto|/cmd · n tok`.
@@ -418,21 +468,42 @@ fn kind_detail(kind: &EventKind) -> Vec<Span<'static>> {
     let dim = Style::new().fg(token::DIM);
     let text = Style::new().fg(token::TEXT);
     match kind {
-        EventKind::Read { lines } => vec![Span::styled(format!(" · {lines} lines"), dim)],
+        EventKind::Read { extent } => extent
+            .added
+            .map(|lines| vec![Span::styled(format!(" · {lines} lines"), dim)])
+            .unwrap_or_default(),
         // The separator spaces stay neutral: colour marks the count, not the
         // padding around it, and a red cell is a scarce thing on this screen
         // (prompt.md rule 5) that must not be spent on whitespace.
-        EventKind::Edit { added, removed } => vec![
-            Span::raw(" "),
-            Span::styled(format!("+{added}"), Style::new().fg(token::GREEN)),
-            Span::raw(" "),
-            Span::styled(format!("-{removed}"), Style::new().fg(token::RED)),
-        ],
-        EventKind::Write { lines } => {
-            vec![Span::styled(format!(" · new file · {lines} lines"), dim)]
-        }
-        EventKind::Delete { lines } => vec![Span::styled(
-            format!(" · -{lines} lines · git-backed · u undo"),
+        //
+        // Both halves or neither: an edit's two numbers are one measurement,
+        // and `+3` alone would read as an addition-only change rather than as
+        // half a reading.
+        EventKind::Edit { extent } => match (extent.added, extent.removed) {
+            (Some(added), Some(removed)) => vec![
+                Span::raw(" "),
+                Span::styled(format!("+{added}"), Style::new().fg(token::GREEN)),
+                Span::raw(" "),
+                Span::styled(format!("-{removed}"), Style::new().fg(token::RED)),
+            ],
+            _ => Vec::new(),
+        },
+        // `new file` is a fact about the call, not a measurement, so it stays
+        // on the row when the line count has not arrived.
+        EventKind::Write { extent } => vec![Span::styled(
+            match extent.added {
+                Some(lines) => format!(" · new file · {lines} lines"),
+                None => " · new file".to_string(),
+            },
+            dim,
+        )],
+        // Likewise the undo affordance: a reader needs to know the deletion is
+        // recoverable whether or not its size has been counted yet.
+        EventKind::Delete { extent } => vec![Span::styled(
+            match extent.removed {
+                Some(lines) => format!(" · -{lines} lines · git-backed · u undo"),
+                None => " · git-backed · u undo".to_string(),
+            },
             dim,
         )],
         EventKind::Skill { trigger, tokens } => vec![

--- a/crates/stella-tui/src/v2/transcript/tests.rs
+++ b/crates/stella-tui/src/v2/transcript/tests.rs
@@ -29,13 +29,17 @@ fn scripted_turn() -> (TurnHead, Vec<Event>, Receipt) {
     );
     skill.footer = Some("  injected 10-layer feature contract · used 42× this repo".into());
 
-    let mut read = Event::new(EventKind::Read { lines: 221 }, "…/lifecycle.rs");
+    let mut read = Event::new(
+        EventKind::Read {
+            extent: Extent::added(221),
+        },
+        "…/lifecycle.rs",
+    );
     read.duration_ms = 3;
 
     let mut edit = Event::new(
         EventKind::Edit {
-            added: 3,
-            removed: 1,
+            extent: Extent::delta(3, 1),
         },
         "…/self_driving_cmd.rs",
     );
@@ -122,16 +126,30 @@ fn a_turn_rule_spans_the_full_width() {
 #[test]
 fn every_event_row_shows_its_rail_in_the_correct_metal() {
     let cases = [
-        (EventKind::Read { lines: 1 }, token::MUTED),
+        (
+            EventKind::Read {
+                extent: Extent::added(1),
+            },
+            token::MUTED,
+        ),
         (
             EventKind::Edit {
-                added: 1,
-                removed: 0,
+                extent: Extent::delta(1, 0),
             },
             token::GOLD,
         ),
-        (EventKind::Write { lines: 1 }, token::GOLD),
-        (EventKind::Delete { lines: 1 }, token::RED),
+        (
+            EventKind::Write {
+                extent: Extent::added(1),
+            },
+            token::GOLD,
+        ),
+        (
+            EventKind::Delete {
+                extent: Extent::removed(1),
+            },
+            token::RED,
+        ),
         (EventKind::Run, token::GOLD),
         (
             EventKind::Skill {
@@ -172,11 +190,15 @@ fn every_event_row_shows_its_rail_in_the_correct_metal() {
 /// SPEC 6.3: reads collapse by default, edits expand.
 #[test]
 fn reads_collapse_and_edits_expand_by_default() {
-    assert!(EventKind::Read { lines: 1 }.collapses_by_default());
+    assert!(
+        EventKind::Read {
+            extent: Extent::added(1)
+        }
+        .collapses_by_default()
+    );
     assert!(
         !EventKind::Edit {
-            added: 1,
-            removed: 1
+            extent: Extent::delta(1, 1)
         }
         .collapses_by_default()
     );
@@ -187,8 +209,7 @@ fn reads_collapse_and_edits_expand_by_default() {
 fn folding_an_event_hides_its_body_and_flips_the_glyph() {
     let mut event = Event::new(
         EventKind::Edit {
-            added: 1,
-            removed: 0,
+            extent: Extent::delta(1, 0),
         },
         "src/lib.rs",
     );

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -189,7 +189,11 @@ mod tests {
     /// the tool ran and changed nothing — sitting on the one row a reader
     /// scans to find out what a turn touched. The same substitution had
     /// already shipped once in the files panel and been removed there for this
-    /// reason ([`crate::deck::FileLedger`]).
+    /// reason ([`crate::deck::FileLedger`]), and `AgentEvent::FileChange`'s own
+    /// doc names that instance (#2290) while forbidding the repair that looks
+    /// easiest: deriving the counts from the tool's *input* or its result text.
+    /// This row therefore states no number at all rather than a wrong one
+    /// (#4150).
     #[test]
     fn a_dispatched_head_states_no_size_it_has_not_measured() {
         for (tool, path) in [

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -27,7 +27,7 @@
 
 use ratatui::text::Line;
 
-use super::transcript::{Event, EventKind, Receipt, event_rows, receipt, turn_end};
+use super::transcript::{Event, EventKind, Extent, Receipt, event_rows, receipt, turn_end};
 
 /// The metal-bearing head of a dispatched call (SPEC 6.2).
 ///
@@ -72,15 +72,29 @@ pub fn compaction_rows(
 /// Deliberately the same six names [`stella_transcript::ToolKind::from_name`]
 /// recognises, so the two renderers of the same transcript cannot disagree
 /// about what a `bash` row is.
+///
+/// Every file kind takes an **unmeasured** [`Extent`], and that is the whole
+/// point of the type. This function runs when the call *dispatches*: the tool
+/// has not returned, no `FileChange` has been emitted, and there is nothing to
+/// count. Filling the fields with zeros instead put `edit <path> +0 -0` over
+/// every real edit in the deck — a row asserting the change was empty, on the
+/// one screen a reader consults to find out what changed. The measured numbers
+/// live on the result row (`render::entry`'s `resolve_inline_delta`), which is
+/// where they can be true; this row states the verb and its subject.
 fn kind_for(name: &str) -> EventKind {
     match name {
-        "read_file" => EventKind::Read { lines: 0 },
-        "edit_file" => EventKind::Edit {
-            added: 0,
-            removed: 0,
+        "read_file" => EventKind::Read {
+            extent: Extent::default(),
         },
-        "write_file" => EventKind::Write { lines: 0 },
-        "delete_file" => EventKind::Delete { lines: 0 },
+        "edit_file" => EventKind::Edit {
+            extent: Extent::default(),
+        },
+        "write_file" => EventKind::Write {
+            extent: Extent::default(),
+        },
+        "delete_file" => EventKind::Delete {
+            extent: Extent::default(),
+        },
         "bash" => EventKind::Run,
         _ => EventKind::Other,
     }
@@ -139,6 +153,13 @@ mod tests {
         line.spans.iter().map(|s| s.content.clone()).collect()
     }
 
+    /// Every row of a head, joined — a head is one row today, but an assertion
+    /// that a number is absent must not pass merely by looking at the wrong
+    /// row if that ever changes.
+    fn text_of_rows(rows: &[Line<'static>]) -> String {
+        rows.iter().map(text_of).collect::<Vec<_>>().join("\n")
+    }
+
     /// An unknown tool still renders — the vocabulary is open (MCP, custom
     /// tools), and a missing row is the failure this guards against.
     #[test]
@@ -159,5 +180,60 @@ mod tests {
         let text = text_of(&rows[0]);
         assert!(text.contains("read src/main.rs"), "{text}");
         assert!(!text.contains('{'), "the raw argument blob must not leak");
+    }
+
+    /// A dispatched call has measured nothing yet, so its head states no size.
+    ///
+    /// The zeros this guards against were not cosmetic: `edit <path> +0 -0`
+    /// rode over every real edit in the deck, and `+0 -0` is a *claim* — that
+    /// the tool ran and changed nothing — sitting on the one row a reader
+    /// scans to find out what a turn touched. The same substitution had
+    /// already shipped once in the files panel and been removed there for this
+    /// reason ([`crate::deck::FileLedger`]).
+    #[test]
+    fn a_dispatched_head_states_no_size_it_has_not_measured() {
+        for (tool, path) in [
+            ("edit_file", "crates/stella-tools/Cargo.toml"),
+            ("read_file", "src/main.rs"),
+            ("write_file", "src/new.rs"),
+            ("delete_file", "src/old.rs"),
+        ] {
+            let text = text_of_rows(&head_rows(tool, Some(path), "{}", 120));
+            for zero in ["+0", "-0", "0 lines"] {
+                assert!(
+                    !text.contains(zero),
+                    "`{tool}` head fabricates `{zero}` before its result exists: {text}"
+                );
+            }
+            assert!(text.contains(path), "{text}");
+        }
+    }
+
+    /// Absent counts are not the same as an absent row: `write` still says the
+    /// file is new and `delete` still says it is recoverable, because neither
+    /// is a measurement.
+    #[test]
+    fn an_unmeasured_head_keeps_the_facts_that_are_not_measurements() {
+        let write = text_of_rows(&head_rows("write_file", Some("src/new.rs"), "{}", 120));
+        assert!(write.contains("new file"), "{write}");
+        let delete = text_of_rows(&head_rows("delete_file", Some("src/old.rs"), "{}", 120));
+        assert!(delete.contains("git-backed"), "{delete}");
+        assert!(delete.contains("u undo"), "{delete}");
+    }
+
+    /// And a measured extent still renders its numbers — the fix removes the
+    /// fabrication, not the column.
+    #[test]
+    fn a_measured_edit_still_renders_its_delta() {
+        let mut event = Event::new(
+            EventKind::Edit {
+                extent: Extent::delta(3, 1),
+            },
+            "src/lib.rs",
+        );
+        event.collapsed = Some(false);
+        let text = text_of_rows(&event_rows(&event, 120));
+        assert!(text.contains("+3"), "{text}");
+        assert!(text.contains("-1"), "{text}");
     }
 }


### PR DESCRIPTION
## What

The v2 transcript's head row stated a measurement it never took. Every `edit_file` call in the interactive Command Deck rendered:

```text
 │ ● edit crates/stella-tools/Cargo.toml +0 -0
 └
   replaced 1 occurrence(s) in crates/stella-tools/Cargo.toml at byte 1774 …
```

`+0 -0` is not a measurement that came back zero — it was a literal `0` compiled into the row, and it rode over reads, writes and deletes too (`· 0 lines`, `· new file · 0 lines`, `· -0 lines · git-backed · u undo`).

## Cause

`crates/stella-tui/src/v2/transcript_source.rs::kind_for` built every file kind with `added: 0, removed: 0` / `lines: 0`. It is structural, not a missed assignment: `v2_rows` routes `TranscriptEntry::ToolStart` into `head_rows`, the head draws **the moment the call dispatches**, and at that point the tool has not run and no `FileChange` has been emitted. There is genuinely nothing to count — but a zero is not the neutral stand-in for "not counted". `+0 -0` beside a path asserts the tool ran and changed nothing, on the one row a reader scans to find out what a turn touched.

## Fix

Make the absence expressible instead of substituting a zero.

- New `Extent { added: Option<u32>, removed: Option<u32> }` replaces the bare `u32` fields on `EventKind::{Read,Edit,Write,Delete}`, with measured constructors `Extent::delta/added/removed`.
- `kind_detail` renders no column for a side it has not measured. An edit is both halves or neither — `+3` alone would read as an addition-only change rather than as half a reading.
- Facts that are **not** measurements stay on the row regardless: `write` still says `new file`, `delete` still says `git-backed · u undo`.
- `kind_for` yields `Extent::default()` — unmeasured — with the reasoning in its doc.

The true numbers keep coming from the result row, where `render::entry::resolve_inline_delta` sources them from the emitter. No count is derived from the tool's input or its result text: that is precisely what #2290 established as the defect, and `AgentEvent::FileChange`'s doc forbids it. `edit_file` with `replace_all` would make an input-derived number wrong anyway.

**Exemplar:** this is the same repair `deck::FileLedger` already carries — its doc records that these counts "are no longer re-derived here … for a bulk edit or a worker lane, nothing at all, rendering as `+0 -0` over real work."

## What this does NOT do

It does not fill in the real `+a -b`. SPEC 6.2 pictures `● edit …/self_driving_cmd.rs +3 -1`, and delivering that needs the head re-rendered once the turn-boundary `FileChange` for that `(path, seq)` lands — the draw-once-at-dispatch shape does not do that. `Extent`'s measured constructors exist and nothing in production calls them yet. That is #4150's suggested fix (1) and is filed as **#4154**. Saying so out loud per CLAUDE.md: the head is honestly silent about size until #4154 lands, which is strictly better than a false claim but is not the finished row.

Separately, while tracing this I found the result row's `+N −M` can *also* be absent for a successful `edit_file` — its metric is gated on an inline diff that may not resolve. Filed as **#4155** with the inference chain labelled.

## Witness

`a_dispatched_head_states_no_size_it_has_not_measured` (`crates/stella-tui/src/v2/transcript_source.rs`) asserts no `+0`, `-0` or `0 lines` on a dispatched head, for all four file tools.

Checked the artisanal way — re-introduced the zeros in `kind_detail` and re-ran:

```text
`edit_file` head fabricates `+0` before its result exists:  │ ● edit crates/stella-tools/Cargo.toml +0 -0
test result: FAILED. 862 passed; 1 failed
```

That is the exact row from the report. Two companion tests: `an_unmeasured_head_keeps_the_facts_that_are_not_measurements` (write still says `new file`, delete still says `git-backed · u undo`) and `a_measured_edit_still_renders_its_delta` (the fix removes the fabrication, not the column).

## Verification

- `make gate CARGO_SCOPE="-p stella-tui"` — exit 0.
- `cargo test -p stella-tui` — 12 test binaries, 0 failures.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` — clean.

No tests deleted. No `#[allow]`, no baseline raised, no `TODO` added.

Closes #4150
Refs #4154, #4155, #2290

## Summary by Sourcery

Remove misleading zero-size measurements from dispatched v2 transcript file-tool heads until actual change extents are available.

Bug Fixes:
- Stop v2 transcript heads from displaying fabricated zero-sized file changes before tool results have been measured.

Enhancements:
- Represent file-change extents as optionally measured values so unmeasured heads omit size details while retaining non-measurement facts such as new-file and undo status.
- Preserve rendering of measured read, edit, write, and delete counts through explicit extent constructors.

Tests:
- Add coverage ensuring dispatched file-tool heads omit fabricated zero counts, retain relevant facts, and still render measured edit deltas.