### PR TITLE
fix(stella-cli): the Command Deck's Files tab shows what the turn changed

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1219,19 +1219,15 @@ pub(crate) async fn run_turn(
         }
         engine.run_turn_with_sender(messages, budget, &tx).await
     };
-    // What this turn changed in the shared tree (#3413), measured at the
-    // boundary and emitted *before* the close below: these are the turn's own
-    // events and a consumer folding the stream must see them inside the turn
-    // they describe. See `crate::turn_files` for why a measurement, not a hook.
-    crate::turn_files::emit_shared_tree_changes(cfg, &tx, execution.as_ref());
     // This path owns its run — one raw engine turn, no pipeline above it — so
-    // it owes the run's terminator (#3379). The engine ends the turn with
-    // `TurnComplete` and deliberately says nothing about the run, and every
-    // other owner (the deck, fleet, goal, resume, the pipeline one-shot) goes
-    // through this same seam; without it a raw `stella run` ended on
-    // `turn_complete` and simply stopped, leaving every consumer waiting for a
-    // terminal event that never came. Last, after the turn's own events above.
-    persistence::emit_run_complete_for_turn(&tx, &cfg.model_id, &outcome);
+    // it owes both of the boundary's debts: what the turn changed in the shared
+    // tree (#3413), then the run's terminator (#3379). Emitted *before* the
+    // close below, because these are the turn's own events and a consumer
+    // folding the stream must see them inside the turn they describe. See
+    // `crate::turn_files::close_turn_boundary` for the ordering, for why the
+    // tree is measured rather than inferred from tool inputs, and for the deck
+    // defect that made the two one call.
+    crate::turn_files::close_turn_boundary(cfg, &tx, execution.as_ref(), &outcome);
     // The re-query adapter holds an `EventSender` clone of this run's channel
     // (#3366 telemetry), so it must be released here too — otherwise it keeps
     // the channel open and the renderer's `recv()` loop never ends (#2290).

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -118,13 +118,13 @@ pub(crate) fn emit_run_complete_on_raw(
     emit_run_complete(&stella_core::EventSender::new(tx.clone()), model, cost_usd);
 }
 
-pub(crate) fn emit_run_complete_raw(
-    tx: &mpsc::UnboundedSender<AgentEvent>,
-    model: &str,
-    outcome: &TurnOutcome,
-) {
-    emit_run_complete_for_turn(&stella_core::EventSender::new(tx.clone()), model, outcome);
-}
+// `emit_run_complete_raw` — the turn-outcome sibling of the above — is
+// deliberately gone. It let a driver holding a raw sender pay the terminator
+// half of the turn boundary without the tree measurement that rides beside it,
+// and the Command Deck did exactly that for as long as both existed: every
+// session's Files tab read `no files touched yet` however many files its turns
+// wrote. `turn_files::close_turn_boundary_raw` is the replacement, and it pays
+// both. Restoring a terminator-only raw helper reopens that hole.
 
 #[derive(Default)]
 pub(crate) struct RendererOutcome {

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -3785,7 +3785,7 @@ async fn run_lead_turn(
         }
         engine.run_turn(messages, budget, &tx).await
     };
-    agent::persistence::emit_run_complete_raw(&tx, &cfg.model_id, &outcome);
+    crate::turn_files::close_turn_boundary_raw(cfg, &tx, execution.as_ref(), &outcome);
     // The model is done and the deck already painted "done". Everything below is
     // bookkeeping that can take real time (the forwarder persists every event of the
     // turn) while the driver's `select!` still reads input — so latch the flag that

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -107,13 +107,35 @@ struct Bound {
 
 impl SessionDurability {
     /// Point this handle at the durable record of the session that is now
-    /// running.
+    /// running, and establish that session's tree baseline.
+    ///
+    /// The baseline is taken **here**, at the moment the session opens, rather
+    /// than being left to the first turn's own boundary snapshot.
+    /// [`Self::snapshot_worktree`] reports the delta since the previous
+    /// snapshot and returns empty when there is none, because "every file in
+    /// the workspace" is not a description of what a turn changed. That
+    /// contract is right; taking the session's *first* reading at a turn
+    /// boundary was not. It spent the first turn establishing the baseline, so
+    /// that turn always reported having changed nothing — and for a one-shot
+    /// `stella run`, where every invocation is a fresh session and the first
+    /// turn is the only turn, the file stream was empty by construction on
+    /// every run.
+    ///
+    /// The reading is discarded on purpose: whatever changed before this
+    /// session existed is not this session's work. Best-effort like every
+    /// other journal write — an unmeasurable tree costs the file ledger, never
+    /// the session.
     pub fn bind(&self, journal: WorkJournal) {
-        let mut slot = self.bound.write().unwrap_or_else(|p| p.into_inner());
-        *slot = Some(Bound {
-            journal: Arc::new(journal),
-            pipeline: Arc::new(RwLock::new(None)),
-        });
+        {
+            let mut slot = self.bound.write().unwrap_or_else(|p| p.into_inner());
+            *slot = Some(Bound {
+                journal: Arc::new(journal),
+                pipeline: Arc::new(RwLock::new(None)),
+            });
+        }
+        // After the write lock is released: `snapshot_worktree` takes the read
+        // lock, and this is not a re-entrant lock.
+        let _ = self.snapshot_worktree();
     }
 
     /// Declare that this session's turns are running inside a staged pipeline,
@@ -337,6 +359,7 @@ pub fn bind_session(
 ) -> Option<String> {
     match WorkJournal::open(workspace_root, session_id) {
         Ok(journal) => {
+            // `bind` establishes this session's tree baseline; see its doc.
             durability.bind(journal);
             None
         }
@@ -361,6 +384,88 @@ mod tests {
     #[test]
     fn an_unbound_handle_offers_no_sink() {
         assert!(SessionDurability::default().sink().is_none());
+    }
+
+    /// **Witness.** A session's *first* turn reports what it changed.
+    ///
+    /// [`SessionDurability::snapshot_worktree`] answers with the delta since
+    /// the previous snapshot, and the first call of a lineage has no previous
+    /// snapshot to answer against — it establishes one and returns empty, on
+    /// purpose ("every file in the workspace" is not what a turn changed).
+    /// Nothing established that baseline at session start, so the *turn*
+    /// boundary spent its first reading on it and the session's first turn
+    /// reported having changed nothing, however many files it wrote.
+    ///
+    /// This is not a corner: one-shot `stella run` opens a fresh session per
+    /// invocation, so its first turn is its only turn and the file stream was
+    /// empty by construction on every single run.
+    ///
+    /// Both halves are asserted. A `bind` that reported the whole workspace on
+    /// turn one would satisfy a "not empty" assertion and be a worse bug, so
+    /// the pre-existing file must be absent from the answer and the turn's own
+    /// edit present.
+    #[test]
+    fn the_first_turn_after_a_bind_reports_its_own_changes() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        // Content that predates the session: the baseline must absorb it.
+        std::fs::write(ws.path().join("predates.txt"), "before\n").unwrap();
+
+        let durability = SessionDurability::default();
+        durability.bind(journal(store.path(), ws.path(), "ses-first-turn"));
+
+        // The session's first turn edits one file and creates another.
+        std::fs::write(ws.path().join("predates.txt"), "before\nafter\n").unwrap();
+        std::fs::write(ws.path().join("born.rs"), "new\n").unwrap();
+
+        let mut changes = durability.snapshot_worktree();
+        changes.sort_by(|a, b| a.path.cmp(&b.path));
+        let paths: Vec<&str> = changes.iter().map(|c| c.path.as_str()).collect();
+
+        assert_eq!(
+            paths,
+            vec!["born.rs", "predates.txt"],
+            "the first turn's own changes reach the file ledger"
+        );
+        assert_eq!(
+            (changes[0].added, changes[0].removed),
+            (1, 0),
+            "with git's real counts, never +0 -0 (#2290)"
+        );
+        assert_eq!((changes[1].added, changes[1].removed), (1, 0));
+    }
+
+    /// The other half of the same baseline: `bind` absorbs the pre-existing
+    /// tree rather than reporting it. A bind that primed nothing would pass
+    /// nothing above; a bind that reported everything would make the first
+    /// turn claim authorship of the whole workspace.
+    #[test]
+    fn a_bind_absorbs_the_tree_it_found_rather_than_reporting_it() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::write(ws.path().join("predates.txt"), "before\n").unwrap();
+
+        let durability = SessionDurability::default();
+        durability.bind(journal(store.path(), ws.path(), "ses-absorbs"));
+
+        assert!(
+            durability.snapshot_worktree().is_empty(),
+            "a turn that changed nothing reports nothing, even the first one"
+        );
+    }
+
+    /// `bind` takes the write lock and then reads through
+    /// `snapshot_worktree`, which takes the read lock. `RwLock` is not
+    /// re-entrant, so doing both under one guard deadlocks the session at
+    /// startup — the one failure mode of priming here rather than at the
+    /// caller. A test that returns at all is the assertion.
+    #[test]
+    fn binding_does_not_deadlock_on_its_own_lock() {
+        let store = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let durability = SessionDurability::default();
+        durability.bind(journal(store.path(), ws.path(), "ses-lock"));
+        assert!(durability.sink().is_some(), "the handle really is bound");
     }
 
     /// #2177 witness: every driver that ends a turn marks it.

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -60,11 +60,71 @@
 use std::sync::Arc;
 
 use stella_core::EventSender;
+use stella_core::TurnOutcome;
 use stella_protocol::event::{AgentEvent, FileChangeKind};
 use stella_store::work_journal::{JournalChange, JournalChangeKind};
 use stella_store::{FileTouchRow, Store};
 
 use crate::config::Config;
+
+/// Everything the owner of a turn owes its event stream at the boundary, in
+/// the one order that is correct.
+///
+/// The two debts are separate facts that have to be paid together, because
+/// they are paid to the same stream in the same instant and only one ordering
+/// is right: the tree measurement first — these are the turn's *own* events
+/// and a consumer folding the stream must see them inside the turn they
+/// describe — and then the run's terminator, which is the last thing a run
+/// says (#3379).
+///
+/// **It is one function because it was two, and a driver forgot one of them.**
+/// `emit_shared_tree_changes` had exactly one caller, `agent::run_turn`, so
+/// the Command Deck — the default interactive shell on a TTY, and therefore
+/// the surface almost every human actually watches — emitted no
+/// [`AgentEvent::FileChange`] at all. Its Files tab (`/files`, `/diff`) read
+/// `no files touched yet` for the whole of every session however many files
+/// the turn created, edited or deleted. The terminator was never forgotten,
+/// because a run that omits it visibly hangs every consumer; the measurement
+/// was, because a missing measurement renders as an honest-looking empty
+/// ledger. Folding the silent debt into the loud one is what stops the next
+/// driver making the same omission — the same repair, and the same reasoning,
+/// as `durability`'s `#2177` turn-boundary fence.
+///
+/// Call **before** the turn's event channel closes. Best-effort and silent
+/// throughout: a turn that ended is not made less ended by an unmeasurable
+/// tree.
+pub(crate) fn close_turn_boundary(
+    cfg: &Config,
+    tx: &EventSender,
+    execution: Option<&(Arc<Store>, i64)>,
+    outcome: &TurnOutcome,
+) {
+    emit_shared_tree_changes(cfg, tx, execution);
+    crate::agent::persistence::emit_run_complete_for_turn(tx, &cfg.model_id, outcome);
+}
+
+/// [`close_turn_boundary`] for a driver holding the raw channel sender rather
+/// than an [`EventSender`] — the Command Deck's lead turn, which builds its
+/// channel with `mpsc::unbounded_channel` and hands clones to the forwarder.
+///
+/// The sender it wraps is a **temporary**, dropped when this call returns. It
+/// has to be: the deck ends its turn with `close_turn_stream`, which closes
+/// the channel by dropping the last sender, and a clone left alive in the
+/// driver's scope would leave the forwarder's `recv()` pending forever and
+/// wedge the turn future after the deck had already painted the turn done
+/// (#2290).
+///
+/// This replaces `persistence::emit_run_complete_raw`, which paid only the
+/// terminator half of the boundary — deliberately, so that the deck cannot
+/// terminate a turn without also measuring what it changed.
+pub(crate) fn close_turn_boundary_raw(
+    cfg: &Config,
+    tx: &tokio::sync::mpsc::UnboundedSender<AgentEvent>,
+    execution: Option<&(Arc<Store>, i64)>,
+    outcome: &TurnOutcome,
+) {
+    close_turn_boundary(cfg, &EventSender::new(tx.clone()), execution, outcome);
+}
 
 /// Measure the shared work tree once, then write both of this turn's file
 /// projections from that one reading: the [`AgentEvent::FileChange`] stream
@@ -165,6 +225,81 @@ fn file_change(change: JournalChange) -> AgentEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **Witness.** Every driver that owns a turn measures what that turn
+    /// changed, not just that it ended.
+    ///
+    /// [`emit_shared_tree_changes`] had exactly ONE caller, `agent::run_turn`.
+    /// The Command Deck — the default interactive shell on a TTY, and so the
+    /// surface a human actually watches — drives its lead turn through
+    /// `run_lead_turn`, which paid only the run terminator. It therefore
+    /// emitted no [`AgentEvent::FileChange`] for the whole of any session, and
+    /// its Files tab (`/files`, `/diff`) read `no files touched yet` however
+    /// many files the turn created, edited or deleted.
+    ///
+    /// The asymmetry is the point, and it is why this needs a fence rather
+    /// than trust: a driver that drops the *terminator* hangs every consumer
+    /// immediately and is found in minutes, while a driver that drops the
+    /// *measurement* renders an empty ledger that is indistinguishable from an
+    /// honest one. Only the loud debt was ever noticed. Folding both into
+    /// [`close_turn_boundary`] is the structural half of the repair; this is
+    /// the half that keeps the next driver from unfolding them.
+    ///
+    /// A source fence rather than an end-to-end run, and the choice is the
+    /// same one `durability`'s `#2177` fence names: the difference lives
+    /// inside ~400-line async driver functions needing a provider, a
+    /// journal-bound session and a file-touching turn to reach, and what
+    /// actually decays is the *call site* — exactly as it decayed here. The
+    /// measurement itself is covered end-to-end by
+    /// `durability`'s baseline witnesses and by `stella-store`'s
+    /// `snapshot_worktree` tests.
+    #[test]
+    fn every_turn_owner_pays_both_halves_of_the_boundary() {
+        // Built rather than written out, so this file is not its own match.
+        let seam = format!("close_turn_{}", "boundary");
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        for (file, driver) in [
+            // The raw engine turn: `stella run`, the plain REPL.
+            ("agent.rs", "run_turn"),
+            // The interactive deck's lead turn — the driver that had the hole.
+            ("command_deck.rs", "run_lead_turn"),
+        ] {
+            let body = std::fs::read_to_string(src.join(file))
+                .unwrap_or_else(|e| panic!("cannot read {file}: {e}"));
+            assert!(
+                body.contains(&seam),
+                "{file} ({driver}) owns a turn and no longer closes it through \
+                 `turn_files::close_turn_boundary`. A boundary that stops \
+                 measuring does not degrade loudly — it silently empties the \
+                 Files tab, `stella export` and the audit log for that whole \
+                 surface while every other surface keeps working."
+            );
+        }
+    }
+
+    /// The deleted half of the fence above: the terminator-only raw helper the
+    /// deck used to call must stay deleted.
+    ///
+    /// `persistence::emit_run_complete_raw` is what made the omission possible
+    /// — it let a driver holding a raw sender pay the loud debt alone, and read
+    /// exactly like a complete boundary at the call site. Re-adding a
+    /// terminator-only raw helper reopens the hole this change closed, and the
+    /// fence above would not catch it: a driver calling it would simply stop
+    /// containing the seam string, which is a failure the author is free to
+    /// "fix" by re-adding the string. This pins the removal itself.
+    #[test]
+    fn the_terminator_only_raw_helper_stays_deleted() {
+        let banned = format!("emit_run_complete_{}(", "raw");
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let body = std::fs::read_to_string(src.join("agent/persistence.rs")).expect("persistence");
+        assert!(
+            !body.contains(&banned),
+            "`emit_run_complete_raw` is back. It pays the run terminator \
+             without the tree measurement that rides beside it, which is \
+             exactly how the deck's Files tab stayed empty for every session. \
+             Use `turn_files::close_turn_boundary_raw`, which pays both."
+        );
+    }
 
     fn measured(kind: JournalChangeKind) -> JournalChange {
         JournalChange {


### PR DESCRIPTION
## The bug

The Command Deck's Files tab (`/files`, `/diff`) read `no files touched yet` for the whole of every session, however many files the turn created, edited or deleted.

Two independent causes, both of which had to go:

**1. The deck's turn driver never measured.** `turn_files::emit_shared_tree_changes` had exactly one caller, `agent::run_turn`. The deck drives its lead turn through `command_deck::run_lead_turn`, which paid only the run terminator (`persistence::emit_run_complete_raw`). So the default interactive shell on a TTY — the surface a human actually watches — emitted no `AgentEvent::FileChange` at all.

The asymmetry is why this survived: a driver that drops the *terminator* hangs every consumer immediately and is found in minutes (#2290, #960), while a driver that drops the *measurement* renders an empty ledger indistinguishable from an honest one. Only the loud debt was ever noticed.

**2. The session's first turn always reported nothing.** `snapshot_worktree` answers with the delta since the previous snapshot, and the first call of a lineage has no previous snapshot — it establishes one and returns empty, on purpose ("every file in the workspace" is not what a turn changed). Nothing established that baseline at session start, so the *turn* boundary spent its first reading on it. Not a corner case: one-shot `stella run` opens a fresh session per invocation, so its first turn is its only turn and its file stream was empty by construction on **every run**.

## The fix

- `turn_files::close_turn_boundary` folds the two boundary debts into one call — tree measurement first (these are the turn's own events, and a consumer folding the stream must see them inside the turn they describe), then the run's terminator (#3379). `close_turn_boundary_raw` is the raw-sender variant for the deck, mirroring the helper it replaces; its `EventSender` is a temporary so no clone outlives the call and wedges `close_turn_stream` (#2290).
- **`persistence::emit_run_complete_raw` is deleted.** It was what made the omission possible — it let a driver pay the loud debt alone while reading like a complete boundary at the call site. Removing it is the structural half of the repair: the deck can no longer terminate a turn without also measuring it.
- `SessionDurability::bind` now establishes the session's tree baseline, so the first turn measures against the moment the session opened. One call site covers every bind path (deck start, in-deck session switch, `presence`, `resume`). The reading is discarded on purpose — whatever changed before this session existed is not this session's work.

`command_deck.rs` is a grandfathered god file closed to growth: this change is **net zero lines** there (3912 before and after), which is why the raw-sender variant lives in `turn_files.rs` rather than the call site being expanded inline.

## "do not show read files"

Satisfied structurally, not by filtering. `FileChangeKind::Read` has **no live producer anywhere in the workspace** — both surviving producers diff a tree against a tree, and a read leaves no trace in a tree to diff (`stella-protocol/src/event/payload.rs` L45-56). The variant survives only so replay can parse journals recorded before the 12-tool purge, so the tab's `reads` column stays for that path and is structurally always 0 on a live turn.

## Witnesses

All three fail on `main` and pass here — verified by reverting each production change while keeping the tests.

| Witness | On `main` |
|---|---|
| `durability::tests::the_first_turn_after_a_bind_reports_its_own_changes` | `left: []` vs `right: ["born.rs", "predates.txt"]` — the reported symptom exactly |
| `turn_files::tests::every_turn_owner_pays_both_halves_of_the_boundary` | fails naming `command_deck.rs (run_lead_turn)` |
| `turn_files::tests::the_terminator_only_raw_helper_stays_deleted` | fails — `emit_run_complete_raw` is present |

Plus `a_bind_absorbs_the_tree_it_found_rather_than_reporting_it` (the other half: a bind that reported the whole workspace on turn one would satisfy a "not empty" assertion and be a worse bug) and `binding_does_not_deadlock_on_its_own_lock` (`bind` takes the write lock and then reads through `snapshot_worktree`, which takes the read lock; `RwLock` is not re-entrant).

The source fence follows the idiom `durability`'s #2177 fence already established here, for the same reason and against the same defect shape — what decays is the *call site*, inside ~400-line async drivers that need a provider, a journal-bound session and a file-touching turn to reach. The measurement itself is covered end-to-end by the `durability` baseline witnesses and `stella-store`'s `snapshot_worktree` tests.

## Verification

`make guards` green (32 steps), `cargo fmt --check`, `clippy -D warnings` on `stella-cli`, `RUSTDOCFLAGS=-D warnings cargo doc`, file-size ratchet green, and `cargo test -p stella-cli` at **1894 passed**.

One unrelated failure, `settings::tests::untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt`, reproduces identically on the base commit `37bf308fc` and is already tracked as #3982 / #4060: it overrides `HOME` but not `STELLA_HOME`, so it passes only against a real `~/.stella`. Its failing here confirms this run was correctly isolated.

## Left behind

`stella goal` and `stella daemon resume` own their own turn streams and have the same empty ledger. They are **not** fixed here: a goal run drives several turns over one stream and emits one terminator for the whole run, so swapping in `close_turn_boundary` at the end would attribute every turn's changes to the last one. The measurement has to be per-turn inside the loop, which is a design decision worth making deliberately. Filed as a handoff: #4159.

Sub-agent (`subsession.rs`) and fleet lanes are deliberately excluded — they run beside the session's own turn against the same journal, so a snapshot there would steal the lead's delta.

Refs #3413, #4159

## Summary by Sourcery

Ensure turn file changes are measured and emitted for Command Deck sessions and newly bound sessions.

Bug Fixes:
- Report files created, edited, or deleted during Command Deck and raw turns in the Files tab, diff view, exports, and audit records.
- Ensure the first turn of a newly bound session reports only changes made after the session opened.

Enhancements:
- Unify turn-boundary handling so every turn owner records worktree changes before emitting the run terminator.
- Remove the terminator-only raw completion path that allowed drivers to omit file-change measurement.

Tests:
- Add regression coverage for first-turn worktree changes, baseline isolation, binding lock safety, and enforcement of complete turn-boundary handling.