### PR TITLE
fix(stella-tui): one model-call failure, one error row

### DIFF
--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -49,7 +49,7 @@
 //! resumed turn starts the allowance over, which only re-permits a bounded
 //! amount of work.
 
-use stella_protocol::AgentEvent;
+use stella_protocol::{AgentEvent, MODEL_CALL_FAILED_PREFIX};
 
 use super::{Engine, bus};
 use crate::event_sender::EventSender;
@@ -183,8 +183,11 @@ impl<'a> Engine<'a> {
                 retryable,
             } => {
                 // The abort string keeps its pre-#2679 bytes: consumers and
-                // transcripts read this exact rendering.
-                let reason = format!("model call failed: {message}");
+                // transcripts read this exact rendering. The prefix is named
+                // rather than inline because a renderer has to recognise it to
+                // collapse this reason against the `Error` emitted just below
+                // it (#4146) — see [`MODEL_CALL_FAILED_PREFIX`].
+                let reason = format!("{MODEL_CALL_FAILED_PREFIX}{message}");
                 self.emit_lifecycle(
                     bus::names::MODEL_REQUEST_FAILED,
                     || serde_json::json!({ "step": state.step, "reason": reason }),
@@ -311,7 +314,7 @@ impl<'a> Engine<'a> {
             outcomes.record_failure(self.active_provider().id());
         }
         StepOutcome::Aborted {
-            reason: format!("model call failed: {message}"),
+            reason: format!("{MODEL_CALL_FAILED_PREFIX}{message}"),
             kind: AbortKind::Failure,
             cost_usd: state.total_cost_usd,
         }

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -271,6 +271,27 @@ pub use tags::KNOWN_TYPE_TAGS;
 /// cannot ([`crate::Provider::model`] returning `None`).
 pub const UNKNOWN_MODEL: &str = "unknown";
 
+/// The prefix the engine puts on a `StepOutcome::Aborted` reason when the
+/// abort was a model call failing, so that reason reads as a sentence on its
+/// own: `"model call failed: terminal provider error: …"`.
+///
+/// It lives here, in the crate both the emitter and every renderer already
+/// depend on, because **two surfaces have to agree on it and they cannot see
+/// each other**. `stella-core` writes it onto the abort reason; the host then
+/// re-emits that reason as a second [`AgentEvent::Error`], because some abort
+/// paths (budget, loop detection, cancel) emit no `Error` of their own and
+/// would otherwise show no row at all. For a *model call* failure the engine
+/// has already emitted one, so the host's row is the same failure wearing this
+/// prefix — and a reader saw two red rows and counted two failures (#4146).
+///
+/// The renderer that collapses them is `stella-tui`, which deliberately does
+/// not depend on `stella-core` and must not: it folds `AgentEvent`s and has no
+/// business knowing the engine. Hardcoding the string on that side instead
+/// would put it in two crates with nothing comparing them, so the day the
+/// wording changed the de-duplication would silently stop working and no test
+/// anywhere would go red. One definition, both sides.
+pub const MODEL_CALL_FAILED_PREFIX: &str = "model call failed: ";
+
 /// Content-free reason a provider attempt cannot contribute a truthful usage
 /// envelope. Error bodies and prompts are deliberately unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -107,9 +107,10 @@ pub use error::ProviderError;
 pub use event::{
     AgentEvent, BlockKind, BlockOrigin, BudgetMode, BudgetScope, CacheZone, CiStatus,
     ContextFrameRef, ContextProviderUsage, ContextUsage, FileChangeKind, HunkProposal,
-    KNOWN_TYPE_TAGS, ManifestEntry, MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole,
-    PolicyKind, PrStatus, ProofStep, ProposedHunk, ProviderShare, ScopeProposal, StageKind,
-    StageScope, TaskItem, TaskStatus, UNKNOWN_MODEL, UsageIncompleteReason, VerdictEvidence,
+    KNOWN_TYPE_TAGS, MODEL_CALL_FAILED_PREFIX, ManifestEntry, MediaArtifactRef, MediaJobState,
+    MediaKind, ModelCallRole, PolicyKind, PrStatus, ProofStep, ProposedHunk, ProviderShare,
+    ScopeProposal, StageKind, StageScope, TaskItem, TaskStatus, UNKNOWN_MODEL,
+    UsageIncompleteReason, VerdictEvidence,
 };
 // The *open* stage vocabulary (`doc:roleless-core`). `StageKind` above stays
 // the closed set of boundaries this host emits; `StageName` is what the wire

--- a/crates/stella-tui/src/model/error_rows.rs
+++ b/crates/stella-tui/src/model/error_rows.rs
@@ -1,11 +1,16 @@
 //! Whether an incoming `Error` event is a row the transcript already shows.
 //!
-//! One failure can be reported twice at the engine/host seam. The pipeline
-//! emits `AgentEvent::Error` for an abort it decided itself — "aborted at scope
-//! review" — *and* returns `PipelineStatus::Aborted`, which the host maps to a
-//! failed turn and emits as an `Error` again. The reader saw the same red row
-//! twice and read it, reasonably, as two failures: two aborted attempts, or a
-//! retry that failed the same way.
+//! One failure can be reported twice at the engine/host seam. Whatever decides
+//! an abort emits `AgentEvent::Error` for it *and* returns an aborted outcome,
+//! which the host maps to a failed turn and emits as an `Error` again. The
+//! reader saw the same red row twice and read it, reasonably, as two failures:
+//! two aborted attempts, or a retry that failed the same way.
+//!
+//! The original instance was the staged pipeline's own "aborted at scope
+//! review", reported once by the pipeline and once by the host. That crate is
+//! deleted now (#3865); the seam it exposed is not, because it was never
+//! really about the pipeline — it is about the host re-reporting an outcome
+//! whose `Error` already crossed the stream.
 //!
 //! The rule is deliberately narrow. Only an *adjacent* duplicate collapses, and
 //! only when the retryable flag matches too:
@@ -18,10 +23,32 @@
 //!
 //! Nothing is lost: an identical row sitting directly under its twin carries no
 //! information the first one does not.
+//!
+//! # The host wraps, it does not restate
+//!
+//! Verbatim equality was not enough, because the seam this module was written
+//! for does not produce two identical strings. On a model-call failure the
+//! engine emits the provider's own message, and the host then emits that same
+//! message prefixed with [`MODEL_CALL_FAILED_PREFIX`] — so a live OpenRouter
+//! abort painted (#4146):
+//!
+//! ```text
+//! ✗ error  terminal provider error: OpenRouter stream error: The operation was aborted
+//! ✗ error  model call failed: terminal provider error: OpenRouter stream error: The operation was aborted
+//! ```
+//!
+//! Two red rows, one failure — and the reader counts failures. So a wrapped
+//! restatement collapses too, by **exactly one named prefix** and no other
+//! rule. Deliberately not a substring or similarity test: "looks like the row
+//! above" is how a de-duplicator starts eating genuine second failures, and
+//! adjacency alone is not enough of a guard for that.
+
+use stella_protocol::MODEL_CALL_FAILED_PREFIX;
 
 use super::TranscriptEntry;
 
-/// Does `(message, retryable)` restate the transcript's last row verbatim?
+/// Does `(message, retryable)` restate the transcript's last row — verbatim,
+/// or wrapped by the host in [`MODEL_CALL_FAILED_PREFIX`]?
 pub(super) fn repeats_the_last_row(
     transcript: &[TranscriptEntry],
     message: &str,
@@ -32,8 +59,19 @@ pub(super) fn repeats_the_last_row(
         Some(TranscriptEntry::Error {
             message: prev,
             retryable: prev_retryable,
-        }) if prev == message && *prev_retryable == retryable
+        }) if *prev_retryable == retryable && restates(prev, message)
     )
+}
+
+/// Whether `incoming` says nothing `prev` did not already say.
+///
+/// The prefix is stripped from `incoming` rather than prepended to `prev` so
+/// the comparison stays allocation-free on the common path.
+fn restates(prev: &str, incoming: &str) -> bool {
+    prev == incoming
+        || incoming
+            .strip_prefix(MODEL_CALL_FAILED_PREFIX)
+            .is_some_and(|unwrapped| unwrapped == prev)
 }
 
 #[cfg(test)]
@@ -87,5 +125,53 @@ mod tests {
     #[test]
     fn an_empty_transcript_never_repeats() {
         assert!(!repeats_the_last_row(&[], "anything", false));
+    }
+
+    /// The reported panel (#4146): a live OpenRouter stream abort. The engine
+    /// emits the provider's message; the host emits it again wrapped. Two red
+    /// rows, one failure — and a reader counts failures.
+    #[test]
+    fn the_hosts_wrapped_restatement_repeats_the_engines_row() {
+        let engine = "terminal provider error: OpenRouter stream error: The operation was aborted";
+        let rows = vec![err(engine, false)];
+        let host = format!("{MODEL_CALL_FAILED_PREFIX}{engine}");
+        assert!(repeats_the_last_row(&rows, &host, false));
+    }
+
+    /// The wrap is recognised, not merely tolerated: the SAME prefix over a
+    /// DIFFERENT failure is a second failure and must still show. This is what
+    /// stops the new arm degrading into "starts with the host prefix ⇒ hide".
+    #[test]
+    fn the_same_wrapper_over_a_different_failure_is_not_a_repeat() {
+        let rows = vec![err("terminal provider error: rate limited", false)];
+        let host = format!("{MODEL_CALL_FAILED_PREFIX}terminal provider error: bad request");
+        assert!(!repeats_the_last_row(&rows, &host, false));
+    }
+
+    /// Adjacency still governs the wrapped case too — a wrapped restatement
+    /// arriving after other activity is a second event, and hiding it would
+    /// hide a loop exactly as the verbatim rule guards against.
+    #[test]
+    fn a_wrapped_restatement_separated_by_other_activity_is_not_a_repeat() {
+        let engine = "terminal provider error: timeout";
+        let rows = vec![
+            err(engine, false),
+            TranscriptEntry::Text("retrying".to_string()),
+        ];
+        let host = format!("{MODEL_CALL_FAILED_PREFIX}{engine}");
+        assert!(!repeats_the_last_row(&rows, &host, false));
+    }
+
+    /// The unwrapping is one level, not a general suffix test. A row that
+    /// merely *ends with* the previous row's text — without the host's prefix
+    /// accounting for the difference — is a different message and stays.
+    #[test]
+    fn a_bare_suffix_match_is_not_a_repeat() {
+        let rows = vec![err("provider timeout", false)];
+        assert!(!repeats_the_last_row(
+            &rows,
+            "upstream reported: provider timeout",
+            false
+        ));
     }
 }


### PR DESCRIPTION
## What & why

A live OpenRouter stream abort painted **two** red rows for **one** failure:

```
✗ error  terminal provider error: OpenRouter stream error: The operation was aborted
✗ error  model call failed: terminal provider error: OpenRouter stream error: The operation was aborted
```

The second is the first wearing a four-word prefix. A reader counts failures, so this reads as two aborted attempts — or a retry that failed identically.

`crates/stella-tui/src/model/error_rows.rs` exists for exactly this seam; its module doc opens *"One failure can be reported twice at the engine/host seam."* But it tested **verbatim** equality, and the host does not restate the engine's message — it **wraps** it. The guard's own stated purpose was defeated by a prefix.

Closes #4146

### Why not just stop the host emitting

That was my first instinct and it is wrong — worth recording so nobody retries it. Some abort paths (budget enforcement, loop detection, cancel) produce a `StepOutcome::Aborted` with **no** `AgentEvent::Error` of their own, and would show no row at all without the host's emission. It is load-bearing in general; only the model-call case is a duplicate, because there the engine already emitted one. Removing it would silently drop the error row for every other abort kind.

(Every *side effect* of the second row is already idempotent, incidentally — both events go through the same handler, so the engine's `Error` has already closed the plan, cleared the three pending gates, reset `parked` and cleared `streaming_text` by the time the host's arrives. Only the transcript row duplicates.)

### Where the prefix lives, and why it is not in `stella-core`

The prefix is now `stella_protocol::MODEL_CALL_FAILED_PREFIX`, defined once and used by both the engine that writes it and the renderer that has to recognise it.

The rest of the abort-reason vocabulary lives in `stella-core` (`CANCELLED_REASON`, `SOFT_STOP_REASON` — `StepOutcome::Aborted::reason`'s doc calls them "the two a host matches on"). It cannot go there: **`stella-tui` does not depend on `stella-core` and must not.** It folds `AgentEvent`s and has no business knowing the engine; every edge in its manifest is a leaf or near-leaf with a comment justifying it (invariant 1).

Hardcoding the literal on the renderer's side was the tempting cheap option and I rejected it: the string would then exist in two crates with nothing comparing them, so the day the wording changed the de-duplication would silently stop working and no test anywhere would go red. That is precisely the failure mode this module exists to prevent, so it is not an acceptable way to fix it.

`stella-protocol` is the one crate both sides already depend on. Precedent for shared vocabulary constants there: `event.rs`'s `UNKNOWN_MODEL`, `issue/vocabulary.rs`'s `RESOLUTION_*` / `CANONICAL_RESOLUTIONS`, `tokens.rs`'s `BYTES_PER_TOKEN`. Reviewers should still push back if they read this as widening the protocol's remit — see "Anything reviewers should know" below.

### Scope of the collapse

Exactly **one named prefix**, one level deep. Deliberately not a substring, suffix, or similarity test — "looks like the row above" is how a de-duplicator starts eating genuine second failures, and adjacency alone does not guard that.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_hosts_wrapped_restatement_repeats_the_engines_row`, built from the real observed pair.

Checked the artisanal way by reverting `restates` to verbatim-only (the behavioural half) and re-running: the witness **FAILED**, all eight other tests passed. Restored: 9 passed.

Three guards keep the new arm from over-collapsing, and all three fail if it is widened carelessly:

| Test | Pins |
|---|---|
| `the_same_wrapper_over_a_different_failure_is_not_a_repeat` | the prefix alone never hides a row — the messages must actually match |
| `a_wrapped_restatement_separated_by_other_activity_is_not_a_repeat` | adjacency still governs, so loops stay visible |
| `a_bare_suffix_match_is_not_a_repeat` | one named wrap, not a general suffix rule |

The four pre-existing tests are unchanged and pass.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Full `make gate` run locally, green through `self-driving-test` (the last `GATE_STEPS` entry) — `wire-schema` included, since this touches `stella-protocol`
- [x] Docs updated where behavior changed — the module doc now states the wrapped rule and its bounds

## Nothing left behind

- [x] There is nothing new: everything I noticed in this area is either fixed here or already filed.

One **stale comment fixed in passing**, per "chase renamed concepts through the docs in the same PR": the module doc described the seam in the present tense as the staged pipeline's (`PipelineStatus::Aborted`), a crate deleted in #3865. Rewritten to describe the seam as it actually is, keeping the pipeline instance as the historical origin — the seam was never really about the pipeline.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies, and **no new crate edges** — `stella-tui` already depended on `stella-protocol`
- [x] No new outbound network calls
- [x] No new cross-boundary types (a `&'static str` constant, not a type)

## Anything reviewers should know?

**The judgement call is the constant's home, not the predicate.** I considered three routes, documented in full on #4146: promote the vocabulary to `stella-protocol` (this PR), hardcode it in the TUI (refused, above), or restructure so the host never double-reports. The third is arguably the real fix — the duplicate exists because `command_deck.rs:1966` uses an `Error` **row** to carry a **status** signal, and its own comment says so ("this row flips the dashboard to failed AND clears any pending gate"). Give those effects their own signal and the duplicate disappears at the source with no shared constant at all.

I did not take it here because `crates/stella-cli/src/command_deck.rs` is a god file closed to growth, and because it needs care that every abort path still flips the dashboard and clears a pending gate. **If a maintainer prefers that direction, this PR is the wrong shape and should be closed rather than merged** — I would rather hear that than have the constant land by default.

**Deleted tests**: none.

Companion PR (same reported panel, different defect, independently reviewable): the accounting line that claimed the work was unaffected on a call that aborted — #4147.

## Summary by Sourcery

Deduplicate host-wrapped model-call failures in the TUI while retaining distinct abort errors.

Bug Fixes:
- Prevent duplicate TUI error rows when the host re-emits a model-call failure already reported by the engine.
- Preserve host-generated error rows for abort paths that do not have an engine error event.

Enhancements:
- Share the model-call failure prefix through stella-protocol and narrowly collapse only adjacent matching wrapped error rows.
- Update error-row documentation to describe the current engine/host seam and define the de-duplication boundaries.

Tests:
- Add coverage for wrapped restatements, differing failures, non-adjacent events, and non-matching suffixes.