### PR TITLE
fix(stella-cli): stop telling the user the work landed when the call died

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -553,7 +553,22 @@ pub(crate) enum PersistOutcome {
     /// nothing" is the difference between a footnote and a real gap — and the
     /// surface that renders this is the only place a user ever learns which
     /// one happened.
-    UsageIncomplete(Option<stella_protocol::PartialUsage>),
+    UsageIncomplete {
+        /// Accounting the adapter salvaged from the failure, if any reached
+        /// us.
+        partial: Option<stella_protocol::PartialUsage>,
+        /// Why the attempt produced no usage frame — `None` when the call
+        /// **settled** and only the provider's frame never arrived.
+        ///
+        /// Two unrelated conditions reach this variant, and collapsing them
+        /// is what made the rendered sentence lie (#4147): an
+        /// [`AgentEvent::StepUsage`] with `complete: false` is a call that
+        /// did its work and simply went unbilled, while an
+        /// [`AgentEvent::UsageIncomplete`] is an attempt that **died** and
+        /// produced nothing. The engine already distinguishes them on the
+        /// wire — this field is that distinction, kept instead of dropped.
+        died: Option<stella_protocol::UsageIncompleteReason>,
+    },
 }
 
 impl PersistOutcome {
@@ -575,20 +590,42 @@ impl PersistOutcome {
             PersistOutcome::StoreWriteFailed => {
                 Some(format!("store write failed — {what} could not be written"))
             }
-            PersistOutcome::UsageIncomplete(Some(partial)) => Some(format!(
+            PersistOutcome::UsageIncomplete {
+                partial: Some(partial),
+                ..
+            } => Some(format!(
                 "{what} dropped before its final usage frame — recovered {} \
                  (~${:.4}) as an estimate; every other call is accounted normally",
                 token_summary(&partial),
                 partial.cost_usd,
             )),
-            // Deliberately not "failed": this branch also covers a call that
-            // SETTLED without a provider usage frame, where the work landed
-            // fine and only the accounting is short. Asserting a failure that
-            // did not happen is the same class of mistake as the session-wide
-            // wording this replaces.
-            PersistOutcome::UsageIncomplete(None) => Some(format!(
+            // Deliberately not "failed": this call SETTLED without a provider
+            // usage frame, so the work landed fine and only the accounting is
+            // short. Asserting a failure that did not happen is the same class
+            // of mistake as the session-wide wording this replaces.
+            PersistOutcome::UsageIncomplete {
+                partial: None,
+                died: None,
+            } => Some(format!(
                 "{what} reported no final usage — that call's tokens and cost \
                  are unaccounted (the work itself is unaffected)"
+            )),
+            // ...and the mirror image, which the sentence above used to claim
+            // too (#4147). This attempt DIED, so the reassurance is false: it
+            // was printed directly above the abort rows reporting the very
+            // failure it denied. Say what happened and stop there — the turn's
+            // own error rows are what speak to the work.
+            PersistOutcome::UsageIncomplete {
+                partial: None,
+                died: Some(reason),
+            } => Some(format!(
+                "{what} {} before reporting usage — that call's tokens and \
+                 cost are unaccounted",
+                match reason {
+                    stella_protocol::UsageIncompleteReason::ProviderError => "failed",
+                    stella_protocol::UsageIncompleteReason::Timeout => "timed out",
+                    stella_protocol::UsageIncompleteReason::Cancelled => "was cancelled",
+                }
             )),
         }
     }
@@ -691,6 +728,7 @@ pub(crate) fn persist_event_detailed(
     let mut telemetry_ok = true;
     let mut usage_complete = true;
     let mut recovered = None;
+    let mut died = None;
     if let AgentEvent::StepUsage {
         role,
         provider,
@@ -749,11 +787,17 @@ pub(crate) fn persist_event_detailed(
         duration_ms,
         retries,
         partial,
+        reason,
         ..
     } = event
     {
         usage_complete = false;
         recovered = *partial;
+        // This attempt died; the `StepUsage` branch above is the one where the
+        // call settled. Keeping the engine's own reason is what lets the
+        // rendered sentence tell those apart instead of reassuring the user
+        // about a call that produced nothing (#4147).
+        died = Some(*reason);
         // A failed attempt that salvaged accounting gets a real telemetry row,
         // flagged `usage_complete = false`. Before this the row was simply not
         // written: `stella stats` showed the turn as though the dead attempt
@@ -888,7 +932,10 @@ pub(crate) fn persist_event_detailed(
     if !recorded || !telemetry_ok {
         PersistOutcome::StoreWriteFailed
     } else if !usage_complete {
-        PersistOutcome::UsageIncomplete(recovered)
+        PersistOutcome::UsageIncomplete {
+            partial: recovered,
+            died,
+        }
     } else {
         PersistOutcome::Complete
     }
@@ -915,15 +962,62 @@ mod usage_recovery_tests {
     }
 
     fn incomplete(partial: Option<stella_protocol::PartialUsage>) -> AgentEvent {
+        incomplete_because(
+            stella_protocol::UsageIncompleteReason::ProviderError,
+            partial,
+        )
+    }
+
+    fn incomplete_because(
+        reason: stella_protocol::UsageIncompleteReason,
+        partial: Option<stella_protocol::PartialUsage>,
+    ) -> AgentEvent {
         AgentEvent::UsageIncomplete {
             role: stella_protocol::ModelCallRole::Worker,
             provider: "anthropic".into(),
             model: "claude-opus-5".into(),
-            reason: stella_protocol::UsageIncompleteReason::ProviderError,
+            reason,
             duration_ms: 4_200,
             retries: Some(1),
             partial,
         }
+    }
+
+    /// A call that SETTLED and simply went unbilled: the provider closed the
+    /// stream cleanly but sent no usage frame. The other way into
+    /// [`PersistOutcome::UsageIncomplete`], and the case whose reassurance is
+    /// true.
+    fn settled_without_a_usage_frame() -> AgentEvent {
+        AgentEvent::StepUsage {
+            upstream_provider: None,
+            step: 0,
+            role: stella_protocol::ModelCallRole::Worker,
+            provider: "anthropic".into(),
+            output_text: None,
+            model: "claude-opus-5".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_input_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: None,
+            estimated_input_tokens: 0,
+            cost_usd: 0.0,
+            duration_ms: 1_200,
+            retries: 0,
+            tool_calls: 0,
+            complete: false,
+            finish_reason: None,
+        }
+    }
+
+    fn sentence_for(event: &AgentEvent) -> String {
+        let store = stella_store::Store::in_memory().expect("store");
+        let execution_id = store
+            .begin_execution("cli", "prompt", "anthropic", "claude-opus-5")
+            .expect("begin");
+        persist_event_detailed(&store, execution_id, 0, event, "anthropic")
+            .message("one model call")
+            .expect("an incomplete outcome has a sentence")
     }
 
     /// The storage half of the fix. A dropped attempt that salvaged real
@@ -959,7 +1053,13 @@ mod usage_recovery_tests {
         );
         // And the execution as a whole is marked short.
         assert!(!store.execution_usage_complete(execution_id).unwrap());
-        assert!(matches!(outcome, PersistOutcome::UsageIncomplete(Some(_))));
+        assert!(matches!(
+            outcome,
+            PersistOutcome::UsageIncomplete {
+                partial: Some(_),
+                ..
+            }
+        ));
     }
 
     /// A failure that learned nothing writes no telemetry row. Recording a
@@ -976,7 +1076,15 @@ mod usage_recovery_tests {
 
         assert!(store.telemetry_rows_after(0, 10).expect("rows").is_empty());
         assert!(!store.execution_usage_complete(execution_id).unwrap());
-        assert!(matches!(outcome, PersistOutcome::UsageIncomplete(None)));
+        // A dead attempt, so the reason rides along: this is the case the
+        // rendered sentence must NOT call unaffected (#4147).
+        assert!(matches!(
+            outcome,
+            PersistOutcome::UsageIncomplete {
+                partial: None,
+                died: Some(stella_protocol::UsageIncompleteReason::ProviderError),
+            }
+        ));
     }
 
     /// The wording defect from the report: one retried call must not be
@@ -985,9 +1093,12 @@ mod usage_recovery_tests {
     /// worst.
     #[test]
     fn the_warning_names_one_call_and_reports_what_was_recovered() {
-        let message = PersistOutcome::UsageIncomplete(Some(partial(14_000, 12_000, 130, 0.0213)))
-            .message("one model call")
-            .expect("an incomplete outcome has a sentence");
+        let message = PersistOutcome::UsageIncomplete {
+            partial: Some(partial(14_000, 12_000, 130, 0.0213)),
+            died: Some(stella_protocol::UsageIncompleteReason::ProviderError),
+        }
+        .message("one model call")
+        .expect("an incomplete outcome has a sentence");
         assert!(message.starts_with("one model call"), "{message}");
         assert!(!message.contains("this session"), "{message}");
         assert!(message.contains("14000 input"), "{message}");
@@ -997,9 +1108,12 @@ mod usage_recovery_tests {
 
         // With nothing recovered it stays honest about the gap, and still
         // scopes itself to the one attempt.
-        let bare = PersistOutcome::UsageIncomplete(None)
-            .message("one model call")
-            .expect("still a sentence");
+        let bare = PersistOutcome::UsageIncomplete {
+            partial: None,
+            died: None,
+        }
+        .message("one model call")
+        .expect("still a sentence");
         assert!(bare.contains("tokens and cost"), "{bare}");
         assert!(!bare.contains("this session"), "{bare}");
         // A call that settled without a usage frame did not "fail", and the
@@ -1013,6 +1127,49 @@ mod usage_recovery_tests {
         assert!(
             store_failed.contains("store write failed"),
             "{store_failed}"
+        );
+    }
+
+    /// The reported panel (#4147): an OpenRouter stream aborted, and the very
+    /// first line the user read was the accounting warning telling them the
+    /// work was fine — printed directly above the two rows reporting the
+    /// abort. The reassurance belongs to a call that SETTLED without a usage
+    /// frame; on a call that died it asserts a success that did not happen.
+    ///
+    /// Driven through `persist_event_detailed` rather than by building a
+    /// `PersistOutcome` by hand, deliberately: the fix changes that enum's
+    /// shape, so a hand-built witness would fail to *compile* on the parent
+    /// commit rather than fail its assertion, which proves nothing about the
+    /// behaviour. Feeding the real event through the real path compiles on
+    /// both sides and genuinely flips.
+    #[test]
+    fn a_dead_call_is_never_described_as_leaving_the_work_unaffected() {
+        for reason in [
+            stella_protocol::UsageIncompleteReason::ProviderError,
+            stella_protocol::UsageIncompleteReason::Timeout,
+            stella_protocol::UsageIncompleteReason::Cancelled,
+        ] {
+            let message = sentence_for(&incomplete_because(reason, None));
+            assert!(
+                !message.contains("unaffected"),
+                "{reason:?} claimed the work landed: {message}"
+            );
+            // It still has to say what it came to say: the accounting is short.
+            assert!(message.contains("tokens and cost"), "{message}");
+            assert!(message.starts_with("one model call"), "{message}");
+        }
+    }
+
+    /// The negative control for the test above, and the property the original
+    /// wording existed to protect: a call that settled keeps its reassurance
+    /// verbatim. One dropped frame out of hundreds is a footnote, and losing
+    /// this would regress the sentence #4147's fix is built on top of.
+    #[test]
+    fn a_settled_call_keeps_its_reassurance() {
+        let settled = sentence_for(&settled_without_a_usage_frame());
+        assert!(
+            settled.contains("the work itself is unaffected"),
+            "{settled}"
         );
     }
 }


### PR DESCRIPTION
## What & why

The first line a user read in a failure panel told them the work was fine — printed directly above the two rows reporting the abort:

```
✗ error  one model call reported no final usage — that call's tokens and cost are unaccounted
         (the work itself is unaffected)
✗ error  terminal provider error: OpenRouter stream error: The operation was aborted
✗ error  model call failed: terminal provider error: ...
```

The stream aborted. The call produced nothing. "The work itself is unaffected" is a success claimed for a call that had just died, in the one place a reader is trying to work out what survived.

Closes #4147

### The actual defect

Two unrelated conditions reach `PersistOutcome::UsageIncomplete`, and it could not tell them apart:

| Source | What happened | Is the reassurance true? |
|---|---|---|
| `AgentEvent::StepUsage { complete: false }` | the call **settled**; the provider just never sent a usage frame | **yes** |
| `AgentEvent::UsageIncomplete { .. }` | the attempt **died** and produced nothing | **no** |

Both collapsed to `UsageIncomplete(None)`, and the sentence asserted the reassuring reading unconditionally.

The parenthetical's rationale was sound, and the comment above it said so — it exists to stop one dropped frame out of hundreds reading as a catastrophe, and it warns that *"asserting a failure that did not happen is the same class of mistake as the session-wide wording this replaces."* The defect is that the branch could not distinguish the cases, so it made that same mistake pointed the other way: asserting a **success** that did not happen.

### The fix needed no new types

The engine already draws this distinction on the wire. `AgentEvent::UsageIncomplete` carries a `UsageIncompleteReason` — `ProviderError` / `Timeout` / `Cancelled` — naming exactly which death it was, and `persist_event_detailed` was destructuring it away with `..`.

So this keeps the field instead of dropping it, and lets the sentence branch on it. A dead call now says it *failed*, *timed out*, or *was cancelled* before reporting usage — and says nothing whatsoever about whether the work landed. The turn's own error rows are what speak to that.

A settled call keeps its wording **verbatim**.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_dead_call_is_never_described_as_leaving_the_work_unaffected`, covering all three reasons, with `a_settled_call_keeps_its_reassurance` as the negative control.

Both drive the real `persist_event_detailed` path rather than constructing a `PersistOutcome` by hand — **deliberately**, and it is the part of this PR I would most want reviewed. This change alters that enum's shape, so a hand-built witness would fail to *compile* on the parent commit rather than fail its assertion, and a compile error proves nothing about behaviour. Feeding the real events (`AgentEvent::UsageIncomplete` for a death, `AgentEvent::StepUsage { complete: false }` for a settle) through the real path compiles on both sides and genuinely flips.

Checked the artisanal way by reverting only the `message()` arms to main's unconditional sentence, leaving the enum and the tests in place:

```
a_dead_call_is_never_described_as_leaving_the_work_unaffected ... FAILED
a_settled_call_keeps_its_reassurance ... ok
test result: FAILED. 4 passed; 1 failed
```

The control passing while the witness fails is the point: the pair discriminates, rather than the witness merely being sensitive to any edit. Restored: 5 passed.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Full `make gate` run locally, green through `self-driving-test` (the last `GATE_STEPS` entry)
- [x] Docs updated where behavior changed — the new `died` field carries the argument for why the distinction is kept

## Nothing left behind

- [x] There is nothing: everything I noticed here is fixed in this PR.

One thing I **verified rather than assumed**, since #4147 flagged it as open: the warning does describe the call that died. Both paths into the variant are in `persist_event_detailed` and are now covered by a test each, so the "does it describe an earlier settled call while a later one aborts?" question the issue raised is answered — they are distinguished at the source, per event.

## Ground-rule check

- [x] No I/O added to `stella-core` (not touched); no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types — reuses `stella_protocol::UsageIncompleteReason`, already on the wire

## Anything reviewers should know?

**The wording of the three new sentences is the reviewable surface.** They deliberately stop after stating the accounting gap rather than adding a counterweight like "the turn aborted" — the error rows below already say that, and duplicating it is how this panel got noisy in the first place. If you would rather they named the failing turn explicitly, that is a wording call worth making now.

`PersistOutcome::UsageIncomplete` changes from a tuple variant to a struct variant, so its four existing call sites are updated mechanically. `PersistOutcome` is `pub(crate)` in a binary-only crate, so this reaches nothing outside `stella-cli`.

**Deleted tests**: none.

Companion PR (same reported panel, different defect, independently reviewable): the duplicate error rows — #4161.

## Summary by Sourcery

Correct incomplete-usage warnings so they distinguish calls that settled without billing data from calls that actually died.

Bug Fixes:
- Report incomplete model calls as failed, timed out, or cancelled instead of incorrectly reassuring users that the work was unaffected.
- Preserve the distinction between settled calls missing usage data and attempts that died before producing usage information.

Enhancements:
- Retain usage-incomplete reasons through persistence outcome handling so rendered warnings accurately reflect the call state.

Tests:
- Add end-to-end persistence-path coverage for all dead-call reasons and a control confirming settled calls retain their existing reassurance.