### PR TITLE
docs(stella-tui): the InlineDiffRef seq comment names a type that does not exist

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -734,10 +734,32 @@ impl SessionModel {
                 // Only a *successful* mutation gets an inline-diff reference —
                 // a failed call produced no `FileChange`, and rendering the
                 // path's previous diff under its ✗ would attribute a change
-                // the call never made. The engine's `FileChangeTap` emits the
-                // `FileChange` during the tool's execution, so by the time
-                // this result folds, `files[path].changes` already counts this
-                // call's own change — that value is the freshness tag.
+                // the call never made.
+                //
+                // The `seq` stamped here does NOT currently resolve, and the
+                // comment that used to sit on it is why nobody noticed. It
+                // said "the engine's `FileChangeTap` emits the `FileChange`
+                // during the tool's execution, so by the time this result
+                // folds, `files[path].changes` already counts this call's own
+                // change". There is no `FileChangeTap` anywhere in the
+                // workspace — that string appeared in this comment and nowhere
+                // else. The only producer left is
+                // `stella_cli::turn_files::emit_shared_tree_changes`, called
+                // from `agent.rs` *after* `run_turn_with_sender` returns
+                // (`stella-pipeline`, which did emit per adopted change during
+                // delivery, is deleted — #3865). So every `ToolResult` of the
+                // turn has already folded by the time any `FileChange` arrives,
+                // `changes` here is the pre-turn value, `touch_file` then bumps
+                // it and `remember_diff` records at the bumped seq, and
+                // `diff_at` misses by exactly one — forever, for every
+                // mutation on this path.
+                //
+                // The stamp is left as-is on purpose: `+1` would make all of a
+                // path's calls in one turn point at the single aggregate
+                // `--numstat` change, which is the misattribution
+                // `render::resolve_inline_diff` exists to prevent. Per-call
+                // attribution needs a per-call producer, and that is a design
+                // decision, not a repair — tracked in #4155.
                 let diff = if ok {
                     self.mutated_path_for(call_id).map(|path| {
                         let seq = self

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -736,27 +736,34 @@ impl SessionModel {
                 // path's previous diff under its ✗ would attribute a change
                 // the call never made.
                 //
-                // The `seq` stamped here does NOT currently resolve, and the
-                // comment that used to sit on it is why nobody noticed. It
-                // said "the engine's `FileChangeTap` emits the `FileChange`
-                // during the tool's execution, so by the time this result
-                // folds, `files[path].changes` already counts this call's own
-                // change". There is no `FileChangeTap` anywhere in the
-                // workspace — that string appeared in this comment and nowhere
-                // else. The only producer left is
-                // `stella_cli::turn_files::emit_shared_tree_changes`, called
-                // from `agent.rs` *after* `run_turn_with_sender` returns
-                // (`stella-pipeline`, which did emit per adopted change during
-                // delivery, is deleted — #3865). So every `ToolResult` of the
-                // turn has already folded by the time any `FileChange` arrives,
-                // `changes` here is the pre-turn value, `touch_file` then bumps
-                // it and `remember_diff` records at the bumped seq, and
-                // `diff_at` misses by exactly one — forever, for every
-                // mutation on this path.
+                // The `seq` stamped here does NOT resolve, and the comment that
+                // used to sit on it is why nobody noticed. It said "the
+                // engine's `FileChangeTap` emits the `FileChange` during the
+                // tool's execution, so by the time this result folds,
+                // `files[path].changes` already counts this call's own change".
+                // There is no `FileChangeTap` anywhere in the workspace — that
+                // string appeared in this comment and nowhere else.
+                //
+                // What is true instead, in two layers. `stella-pipeline`, which
+                // emitted one `FileChange` per adopted change *during* delivery,
+                // is deleted (#3865), so the only producer left is
+                // `stella_cli::turn_files::emit_shared_tree_changes` — one
+                // aggregate `--numstat` change per path, at the turn boundary.
+                // On the deck path it is not reached at all today:
+                // `command_deck::run_lead_turn` pays only the run terminator, so
+                // no `FileChange` reaches this fold and `recent_diffs` stays
+                // empty. #4160 fixes that half. Underneath it sits a second,
+                // latent one: the boundary emit lands *after* every `ToolResult`
+                // of the turn has folded, so `changes` here is the pre-turn
+                // value, `touch_file` then bumps it and `remember_diff` records
+                // at the bumped seq, and `diff_at` misses by exactly one. That
+                // is already live for `agent::run_turn` (`stella run`), and
+                // giving the deck a producer will surface it there too — the
+                // Files tab will fill while this row stays diffless.
                 //
                 // The stamp is left as-is on purpose: `+1` would make all of a
                 // path's calls in one turn point at the single aggregate
-                // `--numstat` change, which is the misattribution
+                // change, which is the misattribution
                 // `render::resolve_inline_diff` exists to prevent. Per-call
                 // attribution needs a per-call producer, and that is a design
                 // decision, not a repair — tracked in #4155.


### PR DESCRIPTION
## What

A comment in `crates/stella-tui/src/model.rs` justified the `InlineDiffRef` freshness tag by naming a type that does not exist, and that false premise hid two real defects underneath it.

```rust
// The engine's `FileChangeTap` emits the `FileChange` during the tool's
// execution, so by the time this result folds, `files[path].changes`
// already counts this call's own change — that value is the freshness tag.
```

`rg FileChangeTap crates/` returns **one hit: that comment.** There is no such type.

## What is actually true — two layers, not one

`stella-pipeline`, which emitted one `FileChange` per adopted change *during* delivery, is deleted (#3865). The only producer left is `stella_cli::turn_files::emit_shared_tree_changes`: one aggregate `--numstat` change per path, sent at the **turn boundary**.

**Layer 1 — the deck reaches no producer at all.** On `main`, `emit_shared_tree_changes` has exactly one caller (`agent.rs:1226`), and `command_deck::run_lead_turn` pays only `emit_run_complete_raw` (`command_deck.rs:3788`). So the Command Deck emits no `FileChange`, `touch_file` never runs, `recent_diffs` stays empty, and no diff can resolve. **#4160 (already open, from another session) fixes this half** — it is the live cause of a diffless edit row in the deck today.

**Layer 2 — a latent off-by-one underneath.** The boundary emit lands *after* every `ToolResult` of the turn has folded. So the `ToolResult` stamps `InlineDiffRef` with the **pre-turn** `changes` value; `touch_file` then bumps `changes` and `remember_diff` records at the **bumped** value; `diff_at` misses by exactly one. This is already live for `agent::run_turn` (`stella run`), and giving the deck a producer will surface it there too — the Files tab will fill while the transcript row stays diffless.

Because `render/entry.rs` gates both the inline diff and the `+N −M` column on that lookup, either layer alone produces the same symptom: no diff, no metric, the row falling back to the tool's text preview.

## Correction to this PR's first revision

The first version of this description and comment asserted that Layer 2 explained the reported screenshot. It does not — the screenshot is the deck, where Layer 1 fires first and Layer 2 is unreachable. Both causes produce an identical symptom, so the evidence I had did not distinguish them; I found Layer 1 only after reading #4160. The comment now names both layers and which is live where. Layer 2 is real and independently verified, just not the one on screen.

## What this PR does

Corrects the comment. **No behaviour change, deliberately.** Stamping `seq + 1` would make every call touching a path in one turn point at the single aggregate change — precisely the misattribution `resolve_inline_diff`'s own doc exists to prevent ("never *the path's latest diff*, which would misattribute a later edit's change to an earlier row"). Per-call attribution needs a per-call producer, and choosing between reinstating one, attributing the diff to the turn rather than the call, or leaving the diff to the Files tab is an owner's design decision. Tracked in **#4155**.

Saying it out loud per CLAUDE.md: this PR leaves a live defect in the tree. It converts it from invisible-and-misdocumented to documented-and-tracked, which is the honest step available without making the design call.

## Verification

- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean.
- `cargo test -p stella-tui --lib` — 860 passed, 0 failed.

No witness test: this is a comment correction, and CONTRIBUTING.md exempts pure docs changes. A witness for the underlying defect belongs to whichever fix #4155 chooses — a test pinning today's non-resolution would go green now and red when fixed, which is backwards.

Refs #4155, #4160, #3865, #4150
