### PR TITLE
feat(stella-tools): the file tools batch, so the shell stops being the only way to ask about several files

### DIFF
--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -56,6 +56,22 @@ use super::*;
 /// whole (65,723 bytes) then five more — twelve greps over bytes already in
 /// context, the largest single source of waste in a $3.77 turn.
 ///
+/// The read clause is newer than the write clause, and the asymmetry between
+/// them is why it exists (#4151). One execution ran 24 `sed -n 'A,Bp'` range
+/// reads against 2 `read_file` calls — while making 18 `edit_file` calls and
+/// **zero** `sed -i`. Same model, same turn, same prompt: the paragraph that
+/// named its shell equivalents outright was obeyed, and the paragraph that only
+/// said "use read_file when you already know the exact path" leaked almost
+/// everything. So the read side now names `cat`/`sed -n`/`head`/`tail` the way
+/// the write side has always named `cat > file`/`sed -i`/`rm`.
+///
+/// Wording alone was not expected to carry it, and should not be credited if
+/// the ratio moves: the same telemetry showed 69 distinct timestamps across 71
+/// tool calls, so that model was not emitting the parallel calls the last
+/// paragraph asks for, and `bash` was the only surface through which it could
+/// batch at all. The file tools gained in-schema batch forms in the same change,
+/// which is the half that removes the incentive rather than arguing with it.
+///
 /// No trailing newline: each prompt continues with its own blank line.
 macro_rules! tool_steering {
     () => {
@@ -63,7 +79,9 @@ macro_rules! tool_steering {
 
 To find code, call search first: it takes a description or a name and returns the files that answer it with their symbols, callers and imports attached, so one call usually replaces a run of grep and read_file round trips. Use read_file when you already know the exact path, and bash with grep only when you need every occurrence of one exact literal string. A RANK CEILING note on a search result means your query was too broad, not that search failed: narrow it and search again. Never grep or sed a file you already read in full this turn — those bytes are already in front of you; re-read a specific range with read_file offset and limit only if you need to re-anchor.
 
-To change the workspace, use the file tools rather than the shell: write_file creates or overwrites, edit_file replaces an exact substring, delete_file removes a file. Prefer them over shell equivalents like cat > file, sed -i or rm — they are confined to the workspace root, they report what actually changed, and their edits are what the turn's diff and verification are computed from. bash is for running things: builds, tests, linters, git, anything the task needs executed.
+To read a file, use read_file rather than the shell. Never cat, sed -n, head or tail a file to see it: read_file records what you were shown, and edit_file uses that record to tell a stale needle from a file that changed underneath you — bytes you read through bash leave no such record, so a later edit failure cannot be explained. Needing several files, or several ranges, is not a reason to reach for the shell: pass files to ONE read_file call instead of chaining sed with semicolons.
+
+To change the workspace, use the file tools rather than the shell: write_file creates or overwrites, edit_file replaces an exact substring, delete_file removes a file. Prefer them over shell equivalents like cat > file, sed -i or rm — they are confined to the workspace root, they report what actually changed, and their edits are what the turn's diff and verification are computed from. Each takes a batch too: pass edits to edit_file, or files to write_file or delete_file, to make several changes in one call. A batch is all-or-nothing, which a chain of shell commands can never be — if any part of it fails, nothing is written. bash is for running things: builds, tests, linters, git, anything the task needs executed.
 
 Your coordination tools are the task board (task_create, task_list, task_start, task_complete, task_cancel, task_assign) for multi-step work, delegate to hand a self-contained subtask to a sub-agent, the scratch state plane (save_state, get_state, list_state, delete_state) for intermediate notes and data between steps, and get_environment for the platform facts. Anything beyond these — reaching the network, a service API — arrives as an MCP or custom tool in your schema list; use exactly what is advertised and never assume a capability no schema names.
 

--- a/crates/stella-tools/src/batch.rs
+++ b/crates/stella-tools/src/batch.rs
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One verb, many targets — the shared shape behind the file tools' batch
+//! forms (#4151).
+//!
+//! # The defect this closes
+//!
+//! Telemetry from one execution: **24 `sed -n 'A,Bp'` range reads against 2
+//! `read_file` calls**, with `read_file` recording zero errors and the very
+//! first tool call of the turn already a `sed`. The same turn made 18
+//! `edit_file` calls and **zero** `sed -i` — so the model was not avoiding the
+//! file tools, and it was not falling back after a failure. It was reaching
+//! for the only surface through which it could ask **one question about
+//! several files at once**: eleven of its `bash` calls chained two or three
+//! reads with `; echo ===;`.
+//!
+//! The engine already runs consecutive read-only calls concurrently and the
+//! system prompt already asks the model to send independent calls together
+//! (#2985). That path was not taken: of 71 tool calls in that execution, 69
+//! carried distinct timestamps, and the two collisions each pair a real tool
+//! with a coordination call. Parallel tool calls are a **provider capability**
+//! this workspace declares on no axis and sends on no adapter, so a model that
+//! does not volunteer them leaves `bash` as the only way to batch.
+//!
+//! So the batching lives in the schema, where it holds for every model
+//! regardless of what the wire negotiates. That is the whole argument for this
+//! module: a working surface must not be built on a provider feature nobody
+//! declared (invariant #8).
+//!
+//! # The shape, and why it is not a second tool
+//!
+//! Every file tool keeps its singular form exactly as it was and gains one
+//! optional array — the plural of the same target. [`targets`] parses the
+//! array **with the tool's own single-item parser**, so there is one definition
+//! of what a target is and two spellings of how many.
+//!
+//! This is invariant #9-clean: the array *scopes* the operation to N targets,
+//! it never *selects* a different one. Same verb, same policy gate, same audit
+//! events, same `read_only` claim. Contrast `update_task(delete=true)`, which
+//! is two verbs wearing one schema — nothing here branches on the plural key
+//! except the arity of the loop under it.
+
+use serde_json::Value;
+
+use crate::input::{InputError, present, type_name};
+
+/// Ceiling on the targets one call may name.
+///
+/// Not a performance bound — the read budget and the mutation gates already
+/// bound cost. It bounds **blast radius**: a batch is all-or-nothing for the
+/// mutating tools, so a malformed 10,000-element array should be refused as a
+/// mistake rather than attempted as an instruction. 32 is past anything an
+/// honest turn asks for (the observed `bash` chains batch two or three) and far
+/// under the point where a single refusal stops being readable.
+pub const MAX_BATCH_ITEMS: usize = 32;
+
+/// Why a batch could not be read.
+///
+/// Typed rather than a `String` because callers branch on these: a
+/// [`BatchError::Item`] names an index the model can fix in place, while
+/// [`BatchError::Both`] is a whole-call mistake that no per-item retry
+/// resolves (invariant #5).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BatchError {
+    /// The single form did not parse. Displays as the bare [`InputError`],
+    /// byte-identical to what these tools said before a plural key existed —
+    /// a caller passing no `path` must be told exactly that, not handed an
+    /// array index it never wrote.
+    #[error("{0}")]
+    Single(#[from] InputError),
+
+    /// The plural key was present but was not a JSON array.
+    #[error("field `{field}` must be an array of objects, got {got}")]
+    NotAnArray {
+        /// The plural key.
+        field: &'static str,
+        /// The JSON type that arrived.
+        got: &'static str,
+    },
+
+    /// The plural key was an empty array, which asks for no work at all.
+    #[error("field `{field}` is empty — omit it and pass the single-target fields instead")]
+    Empty {
+        /// The plural key.
+        field: &'static str,
+    },
+
+    /// More targets than [`MAX_BATCH_ITEMS`].
+    #[error(
+        "field `{field}` names {count} targets, past the {max}-target ceiling for one call — split it"
+    )]
+    TooMany {
+        /// The plural key.
+        field: &'static str,
+        /// How many arrived.
+        count: usize,
+        /// The ceiling.
+        max: usize,
+    },
+
+    /// One element of the array did not parse. The index is in the type, not
+    /// only the prose: "one of these is wrong" is not something a caller can
+    /// act on.
+    #[error("`{field}`[{index}]: {source}")]
+    Item {
+        /// The plural key.
+        field: &'static str,
+        /// The offending element's position.
+        index: usize,
+        /// Why that element did not parse.
+        source: InputError,
+    },
+
+    /// Both spellings at once. Refused rather than resolved by precedence:
+    /// either choice silently drops work the caller asked for, and a model
+    /// that sent both cannot tell which half ran.
+    #[error(
+        "pass either the single-target fields or `{field}`, not both — they are two spellings of the same call"
+    )]
+    Both {
+        /// The plural key.
+        field: &'static str,
+    },
+}
+
+impl From<BatchError> for stella_protocol::ToolOutput {
+    /// A malformed batch is the model's mistake, classified the same way
+    /// [`InputError`] is (#3145) so a per-tool error rate can exclude misuse
+    /// without matching on prose.
+    fn from(err: BatchError) -> Self {
+        stella_protocol::ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
+            err.to_string(),
+        )
+    }
+}
+
+/// Read a tool's targets, in whichever of the two spellings the caller used.
+///
+/// `plural` is the array key; `singular_probe` is a field that only the single
+/// form carries, used solely to catch a call that sent both. `item` is the
+/// tool's own parser for one target — the same function the single form uses,
+/// which is what keeps the two spellings from drifting into two meanings.
+///
+/// Returns targets in the caller's order. Order is load-bearing for
+/// `edit_file`, where two edits to one file compose, so this never sorts or
+/// deduplicates.
+pub fn targets<T>(
+    input: &Value,
+    plural: &'static str,
+    singular_probe: &str,
+    item: impl Fn(&Value) -> Result<T, InputError>,
+) -> Result<Vec<T>, BatchError> {
+    let Some(value) = present(input, plural) else {
+        // No plural key: the single form, parsed by the very same function.
+        return item(input).map(|one| vec![one]).map_err(BatchError::Single);
+    };
+
+    if present(input, singular_probe).is_some() {
+        return Err(BatchError::Both { field: plural });
+    }
+
+    let items = value.as_array().ok_or(BatchError::NotAnArray {
+        field: plural,
+        got: type_name(value),
+    })?;
+    if items.is_empty() {
+        return Err(BatchError::Empty { field: plural });
+    }
+    if items.len() > MAX_BATCH_ITEMS {
+        return Err(BatchError::TooMany {
+            field: plural,
+            count: items.len(),
+            max: MAX_BATCH_ITEMS,
+        });
+    }
+
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, raw)| {
+            item(raw).map_err(|source| BatchError::Item {
+                field: plural,
+                index,
+                source,
+            })
+        })
+        .collect()
+}
+
+/// Whether this call used the plural spelling.
+///
+/// The tools render a per-target header for the plural form and keep the
+/// singular form's output byte-identical to what it has always been. That is
+/// deliberate: the footer of a single-file read is compared by the loop
+/// detector and asserted byte-for-byte by existing tests, and a header that
+/// appeared only above two-or-more targets would make the output shape depend
+/// on a count rather than on the call.
+pub fn is_plural(input: &Value, plural: &'static str) -> bool {
+    present(input, plural).is_some()
+}
+
+/// The JSON Schema fragment for one tool's plural key.
+///
+/// Generated rather than hand-written per tool so the four schemas cannot
+/// drift in how they describe the same idea — `docs/tools/*.toml` is
+/// regenerated from these and a reviewer reads them side by side.
+pub fn plural_schema(item_properties: Value, required: &[&str], what: &str) -> Value {
+    serde_json::json!({
+        "type": "array",
+        "description": format!(
+            "{what} Use this to act on several targets in ONE call instead of \
+             several calls. Omit it and use the single-target fields above for \
+             one target; passing both is refused. At most {MAX_BATCH_ITEMS}."
+        ),
+        "items": {
+            "type": "object",
+            "properties": item_properties,
+            "required": required,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One target parser, used by both spellings — the property the whole
+    /// module exists to hold.
+    fn path_of(value: &Value) -> Result<String, InputError> {
+        crate::input::required_str(value, "path").map(str::to_string)
+    }
+
+    #[test]
+    fn the_single_form_is_parsed_by_the_same_item_parser() {
+        let single = serde_json::json!({"path": "a.rs"});
+        assert_eq!(
+            targets(&single, "files", "path", path_of).unwrap(),
+            vec!["a.rs".to_string()]
+        );
+    }
+
+    /// The single form's wording is a contract — the model has been reading
+    /// these exact strings, and `read_file`'s own tests assert them verbatim.
+    /// Adding a plural key must not turn a missing `path` into an array index
+    /// the caller never wrote.
+    #[test]
+    fn a_single_form_miss_keeps_its_original_wording() {
+        let err = targets(&serde_json::json!({}), "files", "path", path_of).unwrap_err();
+        assert_eq!(err.to_string(), "missing required field `path`");
+        assert!(matches!(
+            err,
+            BatchError::Single(InputError::Missing { .. })
+        ));
+    }
+
+    #[test]
+    fn the_plural_form_keeps_the_callers_order() {
+        // Order is load-bearing for edit_file, where two edits to one file
+        // compose. Sorting or deduplicating here would silently change meaning.
+        let many =
+            serde_json::json!({"files": [{"path": "b.rs"}, {"path": "a.rs"}, {"path": "b.rs"}]});
+        assert_eq!(
+            targets(&many, "files", "path", path_of).unwrap(),
+            vec!["b.rs".to_string(), "a.rs".to_string(), "b.rs".to_string()]
+        );
+    }
+
+    /// Sending both spellings is refused, never resolved by precedence: either
+    /// choice drops work the caller asked for, and the model cannot tell which
+    /// half ran.
+    #[test]
+    fn both_spellings_at_once_is_refused() {
+        let both = serde_json::json!({"path": "a.rs", "files": [{"path": "b.rs"}]});
+        assert_eq!(
+            targets(&both, "files", "path", path_of).unwrap_err(),
+            BatchError::Both { field: "files" }
+        );
+    }
+
+    #[test]
+    fn a_bad_element_is_named_by_index_and_carries_the_inner_cause() {
+        let bad = serde_json::json!({"files": [{"path": "a.rs"}, {"nope": 1}]});
+        let err = targets(&bad, "files", "path", path_of).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                BatchError::Item {
+                    index: 1,
+                    source: InputError::Missing { .. },
+                    ..
+                }
+            ),
+            "the index and the cause both belong in the type: {err:?}"
+        );
+        assert!(err.to_string().contains("`files`[1]"), "got {err}");
+    }
+
+    #[test]
+    fn an_empty_or_oversized_or_mistyped_array_is_refused() {
+        let empty = serde_json::json!({"files": []});
+        assert_eq!(
+            targets(&empty, "files", "path", path_of).unwrap_err(),
+            BatchError::Empty { field: "files" }
+        );
+
+        let scalar = serde_json::json!({"files": "a.rs"});
+        assert!(matches!(
+            targets(&scalar, "files", "path", path_of).unwrap_err(),
+            BatchError::NotAnArray { got: "string", .. }
+        ));
+
+        let huge: Vec<Value> = (0..MAX_BATCH_ITEMS + 1)
+            .map(|i| serde_json::json!({"path": format!("f{i}.rs")}))
+            .collect();
+        assert!(matches!(
+            targets(&serde_json::json!({"files": huge}), "files", "path", path_of).unwrap_err(),
+            BatchError::TooMany { count, .. } if count == MAX_BATCH_ITEMS + 1
+        ));
+
+        // The ceiling is inclusive — exactly MAX_BATCH_ITEMS is allowed.
+        let at_limit: Vec<Value> = (0..MAX_BATCH_ITEMS)
+            .map(|i| serde_json::json!({"path": format!("f{i}.rs")}))
+            .collect();
+        assert_eq!(
+            targets(
+                &serde_json::json!({"files": at_limit}),
+                "files",
+                "path",
+                path_of
+            )
+            .unwrap()
+            .len(),
+            MAX_BATCH_ITEMS
+        );
+    }
+
+    /// A malformed batch is the model's mistake, not the tool's — the same
+    /// class `InputError` carries, so per-tool error rates stay comparable.
+    #[test]
+    fn a_batch_error_is_classified_as_invalid_input() {
+        let out: stella_protocol::ToolOutput = BatchError::Empty { field: "files" }.into();
+        let stella_protocol::ToolOutput::Error { class, .. } = out else {
+            panic!("expected an error");
+        };
+        assert_eq!(class, Some(stella_protocol::ErrorClass::InvalidInput));
+    }
+}

--- a/crates/stella-tools/src/batch.rs
+++ b/crates/stella-tools/src/batch.rs
@@ -206,6 +206,20 @@ pub fn is_plural(input: &Value, plural: &'static str) -> bool {
 /// Generated rather than hand-written per tool so the four schemas cannot
 /// drift in how they describe the same idea — `docs/tools/*.toml` is
 /// regenerated from these and a reviewer reads them side by side.
+///
+/// # Why the enclosing tool declares `"required": []`
+///
+/// "Exactly one of the single fields or the plural key" is `oneOf` in JSON
+/// Schema, and that is the honest encoding. It is not the one used, because
+/// this schema is not consumed by a validator we control: it is sent to every
+/// provider, and top-level `oneOf`/`anyOf` in a tool's parameter schema is
+/// unevenly supported across them — the failure mode is a provider rejecting
+/// the tool declaration outright, which costs the tool rather than the
+/// mistake. So the arity requirement is enforced where it can be enforced
+/// exactly, in [`targets`], and the schema states it in the description
+/// instead. A call carrying neither spelling still fails, with the singular
+/// form's original wording (see [`BatchError::Single`]) rather than anything
+/// about arrays.
 pub fn plural_schema(item_properties: Value, required: &[&str], what: &str) -> Value {
     serde_json::json!({
         "type": "array",

--- a/crates/stella-tools/src/delete.rs
+++ b/crates/stella-tools/src/delete.rs
@@ -118,6 +118,15 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         .await;
         match kind {
             Ok(Ok(EntryKind::File | EntryKind::Symlink)) => planned.push((handle, path)),
+            // An escape is a different mistake from a directory, and the
+            // single form has always said so. Collapsing them here would tell
+            // a model that `sub/..` "is not a file", which is true and useless.
+            Ok(Err(e)) if e.is_escape() => {
+                return ToolOutput::error(format!(
+                    "`{FILES_KEY}`[{index}]: path `{path}` escapes the workspace root ({e}) — \
+                     nothing was deleted"
+                ));
+            }
             Ok(Ok(_)) | Ok(Err(_)) => {
                 return ToolOutput::error(format!(
                     "`{FILES_KEY}`[{index}]: `{path}` is not a file (directories and missing \
@@ -165,72 +174,68 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
 }
 
 async fn delete_one(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
-    {
-        let path = match crate::input::required_str(input, "path") {
-            Ok(v) => v,
-            Err(err) => {
-                return ToolOutput::from(err);
-            }
-        };
-        // A delete is the one built-in effect the agent cannot undo, so the
-        // scope is consulted before the descriptor walk starts.
-        let (scope_root, path) = match ctx.resolve_for_write(path) {
-            Ok(resolved) => resolved,
-            Err(refusal) => return ToolOutput::error(refusal.to_string()),
-        };
-        let path = path.as_str();
-        let handle = match RootHandle::open(&scope_root) {
-            Ok(handle) => std::sync::Arc::new(handle),
-            Err(e) => {
-                return ToolOutput::error(format!("cannot open workspace root: {e}"));
-            }
-        };
-        // Classify, read the link, and unlink on one blocking worker. All three
-        // are entry-level calls off the same held directory descriptor, so
-        // nothing planted between them can redirect the removal — and none of
-        // them expands the leaf, which is what keeps a link's target out of it.
-        let outcome = tokio::task::spawn_blocking({
-            let (handle, path) = (std::sync::Arc::clone(&handle), path.to_string());
-            move || -> Result<Option<Removed>, crate::rootfd::RootError> {
-                let kind = handle.symlink_stat(&path)?.kind();
-                let removed = match kind {
-                    EntryKind::File => Removed::File,
-                    // Read the target BEFORE unlinking: afterwards the link is
-                    // gone and the report could not name what it spared.
-                    EntryKind::Symlink => Removed::Symlink(handle.read_link(&path)?),
-                    EntryKind::Dir | EntryKind::Other => return Ok(None),
-                };
-                handle.remove_file(&path)?;
-                Ok(Some(removed))
-            }
-        })
-        .await;
-        match outcome {
-            Ok(Ok(Some(Removed::File))) => ToolOutput::ok(format!("deleted {path}")),
-            Ok(Ok(Some(Removed::Symlink(target)))) => ToolOutput::ok(format!(
-                "deleted symlink {path} — the link only; its target `{}` is untouched",
-                target.display()
-            )),
-            Ok(Ok(None)) => ToolOutput::error(format!(
-                "`{path}` is not a file (directories and missing paths are not deletable \
-                     with this tool)"
-            )),
-            Ok(Err(e)) if e.is_escape() => {
-                ToolOutput::error(format!("path `{path}` escapes the workspace root ({e})"))
-            }
-            // A missing path reaches here as the `stat` failing, and must read
-            // as the same refusal a directory gets — this tool deletes files.
-            Ok(Err(crate::rootfd::RootError::Io(e)))
-                if e.kind() == std::io::ErrorKind::NotFound =>
-            {
-                ToolOutput::error(format!(
-                    "`{path}` is not a file (directories and missing paths are not deletable \
-                         with this tool)"
-                ))
-            }
-            Ok(Err(e)) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
-            Err(e) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
+    let path = match crate::input::required_str(input, "path") {
+        Ok(v) => v,
+        Err(err) => {
+            return ToolOutput::from(err);
         }
+    };
+    // A delete is the one built-in effect the agent cannot undo, so the
+    // scope is consulted before the descriptor walk starts.
+    let (scope_root, path) = match ctx.resolve_for_write(path) {
+        Ok(resolved) => resolved,
+        Err(refusal) => return ToolOutput::error(refusal.to_string()),
+    };
+    let path = path.as_str();
+    let handle = match RootHandle::open(&scope_root) {
+        Ok(handle) => std::sync::Arc::new(handle),
+        Err(e) => {
+            return ToolOutput::error(format!("cannot open workspace root: {e}"));
+        }
+    };
+    // Classify, read the link, and unlink on one blocking worker. All three
+    // are entry-level calls off the same held directory descriptor, so
+    // nothing planted between them can redirect the removal — and none of
+    // them expands the leaf, which is what keeps a link's target out of it.
+    let outcome = tokio::task::spawn_blocking({
+        let (handle, path) = (std::sync::Arc::clone(&handle), path.to_string());
+        move || -> Result<Option<Removed>, crate::rootfd::RootError> {
+            let kind = handle.symlink_stat(&path)?.kind();
+            let removed = match kind {
+                EntryKind::File => Removed::File,
+                // Read the target BEFORE unlinking: afterwards the link is
+                // gone and the report could not name what it spared.
+                EntryKind::Symlink => Removed::Symlink(handle.read_link(&path)?),
+                EntryKind::Dir | EntryKind::Other => return Ok(None),
+            };
+            handle.remove_file(&path)?;
+            Ok(Some(removed))
+        }
+    })
+    .await;
+    match outcome {
+        Ok(Ok(Some(Removed::File))) => ToolOutput::ok(format!("deleted {path}")),
+        Ok(Ok(Some(Removed::Symlink(target)))) => ToolOutput::ok(format!(
+            "deleted symlink {path} — the link only; its target `{}` is untouched",
+            target.display()
+        )),
+        Ok(Ok(None)) => ToolOutput::error(format!(
+            "`{path}` is not a file (directories and missing paths are not deletable \
+                     with this tool)"
+        )),
+        Ok(Err(e)) if e.is_escape() => {
+            ToolOutput::error(format!("path `{path}` escapes the workspace root ({e})"))
+        }
+        // A missing path reaches here as the `stat` failing, and must read
+        // as the same refusal a directory gets — this tool deletes files.
+        Ok(Err(crate::rootfd::RootError::Io(e))) if e.kind() == std::io::ErrorKind::NotFound => {
+            ToolOutput::error(format!(
+                "`{path}` is not a file (directories and missing paths are not deletable \
+                         with this tool)"
+            ))
+        }
+        Ok(Err(e)) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
+        Err(e) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
     }
 }
 

--- a/crates/stella-tools/src/delete.rs
+++ b/crates/stella-tools/src/delete.rs
@@ -43,14 +43,22 @@ impl Tool for DeleteFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "delete_file".into(),
-            description: "Delete a file in the workspace. Prefer this over `bash rm`. A symlink is removed as the link; its target is left alone.".into(),
+            description: "Delete a file in the workspace. Prefer this over `bash rm`. A symlink is removed as the link; its target is left alone. To delete several files, send them in ONE call with `files`: every path is checked before any of them is removed.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "Workspace-relative path" },
+                    "files": crate::batch::plural_schema(
+                        serde_json::json!({
+                            "path": { "type": "string", "description": "Workspace-relative path" }
+                        }),
+                        &["path"],
+                        "Several files deleted in one call — every path is scope-checked and \
+                         confirmed to be a file before any of them is removed.",
+                    ),
                     "reason": { "type": "string", "description": "Why you are deleting this file — recorded in the session's file-touch audit log" }
                 },
-                "required": ["path"]
+                "required": []
             }),
             read_only: false,
             speculation_safe: false,
@@ -58,6 +66,106 @@ impl Tool for DeleteFile {
     }
 
     async fn execute(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+        if crate::batch::is_plural(input, FILES_KEY) {
+            return delete_batch(input, ctx).await;
+        }
+        delete_one(input, ctx).await
+    }
+}
+
+/// The plural key: several files removed in one call.
+const FILES_KEY: &str = "files";
+
+/// Parse one target — shared by the single form and by every element of
+/// `files`.
+fn delete_target(value: &Value) -> Result<String, crate::input::InputError> {
+    crate::input::required_str(value, "path").map(str::to_string)
+}
+
+/// Delete several files, checking every one before removing any.
+///
+/// A delete cannot be rolled back, so this validates the whole batch first —
+/// scope, existence, and that each target is a file rather than a directory.
+/// The failure that actually happens (a typo'd path, a directory, something
+/// outside the scope) is caught with the tree still intact. A mid-batch IO
+/// failure is the case no ordering can prevent, and it is reported naming
+/// exactly what had already been removed.
+async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+    let targets = match crate::batch::targets(input, FILES_KEY, "path", delete_target) {
+        Ok(targets) => targets,
+        Err(err) => return ToolOutput::from(err),
+    };
+
+    // Pass one: resolve and classify. Nothing is unlinked in this loop.
+    let mut planned = Vec::with_capacity(targets.len());
+    for (index, target) in targets.iter().enumerate() {
+        let (scope_root, path) = match ctx.resolve_for_write(target) {
+            Ok(resolved) => resolved,
+            Err(refusal) => {
+                return ToolOutput::error(format!(
+                    "`{FILES_KEY}`[{index}] (`{target}`): {refusal} — nothing was deleted"
+                ));
+            }
+        };
+        let handle = match RootHandle::open(&scope_root) {
+            Ok(handle) => std::sync::Arc::new(handle),
+            Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+        };
+        let kind = tokio::task::spawn_blocking({
+            let (handle, path) = (std::sync::Arc::clone(&handle), path.clone());
+            move || handle.symlink_stat(&path).map(|s| s.kind())
+        })
+        .await;
+        match kind {
+            Ok(Ok(EntryKind::File | EntryKind::Symlink)) => planned.push((handle, path)),
+            Ok(Ok(_)) | Ok(Err(_)) => {
+                return ToolOutput::error(format!(
+                    "`{FILES_KEY}`[{index}]: `{path}` is not a file (directories and missing \
+                     paths are not deletable with this tool) — nothing was deleted"
+                ));
+            }
+            Err(e) => {
+                return ToolOutput::error(format!("could not inspect `{path}`: {e}"));
+            }
+        }
+    }
+
+    // Pass two: every target checked, so remove.
+    let mut removed: Vec<String> = Vec::with_capacity(planned.len());
+    for (handle, path) in planned {
+        let outcome = tokio::task::spawn_blocking({
+            let (handle, path) = (std::sync::Arc::clone(&handle), path.clone());
+            move || handle.remove_file(&path)
+        })
+        .await;
+        // The one failure no ordering can prevent: the checks all passed and
+        // the unlink itself failed. Nothing can be undone at this point, so
+        // the report names exactly what is already gone rather than implying
+        // the batch was atomic.
+        let failure = match outcome {
+            Ok(Ok(())) => {
+                removed.push(path);
+                continue;
+            }
+            Ok(Err(e)) => e.to_string(),
+            Err(e) => e.to_string(),
+        };
+        return ToolOutput::error(format!(
+            "could not delete `{path}`: {failure} — this batch had already deleted {} file(s): \
+             {}",
+            removed.len(),
+            removed.join(", ")
+        ));
+    }
+    ToolOutput::ok(format!(
+        "deleted {} file(s): {}",
+        removed.len(),
+        removed.join(", ")
+    ))
+}
+
+async fn delete_one(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+    {
         let path = match crate::input::required_str(input, "path") {
             Ok(v) => v,
             Err(err) => {
@@ -249,5 +357,52 @@ mod tests {
             assert!(out.is_error(), "`{tail}` must be rejected: {out:?}");
         }
         assert!(dir.path().join("sub").is_dir());
+    }
+
+    // ── batching (#4151) ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn one_call_deletes_several_files() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["a.rs", "b.rs"] {
+            std::fs::write(dir.path().join(name), "x").unwrap();
+        }
+        let out = DeleteFile
+            .execute(
+                &serde_json::json!({"files": [{"path": "a.rs"}, {"path": "b.rs"}]}),
+                &cx(dir.path()),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert!(!dir.path().join("a.rs").exists());
+        assert!(!dir.path().join("b.rs").exists());
+    }
+
+    /// A delete cannot be undone, so the whole batch is checked first. The
+    /// failure that actually happens — a typo'd path, a directory, an escape —
+    /// is caught with the tree still intact.
+    #[tokio::test]
+    async fn a_batch_naming_one_bad_path_deletes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.rs"), "x").unwrap();
+        std::fs::create_dir(dir.path().join("adir")).unwrap();
+
+        for bad in [
+            serde_json::json!({"path": "ghost.rs"}),
+            serde_json::json!({"path": "adir"}),
+            serde_json::json!({"path": "../outside.rs"}),
+        ] {
+            let out = DeleteFile
+                .execute(
+                    &serde_json::json!({"files": [{"path": "real.rs"}, bad]}),
+                    &cx(dir.path()),
+                )
+                .await;
+            assert!(out.is_error(), "{out:?}");
+            assert!(
+                dir.path().join("real.rs").exists(),
+                "the deletable file must survive a batch that was going to fail: {out:?}"
+            );
+        }
     }
 }

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -205,12 +205,41 @@ fn drift_echo(content: &str) -> String {
     numbered
 }
 
+/// The plural key: several edits, applied as one all-or-nothing change.
+const EDITS_KEY: &str = "edits";
+
+/// One replacement — the unit both spellings of an `edit_file` call reduce to.
+struct EditTarget {
+    path: String,
+    old_string: String,
+    new_string: String,
+    replace_all: bool,
+}
+
+/// Parse one edit. Shared by the single form and by every element of `edits`.
+fn edit_target(value: &Value) -> Result<EditTarget, crate::input::InputError> {
+    Ok(EditTarget {
+        path: crate::input::required_str(value, "path")?.to_string(),
+        old_string: crate::input::required_str(value, "old_string")?.to_string(),
+        new_string: crate::input::required_str(value, "new_string")?.to_string(),
+        replace_all: crate::input::optional_bool(value, "replace_all")?.unwrap_or(false),
+    })
+}
+
+/// One file's in-flight content while a batch is being composed.
+struct Pending {
+    scope_root: std::path::PathBuf,
+    path: String,
+    content: String,
+    edits: usize,
+}
+
 #[async_trait]
 impl Tool for EditFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "edit_file".into(),
-            description: "Replace an exact substring in a file. By default the old_string must appear exactly once; set replace_all to replace every occurrence.".into(),
+            description: "Replace an exact substring in a file. By default the old_string must appear exactly once; set replace_all to replace every occurrence. To make several edits — in one file or across files — send them in ONE call with `edits`: the whole batch applies or none of it does, and later edits see the earlier ones.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -218,10 +247,22 @@ impl Tool for EditFile {
                     "old_string": { "type": "string", "description": "Exact text to find" },
                     "new_string": { "type": "string", "description": "Replacement text" },
                     "replace_all": { "type": "boolean", "description": "Replace all occurrences (default false)" },
+                    "edits": crate::batch::plural_schema(
+                        serde_json::json!({
+                            "path": { "type": "string", "description": "File path relative to workspace root" },
+                            "old_string": { "type": "string", "description": "Exact text to find" },
+                            "new_string": { "type": "string", "description": "Replacement text" },
+                            "replace_all": { "type": "boolean", "description": "Replace all occurrences (default false)" }
+                        }),
+                        &["path", "old_string", "new_string"],
+                        "Several edits applied as ONE all-or-nothing change, in order — \
+                         two edits to the same file compose, and if any edit fails nothing \
+                         is written.",
+                    ),
                     "reason": { "type": "string", "description": "Why you are editing this file — recorded in the session's file-touch audit log" },
                     "storage_intent": { "type": "string", "description": "Only when creating a database table/column that the storage gate flagged as similar to an existing one: one sentence of purpose plus why the existing objects don't fit. Recorded in stella.storage.toml." }
                 },
-                "required": ["path", "old_string", "new_string"]
+                "required": []
             }),
             read_only: false,
             speculation_safe: false,
@@ -229,6 +270,19 @@ impl Tool for EditFile {
     }
 
     async fn execute(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+        if crate::batch::is_plural(input, EDITS_KEY) {
+            return self.edit_batch(input, ctx).await;
+        }
+        // The single form runs the original path over the original `input`,
+        // untouched: its success string is an identity stamp the stagnation
+        // detector keys on (#3176) and its drift attribution is asserted
+        // verbatim, so the batch work must not reshape either.
+        self.edit_one(input, ctx).await
+    }
+}
+
+impl EditFile {
+    async fn edit_one(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         let root = ctx.root();
         let path = match crate::input::required_str(input, "path") {
             Ok(v) => v,
@@ -391,6 +445,203 @@ impl Tool for EditFile {
                 ))
             }
             Err(e) => ToolOutput::error(format!("failed to write `{path}`: {e}")),
+        }
+    }
+
+    /// Apply several edits as one change: compose every replacement in memory,
+    /// and touch the disk only once all of them have landed.
+    ///
+    /// **All-or-nothing is the whole point.** A `sed -i` chain applies edit 1,
+    /// fails edit 2, and leaves a tree that neither the model nor the turn's
+    /// diff can describe — the model must now work out which half happened
+    /// before it can retry. Here a miss writes nothing, so a failed batch costs
+    /// a retry instead of a repair. That is a guarantee the shell cannot offer
+    /// at any length, which is what makes this the better tool rather than
+    /// merely the sanctioned one.
+    ///
+    /// Edits compose **in order**, so a second edit to a file sees the first.
+    /// That is what lets one call rename a symbol and then edit the line that
+    /// now mentions it.
+    async fn edit_batch(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+        let root = ctx.root();
+        let targets = match crate::batch::targets(input, EDITS_KEY, "path", edit_target) {
+            Ok(targets) => targets,
+            Err(err) => return ToolOutput::from(err),
+        };
+
+        let mut pending: Vec<Pending> = Vec::new();
+        for (index, target) in targets.iter().enumerate() {
+            // Scope is consulted per target. There is no batch-level path for
+            // a gate to miss: the plural key changes the arity of this loop
+            // and nothing else.
+            let (scope_root, path) = match ctx.resolve_for_write(&target.path) {
+                Ok(resolved) => resolved,
+                Err(refusal) => {
+                    return ToolOutput::error(format!(
+                        "`{EDITS_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
+                        target.path
+                    ));
+                }
+            };
+            if target.old_string.is_empty() {
+                return ToolOutput::error(format!(
+                    "`{EDITS_KEY}`[{index}] (`{path}`): old_string must not be empty — use \
+                     write_file to create or replace a whole file. Nothing was written."
+                ));
+            }
+
+            // One load per file. Every later edit to it composes on the
+            // in-memory copy rather than re-reading a file this batch has not
+            // written yet.
+            let slot = match pending
+                .iter()
+                .position(|p| p.scope_root == scope_root && p.path == path)
+            {
+                Some(slot) => slot,
+                None => {
+                    let handle = match crate::rootfd::RootHandle::open(&scope_root) {
+                        Ok(handle) => Arc::new(handle),
+                        Err(e) => {
+                            return ToolOutput::error(format!("cannot open workspace root: {e}"));
+                        }
+                    };
+                    let content = match crate::rootfd::read_to_string_async(&handle, &path).await {
+                        Ok(content) => content,
+                        Err(e) => {
+                            return ToolOutput::error(format!(
+                                "`{EDITS_KEY}`[{index}]: failed to read `{path}`: {e} — nothing \
+                                 was written"
+                            ));
+                        }
+                    };
+                    pending.push(Pending {
+                        scope_root,
+                        path,
+                        content,
+                        edits: 0,
+                    });
+                    pending.len() - 1
+                }
+            };
+
+            // A needle copied out of `read_file`'s render carries LF newlines
+            // even when the file on disk is CRLF — see [`crlf_promoted`].
+            let promoted = crlf_promoted(
+                &pending[slot].content,
+                &target.old_string,
+                &target.new_string,
+            );
+            let (old_string, new_string) = match &promoted {
+                Some((old, new)) => (old.as_str(), new.as_str()),
+                None => (target.old_string.as_str(), target.new_string.as_str()),
+            };
+
+            let current = &pending[slot].content;
+            if !current.contains(old_string) {
+                return ToolOutput::error(self.batch_miss(root, &pending[slot], index, old_string));
+            }
+            let count = current.matches(old_string).count();
+            if count > 1 && !target.replace_all {
+                return ToolOutput::error(format!(
+                    "`{EDITS_KEY}`[{index}]: old_string appears {count} times in `{}` — set \
+                     replace_all=true or provide a more specific string. Nothing was written.",
+                    pending[slot].path
+                ));
+            }
+            pending[slot].content = if target.replace_all {
+                current.replace(old_string, new_string)
+            } else {
+                current.replacen(old_string, new_string, 1)
+            };
+            pending[slot].edits += 1;
+        }
+
+        // Every edit validated against the composed content. Only now does
+        // anything reach the disk.
+        let mut report = Vec::with_capacity(pending.len());
+        for file in &pending {
+            let handle = match crate::rootfd::RootHandle::open(&file.scope_root) {
+                Ok(handle) => Arc::new(handle),
+                Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+            };
+            if let Err(e) = crate::durable_write::write_file_durably_at(
+                handle,
+                file.path.clone(),
+                file.content.as_bytes().to_vec(),
+                false,
+            )
+            .await
+            {
+                return ToolOutput::error(format!("failed to write `{}`: {e}", file.path));
+            }
+            // The model knows the bytes it just produced — record them so its
+            // own edit is never later misattributed as drift.
+            self.ledger.record_known(root, &file.path, &file.content);
+            report.push(format!(
+                "{} — {} edit(s), file sha256/8 {}",
+                file.path,
+                file.edits,
+                crate::staleness::sha256_8(file.content.as_bytes())
+            ));
+        }
+        // The per-file digests are the batch's identity stamp, for the same
+        // reason the single form carries one (#3176): N distinct batches must
+        // not produce byte-identical output, or the stagnation detector reads
+        // correct work as a stuck loop.
+        ToolOutput::ok(format!(
+            "applied {} edit(s) across {} file(s), all or nothing:\n{}",
+            targets.len(),
+            pending.len(),
+            report.join("\n")
+        ))
+    }
+
+    /// Attribute a miss inside a batch, in the vocabulary the single form uses.
+    ///
+    /// The one thing this must not do is cry drift at its own work: once this
+    /// batch has edited a file, the composed content no longer matches what the
+    /// ledger last saw, and reporting that as an out-of-band modification would
+    /// send the model hunting for a second writer that is itself.
+    fn batch_miss(
+        &self,
+        root: &std::path::Path,
+        file: &Pending,
+        index: usize,
+        old_string: &str,
+    ) -> String {
+        let path = &file.path;
+        let head = format!("`{EDITS_KEY}`[{index}]: old_string not found in `{path}`");
+        if let Some(actual) = indentation_only_match(&file.content, old_string) {
+            return format!(
+                "{head} — but the same text IS present with different leading whitespace, so \
+                 the needle was re-indented. Nothing was written. Copy this span \
+                 byte-exact:\n\n--- {path} (actual indentation) ---\n{actual}"
+            );
+        }
+        let composed = if file.edits > 0 {
+            format!(
+                " (an earlier edit in this same batch already changed `{path}`, so match \
+                 against the text as that edit left it)"
+            )
+        } else {
+            String::new()
+        };
+        let current_sha = crate::staleness::hex_sha256(file.content.as_bytes());
+        match self.ledger.last_seen_sha(root, path) {
+            // Only meaningful before this batch touched the file.
+            Some(seen) if seen != current_sha && file.edits == 0 => format!(
+                "{head} — the file CHANGED after you last read it (out-of-band modification); \
+                 the copy in your context is stale. Nothing was written — re-read it and \
+                 re-issue the batch."
+            ),
+            Some(_) => format!(
+                "{head} — the file is otherwise unchanged since you last saw it{composed}; \
+                 check for exact whitespace/newline differences. Nothing was written."
+            ),
+            None => format!(
+                "{head} — no read of this file is recorded this session; read it first and \
+                 copy old_string byte-exact. Nothing was written."
+            ),
         }
     }
 }
@@ -847,5 +1098,132 @@ mod tests {
             }
             ToolOutput::Ok { content, .. } => panic!("expected drift error, got: {content}"),
         }
+    }
+
+    // ── batching (#4151) ──────────────────────────────────────────────────
+
+    /// One call, several edits, across more than one file.
+    #[tokio::test]
+    async fn one_call_applies_several_edits_across_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "let a = 1;\n").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "let b = 2;\n").unwrap();
+
+        let out = EditFile::default()
+            .execute(
+                &serde_json::json!({"edits": [
+                    {"path": "a.rs", "old_string": "1", "new_string": "10"},
+                    {"path": "b.rs", "old_string": "2", "new_string": "20"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+            "let a = 10;\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("b.rs")).unwrap(),
+            "let b = 20;\n"
+        );
+    }
+
+    /// **The guarantee `sed -i` cannot offer at any length.**
+    ///
+    /// A shell chain applies edit 1, fails edit 2, and leaves a tree neither
+    /// the model nor the turn's diff can describe — the model has to work out
+    /// which half happened before it can retry. Here a miss anywhere writes
+    /// nothing, so a failed batch costs a retry rather than a repair.
+    #[tokio::test]
+    async fn a_batch_that_fails_midway_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "let a = 1;\n").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "let b = 2;\n").unwrap();
+
+        let out = EditFile::default()
+            .execute(
+                &serde_json::json!({"edits": [
+                    {"path": "a.rs", "old_string": "1", "new_string": "10"},
+                    {"path": "b.rs", "old_string": "NOT PRESENT", "new_string": "x"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        let ToolOutput::Error { message, .. } = out else {
+            panic!("a batch with an unmatchable edit must fail: {out:?}");
+        };
+        assert!(message.contains("[1]"), "names the failing edit: {message}");
+        assert!(message.contains("Nothing was written"), "{message}");
+        // The first edit validated cleanly and must STILL not be on disk.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+            "let a = 1;\n",
+            "the edit that would have succeeded must not have landed"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("b.rs")).unwrap(),
+            "let b = 2;\n"
+        );
+    }
+
+    /// Two edits to one file compose in order, so the second sees the first.
+    /// That is what lets a single call rename a symbol and then edit the line
+    /// that now mentions it.
+    #[tokio::test]
+    async fn two_edits_to_one_file_compose_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn old_name() {}\n").unwrap();
+
+        let out = EditFile::default()
+            .execute(
+                &serde_json::json!({"edits": [
+                    {"path": "a.rs", "old_string": "old_name", "new_string": "new_name"},
+                    {"path": "a.rs", "old_string": "fn new_name() {}", "new_string": "pub fn new_name() {}"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        assert!(
+            !out.is_error(),
+            "the second edit must see the first: {out:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+            "pub fn new_name() {}\n"
+        );
+    }
+
+    /// A batch must not cry drift at its own work: once an earlier edit has
+    /// changed the file, the composed content no longer matches the ledger, and
+    /// calling that an out-of-band modification sends the model hunting for a
+    /// second writer that is itself.
+    #[tokio::test]
+    async fn a_batch_does_not_report_its_own_earlier_edit_as_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "let a = 1;\n").unwrap();
+        let ledger = Arc::new(ReadLedger::default());
+        ledger.record_known(dir.path(), "a.rs", "let a = 1;\n");
+
+        let out = EditFile::with_ledger(ledger)
+            .execute(
+                &serde_json::json!({"edits": [
+                    {"path": "a.rs", "old_string": "1", "new_string": "10"},
+                    {"path": "a.rs", "old_string": "NOT PRESENT", "new_string": "x"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        let ToolOutput::Error { message, .. } = out else {
+            panic!("expected the second edit to miss: {out:?}");
+        };
+        assert!(
+            !message.contains("out-of-band"),
+            "the batch's own edit must not be reported as drift: {message}"
+        );
+        assert!(
+            message.contains("earlier edit in this same batch"),
+            "the real cause has to be named: {message}"
+        );
     }
 }

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -37,6 +37,7 @@
 
 pub mod agent_use;
 pub mod bash;
+pub mod batch;
 pub mod catalog;
 pub mod contracts;
 pub mod ctx;

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -323,21 +323,64 @@ fn normalized_key(root: &std::path::Path, path: &str) -> String {
     crate::normalize_workspace_path(root, path).unwrap_or_else(|| path.to_string())
 }
 
+/// The plural key: several files, or several ranges, in one call.
+const FILES_KEY: &str = "files";
+
+/// One file and which slice of it — the unit both spellings of a `read_file`
+/// call reduce to.
+struct ReadTarget {
+    path: String,
+    offset: Option<usize>,
+    limit: usize,
+}
+
+/// Parse one target.
+///
+/// Shared by the single form and by every element of `files`
+/// ([`crate::batch::targets`] is handed this very function), so the two
+/// spellings cannot drift into two meanings.
+fn read_target(value: &Value) -> Result<ReadTarget, crate::input::InputError> {
+    let path = crate::input::required_str(value, "path")?.to_string();
+    // A wrong-typed `offset`/`limit` is refused, never silently defaulted —
+    // `and_then(as_u64)` read `"limit": "200"` as the default window without a
+    // word (#3144). Absent still defaults.
+    let offset = crate::input::optional_u64(value, "offset")?.map(|n| n as usize);
+    // MAX_LINES is a ceiling, not just the default: the flood protection the
+    // module header promises must hold for explicit limits too.
+    let limit = crate::input::optional_u64(value, "limit")?
+        .map(|n| (n as usize).min(MAX_LINES))
+        .unwrap_or(MAX_LINES);
+    Ok(ReadTarget {
+        path,
+        offset,
+        limit,
+    })
+}
+
 #[async_trait]
 impl Tool for ReadFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "read_file".into(),
-            description: "Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges.".into(),
+            description: "Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges. To read several files — or several ranges — read them in ONE call with `files` rather than one call each.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "File path relative to workspace root" },
                     "offset": { "type": "integer", "description": "1-based start line (optional)" },
                     "limit": { "type": "integer", "description": "Max lines to return (optional; default and ceiling 2000)" },
+                    "files": crate::batch::plural_schema(
+                        serde_json::json!({
+                            "path": { "type": "string", "description": "File path relative to workspace root" },
+                            "offset": { "type": "integer", "description": "1-based start line (optional)" },
+                            "limit": { "type": "integer", "description": "Max lines to return (optional; default and ceiling 2000)" }
+                        }),
+                        &["path"],
+                        "Several files, or several ranges of one file, read in a single call.",
+                    ),
                     "reason": { "type": "string", "description": "Why you are reading this file — recorded in the session's file-touch audit log" }
                 },
-                "required": ["path"]
+                "required": []
             }),
             read_only: true,
             speculation_safe: true,
@@ -345,33 +388,97 @@ impl Tool for ReadFile {
     }
 
     async fn execute(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
-        let root = ctx.root();
-        let path = match crate::input::required_str(input, "path") {
-            Ok(v) => v,
-            Err(err) => {
-                return ToolOutput::from(err);
-            }
+        let targets = match crate::batch::targets(input, FILES_KEY, "path", read_target) {
+            Ok(targets) => targets,
+            Err(err) => return ToolOutput::from(err),
         };
 
-        // A wrong-typed `offset`/`limit` is refused, never silently
-        // defaulted — `and_then(as_u64)` read `"limit": "200"` as the
-        // default window without a word (#3144). Absent still defaults.
-        let offset = match crate::input::optional_u64(input, "offset") {
-            Ok(offset) => offset.map(|n| n as usize),
-            Err(err) => {
-                return ToolOutput::from(err);
+        if !crate::batch::is_plural(input, FILES_KEY) {
+            // Byte-identical to what the single form has always emitted. The
+            // footer is what loop comparison strips and what this module's
+            // tests assert verbatim, so the batch path must not reshape it.
+            return self.read_one(&targets[0], ctx, MAX_RENDER_BYTES).await.0;
+        }
+
+        // The payload cap is a BATCH budget, not a per-file one. Ten files at
+        // 64 KB each is 640 KB — the exact flood #1842 closed, which a plural
+        // key would otherwise reopen. Every section spends from one pot, in
+        // the caller's order.
+        let mut rendered = String::new();
+        let mut spent = 0usize;
+        let mut unread: Vec<&str> = Vec::new();
+        for target in &targets {
+            if spent >= MAX_RENDER_BYTES {
+                unread.push(target.path.as_str());
+                continue;
             }
-        };
-        // MAX_LINES is a ceiling, not just the default: the flood protection
-        // the module header promises must hold for explicit limits too.
-        let limit = match crate::input::optional_u64(input, "limit") {
-            Ok(limit) => limit
-                .map(|n| (n as usize).min(MAX_LINES))
-                .unwrap_or(MAX_LINES),
-            Err(err) => {
-                return ToolOutput::from(err);
+            let (out, used) = self.read_one(target, ctx, MAX_RENDER_BYTES - spent).await;
+            spent += used;
+            if !rendered.is_empty() {
+                rendered.push_str("\n\n");
             }
+            rendered.push_str(&format!("===== {} =====\n", target.path));
+            match out {
+                ToolOutput::Ok { content, .. } => rendered.push_str(&content),
+                // A failed target does not end the batch. A read leaves
+                // nothing half-done, so reporting the miss in place is
+                // strictly more useful than discarding the files that did
+                // resolve — which is also what the `sed` chains this replaces
+                // did, minus having to guess which command failed.
+                ToolOutput::Error { message, .. } => {
+                    rendered.push_str(&format!("(not read: {message})"));
+                }
+            }
+        }
+        if !unread.is_empty() {
+            rendered.push_str(&format!(
+                "\n\n({} file(s) not read — the {} KB batch payload cap was reached: {}. \
+                 Ask for them in a follow-up call.)",
+                unread.len(),
+                MAX_RENDER_BYTES / 1024,
+                unread.join(", ")
+            ));
+        }
+        ToolOutput::ok(rendered)
+    }
+}
+
+impl ReadFile {
+    /// Read one target, spending at most `budget` bytes of rendered payload.
+    ///
+    /// Returns the section and the bytes it actually spent, so the caller can
+    /// hold one budget across a whole batch. Every per-file obligation lives
+    /// here rather than in the loop above — the read ledger, the coverage
+    /// flag, and the unchanged-read ceiling are all per file and stay that way
+    /// whichever spelling asked for them.
+    async fn read_one(
+        &self,
+        target: &ReadTarget,
+        ctx: &crate::ctx::ToolCtx,
+        budget: usize,
+    ) -> (ToolOutput, usize) {
+        let out = self.read_section(target, ctx, budget).await;
+        // A refusal costs the batch nothing: it is a sentence, and charging
+        // the budget for it would let a run of missing paths starve the files
+        // that do resolve.
+        let used = match &out {
+            ToolOutput::Ok { content, .. } => content.len(),
+            ToolOutput::Error { .. } => 0,
         };
+        (out, used)
+    }
+
+    /// One target's section, rendered within `budget` bytes.
+    async fn read_section(
+        &self,
+        target: &ReadTarget,
+        ctx: &crate::ctx::ToolCtx,
+        budget: usize,
+    ) -> ToolOutput {
+        let root = ctx.root();
+        let path = target.path.as_str();
+        let offset = target.offset;
+        let limit = target.limit;
 
         // The one read the scope refuses: another session's git worktree. Not
         // a security boundary — it is a correctness one. See
@@ -543,14 +650,14 @@ impl Tool for ReadFile {
                         .iter()
                         .map(|l| l.len().min(MAX_LINE_BYTES) + 32)
                         .sum::<usize>()
-                        .min(MAX_RENDER_BYTES + 1024)
+                        .min(budget + 1024)
                         + 64,
                 );
                 let mut clipped_lines = 0usize;
                 let mut shown = 0usize;
                 let mut payload_capped = false;
                 for (i, line) in lines[start..end].iter().enumerate() {
-                    if numbered.len() >= MAX_RENDER_BYTES {
+                    if numbered.len() >= budget {
                         payload_capped = true;
                         break;
                     }
@@ -615,771 +722,4 @@ impl Tool for ReadFile {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A bare execution context rooted at `root` — every file-tool test
-    /// drives the tool through one, since `Tool::execute` takes the
-    /// context rather than the bare root path it used to (#3284).
-    fn cx(root: impl AsRef<std::path::Path>) -> crate::ctx::ToolCtx {
-        crate::ctx::ToolCtx::bare(root.as_ref().to_path_buf())
-    }
-
-    /// #3145: an input the tool could not read is classified
-    /// [`stella_protocol::ErrorClass::InvalidInput`] — the model's mistake,
-    /// excluded from the tool's own error rate — with the message bytes
-    /// unchanged from the pre-class wording.
-    #[tokio::test]
-    async fn missing_path_is_classified_invalid_input() {
-        use stella_protocol::ErrorClass;
-        let result = ReadFile::default()
-            .execute(&serde_json::json!({}), &cx(std::env::temp_dir()))
-            .await;
-        let ToolOutput::Error { message, class } = result else {
-            panic!("expected an error for a missing required field");
-        };
-        assert_eq!(class, Some(ErrorClass::InvalidInput));
-        assert_eq!(message, "missing required field `path`");
-    }
-
-    #[tokio::test]
-    async fn reads_file_with_line_numbers() {
-        let dir = std::env::temp_dir();
-        let path = format!("stella_test_read_{}.txt", std::process::id());
-        let full = dir.join(&path);
-        tokio::fs::write(&full, "line one\nline two\nline three\n")
-            .await
-            .unwrap();
-
-        let result = ReadFile::default()
-            .execute(&serde_json::json!({"path": path}), &cx(&dir))
-            .await;
-        match result {
-            ToolOutput::Ok { content, .. } => {
-                assert!(content.contains("1\tline one"));
-                assert!(content.contains("2\tline two"));
-                assert!(content.contains("3/3 lines shown"));
-            }
-            ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
-        }
-        let _ = tokio::fs::remove_file(&full).await;
-    }
-
-    #[tokio::test]
-    async fn respects_offset_and_limit() {
-        let dir = std::env::temp_dir();
-        let path = format!("stella_test_range_{}.txt", std::process::id());
-        let full = dir.join(&path);
-        tokio::fs::write(&full, "a\nb\nc\nd\ne\n").await.unwrap();
-
-        let result = ReadFile::default()
-            .execute(
-                &serde_json::json!({"path": path, "offset": 2, "limit": 2}),
-                &cx(&dir),
-            )
-            .await;
-        match result {
-            ToolOutput::Ok { content, .. } => {
-                assert!(content.contains("2\tb"));
-                assert!(content.contains("3\tc"));
-                assert!(!content.contains("4\td"));
-                assert!(content.contains("2/5 lines shown"));
-            }
-            ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
-        }
-        let _ = tokio::fs::remove_file(&full).await;
-    }
-
-    /// The #3144 witness: a wrong-typed `offset`/`limit` is refused, never
-    /// silently defaulted. On main, `{"limit": "200"}` vanished into the
-    /// default window — no refusal, no note, wrong-sized read.
-    #[tokio::test]
-    async fn a_mistyped_offset_or_limit_is_refused_not_defaulted() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("f.txt"), "a\nb\nc\n").unwrap();
-        let tool = ReadFile::default();
-
-        let out = tool
-            .execute(
-                &serde_json::json!({"path": "f.txt", "limit": "200"}),
-                &cx(dir.path()),
-            )
-            .await;
-        let ToolOutput::Error { message, .. } = out else {
-            panic!("a mistyped limit must be an error, got: {out:?}");
-        };
-        assert_eq!(
-            message,
-            "field `limit` must be a non-negative integer, got string"
-        );
-
-        let out = tool
-            .execute(
-                &serde_json::json!({"path": "f.txt", "offset": true}),
-                &cx(dir.path()),
-            )
-            .await;
-        let ToolOutput::Error { message, .. } = out else {
-            panic!("a mistyped offset must be an error, got: {out:?}");
-        };
-        assert_eq!(
-            message,
-            "field `offset` must be a non-negative integer, got boolean"
-        );
-
-        // Absent still defaults — the fix refuses wrong types, not absence.
-        let out = tool
-            .execute(&serde_json::json!({"path": "f.txt"}), &cx(dir.path()))
-            .await;
-        assert!(!out.is_error(), "{out:?}");
-    }
-
-    #[tokio::test]
-    async fn counts_reads_per_file_and_reports_them() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("src")).unwrap();
-        std::fs::write(dir.path().join("src/a.rs"), "one\ntwo\n").unwrap();
-        std::fs::write(dir.path().join("b.rs"), "one\n").unwrap();
-        let tool = ReadFile::default();
-
-        // Two reads of the same file under different spellings aggregate.
-        for spelling in ["src/a.rs", "src/./a.rs"] {
-            let out = tool
-                .execute(&serde_json::json!({"path": spelling}), &cx(dir.path()))
-                .await;
-            assert!(!out.is_error(), "{out:?}");
-        }
-        let third = tool
-            .execute(&serde_json::json!({"path": "src/a.rs"}), &cx(dir.path()))
-            .await;
-        match third {
-            ToolOutput::Ok { content, .. } => {
-                assert!(
-                    content.contains("read 3× this session"),
-                    "third read reports its count: {content}"
-                );
-            }
-            ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
-        }
-        assert_eq!(tool.read_count(dir.path(), "src/a.rs"), 3);
-        assert_eq!(tool.read_count(dir.path(), "src/./a.rs"), 3);
-
-        // Other files and failed reads don't inflate the tally.
-        let other = tool
-            .execute(&serde_json::json!({"path": "b.rs"}), &cx(dir.path()))
-            .await;
-        assert!(!other.is_error());
-        assert_eq!(tool.read_count(dir.path(), "b.rs"), 1);
-        let missing = tool
-            .execute(&serde_json::json!({"path": "ghost.rs"}), &cx(dir.path()))
-            .await;
-        assert!(missing.is_error());
-        assert_eq!(tool.read_count(dir.path(), "ghost.rs"), 0);
-    }
-
-    #[tokio::test]
-    async fn read_records_last_seen_hash_even_for_ranged_reads() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("a.rs"), "one\ntwo\nthree\n").unwrap();
-        let ledger = Arc::new(ReadLedger::default());
-        let tool = ReadFile::with_ledger(ledger.clone());
-
-        assert_eq!(ledger.last_seen_sha(dir.path(), "a.rs"), None);
-        let out = tool
-            .execute(
-                &serde_json::json!({"path": "a.rs", "offset": 2, "limit": 1}),
-                &cx(dir.path()),
-            )
-            .await;
-        assert!(!out.is_error(), "{out:?}");
-        // The hash covers the FULL file content current at read time, not
-        // just the displayed range — drift asks about the file, not the view.
-        assert_eq!(
-            ledger.last_seen_sha(dir.path(), "a.rs"),
-            Some(crate::staleness::hex_sha256(b"one\ntwo\nthree\n")),
-        );
-
-        // An out-of-band change is visible as a hash mismatch…
-        std::fs::write(dir.path().join("a.rs"), "rewritten\n").unwrap();
-        assert_ne!(
-            ledger.last_seen_sha(dir.path(), "a.rs"),
-            Some(crate::staleness::hex_sha256(b"rewritten\n")),
-        );
-        // …until the next read refreshes the baseline.
-        let again = tool
-            .execute(&serde_json::json!({"path": "a.rs"}), &cx(dir.path()))
-            .await;
-        assert!(!again.is_error());
-        assert_eq!(
-            ledger.last_seen_sha(dir.path(), "a.rs"),
-            Some(crate::staleness::hex_sha256(b"rewritten\n")),
-        );
-    }
-
-    /// The line cap alone never saw this file: 5 MB on ONE line is a single
-    /// line, so it sailed under `MAX_LINES` and landed in the transcript
-    /// whole (~1.4M estimated tokens — enough to hard-fail the next provider
-    /// call). The width cap must clip it, loudly, and say so.
-    #[tokio::test]
-    async fn a_single_pathologically_long_line_is_clipped_and_named() {
-        let dir = tempfile::tempdir().unwrap();
-        let huge = "x".repeat(5 * 1024 * 1024);
-        std::fs::write(dir.path().join("bundle.min.js"), &huge).unwrap();
-
-        let out = ReadFile::default()
-            .execute(
-                &serde_json::json!({"path": "bundle.min.js"}),
-                &cx(dir.path()),
-            )
-            .await;
-        let ToolOutput::Ok { content, .. } = out else {
-            panic!("expected ok, got: {out:?}");
-        };
-        assert!(
-            content.len() < 64 * 1024,
-            "a 5 MB one-liner must not reach the model whole (got {} bytes)",
-            content.len()
-        );
-        assert!(
-            content.contains("bytes elided"),
-            "elision is loud: {content}"
-        );
-        assert!(
-            content.contains("clipped at the 1000-byte per-line cap"),
-            "the footer names the cap: {content}"
-        );
-        assert!(content.contains("1/1 lines shown"), "{content}");
-    }
-
-    /// Many long lines blow the payload ceiling even though each one is
-    /// individually clipped — the render stops and the footer says so, with
-    /// an honest shown/total count.
-    #[tokio::test]
-    async fn the_total_payload_cap_stops_the_render_and_reports_it() {
-        let dir = tempfile::tempdir().unwrap();
-        let line = "y".repeat(4096);
-        let body: String = std::iter::repeat_n(line.as_str(), 800)
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(dir.path().join("dump.sql"), &body).unwrap();
-
-        let out = ReadFile::default()
-            .execute(&serde_json::json!({"path": "dump.sql"}), &cx(dir.path()))
-            .await;
-        let ToolOutput::Ok { content, .. } = out else {
-            panic!("expected ok, got: {out:?}");
-        };
-        assert!(
-            content.len() < MAX_RENDER_BYTES + 4096,
-            "payload stays under the ceiling (got {} bytes)",
-            content.len()
-        );
-        // Derived from the constant, not written out: this assertion said
-        // "400 KB" and would have gone on passing for a cap that moved, which
-        // is the shape a size guard can least afford.
-        assert!(
-            content.contains(&format!(
-                "stopped at the {} KB payload cap",
-                MAX_RENDER_BYTES / 1024
-            )),
-            "the footer names the cap: {content}"
-        );
-        assert!(
-            !content.contains("800/800 lines shown"),
-            "the shown count must be the lines actually emitted: {content}"
-        );
-        assert!(content.contains("/800 lines shown"), "{content}");
-
-        // The paging half (#1842). A cap that says "there is more" without
-        // saying WHERE costs the model a guess, and the answer is not the
-        // shown count — `start` may be non-zero and clipped lines still count
-        // as shown. Asserted by re-reading at the named offset and requiring
-        // the continuation to begin exactly one line after the last shown.
-        let resume: usize = content
-            .split("continue with offset=")
-            .nth(1)
-            .and_then(|tail| {
-                let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
-                digits.parse().ok()
-            })
-            .unwrap_or_else(|| panic!("the footer must name the line to resume from: {content}"));
-        assert!(resume > 1, "a resume offset of {resume} names no progress");
-
-        // The offset has to be usable, not merely present: re-reading at it
-        // must begin exactly where this render stopped. An off-by-one here
-        // silently skips a line or repeats one, and the model cannot tell.
-        assert!(
-            !content.contains(&format!("\n{resume:>6}\t")),
-            "line {resume} must NOT already be in this render — it is where the \
-             next one starts"
-        );
-        let next = ReadFile::default()
-            .execute(
-                &serde_json::json!({"path": "dump.sql", "offset": resume}),
-                &cx(dir.path()),
-            )
-            .await;
-        let ToolOutput::Ok { content: next, .. } = next else {
-            panic!("expected ok, got: {next:?}");
-        };
-        assert!(
-            next.starts_with(&format!("{resume:>6}\t")),
-            "reading at the named offset must continue at line {resume}: {next}"
-        );
-    }
-
-    /// The caps must be invisible for ordinary source: no marker, no footer
-    /// noise, byte-identical numbering.
-    #[tokio::test]
-    async fn ordinary_files_are_unaffected_by_the_byte_caps() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("a.rs"), "fn main() {}\nlet x = 1;\n").unwrap();
-        let out = ReadFile::default()
-            .execute(&serde_json::json!({"path": "a.rs"}), &cx(dir.path()))
-            .await;
-        let ToolOutput::Ok { content, .. } = out else {
-            panic!("expected ok, got: {out:?}");
-        };
-        assert!(!content.contains("elided"), "{content}");
-        assert!(!content.contains("cap"), "{content}");
-        assert!(
-            content.ends_with("(2/2 lines shown · read 1× this session)"),
-            "{content}"
-        );
-    }
-
-    /// **The #4034 witness.** A monotonic paging sweep of one file is stopped
-    /// before it can spend a turn's whole budget.
-    ///
-    /// The observed turn made 164 forty-line reads of one 3,943-line file for
-    /// $7.83, ran off the end, wrapped to offset 1 and started over. Every
-    /// loop verdict stayed silent because each read returned a genuinely
-    /// different window — all four are defined on byte-identical *output*, and
-    /// this sweep never repeats one. On `main` this test's forty reads all
-    /// succeed and the turn is left to grind to `max_steps`.
-    #[tokio::test]
-    async fn a_monotonic_paging_sweep_is_refused_before_it_burns_a_turn() {
-        let dir = tempfile::tempdir().unwrap();
-        let body = (1..=4000)
-            .map(|n| format!("line {n}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(dir.path().join("deck_ui.rs"), &body).unwrap();
-        let tool = ReadFile::default();
-        let ctx = cx(dir.path());
-
-        let mut refused_at = None;
-        let mut refusals = Vec::new();
-        for step in 0..40u64 {
-            let out = tool
-                .execute(
-                    &serde_json::json!({
-                        "path": "deck_ui.rs",
-                        "offset": step * 40 + 1,
-                        "limit": 40,
-                    }),
-                    &ctx,
-                )
-                .await;
-            if let ToolOutput::Error { message, .. } = out {
-                refused_at.get_or_insert(step);
-                refusals.push(message);
-            }
-        }
-        let refused_at = refused_at.expect("the sweep must be refused, not run to the cap");
-        assert!(
-            refused_at < 40,
-            "the sweep has to be stopped before step 40, got {refused_at}"
-        );
-        assert_eq!(
-            refused_at, MAX_UNCHANGED_READS,
-            "the 25th read of unchanged bytes is the first refused"
-        );
-        // Constant by construction — a tally inside it would make every
-        // refusal a different string and leave a model that ignores the
-        // ceiling as undetectable as the sweep that earned it.
-        assert!(
-            refusals.windows(2).all(|w| w[0] == w[1]),
-            "every refusal must be byte-identical: {refusals:?}"
-        );
-        // The remedy has to be reachable from inside this same tool, or the
-        // ceiling is a wall rather than a redirection.
-        assert!(refusals[0].contains("omitting `limit`"), "{}", refusals[0]);
-        assert!(refusals[0].contains("`search`"), "{}", refusals[0]);
-    }
-
-    /// The remedy the refusal advertises has to actually work: once the
-    /// paging sweep has tripped the ceiling, the model is told that "omitting
-    /// `limit` shows you all of it at once". A whole-file read at that point
-    /// must be let through — otherwise `record_read` counts it as one more
-    /// unchanged read and the identical refusal comes back, steering the model
-    /// toward an action that can never succeed. Byte-identical whole-file
-    /// rereads stay caught by the loop detector, so nothing is lost.
-    #[tokio::test]
-    async fn a_whole_file_read_escapes_the_ceiling_the_refusal_advertises() {
-        let dir = tempfile::tempdir().unwrap();
-        let body = (1..=200)
-            .map(|n| format!("line {n}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(dir.path().join("small.rs"), &body).unwrap();
-        let tool = ReadFile::default();
-        let ctx = cx(dir.path());
-
-        // Sweep it in small windows until the ceiling trips, exactly as the
-        // pathological turn did.
-        let mut tripped = false;
-        for step in 0..40u64 {
-            let out = tool
-                .execute(
-                    &serde_json::json!({
-                        "path": "small.rs",
-                        "offset": (step % 5) * 40 + 1,
-                        "limit": 40,
-                    }),
-                    &ctx,
-                )
-                .await;
-            if matches!(out, ToolOutput::Error { .. }) {
-                tripped = true;
-                break;
-            }
-        }
-        assert!(tripped, "the windowed sweep must trip the ceiling");
-
-        // Following the refusal's advice — a whole-file read — must succeed.
-        let out = tool
-            .execute(&serde_json::json!({"path": "small.rs"}), &ctx)
-            .await;
-        assert!(
-            matches!(out, ToolOutput::Ok { .. }),
-            "the whole-file read the refusal advertises must be reachable: {out:?}"
-        );
-
-        // A windowed read of the same unchanged bytes is still refused — the
-        // exemption is for whole-file reads only, not a hole in the ceiling.
-        let out = tool
-            .execute(
-                &serde_json::json!({"path": "small.rs", "offset": 1, "limit": 40}),
-                &ctx,
-            )
-            .await;
-        assert!(
-            matches!(out, ToolOutput::Error { .. }),
-            "a windowed sweep must still be refused after the ceiling: {out:?}"
-        );
-    }
-
-    /// The ceiling counts reads of bytes that have not moved, so the
-    /// read → edit → read cycle that is most of an agent's working life never
-    /// approaches it. Without the reset this would refuse the 25th pass of an
-    /// ordinary edit loop.
-    #[tokio::test]
-    async fn editing_the_file_resets_the_read_ceiling() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("a.rs");
-        let tool = ReadFile::default();
-        let ctx = cx(dir.path());
-        for pass in 0..40 {
-            // A file long enough that the read below is a *window*, and a
-            // window on purpose: a whole-file read is exempt from the ceiling
-            // (it returns identical bytes, so the loop verdicts already catch a
-            // spiral of them), which would make this test pass even with the
-            // reset deleted. The reset is the whole safety argument for the
-            // ceiling, so it has to be exercised by a read the ceiling can
-            // actually refuse.
-            let body: String = (0..200)
-                .map(|line| format!("fn f{line}() {{}} // pass {pass}\n"))
-                .collect();
-            std::fs::write(&path, body).unwrap();
-            let out = tool
-                .execute(
-                    &serde_json::json!({"path": "a.rs", "offset": 1, "limit": 40}),
-                    &ctx,
-                )
-                .await;
-            assert!(
-                matches!(out, ToolOutput::Ok { .. }),
-                "pass {pass} of a read→edit→read cycle must never be refused: {out:?}"
-            );
-        }
-    }
-
-    /// A sweep that runs off the end of the file must stagnate like anything
-    /// else. The past-end reply embedded the caller's own offset in its
-    /// payload, so every call produced a different string, nothing ever
-    /// compared equal, and the stagnation rung could not fire on it (#4034).
-    /// The offset now rides the footer, which loop comparison strips.
-    #[tokio::test]
-    async fn past_end_reads_compare_equal_once_the_footer_is_stripped() {
-        use stella_core::driver::loop_evidence::comparable_output;
-
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("a.rs"), "one\ntwo\n").unwrap();
-        let tool = ReadFile::default();
-        let ctx = cx(dir.path());
-        let mut compared = Vec::new();
-        for offset in [10, 50, 900] {
-            let out = tool
-                .execute(&serde_json::json!({"path": "a.rs", "offset": offset}), &ctx)
-                .await;
-            assert!(matches!(out, ToolOutput::Ok { .. }), "{out:?}");
-            let ToolOutput::Ok { content, .. } = &*comparable_output(&out) else {
-                panic!("expected ok, got: {out:?}");
-            };
-            compared.push(content.clone());
-        }
-        assert!(
-            compared.windows(2).all(|w| w[0] == w[1]),
-            "three past-end reads at different offsets must normalize to one \
-             string, or stagnation can never fire on a sweep past EOF: {compared:?}"
-        );
-        assert!(
-            !compared[0].contains("900"),
-            "the caller's offset must not survive normalization: {}",
-            compared[0]
-        );
-        assert!(
-            compared[0].contains("past the end"),
-            "the reply still has to say what happened: {}",
-            compared[0]
-        );
-    }
-
-    /// The footer's producer is here and its consumer is in `stella-core`, so
-    /// neither crate's own tests can catch the two drifting apart. This is the
-    /// seam that can: real tool output, run through the real normalization the
-    /// loop detector compares. Reword the footer on either side without the
-    /// other and this fails.
-    ///
-    /// Every shape has to normalize away, not just the bare tally. A read that
-    /// clipped a long line or stopped at the payload cap appends further
-    /// clauses after it, and a match that ended at the tally would leave the
-    /// per-session count in the compared bytes for exactly the large-file
-    /// rereads a stuck agent produces most.
-    #[tokio::test]
-    async fn the_footer_a_read_writes_is_the_one_loop_comparison_strips() {
-        use stella_core::driver::loop_evidence::comparable_output;
-
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("plain.rs"), "fn main() {}\nlet x = 1;\n").unwrap();
-        std::fs::write(
-            dir.path().join("wide.min.js"),
-            "x".repeat(4 * MAX_LINE_BYTES),
-        )
-        .unwrap();
-        let dump = std::iter::repeat_n("y".repeat(4096), 800)
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(dir.path().join("dump.sql"), &dump).unwrap();
-
-        // One tool, so the ledger's tally really does move between the two
-        // reads of a file — which is the whole reason the footer is volatile.
-        let tool = ReadFile::default();
-        for name in ["plain.rs", "wide.min.js", "dump.sql"] {
-            let input = serde_json::json!({ "path": name });
-            let first = tool.execute(&input, &cx(dir.path())).await;
-            let second = tool.execute(&input, &cx(dir.path())).await;
-            let (
-                ToolOutput::Ok { content: raw, .. },
-                ToolOutput::Ok {
-                    content: raw_again, ..
-                },
-            ) = (&first, &second)
-            else {
-                panic!("expected ok for {name}, got: {first:?} / {second:?}");
-            };
-            assert!(
-                raw.ends_with(READ_FOOTER_CLOSE) && raw.contains(READ_FOOTER_TALLY_END),
-                "{name} emitted no recognizable footer: {raw}"
-            );
-            assert_ne!(
-                raw, raw_again,
-                "{name}: the tally must move, or this proves nothing"
-            );
-
-            let normalized = comparable_output(&first);
-            assert_eq!(
-                normalized,
-                comparable_output(&second),
-                "{name}: two identical reads must compare equal once the footer is off"
-            );
-            let ToolOutput::Ok { content, .. } = normalized.as_ref() else {
-                unreachable!("normalizing an Ok output cannot change its variant");
-            };
-            assert!(
-                !content.contains(READ_FOOTER_TALLY_END),
-                "{name} kept part of the footer: {content}"
-            );
-        }
-    }
-
-    /// The engine's working-set restoration (#2685) replays this tool by the
-    /// name and path parameter `stella_core::restore` spells, and refuses the
-    /// replay unless the schema declares `read_only` — the same one-definition
-    /// tie as the footer test above. A drift on either side is not cosmetic:
-    /// it is restoration silently ceasing to restore files.
-    ///
-    /// This replaces the narrowed `the_read_tool_keeps_the_schema_shape_a_replay_requires`
-    /// that stood in while the replay was disarmed by the tool purge (#3244):
-    /// the constants exist again, so the pin goes back to asserting against
-    /// them rather than against literals (#3470).
-    #[test]
-    fn the_read_tool_is_the_one_the_engines_restoration_replays() {
-        let schema = ReadFile::default().schema();
-        assert_eq!(schema.name, stella_core::restore::READ_TOOL);
-        assert!(
-            schema.read_only,
-            "restoration (and the parked-wait probe) replay only schema-declared \
-             read-only tools; dropping the claim silently disables both"
-        );
-        assert!(
-            schema.input_schema["properties"]
-                .get(stella_core::restore::READ_PATH_PARAM)
-                .is_some(),
-            "the path parameter must keep the spelling the engine replays"
-        );
-    }
-
-    /// A binary file used to come back as "stream did not contain valid
-    /// UTF-8", which reads to a model as a transient IO fault worth retrying.
-    /// It must be named as binary and point somewhere useful.
-    #[tokio::test]
-    async fn a_binary_file_is_named_as_binary_not_as_an_io_fault() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("blob.bin"), [0x00u8, 0xff, 0xfe, 0x41]).unwrap();
-        let out = ReadFile::default()
-            .execute(&serde_json::json!({"path": "blob.bin"}), &cx(dir.path()))
-            .await;
-        match out {
-            ToolOutput::Error { message, .. } => {
-                assert!(message.contains("binary"), "{message}");
-                assert!(message.contains("not UTF-8"), "{message}");
-            }
-            ToolOutput::Ok { content, .. } => panic!("expected error, got: {content}"),
-        }
-    }
-
-    /// A directory used to surface the raw `Is a directory (os error 21)`,
-    /// which says what the syscall thought and not what to do instead.
-    #[tokio::test]
-    async fn a_directory_is_refused_with_the_tool_that_does_answer() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir(dir.path().join("src")).unwrap();
-        let out = ReadFile::default()
-            .execute(&serde_json::json!({"path": "src"}), &cx(dir.path()))
-            .await;
-        match out {
-            ToolOutput::Error { message, .. } => {
-                assert!(message.contains("is a directory"), "{message}");
-                assert!(message.contains("glob("), "names the tool: {message}");
-            }
-            ToolOutput::Ok { content, .. } => panic!("expected error, got: {content}"),
-        }
-    }
-
-    /// The heap half of the caps: `offset`/`limit` bound what the MODEL sees,
-    /// never what Stella loads, so a one-line read of a multi-gigabyte dump
-    /// paid for the whole file. Above the ceiling the refusal is named and
-    /// points at the tools that stream.
-    #[tokio::test]
-    async fn an_oversized_file_is_refused_before_it_is_loaded() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("dump.sql");
-        let file = std::fs::File::create(&path).unwrap();
-        // Sparse: the ceiling is decided from metadata, so no bytes are spent.
-        file.set_len(MAX_FILE_BYTES + 1).unwrap();
-        drop(file);
-
-        let out = ReadFile::default()
-            .execute(
-                &serde_json::json!({"path": "dump.sql", "offset": 1, "limit": 1}),
-                &cx(dir.path()),
-            )
-            .await;
-        match out {
-            ToolOutput::Error { message, .. } => {
-                assert!(message.contains("ceiling"), "{message}");
-                assert!(message.contains("grep"), "points somewhere: {message}");
-            }
-            ToolOutput::Ok { content, .. } => {
-                panic!("an oversized file must be refused, got: {content}")
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn missing_file_returns_error() {
-        let dir = std::env::temp_dir();
-        let result = ReadFile::default()
-            .execute(
-                &serde_json::json!({"path": "nonexistent_xyz_123.txt"}),
-                &cx(&dir),
-            )
-            .await;
-        assert!(result.is_error());
-    }
-
-    /// **Reads are not confined to the workspace**, and this test now says so.
-    ///
-    /// It used to assert that `../../etc/passwd` was refused. That was the
-    /// behaviour when `read_file` opened only the session root, and it is the
-    /// behaviour that was deliberately changed: an agent fixing a build needs
-    /// system headers, the toolchain and a dependency's source, and a read
-    /// cannot damage the user's tree (`stella_core::workspace_scope`).
-    ///
-    /// Worth noting how it was passing on macOS while the change was already
-    /// in: `std::env::temp_dir()` there is `/var/folders/…/T/`, so
-    /// `../../etc/passwd` resolves to a path that does not exist, and the read
-    /// failed for the wrong reason. On Linux CI the same expression resolves
-    /// to the real `/etc/passwd` and the read succeeded — which is how the
-    /// stale assertion surfaced at all. A test that passes on one platform by
-    /// accident of path arithmetic is worse than no test, so this one now
-    /// pins the rule directly, on a file it creates itself.
-    #[tokio::test]
-    async fn a_read_outside_the_workspace_is_allowed() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let elsewhere = tempfile::tempdir().expect("elsewhere");
-        let outside = elsewhere.path().join("readable.txt");
-        std::fs::write(&outside, "readable\n").expect("write");
-
-        let result = ReadFile::default()
-            .execute(
-                &serde_json::json!({ "path": outside.to_string_lossy() }),
-                &cx(workspace.path()),
-            )
-            .await;
-        let ToolOutput::Ok { content, .. } = result else {
-            panic!("a read outside the workspace must succeed: {result:?}");
-        };
-        assert!(content.contains("readable"), "{content}");
-    }
-
-    /// The one read that IS refused: another session's worktree — a second
-    /// checkout of the same repository at another revision, so reading it
-    /// answers about the wrong copy of the file being edited.
-    #[tokio::test]
-    async fn a_read_into_a_sibling_worktree_is_refused() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let worktree = workspace.path().join(".stella/worktrees/sibling");
-        std::fs::create_dir_all(&worktree).expect("mkdir");
-        std::fs::write(worktree.join("other.rs"), "pub fn other() {}\n").expect("write");
-
-        let result = ReadFile::default()
-            .execute(
-                &serde_json::json!({ "path": ".stella/worktrees/sibling/other.rs" }),
-                &cx(workspace.path()),
-            )
-            .await;
-        assert!(result.is_error(), "{result:?}");
-    }
-
-    #[tokio::test]
-    async fn missing_path_field_returns_error() {
-        let dir = std::env::temp_dir();
-        let result = ReadFile::default()
-            .execute(&serde_json::json!({}), &cx(&dir))
-            .await;
-        assert!(result.is_error());
-    }
-}
+mod tests;

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -1,0 +1,926 @@
+
+use super::*;
+
+/// A bare execution context rooted at `root` — every file-tool test
+/// drives the tool through one, since `Tool::execute` takes the
+/// context rather than the bare root path it used to (#3284).
+fn cx(root: impl AsRef<std::path::Path>) -> crate::ctx::ToolCtx {
+    crate::ctx::ToolCtx::bare(root.as_ref().to_path_buf())
+}
+
+/// #3145: an input the tool could not read is classified
+/// [`stella_protocol::ErrorClass::InvalidInput`] — the model's mistake,
+/// excluded from the tool's own error rate — with the message bytes
+/// unchanged from the pre-class wording.
+#[tokio::test]
+async fn missing_path_is_classified_invalid_input() {
+    use stella_protocol::ErrorClass;
+    let result = ReadFile::default()
+        .execute(&serde_json::json!({}), &cx(std::env::temp_dir()))
+        .await;
+    let ToolOutput::Error { message, class } = result else {
+        panic!("expected an error for a missing required field");
+    };
+    assert_eq!(class, Some(ErrorClass::InvalidInput));
+    assert_eq!(message, "missing required field `path`");
+}
+
+#[tokio::test]
+async fn reads_file_with_line_numbers() {
+    let dir = std::env::temp_dir();
+    let path = format!("stella_test_read_{}.txt", std::process::id());
+    let full = dir.join(&path);
+    tokio::fs::write(&full, "line one\nline two\nline three\n")
+        .await
+        .unwrap();
+
+    let result = ReadFile::default()
+        .execute(&serde_json::json!({"path": path}), &cx(&dir))
+        .await;
+    match result {
+        ToolOutput::Ok { content, .. } => {
+            assert!(content.contains("1\tline one"));
+            assert!(content.contains("2\tline two"));
+            assert!(content.contains("3/3 lines shown"));
+        }
+        ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
+    }
+    let _ = tokio::fs::remove_file(&full).await;
+}
+
+#[tokio::test]
+async fn respects_offset_and_limit() {
+    let dir = std::env::temp_dir();
+    let path = format!("stella_test_range_{}.txt", std::process::id());
+    let full = dir.join(&path);
+    tokio::fs::write(&full, "a\nb\nc\nd\ne\n").await.unwrap();
+
+    let result = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": path, "offset": 2, "limit": 2}),
+            &cx(&dir),
+        )
+        .await;
+    match result {
+        ToolOutput::Ok { content, .. } => {
+            assert!(content.contains("2\tb"));
+            assert!(content.contains("3\tc"));
+            assert!(!content.contains("4\td"));
+            assert!(content.contains("2/5 lines shown"));
+        }
+        ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
+    }
+    let _ = tokio::fs::remove_file(&full).await;
+}
+
+/// The #3144 witness: a wrong-typed `offset`/`limit` is refused, never
+/// silently defaulted. On main, `{"limit": "200"}` vanished into the
+/// default window — no refusal, no note, wrong-sized read.
+#[tokio::test]
+async fn a_mistyped_offset_or_limit_is_refused_not_defaulted() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("f.txt"), "a\nb\nc\n").unwrap();
+    let tool = ReadFile::default();
+
+    let out = tool
+        .execute(
+            &serde_json::json!({"path": "f.txt", "limit": "200"}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Error { message, .. } = out else {
+        panic!("a mistyped limit must be an error, got: {out:?}");
+    };
+    assert_eq!(
+        message,
+        "field `limit` must be a non-negative integer, got string"
+    );
+
+    let out = tool
+        .execute(
+            &serde_json::json!({"path": "f.txt", "offset": true}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Error { message, .. } = out else {
+        panic!("a mistyped offset must be an error, got: {out:?}");
+    };
+    assert_eq!(
+        message,
+        "field `offset` must be a non-negative integer, got boolean"
+    );
+
+    // Absent still defaults — the fix refuses wrong types, not absence.
+    let out = tool
+        .execute(&serde_json::json!({"path": "f.txt"}), &cx(dir.path()))
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+}
+
+#[tokio::test]
+async fn counts_reads_per_file_and_reports_them() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/a.rs"), "one\ntwo\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "one\n").unwrap();
+    let tool = ReadFile::default();
+
+    // Two reads of the same file under different spellings aggregate.
+    for spelling in ["src/a.rs", "src/./a.rs"] {
+        let out = tool
+            .execute(&serde_json::json!({"path": spelling}), &cx(dir.path()))
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+    }
+    let third = tool
+        .execute(&serde_json::json!({"path": "src/a.rs"}), &cx(dir.path()))
+        .await;
+    match third {
+        ToolOutput::Ok { content, .. } => {
+            assert!(
+                content.contains("read 3× this session"),
+                "third read reports its count: {content}"
+            );
+        }
+        ToolOutput::Error { message, .. } => panic!("expected ok, got: {message}"),
+    }
+    assert_eq!(tool.read_count(dir.path(), "src/a.rs"), 3);
+    assert_eq!(tool.read_count(dir.path(), "src/./a.rs"), 3);
+
+    // Other files and failed reads don't inflate the tally.
+    let other = tool
+        .execute(&serde_json::json!({"path": "b.rs"}), &cx(dir.path()))
+        .await;
+    assert!(!other.is_error());
+    assert_eq!(tool.read_count(dir.path(), "b.rs"), 1);
+    let missing = tool
+        .execute(&serde_json::json!({"path": "ghost.rs"}), &cx(dir.path()))
+        .await;
+    assert!(missing.is_error());
+    assert_eq!(tool.read_count(dir.path(), "ghost.rs"), 0);
+}
+
+#[tokio::test]
+async fn read_records_last_seen_hash_even_for_ranged_reads() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "one\ntwo\nthree\n").unwrap();
+    let ledger = Arc::new(ReadLedger::default());
+    let tool = ReadFile::with_ledger(ledger.clone());
+
+    assert_eq!(ledger.last_seen_sha(dir.path(), "a.rs"), None);
+    let out = tool
+        .execute(
+            &serde_json::json!({"path": "a.rs", "offset": 2, "limit": 1}),
+            &cx(dir.path()),
+        )
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+    // The hash covers the FULL file content current at read time, not
+    // just the displayed range — drift asks about the file, not the view.
+    assert_eq!(
+        ledger.last_seen_sha(dir.path(), "a.rs"),
+        Some(crate::staleness::hex_sha256(b"one\ntwo\nthree\n")),
+    );
+
+    // An out-of-band change is visible as a hash mismatch…
+    std::fs::write(dir.path().join("a.rs"), "rewritten\n").unwrap();
+    assert_ne!(
+        ledger.last_seen_sha(dir.path(), "a.rs"),
+        Some(crate::staleness::hex_sha256(b"rewritten\n")),
+    );
+    // …until the next read refreshes the baseline.
+    let again = tool
+        .execute(&serde_json::json!({"path": "a.rs"}), &cx(dir.path()))
+        .await;
+    assert!(!again.is_error());
+    assert_eq!(
+        ledger.last_seen_sha(dir.path(), "a.rs"),
+        Some(crate::staleness::hex_sha256(b"rewritten\n")),
+    );
+}
+
+/// The line cap alone never saw this file: 5 MB on ONE line is a single
+/// line, so it sailed under `MAX_LINES` and landed in the transcript
+/// whole (~1.4M estimated tokens — enough to hard-fail the next provider
+/// call). The width cap must clip it, loudly, and say so.
+#[tokio::test]
+async fn a_single_pathologically_long_line_is_clipped_and_named() {
+    let dir = tempfile::tempdir().unwrap();
+    let huge = "x".repeat(5 * 1024 * 1024);
+    std::fs::write(dir.path().join("bundle.min.js"), &huge).unwrap();
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": "bundle.min.js"}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert!(
+        content.len() < 64 * 1024,
+        "a 5 MB one-liner must not reach the model whole (got {} bytes)",
+        content.len()
+    );
+    assert!(
+        content.contains("bytes elided"),
+        "elision is loud: {content}"
+    );
+    assert!(
+        content.contains("clipped at the 1000-byte per-line cap"),
+        "the footer names the cap: {content}"
+    );
+    assert!(content.contains("1/1 lines shown"), "{content}");
+}
+
+/// Many long lines blow the payload ceiling even though each one is
+/// individually clipped — the render stops and the footer says so, with
+/// an honest shown/total count.
+#[tokio::test]
+async fn the_total_payload_cap_stops_the_render_and_reports_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let line = "y".repeat(4096);
+    let body: String = std::iter::repeat_n(line.as_str(), 800)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(dir.path().join("dump.sql"), &body).unwrap();
+
+    let out = ReadFile::default()
+        .execute(&serde_json::json!({"path": "dump.sql"}), &cx(dir.path()))
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert!(
+        content.len() < MAX_RENDER_BYTES + 4096,
+        "payload stays under the ceiling (got {} bytes)",
+        content.len()
+    );
+    // Derived from the constant, not written out: this assertion said
+    // "400 KB" and would have gone on passing for a cap that moved, which
+    // is the shape a size guard can least afford.
+    assert!(
+        content.contains(&format!(
+            "stopped at the {} KB payload cap",
+            MAX_RENDER_BYTES / 1024
+        )),
+        "the footer names the cap: {content}"
+    );
+    assert!(
+        !content.contains("800/800 lines shown"),
+        "the shown count must be the lines actually emitted: {content}"
+    );
+    assert!(content.contains("/800 lines shown"), "{content}");
+
+    // The paging half (#1842). A cap that says "there is more" without
+    // saying WHERE costs the model a guess, and the answer is not the
+    // shown count — `start` may be non-zero and clipped lines still count
+    // as shown. Asserted by re-reading at the named offset and requiring
+    // the continuation to begin exactly one line after the last shown.
+    let resume: usize = content
+        .split("continue with offset=")
+        .nth(1)
+        .and_then(|tail| {
+            let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
+            digits.parse().ok()
+        })
+        .unwrap_or_else(|| panic!("the footer must name the line to resume from: {content}"));
+    assert!(resume > 1, "a resume offset of {resume} names no progress");
+
+    // The offset has to be usable, not merely present: re-reading at it
+    // must begin exactly where this render stopped. An off-by-one here
+    // silently skips a line or repeats one, and the model cannot tell.
+    assert!(
+        !content.contains(&format!("\n{resume:>6}\t")),
+        "line {resume} must NOT already be in this render — it is where the \
+             next one starts"
+    );
+    let next = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": "dump.sql", "offset": resume}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content: next, .. } = next else {
+        panic!("expected ok, got: {next:?}");
+    };
+    assert!(
+        next.starts_with(&format!("{resume:>6}\t")),
+        "reading at the named offset must continue at line {resume}: {next}"
+    );
+}
+
+/// The caps must be invisible for ordinary source: no marker, no footer
+/// noise, byte-identical numbering.
+#[tokio::test]
+async fn ordinary_files_are_unaffected_by_the_byte_caps() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\nlet x = 1;\n").unwrap();
+    let out = ReadFile::default()
+        .execute(&serde_json::json!({"path": "a.rs"}), &cx(dir.path()))
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert!(!content.contains("elided"), "{content}");
+    assert!(!content.contains("cap"), "{content}");
+    assert!(
+        content.ends_with("(2/2 lines shown · read 1× this session)"),
+        "{content}"
+    );
+}
+
+/// **The #4034 witness.** A monotonic paging sweep of one file is stopped
+/// before it can spend a turn's whole budget.
+///
+/// The observed turn made 164 forty-line reads of one 3,943-line file for
+/// $7.83, ran off the end, wrapped to offset 1 and started over. Every
+/// loop verdict stayed silent because each read returned a genuinely
+/// different window — all four are defined on byte-identical *output*, and
+/// this sweep never repeats one. On `main` this test's forty reads all
+/// succeed and the turn is left to grind to `max_steps`.
+#[tokio::test]
+async fn a_monotonic_paging_sweep_is_refused_before_it_burns_a_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = (1..=4000)
+        .map(|n| format!("line {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(dir.path().join("deck_ui.rs"), &body).unwrap();
+    let tool = ReadFile::default();
+    let ctx = cx(dir.path());
+
+    let mut refused_at = None;
+    let mut refusals = Vec::new();
+    for step in 0..40u64 {
+        let out = tool
+            .execute(
+                &serde_json::json!({
+                    "path": "deck_ui.rs",
+                    "offset": step * 40 + 1,
+                    "limit": 40,
+                }),
+                &ctx,
+            )
+            .await;
+        if let ToolOutput::Error { message, .. } = out {
+            refused_at.get_or_insert(step);
+            refusals.push(message);
+        }
+    }
+    let refused_at = refused_at.expect("the sweep must be refused, not run to the cap");
+    assert!(
+        refused_at < 40,
+        "the sweep has to be stopped before step 40, got {refused_at}"
+    );
+    assert_eq!(
+        refused_at, MAX_UNCHANGED_READS,
+        "the 25th read of unchanged bytes is the first refused"
+    );
+    // Constant by construction — a tally inside it would make every
+    // refusal a different string and leave a model that ignores the
+    // ceiling as undetectable as the sweep that earned it.
+    assert!(
+        refusals.windows(2).all(|w| w[0] == w[1]),
+        "every refusal must be byte-identical: {refusals:?}"
+    );
+    // The remedy has to be reachable from inside this same tool, or the
+    // ceiling is a wall rather than a redirection.
+    assert!(refusals[0].contains("omitting `limit`"), "{}", refusals[0]);
+    assert!(refusals[0].contains("`search`"), "{}", refusals[0]);
+}
+
+/// The remedy the refusal advertises has to actually work: once the
+/// paging sweep has tripped the ceiling, the model is told that "omitting
+/// `limit` shows you all of it at once". A whole-file read at that point
+/// must be let through — otherwise `record_read` counts it as one more
+/// unchanged read and the identical refusal comes back, steering the model
+/// toward an action that can never succeed. Byte-identical whole-file
+/// rereads stay caught by the loop detector, so nothing is lost.
+#[tokio::test]
+async fn a_whole_file_read_escapes_the_ceiling_the_refusal_advertises() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = (1..=200)
+        .map(|n| format!("line {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(dir.path().join("small.rs"), &body).unwrap();
+    let tool = ReadFile::default();
+    let ctx = cx(dir.path());
+
+    // Sweep it in small windows until the ceiling trips, exactly as the
+    // pathological turn did.
+    let mut tripped = false;
+    for step in 0..40u64 {
+        let out = tool
+            .execute(
+                &serde_json::json!({
+                    "path": "small.rs",
+                    "offset": (step % 5) * 40 + 1,
+                    "limit": 40,
+                }),
+                &ctx,
+            )
+            .await;
+        if matches!(out, ToolOutput::Error { .. }) {
+            tripped = true;
+            break;
+        }
+    }
+    assert!(tripped, "the windowed sweep must trip the ceiling");
+
+    // Following the refusal's advice — a whole-file read — must succeed.
+    let out = tool
+        .execute(&serde_json::json!({"path": "small.rs"}), &ctx)
+        .await;
+    assert!(
+        matches!(out, ToolOutput::Ok { .. }),
+        "the whole-file read the refusal advertises must be reachable: {out:?}"
+    );
+
+    // A windowed read of the same unchanged bytes is still refused — the
+    // exemption is for whole-file reads only, not a hole in the ceiling.
+    let out = tool
+        .execute(
+            &serde_json::json!({"path": "small.rs", "offset": 1, "limit": 40}),
+            &ctx,
+        )
+        .await;
+    assert!(
+        matches!(out, ToolOutput::Error { .. }),
+        "a windowed sweep must still be refused after the ceiling: {out:?}"
+    );
+}
+
+/// The ceiling counts reads of bytes that have not moved, so the
+/// read → edit → read cycle that is most of an agent's working life never
+/// approaches it. Without the reset this would refuse the 25th pass of an
+/// ordinary edit loop.
+#[tokio::test]
+async fn editing_the_file_resets_the_read_ceiling() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("a.rs");
+    let tool = ReadFile::default();
+    let ctx = cx(dir.path());
+    for pass in 0..40 {
+        // A file long enough that the read below is a *window*, and a
+        // window on purpose: a whole-file read is exempt from the ceiling
+        // (it returns identical bytes, so the loop verdicts already catch a
+        // spiral of them), which would make this test pass even with the
+        // reset deleted. The reset is the whole safety argument for the
+        // ceiling, so it has to be exercised by a read the ceiling can
+        // actually refuse.
+        let body: String = (0..200)
+            .map(|line| format!("fn f{line}() {{}} // pass {pass}\n"))
+            .collect();
+        std::fs::write(&path, body).unwrap();
+        let out = tool
+            .execute(
+                &serde_json::json!({"path": "a.rs", "offset": 1, "limit": 40}),
+                &ctx,
+            )
+            .await;
+        assert!(
+            matches!(out, ToolOutput::Ok { .. }),
+            "pass {pass} of a read→edit→read cycle must never be refused: {out:?}"
+        );
+    }
+}
+
+/// A sweep that runs off the end of the file must stagnate like anything
+/// else. The past-end reply embedded the caller's own offset in its
+/// payload, so every call produced a different string, nothing ever
+/// compared equal, and the stagnation rung could not fire on it (#4034).
+/// The offset now rides the footer, which loop comparison strips.
+#[tokio::test]
+async fn past_end_reads_compare_equal_once_the_footer_is_stripped() {
+    use stella_core::driver::loop_evidence::comparable_output;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "one\ntwo\n").unwrap();
+    let tool = ReadFile::default();
+    let ctx = cx(dir.path());
+    let mut compared = Vec::new();
+    for offset in [10, 50, 900] {
+        let out = tool
+            .execute(&serde_json::json!({"path": "a.rs", "offset": offset}), &ctx)
+            .await;
+        assert!(matches!(out, ToolOutput::Ok { .. }), "{out:?}");
+        let ToolOutput::Ok { content, .. } = &*comparable_output(&out) else {
+            panic!("expected ok, got: {out:?}");
+        };
+        compared.push(content.clone());
+    }
+    assert!(
+        compared.windows(2).all(|w| w[0] == w[1]),
+        "three past-end reads at different offsets must normalize to one \
+             string, or stagnation can never fire on a sweep past EOF: {compared:?}"
+    );
+    assert!(
+        !compared[0].contains("900"),
+        "the caller's offset must not survive normalization: {}",
+        compared[0]
+    );
+    assert!(
+        compared[0].contains("past the end"),
+        "the reply still has to say what happened: {}",
+        compared[0]
+    );
+}
+
+/// The footer's producer is here and its consumer is in `stella-core`, so
+/// neither crate's own tests can catch the two drifting apart. This is the
+/// seam that can: real tool output, run through the real normalization the
+/// loop detector compares. Reword the footer on either side without the
+/// other and this fails.
+///
+/// Every shape has to normalize away, not just the bare tally. A read that
+/// clipped a long line or stopped at the payload cap appends further
+/// clauses after it, and a match that ended at the tally would leave the
+/// per-session count in the compared bytes for exactly the large-file
+/// rereads a stuck agent produces most.
+#[tokio::test]
+async fn the_footer_a_read_writes_is_the_one_loop_comparison_strips() {
+    use stella_core::driver::loop_evidence::comparable_output;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("plain.rs"), "fn main() {}\nlet x = 1;\n").unwrap();
+    std::fs::write(
+        dir.path().join("wide.min.js"),
+        "x".repeat(4 * MAX_LINE_BYTES),
+    )
+    .unwrap();
+    let dump = std::iter::repeat_n("y".repeat(4096), 800)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(dir.path().join("dump.sql"), &dump).unwrap();
+
+    // One tool, so the ledger's tally really does move between the two
+    // reads of a file — which is the whole reason the footer is volatile.
+    let tool = ReadFile::default();
+    for name in ["plain.rs", "wide.min.js", "dump.sql"] {
+        let input = serde_json::json!({ "path": name });
+        let first = tool.execute(&input, &cx(dir.path())).await;
+        let second = tool.execute(&input, &cx(dir.path())).await;
+        let (
+            ToolOutput::Ok { content: raw, .. },
+            ToolOutput::Ok {
+                content: raw_again, ..
+            },
+        ) = (&first, &second)
+        else {
+            panic!("expected ok for {name}, got: {first:?} / {second:?}");
+        };
+        assert!(
+            raw.ends_with(READ_FOOTER_CLOSE) && raw.contains(READ_FOOTER_TALLY_END),
+            "{name} emitted no recognizable footer: {raw}"
+        );
+        assert_ne!(
+            raw, raw_again,
+            "{name}: the tally must move, or this proves nothing"
+        );
+
+        let normalized = comparable_output(&first);
+        assert_eq!(
+            normalized,
+            comparable_output(&second),
+            "{name}: two identical reads must compare equal once the footer is off"
+        );
+        let ToolOutput::Ok { content, .. } = normalized.as_ref() else {
+            unreachable!("normalizing an Ok output cannot change its variant");
+        };
+        assert!(
+            !content.contains(READ_FOOTER_TALLY_END),
+            "{name} kept part of the footer: {content}"
+        );
+    }
+}
+
+/// The engine's working-set restoration (#2685) replays this tool by the
+/// name and path parameter `stella_core::restore` spells, and refuses the
+/// replay unless the schema declares `read_only` — the same one-definition
+/// tie as the footer test above. A drift on either side is not cosmetic:
+/// it is restoration silently ceasing to restore files.
+///
+/// This replaces the narrowed `the_read_tool_keeps_the_schema_shape_a_replay_requires`
+/// that stood in while the replay was disarmed by the tool purge (#3244):
+/// the constants exist again, so the pin goes back to asserting against
+/// them rather than against literals (#3470).
+#[test]
+fn the_read_tool_is_the_one_the_engines_restoration_replays() {
+    let schema = ReadFile::default().schema();
+    assert_eq!(schema.name, stella_core::restore::READ_TOOL);
+    assert!(
+        schema.read_only,
+        "restoration (and the parked-wait probe) replay only schema-declared \
+             read-only tools; dropping the claim silently disables both"
+    );
+    assert!(
+        schema.input_schema["properties"]
+            .get(stella_core::restore::READ_PATH_PARAM)
+            .is_some(),
+        "the path parameter must keep the spelling the engine replays"
+    );
+}
+
+/// A binary file used to come back as "stream did not contain valid
+/// UTF-8", which reads to a model as a transient IO fault worth retrying.
+/// It must be named as binary and point somewhere useful.
+#[tokio::test]
+async fn a_binary_file_is_named_as_binary_not_as_an_io_fault() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("blob.bin"), [0x00u8, 0xff, 0xfe, 0x41]).unwrap();
+    let out = ReadFile::default()
+        .execute(&serde_json::json!({"path": "blob.bin"}), &cx(dir.path()))
+        .await;
+    match out {
+        ToolOutput::Error { message, .. } => {
+            assert!(message.contains("binary"), "{message}");
+            assert!(message.contains("not UTF-8"), "{message}");
+        }
+        ToolOutput::Ok { content, .. } => panic!("expected error, got: {content}"),
+    }
+}
+
+/// A directory used to surface the raw `Is a directory (os error 21)`,
+/// which says what the syscall thought and not what to do instead.
+#[tokio::test]
+async fn a_directory_is_refused_with_the_tool_that_does_answer() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    let out = ReadFile::default()
+        .execute(&serde_json::json!({"path": "src"}), &cx(dir.path()))
+        .await;
+    match out {
+        ToolOutput::Error { message, .. } => {
+            assert!(message.contains("is a directory"), "{message}");
+            assert!(message.contains("glob("), "names the tool: {message}");
+        }
+        ToolOutput::Ok { content, .. } => panic!("expected error, got: {content}"),
+    }
+}
+
+/// The heap half of the caps: `offset`/`limit` bound what the MODEL sees,
+/// never what Stella loads, so a one-line read of a multi-gigabyte dump
+/// paid for the whole file. Above the ceiling the refusal is named and
+/// points at the tools that stream.
+#[tokio::test]
+async fn an_oversized_file_is_refused_before_it_is_loaded() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dump.sql");
+    let file = std::fs::File::create(&path).unwrap();
+    // Sparse: the ceiling is decided from metadata, so no bytes are spent.
+    file.set_len(MAX_FILE_BYTES + 1).unwrap();
+    drop(file);
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": "dump.sql", "offset": 1, "limit": 1}),
+            &cx(dir.path()),
+        )
+        .await;
+    match out {
+        ToolOutput::Error { message, .. } => {
+            assert!(message.contains("ceiling"), "{message}");
+            assert!(message.contains("grep"), "points somewhere: {message}");
+        }
+        ToolOutput::Ok { content, .. } => {
+            panic!("an oversized file must be refused, got: {content}")
+        }
+    }
+}
+
+#[tokio::test]
+async fn missing_file_returns_error() {
+    let dir = std::env::temp_dir();
+    let result = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": "nonexistent_xyz_123.txt"}),
+            &cx(&dir),
+        )
+        .await;
+    assert!(result.is_error());
+}
+
+/// **Reads are not confined to the workspace**, and this test now says so.
+///
+/// It used to assert that `../../etc/passwd` was refused. That was the
+/// behaviour when `read_file` opened only the session root, and it is the
+/// behaviour that was deliberately changed: an agent fixing a build needs
+/// system headers, the toolchain and a dependency's source, and a read
+/// cannot damage the user's tree (`stella_core::workspace_scope`).
+///
+/// Worth noting how it was passing on macOS while the change was already
+/// in: `std::env::temp_dir()` there is `/var/folders/…/T/`, so
+/// `../../etc/passwd` resolves to a path that does not exist, and the read
+/// failed for the wrong reason. On Linux CI the same expression resolves
+/// to the real `/etc/passwd` and the read succeeded — which is how the
+/// stale assertion surfaced at all. A test that passes on one platform by
+/// accident of path arithmetic is worse than no test, so this one now
+/// pins the rule directly, on a file it creates itself.
+#[tokio::test]
+async fn a_read_outside_the_workspace_is_allowed() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let elsewhere = tempfile::tempdir().expect("elsewhere");
+    let outside = elsewhere.path().join("readable.txt");
+    std::fs::write(&outside, "readable\n").expect("write");
+
+    let result = ReadFile::default()
+        .execute(
+            &serde_json::json!({ "path": outside.to_string_lossy() }),
+            &cx(workspace.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = result else {
+        panic!("a read outside the workspace must succeed: {result:?}");
+    };
+    assert!(content.contains("readable"), "{content}");
+}
+
+/// The one read that IS refused: another session's worktree — a second
+/// checkout of the same repository at another revision, so reading it
+/// answers about the wrong copy of the file being edited.
+#[tokio::test]
+async fn a_read_into_a_sibling_worktree_is_refused() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let worktree = workspace.path().join(".stella/worktrees/sibling");
+    std::fs::create_dir_all(&worktree).expect("mkdir");
+    std::fs::write(worktree.join("other.rs"), "pub fn other() {}\n").expect("write");
+
+    let result = ReadFile::default()
+        .execute(
+            &serde_json::json!({ "path": ".stella/worktrees/sibling/other.rs" }),
+            &cx(workspace.path()),
+        )
+        .await;
+    assert!(result.is_error(), "{result:?}");
+}
+
+#[tokio::test]
+async fn missing_path_field_returns_error() {
+    let dir = std::env::temp_dir();
+    let result = ReadFile::default()
+        .execute(&serde_json::json!({}), &cx(&dir))
+        .await;
+    assert!(result.is_error());
+}
+
+// ── batching (#4151) ──────────────────────────────────────────────────
+
+/// **The #4151 witness.** One call, several files.
+///
+/// The measured defect: in one execution the model issued 24 `sed -n
+/// 'A,Bp'` range reads against 2 `read_file` calls, with `read_file`
+/// recording zero errors — it was reaching for `bash` because that was the
+/// only surface through which it could ask about several files at once. On
+/// `main` there is no `files` key, so this call reads nothing.
+#[tokio::test]
+async fn one_call_reads_several_files() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn b() {}\nfn b2() {}\n").unwrap();
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "a.rs"},
+                {"path": "b.rs", "offset": 2, "limit": 1}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    // Each section names its file — with two of them in one payload, an
+    // unlabelled render is unreadable.
+    assert!(content.contains("===== a.rs ====="), "{content}");
+    assert!(content.contains("===== b.rs ====="), "{content}");
+    assert!(content.contains("fn a() {}"), "{content}");
+    // The per-target range is honoured, not just the path.
+    assert!(content.contains("fn b2() {}"), "{content}");
+    assert!(
+        !content.contains("1\tfn b() {}"),
+        "b.rs was asked for from line 2: {content}"
+    );
+}
+
+/// The safety half, and the reason batching could not just be a loop.
+///
+/// `MAX_RENDER_BYTES` bounds one render. Applied per file, a ten-file batch
+/// would be a 640 KB tool result — the exact context flood #1842 closed,
+/// reopened by the new key. The budget is spent across the whole call, and
+/// what did not fit is named rather than dropped silently.
+#[tokio::test]
+async fn the_payload_cap_is_a_batch_budget_not_a_per_file_one() {
+    let dir = tempfile::tempdir().unwrap();
+    // Each file alone would fill the whole single-read budget.
+    let body = std::iter::repeat_n("y".repeat(4096), 800)
+        .collect::<Vec<_>>()
+        .join("\n");
+    for name in ["one.sql", "two.sql", "three.sql"] {
+        std::fs::write(dir.path().join(name), &body).unwrap();
+    }
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "one.sql"}, {"path": "two.sql"}, {"path": "three.sql"}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert!(
+        content.len() < MAX_RENDER_BYTES + 8192,
+        "three files must share one budget, not get one each (got {} bytes, \
+             per-file would be ~{})",
+        content.len(),
+        3 * MAX_RENDER_BYTES
+    );
+    // Silent truncation would read as "you have seen all three".
+    assert!(
+        content.contains("payload cap"),
+        "the cap is named: {content}"
+    );
+}
+
+/// Every file in a batch earns its own ledger entry.
+///
+/// This is the obligation that makes batching safe to prefer over `sed`:
+/// the read→edit drift oracle (#331) and `write_file`'s no-clobber guard
+/// both key on `ReadLedger`, and a shell read records nothing. A batch that
+/// recorded only its first file would reintroduce the same blindness
+/// through the front door.
+#[tokio::test]
+async fn every_file_in_a_batch_is_recorded_in_the_ledger() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "one\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "two\n").unwrap();
+    let ledger = Arc::new(ReadLedger::default());
+    let tool = ReadFile::with_ledger(ledger.clone());
+
+    let out = tool
+        .execute(
+            &serde_json::json!({"files": [{"path": "a.rs"}, {"path": "b.rs"}]}),
+            &cx(dir.path()),
+        )
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+
+    for (name, bytes) in [("a.rs", b"one\n".as_slice()), ("b.rs", b"two\n".as_slice())] {
+        assert_eq!(
+            ledger.last_seen_sha(dir.path(), name),
+            Some(crate::staleness::hex_sha256(bytes)),
+            "{name} must be recorded, or edit_file's drift oracle goes blind on it"
+        );
+        assert!(
+            ledger.saw_whole_file(dir.path(), name),
+            "{name} was shown in full, so the no-clobber guard must know it"
+        );
+    }
+}
+
+/// A miss inside a batch reports in place and the rest still render.
+///
+/// A read leaves nothing half-done, so all-or-nothing would throw away work
+/// that succeeded. This is also what the `sed` chains being replaced did —
+/// minus having to guess from the output which command failed.
+#[tokio::test]
+async fn a_failed_target_does_not_discard_the_rest_of_the_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("real.rs"), "fn real() {}\n").unwrap();
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "ghost.rs"}, {"path": "real.rs"}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("a batch with one bad path must still return the good one: {out:?}");
+    };
+    assert!(content.contains("not read:"), "{content}");
+    assert!(content.contains("fn real() {}"), "{content}");
+}
+
+/// Both spellings at once is refused rather than resolved by precedence:
+/// either choice silently drops work, and the model cannot tell which half
+/// ran.
+#[tokio::test]
+async fn the_single_and_plural_spellings_cannot_be_mixed() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "one\n").unwrap();
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"path": "a.rs", "files": [{"path": "a.rs"}]}),
+            &cx(dir.path()),
+        )
+        .await;
+    assert!(out.is_error(), "{out:?}");
+}

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 /// A bare execution context rooted at `root` — every file-tool test

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -54,16 +54,26 @@ impl Tool for WriteFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "write_file".into(),
-            description: "Create or overwrite a file. Creates parent directories as needed. Overwriting an existing file is refused unless you have already read all of it this session — read_file it in full first, or use edit_file to change part of it in place.".into(),
+            description: "Create or overwrite a file. Creates parent directories as needed. Overwriting an existing file is refused unless you have already read all of it this session — read_file it in full first, or use edit_file to change part of it in place. To create several files, send them in ONE call with `files`: the whole batch is checked before any of it is written.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "File path relative to workspace root" },
                     "content": { "type": "string", "description": "Full file content to write" },
+                    "files": crate::batch::plural_schema(
+                        serde_json::json!({
+                            "path": { "type": "string", "description": "File path relative to workspace root" },
+                            "content": { "type": "string", "description": "Full file content to write" }
+                        }),
+                        &["path", "content"],
+                        "Several files written as ONE all-or-nothing change — every path is \
+                         scope-checked and every overwrite guard is asked before any byte is \
+                         written.",
+                    ),
                     "reason": { "type": "string", "description": "Why you are creating/overwriting this file — recorded in the session's file-touch audit log" },
                     "storage_intent": { "type": "string", "description": "Only when creating a database table/column that the storage gate flagged as similar to an existing one: one sentence of purpose plus why the existing objects don't fit. Recorded in stella.storage.toml." }
                 },
-                "required": ["path", "content"]
+                "required": []
             }),
             read_only: false,
             speculation_safe: false,
@@ -71,6 +81,100 @@ impl Tool for WriteFile {
     }
 
     async fn execute(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+        if crate::batch::is_plural(input, FILES_KEY) {
+            return self.write_batch(input, ctx).await;
+        }
+        self.write_one(input, ctx).await
+    }
+}
+
+/// The plural key: several files written as one all-or-nothing change.
+const FILES_KEY: &str = "files";
+
+/// One file and its contents — the unit both spellings reduce to.
+struct WriteTarget {
+    path: String,
+    content: String,
+}
+
+/// Parse one target. Shared by the single form and by every element of
+/// `files`, so the two spellings cannot drift into two meanings.
+fn write_target(value: &Value) -> Result<WriteTarget, crate::input::InputError> {
+    Ok(WriteTarget {
+        path: crate::input::required_str(value, "path")?.to_string(),
+        content: crate::input::required_str(value, "content")?.to_string(),
+    })
+}
+
+impl WriteFile {
+    /// Write several files as one change.
+    ///
+    /// Every path is scope-resolved and every no-clobber guard is asked
+    /// **before** any byte is written, so a batch that would be refused on its
+    /// third file does not leave the first two on disk. Rolling a write back is
+    /// not possible once the old bytes are gone; validating first is, and it is
+    /// the same guarantee for the case that actually happens.
+    async fn write_batch(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
+        let root = ctx.root();
+        let targets = match crate::batch::targets(input, FILES_KEY, "path", write_target) {
+            Ok(targets) => targets,
+            Err(err) => return ToolOutput::from(err),
+        };
+
+        // Pass one: resolve and check. Nothing is written in this loop.
+        let mut planned = Vec::with_capacity(targets.len());
+        for (index, target) in targets.iter().enumerate() {
+            let (scope_root, path) = match ctx.resolve_for_write(&target.path) {
+                Ok(resolved) => resolved,
+                Err(refusal) => {
+                    return ToolOutput::error(format!(
+                        "`{FILES_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
+                        target.path
+                    ));
+                }
+            };
+            let handle = match crate::rootfd::RootHandle::open(&scope_root) {
+                Ok(handle) => Arc::new(handle),
+                Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+            };
+            if handle.stat(&path).is_ok() && !self.ledger.saw_whole_file(root, &path) {
+                return ToolOutput::error(format!(
+                    "`{FILES_KEY}`[{index}]: refusing to overwrite `{path}`: this session has \
+                     not been shown the whole file, and `write_file` replaces all of it. Read \
+                     it first (`read_file` with no offset/limit), then write — or use \
+                     `edit_file` to change part of it in place. Nothing was written."
+                ));
+            }
+            planned.push((handle, path, target.content.as_str()));
+        }
+
+        // Pass two: every check passed, so commit.
+        let mut report = Vec::with_capacity(planned.len());
+        for (handle, path, content) in planned {
+            match crate::durable_write::write_file_durably_at(
+                handle,
+                path.clone(),
+                content.as_bytes().to_vec(),
+                true,
+            )
+            .await
+            {
+                Ok(()) => {
+                    self.ledger.record_known(root, &path, content);
+                    self.ledger.record_coverage(root, &path, true);
+                    report.push(format!("{path} — {} bytes", content.len()));
+                }
+                Err(e) => return ToolOutput::error(format!("failed to write `{path}`: {e}")),
+            }
+        }
+        ToolOutput::ok(format!(
+            "wrote {} file(s):\n{}",
+            report.len(),
+            report.join("\n")
+        ))
+    }
+
+    async fn write_one(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         let root = ctx.root();
         let path = match crate::input::required_str(input, "path") {
             Ok(v) => v,
@@ -334,5 +438,65 @@ mod tests {
             .execute(&serde_json::json!({"path": "ok.txt"}), &cx(&dir))
             .await;
         assert!(result.is_error());
+    }
+
+    // ── batching (#4151) ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn one_call_writes_several_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = WriteFile::default()
+            .execute(
+                &serde_json::json!({"files": [
+                    {"path": "a.rs", "content": "fn a() {}\n"},
+                    {"path": "nested/b.rs", "content": "fn b() {}\n"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        assert!(!out.is_error(), "{out:?}");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+            "fn a() {}\n"
+        );
+        // Parent directories are still created, as the single form does.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("nested/b.rs")).unwrap(),
+            "fn b() {}\n"
+        );
+    }
+
+    /// Every guard is asked before any byte is written, so a batch refused on
+    /// its second file does not leave the first one on disk. A write cannot be
+    /// rolled back once the old bytes are gone; checking first is the same
+    /// guarantee for the case that actually happens.
+    #[tokio::test]
+    async fn a_batch_refused_on_a_later_file_writes_none_of_them() {
+        let dir = tempfile::tempdir().unwrap();
+        // An existing file this session has never read: the no-clobber guard
+        // must refuse it, and take the whole batch down with it.
+        std::fs::write(dir.path().join("existing.rs"), "original\n").unwrap();
+
+        let out = WriteFile::default()
+            .execute(
+                &serde_json::json!({"files": [
+                    {"path": "fresh.rs", "content": "new\n"},
+                    {"path": "existing.rs", "content": "clobbered\n"}
+                ]}),
+                &cx(dir.path()),
+            )
+            .await;
+        let ToolOutput::Error { message, .. } = out else {
+            panic!("the no-clobber guard must refuse the batch: {out:?}");
+        };
+        assert!(message.contains("Nothing was written"), "{message}");
+        assert!(
+            !dir.path().join("fresh.rs").exists(),
+            "the file that would have succeeded must not have landed"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("existing.rs")).unwrap(),
+            "original\n"
+        );
     }
 }

--- a/docs/tools/delete_file.toml
+++ b/docs/tools/delete_file.toml
@@ -27,13 +27,29 @@ available_for_speculation = false
 risk_level = "destructive"
 
 description = '''
-Delete a file in the workspace. Prefer this over `bash rm`. A symlink is removed as the link; its target is left alone.
+Delete a file in the workspace. Prefer this over `bash rm`. A symlink is removed as the link; its target is left alone. To delete several files, send them in ONE call with `files`: every path is checked before any of them is removed.
 '''
 
 # The JSON Schema the model is handed for this tool's arguments, verbatim.
 input_schema = '''
 {
   "properties": {
+    "files": {
+      "description": "Several files deleted in one call — every path is scope-checked and confirmed to be a file before any of them is removed. Use this to act on several targets in ONE call instead of several calls. Omit it and use the single-target fields above for one target; passing both is refused. At most 32.",
+      "items": {
+        "properties": {
+          "path": {
+            "description": "Workspace-relative path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "path": {
       "description": "Workspace-relative path",
       "type": "string"
@@ -43,9 +59,7 @@ input_schema = '''
       "type": "string"
     }
   },
-  "required": [
-    "path"
-  ],
+  "required": [],
   "type": "object"
 }
 '''

--- a/docs/tools/edit_file.toml
+++ b/docs/tools/edit_file.toml
@@ -27,13 +27,43 @@ available_for_speculation = false
 risk_level = "medium"
 
 description = '''
-Replace an exact substring in a file. By default the old_string must appear exactly once; set replace_all to replace every occurrence.
+Replace an exact substring in a file. By default the old_string must appear exactly once; set replace_all to replace every occurrence. To make several edits — in one file or across files — send them in ONE call with `edits`: the whole batch applies or none of it does, and later edits see the earlier ones.
 '''
 
 # The JSON Schema the model is handed for this tool's arguments, verbatim.
 input_schema = '''
 {
   "properties": {
+    "edits": {
+      "description": "Several edits applied as ONE all-or-nothing change, in order — two edits to the same file compose, and if any edit fails nothing is written. Use this to act on several targets in ONE call instead of several calls. Omit it and use the single-target fields above for one target; passing both is refused. At most 32.",
+      "items": {
+        "properties": {
+          "new_string": {
+            "description": "Replacement text",
+            "type": "string"
+          },
+          "old_string": {
+            "description": "Exact text to find",
+            "type": "string"
+          },
+          "path": {
+            "description": "File path relative to workspace root",
+            "type": "string"
+          },
+          "replace_all": {
+            "description": "Replace all occurrences (default false)",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "path",
+          "old_string",
+          "new_string"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "new_string": {
       "description": "Replacement text",
       "type": "string"
@@ -59,11 +89,7 @@ input_schema = '''
       "type": "string"
     }
   },
-  "required": [
-    "path",
-    "old_string",
-    "new_string"
-  ],
+  "required": [],
   "type": "object"
 }
 '''

--- a/docs/tools/read_file.toml
+++ b/docs/tools/read_file.toml
@@ -27,13 +27,37 @@ available_for_speculation = true
 risk_level = "low"
 
 description = '''
-Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges.
+Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges. To read several files — or several ranges — read them in ONE call with `files` rather than one call each.
 '''
 
 # The JSON Schema the model is handed for this tool's arguments, verbatim.
 input_schema = '''
 {
   "properties": {
+    "files": {
+      "description": "Several files, or several ranges of one file, read in a single call. Use this to act on several targets in ONE call instead of several calls. Omit it and use the single-target fields above for one target; passing both is refused. At most 32.",
+      "items": {
+        "properties": {
+          "limit": {
+            "description": "Max lines to return (optional; default and ceiling 2000)",
+            "type": "integer"
+          },
+          "offset": {
+            "description": "1-based start line (optional)",
+            "type": "integer"
+          },
+          "path": {
+            "description": "File path relative to workspace root",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "limit": {
       "description": "Max lines to return (optional; default and ceiling 2000)",
       "type": "integer"
@@ -51,9 +75,7 @@ input_schema = '''
       "type": "string"
     }
   },
-  "required": [
-    "path"
-  ],
+  "required": [],
   "type": "object"
 }
 '''

--- a/docs/tools/write_file.toml
+++ b/docs/tools/write_file.toml
@@ -27,7 +27,7 @@ available_for_speculation = false
 risk_level = "medium"
 
 description = '''
-Create or overwrite a file. Creates parent directories as needed. Overwriting an existing file is refused unless you have already read all of it this session — read_file it in full first, or use edit_file to change part of it in place.
+Create or overwrite a file. Creates parent directories as needed. Overwriting an existing file is refused unless you have already read all of it this session — read_file it in full first, or use edit_file to change part of it in place. To create several files, send them in ONE call with `files`: the whole batch is checked before any of it is written.
 '''
 
 # The JSON Schema the model is handed for this tool's arguments, verbatim.
@@ -37,6 +37,27 @@ input_schema = '''
     "content": {
       "description": "Full file content to write",
       "type": "string"
+    },
+    "files": {
+      "description": "Several files written as ONE all-or-nothing change — every path is scope-checked and every overwrite guard is asked before any byte is written. Use this to act on several targets in ONE call instead of several calls. Omit it and use the single-target fields above for one target; passing both is refused. At most 32.",
+      "items": {
+        "properties": {
+          "content": {
+            "description": "Full file content to write",
+            "type": "string"
+          },
+          "path": {
+            "description": "File path relative to workspace root",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "type": "object"
+      },
+      "type": "array"
     },
     "path": {
       "description": "File path relative to workspace root",
@@ -51,10 +72,7 @@ input_schema = '''
       "type": "string"
     }
   },
-  "required": [
-    "path",
-    "content"
-  ],
+  "required": [],
   "type": "object"
 }
 '''


### PR DESCRIPTION
## Why

One execution ran **24 `sed -n 'A,Bp'` range reads against 2 `read_file` calls** (`.stella/private/store.db`, execution 178, `openrouter`/`moonshotai/kimi-k3`). `read_file` recorded **zero** errors and the turn's first tool call was already a `sed`, so this was not a fallback after a failure. The same turn made **18 `edit_file` calls and zero `sed -i`** — the write-side steering was obeyed exactly.

What leaked was reads, and the cause was arity: eleven of those `bash` calls chained two or three reads with `; echo ===;`. The model was reaching for the only surface through which it could ask one question about several files.

The engine already runs consecutive read-only calls concurrently and the prompt already asks for independent calls to be sent together (#2985). **That path was not taken** — 69 of 71 tool calls carried distinct timestamps, and the two collisions each pair a real tool with a coordination call. Parallel tool calls are a provider capability this workspace declares on no axis and sends on no adapter (#4163), so a model that does not volunteer them has `bash` as its only way to batch.

So the batching goes in the schema, where it holds for every model whatever the wire negotiates. A working surface should not rest on a provider feature nobody declared — that is invariant #8's argument, pointed at tool arity.

## What

Each tool keeps its singular form **byte-identical** and gains one optional array, parsed by the tool's own single-item parser (`crates/stella-tools/src/batch.rs`):

| tool | plural key |
|---|---|
| `read_file` | `files: [{path, offset?, limit?}]` |
| `edit_file` | `edits: [{path, old_string, new_string, replace_all?}]` |
| `write_file` | `files: [{path, content}]` |
| `delete_file` | `files: [{path}]` |

**Invariant #9-clean.** The array *scopes* the operation to N targets; it never *selects* a different one. The plural key changes the arity of a loop and nothing else — same verb, same policy gate, same audit events, same `read_only` claim, and `ctx.resolve_for_write` is still consulted per target. One definition of a target, two spellings of how many: `batch::targets` is handed the very function the single form uses, so the spellings cannot drift into two meanings. Sending both is refused rather than resolved by precedence.

What the batch forms guarantee that a shell chain cannot:

- **`read_file` spends ONE payload budget across the whole call.** Per-file caps would make a ten-file batch a 640 KB tool result — the exact flood #1842 closed. Every file still earns its own ledger entry, coverage flag and unchanged-read tally, so the drift oracle (#331) and the no-clobber guard keep seeing what the model saw. A miss reports in place and the other files still render.
- **`edit_file` is all-or-nothing.** A `sed -i` chain applies edit 1, fails edit 2, and leaves a tree neither the model nor the turn's diff can describe. Every replacement is composed in memory and validated before anything reaches disk. Edits compose in order, so the second edit to a file sees the first — and a batch never reports its own earlier edit as drift.
- **`write_file` and `delete_file` check every target first** — scope, no-clobber, is-it-a-file — so a batch refused on its third target leaves the first two untouched.

### System prompt

The read clause the write clause always had. That asymmetry is the evidence for it: same model, same turn, the paragraph naming `cat > file`/`sed -i`/`rm` was obeyed, and the one that only said "use `read_file` when you already know the exact path" leaked almost everything.

Stated plainly in the code comment and worth repeating here: **wording alone is not expected to carry this and should not be credited if the ratio moves.** The batch forms are the half that removes the incentive rather than arguing with it. #4164 holds the measurement that decides whether anything further (denying shell reads outright) is warranted — deliberately deferred, not done here.

`bash.rs`'s `drift_advisory` rule is respected: no tool-preference advice was added to any tool *output*. Preference lives in the schemas and the system prompt, which is exactly where that doc comment says it belongs.

## Witness tests

New, and failing on `main` where no plural key exists:

- `one_call_reads_several_files`, `the_payload_cap_is_a_batch_budget_not_a_per_file_one`, `every_file_in_a_batch_is_recorded_in_the_ledger`, `a_failed_target_does_not_discard_the_rest_of_the_batch`, `the_single_and_plural_spellings_cannot_be_mixed`
- `one_call_applies_several_edits_across_files`, **`a_batch_that_fails_midway_writes_nothing`**, `two_edits_to_one_file_compose_in_order`, `a_batch_does_not_report_its_own_earlier_edit_as_drift`
- `one_call_writes_several_files`, `a_batch_refused_on_a_later_file_writes_none_of_them`
- `one_call_deletes_several_files`, `a_batch_naming_one_bad_path_deletes_nothing`
- seven parsing witnesses in `batch::tests`, including `a_single_form_miss_keeps_its_original_wording`

**How the fail-on-main property is established** — stated as the inference it is rather than as an executed run: `main`'s `execute` reads only `path`/`offset`/`limit` and ignores unknown keys, so `{"files": [...]}` takes the identical code path as `{}`. The pre-existing `missing_path_is_classified_invalid_input` executes that path today and asserts it returns `Error("missing required field \`path\`")`. Every new batch test asserts `ToolOutput::Ok`, so each fails on `main`. I did not compile the new tests against `main`.

The byte-identical claim for the single form **is** an executed observation: all 22 pre-existing `read_file` tests pass unchanged, including the ones asserting the footer verbatim and the one tying it to the loop detector's stripping.

## Gate

`make gate` — **exit 0**, all 32 steps. `cargo fmt --check`, rustdoc `-D warnings` and clippy `-D warnings` re-run after the final doc-only commit.

## Deleted tests

None. `crates/stella-tools/src/read.rs` was at 1385 of the 1500 ceiling, so its `mod tests` moved to `crates/stella-tools/src/read/tests.rs` — this crate's own convention (`custom/tests.rs`, `registry/tests.rs`). The move is name-preserving; `check-file-size` reports nothing went over.

## Generated files

`docs/tools/{read,edit,write,delete}_file.toml` regenerated with `make tool-docs-update`.

## New dependencies

None.

Refs #4151
Refs #4163
Refs #4164

## Summary by Sourcery

Enable schema-level batching for file operations so agents can handle multiple files without relying on shell command chains.

New Features:
- Add optional batch forms to read_file, edit_file, write_file, and delete_file for operating on multiple targets in one call.

Bug Fixes:
- Preserve existing singular tool behavior while enforcing shared validation, per-target tracking, payload limits, and mutation safety for batched operations.
- Prevent partial edits, writes, and prevalidated deletes when a later batch target fails validation.

Enhancements:
- Centralize batch parsing, limits, mixed-form rejection, and invalid-input classification across file tools.
- Use a single payload budget for batched reads while retaining per-file ledger and coverage tracking.
- Update system prompt guidance to steer multi-file reads and changes toward the file-tool batch interfaces.

Documentation:
- Regenerate file-tool schemas and descriptions to document the new batch parameters and their safety guarantees.

Tests:
- Add coverage for batched reads, edits, writes, and deletes, including ordering, composition, payload budgeting, ledger recording, and no-partial-change guarantees.
- Move the read_file test module into a dedicated test file without removing existing tests.