### PR TITLE
fix(stella-tui): ctrl+o on a tool call reveals its arguments again

### DIFF
--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -74,7 +74,7 @@ use stella_transcript::syntax::{BodyPaint, body_paint, paint_line};
 /// column: the transcript is a scrollback, and a reader who wants to open the
 /// file at that line wants the number the tool actually printed.
 fn push_body_line(
-    rail: Rail,
+    margin: &[Span<'static>],
     line: &str,
     paint: BodyPaint,
     width: usize,
@@ -82,7 +82,7 @@ fn push_body_line(
 ) {
     let painted = paint_line(paint, line);
     let Some(lang) = painted.lang else {
-        push_detail_line(rail, line, width, out);
+        push_detail_line(margin, line, width, out);
         return;
     };
     let mut spans: Vec<Span<'static>> = Vec::new();
@@ -104,7 +104,36 @@ fn push_body_line(
                 None => Span::styled(text, Style::new().fg(theme::MUTED)),
             }),
     );
-    push_detail_spans(rail, spans, width, out);
+    push_detail_spans(margin, spans, width, out);
+}
+
+/// The `ctrl+o` body of a tool **call**: its full argument object, laid out and
+/// coloured under the head, on the head's own rail.
+///
+/// Pretty-printed rather than shown as it arrived, because that is what makes
+/// the colouring worth having — a compact one-line object has no shape for a
+/// key hue to mark. `raw` is capped to a char budget at fold time, so an
+/// over-budget argument may not re-parse; it is still lexed and wrapped rather
+/// than clipped at the pane edge, since it is capped JSON and not some other
+/// format.
+///
+/// `metal` comes from [`crate::v2::transcript_source::head_metal`] rather than
+/// from a `Rail`, so these rows carry the same rail colour as the head they
+/// hang from: a `read_file`'s block is silver-dim end to end, a mutation's is
+/// gold end to end.
+fn argument_rows(
+    metal: ratatui::style::Color,
+    raw: &str,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
+    let margin = block_margin(Style::new().fg(metal));
+    let pretty = serde_json::from_str::<serde_json::Value>(raw)
+        .and_then(|v| serde_json::to_string_pretty(&v))
+        .unwrap_or_else(|_| raw.to_owned());
+    for l in pretty.lines() {
+        push_body_line(&margin, l, BodyPaint::json(), width, out);
+    }
 }
 
 // Pure content builders (unit-tested directly)
@@ -177,7 +206,7 @@ pub(crate) fn entry_lines(
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
-    if !v2_rows(entry, width, out) {
+    if !v2_rows(entry, expanded, width, out) {
         entry_body(entry, files, expand_thinking, expanded, live, width, out);
     }
     if closes_block(entry) {
@@ -201,13 +230,33 @@ pub(crate) fn entry_lines(
 /// working features to make the screen look newer, which is a regression
 /// wearing a redesign's clothes. The result row is restyled in P2, where the
 /// highlighter it needs is built, not here.
-fn v2_rows(entry: &TranscriptEntry, width: usize, out: &mut Vec<Line<'static>>) -> bool {
+///
+/// **A router still owes every feature of the arm it intercepts.** This one did
+/// not: taking the `ToolStart` head made the whole v1 arm unreachable, and the
+/// `ctrl+o` argument view living in its second half went with it — silently,
+/// because a dead *match arm* is invisible to `dead-code-allows` and to
+/// `module-reachability`, which see items. The row rendered identically
+/// expanded and collapsed for as long as nobody pressed the key (#4157). Hence
+/// `expanded` here: a router that takes a head takes the body under it too.
+fn v2_rows(
+    entry: &TranscriptEntry,
+    expanded: bool,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) -> bool {
     use crate::v2::transcript_source as v2;
     match entry {
         TranscriptEntry::ToolStart {
-            name, input, path, ..
+            name,
+            input,
+            raw,
+            path,
+            ..
         } => {
             out.extend(v2::head_rows(name, path.as_deref(), input, width));
+            if expanded {
+                argument_rows(v2::head_metal(name), raw, width, out);
+            }
             true
         }
         TranscriptEntry::Compaction {
@@ -408,62 +457,6 @@ fn entry_body(
                 out,
             );
         }
-        TranscriptEntry::ToolStart {
-            name,
-            input,
-            raw,
-            path,
-            ..
-        } => {
-            // `name` then `argument`, the name soft-padded to a common column
-            // so arguments line up across a run of calls. Soft, not hard: a
-            // long MCP name (`mcp__github__create_pull_request`) overruns the
-            // column rather than being truncated, since the tool's identity
-            // outranks the alignment it would cost.
-            // The tool name is the one thing in the transcript that carries a
-            // categorical hue. Everything a session did, it did through a tool
-            // call, so the names are the index to the whole scrollback — and
-            // they are the only rows a reader scans *for* rather than reads.
-            // The hue is the call's CLASS (`crate::tool_class`), so the margin
-            // answers "was that a read, a write, a shell, a test, a push, a
-            // hand-off" before a name is read. The argument beside it stays
-            // white/dim (`path_spans`), so the colour marks the verb and never
-            // the object.
-            //
-            // Not the brand accent: gold means brand/active/focus, and every
-            // tool name wearing it made the accent mean "a tool ran", which is
-            // every row.
-            let class = crate::tool_class::classify(name);
-            let mut left = vec![Span::styled(
-                pad_name(name),
-                Style::new().fg(class.color()).add_modifier(Modifier::BOLD),
-            )];
-            // An argument-less tool (`get_environment`, a zero-argument
-            // `task_list`) renders NO argument column at all.
-            // The compact-JSON fallback printed a literal `{}` there, which
-            // reads as an empty *result* — the deck's own owner read it that
-            // way and filed it as a bug. Absence is the honest rendering: the
-            // row is the call, and there was nothing to say about it.
-            if !input.is_empty() {
-                left.extend(path_spans(input, path.is_some()));
-            }
-            push_row(Rail::Call, left, width, out);
-            if expanded {
-                // ctrl+o: the full argument object, pretty-printed and dim.
-                // An over-budget argument may not parse (char-capped raw) —
-                // show it wrapped rather than clipped at the pane edge.
-                // Pretty-printing is what makes the coloring worth having: a
-                // compact one-line object has no shape for a key hue to mark.
-                // A body that failed to re-parse is still lexed — it is capped
-                // JSON, not another format.
-                let pretty = serde_json::from_str::<serde_json::Value>(raw)
-                    .and_then(|v| serde_json::to_string_pretty(&v))
-                    .unwrap_or_else(|_| raw.clone());
-                for l in pretty.lines() {
-                    push_body_line(Rail::Call, l, BodyPaint::json(), width, out);
-                }
-            }
-        }
         TranscriptEntry::ToolResult {
             ok,
             path,
@@ -474,6 +467,10 @@ fn entry_body(
             ..
         } => {
             let rail = if *ok { Rail::Result } else { Rail::Fail };
+            // Bound once: every row of this result's block reproduces the same
+            // margin, and re-deriving it per row is how one of them ends up a
+            // cell out of line with the others.
+            let margin = rail.continuation();
             let dim = Style::new().fg(theme::MUTED);
             // A JSON body is re-laid one member to a line *before* anything
             // counts, anchors or folds it. An API response — `gh api`, an MCP
@@ -539,7 +536,7 @@ fn entry_body(
                 );
                 let paint = body_paint(path.as_deref(), full);
                 for l in full.lines() {
-                    push_body_line(rail, l, paint, width, out);
+                    push_body_line(&margin, l, paint, width, out);
                 }
             } else {
                 // With a diff below, a prose summary ("Applied edit to
@@ -605,7 +602,7 @@ fn entry_body(
                     out,
                 );
                 for l in shown.iter().skip(usize::from(!paint.colored())) {
-                    push_body_line(rail, l.trim_end(), paint, width, out);
+                    push_body_line(&margin, l.trim_end(), paint, width, out);
                 }
                 // The "there is more" row, for a success as well as a failure —
                 // it is the only place the hidden count is stated now, and the
@@ -615,7 +612,7 @@ fn entry_body(
                 let hidden = total.saturating_sub(shown.len());
                 if hidden > 0 && inline.is_none() {
                     push_detail_line(
-                        rail,
+                        &margin,
                         &format!("⋯ {} · ctrl+o", plural_lines(hidden)),
                         width,
                         out,
@@ -649,7 +646,7 @@ fn entry_body(
                 let (body, _) =
                     diff::body_lines_inline(d, Some(&dref.path), cap, Some(" · ctrl+o"));
                 for line in body {
-                    push_diff_line(rail, line, out);
+                    push_diff_line(&margin, line, out);
                 }
             }
         }
@@ -1080,6 +1077,17 @@ fn entry_body(
         // narrowed, a missing turn rule is a visible gap a reader can report,
         // where an `unreachable!()` would take the session down mid-frame.
         TranscriptEntry::Complete { .. } => {}
+        // Also the router's — head *and*, on ctrl+o, the argument object under
+        // it. This one **delegates** rather than drawing nothing, which is the
+        // difference between the two arms and the lesson of #4157: the row a
+        // gap here would cost is the call itself, the single most load-bearing
+        // row in the transcript, and the previous version of this arm sat here
+        // looking live while the router quietly took its `expanded` half away.
+        // Delegating means there is one implementation to keep correct and no
+        // second one to rot.
+        TranscriptEntry::ToolStart { .. } => {
+            v2_rows(entry, expanded, width, out);
+        }
     }
 }
 

--- a/crates/stella-tui/src/render/entry/recall.rs
+++ b/crates/stella-tui/src/render/entry/recall.rs
@@ -643,7 +643,7 @@ fn recall_location(uri: &str, cap: usize) -> String {
 /// One table cell: `text` in exactly `col` display columns, elided if it does
 /// not fit and space-padded if it does.
 ///
-/// This is the invariant the whole table rests on. [`pad_name`]'s soft column
+/// This is the invariant the whole table rests on. the tool head's own soft column
 /// is the deliberate opposite — there an over-wide tool name overruns, because
 /// identity outranks alignment on a row nobody reads down a column. Here the
 /// row *is* read down a column, so a cell that overran would displace every

--- a/crates/stella-tui/src/render/row.rs
+++ b/crates/stella-tui/src/render/row.rs
@@ -76,13 +76,35 @@ pub(crate) const LEAD: usize = 2;
 /// call it belonged to.
 pub(crate) const BODY: usize = 4;
 
+/// Content column of every row in a tool-call block: [`RAIL`], a space, one
+/// glyph cell, a space.
+///
+/// The v2 head renderer arrives at the same number from the other side
+/// (`rail_span` + `" {glyph} "`), which is what makes a call and its result one
+/// block; `render::tests::block_rail` is what holds the two to it.
+pub(crate) const BLOCK_BODY: usize = RAIL_W + 3;
+
+/// The margin every row of a tool-call block reproduces *after* its glyph row:
+/// the rail in `metal`, then blanks out to [`BLOCK_BODY`].
+///
+/// Takes the metal rather than a [`Rail`] because the head of a block is drawn
+/// by the v2 event renderer, whose rail wears its **event kind's** colour —
+/// silver-dim for a read, gold for a mutation — and not one of `Rail`'s three
+/// tones. A body row that hard-coded the result's muted tone would leave a
+/// `read_file`'s block with a muted head above a gold body: one block, two
+/// metals, which is exactly the thing the rail exists to stop.
+pub(crate) fn block_margin(metal: Style) -> Vec<Span<'static>> {
+    vec![
+        Span::styled(RAIL, metal),
+        Span::raw(" ".repeat(BLOCK_BODY - RAIL_W)),
+    ]
+}
+
 /// Which rail a transcript row rides. The glyph is the row's type signature —
 /// a reader scanning the margin sees the shape of the session (calls, their
 /// outcomes, prose, prompts) before reading any content.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Rail {
-    /// A tool invocation — the thing that happened.
-    Call,
     /// A tool result body, subordinate to the call above it.
     Result,
     /// A failed tool result. Distinct glyph *and* column-2 position, so a
@@ -100,7 +122,7 @@ impl Rail {
     /// Whether this rail belongs to a tool-call block, and so opens every one
     /// of its rows with [`RAIL`].
     pub(crate) fn railed(self) -> bool {
-        matches!(self, Rail::Call | Rail::Result | Rail::Fail)
+        matches!(self, Rail::Result | Rail::Fail)
     }
 
     /// The literal prefix this rail prints before a row's first line.
@@ -110,7 +132,6 @@ impl Rail {
     /// call, its result and its body then share one left edge instead of three.
     pub(crate) fn prefix(self) -> &'static str {
         match self {
-            Rail::Call => " │ ● ",
             Rail::Result => " │ ⎿ ",
             Rail::Fail => " │ ✗ ",
             Rail::User => "▌ ",
@@ -136,10 +157,7 @@ impl Rail {
         if !self.railed() {
             return vec![Span::raw(" ".repeat(self.indent()))];
         }
-        vec![
-            Span::styled(RAIL, self.style()),
-            Span::raw(" ".repeat(self.indent() - RAIL_W)),
-        ]
+        block_margin(self.style())
     }
 
     /// The style the rail glyph itself renders in. Content styling is the
@@ -147,7 +165,6 @@ impl Rail {
     /// margin reads consistently even when content colors vary.
     pub(crate) fn style(self) -> Style {
         match self {
-            Rail::Call => Style::new().fg(theme::ACCENT),
             Rail::Result => Style::new().fg(theme::MUTED),
             Rail::Fail => Style::new().fg(theme::DANGER),
             Rail::User => Style::new().fg(theme::VIOLET).add_modifier(Modifier::BOLD),
@@ -314,14 +331,23 @@ pub(crate) fn push_row(
 /// Emit one body row of a tool-call block — a preview line, an expanded
 /// (ctrl+o) body line, the `⋯ N lines` affordance.
 ///
-/// Rides `rail`'s own margin, so the row sits directly under its result's
-/// content and the block's rail runs unbroken past it. `rail` is the *result's*
-/// rail rather than a fixed one because a failure's block is drawn in danger
-/// and a success's in muted: a body that hard-coded either would leave one of
-/// the two with a rail that changes colour halfway down.
-pub(crate) fn push_detail_line(rail: Rail, text: &str, width: usize, out: &mut Vec<Line<'static>>) {
+/// Rides `margin` — [`Rail::continuation`] for a row under a v1 rail,
+/// [`block_margin`] for one under the v2-drawn head — so the row sits at the
+/// block's content column and the rail runs unbroken past it.
+///
+/// The margin is passed rather than derived because the three things a block
+/// body can hang from wear three different metals: a success recedes to muted,
+/// a failure stands in danger, and a call's own arguments take the event kind's
+/// colour from the v2 head above them. Deriving any one of those here would
+/// give one of the three a rail that changes colour halfway down.
+pub(crate) fn push_detail_line(
+    margin: &[Span<'static>],
+    text: &str,
+    width: usize,
+    out: &mut Vec<Line<'static>>,
+) {
     push_detail_spans(
-        rail,
+        margin,
         vec![Span::styled(text.to_owned(), Style::new().fg(theme::MUTED))],
         width,
         out,
@@ -333,21 +359,20 @@ pub(crate) fn push_detail_line(rail: Rail, text: &str, width: usize, out: &mut V
 /// coloring it exists to show. Indent, column, and wrapping are identical, so
 /// the two forms interleave in one body without a seam.
 pub(crate) fn push_detail_spans(
-    rail: Rail,
+    margin: &[Span<'static>],
     content: Vec<Span<'static>>,
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
-    let cont = rail.continuation();
-    let mut spans = cont.clone();
+    let mut spans = margin.to_vec();
     spans.extend(content);
-    wrap_one_lead(Line::from(spans), width, &cont, out);
+    wrap_one_lead(Line::from(spans), width, margin, out);
 }
 
 /// Emit a system-note row: `↻ retry`, `⇣ compacted`, `✗ error` and friends.
 ///
 /// These rows *are* their own rail — each label already opens with a glyph in
-/// column 0, so it indexes the margin exactly like [`Rail::Call`] does without
+/// column 0, so it indexes the margin exactly like [`Rail::Result`] does without
 /// needing a second marker in front of it. Content follows two spaces later;
 /// wrapped lines indent to [`LEAD`].
 pub(crate) fn push_note(
@@ -436,8 +461,12 @@ pub(crate) fn push_gap(out: &mut Vec<Line<'static>>) {
 /// un-wrapped — the transcript renders without wrap (one logical line per row
 /// keeps the scroll math line-exact), so overflow clips at the pane edge like
 /// the diff viewer, and the line-number gutter never mis-aligns mid-diff.
-pub(crate) fn push_diff_line(rail: Rail, line: Line<'static>, out: &mut Vec<Line<'static>>) {
-    let mut spans = rail.continuation();
+pub(crate) fn push_diff_line(
+    margin: &[Span<'static>],
+    line: Line<'static>,
+    out: &mut Vec<Line<'static>>,
+) {
+    let mut spans = margin.to_vec();
     spans.extend(line.spans);
     // The one row that reaches the buffer without passing through
     // [`wrap_one_indent`], and so the one that needs [`expand_tabs`] by name: a
@@ -472,20 +501,9 @@ pub(crate) fn push_row_block(
 /// stay flush-right and only genuinely wide ones are reined in.
 pub(crate) const METRIC_SPAN: usize = 140;
 
-/// Soft column the tool-name field pads to, so arguments align down a run of
-/// calls. A longer name overruns it rather than truncating — identity beats
-/// alignment — and the argument simply starts one space later on that row.
-pub(crate) const NAME_COL: usize = 13;
-
 /// Lines of a *failed* result shown without expanding. Enough for a compiler
 /// error with its location and caret line, or the top of a panic backtrace.
 pub(crate) const FAIL_PREVIEW: usize = 6;
-
-/// Pad a tool name to [`NAME_COL`], display-width aware.
-pub(crate) fn pad_name(name: &str) -> String {
-    let w = UnicodeWidthStr::width(name);
-    format!("{name}{} ", " ".repeat(NAME_COL.saturating_sub(w + 1)))
-}
 
 /// A duration at human scale. Raw milliseconds are the wrong unit above a
 /// second — `4210ms` forces the reader to count digits to learn "about four
@@ -533,23 +551,6 @@ pub(crate) fn thousands(n: usize) -> String {
         out.push(c);
     }
     out
-}
-
-/// Split a path into (directory, basename) spans so the basename carries the
-/// emphasis. In a scan, the file *identity* is what the eye is hunting; the
-/// directory is context that only matters once you've found the file, so it
-/// recedes. Non-path text renders as a single unemphasised span.
-pub(crate) fn path_spans(text: &str, is_path: bool) -> Vec<Span<'static>> {
-    let dim = Style::new().fg(theme::MUTED);
-    let bright = Style::new().fg(theme::INK);
-    match text.rfind('/').filter(|_| is_path) {
-        Some(cut) => vec![
-            Span::styled(text[..=cut].to_owned(), dim),
-            Span::styled(text[cut + 1..].to_owned(), bright),
-        ],
-        None if is_path => vec![Span::styled(text.to_owned(), bright)],
-        None => vec![Span::styled(text.to_owned(), dim)],
-    }
 }
 
 /// Lay a row out as `left … right`, with `right` flush to the pane edge and

--- a/crates/stella-tui/src/render/tests/block_rail.rs
+++ b/crates/stella-tui/src/render/tests/block_rail.rs
@@ -208,7 +208,7 @@ fn the_v1_block_rail_is_the_v2_event_rail() {
         expected_rail(),
         "the transcript now draws two different rails"
     );
-    for rail in [Rail::Call, Rail::Result, Rail::Fail] {
+    for rail in [Rail::Result, Rail::Fail] {
         assert!(
             rail.prefix().starts_with(RAIL),
             "{rail:?} opens a block without the rail"
@@ -228,4 +228,121 @@ fn the_v1_block_rail_is_the_v2_event_rail() {
             "{rail:?}'s continuation drops the rail: {margin:?}"
         );
     }
+}
+
+// ── ctrl+o on a call reveals its arguments again (#4157) ────────────────────
+
+/// A call carrying a `raw` argument object.
+fn call_with_args() -> TranscriptEntry {
+    TranscriptEntry::ToolStart {
+        call_id: "c1".into(),
+        name: "edit_file".into(),
+        input: "src/lib.rs".into(),
+        raw: r#"{"path":"src/lib.rs","old_string":"alpha","new_string":"bravo"}"#.into(),
+        path: Some("src/lib.rs".into()),
+    }
+}
+
+fn render(entry: &TranscriptEntry, expanded: bool) -> Vec<String> {
+    let mut out = Vec::new();
+    entry_lines(entry, &[], false, expanded, false, WIDTH, &mut out);
+    out.iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+/// The witness. `ctrl+o` on a **call** row reveals the argument object it was
+/// dispatched with.
+///
+/// The regression it pins: the v2 head router intercepted every `ToolStart` and
+/// returned before `entry_body` ran, so the `expanded` flag was never consulted
+/// for a call and the row rendered identically either way. Nothing caught it —
+/// a dead *match arm* is invisible to `dead-code-allows` and to
+/// `module-reachability`, both of which see items (#4157).
+#[test]
+fn ctrl_o_on_a_call_reveals_its_arguments() {
+    let call = call_with_args();
+    let collapsed = render(&call, false);
+    let expanded = render(&call, true);
+
+    assert!(
+        !collapsed.iter().any(|r| r.contains("old_string")),
+        "the collapsed row already shows the argument object, so the test \
+         proves nothing:\n{collapsed:#?}"
+    );
+    assert!(
+        expanded.iter().any(|r| r.contains("\"old_string\"")),
+        "ctrl+o revealed nothing — the argument object is unreachable:\n{expanded:#?}"
+    );
+    // Pretty-printed, not the compact one-liner it arrived as: a flat object
+    // has no shape for a key hue to mark, which is the whole reason to expand.
+    assert!(
+        expanded.len() > collapsed.len() + 3,
+        "the arguments were shown, but on one line:\n{expanded:#?}"
+    );
+}
+
+/// Those revealed rows ride the block rail like every other row, and in the
+/// **head's own metal** — a `read_file`'s block is silver-dim end to end, a
+/// mutation's gold end to end, never one above the other.
+#[test]
+fn revealed_arguments_ride_the_heads_own_rail() {
+    let rail = expected_rail();
+    for name in ["read_file", "edit_file", "bash"] {
+        let call = TranscriptEntry::ToolStart {
+            call_id: "c1".into(),
+            name: name.into(),
+            input: "src/lib.rs".into(),
+            raw: r#"{"path":"src/lib.rs","limit":40}"#.into(),
+            path: Some("src/lib.rs".into()),
+        };
+        let mut lines = Vec::new();
+        entry_lines(&call, &[], false, true, false, WIDTH, &mut lines);
+        let railed: Vec<_> = lines
+            .iter()
+            .filter(|l| {
+                l.spans
+                    .first()
+                    .is_some_and(|s| s.content.starts_with(&rail))
+            })
+            .collect();
+        assert!(
+            railed.len() > 1,
+            "{name}: the revealed arguments are not on the rail"
+        );
+        let metals: std::collections::BTreeSet<_> = railed
+            .iter()
+            .map(|l| format!("{:?}", l.spans[0].style.fg))
+            .collect();
+        assert_eq!(
+            metals.len(),
+            1,
+            "{name}: the block's rail changes metal between the head and the \
+             arguments under it: {metals:?}"
+        );
+    }
+}
+
+/// An argument object big enough to have been cut by the fold's char cap no
+/// longer parses. It is still shown — lexed as the capped JSON it is — rather
+/// than swallowed.
+#[test]
+fn an_unparseable_argument_object_is_still_shown() {
+    let call = TranscriptEntry::ToolStart {
+        call_id: "c1".into(),
+        name: "bash".into(),
+        input: "echo".into(),
+        raw: r#"{"command":"echo hello","cwd":"/tm"#.into(),
+        path: None,
+    };
+    let rendered = render(&call, true);
+    assert!(
+        rendered.iter().any(|r| r.contains("echo hello")),
+        "a capped argument object was dropped instead of shown:\n{rendered:#?}"
+    );
 }

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -25,6 +25,7 @@
 //! arm per tool is a renderer that silently drops the ones a user added — the
 //! reasoning [`stella_transcript::ToolKind`] already states.
 
+use ratatui::style::Color;
 use ratatui::text::Line;
 
 use super::transcript::{Event, EventKind, Extent, Receipt, event_rows, receipt, turn_end};
@@ -43,6 +44,19 @@ pub fn head_rows(name: &str, path: Option<&str>, input: &str, width: usize) -> V
     // "collapsed" in the fold sense — there is no body under it yet.
     event.collapsed = Some(false);
     event_rows(&event, width)
+}
+
+/// The rail metal [`head_rows`] draws this call in (SPEC 6.2) — silver-dim for
+/// a read, gold for anything that acts, red for a delete.
+///
+/// Exposed because the head is only the first row of a call's block: the rows
+/// the deck hangs *under* it — the expanded argument object — have to reproduce
+/// the same rail, and deriving the colour a second time from the tool name is
+/// how the two ends of one block come to disagree about what metal it is. One
+/// derivation, read by both.
+#[must_use]
+pub fn head_metal(name: &str) -> Color {
+    kind_for(name).metal()
 }
 
 /// One dim line, no rail (SPEC 6.3).


### PR DESCRIPTION
Closes #4157

`ctrl+o` on a **tool call** row revealed nothing. The row rendered
identically expanded and collapsed, so the argument object a call was
dispatched with was unreachable from the deck. (The *result* row's `ctrl+o`
was fine — this was the call half only.)

Filed rather than smuggled into #4158, which fixed the block's rail
alignment; fixed here on request.

## Cause

`entry_lines` routes through `v2_rows` first, and `v2_rows` matched
`TranscriptEntry::ToolStart { .. }` unconditionally, drew the SPEC 6.2 head,
and returned `true` — so `entry_body` never ran and the `expanded` flag was
never consulted for a call. The whole `ToolStart` arm of `entry_body` was
unreachable, its `serde_json::to_string_pretty` of `raw` included.

Nothing caught it and nothing could: the code it killed was a **match arm**,
and both `dead-code-allows` and `module-reachability` see items. It compiled,
it read as live, and it was covered by no guard.

## Fix

The router takes the body along with the head:

```
 │ ● edit src/lib.rs
 │   {
 │     "new_string": "bravo",
 │     "old_string": "alpha",
 │     "path": "src/lib.rs"
 │   }
```

`argument_rows` carries the pretty-print and the JSON lexing the v1 arm had.
The arm itself is deleted, and `entry_body`'s replacement arm **delegates**
to the router rather than drawing nothing — the difference from the
`Complete` arm beside it, and the lesson of the bug: the row a silent gap
here would cost is the call itself, the most load-bearing row in the
transcript.

The revealed rows ride the head's **own metal**, not a `Rail`'s.
`block_margin` takes the rail colour as an argument and
`v2::transcript_source::head_metal` is the one derivation of it, so a
`read_file`'s block is silver-dim end to end and a mutation's gold end to
end, instead of a muted head over a gold body. `push_body_line` /
`push_detail_line` / `push_detail_spans` / `push_diff_line` take that margin
directly rather than a `Rail`, which is the honest signature — they never
cared which rail, only what margin to reproduce.

## Deletions this exposed

Removing the unreachable arm left `Rail::Call`, `NAME_COL`, `pad_name` and
`path_spans` with no callers. **None is suppressed** — all four are deleted,
per the repo's rule that `#[allow(dead_code)]` asserts the lint is wrong and
here it was not. Two were carrying real v1 typography the v2 head does not
reproduce: the soft name column (deliberately replaced by SPEC 6.2's
`<glyph> <verb> <subject>`, so not a loss) and the dim-directory/
bright-basename split (not deliberate — filed as #4168, which carries the
deleted implementation so it can be restored in v2's own idiom).

## Witnesses

Three, in `render::tests::block_rail`:

- `ctrl_o_on_a_call_reveals_its_arguments` — the reveal itself, with the
  collapsed row asserted *not* to show it so the test cannot pass vacuously.
- `revealed_arguments_ride_the_heads_own_rail` — one rail, one metal, across
  `read_file` / `edit_file` / `bash`.
- `an_unparseable_argument_object_is_still_shown` — a char-capped object that
  no longer parses is lexed and shown, not swallowed.

Checked the artisanal way. With the four touched files reverted, all three
fail:

```
ctrl+o revealed nothing — the argument object is unreachable:
[" │ ● edit src/lib.rs +0 -0"]
read_file: the revealed arguments are not on the rail
a capped argument object was dropped instead of shown: [" │ ● run echo"]
```

The four alignment witnesses from #4158 still pass on both sides, which is
what says this change did not move the geometry.

## New dependencies

None.

## Deleted tests

None.

## Goldens

Unmoved — no deck fixture expands a call.
`cargo test -p stella-tui --test deck_render_snapshots`: 13 passed.

## Gate

`make gate` green (exit 0), run on this branch rebased onto current `main`
(the cherry-pick merged cleanly with #4156's `Extent` change to
`transcript_source.rs`).

## Note on a sibling issue

While probing this I also filed #4167 — zero-valued detail on a dispatched
head. It turned out to duplicate #4156, which had already landed on `main`;
my worktree was branched behind it. I verified the fix is genuinely present
(`kind_for` now builds `Extent::default()` rather than `added: 0,
removed: 0`) and closed #4167 as a duplicate rather than leaving a stale
issue open.

Refs #4168

## Summary by Sourcery

Restore tool-call argument expansion while preserving consistent block rail styling and removing obsolete rendering paths.

Bug Fixes:
- Restore Ctrl+O expansion for tool-call rows so their dispatched arguments are visible, including capped or unparseable argument objects.

Enhancements:
- Keep expanded call arguments aligned with and colored like their tool-call head while simplifying shared block-margin handling and removing obsolete v1 call-rendering helpers.

Tests:
- Add rendering coverage for call argument expansion, head-rail color consistency, and display of unparseable argument objects.