### PR TITLE
fix: five defects found by reading one session export end to end

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -879,8 +879,35 @@ pub(crate) fn persist_event_detailed(
             },
         );
     }
-    let complete = recorded && telemetry_ok && usage_complete;
-    if !complete {
+    // What disqualifies the execution's COST ROLLUP, which is the only thing
+    // `usage_complete` claims — deliberately not `recorded`.
+    //
+    // `recorded` is whether *this event* reached the append-only event log,
+    // for any of the ~40 variants that flow through here: a task update, a
+    // block registration, a manifest. A lossy event log is a real durability
+    // problem and it already has its own channel — `StoreWriteFailed` below,
+    // which the deck surfaces (`command_deck::forwarder`). It says nothing
+    // about whether the cost total is whole, and folding it in here meant one
+    // transient SQLite failure on any event permanently disqualified an
+    // execution whose accounting was provably complete.
+    //
+    // Permanently, because `mark_execution_usage_incomplete` is a one-way
+    // latch: `finish_execution_accounted`'s CASE re-reads `usage_status` and
+    // holds the row at 0 once tripped, and nothing in `stella-store` ever
+    // writes it back to 1. Both consumers require `usage_complete = 1` — the
+    // local rollup and hub replication — so the execution's real spend simply
+    // vanishes from `stella usage report`. Witnessed in the wild: an
+    // execution carrying 69 telemetry rows, every one flagged complete,
+    // summing to its recorded $2.40705242 to the last decimal, reported as
+    // incomplete and excluded.
+    //
+    // The two that DO bear on the total stay: `telemetry_ok` is a receipt
+    // that failed to land (the sum is now short by that call), and
+    // `usage_complete` is a call the provider never accounted for. Neither is
+    // recoverable by reconciliation — a receipt that was never written is
+    // invisible to any later sum — so the latch is still the right shape for
+    // them. It is only the third input that never belonged.
+    if !telemetry_ok || !usage_complete {
         let _ = store.mark_execution_usage_incomplete(execution_id);
     }
     // A failed write outranks unreported usage: it is the more serious of the
@@ -960,6 +987,68 @@ mod usage_recovery_tests {
         // And the execution as a whole is marked short.
         assert!(!store.execution_usage_complete(execution_id).unwrap());
         assert!(matches!(outcome, PersistOutcome::UsageIncomplete(Some(_))));
+    }
+
+    /// A lossy EVENT LOG must not disqualify the COST ROLLUP.
+    ///
+    /// The witness for the defect found in session `ses-1787342320630-36613`:
+    /// an execution carrying 69 telemetry rows, every one flagged complete
+    /// and summing to its recorded cost exactly, reported `usage_complete =
+    /// false` and was therefore excluded from `stella usage report` and from
+    /// hub replication — permanently, since the flag is a one-way latch.
+    ///
+    /// `record_event` is `UNIQUE (execution_id, seq)`, so replaying a seq is
+    /// a real store write failure with no mocking. The event chosen is a text
+    /// delta: it touches no telemetry, so the *only* thing that fails is the
+    /// event-log append. Before this, that alone was enough.
+    #[test]
+    fn a_failed_event_log_write_does_not_disqualify_the_cost_rollup() {
+        let store = stella_store::Store::in_memory().expect("store");
+        let execution_id = store
+            .begin_execution("cli", "prompt", "anthropic", "claude-opus-5")
+            .expect("begin");
+        let event = stella_protocol::event::AgentEvent::TextDelta {
+            delta: "hello".into(),
+        };
+
+        // Seq 0 lands.
+        let first = persist_event_detailed(&store, execution_id, 0, &event, "anthropic");
+        assert!(matches!(first, PersistOutcome::Complete));
+
+        // Replaying seq 0 collides on UNIQUE (execution_id, seq).
+        let replayed = persist_event_detailed(&store, execution_id, 0, &event, "anthropic");
+        assert!(
+            matches!(replayed, PersistOutcome::StoreWriteFailed),
+            "the lossy event log is still reported — this fix narrows what it \
+             disqualifies, it does not hide it"
+        );
+
+        store
+            .finish_execution_accounted(execution_id, "completed", 1.25, true)
+            .expect("finish");
+        assert!(
+            store.execution_usage_complete(execution_id).unwrap(),
+            "no model call went unaccounted for, so the execution's cost total is whole \
+             and must stay visible to `stella usage report`"
+        );
+    }
+
+    /// The other half of the same contract: a receipt that failed to land DOES
+    /// disqualify the total, because the sum is now genuinely short by that
+    /// call and no later reconciliation can see the gap.
+    #[test]
+    fn an_unaccounted_call_still_disqualifies_the_cost_rollup() {
+        let store = stella_store::Store::in_memory().expect("store");
+        let execution_id = store
+            .begin_execution("cli", "prompt", "anthropic", "claude-opus-5")
+            .expect("begin");
+
+        persist_event_detailed(&store, execution_id, 0, &incomplete(None), "anthropic");
+
+        store
+            .finish_execution_accounted(execution_id, "completed", 1.25, true)
+            .expect("finish");
+        assert!(!store.execution_usage_complete(execution_id).unwrap());
     }
 
     /// A failure that learned nothing writes no telemetry row. Recording a

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -570,20 +570,11 @@ pub async fn run_deck_session(
     if let Some(report) = custom.problems_report() {
         let _ = deck_tx.send(system_notice(report));
     }
-    // Honest degradation (#266): a user who pinned a reasoning effort for the
-    // lead but chose a provider whose adapter has no reasoning control gets a
-    // one-line notice instead of a silently-dropped setting. Keyed on the
-    // explicit settings pin for the lead (Default kind), never the
-    // auto-resolved effort — session chrome, re-checked every boot, never
-    // journaled. Also covers a pin accepted at a coarser tier (#1499).
-    for notice in crate::engine_config::effort_notices(
-        cfg.provider.id,
-        cfg.provider.display_name,
-        cfg.engine_settings
-            .as_ref()
-            .and_then(|e| e.agent())
-            .and_then(|a| a.effort),
-    ) {
+    // Honest degradation: every silently-dropped or silently-defaulted
+    // setting the boot can name gets one line instead. Session chrome —
+    // re-checked every boot, never journaled. See `engine_config::boot_notices`
+    // for the roster and why each one earns its line.
+    for notice in crate::engine_config::boot_notices(cfg) {
         let _ = deck_tx.send(system_notice(notice));
     }
     // An idle lead is waiting on the human, not queued behind a supervisor —

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -199,6 +199,16 @@ impl SessionDurability {
     /// Empty while unbound, on the session's first snapshot, and for a turn
     /// that changed nothing — the caller cannot tell those apart and must not
     /// need to: all three mean "no file change to report".
+    ///
+    /// **A failed snapshot is a fourth case wearing those three's clothes**,
+    /// and it does *not* mean the same thing: `.ok()` below discards a
+    /// `git add`/`write-tree` failure into the same empty vector, so
+    /// "measured, nothing changed" and "could not measure" are one value here
+    /// (#4149). Nothing downstream may treat this emptiness as evidence a turn
+    /// wrote nothing — `Store::finalize_execution_reflection` deliberately
+    /// corroborates `wrote_files` against the tool-call ledger for exactly
+    /// this reason, having once reported a turn with nineteen successful
+    /// `edit_file` calls as having written none.
     pub fn snapshot_worktree(&self) -> Vec<stella_store::work_journal::JournalChange> {
         self.journal()
             .and_then(|journal| journal.snapshot_worktree().ok())

--- a/crates/stella-cli/src/engine_config.rs
+++ b/crates/stella-cli/src/engine_config.rs
@@ -449,6 +449,89 @@ pub fn effort_notices(
     .collect()
 }
 
+/// Every honest-degradation line this session's configuration earns, in the
+/// order the deck prints them.
+///
+/// The roster, and why each is a boot line rather than a doc note:
+///
+/// - [`effort_notices`] — a pinned reasoning effort the adapter cannot honor
+///   at all (#266), or cannot express at the tier asked for (#1499).
+/// - [`unpinned_gateway_notice`] — a gateway choosing its own upstream, which
+///   costs real money through the prompt cache.
+///
+/// One composer rather than a call per family, because the deck's boot path
+/// is a grandfathered god file closed to growth (AGENTS.md § "God files") and
+/// a third notice should not have to widen it a third time. Adding one here
+/// costs the call site nothing.
+pub fn boot_notices(cfg: &crate::config::Config) -> Vec<String> {
+    let mut notices = effort_notices(
+        cfg.provider.id,
+        cfg.provider.display_name,
+        // The explicit settings pin for the lead, never the auto-resolved
+        // effort: `effort_auto` synthesizes a level nobody asked for, and
+        // firing on it would spam every boot.
+        cfg.engine_settings
+            .as_ref()
+            .and_then(|e| e.agent())
+            .and_then(|a| a.effort),
+    );
+    notices.extend(unpinned_gateway_notice(
+        cfg.provider.id,
+        cfg.provider.display_name,
+        cfg.effective_base_url(),
+        cfg.provider.upstream_pin,
+    ));
+    notices
+}
+
+/// One line when a **gateway** session is running with upstream routing left
+/// to the gateway, or `None` for a direct vendor or a pinned gateway.
+///
+/// # Why this is worth a boot line
+///
+/// A gateway picks which upstream serves each request, and each upstream
+/// holds its own prompt cache. The sticky `session_id` the adapter sends is a
+/// *hint*, not a guarantee — see [`CACHE_POSTURE`]'s OpenRouter row — so under
+/// congestion a request lands on an upstream that has never seen the prefix
+/// and the whole prompt bills as a cache miss.
+///
+/// It is the single largest avoidable line item measured on this repo's own
+/// runs: in one 17-minute session, 20 of 69 calls read zero cached tokens,
+/// carrying 25% of the input tokens and **54% of the $2.41 spent** — about
+/// $0.93 for tokens that were already cached somewhere else. The misses were
+/// not TTL expiry: median idle before a miss was 0.3s against 0.2s before a
+/// hit, and calls alternated hit/miss inside the same second.
+///
+/// The default stays unpinned, because routing is the gateway's choice until
+/// an operator says otherwise and only a measured comparison needs it fixed
+/// (see `config::providers::ProviderConfig::upstream_pin`). What changes is
+/// that the choice stops being invisible — the same honest-degradation
+/// contract [`unsupported_effort_notice`] applies to a dropped reasoning
+/// effort. A silent default nobody can see is not a default anyone chose.
+///
+/// [`CACHE_POSTURE`]: stella_model::provider_parity::CACHE_POSTURE
+pub fn unpinned_gateway_notice(
+    provider_id: &str,
+    provider_label: &str,
+    base_url: &str,
+    upstream_pin: &[String],
+) -> Option<String> {
+    // Gated on "does this actually address the gateway", never on the id
+    // alone — matching the cache opt-in's own gate, because a settings-defined
+    // provider pointing at OpenRouter is the same routing surface (invariant
+    // 8, and the defect that widened that gate).
+    let is_gateway =
+        provider_id == "openrouter" || stella_model::zai::is_openrouter_endpoint(base_url);
+    if !is_gateway || !upstream_pin.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{provider_label} is a gateway and no upstream is pinned — it may route two turns of \
+         this session to different upstreams, and a prompt cached on one is a full-price miss \
+         on the next. Set `upstream_pin` in settings.json to fix the route."
+    ))
+}
+
 // Enum ↔ string (the TUI edits strings; settings/serde hold enums)
 
 pub fn effort_to_str(effort: ReasoningEffort) -> &'static str {
@@ -694,6 +777,67 @@ mod tests {
 
     fn is_builtin(id: &str) -> bool {
         crate::config::PROVIDERS.iter().any(|p| p.id == id)
+    }
+
+    /// The witness: a gateway session that has not pinned an upstream says so.
+    ///
+    /// Before this, the most expensive routing decision in a session — 54% of
+    /// one measured turn's spend — was the one nothing mentioned.
+    #[test]
+    fn an_unpinned_gateway_session_says_so() {
+        let notice = unpinned_gateway_notice("openrouter", "OpenRouter", "", &[])
+            .expect("an unpinned gateway earns a line");
+        assert!(
+            notice.contains("no upstream is pinned") && notice.contains("upstream_pin"),
+            "the line must name the condition and the remedy — got {notice:?}"
+        );
+    }
+
+    /// Pinning is the fix, so a pinned gateway is silent.
+    #[test]
+    fn a_pinned_gateway_is_silent() {
+        let pin = vec!["moonshotai".to_string()];
+        assert!(unpinned_gateway_notice("openrouter", "OpenRouter", "", &pin).is_none());
+    }
+
+    /// A direct vendor picks no upstream, so it has nothing to declare —
+    /// whatever its pin field happens to hold.
+    #[test]
+    fn a_direct_vendor_is_silent() {
+        for id in ["anthropic", "openai", "zai", "deepseek", "local"] {
+            assert!(
+                unpinned_gateway_notice(id, id, "https://api.example.com/v1", &[]).is_none(),
+                "{id} routes nothing and must stay silent"
+            );
+        }
+    }
+
+    /// Gated on the endpoint, never the id alone: a settings-defined provider
+    /// pointing at the gateway is the same routing surface. Gating on the id
+    /// is the exact defect that once ran Claude routes through OpenRouter
+    /// with zero caching (invariant 8).
+    #[test]
+    fn a_custom_provider_addressing_the_gateway_is_still_a_gateway() {
+        assert!(
+            unpinned_gateway_notice(
+                "my-gateway",
+                "My Gateway",
+                "https://openrouter.ai/api/v1",
+                &[]
+            )
+            .is_some(),
+            "a custom entry pointing at the gateway routes exactly like the built-in one"
+        );
+        // ...and a host that merely mentions it is not the gateway.
+        assert!(
+            unpinned_gateway_notice(
+                "impostor",
+                "Impostor",
+                "https://openrouter.ai.evil.example/v1",
+                &[]
+            )
+            .is_none()
+        );
     }
 
     fn engine_from_json(json: &str) -> AgentEngineConfig {

--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -920,13 +920,37 @@ const esc = s => String(s).replace(/[&<>"']/g, c => ({{'&':'&amp;','<':'&lt;','>
   const el = document.getElementById('insights');
   const tips = [];
 
-  // Cache hit rate.
-  const totalIn = USAGE.reduce((s,r)=>s+r.input_tokens,0);
-  const cacheRead = USAGE.reduce((s,r)=>s+r.cache_read_tokens,0);
-  if (totalIn > 0) {{
-    const rate = (cacheRead/totalIn*100).toFixed(1);
-    if (rate > 50) tips.push({{label:'Cache Efficiency',text:`Prompt caching is saving ${{rate}}% of input tokens — the session is reusing context well.`}});
-    else if (totalIn > 10000) tips.push({{label:'Cache Opportunity',text:`Only ${{rate}}% of input tokens were cache reads. Longer, stable system prompts with cache breakpoints would cut cost.`}});
+  // Prompt cache. TWO statistics, because the token rate hides the one that
+  // costs money. A token-weighted average describes a session that is
+  // uniformly mediocre; it says nothing about a session that is BIMODAL —
+  // most calls reading cache, a minority reading none and paying full input
+  // rate for a whole prefix. Measured on a real session: 63.6% of tokens hit
+  // cache (which the old threshold called "reusing context well") while 20 of
+  // 69 calls read zero and carried 54% of the $2.41 spent.
+  //
+  // The remedies differ, which is why conflating them is worse than silence.
+  // A low token rate is a prompt-shape problem. Scattered cold calls on a
+  // prompt that is already stable are a ROUTING problem: each gateway upstream
+  // holds its own cache, so an unpinned gateway can serve two turns of one
+  // session from two caches. Advising "longer, stable system prompts" there
+  // sends the reader to fix something that was never broken.
+  const billed = TELEMETRY.filter(r => r.input_tokens > 0);
+  const totalIn = billed.reduce((s,r)=>s+r.input_tokens,0);
+  const cacheRead = billed.reduce((s,r)=>s+r.cache_read_tokens,0);
+  const cold = billed.filter(r => r.cache_read_tokens === 0);
+  const spend = billed.reduce((s,r)=>s+r.cost_usd,0);
+  const coldSpend = cold.reduce((s,r)=>s+r.cost_usd,0);
+  if (totalIn > 0 && billed.length > 0) {{
+    const rate = cacheRead / totalIn * 100;
+    const coldCalls = cold.length / billed.length * 100;
+    const coldCost = spend > 0 ? coldSpend / spend * 100 : 0;
+    if (cold.length > 0 && coldCost >= 25) {{
+      tips.push({{label:'Cold Prefixes',text:`${{cold.length}} of ${{billed.length}} calls (${{coldCalls.toFixed(0)}}%) read ZERO cached tokens and carried ${{coldCost.toFixed(0)}}% of the spend ($${{coldSpend.toFixed(2)}}) — even though ${{rate.toFixed(1)}}% of all input tokens did hit cache. Scattered cold calls on a stable prompt point at routing, not prompt shape: on a gateway, set 'upstream_pin' so every turn reaches the same upstream cache.`}});
+    }} else if (rate > 50) {{
+      tips.push({{label:'Cache Efficiency',text:`Prompt caching is saving ${{rate.toFixed(1)}}% of input tokens across ${{billed.length}} calls, and cold prefixes account for only ${{coldCost.toFixed(0)}}% of the spend.`}});
+    }} else if (totalIn > 10000) {{
+      tips.push({{label:'Cache Opportunity',text:`Only ${{rate.toFixed(1)}}% of input tokens were cache reads. Longer, stable system prompts with cache breakpoints would cut cost.`}});
+    }}
   }}
 
   // Resolve rate.

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -158,17 +158,6 @@ fn script_json_cannot_close_the_script_element() {
     assert_eq!(parsed[0]["path"], "</script><img src=x onerror=alert(1)>");
 }
 
-/// A file path an agent created lands in `FILES`, flows into `barChart`
-/// as `d.label`, and is assigned to `innerHTML`. `script_json` only stops
-/// the payload from closing the `<script>` element — the JS parser decodes
-/// `<` straight back and the live string reaches the sink — so every
-/// `innerHTML` interpolation of agent-, MCP-, or repo-chosen text has to
-/// escape at the sink.
-///
-/// The assertion is structural (over the emitted JS) rather than over the
-/// rendered DOM on purpose: the escaping happens in the browser, so no
-/// Rust-side output ever contains the escaped `&lt;img` form.
-#[test]
 /// The cache insight reads per-call rows, and no longer congratulates a
 /// session on a token rate that hides where the money went.
 ///
@@ -209,7 +198,10 @@ fn the_cache_insight_reads_per_call_rows_not_a_token_average() {
         // And the remedy names routing, which is what actually causes it.
         "upstream_pin",
     ] {
-        assert!(html.contains(present), "cache insight must carry: {present}");
+        assert!(
+            html.contains(present),
+            "cache insight must carry: {present}"
+        );
     }
     assert!(
         !html.contains("const cacheRead = USAGE.reduce"),
@@ -217,6 +209,16 @@ fn the_cache_insight_reads_per_call_rows_not_a_token_average() {
     );
 }
 
+/// A file path an agent created lands in `FILES`, flows into `barChart`
+/// as `d.label`, and is assigned to `innerHTML`. `script_json` only stops
+/// the payload from closing the `<script>` element — the JS parser decodes
+/// `<` straight back and the live string reaches the sink — so every
+/// `innerHTML` interpolation of agent-, MCP-, or repo-chosen text has to
+/// escape at the sink.
+///
+/// The assertion is structural (over the emitted JS) rather than over the
+/// rendered DOM on purpose: the escaping happens in the browser, so no
+/// Rust-side output ever contains the escaped `&lt;img` form.
 #[test]
 fn dashboard_escapes_untrusted_text_at_every_innerhtml_sink() {
     let hostile = r#"[{"path":"<img src=x onerror=alert(1)>","lines_added":1,"lines_removed":0}]"#;

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -169,6 +169,55 @@ fn script_json_cannot_close_the_script_element() {
 /// rendered DOM on purpose: the escaping happens in the browser, so no
 /// Rust-side output ever contains the escaped `&lt;img` form.
 #[test]
+/// The cache insight reads per-call rows, and no longer congratulates a
+/// session on a token rate that hides where the money went.
+///
+/// A token-weighted hit rate describes a uniformly mediocre session. It cannot
+/// see a bimodal one — most calls reading cache, a minority reading none and
+/// paying full input rate for a whole prefix. Session
+/// `ses-1787342320630-36613` scored 63.6%, cleared the old `rate > 50`
+/// threshold, and was told it was "reusing context well" while 20 of its 69
+/// calls read zero cached tokens and carried 54% of the $2.41 spent.
+///
+/// This asserts on the shipped script rather than executing it — the tips are
+/// computed in the page. What it pins is that the decision is made from the
+/// per-call table with a cost share in hand, and that the sentence that
+/// misread this session is gone.
+#[test]
+fn the_cache_insight_reads_per_call_rows_not_a_token_average() {
+    let html = render_dashboard(
+        &[],
+        &[],
+        "now",
+        "ses-x",
+        &ExportExclusions::default(),
+        &transcript::render(&Default::default(), &Default::default()),
+    );
+
+    assert!(
+        !html.contains("the session is reusing context well"),
+        "the sentence that called a 29%-cold session healthy must not ship"
+    );
+    for present in [
+        // Per-call rows, not the per-model aggregate: only TELEMETRY can say
+        // how many CALLS were cold.
+        "const billed = TELEMETRY.filter",
+        "r.cache_read_tokens === 0",
+        // The cost share is the statistic that ranks the finding.
+        "coldSpend / spend",
+        "read ZERO cached tokens",
+        // And the remedy names routing, which is what actually causes it.
+        "upstream_pin",
+    ] {
+        assert!(html.contains(present), "cache insight must carry: {present}");
+    }
+    assert!(
+        !html.contains("const cacheRead = USAGE.reduce"),
+        "the aggregate-only derivation is what could not see the cold calls"
+    );
+}
+
+#[test]
 fn dashboard_escapes_untrusted_text_at_every_innerhtml_sink() {
     let hostile = r#"[{"path":"<img src=x onerror=alert(1)>","lines_added":1,"lines_removed":0}]"#;
     let html = render_dashboard(

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -104,8 +104,13 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
         CachePosture::OptIn {
             mechanism: "request-root cache_control {type: ephemeral} — required for Claude \
                         routes, ignored by implicit-cache upstreams — plus a session-stable \
-                        top-level session_id that pins every turn of a session to the same \
-                        upstream provider + cache shard (sticky routing)",
+                        top-level session_id requesting that every turn of a session reach \
+                        the same upstream provider + cache shard (sticky routing). The \
+                        session_id is a HINT the gateway may decline, not a pin: measured \
+                        over one 17-minute session it held for the last 17 calls and not \
+                        the first 32, leaving 20 of 69 calls reading zero cached tokens \
+                        for 54% of the spend. Only a non-empty upstream_pin \
+                        (provider.order + allow_fallbacks:false) actually fixes the route",
             witness: "openrouter_identity_sends_root_level_cache_control",
         },
     ),

--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -125,7 +125,13 @@ fn new_session_id() -> String {
 /// gates what the request BODY carries, not where it is sent, but a sloppy
 /// match would still leak OpenRouter-only fields onto servers that 400 on
 /// unknown keys).
-fn is_openrouter_endpoint(base_url: &str) -> bool {
+///
+/// Public because "is this the gateway?" is asked in two places that must
+/// agree: here, gating the request body, and `stella-cli`'s boot notice for a
+/// gateway running with routing unpinned. Answering it twice is how the cache
+/// opt-in came to be gated on the id alone and silently ran Claude routes
+/// uncached through a custom provider entry (invariant 8).
+pub fn is_openrouter_endpoint(base_url: &str) -> bool {
     let after_scheme = base_url
         .split_once("://")
         .map_or(base_url, |(_, rest)| rest);

--- a/crates/stella-store/src/reflection.rs
+++ b/crates/stella-store/src/reflection.rs
@@ -228,10 +228,39 @@ impl Store {
                 params![execution_id],
                 |r| r.get::<_, i64>(0),
             )? > 0;
+            // Two sources, because either alone answers "did this turn write
+            // anything?" with a confident no when it cannot see (#3413's
+            // measurement, and the tool ledger, have disjoint blind spots):
+            //
+            // - `files_touched` is the turn-boundary tree measurement. It is
+            //   the better evidence — it sees `bash`, MCP servers and custom
+            //   script tools, none of which name a path in a schema the engine
+            //   reads — but it is empty for a session with no work journal
+            //   bound, on the session's first snapshot (baseline only), AND
+            //   whenever the snapshot itself failed, which
+            //   `SessionDurability::snapshot_worktree` cannot distinguish from
+            //   a clean tree.
+            // - A file-writing tool call that returned `ok` is weaker evidence
+            //   about *what* landed — a tool's arguments are a request, not a
+            //   measurement, which is why `stella-cli`'s `turn_files` refuses
+            //   to synthesize line counts from them (#2290). But this column
+            //   is a **boolean**, not a count, and for that question a
+            //   succeeded `edit_file` is a fact. It can only ever turn a wrong
+            //   `false` into a right `true`.
+            //
+            // Witnessed in session `ses-1787342320630-36613`: nineteen
+            // successful `edit_file` calls against two files that git confirms
+            // were left modified, `files_touched` empty, and this column
+            // reported `false` — telling the reflection loop a turn that
+            // edited one file sixteen times had written nothing.
             let wrote_files: bool = conn.query_row(
-                "SELECT COUNT(*) FROM files_touched \
-                 WHERE execution_id = ?1 \
-                   AND (ops LIKE '%C%' OR ops LIKE '%U%' OR ops LIKE '%D%')",
+                "SELECT \
+                   (SELECT COUNT(*) FROM files_touched \
+                     WHERE execution_id = ?1 \
+                       AND (ops LIKE '%C%' OR ops LIKE '%U%' OR ops LIKE '%D%')) \
+                 + (SELECT COUNT(*) FROM tool_calls \
+                     WHERE execution_id = ?1 AND ok = 1 \
+                       AND name IN ('write_file', 'edit_file', 'delete_file'))",
                 params![execution_id],
                 |r| r.get::<_, i64>(0),
             )? > 0;
@@ -261,6 +290,113 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn wrote_files_of(store: &Store, execution_id: i64) -> i64 {
+        let conn = store.lock();
+        conn.query_row(
+            "SELECT wrote_files FROM execution_reflection WHERE execution_id = ?1",
+            params![execution_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    use stella_protocol::event::AgentEvent;
+    use stella_protocol::tool::{ToolCall, ToolOutput};
+
+    fn started(call_id: &str, name: &str) -> AgentEvent {
+        AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: call_id.into(),
+                name: name.into(),
+                input: serde_json::json!({"path": "src/engine.rs"}),
+            },
+        }
+    }
+
+    fn settled(call_id: &str, output: ToolOutput) -> AgentEvent {
+        AgentEvent::ToolResult {
+            call_id: call_id.into(),
+            output,
+            duration_ms: 4,
+            speculated: false,
+        }
+    }
+
+    fn ok_output(content: &str) -> ToolOutput {
+        ToolOutput::Ok {
+            content: content.into(),
+            data: None,
+        }
+    }
+
+    /// The witness: a turn whose only evidence of writing is the tool ledger
+    /// is still a turn that wrote.
+    ///
+    /// `files_touched` has three benign ways to be empty (unbound journal,
+    /// first snapshot of the session, genuinely clean tree) and one that is
+    /// not benign at all — a failed measurement, which
+    /// `SessionDurability::snapshot_worktree` discards into the same empty
+    /// vector. Deriving this column from that table alone therefore reported
+    /// a confident `false` whenever the measurement could not see.
+    ///
+    /// Observed in session `ses-1787342320630-36613`: nineteen successful
+    /// `edit_file` calls against two files git confirms were left modified,
+    /// zero `files_touched` rows, `wrote_files = 0`.
+    #[test]
+    fn a_turn_that_edited_files_wrote_files_even_with_no_tree_measurement() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("deck", "fix the search ladder", "openrouter", "kimi-k3")
+            .unwrap();
+        store.record_event(id, 0, &started("c1", "edit_file")).unwrap();
+        store
+            .record_event(id, 1, &settled("c1", ok_output("edited")))
+            .unwrap();
+        store.materialize_tool_calls(id).unwrap();
+
+        // The tree measurement produced nothing — the defect's exact shape.
+        assert_eq!(store.count("files_touched").unwrap(), 0);
+
+        store.finalize_execution_reflection(id).unwrap();
+        assert_eq!(
+            wrote_files_of(&store, id),
+            1,
+            "a succeeded edit_file is a fact about whether the turn wrote, even when the \
+             turn-boundary snapshot saw nothing"
+        );
+    }
+
+    /// The other direction must not drift: a read-only turn still wrote
+    /// nothing, and a *failed* write is not a write.
+    #[test]
+    fn reading_and_failing_to_write_are_both_still_wrote_nothing() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("deck", "look around", "openrouter", "kimi-k3")
+            .unwrap();
+        store.record_event(id, 0, &started("c1", "read_file")).unwrap();
+        store
+            .record_event(id, 1, &settled("c1", ok_output("fn main() {}")))
+            .unwrap();
+        // An edit that did not land. `ok = 0`, so it proves nothing.
+        store.record_event(id, 2, &started("c2", "edit_file")).unwrap();
+        store
+            .record_event(
+                id,
+                3,
+                &settled("c2", ToolOutput::error("old_string not found")),
+            )
+            .unwrap();
+        store.materialize_tool_calls(id).unwrap();
+
+        store.finalize_execution_reflection(id).unwrap();
+        assert_eq!(
+            wrote_files_of(&store, id),
+            0,
+            "a read is not a write, and neither is an edit that was refused"
+        );
+    }
 
     fn a_review() -> SelfReviewRow {
         SelfReviewRow {

--- a/crates/stella-store/src/reflection.rs
+++ b/crates/stella-store/src/reflection.rs
@@ -349,7 +349,9 @@ mod tests {
         let id = store
             .begin_execution("deck", "fix the search ladder", "openrouter", "kimi-k3")
             .unwrap();
-        store.record_event(id, 0, &started("c1", "edit_file")).unwrap();
+        store
+            .record_event(id, 0, &started("c1", "edit_file"))
+            .unwrap();
         store
             .record_event(id, 1, &settled("c1", ok_output("edited")))
             .unwrap();
@@ -375,12 +377,16 @@ mod tests {
         let id = store
             .begin_execution("deck", "look around", "openrouter", "kimi-k3")
             .unwrap();
-        store.record_event(id, 0, &started("c1", "read_file")).unwrap();
+        store
+            .record_event(id, 0, &started("c1", "read_file"))
+            .unwrap();
         store
             .record_event(id, 1, &settled("c1", ok_output("fn main() {}")))
             .unwrap();
         // An edit that did not land. `ok = 0`, so it proves nothing.
-        store.record_event(id, 2, &started("c2", "edit_file")).unwrap();
+        store
+            .record_event(id, 2, &started("c2", "edit_file"))
+            .unwrap();
         store
             .record_event(
                 id,

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -335,6 +335,94 @@ fn line_at(source: &str, number: u32) -> Option<&str> {
     source.lines().nth(index)
 }
 
+/// Rust definition keywords a query may lead with before naming the symbol.
+///
+/// Ordered longest-first only for readability; [`symbol_terms`] strips
+/// whichever ones lead, repeatedly, so `pub async fn` peels in three steps.
+const DEFINITION_KEYWORDS: &[&str] = &[
+    "macro_rules!",
+    "pub(crate)",
+    "pub(super)",
+    "pub(self)",
+    "unsafe",
+    "static",
+    "struct",
+    "trait",
+    "union",
+    "async",
+    "const",
+    "enum",
+    "impl",
+    "type",
+    "mod",
+    "pub",
+    "fn",
+];
+
+/// Whether `s` is a bare Rust identifier — the only shape the code graph can
+/// be asked about, and the guard that keeps regex fragments out.
+///
+/// A query alternative like `rate.limit`, `429` or `PendingChunk\b` is a
+/// pattern, not a name; looking one up would always miss, and letting it
+/// through would cost a graph round-trip per junk term.
+fn is_bare_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c.is_alphabetic() || c == '_')
+        && chars.all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// The symbol names a query is asking about, in the order it named them.
+///
+/// # Why a query is decomposed at all
+///
+/// [`exact_symbol_hits`] used to take the whole query as one name, so it
+/// answered only for a query that was already exactly one bare identifier.
+/// That is not the shape callers write. Measured over a real session, every
+/// one of the agent's twenty-one code searches was an exact-identifier
+/// lookup, and most named **several** symbols at once in regex alternation
+/// (`warm_chunks_opened|embed_and_store_chunk_file|ChunkWarmOutcome`) or led
+/// with the definition keyword (`pub fn store_chunk_vectors`). Every one of
+/// them missed this rung entirely and fell through to embedding rank — the
+/// instrument the doc above says is measurably wrong for this question —
+/// even though each individual term was an exact graph fact. The session
+/// used `rg` instead, twenty-one times out of twenty-one.
+///
+/// # Why these two decompositions and no others
+///
+/// `|` is unambiguous: it cannot occur in a Rust identifier and carries no
+/// meaning in a natural-language question, so splitting on it reads an
+/// explicit "any of these" rather than inferring an intent. The leading
+/// keywords are unambiguous in the same way — a question does not open with
+/// `pub struct`. Both preserve the rule the strategy exists for: **a
+/// sentence is still not a symbol**, so an alternative that is not a bare
+/// identifier after stripping is dropped rather than guessed at, and a
+/// prose query decomposes to nothing and stays free.
+///
+/// Partial decomposition is deliberate: `429|retry|backoff` yields
+/// `[retry, backoff]`. The junk term costs nothing and the two real names
+/// are still facts.
+pub fn symbol_terms(query: &str) -> Vec<&str> {
+    let mut terms = Vec::new();
+    for alternative in query.split('|') {
+        let mut term = alternative.trim();
+        // Peel leading keywords one at a time so `pub async fn name` reduces
+        // the same way `fn name` does.
+        loop {
+            let Some((head, rest)) = term.split_once(char::is_whitespace) else {
+                break;
+            };
+            if !DEFINITION_KEYWORDS.contains(&head) {
+                break;
+            }
+            term = rest.trim_start();
+        }
+        if is_bare_identifier(term) && !terms.contains(&term) {
+            terms.push(term);
+        }
+    }
+    terms
+}
+
 /// The files that define a symbol the query names **exactly** — a lookup, not
 /// a ranking (#3125).
 ///
@@ -344,43 +432,45 @@ fn line_at(source: &str, number: u32) -> Option<&str> {
 /// symbol name is a handful of tokens against whole files of prose. The graph
 /// already holds the answer as a fact.
 ///
-/// A sentence is not a symbol, so a multi-word query is refused before the
-/// query runs rather than after it returns nothing. That is the common case,
-/// and it keeps this free for every search that is a question.
+/// A sentence is not a symbol, so a query that names none is refused before
+/// any lookup runs rather than after it returns nothing. That is the common
+/// case, and it keeps this free for every search that is a question. Which
+/// names a query does name is [`symbol_terms`]'s job — it reads an explicit
+/// alternation and a leading definition keyword, and nothing else.
 ///
 /// The matched symbol rides as the hit's focus, so the detailed facets the
 /// renderer pays for describe the definition itself rather than whatever
 /// happens to sit first in the file.
 pub fn exact_symbol_hits(graph: &CodeGraph, query: &str, limit: usize) -> Vec<Hit> {
-    let name = query.trim();
-    if name.is_empty() || name.split_whitespace().count() != 1 {
-        return Vec::new();
-    }
-    let Ok(spans) = graph.definition_spans(name) else {
-        return Vec::new();
-    };
-
     let mut seen = std::collections::HashSet::new();
     let mut hits = Vec::new();
-    for span in spans {
-        // `definition_spans` is already `WHERE s.name = ?`, so this only guards
-        // the contract rather than filtering: an inexact hit here would be a
-        // ranking wearing a certainty's label, which is the one thing this
-        // strategy must never do.
-        if span.name != name || !seen.insert(span.path.clone()) {
+    // Term order, not graph order: the caller named these in a sequence and a
+    // certainty found for the first should not be displaced by one found for
+    // the third.
+    for name in symbol_terms(query) {
+        let Ok(spans) = graph.definition_spans(name) else {
             continue;
-        }
-        hits.push(Hit {
-            why: format!(
-                "EXACT name match — `{}` ({}) is DEFINED here at line {}. This is a code-graph \
-                 fact, not a similarity score.",
-                span.name, span.kind, span.start_line
-            ),
-            path: span.path,
-            focus: Some(span.name),
-        });
-        if hits.len() >= limit {
-            break;
+        };
+        for span in spans {
+            // `definition_spans` is already `WHERE s.name = ?`, so this only
+            // guards the contract rather than filtering: an inexact hit here
+            // would be a ranking wearing a certainty's label, which is the one
+            // thing this strategy must never do.
+            if span.name != name || !seen.insert(span.path.clone()) {
+                continue;
+            }
+            hits.push(Hit {
+                why: format!(
+                    "EXACT name match — `{}` ({}) is DEFINED here at line {}. This is a code-graph \
+                     fact, not a similarity score.",
+                    span.name, span.kind, span.start_line
+                ),
+                path: span.path,
+                focus: Some(span.name),
+            });
+            if hits.len() >= limit {
+                return hits;
+            }
         }
     }
     hits
@@ -446,4 +536,123 @@ pub fn name_hits(graph: &CodeGraph, query: &str, limit: usize) -> (Vec<Hit>, usi
         })
         .collect();
     (hits, matched)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single bare identifier is the shape that already worked, and it must
+    /// keep decomposing to itself — the rung's whole contract rests on it.
+    #[test]
+    fn a_bare_identifier_decomposes_to_itself() {
+        assert_eq!(symbol_terms("ContextFrame"), vec!["ContextFrame"]);
+        assert_eq!(symbol_terms("  ContextFrame  "), vec!["ContextFrame"]);
+    }
+
+    /// A sentence is still not a symbol. This is the rule the decomposition
+    /// had to preserve: a question must cost no graph round-trip at all.
+    #[test]
+    fn prose_still_names_no_symbol() {
+        assert!(symbol_terms("where is the retry logic").is_empty());
+        assert!(symbol_terms("how does compaction decide what to evict").is_empty());
+        assert!(symbol_terms("").is_empty());
+        assert!(symbol_terms("   ").is_empty());
+    }
+
+    /// The dominant real shape: several exact names in regex alternation.
+    #[test]
+    fn alternation_names_every_symbol_it_lists() {
+        assert_eq!(
+            symbol_terms("warm_chunks_opened|embed_and_store_chunk_file|ChunkWarmOutcome"),
+            vec![
+                "warm_chunks_opened",
+                "embed_and_store_chunk_file",
+                "ChunkWarmOutcome"
+            ]
+        );
+        assert_eq!(
+            symbol_terms("EMBED_BATCH|MAX_FILES_PER_CHUNK_PASS"),
+            vec!["EMBED_BATCH", "MAX_FILES_PER_CHUNK_PASS"]
+        );
+    }
+
+    /// The second real shape: the caller leads with the definition keyword.
+    #[test]
+    fn a_leading_definition_keyword_is_peeled() {
+        assert_eq!(
+            symbol_terms("pub fn store_chunk_vectors"),
+            vec!["store_chunk_vectors"]
+        );
+        assert_eq!(symbol_terms("pub struct CodeGraph"), vec!["CodeGraph"]);
+        assert_eq!(symbol_terms("impl CodeGraph"), vec!["CodeGraph"]);
+        assert_eq!(
+            symbol_terms("pub async fn warm_chunk_vectors"),
+            vec!["warm_chunk_vectors"]
+        );
+        assert_eq!(
+            symbol_terms("pub(crate) const RANK_CEILING"),
+            vec!["RANK_CEILING"]
+        );
+    }
+
+    /// Both shapes at once, which is how they actually arrive.
+    #[test]
+    fn keywords_are_peeled_from_every_alternative() {
+        assert_eq!(
+            symbol_terms("pub fn store_chunk_vectors|pub struct CodeGraph|impl CodeGraph"),
+            vec!["store_chunk_vectors", "CodeGraph"],
+            "the repeated type is named once"
+        );
+    }
+
+    /// A regex fragment is a pattern, not a name — dropped, without taking
+    /// the real names beside it down with it.
+    #[test]
+    fn pattern_fragments_are_dropped_not_guessed_at() {
+        assert_eq!(
+            symbol_terms("429|rate.limit|retry|backoff"),
+            vec!["retry", "backoff"]
+        );
+        assert_eq!(
+            symbol_terms(r"pub struct PendingChunk\b|pub struct ChunkVector"),
+            vec!["ChunkVector"]
+        );
+    }
+
+    /// The witness that the call site actually consults the decomposition: a
+    /// two-symbol alternation returns BOTH definitions. Under the single-name
+    /// lookup this replaces, the whole query was one candidate name, nothing
+    /// in the graph was called `alpha_symbol|beta_symbol`, and the answer was
+    /// empty — so the exact rung was skipped and the search fell through to
+    /// embedding rank.
+    #[test]
+    fn an_alternation_query_returns_every_definition_it_names() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        for (path, body) in [
+            ("src/alpha.rs", "pub fn alpha_symbol() -> u8 { 1 }\n"),
+            ("src/beta.rs", "pub fn beta_symbol() -> u8 { 2 }\n"),
+        ] {
+            let file = workspace.path().join(path);
+            std::fs::create_dir_all(file.parent().expect("a parent")).expect("mkdir");
+            std::fs::write(&file, body).expect("write");
+        }
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let graph = CodeGraph::open(&root, &root.join("codegraph.db")).expect("open");
+        graph.index_all().expect("index");
+
+        let hits = exact_symbol_hits(&graph, "alpha_symbol|beta_symbol", 10);
+
+        let focuses: Vec<_> = hits.iter().filter_map(|h| h.focus.as_deref()).collect();
+        assert!(
+            focuses.contains(&"alpha_symbol") && focuses.contains(&"beta_symbol"),
+            "both names in the alternation are code-graph facts, so both must be returned as \
+             certainties — got {focuses:?}"
+        );
+
+        // And the single-name path is unchanged by the decomposition.
+        let one = exact_symbol_hits(&graph, "alpha_symbol", 10);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].focus.as_deref(), Some("alpha_symbol"));
+    }
 }

--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -407,10 +407,7 @@ pub fn symbol_terms(query: &str) -> Vec<&str> {
         let mut term = alternative.trim();
         // Peel leading keywords one at a time so `pub async fn name` reduces
         // the same way `fn name` does.
-        loop {
-            let Some((head, rest)) = term.split_once(char::is_whitespace) else {
-                break;
-            };
+        while let Some((head, rest)) = term.split_once(char::is_whitespace) {
             if !DEFINITION_KEYWORDS.contains(&head) {
                 break;
             }


### PR DESCRIPTION
Five fixes found by reading one session export end to end (`ses-1787342320630-36613` — 3 executions, 70 telemetry rows, 71 tool calls, one 17-minute turn costing $2.4071). Every number below is computed from the exported tables; every code claim was read in the tree.

Each commit stands alone and each carries a witness that fails on the parent and passes on the child. The fail→pass flip was checked by hand for all four behaviour changes, not asserted.

---

### 1. `search` reads an alternation and a leading definition keyword — `stella-tools`

All **21** of the agent's code searches in that session were exact-identifier lookups, and **every one of them missed the exact-symbol rung**. `exact_symbol_hits` took the whole query as one candidate name, so it answered only for a query that was already exactly one bare identifier — which is not the shape callers write:

```
warm_chunks_opened|embed_and_store_chunk_file|ChunkWarmOutcome
pub fn store_chunk_vectors|pub struct CodeGraph|impl CodeGraph
EMBED_BATCH|MAX_FILES_PER_CHUNK_PASS
```

All 21 fell through to embedding rank — the instrument that rung's own doc calls measurably wrong for this question (`ContextFrame` at rank 5 of 139) — even though each individual term was an exact graph fact. The session used `rg` instead, 21 times out of 21.

`symbol_terms` decomposes on the two shapes that are unambiguous. `|` cannot occur in a Rust identifier and carries no meaning in a natural-language question, so splitting on it reads an explicit "any of these" rather than inferring an intent; and a question does not open with `pub struct`. **A sentence is still not a symbol** — an alternative that is not a bare identifier after stripping is dropped, prose decomposes to nothing and stays free, and `429|rate.limit|retry|backoff` partially resolves to `[retry, backoff]` rather than failing whole.

This can only add certainties: `dispatch` leads with exact hits and still runs the semantic rung after them.

> Scope note: this is the `search` half only. Making the agent *reach for* `search` over `bash` is being handled in a separate session and is deliberately untouched here.

### 2. An unpinned gateway session says so at boot — `stella-cli`, `stella-model`

**20 of 69 calls read zero cached tokens, carrying 25% of the input tokens and 54% of the $2.41.** Cold calls cost `$0.00314`/1k input against `$0.00088` warm — 3.6x. About **$0.93, 39% of the turn**, is attributable to cold prefixes.

Not TTL expiry: median idle before a miss was 0.3s and before a hit 0.2s, and calls 2–6 run `miss, hit, miss, hit, miss` back to back — a hit reading 11,844 tokens followed 0s later by a total miss on a *larger* prefix. It is routing. `session_id` reaches the wire (`zai.rs:1274`) but `provider.order` + `allow_fallbacks: false` is gated on a non-empty `upstream_pin`, and the built-in row ships without one.

**The default stays unpinned** — `providers.rs:32` documents that as the operator's call, and picking a static vendor default would be wrong for most slugs. What changes is that the choice stops being invisible, on the same honest-degradation contract a dropped reasoning effort already has. The decision itself is filed as #4172 with the full trade written up.

Also corrects the parity matrix, which claimed `session_id` "pins every turn of a session to the same upstream provider + cache shard". It does not; this session is the counter-example.

Gated on the *endpoint*, not the id, so a settings-defined provider pointing at the gateway is covered — gating on the id alone is the exact defect invariant 8 was born from.

### 3. A lossy event log no longer voids the cost rollup — `stella-cli`

`usage_complete` claims one thing — that the execution's cost total is whole — but was derived from three inputs, one of which says nothing about cost. `recorded` is whether *this event* reached the append-only log, for any of ~40 variants: a task update, a block registration, a manifest. It already has its own channel (`StoreWriteFailed`, surfaced by the deck), and folding it in meant **one transient SQLite failure on any event permanently disqualified an execution whose accounting was provably complete**.

Permanently, because `mark_execution_usage_incomplete` is a one-way latch — `finish_execution_accounted`'s `CASE` holds the row at 0 once tripped and nothing ever writes it back to 1 — and both consumers require `usage_complete = 1`. The spend vanishes from `stella usage report` and never replicates.

Witnessed: execution 178 carries 69 telemetry rows, **every one flagged complete**, summing to its recorded `$2.40705242` to the last decimal, reported incomplete.

`telemetry_ok` and `usage_complete` stay. Each is a call the total is genuinely short by, and neither is recoverable by reconciliation — a receipt that was never written is invisible to any later sum, which is why this narrows the trip condition rather than adding a reconciliation pass. A second witness pins that direction so it cannot drift.

### 4. `wrote_files` stops reporting a confident no when it cannot see — `stella-store`

19 successful `edit_file` calls against two files git confirms were left modified; `files_touched` empty; `wrote_files: 0`. The reflection loop was told a turn that edited one file sixteen times had written nothing.

`files_touched` has three benign ways to be empty and one that is not — a **failed** snapshot, which `snapshot_worktree` discards into the same empty vector via `.ok()`. The tool ledger has a disjoint blind spot. It is weaker about *what* landed — a tool's arguments are a request, not a measurement, which is why `turn_files` refuses to synthesize line counts from them (#2290) — but this column is a **boolean**, and for that question a succeeded `edit_file` is a fact. It can only turn a wrong `false` into a right `true`: a read is not a write, and a refused edit (`ok = 0`) is not one either. Both directions are witnessed.

The underlying collapse in `snapshot_worktree` is **not** fixed here — its doc now names the fourth case honestly, and #4170 carries the design decision.

### 5. The cache insight reads per-call rows, not a token average — `stella-cli`

The dashboard scored this session at 63.6%, cleared its `rate > 50` threshold, and printed *"Prompt caching is saving 63.6% of input tokens — the session is reusing context well."* while 29% of calls were cold and carried 54% of the spend. A token-weighted average describes a uniformly mediocre session and cannot see a bimodal one.

The other branch would have misdiagnosed it too — *"longer, stable system prompts with cache breakpoints"* sends the reader to fix prompt shape, and the prompt here was already stable and byte-identical.

`USAGE` is a per-model aggregate and structurally cannot answer "how many *calls* were cold", so the derivation moves to `TELEMETRY` and the new tip names both the call share and the cost share, with `upstream_pin` as the remedy.

---

## Gate

`make gate` — **exit 0**, full workspace. Clippy caught a `while_let_loop` in the new code, fixed in its own commit.

No baseline was raised. `command_deck.rs` is a grandfathered god file and the boot notice would have grown it by 10 lines, so the two notice families compose in `engine_config::boot_notices` instead and **the call site shrank by 12 lines**.

No tests were deleted. One commit (`06c4ce02`) repairs a doc comment and `#[test]` that my own insertion displaced onto the wrong function — caught because the new test registered twice.

## Related

Refs #4170, Refs #4171, Refs #4172 — the three decisions deliberately left out of this PR, each written as a standalone handoff.
Refs #3808 — the blank-reflection half of the same session, already tracked; commented with this session's evidence rather than duplicated.
Refs #2952 — epic: the trace faithfully records what a run did and what it cost.

Heads-up: branch `worktree-files-touched-fix` (referenced by #4159) also touches `durability.rs` and `turn_files.rs`. This PR's only edit there is a doc comment, but check the merge.

## Summary by Sourcery

Correct search certainty, usage accounting, file-write reflection, gateway routing visibility, and cache diagnostics revealed by end-to-end session analysis.

New Features:
- Improve exact code-symbol search to recognize alternations and queries prefixed with Rust definition keywords.
- Add boot-time notices for gateway sessions without a pinned upstream.
- Provide cache insights based on cold-call and cost shares to identify routing-related cache waste.

Bug Fixes:
- Keep complete cost rollups visible when unrelated event-log writes fail while still excluding executions with missing telemetry or usage accounting.
- Report successful file-writing tool calls as evidence that a turn wrote files when worktree measurement is unavailable.
- Correct provider parity documentation so gateway session identifiers are described as routing hints rather than guaranteed pins.

Enhancements:
- Centralize configuration boot notices and share gateway endpoint detection across model and CLI behavior.
- Document the distinction between unavailable worktree measurements and confirmed absence of file changes.

Documentation:
- Update cache-posture documentation to accurately describe gateway routing and upstream pinning behavior.

Tests:
- Add coverage for symbol query decomposition, exact multi-symbol search, gateway notices, cost-rollup durability, file-write reflection, and per-call cache insight derivation.