### PR TITLE
fix(stella-tui): a mutating row shows the change its own call made

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -478,17 +478,20 @@ pub enum TranscriptEntry {
 }
 
 /// A mutating tool result's handle on the diff it may render inline: the
-/// path into [`SessionModel::files`] plus the value of that file's `changes`
-/// counter when the result folded. The renderer shows the inline diff only
-/// while the counter still matches — a later mutation of the same path bumps
-/// it, so a historical entry can never display a diff its call didn't
-/// produce. Only the *reference* lives here; the diff bytes stay on the
-/// single event-borne path (L-T5).
+/// path into [`SessionModel::files`] plus the `changes` seq of the mutation
+/// *this call produced*. The renderer resolves it against
+/// [`FileState::recent_diffs`], so a row shows the change its own call made
+/// and never a neighbour's. Only the *reference* lives here; the diff bytes
+/// stay on the single event-borne path (L-T5).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineDiffRef {
     /// The key into [`SessionModel::files`].
     pub path: String,
-    /// [`FileState::changes`] at fold time — stale (hidden) once it differs.
+    /// The [`FileState::changes`] value this call's own mutation is recorded
+    /// at — one past the counter at fold time, because the surviving producer
+    /// emits at the turn boundary, *after* this result folds (#4155). It
+    /// resolves for as long as that mutation is remembered, and dangles
+    /// (rendering nothing) when the turn measured no net change to the path.
     pub seq: u32,
 }
 
@@ -734,22 +737,46 @@ impl SessionModel {
                 // Only a *successful* mutation gets an inline-diff reference —
                 // a failed call produced no `FileChange`, and rendering the
                 // path's previous diff under its ✗ would attribute a change
-                // the call never made. The engine's `FileChangeTap` emits the
-                // `FileChange` during the tool's execution, so by the time
-                // this result folds, `files[path].changes` already counts this
-                // call's own change — that value is the freshness tag.
+                // the call never made.
+                //
+                // The seq names the change this call *will* produce, not the
+                // one already recorded. `stella-pipeline`, which emitted one
+                // `FileChange` per adopted change during delivery, is deleted
+                // (#3865); the only producer left is
+                // `stella_cli::turn_files::emit_shared_tree_changes`, which
+                // emits one aggregate change per path at the **turn boundary**
+                // — after every `ToolResult` of the turn has folded — and
+                // `touch_file` records it at the *bumped* `changes`. Stamping
+                // the pre-bump value therefore pointed one change into the
+                // past: a path's first turn resolved to nothing, and every
+                // later turn rendered the PREVIOUS turn's diff under this
+                // turn's edit, which is exactly the misattribution
+                // `render::resolve_inline_diff` exists to prevent (#4155).
                 let diff = if ok {
                     self.mutated_path_for(call_id).map(|path| {
                         let seq = self
                             .files
                             .iter()
                             .find(|f| f.path == path)
-                            .map_or(0, |f| f.changes);
+                            .map_or(0, |f| f.changes)
+                            + 1;
                         InlineDiffRef { path, seq }
                     })
                 } else {
                     None
                 };
+                // Several calls may mutate one path in a turn, and they all
+                // compute the same seq — `changes` does not move until the
+                // boundary. Exactly one row may claim that single aggregate
+                // change: the last, whose post-state the diff actually
+                // describes. Earlier rows give up their reference and degrade
+                // to naming their change, the same degradation `DIFF_HISTORY`
+                // aging and `MAX_TRACKED_FILES` eviction already have. The
+                // alternative is every one of them rendering the whole turn's
+                // change as its own.
+                if let Some(dref) = diff.as_ref() {
+                    self.supersede_inline_diff(dref);
+                }
                 self.transcript.push(TranscriptEntry::ToolResult {
                     call_id: call_id.clone(),
                     name,
@@ -1343,6 +1370,27 @@ impl SessionModel {
                 _ => None,
             })
             .and_then(|(name, path)| is_file_mutation(&name).then_some(path).flatten())
+    }
+
+    /// Drop the inline-diff reference from every earlier result that pointed
+    /// at the same change as `dref`, so one change is claimed by one row.
+    ///
+    /// The turn boundary emits **one** aggregate `FileChange` per path, so
+    /// every call that mutated that path in the turn stamps an identical
+    /// `(path, seq)`. Left alone they would each render the turn's whole
+    /// change to that file as their own. The last call keeps it because the
+    /// measured post-state is the one its edit left behind; the earlier rows
+    /// degrade to naming their change rather than showing it.
+    ///
+    /// Called before the new result is pushed, so it never clears its own ref.
+    fn supersede_inline_diff(&mut self, dref: &InlineDiffRef) {
+        for entry in &mut self.transcript {
+            if let TranscriptEntry::ToolResult { diff, .. } = entry
+                && diff.as_ref().is_some_and(|d| d == dref)
+            {
+                *diff = None;
+            }
+        }
     }
 
     /// Record a file touch, retaining the latest diff for the path (L-T5).

--- a/crates/stella-tui/src/model/file_state.rs
+++ b/crates/stella-tui/src/model/file_state.rs
@@ -59,7 +59,18 @@ pub struct FileState {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RememberedDiff {
     pub seq: u32,
-    pub text: String,
+    /// The mutation's diff text, `None` when the emitter measured the change
+    /// but could not attach a patch for it.
+    ///
+    /// Counts and diff text arrive independently — a producer builds each
+    /// change from a name-status listing, then attaches numstat and diff text
+    /// in two calls, either of which can fail, and [`Self::best_diff`] names
+    /// `diff: None` with real counts as a legitimate shape. Recording the
+    /// entry only when text was present conflated "no patch" with "no
+    /// measurement": [`Self::delta_at`] answered `None` for a mutation whose
+    /// `(added, removed)` the emitter had measured, so the row lost its
+    /// `+N −M` as well as its diff (#4155).
+    pub text: Option<String>,
     pub added: u32,
     pub removed: u32,
 }
@@ -99,14 +110,21 @@ pub(crate) fn evict_lru(files: &mut Vec<FileState>) -> bool {
 }
 
 impl FileState {
-    /// Record a mutation's diff against the `changes` value it produced.
-    /// Called only for mutations, and only after `changes` has been bumped, so
-    /// the tag matches the seq a tool result folds at the same moment.
+    /// Record a mutation against the `changes` value it produced, whether or
+    /// not the emitter attached a patch for it. Called only for mutations, and
+    /// only after `changes` has been bumped, so the tag matches the seq the
+    /// mutation's own tool result stamped.
+    ///
+    /// A change carrying `diff: None` is recorded too: it still measured an
+    /// `(added, removed)` the row wants to state, and skipping it made
+    /// [`Self::delta_at`] deny a measurement that existed (#4155). The cost is
+    /// that such an entry occupies a [`DIFF_HISTORY`] slot — [`Self::best_diff`]
+    /// therefore scans back for the newest entry that *has* text rather than
+    /// reading the last one.
     pub(crate) fn remember_diff(&mut self, diff: &Option<String>, added: u32, removed: u32) {
-        let Some(text) = diff else { return };
         self.recent_diffs.push_back(RememberedDiff {
             seq: self.changes,
-            text: text.clone(),
+            text: diff.clone(),
             added,
             removed,
         });
@@ -115,10 +133,11 @@ impl FileState {
         }
     }
 
-    /// The diff this path produced at mutation `seq`, if still remembered.
+    /// The diff this path produced at mutation `seq`, if still remembered and
+    /// if that mutation carried a patch at all.
     #[must_use]
     pub fn diff_at(&self, seq: u32) -> Option<&str> {
-        self.remembered_at(seq).map(|d| d.text.as_str())
+        self.remembered_at(seq).and_then(|d| d.text.as_deref())
     }
 
     /// That mutation's measured `(added, removed)` — the numbers a transcript
@@ -160,10 +179,15 @@ impl FileState {
         if let Some(current) = self.latest_diff.as_deref() {
             return Some((current, true));
         }
+        // The newest entry that carries text, not simply the newest: since
+        // #4155 a measured-but-patchless change is remembered too, and reading
+        // `back()` alone would answer `None` for a path whose diff is sitting
+        // one entry further in — the exact regression #1741 fixed.
         self.recent_diffs
-            .back()
-            .map(|d| (d.text.as_str(), false))
-            .filter(|(text, _)| !text.is_empty())
+            .iter()
+            .rev()
+            .find_map(|d| d.text.as_deref().filter(|text| !text.is_empty()))
+            .map(|text| (text, false))
     }
 }
 

--- a/crates/stella-tui/src/model/file_state.rs
+++ b/crates/stella-tui/src/model/file_state.rs
@@ -64,10 +64,10 @@ pub struct RememberedDiff {
     ///
     /// Counts and diff text arrive independently — a producer builds each
     /// change from a name-status listing, then attaches numstat and diff text
-    /// in two calls, either of which can fail, and [`Self::best_diff`] names
-    /// `diff: None` with real counts as a legitimate shape. Recording the
-    /// entry only when text was present conflated "no patch" with "no
-    /// measurement": [`Self::delta_at`] answered `None` for a mutation whose
+    /// in two calls, either of which can fail, and [`FileState::best_diff`]
+    /// names `diff: None` with real counts as a legitimate shape. Recording
+    /// the entry only when text was present conflated "no patch" with "no
+    /// measurement": [`FileState::delta_at`] answered `None` for a mutation whose
     /// `(added, removed)` the emitter had measured, so the row lost its
     /// `+N −M` as well as its diff (#4155).
     pub text: Option<String>,

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -1190,3 +1190,202 @@ fn a_settled_progress_line_is_never_overwritten_by_a_later_pass() {
         model.transcript
     );
 }
+
+// ---- #4155: a mutating row resolves the change its own call made ----
+
+/// Fold one successful `edit_file` call: the start that names the path, then
+/// the result that folds the transcript row.
+fn edit_call(model: &mut SessionModel, call_id: &str, path: &str) {
+    model.apply(&AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: call_id.into(),
+            name: "edit_file".into(),
+            input: serde_json::json!({ "path": path }),
+        },
+    });
+    model.apply(&AgentEvent::ToolResult {
+        call_id: call_id.into(),
+        output: ToolOutput::ok("replaced 1 occurrence(s)"),
+        duration_ms: 7,
+        speculated: false,
+    });
+}
+
+/// The turn boundary's measurement: `emit_shared_tree_changes` emits one
+/// aggregate change per path *after* every `ToolResult` of the turn has
+/// folded. That ordering is the whole defect, so these tests reproduce it
+/// rather than emitting the change alongside the call.
+fn turn_boundary(model: &mut SessionModel, path: &str, diff: Option<&str>, adds: u32, dels: u32) {
+    model.apply(&AgentEvent::FileChange {
+        path: path.into(),
+        kind: FileChangeKind::Modified,
+        added: adds,
+        removed: dels,
+        diff: diff.map(Into::into),
+    });
+}
+
+/// The inline-diff reference that call's row kept, if any. Panics if the call
+/// folded no row at all — that would be a different defect.
+fn inline_ref<'a>(model: &'a SessionModel, call_id: &str) -> Option<&'a InlineDiffRef> {
+    model
+        .transcript
+        .iter()
+        .find_map(|e| match e {
+            TranscriptEntry::ToolResult {
+                call_id: cid, diff, ..
+            } if cid == call_id => Some(diff.as_ref()),
+            _ => None,
+        })
+        .expect("the call folded a result row")
+}
+
+/// The live cause of #4155: a successful edit rendered no diff and no
+/// `+N −M`, because the seq the row stamped named the change *before* its own.
+#[test]
+fn an_edit_result_resolves_the_change_its_own_call_made() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    turn_boundary(
+        &mut model,
+        "src/a.rs",
+        Some("@@ -1 +1,2 @@\n+first\n"),
+        2,
+        1,
+    );
+
+    let dref = inline_ref(&model, "c1").expect("a successful edit keeps an inline-diff ref");
+    let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+    assert_eq!(
+        file.diff_at(dref.seq),
+        Some("@@ -1 +1,2 @@\n+first\n"),
+        "the row resolves the diff of the change its own call produced"
+    );
+    assert_eq!(
+        file.delta_at(dref.seq),
+        Some((2, 1)),
+        "and the measurement that rides with it"
+    );
+}
+
+/// The half the off-by-one hid: it did not merely blank the row, it pointed
+/// every turn after the first at the PREVIOUS turn's change to that path —
+/// the misattribution `render::resolve_inline_diff` exists to prevent.
+#[test]
+fn a_later_turns_edit_never_renders_an_earlier_turns_diff() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    turn_boundary(&mut model, "src/a.rs", Some("@@ first turn @@\n"), 1, 0);
+    edit_call(&mut model, "c2", "src/a.rs");
+    turn_boundary(&mut model, "src/a.rs", Some("@@ second turn @@\n"), 3, 2);
+
+    let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+    let first = inline_ref(&model, "c1").expect("turn one keeps its ref");
+    let second = inline_ref(&model, "c2").expect("turn two keeps its ref");
+    assert_ne!(first.seq, second.seq, "two turns, two distinct changes");
+    assert_eq!(file.diff_at(first.seq), Some("@@ first turn @@\n"));
+    assert_eq!(
+        file.diff_at(second.seq),
+        Some("@@ second turn @@\n"),
+        "turn two's row shows turn two's change, not the one before it"
+    );
+}
+
+/// One aggregate change per path per turn, so exactly one row may claim it.
+/// Stamping every call that touched the path would render the turn's whole
+/// change under each of them; the last keeps it, the earlier ones degrade to
+/// naming their change.
+#[test]
+fn only_the_last_call_to_a_path_in_a_turn_claims_the_turns_change() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    edit_call(&mut model, "c2", "src/a.rs");
+    turn_boundary(&mut model, "src/a.rs", Some("@@ both edits @@\n"), 4, 1);
+
+    assert!(
+        inline_ref(&model, "c1").is_none(),
+        "the superseded row gives up its ref rather than restating the aggregate"
+    );
+    let last = inline_ref(&model, "c2").expect("the last call keeps it");
+    let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+    assert_eq!(file.diff_at(last.seq), Some("@@ both edits @@\n"));
+}
+
+/// Supersession is per path: two files edited in one turn keep one row each.
+#[test]
+fn calls_to_different_paths_in_one_turn_each_keep_their_own_ref() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    edit_call(&mut model, "c2", "src/b.rs");
+    turn_boundary(&mut model, "src/a.rs", Some("@@ a @@\n"), 1, 0);
+    turn_boundary(&mut model, "src/b.rs", Some("@@ b @@\n"), 2, 0);
+
+    for (call, path, text) in [
+        ("c1", "src/a.rs", "@@ a @@\n"),
+        ("c2", "src/b.rs", "@@ b @@\n"),
+    ] {
+        let dref = inline_ref(&model, call).expect("each path's row keeps its ref");
+        let file = model.files.iter().find(|f| f.path == path).unwrap();
+        assert_eq!(file.diff_at(dref.seq), Some(text));
+    }
+}
+
+/// A turn that measured no net change to the path leaves the ref dangling,
+/// and a dangling ref renders nothing. Silence is the honest answer — an edit
+/// reverted within the same turn changed nothing on disk.
+#[test]
+fn a_turn_that_measured_no_change_leaves_the_row_silent() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    let dref = inline_ref(&model, "c1").expect("the ref is still stamped");
+    assert_eq!(dref.path, "src/a.rs");
+    assert!(
+        model.files.iter().all(|f| f.path != "src/a.rs"),
+        "nothing measured the path, so nothing resolves"
+    );
+}
+
+/// A failed mutation still carries no reference: the change it would point at
+/// is one it never made.
+#[test]
+fn a_failed_mutation_keeps_no_inline_diff_ref() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c1".into(),
+            name: "edit_file".into(),
+            input: serde_json::json!({ "path": "src/a.rs" }),
+        },
+    });
+    model.apply(&AgentEvent::ToolResult {
+        call_id: "c1".into(),
+        output: ToolOutput::error("no such file"),
+        duration_ms: 3,
+        speculated: false,
+    });
+    turn_boundary(&mut model, "src/a.rs", Some("@@ someone else @@\n"), 1, 0);
+    assert!(inline_ref(&model, "c1").is_none());
+}
+
+/// #4155's second named cause: counts and diff text arrive independently, and
+/// a change measured without an attachable patch used to be dropped entirely —
+/// so the row lost its `+N −M` as well as its diff.
+#[test]
+fn a_measured_change_with_no_patch_still_reports_its_delta() {
+    let mut model = SessionModel::new();
+    edit_call(&mut model, "c1", "src/a.rs");
+    turn_boundary(&mut model, "src/a.rs", None, 3, 1);
+
+    let dref = inline_ref(&model, "c1").expect("the row keeps its ref");
+    let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
+    assert_eq!(
+        file.delta_at(dref.seq),
+        Some((3, 1)),
+        "the measurement survives the missing patch"
+    );
+    assert_eq!(
+        file.diff_at(dref.seq),
+        None,
+        "and no patch is invented for it"
+    );
+}

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -511,9 +511,17 @@ fn entry_body(
             // "42 lines of output" would describe the tool's chatter, not the
             // change. Everything else reports output size, and only when
             // there is more than the one line already shown.
+            //
+            // Gated on the *measurement*, not on the diff text: a change can
+            // be measured without a patch being attachable, and gating on the
+            // text denied the row a size it actually knew (#4155). The two
+            // resolve together in the ordinary case; where they part, the row
+            // states the size and falls back to the tool's own preview below
+            // rather than showing nothing at all. `unwrap_or((0, 0))` is gone
+            // with it — a fabricated `+0 −0` over a real edit is the defect
+            // #4156 removed from the head row, and it has no place here.
             let mut metric: Vec<Span<'static>> = Vec::new();
-            if inline.is_some() {
-                let (added, removed) = inline_delta.unwrap_or((0, 0));
+            if let Some((added, removed)) = inline_delta {
                 metric.push(Span::styled(
                     format!("+{added}"),
                     Style::new().fg(theme::OK),

--- a/crates/stella-tui/src/render/tests/inline_diff.rs
+++ b/crates/stella-tui/src/render/tests/inline_diff.rs
@@ -48,7 +48,7 @@ fn mutation_entry_and_files() -> (TranscriptEntry, Vec<FileState>) {
         removed,
         recent_diffs: [crate::model::RememberedDiff {
             seq: 1,
-            text: diff_text,
+            text: Some(diff_text),
             added,
             removed,
         }]
@@ -204,7 +204,7 @@ fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
     files[0].recent_diffs = (2..=files[0].changes)
         .map(|seq| crate::model::RememberedDiff {
             seq,
-            text: format!("@@ -0,0 +1,1 @@\n+later_edit_{seq}\n"),
+            text: Some(format!("@@ -0,0 +1,1 @@\n+later_edit_{seq}\n")),
             added: 1,
             removed: 0,
         })

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -937,10 +937,10 @@ mod tests {
     #[test]
     fn a_later_mutation_leaves_the_settled_inline_diff_showing_its_own_change() {
         use stella_protocol::{FileChangeKind, ToolCall, ToolOutput};
-        // A successful edit_file: ToolStart → FileChange (the engine's tap
-        // fires during execution) → ToolResult. The result's inline diff
-        // must render, and must go on rendering *the change that call made*
-        // when the same path is edited again.
+        // A successful edit_file: ToolStart → ToolResult → FileChange, the
+        // real producer ordering — the turn boundary measures the tree after
+        // the result has folded (#4155). The result's inline diff must
+        // render, and must go on rendering *the change that call made*.
         //
         // It used to vanish instead: `FileState` kept one `latest_diff` and
         // the ref resolved only while `changes` still equalled the recorded
@@ -963,13 +963,6 @@ mod tests {
                 input: serde_json::json!({"path": "src/x.rs"}),
             },
         });
-        model.apply(&AgentEvent::FileChange {
-            path: "src/x.rs".into(),
-            kind: FileChangeKind::Modified,
-            added: 1,
-            removed: 0,
-            diff: Some("@@ -1,1 +1,1 @@\n+first_diff_line".into()),
-        });
         model.apply(&AgentEvent::ToolResult {
             call_id: "c1".into(),
             output: ToolOutput::Ok {
@@ -978,6 +971,13 @@ mod tests {
             },
             duration_ms: 3,
             speculated: false,
+        });
+        model.apply(&AgentEvent::FileChange {
+            path: "src/x.rs".into(),
+            kind: FileChangeKind::Modified,
+            added: 1,
+            removed: 0,
+            diff: Some("@@ -1,1 +1,1 @@\n+first_diff_line".into()),
         });
         let expanded = HashSet::new();
         let mut fold = SessionFold::default();


### PR DESCRIPTION
## What

A successful `edit_file` rendered no diff and no `+N −M` on either row. The
inline-diff reference a tool result stamps named the change **before** its own.

`stella-pipeline`, which emitted one `FileChange` per adopted change *during*
delivery, is deleted (#3865). The only producer left is
`stella_cli::turn_files::emit_shared_tree_changes` — one aggregate `--numstat`
change per path, emitted at the **turn boundary**, after every `ToolResult` of
the turn has folded. `touch_file` then records it at the *bumped* `changes`, so
the seq the row stamped was always one behind:

| | row stamps | diff recorded at | resolves to |
|---|---|---|---|
| turn 1 | `0` | `1` | nothing — the reported blank row |
| turn 2 | `1` | `2` | **turn 1's diff** |

The reported symptom (#4155) is the first line. The second is worse and was
silent: every turn after the first rendered the *previous* turn's diff under
this turn's edit — the exact misattribution `render::resolve_inline_diff`'s own
doc exists to prevent.

This was reachable only after #4160 gave the deck a producer at all. Before
that the deck emitted no `FileChange`, so the ref could not resolve for a
different reason and hid this one.

## The fix

**1. The seq names the change the call will produce** (`changes + 1`), not the
one already recorded.

**2. Supersession.** Several calls may mutate one path in a turn, and they all
compute the same seq — `changes` does not move until the boundary. Left alone
they would each render the turn's whole change to that file as their own, which
is why #4165 declined to stamp `+1` on its own and deferred the choice. The
last call keeps the reference (the measured post-state is the one its edit left
behind) and earlier rows give it up, degrading to naming their change — the
same degradation `DIFF_HISTORY` aging and `MAX_TRACKED_FILES` eviction already
have.

**3. A measurement survives a missing patch.** `remember_diff` returned early on
`diff: None`, so a change the emitter *had* measured was dropped entirely and
`delta_at` denied counts that existed — #4155's second named cause. It is
recorded now, `RememberedDiff::text` became `Option<String>`, and the renderer
gates the `+N −M` column on the **measurement** rather than on the diff text.
`unwrap_or((0, 0))` goes with it: a fabricated `+0 −0` over a real edit is the
defect #4156 removed from the head row. `best_diff` scans back for the newest
entry that *has* text rather than reading `back()`, which preserves #1741.

## Witnesses

Nine tests in `crates/stella-tui/src/model/tests.rs`. Checked the artisanal way
— reverting each production file to `origin/main` while keeping the tests:

| Reverted | Result |
|---|---|
| `model.rs` | 5 fail: `an_edit_result_resolves_the_change_its_own_call_made`, `a_later_turns_edit_never_renders_an_earlier_turns_diff`, `only_the_last_call_to_a_path_in_a_turn_claims_the_turns_change`, `calls_to_different_paths_in_one_turn_each_keep_their_own_ref`, `a_measured_change_with_no_patch_still_reports_its_delta` |
| `model/file_state.rs` | 1 fails: `a_measured_change_with_no_patch_still_reports_its_delta` |

The others pin behaviour that must not change: a failed mutation still keeps no
ref, and a turn measuring no net change leaves the row silent (an edit reverted
within its own turn changed nothing on disk, and silence is the honest answer).

## One existing test changed, not deleted

`views::session::tests::a_later_mutation_leaves_the_settled_inline_diff_showing_its_own_change`
emitted `ToolStart → FileChange → ToolResult`, commented as "the engine's tap
fires during execution". That tap is the `FileChangeTap` #4165 found does not
exist — the ordering had no producer in the workspace. Reordered to the real
one (`ToolStart → ToolResult → FileChange`); all three of its assertions are
unchanged and still pass. `views/session.rs` is a grandfathered god file, so
this is net zero lines there.

## Verification

- `cargo test -p stella-tui` — 878 lib + all integration suites pass, golden
  deck snapshots included and unchanged.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS=-D warnings cargo doc -p stella-tui` — clean.
- `cargo check --workspace --all-targets` — clean.
- `make guards` — 32 steps green; `check-file-size` judged against `b807286e6`,
  nothing over.

## Remaining work

The ceiling this leaves is real and stated out loud: **one tool call per (path,
turn) can show a diff**, because the producer emits one aggregate change per
path per turn. `FileState` already keeps 8 diffs per path keyed by seq for
exactly this, so the depth is there and the producer is what does not fill it.
Lifting it needs a per-call producer and a decision about double-counting
`FileState::added`/`removed`, which is a design call rather than a repair —
filed as a handoff in **#4175**.

Supersedes #4165, which corrected the misleading comment on this code but made
no behaviour change; this PR rewrites the same block against the fixed
behaviour.

Closes #4155
Refs #4160, #3865, #4156, #1741

## Summary by Sourcery

Correct inline diff attribution for mutating tool results and preserve measured change counts when patch text is unavailable.

Bug Fixes:
- Ensure successful mutating tool rows resolve and display the diff produced by their own call rather than a blank or previous-turn change.
- Preserve line-count measurements when a file change has no attachable patch, while avoiding fabricated zero-delta indicators.

Enhancements:
- Prevent multiple mutation rows for the same path in one turn from claiming the same aggregate change by retaining the reference only on the last call.
- Improve diff-history lookup so the newest available patch remains renderable after patchless measurements.

Tests:
- Add coverage for own-call diff resolution, cross-turn attribution, same-turn supersession, per-path attribution, no-op and failed mutations, and patchless measurements.