### PR TITLE
fix(ci): the annotations panel goes green — trybuild's scratch tree leaves before the cache is saved (#4149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,40 @@ jobs:
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo build --workspace --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'
 
+      # Last main step in the job, so it runs before rust-cache's post step —
+      # which is the whole point (#4149).
+      #
+      # `cargo test --workspace` above runs stella-diag's trybuild suite
+      # (crates/stella-diag/tests/compile_fail.rs). trybuild builds its scratch
+      # project under `${target_dir}/tests/trybuild` — hardcoded, with no
+      # override short of moving the whole build (trybuild 1.0.118
+      # src/cargo.rs:58-62) — so `target/tests` exists afterwards, with no
+      # sibling `target/` inside it.
+      #
+      # rust-cache's post step then walks `target/` to prune it before saving.
+      # At the SHA pinned above (and still on its master as of 2026-08-21),
+      # src/cleanup.ts:20-24 classifies ANY directory named `tests` as a build
+      # profile, and :45-50 calls `cleanTargetDir(<dir>/target)` *without
+      # awaiting it*, inside a `try {} catch {}` that therefore cannot catch
+      # the rejection. The ENOENT escapes to save.ts:8-11's `uncaughtException`
+      # handler, which emits `core.error(e.message)` and `core.error(e.stack)`:
+      # two failure-level annotations on a step that cannot fail the job. Every
+      # green run of this job carried them, and an annotations panel that is
+      # permanently red is one a reader stops reading — the same erosion the
+      # main-red-hold reasoning names one layer down. Upstream fixed this same
+      # bug class for the registry path (Swatinem/rust-cache#144) and left this
+      # call site alone.
+      #
+      # Deleting the scratch tree removes the trigger at the one point we
+      # control. It costs one cold trybuild rebuild per run (~5s, measured
+      # locally) because that tree is no longer cached, and it keeps a fixture
+      # cargo manifest out of the saved cache for the next tool that scans for
+      # workspaces. #4177 tracks reporting it upstream and deleting this step
+      # once the pin can be bumped past the fix.
+      - name: drop the trybuild scratch tree before the cache is saved
+        if: ${{ !cancelled() }}
+        run: rm -rf target/tests
+
   supply-chain:
     # NOTE: name is pinned to main's branch-protection required-status-check
     # list (`cargo deny + cargo audit`) even though this job no longer runs


### PR DESCRIPTION
## What

Every green run of `fmt + clippy + test` carried **two `failure`-level
annotations**. They came from `rust-cache`'s post step, so they never failed
the job — which is exactly the problem: an annotations panel that is always red
is one a reader stops reading, and the next genuinely new failure-level
annotation arrives pre-ignored. Same erosion `main-red-hold` exists to prevent,
one layer down.

This adds a final step to the `check` job that deletes trybuild's scratch tree
before rust-cache's post step runs.

## The mechanism, established rather than inferred

The issue named the writer as an inference. It is confirmed, and it is not one
of ours:

- **The writer is trybuild.** `cargo test --workspace` runs
  `crates/stella-diag/tests/compile_fail.rs`; trybuild builds its scratch
  project under `${target_dir}/tests/trybuild`, hardcoded with no override
  (trybuild 1.0.118 `src/cargo.rs:58-62`). Reproduced locally:
  `cargo test -p stella-diag --test compile_fail` creates
  `target/tests/trybuild` and **no** `target/tests/target`.
- **The error is an upstream defect.** In `src/cleanup.ts` at the pinned SHA
  (and still on rust-cache's `master` as of 2026-08-21), lines 20-24 classify
  *any* directory named `tests` under the target dir as a build profile, and
  lines 45-50 call `cleanTargetDir(<dir>/target)` **without `await`**, inside a
  `try {} catch {}` that therefore cannot catch the rejection. The ENOENT
  escapes to `save.ts:8-11`'s `uncaughtException` handler, which emits
  `core.error(e.message)` and `core.error(e.stack)` — the two annotation
  messages in the issue, verbatim and in that shape. Upstream fixed this same
  bug class for the registry path (Swatinem/rust-cache#144, closed 2023-08-02)
  and left this call site alone.

## Why neither remedy the issue listed

- *Fix the writer* — trybuild's location is hardcoded off `cargo metadata`'s
  `target_directory`; pointing it at a tempdir means moving the whole build.
- *Scope the cache action* — a `workspaces:` list cannot help: the fixture
  lives **inside** the very target directory being cleaned, so no scoping
  stops the recursion.

So the trigger goes instead, at the one point we control. The cost is one cold
trybuild rebuild per run (**~5s**, measured locally on a cold
`target/tests`) because that tree is no longer cached; the side benefit is that
no fixture cargo manifest is cached under `target/` for the next
workspace-scanning tool to trip on.

## Constraints honoured

- No action pin touched; `check-action-pins.sh` passes (79 refs).
- The new step is `if: ${{ !cancelled() }}` and is **last** in the job, so it
  aborts nothing and cannot change any other step's verdict.
- Dedicated PR — nothing unrelated bundled in.

## Verification

No witness test: this is a CI workflow change, and the behaviour under test is
the annotations panel of the job itself. The check is on this PR's own run —
its diff reaches past the prose paths, so `check` runs:

```sh
jid=$(gh run view <RUN_ID> --json jobs \
  -q '.jobs[]|select(.name=="fmt + clippy + test")|.databaseId')
gh api repos/macanderson/stella/check-runs/$jid/annotations \
  --jq '[.[]|select(.annotation_level=="failure")]|length'   # expect 0
```

`make guards-fast` is green locally (the rung the pre-push hook picks for a
workflow-only diff). No test was deleted.

## Remaining work

#4177 tracks the two things this PR does not do: reporting the defect upstream
(it posts to a third-party repo under a personal account — a maintainer's
call), and deleting this workaround once the pin can be bumped past a fix.

Closes #4149
Refs #4177

## Summary by Sourcery

Prevent misleading failure annotations in the check workflow by removing trybuild artifacts before the Rust cache is saved.

Bug Fixes:
- Prevent rust-cache from emitting spurious failure annotations during successful CI runs by removing trybuild's scratch tree before cache post-processing.

CI:
- Add a final cleanup step to the check job that deletes target/tests before the rust-cache post step runs.