### PR TITLE
fix(stella-tui): the v2 head states the size of the change its call made

### DIFF
--- a/crates/stella-tui/src/accessible.rs
+++ b/crates/stella-tui/src/accessible.rs
@@ -314,7 +314,7 @@ fn settled_entry_count(transcript_len: usize, include_trailing: bool) -> usize {
 /// which resolves through the identical ledger. The alternative — holding a
 /// mutating head back until the turn boundary measures the tree — would trade a
 /// missing column for a silent reader through the whole of a long call, which
-/// is the one thing this mode exists to prevent. #4178 tracks the divergence
+/// is the one thing this mode exists to prevent. #4181 tracks the divergence
 /// from the pane, where the same row does fill in.
 pub fn block_lines(
     model: &WorkspaceModel,

--- a/crates/stella-tui/src/accessible.rs
+++ b/crates/stella-tui/src/accessible.rs
@@ -301,6 +301,21 @@ fn settled_entry_count(transcript_len: usize, include_trailing: bool) -> usize {
 /// `live` is `false` for every entry: liveness is the tail-follow affordance
 /// for a thought still being written, and nothing in this range is still being
 /// written — that is what makes it flushable at all.
+///
+/// Each entry is rendered against the **whole** lane transcript, not against
+/// the block's own slice: a row's tail is where a tool head finds the result
+/// that measured it (#4154), and a result sitting one index past `block.to` is
+/// no less real for not being in this write.
+///
+/// A row whose measurement has not arrived by flush time keeps no size column,
+/// permanently — scrollback is append-only, so what is written here is what a
+/// reader hears. That is the deliberate choice of the two on offer, and it is
+/// the same one the surface already makes for the v1 result row's `+N −M`,
+/// which resolves through the identical ledger. The alternative — holding a
+/// mutating head back until the turn boundary measures the tree — would trade a
+/// missing column for a silent reader through the whole of a long call, which
+/// is the one thing this mode exists to prevent. #4178 tracks the divergence
+/// from the pane, where the same row does fill in.
 pub fn block_lines(
     model: &WorkspaceModel,
     block: &FlushBlock,
@@ -317,10 +332,11 @@ pub fn block_lines(
     let transcript = &entry.model.transcript;
     let files: &[FileState] = &entry.model.files;
     let to = block.to.min(transcript.len());
-    for item in &transcript[block.from.min(to)..to] {
+    let from = block.from.min(to);
+    for (offset, item) in transcript[from..to].iter().enumerate() {
         crate::render::entry_lines(
             item,
-            files,
+            crate::render::EntryView::at(files, transcript, from + offset),
             expand_thinking,
             expand_thinking,
             false,

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -37,7 +37,7 @@ use crate::theme;
 // The transcript content builders moved to `entry` when this file crossed the
 // 1500-line guard; re-exported so `crate::render::transcript_lines` and
 // `::entry_lines` still resolve for `ui.rs` and `deck_ui.rs`.
-pub(crate) use entry::{entry_lines, reasoning_is_live, streaming_lines};
+pub(crate) use entry::{EntryView, entry_lines, reasoning_is_live, streaming_lines};
 pub(crate) use row::*;
 
 /// The usable interior height of a single-border panel.

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -291,7 +291,9 @@ pub(crate) fn entry_lines(
 /// drawn at dispatch, when nothing has measured the change it is about to make,
 /// so the number can only come from the paired result and the ledger behind it
 /// (#4154). Resolving it here rather than inside the projection keeps
-/// [`v2::head_rows`] a pure function of what is known about one call.
+/// [`crate::v2::transcript_source::head_rows`] a pure function of what is known
+/// about one call. (Spelled in full: the `v2` alias below is a `use` inside the
+/// body, and rustdoc resolves a link against the module, not the function.)
 fn v2_rows(
     entry: &TranscriptEntry,
     view: EntryView<'_>,

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -138,6 +138,45 @@ fn argument_rows(
 
 // Pure content builders (unit-tested directly)
 
+/// What a transcript row needs to know beyond its own entry.
+///
+/// Both fields exist because a row is not a function of its entry alone. An
+/// inline diff resolves against the draw-side file ledger; and a tool **head**
+/// states a size nothing has measured at the moment it dispatches — the
+/// emitter's `(added, removed)` arrives with the call's *result*, a later entry,
+/// and is only recorded once the turn boundary has measured the tree (#4154).
+///
+/// Bundled rather than passed as two more positional arguments: [`entry_lines`]
+/// already carries three booleans, and the pair travels together everywhere —
+/// pairing one entry's ledger with another entry's tail is not a call a caller
+/// should be able to make by ordering its arguments wrongly.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct EntryView<'a> {
+    /// The draw-side file ledger every diff and delta resolves against.
+    pub files: &'a [FileState],
+    /// The lane's entries *after* the one being rendered, in order.
+    pub following: &'a [TranscriptEntry],
+}
+
+impl<'a> EntryView<'a> {
+    /// The view entry `idx` is rendered against.
+    pub fn at(files: &'a [FileState], transcript: &'a [TranscriptEntry], idx: usize) -> Self {
+        Self {
+            files,
+            following: transcript.get(idx.saturating_add(1)..).unwrap_or_default(),
+        }
+    }
+
+    /// A view with no tail, for a row that has no later entry to consult: the
+    /// streaming answer preview, which is not in the transcript at all.
+    pub fn of(files: &'a [FileState]) -> Self {
+        Self {
+            files,
+            following: &[],
+        }
+    }
+}
+
 /// Fold the in-flight answer preview
 /// ([`SessionModel::streaming_text`](crate::model::SessionModel::streaming_text))
 /// as a trailing agent block, or nothing at all when there is none.
@@ -158,7 +197,15 @@ pub(crate) fn streaming_lines(
         return;
     }
     let preview = TranscriptEntry::Text(streaming.to_string());
-    entry_lines(&preview, files, expand_thinking, false, false, width, out);
+    entry_lines(
+        &preview,
+        EntryView::of(files),
+        expand_thinking,
+        false,
+        false,
+        width,
+        out,
+    );
 }
 
 /// Whether the trailing transcript entry is a thought *still being written* —
@@ -199,15 +246,15 @@ fn closes_block(entry: &TranscriptEntry) -> bool {
 /// head; every settled entry passes `false`.
 pub(crate) fn entry_lines(
     entry: &TranscriptEntry,
-    files: &[FileState],
+    view: EntryView<'_>,
     expand_thinking: bool,
     expanded: bool,
     live: bool,
     width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
-    if !v2_rows(entry, expanded, width, out) {
-        entry_body(entry, files, expand_thinking, expanded, live, width, out);
+    if !v2_rows(entry, view, expanded, width, out) {
+        entry_body(entry, view, expand_thinking, expanded, live, width, out);
     }
     if closes_block(entry) {
         push_gap(out);
@@ -238,8 +285,16 @@ pub(crate) fn entry_lines(
 /// `module-reachability`, which see items. The row rendered identically
 /// expanded and collapsed for as long as nobody pressed the key (#4157). Hence
 /// `expanded` here: a router that takes a head takes the body under it too.
+///
+/// The head's size column is the other thing this arm owes, and it is why the
+/// router takes a [`EntryView`] rather than the entry alone: a `ToolStart` is
+/// drawn at dispatch, when nothing has measured the change it is about to make,
+/// so the number can only come from the paired result and the ledger behind it
+/// (#4154). Resolving it here rather than inside the projection keeps
+/// [`v2::head_rows`] a pure function of what is known about one call.
 fn v2_rows(
     entry: &TranscriptEntry,
+    view: EntryView<'_>,
     expanded: bool,
     width: usize,
     out: &mut Vec<Line<'static>>,
@@ -247,13 +302,14 @@ fn v2_rows(
     use crate::v2::transcript_source as v2;
     match entry {
         TranscriptEntry::ToolStart {
+            call_id,
             name,
             input,
             raw,
             path,
-            ..
         } => {
-            out.extend(v2::head_rows(name, path.as_deref(), input, width));
+            let measured = v2::measured_delta(call_id, view.following, view.files);
+            out.extend(v2::head_rows(name, path.as_deref(), input, measured, width));
             if expanded {
                 argument_rows(v2::head_metal(name), raw, width, out);
             }
@@ -339,7 +395,7 @@ const THINKING_FOLD_HINT: &str = "⋯ ctrl+o expands this thought · ctrl+r all"
 
 fn entry_body(
     entry: &TranscriptEntry,
-    files: &[FileState],
+    view: EntryView<'_>,
     expand_thinking: bool,
     expanded: bool,
     live: bool,
@@ -495,13 +551,15 @@ fn entry_body(
             } else {
                 human_duration(*duration_ms)
             };
-            let inline = diff.as_ref().and_then(|d| resolve_inline_diff(d, files));
+            let inline = diff
+                .as_ref()
+                .and_then(|d| resolve_inline_diff(d, view.files));
             // The delta the emitter measured for this very mutation, carried
             // alongside its diff — not a recount of the rendered hunk, which is
             // a bounded view of the changed region and reports a smaller number.
             let inline_delta = diff
                 .as_ref()
-                .and_then(|d| super::resolve_inline_delta(d, files));
+                .and_then(|d| super::resolve_inline_delta(d, view.files));
 
             // The right-hand metric column. A diff states its own size in
             // added/removed lines, which is the honest unit for an edit —
@@ -1094,7 +1152,7 @@ fn entry_body(
         // Delegating means there is one implementation to keep correct and no
         // second one to rot.
         TranscriptEntry::ToolStart { .. } => {
-            v2_rows(entry, expanded, width, out);
+            v2_rows(entry, view, expanded, width, out);
         }
     }
 }

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -67,7 +67,7 @@ fn transcript_lines(
     for (i, entry) in model.transcript.iter().enumerate() {
         entry_lines(
             entry,
-            &model.files,
+            EntryView::at(&model.files, &model.transcript, i),
             expand_thinking,
             expand_thinking,
             live && i == last,
@@ -443,7 +443,7 @@ fn the_turn_receipt_prices_in_gold_not_in_the_pass_colour() {
             cost_usd: 0.11,
             turn: 14,
         },
-        &[],
+        EntryView::default(),
         false,
         false,
         false,
@@ -472,7 +472,15 @@ fn the_turn_receipt_prices_in_gold_not_in_the_pass_colour() {
 
 fn recall_text(entry: &TranscriptEntry, expanded: bool, width: usize) -> String {
     let mut out = Vec::new();
-    entry_lines(entry, &[], false, expanded, false, width, &mut out);
+    entry_lines(
+        entry,
+        EntryView::default(),
+        false,
+        expanded,
+        false,
+        width,
+        &mut out,
+    );
     out.iter()
         .map(|l| {
             l.spans

--- a/crates/stella-tui/src/render/tests/block_rail.rs
+++ b/crates/stella-tui/src/render/tests/block_rail.rs
@@ -60,7 +60,15 @@ fn result(name: &str, ok: bool, body: &str) -> TranscriptEntry {
 fn rows(entries: &[TranscriptEntry]) -> Vec<String> {
     let mut out = Vec::new();
     for entry in entries {
-        entry_lines(entry, &[], false, false, false, WIDTH, &mut out);
+        entry_lines(
+            entry,
+            EntryView::default(),
+            false,
+            false,
+            false,
+            WIDTH,
+            &mut out,
+        );
     }
     out.iter()
         .map(|l| {
@@ -141,7 +149,15 @@ fn a_failed_block_rides_its_own_rail_end_to_end() {
     ];
     let mut lines = Vec::new();
     for entry in &block {
-        entry_lines(entry, &[], false, false, false, WIDTH, &mut lines);
+        entry_lines(
+            entry,
+            EntryView::default(),
+            false,
+            false,
+            false,
+            WIDTH,
+            &mut lines,
+        );
     }
     let rail = expected_rail();
     let railed: Vec<_> = lines
@@ -245,7 +261,15 @@ fn call_with_args() -> TranscriptEntry {
 
 fn render(entry: &TranscriptEntry, expanded: bool) -> Vec<String> {
     let mut out = Vec::new();
-    entry_lines(entry, &[], false, expanded, false, WIDTH, &mut out);
+    entry_lines(
+        entry,
+        EntryView::default(),
+        false,
+        expanded,
+        false,
+        WIDTH,
+        &mut out,
+    );
     out.iter()
         .map(|l| {
             l.spans
@@ -302,7 +326,15 @@ fn revealed_arguments_ride_the_heads_own_rail() {
             path: Some("src/lib.rs".into()),
         };
         let mut lines = Vec::new();
-        entry_lines(&call, &[], false, true, false, WIDTH, &mut lines);
+        entry_lines(
+            &call,
+            EntryView::default(),
+            false,
+            true,
+            false,
+            WIDTH,
+            &mut lines,
+        );
         let railed: Vec<_> = lines
             .iter()
             .filter(|l| {

--- a/crates/stella-tui/src/render/tests/inline_diff.rs
+++ b/crates/stella-tui/src/render/tests/inline_diff.rs
@@ -78,7 +78,15 @@ fn flat_text(lines: &[Line<'_>]) -> String {
 fn collapsed_tool_result_shows_a_capped_syntax_highlighted_inline_diff() {
     let (entry, files) = mutation_entry_and_files();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, false, false, 120, &mut out);
+    entry_lines(
+        &entry,
+        EntryView::of(&files),
+        false,
+        false,
+        false,
+        120,
+        &mut out,
+    );
     let text = flat_text(&out);
 
     // No path rule and no counts footer inline, unlike the standalone diff
@@ -170,7 +178,15 @@ fn collapsed_tool_result_shows_a_capped_syntax_highlighted_inline_diff() {
 fn expanded_tool_result_shows_the_full_inline_diff() {
     let (entry, files) = mutation_entry_and_files();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, true, false, 120, &mut out);
+    entry_lines(
+        &entry,
+        EntryView::of(&files),
+        false,
+        true,
+        false,
+        120,
+        &mut out,
+    );
     let text = flat_text(&out);
     assert!(
         text.contains(&format!("+let x{FIXTURE_ADDS} = {FIXTURE_ADDS};")),
@@ -210,7 +226,15 @@ fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
         })
         .collect();
     let mut out = Vec::new();
-    entry_lines(&entry, &files, false, false, false, 120, &mut out);
+    entry_lines(
+        &entry,
+        EntryView::of(&files),
+        false,
+        false,
+        false,
+        120,
+        &mut out,
+    );
     let text = flat_text(&out);
     assert!(
         !text.contains("+let x1 = 1;"),
@@ -227,7 +251,15 @@ fn a_stale_or_unresolvable_diff_ref_renders_no_inline_diff() {
 
     // A ref whose path is no longer tracked resolves to nothing at all.
     let mut out = Vec::new();
-    entry_lines(&entry, &[], false, false, false, 120, &mut out);
+    entry_lines(
+        &entry,
+        EntryView::default(),
+        false,
+        false,
+        false,
+        120,
+        &mut out,
+    );
     assert!(
         !flat_text(&out).contains("+let x1 = 1;"),
         "unknown path renders no diff"

--- a/crates/stella-tui/src/render/tests/palette.rs
+++ b/crates/stella-tui/src/render/tests/palette.rs
@@ -24,7 +24,15 @@ use super::*;
 fn no_transcript_row_carries_a_raw_ansi_colour() {
     for entry in sample_entries() {
         let mut lines = Vec::new();
-        entry_lines(&entry, &[], true, true, false, 80, &mut lines);
+        entry_lines(
+            &entry,
+            EntryView::default(),
+            true,
+            true,
+            false,
+            80,
+            &mut lines,
+        );
         for line in &lines {
             for span in &line.spans {
                 for (slot, colour) in [("fg", span.style.fg), ("bg", span.style.bg)] {
@@ -53,7 +61,7 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
     // `theme::WARN`, a heading goes bold `INK`): proof none of it leaks.
     entry_lines(
         &TranscriptEntry::User("fix the `parser` bug\nand **ship** it".to_string()),
-        &[],
+        EntryView::default(),
         false,
         false,
         false,
@@ -106,7 +114,15 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
 fn transcript_prefix_colors_stay_in_the_brand_family() {
     let prefix_fg = |entry: &TranscriptEntry| -> Option<Color> {
         let mut out = Vec::new();
-        entry_lines(entry, &[], false, false, false, 80, &mut out);
+        entry_lines(
+            entry,
+            EntryView::default(),
+            false,
+            false,
+            false,
+            80,
+            &mut out,
+        );
         out[0].spans[0].style.fg
     };
     assert_eq!(
@@ -228,7 +244,7 @@ fn a_tool_name_is_hued_by_what_kind_of_call_it_was() {
                 raw: "{}".into(),
                 path: None,
             },
-            &[],
+            EntryView::default(),
             false,
             false,
             false,
@@ -272,7 +288,7 @@ fn a_tool_name_is_hued_by_what_kind_of_call_it_was() {
                 raw: "{}".into(),
                 path: Some("src/lib.rs".into()),
             },
-            &[],
+            EntryView::default(),
             false,
             false,
             false,
@@ -307,7 +323,7 @@ fn an_argument_less_call_prints_no_empty_object() {
             raw: "{}".into(),
             path: None,
         },
-        &[],
+        EntryView::default(),
         false,
         false,
         false,
@@ -338,7 +354,7 @@ fn a_sub_agent_dispatch_is_not_bookkeeping() {
             instruction_preview: "read the layout".into(),
             write_access: false,
         },
-        &[],
+        EntryView::default(),
         false,
         false,
         false,

--- a/crates/stella-tui/src/render/tests/tool_output.rs
+++ b/crates/stella-tui/src/render/tests/tool_output.rs
@@ -57,7 +57,15 @@ fn numbered(first: usize, source: &[&str]) -> String {
 
 fn collapsed(entry: &TranscriptEntry) -> Vec<Line<'static>> {
     let mut out = Vec::new();
-    entry_lines(entry, &[], false, false, false, 120, &mut out);
+    entry_lines(
+        entry,
+        EntryView::default(),
+        false,
+        false,
+        false,
+        120,
+        &mut out,
+    );
     out
 }
 

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -106,9 +106,11 @@ pub enum EventKind {
     /// `▸ read <path> · <n> lines` — folded by default. The count rides
     /// `Extent::added` and has no producer today: only a *mutation* stamps the
     /// inline-diff reference the head's measurement is resolved through, so a
-    /// read states its path and nothing about its size (#4177).
+    /// read states its path and nothing about its size (#4180).
     Read { extent: Extent },
-    /// `● edit <path> +a -b`, the counts absent until the edit returns.
+    /// `● edit <path> +a -b`, both counts or neither — they are one reading.
+    /// Absent until the emitter has measured the change (#4154), which is the
+    /// turn boundary rather than the moment the call returns.
     Edit { extent: Extent },
     /// `＋ write <path> · new file · n lines`, the count on `Extent::added`.
     Write { extent: Extent },

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -49,11 +49,13 @@ pub const RAIL_W: usize = 2;
 /// counts stopped being re-derived for exactly this reason — #2290). `None`
 /// renders as no column at all.
 ///
-/// Nothing constructs a measured `Extent` from a live session yet: the head
-/// draws at dispatch and there is no pass that revisits the row once the
-/// turn-boundary `FileChange` lands. That backfill is the other half of #4150
-/// and is tracked separately; until it exists an edit head is honestly silent
-/// about its size, and the measured numbers stay on the v1 result row.
+/// A measured one is filled in after the fact, not at dispatch:
+/// [`super::transcript_source::measured_delta`] resolves the emitter's counts
+/// through the call's own result once the turn boundary has measured the tree,
+/// and the deck's settled-prefix fold re-renders the row when that lands
+/// (#4154). So `None` is the state of every head at the moment it is drawn, and
+/// of any head whose call failed, was cancelled, or changed nothing — three
+/// facts a zero would misreport as one.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Extent {
     /// Lines added, for an edit or a new file.
@@ -102,7 +104,9 @@ impl Extent {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventKind {
     /// `▸ read <path> · <n> lines` — folded by default. The count rides
-    /// `Extent::added`, and is absent until the read returns.
+    /// `Extent::added` and has no producer today: only a *mutation* stamps the
+    /// inline-diff reference the head's measurement is resolved through, so a
+    /// read states its path and nothing about its size (#4177).
     Read { extent: Extent },
     /// `● edit <path> +a -b`, the counts absent until the edit returns.
     Edit { extent: Extent },

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -85,8 +85,8 @@ pub fn head_metal(name: &str) -> Color {
 ///    closing entry: a result cannot land after the turn that dispatched it
 ///    completed, so this bounds the walk by turn length rather than by session
 ///    length, and an unanswered head (a cancelled call) costs one turn's scan.
-/// 2. **The measurement, through that reference.**
-///    [`crate::render::resolve_inline_delta`] reads
+/// 2. **The measurement, through that reference.** `render::resolve_inline_delta`
+///    (crate-private, so named rather than linked) reads
 ///    [`crate::model::FileState::delta_at`] — the counts the *emitter*
 ///    measured. Never the tool's input, never a recount of the rendered diff:
 ///    the first is what #2290 established as the defect (`edit_file` with
@@ -157,7 +157,7 @@ pub fn compaction_rows(
 /// (they are one reading), a write states what it wrote, a deletion what it
 /// removed. A read never resolves one at all — only a *mutation* stamps an
 /// inline-diff reference, so a read's line count has no source on this path and
-/// stays honestly absent (#4177).
+/// stays honestly absent (#4180).
 fn kind_for(name: &str, measured: Option<(u32, u32)>) -> EventKind {
     match name {
         "read_file" => EventKind::Read {

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -29,15 +29,26 @@ use ratatui::style::Color;
 use ratatui::text::Line;
 
 use super::transcript::{Event, EventKind, Extent, Receipt, event_rows, receipt, turn_end};
+use crate::model::{FileState, TranscriptEntry};
 
 /// The metal-bearing head of a dispatched call (SPEC 6.2).
+///
+/// `measured` is the `(added, removed)` the emitter reported for this call, or
+/// `None` while it is still in flight — [`measured_delta`] is what resolves it,
+/// and a head row is never asked to guess.
 ///
 /// Always at least one row: a tool with no recognised verb still names itself,
 /// because a call that rendered nothing would be a call the reader cannot see
 /// happened.
 #[must_use]
-pub fn head_rows(name: &str, path: Option<&str>, input: &str, width: usize) -> Vec<Line<'static>> {
-    let kind = kind_for(name);
+pub fn head_rows(
+    name: &str,
+    path: Option<&str>,
+    input: &str,
+    measured: Option<(u32, u32)>,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let kind = kind_for(name, measured);
     let subject = subject_for(name, path, input);
     let mut event = Event::new(kind, subject);
     // The head is drawn the moment the call dispatches, so it is never
@@ -56,7 +67,52 @@ pub fn head_rows(name: &str, path: Option<&str>, input: &str, width: usize) -> V
 /// derivation, read by both.
 #[must_use]
 pub fn head_metal(name: &str) -> Color {
-    kind_for(name).metal()
+    // The metal is a fact about the verb, so the extent is irrelevant here and
+    // an unmeasured one is the honest argument rather than a placeholder: a
+    // block's rail must not change colour when its size arrives.
+    kind_for(name, None).metal()
+}
+
+/// The `(added, removed)` the emitter measured for the call `call_id`
+/// dispatched, or `None` while nothing has measured it.
+///
+/// `following` is the rest of the lane's transcript *after* the head, and
+/// `files` the draw-side ledger. Two hops, both deliberate:
+///
+/// 1. **The pair, by `call_id`.** A [`TranscriptEntry::ToolResult`] carries the
+///    [`crate::model::InlineDiffRef`] naming the change its own call produced,
+///    and shares its `call_id` with the head. The scan stops at the turn's
+///    closing entry: a result cannot land after the turn that dispatched it
+///    completed, so this bounds the walk by turn length rather than by session
+///    length, and an unanswered head (a cancelled call) costs one turn's scan.
+/// 2. **The measurement, through that reference.**
+///    [`crate::render::resolve_inline_delta`] reads
+///    [`crate::model::FileState::delta_at`] — the counts the *emitter*
+///    measured. Never the tool's input, never a recount of the rendered diff:
+///    the first is what #2290 established as the defect (`edit_file` with
+///    `replace_all` makes an input-derived number wrong outright), and the
+///    second counts a bounded rendering of the changed region rather than the
+///    change.
+///
+/// `None` therefore covers three honest cases — the call has not returned, it
+/// failed (a failed mutation stamps no reference), or the turn boundary has not
+/// measured the tree yet — and each of them renders as no column at all.
+#[must_use]
+pub fn measured_delta(
+    call_id: &str,
+    following: &[TranscriptEntry],
+    files: &[FileState],
+) -> Option<(u32, u32)> {
+    following
+        .iter()
+        .take_while(|e| !matches!(e, TranscriptEntry::Complete { .. }))
+        .find_map(|e| match e {
+            TranscriptEntry::ToolResult {
+                call_id: cid, diff, ..
+            } if cid == call_id => diff.as_ref(),
+            _ => None,
+        })
+        .and_then(|dref| crate::render::resolve_inline_delta(dref, files))
 }
 
 /// One dim line, no rail (SPEC 6.3).
@@ -87,27 +143,36 @@ pub fn compaction_rows(
 /// recognises, so the two renderers of the same transcript cannot disagree
 /// about what a `bash` row is.
 ///
-/// Every file kind takes an **unmeasured** [`Extent`], and that is the whole
-/// point of the type. This function runs when the call *dispatches*: the tool
-/// has not returned, no `FileChange` has been emitted, and there is nothing to
-/// count. Filling the fields with zeros instead put `edit <path> +0 -0` over
-/// every real edit in the deck — a row asserting the change was empty, on the
-/// one screen a reader consults to find out what changed. The measured numbers
-/// live on the result row (`render::entry`'s `resolve_inline_delta`), which is
-/// where they can be true; this row states the verb and its subject.
-fn kind_for(name: &str) -> EventKind {
+/// `measured` is the emitter's `(added, removed)` for this call once
+/// [`measured_delta`] has resolved one, and `None` for as long as nothing has
+/// measured it — which is every head at the moment it dispatches, because the
+/// tool has not returned and no `FileChange` has been emitted. An unmeasured
+/// kind renders **no size column at all**: filling the fields with zeros
+/// instead put `edit <path> +0 -0` over every real edit in the deck — a row
+/// asserting the change was empty, on the one screen a reader consults to find
+/// out what changed (#4150).
+///
+/// Which half of the pair a kind states is a property of the verb, and lives
+/// here so one measurement cannot be read two ways: an edit states both sides
+/// (they are one reading), a write states what it wrote, a deletion what it
+/// removed. A read never resolves one at all — only a *mutation* stamps an
+/// inline-diff reference, so a read's line count has no source on this path and
+/// stays honestly absent (#4177).
+fn kind_for(name: &str, measured: Option<(u32, u32)>) -> EventKind {
     match name {
         "read_file" => EventKind::Read {
             extent: Extent::default(),
         },
         "edit_file" => EventKind::Edit {
-            extent: Extent::default(),
+            extent: measured.map_or_else(Extent::default, |(added, removed)| {
+                Extent::delta(added, removed)
+            }),
         },
         "write_file" => EventKind::Write {
-            extent: Extent::default(),
+            extent: measured.map_or_else(Extent::default, |(added, _)| Extent::added(added)),
         },
         "delete_file" => EventKind::Delete {
-            extent: Extent::default(),
+            extent: measured.map_or_else(Extent::default, |(_, removed)| Extent::removed(removed)),
         },
         "bash" => EventKind::Run,
         _ => EventKind::Other,
@@ -162,6 +227,8 @@ pub fn turn_end_rows(turn: u32, cost_usd: f64, width: usize) -> Vec<Line<'static
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::SessionModel;
+    use stella_protocol::{AgentEvent, FileChangeKind, ToolCall, ToolOutput};
 
     fn text_of(line: &Line<'static>) -> String {
         line.spans.iter().map(|s| s.content.clone()).collect()
@@ -178,7 +245,7 @@ mod tests {
     /// tools), and a missing row is the failure this guards against.
     #[test]
     fn an_unrecognised_tool_still_renders_a_head() {
-        let rows = head_rows("mcp__fs__read_file", None, "apps/page.tsx", 80);
+        let rows = head_rows("mcp__fs__read_file", None, "apps/page.tsx", None, 80);
         assert_eq!(rows.len(), 1);
         assert!(
             text_of(&rows[0]).contains("mcp__fs__read_file"),
@@ -190,7 +257,13 @@ mod tests {
     /// A file tool names its path, not its raw argument blob.
     #[test]
     fn a_file_tool_names_its_path() {
-        let rows = head_rows("read_file", Some("src/main.rs"), "{\"path\":\"…\"}", 80);
+        let rows = head_rows(
+            "read_file",
+            Some("src/main.rs"),
+            "{\"path\":\"…\"}",
+            None,
+            80,
+        );
         let text = text_of(&rows[0]);
         assert!(text.contains("read src/main.rs"), "{text}");
         assert!(!text.contains('{'), "the raw argument blob must not leak");
@@ -216,7 +289,7 @@ mod tests {
             ("write_file", "src/new.rs"),
             ("delete_file", "src/old.rs"),
         ] {
-            let text = text_of_rows(&head_rows(tool, Some(path), "{}", 120));
+            let text = text_of_rows(&head_rows(tool, Some(path), "{}", None, 120));
             for zero in ["+0", "-0", "0 lines"] {
                 assert!(
                     !text.contains(zero),
@@ -227,19 +300,184 @@ mod tests {
         }
     }
 
+    /// Which half of a measurement a verb states is a property of the verb —
+    /// an edit's two numbers are one reading, a write states what it wrote, a
+    /// deletion what it removed.
+    #[test]
+    fn a_write_states_what_it_wrote_and_a_delete_what_it_removed() {
+        let write = text_of_rows(&head_rows(
+            "write_file",
+            Some("src/new.rs"),
+            "{}",
+            Some((42, 0)),
+            120,
+        ));
+        assert!(write.contains("new file"), "{write}");
+        assert!(write.contains("42 lines"), "{write}");
+        let delete = text_of_rows(&head_rows(
+            "delete_file",
+            Some("src/old.rs"),
+            "{}",
+            Some((0, 17)),
+            120,
+        ));
+        assert!(delete.contains("-17 lines"), "{delete}");
+        assert!(delete.contains("u undo"), "{delete}");
+    }
+
     /// Absent counts are not the same as an absent row: `write` still says the
     /// file is new and `delete` still says it is recoverable, because neither
     /// is a measurement.
     #[test]
     fn an_unmeasured_head_keeps_the_facts_that_are_not_measurements() {
-        let write = text_of_rows(&head_rows("write_file", Some("src/new.rs"), "{}", 120));
+        let write = text_of_rows(&head_rows(
+            "write_file",
+            Some("src/new.rs"),
+            "{}",
+            None,
+            120,
+        ));
         assert!(write.contains("new file"), "{write}");
-        let delete = text_of_rows(&head_rows("delete_file", Some("src/old.rs"), "{}", 120));
+        let delete = text_of_rows(&head_rows(
+            "delete_file",
+            Some("src/old.rs"),
+            "{}",
+            None,
+            120,
+        ));
         assert!(delete.contains("git-backed"), "{delete}");
         assert!(delete.contains("u undo"), "{delete}");
     }
 
-    /// And a measured extent still renders its numbers — the fix removes the
+    /// The whole chain, driven by the events a real session emits: dispatch,
+    /// result, and the turn boundary's measurement of the tree.
+    ///
+    /// `mutations` is `(call_id, path, added, removed)` per `edit_file` call.
+    /// Every `FileChange` follows every `ToolResult`, which is the **real**
+    /// producer ordering and not a convenience: `stella-pipeline` emitted one
+    /// change per adoption during delivery and is deleted (#3865), leaving
+    /// `stella_cli::turn_files::emit_shared_tree_changes` — one aggregate
+    /// `--numstat` change per path, at the boundary, after every result of the
+    /// turn has folded (#4155). A fixture that measured earlier would prove the
+    /// head fills in under an ordering the product does not produce.
+    fn edited(mutations: &[(&str, &str, u32, u32)]) -> SessionModel {
+        let mut model = SessionModel::new();
+        for (call_id, path, ..) in mutations {
+            model.apply(&AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: (*call_id).into(),
+                    name: "edit_file".into(),
+                    input: serde_json::json!({ "path": path }),
+                },
+            });
+            model.apply(&AgentEvent::ToolResult {
+                call_id: (*call_id).into(),
+                output: ToolOutput::Ok {
+                    content: format!("replaced 1 occurrence(s) in {path}"),
+                    data: None,
+                },
+                duration_ms: 2,
+                speculated: false,
+            });
+        }
+        for (_, path, added, removed) in mutations {
+            model.apply(&AgentEvent::FileChange {
+                path: (*path).into(),
+                kind: FileChangeKind::Modified,
+                added: *added,
+                removed: *removed,
+                diff: Some(format!("@@ -1,1 +1,1 @@\n+{path}")),
+            });
+        }
+        model
+    }
+
+    /// Render the head at `idx` the way the deck's fold does — the entry, plus
+    /// everything after it, plus the ledger.
+    fn head_at(model: &SessionModel, idx: usize) -> String {
+        let TranscriptEntry::ToolStart {
+            call_id,
+            name,
+            input,
+            path,
+            ..
+        } = &model.transcript[idx]
+        else {
+            panic!("entry {idx} is not a head: {:?}", model.transcript[idx]);
+        };
+        let measured = measured_delta(call_id, &model.transcript[idx + 1..], &model.files);
+        text_of_rows(&head_rows(name, path.as_deref(), input, measured, 120))
+    }
+
+    /// The witness for #4154: a head that used to be drawn once at dispatch and
+    /// never revisited now states the size of the change its own call made.
+    ///
+    /// The number is the **emitter's**, resolved through `FileState::delta_at`
+    /// — never counted out of the tool's input (`edit_file` with `replace_all`
+    /// makes that wrong outright) and never out of the rendered diff, which is
+    /// a bounded view of the changed region. That is the substitution #2290
+    /// established as the defect and `AgentEvent::FileChange`'s own doc
+    /// forbids.
+    #[test]
+    fn a_returned_edit_head_states_the_delta_the_emitter_measured() {
+        let model = edited(&[("c1", "crates/stella-tools/src/lib.rs", 3, 1)]);
+        let head = head_at(&model, 0);
+        assert!(
+            head.contains("+3") && head.contains("-1"),
+            "the head must state the measured change: {head}"
+        );
+    }
+
+    /// And it stays silent until then. The in-flight head is the case #4150
+    /// fixed and this must not undo: a call that has not returned has measured
+    /// nothing, and `+0 -0` over a real edit is a claim that it changed
+    /// nothing.
+    #[test]
+    fn a_head_whose_call_has_not_returned_still_states_no_size() {
+        let mut model = SessionModel::new();
+        model.apply(&AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "c1".into(),
+                name: "edit_file".into(),
+                input: serde_json::json!({ "path": "src/x.rs" }),
+            },
+        });
+        let head = head_at(&model, 0);
+        for zero in ["+0", "-0", "+", "-"] {
+            assert!(
+                !head.contains(zero),
+                "an in-flight head states `{zero}`: {head}"
+            );
+        }
+        assert!(head.contains("src/x.rs"), "{head}");
+    }
+
+    /// Correlation is by `call_id`, not "the newest change in the ledger": two
+    /// calls in one turn each state their own path's measurement.
+    ///
+    /// The failure this pins is the one `resolve_inline_diff`'s doc names —
+    /// a row wearing a neighbour's numbers — and it is invisible in a
+    /// single-call fixture, where every wrong join gives the right answer.
+    #[test]
+    fn each_head_states_its_own_calls_change_not_a_neighbours() {
+        let model = edited(&[("c1", "src/a.rs", 3, 1), ("c2", "src/b.rs", 20, 7)]);
+        let first = head_at(&model, 0);
+        let second = head_at(&model, 2);
+        assert!(
+            first.contains("+3") && first.contains("-1"),
+            "first head: {first}"
+        );
+        assert!(
+            second.contains("+20") && second.contains("-7"),
+            "second head: {second}"
+        );
+        assert!(
+            !first.contains("+20"),
+            "the first head wears the second call's numbers: {first}"
+        );
+    }
+
+    /// A measured extent still renders its numbers — the fix removes the
     /// fabrication, not the column.
     #[test]
     fn a_measured_edit_still_renders_its_delta() {

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -658,6 +658,10 @@ fn empty_state(area: Rect, buf: &mut Buffer) {
     .render(mid, buf);
 }
 
+// The fold's #4154 backfill, in a sibling: this file is closed to growth.
+#[cfg(test)]
+mod fold_backfill;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -21,8 +21,8 @@ use crate::deck::{AgentEntry, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::model::{FileState, TranscriptEntry};
 use crate::render::{
-    entry_lines, inner_height, inner_width, reasoning_is_live, render_ask_user, render_hud,
-    render_transcript_window, streaming_lines,
+    EntryView, entry_lines, inner_height, inner_width, reasoning_is_live, render_ask_user,
+    render_hud, render_transcript_window, streaming_lines,
 };
 use crate::theme;
 use crate::transcript_nav::TurnDigest;
@@ -260,7 +260,7 @@ impl SessionFold {
             } else {
                 entry_lines(
                     &transcript[i],
-                    files,
+                    EntryView::at(files, transcript, i),
                     thinking,
                     expand_all || expanded.contains(&i),
                     false,
@@ -284,7 +284,7 @@ impl SessionFold {
             } else if !plan.hides(target) {
                 entry_lines(
                     last,
-                    files,
+                    EntryView::at(files, transcript, target),
                     thinking,
                     expand_all || expanded.contains(&target),
                     reasoning_is_live(transcript, streaming),

--- a/crates/stella-tui/src/views/session/fold_backfill.rs
+++ b/crates/stella-tui/src/views/session/fold_backfill.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The one thing #4154 asked of the *fold* rather than of the renderer: a head
+//! row that has already settled must pick up its measurement when that
+//! measurement arrives.
+//!
+//! [`super::SessionFold`] caches a settled prefix and never re-folds an entry
+//! it has already rendered, so a head that settled before the turn boundary
+//! measured the tree would keep the silence it settled with — the exact
+//! draw-once shape #4154 was filed against, moved one layer up. What saves it
+//! is the `file_gen` term in the cache key (the sum of every path's `changes`),
+//! which moves when a `FileChange` lands and drops the whole prefix.
+//!
+//! That is an argument, and this file is the evidence for it. It lives beside
+//! `views/session.rs` rather than inside it because that file is a
+//! grandfathered god file and closed to growth; being a *child* module is what
+//! lets it reach `SessionFold::refresh`, which is private to the parent.
+
+use std::collections::HashSet;
+
+use stella_protocol::{AgentEvent, FileChangeKind, ToolCall, ToolOutput};
+
+use super::{FoldPlan, SessionFold};
+use crate::model::SessionModel;
+
+/// Fold `model` into `fold`, the way a deck frame does.
+fn refresh(fold: &mut SessionFold, model: &SessionModel) {
+    fold.refresh(
+        "lead",
+        &model.transcript,
+        &model.files,
+        "",
+        false,
+        &HashSet::new(),
+        false,
+        0,
+        120,
+        &FoldPlan::default(),
+        0,
+    );
+}
+
+/// Every row the fold holds, as plain text.
+fn text(fold: &SessionFold) -> String {
+    fold.window_lines(0..fold.total())
+        .iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.clone())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The witness that the backfill survives the cache.
+///
+/// The head settles the moment its `ToolResult` lands, which is one frame; the
+/// measurement arrives at the turn boundary, which is a later one. Between them
+/// the row is honestly silent — asserted here, not assumed, because a fold that
+/// showed `+1 -0` in the first frame would be reading something other than the
+/// emitter. After the boundary the *same* fold must state the change.
+///
+/// Reusing one `SessionFold` across both frames is the whole point: a fresh one
+/// would rebuild from zero and prove nothing about the cache that would
+/// otherwise hold the stale row.
+#[test]
+fn a_settled_head_states_its_size_once_the_turn_boundary_measures_it() {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c1".into(),
+            name: "edit_file".into(),
+            input: serde_json::json!({ "path": "src/x.rs" }),
+        },
+    });
+    model.apply(&AgentEvent::ToolResult {
+        call_id: "c1".into(),
+        output: ToolOutput::Ok {
+            content: "replaced 1 occurrence(s) in src/x.rs".into(),
+            data: None,
+        },
+        duration_ms: 3,
+        speculated: false,
+    });
+
+    let mut fold = SessionFold::default();
+    refresh(&mut fold, &model);
+    let before = text(&fold);
+    assert!(
+        before.contains("edit src/x.rs"),
+        "the head must be on screen the moment the call dispatches: {before}"
+    );
+    assert!(
+        !before.contains("+1") && !before.contains("+0"),
+        "nothing has measured this change yet, so the row must state no size: {before}"
+    );
+
+    // The real producer: one aggregate `--numstat` change per path, at the turn
+    // boundary, after every result of the turn has folded (#4155/#4176).
+    model.apply(&AgentEvent::FileChange {
+        path: "src/x.rs".into(),
+        kind: FileChangeKind::Modified,
+        added: 1,
+        removed: 0,
+        diff: Some("@@ -1,1 +1,1 @@\n+measured".into()),
+    });
+    refresh(&mut fold, &model);
+    let after = text(&fold);
+    assert!(
+        after.contains("edit src/x.rs +1 -0"),
+        "the settled head must pick up the measurement the boundary produced: {after}"
+    );
+}


### PR DESCRIPTION
## What

The v2 head row rendered `● edit crates/stella-tools/src/lib.rs` with no size
column at all. It is drawn the moment the call dispatches, when nothing has
measured the change, and no pass revisited it afterwards. #4150 made the metric
*expressible as absent* (`Extent { added: Option<u32>, removed: Option<u32> }`)
and removed the fabricated `+0 -0`; this delivers the number SPEC 6.2 asks for:

```text
 │ ● edit …/self_driving_cmd.rs +3 -1              ⚡2ms · → task 3
```

## Where the number comes from

The emitter's, and only the emitter's. Two hops, in
`v2::transcript_source::measured_delta`:

1. **The pair, by `call_id`** — the head's `ToolResult` carries the
   `InlineDiffRef` naming the change *its own* call produced (#4176). The scan
   stops at the turn's closing entry, so it is bounded by turn length rather
   than session length, and an unanswered head (a cancelled call) costs one
   turn's walk.
2. **The measurement, through that reference** — `resolve_inline_delta` →
   `FileState::delta_at`, the same source the v1 result row already reads.

Never derived from the tool's input (`edit_file` with `replace_all` makes that
wrong outright) and never recounted out of the rendered diff, which is a
bounded view of the changed region. That substitution is what #2290 established
as the defect and what `AgentEvent::FileChange`'s own doc forbids.

Correlation is by `(call_id → path, seq)` and never "the path's latest diff",
which `resolve_inline_diff`'s doc explains would put a later edit's change on an
earlier row.

## The backfill needs no new invalidation

`SessionFold`'s cache key already includes `file_gen` (the sum of per-path
`changes`), so the turn-boundary `FileChange` invalidates the settled prefix and
every affected row re-renders — exactly as #4154 predicted. Ordering was checked
rather than assumed: entry `i` settles only once `i+1` exists, and in the
sequential case the `ToolResult` *is* `i+1`, so the pair is present at settle
time; while the head is the live tail it is not, and it stays silent there.

## `EntryView`

`entry_lines` needed a view of the entries *after* the one it renders. Rather
than an eighth positional argument beside three existing booleans, `files` and
`following` are bundled into one `EntryView`, constructed by
`EntryView::at(files, transcript, i)`. Arity is unchanged, `views/session.rs`
(a grandfathered god file) is **net zero lines**, and a caller can no longer
pair one entry's ledger with another entry's tail by mis-ordering arguments.

`entry_body` takes the view too, so the delegating `ToolStart` arm #4158 added
keeps the same information the router has — the lesson of #4157 was that a
second implementation of that row is one that rots.

## The accessible decision, made rather than left accidental

#4154 asked for it explicitly. `accessible::block_lines` now renders each entry
against the **whole** lane transcript rather than the block's slice, so a result
one index past `block.to` is still found. A row whose measurement has not
arrived by flush time keeps no size column permanently: scrollback is
append-only, and holding a mutating head back until the turn boundary measures
the tree would leave a reader hearing nothing through a long call, which is what
the mode exists to prevent. This is the same choice the surface already makes
for the v1 result row's `+N −M`, which resolves through the identical ledger.
The divergence from the pane is filed as **#4181**, not left in a comment.

## Witnesses

Three new tests in `crates/stella-tui/src/v2/transcript_source.rs`, driven
through a real `SessionModel` with the real producer ordering
(`ToolStart → ToolResult → FileChange` at the turn boundary — #4155/#4176 —
not a fixture ordering the product does not emit):

| Test | Pins |
|---|---|
| `a_returned_edit_head_states_the_delta_the_emitter_measured` | the head fills in with `+3 -1` |
| `each_head_states_its_own_calls_change_not_a_neighbours` | correlation by `call_id`, invisible in a single-call fixture |
| `a_write_states_what_it_wrote_and_a_delete_what_it_removed` | which half of one measurement each verb states |

And one for the fold, in `views/session/fold_backfill.rs` — a sibling module
because that god file is closed to growth, and a *child* one because
`SessionFold::refresh` is private to its parent. It folds one cached
`SessionFold` twice: silent before the boundary, `edit src/x.rs +1 -0` after.
The `file_gen` claim above was read off the cache key; this runs it.

Checked the artisanal way — reverting `head_rows` to the draw-once shape
(`kind_for(name, None)`) while keeping the tests: **all four fail** (the three
above plus the fold witness), and the two that guard the in-flight case still
pass.

Kept passing, unchanged: `a_dispatched_head_states_no_size_it_has_not_measured`
(#4150's guard against `+0 -0`), plus a new
`a_head_whose_call_has_not_returned_still_states_no_size` that asserts the same
silence *through the pairing* rather than by calling the projection with `None`.

No test was deleted.

## Verification

- `cargo test -p stella-tui` — 946 tests across 12 suites pass; golden deck
  snapshots included and unchanged.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS=-D warnings cargo doc -p stella-tui` — clean.
- `cargo check --workspace --all-targets` — clean.
- `make guards` — exit 0, all 32 steps; `check-file-size` judged against
  `cc7da07f7`, nothing over.

## Remaining work, filed as handoffs

- **#4180** — a `read` head's `· n lines` has no producer at all: only a
  *mutation* stamps an `InlineDiffRef`, so `EventKind::Read`'s extent arm is
  expressible and unreachable. Three options priced in the issue, including
  deleting the arm.
- **#4181** — the accessible scrollback divergence above.

Neither is introduced here; both are named rather than left for a reader to
discover.

Closes #4154
Refs #4150, #4155, #4176, #2290

## Summary by Sourcery

Backfill emitter-measured file changes into v2 tool heads and accessible transcript rows without reporting unmeasured sizes.

Bug Fixes:
- Populate v2 tool-head rows with the emitter-measured line changes for their own calls once results and file measurements are available, while keeping unmeasured and in-flight calls free of fabricated size columns.
- Ensure settled cached transcript heads are re-rendered when turn-boundary file measurements arrive.
- Render accessible transcript rows against the full lane transcript so tool heads can resolve measurements from following result entries.

Enhancements:
- Bundle the file ledger and following transcript entries into an EntryView to keep row rendering context consistent across surface and accessible views.
- Correlate head measurements by call ID and preserve verb-specific reporting for edits, writes, and deletes.

Tests:
- Add end-to-end coverage for measured edit heads, call-specific correlation, verb-specific size reporting, in-flight silence, and cached-fold backfill.