### PR TITLE
fix(stella-tui): SPEC 5's status bar re-homes CLOCK, PR and LANES — three v1 cells get their surface back

### DIFF
--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -321,8 +321,8 @@ impl AgentEntry {
     }
 
     /// Whether this lane is a subagent (registered with the `subagent` role) —
-    /// the split the SESSION tab's nested rows and the statline's
-    /// `✦ lead · ◆ sub` counts read.
+    /// the split the SESSION tab's nested rows and the AGENTS tab's
+    /// `✦ lead · ◆ sub` header counts read.
     pub fn is_subagent(&self) -> bool {
         self.meta.role == "subagent"
     }
@@ -331,7 +331,8 @@ impl AgentEntry {
 /// The deck's PR read-model: the latest `AgentEvent::Pr` observation, from
 /// whichever agent emitted it. A session tells one PR story at a time — the
 /// newest event wins outright, so a CI update on the same PR simply replaces
-/// the snapshot in place. Drives the statline's PR cell.
+/// the snapshot in place. Drives the ISSUES tab's PR strip (SPEC 5 §9.4),
+/// which is where the v1 statline's PR cell went.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PrInfo {
     pub url: String,
@@ -360,7 +361,7 @@ pub struct WorkspaceModel {
     /// events). Drives the status-bar gauge (and, later, dispatch backpressure).
     pub global_cpu_pct: f32,
     /// The latest PR observation across all agents (`AgentEvent::Pr` from the
-    /// fleet PR/CI monitor) — the statline's PR cell. Latest event wins;
+    /// fleet PR/CI monitor) — the ISSUES tab's PR strip. Latest event wins;
     /// `None` until a PR has been seen this session.
     pub pr: Option<PrInfo>,
     /// Last pin observed serving each of the three pipeline roles — the

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -510,9 +510,11 @@ pub struct Hud {
     /// Wall clock left before the task deadline, as the last `BudgetTick`
     /// reported it (#2240, #2435). `None` is the load-bearing case and means
     /// **no deadline is armed** — never "no time left", which is
-    /// `Some(0)`. The statline renders the two differently for exactly that
+    /// `Some(0)`. The status bar renders the two differently for exactly that
     /// reason: a HUD showing `0s` for an unarmed run would put back into the
-    /// UI the confusion #2240 took out of the journal.
+    /// UI the confusion #2240 took out of the journal. `None` draws no cell at
+    /// all and `Some(0)` draws the word `expired`
+    /// ([`crate::v2::status_bar`]).
     ///
     /// Milliseconds rather than a `Duration` because that is the wire shape
     /// (`AgentEvent::BudgetTick::deadline_remaining_ms`), and this struct is a

--- a/crates/stella-tui/src/v2/project.rs
+++ b/crates/stella-tui/src/v2/project.rs
@@ -69,6 +69,12 @@ pub fn status<'a>(model: &'a WorkspaceModel, ui: &DeckUi, worker: &'a str) -> St
         spend_usd: model.total_cost(),
         saved_usd: model.total_cache_savings_usd(),
         inbox: ui.notifications.iter().filter(|n| !n.read).count() as u32,
+        // Absent unless a deadline is armed, and the fold already keeps that
+        // distinction: `BudgetTick` carries `None` for an untimed run and
+        // `Some(0)` for one that is out of time (#2435). Passed through
+        // rather than defaulted, because a `0` invented here would render as
+        // `expired` on a run nobody was timing.
+        deadline_remaining_ms: focused.and_then(|a| a.model.hud.deadline_remaining_ms),
     }
 }
 

--- a/crates/stella-tui/src/v2/status_bar.rs
+++ b/crates/stella-tui/src/v2/status_bar.rs
@@ -27,6 +27,29 @@
 //! The row it gives back is not free floor space either: it is the row the
 //! keybinding hint line and the pipeline line above the prompt now occupy.
 //!
+//! ## The one conditional cell
+//!
+//! Everything above is permanent. `deadline` is not: it draws only while a
+//! task deadline is armed, sits third — immediately after the stage — and is
+//! the last cell the drop rule gives up (SPEC 5).
+//!
+//! It is the one cell here that says the run is about to *stop* rather than
+//! how it is going, and an expiring deadline is a `SIGKILL`. It was on the v1
+//! wall, SPEC 5's re-homing sentence did not mention it, and #4123 dropped it
+//! along with the row — for a day nothing on any screen counted it down
+//! (#4126). What survives from v1 is the distinction that made the cell worth
+//! having: `None` is *nobody is timing this run* and draws nothing at all,
+//! `Some(0)` is *this run is out of time* and draws a word. A cell reading
+//! `0s` for an unarmed run would say the first thing in the second thing's
+//! shape.
+//!
+//! v1 coloured it on a three-rung green/amber/red ladder. That does not
+//! survive SPEC 2: green means *pass* here and an unfinished countdown has
+//! passed nothing, and the palette has no amber that is not gold, which means
+//! stella acting. Two rungs, then — `text` while there is time, `red` inside
+//! the last minute, where a kill this close is a destructive event in
+//! progress and that is what §2 keeps red for.
+//!
 //! ## What is deliberately NOT here
 //!
 //! A `det %` cell — the deterministic/model split. An earlier draft of SPEC 5
@@ -81,7 +104,19 @@ pub struct Status<'a> {
     pub saved_usd: f64,
     /// Queued inbound messages.
     pub inbox: u32,
+    /// Wall clock left before the armed task deadline, in milliseconds.
+    ///
+    /// `None` and `Some(0)` are different facts and render differently: see
+    /// the module doc's "The one conditional cell".
+    pub deadline_remaining_ms: Option<u64>,
 }
+
+/// At or under this much left, the countdown turns red.
+///
+/// One minute, because that is the horizon on which a human can still do
+/// something about a `SIGKILL` — steer the turn, raise the deadline, or take
+/// the artifact off the machine before it is taken away.
+const DEADLINE_ALARM_MS: u64 = 60_000;
 
 /// A ratio computed upstream, made safe to draw with.
 ///
@@ -171,9 +206,17 @@ pub fn cells(status: &Status<'_>) -> Vec<Vec<Span<'static>>> {
     // same kind of fact and take the same metal; only their labels differ.
     let money = Style::new().fg(token::GOLD);
 
-    vec![
+    let mut cells = vec![
         vec![Span::styled(status.worker.to_string(), text)],
         vec![Span::styled(status.stage.to_string(), text)],
+    ];
+    // Third, so the drop rule — which pops from the right — gives it up last
+    // of everything it is allowed to give up. The cell that says the run is
+    // about to stop must not be the first casualty of a narrow terminal.
+    if let Some(remaining_ms) = status.deadline_remaining_ms {
+        cells.push(deadline_cell(remaining_ms, label));
+    }
+    cells.extend([
         {
             let mut ctx = vec![Span::styled("ctx ", label)];
             ctx.extend(meter(status.ctx_used));
@@ -191,7 +234,49 @@ pub fn cells(status: &Status<'_>) -> Vec<Vec<Span<'static>>> {
             Span::styled("✉ ", Style::new().fg(token::SILVER)),
             Span::styled(status.inbox.to_string(), text),
         ],
+    ]);
+    cells
+}
+
+/// The CLOCK cell: what is left of an armed task deadline (SPEC 5).
+///
+/// Only ever called with an armed deadline — an unarmed run has no cell,
+/// because "nobody is timing this" is not a duration and must not be drawn as
+/// one.
+fn deadline_cell(remaining_ms: u64, label: Style) -> Vec<Span<'static>> {
+    let value = if remaining_ms <= DEADLINE_ALARM_MS {
+        token::RED
+    } else {
+        token::TEXT
+    };
+    vec![
+        // The word is the state's non-colour carrier (SPEC 13): on a 16-colour
+        // terminal, under `NO_COLOR`, or to a red-blind reader, `deadline` is
+        // still the thing that distinguishes this cell from a number.
+        Span::styled("deadline ", label),
+        Span::styled(fmt_remaining(remaining_ms), Style::new().fg(value)),
     ]
+}
+
+/// The countdown's text: the coarsest unit that still resolves the wait.
+///
+/// Seconds are dropped above an hour deliberately. A run with an hour left is
+/// not one anybody is watching second by second, and a cell that changes width
+/// on every tick costs each of its neighbours a column each time.
+///
+/// Carried over from the v1 statline unchanged, `expired` included — the one
+/// string here that is a word rather than a quantity, because `0s` invites the
+/// reading "no deadline", which is the single thing it does not mean.
+fn fmt_remaining(remaining_ms: u64) -> String {
+    let secs = remaining_ms / 1_000;
+    match secs {
+        0 if remaining_ms == 0 => "expired".to_string(),
+        // Sub-second but not yet crossed: still armed, still counting.
+        0 => "<1s".to_string(),
+        s if s < 60 => format!("{s}s"),
+        s if s < 3_600 => format!("{}m {:02}s", s / 60, s % 60),
+        s => format!("{}h {:02}m", s / 3_600, (s % 3_600) / 60),
+    }
 }
 
 /// A fraction as whole percent, saturating at both ends.
@@ -257,6 +342,11 @@ impl Widget for StatusBar<'_> {
         // with a gap between them. Worker and stage are never dropped — which
         // pin is answering and where the run is are the two facts a status bar
         // exists for; everything after them is negotiable.
+        //
+        // An armed `deadline` is negotiable *last*, which [`cells`] arranges by
+        // placing it third rather than by teaching this loop a priority table.
+        // Position is the priority here, and one mechanism that both the reader
+        // and the renderer can see beats two that have to agree.
         while cells.len() > 2 && joined_width(&cells) + help_width + 2 > width {
             cells.pop();
         }

--- a/crates/stella-tui/src/v2/status_source.rs
+++ b/crates/stella-tui/src/v2/status_source.rs
@@ -28,6 +28,7 @@ pub struct StatusSource {
     spend_usd: f64,
     saved_usd: f64,
     inbox: u32,
+    deadline_remaining_ms: Option<u64>,
 }
 
 impl StatusSource {
@@ -49,6 +50,10 @@ impl StatusSource {
             // Unread only. The badge exists to be cleared, so a read
             // notification is not something the row should still be counting.
             inbox: ui.notifications.iter().filter(|n| !n.read).count() as u32,
+            // The armed task deadline, or nothing. SPEC 5 gives this a cell on
+            // the bar only while it is armed, so the `Option` is the whole
+            // signal and must not be flattened to a number here.
+            deadline_remaining_ms: focused.and_then(|a| a.model.hud.deadline_remaining_ms),
         }
     }
 
@@ -62,6 +67,7 @@ impl StatusSource {
             spend_usd: self.spend_usd,
             saved_usd: self.saved_usd,
             inbox: self.inbox,
+            deadline_remaining_ms: self.deadline_remaining_ms,
         }
     }
 }

--- a/crates/stella-tui/src/views/agents.rs
+++ b/crates/stella-tui/src/views/agents.rs
@@ -91,6 +91,44 @@ const COMPACT_TABLE_WIDTH: u16 = 140;
 /// identity — the wide layout still shows everything.
 const COMPACT_COLUMNS: [usize; 7] = [0, 1, 2, 3, 4, 6, 9];
 
+/// The EXECUTIONS header: the active/total count, and the lane split beside it
+/// once this session has fanned out.
+///
+/// The lane split is the v1 status wall's LANES cell, re-homed here by SPEC 5
+/// (§9.5) after the one-row status bar dropped it with nothing to catch it
+/// (#4126). This is where it belongs and arguably always did: the pane under
+/// this header is one row per lane, so the header is summarizing what it heads
+/// rather than borrowing a fact from somewhere else.
+///
+/// Absent for a solo run, exactly as v1 had it — a session with no subagents
+/// has no split to disambiguate, and `✦ 1 lead · ◆ 0 sub` is a sentence about
+/// nothing. Two metals, because the two lanes are different kinds of thing:
+/// the lead is stella acting, a subagent is a categorical role
+/// ([`theme::SUBAGENT`]) deliberately distinct from it — the same pairing
+/// [`crate::views::subagents`] draws under the transcript.
+fn executions_title(model: &WorkspaceModel) -> Line<'static> {
+    let mut spans = vec![Span::raw(format!(
+        " Executions — {} active / {} total",
+        model.active_count(),
+        model.agents.len()
+    ))];
+    let subs = model.subagent_count();
+    if subs > 0 {
+        spans.push(Span::styled(" · ", theme::muted()));
+        spans.push(Span::styled(
+            format!("✦ {} lead", model.lead_count()),
+            theme::accent(),
+        ));
+        spans.push(Span::styled(" · ", theme::muted()));
+        spans.push(Span::styled(
+            format!("◆ {subs} sub"),
+            Style::default().fg(theme::SUBAGENT),
+        ));
+    }
+    spans.push(Span::raw(" "));
+    Line::from(spans)
+}
+
 /// The EXECUTIONS pane — the pre-existing active-agents dashboard.
 fn render_executions(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     if model.agents.is_empty() {
@@ -98,12 +136,9 @@ fn render_executions(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &
         return;
     }
 
-    let title = format!(
-        " Executions — {} active / {} total ",
-        model.active_count(),
-        model.agents.len()
-    );
-    let block = Block::default().borders(Borders::ALL).title(title);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(executions_title(model));
 
     if ui.accessible {
         render_executions_linear(model, ui.focused, block, area, buf);
@@ -456,6 +491,43 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// #4126 witness. SPEC 5 §9.5 re-homes the v1 status wall's LANES cell to
+    /// this header, and the conditional half comes with it: a solo run has no
+    /// split to disambiguate and says nothing.
+    ///
+    /// Asserted on the rendered buffer rather than on
+    /// [`executions_title`]'s spans, because a `Line` title that the block
+    /// silently truncates is a title nobody reads.
+    #[test]
+    fn the_executions_header_carries_the_lane_split_once_a_session_fans_out() {
+        let render_header = |subs: usize| {
+            let mut model = WorkspaceModel::new();
+            model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "the lead", 0)));
+            for i in 0..subs {
+                let mut meta = AgentMeta::new(format!("sub{i}"), "a lane", 0);
+                meta.role = "subagent".into();
+                model.apply_inbound(&Inbound::Register(meta));
+            }
+            let mut ui = DeckUi::default();
+            let area = Rect::new(0, 0, 200, 8);
+            let mut buf = Buffer::empty(area);
+            render(&model, &mut ui, area, &mut buf);
+            buffer_text(&buf)
+        };
+
+        let fanned_out = render_header(2);
+        assert!(
+            fanned_out.contains("✦ 1 lead · ◆ 2 sub"),
+            "the lane split reached no surface:\n{fanned_out}"
+        );
+
+        let solo = render_header(0);
+        assert!(
+            !solo.contains("lead ·") && !solo.contains("sub"),
+            "a solo run paid columns for a split of one:\n{solo}"
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -27,7 +27,7 @@ const TYPEAHEAD_MAX_ROWS: usize = 8;
 /// Most body lines the create form previews before eliding.
 const FORM_BODY_MAX_LINES: usize = 6;
 
-pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     let title = format!(" ISSUES — {} listed ", ui.issues.rows.len());
     let block = Block::default()
         .borders(Borders::ALL)
@@ -40,6 +40,13 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     }
 
     let mut lines: Vec<Line<'static>> = Vec::new();
+    // The session's own PR, above whatever mode the tab is in — it is a fact
+    // about this session, not about the list, so a search or a half-filled
+    // create form must not hide it.
+    if let Some(pr) = &model.pr {
+        lines.push(pr_strip(pr));
+        lines.push(Line::default());
+    }
     // The line index (within `lines`) of the create form's active field —
     // the type-ahead popup anchors right under it.
     let mut active_field_line = 0usize;
@@ -101,6 +108,67 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     if ui.issues.mode == IssuesMode::Create && ui.issues.typeahead.open() {
         render_typeahead(ui, inner, active_field_line, buf);
     }
+}
+
+/// The session's own PR, as one strip above the list.
+///
+/// SPEC 5 sends the v1 status wall's PR cell here (§9.4) rather than onto the
+/// one-row status bar: a pull request is the tracker-side artifact of the work
+/// this tab is already about, and the bar is six values that fit on one row
+/// (#4126). What is kept from the v1 cell is the part that had teeth — failing
+/// CI is red and bold, because v1 gave a failing PR an elevated drop priority
+/// precisely so a narrow row could not hide it.
+///
+/// The CI verdict carries its **word** as well as its glyph. v1 printed the
+/// glyph alone, which the status wall's width made defensible and a full-width
+/// tab does not: `✓`/`✗` differing only in colour and shape is the failure mode
+/// SPEC 2's "never colour alone" names. `None` prints nothing at all — the
+/// monitor has not polled yet, which is not the same claim as "passing".
+fn pr_strip(pr: &crate::deck::PrInfo) -> Line<'static> {
+    use stella_protocol::{CiStatus, PrStatus};
+
+    let status_color = match pr.status {
+        PrStatus::Draft => theme::WARNING,
+        PrStatus::Open | PrStatus::Merged => theme::ACCENT,
+        PrStatus::Closed => theme::DANGER,
+    };
+    let status_style = Style::default().fg(status_color);
+    let ident = match pr.number {
+        Some(n) => format!("#{n}"),
+        // No number parsed out of the URL — its tail still identifies the PR.
+        None => pr
+            .url
+            .rsplit('/')
+            .find(|s| !s.is_empty())
+            .unwrap_or("pr")
+            .to_string(),
+    };
+    let mut spans = vec![
+        Span::styled("  ⇢ ", theme::muted()),
+        Span::styled(ident, status_style.add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!(" {}", crate::textline::pr_status_label(pr.status)),
+            status_style,
+        ),
+    ];
+    if let Some(ci) = pr.ci {
+        let (glyph, style) = match ci {
+            CiStatus::Passing => ("✓", Style::default().fg(theme::OK)),
+            CiStatus::Failing => (
+                "✗",
+                Style::default().fg(theme::BAD).add_modifier(Modifier::BOLD),
+            ),
+            CiStatus::Pending => ("◌", theme::muted()),
+            CiStatus::Running => ("…", theme::muted()),
+        };
+        spans.push(Span::styled(" · CI ", theme::muted()));
+        spans.push(Span::styled(glyph, style));
+        spans.push(Span::styled(
+            format!(" {}", crate::textline::ci_status_label(ci)),
+            style,
+        ));
+    }
+    Line::from(spans)
 }
 
 /// The browse list, windowed on the selection so long lists keep it in view.

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -827,12 +827,19 @@ fn deck_render_snapshots_diff_explains_a_trailing_newline() {
     );
 }
 
-/// The statline's CLOCK cell (#2435): a run with an armed task deadline shows
-/// the wall clock it has left beside the money it has spent.
+/// The status bar's CLOCK cell (#2435, #4126): a run with an armed task
+/// deadline shows the wall clock it has left, third on the row, right after
+/// the stage (SPEC 5).
 ///
-/// A golden rather than a `contains` assertion because a new cell **moves
-/// columns** — every cell to its right shifts, and only the whole grid can say
-/// whether the band still fits and what it dropped to make room.
+/// A golden **and** a `contains`, and the pair is deliberate. The golden is
+/// here because a new cell **moves columns** — every cell to its right shifts,
+/// and only the whole grid can say whether the band still fits and what it
+/// dropped to make room. The `contains` is here because this test already
+/// failed once in the only way a golden can fail: #4123 replaced the two-row
+/// statline with the one-row bar, the clock stopped rendering entirely, and
+/// this snapshot was re-blessed to a frame with no clock in it while its own
+/// docstring still said the clock was there. A golden pins whatever it is
+/// shown; it cannot pin what it is *for*. The assertion can, so it does.
 ///
 /// The unarmed case needs no golden of its own: every other snapshot in this
 /// file is one, and none of them grew a cell when this landed. That is the
@@ -857,11 +864,49 @@ fn deck_render_snapshots_pin_the_armed_deadline_statline() {
         },
     });
     let frame = render_frame(&model, &mut ui, W, H);
+    assert!(
+        frame.contains("deadline 12m 34s"),
+        "the armed deadline reached no surface on a default deck — the \
+         countdown to a SIGKILL is not something the bar may drop (#4126):\n\
+         {frame}"
+    );
     assert_golden(
         "statline_deadline_armed",
-        "the statline with a task deadline armed — CLOCK beside SPEND",
+        "the status bar with a task deadline armed — the countdown after the stage",
         W,
         H,
         &frame,
+    );
+}
+
+/// SPEC 5 re-homes the v1 wall's PR cell to the ISSUES tab (§9.4), and the
+/// half of it with teeth is failing CI: v1 gave a failing PR an elevated drop
+/// priority so a narrow row could not hide it, and that intent has to survive
+/// the move.
+///
+/// The demo fixture's PR is `… running`, so the tab goldens cover the ordinary
+/// case; this covers the one that is supposed to be impossible to miss. A
+/// `contains` rather than a golden because the strip does not move any column
+/// the tab goldens already pin — it is one line, and what is under test is
+/// that the failure is *stated in words*, not only in a colour the snapshot
+/// strips anyway.
+#[test]
+fn deck_render_snapshots_state_a_failing_pr_on_the_issues_tab() {
+    let mut model = fixture_model();
+    let mut ui = ui_for(DeckTab::Issues);
+    let agent = model.agents[ui.focused].meta.id.clone();
+    model.apply_inbound(&stella_tui::envelope::Inbound::Event {
+        agent,
+        event: stella_protocol::AgentEvent::Pr {
+            url: "https://github.com/macanderson/stella/pull/981".into(),
+            status: stella_protocol::PrStatus::Open,
+            number: Some(981),
+            ci: Some(stella_protocol::CiStatus::Failing),
+        },
+    });
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert!(
+        frame.contains("⇢ #981 open · CI ✗ failing"),
+        "a failing PR is not stated on the tab SPEC 5 sends it to:\n{frame}"
     );
 }

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -1,5 +1,5 @@
 # deck golden · statline_deadline_armed
-# the statline with a task deadline armed — CLOCK beside SPEND
+# the status bar with a task deadline armed — the countdown after the stage
 # viewport 160×40 · rendered through render_deck, styling stripped
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
@@ -42,4 +42,4 @@
 ✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
 >>>
  ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $3.7700  ·  1 line  ·  queue empty
-zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $3.79 · saved $0.00 · ✉ 0                                                                               ? help
+zai/glm-5.2-air · execute · deadline 12m 34s · ctx ▌░░░░░░░░░░░ 4% · $3.79 · saved $0.00 · ✉ 0                                                            ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
@@ -7,7 +7,7 @@
 │ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
   EXECUTIONS  │  INSTALLED AGENTS   ←/→
-┌ Executions — 3 active / 3 total ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+┌ Executions — 3 active / 3 total · ✦ 1 lead · ◆ 2 sub ────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Agent              Goal                 Status       Ctx%   Cost      $/hr      Elapsed  CPU%   MEM     In/Out         Cache  Warmth  Activity                │
 │  ? lead           web-app-2.0 · phase  needs input    4%   $0.04     $0.45     05:12     42%   148M    20.6k/1.5k     73%    —                ▅▃▅▄▃▁▁▅▆▆█▁▁▃▃│
 │> ? sub:auth       wire automations tri needs input    3%   $0.01     $0.13     05:12      8%   61M     5.1k/420       59%    —                        ▃▅▆█▁▁▃│

--- a/crates/stella-tui/tests/snapshots/deck/tab_agents_compact.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_agents_compact.txt
@@ -7,7 +7,7 @@
 │ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                         │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
   EXECUTIONS  │  INSTALLED AGENTS   ←/→
-┌ Executions — 3 active / 3 total ─────────────────────────────────────────────────────────────────────────────────────┐
+┌ Executions — 3 active / 3 total · ✦ 1 lead · ◆ 2 sub ────────────────────────────────────────────────────────────────┐
 │Agent              Goal                                          Status       Ctx%   Cost      Elapsed  In/Out        │
 │  ? lead           web-app-2.0 · phase 3 automations             needs input    4%   $0.04     05:12    20.6k/1.5k    │
 │> ? sub:auth       wire automations triggers API                 needs input    3%   $0.01     05:12    5.1k/420      │

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -7,13 +7,13 @@
 │ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ ISSUES — 3 listed ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  ⇢ #981 open · CI … running                                                                                                                                  │
+│                                                                                                                                                              │
 │  #874 [open] Command-deck render golden tests · dev · enhancement, area:tui                                                                                  │
 │▸ #826 [open] run_deck event-loop pty harness · enhancement                                                                                                   │
 │  #689 [closed] Surface per-server MCP tool truncation · dev · bug                                                                                            │
 │                                                                                                                                                              │
 │   ↑↓ select   r refresh   / search tracker   n new issue   c comment   s set status   w start work                                                           │
-│                                                                                                                                                              │
-│                                                                                                                                                              │
 │                                                                                                                                                              │
 │                                                                                                                                                              │
 │                                                                                                                                                              │

--- a/crates/stella-tui/tests/v2_status_bar.rs
+++ b/crates/stella-tui/tests/v2_status_bar.rs
@@ -129,6 +129,9 @@ fn demo() -> Status<'static> {
         spend_usd: 0.45,
         saved_usd: 0.69,
         inbox: 21,
+        // The rendering shows no deadline, because nothing was timing that
+        // session. `None` is that fact, and it is not the same fact as `0`.
+        deadline_remaining_ms: None,
     }
 }
 
@@ -326,6 +329,146 @@ fn the_meter_tracks_the_number_printed_beside_it() {
             }
         }
     }
+}
+
+// ── the conditional cell: an armed task deadline (#4126) ────────────────────
+
+/// The text of every cell, in order.
+fn flat(status: &Status<'_>) -> Vec<String> {
+    cells(status)
+        .iter()
+        .map(|cell| cell.iter().map(|s| s.content.to_string()).collect())
+        .collect()
+}
+
+/// #4126 witness. An armed task deadline draws a cell; an unarmed run does not.
+///
+/// The two halves are one test because the pair is the property: the v1 cell
+/// was built around `None` and `Some(0)` being different facts, and a test that
+/// only checked the armed half would pass on a bar that printed `deadline 0s`
+/// for a run nobody was timing.
+#[test]
+fn an_armed_deadline_earns_a_cell_and_an_unarmed_run_does_not() {
+    let armed = flat(&Status {
+        deadline_remaining_ms: Some(754_000),
+        ..demo()
+    });
+    assert_eq!(armed.len(), 7, "the armed bar: {armed:?}");
+    assert_eq!(
+        armed[2], "deadline 12m 34s",
+        "SPEC 5 puts the countdown third, right after the stage"
+    );
+
+    let unarmed = flat(&demo());
+    assert_eq!(unarmed.len(), 6, "the unarmed bar grew a cell: {unarmed:?}");
+    assert!(
+        !unarmed.iter().any(|c| c.contains("deadline")),
+        "an unarmed run paid columns for a deadline nobody set: {unarmed:?}"
+    );
+}
+
+/// A crossed deadline reads as a word, never as a quantity.
+///
+/// `0s` invites "no deadline", which is the one thing `Some(0)` does not mean —
+/// it means the `SIGKILL` has already been earned.
+#[test]
+fn a_crossed_deadline_reads_expired_not_zero() {
+    let bar = flat(&Status {
+        deadline_remaining_ms: Some(0),
+        ..demo()
+    });
+    assert_eq!(bar[2], "deadline expired");
+}
+
+/// The countdown escalates to red inside the last minute, and only there.
+///
+/// SPEC 2 keeps red for failure and destructive events. A kill under a minute
+/// away is a destructive event in progress; four minutes out is not, and must
+/// not spend the scarcity that makes red an alarm.
+#[test]
+fn the_countdown_takes_red_only_inside_the_last_minute() {
+    let value_fg = |ms: u64| {
+        cells(&Status {
+            deadline_remaining_ms: Some(ms),
+            ..demo()
+        })[2]
+            .last()
+            .expect("the countdown's value span")
+            .style
+            .fg
+    };
+    for calm in [61_000, 240_000, 7_200_000] {
+        assert_eq!(value_fg(calm), Some(token::TEXT), "{calm}ms took an alarm");
+    }
+    for alarm in [0, 1_000, 59_000, 60_000] {
+        assert_eq!(value_fg(alarm), Some(token::RED), "{alarm}ms drew no alarm");
+    }
+    // And the alarm is not the only carrier: the word survives `NO_COLOR` and
+    // red-blindness, which is SPEC 13's floor.
+    assert!(
+        flat(&Status {
+            deadline_remaining_ms: Some(0),
+            ..demo()
+        })[2]
+            .starts_with("deadline ")
+    );
+}
+
+/// The cell that says the run is about to stop is the last one the drop rule
+/// gives up.
+///
+/// v1 made this a priority number on a table; v2 makes it a position, so this
+/// asserts the consequence rather than the mechanism.
+///
+/// 46 columns is the width `v2_status_bar_narrow` pins: tight enough that the
+/// unarmed bar is down to worker and stage alone. Every other cell is already
+/// gone there, so a countdown that still renders has outranked all of them —
+/// including the context meter, which is what the bar drops last when nothing
+/// is timing the run.
+#[test]
+fn a_narrow_row_drops_everything_before_it_drops_the_deadline() {
+    let rendered = frame(
+        StatusBar(Status {
+            deadline_remaining_ms: Some(30_000),
+            ..demo()
+        }),
+        46,
+        1,
+    );
+    assert!(
+        rendered.contains("deadline 30s"),
+        "a 46-column row dropped the countdown:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("ctx "),
+        "46 columns fit more than the floor, so this proves nothing:\n{rendered}"
+    );
+}
+
+/// An armed deadline is allowed to put red on the frame; nothing else is.
+///
+/// The healthy-frame assertion above is the other half of this pair, and both
+/// have to hold: red that never appears is not a signal, and red that appears
+/// on a healthy frame is not an alarm.
+#[test]
+fn the_alarm_is_the_only_red_the_bar_can_draw() {
+    let armed = Status {
+        deadline_remaining_ms: Some(30_000),
+        ..demo()
+    };
+    assert!(red_cells(StatusBar(armed), 100, 1) > 0);
+    assert_eq!(
+        red_cells(
+            StatusBar(Status {
+                deadline_remaining_ms: Some(3_600_000),
+                ..demo()
+            }),
+            100,
+            1
+        ),
+        0,
+        "an hour of headroom is not an alarm"
+    );
 }
 
 /// Out-of-range input is clamped, not trusted. `ctx_used` is a ratio computed

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -104,6 +104,12 @@ Top to bottom:
 4. **Prompt block**: pipeline line (`✓ plan ▸ execute [bar] 50% · verify`), input line `>>>`, keybinding hint row.
 5. **Status bar** (1 row, replaces the old two-row wall): `worker · stage · ctx [bar] 35% · $spend · saved $x · ✉ n · ? help`. MODEL detail, CPU, MEM, WARMTH, and ENGINE move behind `?` and the AGENTS tab. Money renders gold. Meters render gold fill on `border` gray. No pink, no green meters.
 
+   Three cells the v1 wall carried are named nowhere above. They are **re-homed, not dropped** — a surface that silently stops rendering a fact it used to render is the failure mode AGENTS.md invariant #10 exists to prevent:
+
+   - **CLOCK** earns a place on this bar when, and only when, a task deadline is armed. It sits third, immediately after the stage, and it is the last cell the drop rule gives up: a deadline whose expiry is a `SIGKILL` is the one fact on this row that says the run is about to *stop*. It reads `deadline 12m 34s`, and `deadline expired` once crossed — never `0s`, because "nobody is timing this run" and "this run is out of time" are the two states the cell exists to separate. The value renders `text` while more than a minute is left and `red` at a minute or less: a kill that close is a destructive event in progress, which is exactly what §2 reserves red for. An unarmed run pays no columns at all.
+   - **PR** moves to the ISSUES tab (§9.4). A pull request is a tracker-side artifact of the current work, and that tab is where tracker-side artifacts live.
+   - **LANES** moves to the AGENTS tab (§9.5), onto the EXECUTIONS header beside the active/total count that ENGINE became.
+
    The status bar deliberately carries **no `det %`**. An earlier draft placed the deterministic/model split here; it was removed (2026-08-19, owner's call) rather than plumbed. Do not restore it — a permanent row is the wrong home for a number that changes meaning with scope, and the thesis it serves is expressed where work is actually summarized (the turn receipt, §6.1) and where deterministic work is priced (`$0.00 · det` on gates, §6.3; the graph footer, §9.1). Note that those `det` *tags* are booleans — this call did or did not reach a model — and need no computed ratio behind them.
 
 ## 6. Transcript
@@ -233,12 +239,13 @@ Turn begin, turn end receipt, skill auto-trigger, memory log and promotion, comp
 - **Heat sort**: default ordering is coupling of the issue's touched files times age, computed from the graph. Caption: `from the graph, not vibes`.
 - In-progress rows show their linked plan and live task inline (`plan r3 · task 3 live`).
 - Detail pane: excerpt, `linked` line (plan progress, branch, evidence summary), and the sync rule: `status syncs back to <tracker> on gate green · no manual updates`.
+- **The session's own PR**, once one has been observed, is a strip above the list: `⇢ #183 open · CI ✗ failing`. This is §5's re-homed PR cell. Failing CI renders red and bold, and carries the word beside the glyph — never colour alone (section 2).
 - `w start work` runs section 8.2. Bottom strip explains the flow in one sentence.
 - Keys: `↑↓ select · w start work · n new issue · / search tracker · r refresh`.
 
 ### 9.5 AGENTS and SETTINGS
 
-Keep current information architecture (executions table, installed agents, agent editor, model params). Restyle to sections 3 through 5: kill pink and green meters, single-line status, two-metal rows, `stella*` wordmark. The agent editor gets the section 6.4 highlighter for YAML frontmatter and markdown.
+Keep current information architecture (executions table, installed agents, agent editor, model params). Restyle to sections 3 through 5: kill pink and green meters, single-line status, two-metal rows, `stella*` wordmark. The EXECUTIONS header additionally carries §5's re-homed **LANES** split — `✦ n lead · ◆ n sub`, appended to the active/total count — once a session has fanned out; a solo run shows nothing, because there is nothing to disambiguate. The agent editor gets the section 6.4 highlighter for YAML frontmatter and markdown.
 
 ## 10. Command palette (rendering `08-command-palette`)
 


### PR DESCRIPTION
## What

SPEC 5's one-row status bar (#4123) re-homes five of the ten v1 statline cells and is silent about three others — `CLOCK`, `PR`, `LANES` — which since #4123 rendered **nowhere at all**. This gives SPEC 5 the sentence it was missing and puts each of them where the sentence says.

`CLOCK` is the one with teeth. An armed task deadline expires as a `SIGKILL`, and the countdown was its only always-on surface. Armed deadlines had only just been wired (#3951), so the gap between "visible" and "invisible" was about a day.

## The evidence it went unnoticed is in this diff

The golden test `deck_render_snapshots_pin_the_armed_deadline_statline` — whose own docstring said **"CLOCK beside SPEND"** — had been re-blessed to a frame with no clock in it. A golden pins whatever it is shown; it cannot pin what it is *for*. It now carries a `contains` assertion beside the grid, so the next blind bless fails instead of recording.

## Where each cell went

| Cell | Home | Why there |
|---|---|---|
| `CLOCK` | the bar, conditionally (SPEC 5) | it is the only fact on that row that says the run is about to *stop* |
| `PR` | ISSUES tab (SPEC 9.4) | a PR is the tracker-side artifact of the work that tab is about |
| `LANES` | AGENTS tab header (SPEC 9.5) | the pane under that header is one row per lane |

**CLOCK** sits third, right after the stage, and is the last cell the drop rule gives up — position *is* the priority, so the renderer needs no priority table (v1 had one, and it had already mis-resolved a tie at 150 columns). It reads `deadline 12m 34s`, `deadline expired` once crossed, and nothing at all when unarmed: `None` and `Some(0)` are different facts (#2240, #2435) and must not render alike.

Two colour rungs, not v1's three. Green means *pass* under SPEC 2 and an unfinished countdown has passed nothing; the palette has no amber that is not gold, and gold means stella acting. So `text` while there is time, `red` inside the last minute — a kill that close is a destructive event in progress, which is what §2 keeps red for. The label carries the state for anyone the colour does not reach (SPEC 13).

**PR** keeps the emphasis v1 gave failing CI (v1 raised its drop priority so a narrow row could not hide it) and gains the word beside the glyph — on a full-width tab, `✓`/`✗` differing only in colour and shape is exactly what "never colour alone" names.

**LANES** appends `✦ 1 lead · ◆ 2 sub` to the EXECUTIONS header, and stays absent for a solo run.

## Witness

Fail→pass demonstrated by ablation: reverting the one wiring line in `src/v2/project.rs` to `deadline_remaining_ms: None` fails `deck_render_snapshots_pin_the_armed_deadline_statline` with "the armed deadline reached no surface on a default deck", and nothing else. Restored, 14/14 pass. The re-blessed golden is the same evidence in diff form:

```
-zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $3.79 · saved $0.00 · ✉ 0
+zai/glm-5.2-air · execute · deadline 12m 34s · ctx ▌░░░░░░░░░░░ 4% · $3.79 · saved $0.00 · ✉ 0
```

New tests:

- `an_armed_deadline_earns_a_cell_and_an_unarmed_run_does_not` — both halves in one test, because the pair is the property
- `a_crossed_deadline_reads_expired_not_zero`
- `the_countdown_takes_red_only_inside_the_last_minute` — and the word survives without the colour
- `a_narrow_row_drops_everything_before_it_drops_the_deadline` — at 46 columns, where the unarmed bar is down to worker and stage alone
- `the_alarm_is_the_only_red_the_bar_can_draw` — the other half of `a_healthy_status_bar_has_no_red_cells`
- `the_executions_header_carries_the_lane_split_once_a_session_fans_out`
- `deck_render_snapshots_state_a_failing_pr_on_the_issues_tab`

**Deleted tests:** none.

**Goldens re-blessed (4), diff read on each:** `statline_deadline_armed` (the countdown returns), `tab_agents` + `tab_agents_compact` (the lane split appears), `tab_issues` (the PR strip appears — the demo fixture already carried a PR).

## Also in this PR

Four doc comments still pointed at the deleted v1 statline for facts that now render elsewhere (`AgentEntry::is_subagent`, `PrInfo`, `WorkspaceModel::pr`, `Hud::deadline_remaining_ms`). Repointed, since they are about the exact cells this PR moves.

## Verification

`make gate CARGO_SCOPE="-p stella-tui"` — exit 0, all 32 steps.

## Remaining work filed

Two things noticed and deliberately not fixed here — issues linked in a comment below.

Closes #4126
Refs #4123

## Summary by Sourcery

Restore the missing v1 status information in its SPEC 5 destinations while making deadline and CI warnings explicit and testable.

New Features:
- Restore the armed task deadline countdown to the v2 status bar, including explicit expired-state text and urgency coloring.
- Re-home pull request status to the ISSUES tab and lane counts to the AGENTS executions header.

Bug Fixes:
- Ensure deadline visibility distinguishes unarmed runs from expired deadlines and remains available on narrow status bars.
- Prevent golden snapshots from being re-blessed without verifying that the armed deadline is rendered.

Enhancements:
- Preserve accessible textual status for deadline alarms and CI failures instead of relying on color or glyphs alone.

Documentation:
- Document the new CLOCK, PR, and LANES surfaces in the v2 TUI specification.

Tests:
- Add coverage for deadline rendering, expiration, alarm thresholds, narrow-bar retention, lane splits, and failing PR status.

Chores:
- Update comments and snapshot goldens to reflect the relocated status cells.