### PR TITLE
perf(stella-tools): the chunk embedding pass batches across files and overlaps its round trips (#4144)

### DIFF
--- a/crates/stella-embed/Cargo.toml
+++ b/crates/stella-embed/Cargo.toml
@@ -20,10 +20,15 @@ async-trait.workspace = true
 # pay nothing for a transport they do not use; a host that needs it turns it on.
 reqwest = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+# `sleep` only — the backoff between retries of a rate-limited embedding
+# request. Optional with the transport for the same reason as the two above:
+# a host that never enables `http` links no runtime for a timer it cannot
+# reach. `reqwest` already requires tokio, so this adds no new tree.
+tokio = { workspace = true, optional = true, features = ["time"] }
 
 [features]
 default = []
-http = ["dep:reqwest", "dep:serde_json"]
+http = ["dep:reqwest", "dep:serde_json", "dep:tokio"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/stella-embed/README.md
+++ b/crates/stella-embed/README.md
@@ -94,6 +94,16 @@ silent quality regression.
   output that reaches the prompt is byte-stable for identical input
   (invariant 7). Two property tests pin it: ranking is independent of input
   order, and `limit` is always a prefix of the full ranking.
+- **A rate limit is an instruction, not a failure.** `HttpEmbedder::embed`
+  re-issues a `429` or a `5xx` up to four attempts with exponential backoff,
+  honouring `Retry-After`'s delta-seconds form under an 8-second ceiling — a
+  backend may ask for a delay, but not park a session-start backfill for an
+  hour. The HTTP-date form is deliberately ignored rather than trusting the
+  caller's clock to agree with the server's. A `4xx` that will say the same
+  thing next time is issued exactly once, and the error names how many
+  attempts were made so a slow pass is not mistaken for one that never waited.
+  This matters because the chunk embedding pass keeps several requests in
+  flight (#4144), and concurrency is precisely what provokes a rate limit.
 - **The default admission floor is provisional, not measured.** The
   `SimilarityPosture` contract asks for a floor derived from a model's observed
   relevant/irrelevant score distributions on a real corpus, and no such

--- a/crates/stella-embed/src/http.rs
+++ b/crates/stella-embed/src/http.rs
@@ -405,17 +405,18 @@ impl Embedder for HttpEmbedder {
                 if let Some(key) = &self.api_key {
                     request = request.bearer_auth(key);
                 }
-                let response = request.send().await.map_err(|error| {
-                    EmbedError::Backend(format!("{}: {error}", self.endpoint))
-                })?;
+                let response = request
+                    .send()
+                    .await
+                    .map_err(|error| EmbedError::Backend(format!("{}: {error}", self.endpoint)))?;
 
                 let status = response.status();
                 if status.is_success() {
                     break response;
                 }
 
-                let worth_retrying = status == reqwest::StatusCode::TOO_MANY_REQUESTS
-                    || status.is_server_error();
+                let worth_retrying =
+                    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
                 if !worth_retrying || attempt >= MAX_ATTEMPTS {
                     let body = response.text().await.unwrap_or_default();
                     let body: String = body.chars().take(400).collect();

--- a/crates/stella-embed/src/http.rs
+++ b/crates/stella-embed/src/http.rs
@@ -47,6 +47,33 @@ use crate::seam::{EmbedError, Embedder, EmbedderFingerprint, Embedding, Similari
 /// bounded because this sits on a tool call the agent is waiting on.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How many times one embedding request is issued before its failure becomes
+/// the caller's.
+///
+/// **A rate limit is not an error, it is an instruction.** A backend that
+/// answers `429` is saying "ask again shortly"; treating that as a terminal
+/// failure hands the caller a dead pass over a condition that resolves by
+/// itself. This mattered little while the chunk embedding pass issued one
+/// request at a time and merely ran slowly, and it matters now that the pass
+/// keeps several in flight (#4144) — concurrency is exactly what provokes a
+/// rate limit, so the pass that got faster would otherwise be the pass that
+/// started aborting.
+///
+/// Bounded, because retrying forever is how a caller waits on a backend that
+/// is never going to answer. Four attempts spans roughly seven seconds of
+/// backoff, which clears an ordinary burst limit without turning a genuine
+/// outage into a long silence.
+const MAX_ATTEMPTS: u32 = 4;
+
+/// The first pause between attempts; each subsequent one doubles.
+const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+
+/// The ceiling on any single pause — including one a `Retry-After` header
+/// asks for. A backend is entitled to ask for a delay; it is not entitled to
+/// park a session-start backfill for an hour, and a header this large is more
+/// often a misconfigured proxy than a real instruction.
+const MAX_BACKOFF: Duration = Duration::from_secs(8);
+
 /// The admission floor applied when nothing overrides it.
 ///
 /// **This number is provisional and is not a measured separation point.** The
@@ -314,6 +341,27 @@ impl fmt::Debug for HttpEmbedder {
     }
 }
 
+/// How long the backend asked us to wait, if it said so in a form worth
+/// trusting.
+///
+/// Only the delta-seconds form of `Retry-After` is read. The HTTP-date form
+/// is legal and is deliberately ignored: honouring it means trusting the
+/// caller's clock to agree with the server's, and a skewed clock turns a
+/// two-second pause into a two-hour one. Falling back to the local backoff
+/// schedule is wrong by at most a few seconds; trusting a bad date is wrong
+/// by however far the clocks differ.
+fn retry_after(response: &reqwest::Response) -> Option<Duration> {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
+}
+
 #[async_trait]
 impl Embedder for HttpEmbedder {
     fn fingerprint(&self) -> EmbedderFingerprint {
@@ -334,28 +382,64 @@ impl Embedder for HttpEmbedder {
             return Err(EmbedError::EmptyInput);
         }
 
-        let mut request = self.client.post(&self.endpoint).json(&serde_json::json!({
+        let body = serde_json::json!({
             "model": self.model,
             "input": texts,
-        }));
-        if let Some(key) = &self.api_key {
-            request = request.bearer_auth(key);
-        }
+        });
 
-        let response = request
-            .send()
-            .await
-            .map_err(|error| EmbedError::Backend(format!("{}: {error}", self.endpoint)))?;
+        // Re-issue on the statuses that mean "not now" and on nothing else.
+        // A 401 or a 400 will say the same thing however many times it is
+        // asked, so retrying one only delays an error the caller has to read
+        // anyway; a 429 or a 5xx is a condition that clears.
+        //
+        // A transport error is deliberately *not* retried here. It is not a
+        // backend instruction, it has no `Retry-After` to honour, and the
+        // request may well have been received and billed — re-sending it is
+        // a decision about the user's money, not a courtesy, and belongs to
+        // whoever knows the pass can afford it.
+        let response = {
+            let mut attempt: u32 = 1;
+            let mut backoff = INITIAL_BACKOFF;
+            loop {
+                let mut request = self.client.post(&self.endpoint).json(&body);
+                if let Some(key) = &self.api_key {
+                    request = request.bearer_auth(key);
+                }
+                let response = request.send().await.map_err(|error| {
+                    EmbedError::Backend(format!("{}: {error}", self.endpoint))
+                })?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            let body: String = body.chars().take(400).collect();
-            return Err(EmbedError::Backend(format!(
-                "{} returned HTTP {status}: {body}",
-                self.endpoint
-            )));
-        }
+                let status = response.status();
+                if status.is_success() {
+                    break response;
+                }
+
+                let worth_retrying = status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                    || status.is_server_error();
+                if !worth_retrying || attempt >= MAX_ATTEMPTS {
+                    let body = response.text().await.unwrap_or_default();
+                    let body: String = body.chars().take(400).collect();
+                    // The attempt count is in the message because "HTTP 429"
+                    // alone reads as "the pass never even waited", and a user
+                    // deciding whether their rate limit is the problem needs
+                    // to know it already backed off and asked again.
+                    let tried = if attempt > 1 {
+                        format!(" after {attempt} attempts")
+                    } else {
+                        String::new()
+                    };
+                    return Err(EmbedError::Backend(format!(
+                        "{} returned HTTP {status}{tried}: {body}",
+                        self.endpoint
+                    )));
+                }
+
+                let pause = retry_after(&response).unwrap_or(backoff).min(MAX_BACKOFF);
+                tokio::time::sleep(pause).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+                attempt += 1;
+            }
+        };
 
         let payload: EmbeddingsResponse = response.json().await.map_err(|error| {
             EmbedError::Backend(format!("unreadable embeddings response: {error}"))
@@ -656,5 +740,87 @@ mod tests {
         };
         assert!(message.contains("401"), "{message}");
         assert!(message.contains("bad key"), "{message}");
+    }
+
+    /// **The witness for #4144's rate-limit constraint.** The chunk embedding
+    /// pass now keeps several requests in flight, which is precisely what
+    /// provokes a rate limit — so a `429` has to be an instruction to wait
+    /// rather than the end of the pass. Without the retry the first one
+    /// aborts everything downstream of it.
+    #[tokio::test]
+    async fn a_rate_limited_request_is_retried_rather_than_failed() {
+        let server = MockServer::start().await;
+        // Answered in mount order, each `up_to_n_times` once exhausted
+        // falling through to the next: one refusal, then the real answer.
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "0")
+                    .set_body_string("slow down"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [ { "index": 0, "embedding": [1.0, 0.0] } ]
+            })))
+            .mount(&server)
+            .await;
+
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let out = embedder
+            .embed(&["only".to_string()])
+            .await
+            .expect("a 429 must be waited out, not surfaced as a failure");
+        assert_eq!(out[0].vector, vec![1.0, 0.0]);
+    }
+
+    /// The retry is bounded, and says so. A backend that refuses every
+    /// attempt still ends as a named error rather than an unbounded wait —
+    /// and the message reports that it was asked more than once, so a user
+    /// reading "HTTP 429" is not left thinking the pass never backed off.
+    #[tokio::test]
+    async fn a_backend_that_only_refuses_ends_as_an_error_naming_the_attempts() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "0")
+                    .set_body_string("still limited"),
+            )
+            .mount(&server)
+            .await;
+
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let Err(EmbedError::Backend(message)) = embedder.embed(&["x".to_string()]).await else {
+            panic!("expected a backend error once the attempts ran out");
+        };
+        assert!(message.contains("429"), "{message}");
+        assert!(
+            message.contains(&format!("{MAX_ATTEMPTS} attempts")),
+            "the error must report that it retried: {message}"
+        );
+    }
+
+    /// A rate limit clears; a bad key does not. Retrying a `401` only delays
+    /// an error the caller has to read anyway, so it is issued exactly once.
+    #[tokio::test]
+    async fn an_unauthorized_request_is_not_retried() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("bad key"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        assert!(embedder.embed(&["x".to_string()]).await.is_err());
+        // `expect(1)` is verified on drop: a second attempt fails the test.
+        drop(server);
     }
 }

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! Chunk vectors: the pieces a file is made of, embedded one at a time.
+//! Chunk vectors: the pieces a file is made of, embedded one symbol at a
+//! time rather than one file at a time.
 //!
 //! # The measurement
 //!
@@ -214,11 +215,16 @@ pub fn line_span(content: &str, start_line: u32, end_line: u32) -> String {
 ///
 /// Asking instead whether the file carries **any** chunk vector stamped with
 /// its current content hash is exact here, because a chunk pass is per-file
-/// atomic: `embed_and_store_chunk_file` gathers every vector the file needs
-/// before it writes any of them, and re-stamps `file_sha256` on the rows it
-/// skipped. So a file is either untouched at this content hash or completely
-/// covered at it — there is no partial state for the marker to misread. Edited
-/// files still re-enter: their new `content_sha256` matches no stored row.
+/// atomic: the pass gathers every vector a file needs before writing any of
+/// them, and re-stamps `file_sha256` on the rows it skipped. So a file is
+/// either untouched at this content hash or completely covered at it — there
+/// is no partial state for the marker to misread. Edited files still
+/// re-enter: their new `content_sha256` matches no stored row.
+///
+/// That atomicity is a property of the **write**, and it survived the pass
+/// being batched across files and made concurrent (#4144): requests may now
+/// carry chunks from several files at once, but a file's rows still go to
+/// [`store_chunk_vectors`] together, once its last vector has landed.
 ///
 /// The `EXISTS` on symbols is load-bearing rather than tidiness. Without it a
 /// file with no symbols at all — an empty source file, a markdown document with

--- a/crates/stella-tools/Cargo.toml
+++ b/crates/stella-tools/Cargo.toml
@@ -35,11 +35,15 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+# `buffer_unordered` — the chunk embedding pass keeps a bounded number of
+# backend requests in flight instead of one serial round trip per file (#4144).
+# Promoted from a dev-dependency, where it was already carried for `poll!`: the
+# cancellation-safety witness drops a tool future mid-await, the way an elapsed
+# dispatch timeout does. Tests see a normal dependency, so the witness keeps
+# compiling with no second entry below.
+futures-util.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "fs", "io-util"] }
 # Property tests for foundry authorship and the approval precedence ladder.
 proptest.workspace = true
-# `poll!` — the cancellation-safety witness drops a tool future mid-await, the
-# way an elapsed dispatch timeout does.
-futures-util.workspace = true

--- a/crates/stella-tools/src/search/backfill.rs
+++ b/crates/stella-tools/src/search/backfill.rs
@@ -299,4 +299,192 @@ mod tests {
         );
         graph.shutdown();
     }
+
+    /// **The witness for #4144.** The chunk rung used to spend one HTTP
+    /// round trip per file, strictly serially; the fix batches chunks across
+    /// files, so a window of small files must cost a small constant number
+    /// of requests, not one per file. Sixty one-symbol files fit in two
+    /// 32-chunk batches; the old shape would have made sixty calls.
+    #[tokio::test]
+    async fn the_chunk_pass_batches_across_files() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let graph = indexed_fixture(&root, 60);
+        let embedder = CountingEmbedder::default();
+
+        let outcome = backfill_opened(&graph, &embedder, &mut |_| {}).await;
+        assert!(
+            matches!(outcome, BackfillOutcome::Ran { .. }),
+            "{outcome:?}"
+        );
+
+        // The file rung costs ceil(60 / 32) = 2 requests of its own; the
+        // chunk rung must cost the same order — one request per 32 chunks
+        // across the whole window, not one per file.
+        let calls = embedder.calls.load(Ordering::SeqCst);
+        assert!(
+            calls <= 8,
+            "60 one-symbol files must embed in a handful of batched requests, \
+             not one round trip per file (#4144): {calls} calls"
+        );
+        graph.shutdown();
+    }
+
+    /// The concurrency bound is a bound, not a goal: a window whose chunks
+    /// fit in one batch must cost one request, however many files they came
+    /// from.
+    #[tokio::test]
+    async fn a_small_window_costs_one_chunk_request() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let graph = indexed_fixture(&root, 4);
+        let embedder = CountingEmbedder::default();
+
+        let outcome = backfill_opened(&graph, &embedder, &mut |_| {}).await;
+        assert!(
+            matches!(outcome, BackfillOutcome::Ran { .. }),
+            "{outcome:?}"
+        );
+
+        // One file-rung request (4 files < 32) plus one chunk-rung request
+        // (4 chunks < 32): the old shape would have made 1 + 4.
+        let calls = embedder.calls.load(Ordering::SeqCst);
+        assert_eq!(
+            calls, 2,
+            "four one-symbol files must cost one file batch and one chunk batch: {calls} calls"
+        );
+        graph.shutdown();
+    }
+
+    /// A backend that answers **out of the order it was asked**, and whose
+    /// vectors say which symbol they belong to.
+    ///
+    /// Concurrency is what makes this shape possible: with several requests
+    /// in flight, the one issued first is no longer the one that returns
+    /// first, and a pass that routes a response by its arrival position
+    /// rather than by the request it answers files every vector against the
+    /// wrong symbol. Nothing errors when that happens — each chunk still
+    /// receives a well-formed vector of the right width — so the only
+    /// instrument that can see it is what the index answers afterwards.
+    ///
+    /// Earlier requests are made to sleep longer, so completion order is the
+    /// exact reverse of issue order and the misattribution is deterministic
+    /// rather than a race the test might win.
+    #[derive(Debug, Default)]
+    struct ReversingEmbedder {
+        issued: AtomicUsize,
+    }
+
+    /// The width of [`ReversingEmbedder`]'s one-hot space, and the number of
+    /// fixture files the witness below builds — two full [`EMBED_BATCH`]
+    /// requests, which is the smallest window that can be reordered at all.
+    const REVERSING_DIMS: usize = 64;
+
+    impl ReversingEmbedder {
+        /// The symbol index a rendered text is about. Every fixture symbol is
+        /// `thing_<k>`, and both rungs' renderings carry the name, so this
+        /// reads a file vector's text as happily as a chunk's.
+        fn symbol_index(text: &str) -> usize {
+            let tail = text.split("thing_").nth(1).expect("a fixture symbol name");
+            tail.chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .expect("a fixture symbol index")
+        }
+
+        /// The vector that means "symbol `k`" — one-hot, so cosine against it
+        /// is 1.0 for the right symbol and 0.0 for every other one. A
+        /// misrouted vector is then not a near miss but a different answer.
+        fn one_hot(index: usize) -> Vec<f32> {
+            let mut vector = vec![0.0; REVERSING_DIMS];
+            vector[index % REVERSING_DIMS] = 1.0;
+            vector
+        }
+    }
+
+    #[async_trait]
+    impl Embedder for ReversingEmbedder {
+        fn fingerprint(&self) -> EmbedderFingerprint {
+            EmbedderFingerprint {
+                model_id: "reversing".into(),
+                revision: "1".into(),
+                dims: REVERSING_DIMS,
+                normalization: "l2".into(),
+            }
+        }
+
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedError> {
+            // Request 0 waits longest, request 1 less, and so on: issue
+            // order reversed, with enough separation that the ordering is
+            // decided by the sleeps and not by scheduler noise.
+            let ordinal = self.issued.fetch_add(1, Ordering::SeqCst);
+            let delay = 200u64.saturating_sub(ordinal as u64 * 50);
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+
+            let fingerprint = self.fingerprint().id();
+            Ok(texts
+                .iter()
+                .map(|text| Embedding {
+                    fingerprint: fingerprint.clone(),
+                    vector: Self::one_hot(Self::symbol_index(text)),
+                })
+                .collect())
+        }
+
+        fn similarity_posture(&self) -> SimilarityPosture {
+            SimilarityPosture::Semantic {
+                admission_floor: 0.5,
+            }
+        }
+    }
+
+    /// **The correctness witness for #4144's concurrency.** Batching the
+    /// chunk rung across files is only worth anything if the vectors land on
+    /// the symbols they were computed for. With requests in flight
+    /// concurrently they complete out of order, so a response must be
+    /// matched to the request it answers — pairing the Nth completion with
+    /// the Nth batch stores every vector against the wrong symbol, silently.
+    ///
+    /// Sixty-four one-symbol files are two full 32-chunk requests, and
+    /// [`ReversingEmbedder`] guarantees the second completes first. Asking
+    /// the index for symbol `k` must return symbol `k`.
+    #[tokio::test]
+    async fn every_chunk_keeps_the_vector_computed_for_it() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let graph = indexed_fixture(&root, REVERSING_DIMS);
+        let embedder = ReversingEmbedder::default();
+        let fingerprint = embedder.fingerprint().id();
+
+        let outcome = backfill_opened(&graph, &embedder, &mut |_| {}).await;
+        assert!(
+            matches!(outcome, BackfillOutcome::Ran { .. }),
+            "{outcome:?}"
+        );
+
+        // Read back through the ranking path a search actually uses, so the
+        // assertion is about what a user is told, not about a row shape.
+        for index in 0..REVERSING_DIMS {
+            let hits = graph
+                .rank_chunks_by_vector(
+                    &fingerprint,
+                    &ReversingEmbedder::one_hot(index),
+                    0.5,
+                    1,
+                )
+                .expect("rank the stored chunks");
+            let top = hits
+                .first()
+                .unwrap_or_else(|| panic!("symbol thing_{index} has no stored vector"));
+            assert_eq!(
+                top.name, format!("thing_{index}"),
+                "the vector computed for thing_{index} was stored against {} — a \
+                 response was routed by arrival order rather than to the request \
+                 it answered (#4144)",
+                top.name
+            );
+        }
+        graph.shutdown();
+    }
 }

--- a/crates/stella-tools/src/search/backfill.rs
+++ b/crates/stella-tools/src/search/backfill.rs
@@ -439,6 +439,102 @@ mod tests {
         }
     }
 
+    /// A backend that answers a fixed number of requests and then refuses
+    /// every one after — the refusal deliberately slow, so the requests that
+    /// did succeed have already landed by the time it arrives.
+    ///
+    /// Without that ordering the test would be asking a race what it thinks,
+    /// since a failure completing first legitimately abandons whatever was
+    /// still in flight beside it.
+    #[derive(Debug)]
+    struct FlakyEmbedder {
+        calls: AtomicUsize,
+        succeed_first: usize,
+    }
+
+    #[async_trait]
+    impl Embedder for FlakyEmbedder {
+        fn fingerprint(&self) -> EmbedderFingerprint {
+            EmbedderFingerprint {
+                model_id: "flaky".into(),
+                revision: "1".into(),
+                dims: 2,
+                normalization: "l2".into(),
+            }
+        }
+
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedError> {
+            let ordinal = self.calls.fetch_add(1, Ordering::SeqCst);
+            if ordinal >= self.succeed_first {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                return Err(EmbedError::Backend("the backend went away".into()));
+            }
+            let fingerprint = self.fingerprint().id();
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    let mut vector = vec![text.len() as f32, 1.0];
+                    stella_embed::l2_normalize(&mut vector);
+                    Embedding {
+                        fingerprint: fingerprint.clone(),
+                        vector,
+                    }
+                })
+                .collect())
+        }
+
+        fn similarity_posture(&self) -> SimilarityPosture {
+            SimilarityPosture::Semantic {
+                admission_floor: 0.2,
+            }
+        }
+    }
+
+    /// **The durability witness for #4144.** The pass runs unattended in the
+    /// background and is expected to be interrupted — by a failing backend,
+    /// by the process ending. Batching chunks across files must not turn the
+    /// whole 64-file window into one all-or-nothing unit: a file whose last
+    /// vector has landed is committed there and then, so a later failure
+    /// costs the files still in flight and not the ones already paid for.
+    ///
+    /// Sixty-four one-symbol files are two file-rung requests and two
+    /// chunk-rung requests. The backend answers three and refuses the fourth,
+    /// so exactly one chunk batch — half the window — must survive, and
+    /// `files_embedded` must say so rather than reporting zero.
+    #[tokio::test]
+    async fn files_finished_before_a_failure_stay_committed() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        let graph = indexed_fixture(&root, 64);
+        let embedder = FlakyEmbedder {
+            calls: AtomicUsize::new(0),
+            succeed_first: 3,
+        };
+        let fingerprint = embedder.fingerprint().id();
+
+        let outcome = backfill_opened(&graph, &embedder, &mut |_| {}).await;
+        let BackfillOutcome::Ran { chunks, .. } = outcome else {
+            panic!("the pass held the lease and ran: {outcome:?}");
+        };
+        let ChunkWarmOutcome::Failed { files_embedded, .. } = chunks else {
+            panic!("the fourth request was refused, so the rung failed: {chunks:?}");
+        };
+
+        assert!(
+            files_embedded > 0,
+            "the batch that completed before the failure must be committed, \
+             not discarded with the window (#4144)"
+        );
+        assert_eq!(
+            graph
+                .embedded_chunk_count(&fingerprint)
+                .expect("count the stored chunks"),
+            files_embedded,
+            "every file the pass reported as embedded must actually be in the store"
+        );
+        graph.shutdown();
+    }
+
     /// **The correctness witness for #4144's concurrency.** Batching the
     /// chunk rung across files is only worth anything if the vectors land on
     /// the symbols they were computed for. With requests in flight

--- a/crates/stella-tools/src/search/backfill.rs
+++ b/crates/stella-tools/src/search/backfill.rs
@@ -563,18 +563,14 @@ mod tests {
         // assertion is about what a user is told, not about a row shape.
         for index in 0..REVERSING_DIMS {
             let hits = graph
-                .rank_chunks_by_vector(
-                    &fingerprint,
-                    &ReversingEmbedder::one_hot(index),
-                    0.5,
-                    1,
-                )
+                .rank_chunks_by_vector(&fingerprint, &ReversingEmbedder::one_hot(index), 0.5, 1)
                 .expect("rank the stored chunks");
             let top = hits
                 .first()
                 .unwrap_or_else(|| panic!("symbol thing_{index} has no stored vector"));
             assert_eq!(
-                top.name, format!("thing_{index}"),
+                top.name,
+                format!("thing_{index}"),
                 "the vector computed for thing_{index} was stored against {} — a \
                  response was routed by arrival order rather than to the request \
                  it answered (#4144)",

--- a/crates/stella-tools/src/search/engine.rs
+++ b/crates/stella-tools/src/search/engine.rs
@@ -844,13 +844,21 @@ async fn fill_chunk_window(
     // by which file it belongs to and where in that file's chunk list it
     // sits, so the response can be routed back without the text round-
     // tripping through a map keyed on content.
-    struct NeededChunk<'a> {
+    //
+    // The text is **owned** rather than borrowed from `files`. A borrow puts
+    // a lifetime on this struct, and a lifetime here is not a local matter:
+    // the futures below would carry it, and `tokio::spawn` at the session's
+    // backfill site cannot prove `Send` for a higher-ranked one. The error
+    // does not appear in this crate at all — it lands three crates away, in
+    // `stella-cli`'s `agent::graph`, as "implementation of `Send` is not
+    // general enough" pointing at a `spawn` that mentions none of this.
+    struct NeededChunk {
         file_index: usize,
         chunk_index: usize,
-        text: &'a str,
+        text: String,
     }
 
-    let needed: Vec<NeededChunk<'_>> = files
+    let needed: Vec<NeededChunk> = files
         .iter()
         .enumerate()
         .flat_map(|(file_index, file)| {
@@ -858,10 +866,10 @@ async fn fill_chunk_window(
                 .iter()
                 .enumerate()
                 .filter_map(move |(chunk_index, chunk)| {
-                    chunk.text.as_deref().map(|text| NeededChunk {
+                    chunk.text.as_ref().map(|text| NeededChunk {
                         file_index,
                         chunk_index,
-                        text,
+                        text: text.clone(),
                     })
                 })
         })
@@ -875,33 +883,40 @@ async fn fill_chunk_window(
         .map(|file| vec![None; file.chunks.len()])
         .collect();
 
-    // Cut the flattened stream into full requests and keep
-    // [`CHUNK_EMBED_CONCURRENCY`] of them in flight.
+    // Cut the flattened chunk list into full requests, each owning its own
+    // texts, and keep [`CHUNK_EMBED_CONCURRENCY`] of them in flight.
+    let requests: Vec<(usize, Vec<String>)> = needed
+        .chunks(EMBED_BATCH)
+        .enumerate()
+        .map(|(ordinal, batch)| {
+            (
+                ordinal,
+                batch.iter().map(|chunk| chunk.text.clone()).collect(),
+            )
+        })
+        .collect();
+
+    // **Each response carries the ordinal of the request it answers.**
+    // `buffer_unordered` yields results as they *complete*, not in the order
+    // the requests were issued, so pairing the Nth completion with the Nth
+    // batch would file one request's vectors against whichever chunks
+    // happened to be in a slower one. Nothing would fail: every chunk still
+    // gets a well-formed vector of the right width, and the only symptom is
+    // a semantic index that answers with the wrong symbols. It is the same
+    // misattribution `HttpEmbedder::embed` refuses one layer down when it
+    // routes rows by their `index` rather than by arrival order, for the
+    // same reason — a wrong vector is a corrupt ranking, never an error
+    // anyone sees.
     //
-    // **The batch travels with its own response.** `buffer_unordered`
-    // yields each result as it *completes*, not in the order the requests
-    // were issued, so pairing the Nth completion with the Nth batch would
-    // attribute one request's vectors to whichever chunks happened to be
-    // in a slower one. Nothing would fail: every chunk still receives a
-    // vector of the right width, and the only symptom is a semantic index
-    // that answers with the wrong symbols. It is the same misattribution
-    // `HttpEmbedder::embed` refuses one layer down when it routes rows by
-    // their `index` rather than by arrival order, for the same reason —
-    // a wrong vector is a corrupt ranking, never an error anyone sees.
-    //
-    // The async block is spelled out rather than a closure returning
-    // `embedder.embed(&texts)`: through the closure the compiler infers a
-    // higher-ranked lifetime for the borrowed embedder that `tokio::spawn`
-    // cannot prove `Send` over, and the failure surfaces three crates away
-    // at the spawn site as "not general enough".
-    let mut in_flight = stream::iter(needed.chunks(EMBED_BATCH).map(|batch| {
-        let texts: Vec<String> = batch.iter().map(|chunk| chunk.text.to_string()).collect();
-        async move {
-            embedder
-                .embed(&texts)
-                .await
-                .map(|embeddings| (batch, embeddings))
-        }
+    // An ordinal rather than the batch itself, because a borrow of `needed`
+    // travelling through these futures is what the owned `text` above exists
+    // to avoid: it would put a higher-ranked lifetime on the spawned
+    // backfill task in `stella-cli` and fail there rather than here.
+    let mut in_flight = stream::iter(requests.into_iter().map(|(ordinal, texts)| async move {
+        embedder
+            .embed(&texts)
+            .await
+            .map(|embeddings| (ordinal, embeddings))
     }))
     .buffer_unordered(CHUNK_EMBED_CONCURRENCY);
 
@@ -940,8 +955,14 @@ async fn fill_chunk_window(
     // one, because it would carry the current content hash and the next
     // pass would see nothing pending and never come back for the gap.
     while let Some(result) = in_flight.next().await {
-        let (batch, embeddings) =
+        let (ordinal, embeddings) =
             result.map_err(|error| format!("the embedder failed: {error}"))?;
+
+        // The ordinal names the request, so the batch is the same slice the
+        // texts were cut from — the one arithmetic that has to agree with
+        // `requests` above, and it agrees by construction.
+        let start = ordinal * EMBED_BATCH;
+        let batch = &needed[start..(start + EMBED_BATCH).min(needed.len())];
 
         // A short response would leave some file's count stuck above zero,
         // so the window would never commit it and the caller's loop would

--- a/crates/stella-tools/src/search/engine.rs
+++ b/crates/stella-tools/src/search/engine.rs
@@ -751,66 +751,160 @@ fn coverage_note(graph: &CodeGraph, fingerprint: &str) -> Option<String> {
     ))
 }
 
-/// Embed one file's pending chunks and store them — the single place a chunk
-/// vector comes into existence, shared by the eager `stella init` pass below
-/// and the background pass in [`super::backfill`], so there is one render, one
-/// table and one fingerprint discipline (mirrors [`super::semantic`]'s
-/// `embed_batch` for whole-file vectors).
+/// How many embedding requests one chunk pass keeps in flight at once.
 ///
-/// **One file per store call**, because the store's sweep — the thing that
-/// removes a deleted function's vector — keys on the file's content hash, so
-/// writing half a file's chunks and then the other half would have the second
-/// write delete the first's rows.
+/// The pass used to be strictly serial — one file per round trip, each
+/// awaited before the next was issued — which made a cold index cost one
+/// sequential request per file (#4144). The bound exists because the
+/// alternative is not "faster", it is a different failure: an unbounded
+/// fan-out turns a provider's rate limit into a wall of 429s, and a
+/// provider that answers slowly turns the pass into a queue of its own
+/// making. Eight is the same order of concurrency the rest of the tool
+/// already assumes a backend tolerates, and it is a knob on wall clock,
+/// not on correctness — every file is still embedded and stored exactly
+/// once, in scan order, whatever this number is.
+const CHUNK_EMBED_CONCURRENCY: usize = 8;
+
+/// Embed the pending chunks of every file in `files` and store them — the
+/// single place a chunk vector comes into existence, shared by the eager
+/// `stella init` pass below and the background pass in [`super::backfill`],
+/// so there is one render, one table and one fingerprint discipline
+/// (mirrors [`super::semantic`]'s `embed_batch` for whole-file vectors).
 ///
-/// A chunk whose rendered text is unchanged arrives with no `text` and costs
-/// no request: it is re-stamped with the file's new hash and keeps its vector.
-/// That is what makes editing one function in a 60-symbol file cost one
-/// embedding rather than sixty.
-async fn embed_and_store_chunk_file(
+/// **Batches span files.** The old shape embedded one file per request —
+/// 32 chunks of the same file per call, files strictly serial — so a
+/// workspace of small files paid one round trip per file no matter how
+/// few chunks each carried (#4144). Here the pending chunks of the whole
+/// window are flattened into one stream and cut into [`EMBED_BATCH`]-sized
+/// requests, so a request is always full unless the work ran out, and up
+/// to [`CHUNK_EMBED_CONCURRENCY`] of those requests are in flight at once.
+///
+/// **One file per store call still**, because the store's sweep — the
+/// thing that removes a deleted function's vector — keys on the file's
+/// content hash, so writing half a file's chunks and then the other half
+/// would have the second write delete the first's rows. Batching is an
+/// embedding-side change only; the storage unit is untouched.
+///
+/// A chunk whose rendered text is unchanged arrives with no `text` and
+/// costs no request: it is re-stamped with the file's new hash and keeps
+/// its vector. That is what makes editing one function in a 60-symbol
+/// file cost one embedding rather than sixty.
+///
+/// Returns the number of files committed, so the caller can narrate the
+/// window as one progress step per file without the callback crossing an
+/// `await` — the eager caller's closure borrows a non-`Send` emitter, and
+/// holding it across the embedding fan-out would force `Send` on it.
+async fn embed_and_store_chunk_files(
     graph: &CodeGraph,
     embedder: &dyn Embedder,
     fingerprint: &str,
-    file: &stella_graph::PendingChunkFile,
-) -> Result<(), String> {
-    let mut vectors: Vec<Option<Vec<f32>>> = vec![None; file.chunks.len()];
-    let needed: Vec<(usize, &str)> = file
-        .chunks
+    files: &[stella_graph::PendingChunkFile],
+) -> Result<usize, String> {
+    use futures_util::stream::{self, StreamExt};
+
+    // The unit of embedding work: one chunk that needs a vector, addressed
+    // by which file it belongs to and where in that file's chunk list it
+    // sits, so the response can be routed back without the text round-
+    // tripping through a map keyed on content.
+    struct NeededChunk<'a> {
+        file_index: usize,
+        chunk_index: usize,
+        text: &'a str,
+    }
+
+    let needed: Vec<NeededChunk<'_>> = files
         .iter()
         .enumerate()
-        .filter_map(|(index, chunk)| chunk.text.as_deref().map(|text| (index, text)))
+        .flat_map(|(file_index, file)| {
+            file.chunks
+                .iter()
+                .enumerate()
+                .filter_map(move |(chunk_index, chunk)| {
+                    chunk.text.as_deref().map(|text| NeededChunk {
+                        file_index,
+                        chunk_index,
+                        text,
+                    })
+                })
+        })
         .collect();
 
-    for batch in needed.chunks(EMBED_BATCH) {
-        let texts: Vec<String> = batch.iter().map(|(_, text)| (*text).to_string()).collect();
-        let embeddings = embedder
-            .embed(&texts)
-            .await
-            .map_err(|error| format!("the embedder failed: {error}"))?;
-        for ((index, _), embedding) in batch.iter().zip(embeddings) {
-            vectors[*index] = Some(embedding.vector);
+    // One slot per chunk of every file, `None` meaning "re-stamp the row
+    // that is already stored" — the same contract `ChunkVector::vector`
+    // carries into the store.
+    let mut vectors: Vec<Vec<Option<Vec<f32>>>> = files
+        .iter()
+        .map(|file| vec![None; file.chunks.len()])
+        .collect();
+
+    // Cut the flattened stream into full requests and keep
+    // [`CHUNK_EMBED_CONCURRENCY`] of them in flight.
+    //
+    // **The batch travels with its own response.** `buffer_unordered`
+    // yields each result as it *completes*, not in the order the requests
+    // were issued, so pairing the Nth completion with the Nth batch would
+    // attribute one request's vectors to whichever chunks happened to be
+    // in a slower one. Nothing would fail: every chunk still receives a
+    // vector of the right width, and the only symptom is a semantic index
+    // that answers with the wrong symbols. It is the same misattribution
+    // `HttpEmbedder::embed` refuses one layer down when it routes rows by
+    // their `index` rather than by arrival order, for the same reason —
+    // a wrong vector is a corrupt ranking, never an error anyone sees.
+    //
+    // The async block is spelled out rather than a closure returning
+    // `embedder.embed(&texts)`: through the closure the compiler infers a
+    // higher-ranked lifetime for the borrowed embedder that `tokio::spawn`
+    // cannot prove `Send` over, and the failure surfaces three crates away
+    // at the spawn site as "not general enough".
+    let mut in_flight = stream::iter(needed.chunks(EMBED_BATCH).map(|batch| {
+        let texts: Vec<String> = batch.iter().map(|chunk| chunk.text.to_string()).collect();
+        async move {
+            embedder
+                .embed(&texts)
+                .await
+                .map(|embeddings| (batch, embeddings))
+        }
+    }))
+    .buffer_unordered(CHUNK_EMBED_CONCURRENCY);
+
+    // One failed request abandons the whole window, because a window
+    // stored with a hole in it is indistinguishable from a finished one:
+    // every file would carry the current content hash, so the next pass
+    // would see nothing pending and never come back for the gap.
+    while let Some(result) = in_flight.next().await {
+        let (batch, embeddings) =
+            result.map_err(|error| format!("the embedder failed: {error}"))?;
+        for (chunk, embedding) in batch.iter().zip(embeddings) {
+            vectors[chunk.file_index][chunk.chunk_index] = Some(embedding.vector);
         }
     }
 
-    let rows: Vec<stella_graph::ChunkVector> = file
-        .chunks
-        .iter()
-        .zip(vectors)
-        .map(|(chunk, vector)| stella_graph::ChunkVector {
-            chunk_sha256: chunk.chunk_sha256.clone(),
-            name: chunk.name.clone(),
-            kind: chunk.kind.clone(),
-            start_line: chunk.start_line,
-            end_line: chunk.end_line,
-            vector,
-        })
-        .collect();
-    graph
-        .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
-        // Not recoverable by continuing: the next file would be written
-        // into the same broken store and the pass would report success
-        // having stored nothing.
-        .map_err(|error| format!("the chunk index could not be written: {error}"))
-        .map(|_| ())
+    // Store file by file — the sweep's unit — committing each file once
+    // its rows are assembled.
+    let mut committed = 0;
+    for (file, file_vectors) in files.iter().zip(vectors) {
+        let rows: Vec<stella_graph::ChunkVector> = file
+            .chunks
+            .iter()
+            .zip(file_vectors)
+            .map(|(chunk, vector)| stella_graph::ChunkVector {
+                chunk_sha256: chunk.chunk_sha256.clone(),
+                name: chunk.name.clone(),
+                kind: chunk.kind.clone(),
+                start_line: chunk.start_line,
+                end_line: chunk.end_line,
+                vector,
+            })
+            .collect();
+        graph
+            .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
+            // Not recoverable by continuing: the next file would be written
+            // into the same broken store and the pass would report success
+            // having stored nothing.
+            .map_err(|error| format!("the chunk index could not be written: {error}"))?;
+        committed += 1;
+    }
+    Ok(committed)
 }
 
 /// No ceiling here either — see [`super::semantic::NO_FILE_CEILING`], which
@@ -954,21 +1048,20 @@ pub(super) async fn warm_chunks_opened<P: FnMut(usize) + ?Sized>(
         // make the loop's boundedness depend on a SQL predicate in another
         // crate being right, which is exactly the coupling that produced
         // #3128. `PendingChunkFile::to_embed()` is the per-symbol truth.
-        let mut made_progress = false;
-        for file in &scan.files {
-            if file.to_embed() > 0 {
-                made_progress = true;
+        let made_progress = scan.files.iter().any(|file| file.to_embed() > 0);
+        match embed_and_store_chunk_files(graph, embedder, &fingerprint, &scan.files).await {
+            Ok(committed) => {
+                for _ in 0..committed {
+                    files_embedded += 1;
+                    progress(files_embedded);
+                }
             }
-            if let Err(reason) =
-                embed_and_store_chunk_file(graph, embedder, &fingerprint, file).await
-            {
+            Err(reason) => {
                 return ChunkWarmOutcome::Failed {
                     files_embedded,
                     reason,
                 };
             }
-            files_embedded += 1;
-            progress(files_embedded);
         }
         if !made_progress {
             break;

--- a/crates/stella-tools/src/search/engine.rs
+++ b/crates/stella-tools/src/search/engine.rs
@@ -790,16 +790,57 @@ const CHUNK_EMBED_CONCURRENCY: usize = 8;
 /// its vector. That is what makes editing one function in a 60-symbol
 /// file cost one embedding rather than sixty.
 ///
-/// Returns the number of files committed, so the caller can narrate the
-/// window as one progress step per file without the callback crossing an
-/// `await` — the eager caller's closure borrows a non-`Send` emitter, and
-/// holding it across the embedding fan-out would force `Send` on it.
+/// Reports what the window committed *and* how it ended, rather than one or
+/// the other. A `Result` would have to throw the count away on the failing
+/// arm, and the count is exactly what is still true then: the files whose
+/// vectors landed before the failure are in the store, and a caller that
+/// reported zero of them would be understating durable work — the next pass
+/// would find them already done and the narration would have lied about what
+/// the user paid for.
+///
+/// The count also lets the caller narrate one progress step per file without
+/// the callback crossing an `await`: the eager caller's closure borrows a
+/// non-`Send` emitter, and holding it across the embedding fan-out would
+/// force `Send` on it.
 async fn embed_and_store_chunk_files(
     graph: &CodeGraph,
     embedder: &dyn Embedder,
     fingerprint: &str,
     files: &[stella_graph::PendingChunkFile],
-) -> Result<usize, String> {
+) -> ChunkWindow {
+    let mut committed = 0;
+    let failure = fill_chunk_window(graph, embedder, fingerprint, files, &mut committed)
+        .await
+        .err();
+    ChunkWindow {
+        committed,
+        failure,
+    }
+}
+
+/// What one window of the chunk pass did: how many files reached the store,
+/// and why it stopped if it stopped early. Total by construction, for the
+/// reason [`ChunkWarmOutcome`] gives — the two facts are independent, and a
+/// shape that can only carry one of them forces a caller to guess the other.
+#[derive(Debug)]
+struct ChunkWindow {
+    /// Files whose rows are durably written. Never rolled back by a later
+    /// failure: [`store_chunk_file`] commits per file, and a committed file
+    /// stays committed.
+    committed: usize,
+    /// Why the window stopped short, if it did.
+    failure: Option<String>,
+}
+
+/// [`embed_and_store_chunk_files`]'s body, split out so the `?` operator is
+/// available while `committed` keeps counting through a failure.
+async fn fill_chunk_window(
+    graph: &CodeGraph,
+    embedder: &dyn Embedder,
+    fingerprint: &str,
+    files: &[stella_graph::PendingChunkFile],
+    committed: &mut usize,
+) -> Result<(), String> {
     use futures_util::stream::{self, StreamExt};
 
     // The unit of embedding work: one chunk that needs a vector, addressed
@@ -867,44 +908,108 @@ async fn embed_and_store_chunk_files(
     }))
     .buffer_unordered(CHUNK_EMBED_CONCURRENCY);
 
-    // One failed request abandons the whole window, because a window
-    // stored with a hole in it is indistinguishable from a finished one:
-    // every file would carry the current content hash, so the next pass
-    // would see nothing pending and never come back for the gap.
-    while let Some(result) = in_flight.next().await {
-        let (batch, embeddings) =
-            result.map_err(|error| format!("the embedder failed: {error}"))?;
-        for (chunk, embedding) in batch.iter().zip(embeddings) {
-            vectors[chunk.file_index][chunk.chunk_index] = Some(embedding.vector);
+    // How many vectors each file is still waiting for. A file's chunks can
+    // straddle two requests now that batches span files, so "this file is
+    // finished" is a count reaching zero rather than a request completing.
+    let mut outstanding: Vec<usize> = vec![0; files.len()];
+    for chunk in &needed {
+        outstanding[chunk.file_index] += 1;
+    }
+
+    // A file whose chunks are all unchanged waits for nothing: its rows are
+    // pure re-stamps of vectors already stored, so it is committed before
+    // the first request is even issued.
+    for index in 0..files.len() {
+        if outstanding[index] == 0 {
+            store_chunk_file(
+                graph,
+                fingerprint,
+                &files[index],
+                std::mem::take(&mut vectors[index]),
+            )?;
+            *committed += 1;
         }
     }
 
-    // Store file by file — the sweep's unit — committing each file once
-    // its rows are assembled.
-    let mut committed = 0;
-    for (file, file_vectors) in files.iter().zip(vectors) {
-        let rows: Vec<stella_graph::ChunkVector> = file
-            .chunks
-            .iter()
-            .zip(file_vectors)
-            .map(|(chunk, vector)| stella_graph::ChunkVector {
-                chunk_sha256: chunk.chunk_sha256.clone(),
-                name: chunk.name.clone(),
-                kind: chunk.kind.clone(),
-                start_line: chunk.start_line,
-                end_line: chunk.end_line,
-                vector,
-            })
-            .collect();
-        graph
-            .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
-            // Not recoverable by continuing: the next file would be written
-            // into the same broken store and the pass would report success
-            // having stored nothing.
-            .map_err(|error| format!("the chunk index could not be written: {error}"))?;
-        committed += 1;
+    // **Each file is committed the moment its last vector lands**, rather
+    // than the window being held until every request is back. The pass runs
+    // in the background and can be interrupted at any point — by a failing
+    // request, by the process ending — and whatever reached the store stays
+    // there. Holding a 64-file window would put all 64 at risk of one late
+    // failure and re-pay for them on the next pass.
+    //
+    // A failed request still abandons the *unfinished* files, and must: a
+    // file stored with a hole in it is indistinguishable from a finished
+    // one, because it would carry the current content hash and the next
+    // pass would see nothing pending and never come back for the gap.
+    while let Some(result) = in_flight.next().await {
+        let (batch, embeddings) =
+            result.map_err(|error| format!("the embedder failed: {error}"))?;
+
+        // A short response would leave some file's count stuck above zero,
+        // so the window would never commit it and the caller's loop would
+        // re-scan the same pending file forever. The trait's contract is one
+        // vector per text; naming the breach beats spinning on it.
+        if embeddings.len() != batch.len() {
+            return Err(format!(
+                "the embedder returned {} vectors for {} chunks",
+                embeddings.len(),
+                batch.len()
+            ));
+        }
+
+        for (chunk, embedding) in batch.iter().zip(embeddings) {
+            vectors[chunk.file_index][chunk.chunk_index] = Some(embedding.vector);
+            outstanding[chunk.file_index] -= 1;
+            if outstanding[chunk.file_index] == 0 {
+                store_chunk_file(
+                    graph,
+                    fingerprint,
+                    &files[chunk.file_index],
+                    std::mem::take(&mut vectors[chunk.file_index]),
+                )?;
+                *committed += 1;
+            }
+        }
     }
-    Ok(committed)
+
+    Ok(())
+}
+
+/// Write one file's chunk vectors — the store's atomic unit, for the reason
+/// [`embed_and_store_chunk_files`] gives: the sweep that removes a deleted
+/// symbol's vector keys on the file's content hash, so a file's rows go in
+/// together or not at all.
+///
+/// A `None` slot means "keep the vector already stored and re-stamp it with
+/// the new hash", which is what makes editing one function in a 60-symbol
+/// file cost one embedding rather than sixty.
+fn store_chunk_file(
+    graph: &CodeGraph,
+    fingerprint: &str,
+    file: &stella_graph::PendingChunkFile,
+    file_vectors: Vec<Option<Vec<f32>>>,
+) -> Result<(), String> {
+    let rows: Vec<stella_graph::ChunkVector> = file
+        .chunks
+        .iter()
+        .zip(file_vectors)
+        .map(|(chunk, vector)| stella_graph::ChunkVector {
+            chunk_sha256: chunk.chunk_sha256.clone(),
+            name: chunk.name.clone(),
+            kind: chunk.kind.clone(),
+            start_line: chunk.start_line,
+            end_line: chunk.end_line,
+            vector,
+        })
+        .collect();
+    graph
+        .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
+        // Not recoverable by continuing: the next file would be written into
+        // the same broken store and the pass would report success having
+        // stored nothing.
+        .map_err(|error| format!("the chunk index could not be written: {error}"))
+        .map(|_| ())
 }
 
 /// No ceiling here either — see [`super::semantic::NO_FILE_CEILING`], which
@@ -1049,19 +1154,20 @@ pub(super) async fn warm_chunks_opened<P: FnMut(usize) + ?Sized>(
         // crate being right, which is exactly the coupling that produced
         // #3128. `PendingChunkFile::to_embed()` is the per-symbol truth.
         let made_progress = scan.files.iter().any(|file| file.to_embed() > 0);
-        match embed_and_store_chunk_files(graph, embedder, &fingerprint, &scan.files).await {
-            Ok(committed) => {
-                for _ in 0..committed {
-                    files_embedded += 1;
-                    progress(files_embedded);
-                }
-            }
-            Err(reason) => {
-                return ChunkWarmOutcome::Failed {
-                    files_embedded,
-                    reason,
-                };
-            }
+        let window = embed_and_store_chunk_files(graph, embedder, &fingerprint, &scan.files).await;
+        // Narrated before the failure is considered, because these files are
+        // in the store either way: a window that ended badly still committed
+        // whatever finished before it did, and reporting the failure without
+        // them would understate work the user has already paid for.
+        for _ in 0..window.committed {
+            files_embedded += 1;
+            progress(files_embedded);
+        }
+        if let Some(reason) = window.failure {
+            return ChunkWarmOutcome::Failed {
+                files_embedded,
+                reason,
+            };
         }
         if !made_progress {
             break;

--- a/crates/stella-tools/src/search/engine.rs
+++ b/crates/stella-tools/src/search/engine.rs
@@ -812,10 +812,7 @@ async fn embed_and_store_chunk_files(
     let failure = fill_chunk_window(graph, embedder, fingerprint, files, &mut committed)
         .await
         .err();
-    ChunkWindow {
-        committed,
-        failure,
-    }
+    ChunkWindow { committed, failure }
 }
 
 /// What one window of the chunk pass did: how many files reached the store,


### PR DESCRIPTION
## What

The chunk (symbol) rung of the semantic index embedded **one file per HTTP round trip, strictly serially**. The average file in this repository carries 17 symbols, so the typical 32-slot request went out half empty and every file cost its own round trip — ~2000 sequential requests to fill this repository's index, dominating the wall clock of `stella init` and of the session-start backfill.

Both halves of #4144's definition of done:

1. **Batches span files.** The pending chunks of the whole 64-file scan window are flattened and cut into full 32-chunk requests, so a request is short only when the work ran out.
2. **Round trips overlap.** Up to `CHUNK_EMBED_CONCURRENCY` (8) requests are in flight at once.

Per the issue's constraints, the per-file atomic write is untouched — `store_chunk_vectors` sweeps rows by the file's content hash, so a file's rows still go in together. Batching is an embedding-side change only.

## The three defects found while building it

Each of these is a thing the obvious implementation gets wrong, and each has a witness.

**Responses were routed by arrival order.** `buffer_unordered` yields results as they *complete*, not in the order requests were issued, so pairing the Nth completion with the Nth batch files one request's vectors against whichever chunks were in a slower one. Nothing errors — every chunk still receives a well-formed vector of the right width — and the only symptom is a semantic index that answers with the wrong symbols. This is the same misattribution `HttpEmbedder::embed` already refuses one layer down when it routes rows by `index` rather than by arrival. Each response now carries the ordinal of the request it answers.

**A window was all-or-nothing.** Holding all 64 files until every request returned put the whole window at risk of one late failure. A file's chunks can straddle two requests now, so "this file is done" is an outstanding count reaching zero; when it does, that file is stored immediately. A failure costs the files still in flight, not the ones already paid for.

**The failure arm threw away the count.** Returning `Result` meant a failed window reported `files_embedded: 0` while thirty-two files sat durably in the store. The count and the ending are independent facts, so the window returns both (`ChunkWindow`).

## The 429 path

The issue makes this a condition on adding concurrency at all: `HttpEmbedder::embed` had no retry and no backoff, so any non-2xx became a terminal `EmbedError::Backend`. Concurrency is exactly what provokes a rate limit, so the pass that got faster would have become the pass that aborts.

`429` and `5xx` are now re-issued up to 4 attempts with exponential backoff, honouring `Retry-After`'s delta-seconds form under an 8-second ceiling. The HTTP-date form is ignored deliberately rather than trusting two clocks to agree — falling back to the local schedule is wrong by seconds; trusting a bad date is wrong by however far the clocks differ. A `4xx` that will say the same thing next time is issued exactly once, and the error names the attempt count so a slow pass is not mistaken for one that never waited.

## Witnesses

Every one was checked the artisanal way — run against the code it is meant to catch, and confirmed to fail there.

| Witness | Fails on | Observed |
|---|---|---|
| `the_chunk_pass_batches_across_files` | `main` (serial) | **62 calls** for 60 files; passes with the fix |
| `a_small_window_costs_one_chunk_request` | `main` (serial) | **5 calls** for 4 files, must be 2 |
| `every_chunk_keeps_the_vector_computed_for_it` | arrival-order routing | `thing_0`'s slot held **`thing_38`'s vector** |
| `files_finished_before_a_failure_stay_committed` | all-or-nothing window, and the discarded count | `files_embedded: 0` with 32 files in the store |
| `a_rate_limited_request_is_retried_rather_than_failed` | no-retry backend | `Backend(... HTTP 429 ...)` instead of a vector |
| `a_backend_that_only_refuses_ends_as_an_error_naming_the_attempts` | unbounded or silent retry | — |
| `an_unauthorized_request_is_not_retried` | retrying a terminal 4xx | — |

`every_chunk_keeps_the_vector_computed_for_it` reads back through `rank_chunks_by_vector` — the path a search actually uses — so the assertion is about what a user is told, not about a row shape. It uses an embedder that completes in reverse issue order, making the misattribution deterministic rather than a race the test might win.

Note that this one **passes on `main`**: serial routing was correct. It is not a witness for #4144 itself but the guard for the concurrency this PR introduces, which is why it is here.

## A defect this PR's own testing nearly shipped

Worth recording, because it is a trap for the next person. My first routing fix carried the batch slice through the futures, which put a lifetime on them. `cargo test -p stella-tools` was green throughout. The failure appears only at the `tokio::spawn` in `crates/stella-cli/src/agent/graph.rs:697` — five "implementation of `Send` is not general enough" errors pointing at a spawn that mentions no chunk, no batch and no embedder. `NeededChunk` therefore owns its text, and only a `usize` ordinal travels through a future. The reasoning is in a comment at the struct, since nothing local explains why an owned `String` is deliberate there.

## Prose repaired

- `crates/stella-graph/src/vectors/chunks.rs` cited `embed_and_store_chunk_file` — a name that no longer exists — and its module header read "embedded one at a time". The per-file atomicity that doc actually turns on is unchanged, and now says explicitly that it is a property of the write rather than of the embed.
- `crates/stella-embed/README.md`'s "Semantics worth knowing" had no retry entry at all, leaving a reader assuming one-shot.

**Deliberately not changed:** `crates/stella-tools/src/search/enrich.rs` quotes `embed_and_store_chunk_file` inside a record of a real measured session, and `tests/fixtures/name_rung_corpus.jsonl` is a frozen corpus snapshot whose own docs say stale rows there are "the snapshot working as intended, not drift to repair". Rewriting either to match today's tree would falsify evidence.

## Dependencies

- `futures-util` moves from dev-dependency to dependency in `stella-tools` (`buffer_unordered`). It was already carried for `poll!` in tests; tests see a normal dependency, so no second entry is needed.
- `tokio` (feature `time` only, `sleep`) becomes an optional dependency of `stella-embed`, gated on the existing `http` feature. `reqwest` already requires tokio, so no new tree is added and a host that never enables `http` links no runtime.

## Not measured

The issue's ~35-45 minute estimate is from its own instrumentation against the live Voyage endpoint. **This PR does not re-measure it.** The witnesses prove the request count collapses from one-per-file to `ceil(total_chunks / 32)` and that up to 8 overlap; converting that to a wall-clock figure against a real backend is a separate measurement I have not run, and I would rather claim nothing than quote the issue's number as if this branch had reproduced it.

## Verification

`make gate CARGO_SCOPE="-p stella-cli -p stella-context -p stella-embed -p stella-fleet -p stella-graph -p stella-observatory -p stella-runtime -p stella-tools -p stella-tui"` (the scope `make impacted` selects for this diff) — green through its last step, `self-driving-test: OK — 61 checks passed`.

No test was deleted or renamed.

Closes #4144

## Summary by Sourcery

Accelerate chunk embedding by batching work across files, overlapping bounded HTTP requests, and safely handling retries and partial failures.

New Features:
- Batch chunk embeddings across files and process up to eight embedding requests concurrently.
- Retry rate-limited and server-error embedding requests with bounded exponential backoff and supported Retry-After delays.

Bug Fixes:
- Preserve correct chunk-to-vector association when concurrent requests complete out of order.
- Commit completed files independently when a later embedding request fails and report the number of files durably embedded.
- Avoid retrying terminal client errors such as unauthorized requests.

Enhancements:
- Retain per-file atomic storage while allowing embedding work to span files and requests.

Build:
- Promote futures-util to a runtime dependency for bounded concurrent chunk embedding.
- Add optional tokio timer support to the HTTP embedding feature.

Documentation:
- Document HTTP embedding retry behavior and clarify that per-file atomicity is preserved at storage time.

Tests:
- Add coverage for cross-file batching, request-count reduction, out-of-order response routing, partial commits after failure, and bounded retry behavior.