### PR TITLE
feat(stella-tui): a turn opens on a labelled rule — SPEC 6.1's other half reaches the screen (#4124)

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -84,6 +84,18 @@ pub struct SessionModel {
     /// `turn_instance` that is per-*run*, so a wrapped run restarts it while
     /// the scrollback does not.
     pub turns_completed: u32,
+    /// Whether the turn in flight has already drawn its SPEC 6.1 opening rule.
+    ///
+    /// The turn's *first* stage boundary opens it and every later one is a
+    /// plain section rule ([`TurnOpening`]). Kept as a latch rather than
+    /// derived from the trailing transcript entries because the fold is the
+    /// only place that can see the boundary: front-eviction can drop the
+    /// opening rule itself, and a derivation that looked backwards for one
+    /// would re-open the turn the moment the retention cap bit.
+    ///
+    /// Cleared by whatever ends a turn — a `TurnComplete`, the `RunComplete`
+    /// that ends the run, a terminal `Error`, and `/clear`.
+    turn_head_stamped: bool,
     /// The scrollback transcript, oldest first. Streaming `Text`/`Reasoning`
     /// deltas are accumulated into the trailing entry rather than producing
     /// one line per token.
@@ -254,7 +266,13 @@ pub enum TranscriptEntry {
     /// A stage boundary marker (`triage`, `plan`, `execute`, …) — or a stage a
     /// plugin contributed, under its own word. Open vocabulary, so the deck
     /// renders a stage it has never heard of instead of dropping it.
-    Stage(StageName),
+    Stage {
+        name: StageName,
+        /// Set on the one boundary that **opens** a turn — SPEC 6.1's labelled
+        /// rule. `None` on every later boundary of the same turn, which stays
+        /// the plain section rule it has always been.
+        opens: Option<TurnOpening>,
+    },
     /// Accumulated assistant natural-language output.
     Text(String),
     /// Accumulated model reasoning (rendered dimmed).
@@ -477,6 +495,48 @@ pub enum TranscriptEntry {
     },
 }
 
+/// What SPEC 6.1's opening rule says out loud, stamped onto the stage boundary
+/// that opens a turn.
+///
+/// # Why the facts ride the entry
+///
+/// The same reason [`TranscriptEntry::Complete`]'s `turn` does:
+/// [`crate::render::entry`] renders one entry at a time and holds no session
+/// state, so a fact that is not on the entry is a fact the rule cannot say.
+///
+/// # Why one rule per turn and not one per stage
+///
+/// SPEC 6.1 draws a single labelled boundary and SPEC 2 makes the turn the
+/// transcript's unit. A wrapped run has four or five stages inside one turn, so
+/// a rule per stage would announce `turn 14` five times and the number would
+/// stop reading as the turn's identity. Which boundary is the opening one is
+/// decided at fold time ([`SessionModel::turn_head_stamped`]) rather than at
+/// render time, because the renderer cannot see the entry before this one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnOpening {
+    /// This turn's 1-based ordinal — [`SessionModel::turns_completed`] plus the
+    /// turn in flight, so it is the number the turn's own closing rule will
+    /// carry.
+    ///
+    /// It counts turns that *completed*. A turn that died without one is
+    /// therefore not counted, and the next attempt reopens under the same
+    /// ordinal — which is the honest reading of a counter that means "turns
+    /// this session has finished", not a renumbering.
+    pub turn: u32,
+    /// The model answering, as [`Hud::model`] last observed it.
+    ///
+    /// `None` for the whole first turn of a session: `Hud::model` is fed by
+    /// `AgentEvent::TurnComplete`, which by definition has not arrived yet.
+    /// Elided rather than substituted — the configured default is not evidence
+    /// of what a router picked, and the rule would be asserting a routing
+    /// decision nothing recorded (#4175).
+    pub model: Option<String>,
+    /// The spend ceiling in force, as the last `AgentEvent::BudgetTick`
+    /// reported it. `None` means **no budget is armed**, which is not a budget
+    /// of `$0.00` — the same distinction [`Hud::deadline_remaining_ms`] draws.
+    pub budget_usd: Option<f64>,
+}
+
 /// A mutating tool result's handle on the diff it may render inline: the
 /// path into [`SessionModel::files`] plus the `changes` seq of the mutation
 /// *this call produced*. The renderer resolves it against
@@ -667,7 +727,22 @@ impl SessionModel {
                     // and does so from the event, so replay reconstructs it.
                     self.plan.approve();
                 }
-                self.transcript.push(TranscriptEntry::Stage(name.clone()));
+                // The first boundary of a turn carries SPEC 6.1's rule; the
+                // rest of the turn's stages are plain section rules.
+                let opens = if self.turn_head_stamped {
+                    None
+                } else {
+                    self.turn_head_stamped = true;
+                    Some(TurnOpening {
+                        turn: self.turns_completed.saturating_add(1),
+                        model: self.hud.model.clone(),
+                        budget_usd: self.hud.limit_usd,
+                    })
+                };
+                self.transcript.push(TranscriptEntry::Stage {
+                    name: name.clone(),
+                    opens,
+                });
             }
             AgentEvent::Text { text } => {
                 // The authoritative step text replaces any streamed preview
@@ -1125,6 +1200,10 @@ impl SessionModel {
                 // warning mid-flight; the turn goes on.
                 if !*retryable {
                     self.plan.finish();
+                    // The turn died without a `TurnComplete`, so nothing else
+                    // will clear the latch and the next turn would open with
+                    // no rule at all.
+                    self.turn_head_stamped = false;
                 }
                 self.pending_scope_review = None;
                 self.pending_ask_user = None;
@@ -1156,6 +1235,8 @@ impl SessionModel {
                 self.hud.model = Some(model.clone());
                 self.streaming_text.clear();
                 self.turns_completed += 1;
+                // The next stage boundary opens a new turn, and its rule.
+                self.turn_head_stamped = false;
                 self.transcript.push(TranscriptEntry::Complete {
                     model: model.clone(),
                     cost_usd: *cost_usd,
@@ -1170,6 +1251,10 @@ impl SessionModel {
                 self.hud.model = Some(model.clone());
                 self.hud.final_cost_usd = Some(*cost_usd);
                 self.hud.complete = true;
+                // A run that ended between turns leaves no `TurnComplete` to
+                // clear the latch, and the next run's first stage must still
+                // open a rule (#4124).
+                self.turn_head_stamped = false;
                 self.plan.finish();
                 self.pending_scope_review = None;
                 self.pending_ask_user = None;

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -30,11 +30,13 @@ mod error_rows;
 pub mod file_state;
 pub mod recall;
 mod summarize;
+mod turn;
 
 #[cfg(test)]
 pub use file_state::DIFF_HISTORY;
 pub use file_state::{FileState, MAX_TRACKED_FILES, RememberedDiff};
 pub use recall::{RecallBudget, RecalledFrameRow};
+pub use turn::{Hud, TurnOpening};
 // Re-imported rather than left qualified, so the split was a pure move: every
 // call site in the fold reads exactly as it did before (#2958). See
 // `summarize`'s module doc for why the seam is there and not elsewhere.
@@ -495,48 +497,6 @@ pub enum TranscriptEntry {
     },
 }
 
-/// What SPEC 6.1's opening rule says out loud, stamped onto the stage boundary
-/// that opens a turn.
-///
-/// # Why the facts ride the entry
-///
-/// The same reason [`TranscriptEntry::Complete`]'s `turn` does:
-/// [`crate::render::entry`] renders one entry at a time and holds no session
-/// state, so a fact that is not on the entry is a fact the rule cannot say.
-///
-/// # Why one rule per turn and not one per stage
-///
-/// SPEC 6.1 draws a single labelled boundary and SPEC 2 makes the turn the
-/// transcript's unit. A wrapped run has four or five stages inside one turn, so
-/// a rule per stage would announce `turn 14` five times and the number would
-/// stop reading as the turn's identity. Which boundary is the opening one is
-/// decided at fold time ([`SessionModel::turn_head_stamped`]) rather than at
-/// render time, because the renderer cannot see the entry before this one.
-#[derive(Debug, Clone, PartialEq)]
-pub struct TurnOpening {
-    /// This turn's 1-based ordinal — [`SessionModel::turns_completed`] plus the
-    /// turn in flight, so it is the number the turn's own closing rule will
-    /// carry.
-    ///
-    /// It counts turns that *completed*. A turn that died without one is
-    /// therefore not counted, and the next attempt reopens under the same
-    /// ordinal — which is the honest reading of a counter that means "turns
-    /// this session has finished", not a renumbering.
-    pub turn: u32,
-    /// The model answering, as [`Hud::model`] last observed it.
-    ///
-    /// `None` for the whole first turn of a session: `Hud::model` is fed by
-    /// `AgentEvent::TurnComplete`, which by definition has not arrived yet.
-    /// Elided rather than substituted — the configured default is not evidence
-    /// of what a router picked, and the rule would be asserting a routing
-    /// decision nothing recorded (#4175).
-    pub model: Option<String>,
-    /// The spend ceiling in force, as the last `AgentEvent::BudgetTick`
-    /// reported it. `None` means **no budget is armed**, which is not a budget
-    /// of `$0.00` — the same distinction [`Hud::deadline_remaining_ms`] draws.
-    pub budget_usd: Option<f64>,
-}
-
 /// A mutating tool result's handle on the diff it may render inline: the
 /// path into [`SessionModel::files`] plus the `changes` seq of the mutation
 /// *this call produced*. The renderer resolves it against
@@ -553,69 +513,6 @@ pub struct InlineDiffRef {
     /// resolves for as long as that mutation is remembered, and dangles
     /// (rendering nothing) when the turn measured no net change to the path.
     pub seq: u32,
-}
-
-/// Live HUD numbers, all folded from the event stream.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct Hud {
-    /// Spend as the budget guard reports it on every `BudgetTick`.
-    ///
-    /// Note this is **cumulative for the life of the guard**, not per turn: the
-    /// deck builds one `BudgetGuard` for the whole session and never calls
-    /// `begin_turn`, so this only ever rises. Use [`Hud::turn_spent_usd`] for
-    /// the number a reader would call "what this turn cost".
-    pub spent_usd: f64,
-    pub limit_usd: Option<f64>,
-    pub budget_mode: Option<BudgetMode>,
-    /// Wall clock left before the task deadline, as the last `BudgetTick`
-    /// reported it (#2240, #2435). `None` is the load-bearing case and means
-    /// **no deadline is armed** — never "no time left", which is
-    /// `Some(0)`. The statline renders the two differently for exactly that
-    /// reason: a HUD showing `0s` for an unarmed run would put back into the
-    /// UI the confusion #2240 took out of the journal.
-    ///
-    /// Milliseconds rather than a `Duration` because that is the wire shape
-    /// (`AgentEvent::BudgetTick::deadline_remaining_ms`), and this struct is a
-    /// fold of the stream, not a reinterpretation of it.
-    pub deadline_remaining_ms: Option<u64>,
-    /// The stage the turn is in. [`StageName`], not [`StageKind`]: a
-    /// contributed stage is what the statline must be able to name.
-    pub stage: Option<StageName>,
-    /// The most recent stage that was one of **this host's own** boundaries.
-    ///
-    /// Separate from [`Hud::stage`] because the two answer different questions,
-    /// and one field cannot answer both once the vocabulary is open. `stage` is
-    /// "what is happening right now", which is what the statline says out loud.
-    /// This is "how far through its own shape the turn has got", which is what
-    /// the three-segment progress bar draws — and the bar has only the host's
-    /// three phases to draw with.
-    ///
-    /// Keeping it is what stops a contributed stage reading as a regression: a
-    /// plugin stage arriving after `execute` leaves this at `Execute`, so the
-    /// bar holds. Folding the contributed stage into the same field would make
-    /// it phase-less, and a phase-less stage falls back to phase 0 — the bar
-    /// would snap back to "plan" and claim the run had gone backwards.
-    pub host_stage: Option<StageKind>,
-    pub model: Option<String>,
-    /// [`Hud::spent_usd`] as it stood when the current turn began, so live turn
-    /// cost is the difference. Snapshotted in [`SessionModel::push_user_prompt`]
-    /// — the earliest signal a turn has started.
-    pub turn_start_spent_usd: f64,
-    /// The final turn cost, set once a `Complete` event lands.
-    pub final_cost_usd: Option<f64>,
-    pub complete: bool,
-}
-
-impl Hud {
-    /// What the turn in flight has cost so far.
-    ///
-    /// Once the turn settles this yields to `Complete`'s own `cost_usd`, which
-    /// is authoritative — the driver totals it directly rather than differencing
-    /// a cumulative gauge, so it also catches spend that never produced a tick.
-    pub fn turn_spent_usd(&self) -> f64 {
-        self.final_cost_usd
-            .unwrap_or_else(|| (self.spent_usd - self.turn_start_spent_usd).max(0.0))
-    }
 }
 
 impl SessionModel {

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -167,8 +167,107 @@ fn a_stage_between_text_deltas_breaks_coalescing() {
     // text, stage, text
     assert_eq!(model.transcript.len(), 3);
     assert!(matches!(model.transcript[0], TranscriptEntry::Text(_)));
-    assert!(matches!(model.transcript[1], TranscriptEntry::Stage(_)));
+    assert!(matches!(model.transcript[1], TranscriptEntry::Stage { .. }));
     assert!(matches!(model.transcript[2], TranscriptEntry::Text(_)));
+}
+
+fn stage(kind: StageKind) -> AgentEvent {
+    AgentEvent::Stage {
+        name: kind.into(),
+        scope: stella_protocol::StageScope::Run,
+    }
+}
+
+/// Every `TurnOpening` the fold stamped, in transcript order.
+fn openings(model: &SessionModel) -> Vec<&TurnOpening> {
+    model
+        .transcript
+        .iter()
+        .filter_map(|e| match e {
+            TranscriptEntry::Stage { opens, .. } => opens.as_ref(),
+            _ => None,
+        })
+        .collect()
+}
+
+/// SPEC 6.1's rule opens a **turn**, not a stage: the first boundary of a turn
+/// carries it and the rest of that turn's stages do not.
+///
+/// The witness for the fold half of #4124. Before it every stage boundary was a
+/// bare `Stage(name)` with nothing to open a rule *with* — no turn number, no
+/// model, no budget — which is why the renderer written in #4123 had never been
+/// called.
+#[test]
+fn only_the_first_stage_of_a_turn_opens_a_turn_rule() {
+    let mut model = SessionModel::new();
+    for kind in [StageKind::Triage, StageKind::Plan, StageKind::Execute] {
+        model.apply(&stage(kind));
+    }
+    let opened = openings(&model);
+    assert_eq!(opened.len(), 1, "one rule per turn, not one per stage");
+    assert_eq!(opened[0].turn, 1);
+
+    // …and the next turn opens its own, numbered by what has completed.
+    model.apply(&AgentEvent::TurnComplete {
+        model: "kimi-k3".into(),
+        cost_usd: 0.11,
+    });
+    model.apply(&stage(StageKind::Execute));
+    let opened = openings(&model);
+    assert_eq!(opened.len(), 2);
+    assert_eq!(opened[1].turn, 2, "the ordinal follows the closing rule");
+    assert_eq!(
+        opened[1].turn,
+        model.turns_completed + 1,
+        "the opening and closing rules must agree on the turn's number",
+    );
+}
+
+/// The opening rule states the budget the last `BudgetTick` reported and the
+/// model the HUD has observed — and states neither before anything reported
+/// one. `None` is "nobody said", not `$0.00` and not the configured default.
+#[test]
+fn an_opening_rule_carries_only_facts_the_fold_was_given() {
+    let mut model = SessionModel::new();
+    model.apply(&stage(StageKind::Execute));
+    let first = openings(&model)[0].clone();
+    assert_eq!(
+        first.model, None,
+        "no turn has settled, so no model is known"
+    );
+    assert_eq!(first.budget_usd, None, "no tick has armed a budget");
+
+    model.apply(&AgentEvent::TurnComplete {
+        model: "kimi-k3".into(),
+        cost_usd: 0.11,
+    });
+    model.apply(&AgentEvent::BudgetTick {
+        spent_usd: 0.11,
+        limit_usd: Some(0.60),
+        mode: BudgetMode::Enforced,
+        session_spent_usd: None,
+        session_limit_usd: None,
+        deadline_remaining_ms: None,
+    });
+    model.apply(&stage(StageKind::Execute));
+    let second = openings(&model)[1].clone();
+    assert_eq!(second.model.as_deref(), Some("kimi-k3"));
+    assert_eq!(second.budget_usd, Some(0.60));
+}
+
+/// A turn that died never emits `TurnComplete`, so nothing else clears the
+/// latch — and the turn after it would open with no rule at all, leaving its
+/// events hanging under the dead turn's boundary.
+#[test]
+fn a_turn_that_died_still_lets_the_next_one_open() {
+    let mut model = SessionModel::new();
+    model.apply(&stage(StageKind::Execute));
+    model.apply(&AgentEvent::Error {
+        message: "provider refused".into(),
+        retryable: false,
+    });
+    model.apply(&stage(StageKind::Execute));
+    assert_eq!(openings(&model).len(), 2, "the next turn opened no rule");
 }
 
 fn delta(text: &str) -> AgentEvent {

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -20,7 +20,7 @@ use stella_protocol::{BudgetMode, StageKind, StageName};
 ///
 /// # Why the facts ride the entry
 ///
-/// The same reason [`TranscriptEntry::Complete`]'s `turn` does: `render::entry`
+/// The same reason [`super::TranscriptEntry::Complete`]'s `turn` does: `render::entry`
 /// renders one entry at a time and holds no session state, so a fact that is not
 /// on the entry is a fact the rule cannot say.
 ///
@@ -34,7 +34,7 @@ use stella_protocol::{BudgetMode, StageKind, StageName};
 /// render time, because the renderer cannot see the entry before this one.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TurnOpening {
-    /// This turn's 1-based ordinal — [`SessionModel::turns_completed`] plus the
+    /// This turn's 1-based ordinal — [`super::SessionModel::turns_completed`] plus the
     /// turn in flight, so it is the number the turn's own closing rule will
     /// carry.
     ///
@@ -51,9 +51,18 @@ pub struct TurnOpening {
     /// of what a router picked, and the rule would be asserting a routing
     /// decision nothing recorded (#4183).
     pub model: Option<String>,
-    /// The spend ceiling in force, as the last `AgentEvent::BudgetTick`
-    /// reported it. `None` means **no budget is armed**, which is not a budget
-    /// of `$0.00` — the same distinction [`Hud::deadline_remaining_ms`] draws.
+    /// This turn's spend ceiling, from [`Hud::limit_usd`].
+    ///
+    /// The **turn's**, not the session's, which is what makes it the right
+    /// number for a rule that opens one turn: `AgentEvent::BudgetTick`'s own
+    /// doc states that `spent_usd`/`limit_usd` are turn-scoped and that the
+    /// session axis rides separately on `session_spent_usd`/
+    /// `session_limit_usd`, which the deck does not fold.
+    ///
+    /// `None` means **no budget is armed**, which is not a budget of `$0.00` —
+    /// the same distinction [`Hud::deadline_remaining_ms`] draws, and for the
+    /// same reason: a rule printing `budget $0.00` over an uncapped run would
+    /// state a cap nobody set.
     pub budget_usd: Option<f64>,
 }
 
@@ -100,7 +109,7 @@ pub struct Hud {
     pub host_stage: Option<StageKind>,
     pub model: Option<String>,
     /// [`Hud::spent_usd`] as it stood when the current turn began, so live turn
-    /// cost is the difference. Snapshotted in [`SessionModel::push_user_prompt`]
+    /// cost is the difference. Snapshotted in [`super::SessionModel::push_user_prompt`]
     /// — the earliest signal a turn has started.
     pub turn_start_spent_usd: f64,
     /// The final turn cost, set once a `Complete` event lands.

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -49,7 +49,7 @@ pub struct TurnOpening {
     /// `AgentEvent::TurnComplete`, which by definition has not arrived yet.
     /// Elided rather than substituted — the configured default is not evidence
     /// of what a router picked, and the rule would be asserting a routing
-    /// decision nothing recorded (#4175).
+    /// decision nothing recorded (#4183).
     pub model: Option<String>,
     /// The spend ceiling in force, as the last `AgentEvent::BudgetTick`
     /// reported it. `None` means **no budget is armed**, which is not a budget

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -1,0 +1,121 @@
+//! The **turn in flight** and the boundaries that fence it — the half of
+//! [`super::SessionModel`] that answers "what is happening now", as opposed
+//! to the scrollback that records what happened.
+//!
+//! Two types, and they are the two ends of the same thing. [`Hud`] is live
+//! state, read by the statline while the turn runs and overwritten by the
+//! next one. [`TurnOpening`] is the settled stamp that state leaves on the
+//! transcript when a turn opens, so the boundary can still say what the turn
+//! was long after the HUD has moved on.
+//!
+//! Split out of `model.rs` when it crossed the 1500-line guard, on the
+//! sibling-submodule remedy AGENTS.md names rather than a raised baseline —
+//! the same cut `file_state` and `recall` already make, and along the same
+//! seam: a `TranscriptEntry`'s supporting types live beside it, not in it.
+
+use stella_protocol::{BudgetMode, StageKind, StageName};
+
+/// What SPEC 6.1's opening rule says out loud, stamped onto the stage boundary
+/// that opens a turn.
+///
+/// # Why the facts ride the entry
+///
+/// The same reason [`TranscriptEntry::Complete`]'s `turn` does: `render::entry`
+/// renders one entry at a time and holds no session state, so a fact that is not
+/// on the entry is a fact the rule cannot say.
+///
+/// # Why one rule per turn and not one per stage
+///
+/// SPEC 6.1 draws a single labelled boundary and SPEC 2 makes the turn the
+/// transcript's unit. A wrapped run has four or five stages inside one turn, so
+/// a rule per stage would announce `turn 14` five times and the number would
+/// stop reading as the turn's identity. Which boundary is the opening one is
+/// decided at fold time (`SessionModel::turn_head_stamped`) rather than at
+/// render time, because the renderer cannot see the entry before this one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnOpening {
+    /// This turn's 1-based ordinal — [`SessionModel::turns_completed`] plus the
+    /// turn in flight, so it is the number the turn's own closing rule will
+    /// carry.
+    ///
+    /// It counts turns that *completed*. A turn that died without one is
+    /// therefore not counted, and the next attempt reopens under the same
+    /// ordinal — which is the honest reading of a counter that means "turns
+    /// this session has finished", not a renumbering.
+    pub turn: u32,
+    /// The model answering, as [`Hud::model`] last observed it.
+    ///
+    /// `None` for the whole first turn of a session: `Hud::model` is fed by
+    /// `AgentEvent::TurnComplete`, which by definition has not arrived yet.
+    /// Elided rather than substituted — the configured default is not evidence
+    /// of what a router picked, and the rule would be asserting a routing
+    /// decision nothing recorded (#4175).
+    pub model: Option<String>,
+    /// The spend ceiling in force, as the last `AgentEvent::BudgetTick`
+    /// reported it. `None` means **no budget is armed**, which is not a budget
+    /// of `$0.00` — the same distinction [`Hud::deadline_remaining_ms`] draws.
+    pub budget_usd: Option<f64>,
+}
+
+/// Live HUD numbers, all folded from the event stream.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Hud {
+    /// Spend as the budget guard reports it on every `BudgetTick`.
+    ///
+    /// Note this is **cumulative for the life of the guard**, not per turn: the
+    /// deck builds one `BudgetGuard` for the whole session and never calls
+    /// `begin_turn`, so this only ever rises. Use [`Hud::turn_spent_usd`] for
+    /// the number a reader would call "what this turn cost".
+    pub spent_usd: f64,
+    pub limit_usd: Option<f64>,
+    pub budget_mode: Option<BudgetMode>,
+    /// Wall clock left before the task deadline, as the last `BudgetTick`
+    /// reported it (#2240, #2435). `None` is the load-bearing case and means
+    /// **no deadline is armed** — never "no time left", which is
+    /// `Some(0)`. The statline renders the two differently for exactly that
+    /// reason: a HUD showing `0s` for an unarmed run would put back into the
+    /// UI the confusion #2240 took out of the journal.
+    ///
+    /// Milliseconds rather than a `Duration` because that is the wire shape
+    /// (`AgentEvent::BudgetTick::deadline_remaining_ms`), and this struct is a
+    /// fold of the stream, not a reinterpretation of it.
+    pub deadline_remaining_ms: Option<u64>,
+    /// The stage the turn is in. [`StageName`], not [`StageKind`]: a
+    /// contributed stage is what the statline must be able to name.
+    pub stage: Option<StageName>,
+    /// The most recent stage that was one of **this host's own** boundaries.
+    ///
+    /// Separate from [`Hud::stage`] because the two answer different questions,
+    /// and one field cannot answer both once the vocabulary is open. `stage` is
+    /// "what is happening right now", which is what the statline says out loud.
+    /// This is "how far through its own shape the turn has got", which is what
+    /// the three-segment progress bar draws — and the bar has only the host's
+    /// three phases to draw with.
+    ///
+    /// Keeping it is what stops a contributed stage reading as a regression: a
+    /// plugin stage arriving after `execute` leaves this at `Execute`, so the
+    /// bar holds. Folding the contributed stage into the same field would make
+    /// it phase-less, and a phase-less stage falls back to phase 0 — the bar
+    /// would snap back to "plan" and claim the run had gone backwards.
+    pub host_stage: Option<StageKind>,
+    pub model: Option<String>,
+    /// [`Hud::spent_usd`] as it stood when the current turn began, so live turn
+    /// cost is the difference. Snapshotted in [`SessionModel::push_user_prompt`]
+    /// — the earliest signal a turn has started.
+    pub turn_start_spent_usd: f64,
+    /// The final turn cost, set once a `Complete` event lands.
+    pub final_cost_usd: Option<f64>,
+    pub complete: bool,
+}
+
+impl Hud {
+    /// What the turn in flight has cost so far.
+    ///
+    /// Once the turn settles this yields to `Complete`'s own `cost_usd`, which
+    /// is authoritative — the driver totals it directly rather than differencing
+    /// a cumulative gauge, so it also catches spend that never produced a tick.
+    pub fn turn_spent_usd(&self) -> f64 {
+        self.final_cost_usd
+            .unwrap_or_else(|| (self.spent_usd - self.turn_start_spent_usd).max(0.0))
+    }
+}

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -277,6 +277,23 @@ fn v2_rows(
             out.extend(v2::turn_end_rows(*turn, *cost_usd, width));
             true
         }
+        // Only the boundary that *opens* the turn. A later stage of the same
+        // turn falls through to the plain section rule below, which is what
+        // keeps SPEC 6.1's labelled rule one-per-turn rather than one-per-stage
+        // (see `model::TurnOpening`).
+        TranscriptEntry::Stage {
+            name,
+            opens: Some(opening),
+        } => {
+            out.extend(v2::turn_begin_rows(
+                opening.turn,
+                stage_label(name),
+                opening.model.as_deref(),
+                opening.budget_usd,
+                width,
+            ));
+            true
+        }
         _ => false,
     }
 }
@@ -367,7 +384,10 @@ fn entry_body(
                 .collect();
             push_row_block(Rail::User, lines, width, out);
         }
-        TranscriptEntry::Stage(name) => {
+        // Reached only for a boundary *inside* a turn — the one that opens the
+        // turn is claimed by the v2 router above, which draws SPEC 6.1's
+        // labelled rule instead.
+        TranscriptEntry::Stage { name, .. } => {
             // A section rule, not a row — see `push_rule`. The word "stage" is
             // dropped with it: the label *is* the stage, and prefixing every
             // one with its own type name was three columns spent restating

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -473,7 +473,7 @@ fn a_turn_opens_on_a_labelled_rule() {
 /// no ceiling. Both elide. The failure this guards is not cosmetic: a rule that
 /// filled the gaps would open the transcript by naming a model nobody routed to
 /// and a `$0.00` nobody set, on the row a reader trusts to say what this turn
-/// is (#4175).
+/// is (#4183).
 #[test]
 fn an_opening_rule_names_no_model_or_budget_it_was_never_told() {
     let text = recall_text(

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -89,7 +89,10 @@ fn transcript_lines(
 fn sample_entries() -> Vec<TranscriptEntry> {
     vec![
         TranscriptEntry::User("hi".into()),
-        TranscriptEntry::Stage(StageKind::Execute.into()),
+        TranscriptEntry::Stage {
+            name: StageKind::Execute.into(),
+            opens: None,
+        },
         TranscriptEntry::Text("ok".into()),
         TranscriptEntry::Reasoning("hmm".into()),
         TranscriptEntry::ToolStart {
@@ -429,6 +432,158 @@ fn a_completed_turn_closes_on_a_rule_and_a_receipt() {
             "the receipt invented {absent:?}:\n{text}"
         );
     }
+}
+
+/// SPEC 6.1: a turn opens on a labelled rule naming the turn, its stage, the
+/// model and the budget in force.
+///
+/// The witness for the opening boundary landing. On the old renderer a stage
+/// was a hairline carrying the stage word alone, so every assertion below fails
+/// on it: no `turn 4`, no model, no budget, and — the point of the rule —
+/// nothing tying the events under it to the receipt that closes them.
+#[test]
+fn a_turn_opens_on_a_labelled_rule() {
+    let entry = TranscriptEntry::Stage {
+        name: StageKind::Execute.into(),
+        opens: Some(crate::model::TurnOpening {
+            turn: 4,
+            model: Some("kimi-k3".into()),
+            budget_usd: Some(0.60),
+        }),
+    };
+    let text = recall_text(&entry, false, 100);
+
+    assert!(text.contains("turn 4"), "no opening rule:\n{text}");
+    assert!(text.contains("execute"), "the rule lost its stage:\n{text}");
+    assert!(text.contains("kimi-k3"), "the rule lost its model:\n{text}");
+    assert!(
+        text.contains("budget $0.60"),
+        "the rule lost its budget:\n{text}"
+    );
+    assert!(
+        text.contains("──"),
+        "the rule does not reach the row:\n{text}"
+    );
+}
+
+/// …and states only what the session actually knows.
+///
+/// The first turn of a session has no model — `Hud::model` is fed by
+/// `TurnComplete`, which has not arrived — and a run with no budget armed has
+/// no ceiling. Both elide. The failure this guards is not cosmetic: a rule that
+/// filled the gaps would open the transcript by naming a model nobody routed to
+/// and a `$0.00` nobody set, on the row a reader trusts to say what this turn
+/// is (#4175).
+#[test]
+fn an_opening_rule_names_no_model_or_budget_it_was_never_told() {
+    let text = recall_text(
+        &TranscriptEntry::Stage {
+            name: StageKind::Execute.into(),
+            opens: Some(crate::model::TurnOpening {
+                turn: 1,
+                model: None,
+                budget_usd: None,
+            }),
+        },
+        false,
+        100,
+    );
+    assert!(text.contains("turn 1 execute"), "{text}");
+    for absent in ["budget", "$0.00", "$"] {
+        assert!(
+            !text.contains(absent),
+            "the opening rule invented {absent:?}:\n{text}"
+        );
+    }
+}
+
+/// SPEC 6.1 draws **one** labelled rule per turn, and SPEC 2 makes the turn the
+/// transcript's unit. A later stage of the same turn stays the plain section
+/// rule it has always been — otherwise a wrapped run with triage, plan, execute
+/// and verify inside one turn would announce `turn 4` four times and the number
+/// would stop reading as the turn's identity.
+#[test]
+fn a_stage_inside_a_turn_is_not_a_second_turn_rule() {
+    let text = recall_text(
+        &TranscriptEntry::Stage {
+            name: StageKind::Verify.into(),
+            opens: None,
+        },
+        false,
+        100,
+    );
+    // The v1 section rule sets its label in caps; what matters here is that the
+    // stage still names itself and that no turn number rides beside it.
+    assert!(
+        text.to_ascii_lowercase().contains("verify"),
+        "the section rule vanished:\n{text}"
+    );
+    assert!(
+        !text.to_ascii_lowercase().contains("turn "),
+        "a second turn rule:\n{text}"
+    );
+}
+
+/// SPEC 6.1 end to end, over the live path: events fold into a
+/// [`SessionModel`], the model's entries render through [`entry_lines`], and
+/// the result is a turn wrapped in its two rules with the receipt beneath.
+///
+/// This is #4124's definition of done — that
+/// `design/tui-v2/renderings/png/01-session-turn-lifecycle.png` is reproducible
+/// as a *live screen* and not merely as a call to the pure renderers. The unit
+/// tests above each prove one row from a hand-built entry; only this one proves
+/// that the fold stamps what the renderer needs and that the router reaches it.
+/// It asserts order, because a receipt above its own turn rule would be a
+/// correct set of rows and a wrong transcript.
+#[test]
+fn a_folded_turn_renders_its_whole_lifecycle_in_order() {
+    use stella_protocol::{StageScope, ToolCall};
+
+    let mut model = crate::model::SessionModel::new();
+    for event in [
+        AgentEvent::Stage {
+            name: StageKind::Execute.into(),
+            scope: StageScope::Run,
+        },
+        AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "c1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({ "path": "src/lifecycle.rs" }),
+            },
+        },
+        AgentEvent::TurnComplete {
+            model: "kimi-k3".into(),
+            cost_usd: 0.11,
+        },
+    ] {
+        model.apply(&event);
+    }
+
+    let mut out = Vec::new();
+    for entry in &model.transcript {
+        entry_lines(entry, &[], false, false, false, 100, &mut out);
+    }
+    let rows: Vec<String> = out
+        .iter()
+        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+        .collect();
+    let index_of = |needle: &str| {
+        rows.iter()
+            .position(|r| r.contains(needle))
+            .unwrap_or_else(|| panic!("no row containing {needle:?} in:\n{}", rows.join("\n")))
+    };
+
+    let begin = index_of("turn 1 execute");
+    let event = index_of("src/lifecycle.rs");
+    let end = index_of("turn 1 done");
+    let receipt = index_of("receipt");
+    assert!(
+        begin < event && event < end && end < receipt,
+        "the turn's rows are out of order (begin {begin}, event {event}, end {end}, \
+         receipt {receipt}):\n{}",
+        rows.join("\n")
+    );
 }
 
 /// SPEC 2: money is gold. The v1 row rendered a settled turn cost in

--- a/crates/stella-tui/src/render/tests/palette.rs
+++ b/crates/stella-tui/src/render/tests/palette.rs
@@ -183,7 +183,10 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
     // rule is precisely the transcript's coarsest structure, and at that
     // contrast neither the line nor the label set into it could be read.
     assert_eq!(
-        prefix_fg(&TranscriptEntry::Stage(StageKind::Execute.into())),
+        prefix_fg(&TranscriptEntry::Stage {
+            name: StageKind::Execute.into(),
+            opens: None,
+        }),
         Some(theme::HAIRLINE_STRONG),
         "a stage opens a section rule on the louder seam",
     );

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -136,7 +136,7 @@ pub fn entry_fields(entry: &TranscriptEntry) -> Vec<&str> {
         E::Error { message, .. } => vec![message],
         E::Complete { model, .. } => vec![model],
         E::Evicted { .. }
-        | E::Stage(_)
+        | E::Stage { .. }
         | E::Compaction { .. }
         | E::BudgetTick { .. }
         | E::MediaProgress { .. }
@@ -485,9 +485,10 @@ mod tests {
             assert_eq!(search_hits(&t, query), vec![0], "no hit for {query:?}");
         }
         assert!(
-            entry_fields(&TranscriptEntry::Stage(
-                stella_protocol::StageKind::Verify.into()
-            ))
+            entry_fields(&TranscriptEntry::Stage {
+                name: stella_protocol::StageKind::Verify.into(),
+                opens: None,
+            })
             .is_empty()
         );
     }

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -244,12 +244,22 @@ impl Event {
 }
 
 /// The label on a turn's opening rule (SPEC 6.1).
+///
+/// Three of the four fields beside the number are optional, and for the reason
+/// [`Receipt`]'s are: the rule states what something observed and elides the
+/// rest. A turn opens *before* most of what describes it is known — the first
+/// turn of a session has not been told which model answered, and a run with no
+/// budget armed has no ceiling to print — so the alternative to eliding is a
+/// rule that opens by naming a model nobody routed to and a `$0.00` nobody set.
 #[derive(Clone, Debug)]
 pub struct TurnHead {
     pub number: u32,
     pub stage: String,
-    pub model: String,
-    pub budget_usd: f64,
+    /// The model that is answering, when the session knows it yet.
+    pub model: Option<String>,
+    /// The spend ceiling in force. `None` is **no budget armed**, which is a
+    /// different fact from `Some(0.0)` — a run capped at nothing.
+    pub budget_usd: Option<f64>,
     /// The steer this turn consumed, if any. Rendered `queued: "…"` so
     /// queue-never-blocks has a visible payoff (SPEC 6.1).
     pub queued_steer: Option<String>,
@@ -302,13 +312,15 @@ pub fn turn_begin(head: &TurnHead, width: usize) -> Line<'static> {
         Span::styled("turn ", dim),
         Span::styled(head.number.to_string(), Style::new().fg(token::GOLD)),
         Span::styled(format!(" {}", head.stage), text),
-        Span::styled(" · ", dim),
-        Span::styled(head.model.clone(), text),
     ];
-    if head.budget_usd > 0.0 {
+    if let Some(model) = &head.model {
+        label.push(Span::styled(" · ", dim));
+        label.push(Span::styled(model.clone(), text));
+    }
+    if let Some(budget) = head.budget_usd {
         label.push(Span::styled(" · budget ", dim));
         label.push(Span::styled(
-            format!("${:.2}", head.budget_usd),
+            format!("${budget:.2}"),
             Style::new().fg(token::GOLD),
         ));
     }

--- a/crates/stella-tui/src/v2/transcript/tests.rs
+++ b/crates/stella-tui/src/v2/transcript/tests.rs
@@ -15,8 +15,8 @@ fn scripted_turn() -> (TurnHead, Vec<Event>, Receipt) {
     let head = TurnHead {
         number: 14,
         stage: "execute".into(),
-        model: "kimi-k3".into(),
-        budget_usd: 0.60,
+        model: Some("kimi-k3".into()),
+        budget_usd: Some(0.60),
         queued_steer: None,
     };
 

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -28,7 +28,9 @@
 use ratatui::style::Color;
 use ratatui::text::Line;
 
-use super::transcript::{Event, EventKind, Extent, Receipt, event_rows, receipt, turn_end};
+use super::transcript::{
+    Event, EventKind, Extent, Receipt, TurnHead, event_rows, receipt, turn_begin, turn_end,
+};
 
 /// The metal-bearing head of a dispatched call (SPEC 6.2).
 ///
@@ -134,6 +136,39 @@ fn subject_for(name: &str, path: Option<&str>, input: &str) -> String {
 /// The first line of a blob, for a row that has exactly one.
 fn first_line(text: &str) -> &str {
     text.lines().next().unwrap_or("").trim_end()
+}
+
+/// A turn's opening rule (SPEC 6.1).
+///
+/// One row, and only on the stage boundary that **opens** the turn — see
+/// [`crate::model::TurnOpening`] for why a wrapped run's four inner stages do
+/// not each announce the same turn number.
+///
+/// `queued_steer` is deliberately never fed here. A steer that landed is
+/// already its own transcript row ([`crate::TranscriptEntry::User`], prefixed
+/// `(steered mid-turn)`), so naming it a second time on the rule above it would
+/// report one interruption twice; and a steer *queued before* the turn opened
+/// arrives as an ordinary prompt, which the deck cannot tell apart from any
+/// other. The label stays unfed rather than fed something that is not it
+/// (#4176).
+#[must_use]
+pub fn turn_begin_rows(
+    turn: u32,
+    stage: &str,
+    model: Option<&str>,
+    budget_usd: Option<f64>,
+    width: usize,
+) -> Vec<Line<'static>> {
+    vec![turn_begin(
+        &TurnHead {
+            number: turn,
+            stage: stage.to_string(),
+            model: model.map(str::to_string),
+            budget_usd,
+            queued_steer: None,
+        },
+        width,
+    )]
 }
 
 /// A turn's closing rule and its receipt (SPEC 6.1).

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -150,7 +150,7 @@ fn first_line(text: &str) -> &str {
 /// report one interruption twice; and a steer *queued before* the turn opened
 /// arrives as an ordinary prompt, which the deck cannot tell apart from any
 /// other. The label stays unfed rather than fed something that is not it
-/// (#4176).
+/// (#4185).
 #[must_use]
 pub fn turn_begin_rows(
     turn: u32,
@@ -182,7 +182,9 @@ pub fn turn_begin_rows(
 /// double-count the spend the budget gauge tracks), keeps no per-turn clock,
 /// and counts no per-turn files, tests or memories. A receipt reading
 /// `0 tok · 0 files · 0/0 tests` would be four measurements nobody took, on the
-/// one line whose whole job is to be the settled account of a turn.
+/// one line whose whole job is to be the settled account of a turn. Sourcing
+/// the other five — `det %` above all, which SPEC 5 moved off the status bar
+/// and re-homed here — is #4184.
 #[must_use]
 pub fn turn_end_rows(turn: u32, cost_usd: f64, width: usize) -> Vec<Line<'static>> {
     vec![


### PR DESCRIPTION
`turn_begin` was written in #4123 and never called. #4143 wired the closing
rule and the receipt; the opening rule stayed unreachable, so a turn had an end
and no beginning — its events sat under a bare `── EXECUTE ──` hairline with
nothing tying them to the receipt that priced them.

```
── turn 4 execute · kimi-k3 · budget $0.60 ──────────────────────────────
 │ ● read src/lifecycle.rs
── turn 4 done ─────────────────────────────────────────────────────────
   receipt $0.11 · ↵ audit
```

That is a real render, printed from `a_folded_turn_renders_its_whole_lifecycle_in_order`
(model and budget elide there because that fixture supplies neither — see
below).

## One rule per turn, not one per stage

`TranscriptEntry::Stage` becomes `Stage { name, opens: Option<TurnOpening> }`.
`opens` is `Some` on the first boundary of a turn and `None` on every later
one, so a stage *inside* a turn keeps the plain section rule it has always had.

SPEC 6.1 draws a single labelled boundary and SPEC 2 makes the turn the
transcript's unit. A wrapped run has four or five stages inside one turn, so a
rule per stage would announce `turn 4` four times and the number would stop
reading as the turn's identity.

Which boundary is the opening one is decided **at fold time**, on a
`SessionModel::turn_head_stamped` latch cleared by `TurnComplete`,
`RunComplete`, a terminal `Error` and `/clear`. Not at render time, and not by
looking backwards through the transcript: `render::entry` sees one entry and no
session state, and front-eviction can drop the opening rule itself — so a
backwards derivation would re-open the turn the moment the retention cap bit.
This is the same reasoning that put `turn` on `Complete` in #4143.

## The rule states only what the session was told

`TurnHead::model` and `TurnHead::budget_usd` become `Option`, the move #4143
made on the receipt and for the same reason:

| Field | Why it can be absent | Tracked |
|---|---|---|
| `model` | `Hud::model` is written only by `TurnComplete`/`RunComplete`, so the first turn of a session has not been told which model answered | #4183 |
| `budget_usd` | `None` is *no budget armed*, which is not a budget of `$0.00` | — |
| `queued_steer` | never fed: a steer that landed is already its own `(steered mid-turn)` row, so naming it again would report one interruption twice | #4185 |

`budget_usd` reads `Hud::limit_usd`, and that is the correct field rather than a
convenient one: `AgentEvent::BudgetTick`'s own doc states `spent_usd`/`limit_usd`
are **turn-scoped**, with the session axis riding separately on
`session_spent_usd`/`session_limit_usd`.

## `model.rs` split rather than baselined

`TurnOpening` pushed `model.rs` to 1532 lines, 32 over the guard. AGENTS.md's
remedy is a sibling submodule, and the baseline covers only files that predate
the guard — so `Hud` and `TurnOpening` moved to `crates/stella-tui/src/model/turn.rs`
(the seam `file_state` and `recall` already cut). `Hud` went with it because
the two are the ends of one thing — `Hud` is the turn's live state,
`TurnOpening` is the stamp that state leaves on the transcript — and moving
only the 44 new lines would have landed at 1490, which is a ceiling to hit
again next month rather than headroom. Both re-exported from `crate::model`, so
no call site changed. 1430 lines now.

## Witness

Both halves, each verified by disarming the thing it tests:

- **Render** — `a_turn_opens_on_a_labelled_rule`,
  `an_opening_rule_names_no_model_or_budget_it_was_never_told`,
  `a_stage_inside_a_turn_is_not_a_second_turn_rule`. Removing the `v2_rows`
  router arm fails the first two on `no opening rule`, printing the old
  `── EXECUTE ──` screen. (The arm's presence is asserted before removing it,
  so the disarm cannot pass by not applying — the trap #4143 hit.)
- **Fold** — `only_the_first_stage_of_a_turn_opens_a_turn_rule`,
  `an_opening_rule_carries_only_facts_the_fold_was_given`,
  `a_turn_that_died_still_lets_the_next_one_open`. Forcing `opens` to `None`
  fails all three.
- **End to end** — `a_folded_turn_renders_its_whole_lifecycle_in_order` is
  #4124's definition of done: events fold through `SessionModel`, entries
  render through `entry_lines`, and begin/event/end/receipt come out **in that
  order** (a receipt above its own turn rule would be a correct set of rows and
  a wrong transcript). It fails under either disarm.

## Deck goldens

Unchanged, and that is itself a finding rather than a pass. The demo scenario
(`crates/stella-tui/src/scenario.rs`) emits `Stage(Triage)` first — which now
carries the rule — but the golden's viewport is scrolled past it, and the
scenario emits no `TurnComplete` at all, so no fixture has ever shown either
half of SPEC 6.1's boundary. #4143 recorded the same for the closing rule. The
lifecycle test above is the evidence in its place; noted in #4184 so a fixture
that shows a whole turn can be a deliberate decision rather than an omission.

## Tests deleted

None.

## Left behind, filed as handoffs

- #4183 — the opening rule cannot name the model on the first turn
- #4184 — the receipt states one number out of six; `det %` above all, which
  SPEC 5 re-homed here and nothing has ever fed
- #4185 — the queued-steer label is rendered but never fed

Each is cited from the code comment that elides the field, so the gap and its
issue are read together.

## Verification

`make gate CARGO_SCOPE="-p stella-tui"` green (all 32 steps: clippy
`-D warnings`, rustdoc `-D warnings`, `cargo test --workspace`, and every
guard). `cargo test -p stella-tui`: 12 targets, 0 failures.

One thing the gate caught that I had missed: the split moved three intra-doc
links out of the scope that resolved them, and my earlier rustdoc run predated
the split. Fixed in dac5d70d0.

Closes #4124

## Summary by Sourcery

Open each transcript turn with a labelled rule that connects its stages to the turn’s closing receipt.

New Features:
- Render the first stage boundary of each turn as a labelled opening rule with its turn number, stage, and any known model or budget.
- Fold turn-opening metadata into the transcript so complete turn lifecycles render in order from opening rule through events, closing rule, and receipt.

Bug Fixes:
- Ensure subsequent turns still receive opening rules after terminal errors, completed turns, completed runs, or clearing the session.

Enhancements:
- Represent optional model and budget facts without inventing values that the session has not reported.
- Split turn-related model types into a dedicated module while preserving existing model re-exports.

Tests:
- Add fold, rendering, and end-to-end coverage for one opening rule per turn, optional metadata, failed turns, and lifecycle ordering.