### PR TITLE
fix(bench): the witness arm is refused at the launch, and the mirror becomes a reader of postures as written

### DIFF
--- a/bench/READINESS.md
+++ b/bench/READINESS.md
@@ -692,12 +692,28 @@ of it.
 Selecting an arm:
 
 ```bash
-# control arm — the default, and the posture every published number used
+# control arm — the default, the posture every published number used, and
+# the only arm this workspace's binary can run at all (see the box below)
 unset STELLA_WITNESS_AUTHOR_MODEL
 
-# treatment arm — a second pinned model on the worker's provider
+# treatment arm — REFUSED at launch since #4103, not selected
 export STELLA_WITNESS_AUTHOR_MODEL=openrouter/deepseek/deepseek-v4-pro
 ```
+
+> [!WARNING]
+> **The treatment arm is unrunnable on this workspace's engine and is refused
+> rather than measured** ([#4103](https://github.com/macanderson/stella/issues/4103)).
+> `AgentEngineConfig::model_for` resolves `agents.default.model` >
+> `default_model` with no role argument (#3944), and `pipeline_verifier_model` /
+> `agents.verifier` are retired keys the launcher recognizes, reports and
+> ignores. So the pin reaches no model call: a treatment-arm run would execute
+> the control arm's configuration under a treatment arm's digest, which is
+> #1147's failure with the guard that used to catch it deleted (#3865).
+> `refuse_unauthorable_witness_arm` stops such a launch before it spends
+> anything. Nothing below is retracted — the *reading* path is unchanged, so
+> every digest and every recorded `assurance` block in this document still
+> re-derives byte for byte — but the arm is a description of a configuration,
+> not a run anyone can perform today.
 
 The arm changes `stella_engine_posture_sha256`, and therefore the registered
 SUT — that is intended. Two arms over the same 89 tasks on the same SUT is a
@@ -731,14 +747,24 @@ Constraints, each enforced fail-closed by `_validated_witness_author`:
   provider. A trial runs with `STELLA_CATALOG_AUTO_REFRESH=0`, so an unlisted
   slug fails model validation and the verifier pin is dropped — which is how the
   first witness-arm run executed the control arm under a witness-arm digest
-  (#1147). The posture is unchanged; what changed is that such a run now
-  refuses instead of scoring.
+  (#1147). Every author is in that position now, listed or not, which is why the
+  refusal above is unconditional rather than a slug check.
 
 Guarded by `config::tests::the_benchmark_witness_arm_posture_survives_the_trusted_launcher_seam`
-(the arm passes the fail-closed launcher seam),
-`agent::tests::engine_wiring::the_benchmark_posture_splits_worker_and_verifier_only_on_the_witness_arm`
-(the arm actually separates the two roles the witness check compares),
-`agent::tests::engine_wiring::the_flat_pipeline_verifier_model_alone_resolves_role_verifier_to_the_witness_author`
-(the flat root key alone reaches `Role::Verifier`), and
-`pipeline::tests::witness_isolation::requiring_an_independent_witness_refuses_before_spending_anything`
-(a witness arm without an independent author produces no number at all).
+(the arm's posture still passes the fail-closed launcher seam, which is what
+lets registered treatment-arm digests keep re-deriving), and, in the adapter's
+own suite, `TestWitnessArmIsUnlaunchable` plus
+`TestRolesConfigReachesTheDeclaration::test_a_harness_roles_config_verifier_is_refused_at_the_launch`
+(both channels into the declaration are refused before anything is spent, and
+the control arm passes the gate untouched).
+
+Three Rust guards this section used to name were deleted with
+`crates/stella-pipeline` (#3865) and with the role collapse (#3944), and are
+removed here rather than left as citations that resolve to nothing — each was
+grepped to zero hits in this workspace on 2026-08-21 (#4103):
+`the_benchmark_posture_splits_worker_and_verifier_only_on_the_witness_arm`,
+`the_flat_pipeline_verifier_model_alone_resolves_role_verifier_to_the_witness_author`,
+and `pipeline::tests::witness_isolation::requiring_an_independent_witness_refuses_before_spending_anything`.
+The last is the load-bearing one: it is what this document cited as the reason a
+witness arm without an independent author "produces no number at all", and it
+had not existed for the whole time that claim stood.

--- a/bench/evidence/compare_arms.py
+++ b/bench/evidence/compare_arms.py
@@ -13,8 +13,17 @@ because the posture pinned one model for every role and Stella refuses to let a
 worker author its own witness. Those numbers are a lower bound on the ladder,
 not a measurement of it.
 
-Turning the rung on is one environment variable (`STELLA_WITNESS_AUTHOR_MODEL`,
-#1007) over a workspace that now has a git baseline to compare against (#1225).
+Turning the rung on **used to be** one environment variable
+(`STELLA_WITNESS_AUTHOR_MODEL`, #1007) over a workspace that now has a git
+baseline to compare against (#1225). It no longer turns anything on: the engine
+has one role, so that pin reaches no model call, and a launch carrying it is
+refused rather than measured (#4103,
+`stella_harbor.posture.refuse_unauthorable_witness_arm`). This script is
+therefore a reader of evidence recorded on binaries that could still split the
+two roles — which is exactly what it always was, and why nothing in it changes:
+it has never trusted a posture's declaration on its own. See property 2 below,
+which is the same skepticism aimed at the same failure from the other side.
+
 What was missing is the arithmetic that turns two runs into an answer, and the
 evidence to run it over: the per-trial verdict and witness observations lived
 only in the multi-gigabyte Harbor job tree, which is never committed, so the

--- a/bench/evidence/run/witness_ab.sh
+++ b/bench/evidence/run/witness_ab.sh
@@ -40,14 +40,25 @@ AUTHOR="${STELLA_WITNESS_AUTHOR_MODEL:-}"
 case "$ARM" in
   off) unset STELLA_WITNESS_AUTHOR_MODEL ;;
   on)
-    test -n "$AUTHOR" || {
-      echo "FATAL: arm 'on' needs STELLA_WITNESS_AUTHOR_MODEL exported"
-      echo "       (a second provider/model on TB_MODEL's provider — one"
-      echo "       credential reaches the container, so it must be the same"
-      echo "       provider as the worker)"
-      exit 1
-    }
-    export STELLA_WITNESS_AUTHOR_MODEL="$AUTHOR"
+    # #4103: refused before the "did you export an author?" check below, and
+    # deliberately so — that check tells an operator to go and set a variable
+    # that would not help. The engine has one role, so the author reaches no
+    # model call, and this arm would execute the CONTROL arm under a
+    # treatment-arm digest (#1147). Refusing here rather than letting the
+    # adapter's own gate do it: by then env.sh has sourced, a job tree exists
+    # and Harbor is pulling task images, all for a run that cannot produce a
+    # number.
+    echo "FATAL: arm 'on' cannot run on this workspace's Stella (#4103)."
+    echo "       AgentEngineConfig::model_for resolves agents.default.model >"
+    echo "       default_model with no role argument, and pipeline_verifier_model"
+    echo "       is a retired key the launcher recognizes and ignores, so no"
+    echo "       author${AUTHOR:+ (including '$AUTHOR')} reaches a model call."
+    echo
+    echo "       The control arm still runs: witness_ab.sh off <job> [tasks]"
+    echo "       An independent author needs a verification plugin over the"
+    echo "       wrapper socket (doc:pipeline-as-plugins §8), not an engine key."
+    echo "       See bench/evidence/witness-ab/README.md."
+    exit 1
     ;;
   *) echo "FATAL: arm must be 'off' or 'on'"; exit 1 ;;
 esac

--- a/bench/evidence/witness-ab/README.md
+++ b/bench/evidence/witness-ab/README.md
@@ -18,7 +18,7 @@ no author independent of the worker` and carried on with the judge alone. Those
 numbers are a lower bound on the ladder, not a measurement of it
 ([`../../READINESS.md`](../../READINESS.md) §9).
 
-Two things used to block turning it on, and both are fixed:
+Two things used to block turning it on, and both were fixed:
 
 * [#1007](https://github.com/macanderson/stella/issues/1007) added
   `STELLA_WITNESS_AUTHOR_MODEL`, which names a second model on the worker's
@@ -27,12 +27,35 @@ Two things used to block turning it on, and both are fixed:
 * [#1225](https://github.com/macanderson/stella/issues/1225) gave each task
   folder a git baseline, so a witness has something to be diffed against.
 
+> [!IMPORTANT]
+> **A third thing blocks it now, and this one is structural: the treatment arm
+> cannot be run on the binary this workspace builds**
+> ([#4103](https://github.com/macanderson/stella/issues/4103)).
+>
+> The engine has one role. `AgentEngineConfig::model_for` resolves
+> `agents.default.model` > `default_model` and takes no role argument;
+> `pipeline_verifier_model` and `agents.verifier` are retired keys the launcher
+> recognizes, reports and ignores. So the second model this experiment's whole
+> design rests on reaches no model call, and both arms would execute the same
+> configuration — the treatment arm merely carrying a different digest. That is
+> not a null result, it is a measurement artifact, and it would have been
+> reported as the answer to the question this directory exists to ask.
+>
+> `refuse_unauthorable_witness_arm` now refuses such a launch before it spends
+> anything, so the experiment cannot be run accidentally. Running it for real
+> needs an independent author to exist again — which in this workspace means a
+> verification plugin over the wrapper socket (`doc:pipeline-as-plugins` §8),
+> not an engine key. **The protocol, the denominator, the decision rule and the
+> preregistration below are unaffected and stay valid**; what changed is the
+> mechanism that would deliver an author, and therefore what a run must be
+> pointed at.
+
 This directory holds the protocol, the preregistered analysis plan and the
 decision rule for the run that answers the question. **The run itself has not
-happened yet** — it needs a spend-capable credential and a host that can run
-89 Docker task images, neither of which any amount of code in this repository
-can supply. Results land in a sibling `witness-ab-<YYYYMMDD>/` directory and
-this file gains a row pointing at them.
+happened yet** — and, per the note above, cannot happen against this
+workspace's engine keys until an independent author exists again. Results land
+in a sibling `witness-ab-<YYYYMMDD>/` directory and this file gains a row
+pointing at them.
 
 ## What gets measured
 

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -119,6 +119,7 @@ from .posture import (
     _benchmark_engine_posture,
     assurance_tiers_from_posture,
     read_posture_selectors,
+    refuse_unauthorable_witness_arm,
 )
 from .stream_envelope import (
     _extract_metrics,
@@ -1045,6 +1046,13 @@ class StellaAgent(BaseInstalledAgent):
             self._assurance_tiers_json,
             self._assurance_tiers_sha256,
         ) = assurance_tiers_from_posture(self._engine_posture)
+        # Declaring a tier and being able to run it are two questions, and this
+        # is where the second one is asked — after every channel has folded
+        # into one declaration, before a credential is selected or a container
+        # is touched. This binary has one engine role, so a `witness-on`
+        # posture would run the control arm under a treatment-arm digest
+        # (#4103, #1147).
+        refuse_unauthorable_witness_arm(self._assurance_tiers)
         self._verifier_model_value = self._assurance_tiers.get("verifier_model")
         # Highest precedence, after ambient and all Harbor extra env. A task
         # cannot replace this with its own routing or request-effort config.
@@ -1262,13 +1270,20 @@ class StellaAgent(BaseInstalledAgent):
         and every registered posture hash exactly as it was — the treatment arm
         has to be asked for, so this can never change a run's meaning by
         arriving in the tree.
+
+        Asking for it now ends the run rather than selecting an arm, but the
+        refusal is deliberately **not** raised here (#4103). This reads one
+        channel; an overriding ``_build_engine_posture`` (an ArenaBench roles
+        config, #2134's channel) is another, and a guard on this selector alone
+        would leave that one open. Both fold into the declaration, which is
+        where :func:`~stella_harbor.posture.refuse_unauthorable_witness_arm`
+        asks the question once for all of them.
         """
         value = self._configured_value(_WITNESS_AUTHOR_ENV)
         if value is None:
             return None
         stripped = value.strip()
         return stripped or None
-
 
     def _effective_base_url(self, model: str) -> str | None:
         """Resolve and validate the authoritative provider endpoint."""

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -1046,12 +1046,6 @@ class StellaAgent(BaseInstalledAgent):
             self._assurance_tiers_json,
             self._assurance_tiers_sha256,
         ) = assurance_tiers_from_posture(self._engine_posture)
-        # Declaring a tier and being able to run it are two questions, and this
-        # is where the second one is asked — after every channel has folded
-        # into one declaration, before a credential is selected or a container
-        # is touched. This binary has one engine role, so a `witness-on`
-        # posture would run the control arm under a treatment-arm digest
-        # (#4103, #1147).
         refuse_unauthorable_witness_arm(self._assurance_tiers)
         self._verifier_model_value = self._assurance_tiers.get("verifier_model")
         # Highest precedence, after ambient and all Harbor extra env. A task
@@ -1266,18 +1260,9 @@ class StellaAgent(BaseInstalledAgent):
     def _verifier_model(self) -> str | None:
         """Return the pinned witness/verifier author, or ``None`` for the control arm.
 
-        Unset defaults to the control arm, which keeps every published number
-        and every registered posture hash exactly as it was — the treatment arm
-        has to be asked for, so this can never change a run's meaning by
-        arriving in the tree.
-
-        Asking for it now ends the run rather than selecting an arm, but the
-        refusal is deliberately **not** raised here (#4103). This reads one
-        channel; an overriding ``_build_engine_posture`` (an ArenaBench roles
-        config, #2134's channel) is another, and a guard on this selector alone
-        would leave that one open. Both fold into the declaration, which is
-        where :func:`~stella_harbor.posture.refuse_unauthorable_witness_arm`
-        asks the question once for all of them.
+        Unset is the control arm, the posture every published number used.
+        Asking for the other now ends the run, from the gate on the resolved
+        declaration rather than here, so both channels are covered (#4103).
         """
         value = self._configured_value(_WITNESS_AUTHOR_ENV)
         if value is None:

--- a/bench/harbor_adapter/stella_harbor/posture.py
+++ b/bench/harbor_adapter/stella_harbor/posture.py
@@ -47,11 +47,19 @@ _ENGINE_POSTURE_VERSION = "stella-tb21-engine-posture-v1"
 _ASSURANCE_TIERS_VERSION = "stella-tb21-assurance-tiers-v2"
 
 # Host-side selector for the witness/verifier author. Unset (the default) is the
-# control arm: one inherited model, authored witness structurally off. Set to a
-# second `provider/model` on the worker's provider and the same 89 tasks run the
-# treatment arm. Never forwarded into the container — the decision reaches
-# Stella only as `pipeline_verifier_model` inside the hashed posture, so the arm a
-# trial ran cannot disagree with the arm its digest records (#1007).
+# control arm: one inherited model, authored witness structurally off. Never
+# forwarded into the container — the decision reaches Stella only as
+# `pipeline_verifier_model` inside the hashed posture, so the arm a trial ran
+# cannot disagree with the arm its digest records (#1007).
+#
+# **Setting it no longer selects a treatment arm; it refuses the launch**
+# (#4103, `refuse_unauthorable_witness_arm`). The engine this workspace ships
+# has one role — `AgentEngineConfig::model_for` resolves `agents.default.model`
+# > `default_model` with no role argument at all, and `verifier` is a name in
+# `RETIRED_ENGINE_AGENT_NAMES` recognized and ignored — so no key in a posture
+# can route a second model to the verifier. A run launched with this set would
+# spend a treatment arm's money on a control arm's configuration and record it
+# under a treatment arm's digest, which is #1147 exactly.
 _WITNESS_AUTHOR_ENV = "STELLA_WITNESS_AUTHOR_MODEL"
 
 # Host-side selector for the worker's effort tier. The rule that sets it has
@@ -664,21 +672,32 @@ def _benchmark_engine_posture(
 
     * ``verifier=None`` — the **control arm**. Model routing is expressed
       only by ``default_model``; every role inherits it and no role has a
-      provider/model override. Stella will not let the worker write the test
-      that verifies it, so with one model for every role the independent author
-      never exists: the run reports ``WitnessUnavailable`` and proceeds unproven
-      (#973). Every Terminal-Bench number published before #1007 is this arm.
+      provider/model override. With one model for every role the independent
+      author never exists. Every Terminal-Bench number Stella has published is
+      this arm.
     * ``verifier="provider/slug"`` — the **treatment arm**. A second model
       is pinned for the verifier role via ``pipeline_verifier_model``, which is what
       the authored-witness tier resolves its author from, and ``allowed_models``
       widens to name both. Still fully pinned, still one hash, still no
-      auto-selection — the reproducibility argument is untouched; the posture
-      simply now says which of two frozen configurations it is.
+      auto-selection.
 
-    Both arms are frozen and disclosed. Choosing between them is a measurement
-    decision that changes ``digest``, and therefore the registered SUT; the
-    point of having both is that the choice is made in the manifest instead of
-    being discovered by grepping a trajectory for a warning line.
+    **This function stays total on both arms, and no longer launches one of
+    them** (#4103). Building a treatment-arm posture is still exactly right for
+    what this function is — the frozen claim implementation, whose output every
+    registered digest in ``bench/READINESS.md`` §8.4 and §9 must keep
+    reproducing byte for byte. What changed is underneath it: the engine this
+    workspace ships has one role, so the pin this emits reaches no model call
+    (see :func:`refuse_unauthorable_witness_arm`, which is where a *run*
+    carrying that declaration is refused). Keeping the builder total and gating
+    the launch is the split that lets history re-derive while no new number can
+    misdescribe itself.
+
+    This is deliberately not the shape #3871 used for ``max_revisions`` and its
+    two siblings, which became a ``TypeError`` at the call site. Those emitted
+    keys the launcher now **refuses** outright, so no reproducible digest could
+    contain one; ``pipeline_verifier_model`` is recognized-and-ignored
+    (``RETIRED_ENGINE_ROOT``), so treatment-arm postures still parse through
+    the trusted seam and still have digests on record to reproduce.
 
     ``max_revisions``, ``candidates`` and ``verifier_evidence_demand`` were
     three more arguments of the same shape (#1211 §6.7, §6.8; #1295). They are
@@ -806,28 +825,29 @@ def _benchmark_engine_posture(
     }
     if verifier is not None:
         author = _validated_verifier(selected_model, verifier)
-        # The flat root key, never `agents.verifier.model`. Both resolve — the
-        # engine reads `agents.<role>.model` first and falls through to the
-        # flat key (`AgentEngineConfig::model_for`), and
-        # `the_flat_pipeline_verifier_model_alone_resolves_role_verifier_to_the_verifier`
-        # pins that the flat key alone reaches `Role::Verifier` — but the flat key
-        # is what `settings_check` and `stella config` report as the verifier's
-        # origin, so the disclosed posture and the engine's own account of its
-        # wiring name the same field.
+        # The flat root key, never `agents.verifier.model`. It is the field
+        # `settings_check` and `stella config` report as the verifier's origin,
+        # so the disclosed posture and the engine's own account of its wiring
+        # name the same one.
         #
-        # Naming the author is not the same as reaching it. A trial runs with
-        # the catalog frozen (`STELLA_CATALOG_AUTO_REFRESH=0`), so the author
-        # must be a slug Stella's OFFLINE seed catalog carries for that
-        # provider; an unlisted one fails slug validation, the verifier pin is
-        # dropped, and the verifier falls back to the worker. That used to make
-        # the treatment arm run as the control arm under a treatment-arm digest
-        # (#1147). It now refuses the run instead: a posture delivered through
-        # the trusted launcher seam that names a verifier other than the worker
-        # arms `PipelineConfig::require_independent_witness`, and a run that
-        # cannot resolve an independent author fails before it spends anything.
-        # A witness arm whose author is outside the seed therefore produces no
-        # number at all, which is the intended outcome — the alternative is a
-        # number this digest misdescribes.
+        # **Naming the author is not the same as reaching it, and today it
+        # never reaches it** (#4103). This key is in `RETIRED_ENGINE_ROOT`: the
+        # launcher recognizes it, reports it and ignores it, because
+        # `AgentEngineConfig::model_for` has no role argument left to spend it
+        # on. Writing it here is still correct — this is the frozen claim
+        # implementation and its digests must keep reproducing — but the
+        # *launch* carrying it is refused by
+        # `refuse_unauthorable_witness_arm`, which is the only reason it is
+        # safe for this builder to keep emitting a pin the engine drops.
+        #
+        # The catalog rule below is the older half of the same hazard and is
+        # now subsumed by that refusal. A trial runs with the catalog frozen
+        # (`STELLA_CATALOG_AUTO_REFRESH=0`), so an author outside Stella's
+        # offline seed used to fail slug validation, drop the pin, and run the
+        # control arm under a treatment-arm digest (#1147). What caught that
+        # was `PipelineConfig::require_independent_witness`, deleted with
+        # `crates/stella-pipeline` (#3865) with no successor — so the guard
+        # named here for two releases has not existed for any of them.
         posture["pipeline_verifier_model"] = author
         posture["allowed_models"] = [selected_model, author]
     # Triage, research and plan pin identically — flat key plus a widened
@@ -905,14 +925,20 @@ _FLAT_ROLE_MODEL_KEY = {
 #: The roles whose UNPINNED default is the worker's model, not ``default_model``.
 #:
 #: Every other role has a standing identity — unpinned, triage and the verifier
-#: still have a model of their own, and ``default_model`` is it. These two are
-#: documented as "run whatever the worker runs"
-#: (``own_model_spec_for``, ``crates/stella-cli/src/engine_config.rs``), so
-#: falling through to ``default_model`` for them would split them onto a
-#: different model the moment anything re-points the worker without touching
-#: settings. The two coincide in the frozen posture below, where the worker
-#: carries no pin of its own — which is exactly why a resolver that got this
-#: wrong would keep agreeing with reality until the first arm that pinned one.
+#: still have a model of their own, and ``default_model`` is it. These two were
+#: documented as "run whatever the worker runs", so falling through to
+#: ``default_model`` for them would split them onto a different model the moment
+#: anything re-pointed the worker without touching settings. The two coincide in
+#: the frozen posture below, where the worker carries no pin of its own — which
+#: is exactly why a resolver that got this wrong would keep agreeing with
+#: reality until the first arm that pinned one.
+#:
+#: The engine function that drew this split, ``own_model_spec_for``, is **gone**
+#: (#4103): ``crates/stella-cli/src/engine_config.rs`` has ``model_spec_for``
+#: alone now, taking no role. The distinction survives here for the same reason
+#: the flat rung does — this reads postures as written, and postures in the
+#: corpus were written while it was real. It is not a claim about any live
+#: binary; see :func:`resolve_posture_role_model`.
 _WORKER_INHERITING_ROLES = frozenset({"research", "plan"})
 
 
@@ -960,28 +986,45 @@ def resolve_posture_role_model(
 ) -> tuple[str, str]:
     """Resolve one role's model from a posture, and name the key it came from.
 
-    Mirrors ``AgentEngineConfig::model_for``
-    (``crates/stella-cli/src/settings/engine.rs``): ``agents.<role>.model``
-    outranks the flat ``pipeline_<role>_model``, which outranks
-    ``default_model`` — except for the two roles that inherit the worker
-    instead on that last rung (``_WORKER_INHERITING_ROLES``, which is the
-    engine's own split between ``model_spec_for`` and ``own_model_spec_for``,
-    not an approximation of it). Mirroring it is the whole point: a declaration
-    that resolves roles by a different rule than the engine does is free to
-    disagree with the run it describes, which is the shape of #2134 and of
-    #1147 before it.
+    **Reads a posture as written; it is not a mirror of any live engine.**
+    That distinction is the resolution of #4103 and it is load-bearing, so it
+    is stated before the ladder rather than after it. The subject of this
+    function is a *document* — a posture dict, possibly one recorded years ago
+    and hashed into a registered SUT — and the question it answers is "what
+    does this posture say about this role?". Answering it the same way forever
+    is what lets ``bench/READINESS.md`` §8.4's digests and every recorded
+    ``assurance`` block re-derive; re-pointing it at whatever the current
+    binary happens to resolve would silently re-characterise evidence nobody
+    re-ran.
 
-    **The middle rung is knowingly ahead of the engine.** #3908 collapsed
-    ``agent_engine_config`` to the one role core has, so ``model_for`` now
-    reads ``agents.default.model`` > ``default_model`` and the five flat
-    ``pipeline_<role>_model`` keys are **retired** — recognized, ignored and
-    reported by name (``settings::unknown::RETIRED_ENGINE_ROOT``) rather than
-    removed, because this harness and ``arenabench`` still write them into
-    postures whose digests are registered in ``bench/READINESS.md`` §8.4.
-    Reading them here is therefore still correct for what this function
-    describes — the posture as written — and stops being correct when slice 6
-    (#3910) stops writing them. Both halves of that are pinned by
-    ``test_assurance_tiers.py``; do not narrow this ladder without it.
+    The ladder, therefore, is the union of every spelling a posture in this
+    corpus can carry: ``agents.<role>.model`` outranks the flat
+    ``pipeline_<role>_model``, which outranks ``default_model`` — except for
+    the two roles documented as running whatever the worker runs, which fall
+    back to the worker on that last rung (``_WORKER_INHERITING_ROLES``).
+
+    **What the engine does now, and why that is no longer this function's
+    business.** ``AgentEngineConfig::model_for``
+    (``crates/stella-cli/src/settings/engine.rs``) reads
+    ``agents.default.model`` > ``default_model``, takes no role argument, and
+    resolves every role to one model; the five flat keys and the five persona
+    agent names are retired — recognized, reported, ignored
+    (``settings::unknown::RETIRED_ENGINE_ROOT`` /
+    ``RETIRED_ENGINE_AGENT_NAMES``). So a posture's role pins describe an
+    intent the binary no longer honors.
+
+    This function keeps reporting that intent, and the divergence is made safe
+    at the other end rather than here: :func:`refuse_unauthorable_witness_arm`
+    refuses to *launch* a run whose declaration depends on a distinction the
+    binary cannot make. Reading stays truthful about the document; launching
+    stays truthful about the binary. Collapsing this ladder instead would have
+    made the reader agree with today's engine at the cost of every historical
+    posture it also describes — see #4103 for the three options and which one
+    was taken.
+
+    ``test_assurance_tiers.py`` pins both halves: the engine's real two rungs,
+    and that the flat keys are *declared* retired rather than quietly dropped.
+    Do not narrow this ladder without it.
 
     Two of those rungs bit in the same match. ``cc00894779ff`` read only the
     host-side selector and so missed the flat key an ArenaBench roles config
@@ -1030,13 +1073,24 @@ def assurance_tiers_from_posture(
     for a run whose posture named kimi-k3 as the verifier and whose trials
     demonstrably authored a witness (#2134).
 
-    The witness arm's predicate is exactly one sentence, and it is the engine's
-    own: the verifier role resolves to a model different from the worker's
-    (``Pipeline::witness_author_independence``). Both sides are resolved here
-    through :func:`resolve_posture_role_model`, so "the verifier inherits" is
-    never *assumed* to mean "the verifier equals the worker" — a posture that
-    pins only the worker leaves the verifier on ``default_model``, which is an
-    independent author and used to be declared as the opposite.
+    The witness arm's predicate is exactly one sentence: the verifier role
+    resolves to a model different from the worker's. It was the engine's own —
+    ``Pipeline::witness_author_independence`` — and that predicate no longer
+    exists anywhere in this workspace, deleted with ``crates/stella-pipeline``
+    (#3865). What it means for this function is nothing, and that is the point:
+    the sentence is evaluated against the **posture**, so it keeps describing
+    what a posture claims however the engine changes. What it means for a
+    *launch* is everything, and lives in
+    :func:`refuse_unauthorable_witness_arm` — on today's binary no posture can
+    satisfy the predicate in a way any model call would honor, so a run
+    carrying a ``witness-on`` declaration is refused rather than scored
+    (#4103).
+
+    Both sides are resolved here through :func:`resolve_posture_role_model`, so
+    "the verifier inherits" is never *assumed* to mean "the verifier equals the
+    worker" — a posture that pins only the worker leaves the verifier on
+    ``default_model``, which is an independent author and used to be declared
+    as the opposite.
 
     When the predicate fails, the recorded off-reason states the models both
     roles resolved to and the posture keys they came from — never a claim about
@@ -1138,6 +1192,64 @@ def _benchmark_assurance_tiers(
     if author is not None:
         posture["pipeline_verifier_model"] = author
     return assurance_tiers_from_posture(posture)
+
+
+def refuse_unauthorable_witness_arm(tiers: dict[str, Any]) -> None:
+    """Refuse a *launch* whose declaration claims a tier this binary cannot run.
+
+    The gate for #4103, and it is deliberately about launching rather than
+    about reading. :func:`assurance_tiers_from_posture` stays total: it
+    describes a posture **as written**, which is what lets a registered digest
+    and a recorded run re-derive byte for byte years later. This is the second
+    question, asked only where money is about to be spent — *can the binary in
+    front of us actually author what that declaration promises?*
+
+    Today it cannot, and the reason is structural rather than a missing pin.
+    ``AgentEngineConfig::model_for`` (``crates/stella-cli/src/settings/
+    engine.rs``) resolves ``agents.default.model`` > ``default_model`` and
+    takes no role argument at all; ``ENGINE_AGENT_NAMES`` is the single name
+    ``default``, with ``verifier`` sitting in ``RETIRED_ENGINE_AGENT_NAMES``
+    beside ``pipeline_verifier_model`` in ``RETIRED_ENGINE_ROOT`` — recognized,
+    reported, ignored (``crates/stella-cli/src/settings/unknown.rs``). So every
+    role resolves to one model, and no posture key can separate the verifier
+    from the worker.
+
+    That is #1147's shape with the guard removed. A witness-arm run whose
+    author does not resolve executes the control arm under a treatment-arm
+    digest; what used to catch it was
+    ``PipelineConfig::require_independent_witness``, which was deleted with
+    ``crates/stella-pipeline`` (#3865) and has no successor in this workspace —
+    host-run verification does not exist here at all any more, so there is no
+    place left to arm it. Failing closed here is what keeps the treatment arm
+    from becoming a number that misdescribes itself.
+
+    Every channel into the posture is covered because the input is the
+    resolved declaration rather than a selector: the host-side
+    ``STELLA_WITNESS_AUTHOR_MODEL`` and a harness's overridden
+    ``_build_engine_posture`` (an ArenaBench roles config, #2134's channel)
+    both arrive here as the same ``witness-on``.
+
+    Raises ``RuntimeError`` before anything is spent; returns ``None`` for the
+    control arm, which is every run this workspace's binary can honestly
+    record.
+    """
+    if tiers.get("arm") != "witness-on":
+        return
+    raise RuntimeError(
+        "refusing to launch the witness treatment arm: this Stella has one "
+        f"engine role, so the posture's verifier pin "
+        f"(`{tiers.get('verifier_model')}`) cannot reach any model call and "
+        f"the worker (`{tiers.get('worker_model')}`) would author its own "
+        "witness. `AgentEngineConfig::model_for` resolves "
+        "`agents.default.model` > `default_model` with no role argument, and "
+        "`pipeline_verifier_model`/`agents.verifier` are retired keys the "
+        "launcher recognizes and ignores. The run would spend a treatment "
+        "arm's money on a control arm's configuration and record it under a "
+        "treatment arm's digest (#1147). Unset "
+        f"`{_WITNESS_AUTHOR_ENV}` to run the control arm, which is the only "
+        "arm this binary can honestly record; see #4103 for why the arm is "
+        "not merely unset here but unavailable."
+    )
 
 
 def fold_witness_observations(events: list[dict[str, Any]]) -> dict[str, Any]:

--- a/bench/harbor_adapter/tests/test_assurance_tiers.py
+++ b/bench/harbor_adapter/tests/test_assurance_tiers.py
@@ -165,10 +165,10 @@ _COMPLETED_TRIAL = [
 class TestRolesConfigReachesTheDeclaration:
     """#2134's headline: a verifier the host selector never saw."""
 
-    def test_a_harness_roles_config_verifier_puts_the_witness_arm_on(
+    def test_a_harness_roles_config_verifier_is_refused_at_the_launch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The witness test for #2134.
+        """#2134's channel, and #4103's refusal, in one trial.
 
         A roles config sets `pipeline_verifier_model` through the posture seam
         and never touches `STELLA_WITNESS_AUTHOR_MODEL`. The declaration used to
@@ -176,6 +176,14 @@ class TestRolesConfigReachesTheDeclaration:
         `verifier_model: null`, and an off-reason asserting facts about roles
         nothing had examined — for a run whose engine had an independent author
         the whole time.
+
+        #2134's half is still the subject and is still asserted: the refusal
+        can only name `_VERIFIER` if this channel reached the declaration, so a
+        regression that went back to reading the host selector alone would
+        compute `witness-off` here, launch, and fail this test on the missing
+        `RuntimeError`. What #4103 changes is what happens *next* — the engine
+        has one role now, so a declaration this channel puts on cannot be
+        honored by any model call, and the run is refused instead of scored.
         """
         monkeypatch.delenv("STELLA_SPEND_LIMIT", raising=False)
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
@@ -183,38 +191,40 @@ class TestRolesConfigReachesTheDeclaration:
 
         agent = _RolesConfigAgent.__new__(_RolesConfigAgent)
         agent.posture_override = _roles_posture()
-        context = _run_trial(agent, tmp_path, _COMPLETED_TRIAL)
 
-        assert context.metadata["stella_assurance_arm"] == "witness-on"
-        assert context.metadata["stella_verifier_model"] == _VERIFIER
-        tiers = context.metadata["stella_assurance_tiers"]
-        assert tiers["verifier_model"] == _VERIFIER
-        assert tiers["worker_model"] == _WORKER
-        assert tiers["tiers"]["authored_witness"] == "on"
-        assert tiers["tiers"]["model_verdict"] == "on-independent-of-worker"
-        assert tiers["authored_witness_off_reason"] is None
+        with pytest.raises(RuntimeError) as refusal:
+            _run_trial(agent, tmp_path, _COMPLETED_TRIAL)
 
-    def test_the_declaration_and_the_posture_name_the_same_verifier(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+        reason = str(refusal.value)
+        assert _VERIFIER in reason, (
+            "the refusal must name the verifier the ROLES CONFIG pinned — that "
+            "is the #2134 channel, and a reason naming anything else means the "
+            "declaration was recomputed from the host selector again"
+        )
+        assert _WORKER in reason
+        assert "#4103" in reason
+
+    def test_the_declaration_and_the_posture_name_the_same_verifier(self) -> None:
         """One source, so the two metadata blocks cannot contradict each other.
 
         The contradiction is the artifact a bench forensic reads first: #2134
         was diagnosed by opening `stella_engine_posture` and
         `stella_assurance_tiers` side by side in one `result.json`.
+
+        Asserted on the declaration directly rather than by driving a trial,
+        because the trial that used to carry it is now refused (#4103) — but
+        the claim itself is about *reading* a posture, which is exactly the
+        half the refusal deliberately leaves working. An archived `result.json`
+        from before the collapse is read by this same function.
         """
-        monkeypatch.delenv("STELLA_SPEND_LIMIT", raising=False)
-        monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
-        monkeypatch.delenv(_WITNESS_AUTHOR_ENV, raising=False)
+        posture = _roles_posture()
+        tiers, _json, _digest = assurance_tiers_from_posture(posture)
 
-        agent = _RolesConfigAgent.__new__(_RolesConfigAgent)
-        agent.posture_override = _roles_posture()
-        context = _run_trial(agent, tmp_path, _COMPLETED_TRIAL)
-
-        posture = context.metadata["stella_engine_posture"]
-        tiers = context.metadata["stella_assurance_tiers"]
         assert posture["pipeline_verifier_model"] == tiers["verifier_model"]
-        assert context.metadata["stella_verifier_model"] == tiers["verifier_model"]
+        assert tiers["worker_model"] == _WORKER
+        assert tiers["tiers"]["authored_witness"] == "on"
+        assert tiers["tiers"]["model_verdict"] == "on-independent-of-worker"
+        assert tiers["authored_witness_off_reason"] is None
 
     def test_an_outer_timeout_reconstructs_the_declaration_from_the_seam(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -36,6 +36,8 @@ from stella_harbor import (  # noqa: E402 - after importorskip by design
     _benchmark_assurance_tiers,
     _benchmark_engine_posture,
     _stream_to_envelope,
+    assurance_tiers_from_posture,
+    refuse_unauthorable_witness_arm,
 )
 
 # Imported from the module rather than the package: internals of the posture's
@@ -774,19 +776,94 @@ class TestSelfVerdictStreamObservation:
         assert stream["self_verdict_state"] == "not_reported"
 
 
-class TestWitnessArmEndToEnd:
-    """Env knob -> posture -> container -> trial metadata."""
+class TestWitnessArmIsUnlaunchable:
+    """#4103: the arm can still be described, and can no longer be run.
 
-    def test_witness_arm_reaches_the_container_and_the_trial_metadata(
+    The gate is tested here, on the declaration alone, as well as through the
+    two run paths below and in `test_assurance_tiers.py`. That is deliberate
+    rather than redundant: the run-path tests prove the gate is *wired* into
+    every channel, and these prove it says the right thing about a declaration
+    it is handed — which is what a future caller (a new harness, a manifest
+    tool) will depend on.
+    """
+
+    def test_a_witness_on_declaration_is_refused(self) -> None:
+        """The predicate, and the reason an operator has to act on."""
+        worker = "openrouter/z-ai/glm-5.1"
+        author = "openrouter/deepseek/deepseek-v4-pro"
+        tiers, _json, _digest = _benchmark_assurance_tiers(worker, verifier=author)
+        assert tiers["arm"] == "witness-on", "precondition: the declaration is on"
+
+        with pytest.raises(RuntimeError) as refusal:
+            refuse_unauthorable_witness_arm(tiers)
+
+        reason = str(refusal.value)
+        # Both models, the knob, and the issue — an operator must be able to
+        # act on the refusal without opening this file.
+        assert author in reason
+        assert worker in reason
+        assert _WITNESS_AUTHOR_ENV in reason
+        assert "#4103" in reason
+        assert "model_for" in reason, (
+            "the reason must name the engine function whose collapse makes the "
+            "arm unrunnable, or the next reader cannot check the claim"
+        )
+
+    def test_the_control_arm_passes_the_gate_untouched(self) -> None:
+        """Every run this binary can honestly record still launches.
+
+        The half that keeps this from being a bench-wide outage: the control
+        arm is what every published Terminal-Bench number used, and the gate
+        must be invisible to it.
+        """
+        tiers, _json, _digest = _benchmark_assurance_tiers("openrouter/z-ai/glm-5.1")
+        assert tiers["arm"] == "witness-off"
+        assert refuse_unauthorable_witness_arm(tiers) is None
+
+    def test_a_recorded_declaration_still_reads_without_being_relaunched(self) -> None:
+        """Reading is not launching, which is the whole shape of the decision.
+
+        A witness-on declaration recorded before the collapse must still parse,
+        still name its two models and still report its tiers — `compare_arms.py`
+        and any forensic on an archived `result.json` depend on it. The gate is
+        a launch-time question asked somewhere else; nothing about holding this
+        dict may raise.
+        """
+        recorded = {
+            "default_model": "openrouter/z-ai/glm-5.1",
+            "pipeline_verifier_model": "openrouter/deepseek/deepseek-v4-pro",
+        }
+        tiers, _json, _digest = assurance_tiers_from_posture(recorded)
+
+        assert tiers["arm"] == "witness-on"
+        assert tiers["worker_model"] == "openrouter/z-ai/glm-5.1"
+        assert tiers["verifier_model"] == "openrouter/deepseek/deepseek-v4-pro"
+        assert tiers["authored_witness_off_reason"] is None
+
+
+class TestWitnessArmEndToEnd:
+    """Env knob -> the refusal that now ends it, and the control arm beside it."""
+
+    def test_witness_arm_env_knob_refuses_the_run_before_the_container(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The treatment arm, end to end: env knob → posture → container → metadata.
+        """The treatment arm, end to end, now ends at the refusal (#4103).
 
-        The interesting hop is the middle one. `_secure_exec_with_credential_fd`
-        deliberately *recomputes* the posture from argv at the process boundary
-        rather than trusting the caller, so before #1007 an arm expressed only
-        in `run()` would have been rebuilt as the control posture and shipped —
-        the container running witness-off while the trial recorded witness-on.
+        This used to assert the whole hop — env knob → posture → container →
+        metadata — and the interesting middle one was that
+        `_secure_exec_with_credential_fd` *recomputes* the posture from argv at
+        the process boundary rather than trusting the caller (#1007).
+
+        That hop is no longer reachable and asserting it would be asserting a
+        fiction. The engine has one role, so the author this knob pins reaches
+        no model call; a run that proceeded would put a control arm's
+        configuration in the container under a treatment arm's digest, which is
+        #1147 with the guard that used to catch it deleted (#3865). So the
+        end-to-end claim this test makes is the one that is still true and
+        still worth guarding: **asking for the arm stops the run, and stops it
+        before the container is touched at all.**
+
+        The exec stub asserts its own absence — reaching it is the failure.
         """
         worker = "openrouter/z-ai/glm-5.1"
         author = "openrouter/deepseek/deepseek-v4-pro"
@@ -794,71 +871,68 @@ class TestWitnessArmEndToEnd:
         monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-secret")
         monkeypatch.setenv(_WITNESS_AUTHOR_ENV, author)
 
-        events = [
-            {
-                "type": "proof",
-                "step": {"kind": "warrant", "required": True, "diff_lines": 30},
-            },
-            {
-                "type": "proof",
-                "step": {
-                    "kind": "witness_authored",
-                    "path": "tests/test_fix.py",
-                    "command": "pytest tests/test_fix.py",
-                    "fingerprint": "f" * 64,
-                },
-            },
-            {"type": "complete", "status": "completed", "cost_usd": 0.42},
-        ]
-        (tmp_path / "stella-events.jsonl").write_text(
-            "\n".join(json.dumps(event) for event in events)
-        )
-
         agent = _bare_agent()
         agent.logs_dir = tmp_path
         agent.model_name = worker
         agent._extra_env = {}
         agent._version = "stella 0.6.21"
 
-        _posture, posture_json, posture_digest = _benchmark_engine_posture(
-            worker, verifier=author
-        )
-        seen: dict[str, str] = {}
-
         class _Environment:
             async def _stella_secure_exec_with_stdin(
                 self, *, command: list[str], env: dict[str, str], stdin: bytes
             ):
-                seen["posture"] = env[_ENGINE_CONFIG_ENV]
-                # The author must never travel as its own container variable:
-                # the posture is the single channel, so there is exactly one
-                # thing to hash and exactly one thing that can disagree.
-                assert _WITNESS_AUTHOR_ENV not in env
-                return SimpleNamespace(stdout=None, stderr=None, return_code=0)
+                raise AssertionError(
+                    "the refused witness arm reached the container: the guard "
+                    "must fire before any exec, not after"
+                )
 
         context = AgentContext()
-        asyncio.run(
-            StellaAgent.run.__wrapped__(agent, "Fix the task.", _Environment(), context)
-        )
+        with pytest.raises(RuntimeError) as refusal:
+            asyncio.run(
+                StellaAgent.run.__wrapped__(
+                    agent, "Fix the task.", _Environment(), context
+                )
+            )
 
-        assert seen["posture"] == posture_json
-        assert json.loads(seen["posture"])["pipeline_verifier_model"] == author
-        assert agent._engine_posture_sha256 == posture_digest
+        reason = str(refusal.value)
+        assert author in reason and worker in reason, (
+            "the refusal must name both models, so an operator reads which two "
+            "the posture believed it had rather than a bare policy sentence"
+        )
+        assert _WITNESS_AUTHOR_ENV in reason, "it must name the knob to unset"
+        assert "#4103" in reason
+        assert not context.metadata, "a refused arm records no trial metadata"
 
-        assert context.metadata["stella_assurance_arm"] == "witness-on"
-        assert context.metadata["stella_verifier_model"] == author
-        assert context.metadata["stella_assurance_tiers_version"] == (
-            _ASSURANCE_TIERS_VERSION
-        )
-        assert (
-            context.metadata["stella_assurance_tiers"]["tiers"]["authored_witness"]
-            == "on"
-        )
-        assert len(context.metadata["stella_assurance_tiers_sha256"]) == 64
-        # Declared *and* observed, which are different claims: the posture
-        # enabled the tier, and this trial's proof stream shows it ran.
-        assert context.metadata["stella_witness_authored_state"] == "authored"
-        assert context.metadata["stella_stream"]["witness_authored"] is True
+    def test_the_treatment_posture_still_builds_so_its_digests_re_derive(
+        self,
+    ) -> None:
+        """Refusing the launch must not silence the builder (#4103).
+
+        The two halves of the decision, in one assertion. Running the arm is
+        refused because this binary cannot honor it; *describing* it stays
+        total, because `bench/READINESS.md` §8.4 and §9 register digests
+        computed from this exact function and a reader must be able to
+        reproduce them byte for byte years later. Collapsing the builder to
+        match the engine would have re-characterised recorded evidence nobody
+        re-ran, which is the option #4103 declined.
+
+        The digest is asserted against the control arm rather than a literal:
+        a frozen hash here would pin the posture's *contents*, which is
+        `TestBenchmarkPosture`'s job, and would fail for reasons that have
+        nothing to do with this claim.
+        """
+        worker = "openrouter/z-ai/glm-5.1"
+        author = "openrouter/deepseek/deepseek-v4-pro"
+
+        arm, arm_json, arm_digest = _benchmark_engine_posture(worker, verifier=author)
+        _control, _control_json, control_digest = _benchmark_engine_posture(worker)
+
+        assert arm["pipeline_verifier_model"] == author
+        assert json.loads(arm_json) == arm
+        assert arm_digest != control_digest
+        # Deterministic across calls: a digest that moved between two builds in
+        # one process could never reproduce one recorded a year ago.
+        assert _benchmark_engine_posture(worker, verifier=author)[2] == arm_digest
 
     def test_control_arm_metadata_declares_the_witness_off(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What & why

Closes #4103, by taking a split its three options did not offer — because all
three were written before the arm went inert.

#4103 asked whether the Python mirror `resolve_posture_role_model` should
collapse to match `AgentEngineConfig::model_for`, keep its extra rungs as a
documented exception, or retire the tier. Reading the tree first turned up the
fact that reframes the choice:

**The witness treatment arm cannot fire on this workspace's binary, and nothing
refuses the launch.**

| claim | checked |
|---|---|
| `model_for` takes no role | `crates/stella-cli/src/settings/engine.rs:459` — `agents.default.model` > `default_model` |
| `verifier` is not an engine role | `ENGINE_AGENT_NAMES = ["default"]`; `verifier` is in `RETIRED_ENGINE_AGENT_NAMES` (`settings/unknown.rs`) |
| the pin is recognized-and-ignored | `pipeline_verifier_model` ∈ `RETIRED_ENGINE_ROOT` (`settings/unknown.rs:375`) |
| the guard that caught this is gone | `require_independent_witness`, `witness_author_independence` — **0 hits** in the workspace, deleted with `crates/stella-pipeline` (#3865) |

So `STELLA_WITNESS_AUTHOR_MODEL` moves the digest but reaches no model call: a
witness-on run spends a treatment arm's money on a control arm's configuration
and records it under a treatment arm's digest. That is #1147 exactly, with its
fix deleted.

## The decision, and what it costs

Approved by @macanderson before implementation: **fail closed on new arms, keep
the reader.**

- **Reading stays total.** `resolve_posture_role_model` and
  `assurance_tiers_from_posture` keep every rung, restated as readers of a
  posture *as written* rather than mirrors of a live engine. Every registered
  digest in `READINESS.md` §8.4/§9 and every archived `result.json` re-derives
  byte for byte. `_benchmark_engine_posture(verifier=…)` stays total for the
  same reason — deliberately **not** #3871's `TypeError` shape, because those
  keys the launcher now *refuses* while this one it merely *ignores*, so
  treatment-arm postures still parse and still have digests on record.
- **Launching fails closed.** `refuse_unauthorable_witness_arm` refuses a run
  whose declaration claims a tier this binary cannot author, before a credential
  is selected or a container is touched.

It takes the **resolved declaration**, not a selector, so it covers both
channels — the host-side env knob *and* an overriding `_build_engine_posture`
(#2134's ArenaBench roles config). That is not theoretical: a guard on the env
knob alone would have missed two of the three tests that caught this.

Option 1 was declined for the reason the triage note gives — it re-characterises
recorded runs. Option 3 is where this ends up if an independent author never
returns; it is not taken now because the reading half is still load-bearing for
archived evidence.

## The witness

Behavioral, checked the artisanal way — source reverted, new tests kept:

| tree | result |
|---|---|
| gate unwired | `test_witness_arm_env_knob_refuses_the_run_before_the_container` → **"the refused witness arm reached the container"**; `test_a_harness_roles_config_verifier_is_refused_at_the_launch` → **DID NOT RAISE** |
| this branch | `721 passed, 2 skipped` |

The first failure is the defect itself: the old code shipped a treatment-arm
posture into the container.

## Deleted tests, named as the guard requires

No deletions. Three tests are **rewritten in place**; two change name because
the old name asserted behavior this PR removes:

- `test_witness_arm_reaches_the_container_and_the_trial_metadata` →
  `test_witness_arm_env_knob_refuses_the_run_before_the_container`
- `test_a_harness_roles_config_verifier_puts_the_witness_arm_on` →
  `test_a_harness_roles_config_verifier_is_refused_at_the_launch` — **#2134's
  coverage is preserved**: the refusal can only name the roles-config verifier
  if that channel reached the declaration, so a regression to reading the host
  selector alone still fails this test.
- `test_the_declaration_and_the_posture_name_the_same_verifier` keeps its name
  and its assertions, moved from the run path (now refused) to the reading path,
  where the claim was always really about.

Four new tests: the gate's predicate, the control arm passing it untouched, a
recorded witness-on declaration still reading, and the treatment posture's
digest still re-deriving.

## Documents corrected — three made claims the tree disproves

- **`READINESS.md` §9** cited four Rust guards; **three return zero hits**. The
  load-bearing one,
  `requiring_an_independent_witness_refuses_before_spending_anything`, is what
  the document cited as the reason a witness arm without an independent author
  "produces no number at all" — it had not existed for the whole time that claim
  stood.
- **`evidence/witness-ab/README.md`** said "two things used to block turning it
  on, and both are fixed", inviting a reader to run a preregistered experiment
  whose treatment arm is inert. The protocol, denominator, decision rule and
  preregistration are untouched and stay valid; the third, structural blocker is
  named.
- **`evidence/compare_arms.py`** said turning the rung on is one environment
  variable.

Four dead code citations also corrected in `posture.py`
(`Pipeline::witness_author_independence`, `own_model_spec_for`,
`PipelineConfig::require_independent_witness`, and a Rust test name) — each
grepped to zero hits.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps; **no Rust touched at all**
- [x] No `#[allow]`, no `TODO`, no baseline entry, no skip or `xfail`
- [x] No posture value, arm or digest changed — `file-size` confirms **no
      baseline diff**: the god file `stella_harbor/__init__.py` lands one line
      *under* its 1862 ceiling, with the argument living in the sibling module
      rather than in it
- [x] Guards run: `file-size` OK, `doc-links` OK, `left-behind` OK,
      `no-scratch` OK; `ruff` on the changed files adds zero findings

## Test evidence

`make bench-test`: six of seven suites green (harbor_adapter **721 passed, 2
skipped**; 270 / 10 / 66 / 90 / 27). The seventh, `arenabench tests/test_sut.py`,
fails 5 tests on this machine's `/usr/bin/python3` (3.9, no `tomllib`) — already
tracked as **#4117**, and this diff touches **zero files under `arenabench/`**,
so its code under test is byte-identical to base.

## Nothing left behind

Filed **#4207**: every default trial records `stella_loop_mode:
"staged_pipeline"` for a run that was the bare step loop, since #3865 deleted the
staged pipeline. Same class as this issue, same maintainer-numbers question, so
it is filed rather than folded in.

Closes #4103

## Summary by Sourcery

Refuse unsupported witness treatment-arm launches while preserving historical posture and evidence interpretation.

Bug Fixes:
- Prevent witness treatment-arm runs from executing the control configuration under a treatment-arm digest by refusing unsupported launches before container execution.
- Ensure both environment-based and roles-configuration witness declarations are covered by the launch refusal.

Enhancements:
- Keep posture and assurance readers total so historical witness-on declarations, evidence, and registered digests continue to re-derive unchanged.
- Update benchmark posture logic and diagnostics to distinguish reading recorded declarations from validating what the current engine can launch.

Documentation:
- Correct readiness and witness experiment documentation to identify the treatment arm as unavailable on the current binary and explain the independent-author requirement.

Tests:
- Rewrite witness-arm integration coverage to verify early refusal, preserve control-arm behavior, and retain historical posture and digest readability.

Chores:
- Remove stale references to deleted witness-isolation and role-resolution guards.