### PR TITLE
feat(stella-tui): a tool result wears its call's metal — one event, one rail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -671,7 +671,7 @@ a plan needs and the part that rarely changes:
 | `stella-core` | `src/driver/tests.rs`, `src/driver.rs`, `src/bus.rs` |
 | `stella-model` | `src/openai.rs`, `src/zai/tests.rs`, `src/anthropic/tests.rs` |
 | `stella-store` | `src/tests.rs`, `src/lib.rs`, `src/usage.rs` |
-| `stella-tui` | `src/deck_ui.rs`, `src/views/engine.rs`, `src/views/session.rs`, `src/deck_render.rs` |
+| `stella-tui` | `src/deck_ui.rs`, `src/views/engine.rs`, `src/deck_render.rs` |
 
 The other twenty-one crates carry no god files — keep it that way. Each crate's
 README repeats its own list under "God files — do not add lines", so the

--- a/crates/stella-tui/README.md
+++ b/crates/stella-tui/README.md
@@ -117,15 +117,19 @@ crate's own precedent is the [`src/views/`](src/views) directory — one render
 module per tab, split out of the deck files — so a change that adds rendering
 goes in a `views/` module, not `deck_ui.rs` or `deck_render.rs`; new modal
 key handling goes in a `src/deck_ui/` submodule the way
-[`src/deck_ui/cards.rs`](src/deck_ui/cards.rs) already does. Note that two
-`views/` modules (`engine.rs`, `session.rs`) are themselves grandfathered: a
-split buys headroom, not immunity, so code you touch inside any of these
-files is a candidate to extract.
+[`src/deck_ui/cards.rs`](src/deck_ui/cards.rs) already does. Note that
+[`src/views/engine.rs`](src/views/engine.rs) is itself grandfathered: a split
+buys headroom, not immunity, so code you touch inside any of these files is a
+candidate to extract.
 
 - [`src/deck_render.rs`](src/deck_render.rs)
 - [`src/deck_ui.rs`](src/deck_ui.rs)
 - [`src/views/engine.rs`](src/views/engine.rs)
-- [`src/views/session.rs`](src/views/session.rs)
+
+`src/views/session.rs` left this list in #4127: its incremental transcript fold
+moved to [`src/views/session/fold.rs`](src/views/session/fold.rs), which took it
+under the limit. That is the shape a split is meant to have — a self-contained
+concern leaving, not lines redistributed.
 
 A ceiling can move only via `make file-size-update`, which lands as a
 reviewable baseline diff justified like any other change — treat it as an

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -85,6 +85,11 @@ fn push_body_line(
         push_detail_line(margin, line, width, out);
         return;
     };
+    // The deck's single highlight site, and so where SPEC 6.4's "once when the
+    // event arrives, never per frame" budget is counted. See
+    // [`crate::syntax::lex_count`], and `views::session::fold` for what holds it.
+    #[cfg(test)]
+    syntax::lex_count::bump();
     let mut spans: Vec<Span<'static>> = Vec::new();
     if let Some(gutter) = painted.gutter {
         // The gutter is chrome, not source: it wears the dimmest text tone so
@@ -536,6 +541,7 @@ fn entry_body(
             );
         }
         TranscriptEntry::ToolResult {
+            name,
             ok,
             path,
             full,
@@ -544,7 +550,15 @@ fn entry_body(
             diff,
             ..
         } => {
-            let rail = if *ok { Rail::Result } else { Rail::Fail };
+            // One event, one metal (SPEC 6.2). The head above this row read the
+            // same table, so the block is one unbroken vertical instead of a v2
+            // rail over a v1 body. Failure is the one override — see
+            // [`Rail::Fail`].
+            let rail = if *ok {
+                Rail::Result(crate::v2::transcript_source::head_metal(name))
+            } else {
+                Rail::Fail
+            };
             // Bound once: every row of this result's block reproduces the same
             // margin, and re-deriving it per row is how one of them ends up a
             // cell out of line with the others.
@@ -734,7 +748,7 @@ fn entry_body(
                 let (body, _) =
                     diff::body_lines_inline(d, Some(&dref.path), cap, Some(" · ctrl+o"));
                 for line in body {
-                    push_diff_line(&margin, line, out);
+                    push_diff_line(&margin, line, width, out);
                 }
             }
         }

--- a/crates/stella-tui/src/render/row.rs
+++ b/crates/stella-tui/src/render/row.rs
@@ -13,7 +13,7 @@
 //! glyph names the row's kind, so the margin can be scanned for shape before
 //! anything is read for content.
 
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -27,10 +27,16 @@ use crate::v2::transcript::RAIL_W;
 /// it (`render::tests::block_rail` is what says so): the head of every
 /// call renders through the v2 event renderer (SPEC 6.2) while the result below
 /// it still renders here, and the two must agree on the column or the rail dies
-/// one row into the block — which is exactly what it did. The *metal* is
-/// deliberately not shared: a v2 head wears its event's colour and a result
-/// recedes to [`Rail::style`]'s muted (or danger) tone under it, for the reason
-/// `render::tests::palette` states.
+/// one row into the block — which is exactly what it did.
+///
+/// The *metal* is shared too, as of #4127. It was not: a v2 head wore its
+/// event's colour while the result under it receded to a fixed muted tone, so
+/// the rail changed colour one row into the block it exists to hold together.
+/// SPEC 6.2 makes the rail a property of the **event**, and a call and its
+/// result are one event — the transcript records them as two entries only
+/// because the head has to draw before the result exists. So the metal rides
+/// [`Rail::Result`] from the call's own kind; see [`Rail::style`] and
+/// [`block_margin`], which had already reached this conclusion for body rows.
 pub(crate) const RAIL: &str = " │";
 
 // The rail is two cells wide on both sides of the seam, or every column below
@@ -105,10 +111,21 @@ pub(crate) fn block_margin(metal: Style) -> Vec<Span<'static>> {
 /// outcomes, prose, prompts) before reading any content.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Rail {
-    /// A tool result body, subordinate to the call above it.
-    Result,
+    /// A tool result, in the metal of the **call** above it
+    /// ([`crate::v2::transcript_source::head_metal`]) — one event, one rail.
+    ///
+    /// The colour is carried rather than chosen in [`Rail::style`] for the
+    /// reason [`block_margin`] already gives about body rows: the head is drawn
+    /// by the v2 event renderer and wears its event kind's metal, and this
+    /// function cannot see which tool ran. It applied to the result's own glyph
+    /// row too, and did not reach it — so an `edit_file` block drew a gold rail
+    /// for exactly one row and a fixed muted one for every row beneath (#4127).
+    Result(Color),
     /// A failed tool result. Distinct glyph *and* column-2 position, so a
-    /// failure is findable by margin-scan alone.
+    /// failure is findable by margin-scan alone — and legible with the colour
+    /// switched off, which SPEC 13 requires and a red-only rail would not give.
+    /// The one metal that overrides its call's: a call that failed has stopped
+    /// being the kind of thing its verb claims.
     Fail,
     /// A user prompt — the strongest landmark in the scrollback, since it is
     /// where a reader re-orients when scrolling back.
@@ -122,7 +139,7 @@ impl Rail {
     /// Whether this rail belongs to a tool-call block, and so opens every one
     /// of its rows with [`RAIL`].
     pub(crate) fn railed(self) -> bool {
-        matches!(self, Rail::Result | Rail::Fail)
+        matches!(self, Rail::Result(_) | Rail::Fail)
     }
 
     /// The literal prefix this rail prints before a row's first line.
@@ -132,7 +149,7 @@ impl Rail {
     /// call, its result and its body then share one left edge instead of three.
     pub(crate) fn prefix(self) -> &'static str {
         match self {
-            Rail::Result => " │ ⎿ ",
+            Rail::Result(_) => " │ ⎿ ",
             Rail::Fail => " │ ✗ ",
             Rail::User => "▌ ",
             Rail::Agent => "  ",
@@ -165,7 +182,7 @@ impl Rail {
     /// margin reads consistently even when content colors vary.
     pub(crate) fn style(self) -> Style {
         match self {
-            Rail::Result => Style::new().fg(theme::MUTED),
+            Rail::Result(metal) => Style::new().fg(metal),
             Rail::Fail => Style::new().fg(theme::DANGER),
             Rail::User => Style::new().fg(theme::VIOLET).add_modifier(Modifier::BOLD),
             Rail::Agent => Style::new(),
@@ -461,11 +478,29 @@ pub(crate) fn push_gap(out: &mut Vec<Line<'static>>) {
 /// un-wrapped — the transcript renders without wrap (one logical line per row
 /// keeps the scroll math line-exact), so overflow clips at the pane edge like
 /// the diff viewer, and the line-number gutter never mis-aligns mid-diff.
+///
+/// A tinted row is padded out to `width` so the add/remove ground reads as a
+/// **band** rather than as a shape traced around the ragged end of the code
+/// (SPEC 6.4). The tint is read off the row's own marker cell rather than passed
+/// in, so a renderer that stops tinting stops padding and the two can never
+/// disagree about which rows are changed ones.
+///
+/// SPEC 6.4 words this as `Line.style` carrying the tint while spans keep their
+/// syntax foreground. The deck cannot say it that way: `Line.style` paints the
+/// whole row, including the `margin` prepended here — and that margin is the
+/// **call's** metal, not the hunk's. Padding a trailing span is the same two
+/// layers with the margin left out of the second one (#4195).
 pub(crate) fn push_diff_line(
     margin: &[Span<'static>],
     line: Line<'static>,
+    width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
+    // The marker cell (`+`/`-`/` `) is the first span after the gutter, and the
+    // one that always carries the row's *base* tint — a word-level emphasis span
+    // carries the brighter `*_EMPH` ground instead, so reading the tint off any
+    // old span would pad a changed row in the wrong colour.
+    let tint = line.spans.get(1).and_then(|s| s.style.bg);
     let mut spans = margin.to_vec();
     spans.extend(line.spans);
     // The one row that reaches the buffer without passing through
@@ -473,6 +508,15 @@ pub(crate) fn push_diff_line(
     // tab-indented file's diff would otherwise lose its indentation entirely.
     let mut row = Line::from(spans);
     expand_tabs(&mut row);
+    if let Some(tint) = tint {
+        let used = row.width();
+        if used < width {
+            row.spans.push(Span::styled(
+                " ".repeat(width - used),
+                Style::new().bg(tint),
+            ));
+        }
+    }
     out.push(row);
 }
 

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -27,6 +27,7 @@ use stella_protocol::{
 mod block_rail;
 mod inline_diff;
 mod palette;
+mod result_row;
 mod slash;
 mod thinking;
 mod tool_output;

--- a/crates/stella-tui/src/render/tests/block_rail.rs
+++ b/crates/stella-tui/src/render/tests/block_rail.rs
@@ -224,7 +224,9 @@ fn the_v1_block_rail_is_the_v2_event_rail() {
         expected_rail(),
         "the transcript now draws two different rails"
     );
-    for rail in [Rail::Result, Rail::Fail] {
+    // The metal a result wears is now its call's (SPEC 6.2, #4127), so this is
+    // constructed with one — the margin's *shape* is the same whichever it is.
+    for rail in [Rail::Result(stella_tui_theme::token::GOLD), Rail::Fail] {
         assert!(
             rail.prefix().starts_with(RAIL),
             "{rail:?} opens a block without the rail"

--- a/crates/stella-tui/src/render/tests/palette.rs
+++ b/crates/stella-tui/src/render/tests/palette.rs
@@ -103,13 +103,18 @@ fn user_prompt_entry_is_one_violet_color_end_to_end() {
 /// crimson, calls deep gold, prompts violet — so no raw ANSI cyan/blue/
 /// magenta survives from before the palette landed.
 ///
-/// The margin's colour is itself the hierarchy, in three steps: the `●`
-/// call rail is brand gold because the call *is* the event; the `⎿` result
-/// rail is muted because a successful outcome is that event's consequence,
-/// subordinate chrome rather than a second thing to look at; and the `✗`
-/// fail rail is danger, the one outcome worth interrupting a scan for.
-/// Painting every ✓ as loudly as every ✗ would leave a failure with nothing
-/// to stand out against.
+/// The margin's colour is itself the hierarchy. Since #4127 a call and its
+/// result share one metal, because SPEC 6.2 makes the rail a property of the
+/// **event** and they are two entries of one event — read silver-dim, mutation
+/// gold. What distinguishes the result from the head is its glyph (`⎿`), not a
+/// second colour. The `✗` fail rail is the one override, in danger: it is the
+/// outcome worth interrupting a scan for, and painting every ✓ as loudly would
+/// leave a failure with nothing to stand out against.
+///
+/// This assertion previously read the other way — a successful result receded
+/// to a fixed muted tone under whatever metal its head wore. That is what made
+/// an `edit_file` block draw a gold rail for exactly one row and a silver one
+/// for every row beneath it, which is the defect #4127 is named for.
 #[test]
 fn transcript_prefix_colors_stay_in_the_brand_family() {
     let prefix_fg = |entry: &TranscriptEntry| -> Option<Color> {
@@ -169,9 +174,8 @@ fn transcript_prefix_colors_stay_in_the_brand_family() {
             speculated: false,
             diff: None,
         }),
-        Some(theme::MUTED),
-        "a successful result's rail recedes — it is a continuation of its \
-         call, not a second event competing for the eye",
+        Some(stella_tui_theme::token::MUTED),
+        "a successful result wears its call's metal — one event, one rail",
     );
     assert_eq!(
         prefix_fg(&TranscriptEntry::ToolResult {

--- a/crates/stella-tui/src/render/tests/result_row.rs
+++ b/crates/stella-tui/src/render/tests/result_row.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The tool-result row through SPEC 6 (#4127).
+//!
+//! #4123 routed a call's **head** through the v2 renderer and left the result
+//! on v1, because the result carries four things a fresh v2 renderer had not
+//! been taught — syntax highlighting in the file's own language, word-level
+//! inline diffs, the emitter's line-number gutter, and a truncation notice that
+//! has to agree with the export fold. Those four are pinned by
+//! [`super::tool_output`] and [`super::inline_diff`], which stayed green
+//! through this change and are the evidence that nothing was dropped.
+//!
+//! What is pinned *here* is the half those files do not watch: that the block
+//! is now one event with one rail, and that its body still obeys SPEC 6.4.
+//!
+//! The head's own `ctrl+o` body — the other thing #4123 unwired — is covered by
+//! `block_rail`'s `ctrl_o_on_a_call_reveals_its_arguments` and its two
+//! siblings, which landed in #4169. Nothing here re-tests it.
+
+use super::*;
+use crate::v2::transcript_source as v2;
+use stella_tui_theme::token;
+
+const WIDTH: usize = 100;
+
+fn start(name: &str, path: Option<&str>) -> TranscriptEntry {
+    TranscriptEntry::ToolStart {
+        call_id: "c1".into(),
+        name: name.into(),
+        input: path.unwrap_or("x").into(),
+        raw: "{\"path\":\"src/lib.rs\"}".into(),
+        path: path.map(str::to_owned),
+    }
+}
+
+fn result(name: &str, ok: bool, path: Option<&str>, body: &str) -> TranscriptEntry {
+    TranscriptEntry::ToolResult {
+        call_id: "c1".into(),
+        name: name.into(),
+        path: path.map(str::to_owned),
+        ok,
+        summary: "ok".into(),
+        full: body.into(),
+        duration_ms: 42,
+        speculated: false,
+        diff: None,
+    }
+}
+
+/// Every rendered row of a block, with the foreground its first span carries —
+/// which for a railed row is the rail's own metal.
+fn rail_metals(entries: &[TranscriptEntry], expanded: bool) -> Vec<Color> {
+    let mut out = Vec::new();
+    for entry in entries {
+        entry_lines(
+            entry,
+            EntryView::default(),
+            false,
+            expanded,
+            false,
+            WIDTH,
+            &mut out,
+        );
+    }
+    out.iter()
+        .filter(|l| l.spans.first().is_some_and(|s| s.content.starts_with(" │")))
+        .filter_map(|l| l.spans[0].style.fg)
+        .collect()
+}
+
+/// **The witness.** A mutation's whole block wears one metal.
+///
+/// It did not. The head rendered through v2 and took its event's gold
+/// ([`v2::head_metal`]); the result under it took a fixed muted tone from
+/// `Rail::style`, so an `edit_file` block drew `Rgb(239, 197, 63)` on its first
+/// row and `Rgb(169, 170, 181)` on every row after it — a rail that changed
+/// colour one row into the block it exists to hold together. SPEC 6.2 makes the
+/// rail a property of the *event*, and a call and its result are one event.
+///
+/// Asserted as "one distinct metal, and it is the call's" rather than against a
+/// literal: a regression that repainted both halves the same *wrong* colour
+/// would satisfy the first half alone.
+#[test]
+fn a_mutations_whole_block_wears_one_metal() {
+    let metals = rail_metals(
+        &[
+            start("edit_file", Some("src/lib.rs")),
+            result(
+                "edit_file",
+                true,
+                Some("src/lib.rs"),
+                "applied\nline two\nline three",
+            ),
+        ],
+        false,
+    );
+    assert!(metals.len() >= 4, "the block lost rows: {metals:?}");
+    let distinct: std::collections::BTreeSet<String> =
+        metals.iter().map(|c| format!("{c:?}")).collect();
+    assert_eq!(
+        distinct.len(),
+        1,
+        "the block's rail changes metal partway down: {distinct:?}"
+    );
+    assert_eq!(
+        metals[0],
+        v2::head_metal("edit_file"),
+        "and the metal is the call's own (SPEC 6.2), not a tone picked by the \
+         row that happens to be drawing"
+    );
+}
+
+/// The same, for the other metal — a read is the world coming in, so the whole
+/// block is silver-dim rather than gold.
+///
+/// Kept apart from the mutation case because a renderer that hardcoded gold for
+/// every block would pass that one: the point of SPEC 6.2's table is that the
+/// margin answers *what kind of thing this was* before anything is read.
+#[test]
+fn a_reads_whole_block_wears_the_reading_metal() {
+    let metals = rail_metals(
+        &[
+            start("read_file", Some("src/main.rs")),
+            result(
+                "read_file",
+                true,
+                Some("src/main.rs"),
+                "     1\tfn main() {}",
+            ),
+        ],
+        false,
+    );
+    let distinct: std::collections::BTreeSet<String> =
+        metals.iter().map(|c| format!("{c:?}")).collect();
+    assert_eq!(
+        distinct.len(),
+        1,
+        "a read's block is not one metal: {distinct:?}"
+    );
+    assert_eq!(metals[0], token::MUTED, "a read takes the silver-dim rail");
+    assert_ne!(
+        v2::head_metal("read_file"),
+        v2::head_metal("edit_file"),
+        "the two metals must differ, or the rail says nothing"
+    );
+}
+
+/// A failure overrides its call's metal on every row of the result — and keeps
+/// a glyph, because SPEC 13 will not let colour be the only carrier.
+#[test]
+fn a_failure_overrides_the_metal_and_still_says_so_without_colour() {
+    let mut out = Vec::new();
+    entry_lines(
+        &result(
+            "bash",
+            false,
+            None,
+            "error[E0432]: unresolved import\n  --> src/lib.rs:3:5",
+        ),
+        EntryView::default(),
+        false,
+        false,
+        false,
+        WIDTH,
+        &mut out,
+    );
+    let railed: Vec<_> = out
+        .iter()
+        .filter(|l| l.spans.first().is_some_and(|s| s.content.starts_with(" │")))
+        .collect();
+    assert!(!railed.is_empty(), "the failed result lost its rail");
+    for line in &railed {
+        assert_eq!(
+            line.spans[0].style.fg,
+            Some(theme::DANGER),
+            "a failed result row is not in the danger metal"
+        );
+    }
+    let text: String = railed[0].spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+        text.contains('✗'),
+        "a failure must be legible with the colour switched off: {text:?}"
+    );
+}
+
+// ── SPEC 6.4: the diff body ─────────────────────────────────────────────────
+
+/// A Rust diff renders add and remove rows with everything SPEC 6.4 names: a
+/// dim line-number gutter, a **coloured sign column** (never colour alone), the
+/// language's own syntax foreground, and an add/remove ground.
+///
+/// The rows themselves are `crate::diff`'s and are tested there; what this pins
+/// is that routing the result through v2 did not cost them — which is the
+/// specific loss #4123 refused to take.
+#[test]
+fn a_rust_diff_renders_add_and_remove_rows_per_spec_64() {
+    let diff_text = "@@ -1,2 +1,2 @@\n-let old = 1;\n+let new = 2;\n";
+    let (added, removed) = crate::diff::count_diff_lines(diff_text);
+    let files = vec![FileState {
+        path: "src/x.rs".into(),
+        kind: FileChangeKind::Modified,
+        latest_diff: Some(diff_text.to_string()),
+        added,
+        removed,
+        recent_diffs: [crate::model::RememberedDiff {
+            seq: 1,
+            text: Some(diff_text.to_string()),
+            added,
+            removed,
+        }]
+        .into_iter()
+        .collect(),
+        changes: 1,
+        reads: 0,
+        touched_seq: 1,
+    }];
+    let entry = TranscriptEntry::ToolResult {
+        call_id: "c1".into(),
+        name: "edit_file".into(),
+        path: None,
+        ok: true,
+        summary: "ok".into(),
+        full: "ok".into(),
+        duration_ms: 7,
+        speculated: false,
+        diff: Some(InlineDiffRef {
+            path: "src/x.rs".into(),
+            seq: 1,
+        }),
+    };
+    let mut out = Vec::new();
+    entry_lines(
+        &entry,
+        EntryView::of(&files),
+        false,
+        false,
+        false,
+        WIDTH,
+        &mut out,
+    );
+
+    let ground = |bg: Color| -> Vec<&Line<'static>> {
+        out.iter()
+            .filter(|l| l.spans.iter().any(|s| s.style.bg == Some(bg)))
+            .collect()
+    };
+    let adds = ground(theme::DIFF_ADD_BG);
+    let dels = ground(theme::DIFF_DEL_BG);
+    assert_eq!(adds.len(), 1, "one added row");
+    assert_eq!(dels.len(), 1, "one removed row");
+
+    for (rows, sign, fg) in [(&adds, '+', theme::OK), (&dels, '-', theme::BAD)] {
+        let row = rows[0];
+        // The sign column is mandatory and coloured — colour is never the only
+        // diff signal, so the glyph has to be there when the ground is not
+        // rendered at all (a 16-colour terminal, a piped capture).
+        let marker = row
+            .spans
+            .iter()
+            .find(|s| s.content.trim() == sign.to_string())
+            .unwrap_or_else(|| panic!("no `{sign}` sign column on the row"));
+        assert_eq!(marker.style.fg, Some(fg), "the `{sign}` sign is uncoloured");
+        // The gutter is chrome and stays dim. Found by content rather than by
+        // index: the rail's margin is more than one span, and an index here
+        // would be asserting about whichever cell the margin happens to end on.
+        let gutter = row
+            .spans
+            .iter()
+            .find(|s| s.content.trim() == "1")
+            .unwrap_or_else(|| panic!("no line-number gutter on the `{sign}` row"));
+        assert_eq!(
+            gutter.style.fg,
+            Some(theme::MUTED),
+            "the line-number gutter is not in the dim tone"
+        );
+        // Syntax foreground survives on top of the ground: two layers, per 6.4.
+        assert!(
+            row.spans
+                .iter()
+                .any(|s| s.content == "let" && s.style.fg == Some(theme::SYNTAX_KEYWORD)),
+            "the diff row lost its syntax colouring"
+        );
+    }
+
+    // And the ground is a *band*: it runs to the pane edge rather than tracing
+    // the ragged end of the code. SPEC 6.4 phrases this as `Line.style` holding
+    // the tint; the deck pads a trailing span instead, because a line-level
+    // style would also paint the rail — which is the call's metal, not the
+    // diff's. Same two layers, margin excluded.
+    for (rows, bg) in [(&adds, theme::DIFF_ADD_BG), (&dels, theme::DIFF_DEL_BG)] {
+        assert_eq!(
+            rows[0].width(),
+            WIDTH,
+            "a tinted diff row stops short of the pane edge"
+        );
+        let last = rows[0].spans.last().expect("a trailing span");
+        assert_eq!(last.style.bg, Some(bg), "the band does not reach the edge");
+    }
+
+    // The rail is emphatically NOT tinted — it belongs to the event, not to the
+    // hunk under it.
+    for row in adds.iter().chain(dels.iter()) {
+        assert_eq!(
+            row.spans[0].style.bg, None,
+            "the diff's ground bled onto the block's rail"
+        );
+    }
+}

--- a/crates/stella-tui/src/syntax.rs
+++ b/crates/stella-tui/src/syntax.rs
@@ -63,6 +63,45 @@ impl HighlightSpans for Highlighter {
     }
 }
 
+/// A tally of body lines this crate has actually lexed.
+///
+/// SPEC 6.4 says highlighting happens **once when the event arrives** and is
+/// cached — never once per frame — and the implementation plan names the way to
+/// hold that: "benchmark proving highlight runs once per event (call counter in
+/// tests)". A budget nobody counts is a budget that quietly stops holding, so
+/// the counter is the enforcement rather than a note in a doc comment.
+///
+/// `#[cfg(test)]` on purpose: an atomic bumped once per rendered body line would
+/// be pure cost in a shipped binary, and the rule this pins is about the *shape*
+/// of the render path, which a test observes exactly as well as production. It
+/// is also what AGENTS.md asks for over an `#[allow]` — the compiler, not a
+/// comment, keeps it out of the product.
+#[cfg(test)]
+pub(crate) mod lex_count {
+    use std::cell::Cell;
+
+    thread_local! {
+        static LEXED: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Record one lexed body line. Called from the deck's single highlight
+    /// site, `render::entry::push_body_line`.
+    pub(crate) fn bump() {
+        LEXED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Lines lexed so far **on this thread**. Tests measure a delta across a
+    /// scenario, and thread-local is what makes that delta mean anything:
+    /// `cargo test` runs the suite in one process across many threads, so a
+    /// shared counter reports whatever else happened to be rendering at the same
+    /// moment. As a process-global atomic it read `40` for ten frames against
+    /// `56` for one — a measurement that moved with the scheduler, which is
+    /// worse than no measurement.
+    pub(crate) fn snapshot() -> usize {
+        LEXED.with(Cell::get)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -15,17 +15,21 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Range;
 
 use crate::deck::{AgentEntry, WorkspaceModel};
 use crate::deck_ui::DeckUi;
-use crate::model::{FileState, TranscriptEntry};
+use crate::model::TranscriptEntry;
 use crate::render::{
-    EntryView, entry_lines, inner_height, inner_width, reasoning_is_live, render_ask_user,
-    render_hud, render_transcript_window, streaming_lines,
+    inner_height, inner_width, render_ask_user, render_hud, render_transcript_window,
 };
 use crate::theme;
 use crate::transcript_nav::TurnDigest;
+
+// The incremental transcript fold. Split out in #4127, which took this file
+// under the god-file limit it had been grandfathered against — the fold reads
+// `FoldPlan` and `digest_line` below and nothing else here.
+mod fold;
+pub use fold::SessionFold;
 
 /// Which turns render as a one-line digest this frame, and which entries that
 /// hides.
@@ -128,201 +132,6 @@ fn digest_line(d: &TurnDigest, folded: bool, width: usize) -> Vec<Line<'static>>
     )];
     spans.extend(crate::render::justify(left, metric, width, 2));
     vec![Line::from(spans)]
-}
-
-/// Everything the settled prefix was folded under. Any change invalidates it,
-/// so each term is a thing that can silently alter an already-rendered row:
-/// the agent, thinking/expand-all overlays and their revision, the pane width,
-/// how many entries have been evicted off the front, the file-mutation count
-/// (an inline diff can go stale without anything being appended), the set of
-/// folded turns (which changes on its own when a turn finishes under the
-/// fold-all overlay), and how many leading entries have moved into the
-/// terminal's scrollback (accessible mode — those must stop being drawn).
-type FoldKey = (String, bool, bool, u64, usize, usize, u64, u64, usize);
-
-/// Incremental transcript fold for the Session tab.
-///
-/// Everything before the last entry is *settled* — streaming deltas only ever
-/// mutate the final entry — so settled entries fold (markdown, labels, wrap)
-/// exactly once and are cached with their visual-row ranges; only the tail
-/// entry re-folds per frame. The cache invalidates whole when anything that
-/// changes how settled entries render changes: focused agent, the thinking
-/// toggle, a ctrl+o expansion, the pane width, or the retention cap evicting
-/// a chunk of the front (which shifts every retained index). This turns the
-/// old O(whole-history) fold per frame into O(tail) — typing latency no
-/// longer grows with session length.
-#[derive(Debug, Clone, Default)]
-pub struct SessionFold {
-    key: Option<FoldKey>,
-    settled: usize,
-    prefix: Vec<Line<'static>>,
-    entry_rows: Vec<Range<usize>>,
-    tail: Vec<Line<'static>>,
-}
-
-impl SessionFold {
-    /// Bring the cache up to date for this frame. `expand_all` is the
-    /// no-selection ctrl+o overlay: every expandable entry folds as if
-    /// individually expanded (it participates in the cache key, so toggling
-    /// it invalidates exactly once).
-    /// `streaming` is the in-flight `TextDelta` preview
-    /// ([`SessionModel::streaming_text`](crate::model::SessionModel)): folded
-    /// into the live tail after the last entry, so it re-wraps per frame
-    /// like the tail does and vanishes without residue when the
-    /// authoritative `Text` clears it — never a settled entry.
-    #[allow(clippy::too_many_arguments)] // mirrors the fold's inputs one to one; a struct would just add a second shape
-    fn refresh(
-        &mut self,
-        agent: &str,
-        transcript: &[TranscriptEntry],
-        files: &[FileState],
-        streaming: &str,
-        thinking: bool,
-        expanded: &HashSet<usize>,
-        expand_all: bool,
-        expanded_rev: u64,
-        width: usize,
-        plan: &FoldPlan,
-        flushed: usize,
-    ) {
-        // Front-eviction shifts every retained index, so the settled prefix
-        // no longer describes the entries now occupying 0..settled. The
-        // marker's cumulative count grows on every pass, so keying on it
-        // invalidates exactly when the front moves — the shrink check alone
-        // misses an eviction whose survivors still outnumber `settled`.
-        let evicted = match transcript.first() {
-            Some(TranscriptEntry::Evicted { count }) => *count,
-            _ => 0,
-        };
-        // A settled tool result's inline diff resolves against `files` at
-        // fold time, and a later mutation can stale it (freshness gate in
-        // `entry_lines`) without appending anything — the total mutation
-        // count is the only fingerprint that moves, so it keys the cache.
-        let file_gen: u64 = files.iter().map(|f| u64::from(f.changes)).sum();
-        let key = (
-            agent.to_string(),
-            thinking,
-            expand_all,
-            expanded_rev,
-            width,
-            evicted,
-            file_gen,
-            plan.signature,
-            flushed,
-        );
-        // Invalidation CLEARS the key; the commit happens after the fold loop
-        // below. A panic inside `entry_lines` would otherwise leave `prefix`
-        // extended with no matching `entry_rows` range and no `settled` bump,
-        // and the next frame — key still matching — would resume at the same
-        // index and double-append. With the commit moved after the loop, a
-        // caught panic leaves `key = None` and the cache rebuilds from zero
-        // (see `crate::panel_guard` for why that matters).
-        if self.key.as_ref() != Some(&key) || self.settled > transcript.len().saturating_sub(1) {
-            self.key = None;
-            self.settled = 0;
-            self.prefix.clear();
-            self.entry_rows.clear();
-        }
-        let target = transcript.len().saturating_sub(1);
-        while self.settled < target {
-            let i = self.settled;
-            let start = self.prefix.len();
-            if i < flushed {
-                // Already ordinary terminal output above this pane
-                // (`accessible::Scrollback`). Drawing it again would have a
-                // reader hear the conversation twice — once as it arrived in
-                // scrollback, once as part of a pane that repaints. It still
-                // gets a (zero-width) row range so every index-keyed
-                // affordance — selection, search, scroll-into-view — stays
-                // aligned with the transcript rather than shifting by
-                // however much has been flushed.
-                self.entry_rows.push(start..start);
-                self.settled += 1;
-                continue;
-            }
-            if let Some(d) = plan.digests.get(&i) {
-                self.prefix.extend(digest_line(d, true, width));
-            } else if plan.hides(i) {
-                // Swallowed by the turn above. It still gets a row range —
-                // the digest's — so that selecting, scrolling to, or
-                // searching a hidden entry lands on the line standing in for
-                // it rather than on nothing.
-                let digest_rows = self
-                    .entry_rows
-                    .iter()
-                    .rev()
-                    .find(|r| !r.is_empty())
-                    .cloned()
-                    .unwrap_or(start..start);
-                self.entry_rows.push(digest_rows);
-                self.settled += 1;
-                continue;
-            } else {
-                entry_lines(
-                    &transcript[i],
-                    EntryView::at(files, transcript, i),
-                    thinking,
-                    expand_all || expanded.contains(&i),
-                    false,
-                    width,
-                    &mut self.prefix,
-                );
-            }
-            // The tearing window: `prefix` is extended, `entry_rows` is not.
-            #[cfg(test)]
-            crate::panel_guard::fail_if_armed("session fold");
-            self.entry_rows.push(start..self.prefix.len());
-            self.settled += 1;
-        }
-        self.key = Some(key);
-        self.tail.clear();
-        if let Some(last) = transcript.last() {
-            // The tail obeys the same plan: a last entry inside a folded turn
-            // must not reappear below the digest that already stands for it.
-            if let Some(d) = plan.digests.get(&target) {
-                self.tail.extend(digest_line(d, true, width));
-            } else if !plan.hides(target) {
-                entry_lines(
-                    last,
-                    EntryView::at(files, transcript, target),
-                    thinking,
-                    expand_all || expanded.contains(&target),
-                    reasoning_is_live(transcript, streaming),
-                    width,
-                    &mut self.tail,
-                );
-            }
-        }
-        streaming_lines(streaming, files, thinking, width, &mut self.tail);
-    }
-
-    /// Total visual rows (settled prefix + live tail).
-    pub fn total(&self) -> usize {
-        self.prefix.len() + self.tail.len()
-    }
-
-    /// The visual-row range entry `idx` occupies (the live tail entry spans
-    /// everything past the prefix).
-    pub fn rows_of(&self, idx: usize) -> Range<usize> {
-        if idx < self.entry_rows.len() {
-            self.entry_rows[idx].clone()
-        } else {
-            self.prefix.len()..self.total()
-        }
-    }
-
-    /// Materialize just the rows in `window` — ≤ one viewport of clones.
-    fn window_lines(&self, window: Range<usize>) -> Vec<Line<'static>> {
-        window
-            .filter_map(|r| {
-                if r < self.prefix.len() {
-                    self.prefix.get(r).cloned()
-                } else {
-                    self.tail.get(r - self.prefix.len()).cloned()
-                }
-            })
-            .collect()
-    }
 }
 
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
@@ -666,7 +475,7 @@ mod fold_backfill;
 mod tests {
     use super::*;
     use crate::envelope::{AgentMeta, Inbound};
-    use crate::model::{MAX_TRANSCRIPT_ENTRIES, SessionModel};
+    use crate::model::{FileState, MAX_TRANSCRIPT_ENTRIES, SessionModel};
     use stella_protocol::{AgentEvent, ScopeProposal, TaskItem, TaskStatus};
 
     /// Flatten a `Buffer` to plain text (content, not ANSI — the crate-wide

--- a/crates/stella-tui/src/views/session/fold.rs
+++ b/crates/stella-tui/src/views/session/fold.rs
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The Session tab's incremental transcript fold.
+//!
+//! Split out of [`super`] rather than grown there: `views/session.rs` is one of
+//! the crate's grandfathered god files and is closed to new lines (AGENTS.md
+//! § God files), and the fold is a self-contained concern — it turns a
+//! transcript plus a set of view flags into `Line`s and their row ranges, and
+//! touches no `Frame`, no layout and no key routing. A pure move, plus the tail
+//! cache described on [`SessionFold::tail`].
+
+use std::collections::HashSet;
+use std::ops::Range;
+
+use ratatui::text::Line;
+
+use crate::model::{FileState, TranscriptEntry};
+use crate::render::{EntryView, entry_lines, reasoning_is_live, streaming_lines};
+
+use super::{FoldPlan, digest_line};
+
+/// Everything the settled prefix was folded under. Any change invalidates it,
+/// so each term is a thing that can silently alter an already-rendered row:
+/// the agent, thinking/expand-all overlays and their revision, the pane width,
+/// how many entries have been evicted off the front, the file-mutation count
+/// (an inline diff can go stale without anything being appended), the set of
+/// folded turns (which changes on its own when a turn finishes under the
+/// fold-all overlay), and how many leading entries have moved into the
+/// terminal's scrollback (accessible mode — those must stop being drawn).
+type FoldKey = (String, bool, bool, u64, usize, usize, u64, u64, usize);
+
+/// Incremental transcript fold for the Session tab.
+///
+/// Everything before the last entry is *settled* — streaming deltas only ever
+/// mutate the final entry — so settled entries fold (markdown, labels, wrap)
+/// exactly once and are cached with their visual-row ranges; only the tail
+/// entry re-folds per frame. The cache invalidates whole when anything that
+/// changes how settled entries render changes: focused agent, the thinking
+/// toggle, a ctrl+o expansion, the pane width, or the retention cap evicting
+/// a chunk of the front (which shifts every retained index). This turns the
+/// old O(whole-history) fold per frame into O(tail) — typing latency no
+/// longer grows with session length.
+#[derive(Debug, Clone, Default)]
+pub struct SessionFold {
+    // Visible to `super`'s tests, which assert the cache's tearing and eviction
+    // behaviour on the fields themselves rather than through a rendered frame —
+    // the states they pin (a half-extended prefix, a cleared key) are by
+    // definition ones no frame ever draws.
+    pub(super) key: Option<FoldKey>,
+    settled: usize,
+    pub(super) prefix: Vec<Line<'static>>,
+    pub(super) entry_rows: Vec<Range<usize>>,
+    /// The last entry's rows, plus the streaming preview under them.
+    ///
+    /// Re-folded per frame *unless* [`Self::tail_key`] says the last entry
+    /// cannot have changed since the previous frame — see [`rewritable`] for
+    /// what makes that answerable.
+    tail: Vec<Line<'static>>,
+    /// How many of [`Self::tail`]'s leading rows belong to the entry rather than
+    /// to the streaming preview appended after it. The preview re-folds every
+    /// frame (it is a live buffer by definition); the entry's rows above it are
+    /// what the cache keeps.
+    tail_entry_rows: usize,
+    /// The fold key and entry index [`Self::tail`]'s entry rows were built
+    /// under, when they are reusable at all. `None` re-folds — either nothing is
+    /// cached, or the tail is an entry the model can still rewrite.
+    tail_key: Option<(FoldKey, usize)>,
+}
+
+/// Whether the model can still rewrite `entry` in place, and so whether its
+/// folded rows may be cached across frames.
+///
+/// Exactly two kinds can be: [`TranscriptEntry::Text`] and
+/// [`TranscriptEntry::Reasoning`] coalesce streaming deltas into a buffer they
+/// already pushed (`SessionModel`'s `push_text`, `push_reasoning`, and
+/// `push_progress_line`, which rewrites a region of the last `Text`). Those are
+/// the only three `last_mut()` call sites in the model; every other entry is
+/// pushed whole and never touched again — front eviction moves indices, which
+/// the `evicted` term of [`FoldKey`] already invalidates on.
+///
+/// That asymmetry is the whole cache. A [`TranscriptEntry::ToolResult`] is
+/// immutable once folded *and* is the expensive entry — SPEC 6.4 wants its body
+/// syntax-highlighted once when the event arrives, and while it sat in the live
+/// tail it was re-lexed on every single frame instead. Keying on a content hash
+/// or a length would be guessing at mutation; keying on "this kind cannot
+/// mutate" is a property of the model, which is why this is a predicate over
+/// kinds rather than a fingerprint over content.
+fn rewritable(entry: &TranscriptEntry) -> bool {
+    matches!(
+        entry,
+        TranscriptEntry::Text(_) | TranscriptEntry::Reasoning(_)
+    )
+}
+
+impl SessionFold {
+    /// Bring the cache up to date for this frame. `expand_all` is the
+    /// no-selection ctrl+o overlay: every expandable entry folds as if
+    /// individually expanded (it participates in the cache key, so toggling
+    /// it invalidates exactly once).
+    /// `streaming` is the in-flight `TextDelta` preview
+    /// ([`SessionModel::streaming_text`](crate::model::SessionModel)): folded
+    /// into the live tail after the last entry, so it re-wraps per frame
+    /// like the tail does and vanishes without residue when the
+    /// authoritative `Text` clears it — never a settled entry.
+    #[allow(clippy::too_many_arguments)] // mirrors the fold's inputs one to one; a struct would just add a second shape
+    pub(super) fn refresh(
+        &mut self,
+        agent: &str,
+        transcript: &[TranscriptEntry],
+        files: &[FileState],
+        streaming: &str,
+        thinking: bool,
+        expanded: &HashSet<usize>,
+        expand_all: bool,
+        expanded_rev: u64,
+        width: usize,
+        plan: &FoldPlan,
+        flushed: usize,
+    ) {
+        // Front-eviction shifts every retained index, so the settled prefix
+        // no longer describes the entries now occupying 0..settled. The
+        // marker's cumulative count grows on every pass, so keying on it
+        // invalidates exactly when the front moves — the shrink check alone
+        // misses an eviction whose survivors still outnumber `settled`.
+        let evicted = match transcript.first() {
+            Some(TranscriptEntry::Evicted { count }) => *count,
+            _ => 0,
+        };
+        // A settled tool result's inline diff resolves against `files` at
+        // fold time, and a later mutation can stale it (freshness gate in
+        // `entry_lines`) without appending anything — the total mutation
+        // count is the only fingerprint that moves, so it keys the cache.
+        let file_gen: u64 = files.iter().map(|f| u64::from(f.changes)).sum();
+        let key = (
+            agent.to_string(),
+            thinking,
+            expand_all,
+            expanded_rev,
+            width,
+            evicted,
+            file_gen,
+            plan.signature,
+            flushed,
+        );
+        // Invalidation CLEARS the key; the commit happens after the fold loop
+        // below. A panic inside `entry_lines` would otherwise leave `prefix`
+        // extended with no matching `entry_rows` range and no `settled` bump,
+        // and the next frame — key still matching — would resume at the same
+        // index and double-append. With the commit moved after the loop, a
+        // caught panic leaves `key = None` and the cache rebuilds from zero
+        // (see `crate::panel_guard` for why that matters).
+        if self.key.as_ref() != Some(&key) || self.settled > transcript.len().saturating_sub(1) {
+            self.key = None;
+            self.settled = 0;
+            self.prefix.clear();
+            self.entry_rows.clear();
+        }
+        let target = transcript.len().saturating_sub(1);
+        while self.settled < target {
+            let i = self.settled;
+            let start = self.prefix.len();
+            if i < flushed {
+                // Already ordinary terminal output above this pane
+                // (`accessible::Scrollback`). Drawing it again would have a
+                // reader hear the conversation twice — once as it arrived in
+                // scrollback, once as part of a pane that repaints. It still
+                // gets a (zero-width) row range so every index-keyed
+                // affordance — selection, search, scroll-into-view — stays
+                // aligned with the transcript rather than shifting by
+                // however much has been flushed.
+                self.entry_rows.push(start..start);
+                self.settled += 1;
+                continue;
+            }
+            if let Some(d) = plan.digests.get(&i) {
+                self.prefix.extend(digest_line(d, true, width));
+            } else if plan.hides(i) {
+                // Swallowed by the turn above. It still gets a row range —
+                // the digest's — so that selecting, scrolling to, or
+                // searching a hidden entry lands on the line standing in for
+                // it rather than on nothing.
+                let digest_rows = self
+                    .entry_rows
+                    .iter()
+                    .rev()
+                    .find(|r| !r.is_empty())
+                    .cloned()
+                    .unwrap_or(start..start);
+                self.entry_rows.push(digest_rows);
+                self.settled += 1;
+                continue;
+            } else {
+                entry_lines(
+                    &transcript[i],
+                    EntryView::at(files, transcript, i),
+                    thinking,
+                    expand_all || expanded.contains(&i),
+                    false,
+                    width,
+                    &mut self.prefix,
+                );
+            }
+            // The tearing window: `prefix` is extended, `entry_rows` is not.
+            #[cfg(test)]
+            crate::panel_guard::fail_if_armed("session fold");
+            self.entry_rows.push(start..self.prefix.len());
+            self.settled += 1;
+        }
+        // The tail entry's own rows, kept from the previous frame when nothing
+        // about them can have changed. `key` covers every view input; `target`
+        // covers a new entry arriving; [`rewritable`] covers the entry being
+        // rewritten under us. A tail that is `Text` or `Reasoning` is never
+        // cached and re-folds exactly as it always did — it is a live buffer,
+        // and it is also the cheap one.
+        //
+        // SPEC 6.4 asks that a body be highlighted once when its event arrives
+        // and never per frame. Settled entries already were; the tail was not,
+        // so a `read_file` result — the entry whose whole body is lexed — paid
+        // to re-lex it on every repaint for as long as it was the newest thing
+        // on screen. `crate::syntax::lex_count` is what holds this now.
+        let tail_key = transcript
+            .last()
+            .is_some_and(|last| !rewritable(last))
+            .then(|| (key.clone(), target));
+        self.key = Some(key);
+        let reuse = tail_key.is_some() && self.tail_key == tail_key;
+        if reuse {
+            self.tail.truncate(self.tail_entry_rows);
+        } else {
+            self.tail.clear();
+            if let Some(last) = transcript.last() {
+                // The tail obeys the same plan: a last entry inside a folded turn
+                // must not reappear below the digest that already stands for it.
+                if let Some(d) = plan.digests.get(&target) {
+                    self.tail.extend(digest_line(d, true, width));
+                } else if !plan.hides(target) {
+                    entry_lines(
+                        last,
+                        EntryView::at(files, transcript, target),
+                        thinking,
+                        expand_all || expanded.contains(&target),
+                        reasoning_is_live(transcript, streaming),
+                        width,
+                        &mut self.tail,
+                    );
+                }
+            }
+            self.tail_entry_rows = self.tail.len();
+            self.tail_key = tail_key;
+        }
+        streaming_lines(streaming, files, thinking, width, &mut self.tail);
+    }
+
+    /// Total visual rows (settled prefix + live tail).
+    pub fn total(&self) -> usize {
+        self.prefix.len() + self.tail.len()
+    }
+
+    /// The visual-row range entry `idx` occupies (the live tail entry spans
+    /// everything past the prefix).
+    pub fn rows_of(&self, idx: usize) -> Range<usize> {
+        if idx < self.entry_rows.len() {
+            self.entry_rows[idx].clone()
+        } else {
+            self.prefix.len()..self.total()
+        }
+    }
+
+    /// Materialize just the rows in `window` — ≤ one viewport of clones.
+    pub(super) fn window_lines(&self, window: Range<usize>) -> Vec<Line<'static>> {
+        window
+            .filter_map(|r| {
+                if r < self.prefix.len() {
+                    self.prefix.get(r).cloned()
+                } else {
+                    self.tail.get(r - self.prefix.len()).cloned()
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::SessionModel;
+    use crate::syntax::lex_count;
+
+    /// A `read_file` result whose body is a numbered Rust listing — the entry
+    /// SPEC 6.4's budget is about, since every line of it is lexed.
+    fn read_result(lines: usize) -> TranscriptEntry {
+        let body: String = (1..=lines)
+            .map(|i| format!("{i:>6}\tlet x{i} = {i};\n"))
+            .collect();
+        TranscriptEntry::ToolResult {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            path: Some("src/lib.rs".into()),
+            ok: true,
+            summary: "ok".into(),
+            full: body,
+            duration_ms: 7,
+            speculated: false,
+            diff: None,
+        }
+    }
+
+    fn refresh(fold: &mut SessionFold, transcript: &[TranscriptEntry], streaming: &str) {
+        fold.refresh(
+            "lead",
+            transcript,
+            &[],
+            streaming,
+            false,
+            &HashSet::new(),
+            true,
+            0,
+            100,
+            &FoldPlan::default(),
+            0,
+        );
+    }
+
+    /// Fold `transcript` `frames` times the way the Session tab does, and
+    /// report how many body lines were lexed doing it.
+    fn lexed_over(transcript: &[TranscriptEntry], frames: usize) -> usize {
+        let mut fold = SessionFold::default();
+        let before = lex_count::snapshot();
+        for _ in 0..frames {
+            refresh(&mut fold, transcript, "");
+        }
+        lex_count::snapshot() - before
+    }
+
+    fn text_of(fold: &SessionFold) -> String {
+        fold.window_lines(0..fold.total())
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// **The SPEC 6.4 budget, as a counter.**
+    ///
+    /// "Highlight once when the event arrives, cache `Vec<Line<'static>>`.
+    /// Never highlight per frame." Settled entries always honoured that — they
+    /// fold once into `prefix` and are never revisited. The **tail** did not:
+    /// `refresh` cleared it and re-folded the last entry on every frame, so the
+    /// newest tool result — the one a reader is actually watching — paid to
+    /// re-lex its whole body on every repaint, for as long as it stayed the
+    /// newest thing on screen.
+    ///
+    /// Measured as a ratio rather than an absolute, so the test says nothing
+    /// about how many lines a preview happens to show: ten frames of an
+    /// unchanged transcript must lex exactly what one frame lexes. On the old
+    /// code this was ten times as many.
+    #[test]
+    fn an_unchanged_tail_is_highlighted_once_not_once_per_frame() {
+        let transcript = [read_result(40)];
+        let one = lexed_over(&transcript, 1);
+        assert!(one > 0, "the fixture lexed nothing, so this proves nothing");
+        let ten = lexed_over(&transcript, 10);
+        assert_eq!(
+            ten, one,
+            "ten frames of an unchanged transcript lexed {ten} lines where one \
+             frame lexed {one} — the live tail is being highlighted per frame \
+             again (SPEC 6.4)"
+        );
+    }
+
+    /// The cache is not a freeze: a new entry re-folds the tail, and the one it
+    /// displaced settles into the prefix rather than vanishing.
+    #[test]
+    fn a_new_entry_still_reaches_the_frame() {
+        let mut fold = SessionFold::default();
+        let mut transcript = vec![read_result(4)];
+        refresh(&mut fold, &transcript, "");
+        let first = fold.total();
+        transcript.push(read_result(4));
+        refresh(&mut fold, &transcript, "");
+        assert!(
+            fold.total() > first,
+            "a second result did not reach the frame: {} rows",
+            fold.total()
+        );
+    }
+
+    /// The streaming preview still re-folds under a cached tail.
+    ///
+    /// It rides *after* the tail entry's rows and is a live buffer by
+    /// definition, so reusing the entry's rows must not take the preview with
+    /// them — which is what `tail_entry_rows` exists to keep apart.
+    #[test]
+    fn a_cached_tail_still_refolds_the_streaming_preview_under_it() {
+        let mut fold = SessionFold::default();
+        let transcript = [read_result(4)];
+        refresh(&mut fold, &transcript, "first draft");
+        assert!(text_of(&fold).contains("first draft"));
+        refresh(&mut fold, &transcript, "second draft");
+        let text = text_of(&fold);
+        assert!(
+            text.contains("second draft"),
+            "the preview froze under a cached tail:\n{text}"
+        );
+        assert!(
+            !text.contains("first draft"),
+            "the previous preview was never cleared:\n{text}"
+        );
+    }
+
+    /// A tail the model **can** rewrite is never cached.
+    ///
+    /// `Text` and `Reasoning` coalesce streaming deltas into a buffer they
+    /// already pushed, so their rows change without the transcript's length or
+    /// any view flag moving. Caching one would freeze a streaming answer on its
+    /// first delta — the worst thing this optimisation could do, and the reason
+    /// [`rewritable`] is a statement about the model rather than a hash of the
+    /// content.
+    #[test]
+    fn a_streaming_answer_is_never_frozen_by_the_cache() {
+        let mut model = SessionModel::default();
+        let mut fold = SessionFold::default();
+        for delta in ["first", " second", " third"] {
+            model.apply(&stella_protocol::AgentEvent::Text { text: delta.into() });
+            refresh(&mut fold, &model.transcript, "");
+        }
+        let text = text_of(&fold);
+        assert!(
+            text.contains("third"),
+            "the streaming answer froze on an earlier delta:\n{text}"
+        );
+    }
+}

--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -29,4 +29,3 @@
 1518 crates/stella-tui/src/deck_render.rs
 3991 crates/stella-tui/src/deck_ui.rs
 1599 crates/stella-tui/src/views/engine.rs
-1587 crates/stella-tui/src/views/session.rs


### PR DESCRIPTION
Supersedes #4198, which was cut before thirteen commits landed on `main` — several of them in this exact code. That PR conflicted, and a conflicting PR has no merge ref, so GitHub started **no** `pull_request` workflows for it at all: its only checks were Vercel (which fails on every PR here) and a skipped CLA. This branch is the same work rebuilt on the current `main`, and it is deliberately **smaller**, because main had independently landed part of it.

## What

SPEC 6.2 makes the rail a property of the **event**, and a call and its result are one event — the deck records them as two entries only because the head has to draw before the result exists. The head has rendered through v2 since #4123; the result under it took a fixed muted tone:

```
 │ ● edit src/lib.rs                          ← Rgb(239, 197, 63)  gold
 │ ⎿ applied                            42ms  ← Rgb(169, 170, 181) silver
 │   line two                                 ← silver
```

Measured, not inferred — those are the colours the renderer actually produced.

`row::block_margin` had already reached this conclusion and says so in its own doc ("one block, two metals, which is exactly the thing the rail exists to stop"), but it governs only *body* rows. The result's own glyph row never got the memo. `Rail::Result` now carries the metal, read from `v2::head_metal` — the same table the head reads.

## Why not a second renderer

The result row carries syntax highlighting in the file's own language (#4019, #4036), word-level inline diffs, the emitter's line-number gutter (#4020), and a truncation notice that has to agree with the export and Observatory fold (#3644). #4123 left it on v1 rather than lose them, and its attempt at a fresh v2 renderer turned 16 tests red for exactly that reason.

**Every test in `render/tests/tool_output.rs` and `render/tests/inline_diff.rs` stayed green and untouched.** Those are the files the issue named as the guard, and that is the evidence nothing was dropped.

## Witnesses

Each was confirmed to fail by reverting the production change and keeping the test.

| Test | Fails on old code because |
|---|---|
| `a_mutations_whole_block_wears_one_metal` | the result rail was a fixed muted tone under a gold head |
| `a_reads_whole_block_wears_the_reading_metal` | same, and it pins that the two metals differ |
| `a_rust_diff_renders_add_and_remove_rows_per_spec_64` | the tinted row is 23 columns wide in a 100-column pane |
| `an_unchanged_tail_is_highlighted_once_not_once_per_frame` | ten frames lexed ten times what one frame lexed |

Three more are regression guards and pass both ways, which is what they are for: the failure metal, a new entry still reaching the frame, and the streaming preview re-folding under a cached tail.

## The other two halves of SPEC 6.4

**A diff's ground is a band, not a shape traced around the code.** 6.4 words this as `Line.style` carrying the tint. The deck cannot say it that way: `Line.style` paints the whole row including the margin `push_diff_line` prepends, and that margin is the call's metal, not the hunk's. A padded trailing span is the same two layers with the margin left out of the second one. Filed as #4195 so the next surface to implement 6.4 does not fall in.

**Highlighting runs once per event.** Settled entries always did; the live tail did not — `refresh` cleared it and re-folded the last entry every frame, so the newest tool result re-lexed its whole body on every repaint. The tail's rows are now kept when the entry is one the model cannot rewrite in place. That predicate is exact rather than a fingerprint: `Text` and `Reasoning` are the only kinds reachable from the three `last_mut()` sites in `model.rs`, so every other kind — `ToolResult` above all — is immutable once pushed.

`syntax::lex_count` is thread-local, and that is load-bearing: as a process-global atomic it read 40 for ten frames against 56 for one, because the rest of the suite was rendering on other threads. A measurement that moves with the scheduler is worse than none.

## God-file ledger

`SessionFold` moved to `views/session/fold.rs` so the cache did not grow a god file — and the split took `views/session.rs` from 1575 to 1382 lines, under the 1500 limit. It therefore leaves `scripts/file-size-baseline.txt`, AGENTS.md's per-crate table and the crate README, as `god-files` requires. The baseline entry was removed **by hand** rather than by `make file-size-update`, deliberately: a full regeneration retightens every unrelated ceiling, which is the shared-cell shape that has reddened `main` before.

## What main had already done, and this PR therefore does not

- **#4169 restored `ctrl+o` on a call row.** I had independently fixed the same regression and written a test for it; both are dropped here. `block_rail`'s `ctrl_o_on_a_call_reveals_its_arguments` and its two siblings cover it, and the test module says so rather than re-testing it.
- **`head_metal` already existed**, so this uses it instead of adding a second name for the same mapping.
- I had also extracted the tool block into `render/entry/tool.rs`. Dropped: main's `entry.rs` is 1203 lines, under the limit, so the extraction was optional polish and pure conflict surface against a fast-moving file.

## Deleted tests

None. One **changed contract**, named as the issue asks: in `render/tests/palette.rs`, `transcript_prefix_colors_stay_in_the_brand_family` asserted that a successful result's rail *recedes* to a fixed muted tone under whatever metal its head wore. That assertion described the defect. It now reads the call's own metal, with the old reasoning replaced rather than deleted.

## Not done, tracked

- `tool_class::classify` has **zero** production callers — the v1 call row was its only one, and `dead_code` cannot see it (`pub` in a `pub mod`). Reported on #4125, which owns that decision; nothing changed here.
- The v2 head still renders a path in one flat tone — already tracked as #4168.

## Verification

`make gate CARGO_SCOPE="-p stella-tui"` green (902 tests), `cargo test --workspace` green.

Closes #4127

## Summary by Sourcery

Align tool-result rendering with the event-based rail and highlighting rules while preserving diff presentation and reducing session folding overhead.

Bug Fixes:
- Make successful tool-result rails inherit the originating call's metal while preserving a distinct danger rail for failures.
- Ensure inline diff rows render full-width tinted bands without losing syntax highlighting, gutters, or accessible add/remove markers.
- Cache immutable tool-result tails so syntax highlighting runs once per event instead of on every frame.

Enhancements:
- Move the session transcript fold into a dedicated module to keep the session view below its god-file size limit.

Documentation:
- Update stella-tui god-file documentation and crate guidance to reflect the extracted session fold.

Tests:
- Add regression coverage for event-consistent result rails, failure visibility, full-width diff bands, and one-time highlighting across frames.