### PR TITLE
docs: retire the deleted staged pipeline from docs/spec and docs/design; ship stella.example.toml and fix two config-vocabulary bugs

### DIFF
--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -37,7 +37,8 @@
 //! the same discipline `stella-protocol`'s event-consumer table uses (`E0004`
 //! over a red test) — the answer may be "nothing", but it may not be silence.
 
-use super::unknown::{PROVIDER_FIELDS, ROOT_FIELDS};
+use super::toml_config::TomlConfig;
+use super::unknown::{PROVIDER_FIELDS, ROOT_FIELDS, TOML_ROOT_FIELDS};
 use super::*;
 
 /// What the three-scope merge is expected to do with one field.
@@ -499,4 +500,95 @@ fn the_unknown_key_vocabulary_matches_the_structs() {
         provider_ledger(&ProviderSettings::default()),
         PROVIDER_FIELDS,
     );
+}
+
+/// Every root section of `stella.toml` is in the TOML vocabulary, and nothing
+/// else is.
+///
+/// The module docs name four edits a settings key needs, and until now this
+/// file compile-enforced three of them: the struct, the overlay, and the JSON
+/// vocabulary. The fourth — the TOML document — was enforced by a comment, and
+/// the comment lost three times:
+///
+/// - `[seats]` shipped absent from [`TOML_ROOT_FIELDS`] (#3908);
+/// - `[self_driving]` and `[issues]` shipped with the identical omission;
+/// - `[plugins]` made it three, and it is the worst of the set — the operator
+///   most likely to write that section is the one switching a plugin OFF, and
+///   the walker told them their working config was misspelled.
+///
+/// Each time the symptom is the same and is *not* a broken config: the loader
+/// reads the section correctly and the operator is advised to check the
+/// spelling of something that works. That is a warning which trains people to
+/// ignore warnings, which is what makes it worth a compile error.
+///
+/// The destructure below is exhaustive and carries no `..` rest pattern, so
+/// adding a section to [`TomlConfig`] stops this file compiling until its
+/// author places it — exactly the discipline [`settings_ledger`] applies to
+/// [`Settings`].
+///
+/// **Witness.** Fails on the base commit: `TOML_ROOT_FIELDS` omits `plugins`.
+#[test]
+fn the_toml_root_vocabulary_matches_the_document() {
+    let TomlConfig {
+        meta: _,
+        run: _,
+        workspace: _,
+        providers: _,
+        models: _,
+        agents: _,
+        seats: _,
+        tools: _,
+        hooks: _,
+        mcp: _,
+        context: _,
+        context_providers: _,
+        ui: _,
+        plugins: _,
+        reward: _,
+        authority: _,
+        enterprise_telemetry: _,
+        self_driving: _,
+        issues: _,
+    } = TomlConfig::default();
+
+    // One entry per field bound above, in the same order. Adding a field to
+    // the destructure without adding it here leaves the two lists different
+    // lengths, which the assertions below catch.
+    let declared = [
+        "meta",
+        "run",
+        "workspace",
+        "providers",
+        "models",
+        "agents",
+        "seats",
+        "tools",
+        "hooks",
+        "mcp",
+        "context",
+        "context_providers",
+        "ui",
+        "plugins",
+        "reward",
+        "authority",
+        "enterprise_telemetry",
+        "self_driving",
+        "issues",
+    ];
+
+    for key in &declared {
+        assert!(
+            TOML_ROOT_FIELDS.contains(key),
+            "`TomlConfig` has a root section `[{key}]` that `TOML_ROOT_FIELDS` does not \
+             list, so an operator who writes it correctly is told it is a possible typo"
+        );
+    }
+    for key in TOML_ROOT_FIELDS {
+        assert!(
+            declared.contains(key),
+            "`TOML_ROOT_FIELDS` lists `[{key}]`, which no `TomlConfig` field claims — a \
+             stale entry silences a real typo. Remove it, or move it to \
+             `unknown::RETIRED` with the sentence an operator needs."
+        );
+    }
 }

--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -37,8 +37,8 @@
 //! the same discipline `stella-protocol`'s event-consumer table uses (`E0004`
 //! over a red test) — the answer may be "nothing", but it may not be silence.
 
-use super::toml_config::TomlConfig;
-use super::unknown::{PROVIDER_FIELDS, ROOT_FIELDS, TOML_ROOT_FIELDS};
+use super::toml_config::{AgentsSection, TomlConfig};
+use super::unknown::{PROVIDER_FIELDS, ROOT_FIELDS, TOML_AGENTS_FIELDS, TOML_ROOT_FIELDS};
 use super::*;
 
 /// What the three-scope merge is expected to do with one field.
@@ -589,6 +589,65 @@ fn the_toml_root_vocabulary_matches_the_document() {
             "`TOML_ROOT_FIELDS` lists `[{key}]`, which no `TomlConfig` field claims — a \
              stale entry silences a real typo. Remove it, or move it to \
              `unknown::RETIRED` with the sentence an operator needs."
+        );
+    }
+}
+
+/// Every key of `[agents]` is in the TOML vocabulary, and nothing else is.
+///
+/// The same check as above, one level down, and it needs its own test because
+/// this is where the two vocabularies genuinely diverge: `[agents]` flattens
+/// `agent_engine_config.agents.<name>` up a level, and three JSON keys are
+/// renamed into other sections entirely (`allowed_models` → `[models].allowed`,
+/// `model_output_caps` → `[models].output_caps`, `seat_models` → `[seats]`).
+///
+/// That divergence is deliberate — a JSON-only spelling must not look valid in
+/// TOML — and it is exactly what made the gap invisible: with the two lists
+/// legitimately different, nothing distinguished "renamed on purpose" from
+/// "forgotten". `model_timeout_secs`, `compaction_budget_tokens` and
+/// `tool_result_horizon_steps` were forgotten, so the same knob was accepted in
+/// `settings.json` and called a typo in `stella.toml`.
+///
+/// **Witness.** Fails on the base commit: `TOML_AGENTS_FIELDS` omits all three.
+#[test]
+fn the_toml_agents_vocabulary_matches_the_section() {
+    let AgentsSection {
+        default_model: _,
+        auto_mode: _,
+        effort_auto: _,
+        reasoning_auto: _,
+        headless_scope_bypass: _,
+        model_timeout_secs: _,
+        compaction_budget_tokens: _,
+        tool_result_horizon_steps: _,
+        default: _,
+    } = AgentsSection::default();
+
+    let declared = [
+        "default_model",
+        "auto_mode",
+        "effort_auto",
+        "reasoning_auto",
+        "headless_scope_bypass",
+        "model_timeout_secs",
+        "compaction_budget_tokens",
+        "tool_result_horizon_steps",
+        "default",
+    ];
+
+    for key in &declared {
+        assert!(
+            TOML_AGENTS_FIELDS.contains(key),
+            "`AgentsSection` has a field `agents.{key}` that `TOML_AGENTS_FIELDS` does not \
+             list, so writing it correctly in stella.toml is reported as a possible typo — \
+             while the same key is accepted in settings.json"
+        );
+    }
+    for key in TOML_AGENTS_FIELDS {
+        assert!(
+            declared.contains(key),
+            "`TOML_AGENTS_FIELDS` lists `agents.{key}`, which no `AgentsSection` field \
+             claims — a stale entry silences a real typo."
         );
     }
 }

--- a/crates/stella-cli/src/settings/tests/toml.rs
+++ b/crates/stella-cli/src/settings/tests/toml.rs
@@ -427,6 +427,38 @@ fn unknown_toml_roots_are_flagged() {
     );
 }
 
+/// `[plugins]` is read by the loader, so it must not be reported as a typo.
+///
+/// The third instance of the omission `unknown::TOML_ROOT_FIELDS` already
+/// documents twice — `[seats]` (#3908) and `[self_driving]`/`[issues]` — and it
+/// bites hardest here: `plugins.<name> = "off"` is the per-plugin retraction
+/// switch, so the operator most likely to hit the warning is the one switching
+/// a plugin OFF, being told the section they used to do it is misspelled.
+#[test]
+fn the_plugin_retraction_table_is_a_recognized_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write(
+        dir.path(),
+        "stella.toml",
+        "[plugins]\nvera = \"off\"\n",
+    );
+
+    // It really is read: the switch survives into `Settings`.
+    let settings = load_toml(&path, ConfigScope::Project).expect("should load");
+    assert_eq!(
+        settings.plugins.get("vera"),
+        Some(&Toggle::Off),
+        "the loader lowers [plugins] into Settings"
+    );
+
+    // ...so the walker must not call it a typo.
+    assert_eq!(
+        super::unknown::unknown_toml_keys_in(&path),
+        Vec::<String>::new(),
+        "a section the loader reads was reported as an unrecognized key"
+    );
+}
+
 /// The two vocabularies are genuinely different, and each must reject the
 /// other's spelling — otherwise the warning would bless a key that configures
 /// nothing in the format actually being read.

--- a/crates/stella-cli/src/settings/tests/toml.rs
+++ b/crates/stella-cli/src/settings/tests/toml.rs
@@ -437,11 +437,7 @@ fn unknown_toml_roots_are_flagged() {
 #[test]
 fn the_plugin_retraction_table_is_a_recognized_root() {
     let dir = tempfile::tempdir().unwrap();
-    let path = write(
-        dir.path(),
-        "stella.toml",
-        "[plugins]\nvera = \"off\"\n",
-    );
+    let path = write(dir.path(), "stella.toml", "[plugins]\nvera = \"off\"\n");
 
     // It really is read: the switch survives into `Settings`.
     let settings = load_toml(&path, ConfigScope::Project).expect("should load");
@@ -674,6 +670,57 @@ fn the_shipped_reference_config_loads_with_no_unrecognized_keys() {
     // It declares scope = "project", so it must load as one — and refuse to
     // load as anything else.
     load_toml(&path, ConfigScope::Project).expect("reference config should load");
+}
+
+/// `stella.example.toml` is the file people copy, so it gets the strictest
+/// check in this module: it must load, use no key stella ignores, and — unlike
+/// `stella.today.toml` — carry **every** root section the document has.
+///
+/// The completeness half is the point. `stella.today.toml` is a design-era
+/// artifact and was missing five sections outright (`workspace`, `plugins`,
+/// `self_driving`, `issues`, `enterprise_telemetry`) while the repository's own
+/// `stella.toml` pointed at it as the "full reference". A reference that
+/// silently omits the section you need is how an operator concludes a feature
+/// does not exist.
+///
+/// A section may be *commented out* with a reason — `[authority]` and
+/// `[enterprise_telemetry]` are managed-scope-only and would do nothing in a
+/// project file — so the check reads the raw text rather than the parsed
+/// document. That is deliberate: the obligation is that the example **shows**
+/// every section, not that it sets one.
+#[test]
+fn the_copy_paste_example_covers_every_root_section() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("stella.example.toml");
+    assert!(
+        path.exists(),
+        "example config missing at {}",
+        path.display()
+    );
+
+    let text = std::fs::read_to_string(&path).expect("example config should be readable");
+
+    for section in super::unknown::TOML_ROOT_FIELDS {
+        assert!(
+            text.contains(&format!("[{section}")),
+            "stella.example.toml never mentions the `[{section}]` section. Every root \
+             section of `TomlConfig` must appear — set, or commented out with the reason \
+             it would do nothing here."
+        );
+    }
+
+    // No key stella does not read.
+    assert_eq!(
+        super::unknown::unknown_toml_keys_in(&path),
+        Vec::<String>::new(),
+        "the copy-paste example uses keys stella does not read"
+    );
+
+    // And it is a working project config, not just well-formed TOML. This also
+    // exercises `validate_project_secrets`: a literal api_key in the example
+    // would be refused here, which is the mistake a copied file propagates.
+    load_toml(&path, ConfigScope::Project).expect("example config should load as a project");
 }
 
 // ── Migration ───────────────────────────────────────────────────────────────

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -438,7 +438,7 @@ pub(super) fn unknown_keys_in(path: &Path) -> Vec<String> {
 /// `allowed_models` → `models.allowed`) and adds `meta`. Sharing one list
 /// would make a JSON-only key look valid in TOML and vice versa, which is the
 /// exact confusion this pass exists to prevent.
-const TOML_ROOT_FIELDS: &[&str] = &[
+pub(super) const TOML_ROOT_FIELDS: &[&str] = &[
     "meta",
     "run",
     "workspace",
@@ -471,6 +471,18 @@ const TOML_ROOT_FIELDS: &[&str] = &[
     // change, or this walker tells people their working config is a typo.
     "self_driving",
     "issues",
+    // `[plugins]` — the per-plugin retraction switches
+    // (`TomlConfig::plugins`). The THIRD instance of the omission the two
+    // comments above record, and the one that bites hardest: the operator most
+    // likely to write this section is the one switching a plugin OFF, and the
+    // walker told them the section they used to do it was a typo while the
+    // loader was reading it correctly the whole time.
+    //
+    // Twice was a pattern; three times is a missing guard. See
+    // `toml_root_vocabulary_is_total` in `super::completeness`, which now
+    // destructures `TomlConfig` exhaustively so a root section added without an
+    // entry here stops the crate compiling instead of shipping this warning.
+    "plugins",
 ];
 
 const META_FIELDS: &[&str] = &["schema_version", "scope"];

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -497,12 +497,27 @@ const TOML_MCP_FIELDS: &[&str] = &["registry_url", "servers"];
 /// `[agents]` — the flat engine fields plus the four agent tables, which live
 /// in the same table because the TOML shape flattens
 /// `agent_engine_config.agents.<name>` up one level.
-const TOML_AGENTS_FIELDS: &[&str] = &[
+pub(super) const TOML_AGENTS_FIELDS: &[&str] = &[
     "default_model",
     "auto_mode",
     "effort_auto",
     "reasoning_auto",
     "headless_scope_bypass",
+    // The three engine budgets. Present in `ENGINE_ROOT_FIELDS` since they
+    // shipped, and absent here until the reference config was written against
+    // the struct rather than against this list — so the SAME knob was accepted
+    // in `settings.json` and reported as a possible typo in `stella.toml`.
+    //
+    // That is the worst shape this divergence can take. The two vocabularies
+    // are deliberately separate (a JSON-only key must not look valid in TOML
+    // and vice versa), which makes every intentional difference load-bearing
+    // and every accidental one invisible: nothing distinguishes "renamed on
+    // purpose" from "forgotten" except a human reading both lists.
+    // `AgentsSection` is now destructured against this one in
+    // `super::completeness`, so the compiler makes that distinction instead.
+    "model_timeout_secs",
+    "compaction_budget_tokens",
+    "tool_result_horizon_steps",
     "default",
 ];
 

--- a/docs/design/pipeline-journey.md
+++ b/docs/design/pipeline-journey.md
@@ -1,445 +1,391 @@
 ---
 id: pipeline-journey
-title: "The journey of a prompt — full pipeline mode, in plain language"
+title: "The journey of a prompt — the raw loop, and what a wrapper plugin adds"
 status: living
 ---
 
-# The journey of a prompt — full pipeline mode, in plain language
+# The journey of a prompt — the raw loop, and what a wrapper plugin adds
 
-**Status:** Living document. Describes the staged pipeline (`--pipeline classic`)
-as of 0.6.x.
+**Status:** living. Part I describes what this workspace runs today. Part II is
+an **archived record** of the built-in staged pipeline, kept in the past tense
+because it is the shape `doc:pipeline-as-plugins` §8 asks a verification plugin
+to port — not code you can step through here.
 
-> **The machinery below is no longer in this workspace.** `stella-pipeline` was
-> deleted and `--pipeline classic` is refused outright; what this document walks
-> through is the *shape* a verification plugin implements on its own side of the
-> wrapper socket, not code you can still step through here. Read it as the
-> design being ported, not as a map of the tree. Bringing the rest of the
-> present-tense pipeline prose into line is tracked as its own pass (#3901);
-> this note is here so the page cannot be mistaken for current in the meantime.
+> **What changed.** `crates/stella-pipeline` was deleted from the workspace
+> (#3865) and `--pipeline classic` is refused outright (#3867). Host-run
+> verification no longer exists here at all. The only verification path left is
+> an **installed wrapper plugin**, whose evidence is self-reported and which
+> Stella evaluates against the plugin's own declared rule without re-running it
+> (#3511). This page was rewritten to say so; the sweep of the rest of the tree
+> is #3901.
 
-This is the maintainer's companion to the user-facing
-[Inference Pipeline](/docs/inference-pipeline) page. That
-page explains *what* the pipeline promises; this one walks a single prompt from
-the moment it enters `stella run` to the moment the run reports done, naming
-the module that owns each step so you can find the code in one hop. Everything
-here lives in `stella-pipeline` unless stated otherwise; the async orchestrator
-is `src/pipeline.rs`, and every *decision* it makes is a pure synchronous
-function in a sibling module (`triage`, `plan`, `scope`, `verify`, `witness`,
-`candidate`) — that split is the crate's core invariant.
+---
 
-The one-line itinerary:
+# Part I — what actually runs
 
-> **prompt → triage (+ recall, concurrently) → [conversational fast path?] →
+## 0. Two ways a prompt is served
+
+Every door — `run`, `arena`, `goal`, `fleet`, the Command Deck — resolves one of
+two choices, in `stella_cli::wrapper_plugin::PipelineChoice::resolve`:
+
+- **`Raw` — the default, and what you get with no flag at all.**
+  `stella_core::Engine::run_turn`: the model proposes tool calls, tools run,
+  results feed back, repeat until the model stops or a budget/backstop fires.
+  No stages, no verification, no second opinion. `--no-pipeline` is a
+  deprecated hidden no-op that names this default explicitly.
+- **`Plugin(variant)` — `stella run --pipeline <plugin-id>`, opt-in.** The
+  named plugin must be installed (`stella plugin install`). The host drives it
+  over the **wrapper socket**, and the turn is still the same
+  `Engine::run_turn` underneath — the plugin gets to speak before it and after
+  it, and to say *not yet*.
+
+There is no third choice. `--pipeline classic` names the deleted built-in path
+and is refused with a message pointing at `stella plugin install`; the
+verification-only flags `--test-command`, `--keep-witness` and
+`--require-verified` are refused unconditionally on every resolution
+(`reject_verification_flags_without_pipeline`), because the host no longer owns
+a verification stage for them to configure.
+
+## 1. The wrapper socket — four points
+
+`doc:wrapper-socket` is the design and `stella_runtime::wrapper` is the
+implementation. A wrapper is **two async calls it makes, plus two pure
+functions the host runs on its behalf**, and that asymmetry is the whole
+contract:
+
+| Point | Shape | Owner |
+|---|---|---|
+| `before_turn` | async, may be remoted | the plugin |
+| `after_turn` | async, may be remoted | the plugin |
+| `judge` | synchronous, host-run, total | the host |
+| `again?` | synchronous, host-run, total | the host |
+
+The split is what keeps a plugin from grading its own work with a model. It may
+gather evidence in `after_turn` — run its oracle, report a flip, report
+measurements — but the *verdict* is `judge`, a total synchronous function the
+host evaluates against the rule the plugin declared in its manifest at install
+time. A plugin cannot buy a model call to decide whether it is done, and it
+cannot change the rule after consent.
+
+`stella_runtime::wrapper::WrapperDispatch` is the host sequence that drives the
+four points. It lives in `stella-runtime` rather than in `stella-cli` because
+the same plugin must run under three drivers, and a sequence living in the
+binary is one the other two cannot reach.
+
+`admissible` sits **on** that path, not beside it: it consumes the plugin's
+response and yields an `AdmittedContribution`, which is the only value
+`WrapperDispatch` will apply. A role intent the manifest never declared is
+refused, and a signal published at the wrong type is refused — the same rules
+`stella-plugin` enforces on *declarations* at load, enforced again on *values*
+at dispatch, so the manifest's guarantees do not stop at the process boundary.
+
+Two transports carry the same owned types: `SubprocessWrapper` speaks the wire
+contract over stdio in any language, and `InProcessWrapper` is a permitted Rust
+fast path. Nothing is reachable through one that is not reachable through the
+other — if Rust ever gained a capability Python could not ask for, the wire
+contract would have become second-class.
+
+## 2. A plugin may ask, never reach
+
+A point is a bounded conversation, not a one-shot (#3540). A plugin may ask the
+host for a capability; it may never reach for one. `HostCallGate` is the host
+half: every call is performed by the host, behind
+`LoopGrant::permits_call` and a clamped per-point allowance, so what the plugin
+gets is what a human consented to at install and nothing more. Host calls are
+available during `before_turn` and `after_turn` only, which is what keeps
+`judge` and `again` synchronous, I/O-free and total.
+
+## 3. What a manifest declares
+
+`plugin.toml`, parsed and validated by `stella-plugin`. Participation is
+declared, never inferred, and **undeclared means none**:
+
+| Block | What it grants |
+|---|---|
+| `[loop] participation` | `none` / `observer` / `steering` / `arbiter` — a monotone ladder |
+| `[loop] hooks` | the hook points this plugin answers, exhaustively |
+| `[loop] points` | the wrapper socket points it answers, exhaustively |
+| `[requirements]` | arbiter only: the enumerable definition of done |
+| `[oracle]` | arbiter only: the evidence shape and the verdict rule as data |
+| `[subloop]` / `[roles]` | stages run as bounded child turns, and their routing intents |
+| `[wrapper]` | the stage order and the conditions under which each stage runs |
+| `[runtime]` | the process it runs as, and the exact environment slice it inherits |
+| `[capabilities]` | what it asks to reach outside the turn, each risk-graded |
+| `[[configure]]` | config it sets for as long as it is installed |
+
+An undeclared hook is never invoked and an undeclared point is never dispatched,
+even if the plugin's process would happily answer. Unknown keys are a load
+error, so a typo'd grant fails loudly at install instead of silently granting
+nothing.
+
+`[oracle]` is where a verification plugin puts what used to be host machinery.
+`flip = "required"` says the host credits the requirement only on a fail→pass
+flip the plugin **reports having seen**; `flip = "not-applicable"` says this
+oracle's evidence is measurements rather than a flip, and is not a weaker
+contract — with no flip to decide anything, every requirement must be decided by
+a declared check or the manifest is refused. `tamper` names what the *host*
+does: it snapshots witness-artifact identity and refuses the flip if it changed,
+which is why tamper findings are not something a plugin may report.
+
+## 4. Where the seats come from
+
+A plugin declares a bare role name; the host applies the `<plugin-id>/` prefix,
+so the namespace cannot be forged by a plugin claiming another's. The operator
+assigns each seat a model in `stella.toml`:
+
+```toml
+[seats]
+"vera/verifier" = "anthropic/claude-opus-5"
+"stella-plan/planner" = "openrouter/openai/gpt-5.5"
+```
+
+`[seats]` is its own top-level table rather than part of `[agents]` precisely
+because seat names are an **open** set chosen by whatever the operator
+installed, and `[agents]`' flattening is only safe because its set is closed.
+
+---
+
+# Part II — archived: the built-in staged pipeline
+
+Everything below is written in the past tense and describes
+`crates/stella-pipeline`, **deleted from this workspace in #3865**. No file
+named here still exists. It is kept because `doc:pipeline-as-plugins` §8 asks a
+verification plugin to *port* this shape rather than reinvent it, and because
+several of these rungs exist only as the scar of a specific measured failure —
+the reasons are the part worth carrying forward.
+
+The one-line itinerary it ran:
+
+> prompt → triage (+ recall, concurrently) → [conversational fast path?] →
 > plan → scope review → execute → diff probe → witness warrant → witness
 > authoring (on demand) → evidence ladder → { submit fast | revise | nothing
-> attempted | abstain | unverified } → verdict → complete.**
+> attempted | abstain | unverified } → verdict → complete.
 
-A detail worth calling out immediately, because older docs got it backwards:
-**the witness test is authored *after* execution, not before it.** Authoring
-waits until the warrant (`witness::warrant`) has read the actual diff, so a
-docs-only change never buys a test, and the author is kept *blind* to the diff
-(it works in a pristine snapshot of the pre-execution tree) so it cannot write
-a test that merely restates the patch.
+A detail worth carrying forward, because older docs had it backwards: **the
+witness test was authored *after* execution, not before it.** Authoring waited
+until the warrant had read the actual diff, so a docs-only change never bought a
+test, and the author was kept *blind* to the diff (it worked in a pristine
+snapshot of the pre-execution tree) so it could not write a test that merely
+restated the patch.
 
----
+## A. Intake — triage and recall ran side by side
 
-## 0. What "full pipeline mode" is
+Two things started at once, because neither depended on the other. **Triage**
+was one cheap model call classifying the prompt on two independent axes — *is
+this even a software task?* and *how much ceremony does it deserve?* — under a
+hard latency ceiling, falling through to the full path rather than waiting. A
+**deterministic floor** pattern-matched the goal and could only ever *raise* the
+class toward more planning, never lower it: a misclassified complex task had to
+still complete, just with less scaffolding, never fail outright.
 
-Stella has two ways to run a prompt, and since #3381/#3694 the raw loop is the
-default on every door (`run`, `arena`, `goal`, `fleet`, the Command Deck):
+**Context recall** was advisory memory/graph recall over the goal, bounded by
+its own ceiling and degraded to "no frames" on expiry. Recalled frames rode as a
+**volatile user message after the byte-stable system prefix** — never mutated
+into the system block — so prompt-cache hits survived across turns. That
+discipline is invariant 7 and is unaffected by the deletion: it still governs
+`stella_cli::agent::build_system_prompt` today.
 
-- **The raw step loop** (the default; `--no-pipeline` is a deprecated hidden
-  no-op that names it explicitly, as does interactive chat):
-  `stella-core::Engine::run_turn` — the model proposes tool calls, tools run,
-  results feed back, repeat until the model stops or a budget/backstop fires.
-  No stages, no verification.
-- **The staged pipeline** (`stella run --pipeline classic`, opt-in; per-turn
-  in the Command Deck while `/pipeline` is ON): the step loop wrapped in the
-  stages below, with deterministic verification and terminal-event ownership
-  moved up into `Pipeline::run`. `--pipeline classic` is one instance of the
-  general `--pipeline <variant>` opt-in — the wrapper socket
-  (`stella-runtime::wrapper`) drives an installed wrapper plugin the same way
-  for any other variant id, with `plugins/stella-research` shipped as the
-  reference plugin.
+## B. The conversational fast path
 
-"Full pipeline mode" is the second one. The engine still does all the actual
-work — reading files, editing, running commands — but the pipeline decides
-*when* the engine runs, *what evidence* is collected around it, and *whether
-the result may be called done*.
+If triage said "this is chat, not work" and the deterministic floor saw no task
+signal to overrule it, the pipeline answered in one plain, tool-less completion
+and exited. This was the escape hatch that kept a bare `hi` from being planned,
+executed and witness-tested.
 
-The pipeline owns the terminal events. `Engine::run_turn` emits its own
-`Stage { Complete }` per turn, which is correct for one turn but wrong for a
-multi-step or revising run — so the pipeline gives each engine turn a private
-channel, forwards everything except the engine's stage/terminal events, and is
-the single authority for `Complete` / terminal `Error` (see the "Event
-ownership" section of the `pipeline.rs` module docs).
+## C. Plan, then scope review
 
-## 1. Intake: triage and recall run side by side
+Only a multi-step class planned. A plan that failed to parse got one bounded
+repair attempt, then degraded to a single-step plan — a stubborn planner never
+blocked the work.
 
-Entry point: `Pipeline::run` (`src/pipeline.rs`).
+If the plan's blast radius crossed a configured threshold (more than 5 steps,
+more than 8 estimated files, or estimated cost over $1, all strict `>`), the run
+paused for **scope review**. Interactively you approved, trimmed to the largest
+under-threshold prefix, aborted, or sent the plan back with a note. Headless, an
+over-threshold plan ended the run rather than silently auto-approving.
 
-Two things start at once, because neither depends on the other:
+> The `headless_scope_bypass` engine-config key that steered the headless half
+> still parses today and does nothing — the stage it steered went with the
+> crate. It is kept only because a published benchmark posture hashes it. Do
+> not read it as a knob you can still turn.
 
-- **Triage** (`Pipeline::triage` + the pure `triage` module): one cheap model
-  call, on the triage role's configured model, that classifies the prompt.
-  It answers two independent questions — *is this even a software task?*
-  (`conversational`), and *how much ceremony does it deserve?* (`TaskClass`:
-  `SimpleLookup` / `SingleTask` / `MultiStep`) — plus two optional opinions:
-  whether an authored witness is warranted and whether independent review is
-  warranted (`VERIFIER: yes|no`, which since #2584 gates a *waiver* rather than
-  a call — see §10). The call runs under a hard latency ceiling
-  (`triage_latency_ceiling`, default 10 s); if the model doesn't answer in
-  time the pipeline falls through to the full path rather than waiting.
-  A **deterministic floor** (`triage::resolve_task_class`) pattern-matches the
-  goal and can only *raise* the class toward more planning, never lower it —
-  a misclassified complex task must still complete, just with less
-  scaffolding, never fail outright.
-- **Context recall** (`ContextRecallPort`): advisory memory/graph recall over
-  the goal, bounded by its own latency ceiling (`recall_latency_ceiling`,
-  default 5 s) and degraded to "no frames" on expiry. Recalled frames are
-  bounded at the source (`bound_recalled_frames`) and ride as a **volatile
-  user message after the byte-stable system prefix** — never mutated into the
-  system block — so prompt-cache hits on the stable prefix survive across
-  turns (invariant 7, L-E8).
+## D. Deciding where the work happened
 
-## 2. The conversational fast path
+Before executing, the pipeline resolved *whose tree* the candidate worked in.
+Best-of-N always isolated: each candidate ran in a snapshot of the current tree
+(HEAD + uncommitted + untracked, via a detached git worktree), and only the
+winner's changes were adopted. An authored witness always required a disposable
+candidate, even at N = 1, so authoring could never mutate the session tree.
+Otherwise the worktree policy decided, consulted only when the run would
+actually change files.
 
-If triage said "this is chat, not work" — and the deterministic floor saw no
-task signal to overrule it — the pipeline answers in **one plain, tool-less
-completion** under a conversational system prompt and exits
-(`Pipeline::run_conversational`). This is the escape hatch that keeps a bare
-`hi` from being planned, executed, and witness-tested.
+There was a "never choose nothing" backstop: a candidate that aborted in *setup*
+degraded to a bare worker run on the working tree — the fancy path being
+unavailable is a reason to do less, never a reason to do nothing. Genuine
+execution aborts (budget, loop detection, step caps) kept their stop.
 
-## 3. Plan, then scope review (multi-step only)
+## E. Baselines — the flip oracle armed before execution
 
-Only a `MultiStep` class plans (`TaskClass::plans`). The planner
-(`plan::build_planner_prompt` / `parse_plan`) turns the goal, the recalled
-frames, and a repository-structure summary into explicit steps. A plan that
-fails to parse gets one bounded repair attempt (`plan_repair_prompt`), then
-degrades to a single-step plan — a stubborn planner never blocks the work.
+When the user supplied a test command, the candidate ran it **once before
+executing anything** and recorded the result in the **flip oracle**: a state
+machine keyed on the normalized command string that locked onto the first
+*failure* it observed, and moved to `Flipped` only on a later *pass of that same
+command*. A suite that was already green could never produce a flip — which
+structurally excluded the "it passed, ship it" false positive.
 
-If the plan's blast radius crosses any configured threshold
-(`scope::ScopeThresholds`: more than 5 steps, more than 8 estimated files, or
-estimated cost over $1 by default; all strict `>`), the run pauses for **scope
-review** (`pipeline/scope_stage.rs`). Interactively, you approve, trim to the
-largest under-threshold prefix, abort, or send the plan back to the planner
-with a note (bounded at `MAX_SCOPE_REVISIONS` re-plans). Headless, an
-over-threshold plan ended the run rather than silently auto-approving, unless
-the run opted out (`headless_bypass_scope_review`, fed by the
-`headless_scope_bypass` engine-config toggle). That toggle still parses today
-and does nothing: the stage it steered went with the crate, and the key is kept
-only because a published benchmark posture hashes it. Do not read it as a knob
-a reader of this document can still turn.
+Two refinements kept it honest, and both are worth porting:
 
-## 4. Deciding where the work happens
+- **Typed outcomes (#860).** A baseline that timed out or never spawned observed
+  no assertion and did not lock the oracle — infra noise plus a merely-faster
+  candidate must not read as a verified flip.
+- **Failure fingerprints (#867).** A failing baseline contributed the *names* of
+  its failing tests; a later pass that named its tests without naming the
+  baseline's failures was no evidence. This refused fix-by-disappearance —
+  delete the failing test, suite exits 0.
 
-Before executing, the pipeline resolves *whose tree* the candidate works in
-(`worktree_decision_without_asking` + `Pipeline::isolate_in_worktree`):
+## F. Execute, then the diff probe
 
-- **Best-of-N** (`candidates = Some(n)`) always isolates: each candidate runs
-  in a snapshot of the current tree (HEAD + uncommitted + untracked, via a
-  detached git worktree), and only the winner's changes are adopted.
-- **An authored witness** always requires a disposable candidate, even at
-  N = 1, so authoring can never mutate the session tree.
-- Otherwise the **worktree policy** (`create_worktrees`: always / never / ask)
-  decides — and it is consulted only when the run will actually change files,
-  and only when isolation is available (a plain directory can't offer it; a
-  configured `always` that can't be honoured says so out loud).
+The worker ran one engine turn for a simple task, or one per plan step for a
+multi-step plan. The pipeline counted `FileChange` events and **mutating
+actions** (dispatched tool calls whose tool is not advertised read-only; unknown
+tools counted as mutating).
 
-There is a "never choose nothing" backstop: a candidate that aborts in *setup*
-(no isolation port, unsnapshottable tree, no independent witness author)
-degrades to a bare worker run on the working tree
-(`Pipeline::degrade_to_bare_execution`) — the fancy path being unavailable is
-a reason to do less, never a reason to do nothing. Genuine execution aborts
-(budget, loop detection, step caps) keep their stop.
-
-## 5. Baselines: the flip oracle arms before execution
-
-For any class that verifies, and only when the user supplied `--test-command`,
-the candidate runs that command **once before executing anything**
-(`Pipeline::run_candidate`) and records the result in the **flip oracle**
-(`verify::FlipOracle`). The oracle is a state machine keyed on the normalized
-command string: it locks onto the first *failure* it observes, and only a
-later *pass of that same command* moves it to `Flipped`. A suite that was
-already green can never produce a flip — which structurally excludes the
-"it passed, ship it" false positive.
-
-Details that keep the oracle honest:
-
-- **Typed outcomes (#860):** a baseline that timed out or never spawned
-  observed no assertion and does not lock the oracle — infra noise plus a
-  merely-faster candidate must not read as a verified flip.
-- **Failure fingerprints (#867):** a failing baseline contributes the *names*
-  of its failing tests; a later pass that names its tests without naming the
-  baseline's failures is no evidence — the fix-by-disappearance case (delete
-  the failing test, suite exits 0) is refused.
-
-Two other baselines are captured here: a lint/typecheck snapshot for the
-regression veto (#861), and content fingerprints of untracked files so the
-diff probe can tell this turn's new files from pre-existing dirt.
-
-## 6. Execute: the engine does the work
-
-`Pipeline::execute_plan` emits `Stage { Execute }` and runs the worker:
-
-- **Simple / single-task:** one engine turn against the goal.
-- **Multi-step:** one engine turn per plan step, each fed
-  `Step i/n: <description>` on top of the shared conversation.
-
-Each turn is `stella-core::Engine::run_turn` — the full tool loop with
-compaction, loop detection, and hooks — running on the **worker** role's
-model. The pipeline counts two things as the turn runs: `FileChange` events
-(observed file touches) and **mutating actions** (dispatched tool calls whose
-tool is not advertised read-only; unknown tools count as mutating). The budget guard is consulted only at
-safe boundaries — between model calls, never mid-tool (invariant 6).
-
-## 7. The diff probe — engineered to be incapable of lying
-
-After execution the pipeline reads what changed (`Pipeline::gather_diff`):
-tracked changes via the configured diff diagnostic (default `git diff`), plus
-per-file `--no-index` numstats for created/modified untracked files (bounded
-concurrency). The probe's output is deliberately three-valued:
+The diff probe was **engineered to be incapable of lying**, and its output was
+deliberately three-valued:
 
 - a real diff;
-- "the tree changed but the diff could not be captured" — when `FileChange`
-  events are positive but the diff came back empty
-  (`verification_honest_diff`), which downstream readers must treat as
-  *couldn't verify*, never *verified nothing*;
-- "the probe could not read the tree at all" (`DIFF_PROBE_FAILED`), with a
-  separately named case for "this is not a git repository, so `git diff` can
-  never answer here" (`DIFF_PROBE_NOT_A_REPO` — the permanent condition of a
-  Terminal-Bench task image, #973).
+- "the tree changed but the diff could not be captured" — `FileChange` events
+  positive, diff empty — which downstream readers had to treat as *couldn't
+  verify*, never *verified nothing*;
+- "the probe could not read the tree at all", with a separately named case for
+  "this is not a git repository, so `git diff` can never answer here" — the
+  permanent condition of a Terminal-Bench task image (#973).
 
-The distinction exists because an ambiguous empty diff once convinced a verifier
-that "no changes were made" — the archetypal verification lie.
+That three-valued shape exists because an ambiguous empty diff once convinced a
+verifier that "no changes were made" — the archetypal verification lie. **This
+is the single most portable lesson in Part II.**
 
-Simple lookups exit here if they touched nothing: a clean lookup has nothing
-to verify. A lookup that unexpectedly *did* touch files has its verifier-skip
-revoked (the zero-diff guard) and continues into verification like any other
-change.
+## G. The witness warrant, then on-demand authoring
 
-## 8. The witness warrant, then on-demand authoring
+With no test command armed, verification still wanted a deterministic oracle,
+but only when the change *warranted* one. The **warrant** read the diff and
+answered "does this change need a witness test, and if not, why not":
+`NothingChanged`, `DocsOnly`, `TestsOnly`, `ConfigOnly`, `CommentsOnly`,
+`PureRemoval` — each a *stated reason*, recorded in the verdict, mirroring the
+contributor rule ("ship a witness test, or a stated reason there isn't one").
+Anything mixed, unrecognized or unreadable **failed closed to Required**: an
+unnecessary witness costs one model call; a missing one ships unverified
+behavior.
 
-If no `--test-command` is armed, verification still wants a deterministic
-oracle — but only when the change *warrants* one. The **warrant**
-(`witness::warrant`) reads the diff and answers "does this change need a
-witness test, and if not, why not":
+When required, an independent model wrote a minimal *failing* test, working in a
+pristine snapshot of the pre-execution tree, blind to the diff. The authored
+test had to fail on the old code first, pass a static assertion-density screen
+(no assertion-free tests, no constant-only assertions, no self-comparisons, no
+bare `#[should_panic]` — #863), and survive tamper checks every verify
+iteration.
 
-- `NothingChanged`, `DocsOnly`, `TestsOnly`, `ConfigOnly`, `CommentsOnly`,
-  `PureRemoval` — each a *stated reason*, recorded in the verdict, mirroring
-  the contributor rule ("ship a witness test, or a stated reason there isn't
-  one"). Test-only changes and pure removals still warrant an independent
-  review even though no test is warranted.
-- Anything mixed, unrecognized, or unreadable **fails closed to Required**:
-  an unnecessary witness costs one model call; a missing one ships unverified
-  behavior.
+The author was skipped, degrading to an unauthored ladder, if it would have been
+the same model as the worker — **Stella would not let the worker write the test
+that proves the worker.** Under `require_independent_witness` that degradation
+became an up-front refusal instead (#1147: a benchmark arm whose manifest claims
+an independent author must not silently produce a number without one).
 
-When a witness is required, the **witness author** — an independent model,
-resolved from the verifier's slot and skipped (the run degrades to an
-unauthored ladder) if it would be the same model as the worker — writes a minimal *failing* test (`pipeline/witness_stage.rs`).
-The author works in a **pristine snapshot of the pre-execution tree**, blind
-to the diff, so the test pins the *intended behavior* rather than restating
-the patch. The authored test must:
+## H. Verify — the evidence ladder
 
-- fail on the old code first (the fail-first gate — a test that passes before
-  the change proves nothing);
-- pass a static assertion-density screen (`witness::density`, #863): no
-  assertion-free tests, no constant-only assertions, no self-comparisons, no
-  bare `#[should_panic]`;
-- survive tamper checks every verify iteration: a worker (or revise turn)
-  that edits the witness files hard-fails the candidate
-  (`witness::airlock`).
+A pure function took one snapshot — flip state, touched-test result, diff size
+and availability, file-touch count, mutating actions, new lint diagnostics, and
+whether the witness proved tautological — and answered **in this order**:
 
-Its command then arms the same flip oracle. The witness is scaffolding for
-this one run — it lives and dies with the candidate workspace unless
-`--keep-witness` promotes it.
-
-If no independent author can be resolved, the run degrades to the unauthored
-ladder with a warning — unless `require_independent_witness` is set, in which
-case the run refuses up front (#1147: a benchmark arm whose manifest names an
-independent author must not silently produce a number without one).
-
-## 9. Verify: the evidence ladder
-
-`Pipeline::verify_candidate` re-runs the tracked command (the configured one,
-else the witness's), feeds every observation back to the oracle, and hands the
-pure `verify::ladder_decision` one `LadderInputs` snapshot: flip state,
-touched-test result, diff size and availability, file-touch count, mutating
-actions, new lint errors/warnings, and whether the witness proved
-tautological. The ladder answers **in this order**:
-
-1. **Touched tests red → `Revise`.** Already a deterministic failure; nothing
-   is spent confirming it.
-2. **Nothing attempted → `NothingAttempted`.** The turn dispatched zero
-   mutating calls and nothing observed a change: the model narrated a solution
-   and wrote none of it down. This rung is *knowledge*, not abstention — the
-   revision turn gets a blunt nudge ("reasoning about a solution, or stating
-   one in prose, does not perform it"), and a run that never acts ends
-   `passed: false`. Before this rung existed, eleven untouched Terminal-Bench
-   tasks were reported as successes.
-3. **Every channel blind → `Unverifiable`.** No flip, no test result, an
-   unreadable tree, no recorded touch: the ladder *abstains*. A verifier asked
+1. **Touched tests red → revise.** Already a deterministic failure; nothing was
+   spent confirming it.
+2. **Nothing attempted.** Zero mutating calls and nothing observed a change: the
+   model narrated a solution and wrote none of it down. This rung is
+   *knowledge*, not abstention — a run that never acted ended `passed: false`.
+   Before it existed, eleven untouched Terminal-Bench tasks were reported as
+   successes.
+3. **Every channel blind → unverifiable.** No flip, no test result, an
+   unreadable tree, no recorded touch: the ladder *abstained*. A verifier asked
    to rule on an empty record once answered with a confident `FAIL` naming a
-   file that existed. The run is scored unverified, never passed or failed.
-4. **Flip + green + diff within budget (default ≤ 400 lines) + no new lint
-   errors + witness not tautological → `SubmitFast`.** The full deterministic
-   pass. Two audits run before the
-   submit is final: a **confirmation run** (#859 — one extra suite run; a
-   flake demotes the oracle to `Unstable` and drops through to rung 5) and the
-   **mutation check** (#870 — break the changed lines one at a time; a
-   witness that stays green under every mutant is tautological and loses its
-   fast-submit).
-5. **Otherwise → `Unverified`.** Genuinely inconclusive: at least one channel
-   saw something, and what it saw does not amount to a proof. **Terminal**, like
-   every rung above it.
+   file that existed. The run scored unverified, never passed or failed.
+4. **Flip + green + diff within budget + no new lint errors + witness not
+   tautological → submit fast.** Two audits ran before the submit was final: a
+   **confirmation run** (#859 — one extra suite run; a flake demoted the oracle
+   and dropped through) and the **mutation check** (#870 — break the changed
+   lines one at a time; a witness that stayed green under every mutant was
+   tautological and lost its fast-submit).
+5. **Otherwise → unverified.** Genuinely inconclusive.
 
-## 10. Verdict: the ladder's answer is the answer
+**Every rung was terminal — no arm escalated to a model.** That is the property
+`doc:pipeline-as-plugins` §8 asks a verification plugin to preserve as it ports
+the logic, and it is the reason the ladder cost nothing to run.
 
-Rung 5 used to escalate to a **verifier** — a separate model call, by preference
-from a different model *family* than the worker — which reviewed the goal, the
-honest diff, and a structured evidence snapshot and answered with a leading
-`PASS` or `FAIL`. #2584 removed it, along with the heuristic fallback that
-covered its outages.
+## I. Verdict — the ladder's answer was the answer
 
-The reason is that its authority was measured and found wanting: across an
-89-task Terminal-Bench run where the witness rung couldn't fire (single-model
-posture), it agreed with the benchmark's own grader 46% of the time, and 17 of
-its false passes cost 5 tasks outright. The intermediate design was *asymmetric
-trust* — a "not yet" was actionable, a "done" standing alone was downgraded to
-unverified — and the removal is that asymmetry taken to its limit. If a verdict
-standing on nothing deterministic could never be believed, the call that
-produced it was buying only the half that could still be wrong.
+Rung 5 used to escalate to a **verifier**: a separate model call, by preference
+from a different model *family* than the worker, which reviewed the goal, the
+honest diff and a structured evidence snapshot. #2584 removed it, along with the
+heuristic fallback that covered its outages, and along with **distress
+guidance** — a course-correction note that rode with the next revision prompt
+after a second deterministic failure.
 
-So the turn is settled from the rung alone, inside the verify stage itself:
-`Pipeline::verify_candidate` emits `AgentEvent::Verdict` with the evidence
-summary and the decision-time `LadderSnapshot` that lets `replay` explain the
-answer later, and buys nothing. There is no separate verdict stage in the
-pipeline — `StageKind::Verdict` keeps its rank in `stage_rank` and its
-Verify/Verdict → Execute back-edge, but nothing in `pipeline.rs` emits it; goal
-mode does.
+The reason was measured, not aesthetic. Across an 89-task Terminal-Bench run
+where the witness rung could not fire, the verifier agreed with the benchmark's
+own grader 46% of the time, and 17 of its false passes cost 5 tasks outright.
+The intermediate design was *asymmetric trust* — a "not yet" was actionable, a
+"done" standing alone was downgraded to unverified — and the removal is that
+asymmetry taken to its limit: if a verdict standing on nothing deterministic
+could never be believed, the call that produced it was buying only the half that
+could still be wrong.
 
-Before recording an unverified pass, the pipeline still asks for the missing
-evidence once (`evidence_demand_prompt`, #1295): one revision turn telling the
-worker to make the tracked command observe its change. The ask is raised **only
-where a tracked command exists**, and that precondition is what makes it
-affordable — the two facts that would clear `verifier_pass_stands_alone` are both
-observations of that command, so with none resolved no worker could satisfy the
-ask on any turn. That is exactly what the feature's first measurement ran into:
-on Terminal-Bench, with no `--test-command` and the authored-witness rung unable
-to fire under a single-model posture, the condition held on nearly every turn
-and the extra turn bought nothing on all of them. Capped at one ask per
-candidate and drawn from the same `max_revisions` budget a real failure spends.
-The measurement that switched it back on is in
-`bench/evidence/judge-evidence-demand-1295/` — the directory keeps the old word
-because `bench/evidence/` is frozen at the vocabulary each run was recorded in.
+Distress guidance died on the same principle from the other side: **a claim
+appended to a measurement inherits the measurement's authority**, and a worker
+receiving both cannot tell them apart. On `fix-git` that narration talked a
+worker into resetting `master` and destroying a correctly-recovered commit,
+twice. The measurement was already there and already conclusive.
 
-## 11. Revise: bounded retries with escalating candor
+Both removals are structural rather than defaulted, and that survives the
+deletion: `Roster::apply` still rejects a `verdict` or `distress_guidance`
+assignment as `NotAssignable`, so no configuration restores them.
 
-A `Revise` decision sends the evidence back into a fresh
-worker turn (`Pipeline::revise_candidate`), up to `max_revisions` times
-(default 2). The worker receives `brief.message()` — the sealed, redacted
-account of the test that went red — and nothing else. On the **second**
-deterministic failure a candidate accumulates — consecutive or not (#868) — the
-pipeline used to spend one verifier call on **distress guidance**, a
-course-correction note riding with the next revision prompt. That went with the
-verdict in #2584 and for the same reason: a claim appended to a measurement
-inherits the measurement's authority, and the worker receiving both cannot tell
-them apart. On `fix-git` that narration talked a worker into resetting `master`
-and destroying a correctly-recovered commit, twice. The measurement was already
-there and already conclusive. Repeated identical failures still widen
-what the revision prompt discloses about the failure
-(`witness::airlock::grain_for_repeats` — sealed failure output is scrubbed of
-secrets and disclosed at coarser or finer grain by repeat count). After every
-revise turn the tracked command is re-run and the ladder re-decides; the
-witness tamper check runs every iteration, so a revise turn that edits the
-witness is caught at the next check.
+## J. Revise, select, complete
 
-## 12. Best-of-N selection and adoption
+A revise decision sent the evidence back into a fresh worker turn, up to a
+bounded budget. The worker received the sealed, redacted account of the test
+that went red and nothing else; repeated identical failures widened what the
+prompt disclosed, at coarser or finer grain by repeat count, scrubbed of
+secrets. After every revise turn the command was re-run and the ladder
+re-decided.
 
-With `candidates = Some(n)`, each candidate runs steps 5–11 in its own
-isolated snapshot (steered apart by `candidate_steering::SteeringFanOut`) and
-is scored (`candidate::score_from_verification`):
+With best-of-N, each candidate ran in its own isolated snapshot and was scored
+`DeterministicPass > VerifierPass > Unverified > Failed`, ties broken by
+mutation-survival, then fewer new diagnostics, then smaller diff. Only the
+winner's changes were adopted — atomically, failing loudly with the conflicting
+paths named if you edited the same files mid-run.
 
-> `DeterministicPass > VerifierPass > Unverified > Failed`
+The pipeline emitted exactly one terminal signal, and its outcome recorded the
+task class, total cost, revision count, how many candidates actually *ran* (not
+how many were configured), and `deterministic: true/false` — so a headless
+caller could tell a determinate finding from an unproven pass.
 
-Ties break within a rank by mutation-survival, then fewer new diagnostics,
-then smaller diff (#869/#870). Only the winner's changes are adopted into the
-real tree — atomically, failing loudly with the conflicting paths named if
-you edited the same files mid-run. Losing candidates leave no residue.
+## K. Who ran on which model
 
-## 13. Complete: one terminal event, honest accounting
+Six roles, each configured through `agent_engine_config`: triage, worker,
+research, plan, verifier, and the witness author resolving from the verifier's
+slot.
 
-`Pipeline::run` adopts the winning candidate's message trajectory and emits
-exactly one terminal signal:
+> **All six are gone.** Core knows exactly one role today, `default` (#3903,
+> `doc:roleless-core`), and the `pipeline_triage_model` / `pipeline_worker_model`
+> / `pipeline_verifier_model` keys plus the `[agents.worker]`,
+> `[agents.verifier]` and `[agents.triage]` tables are recognized, ignored, and
+> named on load (#3908). A plugin that wants a second model asks for a **seat**
+> instead — see Part I §4.
 
-- **`Complete`** (with the worker model's label and the run's total spend)
-  when verification passed or was legitimately not needed;
-- a non-retryable **`Error`** when verification stayed red after the revision
-  budget (`PipelineStatus::VerificationFailed`) or the run aborted;
-- hard infrastructure failures return out of band as `PipelineRunError`.
-
-The `PipelineOutcome` records the task class, final text, total cost, revision
-count, how many candidates actually *ran* (not how many were configured), and
-the verdict — including `deterministic: true/false`, so a headless caller can
-tell a determinate finding from an unproven pass, and the frozen
-`LadderSnapshot` (#865), so `stella replay` can answer "which rung did this run
-come to rest on?" from the recording alone without re-deriving.
-
-Every stage boundary along the way emitted a `Stage` event, every model call
-was metered into the budget guard, and every proof-relevant step (oracle
-observations, warrant, tamper checks, audits) landed on the proof rail
-(`ProofStep`) — which is what makes a pipeline run *replayable* and its
-verdict *auditable* after the fact.
-
----
-
-## Who runs on which model
-
-Every role is configured through `agent_engine_config` (see the README's
-"Agent engine config" section):
-
-| Role | What it does in the journey | Default resolution |
-|---|---|---|
-| **triage** | Stage 1 classification call | `pipeline_triage_model` → `default_model` |
-| **worker** | Execute turns, revise turns (conversational rides this tier too) | `pipeline_worker_model` → `default_model` |
-| **research** | The read-only sub-agents answering triage's pre-plan questions, one child per question | `pipeline_research_model` → **the worker**, never `default_model` |
-| **plan** | The planner writing the ordered work order | `pipeline_plan_model` → **the worker**, never `default_model` |
-| **verifier** | The witness author only, since #2584 removed the verdict and distress-guidance calls | `pipeline_verifier_model` → `default_model`; prefers a different model *family* than the worker |
-| **witness author** | Authors the failing witness test | Resolves from the verifier slot; **degrades to no authored witness** if it would equal the worker's model (refused outright only under `require_independent_witness`) — Stella will not let the worker write the test that proves the worker |
-
-Research and plan end their chain at the worker rather than `default_model`
+Two inheritance rules are worth recording because they were both bug fixes.
+Research and plan ended their chain at *the worker* rather than `default_model`,
 because `--model` re-points the worker for one invocation and deliberately
-leaves settings alone: inheriting `default_model` would split them onto the
-model the flag just overrode, and the run would report one model while buying
-two. The inheritance is field by field and covers request shaping as well —
-`agents.worker.prompt` still reaches the planner while `agents.plan.prompt` is
-unset. `agents.research.prompt` is the one field that does not apply: a
-research child is an engine sub-agent turn whose built-in read-only system
-prompt is the contract that makes it read-only.
-
-A configured role model whose provider has no resolvable key degrades softly
-to the worker with a notice — configuration can never turn a runnable
-pipeline into an error. The one exception is deliberate:
-`require_independent_witness` makes a missing independent author a refusal
-instead of a degradation, for callers whose published posture claims one.
-
-## Where the knobs live
-
-`PipelineConfig` (`src/pipeline.rs`) is the single tuning surface: latency
-ceilings, scope thresholds, headless behavior, `test_command`, `roster`,
-`keep_witness`, `diff_budget_lines`
-(400), `diagnostics_veto_warnings`, `max_revisions` (2),
-`verifier_evidence_demand`, `require_independent_witness`, `candidates`, and
-`create_worktrees`.
-
-`roster` (`src/roster.rs`) holds who performs each responsibility and whether
-it runs at all — including whether a witness is authored, which was briefly a
-separate bool ANDed with its roster row at run time until #2458 collapsed them.
-The `verdict` and `distress_guidance` rows are gone entirely: `default_agent`
-answers `None`, so `Roster::apply` rejects either key as `NotAssignable` rather
-than offering a switch that would steer nothing. One decision, one place;
-the whole roster rides the resume frame, so an ablation survives a kill. The
-verification half's design history and remaining work are tracked in
-[`ROADMAP.md`](../ROADMAP.md); every decision and its spend is pinned by the
-per-PR degradation gate (`crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs`,
-`docs/spec/verification-gate.md`).
+leaves settings alone: inheriting `default_model` would have split them onto the
+model the flag had just overridden, and the run would report one model while
+buying two. And a configured role model whose provider had no resolvable key
+degraded softly to the worker with a notice — **configuration could never turn a
+runnable pipeline into an error**, with `require_independent_witness` the one
+deliberate exception.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -397,19 +397,10 @@
         1,
         2,
         3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13
+        4
       ],
       "status": "living",
-      "title": "The journey of a prompt \u2014 full pipeline mode, in plain language"
+      "title": "The journey of a prompt \u2014 the raw loop, and what a wrapper plugin adds"
     },
     "plugin-completion-plan": {
       "path": "docs/spec/plugin-completion-plan.md",

--- a/docs/spec/adaptive-context/context-reuse.md
+++ b/docs/spec/adaptive-context/context-reuse.md
@@ -16,8 +16,9 @@ status: vendored
   Rev:    c5fb2fec5820494ab6921dc088c03d7f43301fa7
 
   This is the normative contract cited by 23 rustdoc comments across five
-  crates (stella-cli, stella-context, stella-graph, stella-pipeline,
-  stella-protocol). It lived only upstream, so every one of those citations
+  crates as counted at the time (stella-cli, stella-context, stella-graph,
+  stella-pipeline, stella-protocol; the fourth was deleted in #3865, so the
+  count is lower today). It lived only upstream, so every one of those citations
   dangled: `cargo doc` rendered them as plain text. Vendoring makes them
   resolve offline for a reader working without a network.
 

--- a/docs/spec/agent-native-delivery.md
+++ b/docs/spec/agent-native-delivery.md
@@ -762,7 +762,7 @@ P4 is the phase that pays for the document. P0–P3 are the substrate it needs.
 |---|---|
 | `Issue`, `IssueState`, `IssueClass`, `ResidueItem` | `stella-protocol` (wire types) |
 | Residue detection Pass 1 + Pass 2, policy evaluation, discharge rules | `stella-core` (pure, proptestable, no I/O) |
-| The gate stage, Pass 3's verifier call | `stella-pipeline`, beside `verify` and `witness` |
+| The gate stage, Pass 3's verifier call | **Homeless.** This row named `stella-pipeline`, deleted in #3865 — a home has to be picked before it can be built: a wrapper plugin's own side of the socket, or a `stella-cli` check over the turn's transcript. Same open question as `doc:backlog-self-driving`'s residue-gate row. |
 | Provider manifests, transports, the `exec` adapter | `stella-tools`, as new code — no issue surface exists to generalize |
 | `[delivery]`, `.stella/issues/*.toml` discovery | `crates/stella-cli/src/settings` |
 | Issue claims | `stella-fleet` ledger |

--- a/docs/spec/config-system/stella.next.toml
+++ b/docs/spec/config-system/stella.next.toml
@@ -1,6 +1,13 @@
 # =============================================================================
 # stella.next.toml
 #
+# *** DO NOT COPY THIS FILE INTO A PROJECT. ***
+#
+# It describes config that DOES NOT EXIST. Blocks marked NEW parse as
+# unrecognized keys and configure nothing. The file you want is
+# `stella.example.toml` at the repository root — every section stella actually
+# reads, commented, and gate-checked against the loader so it cannot drift.
+#
 # The config shape AFTER the five features in DESIGN.md are built. This is a
 # TARGET, not a plan of record — every block marked NEW needs the
 # corresponding phase in DESIGN.md before it does anything.

--- a/docs/spec/config-system/stella.today.toml
+++ b/docs/spec/config-system/stella.today.toml
@@ -1,6 +1,14 @@
 # =============================================================================
 # stella.today.toml
 #
+# *** NOT THE COPY-PASTE REFERENCE — use `stella.example.toml` at the repo
+# root. *** This file is a design-era artifact: it records the phase-1
+# transliteration and the reasoning behind it, and it is deliberately
+# INCOMPLETE as a reference. It has never carried `[workspace]`, `[plugins]`,
+# `[self_driving]`, `[issues]` or `[enterprise_telemetry]`, so an operator
+# reading it as "everything stella reads" concludes five features do not exist.
+# `stella.example.toml` covers every root section and is gate-checked for it.
+#
 # Every knob Stella ACTUALLY READS as of 2026-07, rendered in the proposed
 # single-file TOML shape. This is the migration target for phase 1: a pure
 # transliteration, no new semantics, no invented keys.

--- a/docs/spec/engine-embedding.md
+++ b/docs/spec/engine-embedding.md
@@ -57,7 +57,7 @@ flowchart TB
         MODEL["stella-model<br/>provider adapters + parity matrix"]
         TOOLS["stella-tools<br/>sandboxed tool registry"]
         STORE["stella-store<br/>sessions, telemetry, drift samples"]
-        PIPE["stella-pipeline<br/>plan → witness → verify → verdict"]
+        PLUG["stella-plugin<br/>plugin manifest + wrapper wire contract<br/>(the socket itself is stella-runtime::wrapper)"]
         MCP["stella-mcp"]
         CTX["stella-context / stella-graph"]
     end
@@ -68,13 +68,13 @@ flowchart TB
     end
 
     CLI --> RUNTIME
-    CLI --> PIPE
+    CLI --> PLUG
     CLI --> CORE
     SERVE --> ENGINE
-    RUNTIME --> MODEL & TOOLS & STORE & MCP & CTX & PIPE
+    RUNTIME --> MODEL & TOOLS & STORE & MCP & CTX & PLUG
     ENGINE --> CORE
     RUNTIME --> CORE
-    MODEL & TOOLS & STORE & PIPE & MCP & CTX --> PROTO
+    MODEL & TOOLS & STORE & PLUG & MCP & CTX --> PROTO
     CORE --> PROTO
 ```
 
@@ -160,9 +160,11 @@ Wire contract artifacts already exist: `docs/wire/serveframe.schema.json`,
 ### Mode C — the community CLI (the reference host)
 
 `stella` itself is Mode A taken to its richest conclusion: the CLI is the
-one host that wires *everything* — the staged pipeline (including its
-witness/verify stages), memory, skills, MCP, fleet, the deck. Treat it as the
-living reference implementation for what a full embedding looks like; the parity matrix below is what keeps the
+one host that wires *everything* — installed wrapper plugins over the wrapper
+socket (`stella run --pipeline <plugin-id>`; the built-in staged pipeline this
+line used to name was deleted in #3865), memory, skills, MCP, fleet, the deck.
+Treat it as the living reference implementation for what a full embedding looks
+like; the parity matrix below is what keeps the
 API surface from quietly falling behind it.
 
 ---

--- a/docs/spec/file-budget.md
+++ b/docs/spec/file-budget.md
@@ -14,6 +14,17 @@ enforceable *numbers* live in exactly one place — `scripts/check-file-size.sh`
 — and `AGENTS.md` restates the rules in imperative form under a parity test
 (§8.3). Three copies of a number is how the last limit died.
 
+> **On the `stella-pipeline` rows.** Every table below is a **census taken on
+> 2026-08-02** and is left exactly as measured. `crates/stella-pipeline` was
+> deleted from the workspace in #3865, so its rows — `src/pipeline.rs` (3,465
+> lines) and `src/pipeline/tests.rs` (2,590) — describe files that no longer
+> exist, and work-order items #3 and #9 in §7.4 are **moot: those splits will
+> never be done, because the crate was removed instead.** The numbers are not
+> restated or re-ranked here, because a measurement edited after the fact stops
+> being one and the *reasoning* this document owns is unaffected by which files
+> happened to be large that day. For the live ceilings, read
+> `scripts/file-size-baseline.txt`, which is generated and gate-enforced.
+
 ---
 
 ## 1. Why a codebase written entirely by agents needs *tighter* file limits, not looser ones

--- a/docs/spec/replay-golden-trajectories.md
+++ b/docs/spec/replay-golden-trajectories.md
@@ -9,52 +9,58 @@ status: archived
 > **Status (2026-08-19):** this document describes machinery that lived in
 > `crates/stella-pipeline`, which was removed from the workspace (#3865)
 > along with `make record-golden`. It is kept as the design record for the
-> replay-fixture approach; none of the commands below run against the
-> current tree.
+> replay-fixture approach; **none of the commands, paths or types below exist
+> in the current tree**, and the whole document is written in the past tense
+> for that reason. A verification plugin that wants trajectory fixtures
+> implements this on its own side of the wrapper socket
+> (`doc:pipeline-as-plugins` §8); the surviving per-PR wire gate is
+> `doc:verification-gate` Layer 2.
 
-How the golden-trajectory fixtures are recorded and refreshed, and what a
-**reference** engine has to do before its runs can join them.
+How the golden-trajectory fixtures were recorded and refreshed, and what a
+**reference** engine had to do before its runs could join them.
 
 Machinery: `crates/stella-pipeline/src/replay.rs` (`validate_stream`,
 `structural_diff`, `streams_equivalent`) and
-`crates/stella-pipeline/src/replay/golden.rs` (the fixture format and its load gates).
+`crates/stella-pipeline/src/replay/golden.rs` (the fixture format and its load
+gates) — both deleted in #3865.
 
 ---
 
 ## Two kinds of recording, deliberately not interchangeable
 
-A golden's manifest names its `source`, and the distinction is load-bearing:
+A golden's manifest named its `source`, and the distinction was load-bearing:
 
 | Source | What it is | What it proves |
 |---|---|---|
 | `rust_stack` | Recorded from this workspace's own pipeline | **Drift baseline.** Catches a stage that stopped being emitted, a tool that changed name, an event that moved or vanished. Both sides are the same code, so it is not independent evidence. |
 | `reference` | Recorded from another engine through an adapter that emits this protocol | **Reference trajectory.** The only kind that answers "does the Rust stack agree with the reference implementation?" |
 
-Encoding this in the fixture rather than in prose is what stops a baseline from
-being cited later as a reference. `RecordingSource::is_reference()` is asserted
-in `crates/stella-pipeline/src/pipeline/tests/golden.rs`.
+Encoding this in the fixture rather than in prose is what stopped a baseline
+from being cited later as a reference — a rule worth carrying into any
+successor. `RecordingSource::is_reference()` was asserted in
+`crates/stella-pipeline/src/pipeline/tests/golden.rs`.
 
-Today every committed golden is a `rust_stack` baseline. No `reference`
-recording exists — see [The reference-engine gap](#the-reference-engine-gap).
+Every committed golden was a `rust_stack` baseline. No `reference` recording was
+ever made — see [The reference-engine gap](#the-reference-engine-gap).
 
 ---
 
 ## The fixture format
 
-Two files per task under `crates/stella-pipeline/tests/fixtures/golden/`:
+Two files per task lived under `crates/stella-pipeline/tests/fixtures/golden/`:
 
 - `<task_id>.jsonl` — one `AgentEvent` per line, the same wire format
   `stella run --output-format stream-json` emits.
 - `<task_id>.manifest.json` — `task_id`, a one-line `description`, the
   `source`, and `event_count`.
 
-`event_count` is not decoration. `parse_jsonl` deliberately tolerates a torn
+`event_count` was not decoration. `parse_jsonl` deliberately tolerates a torn
 final line (L-T1) — correct for a live reader recovering from a crashed writer,
 and exactly wrong for a committed fixture, where it would silently hand back a
 recording one event short and weaken every assertion made against it. The count
-turns that into a loud `GoldenError::Truncated`.
+turned that into a loud `GoldenError::Truncated`.
 
-`GoldenTrajectory::load` additionally refuses:
+`GoldenTrajectory::load` additionally refused:
 
 - a recording that is not parseable as an `AgentEvent` stream
   (`GoldenError::Recording`) — this is what a foreign wire format produces;
@@ -68,36 +74,40 @@ turns that into a loud `GoldenError::Truncated`.
 
 ## Recording and refreshing
 
-```bash
-make record-golden        # re-record every golden from the current code
-```
-
-or directly:
+> **Neither command exists.** `make record-golden` is not a Makefile target and
+> `-p stella-pipeline` names no crate. They are shown because the *shape* of the
+> refresh loop is the part a successor should copy.
 
 ```bash
-STELLA_REFRESH_GOLDEN=1 cargo test -p stella-pipeline --lib golden
+make record-golden                                       # (removed, #3865)
+STELLA_REFRESH_GOLDEN=1 cargo test -p stella-pipeline --lib golden   # (removed)
 ```
 
-The recorders live in `crates/stella-pipeline/src/pipeline/tests/golden.rs`. Each
-drives the real `Pipeline` over scripted model/test ports and records the
-stream it actually emits — deterministic, no API key, runnable in CI, which is
-the only reason a recording can be asserted on every `cargo test` instead of
-refreshed by hand and hoped over.
+The recorders lived in `crates/stella-pipeline/src/pipeline/tests/golden.rs`.
+Each drove the real `Pipeline` over scripted model/test ports and recorded the
+stream it actually emitted — deterministic, no API key, runnable in CI, which
+was the only reason a recording could be asserted on every `cargo test` instead
+of refreshed by hand and hoped over. **Any successor that needs a live model to
+refresh its fixtures has already lost this property.**
 
-**A non-empty fixture diff is a change to the observable event contract.**
-Review it as one. If the change is intended, commit the refreshed fixture with
-the change that caused it; if it is not, you have found a regression.
+**A non-empty fixture diff was a change to the observable event contract**, and
+was reviewed as one. If the change was intended, the refreshed fixture landed
+with the change that caused it; if not, it was a regression.
 
 ### Adding a task
 
+The loop was:
+
 1. Add a `#[tokio::test]` to `crates/stella-pipeline/src/pipeline/tests/golden.rs`
-   that drives the pipeline over scripted ports and ends in `check_golden`.
+   driving the pipeline over scripted ports and ending in `check_golden`.
 2. Run `make record-golden` to write the fixture.
-3. Read the recorded `.jsonl`. It is evidence — confirm it is the flow you
-   meant to capture.
+3. **Read the recorded `.jsonl`.** It is evidence — confirm it is the flow you
+   meant to capture. (A golden blessed without looking is a changelog, not a
+   test; the same rule still governs the TUI's deck snapshots today.)
 4. Keep the set discriminating: `the_recorded_flows_are_structurally_distinct`
-   fails if two goldens collapse into the same trajectory, because a golden set
-   whose members are indistinguishable passes no matter what the pipeline does.
+   failed if two goldens collapsed into the same trajectory, because a golden
+   set whose members are indistinguishable passes no matter what the pipeline
+   does.
 
 ---
 
@@ -133,10 +143,12 @@ The two kinds that already parse (`text`, `reasoning`) are exactly the ones
 `event_signature` treats as structurally inert, and every event carrying
 structural identity fails. A half-imported reference recording would therefore
 be **all volatile content and no structure**: it would parse into something
-shaped like a trajectory that asserts nothing. That is why the loader gates
+shaped like a trajectory that asserts nothing. That is why the loader gated
 instead of trusting a recording, and why
-`crates/stella-pipeline/tests/reference_conformance.rs` pins the gap executably rather
-than leaving it as a comment that can rot.
+`crates/stella-pipeline/tests/reference_conformance.rs` pinned the gap
+executably rather than leaving it as a comment that can rot. That test went with
+the crate, so **the gap is now recorded here in prose only** — exactly the shape
+it was written to avoid.
 
 Note also that `structural_diff` is *positional* by design. Even with the wire
 format fixed, a reference stream would have to align stage-for-stage with the
@@ -145,9 +157,9 @@ or `ContextWrite` stage at all.
 
 ### The adapter
 
-The adapter is `crates/stella-pipeline/src/replay/reference_adapter.rs`
+The adapter was `crates/stella-pipeline/src/replay/reference_adapter.rs`
 (`adapt_reference_stream`, manifest id `replay::reference_adapter@v1`). It
-discharges the obligations `reference_conformance.rs` states — a typed
+discharged the obligations `reference_conformance.rs` stated — a typed
 `StageKind` per known stage label, synthesized `ref-N` call ids with FIFO
 pairing (the only order the id-less wire can support), and a terminal
 `Complete` translated from `result` — and it **fails closed** on everything
@@ -161,9 +173,10 @@ The reference transmits no tool arguments, so `ToolCall::input` is an empty
 object in adapted streams: a reference golden asserts stage order, tool
 identity/pairing, and termination — not arguments. `structural_diff` is also
 *positional*, and the reference emits no `Witness`, `ScopeReview`, `Reflect`,
-or `ContextWrite` stage at all, so a reference golden is only comparable
-against runs whose configuration skips those stages (e.g. a `--test-command`
-run that never authors a witness).
+or `ContextWrite` stage at all, so a reference golden was only comparable
+against runs whose configuration skipped those stages (e.g. a run with a
+supplied test command that never authored a witness — `--test-command` is
+refused outright today, #3867).
 
 ### Provenance of reference recordings — the settled policy
 
@@ -184,6 +197,8 @@ public OSS repo's CI can never regenerate a reference fixture. The policy
   version that produced it; drift between adapter versions is visible in the
   manifest diff.
 
-`STELLA_REFRESH_GOLDEN=1` and `make record-golden` remain the *rust-stack*
-refresh path only — a reference fixture can never be refreshed from this
-repo, by construction.
+`STELLA_REFRESH_GOLDEN=1` and `make record-golden` were the *rust-stack* refresh
+path only — a reference fixture could never be refreshed from this repo, by
+construction. Both are gone; the policy above is the part that outlives them,
+and applies unchanged to any verification plugin that commits opaque fixtures it
+cannot regenerate downstream.

--- a/docs/spec/self-driving-foundry.md
+++ b/docs/spec/self-driving-foundry.md
@@ -59,11 +59,11 @@ each row is a dependency of a later section.
 | Match configuration and artifacts (seats, attempts, `stella-events.jsonl` per trial, `result.json`, reward at `verifier_result.rewards.reward`) | `arenabench/arenabench/{config,model,runner,telemetry}.py` | Shipped. |
 | Paired statistical comparison with guard metrics and a `GuardBlocked` verdict | `crates/stella-core/src/comparison.rs` + `self_tuning::select_winner` | Shipped, deterministic, unused by arenabench (§5.4). |
 | Byte-exact model-call reconstruction, digest-verified | `crates/stella-store/src/reconstruct.rs` | Shipped. |
-| Full-transcript trace capture with reward labels | `crates/stella-cli/src/trace.rs` (#1042), `crates/stella-pipeline/src/reward.rs` (#1043) | Shipped; `trace_capture` defaults off, so no corpus accumulates. |
+| Full-transcript trace capture with reward labels | `crates/stella-cli/src/trace.rs` (#1042); the reward-labelling half was `crates/stella-pipeline/src/reward.rs` (#1043) | **Half gone.** Trace capture ships and still defaults off, so no corpus accumulates. Reward labelling went with `stella-pipeline` (#3865) — a captured trace now carries no reward label, so this row cannot be read as "shipped". |
 | SFT dataset exporter with named acceptance predicate and manifest | `stella dataset export`, `crates/stella-cli/src/dataset_cmd.rs` (#872) | Shipped; predates reward labels and transcript reconstruction — carries neither. |
 | Flip proof, tamper exclusion, verdict evidence | `crates/stella-protocol/src/proof.rs`, `ladder.rs`; doc:witness-protocol, doc:verification-gate | Shipped. |
 | Local/OpenAI-compatible serving of arbitrary weights | reserved `local` provider (`crates/stella-model/src/factory.rs`), custom providers in `settings.json` | Shipped. |
-| Event-stream replay and equivalence checking | `crates/stella-pipeline/src/replay.rs`; doc:replay-golden-trajectories | Shipped (stream conformance, not model-response replay). |
+| Event-stream replay and equivalence checking | was `crates/stella-pipeline/src/replay.rs`; doc:replay-golden-trajectories | **Gone** (#3865). Shipped as stream conformance, never as model-response replay; the committed `docs/wire/` schema gate is all that survives. |
 | Closed-loop playbook prose | `docs/playbooks/self-improving-model.html` | Written; not code. |
 
 Gaps, in one line each: no manifest; no generation layer above cycles; no
@@ -453,10 +453,12 @@ an answer" is a property of the pipeline, not a slogan.
 Two exporter upgrades fall out immediately (they are Phase 0, §12,
 because they are valuable independent of campaigns):
 
-- `stella dataset export` gains `reward` (from
-  `stella-pipeline/src/reward.rs`) and `prompt_messages` (from
+- `stella dataset export` gains `reward` and `prompt_messages` (from
   `Store::reconstruct_call`, gated on `is_verified()`), closing the two
-  gaps it shipped with.
+  gaps it shipped with. **The `reward` half now needs a source:** it was to
+  come from `stella-pipeline/src/reward.rs`, deleted in #3865. A reward label
+  is a verdict, and verdicts are now a verification plugin's to report, so
+  this reads a plugin's evidence rather than a host module.
 - A **preference-pair emitter**: two twins attempting the same task in
   the same generation with divergent rewards are a natural DPO pair —
   same prompt, chosen/rejected trajectories, plus the paired metadata

--- a/docs/spec/serve-surface.fleet.toml
+++ b/docs/spec/serve-surface.fleet.toml
@@ -1,4 +1,11 @@
 # Stella serve surface — fleet plan
+#
+# HISTORICAL: this is the frozen dispatch record of an already-executed fleet
+# run, kept verbatim as the prompts the workers actually received. Task 4 below
+# permits stella-engine to depend on `stella-pipeline`; that crate was deleted
+# from the workspace in #3865, so the clause is dead. Do not re-run this plan
+# against the current tree.
+#
 # Source: docs/design/serve-surface.md (2026-07-20). Builds the headless engine
 # service (Option B of oxagen ADR-033) so Oxagen drives the Rust core over HTTP/SSE.
 #

--- a/docs/spec/serve-surface.md
+++ b/docs/spec/serve-surface.md
@@ -368,30 +368,30 @@ the engine is structured as a headless library, not a terminal program:
    but `stella-protocol`). **A web client is a drop-in peer of the TUI**: attach
    an SSE pump to the same `UnboundedReceiver<AgentEvent>`.
 
-3. **The pipeline is headless-first.** `stella-pipeline` has no TTY coupling in
-   its core; `PipelineConfig.headless` and `headless_bypass_scope_review` are
-   first-class, and a headless scope-review over threshold returns the named
+3. **The pipeline was headless-first** — and is now gone. As read in the
+   2026-07-20 sweep, `stella-pipeline` had no TTY coupling in its core;
+   `PipelineConfig.headless` and `headless_bypass_scope_review` were
+   first-class, and a headless scope-review over threshold returned the named
    error `ScopeReviewRequiredHeadless` — **never a silent auto-approve**.
-   `AutoApproveGate` / `AlwaysAbortGate` are the headless approval ports.
 
-   **Correction (#932 approval half).** This paragraph is the premise behind
-   "surface `ScopeReviewRequiredHeadless` to the host as a decision", and the
-   premise does not hold for `stella-serve` as built: **a served turn never
-   reaches a scope review at all.** `ApprovalGate::review` has exactly one
-   call site — `crates/stella-pipeline/src/pipeline/scope_stage.rs` — and
-   `stella-serve` does not depend on `stella-pipeline`. It drives the
-   *engine* (`stella_engine::run_step`), which has no plan or scope stage.
-   Only `stella-cli` and `stella-runtime` link the pipeline.
+   **Correction (#932 approval half), now overtaken.** That paragraph was the
+   premise behind "surface `ScopeReviewRequiredHeadless` to the host as a
+   decision", and the premise already did not hold for `stella-serve` as built:
+   a served turn never reached a scope review at all. `ApprovalGate::review`
+   had exactly one call site, in the pipeline's scope stage, and `stella-serve`
+   never depended on that crate — it drives the *engine*
+   (`stella_engine::run_step`), which has no plan or scope stage.
 
-   So `POST /v1/turns/{id}/approve` is not merely unbuilt, it is currently
-   **unreachable**: a route no turn could trigger, and a row in the table
-   above that a client could code against and never exercise. Building it
-   is blocked on a prior decision — whether `stella-serve` grows a
-   pipeline-driving surface (`POST /v1/runs`, distinct from `/v1/turns`)
-   or whether the approval boundary moves down into the engine. That is a
-   design question, not an increment, which is why the steering and
-   pause/resume halves of #932 shipped on their own (#1056) and this one
-   did not. It stays out of the table until that decision is made.
+   **`crates/stella-pipeline` has since been deleted outright (#3865)**, so
+   there is no scope review anywhere in the workspace and the last caller of
+   `ApprovalGate::review` went with it. `POST /v1/turns/{id}/approve` is
+   therefore not blocked on the design question this paragraph used to pose
+   (whether serve grows a pipeline-driving surface, or the approval boundary
+   moves down into the engine) — **it is blocked on there being nothing left to
+   approve.** Any future scope-review-shaped hold arrives through the wrapper
+   socket instead: a plugin's `before_turn` asking the host for a decision
+   (`doc:wrapper-socket` §6b), which is a different route and a different
+   design question. It stays out of the table.
 
    **What *did* ship in its place — the hold, made observable.** The half of
    the approval story that does not depend on that decision is the part the
@@ -546,7 +546,8 @@ consecutive backoffs — ends the loop.
 ### The step-scoped facade (`stella-engine`)
 
 ```rust
-// crates/stella-engine/src/lib.rs (facade over stella-core + stella-pipeline)
+// crates/stella-engine/src/lib.rs (facade over stella-core; the pipeline half
+// of this sketch is gone with `stella-pipeline`, #3865)
 pub struct TurnState { /* messages, budget, oracle_state, calibration, seq */ }
 
 impl Engine {
@@ -685,8 +686,11 @@ ADR-033 §7 names).
    `docs/wire/`. `scripts/check-wire-schema.sh` fails the gate on drift, and
    `validate_stream` runs as a conformance check over recorded fixtures and
    deliberate corruptions.
-   **Correction:** `validate_stream` lives in `crates/stella-pipeline/src/replay.rs`,
-   not `stella-protocol` as earlier editions of this document said.
+   **Correction:** `validate_stream` lived in
+   `crates/stella-pipeline/src/replay.rs`, not `stella-protocol` as earlier
+   editions of this document said — and went with that crate in #3865, so the
+   conformance half of this item no longer runs. The committed `docs/wire/`
+   artifacts and `scripts/check-wire-schema.sh` are the part that survives.
 5. ✅ **DONE (#1133).** Bus lifecycle events at the turn, step and model-call
    boundaries — closes "the bus is only emitted from the tool registry."
    `Engine::with_bus` attaches a `HookBus`; the engine then emits

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -35,8 +35,10 @@ a clock.
 | 5 | Selection / lifecycle | `four_class_certification` and `time_lapse_certification` — `crates/stella-core/src/records/tests.rs:462`, `:709` | none — landed in #2306 |
 
 So exactly one seam needs a test double, and the double already exists:
-`ScriptedProvider` appears in 42 files across `stella-core`, `stella-pipeline`,
-`stella-engine` and `stella-cli` (canonically
+`ScriptedProvider` appeared in 42 files across `stella-core`, `stella-pipeline`,
+`stella-engine` and `stella-cli` when this was measured — `stella-pipeline` has
+since been deleted (#3865), so the count is lower and the seam is unchanged
+(canonically
 `crates/stella-core/src/subagent/tests.rs:36`). Replaying canned reflection
 outputs per turn **is** the no-model harness.
 

--- a/docs/spec/turn-lane-assembly.md
+++ b/docs/spec/turn-lane-assembly.md
@@ -11,6 +11,16 @@ review. Everything in §1–§3 is descriptive of `origin/main` at `a41de7be8` a
 was read out of the tree, not recalled; the measurements in §9.5, §9.6 and
 §10.2 were read at `a4b87649a`.
 
+> **§10's question has since been answered, and not by the route it proposed.**
+> `crates/stella-pipeline` was **deleted** from the workspace (#3865) rather
+> than extracted into a lane, so the "Later" row of §10.3, PR 6 and PR 8 of §8,
+> and the definition of done in §10.4 are all overtaken by events. Every
+> `stella-pipeline` count and file:line below is a **measurement taken at the
+> commit named above** and is left exactly as recorded — a measurement rewritten
+> after the fact is not a measurement. Read §10 as the decision record for why
+> the cut was worth making, not as a description of the tree. The lane seam
+> itself (Moves 1–4) is unaffected by the deletion and is still the proposal.
+
 **Companion docs:** `doc:engine-embedding` (the CLI↔API parity matrix this
 generalises), `doc:serve-surface`. **Subordinate to #3246** (the plugin
 authority plane) wherever the two touch — see §9.
@@ -59,7 +69,7 @@ cannot write a table whose rows have no names.
 | Sub-session | `stella-cli/src/subsession.rs:729` |
 | Subagent fork | `stella-core/src/subagent.rs:705` |
 | Fleet worker (raw) | `stella-cli/src/fleet_cmd.rs:914` |
-| Pipeline stage | `stella-pipeline/src/pipeline/execute_stage.rs:363`, `witness_stage.rs:361` |
+| Pipeline stage *(gone — #3865)* | `stella-pipeline/src/pipeline/execute_stage.rs:363`, `witness_stage.rs:361` |
 | Serve session | `stella-serve/src/session.rs:675` |
 
 Plus `stella-core/src/goal.rs:240`, which is a lane-shaped *derivation*
@@ -350,10 +360,14 @@ is a different layer and should stay one. "Re-implement the pipeline" remains a
 change to a stage graph — the matrix makes that boundary explicit rather than
 moving it. If the goal is that re-implementing the pipeline touches one place,
 that is a separate (and mostly already-satisfied) property: `stage_rank` in
-`stella-pipeline/src/replay.rs` is the canonical ordering.
+`stella-pipeline/src/replay.rs` was the canonical ordering.
 
-It also does not move the pipeline *out*. That is the opposite direction and a
-live question — §10.
+It also does not move the pipeline *out*. That was the opposite direction and,
+when this was written, a live question — §10. It is no longer live: the pipeline
+left by deletion (#3865), and the stage graph it supervised is now something a
+verification plugin owns on its own side of the wrapper socket. The paragraph
+above still holds for any *future* supervisor: a supervisor stays a layer, and
+merging one into the loop remains the wrong move.
 
 **It does not, on its own, carry a behavioural witness for Moves 2–3.** They
 are refactors. Move 2's fork witness is real and load-bearing; the rest of
@@ -377,9 +391,9 @@ whichever site was edited last.
 | 3 | Migrate all seven sites; delete shims; no `Default` | — | M |
 | 4 | Lane matrix in `stella-parity`, both-sides enforced | — | M |
 | 5 | `ResumeAuthority` + terminal-frame write side | #3232, #3233 | M |
-| 6 | Drop `stella-runtime`'s dead `stella-pipeline` dependency (§10.2) | — | XS |
+| 6 | ~~Drop `stella-runtime`'s dead `stella-pipeline` dependency (§10.2)~~ | **moot** — the crate is deleted (#3865) | — |
 | 7 | Manifest-declared lanes: `LaneId`, load-time totality, `stella plugins doctor` (§9) | #3246 | L |
-| 8 | Pipeline registers as a lane; cut `stella-cli`'s pipeline dependency (§10.4) | #3246 | XL |
+| 8 | ~~Pipeline registers as a lane; cut `stella-cli`'s pipeline dependency (§10.4)~~ | **moot** — deleted rather than extracted (#3865); a verification *plugin* now reaches the turn through the wrapper socket (`doc:wrapper-socket`), not through a lane | — |
 
 PRs 1 and 2 are independent and can run in parallel. PR 3 is the one that must
 not be split across two sessions — it is a single mechanical sweep, and half a
@@ -563,6 +577,11 @@ thing that looks like a style choice and is not:
 
 ## 10. Does the pipeline leave — now, later, or never?
 
+> **Answered: it left, by deletion (#3865).** This section is kept as the
+> decision record — the costs it weighs are why the cut happened, and §10.5's
+> warning about what an extraction does *not* buy still applies to the plugin
+> path that replaced it. The tables below are measurements at `a4b87649a`.
+
 ### 10.1 The premise, corrected
 
 It has already left `stella-core` (§9.6). What has not left is `stella-cli`.
@@ -602,6 +621,13 @@ So it is decidable rather than debatable:
   from a manifest;
 - a side-by-side bench on the same panel holds — this is the gate #3245 already
   imposes, and it is a measurement, not a review.
+
+**How it actually resolved.** The first bullet is satisfied. The second was
+**not met and was consciously given up**: `--pipeline classic` is refused rather
+than re-delivered, so today's default is the raw loop and verification is opt-in
+through an installed plugin. The third therefore has nothing to compare — there
+is no in-tree arm left to bench against. That is a weaker outcome than this
+section asked for, and naming it is the point of leaving the bullets in.
 
 ### 10.5 What the extraction buys, and what it does not
 

--- a/docs/spec/turn-loop-wrappers.md
+++ b/docs/spec/turn-loop-wrappers.md
@@ -51,11 +51,18 @@ file, the file is named so you can go check it.
 
 Stella has one step loop. Everything else is something wrapped around it.
 
-Today one of those wrappers — the staged pipeline — is not just a caller of the
-loop. It also reaches *into* the loop: it takes over the loop's own "I am done"
-event, and it hands each turn a private event channel so it can filter what the
-loop says. That is a two-way connection between the engine and one of its
-callers, and two-way connections are where bugs live.
+When this was written, one of those wrappers — the staged pipeline — was not
+just a caller of the loop. It also reached *into* the loop: it took over the
+loop's own "I am done" event, and it handed each turn a private event channel so
+it could filter what the loop said. That is a two-way connection between the
+engine and one of its callers, and two-way connections are where bugs live.
+
+That particular wrapper is gone (#3865, see the status note above), but the
+problem it exemplified is not: **the diagnosis is about the shape, not about
+that crate.** Any future wrapper that reaches into the loop instead of sitting
+around it re-creates it, which is exactly why the socket that replaced it makes
+the engine own its own ending (move one, landed) and gives a wrapper four
+declared points rather than a channel it can filter.
 
 This document says what to do about that, in three moves:
 
@@ -162,12 +169,15 @@ to plug in, and nothing else:
 | `judge` | after `after_turn` | turn the evidence into a verdict | call a model |
 | `again?` | after `judge` | say "another turn, here is the correction" or "stop, here is the outcome" | fake an ending the engine did not emit |
 
-`judge` calls no model on purpose. That is already the rule in the pipeline:
-`ladder_decision` in `crates/stella-pipeline/src/verify.rs` is terminal at every
-arm of `LadderDecision` — that enum is the enumeration, and this document
+`judge` calls no model on purpose. That was already the rule in the pipeline:
+`ladder_decision` in `crates/stella-pipeline/src/verify.rs` was terminal at every
+arm of `LadderDecision` — that enum was the enumeration, and this document
 deliberately does not restate it or its count, because a number copied into a
 second file drifts (#3473) — and #2584 removed the model verdict structurally.
-The wrapper contract keeps that rule instead of re-arguing it.
+The wrapper contract **keeps that rule** instead of re-arguing it, and since the
+crate that used to demonstrate it is deleted (#3865), the socket is now the only
+place the rule is enforced: `judge` is a synchronous, I/O-free, total function,
+so a plugin cannot buy a model call to grade its own work even if it wanted to.
 
 The arm a plugin author most needs from that enum is `WitnessUnsatisfiable`: the
 witness was authored and its red does not discriminate, so `judge` must be able
@@ -176,11 +186,15 @@ to say "the instrument is broken", not only "the work failed".
 `before_turn` is where the steering plane (#3243) is asked its one question —
 "what could help here?" — for a wrapped run. It is not a fifth plane.
 
-### What each of today's wrappers becomes
+### What each of the wrappers becomes
 
-- **The staged pipeline** is the first plugin. `triage`, `recall`, `research`,
-  `plan`, `scope` are `before_turn`. `witness` is `after_turn`. `verify` is
-  `judge`. `revise` is `again?`.
+- **The staged pipeline** was to be the first plugin, with `triage`, `recall`,
+  `research`, `plan`, `scope` as `before_turn`, `witness` as `after_turn`,
+  `verify` as `judge` and `revise` as `again?`. It was **deleted rather than
+  ported** (#3865), so this mapping is now the porting instruction handed to a
+  verification plugin (`doc:pipeline-as-plugins` §8) rather than a description
+  of a migration in flight. The mapping itself is unchanged and is the useful
+  part: it is how a stage graph lands on four points.
 - **Goal mode** is the second, or the same one with a different `judge`. Its
   rounds are `again?`; its independent verifier is `judge`.
 - **`stella monitor`** is goal mode with a pinned goal. It was never a separate
@@ -276,9 +290,9 @@ rules apply to it:
 
 ### Flip the default
 
-Today the pipeline is the default and `--no-pipeline` opts out. That is
-backwards once wrappers are plugins: the raw loop is the ground truth and a
-wrapper is the extra thing you asked for.
+When this was written the pipeline was the default and `--no-pipeline` opted
+out. That is backwards once wrappers are plugins: the raw loop is the ground
+truth and a wrapper is the extra thing you asked for.
 
 So: every door hits the raw loop by default, and `--pipeline <variant>` opts in.
 `--no-pipeline` stays as a deprecated alias that does nothing, so no script

--- a/docs/spec/verification-gate.md
+++ b/docs/spec/verification-gate.md
@@ -8,89 +8,105 @@ status: living
 
 Experiments on the agent loop fail in a specific, ugly way: the change ships,
 every unit test stays green, and three weeks later a benchmark run shows the
-agent quietly got worse — or more expensive, which is the same thing arriving
-on a different invoice. This document names the three layers CI uses to catch
-that early, what each one can honestly claim, and what none of them can.
+agent quietly got worse — or more expensive, which is the same thing arriving on
+a different invoice. This document names the layers CI uses to catch that early,
+what each one can honestly claim, and what none of them can.
 
-The layers are ordered by cost. Every PR pays for the first two on every
-`cargo test --workspace` (they are ordinary tests — free, deterministic, no
-API key, no Docker). The third is bought deliberately.
+> **Read this first: two of the three layers no longer exist.** Layers 1 and 2
+> were tests inside `crates/stella-pipeline`, deleted from the workspace in
+> #3865. Nothing replaced them, so **no per-PR gate observes what the agent
+> decides or spends today** — only the wire-contract half of Layer 2 survives.
+> They are described below in the past tense because they are the shape a
+> verification plugin is asked to port (`doc:pipeline-as-plugins` §8) and
+> because the hole they left is the thing a reader most needs to know about.
+> Tracked in #3901 alongside the rest of the sweep.
 
-## Layer 1 — the degradation gate (blocking, per-PR)
+## Layer 1 — the degradation gate (**gone**; was blocking, per-PR)
 
-`crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs` drives the **real
-pipeline** — triage, execution, witness plumbing, the verification ladder,
+`crates/stella-pipeline/src/pipeline/tests/degradation_gate.rs` drove the real
+staged pipeline — triage, execution, witness plumbing, the verification ladder,
 the verifier — over scripted model/test doubles, through a fixed matrix of
-scenarios, and pins three things per scenario:
+scenarios, and pinned three things per scenario:
 
-1. **The decision.** A clean fail→pass flip fast-submits deterministically; a
-   flaky flip escalates; a timed-out baseline never manufactures a flip; a
-   fresh lint error vetoes; a red suite revises without buying a verifier.
-2. **The spend.** The exact number of model calls, by role, and the exact
-   number of test-suite invocations. A change that leaves every verdict
-   intact but buys a verifier call where the ladder used to decide for free is
-   a **cost regression**, and it fails here with a message naming the extra
-   call.
-3. **The evidence.** Verdicts carry their ladder snapshot (provenance), and
-   the verifier prompt carries the oracle trace — degradations in what the
-   verifier is told are degradations in verifier quality one step removed.
+1. **The decision.** A clean fail→pass flip fast-submitted deterministically; a
+   flaky flip escalated; a timed-out baseline never manufactured a flip; a fresh
+   lint error vetoed; a red suite revised without buying a verifier.
+2. **The spend.** The exact number of model calls, by role, and the exact number
+   of test-suite invocations. A change that left every verdict intact but bought
+   a verifier call where the ladder used to decide for free was a **cost
+   regression**, and it failed here with a message naming the extra call.
+3. **The evidence.** Verdicts carried their ladder snapshot, and the verifier
+   prompt carried the oracle trace — degradations in what the verifier is told
+   are degradations in verifier quality one step removed.
 
-What it proves: **the decision policy and its price did not drift.** What it
-cannot prove: that the policy is *good* — both sides of every assertion are
+What it proved: **the decision policy and its price did not drift.** What it
+could not prove: that the policy was *good* — both sides of every assertion were
 this codebase's own logic.
 
-When it fails on your PR, one of two things is true. Either you broke
-something — fix it — or you *intended* the new behavior, in which case the
-scenario's expectation is updated **in the same PR**, where the reviewer
-sees "this change makes flaky flips escalate" stated as a diff line instead
-of discovering it in production. Never widen an expectation to "whatever it
-now does"; the gate's entire value is that intent has to be written down.
+Its operating rule is the part worth porting. When it failed on your PR, one of
+two things was true: either you broke something — fix it — or you *intended* the
+new behavior, in which case the scenario's expectation was updated **in the same
+PR**, where the reviewer sees "this change makes flaky flips escalate" stated as
+a diff line instead of discovering it in production. Never widen an expectation
+to "whatever it now does"; the gate's entire value is that intent has to be
+written down.
 
-## Layer 2 — golden trajectories (blocking, per-PR)
+**A verification plugin owns this now.** Its oracle and its declared verdict rule
+are its decision policy, and pinning them against scripted doubles is work on the
+plugin's own side of the wrapper socket — a host that neither runs the check nor
+re-checks the evidence (#3511) cannot gate on either.
 
-`pipeline/tests/golden.rs` records full `AgentEvent` streams from fixed runs
-and structurally diffs them against committed fixtures. This is a **drift
-baseline**: it catches a stage that stopped being emitted, an event that
-moved, a protocol field that vanished — the wire-contract regressions no
-single-flow assertion notices. (`make record-golden` was removed with `crates/stella-pipeline`, #3865.) Historically these were refreshed and reviewed
-the fixture diff as a contract change. It is not independent evidence; both
-sides are the same code.
+## Layer 2 — golden trajectories (**mostly gone**; the wire half survives)
 
-The wire schema itself (`docs/wire/agentevent.schema.json`) is committed and
-asserted by `crates/stella-protocol/tests/wire_contract.rs`; regenerate with
-`scripts/export-agentevent-schema.sh`. Protocol changes must be additive —
-old streams must keep parsing (pinned by tests).
+`pipeline/tests/golden.rs` recorded full `AgentEvent` streams from fixed runs and
+structurally diffed them against committed fixtures — a **drift baseline** for a
+stage that stopped being emitted, an event that moved, a protocol field that
+vanished. It went with the crate in #3865, and `make record-golden` no longer
+exists as a target. It was never independent evidence; both sides were the same
+code.
+
+**What still runs:** the wire schema itself. `docs/wire/agentevent.schema.json`
+is committed and asserted by `crates/stella-protocol/tests/wire_contract.rs`;
+regenerate with `scripts/export-agentevent-schema.sh`. Protocol changes must be
+additive — old streams must keep parsing, pinned by tests — and the `wire-schema`
+gate step plus `.github/workflows/wire-schema.yml` enforce that a hand-edited
+generated schema cannot land alone.
+
+So the wire *contract* is still gated. The event *trajectory* is not.
 
 ## Layer 3 — the benchmark arm (deliberate, expensive, honest by protocol)
 
-Terminal-Bench runs under `bench/` measure the thing the first two layers
-cannot: **capability on real tasks**. They cost real money and hours, so
-they are not per-PR. What keeps them honest is protocol, not frequency:
+Terminal-Bench runs under `bench/` measure the thing the other layers cannot:
+**capability on real tasks**. They cost real money and hours, so they are not
+per-PR. What keeps them honest is protocol, not frequency:
 
 - **Preregistration.** The comparison, task set, SUT commit, and scoring are
   filed as an issue *before* the run (e.g. #1002, #1013). No moving the
   goalposts after seeing the number.
-- **The witness arm.** A frozen control adapter (digest-pinned) runs beside
-  the candidate, so "the harness changed" and "the agent changed" cannot be
+- **The witness arm.** A frozen control adapter (digest-pinned) runs beside the
+  candidate, so "the harness changed" and "the agent changed" cannot be
   confused.
-- **Small-N discipline.** A 7-task smoke run distinguishes "obviously
-  broken" from "plausibly fine"; it does not rank models or prove a 3%
-  improvement. Claims must match the N.
+- **Small-N discipline.** A 7-task smoke run distinguishes "obviously broken"
+  from "plausibly fine"; it does not rank models or prove a 3% improvement.
+  Claims must match the N.
 
-## How to read the three layers together
+This is the only layer still standing at full strength, which raises its price:
+a change to the loop, prompts, routing or a wrapper plugin now has no cheap
+per-PR observation between it and a benchmark run.
 
-- Layer 1 red → your change altered what the agent *decides* or *spends*.
-  This is the signal the gate exists for; treat an unintended red as a bug
-  in the change, not the gate.
-- Layer 2 red → your change altered what the agent *emits*. Consumers
-  (TUI, serve, store projections) are affected; review the fixture diff.
-- Layers 1–2 green but you touched the loop, prompts, routing, or
-  verification: the change is *safe*, not yet *good*. If it claims to make
-  the agent better, it earns a preregistered Layer 3 run before that claim
-  appears anywhere.
+## How to read the layers together
+
+- Wire schema red → your change altered what the agent *emits*. Consumers (TUI,
+  serve, store projections) are affected; review the schema diff.
+- Green but you touched the loop, prompts, routing, or a verification plugin:
+  the change is *unobserved*, not *safe*. With Layers 1 and 2 gone there is no
+  per-PR signal for what the agent decides or spends, so "the tests pass" now
+  carries strictly less information than this document was written to describe.
+- If a change claims to make the agent better, it earns a preregistered Layer 3
+  run before that claim appears anywhere.
 
 None of this measures model quality drift, provider-side changes, or tasks
-outside the scenario matrix and bench set. When an experiment targets
-something no layer observes, the first commit should extend the matrix with
-a scenario that observes it — a gate that never grows is a gate experiments
-learn to route around.
+outside the bench set. When an experiment targets something no layer observes,
+the first commit should extend the observation — a gate that never grows is a
+gate experiments learn to route around, and a gate that shrinks without anyone
+saying so is worse.

--- a/docs/spec/witness-protocol.md
+++ b/docs/spec/witness-protocol.md
@@ -6,7 +6,18 @@ status: living
 
 # The Witness Protocol, adapted
 
-Status: approved for implementation — §4 and §7 land in `stella-pipeline`; §5 records what is deliberately declined
+Status: approved for implementation. §4 and §7 landed in `stella-pipeline`,
+which has since been **deleted from this workspace** (#3865); §5 records what is
+deliberately declined.
+
+> **Where this lands now.** Host-run verification no longer exists here, so the
+> adopted half of this protocol is what a **verification wrapper plugin**
+> implements on its own side of the wrapper socket — see
+> `doc:pipeline-as-plugins` §8 for the porting plan and `doc:wrapper-socket` for
+> the contract it implements against. The adoption *decision* below is unchanged
+> by the move: which ideas Stella takes and which it declines is a judgement
+> about the ideas, not about which crate hosts them. Citations into
+> `stella-pipeline` are historical (#3901).
 
 ## Purpose
 

--- a/docs/spec/wrapper-socket.md
+++ b/docs/spec/wrapper-socket.md
@@ -180,8 +180,10 @@ declared role instead of being described as a `judge`.
 ### `judge` — synchronous, host-run, total
 
 Evidence in, verdict out. §4. No arm escalates to a model — the same property
-`ladder_decision` already has (`crates/stella-pipeline/src/verify.rs`), which is
-why porting it is a re-home rather than a rewrite.
+`ladder_decision` had (`crates/stella-pipeline/src/verify.rs`, deleted in
+#3865), which is why porting it is a re-home rather than a rewrite. The property
+is the thing being ported; the code is no longer here to copy, so a plugin
+implements it from this contract.
 
 ### `again?` — synchronous, host-run, total
 
@@ -223,8 +225,9 @@ The design rules that make it passable:
   constraint #3387 answered for `TurnCapabilities` with owned slots, applied
   one layer out.
 - **The candidate worktree crosses as a serializable handle, not as a port.**
-  `CandidateWorkspacePort` + `CandidateWorkspace` are 19 methods returning
-  borrowed trait objects (`crates/stella-pipeline/src/ports/workspace.rs:94-335`).
+  `CandidateWorkspacePort` + `CandidateWorkspace` were 19 methods returning
+  borrowed trait objects (`crates/stella-pipeline/src/ports/workspace.rs:94-335`,
+  as measured before the crate's deletion in #3865).
   The socket takes the minimum serializable subset — create, root path,
   run-test, seal, adopt, remove — and the **host** fences filesystem access.
   Tamper snapshotting stays host-side, which `TamperPolicy::ArtifactIdentity`

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -1,0 +1,634 @@
+# =============================================================================
+# stella.example.toml — the complete reference configuration
+#
+#   cp stella.example.toml stella.toml
+#
+# Then delete what you do not need. Every section below is optional: an empty
+# file is exactly the defaults, and each value shown is either the real shipped
+# default (marked "default") or a realistic example.
+#
+# WHERE THIS FILE GOES — three scopes, merged in this order:
+#
+#   1. ~/.stella/stella.toml     your settings, every workspace
+#   2. the org-managed file      set by STELLA_MANAGED_SETTINGS; see [authority]
+#   3. <repo>/stella.toml        this workspace — committed, reviewed like source
+#
+# Project wins per field, with two deliberate exceptions noted at [hooks]
+# (which concatenate) and [authority] (a ceiling nothing below can raise).
+#
+# CREDENTIALS DO NOT GO HERE. `~/.stella/credentials.toml` is a separate file,
+# 0600, zeroized on drop, never merged into this one. A literal
+# `providers.<id>.api_key` at project scope is REFUSED at load, because this
+# file belongs in version control — use `api_key_env`, or `stella auth set`.
+#
+# Every key in this file is verified against a serde struct by
+# `settings::tests::toml::the_shipped_reference_config_loads_with_no_unrecognized_keys`,
+# so it cannot drift from what stella actually reads. If you add a key here and
+# stella does not read it, that test fails.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# META — the migration seam
+# -----------------------------------------------------------------------------
+[meta]
+# The schema version this build writes and understands. A file with no [meta]
+# block is version 1 by definition. A version this build does not know is a
+# hard refusal, not a silent partial read.
+schema_version = 1
+
+# Optional self-declaration, checked against where the file was actually found.
+# The file's LOCATION decides its scope; this only restates it, and a mismatch
+# is an error — a project file claiming "managed" is borrowing authority.
+scope = "project"
+
+
+# -----------------------------------------------------------------------------
+# RUN — per-run behavior
+#
+# This table exists because a bare key at the TOML document root attaches to
+# whatever [table] precedes it: move one line and it silently becomes that
+# table's key. That is not hypothetical — drafting the first reference config,
+# a root-level `enable_recap` landed inside [authority] and configured nothing.
+# -----------------------------------------------------------------------------
+[run]
+# always | ask | never — whether a run works in a throwaway git worktree
+# instead of your checkout. Default: "ask". Consulted only when the run will
+# actually change files, and only when isolation is available.
+create_worktrees = "ask"
+
+# on (default) | off — the workspace probe skips paths your .gitignore excludes.
+ignore_gitignore = "on"
+
+# NOTE: `recap` and `trace_capture` used to live here. Both were retired in
+# #3870 — the code behind them was orphaned by the staged pipeline's removal
+# (#3865). Stella recognizes them, reads nothing, and says so on load rather
+# than pretending they still work.
+
+
+# -----------------------------------------------------------------------------
+# WORKSPACE — facts about the tree this config belongs to
+# -----------------------------------------------------------------------------
+[workspace]
+# Directories OUTSIDE the repository root that write tools may touch. Relative
+# entries resolve against the project root. Default: none — writes are confined
+# to the workspace.
+allowed_dirs = ["../shared-fixtures", "/tmp/stella-scratch"]
+
+
+# -----------------------------------------------------------------------------
+# PROVIDERS — BYOK model endpoints, keyed by id
+#
+# Merged per-id AND per-field across scopes, so an org base_url and a user
+# api_key_env compose instead of one replacing the whole entry.
+#
+# Built-in ids: openrouter, zai, anthropic, openai, xai, deepseek, gemini,
+# vertex, bedrock, local. Naming one here OVERRIDES its fields; naming anything
+# else DEFINES a new OpenAI-compatible provider.
+# -----------------------------------------------------------------------------
+[providers.anthropic]
+# Name an environment variable to read the credential from. Prefer this to a
+# literal for anything long-lived.
+api_key_env = "ANTHROPIC_API_KEY"
+default_model = "claude-fable-5"
+# Prompt-cache window pin: "5m" | "1h". Absent — the normal case — lets the
+# surface decide: the interactive deck asks for 1h (human-paced gaps outlive
+# 5 minutes), headless runs keep the 5m provider default. Honored by
+# `anthropic` only.
+cache_ttl = "1h"
+
+[providers.openrouter]
+api_key_env = "OPENROUTER_API_KEY"
+# Pin a GATEWAY to these upstreams in preference order and forbid it falling
+# back to any other. Set this when two runs must be comparable: a gateway can
+# serve the same slug from a different vendor between runs, which silently
+# varies the model a head-to-head claims to hold fixed. Inert on a direct
+# endpoint, which has no upstream to choose.
+upstream_pin = ["anthropic", "google-vertex"]
+
+# A provider stella has no built-in for. `dialect` defaults to
+# "openai-compatible" and is ignored when overriding a built-in (a built-in's
+# dialect is fixed by its adapter).
+[providers.my-vllm]
+name = "Internal vLLM"
+base_url = "http://vllm.internal:8000/v1"
+dialect = "openai-compatible"
+default_model = "qwen3-coder"
+api_key_env = "VLLM_TOKEN"
+
+
+# -----------------------------------------------------------------------------
+# MODELS — policy OVER the catalog, not a model table
+#
+# `~/.stella/catalog.db` is the authority on what models exist and what they
+# cost. This block says only which of them this workspace may use — which is
+# what stops a hand-written model list from rotting the week a model ships.
+# -----------------------------------------------------------------------------
+[models]
+# REPLACES wholesale across scopes rather than concatenating: it is one
+# vocabulary, and merging would make it impossible for a project to NARROW the
+# user's list. Absent = every model in the catalog is allowed.
+allowed = ["anthropic/claude-fable-5", "openrouter/moonshotai/kimi-k3"]
+
+# Deliberately spend FEWER output tokens than a model can write, per model.
+# Merges per KEY across scopes, unlike `allowed` above. An unlisted model needs
+# no entry — it gets its own maximum — so deleting a line restores the correct
+# default instead of leaving a stale number behind.
+[models.output_caps]
+"anthropic/claude-sonnet-5" = 64000
+"deepseek-chat" = 32000
+
+
+# -----------------------------------------------------------------------------
+# AGENTS — the engine config
+#
+# Core knows exactly ONE role: `default` (#3903). The five `pipeline_*_model`
+# keys and the [agents.worker] / [agents.verifier] / [agents.triage] tables were
+# retired in #3908 — they pinned models for the deleted staged pipeline's roles
+# and, on a workspace without it, bought nothing for the whole time they
+# existed. A plugin that wants a second model asks for a SEAT instead; see
+# [seats] below.
+# -----------------------------------------------------------------------------
+[agents]
+# The model every turn runs on, as `provider/slug`.
+default_model = "anthropic/claude-fable-5"
+
+# on | off (default off) — let stella pick the model per turn from the catalog
+# rather than always using `default_model`.
+auto_mode = "off"
+
+# on | off (default off) — let stella pick reasoning effort per turn. Overrides
+# an explicit `effort` under [agents.default] when on.
+effort_auto = "off"
+
+# on | off (default off) — let stella decide whether to think per turn.
+reasoning_auto = "off"
+
+# Seconds before a model call is abandoned.
+model_timeout_secs = 600
+
+# Token budget the compactor aims to leave free before it summarizes.
+compaction_budget_tokens = 120000
+
+# How many steps a tool result stays verbatim in the transcript before it is
+# elided to a digest.
+tool_result_horizon_steps = 12
+
+# NOTE: `headless_scope_bypass` still parses and does nothing. The headless
+# scope-review stage it steered went with the staged pipeline (#3865); the key
+# is kept only because a published benchmark posture hashes it. Do not read it
+# as a knob you can turn.
+
+# The built-in agent. Written LAST in this table on purpose: TOML would read
+# any flat scalar placed after a table header as a key of that table.
+[agents.default]
+# Reasoning effort: low | medium | high | xhigh | max. Overridden by
+# `effort_auto = "on"`.
+effort = "high"
+# on | off — thinking mode. Absent = the provider's default.
+reasoning = "on"
+# Replace the built-in system prompt for this agent. Workspace memories and
+# rules still append to it — they are additive context, not part of the base
+# instruction set. PROJECT SCOPE CANNOT SET THIS unless the workspace is
+# trusted; see [authority].
+# prompt = "Prefer small, reviewable diffs."
+
+# Generation parameters — the "include" model: a value set here goes on the
+# wire where the provider's dialect supports it; anything absent leaves the
+# provider default untouched.
+[agents.default.params]
+temperature = 0.2
+top_p = 0.9
+max_tokens = 8192
+# top_k = 40
+# frequency_penalty = 0.0
+# presence_penalty = 0.0
+# repetition_penalty = 1.0
+# seed = 42
+# verbosity = "medium"
+# service_tier = "default"
+
+
+# -----------------------------------------------------------------------------
+# SEATS — which model each PLUGIN-declared seat runs on
+#
+# Keys are `<plugin-id>/<role>`. The plugin declares only the bare role name and
+# the host applies the prefix, so one plugin cannot forge another's namespace.
+#
+# Its own top-level table rather than part of [agents] on purpose: the [agents]
+# set is CLOSED (its names are struct fields), which is what makes flattening
+# safe there. Seat names are an OPEN set chosen by whatever you installed, so a
+# plugin author could ship a seat called `auto_mode` tomorrow.
+# -----------------------------------------------------------------------------
+[seats]
+"vera/verifier" = "anthropic/claude-opus-5"
+"stella-plan/planner" = "openrouter/openai/gpt-5.5"
+
+
+# -----------------------------------------------------------------------------
+# TOOLS — per-tool and per-group switches
+#
+# An open map of `"<key>" = "on" | "off"`. A key is a tool name, a group name,
+# or the wildcard. Every built-in is registered by default.
+#
+# Keys: the shell (`bash`), the file quartet (`read_file`, `write_file`,
+# `edit_file`, `delete_file`), `search`, `delegate`, the task board, the scratch
+# state plane (`save_state` / `get_state` / `list_state` / `delete_state`), and
+# `get_environment`. The authoritative list is
+# `crates/stella-tools/src/catalog.rs` — never a number written in prose.
+# -----------------------------------------------------------------------------
+[tools]
+delegate = "off"      # one tool
+scratch = "off"       # one whole group
+"*" = "on"            # the wildcard — quoted, because bare * is not a TOML key
+
+
+# -----------------------------------------------------------------------------
+# HOOKS — lifecycle shell-outs
+#
+# THE ONE BLOCK THAT DOES NOT FOLLOW LAST-WINS: hooks CONCATENATE across scopes.
+# Any scope may add a gate; no scope can remove another's.
+#
+# Event keys are PascalCase, matching what you already type in settings.json.
+# `matcher` globs the TOOL name for the two ToolUse events; SessionStart ignores
+# it and runs every action. `timeoutMs` is camelCase, defaults to 60_000, and is
+# hard-capped at 600_000. The command receives the event payload as JSON on
+# stdin.
+#
+# TRUST: project-scope hooks are NOT loaded unless STELLA_PROJECT_HOOKS=1 or
+# STELLA_TRUST_PROJECT=1. A hook is arbitrary code execution on `git clone`.
+# -----------------------------------------------------------------------------
+[[hooks.SessionStart]]
+  [[hooks.SessionStart.hooks]]
+  type = "command"
+  command = "./scripts/session-context.sh"
+
+[[hooks.PreToolUse]]
+matcher = "delegate"
+  [[hooks.PreToolUse.hooks]]
+  type = "command"
+  command = "./scripts/audit-spawns.sh"
+  timeoutMs = 5000
+
+[[hooks.PostToolUse]]
+matcher = "write_file"
+  [[hooks.PostToolUse.hooks]]
+  type = "command"
+  command = "./scripts/fmt-on-write.sh"
+
+
+# -----------------------------------------------------------------------------
+# MCP — external tool servers
+#
+# `[mcp.servers.<name>]` is the whole of `.stella/mcp.toml` under a prefix.
+#
+# HEADS UP: this block PARSES but is NOT YET CONSUMED — MCP servers still load
+# from `.stella/mcp.toml`. Stella says so loudly at startup rather than dropping
+# them silently. `registry_url` below IS live.
+#
+# TRUST: MCP servers sit on the same code-execution boundary as hooks; project
+# scope needs STELLA_TRUST_PROJECT=1.
+#
+# CREDENTIAL SCRUB: a stdio child inherits NO ambient environment except the
+# keys in its own `env` table, plus PATH (the one exception, without which
+# npx/uvx/docker could not resolve). An ANTHROPIC_API_KEY in your shell can
+# never reach an MCP subprocess.
+# -----------------------------------------------------------------------------
+[mcp]
+# Base URL of an MCP Server Registry API. Unset = the official registry.
+registry_url = "https://registry.modelcontextprotocol.io"
+
+[mcp.servers.filesystem]
+transport = "stdio"
+cmd = "mcp-server-filesystem"
+args = ["--root", "/workspace"]
+env = { LOG_LEVEL = "info" }
+# Explicit opt-in for Best-of-N candidate sharing. NEVER inferred from the
+# server's own `read_only_hint`, which is untrusted and cannot tell "reads an
+# external system" (safe across candidates) from "reads the local tree" (would
+# read stale bytes from an isolated snapshot).
+candidate_safe = false
+
+[mcp.servers.github]
+transport = "http"
+url = "https://mcp.example.com/mcp"
+headers = { Authorization = "Bearer ${GITHUB_MCP_TOKEN}" }
+
+
+# -----------------------------------------------------------------------------
+# CONTEXT — the retrieval and adaptive-context planes
+#
+# Whole-block last-wins across scopes (not per-field). Enums are "loud": an
+# unrecognized value is a hard parse error, never a silent fallback.
+# -----------------------------------------------------------------------------
+[context.lifecycle]
+# Ships ON. Setting it false restores every pre-adaptive-context behavior. Every
+# other block here EXCEPT `retrieval` is ignored while this is off.
+enabled = true
+
+[context.learning]
+# off (default) | record_only | advisory
+#   off         — no mining, no proposal induction, no efficacy learning
+#   record_only — capture observations and outcomes, but never select or
+#                 promote inferred records
+#   advisory    — governed inferred advisory use
+mode = "off"
+
+[context.governance]
+# solo (default) | team | regulated
+mode = "solo"
+
+[context.promotion.inferred_directive]
+min_observations = 3
+min_distinct_tasks = 3
+auto_activate_at_confidence = 85          # 0..=100
+# An inferred directive can never START blocking.
+initial_enforcement = "advisory"          # advisory | blocking
+
+[context.promotion.blocking_directive]
+# A blocking directive always requires explicit human confirmation. Do not turn
+# this off lightly.
+requires_explicit_confirmation = true
+
+[context.efficacy]
+min_attributable_uses = 5
+not_helpful_ratio_threshold = 0.8         # 0.0..=1.0
+min_attribution_confidence = 80           # 0..=100
+receipt_display_min_attribution_confidence = 80
+
+[context.retention]
+raw_observation_days = 30
+proposal_days = 30
+inferred_directive_review_days = 180
+
+# UNLIKE the rest of this block, retrieval is LIVE regardless of
+# `lifecycle.enabled` — it configures the retrieval plane that already runs for
+# every user. Every value below is the real shipped constant, so a workspace
+# configuring nothing behaves identically.
+#
+# Out-of-range values are CLAMPED, not rejected: this is a file a person edits,
+# and failing a turn over a typo in a tuning knob is a worse answer.
+[context.retrieval]
+max_frames = 5
+max_tokens = 1200
+rrf_k = 60.0                  # higher flattens the ranking
+recency_weight = 0.25         # damped on purpose: at parity the newest rows
+                              # take every slot no matter what was asked
+mmr_lambda = 0.7              # relevance vs. diversity
+min_coverage = 0.3
+coverage_topk = 5
+max_vector_seeds = 32
+lexical_limit = 64
+mmr_candidate_multiple = 3
+
+# OFF by default, deliberately: this is the one knob here that changes WHICH
+# memories a turn can recall rather than how they are ordered. An approximate
+# index considers a subset, so a frame the exact scan would find can be missed.
+# It also does nothing until `stella memory index` has built one.
+ann_enabled = false
+ann_probes = 8
+
+# ON by default (#2289). With it off, `max_frames` is a cap that always fills,
+# so a small workspace surfaces the same frames on every prompt no matter what
+# was asked. `false` is the escape hatch back to that padding behavior.
+require_evidence = true
+
+# A/B recall control: every Nth turn runs with recall suppressed so recall's
+# value is readable from the two arms. 0 (and 1) disable it entirely.
+ab_recall_rate = 0
+
+[context.steering]
+# The steering plane's master switch (#3243). Ships ON. Setting it false
+# withholds every non-prefix injection — recalled frames, the volatile record
+# channel, and skills — and leaves the byte-stable system prefix untouched,
+# which is what makes it a clean control arm rather than a different agent.
+#
+# Precedence: anyone may turn steering OFF; only the org may prevent it being
+# turned back on.
+enabled = true
+
+
+# -----------------------------------------------------------------------------
+# CONTEXT PROVIDERS — third-party CGP context sources
+#
+# The map key is the host's routing AND consent key, so renaming an entry makes
+# it a new provider whose consent must be granted afresh.
+#
+# Two properties are not optional: conformance is an ADMISSION GATE (a provider
+# is run through the protocol's conformance suite before it is registered, so
+# one that lies about token cost or serves uncited frames never serves a turn),
+# and egress is CONSENTED, never assumed. An untrusted project scope
+# contributes nothing here.
+# -----------------------------------------------------------------------------
+[context_providers.acme-docs]
+transport = "stdio"           # stdio | http
+command = "acme-context-server"
+args = ["--index", "./docs"]
+enabled = true
+
+[context_providers.corp-kb]
+transport = "http"
+url = "https://kb.corp.example/cgp"
+enabled = false
+# Hosts this provider may send workspace content to. Empty = no egress.
+egress_consent = ["kb.corp.example"]
+consent_grantor = "security@corp.example"
+
+
+# -----------------------------------------------------------------------------
+# UI
+# -----------------------------------------------------------------------------
+[ui]
+# stella-dark (default) | stella-light. An unrecognized slug falls back to the
+# default rather than failing.
+theme = "stella-dark"
+
+
+# -----------------------------------------------------------------------------
+# PLUGINS — the per-plugin retraction switches
+#
+# `"<plugin-name>" = "on" | "off"`, where the name is what `stella plugin list`
+# prints. Installed plugins are on by default; "off" retracts one without
+# uninstalling it.
+#
+# Plugins themselves are installed with `stella plugin install <dir>`, from
+# `.stella/plugins/` (this workspace) or `~/.stella/plugins/` (every
+# workspace) — not declared here. This table only switches them.
+# -----------------------------------------------------------------------------
+[plugins]
+vera = "on"
+some-noisy-observer = "off"
+
+
+# -----------------------------------------------------------------------------
+# REWARD — what a finished turn's verdict is worth as a training label (#1043)
+#
+# Carries no credential or egress authority, so no trust restoration: a project
+# setting a weight is stating an opinion about its own evidence, not borrowing
+# permission.
+#
+# RETIRED: `verifier_weight` priced a model verifier's opinion against a test's
+# observation. No rung carries that magnitude any more, so a label is priced by
+# `deterministic_weight` alone.
+# -----------------------------------------------------------------------------
+[reward]
+deterministic_weight = 1.0    # magnitude of a deterministic pass or fail
+per_step = 0.02               # subtracted per model call
+per_usd = 0.5                 # subtracted per USD spent
+per_revision = 0.1            # subtracted per verification round beyond the first
+
+
+# -----------------------------------------------------------------------------
+# SELF-DRIVING — the autonomous loop's own configuration
+#
+# Here rather than in a file of its own because everything configurable about
+# stella comes from stella.toml: a second config system is a second place to
+# look, and the one thing worse than a setting nobody can find is two settings
+# that disagree.
+#
+# This whole block is strict — an unknown key is a load error, not a warning.
+# -----------------------------------------------------------------------------
+[self_driving.attribution]
+# What the loop appends to what it writes. Source-tracked so it travels with the
+# repository, and rewritable by an installed plugin — a downstream distribution
+# signs in its own name, and that is configuration rather than a fork.
+commit = "created by stella*"
+pull_request = "created by stella*"
+issue = "created by stella*"
+issue_comment = "created by stella*"
+# A prefix that does not end in `/` is used verbatim rather than corrected:
+# some teams namespace with `-`, and silently rewriting your choice is worse
+# than honouring an unusual one.
+branch_prefix = "stella/"
+# Prefixes the PR TITLE, so an autonomous PR is distinguishable in the list,
+# where a maintainer actually triages. Deliberately NOT applied to commit
+# messages: those follow Conventional Commits, the scope is load-bearing, and a
+# prefix in front of it would break the convention.
+title_prefix = "stella self-driving:"
+
+[self_driving.merge]
+# Checks that never block a merge, whatever their history. The operator's escape
+# hatch: automatic detection needs several commits of evidence, and somebody who
+# already knows their deploy provider is suspended should not have to wait for
+# the loop to infer it.
+ignore_checks = ["Vercel", "license/cla"]
+# Consecutive failing base commits after which a check is treated as unwinnable.
+# Default 3. `0` disables the inference, leaving only `ignore_checks`.
+#
+# Why this exists: a required check fails identically whether the code is wrong
+# or the billing account is suspended, and only one of those is fixable by a
+# pull request.
+stuck_after = 3
+
+[self_driving.verify]
+# The command that proves a change, run in the work worktree. Absent = auto-
+# detect from the project's own tooling.
+#
+# A repository whose remote checks cannot go green — a suspended account, an
+# exhausted quota — still has a test suite. Running it here is a weaker signal
+# than a clean CI run and a far stronger one than nothing.
+command = "make gate"
+# Seconds before the command is abandoned. Default 1800 — long enough for a
+# monorepo suite, short enough that a wedged process does not hold the loop
+# overnight.
+timeout_secs = 1800
+
+[self_driving.doctrine]
+# How the loop decides, where two operators would decide differently. These are
+# judgement calls about YOUR team's norms, not facts about the code.
+
+# file_and_adopt (default) | file_and_wait | ignore — what to do about breakage
+# the loop did not cause. A red base blocks this loop exactly as hard as it
+# blocks its author, so a loop that files and waits has handed its throughput to
+# somebody else's response time. `ignore` exists for completeness and is
+# deliberately not the default: a system that notices breakage and says nothing
+# is the worst of the three.
+foreign_breakage = "file_and_adopt"
+
+# defer (default) | claims_only | proceed — how much weight another actor's
+# apparent work carries.
+contention = "defer"
+
+# Whether an escalated PR parks the loop (false, the default) or is abandoned so
+# it can carry on. A PR a human must look at is usually a sign the loop should
+# stop making more of them.
+abandon_escalated = false
+
+[self_driving.triage]
+# The vocabulary the loop places issues in. Here rather than in the tracker
+# manifest because these are YOUR judgements about your own backlog — which
+# labels mean urgent, which mean "not ours" — not how the tracker spells a
+# concept every tracker has.
+#
+# Declaring any one of these REPLACES that list wholesale rather than adding to
+# it: a partial override would leave you unable to remove a built-in you
+# disagree with. Every field defaults, so writing none of it gets a working loop
+# on GitHub's common conventions.
+priorities = ["P0", "P1", "P2", "P3"]           # most urgent first
+defect_kinds = ["bug", "triage"]                # "this loop works this"
+excluded_kinds = ["enhancement", "feature", "documentation", "question"]
+
+
+# -----------------------------------------------------------------------------
+# ISSUES — the active tracker
+#
+# Two fields and no more, deliberately. WHICH tracker is a stella-level decision
+# and belongs here; HOW that tracker spells things is the tracker's own
+# vocabulary and belongs in its manifest, which this points at. Putting the
+# spellings here too would leave a customer with two trackers nowhere to put the
+# second one's words.
+# -----------------------------------------------------------------------------
+[issues]
+provider = "github"
+# Path to the provider's manifest, relative to the workspace root. Absent
+# resolves to `.stella/issues/<provider>.toml`, and an absent FILE yields the
+# built-in defaults — so a workspace that has configured nothing still works.
+manifest = ".stella/issues/github.toml"
+
+
+# -----------------------------------------------------------------------------
+# AUTHORITY — ***MANAGED SCOPE ONLY***
+#
+# Honored ONLY from the org-managed settings file. Present in a user or project
+# file it is ignored, because the containing file IS the policy source.
+#
+# It is a CEILING, not a default: computed from the managed snapshot alone, so
+# no later fold — including an explicitly trusted project — can raise it.
+#
+# This is the block that makes the whole scope model safe, and it is the ONE
+# strict object in the schema: a misspelled ceiling fails loudly rather than
+# silently not applying.
+#
+# Managed file location:
+#   macOS   /Library/Application Support/stella/settings.json
+#   else    /etc/stella/settings.json
+#   override with STELLA_MANAGED_SETTINGS
+#
+# Left commented out because THIS file declares `scope = "project"`, where the
+# block would do nothing. Uncomment it in the managed file.
+# -----------------------------------------------------------------------------
+# [authority]
+# project_prompts = "off"               # may a repo replace an agent's prompt?
+# project_custom_tools = "off"          # may a repo's .stella/tools/*.toml load?
+# media_requires_host_approval = "on"
+
+
+# -----------------------------------------------------------------------------
+# ENTERPRISE TELEMETRY — ***MANAGED SCOPE ONLY***
+#
+# Community/default Stella sends NO telemetry anywhere (architectural invariant
+# 3). The sole additional egress is an explicitly enrolled Oxagen Enterprise
+# managed mode, where a signed org-managed document may authorize a minimal
+# operational rollup to one exact allowlisted HTTPS sink.
+#
+# Prompts, paths, tool payloads and results, reasoning, errors, git state,
+# memories, rules and local identifiers are NEVER exportable — enforced by an
+# allowlist and a sentinel harness in `crates/stella-store/src/content_free.rs`,
+# not by convention.
+#
+# Assigned from the managed snapshot alone, bypassing the scope overlay: the
+# enrollment is what the ORG said, and a project file offering one would be
+# forging authority. Left commented out for that reason.
+# -----------------------------------------------------------------------------
+# [enterprise_telemetry]
+# ...enrollment document, as supplied by your organization

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -463,6 +463,14 @@ some-noisy-observer = "off"
 # -----------------------------------------------------------------------------
 # REWARD — what a finished turn's verdict is worth as a training label (#1043)
 #
+# *** NOTHING CONSUMES THIS TODAY (#4224). *** These keys parse and resolve into
+# a `RewardPolicy`, but the code that applied that policy to a finished turn's
+# verdict was deleted with the staged pipeline (#3865). A reward label is a
+# verdict, and verdicts are now a wrapper plugin's to report — so setting a
+# weight here changes nothing until that path is rebuilt or the block is
+# retired. Documented rather than hidden, because a config block that silently
+# steers nothing is worse than one that says so.
+#
 # Carries no credential or egress authority, so no trust restoration: a project
 # setting a weight is stating an opinion about its own evidence, not borrowing
 # permission.

--- a/stella.toml
+++ b/stella.toml
@@ -9,7 +9,10 @@
 # The original settings.json was NOT deleted. Check this file, then
 # remove the JSON — until you do, stella reads this one and says so.
 #
-# Full reference: docs/spec/config-system/stella.today.toml
+# Full reference: stella.example.toml at the repository root — every section,
+# commented, copy-pasteable. (It used to point at
+# docs/spec/config-system/stella.today.toml, which is a design-era artifact and
+# was missing five sections outright.)
 
 [meta]
 schema_version = 1


### PR DESCRIPTION
Two halves of one request: retire the deleted staged pipeline from the design
docs and point them at the plugin system, then review `stella.toml` and ship a
copy-pasteable reference.

## Part 1 — docs/spec and docs/design

Every citation of `crates/stella-pipeline`, `--pipeline classic`, or a staged
pipeline stage across `docs/spec/**` and `docs/design/**` is now either
rewritten to the plugin path or **explicitly framed as historical with its issue
number** — the rule #3901 states for this sweep. That issue tracks the whole
tree; this PR is its `docs/spec` + `docs/design` slice. The website, `docs/prompts`,
`bench/**` and `ROADMAP.md` groups remain open there.

The load-bearing edits are where the prose was not merely stale but **false**:

- **`doc:verification-gate`** claimed three per-PR layers. Two were tests inside
  the deleted crate and nothing replaced them, so **no per-PR gate observes what
  the agent decides or spends today**; only the wire-schema half of Layer 2
  survives. Filed as **#4223**.
- **`doc:pipeline-journey`** was the staged pipeline end to end in the present
  tense. Rewritten as Part I (raw loop default, the four wrapper-socket points,
  what a `plugin.toml` declares, where `[seats]` come from) and Part II — the
  same walkthrough in the past tense, kept because it is the shape
  `doc:pipeline-as-plugins` §8 asks a verification plugin to port.
- **`doc:turn-lane-assembly`** §10 asked "does the pipeline leave — now, later,
  or never?". It left by *deletion*, not the extraction that section proposed,
  so §10.4's definition of done is annotated with how it actually resolved:
  bullet one satisfied, bullet two **consciously given up**, bullet three left
  with nothing to compare.
- **`doc:serve-surface`**'s approve-route argument was blocked on a design
  question; it is now blocked on there being nothing left to approve.
- **`doc:self-driving-foundry`** marked reward labelling and event-stream replay
  "Shipped". Both went with the crate. Filed as **#4224**.
- **`doc:agent-native-delivery`**'s gate-stage row was homed in the deleted crate.
- **`doc:engine-embedding`**'s dependency diagram had a `stella-pipeline` node;
  it is now `stella-plugin`, with all three edges repointed.

**Measurements are annotated, never rewritten.** The censuses in
`doc:file-budget`, the commit-anchored counts in `doc:turn-lane-assembly`, and
the dated sweep in `doc:serve-surface` are left exactly as recorded — a
measurement edited after the fact stops being one.

## Part 2 — `stella.toml`

### `stella.example.toml` (new, repo root)

`cp stella.example.toml stella.toml`. Every root section, commented for an
operator rather than a design reviewer, with the real shipped default beside
each key and the merge rule and trust gate for each block.

It replaces `docs/spec/config-system/stella.today.toml` as the reference, which
the repository's own `stella.toml` pointed at as "Full reference" while never
carrying `[workspace]`, `[plugins]`, `[self_driving]`, `[issues]` or
`[enterprise_telemetry]` — five sections, so a reader taking it at its word
concludes five features do not exist. That file stays as the design-era artifact
it is, now labelled; `stella.next.toml` gains a **DO NOT COPY** banner, because
it sits in the same directory and documents config that does not exist.

### Two bugs the review found, both fixed with witnesses

**1. `[plugins]` was read, then reported as a typo.** `TomlConfig::plugins` is
lowered into `Settings` by the loader, but `plugins` was missing from
`unknown::TOML_ROOT_FIELDS`. It bites hardest of any section this could have hit:
`plugins.<name> = "off"` is the per-plugin retraction switch, so the person most
likely to write it is the one switching a plugin **off**, and the answer they got
was advice to check the spelling of the mechanism they just used correctly.

This was the **third** instance of one omission — `unknown.rs` already carried
two comments recording it (`[seats]` #3908, then `[self_driving]`/`[issues]`),
the second of which says *"twice is a pattern"*. It was still enforced by that
comment alone, and the comment lost again.

**2. Three `[agents]` keys had the same problem.** `model_timeout_secs`,
`compaction_budget_tokens` and `tool_result_horizon_steps` are lowered by
`lower_agents` and present in `ENGINE_ROOT_FIELDS`, but were missing from
`TOML_AGENTS_FIELDS` — so the **same knob was accepted in `settings.json` and
called a typo in `stella.toml`**. Found by writing the example against the
structs rather than against the existing reference.

That gap was invisible for a structural reason worth naming: the two
vocabularies are *deliberately* different, because a JSON-only spelling must not
look valid in TOML (`allowed_models` → `[models].allowed`, `seat_models` →
`[seats]`). With legitimate differences in the list, nothing distinguished
"renamed on purpose" from "forgotten" except a human reading both.

### The class is now closed by the compiler

`completeness.rs`'s module docs name **four** edits a settings key needs — the
struct, the overlay, the unrecognized-key vocabulary, and the TOML document —
and it compile-enforced only the first three. Two new ledgers destructure
`TomlConfig` and `AgentsSection` exhaustively with no `..` rest pattern, so
adding a section or a key now stops the crate compiling until its author places
it. Same discipline the file already applied to `Settings`, `Hooks` and
`ProviderSettings`.

## Witnesses

All fail on the base commit:

- `settings::tests::toml::the_plugin_retraction_table_is_a_recognized_root` —
  asserts the switch reaches `Settings` **and** that the walker stays quiet.
  Before: `left: ["plugins"], right: []`.
- `settings::completeness::the_toml_root_vocabulary_matches_the_document`
- `settings::completeness::the_toml_agents_vocabulary_matches_the_section`
- `settings::tests::toml::the_copy_paste_example_covers_every_root_section` —
  loads the example, requires every `TOML_ROOT_FIELDS` section to **appear** in
  it (set, or commented out with the reason it would do nothing at project
  scope, which is how `[authority]` and `[enterprise_telemetry]` qualify), and
  runs it through `validate_project_secrets` so a literal `api_key` can never
  ship in the file people copy. **This is the test that caught bug 2.**

No test was deleted.

## Verification

`make gate` green — 182 test binaries, 0 failures, clippy `-D warnings` over the
workspace, `doc-links` resolving 719 citations across 81 documents.

## Left behind

- **#4223** — the verification gate lost 2 of 3 layers; no per-PR check observes
  what the agent decides or spends. Options weighed in the issue.
- **#4224** — `stella dataset export`'s planned `reward` column has no source,
  and `[reward]` in `stella.toml` now steers nothing. The example says so in
  place rather than documenting a knob with no consumer.

Refs #3901, #3865, #3908.

## Summary by Sourcery

Align the documentation and configuration guidance with the plugin-based runtime while making TOML vocabulary and reference coverage compiler- and test-enforced.

New Features:
- Add a complete, copy-pasteable root-level TOML configuration reference covering all supported sections and documenting defaults, scope merging, trust requirements, and inactive settings.

Bug Fixes:
- Recognize the `[plugins]` TOML section so plugin retraction settings are no longer reported as unknown keys.
- Recognize the three supported `[agents]` TOML keys for model timeouts, compaction budgets, and tool-result horizons.

Enhancements:
- Retire stale staged-pipeline documentation by redirecting current guidance to the raw loop and wrapper-plugin architecture while preserving historical design records and measurements.
- Document the loss of host-run verification and replay capabilities, including the remaining wire-schema gate and tracked follow-up gaps.
- Add exhaustive completeness checks that keep TOML root sections and `[agents]` keys synchronized with their configuration structures.
- Relabel design-era configuration examples as incomplete or non-copyable and point repository guidance to the new reference configuration.

Documentation:
- Update design and specification documents to identify deleted pipeline material as historical and explain its plugin-based successor.

Tests:
- Add regression coverage for plugin recognition, TOML vocabulary completeness, and full example-configuration loading, unknown-key validation, and project-secret validation.