### PR TITLE
feat(stella-protocol): a task's definition of done, and a board that refuses to close without it

### DIFF
--- a/crates/stella-cli/src/command_deck/session_clear.rs
+++ b/crates/stella-cli/src/command_deck/session_clear.rs
@@ -553,11 +553,11 @@ mod tests {
         );
         // The cleared session goes on to plan again — and ordinal ids
         // restart, so this brand-new task is also "1".
-        registry
-            .task_board()
-            .lock()
-            .unwrap()
-            .create("a task the user created after clearing", None);
+        registry.task_board().lock().unwrap().create(
+            "a task the user created after clearing",
+            None,
+            None,
+        );
         while in_rx.try_recv().is_ok() {}
 
         settle_worker_task(
@@ -639,7 +639,7 @@ mod tests {
             .task_board()
             .lock()
             .unwrap()
-            .create("post-clear work", None);
+            .create("post-clear work", None, None);
         let fresh = subs.started_for_test("sub:1");
         registry
             .task_board()
@@ -698,7 +698,7 @@ mod tests {
             let board = registry.task_board();
             let mut guard = board.lock().unwrap();
             for subject in subjects {
-                guard.create(*subject, None);
+                guard.create(*subject, None, None);
             }
         }
         (registry, SubSessions::new())

--- a/crates/stella-cli/src/subsession/closeout.rs
+++ b/crates/stella-cli/src/subsession/closeout.rs
@@ -78,6 +78,7 @@ mod tests {
             description: None,
             status: TaskStatus::Pending,
             owner: None,
+            contract: None,
         }
     }
 
@@ -109,7 +110,7 @@ mod tests {
             .task_board()
             .lock()
             .unwrap()
-            .create("read the grammar", None);
+            .create("read the grammar", None, None);
         (store, worker_exec, registry, root)
     }
 

--- a/crates/stella-core/src/tasks.rs
+++ b/crates/stella-core/src/tasks.rs
@@ -14,7 +14,7 @@
 //! driver drains them (`stella-tools`' `ToolRegistry::take_spawn_requests`)
 //! and runs each on its own deck sub-session lane.
 
-use stella_protocol::{TaskItem, TaskStatus};
+use stella_protocol::{Closure, TaskContract, TaskItem, TaskStatus};
 
 /// Why a board mutation was rejected. Named errors, never a bare string —
 /// the tools surface these verbatim to the model so it can self-correct.
@@ -35,6 +35,21 @@ pub enum TaskBoardError {
         id: String,
         open_id: String,
         open_subject: String,
+    },
+    #[error(
+        "task {id} cannot be completed: its definition of done has {pending} check(s) not yet \
+         run and {failed} that did not pass — {outstanding}. Run them and record the outcome; a \
+         task closes when its checks pass, not when it is reported done. If a check turns out to \
+         be the wrong check, change the contract deliberately — do not cancel the task to get \
+         past this."
+    )]
+    ContractUnsatisfied {
+        id: String,
+        pending: usize,
+        failed: usize,
+        /// The outstanding clauses, quoted, so the refusal names the work
+        /// rather than only its count.
+        outstanding: String,
     },
 }
 
@@ -70,6 +85,20 @@ impl TaskBoard {
         &self.items
     }
 
+    /// A task's contract, mutably — how a check runner records an outcome.
+    ///
+    /// Scoped to the contract rather than handing out the whole item (or the
+    /// whole board) because recording an outcome is the only mutation anything
+    /// outside this module needs, and `status` in particular must stay
+    /// reachable only through [`Self::set_status`] — that is where the refusal
+    /// lives, and an escape hatch beside it would be a way around it.
+    ///
+    /// `Ok(None)` is a task that declared no contract; the error is an unknown
+    /// id.
+    pub fn contract_mut(&mut self, id: &str) -> Result<Option<&mut TaskContract>, TaskBoardError> {
+        Ok(Self::find(&mut self.items, id)?.contract.as_mut())
+    }
+
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
@@ -92,7 +121,19 @@ impl TaskBoard {
     /// Create a task in `Pending`; returns the new item. Ids are ordinal and
     /// never reused — cancelling task "2" does not renumber task "3", so ids
     /// in the transcript stay valid for the whole session.
-    pub fn create(&mut self, subject: impl Into<String>, description: Option<String>) -> &TaskItem {
+    /// `contract` is what the task means by done (SPEC 7.1). `None` records
+    /// that nobody has said yet — deliberately not the same fact as
+    /// [`TaskContract::ReadOnly`], which records that someone looked and found
+    /// nothing to prove. An undeclared task is created rather than refused, and
+    /// pays for it at [`Self::set_status`]: it can be completed, because
+    /// refusing every legacy task would break every board that predates
+    /// contracts, while a *declared* one closes only on its checks.
+    pub fn create(
+        &mut self,
+        subject: impl Into<String>,
+        description: Option<String>,
+        contract: Option<TaskContract>,
+    ) -> &TaskItem {
         let id = (self.items.len() + 1).to_string();
         self.items.push(TaskItem {
             id,
@@ -100,6 +141,7 @@ impl TaskBoard {
             description,
             status: TaskStatus::Pending,
             owner: None,
+            contract,
         });
         self.items.last().expect("just pushed")
     }
@@ -125,7 +167,7 @@ impl TaskBoard {
             return false;
         }
         for step in steps {
-            self.create(step.as_ref(), None);
+            self.create(step.as_ref(), None, None);
         }
         true
     }
@@ -192,6 +234,32 @@ impl TaskBoard {
                 open_subject,
             });
         }
+        // A task closes when its checks pass (SPEC 7.1, and SPEC 1's second
+        // thesis). This is the enforcement point `TaskStatus`'s own doc has
+        // always pointed at: `set_status` is the single transition gate, so a
+        // refusal here cannot be routed around by a caller that reaches for a
+        // different setter — there is no different setter.
+        //
+        // Only `Completed` is gated. `Cancelled` is not a claim that the work
+        // was done and must stay available precisely when the checks are
+        // failing, or the board would trap a task nobody can honestly close.
+        if status == TaskStatus::Completed
+            && let Some(contract) = &item.contract
+            && let Closure::Outstanding { pending, failed } = contract.closure()
+        {
+            let outstanding = contract
+                .checks()
+                .filter(|c| !c.passed())
+                .map(|c| format!("`{}`", c.statement))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(TaskBoardError::ContractUnsatisfied {
+                id: id.to_string(),
+                pending,
+                failed,
+                outstanding,
+            });
+        }
         item.status = status;
         Ok(item)
     }
@@ -233,10 +301,10 @@ mod tests {
     #[test]
     fn ids_are_ordinal_and_survive_cancellation() {
         let mut board = TaskBoard::new();
-        board.create("one", None);
-        board.create("two", None);
+        board.create("one", None, None);
+        board.create("two", None, None);
         board.set_status("1", TaskStatus::Cancelled).unwrap();
-        board.create("three", None);
+        board.create("three", None, None);
         let ids: Vec<&str> = board.items().iter().map(|t| t.id.as_str()).collect();
         assert_eq!(ids, ["1", "2", "3"]);
         assert_eq!(board.items()[2].subject, "three");
@@ -249,8 +317,8 @@ mod tests {
     #[test]
     fn clear_empties_the_board_and_restarts_the_ids() {
         let mut board = TaskBoard::new();
-        board.create("one", None);
-        board.create("two", None);
+        board.create("one", None, None);
+        board.create("two", None, None);
         board.set_status("1", TaskStatus::Completed).unwrap();
         board.assign("2", "sub:2").unwrap();
 
@@ -258,7 +326,7 @@ mod tests {
 
         assert!(board.is_empty());
         assert!(board.items().is_empty());
-        let fresh = board.create("a brand new plan", None);
+        let fresh = board.create("a brand new plan", None, None);
         assert_eq!(
             fresh.id, "1",
             "ids restart — the cleared board is a new one"
@@ -267,7 +335,7 @@ mod tests {
         // And seeding works again, which it would not if `clear` had merely
         // hidden the rows: `seed_from_plan` no-ops on a non-empty board.
         let mut seeded = TaskBoard::new();
-        seeded.create("stale", None);
+        seeded.create("stale", None, None);
         seeded.clear();
         assert!(seeded.seed_from_plan(&["step one", "step two"]));
         assert_eq!(seeded.items().len(), 2);
@@ -276,7 +344,7 @@ mod tests {
     #[test]
     fn terminal_tasks_reject_every_transition() {
         let mut board = TaskBoard::new();
-        board.create("t", None);
+        board.create("t", None, None);
         board.set_status("1", TaskStatus::Completed).unwrap();
         for attempt in [
             board.set_status("1", TaskStatus::Pending).unwrap_err(),
@@ -318,7 +386,7 @@ mod tests {
     #[test]
     fn seeding_never_disturbs_a_board_that_has_rows() {
         let mut board = TaskBoard::new();
-        board.create("already here", None);
+        board.create("already here", None, None);
         board.set_status("1", TaskStatus::Completed).unwrap();
         assert!(!board.seed_from_plan(&["a", "b"]));
         assert_eq!(board.items().len(), 1);
@@ -400,8 +468,8 @@ mod tests {
     #[test]
     fn cancelling_the_open_task_also_frees_the_lane() {
         let mut board = TaskBoard::new();
-        board.create("abandoned", None);
-        board.create("the real work", None);
+        board.create("abandoned", None, None);
+        board.create("the real work", None, None);
         board.set_status("1", TaskStatus::InProgress).unwrap();
         board.set_status("1", TaskStatus::Cancelled).unwrap();
         board.set_status("2", TaskStatus::InProgress).unwrap();
@@ -414,7 +482,7 @@ mod tests {
     #[test]
     fn restarting_the_task_you_already_hold_is_not_a_collision() {
         let mut board = TaskBoard::new();
-        board.create("mine", None);
+        board.create("mine", None, None);
         board.set_status("1", TaskStatus::InProgress).unwrap();
         board.set_status("1", TaskStatus::InProgress).unwrap();
         assert_eq!(board.items()[0].status, TaskStatus::InProgress);
@@ -433,7 +501,7 @@ mod tests {
             "port the printer",
             "review it all",
         ] {
-            board.create(subject, None);
+            board.create(subject, None, None);
         }
         board.assign("1", "sub:1").unwrap();
         board.assign("2", "sub:2").unwrap();
@@ -450,8 +518,8 @@ mod tests {
     #[test]
     fn a_terminal_target_reports_terminality_not_the_open_lane() {
         let mut board = TaskBoard::new();
-        board.create("open", None);
-        board.create("done", None);
+        board.create("open", None, None);
+        board.create("done", None, None);
         board.set_status("1", TaskStatus::InProgress).unwrap();
         board.set_status("2", TaskStatus::Completed).unwrap();
         assert_eq!(
@@ -466,7 +534,7 @@ mod tests {
     #[test]
     fn assign_records_owner_and_marks_in_progress() {
         let mut board = TaskBoard::new();
-        board.create("t", None);
+        board.create("t", None, None);
         let item = board.assign("1", "sub:1").unwrap();
         assert_eq!(item.owner.as_deref(), Some("sub:1"));
         assert_eq!(item.status, TaskStatus::InProgress);
@@ -508,7 +576,7 @@ mod tests {
             for board in [&mut a, &mut b] {
                 for op in &ops {
                     match op {
-                        Op::Create(s) => { board.create(s.clone(), None); }
+                        Op::Create(s) => { board.create(s.clone(), None, None); }
                         Op::SetStatus(i, s) => { let _ = board.set_status(&(i + 1).to_string(), *s); }
                         Op::Assign(i, o) => { let _ = board.assign(&(i + 1).to_string(), o.clone()); }
                     }
@@ -522,17 +590,123 @@ mod tests {
         #[test]
         fn terminal_states_are_absorbing(ops in proptest::collection::vec(arb_op(), 0..40)) {
             let mut board = TaskBoard::new();
-            board.create("pinned", None);
+            board.create("pinned", None, None);
             board.set_status("1", TaskStatus::Cancelled).unwrap();
             let frozen = board.items()[0].clone();
             for op in &ops {
                 match op {
-                    Op::Create(s) => { board.create(s.clone(), None); }
+                    Op::Create(s) => { board.create(s.clone(), None, None); }
                     Op::SetStatus(i, s) => { let _ = board.set_status(&(i + 1).to_string(), *s); }
                     Op::Assign(i, o) => { let _ = board.assign(&(i + 1).to_string(), o.clone()); }
                 }
             }
             prop_assert_eq!(&board.items()[0], &frozen);
         }
+    }
+
+    // ── SPEC 7.1: a task closes on its checks, not on being reported done ────
+
+    fn contracted(statement: &str) -> TaskContract {
+        TaskContract::DefinitionOfDone(stella_protocol::DefinitionOfDone::new(
+            stella_protocol::Check::new(
+                statement,
+                stella_protocol::CheckMechanism::Known(stella_protocol::CheckKind::Unit),
+            ),
+            Vec::new(),
+        ))
+    }
+
+    /// The witness. On the old board this was a plain `Ok` — `task_complete`
+    /// set the field and the task was done because something said so.
+    #[test]
+    fn a_contracted_task_is_refused_a_close_while_a_check_is_outstanding() {
+        let mut board = TaskBoard::default();
+        board.create(
+            "wire the dedup digest",
+            None,
+            Some(contracted("the dedup suite is green")),
+        );
+        let err = board
+            .set_status("1", TaskStatus::Completed)
+            .expect_err("an unsatisfied contract must refuse the close");
+        assert!(
+            matches!(
+                err,
+                TaskBoardError::ContractUnsatisfied {
+                    pending: 1,
+                    failed: 0,
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+        // The refusal names the work, not just its count — a reader who cannot
+        // tell *which* check is outstanding cannot act on the message.
+        assert!(
+            err.to_string().contains("the dedup suite is green"),
+            "{err}"
+        );
+        assert_eq!(board.items()[0].status, TaskStatus::Pending);
+    }
+
+    #[test]
+    fn a_contracted_task_closes_once_its_checks_pass() {
+        let mut board = TaskBoard::default();
+        board.create(
+            "wire the dedup digest",
+            None,
+            Some(contracted("the dedup suite is green")),
+        );
+        if let Some(TaskContract::DefinitionOfDone(dod)) =
+            board.contract_mut("1").expect("known task")
+        {
+            for check in dod.iter_mut() {
+                check.outcome = stella_protocol::CheckOutcome::Passed {
+                    evidence: "12 tests, 0 failures".into(),
+                };
+            }
+        }
+        board
+            .set_status("1", TaskStatus::Completed)
+            .expect("a satisfied contract permits the close");
+        assert_eq!(board.items()[0].status, TaskStatus::Completed);
+    }
+
+    /// A read-only task has nothing to prove and must not be trapped by a gate
+    /// meant for tasks that produce diffs.
+    #[test]
+    fn a_read_only_task_still_closes() {
+        let mut board = TaskBoard::default();
+        board.create("read the retry policy", None, Some(TaskContract::ReadOnly));
+        board
+            .set_status("1", TaskStatus::Completed)
+            .expect("a read-only task closes on its events");
+    }
+
+    /// Every board that predates contracts keeps working: `None` means nobody
+    /// said, and the gate has nothing to enforce.
+    #[test]
+    fn an_undeclared_task_closes_as_it_always_did() {
+        let mut board = TaskBoard::default();
+        board.create("legacy task", None, None);
+        board
+            .set_status("1", TaskStatus::Completed)
+            .expect("an undeclared task is not gated");
+    }
+
+    /// Cancelling must stay available precisely when the checks are failing, or
+    /// a task nobody can honestly close would be stuck on the board forever —
+    /// and the pressure would be to fake a passing check.
+    #[test]
+    fn a_failing_contract_can_still_be_cancelled() {
+        let mut board = TaskBoard::default();
+        board.create(
+            "wire the dedup digest",
+            None,
+            Some(contracted("the suite is green")),
+        );
+        board
+            .set_status("1", TaskStatus::Cancelled)
+            .expect("cancel is not a claim that the work was done");
     }
 }

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -231,6 +231,7 @@ fn real_store_workspace() -> tempfile::TempDir {
                 description: None,
                 status: TaskStatus::Completed,
                 owner: Some("lead".into()),
+                contract: None,
             }],
             1_700_000_000_000,
         )

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -286,6 +286,20 @@ pub struct TaskItem {
     /// dedicated worker for it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
+    /// What this task means by done (SPEC 7.1).
+    ///
+    /// `None` is *nobody has said yet*, and is deliberately not the same fact
+    /// as [`TaskContract::ReadOnly`], which is *somebody looked and there is
+    /// nothing to prove*. A board that collapsed the two would let an
+    /// undeclared task close on the same terms as one declared harmless —
+    /// which is the self-report [`TaskContract`] exists to end.
+    ///
+    /// Optional because the board predates contracts and a session may still
+    /// create a task without one; `stella_core::tasks` refuses the *close*, not
+    /// the creation, so an undeclared task is visible on the board rather than
+    /// rejected at the door.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract: Option<crate::TaskContract>,
 }
 
 /// Lifecycle of a `TaskItem`. Terminal states are `Completed` and

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -28,6 +28,11 @@ use crate::ladder::LadderSnapshot;
 // and `agentevent.d.ts` (#3450).
 #[cfg(doc)]
 use super::AgentEvent;
+// Same `cfg(doc)` treatment, and for the same reason: `TaskItem::contract`'s
+// docs link it, and spelling the link as a path would put `crate::…` into the
+// published wire contract.
+#[cfg(doc)]
+use crate::TaskContract;
 
 /// What happened to a file in a [`AgentEvent::FileChange`] event.
 ///
@@ -299,7 +304,7 @@ pub struct TaskItem {
     /// the creation, so an undeclared task is visible on the board rather than
     /// rejected at the door.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contract: Option<crate::TaskContract>,
+    pub contract: Option<crate::task_contract::TaskContract>,
 }
 
 /// Lifecycle of a `TaskItem`. Terminal states are `Completed` and

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -784,6 +784,7 @@ fn task_update_roundtrips_a_full_board_snapshot() {
                 description: None,
                 status: TaskStatus::Completed,
                 owner: Some("lead".into()),
+                contract: None,
             },
             TaskItem {
                 id: "2".into(),
@@ -791,6 +792,7 @@ fn task_update_roundtrips_a_full_board_snapshot() {
                 description: Some("token refresh races the redirect".into()),
                 status: TaskStatus::InProgress,
                 owner: Some("sub:2".into()),
+                contract: None,
             },
             TaskItem {
                 id: "3".into(),
@@ -798,6 +800,7 @@ fn task_update_roundtrips_a_full_board_snapshot() {
                 description: None,
                 status: TaskStatus::Pending,
                 owner: None,
+                contract: None,
             },
         ],
     };

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -78,6 +78,7 @@ pub mod role;
 pub mod schema_export;
 pub mod stage;
 pub mod subagent_event;
+pub mod task_contract;
 pub mod tokens;
 pub mod tool;
 
@@ -117,6 +118,9 @@ pub use event::{
 // the closed set of boundaries this host emits; `StageName` is what the wire
 // carries, so a stage a plugin contributed can be named at all.
 pub use stage::StageName;
+pub use task_contract::{
+    Check, CheckKind, CheckMechanism, CheckOutcome, Closure, DefinitionOfDone, Judge, TaskContract,
+};
 // The journal line is the event plus the wall-clock stamp its sink adds
 // (#2111). Deliberately a separate type from `AgentEvent`: a stamp is a fact
 // about a write, and the engine that produces events owns no clock.

--- a/crates/stella-protocol/src/task_contract.rs
+++ b/crates/stella-protocol/src/task_contract.rs
@@ -1,0 +1,694 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A task's definition of done — the wire half of "tasks close on checks, not
+//! on model self-report" (`design/tui-v2/SPEC.md` §7.1).
+//!
+//! # The claim this type exists to make true
+//!
+//! A board task used to close because something said so. [`crate::TaskStatus`]
+//! is a field, `task_complete` sets it, and the caller with the strongest
+//! incentive to set it is the model whose work is being judged. Nothing in the
+//! type system distinguished "this task passed its checks" from "the model said
+//! it did" — they were the same bytes.
+//!
+//! So the closing condition is not stored here. [`TaskContract::closure`]
+//! *derives* it from the checks, every time it is asked, and there is no field
+//! anywhere in this module that a caller can set to mean "done". A task with an
+//! unsatisfied contract has no representation that says otherwise.
+//!
+//! # Two shapes, and the rule is the type
+//!
+//! SPEC 7.1: *contracts are required only for tasks that produce diffs;
+//! read-only tasks close on completion of their events.* Both halves are
+//! structural rather than validated:
+//!
+//! - [`TaskContract::ReadOnly`] has no field a check could go in, so a
+//!   read-only task cannot carry one. That matters more than it looks — the
+//!   spec's reason for the rule is that a required contract on a task with
+//!   nothing to prove produces *fake checks written to satisfy the UI*, and a
+//!   variant with nowhere to put them is the only version of that rule which
+//!   cannot be worked around.
+//! - [`TaskContract::DefinitionOfDone`] holds a [`DefinitionOfDone`], which is
+//!   non-empty by construction. There is no way to build one with zero checks,
+//!   in Rust or over the wire — its `Deserialize` rejects an empty list rather
+//!   than accepting a contract that promises nothing.
+//!
+//! A validation function would have been the smaller change and the weaker one:
+//! it holds only where someone remembers to call it, and the call site that
+//! forgets is the one that ships.
+//!
+//! # Deterministic where it can be, and it says which
+//!
+//! Every check names the [`Judge`] that decides it. That is not decoration: it
+//! is the split SPEC 1's first thesis is about, and the number the turn receipt
+//! (SPEC 6.1) reports as `det %`. A check a machine settles costs `$0.00`; one
+//! a model settles costs a call, and the contract says out loud which it bought.
+//!
+//! [`CheckMechanism`] is an **open** vocabulary over a closed [`CheckKind`],
+//! the shape [`crate::StageName`] already uses and for the same reason: a
+//! verification plugin contributes mechanisms this host has never heard of, and
+//! a closed enum would either reject them or silently retype them as something
+//! they are not. The closed half survives because the question that must stay
+//! answerable — *did a machine decide this, or did a model?* — is answerable
+//! for a contributed mechanism too: whoever contributes it declares its judge.
+
+use serde::de::{self, Deserializer};
+use serde::{Deserialize, Serialize};
+
+/// Who settles a check.
+///
+/// The axis SPEC 1's first thesis prices: deterministic work never reaches a
+/// model and costs `$0.00`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Judge {
+    /// A machine decided: an exit status, a count, a graph query. No model call,
+    /// and the same inputs give the same answer on any run.
+    Deterministic,
+    /// A model decided, because the property is not reducible to a check.
+    ///
+    /// SPEC 7.1 permits this "only when irreducible", which is a review
+    /// judgement rather than something a type can enforce. What the type does
+    /// is make the choice **visible**: a contract full of model-judged checks
+    /// is a contract that proves very little, and it says so on its face.
+    Model,
+}
+
+impl Judge {
+    /// Whether this judge costs a model call.
+    #[must_use]
+    pub const fn is_deterministic(self) -> bool {
+        matches!(self, Self::Deterministic)
+    }
+}
+
+/// A mechanism this host knows how to run.
+///
+/// Closed, and deliberately small. It is not the mechanism vocabulary — it is
+/// the set *this host* can carry out itself, which is a smaller and honest
+/// claim (the argument [`crate::StageKind`] makes about stages).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CheckKind {
+    /// A code-graph query: "no inbound references to the deleted symbol".
+    /// Deterministic — the index answers it.
+    Graph,
+    /// The workspace's own test runner, scoped to what the task touched.
+    Unit,
+    /// An external command's exit status: a linter, a build, a bench.
+    Harness,
+    /// A model reads the diff and judges a property no command can express.
+    /// The one known kind whose judge is [`Judge::Model`].
+    Review,
+}
+
+impl CheckKind {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Graph => "graph",
+            Self::Unit => "unit",
+            Self::Harness => "harness",
+            Self::Review => "review",
+        }
+    }
+
+    /// Resolve a wire spelling, or `None` if this host does not know it.
+    #[must_use]
+    pub fn from_wire_str(name: &str) -> Option<Self> {
+        match name {
+            "graph" => Some(Self::Graph),
+            "unit" => Some(Self::Unit),
+            "harness" => Some(Self::Harness),
+            "review" => Some(Self::Review),
+            _ => None,
+        }
+    }
+
+    /// Who settles this kind.
+    ///
+    /// Fixed per kind rather than declared per check, because it is a property
+    /// of the mechanism and not of the author: a `unit` check that claimed to
+    /// be model-judged, or a `review` that claimed to be deterministic, would
+    /// be describing something other than what it runs.
+    #[must_use]
+    pub const fn judge(self) -> Judge {
+        match self {
+            Self::Graph | Self::Unit | Self::Harness => Judge::Deterministic,
+            Self::Review => Judge::Model,
+        }
+    }
+}
+
+/// How a check is carried out: one of this host's, or a contributed mechanism.
+///
+/// Encodes as a plain string either way, so every known kind writes exactly the
+/// byte it always did. See the module docs for why the vocabulary is open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckMechanism {
+    /// A mechanism this host runs itself.
+    Known(CheckKind),
+    /// A mechanism something outside the host contributed, under its own word,
+    /// with the judge that contributor declared.
+    ///
+    /// Never a name [`CheckKind::from_wire_str`] resolves — [`CheckMechanism::new`]
+    /// is the only constructor that can produce this arm, and it normalizes, so
+    /// `Contributed("unit")` cannot exist to decode as one thing and re-encode
+    /// as another (invariant 4).
+    Contributed { name: String, judge: Judge },
+}
+
+impl CheckMechanism {
+    /// Resolve a mechanism name, preferring this host's own vocabulary.
+    ///
+    /// `judge` is consulted only when the name is not one of the host's — a
+    /// known kind's judge is a property of what it runs, not a claim a caller
+    /// may override.
+    #[must_use]
+    pub fn new(name: &str, judge: Judge) -> Self {
+        CheckKind::from_wire_str(name).map_or_else(
+            || Self::Contributed {
+                name: name.to_owned(),
+                judge,
+            },
+            Self::Known,
+        )
+    }
+
+    /// The kind this is, or `None` for a contributed mechanism.
+    #[must_use]
+    pub const fn kind(&self) -> Option<CheckKind> {
+        match self {
+            Self::Known(kind) => Some(*kind),
+            Self::Contributed { .. } => None,
+        }
+    }
+
+    /// The name as it appears on the wire and on screen.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Known(kind) => kind.as_wire_str(),
+            Self::Contributed { name, .. } => name.as_str(),
+        }
+    }
+
+    /// Who settles a check run this way.
+    #[must_use]
+    pub const fn judge(&self) -> Judge {
+        match self {
+            Self::Known(kind) => kind.judge(),
+            Self::Contributed { judge, .. } => *judge,
+        }
+    }
+}
+
+/// The wire form of a mechanism: its name, plus the judge a contributed one
+/// declares.
+///
+/// A known kind writes no judge — it has one by definition, and a second copy
+/// on the wire is a second thing to disagree with.
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+struct MechanismWire {
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    judge: Option<Judge>,
+}
+
+impl Serialize for CheckMechanism {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        MechanismWire {
+            name: self.as_str().to_owned(),
+            judge: match self {
+                Self::Known(_) => None,
+                Self::Contributed { judge, .. } => Some(*judge),
+            },
+        }
+        .serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for CheckMechanism {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let wire = MechanismWire::deserialize(d)?;
+        // A contributed mechanism with no declared judge would leave the
+        // det/model split unanswerable for it, and the split is the whole
+        // reason the field exists. Refuse rather than guess: guessing
+        // `Deterministic` would price a model call at $0.00, and guessing
+        // `Model` would make a plugin's own graph query look like one.
+        match CheckKind::from_wire_str(&wire.name) {
+            Some(kind) => Ok(Self::Known(kind)),
+            None => {
+                let judge = wire.judge.ok_or_else(|| {
+                    de::Error::custom(format!(
+                        "contributed check mechanism {:?} declares no judge; \
+                         a mechanism this host cannot run must say whether a \
+                         machine or a model settles it",
+                        wire.name
+                    ))
+                })?;
+                Ok(Self::Contributed {
+                    name: wire.name,
+                    judge,
+                })
+            }
+        }
+    }
+}
+
+/// Where a check stands.
+///
+/// [`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence
+/// because an outcome without it is exactly the self-report this module exists
+/// to replace — "it passed" is a claim, and "42 tests, 0 failures" is the thing
+/// that makes it checkable by someone else.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum CheckOutcome {
+    /// Not run yet.
+    Pending,
+    /// Ran and passed. `evidence` is what the judge saw.
+    Passed { evidence: String },
+    /// Ran and did not pass. `evidence` is what the judge saw.
+    Failed { evidence: String },
+}
+
+impl CheckOutcome {
+    /// Whether this outcome closes its clause.
+    #[must_use]
+    pub const fn passed(&self) -> bool {
+        matches!(self, Self::Passed { .. })
+    }
+}
+
+/// One clause of a task's definition of done.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Check {
+    /// What must be true, in the author's words: "no inbound refs to the
+    /// removed symbol", "the auth suite is green".
+    pub statement: String,
+    /// How it is settled.
+    pub mechanism: CheckMechanism,
+    /// Where it stands. Defaults to [`CheckOutcome::Pending`] so a plan can be
+    /// written before anything has run.
+    #[serde(default = "pending")]
+    pub outcome: CheckOutcome,
+}
+
+fn pending() -> CheckOutcome {
+    CheckOutcome::Pending
+}
+
+impl Check {
+    /// A check that has not run yet.
+    #[must_use]
+    pub fn new(statement: impl Into<String>, mechanism: CheckMechanism) -> Self {
+        Self {
+            statement: statement.into(),
+            mechanism,
+            outcome: CheckOutcome::Pending,
+        }
+    }
+
+    /// Whether this clause is settled in the affirmative.
+    #[must_use]
+    pub const fn passed(&self) -> bool {
+        self.outcome.passed()
+    }
+}
+
+/// A task's definition of done: **at least one** check, always.
+///
+/// The non-emptiness is the point, and it is why this is a struct with a
+/// private head rather than a `Vec`. SPEC 7.1 requires a contract on every
+/// diff-producing task; a `Vec` that happens to be empty is that requirement
+/// silently unmet, and the only way to catch it is a validator someone has to
+/// remember to run.
+///
+/// On the wire it is a plain JSON array, so the shape is what a reader would
+/// expect; the emptiness rule is enforced on the way in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(into = "Vec<Check>")]
+pub struct DefinitionOfDone {
+    head: Check,
+    tail: Vec<Check>,
+}
+
+impl From<DefinitionOfDone> for Vec<Check> {
+    fn from(dm: DefinitionOfDone) -> Self {
+        let mut out = Vec::with_capacity(dm.tail.len() + 1);
+        out.push(dm.head);
+        out.extend(dm.tail);
+        out
+    }
+}
+
+impl DefinitionOfDone {
+    /// A contract from one check and any number of further ones.
+    #[must_use]
+    pub fn new(head: Check, tail: Vec<Check>) -> Self {
+        Self { head, tail }
+    }
+
+    /// A contract from a list, or `None` if the list is empty.
+    ///
+    /// The fallible constructor for callers holding a `Vec` — the one place
+    /// "a diff-producing task with no checks" is rejected in Rust.
+    #[must_use]
+    pub fn from_vec(checks: Vec<Check>) -> Option<Self> {
+        let mut it = checks.into_iter();
+        let head = it.next()?;
+        Some(Self {
+            head,
+            tail: it.collect(),
+        })
+    }
+
+    /// Every check, in order.
+    pub fn iter(&self) -> impl Iterator<Item = &Check> {
+        std::iter::once(&self.head).chain(self.tail.iter())
+    }
+
+    /// Every check, mutably — how a runner records an outcome.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Check> {
+        std::iter::once(&mut self.head).chain(self.tail.iter_mut())
+    }
+
+    /// How many clauses this contract has. Never zero.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.tail.len() + 1
+    }
+
+    /// Always `false` — stated so callers do not reach for `len() == 0` and
+    /// readers do not wonder.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<'de> Deserialize<'de> for DefinitionOfDone {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let checks = Vec::<Check>::deserialize(d)?;
+        Self::from_vec(checks).ok_or_else(|| {
+            de::Error::custom(
+                "a definition of done needs at least one check; a task that \
+                 produces diffs and promises nothing cannot be closed by \
+                 anything but a self-report",
+            )
+        })
+    }
+}
+
+/// What a task means by done (SPEC 7.1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "kind", content = "checks")]
+pub enum TaskContract {
+    /// The task produces no diff. It closes when its own events are done, and
+    /// it carries no checks — there is nowhere here to put one.
+    ReadOnly,
+    /// The task produces a diff. It closes when every check passes.
+    DefinitionOfDone(DefinitionOfDone),
+}
+
+/// Whether a contract is satisfied, and why not when it is not.
+///
+/// Three-valued on purpose. A read-only task is not "done because its checks
+/// passed" — it has none — and collapsing that into the same `true` a satisfied
+/// contract returns is how a surface ends up claiming a read of a file was
+/// verified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Closure {
+    /// Every check passed. The task has earned its close.
+    Earned,
+    /// Checks remain. The task may not close.
+    Outstanding {
+        /// Clauses that have not run.
+        pending: usize,
+        /// Clauses that ran and did not pass.
+        failed: usize,
+    },
+    /// There is no contract to satisfy; closure is decided by the task's own
+    /// events, not here.
+    NotContracted,
+}
+
+impl Closure {
+    /// Whether a close is permitted right now.
+    ///
+    /// [`Closure::NotContracted`] permits one because a read-only task has
+    /// nothing to prove — the caller still decides *when*, from the task's
+    /// events; this only declines to stand in the way.
+    #[must_use]
+    pub const fn permits_close(self) -> bool {
+        matches!(self, Self::Earned | Self::NotContracted)
+    }
+}
+
+impl TaskContract {
+    /// Whether the contract is satisfied — **derived, never stored**.
+    ///
+    /// There is no setter and no cached field. The only way to make this return
+    /// [`Closure::Earned`] is to pass the checks, which is the whole of SPEC 1's
+    /// second thesis expressed as a function signature.
+    #[must_use]
+    pub fn closure(&self) -> Closure {
+        let Self::DefinitionOfDone(checks) = self else {
+            return Closure::NotContracted;
+        };
+        let mut pending = 0;
+        let mut failed = 0;
+        for check in checks.iter() {
+            match check.outcome {
+                CheckOutcome::Passed { .. } => {}
+                CheckOutcome::Pending => pending += 1,
+                CheckOutcome::Failed { .. } => failed += 1,
+            }
+        }
+        if pending == 0 && failed == 0 {
+            Closure::Earned
+        } else {
+            Closure::Outstanding { pending, failed }
+        }
+    }
+
+    /// Every check, or an empty iterator for a read-only task.
+    pub fn checks(&self) -> impl Iterator<Item = &Check> {
+        // `Option`'s iterator, so read-only yields nothing without a second
+        // code path for callers to get wrong.
+        match self {
+            Self::ReadOnly => None,
+            Self::DefinitionOfDone(dm) => Some(dm),
+        }
+        .into_iter()
+        .flat_map(DefinitionOfDone::iter)
+    }
+
+    /// How many clauses a machine settles, and how many a model does.
+    ///
+    /// The numerator and denominator of SPEC 6.1's `det %`, computed where the
+    /// contract is rather than re-derived by each surface that wants to show
+    /// it.
+    #[must_use]
+    pub fn judge_split(&self) -> (usize, usize) {
+        self.checks().fold((0, 0), |(det, model), check| {
+            if check.mechanism.judge().is_deterministic() {
+                (det + 1, model)
+            } else {
+                (det, model + 1)
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit(statement: &str) -> Check {
+        Check::new(statement, CheckMechanism::Known(CheckKind::Unit))
+    }
+
+    fn passed(statement: &str) -> Check {
+        let mut c = unit(statement);
+        c.outcome = CheckOutcome::Passed {
+            evidence: "42 tests, 0 failures".into(),
+        };
+        c
+    }
+
+    // ── invariant 4: everything crossing a boundary round-trips ──────────────
+
+    #[test]
+    fn a_contract_round_trips_byte_for_byte() {
+        let contract = TaskContract::DefinitionOfDone(DefinitionOfDone::new(
+            passed("the auth suite is green"),
+            vec![
+                Check::new(
+                    "no inbound refs to the removed symbol",
+                    CheckMechanism::Known(CheckKind::Graph),
+                ),
+                Check::new(
+                    "the migration reads as reversible",
+                    CheckMechanism::new("vera:reversibility", Judge::Model),
+                ),
+            ],
+        ));
+        let json = serde_json::to_string(&contract).expect("serialize");
+        let back: TaskContract = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(contract, back);
+        assert_eq!(json, serde_json::to_string(&back).expect("re-serialize"));
+    }
+
+    #[test]
+    fn a_read_only_contract_round_trips() {
+        let json = serde_json::to_string(&TaskContract::ReadOnly).expect("serialize");
+        let back: TaskContract = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, TaskContract::ReadOnly);
+    }
+
+    /// A known mechanism must not decode into the contributed arm, or it would
+    /// re-encode carrying a `judge` it did not arrive with — a value that does
+    /// not survive its own round trip.
+    #[test]
+    fn a_known_mechanism_never_decodes_as_contributed() {
+        let m = CheckMechanism::new("unit", Judge::Model);
+        assert_eq!(m, CheckMechanism::Known(CheckKind::Unit));
+        assert_eq!(
+            m.judge(),
+            Judge::Deterministic,
+            "a known kind's judge is a property of what it runs, not a caller's claim"
+        );
+        let json = serde_json::to_string(&m).expect("serialize");
+        assert!(!json.contains("judge"), "{json}");
+    }
+
+    // ── SPEC 7.1: the rule is the type ──────────────────────────────────────
+
+    /// The acceptance criterion: a diff-producing task with no checks is
+    /// rejected. Not by a validator someone must remember to call — by the only
+    /// constructor there is.
+    #[test]
+    fn a_definition_of_done_contract_cannot_be_empty() {
+        assert!(DefinitionOfDone::from_vec(Vec::new()).is_none());
+
+        let err =
+            serde_json::from_str::<TaskContract>(r#"{"kind":"definition_of_done","checks":[]}"#)
+                .expect_err("an empty contract must not deserialize");
+        assert!(
+            err.to_string().contains("at least one check"),
+            "the refusal should say why: {err}"
+        );
+    }
+
+    /// The other half of SPEC 7.1, and the reason it is a variant rather than a
+    /// flag: a read-only task has nowhere to put a check, so the fake checks
+    /// the spec warns about have nowhere to go.
+    #[test]
+    fn a_read_only_task_has_nowhere_to_put_a_check() {
+        assert_eq!(TaskContract::ReadOnly.checks().count(), 0);
+        assert_eq!(TaskContract::ReadOnly.closure(), Closure::NotContracted);
+    }
+
+    // ── SPEC 1 thesis 2: closure is derived, never asserted ─────────────────
+
+    #[test]
+    fn closure_is_earned_only_when_every_check_passes() {
+        let mut dm = DefinitionOfDone::new(unit("a"), vec![unit("b")]);
+        let contract = TaskContract::DefinitionOfDone(dm.clone());
+        assert_eq!(
+            contract.closure(),
+            Closure::Outstanding {
+                pending: 2,
+                failed: 0
+            }
+        );
+        assert!(!contract.closure().permits_close());
+
+        for check in dm.iter_mut() {
+            check.outcome = CheckOutcome::Passed {
+                evidence: "ok".into(),
+            };
+        }
+        let contract = TaskContract::DefinitionOfDone(dm);
+        assert_eq!(contract.closure(), Closure::Earned);
+        assert!(contract.closure().permits_close());
+    }
+
+    /// A failed check is not a pending one, and neither closes the task. The
+    /// distinction is what a surface needs to tell "not yet" from "no".
+    #[test]
+    fn a_failed_check_is_counted_apart_from_a_pending_one() {
+        let mut failing = unit("the suite is green");
+        failing.outcome = CheckOutcome::Failed {
+            evidence: "3 failures in auth::redirect".into(),
+        };
+        let contract =
+            TaskContract::DefinitionOfDone(DefinitionOfDone::new(failing, vec![unit("b")]));
+        assert_eq!(
+            contract.closure(),
+            Closure::Outstanding {
+                pending: 1,
+                failed: 1
+            }
+        );
+    }
+
+    /// A read-only task stands out of the way rather than claiming a pass it
+    /// did not earn: `permits_close`, but never `Earned`.
+    #[test]
+    fn a_read_only_task_permits_close_without_claiming_it_was_earned() {
+        let closure = TaskContract::ReadOnly.closure();
+        assert!(closure.permits_close());
+        assert_ne!(closure, Closure::Earned);
+    }
+
+    // ── the det/model split (SPEC 1 thesis 1, SPEC 6.1's `det %`) ───────────
+
+    #[test]
+    fn the_judge_split_counts_machines_and_models_apart() {
+        let contract = TaskContract::DefinitionOfDone(DefinitionOfDone::new(
+            unit("a"),
+            vec![
+                Check::new("b", CheckMechanism::Known(CheckKind::Graph)),
+                Check::new("c", CheckMechanism::Known(CheckKind::Review)),
+            ],
+        ));
+        assert_eq!(contract.judge_split(), (2, 1));
+        assert_eq!(TaskContract::ReadOnly.judge_split(), (0, 0));
+    }
+
+    /// A contributed mechanism carries its judge, so the split stays answerable
+    /// for a plugin's own check.
+    #[test]
+    fn a_contributed_mechanism_declares_its_judge() {
+        let m = CheckMechanism::new("vera:flip-oracle", Judge::Deterministic);
+        assert_eq!(m.kind(), None);
+        assert_eq!(m.judge(), Judge::Deterministic);
+        assert_eq!(m.as_str(), "vera:flip-oracle");
+
+        let json = serde_json::to_string(&m).expect("serialize");
+        let back: CheckMechanism = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(m, back);
+    }
+
+    /// Refused rather than guessed. Defaulting would price a model call at
+    /// `$0.00` or make a plugin's graph query look like one, and both lie on
+    /// the receipt.
+    #[test]
+    fn a_contributed_mechanism_without_a_judge_is_refused() {
+        let err = serde_json::from_str::<CheckMechanism>(r#"{"name":"vera:flip"}"#)
+            .expect_err("a judgeless contributed mechanism must not deserialize");
+        assert!(err.to_string().contains("declares no judge"), "{err}");
+    }
+}

--- a/crates/stella-protocol/src/task_contract.rs
+++ b/crates/stella-protocol/src/task_contract.rs
@@ -261,6 +261,66 @@ impl<'de> Deserialize<'de> for CheckMechanism {
     }
 }
 
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for CheckMechanism {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "CheckMechanism".into()
+    }
+
+    /// An object with a free-form `name`, **not** an enum of the four.
+    ///
+    /// The schema is the contract a non-Rust reader validates against, and a
+    /// closed enum there would make a plugin's own mechanism a schema
+    /// violation — re-closing on the wire exactly the vocabulary this type
+    /// opened. The four the host runs ride along as `examples`, which
+    /// documents without constraining.
+    ///
+    /// `judge` is optional here rather than required, because a known name
+    /// carries no judge on the wire: the mechanism defines it. A reader that
+    /// sees a name it does not recognise and no `judge` is looking at a
+    /// malformed message, and `Deserialize` rejects it for the same reason —
+    /// the det/model split has to stay answerable for every check.
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // `subschema_for` both registers `Judge` in `$defs` and returns the
+        // reference to it. A hand-written `$ref` would compile and then dangle,
+        // because nothing would have put the definition there.
+        let judge = generator.subschema_for::<Judge>();
+        let mut schema = schemars::json_schema!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "judge": judge
+            },
+            "required": ["name"]
+        });
+        schema.insert(
+            "description".to_owned(),
+            serde_json::Value::String(
+                "How a check is settled — an OPEN vocabulary. The mechanisms this host runs \
+                 itself are listed in `examples` and imply their own judge; any other name is a \
+                 contributed mechanism and MUST carry `judge`, so a consumer can always tell \
+                 whether a machine or a model decided."
+                    .to_owned(),
+            ),
+        );
+        schema.insert(
+            "examples".to_owned(),
+            serde_json::Value::Array(
+                [
+                    CheckKind::Graph,
+                    CheckKind::Unit,
+                    CheckKind::Harness,
+                    CheckKind::Review,
+                ]
+                .iter()
+                .map(|k| serde_json::json!({ "name": k.as_wire_str() }))
+                .collect(),
+            ),
+        );
+        schema
+    }
+}
+
 /// Where a check stands.
 ///
 /// [`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence
@@ -335,7 +395,6 @@ impl Check {
 /// On the wire it is a plain JSON array, so the shape is what a reader would
 /// expect; the emptiness rule is enforced on the way in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(into = "Vec<Check>")]
 pub struct DefinitionOfDone {
     head: Check,
@@ -406,6 +465,38 @@ impl<'de> Deserialize<'de> for DefinitionOfDone {
                  anything but a self-report",
             )
         })
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for DefinitionOfDone {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "DefinitionOfDone".into()
+    }
+
+    /// A non-empty **array** of checks, not the `{head, tail}` struct.
+    ///
+    /// Hand-written because `serde(into = "Vec<Check>")` moves the wire shape
+    /// away from the Rust shape, and a derived schema would describe the
+    /// latter — publishing a contract no message this type emits could ever
+    /// satisfy. `minItems: 1` is the non-emptiness rule stated where a
+    /// non-Rust reader can enforce it, so the guarantee survives the crate
+    /// boundary instead of stopping at it.
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let mut schema = schemars::json_schema!({
+            "type": "array",
+            "minItems": 1,
+            "items": generator.subschema_for::<Check>()
+        });
+        schema.insert(
+            "description".to_owned(),
+            serde_json::Value::String(
+                "What a diff-producing task means by done: at least one check, always. An empty \
+                 array is refused rather than accepted as a contract that promises nothing."
+                    .to_owned(),
+            ),
+        );
+        schema
     }
 }
 

--- a/crates/stella-protocol/tests/wire_contract.rs
+++ b/crates/stella-protocol/tests/wire_contract.rs
@@ -144,6 +144,7 @@ fn errors(root: &Value, schema: &Value, instance: &Value, path: &str) -> Vec<Str
                         | "required"
                         | "additionalProperties"
                         | "items"
+                        | "minItems"
                 ),
             "{path}: unmodelled JSON Schema keyword `{key}` — extend this validator \
              rather than letting the proof silently weaken"
@@ -248,6 +249,25 @@ fn errors(root: &Value, schema: &Value, instance: &Value, path: &str) -> Vec<Str
     {
         for (i, element) in array.iter().enumerate() {
             out.extend(errors(root, items, element, &format!("{path}/{i}")));
+        }
+    }
+
+    // `minItems` is how a non-empty list states its guarantee to a reader who
+    // is not compiling our Rust — `DefinitionOfDone` is the first, and the
+    // whole point of it is that an empty contract is not merely discouraged.
+    // Modelled rather than ignored, so the committed schema is proved to
+    // reject the case the type refuses.
+    if let Some(min) = map.get("minItems")
+        && let Some(array) = instance.as_array()
+    {
+        let min = min
+            .as_u64()
+            .unwrap_or_else(|| panic!("{path}: minItems is not a non-negative integer"));
+        if (array.len() as u64) < min {
+            out.push(format!(
+                "{path}: {} item(s), schema requires at least {min}",
+                array.len()
+            ));
         }
     }
 
@@ -514,6 +534,9 @@ fn every_nested_vocabulary_is_fully_sampled() {
         "PrStatus",
         "CiStatus",
         "TaskStatus",
+        "TaskContract",
+        "Judge",
+        "CheckOutcome",
         "BlockKind",
         "CacheZone",
         "SubAgentStatus",

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -583,6 +583,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                     description: Some("it loops on 302".into()),
                     status: TaskStatus::InProgress,
                     owner: Some("lead".into()),
+                    contract: None,
                 },
                 TaskItem {
                     id: "2".into(),
@@ -590,6 +591,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                     description: None,
                     status: TaskStatus::Pending,
                     owner: None,
+                    contract: None,
                 },
             ],
         },
@@ -951,6 +953,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                     description: None,
                     status,
                     owner: None,
+                    contract: None,
                 }],
             }),
     );

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -25,6 +25,9 @@ use stella_protocol::{
     AgentEvent, CompiledContextFrameBuilt, ErrorClass, MediaArtifactRef, StageScope, SubAgentPhase,
     SubAgentStatus, ToolCall, ToolOutput, VerdictEvidence,
 };
+use stella_protocol::{
+    Check, CheckKind, CheckMechanism, CheckOutcome, DefinitionOfDone, Judge, TaskContract,
+};
 
 /// Both scopes an [`AgentEvent::Stage`] can report (#3398). Enumerated like
 /// every other nested vocabulary so the wire contract fails if a third is
@@ -577,16 +580,58 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
         },
         AgentEvent::TaskUpdate {
             tasks: vec![
+                // A diff-producing task, mid-contract: one check settled, one
+                // still to run, and a contributed mechanism carrying the judge
+                // its contributor declared. Covers `definition_of_done`,
+                // `passed` and `pending` in one row, which is the shape a real
+                // board is in most of the time.
                 TaskItem {
                     id: "1".into(),
                     subject: "fix the redirect loop".into(),
                     description: Some("it loops on 302".into()),
                     status: TaskStatus::InProgress,
                     owner: Some("lead".into()),
-                    contract: None,
+                    contract: Some(TaskContract::DefinitionOfDone(DefinitionOfDone::new(
+                        Check {
+                            statement: "the auth suite is green".into(),
+                            mechanism: CheckMechanism::Known(CheckKind::Unit),
+                            outcome: CheckOutcome::Passed {
+                                evidence: "42 tests, 0 failures".into(),
+                            },
+                        },
+                        vec![
+                            Check::new(
+                                "no inbound refs to the removed handler",
+                                CheckMechanism::new("vera:flip-oracle", Judge::Deterministic),
+                            ),
+                            // The irreducible one. Deliberately a *contributed*
+                            // mechanism rather than `CheckKind::Review`,
+                            // because `Judge::Model` only ever reaches the wire
+                            // this way: a known kind implies its judge and
+                            // writes no field, so a sample built from one would
+                            // leave the arm unproven while looking like it
+                            // covered it.
+                            Check::new(
+                                "the migration reads as reversible",
+                                CheckMechanism::new("vera:reversibility", Judge::Model),
+                            ),
+                        ],
+                    ))),
                 },
+                // Declared as producing no diff: it closes on its events and
+                // has nowhere to put a check.
                 TaskItem {
                     id: "2".into(),
+                    subject: "read the retry policy".into(),
+                    description: None,
+                    status: TaskStatus::Pending,
+                    owner: None,
+                    contract: Some(TaskContract::ReadOnly),
+                },
+                // Undeclared — nobody has said yet, which is deliberately not
+                // the same fact as `ReadOnly`.
+                TaskItem {
+                    id: "3".into(),
                     subject: "a bare task".into(),
                     description: None,
                     status: TaskStatus::Pending,

--- a/crates/stella-store/src/task_board.rs
+++ b/crates/stella-store/src/task_board.rs
@@ -155,6 +155,7 @@ mod tests {
             description: None,
             status: TaskStatus::Completed,
             owner: Some("sub:1".into()),
+            contract: None,
         }
     }
 

--- a/crates/stella-store/src/task_board.rs
+++ b/crates/stella-store/src/task_board.rs
@@ -107,6 +107,19 @@ impl Store {
                 description,
                 status: task_status_from_string(&status)?,
                 owner,
+                // The `tasks` table has no contract column, so this record
+                // cannot carry one — `None` here means *this row does not
+                // record it*, not *the task promised nothing*.
+                //
+                // It weakens no guarantee. The live board lives in
+                // `stella_core::tasks::TaskBoard` for the length of the
+                // session and never rehydrates from here, so the refusal in
+                // `set_status` reads the real contract every time. What is
+                // lost is the audit view: a historical board cannot show what
+                // a task promised, only what became of it. Persisting it is a
+                // column-guarded `ADD COLUMN` away — see the issue on the PR
+                // that introduced the field.
+                contract: None,
             });
         }
         Ok(board)

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -587,6 +587,7 @@ fn task(id: &str, subject: &str, status: TaskStatus, owner: Option<&str>) -> Tas
         description: None,
         status,
         owner: owner.map(str::to_string),
+        contract: None,
     }
 }
 

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -16,7 +16,9 @@ use async_trait::async_trait;
 use serde_json::Value;
 use stella_core::tasks::{SpawnRequest, TaskBoard};
 use stella_protocol::tool::{ToolOutput, ToolSchema};
-use stella_protocol::{TaskItem, TaskStatus};
+use stella_protocol::{
+    Check, CheckMechanism, DefinitionOfDone, Judge, TaskContract, TaskItem, TaskStatus,
+};
 
 use crate::registry::Tool;
 
@@ -121,7 +123,26 @@ impl Tool for TaskCreate {
                         }
                     },
                     "subject": { "type": "string", "description": "Imperative title (e.g. \"Fix the auth redirect loop\")" },
-                    "description": { "type": "string", "description": "What needs to be done, if the subject alone is not enough" }
+                    "description": { "type": "string", "description": "What needs to be done, if the subject alone is not enough" },
+                    "definition_of_done": {
+                        "description": "What would make this task done. \"read_only\" if it produces no diff; otherwise a non-empty array of checks. A task that produces a diff closes when these pass — task_complete is refused while any is outstanding.",
+                        "oneOf": [
+                            { "const": "read_only" },
+                            {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "statement": { "type": "string", "description": "What must be true (e.g. \"the auth suite is green\")" },
+                                        "mechanism": { "type": "string", "description": "How it is settled: graph | unit | harness | review, or a plugin's own name" },
+                                        "judge": { "type": "string", "enum": ["deterministic", "model"], "description": "Only read for a mechanism this host does not know; the four above judge themselves" }
+                                    },
+                                    "required": ["statement"]
+                                }
+                            }
+                        ]
+                    }
                 }
             }),
             read_only: false,
@@ -156,7 +177,11 @@ impl Tool for TaskCreate {
                         ));
                     }
                 };
-                let item = board.create(subject, description);
+                let contract = match parse_contract(entry) {
+                    Ok(c) => c,
+                    Err(e) => return e,
+                };
+                let item = board.create(subject, description, contract);
                 created.push(serde_json::json!({
                     "id": item.id,
                     "subject": item.subject,
@@ -178,8 +203,12 @@ impl Tool for TaskCreate {
             Err(e) => return e,
         };
         let description = optional_str(input, "description");
+        let contract = match parse_contract(input) {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
         let mut board = self.0.lock().unwrap_or_else(|p| p.into_inner());
-        let item = board.create(subject, description);
+        let item = board.create(subject, description, contract);
         let payload = serde_json::json!({
             "id": item.id,
             "subject": item.subject,
@@ -277,6 +306,74 @@ impl Tool for TaskStart {
             },
             Err(e) => ToolOutput::error(e.to_string()),
         }
+    }
+}
+
+/// Read a task's `definition_of_done` from tool input (SPEC 7.1).
+///
+/// Three answers, and they are three different facts:
+///
+/// * `Ok(None)` — the key is absent. Nobody said. The board records that as
+///   `None` and lets the task close, because refusing every task that predates
+///   contracts would break every existing board.
+/// * `Ok(Some(TaskContract::ReadOnly))` — declared as producing no diff. It
+///   closes on its events, and it cannot carry checks.
+/// * `Ok(Some(TaskContract::DefinitionOfDone(..)))` — at least one check, by
+///   construction.
+///
+/// The refusal path matters as much as the happy one: `definition_of_done: []`
+/// is a caller promising nothing while appearing to promise something, and it
+/// is rejected here rather than stored as an empty contract that would close on
+/// the first `task_complete`.
+fn parse_contract(input: &Value) -> Result<Option<TaskContract>, ToolOutput> {
+    let Some(raw) = input.get("definition_of_done") else {
+        return Ok(None);
+    };
+    if raw.is_null() {
+        return Ok(None);
+    }
+    if raw.as_str() == Some("read_only") {
+        return Ok(Some(TaskContract::ReadOnly));
+    }
+    let Some(items) = raw.as_array() else {
+        return Err(ToolOutput::error(
+            "definition_of_done must be \"read_only\" for a task that produces no \
+             diff, or a non-empty array of checks",
+        ));
+    };
+    let mut checks = Vec::with_capacity(items.len());
+    for (i, item) in items.iter().enumerate() {
+        let statement = match item.get("statement").and_then(Value::as_str) {
+            Some(t) if !t.trim().is_empty() => t.to_string(),
+            _ => {
+                return Err(ToolOutput::error(format!(
+                    "definition_of_done[{i}] needs a non-empty `statement` saying what must be true"
+                )));
+            }
+        };
+        let mechanism = item
+            .get("mechanism")
+            .and_then(Value::as_str)
+            .unwrap_or("harness");
+        // A contributed mechanism must say who settles it; a known one already
+        // does, and `CheckMechanism::new` ignores the argument for those.
+        let judge = match item.get("judge").and_then(Value::as_str) {
+            Some("model") => Judge::Model,
+            Some("deterministic") | None => Judge::Deterministic,
+            Some(other) => {
+                return Err(ToolOutput::error(format!(
+                    "definition_of_done[{i}].judge must be \"deterministic\" or \"model\", got {other:?}"
+                )));
+            }
+        };
+        checks.push(Check::new(statement, CheckMechanism::new(mechanism, judge)));
+    }
+    match DefinitionOfDone::from_vec(checks) {
+        Some(dod) => Ok(Some(TaskContract::DefinitionOfDone(dod))),
+        None => Err(ToolOutput::error(
+            "definition_of_done was an empty array — a task that produces diffs \
+             must say what would make it done, or declare \"read_only\"",
+        )),
     }
 }
 
@@ -981,7 +1078,7 @@ mod tests {
     #[tokio::test]
     async fn task_assign_refusal_tells_the_model_to_do_the_work_itself() {
         let (board, queue) = handles();
-        board.lock().unwrap().create("do a thing", None);
+        board.lock().unwrap().create("do a thing", None, None);
         let out = TaskAssign(board.clone(), queue.clone(), dispatch_off())
             .execute(
                 &serde_json::json!({"id": "1", "briefing": "b"}),

--- a/crates/stella-tui/src/deck_ui/cards.rs
+++ b/crates/stella-tui/src/deck_ui/cards.rs
@@ -229,6 +229,7 @@ mod tests {
                         description: None,
                         status: TaskStatus::Completed,
                         owner: Some("lead".into()),
+                        contract: None,
                     },
                     TaskItem {
                         id: "2".into(),
@@ -236,6 +237,7 @@ mod tests {
                         description: Some("the long form".into()),
                         status: TaskStatus::InProgress,
                         owner: Some("lead".into()),
+                        contract: None,
                     },
                     TaskItem {
                         id: "3".into(),
@@ -243,6 +245,7 @@ mod tests {
                         description: None,
                         status: TaskStatus::Pending,
                         owner: None,
+                        contract: None,
                     },
                 ],
             },

--- a/crates/stella-tui/src/plan.rs
+++ b/crates/stella-tui/src/plan.rs
@@ -335,6 +335,7 @@ mod tests {
             description: None,
             status,
             owner: None,
+            contract: None,
         }
     }
 

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -648,6 +648,9 @@ pub fn demo_tasks(tasks_done: usize) -> Vec<stella_protocol::TaskItem> {
                 TaskStatus::Pending
             },
             owner: (i <= tasks_done).then(|| "lead".to_string()),
+            // The demo board predates contracts, and a fixture that invented
+            // one would put checks on screen that no scenario ran.
+            contract: None,
         })
         .collect()
 }

--- a/crates/stella-tui/src/views/plan_card.rs
+++ b/crates/stella-tui/src/views/plan_card.rs
@@ -334,6 +334,7 @@ mod tests {
             ),
             status: TaskStatus::InProgress,
             owner: None,
+            contract: None,
         }]);
         let text: String = step_rows(&plan, 52, None, 0, false)
             .0
@@ -362,6 +363,7 @@ mod tests {
             description: Some(long.into()),
             status: TaskStatus::Pending,
             owner: None,
+            contract: None,
         }]);
         let (rows, _) = step_rows(&plan, 40, None, 0, false);
         assert!(rows.len() > 2, "the detail wrapped onto its own rows");

--- a/crates/stella-tui/src/views/plan_rail.rs
+++ b/crates/stella-tui/src/views/plan_rail.rs
@@ -331,6 +331,7 @@ mod tests {
             description: None,
             status,
             owner: None,
+            contract: None,
         }
     }
 

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -967,6 +967,7 @@ mod tests {
             description: None,
             status,
             owner: owner.map(str::to_string),
+            contract: None,
         }
     }
 

--- a/crates/stella-tui/tests/render_robustness.rs
+++ b/crates/stella-tui/tests/render_robustness.rs
@@ -140,6 +140,7 @@ fn nasty_unicode_cards_never_panic_at_any_width() {
                         description: Some(text.clone()),
                         status: TaskStatus::InProgress,
                         owner: None,
+                        contract: None,
                     },
                     TaskItem {
                         id: "2".into(),
@@ -147,6 +148,7 @@ fn nasty_unicode_cards_never_panic_at_any_width() {
                         description: None,
                         status: TaskStatus::Pending,
                         owner: None,
+                        contract: None,
                     },
                 ],
             },

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -12,7 +12,7 @@ Companion docs: `IMPLEMENTATION-PLAN.md`, `renderings/`
 Every screen exists to make these four claims visible without saying them:
 
 1. **Deterministic first, model last.** Anything answerable by computation never goes to a model. The UI prices deterministic work at $0.00 and shows the det/model split everywhere work is summarized.
-2. **Tasks close on checks, not on model self-report.** A task is a contract (done means), evidence, and cost. The model cannot mark its own homework.
+2. **Tasks close on checks, not on model self-report.** A task is a contract (definition of done), evidence, and cost. The model cannot mark its own homework.
 3. **Drift is recorded, not hidden.** The plan graph distinguishes `[:NEXT]` (planned) from `[:THEN]` (actual). Divergence is rendered, causal, and feeds the learner.
 4. **Traces are the product.** Verified traces train the customer's private model. The UI shows trace capture, learned skills, and receipts as first-class objects.
 
@@ -155,7 +155,9 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
 
 A task has three parts:
 
-- **done means**: the contract. A list of checks, each deterministic (`graph`, `unit`, `harness`) where possible, model-judged only when irreducible. A task closes when its checks pass, never when the model says so.
+- **definition of done**: the contract. A list of checks, each deterministic (`graph`, `unit`, `harness`) where possible, model-judged only when irreducible. A task closes when its checks pass, never when the model says so.
+
+  Implemented in `stella_protocol::task_contract`, and the rule is the type rather than a validator: `TaskContract::ReadOnly` has no field a check could go in, and `DefinitionOfDone` is non-empty by construction in Rust and on the wire. Closure is **derived** (`TaskContract::closure`), never stored — there is no field a caller can set to mean done. `TaskBoard::set_status` refuses `Completed` while any check is outstanding, which is where "the model cannot mark its own homework" stops being a slogan. `Cancelled` is deliberately not gated: it is not a claim the work was done, and it has to stay available exactly when checks are failing.
 - **evidence**: the ledger of events tagged with this task id (edits, runs, graph writes).
 - **cost**: `$ · tok · cache rd% · det/model split · model calls · est remain`.
 
@@ -199,7 +201,7 @@ The single best demo moment: an issue becomes a plan while the user watches, and
 1. In ISSUES, `w` on a triaged issue opens a centered overlay (ratatui `Clear` over a centered `Rect`).
 2. Header: `w start work · <issue id> <title>`, subtitle `draft plan r1 · built from issue text + graph + memory`.
 3. Sources line names exactly what was used: the issue, the coupled files from the graph, and any applied memory RULEs with their text.
-4. Task list with contract previews: read-only tasks marked `read only · no contract`, diff-producing tasks each show one `done means` line with its mechanism and `det` tag, final task is `◇ verify · n gates · blocks merge`.
+4. Task list with contract previews: read-only tasks marked `read only · no contract`, diff-producing tasks each show one `definition of done` line with its mechanism and `det` tag, final task is `◇ verify · n gates · blocks merge`.
 5. Estimate line: `~$ · ~tok · det est % · ~minutes`.
 6. Action row: `a approve and start · e edit tasks · x cancel`. Footer states plainly: `nothing runs before approval`.
 7. On approval, stella creates the branch, the plan becomes r1 with `[:NEXT]` edges, and the breadcrumb strip updates.
@@ -299,7 +301,7 @@ Keep current information architecture (executions table, installed agents, agent
 |---|---|
 | `01-session-turn-lifecycle` | turn begin, skill, collapsed read, highlighted edit diff, receipt, verify turn, single-line status |
 | `02-event-vocabulary` | write, delete with graph check, memory log, memory promotion, compaction, queued-steer consumption, rail legend |
-| `03-task-zoom` | task contract view: done means, evidence, planned vs actual, spend strip |
+| `03-task-zoom` | task contract view: definition of done, evidence, planned vs actual, spend strip |
 | `04-graph` | graph tab: grouped relations, reverse edges, coupling ranking |
 | `05-skills` | unified installed + registry search, learned skills, signature policy |
 | `06-mcp` | server table, oauth flow, registry install, sandbox-until-review |

--- a/docs/tools/task_create.toml
+++ b/docs/tools/task_create.toml
@@ -34,6 +34,42 @@ Add tasks to the session task board — the board is the session's visible plan,
 input_schema = '''
 {
   "properties": {
+    "definition_of_done": {
+      "description": "What would make this task done. \"read_only\" if it produces no diff; otherwise a non-empty array of checks. A task that produces a diff closes when these pass — task_complete is refused while any is outstanding.",
+      "oneOf": [
+        {
+          "const": "read_only"
+        },
+        {
+          "items": {
+            "properties": {
+              "judge": {
+                "description": "Only read for a mechanism this host does not know; the four above judge themselves",
+                "enum": [
+                  "deterministic",
+                  "model"
+                ],
+                "type": "string"
+              },
+              "mechanism": {
+                "description": "How it is settled: graph | unit | harness | review, or a plugin's own name",
+                "type": "string"
+              },
+              "statement": {
+                "description": "What must be true (e.g. \"the auth suite is green\")",
+                "type": "string"
+              }
+            },
+            "required": [
+              "statement"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      ]
+    },
     "description": {
       "description": "What needs to be done, if the subject alone is not enough",
       "type": "string"

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -82,6 +82,52 @@ export type BudgetScope = "turn" | "session";
 export type CacheZone = "stable_prefix" | "cacheable" | "volatile" | "other";
 
 /**
+ * One clause of a task's definition of done.
+ */
+export interface Check {
+  /**
+   * How it is settled.
+   */
+  mechanism: CheckMechanism;
+  /**
+   * Where it stands. Defaults to [`CheckOutcome::Pending`] so a plan can be
+   * written before anything has run.
+   */
+  outcome?: CheckOutcome;
+  /**
+   * What must be true, in the author's words: "no inbound refs to the
+   * removed symbol", "the auth suite is green".
+   */
+  statement: string;
+}
+
+/**
+ * How a check is settled — an OPEN vocabulary. The mechanisms this host runs itself are listed in `examples` and imply their own judge; any other name is a contributed mechanism and MUST carry `judge`, so a consumer can always tell whether a machine or a model decided.
+ */
+export interface CheckMechanism {
+  judge?: Judge;
+  name: string;
+}
+
+/**
+ * Where a check stands.
+ *
+ * [`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence
+ * because an outcome without it is exactly the self-report this module exists
+ * to replace — "it passed" is a claim, and "42 tests, 0 failures" is the thing
+ * that makes it checkable by someone else.
+ */
+export type CheckOutcome = {
+  state: "pending";
+} | {
+  evidence: string;
+  state: "passed";
+} | {
+  evidence: string;
+  state: "failed";
+};
+
+/**
  * Aggregate CI verdict for a PR's head commit, as observed by the
  * fleet monitor (`gh pr checks`). Reconciled against the live source
  * before rendering, never served from cache alone (L-V3).
@@ -305,6 +351,11 @@ export interface ContextUsage {
 }
 
 /**
+ * What a diff-producing task means by done: at least one check, always. An empty array is refused rather than accepted as a contract that promises nothing.
+ */
+export type DefinitionOfDone = Check[];
+
+/**
  * Why a candidate's work did not reach the real tree.
  *
  * Exhaustive over the pipeline's decision: the three arms are the two
@@ -432,6 +483,14 @@ export interface HunkProposal {
    */
   tool: string;
 }
+
+/**
+ * Who settles a check.
+ *
+ * The axis SPEC 1's first thesis prices: deterministic work never reaches a
+ * model and costs `$0.00`.
+ */
+export type Judge = "deterministic" | "model";
 
 /**
  * Which rung of the evidence ladder a `verdict` event actually came to rest on. The verdict's `passed` and `deterministic` flags cannot express this on their own: several distinct outcomes share the same pair of booleans, so the rung is carried explicitly rather than inferred. Read this field, not the flags, when you need to know what was established.
@@ -1066,11 +1125,36 @@ export type SubAgentPhase = {
 export type SubAgentStatus = "completed" | "incomplete" | "refused";
 
 /**
+ * What a task means by done (SPEC 7.1).
+ */
+export type TaskContract = {
+  kind: "read_only";
+} | {
+  checks: DefinitionOfDone;
+  kind: "definition_of_done";
+};
+
+/**
  * One entry on the turn's task board (the `task_*` tools). The board is
  * session-scoped working state — what the agent has planned, is doing,
  * and has finished — mirrored to the store for cross-session findability.
  */
 export interface TaskItem {
+  /**
+   * What this task means by done (SPEC 7.1).
+   *
+   * `None` is *nobody has said yet*, and is deliberately not the same fact
+   * as [`TaskContract::ReadOnly`], which is *somebody looked and there is
+   * nothing to prove*. A board that collapsed the two would let an
+   * undeclared task close on the same terms as one declared harmless —
+   * which is the self-report [`TaskContract`] exists to end.
+   *
+   * Optional because the board predates contracts and a session may still
+   * create a task without one; `stella_core::tasks` refuses the *close*, not
+   * the creation, so an undeclared task is visible on the board rather than
+   * rejected at the door.
+   */
+  contract?: TaskContract | null;
   /**
    * What needs to be done, if the creator elaborated beyond the subject.
    */

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -151,6 +151,112 @@
         }
       ]
     },
+    "Check": {
+      "description": "One clause of a task's definition of done.",
+      "properties": {
+        "mechanism": {
+          "$ref": "#/$defs/CheckMechanism",
+          "description": "How it is settled."
+        },
+        "outcome": {
+          "$ref": "#/$defs/CheckOutcome",
+          "default": {
+            "state": "pending"
+          },
+          "description": "Where it stands. Defaults to [`CheckOutcome::Pending`] so a plan can be\nwritten before anything has run."
+        },
+        "statement": {
+          "description": "What must be true, in the author's words: \"no inbound refs to the\nremoved symbol\", \"the auth suite is green\".",
+          "type": "string"
+        }
+      },
+      "required": [
+        "statement",
+        "mechanism"
+      ],
+      "type": "object"
+    },
+    "CheckMechanism": {
+      "description": "How a check is settled — an OPEN vocabulary. The mechanisms this host runs itself are listed in `examples` and imply their own judge; any other name is a contributed mechanism and MUST carry `judge`, so a consumer can always tell whether a machine or a model decided.",
+      "examples": [
+        {
+          "name": "graph"
+        },
+        {
+          "name": "unit"
+        },
+        {
+          "name": "harness"
+        },
+        {
+          "name": "review"
+        }
+      ],
+      "properties": {
+        "judge": {
+          "$ref": "#/$defs/Judge"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "CheckOutcome": {
+      "description": "Where a check stands.\n\n[`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence\nbecause an outcome without it is exactly the self-report this module exists\nto replace — \"it passed\" is a claim, and \"42 tests, 0 failures\" is the thing\nthat makes it checkable by someone else.",
+      "oneOf": [
+        {
+          "description": "Not run yet.",
+          "properties": {
+            "state": {
+              "const": "pending",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Ran and passed. `evidence` is what the judge saw.",
+          "properties": {
+            "evidence": {
+              "type": "string"
+            },
+            "state": {
+              "const": "passed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Ran and did not pass. `evidence` is what the judge saw.",
+          "properties": {
+            "evidence": {
+              "type": "string"
+            },
+            "state": {
+              "const": "failed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state",
+            "evidence"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "CiStatus": {
       "description": "Aggregate CI verdict for a PR's head commit, as observed by the\nfleet monitor (`gh pr checks`). Reconciled against the live source\nbefore rendering, never served from cache alone (L-V3).",
       "oneOf": [
@@ -404,6 +510,14 @@
       ],
       "type": "object"
     },
+    "DefinitionOfDone": {
+      "description": "What a diff-producing task means by done: at least one check, always. An empty array is refused rather than accepted as a contract that promises nothing.",
+      "items": {
+        "$ref": "#/$defs/Check"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
     "DeliveryDecline": {
       "description": "Why a candidate's work did not reach the real tree.\n\nExhaustive over the pipeline's decision: the three arms are the two\n`Withhold` paths of `pipeline::delivery::decide` plus the one way a\nsanctioned delivery can still fail at the git layer.",
       "oneOf": [
@@ -640,6 +754,21 @@
         "hunks"
       ],
       "type": "object"
+    },
+    "Judge": {
+      "description": "Who settles a check.\n\nThe axis SPEC 1's first thesis prices: deterministic work never reaches a\nmodel and costs `$0.00`.",
+      "oneOf": [
+        {
+          "const": "deterministic",
+          "description": "A machine decided: an exit status, a count, a graph query. No model call,\nand the same inputs give the same answer on any run.",
+          "type": "string"
+        },
+        {
+          "const": "model",
+          "description": "A model decided, because the property is not reducible to a check.\n\nSPEC 7.1 permits this \"only when irreducible\", which is a review\njudgement rather than something a type can enforce. What the type does\nis make the choice **visible**: a contract full of model-judged checks\nis a contract that proves very little, and it says so on its face.",
+          "type": "string"
+        }
+      ]
     },
     "LadderRung": {
       "description": "Which rung of the evidence ladder a `verdict` event actually came to rest on. The verdict's `passed` and `deterministic` flags cannot express this on their own: several distinct outcomes share the same pair of booleans, so the rung is carried explicitly rather than inferred. Read this field, not the flags, when you need to know what was established.",
@@ -1683,9 +1812,55 @@
         }
       ]
     },
+    "TaskContract": {
+      "description": "What a task means by done (SPEC 7.1).",
+      "oneOf": [
+        {
+          "description": "The task produces no diff. It closes when its own events are done, and\nit carries no checks — there is nowhere here to put one.",
+          "properties": {
+            "kind": {
+              "const": "read_only",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The task produces a diff. It closes when every check passes.",
+          "properties": {
+            "checks": {
+              "$ref": "#/$defs/DefinitionOfDone"
+            },
+            "kind": {
+              "const": "definition_of_done",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "checks"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "TaskItem": {
       "description": "One entry on the turn's task board (the `task_*` tools). The board is\nsession-scoped working state — what the agent has planned, is doing,\nand has finished — mirrored to the store for cross-session findability.",
       "properties": {
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is deliberately not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_core::tasks` refuses the *close*, not\nthe creation, so an undeclared task is visible on the board rather than\nrejected at the door."
+        },
         "description": {
           "description": "What needs to be done, if the creator elaborated beyond the subject.",
           "type": [

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -747,6 +747,52 @@ export type BudgetScope = "turn" | "session";
 export type CacheZone = "stable_prefix" | "cacheable" | "volatile" | "other";
 
 /**
+ * One clause of a task's definition of done.
+ */
+export interface Check {
+  /**
+   * How it is settled.
+   */
+  mechanism: CheckMechanism;
+  /**
+   * Where it stands. Defaults to [`CheckOutcome::Pending`] so a plan can be
+   * written before anything has run.
+   */
+  outcome?: CheckOutcome;
+  /**
+   * What must be true, in the author's words: "no inbound refs to the
+   * removed symbol", "the auth suite is green".
+   */
+  statement: string;
+}
+
+/**
+ * How a check is settled — an OPEN vocabulary. The mechanisms this host runs itself are listed in `examples` and imply their own judge; any other name is a contributed mechanism and MUST carry `judge`, so a consumer can always tell whether a machine or a model decided.
+ */
+export interface CheckMechanism {
+  judge?: Judge;
+  name: string;
+}
+
+/**
+ * Where a check stands.
+ *
+ * [`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence
+ * because an outcome without it is exactly the self-report this module exists
+ * to replace — "it passed" is a claim, and "42 tests, 0 failures" is the thing
+ * that makes it checkable by someone else.
+ */
+export type CheckOutcome = {
+  state: "pending";
+} | {
+  evidence: string;
+  state: "passed";
+} | {
+  evidence: string;
+  state: "failed";
+};
+
+/**
  * Aggregate CI verdict for a PR's head commit, as observed by the
  * fleet monitor (`gh pr checks`). Reconciled against the live source
  * before rendering, never served from cache alone (L-V3).
@@ -1043,6 +1089,11 @@ export interface ContextUsage {
 }
 
 /**
+ * What a diff-producing task means by done: at least one check, always. An empty array is refused rather than accepted as a contract that promises nothing.
+ */
+export type DefinitionOfDone = Check[];
+
+/**
  * Why a candidate's work did not reach the real tree.
  *
  * Exhaustive over the pipeline's decision: the three arms are the two
@@ -1213,6 +1264,14 @@ export interface HunkProposal {
    */
   tool: string;
 }
+
+/**
+ * Who settles a check.
+ *
+ * The axis SPEC 1's first thesis prices: deterministic work never reaches a
+ * model and costs `$0.00`.
+ */
+export type Judge = "deterministic" | "model";
 
 /**
  * Which rung of the evidence ladder a `verdict` event actually came to rest on. The verdict's `passed` and `deterministic` flags cannot express this on their own: several distinct outcomes share the same pair of booleans, so the rung is carried explicitly rather than inferred. Read this field, not the flags, when you need to know what was established.
@@ -1868,11 +1927,36 @@ export type SubAgentPhase = {
 export type SubAgentStatus = "completed" | "incomplete" | "refused";
 
 /**
+ * What a task means by done (SPEC 7.1).
+ */
+export type TaskContract = {
+  kind: "read_only";
+} | {
+  checks: DefinitionOfDone;
+  kind: "definition_of_done";
+};
+
+/**
  * One entry on the turn's task board (the `task_*` tools). The board is
  * session-scoped working state — what the agent has planned, is doing,
  * and has finished — mirrored to the store for cross-session findability.
  */
 export interface TaskItem {
+  /**
+   * What this task means by done (SPEC 7.1).
+   *
+   * `None` is *nobody has said yet*, and is deliberately not the same fact
+   * as [`TaskContract::ReadOnly`], which is *somebody looked and there is
+   * nothing to prove*. A board that collapsed the two would let an
+   * undeclared task close on the same terms as one declared harmless —
+   * which is the self-report [`TaskContract`] exists to end.
+   *
+   * Optional because the board predates contracts and a session may still
+   * create a task without one; `stella_core::tasks` refuses the *close*, not
+   * the creation, so an undeclared task is visible on the board rather than
+   * rejected at the door.
+   */
+  contract?: TaskContract | null;
   /**
    * What needs to be done, if the creator elaborated beyond the subject.
    */

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -1620,6 +1620,112 @@
         }
       ]
     },
+    "Check": {
+      "description": "One clause of a task's definition of done.",
+      "properties": {
+        "mechanism": {
+          "$ref": "#/$defs/CheckMechanism",
+          "description": "How it is settled."
+        },
+        "outcome": {
+          "$ref": "#/$defs/CheckOutcome",
+          "default": {
+            "state": "pending"
+          },
+          "description": "Where it stands. Defaults to [`CheckOutcome::Pending`] so a plan can be\nwritten before anything has run."
+        },
+        "statement": {
+          "description": "What must be true, in the author's words: \"no inbound refs to the\nremoved symbol\", \"the auth suite is green\".",
+          "type": "string"
+        }
+      },
+      "required": [
+        "statement",
+        "mechanism"
+      ],
+      "type": "object"
+    },
+    "CheckMechanism": {
+      "description": "How a check is settled — an OPEN vocabulary. The mechanisms this host runs itself are listed in `examples` and imply their own judge; any other name is a contributed mechanism and MUST carry `judge`, so a consumer can always tell whether a machine or a model decided.",
+      "examples": [
+        {
+          "name": "graph"
+        },
+        {
+          "name": "unit"
+        },
+        {
+          "name": "harness"
+        },
+        {
+          "name": "review"
+        }
+      ],
+      "properties": {
+        "judge": {
+          "$ref": "#/$defs/Judge"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "CheckOutcome": {
+      "description": "Where a check stands.\n\n[`CheckOutcome::Passed`] and [`CheckOutcome::Failed`] both carry evidence\nbecause an outcome without it is exactly the self-report this module exists\nto replace — \"it passed\" is a claim, and \"42 tests, 0 failures\" is the thing\nthat makes it checkable by someone else.",
+      "oneOf": [
+        {
+          "description": "Not run yet.",
+          "properties": {
+            "state": {
+              "const": "pending",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Ran and passed. `evidence` is what the judge saw.",
+          "properties": {
+            "evidence": {
+              "type": "string"
+            },
+            "state": {
+              "const": "passed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Ran and did not pass. `evidence` is what the judge saw.",
+          "properties": {
+            "evidence": {
+              "type": "string"
+            },
+            "state": {
+              "const": "failed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "state",
+            "evidence"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "CiStatus": {
       "description": "Aggregate CI verdict for a PR's head commit, as observed by the\nfleet monitor (`gh pr checks`). Reconciled against the live source\nbefore rendering, never served from cache alone (L-V3).",
       "oneOf": [
@@ -1980,6 +2086,14 @@
       ],
       "type": "object"
     },
+    "DefinitionOfDone": {
+      "description": "What a diff-producing task means by done: at least one check, always. An empty array is refused rather than accepted as a contract that promises nothing.",
+      "items": {
+        "$ref": "#/$defs/Check"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
     "DeliveryDecline": {
       "description": "Why a candidate's work did not reach the real tree.\n\nExhaustive over the pipeline's decision: the three arms are the two\n`Withhold` paths of `pipeline::delivery::decide` plus the one way a\nsanctioned delivery can still fail at the git layer.",
       "oneOf": [
@@ -2294,6 +2408,21 @@
         "hunks"
       ],
       "type": "object"
+    },
+    "Judge": {
+      "description": "Who settles a check.\n\nThe axis SPEC 1's first thesis prices: deterministic work never reaches a\nmodel and costs `$0.00`.",
+      "oneOf": [
+        {
+          "const": "deterministic",
+          "description": "A machine decided: an exit status, a count, a graph query. No model call,\nand the same inputs give the same answer on any run.",
+          "type": "string"
+        },
+        {
+          "const": "model",
+          "description": "A model decided, because the property is not reducible to a check.\n\nSPEC 7.1 permits this \"only when irreducible\", which is a review\njudgement rather than something a type can enforce. What the type does\nis make the choice **visible**: a contract full of model-judged checks\nis a contract that proves very little, and it says so on its face.",
+          "type": "string"
+        }
+      ]
     },
     "LadderRung": {
       "description": "Which rung of the evidence ladder a `verdict` event actually came to rest on. The verdict's `passed` and `deterministic` flags cannot express this on their own: several distinct outcomes share the same pair of booleans, so the rung is carried explicitly rather than inferred. Read this field, not the flags, when you need to know what was established.",
@@ -3417,9 +3546,55 @@
         }
       ]
     },
+    "TaskContract": {
+      "description": "What a task means by done (SPEC 7.1).",
+      "oneOf": [
+        {
+          "description": "The task produces no diff. It closes when its own events are done, and\nit carries no checks — there is nowhere here to put one.",
+          "properties": {
+            "kind": {
+              "const": "read_only",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The task produces a diff. It closes when every check passes.",
+          "properties": {
+            "checks": {
+              "$ref": "#/$defs/DefinitionOfDone"
+            },
+            "kind": {
+              "const": "definition_of_done",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "checks"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "TaskItem": {
       "description": "One entry on the turn's task board (the `task_*` tools). The board is\nsession-scoped working state — what the agent has planned, is doing,\nand has finished — mirrored to the store for cross-session findability.",
       "properties": {
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is deliberately not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_core::tasks` refuses the *close*, not\nthe creation, so an undeclared task is visible on the board rather than\nrejected at the door."
+        },
         "description": {
           "description": "What needs to be done, if the creator elaborated beyond the subject.",
           "type": [


### PR DESCRIPTION
SPEC 7.1 and SPEC 1's second thesis: **tasks close on checks, not on model self-report.** Nothing in the tree made that true. `TaskItem.status` is a field, `task_complete` sets it, and the caller with the strongest incentive to set it is the model whose work is being judged — "this passed its checks" and "the model said it did" were the same bytes.

This is the protocol layer P3 was blocked on, plus the enforcement that makes it mean something.

## The closing condition is derived, never stored

`TaskContract::closure()` computes closure from the checks every time it is asked. There is **no field anywhere in the new module a caller can set to mean done**, so a task with an unsatisfied contract has no representation that says otherwise. That is thesis 2 written as a function signature rather than as a convention.

## The rule is the type, not a validator

SPEC 7.1 requires a contract on diff-producing tasks and forbids one on read-only tasks. Both halves are structural:

- **`TaskContract::ReadOnly` has no field a check could go in.** The spec's stated reason for the rule is that a required contract on a task with nothing to prove produces *"fake checks written to satisfy the UI"* — a variant with nowhere to put them is the only version of that rule which cannot be worked around.
- **`DefinitionOfDone` is non-empty by construction**, in Rust and on the wire. Its `Deserialize` rejects an empty list; the published schema carries `minItems: 1` so a non-Rust reader enforces the same thing.

A validation function was the smaller change and the weaker one: it holds only where someone remembers to call it, and the call site that forgets is the one that ships.

## Deterministic where it can be, and it says which

Every check names the `Judge` that settles it — the split thesis 1 prices at `$0.00` and the receipt reports as `det %`. `CheckMechanism` is an **open** vocabulary over a closed `CheckKind`, the `StageName` shape and for the same reason: a verification plugin contributes mechanisms this host has never heard of, and a closed enum would either reject them or silently retype them.

A contributed mechanism that declares no judge is **refused, not defaulted**. Guessing `Deterministic` would price a model call at `$0.00`; guessing `Model` would make a plugin's own graph query look like one. Both lie on the receipt.

## Enforcement, not decoration

`TaskBoard::set_status` refuses `Completed` while any check is outstanding, and names the outstanding clauses so the refusal is actionable by the model that reads it. It is the single transition gate, so the refusal cannot be routed around — there is no other setter, and `contract_mut` is deliberately scoped to the contract so recording an outcome cannot reach `status`.

**`Cancelled` is not gated, on purpose.** It is not a claim the work was done, and it must stay available exactly when checks are failing — gating it would trap a task nobody can honestly close, and the pressure would be to fake a passing check.

## Witness

`a_contracted_task_is_refused_a_close_while_a_check_is_outstanding`, verified by disarming the gate: the task then closes with its check still `Pending`. Five board tests in total, covering the read-only path, the undeclared-legacy path, and cancellation under a failing contract.

## Three gates caught three real defects

Worth reading, because each one was invisible to the tests I wrote:

1. The **wire-schema exporter** would not compile — a hand-written `Serialize` needs a hand-written `JsonSchema`.
2. `DefinitionOfDone`'s **derived schema described the wrong shape**: `serde(into = "Vec<Check>")` makes the bytes an array while the Rust shape is `{head, tail}`, so the published contract was one no message could satisfy. Hand-written now.
3. The **schema validator refused `minItems`** as unmodelled rather than ignoring it — *"extend this validator rather than letting the proof silently weaken"*. Extended.

And the **arm-coverage test** surfaced something worth stating: `Judge::Model` can only ever be serialized by a *contributed* mechanism, because a known kind implies its judge and writes no field. A sample built from `CheckKind::Review` would have left the arm unproven while looking like it covered it. The sample says so where it is built.

## Naming

`definition_of_done`, not `done_means` — the standard term, and the owner's call while the module was minutes old. `design/tui-v2/SPEC.md` §7.1 is updated to match, because spec and code disagreeing is itself a bug.

## Breaking changes

Taken deliberately, per direction:

- `TaskItem` gains `contract: Option<TaskContract>` (`serde(default)`, so recorded streams still parse).
- `TaskBoard::create` gains a third parameter.
- `task_create` gains an optional `definition_of_done` — one new parameter in `docs/tools/task_create.toml`, nothing else changed.

`None` is *nobody has said yet* and is deliberately **not** the same fact as `ReadOnly` (*someone looked and there is nothing to prove*). Undeclared tasks close as they always did, so every board that predates contracts keeps working.

## What is not here

The store's `tasks` table has no contract column, so the **audit** record does not carry one. It weakens nothing — the live board is in-memory in `stella-core` and never rehydrates from SQLite, so the refusal always reads the real contract. What is lost is a historical view of what a task promised. The rehydration site says exactly that, rather than leaving a bare `None` to be misread as "promised nothing". Persisting it is a column-guarded `ADD COLUMN` away and I will file it.

## Verification

`cargo test --workspace` green, `cargo clippy --workspace --all-targets -D warnings` clean, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace` clean, `make guards` green. `docs/wire/` and `docs/tools/` regenerated and their diffs read.

## Tests deleted

None.

Refs #4058

## Summary by Sourcery

Enforce task completion through explicit, evidence-bearing checks while retaining read-only, cancellation, and legacy task workflows.

New Features:
- Add task contracts with non-empty definitions of done for diff-producing tasks and an explicit read-only contract.
- Expose check mechanisms, outcomes, judges, closure state, and judge splits through the protocol and wire schemas.
- Allow task creation tools to accept and parse definitions of done, including contributed mechanisms with explicit judges.

Bug Fixes:
- Prevent contracted tasks from being marked completed while checks are pending or failed.
- Reject empty definitions of done and contributed mechanisms that omit their judge instead of accepting ambiguous contracts.
- Keep published schemas aligned with serialized contract shapes and enforce non-empty check arrays during schema validation.

Enhancements:
- Make task closure derived from check outcomes rather than stored or self-reported.
- Centralize completion enforcement in the task board while preserving cancellation and legacy undeclared-task behavior.
- Restrict contract outcome mutation to the contract itself and preserve backward-compatible task deserialization.

Documentation:
- Update the task specification, tool documentation, and generated wire documentation to use and describe definitions of done.

Tests:
- Add protocol, board, wire-schema, and round-trip coverage for task contracts, closure enforcement, judge attribution, read-only tasks, legacy tasks, cancellation, and schema constraints.

Chores:
- Add the task contract protocol module and include optional contracts on task items, with store rehydration explicitly remaining contract-less until persistence is added.