### PR TITLE
feat(stella-tui,stella-cli): the Command Deck can park a turn on a human — ask_question and approvals both land

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -197,13 +197,12 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
 
     crate::subagent::install_for_session(cfg, &registry)?;
     let ask = human_is_present(true);
-    let active_rules =
-        crate::rules::enforce_workspace_rules(
-            &registry,
-            &cfg.workspace_root,
-            &cfg.authority,
-            crate::rules::MidTurnAsk::tty_when(ask),
-        );
+    let active_rules = crate::rules::enforce_workspace_rules(
+        &registry,
+        &cfg.workspace_root,
+        &cfg.authority,
+        crate::rules::MidTurnAsk::tty_when(ask),
+    );
     // Auto-build the code-graph index in the background (a cheap incremental
     // refresh if it already exists) and keep it fresh via the live watcher, so
     // `stella search` and the deck's Graph tab have an index this session

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -198,7 +198,12 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
     crate::subagent::install_for_session(cfg, &registry)?;
     let ask = human_is_present(true);
     let active_rules =
-        crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root, &cfg.authority, ask);
+        crate::rules::enforce_workspace_rules(
+            &registry,
+            &cfg.workspace_root,
+            &cfg.authority,
+            crate::rules::MidTurnAsk::tty_when(ask),
+        );
     // Auto-build the code-graph index in the background (a cheap incremental
     // refresh if it already exists) and keep it fresh via the live watcher, so
     // `stella search` and the deck's Graph tab have an index this session

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -170,7 +170,12 @@ pub(crate) async fn run_raw_one_shot(
     // responder and the rules-enforcement prompt both read this value.
     let ask = human_is_present(format == OutputFormat::Text);
     let active_rules =
-        crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root, &cfg.authority, ask);
+        crate::rules::enforce_workspace_rules(
+            &registry,
+            &cfg.workspace_root,
+            &cfg.authority,
+            crate::rules::MidTurnAsk::tty_when(ask),
+        );
     // Auto-build + live-refresh the code graph in the background so
     // `stella search` and the deck's Graph tab have a fresh index. Status
     // goes to stderr — stdout may be machine-readable JSON.
@@ -517,7 +522,12 @@ pub async fn run_goal_cmd(
     // fact is fixed at `true`; the stdio handles settle the rest.
     let ask = human_is_present(true);
     let active_rules =
-        crate::rules::enforce_workspace_rules(&registry, &cfg.workspace_root, &cfg.authority, ask);
+        crate::rules::enforce_workspace_rules(
+            &registry,
+            &cfg.workspace_root,
+            &cfg.authority,
+            crate::rules::MidTurnAsk::tty_when(ask),
+        );
     // Auto-build + live-refresh the code-graph index in the background so
     // `stella search` and the deck's Graph tab stay current without a manual
     // `stella init`. Non-blocking; status to stderr. Kept alive until the

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -169,13 +169,12 @@ pub(crate) async fn run_raw_one_shot(
     // The one derivation of "a human is here to answer" — the #2676 approval
     // responder and the rules-enforcement prompt both read this value.
     let ask = human_is_present(format == OutputFormat::Text);
-    let active_rules =
-        crate::rules::enforce_workspace_rules(
-            &registry,
-            &cfg.workspace_root,
-            &cfg.authority,
-            crate::rules::MidTurnAsk::tty_when(ask),
-        );
+    let active_rules = crate::rules::enforce_workspace_rules(
+        &registry,
+        &cfg.workspace_root,
+        &cfg.authority,
+        crate::rules::MidTurnAsk::tty_when(ask),
+    );
     // Auto-build + live-refresh the code graph in the background so
     // `stella search` and the deck's Graph tab have a fresh index. Status
     // goes to stderr — stdout may be machine-readable JSON.
@@ -521,13 +520,12 @@ pub async fn run_goal_cmd(
     // Goal mode always renders human-readable output, so its half of the
     // fact is fixed at `true`; the stdio handles settle the rest.
     let ask = human_is_present(true);
-    let active_rules =
-        crate::rules::enforce_workspace_rules(
-            &registry,
-            &cfg.workspace_root,
-            &cfg.authority,
-            crate::rules::MidTurnAsk::tty_when(ask),
-        );
+    let active_rules = crate::rules::enforce_workspace_rules(
+        &registry,
+        &cfg.workspace_root,
+        &cfg.authority,
+        crate::rules::MidTurnAsk::tty_when(ask),
+    );
     // Auto-build + live-refresh the code-graph index in the background so
     // `stella search` and the deck's Graph tab stay current without a manual
     // `stella init`. Non-blocking; status to stderr. Kept alive until the

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -84,7 +84,7 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         &tools_registry,
         &cfg.workspace_root,
         &cfg.authority,
-        false,
+        crate::rules::MidTurnAsk::Headless,
     );
     let (_session_graph, _graph_build) = spawn_session_graph(
         &cfg.workspace_root,

--- a/crates/stella-cli/src/approval.rs
+++ b/crates/stella-cli/src/approval.rs
@@ -97,22 +97,19 @@ impl ApprovalResponder for AskUserApprovalResponder {
     }
 }
 
-/// Attach the TTY-backed approval responder to `registry` when a human is
-/// present to answer.
+/// Attach the TTY-backed approval responder to `registry`.
 ///
-/// `human_present` is [`crate::interactive::human_can_answer`]'s answer,
-/// derived once by the session driver and passed down — never re-derived
-/// here. Without a human the broker stays headless and refuses with the
-/// grant-path message (`tools.<name>` policy, or rerunning interactively)
-/// instead of reading a stdin nobody is holding.
+/// Called only for [`crate::rules::MidTurnAsk::Tty`] — whether a human is
+/// present is decided once by the session driver
+/// ([`crate::interactive::human_can_answer`]) and expressed in that value,
+/// never re-derived here. Without a human the broker is left headless and
+/// refuses with the grant-path message (`tools.<name>` policy, or rerunning
+/// interactively) instead of reading a stdin nobody is holding.
 ///
-/// A supervised child never reaches this attachment with `true`: its
-/// approvals ride the sidecar transport (#1585), and its staged stdin could
-/// not pass the terminal test in any case.
-pub(crate) fn attach_interactive_approvals(registry: &ToolRegistry, human_present: bool) {
-    if !human_present {
-        return;
-    }
+/// A supervised child never reaches this attachment: its approvals ride the
+/// sidecar transport (#1585), and its staged stdin could not pass the
+/// terminal test in any case.
+pub(crate) fn attach_interactive_approvals(registry: &ToolRegistry) {
     registry.attach_approval_responder(
         Arc::new(AskUserApprovalResponder::new(Box::new(TtyAskUserIo))),
         DEFAULT_APPROVAL_TTL,

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -27,12 +27,13 @@
 //!
 //! ## The two engine seams handled here
 //!
-//! - **Interactive questions** ([`DeckAskUserIo`]): the plain REPL reads
-//!   stdin, which raw mode owns in deck mode. The deck io emits its own
-//!   `AskUser` card, waits for the deck's `AskUserAnswer`, then echoes the
-//!   answer back as that card's `ToolResult` — the documented event-pure path
-//!   that clears the pending gate (`stella_tui::model`). Its consumer is the
-//!   approvals plane: scope review's confirm question routes through it.
+//! - **Mid-turn asks** ([`mid_turn_ask`]): the plain REPL reads stdin, which
+//!   raw mode owns in deck mode, so both places a tool call parks on a
+//!   person get a deck-backed responder instead. An approval rides the
+//!   `AskUser` card ([`mid_turn_ask::DeckAskUserIo`]) — emit, wait for the
+//!   deck's `AskUserAnswer`, echo the answer back as that card's
+//!   `ToolResult`, the documented event-pure path that clears the pending
+//!   gate (`stella_tui::model`); an `ask_question` rides the #4220 overlay.
 //! - **Cancel** (`Stop` / `UserInput::Cancel`): the engine has no abort input;
 //!   cancelling drops the in-flight turn future at its next await point and
 //!   truncates the partial turn out of the conversation so the next prompt

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -121,12 +121,6 @@ mod steer;
 /// The lead agent's id — the one conversation this driver runs.
 pub(crate) const LEAD: &str = "lead";
 
-/// Ids for the cards [`DeckAskUserIo`] mints (`deck-ask-N`). Process-unique
-/// like `interactive::NEXT_ASK_ID`, and deliberately a different namespace:
-/// the deck io's card must be cleared by the deck io's own echoed
-/// `ToolResult`, never by an unrelated result.
-static NEXT_DECK_ASK: AtomicU64 = AtomicU64::new(0);
-
 pub(crate) fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -367,24 +361,13 @@ pub async fn run_deck_session(
     // Neither may be the plain-TTY responder — the deck holds the terminal
     // in raw mode, and a blocking stdin read behind its render loop would
     // fight it for every keystroke.
-    let ask_io = DeckAskUserIo {
-        agent: LEAD.to_string(),
-        inbound: in_tx.clone(),
-        answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
-    };
+    let (mid_turn_posture, ask_io) =
+        mid_turn_ask::surface(LEAD.to_string(), in_tx.clone(), ask_rx, question_rx);
     let active_rules = rules::enforce_workspace_rules(
         &registry,
         &cfg.workspace_root,
         &cfg.authority,
-        rules::MidTurnAsk::Surface {
-            approval: Arc::new(crate::approval::AskUserApprovalResponder::new(Box::new(
-                ask_io.clone(),
-            ))),
-            question: Arc::new(DeckQuestionResponder {
-                inbound: in_tx.clone(),
-                answers: Arc::new(tokio::sync::Mutex::new(question_rx)),
-            }),
-        },
+        mid_turn_posture,
     );
     let custom_tools = agent::discover_custom_tools(cfg, true).await;
     let mut budget = agent::build_budget_guard(budget_limit);
@@ -3859,143 +3842,7 @@ async fn run_lead_turn(
     agent::outcome::turn_outcome_result(&outcome)
 }
 
-// ── interactive questions through the deck ──────────────────────────────────
-
-/// [`AskUserIo`] over the deck's channels — how the approvals plane's
-/// questions (scope review's confirm) reach the human at the deck. `prompt`
-/// emits an `AskUser` card, awaits the user's `AskUserAnswer`, echoes the
-/// answer back as the card's own `ToolResult` (the event-pure clear), and
-/// returns the answer with an exact option match becoming its 1-based index
-/// (the numeric quick-pick), anything else passing verbatim as free text.
-#[derive(Clone)]
-struct DeckAskUserIo {
-    agent: String,
-    inbound: UnboundedSender<Inbound>,
-    answers: Arc<tokio::sync::Mutex<UnboundedReceiver<String>>>,
-}
-
-#[async_trait]
-impl AskUserIo for DeckAskUserIo {
-    async fn prompt(&self, question: &str, options: &[String]) -> Result<String, String> {
-        // A caller may append the free-text affordance; the deck's card
-        // renders its own (Enter submits the composer), so presenting the
-        // label as a pickable option would double it — and picking it would
-        // return the label itself as an "answer". Strip it; every other
-        // option passes through untouched.
-        let mut presented: Vec<String> = options.to_vec();
-        if presented
-            .last()
-            .is_some_and(|o| o.starts_with(FREE_TEXT_LABEL))
-        {
-            presented.pop();
-        }
-
-        let id = format!("deck-ask-{}", NEXT_DECK_ASK.fetch_add(1, Ordering::Relaxed));
-        let mut answers = self.answers.lock().await;
-        // Drop answers stranded by a cancelled turn — they belong to a card
-        // that no longer exists.
-        while answers.try_recv().is_ok() {}
-
-        let _ = self.inbound.send(Inbound::Event {
-            agent: self.agent.clone(),
-            event: AgentEvent::AskUser {
-                id: id.clone(),
-                question: question.to_string(),
-                options: presented.clone(),
-            },
-        });
-
-        let answer = answers
-            .recv()
-            .await
-            .ok_or_else(|| "the deck closed before the question was answered".to_string())?;
-
-        // The echoed ToolResult is what clears the pending card in the fold
-        // (matched by this exact id) — without it the gate would keep eating
-        // keys for the rest of the turn.
-        let _ = self.inbound.send(Inbound::Event {
-            agent: self.agent.clone(),
-            event: AgentEvent::ToolResult {
-                call_id: id,
-                output: ToolOutput::Ok {
-                    content: answer.clone(),
-                    data: None,
-                },
-                duration_ms: 0,
-                speculated: false,
-            },
-        });
-
-        match presented.iter().position(|option| *option == answer) {
-            Some(i) => Ok((i + 1).to_string()),
-            None => Ok(answer),
-        }
-    }
-}
-
-/// [`QuestionResponder`] over the deck's channels (#4220): raise the question
-/// overlay, park until the driver settles it, take the card down.
-///
-/// The deck's counterpart to [`crate::question::TtyQuestionResponder`]. That
-/// one renders a card to stdout and blocks on a stdin line; this one hands
-/// the whole [`QuestionRequest`] to the render loop as
-/// [`Inbound::QuestionAsked`] and waits for the [`QuestionOutcome`] the
-/// overlay folds out — so the wait never touches the terminal the deck is
-/// holding, and the deck keeps rendering (and stays Ctrl-C-able) throughout.
-///
-/// The overlay is a pure fold, so **every** decision about what the driver
-/// may do — the note editor, the free-text row, the review pane's three ways
-/// out — lives in `stella_tui::views::question` and is unit-tested without a
-/// terminal. Nothing here interprets an answer; it only carries one.
-struct DeckQuestionResponder {
-    inbound: UnboundedSender<Inbound>,
-    answers: Arc<tokio::sync::Mutex<UnboundedReceiver<QuestionOutcome>>>,
-}
-
-/// Takes the card down however the wait ends.
-///
-/// A `Drop` guard rather than a line at each exit, because the exit that
-/// matters is the one with no line to put it on: at the 30-minute
-/// `DEFAULT_QUESTION_TTL` the broker's `timeout` drops the `respond` future
-/// where it stands, and no code in this file runs again. Without this the
-/// deck would keep a live-looking card up over a turn that had already given
-/// up on it, and a driver's considered answer would go into a oneshot nobody
-/// was holding.
-struct WithdrawOnDrop(UnboundedSender<Inbound>);
-
-impl Drop for WithdrawOnDrop {
-    fn drop(&mut self) {
-        let _ = self.0.send(Inbound::QuestionWithdrawn);
-    }
-}
-
-#[async_trait]
-impl stella_tools::registry::question::QuestionResponder for DeckQuestionResponder {
-    async fn respond(&self, request: &QuestionRequest) -> QuestionOutcome {
-        let mut answers = self.answers.lock().await;
-        // Drop outcomes stranded by a cancelled turn — they answer a card
-        // that no longer exists, and reading one as this question's answer
-        // would resolve it without the driver having looked at it.
-        while answers.try_recv().is_ok() {}
-
-        let _withdraw = WithdrawOnDrop(self.inbound.clone());
-        let _ = self
-            .inbound
-            .send(Inbound::QuestionAsked(Box::new(request.clone())));
-
-        match answers.recv().await {
-            Some(outcome) => outcome,
-            // The deck went away mid-question. Declined, never a silent
-            // default: the model must hear that no answer is coming rather
-            // than act on one nobody gave.
-            None => QuestionOutcome::Declined {
-                reason: "the deck closed before the question was answered — do not re-ask; \
-                         proceed with your best judgement and state the assumption you made"
-                    .to_string(),
-            },
-        }
-    }
-}
+mod mid_turn_ask;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -71,7 +71,8 @@ use stella_core::ports::{Principal, ToolExecutor};
 use stella_core::{BudgetGuard, CalibrationMap, Engine, TurnOutcome};
 use stella_model::provider::Provider;
 use stella_protocol::{
-    AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, TaskItem, ToolOutput,
+    AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, QuestionOutcome,
+    QuestionRequest, TaskItem, ToolOutput,
 };
 use stella_store::Store;
 use stella_tools::ToolRegistry;
@@ -339,9 +340,52 @@ pub async fn run_deck_session(
     let provider = agent::build_provider(cfg)?;
     let registry: Arc<ToolRegistry> = Arc::new(crate::write_dirs::registry_for(cfg));
 
+    // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
+    // The driver's send side (`in_tx`) reaches the deck through the journal
+    // tee — the single choke point that makes the session durable. Direct
+    // `deck_tx` sends bypass the journal: replay (which must never
+    // re-journal itself) and ephemeral session chrome (boot narration,
+    // hints) that would otherwise pile up in the transcript on every resume.
+    //
+    // Created here, ahead of the registry wiring rather than beside the deck
+    // spawn, because the deck's mid-turn ask responders are built over them
+    // and `enforce_workspace_rules` below is where a surface declares who
+    // answers (#4220). Attaching them later would leave one window in which
+    // the registry's answer to "who is driving?" was wrong.
+    let (in_tx, raw_rx) = mpsc::unbounded_channel::<Inbound>();
+    let (deck_tx, deck_rx) = mpsc::unbounded_channel::<Inbound>();
+    let (sub_tx, mut sub_rx) = mpsc::unbounded_channel::<WorkspaceInput>();
+    let (ask_tx, ask_rx) = mpsc::unbounded_channel::<String>();
+    let (question_tx, question_rx) = mpsc::unbounded_channel::<QuestionOutcome>();
+
     crate::subagent::install_for_session(cfg, &registry)?;
-    let active_rules =
-        rules::enforce_workspace_rules(&registry, &cfg.workspace_root, &cfg.authority, false);
+    // The deck can park a turn on a human, so it declares a surface rather
+    // than the headless posture it was stuck with before it had an overlay
+    // to park on. Both responders ride the deck's own channels: the
+    // approvals half reuses the existing `AskUser` card through
+    // [`DeckAskUserIo`], and the question half raises the #4220 overlay.
+    // Neither may be the plain-TTY responder — the deck holds the terminal
+    // in raw mode, and a blocking stdin read behind its render loop would
+    // fight it for every keystroke.
+    let ask_io = DeckAskUserIo {
+        agent: LEAD.to_string(),
+        inbound: in_tx.clone(),
+        answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
+    };
+    let active_rules = rules::enforce_workspace_rules(
+        &registry,
+        &cfg.workspace_root,
+        &cfg.authority,
+        rules::MidTurnAsk::Surface {
+            approval: Arc::new(crate::approval::AskUserApprovalResponder::new(Box::new(
+                ask_io.clone(),
+            ))),
+            question: Arc::new(DeckQuestionResponder {
+                inbound: in_tx.clone(),
+                answers: Arc::new(tokio::sync::Mutex::new(question_rx)),
+            }),
+        },
+    );
     let custom_tools = agent::discover_custom_tools(cfg, true).await;
     let mut budget = agent::build_budget_guard(budget_limit);
     let store = agent::open_store(&cfg.workspace_root);
@@ -448,16 +492,6 @@ pub async fn run_deck_session(
         budget.reseed_session_spend(rs.spent_usd.unwrap_or(0.0));
     }
 
-    // ── Channels: engine → deck (Inbound) and deck → driver (WorkspaceInput)
-    // The driver's send side (`in_tx`) reaches the deck through the journal
-    // tee — the single choke point that makes the session durable. Direct
-    // `deck_tx` sends bypass the journal: replay (which must never
-    // re-journal itself) and ephemeral session chrome (boot narration,
-    // hints) that would otherwise pile up in the transcript on every resume.
-    let (in_tx, raw_rx) = mpsc::unbounded_channel::<Inbound>();
-    let (deck_tx, deck_rx) = mpsc::unbounded_channel::<Inbound>();
-    let (sub_tx, mut sub_rx) = mpsc::unbounded_channel::<WorkspaceInput>();
-    let (ask_tx, ask_rx) = mpsc::unbounded_channel::<String>();
     // The supervisor channel: `task_assign` spawn requests (tap → driver)
     // and sub-session endings (worker → driver). See `crate::subsession`.
     let (sup_tx, mut sup_rx) = mpsc::unbounded_channel::<SupervisorMsg>();
@@ -644,12 +678,6 @@ pub async fn run_deck_session(
         &crate::tool_switches::session_tool_names(&*registry, &custom_tools),
         None,
     ));
-
-    let ask_io = DeckAskUserIo {
-        agent: LEAD.to_string(),
-        inbound: in_tx.clone(),
-        answers: Arc::new(tokio::sync::Mutex::new(ask_rx)),
-    };
 
     // Honour the persisted colour theme (`ui.theme`) before the deck spawns its
     // render task, so the very first frame — the launch cinematic — is already
@@ -1627,6 +1655,12 @@ pub async fn run_deck_session(
                             input: UserInput::AskUserAnswer { answer, .. }, ..
                         }) => {
                             let _ = ask_tx.send(answer);
+                        }
+                        // The settled `ask_question` card: hand the outcome
+                        // to the parked `DeckQuestionResponder`, which is
+                        // what unblocks the tool call and the turn behind it.
+                        Some(WorkspaceInput::QuestionAnswered(outcome)) => {
+                            let _ = question_tx.send(*outcome);
                         }
                         // A hunk decision answers no card this driver raises —
                         // journal replays can render the card, but nothing
@@ -3895,6 +3929,70 @@ impl AskUserIo for DeckAskUserIo {
         match presented.iter().position(|option| *option == answer) {
             Some(i) => Ok((i + 1).to_string()),
             None => Ok(answer),
+        }
+    }
+}
+
+/// [`QuestionResponder`] over the deck's channels (#4220): raise the question
+/// overlay, park until the driver settles it, take the card down.
+///
+/// The deck's counterpart to [`crate::question::TtyQuestionResponder`]. That
+/// one renders a card to stdout and blocks on a stdin line; this one hands
+/// the whole [`QuestionRequest`] to the render loop as
+/// [`Inbound::QuestionAsked`] and waits for the [`QuestionOutcome`] the
+/// overlay folds out — so the wait never touches the terminal the deck is
+/// holding, and the deck keeps rendering (and stays Ctrl-C-able) throughout.
+///
+/// The overlay is a pure fold, so **every** decision about what the driver
+/// may do — the note editor, the free-text row, the review pane's three ways
+/// out — lives in `stella_tui::views::question` and is unit-tested without a
+/// terminal. Nothing here interprets an answer; it only carries one.
+struct DeckQuestionResponder {
+    inbound: UnboundedSender<Inbound>,
+    answers: Arc<tokio::sync::Mutex<UnboundedReceiver<QuestionOutcome>>>,
+}
+
+/// Takes the card down however the wait ends.
+///
+/// A `Drop` guard rather than a line at each exit, because the exit that
+/// matters is the one with no line to put it on: at the 30-minute
+/// `DEFAULT_QUESTION_TTL` the broker's `timeout` drops the `respond` future
+/// where it stands, and no code in this file runs again. Without this the
+/// deck would keep a live-looking card up over a turn that had already given
+/// up on it, and a driver's considered answer would go into a oneshot nobody
+/// was holding.
+struct WithdrawOnDrop(UnboundedSender<Inbound>);
+
+impl Drop for WithdrawOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.send(Inbound::QuestionWithdrawn);
+    }
+}
+
+#[async_trait]
+impl stella_tools::registry::question::QuestionResponder for DeckQuestionResponder {
+    async fn respond(&self, request: &QuestionRequest) -> QuestionOutcome {
+        let mut answers = self.answers.lock().await;
+        // Drop outcomes stranded by a cancelled turn — they answer a card
+        // that no longer exists, and reading one as this question's answer
+        // would resolve it without the driver having looked at it.
+        while answers.try_recv().is_ok() {}
+
+        let _withdraw = WithdrawOnDrop(self.inbound.clone());
+        let _ = self
+            .inbound
+            .send(Inbound::QuestionAsked(Box::new(request.clone())));
+
+        match answers.recv().await {
+            Some(outcome) => outcome,
+            // The deck went away mid-question. Declined, never a silent
+            // default: the model must hear that no answer is coming rather
+            // than act on one nobody gave.
+            None => QuestionOutcome::Declined {
+                reason: "the deck closed before the question was answered — do not re-ask; \
+                         proceed with your best judgement and state the assumption you made"
+                    .to_string(),
+            },
         }
     }
 }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -64,16 +64,14 @@ use skills::{deck_slash_commands, handle_skills_input, skills_snapshot};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use async_trait::async_trait;
 use stella_core::ports::{Principal, ToolExecutor};
 use stella_core::{BudgetGuard, CalibrationMap, Engine, TurnOutcome};
 use stella_model::provider::Provider;
 use stella_protocol::{
-    AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, QuestionOutcome,
-    QuestionRequest, TaskItem, ToolOutput,
+    AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, QuestionOutcome, TaskItem,
 };
 use stella_store::Store;
 use stella_tools::ToolRegistry;
@@ -84,11 +82,11 @@ use stella_tui::{
     SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
     run_deck,
 };
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, UnboundedSender};
 
 use crate::claims::ClaimTap;
 use crate::config::Config;
-use crate::interactive::{AskUserIo, FREE_TEXT_LABEL, SkillRegistry};
+use crate::interactive::{AskUserIo, SkillRegistry};
 use crate::{agent, rules};
 
 mod add_dir;

--- a/crates/stella-cli/src/command_deck/mid_turn_ask.rs
+++ b/crates/stella-cli/src/command_deck/mid_turn_ask.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! How the Command Deck answers a **mid-turn ask** — the two places a tool
+//! call parks on the person driving.
+//!
+//! There are exactly two, they are the same shape, and they are declared
+//! together as one [`crate::rules::MidTurnAsk::Surface`] at session assembly:
+//!
+//! - an **approval** (#2676): a gate decided a call needs a human yes/no, so
+//!   [`DeckAskUserIo`] raises the deck's existing `AskUser` card and the
+//!   shared [`crate::approval::AskUserApprovalResponder`] reads the answer;
+//! - a **question** (#4212): an agent cannot make a decision itself, so
+//!   [`DeckQuestionResponder`] raises the #4220 overlay and waits for the
+//!   whole [`QuestionOutcome`] the fold produces.
+//!
+//! # Why the deck cannot use the plain-TTY responders
+//!
+//! Both of `stella-cli`'s TTY responders answer by printing to stdout and
+//! blocking on a stdin line. The deck holds the terminal in raw mode and
+//! owns its own input loop, so that read would fight it for every keystroke
+//! — which is why the deck was stuck declaring itself headless, and every
+//! `ask_question` on Stella's default interactive shell resolved to the
+//! "no driver is attached" decline (#4220).
+//!
+//! Everything here is transport. No decision about what a driver may do
+//! lives in this file: the overlay's fold
+//! (`stella_tui::views::question`) owns those, and is unit-tested without a
+//! terminal.
+//!
+//! # This module is deliberately separate from `command_deck.rs`
+//!
+//! That file is a god file closed to growth
+//! (`scripts/file-size-baseline.txt`). These types are cohesive on their own
+//! — one subject, one seam — so they land here rather than pushing the
+//! ceiling up.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use stella_protocol::{AgentEvent, QuestionOutcome, QuestionRequest, ToolOutput};
+use stella_tui::Inbound;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use crate::interactive::{AskUserIo, FREE_TEXT_LABEL};
+
+/// Ids for the cards [`DeckAskUserIo`] mints (`deck-ask-N`). Process-unique
+/// rather than per-session: a stale answer from a cancelled turn must never
+/// match a live card's id.
+static NEXT_DECK_ASK: AtomicU64 = AtomicU64::new(0);
+
+/// Both of the deck's mid-turn ask responders, as the one posture
+/// `enforce_workspace_rules` consumes — plus the [`DeckAskUserIo`] behind
+/// the approvals half, which the caller also needs.
+///
+/// One constructor rather than two exported types, because they are one
+/// declaration: a surface that can park a call on a yes/no is exactly a
+/// surface that can park one on a question, and handing them out separately
+/// would let a caller arm half of it.
+///
+/// The io comes back because slash commands ask their own questions through
+/// the same card (`/init`'s confirmations), and it must be the **same** io —
+/// it holds the receiver, and a second one built over a clone of the channel
+/// would race it for every answer.
+pub(crate) fn surface(
+    agent: String,
+    inbound: UnboundedSender<Inbound>,
+    approvals: UnboundedReceiver<String>,
+    questions: UnboundedReceiver<QuestionOutcome>,
+) -> (crate::rules::MidTurnAsk, DeckAskUserIo) {
+    let ask_io = DeckAskUserIo {
+        agent,
+        inbound: inbound.clone(),
+        answers: Arc::new(tokio::sync::Mutex::new(approvals)),
+    };
+    let posture = crate::rules::MidTurnAsk::Surface {
+        approval: Arc::new(crate::approval::AskUserApprovalResponder::new(Box::new(
+            ask_io.clone(),
+        ))),
+        question: Arc::new(DeckQuestionResponder {
+            inbound,
+            answers: Arc::new(tokio::sync::Mutex::new(questions)),
+        }),
+    };
+    (posture, ask_io)
+}
+
+/// [`AskUserIo`] over the deck's channels — how the approvals plane's
+/// questions (scope review's confirm) reach the human at the deck. `prompt`
+/// emits an `AskUser` card, awaits the user's `AskUserAnswer`, echoes the
+/// answer back as the card's own `ToolResult` (the event-pure clear), and
+/// returns the answer with an exact option match becoming its 1-based index
+/// (the numeric quick-pick), anything else passing verbatim as free text.
+#[derive(Clone)]
+pub(crate) struct DeckAskUserIo {
+    pub(crate) agent: String,
+    pub(crate) inbound: UnboundedSender<Inbound>,
+    pub(crate) answers: Arc<tokio::sync::Mutex<UnboundedReceiver<String>>>,
+}
+
+#[async_trait]
+impl AskUserIo for DeckAskUserIo {
+    async fn prompt(&self, question: &str, options: &[String]) -> Result<String, String> {
+        // A caller may append the free-text affordance; the deck's card
+        // renders its own (Enter submits the composer), so presenting the
+        // label as a pickable option would double it — and picking it would
+        // return the label itself as an "answer". Strip it; every other
+        // option passes through untouched.
+        let mut presented: Vec<String> = options.to_vec();
+        if presented
+            .last()
+            .is_some_and(|o| o.starts_with(FREE_TEXT_LABEL))
+        {
+            presented.pop();
+        }
+
+        let id = format!("deck-ask-{}", NEXT_DECK_ASK.fetch_add(1, Ordering::Relaxed));
+        let mut answers = self.answers.lock().await;
+        // Drop answers stranded by a cancelled turn — they belong to a card
+        // that no longer exists.
+        while answers.try_recv().is_ok() {}
+
+        let _ = self.inbound.send(Inbound::Event {
+            agent: self.agent.clone(),
+            event: AgentEvent::AskUser {
+                id: id.clone(),
+                question: question.to_string(),
+                options: presented.clone(),
+            },
+        });
+
+        let answer = answers
+            .recv()
+            .await
+            .ok_or_else(|| "the deck closed before the question was answered".to_string())?;
+
+        // The echoed ToolResult is what clears the pending card in the fold
+        // (matched by this exact id) — without it the gate would keep eating
+        // keys for the rest of the turn.
+        let _ = self.inbound.send(Inbound::Event {
+            agent: self.agent.clone(),
+            event: AgentEvent::ToolResult {
+                call_id: id,
+                output: ToolOutput::Ok {
+                    content: answer.clone(),
+                    data: None,
+                },
+                duration_ms: 0,
+                speculated: false,
+            },
+        });
+
+        match presented.iter().position(|option| *option == answer) {
+            Some(i) => Ok((i + 1).to_string()),
+            None => Ok(answer),
+        }
+    }
+}
+
+/// [`QuestionResponder`] over the deck's channels (#4220): raise the question
+/// overlay, park until the driver settles it, take the card down.
+///
+/// The deck's counterpart to [`crate::question::TtyQuestionResponder`]. That
+/// one renders a card to stdout and blocks on a stdin line; this one hands
+/// the whole [`QuestionRequest`] to the render loop as
+/// [`Inbound::QuestionAsked`] and waits for the [`QuestionOutcome`] the
+/// overlay folds out — so the wait never touches the terminal the deck is
+/// holding, and the deck keeps rendering (and stays Ctrl-C-able) throughout.
+///
+/// The overlay is a pure fold, so **every** decision about what the driver
+/// may do — the note editor, the free-text row, the review pane's three ways
+/// out — lives in `stella_tui::views::question` and is unit-tested without a
+/// terminal. Nothing here interprets an answer; it only carries one.
+pub(crate) struct DeckQuestionResponder {
+    pub(crate) inbound: UnboundedSender<Inbound>,
+    pub(crate) answers: Arc<tokio::sync::Mutex<UnboundedReceiver<QuestionOutcome>>>,
+}
+
+/// Takes the card down however the wait ends.
+///
+/// A `Drop` guard rather than a line at each exit, because the exit that
+/// matters is the one with no line to put it on: at the 30-minute
+/// `DEFAULT_QUESTION_TTL` the broker's `timeout` drops the `respond` future
+/// where it stands, and no code in this file runs again. Without this the
+/// deck would keep a live-looking card up over a turn that had already given
+/// up on it, and a driver's considered answer would go into a oneshot nobody
+/// was holding.
+struct WithdrawOnDrop(UnboundedSender<Inbound>);
+
+impl Drop for WithdrawOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.send(Inbound::QuestionWithdrawn);
+    }
+}
+
+#[async_trait]
+impl stella_tools::registry::question::QuestionResponder for DeckQuestionResponder {
+    async fn respond(&self, request: &QuestionRequest) -> QuestionOutcome {
+        let mut answers = self.answers.lock().await;
+        // Drop outcomes stranded by a cancelled turn — they answer a card
+        // that no longer exists, and reading one as this question's answer
+        // would resolve it without the driver having looked at it.
+        while answers.try_recv().is_ok() {}
+
+        let _withdraw = WithdrawOnDrop(self.inbound.clone());
+        let _ = self
+            .inbound
+            .send(Inbound::QuestionAsked(Box::new(request.clone())));
+
+        match answers.recv().await {
+            Some(outcome) => outcome,
+            // The deck went away mid-question. Declined, never a silent
+            // default: the model must hear that no answer is coming rather
+            // than act on one nobody gave.
+            None => QuestionOutcome::Declined {
+                reason: "the deck closed before the question was answered — do not re-ask; \
+                         proceed with your best judgement and state the assumption you made"
+                    .to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use stella_protocol::{Answer, Question, QuestionOption};
+    use stella_tools::registry::question::QuestionResponder as _;
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn request() -> QuestionRequest {
+        QuestionRequest {
+            asker: Some("research-child".into()),
+            questions: vec![Question {
+                header: "Auth method".into(),
+                question: "Which auth should the new endpoint use?".into(),
+                options: vec![QuestionOption {
+                    label: "Session cookie".into(),
+                    description: String::new(),
+                }],
+                multi_select: false,
+            }],
+        }
+    }
+
+    fn responder() -> (
+        DeckQuestionResponder,
+        mpsc::UnboundedReceiver<Inbound>,
+        mpsc::UnboundedSender<QuestionOutcome>,
+    ) {
+        let (in_tx, in_rx) = mpsc::unbounded_channel();
+        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        (
+            DeckQuestionResponder {
+                inbound: in_tx,
+                answers: Arc::new(tokio::sync::Mutex::new(out_rx)),
+            },
+            in_rx,
+            out_tx,
+        )
+    }
+
+    /// **The transport witness.** The request reaches the deck as a card, and
+    /// the outcome the overlay folds out comes back as this call's answer —
+    /// note and all.
+    ///
+    /// The overlay's own fold is tested in `stella_tui::views::question`;
+    /// what is proved here is that nothing is lost in the round trip, which
+    /// is the half a pure fold cannot cover.
+    #[tokio::test]
+    async fn a_question_reaches_the_deck_and_its_answer_comes_back() {
+        let (responder, mut inbound, answers) = responder();
+        let ask = request();
+        let asking = tokio::spawn(async move { responder.respond(&ask).await });
+
+        // The card carries the whole request, attribution included — a driver
+        // answering a fanned-out delegation needs to know whose question it is.
+        let Some(Inbound::QuestionAsked(carried)) = inbound.recv().await else {
+            panic!("the question must reach the deck as a card");
+        };
+        assert_eq!(carried.asker.as_deref(), Some("research-child"));
+        assert_eq!(carried.questions.len(), 1);
+
+        answers
+            .send(QuestionOutcome::Answered {
+                answers: vec![Answer {
+                    header: "Auth method".into(),
+                    question: "Which auth should the new endpoint use?".into(),
+                    chosen: vec!["Session cookie".into()],
+                    note: Some("only for the admin routes".into()),
+                }],
+            })
+            .expect("the parked call is still listening");
+
+        let QuestionOutcome::Answered { answers } = asking.await.expect("settles") else {
+            panic!("the driver answered, so the call must be answered");
+        };
+        assert_eq!(answers[0].chosen, vec!["Session cookie"]);
+        assert_eq!(
+            answers[0].note.as_deref(),
+            Some("only for the admin routes"),
+            "the note must survive the round trip — it is the half of the answer \
+             the option list could not hold"
+        );
+    }
+
+    /// **The witness for the card that outlives its broker.** At the TTL the
+    /// broker drops the `respond` future where it stands; the deck must be
+    /// told to take the card down, or a driver types a considered answer into
+    /// a oneshot nobody is holding.
+    #[tokio::test]
+    async fn an_abandoned_wait_withdraws_the_card() {
+        let (responder, mut inbound, _answers) = responder();
+        let ask = request();
+
+        // Exactly what the broker does at `DEFAULT_QUESTION_TTL`: drop the
+        // future mid-await, with no answer and no cooperation from us.
+        let timed_out = tokio::time::timeout(Duration::from_millis(30), responder.respond(&ask))
+            .await
+            .is_err();
+        assert!(timed_out, "nobody answered, so the wait must expire");
+
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::QuestionAsked(_))),
+            "the card went up"
+        );
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::QuestionWithdrawn)),
+            "and must come down again when the wait is abandoned"
+        );
+    }
+
+    /// A deck that goes away mid-question declines — never a silent default.
+    /// The model has to hear that no answer is coming rather than act on one
+    /// nobody gave.
+    #[tokio::test]
+    async fn a_closed_deck_declines_with_an_instruction() {
+        let (responder, _inbound, answers) = responder();
+        drop(answers);
+        let QuestionOutcome::Declined { reason } = responder.respond(&request()).await else {
+            panic!("a closed deck cannot answer");
+        };
+        assert!(reason.contains("do not re-ask"), "{reason}");
+        assert!(reason.contains("state the assumption"), "{reason}");
+    }
+
+    /// An outcome stranded by a cancelled turn must not resolve the NEXT
+    /// question: it answers a card the driver never saw, and reading it here
+    /// would settle a decision nobody made.
+    #[tokio::test]
+    async fn a_stranded_answer_does_not_resolve_the_next_question() {
+        let (responder, mut inbound, answers) = responder();
+        answers
+            .send(QuestionOutcome::Deferred {
+                note: "from a turn that is already gone".into(),
+            })
+            .expect("queued before anyone asked");
+
+        let ask = request();
+        let asking = tokio::spawn(async move { responder.respond(&ask).await });
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::QuestionAsked(_))),
+            "the stale answer must not have short-circuited the ask"
+        );
+
+        answers
+            .send(QuestionOutcome::Declined {
+                reason: "the real answer".into(),
+            })
+            .expect("still listening");
+        let QuestionOutcome::Declined { reason } = asking.await.expect("settles") else {
+            panic!("the live answer is the one that counts");
+        };
+        assert_eq!(reason, "the real answer");
+    }
+}

--- a/crates/stella-cli/src/command_deck/mid_turn_ask.rs
+++ b/crates/stella-cli/src/command_deck/mid_turn_ask.rs
@@ -158,7 +158,7 @@ impl AskUserIo for DeckAskUserIo {
     }
 }
 
-/// [`QuestionResponder`] over the deck's channels (#4220): raise the question
+/// [`QuestionResponder`][r] over the deck's channels (#4220): raise the question
 /// overlay, park until the driver settles it, take the card down.
 ///
 /// The deck's counterpart to [`crate::question::TtyQuestionResponder`]. That
@@ -172,6 +172,8 @@ impl AskUserIo for DeckAskUserIo {
 /// may do — the note editor, the free-text row, the review pane's three ways
 /// out — lives in `stella_tui::views::question` and is unit-tested without a
 /// terminal. Nothing here interprets an answer; it only carries one.
+///
+/// [r]: stella_tools::registry::question::QuestionResponder
 pub(crate) struct DeckQuestionResponder {
     pub(crate) inbound: UnboundedSender<Inbound>,
     pub(crate) answers: Arc<tokio::sync::Mutex<UnboundedReceiver<QuestionOutcome>>>,

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -1,3 +1,8 @@
+// Imported here rather than inherited through `use super::*`: the label
+// belongs to the deck's ask io, which lives in `mid_turn_ask` now, and this
+// module is its only remaining user in `command_deck`'s namespace.
+use crate::interactive::FREE_TEXT_LABEL;
+
 use super::pr_observe::scrub_gh_command;
 use super::skills::{
     build_skill_creation_prompt, extract_skill_md, extract_skill_md_from_use, parse_installs_count,

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -288,7 +288,7 @@ fn mcp_outcome_report_names_every_claimant_of_a_contested_wire_name() {
 async fn run_prompt(options: &[&str], answer: &str) -> (Result<String, String>, Vec<Inbound>) {
     let (in_tx, mut in_rx) = mpsc::unbounded_channel();
     let (ans_tx, ans_rx) = mpsc::unbounded_channel();
-    let io = DeckAskUserIo {
+    let io = super::mid_turn_ask::DeckAskUserIo {
         agent: "lead".into(),
         inbound: in_tx,
         answers: Arc::new(tokio::sync::Mutex::new(ans_rx)),

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -925,7 +925,12 @@ async fn run_task(
     // reach. A worker's children inherit its headless posture through the
     // registry they run against.
     crate::subagent::install_for_session(&cfg, &registry)?;
-    let active_rules = rules::enforce_workspace_rules(&registry, root, &cfg.authority, rules::MidTurnAsk::Headless);
+    let active_rules = rules::enforce_workspace_rules(
+        &registry,
+        root,
+        &cfg.authority,
+        rules::MidTurnAsk::Headless,
+    );
     // Commit attribution (#1216): records the `HEAD` advance this worker is
     // observed making. It sits UNDER the claim tap on purpose — the tap holds
     // the workspace-wide commit lane across the call, so the window this

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -925,7 +925,7 @@ async fn run_task(
     // reach. A worker's children inherit its headless posture through the
     // registry they run against.
     crate::subagent::install_for_session(&cfg, &registry)?;
-    let active_rules = rules::enforce_workspace_rules(&registry, root, &cfg.authority, false);
+    let active_rules = rules::enforce_workspace_rules(&registry, root, &cfg.authority, rules::MidTurnAsk::Headless);
     // Commit attribution (#1216): records the `HEAD` advance this worker is
     // observed making. It sits UNDER the claim tap on purpose — the tap holds
     // the workspace-wide commit lane across the call, so the window this

--- a/crates/stella-cli/src/interactive.rs
+++ b/crates/stella-cli/src/interactive.rs
@@ -67,7 +67,12 @@ pub fn human_is_present(interactive_output: bool) -> bool {
 /// interactive question card: whatever the structured options are, the human
 /// can always answer in their own words, and the affordance is appended by
 /// the runtime, never listed by the asker.
-pub const FREE_TEXT_LABEL: &str = "Type your own answer";
+///
+/// Re-exported rather than defined here: the Command Deck's question overlay
+/// ([`stella_tui::views::question`]) draws the same row, and `stella-tui`
+/// cannot depend on this crate — so the one copy lives in `stella-protocol`
+/// beside the question types both surfaces render.
+pub use stella_protocol::FREE_TEXT_LABEL;
 
 /// How an interactive question — an approval (#2676), a scope-review confirm
 /// — reaches the human. Injectable so the decision logic is unit-testable
@@ -294,9 +299,20 @@ mod tests {
         // Consumer 1 — the #2676 approval responder is not attached, so the
         // broker refuses with the grant-path message instead of parking on a
         // stdin nobody is holding.
+        //
+        // Asked through `MidTurnAsk::tty_when`, which is where the fact is
+        // turned into a posture since #4220 replaced the boolean parameter.
+        // That is the seam the production callers use, so this is the same
+        // question they ask rather than a re-derivation beside it.
+        assert!(
+            matches!(
+                crate::rules::MidTurnAsk::tty_when(present),
+                crate::rules::MidTurnAsk::Headless
+            ),
+            "no human means no surface to attach"
+        );
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let registry = stella_tools::ToolRegistry::new(workspace.path().to_path_buf());
-        crate::approval::attach_interactive_approvals(&registry, present);
         let outcome = registry
             .approval_broker()
             .resolve(None, &approval_request())

--- a/crates/stella-cli/src/question.rs
+++ b/crates/stella-cli/src/question.rs
@@ -379,18 +379,20 @@ fn cancelled() -> QuestionOutcome {
     }
 }
 
-/// Attach the TTY-backed question responder to `registry` when a human is
-/// present to answer.
+/// Attach the TTY-backed question responder to `registry`.
 ///
-/// `human_present` is [`crate::interactive::human_can_answer`]'s answer,
-/// derived once by the session driver and passed down — never re-derived
-/// here, which is the #3035 discipline. Without a human the broker stays
-/// headless and the tool tells the model to decide for itself, rather than
-/// reading a stdin nobody is holding.
-pub(crate) fn attach_interactive_questions(registry: &ToolRegistry, human_present: bool) {
-    if !human_present {
-        return;
-    }
+/// Called only for [`crate::rules::MidTurnAsk::Tty`] — whether a human is
+/// present is decided once by the session driver
+/// ([`crate::interactive::human_can_answer`]) and expressed in that value,
+/// never re-derived here, which is the #3035 discipline. Without a human the
+/// broker is left headless and the tool tells the model to decide for
+/// itself, rather than reading a stdin nobody is holding.
+///
+/// The Command Deck takes [`crate::rules::MidTurnAsk::Surface`] instead and
+/// brings its own card-backed responder (#4220): it owns the terminal in raw
+/// mode, so [`TtyLineIo`]'s blocking stdin read would fight its input loop
+/// for every keystroke.
+pub(crate) fn attach_interactive_questions(registry: &ToolRegistry) {
     registry.attach_question_responder(
         Arc::new(TtyQuestionResponder::new(Box::new(TtyLineIo))),
         DEFAULT_QUESTION_TTL,

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -373,37 +373,84 @@ fn merge_rule_trust_tiers(mut user_rules: Vec<Rule>, project_rules: Vec<Rule>) -
     user_rules
 }
 
+/// Who answers a mid-turn ask on this driver's surface, and through what.
+///
+/// One value, consulted once, arming **both** mid-turn asks: a gate's
+/// `RequireApproval` (#2676) and an agent's `ask_question` (#4212). They are
+/// one fact — a surface that can park a tool call on a human yes/no is
+/// exactly a surface that can park one on a question — and deriving it twice
+/// is what let two consumers of "is anyone here?" disagree before #3035.
+///
+/// It replaces the `bool` this parameter used to be, because a boolean can
+/// say *whether* a human is reachable but not *how to reach them*, and the
+/// two surfaces that can reach one do it in incompatible ways. `true` meant
+/// "attach the stdin-reading TTY responder", so the Command Deck — which
+/// owns the terminal in raw mode and would have fought that reader for every
+/// keystroke — had no answer but `false`, and every question on Stella's
+/// default interactive shell resolved to the headless decline (#4220). An
+/// enum lets the deck say the true thing.
+pub(crate) enum MidTurnAsk {
+    /// Nobody is at the controls: fleet workers, sub-agent lanes,
+    /// machine-output runs, a daemon-resumed turn. Both brokers stay
+    /// headless — the approval refusal names the grant path, and the
+    /// question decline tells the model to decide and state its assumption.
+    /// Never a hang on a stdin nobody is holding.
+    Headless,
+    /// A plain terminal: line-oriented cards on stdout, one line of stdin
+    /// back. The non-deck REPL, `stella run` on a TTY.
+    Tty,
+    /// A surface that owns its own input loop and brings its own responders
+    /// — the Command Deck. The host builds them over its channels and hands
+    /// them in, because only it knows how to reach its own driver.
+    Surface {
+        /// Answers a gate's `RequireApproval`.
+        approval: std::sync::Arc<dyn stella_tools::registry::approval::ApprovalResponder>,
+        /// Answers an agent's `ask_question`.
+        question: std::sync::Arc<dyn stella_tools::registry::question::QuestionResponder>,
+    },
+}
+
+impl MidTurnAsk {
+    /// The TTY surface when a human is present, headless otherwise.
+    ///
+    /// `human_present` is [`crate::interactive::human_can_answer`]'s answer,
+    /// derived once by the session driver and passed down — never re-derived
+    /// here, which is the #3035 discipline.
+    pub(crate) fn tty_when(human_present: bool) -> Self {
+        if human_present { Self::Tty } else { Self::Headless }
+    }
+}
+
 /// Session wiring shorthand: load the workspace rules and attach their
 /// Tier-2 guards to `registry`. Every session driver calls this right after
 /// constructing its registry.
 ///
-/// `interactive_approvals` declares whether this driver's surface can ask a
-/// human mid-turn, and now arms **both** mid-turn asks against that one fact
-/// (#4212): `true` (a TTY REPL/goal surface) attaches the #2676 approval
-/// responder so a gate's `RequireApproval` parks on a real yes/no, and the
-/// `ask_question` responder so an agent's question parks on a real answer;
-/// `false` (fleet workers, sub-agent lanes, machine-output runs, the deck
-/// until it grows an approval card) leaves both registry brokers headless —
-/// the approval refusal names the grant path, and the question decline tells
-/// the model to decide and state its assumption. It rides here because this
-/// is the same call that arms the guards able to produce a
-/// `RequireApproval`.
-///
-/// The parameter keeps its approvals-era name rather than growing a second
-/// one: two booleans would be two places for "is a human here?" to be
-/// answered differently, which is the exact defect #3035 collapsed.
+/// `ask` declares who can answer a mid-turn question on this surface — see
+/// [`MidTurnAsk`]. It rides here because this is the same call that arms the
+/// guards able to *produce* a `RequireApproval`.
 pub(crate) fn enforce_workspace_rules(
     registry: &ToolRegistry,
     workspace_root: &Path,
     authority: &crate::settings::AuthorityPolicy,
-    interactive_approvals: bool,
+    ask: MidTurnAsk,
 ) -> ResolvedRules {
-    crate::approval::attach_interactive_approvals(registry, interactive_approvals);
-    // The same fact answers both: a surface that can park a tool call on a
-    // human yes/no is exactly a surface that can park one on a question
-    // (#4212). Deriving it twice is what let two consumers of "is anyone
-    // here?" disagree before #3035.
-    crate::question::attach_interactive_questions(registry, interactive_approvals);
+    match ask {
+        MidTurnAsk::Headless => {}
+        MidTurnAsk::Tty => {
+            crate::approval::attach_interactive_approvals(registry);
+            crate::question::attach_interactive_questions(registry);
+        }
+        MidTurnAsk::Surface { approval, question } => {
+            registry.attach_approval_responder(
+                approval,
+                stella_tools::registry::approval::DEFAULT_APPROVAL_TTL,
+            );
+            registry.attach_question_responder(
+                question,
+                stella_tools::registry::question::DEFAULT_QUESTION_TTL,
+            );
+        }
+    }
     let rules = load_workspace_rules(workspace_root, authority);
     attach_rule_guards(registry, &rules);
     rules
@@ -686,7 +733,7 @@ mod tests {
                 &registry,
                 root.path(),
                 &crate::settings::AuthorityPolicy::default(),
-                false,
+                MidTurnAsk::Headless,
             );
         }
 
@@ -850,7 +897,7 @@ mod tests {
                 .unwrap();
         }
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), false);
+        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
 
         let denied = registry
             .execute(
@@ -884,7 +931,7 @@ mod tests {
         std::fs::write(&target, "SELECT 1;\n").unwrap();
 
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), false);
+        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
 
         let denied = registry
             .execute(
@@ -934,7 +981,7 @@ mod tests {
         // tool resolution — a shell-shaped custom or MCP tool carrying that
         // name is denied before it can run.
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), false);
+        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
 
         let denied = registry
             .execute(

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -417,7 +417,11 @@ impl MidTurnAsk {
     /// derived once by the session driver and passed down — never re-derived
     /// here, which is the #3035 discipline.
     pub(crate) fn tty_when(human_present: bool) -> Self {
-        if human_present { Self::Tty } else { Self::Headless }
+        if human_present {
+            Self::Tty
+        } else {
+            Self::Headless
+        }
     }
 }
 
@@ -897,7 +901,12 @@ mod tests {
                 .unwrap();
         }
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
+        enforce_workspace_rules(
+            &registry,
+            root.path(),
+            &trusted_project_authority(),
+            MidTurnAsk::Headless,
+        );
 
         let denied = registry
             .execute(
@@ -931,7 +940,12 @@ mod tests {
         std::fs::write(&target, "SELECT 1;\n").unwrap();
 
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
+        enforce_workspace_rules(
+            &registry,
+            root.path(),
+            &trusted_project_authority(),
+            MidTurnAsk::Headless,
+        );
 
         let denied = registry
             .execute(
@@ -981,7 +995,12 @@ mod tests {
         // tool resolution — a shell-shaped custom or MCP tool carrying that
         // name is denied before it can run.
         let registry = ToolRegistry::new(root.path().to_path_buf());
-        enforce_workspace_rules(&registry, root.path(), &trusted_project_authority(), MidTurnAsk::Headless);
+        enforce_workspace_rules(
+            &registry,
+            root.path(),
+            &trusted_project_authority(),
+            MidTurnAsk::Headless,
+        );
 
         let denied = registry
             .execute(

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -665,7 +665,7 @@ async fn run_worker(
         &registry,
         &cfg.workspace_root,
         &cfg.authority,
-        false,
+        crate::rules::MidTurnAsk::Headless,
     );
 
     let system_prompt = agent::with_session_hook_context(

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -129,7 +129,9 @@ pub use lane::{BuiltinLane, LaneId, TurnLane};
 // The `ask_question` vocabulary (#4212). Re-exported flat because both the
 // tool that raises a question and every surface that renders one name these
 // types constantly, and neither should have to spell the module path.
-pub use question::{Answer, Question, QuestionOption, QuestionOutcome, QuestionRequest};
+pub use question::{
+    Answer, FREE_TEXT_LABEL, Question, QuestionOption, QuestionOutcome, QuestionRequest,
+};
 // The ladder vocabulary moved out of `event` when the rung joined it (#1043);
 // re-exported here so `stella_protocol::LadderSnapshot` never moved.
 pub use issue::{Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState};

--- a/crates/stella-protocol/src/question.rs
+++ b/crates/stella-protocol/src/question.rs
@@ -34,6 +34,20 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The label every answering surface appends as its free-text escape.
+///
+/// It lives here rather than in one surface because **more than one surface
+/// renders it** — the plain-TTY card numbers it after the asker's options,
+/// and the Command Deck's overlay draws it as the last selectable row — and
+/// the two must name the same affordance. A second copy is a string that
+/// drifts: the deck would offer "Something else" while the TTY offered this,
+/// and the same question would read as two different questions depending on
+/// which shell the person happened to be in.
+///
+/// Not a wire field. It is a rendering constant that crosses a crate
+/// boundary, which is the same reason the types around it live here.
+pub const FREE_TEXT_LABEL: &str = "Type your own answer";
+
 /// One choice offered for a [`Question`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QuestionOption {

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -163,6 +163,13 @@ async fn main() -> std::io::Result<()> {
                     }
                     UserInput::Prompt { .. } | UserInput::Cancel => {}
                 },
+                // A settled question: the demo has no parked tool call to
+                // resolve, so it just withdraws the card — which is exactly
+                // what the deck's own fold already did locally, and is here
+                // so the round trip is visible rather than implied.
+                WorkspaceInput::QuestionAnswered(_) => {
+                    let _ = react_tx.send(Inbound::QuestionWithdrawn);
+                }
                 // Queue edits are already reflected in the deck's local queue
                 // (the shell's out-of-band echo); a real engine would also
                 // drop the prompt from its own backlog here.

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -746,6 +746,12 @@ impl WorkspaceModel {
             | Inbound::RecordedCalls(_)
             | Inbound::InspectedCall(_)
             | Inbound::ShowHelp
+            // A parked question is a tool call waiting, not speech. Nothing
+            // has been said until the driver answers, and folding the
+            // question into the transcript would leave an unanswered one
+            // there for good if the answer never comes.
+            | Inbound::QuestionAsked(_)
+            | Inbound::QuestionWithdrawn
             | Inbound::Splash(_)
             // The whole point of `Notice`: a system notification is not agent
             // or user speech, so the fold must NOT give it a transcript row.

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -195,6 +195,16 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // (The former ENGINE overlay is gone: the engine panel is the full-width
     // body of the SETTINGS tab — see `views::settings::render`.)
 
+    // The parked question (#4220). Drawn above the cards and below help: the
+    // user can still open help over it (they may need to read what a key
+    // does before answering), but nothing else may cover the one overlay a
+    // turn is stopped on.
+    if ui.question.is_open() {
+        guarded_overlay(buf, area, "question", |b| {
+            views::question::render(&ui.question, area, b)
+        });
+    }
+
     // Startup system notifications: a transient dialog over the deck, drawn
     // last but one so help — which the user asked for — still wins the top.
     // It is a no-op once dismissed or expired — asked here rather than left to
@@ -217,6 +227,9 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // notice is deliberately excluded: it is non-modal, and a key still
     // reaches the composer while it's showing (see `handle_key`).
     let overlay_owns_keyboard = ui.help_open
+        // A parked question is claimed ahead of everything else in
+        // `handle_key_inner`, so it owns the keyboard whenever it is up.
+        || ui.question.is_open()
         || ui.queue_open
         || ui.graph_picker_open
         || ui.sessions_open

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -200,7 +200,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // cover the one overlay a turn is stopped on.
     if ui.question.is_open() {
         guarded_overlay(buf, area, "question", |b| {
-            views::question::render(&ui.question, area, b)
+            views::question::render(&ui.question, ui.accessible, area, b)
         });
     }
 

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -195,10 +195,9 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // (The former ENGINE overlay is gone: the engine panel is the full-width
     // body of the SETTINGS tab — see `views::settings::render`.)
 
-    // The parked question (#4220). Drawn above the cards and below help: the
-    // user can still open help over it (they may need to read what a key
-    // does before answering), but nothing else may cover the one overlay a
-    // turn is stopped on.
+    // The parked question (#4220): above the cards, below help — a user may
+    // need to read what a key does before answering, but nothing else may
+    // cover the one overlay a turn is stopped on.
     if ui.question.is_open() {
         guarded_overlay(buf, area, "question", |b| {
             views::question::render(&ui.question, area, b)

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -783,6 +783,11 @@ pub struct DeckUi {
     /// driver-owned snapshot ([`Inbound::ToolPolicy`]). Modal while open, and
     /// mutually exclusive with `engine`: one editor owns the tab's keyboard.
     pub tools: crate::views::tools::ToolsOverlay,
+    /// The `ask_question` overlay (#4220): the wizard a **parked turn** waits
+    /// on. Modal ahead of everything but Ctrl-C while a question is up —
+    /// nothing else in this struct holds a live tool call open, which is why
+    /// it wins the keyboard over every other modal here.
+    pub question: crate::views::question::QuestionOverlay,
 }
 
 impl Default for DeckUi {
@@ -862,6 +867,7 @@ impl Default for DeckUi {
             pending_inputs: Vec::new(),
             engine: crate::views::engine::EngineOverlay::default(),
             tools: crate::views::tools::ToolsOverlay::default(),
+            question: crate::views::question::QuestionOverlay::default(),
         }
     }
 }
@@ -1188,6 +1194,19 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
         // reply can outlive the inspector that asked for it when a registry
         // lookup is in the middle.
         ui.mcp.apply_detail(detail.as_ref().clone());
+        return;
+    }
+    // A parked question raises its overlay and nothing else: out-of-band view
+    // state, deliberately never folded into the transcript. Nothing has been
+    // *said* yet — the turn is stopped waiting — and writing an unanswered
+    // question into the history would leave one there if the answer never
+    // comes.
+    if let Inbound::QuestionAsked(request) = inbound {
+        ui.question.open(request.as_ref().clone());
+        return;
+    }
+    if let Inbound::QuestionWithdrawn = inbound {
+        ui.question.close();
         return;
     }
     // `/help` from the driver opens the same overlay the `?` key opens. Reset
@@ -1521,6 +1540,20 @@ pub fn handle_deck_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -
 fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
     if key.kind == KeyEventKind::Release {
         return DeckAction::Ignored;
+    }
+
+    // A parked question outranks every other modal here, including the
+    // routing card below: it is the only one holding a live tool call open,
+    // and a turn that is stopped waiting for an answer cannot make progress
+    // on any key that is not that answer. Like the routing card it declines
+    // Ctrl-C, so the quit branch below still fires.
+    match ui.question.key(key) {
+        crate::views::question::QuestionAction::Ignored => {}
+        crate::views::question::QuestionAction::Handled => return DeckAction::Handled,
+        crate::views::question::QuestionAction::Resolve(outcome) => {
+            ui.question.close();
+            return DeckAction::Send(WorkspaceInput::QuestionAnswered(Box::new(outcome)));
+        }
     }
 
     // The routing card owns every key while it is up — it is holding the

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -1199,14 +1199,8 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
     // A parked question raises its overlay and nothing else: out-of-band view
     // state, deliberately never folded into the transcript. Nothing has been
     // *said* yet — the turn is stopped waiting — and writing an unanswered
-    // question into the history would leave one there if the answer never
-    // comes.
-    if let Inbound::QuestionAsked(request) = inbound {
-        ui.question.open(request.as_ref().clone());
-        return;
-    }
-    if let Inbound::QuestionWithdrawn = inbound {
-        ui.question.close();
+    // question into the history would leave one there if the answer never came.
+    if ui.question.ingest(inbound) {
         return;
     }
     // `/help` from the driver opens the same overlay the `?` key opens. Reset

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -318,6 +318,32 @@ pub enum Inbound {
     /// [`crate::deck_ui::ingest_inbound`]. Out-of-band view state, ignored by
     /// the model fold — like [`Inbound::GraphSnapshot`].
     ShowHelp,
+    /// An agent asked the driver a question and its turn is **parked** on the
+    /// answer (#4220). Raises the question overlay
+    /// ([`crate::views::question`]); the driver is holding a `QuestionResponder`
+    /// open on the other side and unblocks only on
+    /// [`WorkspaceInput::QuestionAnswered`] or its own TTL.
+    ///
+    /// Out-of-band view state like [`Inbound::ShowHelp`] — the model fold
+    /// ignores it. A parked tool call is not conversation: nothing is said
+    /// until the answer comes back, and folding a pending question into the
+    /// transcript would put a question in the history that may never have
+    /// been answered.
+    ///
+    /// Boxed for the same reason as [`Inbound::McpDetail`]: it carries a
+    /// whole batch of questions with their option lists, and the per-token
+    /// [`Inbound::Event`] must not grow to the size of the rarest variant.
+    QuestionAsked(Box<stella_protocol::QuestionRequest>),
+    /// The parked question is no longer answerable — its TTL expired, or the
+    /// turn holding it was cancelled — so take the card down.
+    ///
+    /// The half that makes the overlay safe to leave up for the full
+    /// thirty-minute TTL: without it a card would outlive its broker and
+    /// still offer to resolve, and the driver would type a considered answer
+    /// into a oneshot nobody is holding. Sent by the responder's own drop
+    /// path, so it fires on every way the wait can end rather than only the
+    /// ones somebody remembered to handle.
+    QuestionWithdrawn,
     /// A launch-mark cue (see [`SplashCue`]): the driver holds the mark
     /// open over a running init (session startup, `/init`) and
     /// releases it when init finishes. Out-of-band view state, applied
@@ -677,6 +703,17 @@ pub enum WorkspaceInput {
     /// the deck's only optimistic mirror is dropping its queue view, since a
     /// session reset to seq-0 has no backlog by definition.
     SessionClear,
+    /// How the driver settled the parked question the overlay was showing
+    /// (#4220) — the return leg of [`Inbound::QuestionAsked`].
+    ///
+    /// The whole outcome travels, not just the answers: `Deferred` ("the
+    /// options are the wrong shape, let's talk") and `Declined` (cancelled)
+    /// are real answers the asking model acts on differently, and collapsing
+    /// them into "no answers" would tell it the same thing three ways.
+    ///
+    /// Boxed to match [`Inbound::QuestionAsked`]: the answer set carries a
+    /// note and free text per question.
+    QuestionAnswered(Box<stella_protocol::QuestionOutcome>),
     /// Pause / resume / stop / restart a specific agent.
     Control {
         agent: AgentId,

--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -45,6 +45,7 @@ pub mod models_card;
 pub mod plan_card;
 pub mod plan_rail;
 pub(crate) mod plan_style;
+pub mod question;
 pub(crate) mod queue_popup;
 pub mod seats;
 pub mod session;

--- a/crates/stella-tui/src/views/question.rs
+++ b/crates/stella-tui/src/views/question.rs
@@ -502,15 +502,21 @@ fn cancelled() -> QuestionOutcome {
 // ───────────────────────────────── render ─────────────────────────────────
 
 /// Paint the overlay over `area`. A no-op when nothing is parked.
-pub fn render(overlay: &QuestionOverlay, area: Rect, buf: &mut Buffer) {
+///
+/// `accessible` spans the card across the frame instead of floating it, the
+/// same contract every other card here honours ([`cards::card_area`]). It
+/// matters more on this one than on any of them: a float clips its rows at
+/// its right border, and a screen reader that never reaches the end of an
+/// option is a driver answering a question they only half heard — on the one
+/// overlay where the answer stops a turn.
+pub fn render(overlay: &QuestionOverlay, accessible: bool, area: Rect, buf: &mut Buffer) {
     let Some(request) = &overlay.request else {
         return;
     };
-    let body = match overlay.mode {
+    let mut body = match overlay.mode {
         QuestionMode::Review | QuestionMode::Chat => review_body(overlay),
         _ => question_body(overlay, request),
     };
-    let mut body = body;
     // Attribution goes in the BODY, never the title row. It shares that row
     // with the right-aligned key hints, and at this card's width the hints
     // win: the first golden of this overlay rendered the chip as `fro`,
@@ -521,7 +527,7 @@ pub fn render(overlay: &QuestionOverlay, area: Rect, buf: &mut Buffer) {
         body.insert(1, Line::from(""));
     }
     let rows = u16::try_from(body.len()).unwrap_or(u16::MAX);
-    let card = cards::card_area(area, rows, QUESTION_CARD_W, false);
+    let card = cards::card_area(area, rows, QUESTION_CARD_W, accessible);
     let inner = cards::card_frame(card, "question", Vec::new(), hints(overlay.mode), buf);
     cards::render_body(body, None, inner, buf);
 }

--- a/crates/stella-tui/src/views/question.rs
+++ b/crates/stella-tui/src/views/question.rs
@@ -45,8 +45,11 @@
 //! - **Who is asking.** [`QuestionRequest::asker`] names the sub-agent when a
 //!   delegated child raised the question. A driver answering a fanned-out
 //!   delegation who cannot see which child is asking is answering a coin
-//!   flip, so the title carries it — the same fact the TTY card renders as
-//!   "(from the `<id>` sub-agent)".
+//!   flip, so the card carries it as its first body row — the same fact the
+//!   TTY card renders as "(from the `<id>` sub-agent)". A **body** row, not
+//!   the title: the title shares its width with the right-aligned key hints,
+//!   and this overlay's first golden caught the hints winning and the chip
+//!   rendering as `fro`.
 //! - **That nothing is running.** The turn is parked. The overlay owns the
 //!   keyboard ahead of the composer while it is up, which is what makes that
 //!   legible without a word of chrome saying so.
@@ -72,9 +75,11 @@ const QUESTION_CARD_W: u16 = 76;
 /// exclusive and the text-entry ones all borrow the same buffer — three
 /// `bool`s would make "note editor open while the review pane is up" a
 /// representable state that means nothing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum QuestionMode {
-    /// Moving over one question's options.
+    /// Moving over one question's options. Where a freshly raised card
+    /// starts, and where every editor returns to.
+    #[default]
     Answering,
     /// Typing a note for the focused question's answer.
     Note,
@@ -143,12 +148,6 @@ pub struct QuestionOverlay {
     editor: String,
 }
 
-impl Default for QuestionMode {
-    fn default() -> Self {
-        Self::Answering
-    }
-}
-
 impl QuestionOverlay {
     /// Whether a question is parked and the overlay owns the keyboard.
     #[must_use]
@@ -185,6 +184,29 @@ impl QuestionOverlay {
         self.review_row = 0;
         self.mode = QuestionMode::Answering;
         self.editor.clear();
+    }
+
+    /// Apply an inbound envelope, reporting whether it was one of ours.
+    ///
+    /// The overlay owns **both** directions of its own envelope contract:
+    /// `QuestionAsked` / `QuestionWithdrawn` in here, `QuestionAnswered` out
+    /// of [`Self::key`]. Keeping the mapping beside the state it drives is
+    /// what lets `deck_ui`'s fold spend two lines on it rather than a dozen
+    /// — that file is a god file closed to growth
+    /// (`scripts/file-size-baseline.txt`), and this is the shape the
+    /// constraint asks for rather than a workaround for it.
+    pub fn ingest(&mut self, inbound: &crate::envelope::Inbound) -> bool {
+        match inbound {
+            crate::envelope::Inbound::QuestionAsked(request) => {
+                self.open(request.as_ref().clone());
+                true
+            }
+            crate::envelope::Inbound::QuestionWithdrawn => {
+                self.close();
+                true
+            }
+            _ => false,
+        }
     }
 
     /// The focused question, when one is parked.
@@ -335,9 +357,7 @@ impl QuestionOverlay {
         if self.request.is_none() {
             return QuestionAction::Ignored;
         }
-        if key.modifiers.contains(KeyModifiers::CONTROL)
-            && matches!(key.code, KeyCode::Char('c'))
-        {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             return QuestionAction::Ignored;
         }
 
@@ -570,7 +590,10 @@ fn question_body(overlay: &QuestionOverlay, request: &QuestionRequest) -> Vec<Li
     };
     rows.push(Line::from(vec![
         Span::styled(position, dim),
-        Span::styled(question.question.clone(), Style::new().fg(theme::TEXT_PRIMARY)),
+        Span::styled(
+            question.question.clone(),
+            Style::new().fg(theme::TEXT_PRIMARY),
+        ),
     ]));
     if question.multi_select {
         rows.push(Line::from(Span::styled(
@@ -580,7 +603,11 @@ fn question_body(overlay: &QuestionOverlay, request: &QuestionRequest) -> Vec<Li
     }
     rows.push(Line::from(""));
 
-    let pick = overlay.picks.get(overlay.focus).cloned().unwrap_or_default();
+    let pick = overlay
+        .picks
+        .get(overlay.focus)
+        .cloned()
+        .unwrap_or_default();
     let inner_w = usize::from(QUESTION_CARD_W) - 2;
     for (i, option) in question.options.iter().enumerate() {
         let chosen = pick.chosen.contains(&i);
@@ -682,13 +709,18 @@ fn review_body(overlay: &QuestionOverlay) -> Vec<Line<'static>> {
     let inner_w = usize::from(QUESTION_CARD_W) - 2;
     let mut rows = vec![Line::from(Span::styled(
         "Review your answers",
-        Style::new().fg(theme::TEXT_PRIMARY).add_modifier(Modifier::BOLD),
+        Style::new()
+            .fg(theme::TEXT_PRIMARY)
+            .add_modifier(Modifier::BOLD),
     ))];
 
     for answer in overlay.answers() {
         rows.push(Line::from(""));
         rows.push(Line::from(Span::styled(
-            format!("  • {}", cards::truncate_cols(&answer.question, inner_w - 4)),
+            format!(
+                "  • {}",
+                cards::truncate_cols(&answer.question, inner_w - 4)
+            ),
             Style::new().fg(theme::TEXT_PRIMARY),
         )));
         if answer.chosen.is_empty() {
@@ -710,7 +742,11 @@ fn review_body(overlay: &QuestionOverlay) -> Vec<Line<'static>> {
 
     rows.push(Line::from(""));
     if overlay.mode == QuestionMode::Chat {
-        rows.push(editor_row("what would you like to say", &overlay.editor, inner_w));
+        rows.push(editor_row(
+            "what would you like to say",
+            &overlay.editor,
+            inner_w,
+        ));
         return rows;
     }
     for (i, label) in REVIEW_ROWS.iter().enumerate() {
@@ -794,14 +830,20 @@ mod tests {
         assert_eq!(overlay.focus, 0);
 
         // Attach the note the option list could not hold.
-        assert_eq!(overlay.key(key(KeyCode::Char('n'))), QuestionAction::Handled);
+        assert_eq!(
+            overlay.key(key(KeyCode::Char('n'))),
+            QuestionAction::Handled
+        );
         assert_eq!(overlay.mode, QuestionMode::Note);
         typing(&mut overlay, "only for the admin routes");
         assert_eq!(overlay.key(key(KeyCode::Enter)), QuestionAction::Handled);
         assert_eq!(overlay.mode, QuestionMode::Answering);
 
         // Review, submit.
-        assert_eq!(overlay.key(key(KeyCode::Char('r'))), QuestionAction::Handled);
+        assert_eq!(
+            overlay.key(key(KeyCode::Char('r'))),
+            QuestionAction::Handled
+        );
         let QuestionAction::Resolve(QuestionOutcome::Answered { answers }) =
             overlay.key(key(KeyCode::Enter))
         else {
@@ -810,7 +852,10 @@ mod tests {
         assert_eq!(answers.len(), 1);
         assert_eq!(answers[0].header, "Auth method");
         assert_eq!(answers[0].chosen, vec!["Bearer token"]);
-        assert_eq!(answers[0].note.as_deref(), Some("only for the admin routes"));
+        assert_eq!(
+            answers[0].note.as_deref(),
+            Some("only for the admin routes")
+        );
     }
 
     /// A note typed into the editor must not be readable as a navigation key.
@@ -862,7 +907,11 @@ mod tests {
         multi.key(key(KeyCode::Enter));
         multi.key(key(KeyCode::Down));
         multi.key(key(KeyCode::Enter));
-        assert_eq!(multi.mode, QuestionMode::Answering, "multi-select stays put");
+        assert_eq!(
+            multi.mode,
+            QuestionMode::Answering,
+            "multi-select stays put"
+        );
         assert_eq!(
             multi.answers()[0].chosen,
             vec!["Session cookie", "Bearer token"]

--- a/crates/stella-tui/src/views/question.rs
+++ b/crates/stella-tui/src/views/question.rs
@@ -504,8 +504,9 @@ fn cancelled() -> QuestionOutcome {
 /// Paint the overlay over `area`. A no-op when nothing is parked.
 ///
 /// `accessible` spans the card across the frame instead of floating it, the
-/// same contract every other card here honours ([`cards::card_area`]). It
-/// matters more on this one than on any of them: a float clips its rows at
+/// same contract every other card here honours (`cards::card_area` — not a
+/// link: it is `pub(crate)`, and this is a `pub fn`). It matters more on this
+/// one than on any of them: a float clips its rows at
 /// its right border, and a screen reader that never reaches the end of an
 /// option is a driver answering a question they only half heard — on the one
 /// overlay where the answer stops a turn.

--- a/crates/stella-tui/src/views/question.rs
+++ b/crates/stella-tui/src/views/question.rs
@@ -1,0 +1,1035 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The Command Deck's `ask_question` overlay (#4220): the wizard a parked
+//! turn waits on.
+//!
+//! # Why the deck needed its own
+//!
+//! `ask_question` (#4212) parks a turn on whoever is driving it, through the
+//! `QuestionResponder` port. The plain-TTY responder answers by printing a
+//! card and reading a line of stdin — which is exactly what the deck cannot
+//! do: it owns the terminal in raw mode, and a blocking stdin read behind its
+//! render loop would fight it for every keystroke. So the deck, the *default*
+//! interactive shell on a TTY, was the one interactive surface where every
+//! question resolved to the headless "no driver is attached" decline. Honest,
+//! and not the feature.
+//!
+//! This module is the deck's half. It is a **pure fold** like every other
+//! overlay here: [`QuestionOverlay::key`] takes a keystroke and returns what
+//! it did, [`render`] paints the state, and neither touches a channel, a
+//! clock, or the filesystem. The host ([`crate::envelope::Inbound::QuestionAsked`]
+//! in, [`crate::envelope::WorkspaceInput::QuestionAnswered`] out) is the only
+//! thing that knows a tool call is waiting on the other side.
+//!
+//! # The flow matches the plain TTY's, key for key
+//!
+//! The two surfaces must ask the same question, or the same agent asking the
+//! same thing reads as two different questions depending on which shell the
+//! person launched. `stella_cli::question`'s three steps map across exactly:
+//!
+//! | plain TTY | here |
+//! | --- | --- |
+//! | numbered options, `❯` on the recommendation | ↑/↓ over the option rows |
+//! | one card per question, in order | Tab / ⇧Tab across the tab strip |
+//! | `… # note` appended to the answer line | `n` opens the note editor |
+//! | the appended free-text row | the last row, `⏎` opens the editor |
+//! | review block: submit / chat / cancel | the review pane, same three |
+//!
+//! The affordances differ (a grid can highlight where a line can only
+//! number); the *decisions* available do not, and neither does the
+//! [`QuestionOutcome`] that comes out.
+//!
+//! # Two things the card must say
+//!
+//! - **Who is asking.** [`QuestionRequest::asker`] names the sub-agent when a
+//!   delegated child raised the question. A driver answering a fanned-out
+//!   delegation who cannot see which child is asking is answering a coin
+//!   flip, so the title carries it — the same fact the TTY card renders as
+//!   "(from the `<id>` sub-agent)".
+//! - **That nothing is running.** The turn is parked. The overlay owns the
+//!   keyboard ahead of the composer while it is up, which is what makes that
+//!   legible without a word of chrome saying so.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use stella_protocol::{Answer, FREE_TEXT_LABEL, Question, QuestionOutcome, QuestionRequest};
+
+use crate::theme;
+use crate::views::cards;
+
+/// The overlay is wider than the `/plan`-family cards: a question's options
+/// carry descriptions, and eliding the half that says what a choice *means*
+/// turns an informed decision back into a guess.
+const QUESTION_CARD_W: u16 = 76;
+
+/// What owns the keyboard inside the overlay.
+///
+/// One enum rather than a set of booleans, because the modes are genuinely
+/// exclusive and the text-entry ones all borrow the same buffer — three
+/// `bool`s would make "note editor open while the review pane is up" a
+/// representable state that means nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuestionMode {
+    /// Moving over one question's options.
+    Answering,
+    /// Typing a note for the focused question's answer.
+    Note,
+    /// Typing a free-text answer for the focused question.
+    FreeText,
+    /// The whole answer set, with submit / chat / cancel.
+    Review,
+    /// Typing the words that ride along with a "chat about this instead".
+    Chat,
+}
+
+/// One question's working answer, as the wizard builds it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Pick {
+    /// Indices into the question's own `options`, in the order chosen. A
+    /// single-select question holds at most one.
+    chosen: Vec<usize>,
+    /// The answerer's own words, when they took the free-text row. Mutually
+    /// exclusive with `chosen` by construction — taking one clears the other,
+    /// because "option 2, and also my own thing" is not a decision the tool
+    /// can report.
+    free_text: Option<String>,
+    /// The note attached to *this* answer.
+    note: Option<String>,
+}
+
+/// The rows of the review pane, in the order they are drawn.
+const REVIEW_ROWS: [&str; 3] = [
+    "Submit answers",
+    "Chat about this instead",
+    "Cancel — no answer",
+];
+
+/// What a keystroke did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuestionAction {
+    /// Not the overlay's key (it is not open).
+    Ignored,
+    /// Consumed; nothing left the overlay.
+    Handled,
+    /// The driver settled it — send this back to the parked call and close.
+    Resolve(QuestionOutcome),
+}
+
+/// The overlay's whole state. `request: None` is "nothing is parked", which
+/// is also the closed state — there is no second `open` flag to disagree with
+/// it.
+#[derive(Debug, Clone, Default)]
+pub struct QuestionOverlay {
+    /// The parked request, or `None` when no question is waiting.
+    pub request: Option<QuestionRequest>,
+    /// One working answer per question, same length and order as
+    /// `request.questions` whenever a request is live.
+    picks: Vec<Pick>,
+    /// Which question the tab strip is on.
+    focus: usize,
+    /// The highlighted row within the focused question: `0..options.len()`
+    /// are the asker's options, and `options.len()` is the appended free-text
+    /// row.
+    row: usize,
+    /// Which of [`REVIEW_ROWS`] is highlighted.
+    review_row: usize,
+    /// The mode that owns the keyboard.
+    pub mode: QuestionMode,
+    /// The buffer the three text-entry modes share.
+    editor: String,
+}
+
+impl Default for QuestionMode {
+    fn default() -> Self {
+        Self::Answering
+    }
+}
+
+impl QuestionOverlay {
+    /// Whether a question is parked and the overlay owns the keyboard.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        self.request.is_some()
+    }
+
+    /// Park `request`, discarding whatever was there.
+    ///
+    /// Discarding rather than queueing is correct and not a shortcut: the
+    /// broker holds a fairness gate and asks one question at a time, so a
+    /// second request can only arrive after the first resolved. Modelling a
+    /// queue here would be modelling a state the port cannot produce.
+    pub fn open(&mut self, request: QuestionRequest) {
+        self.picks = vec![Pick::default(); request.questions.len()];
+        self.request = Some(request);
+        self.focus = 0;
+        self.row = 0;
+        self.review_row = 0;
+        self.mode = QuestionMode::Answering;
+        self.editor.clear();
+    }
+
+    /// Take the card down and forget the working answers.
+    ///
+    /// Called both when the driver settles it and when the host withdraws it
+    /// — a request whose broker timed out is a card that must not stay up
+    /// offering to resolve a oneshot nobody is holding.
+    pub fn close(&mut self) {
+        self.request = None;
+        self.picks.clear();
+        self.focus = 0;
+        self.row = 0;
+        self.review_row = 0;
+        self.mode = QuestionMode::Answering;
+        self.editor.clear();
+    }
+
+    /// The focused question, when one is parked.
+    fn question(&self) -> Option<&Question> {
+        self.request.as_ref()?.questions.get(self.focus)
+    }
+
+    /// How many selectable rows the focused question has: its options plus
+    /// the free-text row the runtime appends.
+    fn row_count(&self) -> usize {
+        self.question().map_or(1, |q| q.options.len() + 1)
+    }
+
+    /// Whether `row` is the appended free-text row rather than one of the
+    /// asker's options.
+    fn is_free_text_row(&self, row: usize) -> bool {
+        self.question().is_some_and(|q| row == q.options.len())
+    }
+
+    /// The answer set as it stands — what a submit would send.
+    ///
+    /// Every question yields an [`Answer`] even when nothing was chosen: the
+    /// tool reports one answer per question asked, and silently dropping the
+    /// unanswered ones would let a half-filled card read as a complete one.
+    #[must_use]
+    pub fn answers(&self) -> Vec<Answer> {
+        let Some(request) = &self.request else {
+            return Vec::new();
+        };
+        request
+            .questions
+            .iter()
+            .enumerate()
+            .map(|(i, question)| {
+                let pick = self.picks.get(i).cloned().unwrap_or_default();
+                let chosen = match &pick.free_text {
+                    Some(words) => vec![words.clone()],
+                    None => pick
+                        .chosen
+                        .iter()
+                        .filter_map(|&o| question.options.get(o))
+                        .map(|o| o.label.clone())
+                        .collect(),
+                };
+                Answer {
+                    header: question.header.clone(),
+                    question: question.question.clone(),
+                    chosen,
+                    note: pick.note.clone(),
+                }
+            })
+            .collect()
+    }
+
+    /// Choose the highlighted option for the focused question.
+    ///
+    /// Multi-select toggles; single-select replaces. **Neither advances** —
+    /// `⇥` is the only thing that moves between questions, and that is a
+    /// deliberate divergence from the plain TTY, which advances on the
+    /// answer only because a line-oriented prompt has no other way to move.
+    ///
+    /// A grid does, and the difference matters for exactly one gesture: `n`
+    /// annotates the *focused* question, so a `⏎` that also advanced would
+    /// put "pick option 2 and say why" — the single most common thing a
+    /// driver wants to do here — one question out of step, silently
+    /// attaching the note to whatever came next. One rule for both select
+    /// kinds also means there is no mode where `⏎` means two different
+    /// things.
+    fn select(&mut self) {
+        let Some(question) = self.question().cloned() else {
+            return;
+        };
+        let row = self.row;
+        let Some(pick) = self.picks.get_mut(self.focus) else {
+            return;
+        };
+        // Any option selection retires a free-text answer: the two are one
+        // decision, and keeping both would report an answer the driver
+        // replaced.
+        pick.free_text = None;
+        if question.multi_select {
+            match pick.chosen.iter().position(|&c| c == row) {
+                Some(at) => {
+                    pick.chosen.remove(at);
+                }
+                None => pick.chosen.push(row),
+            }
+            return;
+        }
+        pick.chosen = vec![row];
+    }
+
+    /// Commit whatever the text editor holds, per the mode that opened it.
+    ///
+    /// Returns the action, because committing a chat note is the one text
+    /// entry that resolves the whole card rather than returning to the grid.
+    fn commit_editor(&mut self) -> QuestionAction {
+        let text = self.editor.trim().to_string();
+        match self.mode {
+            QuestionMode::Chat => {
+                self.editor.clear();
+                QuestionAction::Resolve(QuestionOutcome::Deferred { note: text })
+            }
+            QuestionMode::Note => {
+                if let Some(pick) = self.picks.get_mut(self.focus) {
+                    // An emptied note is no note — the same rule
+                    // `parse_answer` applies to a trailing ` # ` with nothing
+                    // after it, so clearing the field removes the note rather
+                    // than attaching an empty string.
+                    pick.note = (!text.is_empty()).then_some(text);
+                }
+                self.editor.clear();
+                self.mode = QuestionMode::Answering;
+                QuestionAction::Handled
+            }
+            QuestionMode::FreeText => {
+                if let Some(pick) = self.picks.get_mut(self.focus) {
+                    if text.is_empty() {
+                        // Nothing typed is not an answer: leave whatever was
+                        // chosen before standing rather than blanking it.
+                        pick.free_text = None;
+                    } else {
+                        pick.free_text = Some(text);
+                        pick.chosen.clear();
+                    }
+                }
+                self.editor.clear();
+                self.mode = QuestionMode::Answering;
+                QuestionAction::Handled
+            }
+            _ => QuestionAction::Handled,
+        }
+    }
+
+    /// Fold one keystroke.
+    ///
+    /// Returns [`QuestionAction::Ignored`] when nothing is parked, so the
+    /// caller can route it in front of every other handler unconditionally
+    /// and let the closed overlay decline.
+    ///
+    /// Ctrl-C is **also** declined while open, deliberately and for the same
+    /// reason [`crate::deck_ui::dispatch::handle_key`] declines it: this
+    /// handler runs ahead of the deck's quit branch, so claiming it would
+    /// make a parked question the one state a user cannot Ctrl-C out of.
+    pub fn key(&mut self, key: crossterm::event::KeyEvent) -> QuestionAction {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        if self.request.is_none() {
+            return QuestionAction::Ignored;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(key.code, KeyCode::Char('c'))
+        {
+            return QuestionAction::Ignored;
+        }
+
+        // The text-entry modes own every printable key, so they are claimed
+        // before the navigation letters below — otherwise `n` typed into a
+        // note would open a second note editor.
+        if matches!(
+            self.mode,
+            QuestionMode::Note | QuestionMode::FreeText | QuestionMode::Chat
+        ) {
+            return match key.code {
+                KeyCode::Esc => {
+                    // Abandon the text, keep the card: Esc out of an editor
+                    // must not cancel the question, or a typo becomes a
+                    // declined turn.
+                    self.editor.clear();
+                    self.mode = if self.mode == QuestionMode::Chat {
+                        QuestionMode::Review
+                    } else {
+                        QuestionMode::Answering
+                    };
+                    QuestionAction::Handled
+                }
+                KeyCode::Enter => self.commit_editor(),
+                KeyCode::Backspace => {
+                    self.editor.pop();
+                    QuestionAction::Handled
+                }
+                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.editor.push(c);
+                    QuestionAction::Handled
+                }
+                _ => QuestionAction::Handled,
+            };
+        }
+
+        if self.mode == QuestionMode::Review {
+            return match key.code {
+                KeyCode::Esc => QuestionAction::Resolve(cancelled()),
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.review_row = self.review_row.saturating_sub(1);
+                    QuestionAction::Handled
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.review_row = (self.review_row + 1).min(REVIEW_ROWS.len() - 1);
+                    QuestionAction::Handled
+                }
+                KeyCode::Tab | KeyCode::BackTab => {
+                    // Back to the questions to change something — the review
+                    // is a checkpoint, not a one-way door.
+                    self.mode = QuestionMode::Answering;
+                    QuestionAction::Handled
+                }
+                KeyCode::Enter => match self.review_row {
+                    0 => QuestionAction::Resolve(QuestionOutcome::Answered {
+                        answers: self.answers(),
+                    }),
+                    1 => {
+                        self.mode = QuestionMode::Chat;
+                        self.editor.clear();
+                        QuestionAction::Handled
+                    }
+                    _ => QuestionAction::Resolve(cancelled()),
+                },
+                _ => QuestionAction::Handled,
+            };
+        }
+
+        let total = self.request.as_ref().map_or(0, |r| r.questions.len());
+        match key.code {
+            KeyCode::Esc => QuestionAction::Resolve(cancelled()),
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.row = self.row.saturating_sub(1);
+                QuestionAction::Handled
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.row = (self.row + 1).min(self.row_count().saturating_sub(1));
+                QuestionAction::Handled
+            }
+            KeyCode::Tab => {
+                if self.focus + 1 < total {
+                    self.focus += 1;
+                    self.row = 0;
+                } else {
+                    self.mode = QuestionMode::Review;
+                    self.review_row = 0;
+                }
+                QuestionAction::Handled
+            }
+            KeyCode::BackTab => {
+                self.focus = self.focus.saturating_sub(1);
+                self.row = 0;
+                QuestionAction::Handled
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if self.is_free_text_row(self.row) {
+                    self.mode = QuestionMode::FreeText;
+                    self.editor = self
+                        .picks
+                        .get(self.focus)
+                        .and_then(|p| p.free_text.clone())
+                        .unwrap_or_default();
+                } else {
+                    self.select();
+                }
+                QuestionAction::Handled
+            }
+            KeyCode::Char('n') => {
+                self.mode = QuestionMode::Note;
+                // Seeded with the existing note so `n` is an edit, not a
+                // silent overwrite of what is already attached.
+                self.editor = self
+                    .picks
+                    .get(self.focus)
+                    .and_then(|p| p.note.clone())
+                    .unwrap_or_default();
+                QuestionAction::Handled
+            }
+            KeyCode::Char('r') => {
+                self.mode = QuestionMode::Review;
+                self.review_row = 0;
+                QuestionAction::Handled
+            }
+            _ => QuestionAction::Handled,
+        }
+    }
+}
+
+/// The decline a cancel produces.
+///
+/// Worded as an instruction rather than a bare "cancelled", matching
+/// `stella_cli::question`'s own cancel: a refusal that only says no leaves
+/// the model to invent a recovery, and the one it invents is to ask again.
+fn cancelled() -> QuestionOutcome {
+    QuestionOutcome::Declined {
+        reason: "the driver cancelled without answering — do not re-ask; proceed with your best \
+                 judgement and state the assumption you made"
+            .to_string(),
+    }
+}
+
+// ───────────────────────────────── render ─────────────────────────────────
+
+/// Paint the overlay over `area`. A no-op when nothing is parked.
+pub fn render(overlay: &QuestionOverlay, area: Rect, buf: &mut Buffer) {
+    let Some(request) = &overlay.request else {
+        return;
+    };
+    let body = match overlay.mode {
+        QuestionMode::Review | QuestionMode::Chat => review_body(overlay),
+        _ => question_body(overlay, request),
+    };
+    let rows = u16::try_from(body.len()).unwrap_or(u16::MAX);
+    let card = cards::card_area(area, rows, QUESTION_CARD_W, false);
+    let inner = cards::card_frame(
+        card,
+        "question",
+        asker_context(request.asker.as_deref()),
+        hints(overlay.mode),
+        buf,
+    );
+    cards::render_body(body, None, inner, buf);
+}
+
+/// The title's context spans: who is asking, when a sub-agent is.
+///
+/// Empty for a top-level turn — the driver's own agent needs no attribution,
+/// and a "(from the lead)" chip on every card would train the eye to skip the
+/// one place the answer matters.
+fn asker_context(asker: Option<&str>) -> Vec<Span<'static>> {
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    match asker {
+        Some(agent) => vec![Span::styled(
+            format!("from the `{agent}` sub-agent"),
+            dim,
+        )],
+        None => Vec::new(),
+    }
+}
+
+/// The right-aligned key hints for the mode that owns the keyboard.
+fn hints(mode: QuestionMode) -> &'static str {
+    match mode {
+        QuestionMode::Answering => "↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel",
+        QuestionMode::Note => "⏎ save note · esc discard",
+        QuestionMode::FreeText => "⏎ save answer · esc discard",
+        QuestionMode::Review => "↑↓ move · ⏎ choose · ⇥ back · esc cancel",
+        QuestionMode::Chat => "⏎ send · esc back",
+    }
+}
+
+/// The answering pane: the tab strip (when there is more than one question),
+/// the question, its options, the free-text row, and any attached note.
+fn question_body(overlay: &QuestionOverlay, request: &QuestionRequest) -> Vec<Line<'static>> {
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    let mut rows: Vec<Line<'static>> = Vec::new();
+
+    // The tab strip earns its row only when there is something to move
+    // between; a one-question card drawing a strip of one is chrome that
+    // says nothing.
+    if request.questions.len() > 1 {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        for (i, question) in request.questions.iter().enumerate() {
+            if i > 0 {
+                spans.push(Span::styled("  ", dim));
+            }
+            let answered = overlay.picks.get(i).is_some_and(is_answered);
+            // A glyph, not a colour: the golden suite strips style, so a
+            // style-only "this one is done" mark would be invisible to it.
+            let mark = if answered { "●" } else { "○" };
+            let label = format!("{mark} {}", question.header);
+            spans.push(if i == overlay.focus {
+                Span::styled(label, theme::accent().add_modifier(Modifier::BOLD))
+            } else {
+                Span::styled(label, dim)
+            });
+        }
+        rows.push(Line::from(spans));
+        rows.push(Line::from(""));
+    }
+
+    let Some(question) = request.questions.get(overlay.focus) else {
+        return rows;
+    };
+    let position = if request.questions.len() > 1 {
+        format!("[{}/{}] ", overlay.focus + 1, request.questions.len())
+    } else {
+        String::new()
+    };
+    rows.push(Line::from(vec![
+        Span::styled(position, dim),
+        Span::styled(question.question.clone(), Style::new().fg(theme::TEXT_PRIMARY)),
+    ]));
+    if question.multi_select {
+        rows.push(Line::from(Span::styled(
+            "several answers may be chosen",
+            dim,
+        )));
+    }
+    rows.push(Line::from(""));
+
+    let pick = overlay.picks.get(overlay.focus).cloned().unwrap_or_default();
+    let inner_w = usize::from(QUESTION_CARD_W) - 2;
+    for (i, option) in question.options.iter().enumerate() {
+        let chosen = pick.chosen.contains(&i);
+        let mut spans = vec![
+            cards::marker(i == overlay.row && overlay.mode == QuestionMode::Answering),
+            Span::styled(
+                if chosen { "[x] " } else { "[ ] " },
+                if chosen { theme::accent() } else { dim },
+            ),
+            Span::styled(option.label.clone(), Style::new().fg(theme::TEXT_PRIMARY)),
+        ];
+        if !option.description.is_empty() {
+            let used: usize = 4 + 4 + option.label.chars().count();
+            spans.push(Span::styled(
+                format!(
+                    " — {}",
+                    cards::truncate_cols(
+                        &option.description,
+                        inner_w.saturating_sub(used + 3).max(8)
+                    )
+                ),
+                dim,
+            ));
+        }
+        rows.push(Line::from(spans));
+    }
+
+    // The runtime's own escape, always last and never listed by the asker.
+    let free_row = question.options.len();
+    let free_selected = pick.free_text.is_some();
+    let mut spans = vec![
+        cards::marker(overlay.row == free_row && overlay.mode == QuestionMode::Answering),
+        Span::styled(
+            if free_selected { "[x] " } else { "[ ] " },
+            if free_selected { theme::accent() } else { dim },
+        ),
+        Span::styled(FREE_TEXT_LABEL.to_string(), dim),
+    ];
+    if let Some(words) = &pick.free_text {
+        spans.push(Span::styled(
+            format!(" — {}", cards::truncate_cols(words, inner_w / 2)),
+            Style::new().fg(theme::TEXT_PRIMARY),
+        ));
+    }
+    rows.push(Line::from(spans));
+
+    match overlay.mode {
+        QuestionMode::FreeText => {
+            rows.push(Line::from(""));
+            rows.push(editor_row("your answer", &overlay.editor, inner_w));
+        }
+        QuestionMode::Note => {
+            rows.push(Line::from(""));
+            rows.push(editor_row("note", &overlay.editor, inner_w));
+        }
+        _ => {
+            if let Some(note) = &pick.note {
+                rows.push(Line::from(Span::styled(
+                    format!("    note: {}", cards::truncate_cols(note, inner_w - 10)),
+                    dim,
+                )));
+            }
+        }
+    }
+    rows
+}
+
+/// Whether a working answer holds anything at all — what the tab strip's
+/// filled/hollow mark reports.
+fn is_answered(pick: &Pick) -> bool {
+    !pick.chosen.is_empty() || pick.free_text.is_some()
+}
+
+/// One open text field: a dim label, the buffer, and a block caret.
+///
+/// The caret is a glyph rather than the hardware cursor because the deck
+/// parks its real cursor in the composer, and because a style-blind golden
+/// can pin a `▏` where it cannot pin a cursor position.
+fn editor_row(label: &str, text: &str, inner_w: usize) -> Line<'static> {
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    let room = inner_w.saturating_sub(label.chars().count() + 8).max(8);
+    // Show the tail, not the head: a person typing past the field's width
+    // needs to see what they are typing now.
+    let shown: String = if text.chars().count() > room {
+        text.chars().skip(text.chars().count() - room).collect()
+    } else {
+        text.to_string()
+    };
+    Line::from(vec![
+        Span::styled(format!("  {label}: "), dim),
+        Span::styled(shown, Style::new().fg(theme::TEXT_PRIMARY)),
+        Span::styled("▏", theme::accent()),
+    ])
+}
+
+/// The review pane: everything that would be sent, then the three ways out.
+fn review_body(overlay: &QuestionOverlay) -> Vec<Line<'static>> {
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    let inner_w = usize::from(QUESTION_CARD_W) - 2;
+    let mut rows = vec![Line::from(Span::styled(
+        "Review your answers",
+        Style::new().fg(theme::TEXT_PRIMARY).add_modifier(Modifier::BOLD),
+    ))];
+
+    for answer in overlay.answers() {
+        rows.push(Line::from(""));
+        rows.push(Line::from(Span::styled(
+            format!("  • {}", cards::truncate_cols(&answer.question, inner_w - 4)),
+            Style::new().fg(theme::TEXT_PRIMARY),
+        )));
+        if answer.chosen.is_empty() {
+            rows.push(Line::from(Span::styled("      → (no answer)", dim)));
+        }
+        for chosen in &answer.chosen {
+            rows.push(Line::from(Span::styled(
+                format!("      → {}", cards::truncate_cols(chosen, inner_w - 8)),
+                theme::accent(),
+            )));
+        }
+        if let Some(note) = &answer.note {
+            rows.push(Line::from(Span::styled(
+                format!("        note: {}", cards::truncate_cols(note, inner_w - 14)),
+                dim,
+            )));
+        }
+    }
+
+    rows.push(Line::from(""));
+    if overlay.mode == QuestionMode::Chat {
+        rows.push(editor_row("what would you like to say", &overlay.editor, inner_w));
+        return rows;
+    }
+    for (i, label) in REVIEW_ROWS.iter().enumerate() {
+        rows.push(Line::from(vec![
+            cards::marker(i == overlay.review_row),
+            Span::styled(
+                (*label).to_string(),
+                if i == overlay.review_row {
+                    theme::accent()
+                } else {
+                    dim
+                },
+            ),
+        ]));
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use stella_protocol::QuestionOption;
+
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn typing(overlay: &mut QuestionOverlay, text: &str) {
+        for c in text.chars() {
+            assert_eq!(overlay.key(key(KeyCode::Char(c))), QuestionAction::Handled);
+        }
+    }
+
+    fn question(header: &str, multi: bool) -> Question {
+        Question {
+            header: header.into(),
+            question: format!("{header}?"),
+            options: vec![
+                QuestionOption {
+                    label: "Session cookie".into(),
+                    description: "Matches the rest of the app".into(),
+                },
+                QuestionOption {
+                    label: "Bearer token".into(),
+                    description: String::new(),
+                },
+            ],
+            multi_select: multi,
+        }
+    }
+
+    fn open(questions: Vec<Question>) -> QuestionOverlay {
+        let mut overlay = QuestionOverlay::default();
+        overlay.open(QuestionRequest {
+            asker: None,
+            questions,
+        });
+        overlay
+    }
+
+    /// **The witness for #4220.** Select an option, attach a note, submit —
+    /// and the `QuestionOutcome` that leaves the fold carries both. This is
+    /// the whole feature: before it, every `ask_question` on the deck
+    /// resolved to the headless decline no matter what the driver did.
+    #[test]
+    fn select_then_note_then_submit_produces_the_answer_and_its_note() {
+        let mut overlay = open(vec![question("Auth method", false)]);
+
+        // Down to the second option, pick it — and stay, so the note that
+        // follows lands on the answer just given.
+        assert_eq!(overlay.key(key(KeyCode::Down)), QuestionAction::Handled);
+        assert_eq!(overlay.key(key(KeyCode::Enter)), QuestionAction::Handled);
+        assert_eq!(
+            overlay.mode,
+            QuestionMode::Answering,
+            "picking must not advance: `n` annotates the FOCUSED question, so an \
+             advancing ⏎ would attach the note to the next one"
+        );
+        assert_eq!(overlay.focus, 0);
+
+        // Attach the note the option list could not hold.
+        assert_eq!(overlay.key(key(KeyCode::Char('n'))), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::Note);
+        typing(&mut overlay, "only for the admin routes");
+        assert_eq!(overlay.key(key(KeyCode::Enter)), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::Answering);
+
+        // Review, submit.
+        assert_eq!(overlay.key(key(KeyCode::Char('r'))), QuestionAction::Handled);
+        let QuestionAction::Resolve(QuestionOutcome::Answered { answers }) =
+            overlay.key(key(KeyCode::Enter))
+        else {
+            panic!("submitting the review must answer");
+        };
+        assert_eq!(answers.len(), 1);
+        assert_eq!(answers[0].header, "Auth method");
+        assert_eq!(answers[0].chosen, vec!["Bearer token"]);
+        assert_eq!(answers[0].note.as_deref(), Some("only for the admin routes"));
+    }
+
+    /// A note typed into the editor must not be readable as a navigation key.
+    /// `n` and `r` are the note and review hotkeys on the grid; inside the
+    /// editor they are letters, or every note containing an `n` would reopen
+    /// the editor it was typed in.
+    #[test]
+    fn the_note_editor_owns_its_letters() {
+        let mut overlay = open(vec![question("Scope", false)]);
+        overlay.key(key(KeyCode::Char('n')));
+        typing(&mut overlay, "narrow");
+        assert_eq!(overlay.mode, QuestionMode::Note, "still in the editor");
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(overlay.picks[0].note.as_deref(), Some("narrow"));
+    }
+
+    /// Esc out of an editor abandons the text and keeps the card. Cancelling
+    /// the whole question on a typo would turn a slip into a declined turn.
+    #[test]
+    fn esc_in_an_editor_discards_the_text_not_the_question() {
+        let mut overlay = open(vec![question("Scope", false)]);
+        overlay.key(key(KeyCode::Char('n')));
+        typing(&mut overlay, "oops");
+        assert_eq!(overlay.key(key(KeyCode::Esc)), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::Answering);
+        assert!(overlay.request.is_some(), "the question is still parked");
+        assert_eq!(overlay.picks[0].note, None);
+    }
+
+    /// Esc on the grid declines — and the decline is an instruction, the same
+    /// wording the plain-TTY cancel produces, so the model reacts the same
+    /// way whichever surface the driver was using.
+    #[test]
+    fn esc_on_the_grid_declines_with_an_instruction() {
+        let mut overlay = open(vec![question("Scope", false)]);
+        let QuestionAction::Resolve(QuestionOutcome::Declined { reason }) =
+            overlay.key(key(KeyCode::Esc))
+        else {
+            panic!("esc must decline");
+        };
+        assert!(reason.contains("do not re-ask"), "{reason}");
+        assert!(reason.contains("state the assumption"), "{reason}");
+    }
+
+    /// Multi-select toggles and stays; single-select replaces and moves on.
+    #[test]
+    fn multi_select_accumulates_where_single_select_replaces() {
+        let mut multi = open(vec![question("Targets", true)]);
+        multi.key(key(KeyCode::Enter));
+        multi.key(key(KeyCode::Down));
+        multi.key(key(KeyCode::Enter));
+        assert_eq!(multi.mode, QuestionMode::Answering, "multi-select stays put");
+        assert_eq!(
+            multi.answers()[0].chosen,
+            vec!["Session cookie", "Bearer token"]
+        );
+        // Toggling the same row again removes it.
+        multi.key(key(KeyCode::Enter));
+        assert_eq!(multi.answers()[0].chosen, vec!["Session cookie"]);
+
+        let mut single = open(vec![question("Auth", false)]);
+        single.key(key(KeyCode::Enter));
+        single.key(key(KeyCode::Down));
+        assert_eq!(
+            single.answers()[0].chosen,
+            vec!["Session cookie"],
+            "a single-select question reports one answer"
+        );
+    }
+
+    /// Tab walks the questions and lands on the review pane past the last —
+    /// and every question is reported, including one nobody answered.
+    #[test]
+    fn tab_walks_every_question_and_unanswered_ones_still_report() {
+        let mut overlay = open(vec![question("Auth", false), question("Rollout", false)]);
+        overlay.key(key(KeyCode::Enter)); // answers Auth
+        assert_eq!(overlay.key(key(KeyCode::Tab)), QuestionAction::Handled);
+        assert_eq!(overlay.focus, 1, "⇥ is what moves between questions");
+        assert_eq!(overlay.key(key(KeyCode::Tab)), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::Review, "past the last question");
+
+        let QuestionAction::Resolve(QuestionOutcome::Answered { answers }) =
+            overlay.key(key(KeyCode::Enter))
+        else {
+            panic!("submit");
+        };
+        assert_eq!(answers.len(), 2, "one answer per question asked");
+        assert_eq!(answers[0].chosen, vec!["Session cookie"]);
+        assert!(
+            answers[1].chosen.is_empty(),
+            "an unanswered question reports as unanswered, not as absent"
+        );
+    }
+
+    /// The free-text row prompts for words, and those words are the answer —
+    /// the deck's form of the escape the runtime appends everywhere.
+    #[test]
+    fn the_free_text_row_takes_the_answerers_own_words() {
+        let mut overlay = open(vec![question("Auth", false)]);
+        // Two options, so row 2 is the appended free-text row.
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Down));
+        assert_eq!(overlay.key(key(KeyCode::Enter)), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::FreeText);
+        typing(&mut overlay, "reuse the gateway's mTLS");
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(
+            overlay.answers()[0].chosen,
+            vec!["reuse the gateway's mTLS"]
+        );
+    }
+
+    /// Free text and an option are one decision: taking either retires the
+    /// other, so an answer never reports both.
+    #[test]
+    fn choosing_an_option_retires_a_free_text_answer() {
+        let mut overlay = open(vec![question("Auth", true)]);
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Enter));
+        typing(&mut overlay, "something else");
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(overlay.answers()[0].chosen, vec!["something else"]);
+
+        // Now pick a real option.
+        overlay.key(key(KeyCode::Up));
+        overlay.key(key(KeyCode::Up));
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(
+            overlay.answers()[0].chosen,
+            vec!["Session cookie"],
+            "the free-text answer was replaced, not appended to"
+        );
+    }
+
+    /// "Chat about this instead" defers with the driver's words — a distinct
+    /// outcome from cancelling, which is what lets the model tell "the
+    /// options were the wrong shape" from "no answer is coming".
+    #[test]
+    fn chatting_about_it_defers_with_their_words() {
+        let mut overlay = open(vec![question("Auth", false)]);
+        overlay.key(key(KeyCode::Enter)); // pick
+        overlay.key(key(KeyCode::Char('r'))); // → review
+        overlay.key(key(KeyCode::Down)); // → chat
+        assert_eq!(overlay.key(key(KeyCode::Enter)), QuestionAction::Handled);
+        assert_eq!(overlay.mode, QuestionMode::Chat);
+        typing(&mut overlay, "the options miss the shared-gateway case");
+        let QuestionAction::Resolve(QuestionOutcome::Deferred { note }) =
+            overlay.key(key(KeyCode::Enter))
+        else {
+            panic!("chat must defer");
+        };
+        assert_eq!(note, "the options miss the shared-gateway case");
+    }
+
+    /// A closed overlay declines every key, so the caller may route keys to
+    /// it unconditionally and ahead of everything else.
+    #[test]
+    fn a_closed_overlay_claims_nothing() {
+        let mut overlay = QuestionOverlay::default();
+        assert!(!overlay.is_open());
+        for code in [KeyCode::Esc, KeyCode::Enter, KeyCode::Char('n')] {
+            assert_eq!(overlay.key(key(code)), QuestionAction::Ignored);
+        }
+    }
+
+    /// Withdrawing takes the card down and forgets the working answers — a
+    /// question whose broker timed out must not leave a card offering to
+    /// resolve a oneshot nobody is holding.
+    #[test]
+    fn closing_forgets_the_working_answers() {
+        let mut overlay = open(vec![question("Auth", false)]);
+        overlay.key(key(KeyCode::Enter));
+        overlay.close();
+        assert!(!overlay.is_open());
+        assert!(overlay.answers().is_empty());
+
+        // Re-opening starts clean rather than inheriting the last card's picks.
+        overlay.open(QuestionRequest {
+            asker: None,
+            questions: vec![question("Auth", false)],
+        });
+        assert!(overlay.answers()[0].chosen.is_empty());
+    }
+
+    /// Every question's row cursor is clamped to its own option count: a
+    /// question with fewer options than the one before it must not inherit an
+    /// out-of-range row (which `answers` would then read as no answer).
+    #[test]
+    fn moving_between_questions_lands_on_a_valid_row() {
+        let mut wide = question("Wide", false);
+        wide.options.push(QuestionOption {
+            label: "mTLS".into(),
+            description: String::new(),
+        });
+        let mut narrow = question("Narrow", false);
+        narrow.options.truncate(1);
+        let mut overlay = open(vec![wide, narrow]);
+
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Tab));
+        assert_eq!(overlay.focus, 1);
+        assert_eq!(overlay.row, 0, "a fresh question starts at its first row");
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(overlay.answers()[1].chosen, vec!["Session cookie"]);
+    }
+
+    /// The card names the sub-agent when one is asking. A driver answering a
+    /// fanned-out delegation who cannot see which child is asking is
+    /// answering a coin flip.
+    #[test]
+    fn a_sub_agents_question_says_whose_it_is() {
+        let spans = asker_context(Some("research-child"));
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("research-child"), "{text}");
+        assert!(text.contains("sub-agent"), "{text}");
+        assert!(
+            asker_context(None).is_empty(),
+            "a top-level turn needs no attribution chip"
+        );
+    }
+}

--- a/crates/stella-tui/src/views/question.rs
+++ b/crates/stella-tui/src/views/question.rs
@@ -490,32 +490,33 @@ pub fn render(overlay: &QuestionOverlay, area: Rect, buf: &mut Buffer) {
         QuestionMode::Review | QuestionMode::Chat => review_body(overlay),
         _ => question_body(overlay, request),
     };
+    let mut body = body;
+    // Attribution goes in the BODY, never the title row. It shares that row
+    // with the right-aligned key hints, and at this card's width the hints
+    // win: the first golden of this overlay rendered the chip as `fro`,
+    // silently amputating the one fact that tells a driver which fanned-out
+    // child is asking. A body row cannot be squeezed by a neighbour.
+    if let Some(row) = asker_row(request.asker.as_deref()) {
+        body.insert(0, row);
+        body.insert(1, Line::from(""));
+    }
     let rows = u16::try_from(body.len()).unwrap_or(u16::MAX);
     let card = cards::card_area(area, rows, QUESTION_CARD_W, false);
-    let inner = cards::card_frame(
-        card,
-        "question",
-        asker_context(request.asker.as_deref()),
-        hints(overlay.mode),
-        buf,
-    );
+    let inner = cards::card_frame(card, "question", Vec::new(), hints(overlay.mode), buf);
     cards::render_body(body, None, inner, buf);
 }
 
-/// The title's context spans: who is asking, when a sub-agent is.
+/// Who is asking, when a sub-agent is.
 ///
-/// Empty for a top-level turn — the driver's own agent needs no attribution,
-/// and a "(from the lead)" chip on every card would train the eye to skip the
-/// one place the answer matters.
-fn asker_context(asker: Option<&str>) -> Vec<Span<'static>> {
-    let dim = Style::new().fg(theme::TEXT_TERTIARY);
-    match asker {
-        Some(agent) => vec![Span::styled(
-            format!("from the `{agent}` sub-agent"),
-            dim,
-        )],
-        None => Vec::new(),
-    }
+/// `None` for a top-level turn — the driver's own agent needs no
+/// attribution, and a "from the lead" chip on every card would train the eye
+/// to skip the one place the answer matters.
+fn asker_row(asker: Option<&str>) -> Option<Line<'static>> {
+    let agent = asker?;
+    Some(Line::from(Span::styled(
+        format!("from the `{agent}` sub-agent"),
+        Style::new().fg(theme::TEXT_TERTIARY),
+    )))
 }
 
 /// The right-aligned key hints for the mode that owns the keyboard.
@@ -1023,13 +1024,13 @@ mod tests {
     /// answering a coin flip.
     #[test]
     fn a_sub_agents_question_says_whose_it_is() {
-        let spans = asker_context(Some("research-child"));
-        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        let row = asker_row(Some("research-child")).expect("a sub-agent is attributed");
+        let text: String = row.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("research-child"), "{text}");
         assert!(text.contains("sub-agent"), "{text}");
         assert!(
-            asker_context(None).is_empty(),
-            "a top-level turn needs no attribution chip"
+            asker_row(None).is_none(),
+            "a top-level turn needs no attribution row"
         );
     }
 }

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -756,6 +756,140 @@ fn deck_render_snapshots_pin_the_floating_cards() {
     }
 }
 
+/// The two questions the `ask_question` overlay fixtures are built from.
+///
+/// Deliberately unlike each other: the first is single-select with a
+/// description on one option and none on the other (so both option shapes are
+/// pinned in one frame), the second is multi-select (so the tab strip has a
+/// second entry and the `[x]` accumulation is reachable). The asker is a
+/// sub-agent, because the attribution chip is the half a driver answering a
+/// fanned-out delegation cannot do without — and a golden is the only thing
+/// that would notice it silently vanishing from the title row.
+fn fixture_question_request(count: usize) -> stella_protocol::QuestionRequest {
+    let questions = vec![
+        stella_protocol::Question {
+            header: "Auth method".into(),
+            question: "Which auth should the new endpoint use?".into(),
+            options: vec![
+                stella_protocol::QuestionOption {
+                    label: "Session cookie".into(),
+                    description: "Matches the rest of the app".into(),
+                },
+                stella_protocol::QuestionOption {
+                    label: "Bearer token".into(),
+                    description: String::new(),
+                },
+            ],
+            multi_select: false,
+        },
+        stella_protocol::Question {
+            header: "Rollout".into(),
+            question: "Which environments should it reach first?".into(),
+            options: vec![
+                stella_protocol::QuestionOption {
+                    label: "staging".into(),
+                    description: "the usual soak".into(),
+                },
+                stella_protocol::QuestionOption {
+                    label: "canary".into(),
+                    description: String::new(),
+                },
+            ],
+            multi_select: true,
+        },
+    ];
+    stella_protocol::QuestionRequest {
+        asker: Some("research-child".into()),
+        questions: questions.into_iter().take(count).collect(),
+    }
+}
+
+/// Golden frames for the `ask_question` overlay (#4220) — the wizard a
+/// **parked turn** waits on.
+///
+/// This overlay earns goldens more than most: it is the one surface where a
+/// layout regression costs a decision rather than a glance. Every affordance
+/// it offers is drawn as a glyph — `▸` selection, `[x]`/`[ ]` choice,
+/// `●`/`○` per-question progress, the `▏` editor caret — specifically so a
+/// style-stripped golden can pin all of them. A `[x]` that stops rendering,
+/// or a tab strip that loses the question it is on, is a driver answering the
+/// wrong question, and neither shows up in a `contains` assertion.
+#[test]
+fn deck_render_snapshots_pin_the_question_overlay() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let model = fixture_model();
+    let press = |ui: &mut DeckUi, code: KeyCode| {
+        ui.question.key(KeyEvent::new(code, KeyModifiers::NONE));
+    };
+
+    // 1. One question, nothing chosen yet — the card as it first appears.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.question.open(fixture_question_request(1));
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_question_single",
+        "one parked question, freshly raised — options, the appended free-text row, the asker chip",
+        W,
+        H,
+        &frame,
+    );
+
+    // 2. Two questions, the first answered — so the tab strip shows both and
+    //    marks which one is settled.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.question.open(fixture_question_request(2));
+    press(&mut ui, KeyCode::Enter);
+    press(&mut ui, KeyCode::Tab);
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_question_tabstrip",
+        "two questions, the first answered — the tab strip, on the multi-select second",
+        W,
+        H,
+        &frame,
+    );
+
+    // 3. The note editor open over a chosen option — the affordance the plain
+    //    TTY spells ` # note`.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.question.open(fixture_question_request(1));
+    press(&mut ui, KeyCode::Down);
+    press(&mut ui, KeyCode::Enter);
+    press(&mut ui, KeyCode::Char('n'));
+    for c in "only for the admin routes".chars() {
+        press(&mut ui, KeyCode::Char(c));
+    }
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_question_note",
+        "the note editor open on a chosen option, mid-typing",
+        W,
+        H,
+        &frame,
+    );
+
+    // 4. The review pane: the whole answer set, then the three ways out.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.question.open(fixture_question_request(2));
+    press(&mut ui, KeyCode::Enter);
+    press(&mut ui, KeyCode::Char('n'));
+    for c in "admin routes only".chars() {
+        press(&mut ui, KeyCode::Char(c));
+    }
+    press(&mut ui, KeyCode::Enter);
+    press(&mut ui, KeyCode::Tab);
+    press(&mut ui, KeyCode::Enter);
+    press(&mut ui, KeyCode::Char('r'));
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_question_review",
+        "the review pane — every answer with its note, then submit / chat / cancel",
+        W,
+        H,
+        &frame,
+    );
+}
+
 // ─────────────────────────── the harness itself ───────────────────────────
 
 /// The suite's own guard: rendering the same fixture twice must produce the

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -888,6 +888,23 @@ fn deck_render_snapshots_pin_the_question_overlay() {
         H,
         &frame,
     );
+
+    // 5. Accessible mode spans the card across the frame instead of floating
+    //    it. A float clips its rows at its right border, and this is the one
+    //    overlay where a half-heard option is a decision made on half the
+    //    facts — so the widening gets a golden of its own rather than living
+    //    on a `ui.accessible` nobody would notice going missing.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.accessible = true;
+    ui.question.open(fixture_question_request(1));
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_question_accessible",
+        "accessible mode — the card spans the frame, so no option is clipped",
+        W,
+        H,
+        &frame,
+    );
 }
 
 // ─────────────────────────── the harness itself ───────────────────────────

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_question_accessible
+# accessible mode — the card spans the frame, so no option is clipped
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+· subagent sub:auth · status needs input · elapsed 5:12
+· model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+· last tool search_code trigger
+· returns wire automations triggers API → lead inbox
+· subagent sub:ci · status running · elapsed 5:12
+· model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+· last tool none yet
+· returns watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ PLAN ○ pending approval 0/3 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│Refactor the automations store into a shared workspace package                                                                                                │
+│○ 1. extract types                                                                                                                                            │
+│  +2 more                                                                                                                                                     │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── /plan reads it ┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                                                              │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                                                        │
+│                                                                                                                                                              │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│
+┌ question ──────────────────────────────────────────────────────────────────────────────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐
+│from the `research-child` sub-agent                                                                                                                           │
+│                                                                                                                                                              │
+│Which auth should the new endpoint use?                                                                                                                       │
+│                                                                                                                                                              │
+│▸ [ ] Session cookie — Matches the rest of the app                                                                                                            │
+│  [ ] Bearer token                                                                                                                                            │
+│  [ ] Type your own answer                                                                                                                                    │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_question_note
+# the note editor open on a chosen option, mid-typing
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││                                      │
+│                                         ┌ question ───────────────────────────────────── ⏎ save note · esc discard ┐ ││                                      │
+│── EXECUTE ──────────────────────────────│from the `research-child` sub-agent                                       │─││                                      │
+│                                         │                                                                          │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │Which auth should the new endpoint use?                                   │ ││                                      │
+│ │ ⎿ 312 lines                           │                                                                          │s││                                      │
+│                                         │  [ ] Session cookie — Matches the rest of the app                        │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │  [x] Bearer token                                                        │ ││                                      │
+│                                         │  [ ] Type your own answer                                                │ ││                                      │
+│⏸ plan  Refactor the automations store in│                                                                          │ ││                                      │
+│                                         │  note: only for the admin routes▏                                        │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_question_review
+# the review pane — every answer with its note, then submit / chat / cancel
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ─────────────────────────────────┌ question ────────────────────── ↑↓ move · ⏎ choose · ⇥ back · esc cancel ┐─││○ 2. move hooks                       │
+│                                         │from the `research-child` sub-agent                                       │ ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list,│                                                                          │ ││                                      │
+│                                         │Review your answers                                                       │ ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API   │                                                                          │ ││                                      │
+│                                         │  • Which auth should the new endpoint use?                               │ ││                                      │
+│── EXECUTE ──────────────────────────────│      → Session cookie                                                    │─││                                      │
+│                                         │        note: admin routes only                                           │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⎿ 312 lines                           │  • Which environments should it reach first?                             │s││                                      │
+│                                         │      → staging                                                           │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │
+│                                         │▸ Submit answers                                                          │ ││                                      │
+│⏸ plan  Refactor the automations store in│  Chat about this instead                                                 │ ││                                      │
+│                                         │  Cancel — no answer                                                      │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_question_single
+# one parked question, freshly raised — options, the appended free-text row, the asker chip
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
+│                                         ┌ question ──── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │from the `research-child` sub-agent                                       │ ││                                      │
+│ │ ⎿ 312 lines                           │                                                                          │s││                                      │
+│                                         │Which auth should the new endpoint use?                                   │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │
+│                                         │▸ [ ] Session cookie — Matches the rest of the app                        │ ││                                      │
+│⏸ plan  Refactor the automations store in│  [ ] Bearer token                                                        │ ││                                      │
+│                                         │  [ ] Type your own answer                                                │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_question_tabstrip
+# two questions, the first answered — the tab strip, on the multi-select second
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API   ┌ question ──── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐ ││                                      │
+│                                         │from the `research-child` sub-agent                                       │ ││                                      │
+│── EXECUTE ──────────────────────────────│                                                                          │─││                                      │
+│                                         │● Auth method  ○ Rollout                                                  │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⎿ 312 lines                           │[2/2] Which environments should it reach first?                           │s││                                      │
+│                                         │several answers may be chosen                                             │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │
+│                                         │▸ [ ] staging — the usual soak                                            │ ││                                      │
+│⏸ plan  Refactor the automations store in│  [ ] canary                                                              │ ││                                      │
+│                                         │  [ ] Type your own answer                                                │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
The Command Deck is Stella's default interactive shell on a TTY, and it was
the one interactive surface that could not ask a human anything mid-turn.
Both mid-turn asks dead-ended on it: an `ask_question` resolved to the
headless "no driver is attached — make the call yourself" decline, and a
gate's `RequireApproval` refused with the grant-path message. Honest in both
cases, and not the feature.

`rules.rs` had been saying so in passing for a while — "the deck until it
grows an approval card". This grows it.

Built on the `ask_question` port #4225 landed; rebased onto `main` after
that merged.

## What landed

**`crates/stella-tui/src/views/question.rs` — the overlay (new file).** A
pure fold, like every other overlay in `views/`: `key()` takes a keystroke and
returns what it did, `render()` paints the state, and neither touches a
channel, a clock, or the filesystem. Keys match the plain-TTY responder's
affordances one for one — ↑/↓ over options, ⇥/⇧⇥ across the tab strip, `n` for
the note editor, the appended free-text row as the last selectable row, and a
review pane with submit / chat-about-this / cancel.

**`Inbound::QuestionAsked` / `QuestionWithdrawn` and
`WorkspaceInput::QuestionAnswered`** — the round trip. The whole
`QuestionOutcome` travels back, not just the answers: `Deferred` ("the options
are the wrong shape") and `Declined` (cancelled) are things the asking model
acts on differently, and collapsing them would tell it the same thing three
ways.

**`crates/stella-cli/src/command_deck/mid_turn_ask.rs` (new file)** — both
deck-backed responders. The question half raises the overlay and parks; the
approval half reuses the deck's existing `AskUser` card through the shared
`AskUserApprovalResponder`, so the approvals gap closes with the same
declaration rather than a second mechanism.

**`MidTurnAsk` replaces the `interactive_approvals` boolean.** This is the
part worth arguing about, so: a boolean can say *whether* a human is reachable
but not *how to reach them*, and the two surfaces that can reach one do it in
incompatible ways. `true` meant "attach the stdin-reading TTY responder", so
the deck — which owns the terminal in raw mode and would have fought that
reader for every keystroke — had no answer available but `false`. The issue
asks for `rules.rs` to "pass `true` for the deck"; passing `true` would attach
a stdin reader and then replace it, leaving a live landmine if the second
attach were ever reordered. `MidTurnAsk::{Headless, Tty, Surface}` lets the
deck say the true thing once. It stays one value consulted once, which is the
#3035 discipline the boolean was protecting.

`FREE_TEXT_LABEL` moves to `stella-protocol` beside the question types, because
two surfaces now render it and `stella-tui` cannot depend on `stella-cli`.

## Two defects the work surfaced

**The asker chip was being eaten by its own title row.** The first golden
rendered `from the \`research-child\` sub-agent` as **`fro`** — the title
shares its width with the right-aligned key hints, and the hints won. That is
precisely the fact a driver answering a fanned-out delegation cannot do
without, and no `contains` assertion would have seen it go. Attribution moved
to a body row, which no neighbour can squeeze.

**The overlay did not widen in accessible mode.** It hardcoded a float where
`budget`/`models`/`plan` all pass `ui.accessible`. A float clips its rows at
its right border, so a screen reader would never reach the end of a long
option — on the one overlay where the answer stops a turn. Fixed, with a
golden of its own.

## Evidence

**Witness — `select_then_note_then_submit_produces_the_answer_and_its_note`**
(`views/question.rs`). Drives the fold through select → note → submit and
asserts the `QuestionOutcome` that comes out carries both the chosen option
and its note. Genuinely absent on the base: the module does not exist there,
and every `ask_question` on the deck resolved to the headless decline.

**Four transport witnesses** (`command_deck/mid_turn_ask.rs`) cover the half a
pure fold cannot: the request reaches the deck and its answer comes back with
the note intact; **an abandoned wait withdraws the card** (the broker drops
the `respond` future at its 30-minute TTL, so a `Drop` guard is the only thing
that can take the card down — without it a driver types a considered answer
into a oneshot nobody is holding); a closed deck declines rather than
defaulting; a stranded answer from a cancelled turn does not resolve the next
question.

**Five golden frames** under `tests/snapshots/deck/`: the single question card,
the multi-question card with the tab strip, the note editor open, the review
pane, and accessible mode. Every affordance is drawn as a glyph — `▸`, `[x]`,
`●`/`○`, the `▏` caret — specifically so a style-stripped golden can pin them.
All five were read, not just blessed; two of them are why the defects above
are in this PR rather than in the tree.

**Gate**, re-run after the rebase onto post-#4225 `main`: `cargo test
--workspace` 8141 passed / 0 failed · workspace clippy
`-D warnings` clean · `make guards` all green · rustdoc `-D warnings` clean ·
`cargo fmt --check` clean.

## God files

`command_deck.rs`, `deck_ui.rs` and `deck_render.rs` are all closed to growth,
and the first pass pushed all three over their ceilings (+86 / +5 / +1). No
baseline was raised. The responders moved to their own module, and the overlay
took ownership of both directions of its own envelope contract
(`QuestionOverlay::ingest`) so the fold costs two lines in `deck_ui.rs`
instead of a dozen. `command_deck.rs` ends up **51 lines below** where it
started.

## Deleted tests

None.

## New dependencies

None.

Closes #4220

## Summary by Sourcery

Allow the Command Deck to park turns on human questions and approvals through dedicated interactive responders.

New Features:
- Enable the Command Deck to pause turns for interactive agent questions, including option selection, free-text responses, notes, review, and cancellation.
- Support Command Deck-backed approval prompts through the existing approval card flow.

Bug Fixes:
- Prevent question attribution from being truncated by overlay title hints.
- Ensure question overlays use accessible sizing so long options are not clipped.

Enhancements:
- Replace the mid-turn interaction boolean with an explicit headless, TTY, or surface responder configuration.
- Move the shared free-text answer label into the protocol crate for reuse across interactive surfaces.

Tests:
- Add unit, transport, and golden-render coverage for question interaction, cancellation, stale responses, card withdrawal, attribution, and accessible layouts.