### PR TITLE
feat(stella-tui,stella-cli): the deck's approval card shows the request, not a sentence about it

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -77,6 +77,7 @@ use stella_store::Store;
 use stella_tools::ToolRegistry;
 use stella_tools::custom::CustomTool;
 use stella_tools::hook_runner::ShellHookRunner;
+use stella_tools::registry::approval::ApprovalResponse;
 use stella_tui::{
     AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityField, EntityHit, Inbound, SkillOp,
     SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
@@ -350,6 +351,7 @@ pub async fn run_deck_session(
     let (sub_tx, mut sub_rx) = mpsc::unbounded_channel::<WorkspaceInput>();
     let (ask_tx, ask_rx) = mpsc::unbounded_channel::<String>();
     let (question_tx, question_rx) = mpsc::unbounded_channel::<QuestionOutcome>();
+    let (approval_tx, approval_rx) = mpsc::unbounded_channel::<ApprovalResponse>();
 
     crate::subagent::install_for_session(cfg, &registry)?;
     // The deck can park a turn on a human, so it declares a surface rather
@@ -360,8 +362,13 @@ pub async fn run_deck_session(
     // Neither may be the plain-TTY responder — the deck holds the terminal
     // in raw mode, and a blocking stdin read behind its render loop would
     // fight it for every keystroke.
-    let (mid_turn_posture, ask_io) =
-        mid_turn_ask::surface(LEAD.to_string(), in_tx.clone(), ask_rx, question_rx);
+    let (mid_turn_posture, ask_io) = mid_turn_ask::surface(
+        LEAD.to_string(),
+        in_tx.clone(),
+        ask_rx,
+        approval_rx,
+        question_rx,
+    );
     let active_rules = rules::enforce_workspace_rules(
         &registry,
         &cfg.workspace_root,
@@ -1643,6 +1650,12 @@ pub async fn run_deck_session(
                         // what unblocks the tool call and the turn behind it.
                         Some(WorkspaceInput::QuestionAnswered(outcome)) => {
                             let _ = question_tx.send(*outcome);
+                        }
+                        // The decided approval card: hand the response to the
+                        // parked `DeckApprovalResponder`, which is what
+                        // releases (or refuses) the gated dispatch.
+                        Some(WorkspaceInput::ApprovalAnswered(response)) => {
+                            let _ = approval_tx.send(*response);
                         }
                         // A hunk decision answers no card this driver raises —
                         // journal replays can render the card, but nothing

--- a/crates/stella-cli/src/command_deck/mid_turn_ask.rs
+++ b/crates/stella-cli/src/command_deck/mid_turn_ask.rs
@@ -8,11 +8,16 @@
 //! together as one [`crate::rules::MidTurnAsk::Surface`] at session assembly:
 //!
 //! - an **approval** (#2676): a gate decided a call needs a human yes/no, so
-//!   [`DeckAskUserIo`] raises the deck's existing `AskUser` card and the
-//!   shared [`crate::approval::AskUserApprovalResponder`] reads the answer;
+//!   [`DeckApprovalResponder`] raises the #4240 card — every field of the
+//!   request as a field, `read_only` and `gate` included — and waits for the
+//!   driver's [`ApprovalResponse`];
 //! - a **question** (#4212): an agent cannot make a decision itself, so
 //!   [`DeckQuestionResponder`] raises the #4220 overlay and waits for the
 //!   whole [`QuestionOutcome`] the fold produces.
+//!
+//! [`DeckAskUserIo`] is here too, but it is no longer either of them: it
+//! backs the deck's *generic* `AskUser` card, which slash commands
+//! (`/init`'s confirmations) still ask through.
 //!
 //! # Why the deck cannot use the plain-TTY responders
 //!
@@ -24,9 +29,14 @@
 //! "no driver is attached" decline (#4220).
 //!
 //! Everything here is transport. No decision about what a driver may do
-//! lives in this file: the overlay's fold
-//! (`stella_tui::views::question`) owns those, and is unit-tested without a
+//! lives in this file: the folds (`stella_tui::views::question` and
+//! `stella_tui::views::approval`) own those, and are unit-tested without a
 //! terminal.
+//!
+//! The one invariant this file does carry is the **direction of failure**.
+//! An approval that cannot be answered — closed deck, dropped wait, stranded
+//! decision — denies. No path here produces an `Approve` the driver did not
+//! choose.
 //!
 //! # This module is deliberately separate from `command_deck.rs`
 //!
@@ -43,6 +53,8 @@ use stella_protocol::{AgentEvent, QuestionOutcome, QuestionRequest, ToolOutput};
 use stella_tui::Inbound;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
+use stella_tools::registry::approval::{ApprovalRequest, ApprovalResponse};
+
 use crate::interactive::{AskUserIo, FREE_TEXT_LABEL};
 
 /// Ids for the cards [`DeckAskUserIo`] mints (`deck-ask-N`). Process-unique
@@ -51,33 +63,37 @@ use crate::interactive::{AskUserIo, FREE_TEXT_LABEL};
 static NEXT_DECK_ASK: AtomicU64 = AtomicU64::new(0);
 
 /// Both of the deck's mid-turn ask responders, as the one posture
-/// `enforce_workspace_rules` consumes — plus the [`DeckAskUserIo`] behind
-/// the approvals half, which the caller also needs.
+/// `enforce_workspace_rules` consumes — plus the [`DeckAskUserIo`] the
+/// caller also needs for its slash commands.
 ///
-/// One constructor rather than two exported types, because they are one
+/// One constructor rather than three exported types, because they are one
 /// declaration: a surface that can park a call on a yes/no is exactly a
 /// surface that can park one on a question, and handing them out separately
 /// would let a caller arm half of it.
 ///
 /// The io comes back because slash commands ask their own questions through
-/// the same card (`/init`'s confirmations), and it must be the **same** io —
-/// it holds the receiver, and a second one built over a clone of the channel
-/// would race it for every answer.
+/// the generic `AskUser` card (`/init`'s confirmations), and it must be the
+/// **same** io — it holds the receiver, and a second one built over a clone
+/// of the channel would race it for every answer. Note it is no longer what
+/// answers *approvals*: #4240 gave those their own card, because the generic
+/// one flattened a five-field `ApprovalRequest` into a line of prose.
 pub(crate) fn surface(
     agent: String,
     inbound: UnboundedSender<Inbound>,
-    approvals: UnboundedReceiver<String>,
+    asks: UnboundedReceiver<String>,
+    approvals: UnboundedReceiver<ApprovalResponse>,
     questions: UnboundedReceiver<QuestionOutcome>,
 ) -> (crate::rules::MidTurnAsk, DeckAskUserIo) {
     let ask_io = DeckAskUserIo {
         agent,
         inbound: inbound.clone(),
-        answers: Arc::new(tokio::sync::Mutex::new(approvals)),
+        answers: Arc::new(tokio::sync::Mutex::new(asks)),
     };
     let posture = crate::rules::MidTurnAsk::Surface {
-        approval: Arc::new(crate::approval::AskUserApprovalResponder::new(Box::new(
-            ask_io.clone(),
-        ))),
+        approval: Arc::new(DeckApprovalResponder {
+            inbound: inbound.clone(),
+            answers: Arc::new(tokio::sync::Mutex::new(approvals)),
+        }),
         question: Arc::new(DeckQuestionResponder {
             inbound,
             answers: Arc::new(tokio::sync::Mutex::new(questions)),
@@ -158,6 +174,54 @@ impl AskUserIo for DeckAskUserIo {
     }
 }
 
+/// [`ApprovalResponder`][a] over the deck's channels (#4240): raise the
+/// approval card, park until the driver decides, take the card down.
+///
+/// Replaces wrapping [`DeckAskUserIo`] in the shared
+/// [`crate::approval::AskUserApprovalResponder`], which worked but had to
+/// flatten a five-field [`ApprovalRequest`] into one line of prose — losing
+/// `read_only` and `gate` entirely on the way to the person deciding.
+/// Handing the whole request to the card keeps every field a field.
+///
+/// **Denies on every path that is not an explicit approval**: a closed deck,
+/// a dropped wait, a card the driver dismissed. There is no arm here that
+/// produces [`ApprovalResponse::Approve`] without the driver having chosen
+/// it, and that is the property to preserve if this is ever edited.
+///
+/// [a]: stella_tools::registry::approval::ApprovalResponder
+pub(crate) struct DeckApprovalResponder {
+    pub(crate) inbound: UnboundedSender<Inbound>,
+    pub(crate) answers: Arc<tokio::sync::Mutex<UnboundedReceiver<ApprovalResponse>>>,
+}
+
+#[async_trait]
+impl stella_tools::registry::approval::ApprovalResponder for DeckApprovalResponder {
+    async fn respond(&self, request: &ApprovalRequest) -> ApprovalResponse {
+        let mut answers = self.answers.lock().await;
+        // Drop decisions stranded by a cancelled turn — they answer a card
+        // that no longer exists, and reading one here would let a stale
+        // "allow" approve a call the driver never saw.
+        while answers.try_recv().is_ok() {}
+
+        let _withdraw = WithdrawOnDrop {
+            inbound: self.inbound.clone(),
+            withdraw: Inbound::ApprovalWithdrawn,
+        };
+        let _ = self
+            .inbound
+            .send(Inbound::ApprovalAsked(Box::new(request.clone())));
+
+        match answers.recv().await {
+            Some(response) => response,
+            // The deck went away mid-approval. Deny, naming the cause —
+            // never approve on silence.
+            None => ApprovalResponse::Deny {
+                reason: "the deck closed before the approval was answered".to_string(),
+            },
+        }
+    }
+}
+
 /// [`QuestionResponder`][r] over the deck's channels (#4220): raise the question
 /// overlay, park until the driver settles it, take the card down.
 ///
@@ -179,20 +243,27 @@ pub(crate) struct DeckQuestionResponder {
     pub(crate) answers: Arc<tokio::sync::Mutex<UnboundedReceiver<QuestionOutcome>>>,
 }
 
-/// Takes the card down however the wait ends.
+/// Takes a card down however its wait ends — `withdraw` is the envelope for
+/// whichever card is up.
 ///
 /// A `Drop` guard rather than a line at each exit, because the exit that
-/// matters is the one with no line to put it on: at the 30-minute
-/// `DEFAULT_QUESTION_TTL` the broker's `timeout` drops the `respond` future
-/// where it stands, and no code in this file runs again. Without this the
-/// deck would keep a live-looking card up over a turn that had already given
-/// up on it, and a driver's considered answer would go into a oneshot nobody
-/// was holding.
-struct WithdrawOnDrop(UnboundedSender<Inbound>);
+/// matters is the one with no line to put it on: at its TTL the broker's
+/// `timeout` drops the `respond` future where it stands, and no code in this
+/// file runs again. Without this the deck would keep a live-looking card up
+/// over a call that had already given up on it, and a driver's considered
+/// answer would go into a oneshot nobody was holding.
+///
+/// Both TTLs need it and they are far apart — thirty minutes for a question,
+/// two for an approval — so the approval card is the one a driver is far more
+/// likely to watch expire.
+struct WithdrawOnDrop {
+    inbound: UnboundedSender<Inbound>,
+    withdraw: Inbound,
+}
 
 impl Drop for WithdrawOnDrop {
     fn drop(&mut self) {
-        let _ = self.0.send(Inbound::QuestionWithdrawn);
+        let _ = self.inbound.send(self.withdraw.clone());
     }
 }
 
@@ -205,7 +276,10 @@ impl stella_tools::registry::question::QuestionResponder for DeckQuestionRespond
         // would resolve it without the driver having looked at it.
         while answers.try_recv().is_ok() {}
 
-        let _withdraw = WithdrawOnDrop(self.inbound.clone());
+        let _withdraw = WithdrawOnDrop {
+            inbound: self.inbound.clone(),
+            withdraw: Inbound::QuestionWithdrawn,
+        };
         let _ = self
             .inbound
             .send(Inbound::QuestionAsked(Box::new(request.clone())));
@@ -229,10 +303,136 @@ mod tests {
     use std::time::Duration;
 
     use stella_protocol::{Answer, Question, QuestionOption};
+    use stella_tools::registry::approval::ApprovalResponder as _;
     use stella_tools::registry::question::QuestionResponder as _;
     use tokio::sync::mpsc;
 
     use super::*;
+
+    fn approval_request() -> ApprovalRequest {
+        ApprovalRequest {
+            tool: "bash".into(),
+            read_only: false,
+            reason: "matched rule no-destructive-shell".into(),
+            gate: "command.started".into(),
+            subject: Some("rm -rf build/".into()),
+        }
+    }
+
+    fn approval_responder() -> (
+        DeckApprovalResponder,
+        mpsc::UnboundedReceiver<Inbound>,
+        mpsc::UnboundedSender<ApprovalResponse>,
+    ) {
+        let (in_tx, in_rx) = mpsc::unbounded_channel();
+        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        (
+            DeckApprovalResponder {
+                inbound: in_tx,
+                answers: Arc::new(tokio::sync::Mutex::new(out_rx)),
+            },
+            in_rx,
+            out_tx,
+        )
+    }
+
+    /// **The #4240 witness.** The whole structured request reaches the deck —
+    /// `read_only` and `gate` included, the two fields the generic `AskUser`
+    /// card could not carry — and the driver's decision comes back.
+    #[tokio::test]
+    async fn the_whole_approval_request_reaches_the_card() {
+        let (responder, mut inbound, decisions) = approval_responder();
+        let ask = approval_request();
+        let deciding = tokio::spawn(async move { responder.respond(&ask).await });
+
+        let Some(Inbound::ApprovalAsked(carried)) = inbound.recv().await else {
+            panic!("the approval must reach the deck as a card");
+        };
+        assert_eq!(carried.tool, "bash");
+        assert!(
+            !carried.read_only,
+            "read_only must survive — it is what separates a read from a write, \
+             and the generic AskUser card dropped it entirely"
+        );
+        assert_eq!(
+            carried.gate, "command.started",
+            "the gate that raised the demand is what makes a deny defensible"
+        );
+        assert_eq!(carried.subject.as_deref(), Some("rm -rf build/"));
+
+        decisions
+            .send(ApprovalResponse::Deny {
+                reason: "use the staging bucket instead".into(),
+            })
+            .expect("the parked dispatch is still listening");
+
+        let ApprovalResponse::Deny { reason } = deciding.await.expect("settles") else {
+            panic!("the driver denied");
+        };
+        assert_eq!(reason, "use the staging bucket instead");
+    }
+
+    /// **The safety property, at the transport layer.** Every way the wait
+    /// can fail denies. There is no path to `Approve` the driver did not
+    /// choose — and an approval that defaulted open would run the exact call
+    /// a gate stopped.
+    #[tokio::test]
+    async fn every_failed_approval_wait_denies() {
+        // A closed deck.
+        let (responder, _inbound, decisions) = approval_responder();
+        drop(decisions);
+        assert!(
+            matches!(
+                responder.respond(&approval_request()).await,
+                ApprovalResponse::Deny { .. }
+            ),
+            "a closed deck must deny"
+        );
+
+        // A decision stranded by a cancelled turn must not answer the next
+        // card — least of all a stale `Approve`.
+        let (responder, mut inbound, decisions) = approval_responder();
+        decisions
+            .send(ApprovalResponse::Approve)
+            .expect("queued before anyone asked");
+        let ask = approval_request();
+        let deciding = tokio::spawn(async move { responder.respond(&ask).await });
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::ApprovalAsked(_))),
+            "the stale approve must not have short-circuited the ask"
+        );
+        decisions
+            .send(ApprovalResponse::Deny {
+                reason: "the real answer".into(),
+            })
+            .expect("still listening");
+        let ApprovalResponse::Deny { reason } = deciding.await.expect("settles") else {
+            panic!("the live decision is the one that counts");
+        };
+        assert_eq!(reason, "the real answer");
+    }
+
+    /// The approval card comes down when its wait is abandoned, exactly like
+    /// the question overlay's. Its TTL is `DEFAULT_APPROVAL_TTL` — two
+    /// minutes, not thirty — so this is the card a driver is far more likely
+    /// to watch expire.
+    #[tokio::test]
+    async fn an_abandoned_approval_withdraws_the_card() {
+        let (responder, mut inbound, _decisions) = approval_responder();
+        let ask = approval_request();
+        let timed_out = tokio::time::timeout(Duration::from_millis(30), responder.respond(&ask))
+            .await
+            .is_err();
+        assert!(timed_out, "nobody decided, so the wait must expire");
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::ApprovalAsked(_))),
+            "the card went up"
+        );
+        assert!(
+            matches!(inbound.recv().await, Some(Inbound::ApprovalWithdrawn)),
+            "and must come down again when the wait is abandoned"
+        );
+    }
 
     fn request() -> QuestionRequest {
         QuestionRequest {

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -170,6 +170,11 @@ async fn main() -> std::io::Result<()> {
                 WorkspaceInput::QuestionAnswered(_) => {
                     let _ = react_tx.send(Inbound::QuestionWithdrawn);
                 }
+                // Likewise for a settled approval: no real dispatch is parked
+                // here, so the demo just takes the card down.
+                WorkspaceInput::ApprovalAnswered(_) => {
+                    let _ = react_tx.send(Inbound::ApprovalWithdrawn);
+                }
                 // Queue edits are already reflected in the deck's local queue
                 // (the shell's out-of-band echo); a real engine would also
                 // drop the prompt from its own backlog here.

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -752,6 +752,10 @@ impl WorkspaceModel {
             // there for good if the answer never comes.
             | Inbound::QuestionAsked(_)
             | Inbound::QuestionWithdrawn
+            // Same for a parked approval: a gate demanding a yes/no is not
+            // speech either, and the call it gates has not run.
+            | Inbound::ApprovalAsked(_)
+            | Inbound::ApprovalWithdrawn
             | Inbound::Splash(_)
             // The whole point of `Notice`: a system notification is not agent
             // or user speech, so the fold must NOT give it a transcript row.

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -195,14 +195,8 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // (The former ENGINE overlay is gone: the engine panel is the full-width
     // body of the SETTINGS tab — see `views::settings::render`.)
 
-    // The parked question (#4220): above the cards, below help — a user may
-    // need to read what a key does before answering, but nothing else may
-    // cover the one overlay a turn is stopped on.
-    if ui.question.is_open() {
-        guarded_overlay(buf, area, "question", |b| {
-            views::question::render(&ui.question, ui.accessible, area, b)
-        });
-    }
+    // The parked asks (#4220, #4240) — see `parked` for the stacking rule.
+    parked::render(ui, area, buf);
 
     // Startup system notifications: a transient dialog over the deck, drawn
     // last but one so help — which the user asked for — still wins the top.
@@ -226,9 +220,9 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // notice is deliberately excluded: it is non-modal, and a key still
     // reaches the composer while it's showing (see `handle_key`).
     let overlay_owns_keyboard = ui.help_open
-        // A parked question is claimed ahead of everything else in
-        // `handle_key_inner`, so it owns the keyboard whenever it is up.
-        || ui.question.is_open()
+        // Both parked asks are claimed ahead of everything else in
+        // `handle_key_inner`, so either owns the keyboard while it is up.
+        || parked::owns_keyboard(ui)
         || ui.queue_open
         || ui.graph_picker_open
         || ui.sessions_open
@@ -1513,6 +1507,8 @@ fn render_help(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
         .scroll((window.start as u16, 0))
         .render(inner, buf);
 }
+
+mod parked;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-tui/src/deck_render/parked.rs
+++ b/crates/stella-tui/src/deck_render/parked.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Drawing for the **parked asks** — the question overlay (#4220) and the
+//! approval card (#4240), the two surfaces that each hold a live tool call
+//! open while they are up.
+//!
+//! The render counterpart to `deck_ui::parked`, and its own module
+//! for the same reason: `deck_render.rs` is a god file closed to growth
+//! (`scripts/file-size-baseline.txt`).
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+use crate::deck_ui::DeckUi;
+use crate::views;
+
+/// Draw whichever parked asks are up.
+///
+/// Called above the floating cards and below help — a driver may need to
+/// read what a key does before answering, but nothing else may cover an
+/// overlay a turn is stopped on.
+///
+/// **The approval card draws last, so it lands on top.** That mirrors
+/// `deck_ui::parked::handle_key`, which gives it the keyboard first: a card
+/// taking the keys while sitting *under* another card would leave the driver
+/// typing into something they cannot see.
+pub(super) fn render(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    if ui.question.is_open() {
+        super::guarded_overlay(buf, area, "question", |b| {
+            views::question::render(&ui.question, ui.accessible, area, b)
+        });
+    }
+    if ui.approval.is_open() {
+        super::guarded_overlay(buf, area, "approval", |b| {
+            views::approval::render(&ui.approval, ui.accessible, area, b)
+        });
+    }
+}
+
+/// Whether either parked ask is up, and so owns the keyboard.
+///
+/// Read by `render_deck`'s cursor-suppression rule: the hardware caret must
+/// not sit in the composer while the driver is answering a card.
+pub(super) fn owns_keyboard(ui: &DeckUi) -> bool {
+    ui.question.is_open() || ui.approval.is_open()
+}

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -788,6 +788,11 @@ pub struct DeckUi {
     /// nothing else in this struct holds a live tool call open, which is why
     /// it wins the keyboard over every other modal here.
     pub question: crate::views::question::QuestionOverlay,
+    /// The approval card (#4240): the yes/no a parked **dispatch** waits on.
+    /// Outranks `question` for the keyboard — a call about to execute is a
+    /// tighter gate than a decision being deliberated, and its TTL is two
+    /// minutes against the question's thirty.
+    pub approval: crate::views::approval::ApprovalOverlay,
 }
 
 impl Default for DeckUi {
@@ -868,6 +873,7 @@ impl Default for DeckUi {
             engine: crate::views::engine::EngineOverlay::default(),
             tools: crate::views::tools::ToolsOverlay::default(),
             question: crate::views::question::QuestionOverlay::default(),
+            approval: crate::views::approval::ApprovalOverlay::default(),
         }
     }
 }
@@ -1200,7 +1206,7 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
     // state, deliberately never folded into the transcript. Nothing has been
     // *said* yet — the turn is stopped waiting — and writing an unanswered
     // question into the history would leave one there if the answer never came.
-    if ui.question.ingest(inbound) {
+    if ui.question.ingest(inbound) || ui.approval.ingest(inbound) {
         return;
     }
     // `/help` from the driver opens the same overlay the `?` key opens. Reset
@@ -1512,6 +1518,7 @@ pub mod cards;
 mod create;
 pub mod dispatch;
 mod gates;
+mod parked;
 /// Esc-with-something-to-say — see [`steer`].
 mod steer;
 pub use gates::HunkMarks;
@@ -1536,18 +1543,11 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
         return DeckAction::Ignored;
     }
 
-    // A parked question outranks every other modal here, including the
-    // routing card below: it is the only one holding a live tool call open,
-    // and a turn that is stopped waiting for an answer cannot make progress
-    // on any key that is not that answer. Like the routing card it declines
-    // Ctrl-C, so the quit branch below still fires.
-    match ui.question.key(key) {
-        crate::views::question::QuestionAction::Ignored => {}
-        crate::views::question::QuestionAction::Handled => return DeckAction::Handled,
-        crate::views::question::QuestionAction::Resolve(outcome) => {
-            ui.question.close();
-            return DeckAction::Send(WorkspaceInput::QuestionAnswered(Box::new(outcome)));
-        }
+    // The parked asks (#4220, #4240) outrank every other modal here, the
+    // routing card below included — see `parked` for why, and for why
+    // approval is asked before question.
+    if let Some(action) = parked::handle_key(key, ui) {
+        return action;
     }
 
     // The routing card owns every key while it is up — it is holding the

--- a/crates/stella-tui/src/deck_ui/parked.rs
+++ b/crates/stella-tui/src/deck_ui/parked.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Key routing for the **parked asks** — the two overlays that each hold a
+//! live tool call open while they are up (#4220, #4240).
+//!
+//! They are claimed ahead of every other modal on the deck, the routing card
+//! included, for a reason none of the others share: a turn stopped waiting
+//! for an answer cannot make progress on any key that is not that answer.
+//! Everything else the deck can be modal about — the queue editor, a config
+//! panel, help — is something the user opened while the session was free to
+//! keep running.
+//!
+//! Its own module rather than lines in `deck_ui.rs`, matching
+//! [`super::dispatch`] right beside it in the routing order, and because that
+//! file is a god file closed to growth (`scripts/file-size-baseline.txt`).
+
+use crossterm::event::KeyEvent;
+
+use crate::envelope::WorkspaceInput;
+use crate::views::approval::ApprovalAction;
+use crate::views::question::QuestionAction;
+
+use super::{DeckAction, DeckUi};
+
+/// Route `key` to whichever parked ask owns the keyboard.
+///
+/// `None` means neither is up (or the key was Ctrl-C, which both decline so
+/// the deck's quit branch still fires — [`super::dispatch::handle_key`]
+/// takes the same line for the same reason).
+///
+/// **Approval is asked first.** It gates a call that is about to execute,
+/// where a question is a decision still being deliberated; and its TTL is
+/// two minutes against the question's thirty, so it is also the one that
+/// expires out from under the driver if made to wait its turn. Rendering
+/// mirrors this — `deck_render` draws the approval card last, so it lands on
+/// top of the overlay whose keys it is already taking.
+pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
+    match ui.approval.key(key) {
+        ApprovalAction::Ignored => {}
+        ApprovalAction::Handled => return Some(DeckAction::Handled),
+        ApprovalAction::Resolve(response) => {
+            ui.approval.close();
+            return Some(DeckAction::Send(WorkspaceInput::ApprovalAnswered(
+                Box::new(response),
+            )));
+        }
+    }
+    match ui.question.key(key) {
+        QuestionAction::Ignored => None,
+        QuestionAction::Handled => Some(DeckAction::Handled),
+        QuestionAction::Resolve(outcome) => {
+            ui.question.close();
+            Some(DeckAction::Send(WorkspaceInput::QuestionAnswered(
+                Box::new(outcome),
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use stella_tools::registry::approval::{ApprovalRequest, ApprovalResponse};
+
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn approval() -> ApprovalRequest {
+        ApprovalRequest {
+            tool: "bash".into(),
+            read_only: false,
+            reason: "matched rule no-destructive-shell".into(),
+            gate: "command.started".into(),
+            subject: Some("rm -rf build/".into()),
+        }
+    }
+
+    fn question() -> stella_protocol::QuestionRequest {
+        stella_protocol::QuestionRequest {
+            asker: None,
+            questions: vec![stella_protocol::Question {
+                header: "Scope".into(),
+                question: "How far should this go?".into(),
+                options: vec![stella_protocol::QuestionOption {
+                    label: "Just the parser".into(),
+                    description: String::new(),
+                }],
+                multi_select: false,
+            }],
+        }
+    }
+
+    /// Nothing parked means nothing claimed, so the caller can route every
+    /// key here unconditionally and ahead of everything else.
+    #[test]
+    fn nothing_parked_claims_nothing() {
+        let mut ui = DeckUi::default();
+        for code in [KeyCode::Esc, KeyCode::Enter, KeyCode::Char('n')] {
+            assert!(handle_key(key(code), &mut ui).is_none());
+        }
+    }
+
+    /// **Approval wins the keyboard when both are up.** Its TTL is two
+    /// minutes against the question's thirty, so a card made to wait its turn
+    /// is a card that expires under the driver — and the call it gates is
+    /// about to run either way.
+    #[test]
+    fn an_approval_takes_the_keyboard_from_a_parked_question() {
+        let mut ui = DeckUi::default();
+        ui.question.open(question());
+        ui.approval.open(approval());
+
+        // Esc denies the approval and leaves the question standing.
+        let Some(DeckAction::Send(WorkspaceInput::ApprovalAnswered(response))) =
+            handle_key(key(KeyCode::Esc), &mut ui)
+        else {
+            panic!("the approval must claim the key");
+        };
+        assert!(matches!(*response, ApprovalResponse::Deny { .. }));
+        assert!(!ui.approval.is_open(), "the approval card came down");
+        assert!(
+            ui.question.is_open(),
+            "the question underneath is untouched — it is a separate parked call"
+        );
+
+        // With the approval gone the question gets the keyboard back.
+        assert!(matches!(
+            handle_key(key(KeyCode::Esc), &mut ui),
+            Some(DeckAction::Send(WorkspaceInput::QuestionAnswered(_)))
+        ));
+    }
+
+    /// Ctrl-C is declined by both, so the deck's quit branch still fires from
+    /// inside a parked ask. Otherwise a card would be the one state a user
+    /// cannot get out of.
+    #[test]
+    fn ctrl_c_is_declined_by_both() {
+        let mut ui = DeckUi::default();
+        ui.question.open(question());
+        ui.approval.open(approval());
+        assert!(
+            handle_key(
+                KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                &mut ui
+            )
+            .is_none()
+        );
+        assert!(ui.approval.is_open() && ui.question.is_open());
+    }
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -344,6 +344,29 @@ pub enum Inbound {
     /// path, so it fires on every way the wait can end rather than only the
     /// ones somebody remembered to handle.
     QuestionWithdrawn,
+    /// A gate demands a human yes/no before a tool call may run, and that
+    /// dispatch is **parked** on the answer (#4240). Raises the approval card
+    /// ([`crate::views::approval`]).
+    ///
+    /// Separate from [`Inbound::QuestionAsked`] because the two asks are
+    /// different decisions: this one is a yes/no over a call already chosen,
+    /// where the whole job is showing enough of the request — the tool,
+    /// whether it mutates, the gate that stopped it — to make a refusal
+    /// defensible. It rode the generic `AskUser` card until #4240, which
+    /// flattened all five fields into one line of prose.
+    ///
+    /// Out-of-band view state; the model fold ignores it. Boxed like its
+    /// siblings so the per-token [`Inbound::Event`] does not grow to the size
+    /// of the rarest variant.
+    ApprovalAsked(Box<stella_tools::registry::approval::ApprovalRequest>),
+    /// The parked approval is no longer answerable — its TTL expired (a much
+    /// shorter one than a question's: `DEFAULT_APPROVAL_TTL` is two minutes)
+    /// or the turn holding it was cancelled — so take the card down.
+    ///
+    /// The dispatch is denied on that path, never approved, so this is
+    /// strictly about not leaving a card up that offers to decide something
+    /// already decided.
+    ApprovalWithdrawn,
     /// A launch-mark cue (see [`SplashCue`]): the driver holds the mark
     /// open over a running init (session startup, `/init`) and
     /// releases it when init finishes. Out-of-band view state, applied
@@ -714,6 +737,14 @@ pub enum WorkspaceInput {
     /// Boxed to match [`Inbound::QuestionAsked`]: the answer set carries a
     /// note and free text per question.
     QuestionAnswered(Box<stella_protocol::QuestionOutcome>),
+    /// How the driver decided the parked approval the card was showing
+    /// (#4240) — the return leg of [`Inbound::ApprovalAsked`].
+    ///
+    /// A `Deny` carries the driver's own words when they gave any, and the
+    /// broker forwards them to the model verbatim: "no, use the staging
+    /// bucket" is a redirection the turn can act on, where a bare refusal is
+    /// a wall it has to guess its way around.
+    ApprovalAnswered(Box<stella_tools::registry::approval::ApprovalResponse>),
     /// Pause / resume / stop / restart a specific agent.
     Control {
         agent: AgentId,

--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -31,6 +31,7 @@ pub(crate) fn spinner_glyph(now_ms: u64, no_anim: bool) -> &'static str {
 }
 
 pub mod agents;
+pub mod approval;
 pub mod budget_card;
 pub(crate) mod cards;
 pub mod dispatch_card;

--- a/crates/stella-tui/src/views/approval.rs
+++ b/crates/stella-tui/src/views/approval.rs
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The Command Deck's approval card (#4240): the yes/no a parked dispatch
+//! waits on.
+//!
+//! # Why this is not the question overlay
+//!
+//! #4220 gave the deck both mid-turn asks and wired the approval half
+//! through the deck's generic `AskUser` card, which closed the dead-end with
+//! one declaration and no second mechanism. It also flattened a structured
+//! [`ApprovalRequest`] into a single prose line, and two of its five fields
+//! never reached the person deciding at all: `read_only` — the bit that
+//! separates *this reads something* from *this writes something* — and
+//! `gate`, which names the rule or hook that raised the demand and is what
+//! makes a deny defensible.
+//!
+//! So this is a card of its own, in a file of its own. An approval is a
+//! yes/no over a call that is **already decided**; a question
+//! ([`crate::views::question`]) is a decision the model could not make. One
+//! fold with both jobs would serve neither, and their keys genuinely differ:
+//! a question wants a note editor and a review pane, an approval wants the
+//! shortest path to a defensible refusal.
+//!
+//! # Default-deny is structural here, not a preference
+//!
+//! The cursor lands on **Deny**, and every way out that is not an explicit
+//! choice of *Allow* denies: Esc, a withdrawn card, a closed deck, the
+//! broker's TTL. A stray `⏎` on a card the driver has not read must never
+//! run a destructive call, and the plain-TTY responder already takes this
+//! line — an empty line at its prompt is a deny
+//! (`stella_cli::approval::AskUserApprovalResponder`). #2128's rule, applied
+//! where the permissive branch is the expensive one.
+//!
+//! # Deny must be able to carry words
+//!
+//! [`ApprovalResponse::Deny`] has a `reason`, and the broker forwards it to
+//! the model verbatim. "No, use the staging bucket instead" is a redirection
+//! the turn can act on; a bare refusal is a wall it has to guess its way
+//! around. The third row exists for that, and is the reason this card has a
+//! text mode at all.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use stella_tools::registry::approval::{ApprovalRequest, ApprovalResponse};
+
+use crate::theme;
+use crate::views::cards;
+
+/// Matches the question overlay's width so the two mid-turn asks read as one
+/// system — a driver should not have to re-find the layout depending on
+/// which kind of card came up.
+const APPROVAL_CARD_W: u16 = 76;
+
+/// Width of the dimmed label column, as `views::plan_card` uses.
+const LABEL_W: usize = 8;
+
+/// What owns the keyboard inside the card.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ApprovalMode {
+    /// Moving over the three ways out.
+    #[default]
+    Choosing,
+    /// Typing the words that ride along with a deny.
+    Reason,
+}
+
+/// The three ways out, in the order they are drawn.
+///
+/// Allow reads first because that is the order the question is asked in
+/// ("may I?"), but [`DENY_ROW`] is where the cursor starts — see the module
+/// docs on why those are not the same decision.
+const CHOICES: [&str; 3] = ["Allow this call, once", "Deny", "Deny, and say why"];
+
+/// The row the cursor starts on, and the row every non-choice exit resolves
+/// to. Named rather than spelled `1` at each use, because it being the
+/// *deny* row is the safety property, not an index.
+const DENY_ROW: usize = 1;
+
+/// The row that opens the reason editor.
+const DENY_WITH_REASON_ROW: usize = 2;
+
+/// What a keystroke did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApprovalAction {
+    /// Not the card's key (it is not open, or it is Ctrl-C).
+    Ignored,
+    /// Consumed; nothing left the card.
+    Handled,
+    /// The driver decided — send this back to the parked dispatch and close.
+    Resolve(ApprovalResponse),
+}
+
+/// The card's whole state. `request: None` is "nothing is parked", which is
+/// also the closed state.
+#[derive(Debug, Clone, Default)]
+pub struct ApprovalOverlay {
+    /// The parked request, or `None` when no dispatch is waiting.
+    pub request: Option<ApprovalRequest>,
+    /// Which of [`CHOICES`] is highlighted.
+    row: usize,
+    /// The mode that owns the keyboard.
+    pub mode: ApprovalMode,
+    /// The deny reason as it is typed.
+    editor: String,
+}
+
+/// A bare refusal — no words, and the model is told nothing but "no".
+fn deny() -> ApprovalResponse {
+    ApprovalResponse::Deny {
+        reason: String::new(),
+    }
+}
+
+impl ApprovalOverlay {
+    /// Whether a dispatch is parked and the card owns the keyboard.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        self.request.is_some()
+    }
+
+    /// Park `request`.
+    ///
+    /// The cursor lands on the **deny** row, never on Allow — see the module
+    /// docs. Re-opening always re-lands there, so a card raised while the
+    /// driver's hand is on `⏎` cannot inherit a permissive cursor from the
+    /// last one they answered.
+    pub fn open(&mut self, request: ApprovalRequest) {
+        self.request = Some(request);
+        self.row = DENY_ROW;
+        self.mode = ApprovalMode::Choosing;
+        self.editor.clear();
+    }
+
+    /// Take the card down and forget the half-typed reason.
+    pub fn close(&mut self) {
+        self.request = None;
+        self.row = DENY_ROW;
+        self.mode = ApprovalMode::Choosing;
+        self.editor.clear();
+    }
+
+    /// Apply an inbound envelope, reporting whether it was one of ours.
+    ///
+    /// The card owns both directions of its own envelope contract, the shape
+    /// [`crate::views::question::QuestionOverlay::ingest`] establishes — and
+    /// for the same reason: `deck_ui.rs` is a god file closed to growth
+    /// (`scripts/file-size-baseline.txt`), so the fold there costs two lines.
+    pub fn ingest(&mut self, inbound: &crate::envelope::Inbound) -> bool {
+        match inbound {
+            crate::envelope::Inbound::ApprovalAsked(request) => {
+                self.open(request.as_ref().clone());
+                true
+            }
+            crate::envelope::Inbound::ApprovalWithdrawn => {
+                self.close();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Fold one keystroke.
+    ///
+    /// Returns [`ApprovalAction::Ignored`] when nothing is parked, so the
+    /// caller can route it unconditionally, and for Ctrl-C, so the deck's
+    /// quit branch still fires — a parked approval must not be the one state
+    /// a user cannot Ctrl-C out of.
+    pub fn key(&mut self, key: crossterm::event::KeyEvent) -> ApprovalAction {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        if self.request.is_none() {
+            return ApprovalAction::Ignored;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+            return ApprovalAction::Ignored;
+        }
+
+        if self.mode == ApprovalMode::Reason {
+            return match key.code {
+                // Abandon the words, keep the card — a typo must not decide
+                // the call by itself, in either direction.
+                KeyCode::Esc => {
+                    self.editor.clear();
+                    self.mode = ApprovalMode::Choosing;
+                    ApprovalAction::Handled
+                }
+                KeyCode::Enter => {
+                    let reason = self.editor.trim().to_string();
+                    self.editor.clear();
+                    // Still a deny with nothing typed: the row the driver
+                    // chose was a deny, and the words were only ever the
+                    // optional half.
+                    ApprovalAction::Resolve(ApprovalResponse::Deny { reason })
+                }
+                KeyCode::Backspace => {
+                    self.editor.pop();
+                    ApprovalAction::Handled
+                }
+                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.editor.push(c);
+                    ApprovalAction::Handled
+                }
+                _ => ApprovalAction::Handled,
+            };
+        }
+
+        match key.code {
+            // Every non-choice exit denies. Never Approve on silence.
+            KeyCode::Esc => ApprovalAction::Resolve(deny()),
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.row = self.row.saturating_sub(1);
+                ApprovalAction::Handled
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.row = (self.row + 1).min(CHOICES.len() - 1);
+                ApprovalAction::Handled
+            }
+            KeyCode::Enter => match self.row {
+                0 => ApprovalAction::Resolve(ApprovalResponse::Approve),
+                DENY_WITH_REASON_ROW => {
+                    self.mode = ApprovalMode::Reason;
+                    self.editor.clear();
+                    ApprovalAction::Handled
+                }
+                _ => ApprovalAction::Resolve(deny()),
+            },
+            // Deliberately no bare `y`/`n` hotkeys. On a gate whose wrong
+            // answer runs somebody's `rm -rf`, one keystroke must not be the
+            // whole decision — the plain-TTY responder accepts them because a
+            // line prompt has nothing else, and a modal card does.
+            _ => ApprovalAction::Handled,
+        }
+    }
+}
+
+// ───────────────────────────────── render ─────────────────────────────────
+
+/// Paint the card over `area`. A no-op when nothing is parked.
+///
+/// `accessible` spans the card across the frame instead of floating it
+/// (`cards::card_area` — not a link: it is `pub(crate)`, and this is a
+/// `pub fn`). A float clips at its right border, and the fields most likely
+/// to be long are `subject` and `reason` — the command line about to run and
+/// the rule that stopped it, which is to say the whole basis for the answer.
+pub fn render(overlay: &ApprovalOverlay, accessible: bool, area: Rect, buf: &mut Buffer) {
+    let Some(request) = &overlay.request else {
+        return;
+    };
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    let inner_w = usize::from(APPROVAL_CARD_W) - 2;
+    let mut rows: Vec<Line<'static>> = Vec::new();
+
+    // The headline: what would run, and whether running it changes anything.
+    // `read_only` is rendered as a WORD rather than a colour — the golden
+    // suite strips style, and this is the field a reviewer most needs pinned.
+    rows.push(Line::from(vec![
+        Span::styled(
+            request.tool.clone(),
+            Style::new()
+                .fg(theme::TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            if request.read_only {
+                "  read-only"
+            } else {
+                "  mutating"
+            },
+            dim,
+        ),
+    ]));
+    if let Some(subject) = &request.subject {
+        rows.push(Line::from(Span::styled(
+            format!("  {}", cards::truncate_cols(subject, inner_w - 2)),
+            Style::new().fg(theme::TEXT_PRIMARY),
+        )));
+    }
+    rows.push(Line::from(""));
+    rows.push(labelled("gate", &request.gate, inner_w, accessible));
+    rows.push(labelled("reason", &request.reason, inner_w, accessible));
+    rows.push(Line::from(""));
+
+    if overlay.mode == ApprovalMode::Reason {
+        rows.push(Line::from(Span::styled(
+            "  denying — say why (the model is told, verbatim):",
+            dim,
+        )));
+        rows.push(editor_row(&overlay.editor, inner_w));
+    } else {
+        for (i, label) in CHOICES.iter().enumerate() {
+            rows.push(Line::from(vec![
+                cards::marker(i == overlay.row),
+                Span::styled(
+                    (*label).to_string(),
+                    if i == overlay.row {
+                        theme::accent()
+                    } else {
+                        dim
+                    },
+                ),
+            ]));
+        }
+    }
+
+    let height = u16::try_from(rows.len()).unwrap_or(u16::MAX);
+    let card = cards::card_area(area, height, APPROVAL_CARD_W, accessible);
+    let inner = cards::card_frame(card, "approval", Vec::new(), hints(overlay.mode), buf);
+    cards::render_body(rows, None, inner, buf);
+}
+
+/// The right-aligned key hints for the mode that owns the keyboard.
+fn hints(mode: ApprovalMode) -> &'static str {
+    match mode {
+        ApprovalMode::Choosing => "↑↓ move · ⏎ choose · esc denies",
+        ApprovalMode::Reason => "⏎ deny with these words · esc back",
+    }
+}
+
+/// One labelled field: dim fixed-width label, then the value.
+///
+/// In accessible mode the column alignment goes away and the row reads as a
+/// labelled record — column alignment carries meaning only to an eye, which
+/// is `crate::views::plan_card`'s rule and the deck's convention.
+fn labelled(label: &str, value: &str, inner_w: usize, accessible: bool) -> Line<'static> {
+    let dim = Style::new().fg(theme::TEXT_TERTIARY);
+    let room = inner_w.saturating_sub(LABEL_W + 2).max(8);
+    let value = cards::truncate_cols(value, room);
+    if accessible {
+        return Line::from(vec![
+            Span::styled(format!("· {label} "), dim),
+            Span::styled(value, Style::new().fg(theme::TEXT_PRIMARY)),
+        ]);
+    }
+    Line::from(vec![
+        Span::styled(format!("{label:<LABEL_W$}"), dim),
+        Span::styled(value, Style::new().fg(theme::TEXT_PRIMARY)),
+    ])
+}
+
+/// The open reason field: the buffer and a block caret.
+fn editor_row(text: &str, inner_w: usize) -> Line<'static> {
+    let room = inner_w.saturating_sub(6).max(8);
+    // Show the tail: a person typing past the field's width needs to see
+    // what they are typing now.
+    let shown: String = if text.chars().count() > room {
+        text.chars().skip(text.chars().count() - room).collect()
+    } else {
+        text.to_string()
+    };
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(shown, Style::new().fg(theme::TEXT_PRIMARY)),
+        Span::styled("▏", theme::accent()),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn request() -> ApprovalRequest {
+        ApprovalRequest {
+            tool: "bash".into(),
+            read_only: false,
+            reason: "matched rule no-destructive-shell".into(),
+            gate: "command.started".into(),
+            subject: Some("rm -rf build/".into()),
+        }
+    }
+
+    fn open() -> ApprovalOverlay {
+        let mut overlay = ApprovalOverlay::default();
+        overlay.open(request());
+        overlay
+    }
+
+    /// **The witness for #4240.** Choosing Allow approves the parked call,
+    /// and it takes a deliberate move off the default row to get there.
+    #[test]
+    fn allowing_takes_a_deliberate_move_off_the_deny_row() {
+        let mut overlay = open();
+        assert_eq!(
+            overlay.row, DENY_ROW,
+            "a freshly raised card starts on deny"
+        );
+        assert_eq!(overlay.key(key(KeyCode::Up)), ApprovalAction::Handled);
+        assert_eq!(
+            overlay.key(key(KeyCode::Enter)),
+            ApprovalAction::Resolve(ApprovalResponse::Approve)
+        );
+    }
+
+    /// **The safety property.** A `⏎` on a card nobody has moved on denies,
+    /// and so does Esc. On a gate whose wrong answer runs somebody's
+    /// `rm -rf`, the permissive branch must never be the one a stray
+    /// keystroke reaches (#2128).
+    #[test]
+    fn every_exit_that_is_not_an_explicit_allow_denies() {
+        for code in [KeyCode::Enter, KeyCode::Esc] {
+            let mut overlay = open();
+            assert_eq!(
+                overlay.key(key(code)),
+                ApprovalAction::Resolve(deny()),
+                "{code:?} must deny"
+            );
+        }
+        // …and no bare letter approves either.
+        for code in [KeyCode::Char('y'), KeyCode::Char('a'), KeyCode::Char(' ')] {
+            let mut overlay = open();
+            assert_eq!(
+                overlay.key(key(code)),
+                ApprovalAction::Handled,
+                "{code:?} must not decide the call"
+            );
+            assert!(overlay.is_open(), "{code:?} left the card up");
+        }
+    }
+
+    /// Deny carries the driver's words to the model verbatim — the
+    /// redirection ("use the staging bucket") a bare refusal cannot express.
+    #[test]
+    fn denying_with_a_reason_sends_the_words() {
+        let mut overlay = open();
+        overlay.key(key(KeyCode::Down));
+        assert_eq!(overlay.row, DENY_WITH_REASON_ROW);
+        assert_eq!(overlay.key(key(KeyCode::Enter)), ApprovalAction::Handled);
+        assert_eq!(overlay.mode, ApprovalMode::Reason);
+        for c in "use the staging bucket instead".chars() {
+            overlay.key(key(KeyCode::Char(c)));
+        }
+        let ApprovalAction::Resolve(ApprovalResponse::Deny { reason }) =
+            overlay.key(key(KeyCode::Enter))
+        else {
+            panic!("committing the reason must deny");
+        };
+        assert_eq!(reason, "use the staging bucket instead");
+    }
+
+    /// Esc out of the reason editor keeps the card up rather than deciding.
+    /// A typo must not settle the call in either direction.
+    #[test]
+    fn esc_in_the_reason_editor_returns_to_the_choices() {
+        let mut overlay = open();
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Enter));
+        for c in "oops".chars() {
+            overlay.key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(overlay.key(key(KeyCode::Esc)), ApprovalAction::Handled);
+        assert_eq!(overlay.mode, ApprovalMode::Choosing);
+        assert!(overlay.is_open());
+        assert!(overlay.editor.is_empty());
+    }
+
+    /// Committing an empty reason is still a deny — the words were always
+    /// the optional half of a decision already made.
+    #[test]
+    fn an_empty_reason_is_still_a_deny() {
+        let mut overlay = open();
+        overlay.key(key(KeyCode::Down));
+        overlay.key(key(KeyCode::Enter));
+        assert_eq!(
+            overlay.key(key(KeyCode::Enter)),
+            ApprovalAction::Resolve(deny())
+        );
+    }
+
+    /// Re-opening re-lands on deny. A card raised while the driver's hand is
+    /// on `⏎` must not inherit a permissive cursor from the last one.
+    #[test]
+    fn reopening_never_inherits_a_permissive_cursor() {
+        let mut overlay = open();
+        overlay.key(key(KeyCode::Up));
+        assert_eq!(overlay.row, 0, "moved to allow");
+        overlay.close();
+        overlay.open(request());
+        assert_eq!(overlay.row, DENY_ROW);
+    }
+
+    /// A closed card claims nothing, and Ctrl-C is declined even while open
+    /// so the deck's quit branch still fires.
+    #[test]
+    fn a_closed_card_claims_nothing_and_ctrl_c_is_always_declined() {
+        let mut overlay = ApprovalOverlay::default();
+        for code in [KeyCode::Esc, KeyCode::Enter, KeyCode::Char('y')] {
+            assert_eq!(overlay.key(key(code)), ApprovalAction::Ignored);
+        }
+        let mut overlay = open();
+        assert_eq!(
+            overlay.key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            ApprovalAction::Ignored,
+            "a parked approval must not be the one state you cannot quit from"
+        );
+    }
+
+    /// The envelope contract, both directions.
+    #[test]
+    fn ingest_raises_and_withdraws_the_card() {
+        let mut overlay = ApprovalOverlay::default();
+        assert!(overlay.ingest(&crate::envelope::Inbound::ApprovalAsked(
+            Box::new(request())
+        )));
+        assert!(overlay.is_open());
+        assert!(overlay.ingest(&crate::envelope::Inbound::ApprovalWithdrawn));
+        assert!(!overlay.is_open());
+        assert!(
+            !overlay.ingest(&crate::envelope::Inbound::ShowHelp),
+            "an envelope that is not ours must fall through"
+        );
+    }
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -907,6 +907,80 @@ fn deck_render_snapshots_pin_the_question_overlay() {
     );
 }
 
+/// Golden frames for the approval card (#4240) — the yes/no a parked
+/// **dispatch** waits on.
+///
+/// The fields are the point. `read_only` renders as the word `mutating` or
+/// `read-only`, and `gate` gets a labelled row, precisely because the generic
+/// `AskUser` card this replaces carried neither to the person deciding. Both
+/// are words rather than colours so a style-stripped golden can pin them —
+/// if either stops rendering, this test says so.
+#[test]
+fn deck_render_snapshots_pin_the_approval_card() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let model = fixture_model();
+    let press = |ui: &mut DeckUi, code: KeyCode| {
+        ui.approval.key(KeyEvent::new(code, KeyModifiers::NONE));
+    };
+    let request = stella_tools::registry::approval::ApprovalRequest {
+        tool: "bash".into(),
+        read_only: false,
+        reason: "matched rule no-destructive-shell".into(),
+        gate: "command.started".into(),
+        subject: Some("rm -rf build/".into()),
+    };
+
+    // 1. The card as it first appears — cursor on Deny, never on Allow.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.approval.open(request.clone());
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_approval",
+        "a parked approval — tool, mutating mark, subject, gate, reason; cursor on deny",
+        W,
+        H,
+        &frame,
+    );
+
+    // 2. The reason editor, where a deny becomes a redirection the turn can
+    //    act on rather than a wall it has to guess around.
+    let mut ui = ui_for(DeckTab::Session);
+    ui.approval.open(request);
+    press(&mut ui, KeyCode::Down);
+    press(&mut ui, KeyCode::Enter);
+    for c in "use the staging bucket instead".chars() {
+        press(&mut ui, KeyCode::Char(c));
+    }
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_approval_reason",
+        "denying with words — the reason editor open, mid-typing",
+        W,
+        H,
+        &frame,
+    );
+
+    // 3. A read-only call, so the mark's other value is pinned too. Nothing
+    //    else distinguishes "this reads a file" from "this rewrites one".
+    let mut ui = ui_for(DeckTab::Session);
+    ui.approval
+        .open(stella_tools::registry::approval::ApprovalRequest {
+            tool: "read_file".into(),
+            read_only: true,
+            reason: "matched rule secrets-are-off-limits".into(),
+            gate: "tool.call.requested".into(),
+            subject: Some(".stella/private/credentials.toml".into()),
+        });
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_approval_read_only",
+        "a read-only call — the other value of the mark the generic card never showed",
+        W,
+        H,
+        &frame,
+    );
+}
+
 // ─────────────────────────── the harness itself ───────────────────────────
 
 /// The suite's own guard: rendering the same fixture twice must produce the

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_approval
+# a parked approval — tool, mutating mark, subject, gate, reason; cursor on deny
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││                                      │
+│                                         ┌ approval ─────────────────────────────── ↑↓ move · ⏎ choose · esc denies ┐ ││                                      │
+│── EXECUTE ──────────────────────────────│bash  mutating                                                            │─││                                      │
+│                                         │  rm -rf build/                                                           │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⎿ 312 lines                           │gate    command.started                                                   │s││                                      │
+│                                         │reason  matched rule no-destructive-shell                                 │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │
+│                                         │  Allow this call, once                                                   │ ││                                      │
+│⏸ plan  Refactor the automations store in│▸ Deny                                                                    │ ││                                      │
+│                                         │  Deny, and say why                                                       │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_approval_read_only
+# a read-only call — the other value of the mark the generic card never showed
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││                                      │
+│                                         ┌ approval ─────────────────────────────── ↑↓ move · ⏎ choose · esc denies ┐ ││                                      │
+│── EXECUTE ──────────────────────────────│read_file  read-only                                                      │─││                                      │
+│                                         │  .stella/private/credentials.toml                                        │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⎿ 312 lines                           │gate    tool.call.requested                                               │s││                                      │
+│                                         │reason  matched rule secrets-are-off-limits                               │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │
+│                                         │  Allow this call, once                                                   │ ││                                      │
+│⏸ plan  Refactor the automations store in│▸ Deny                                                                    │ ││                                      │
+│                                         │  Deny, and say why                                                       │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_approval_reason
+# denying with words — the reason editor open, mid-typing
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────stella* ┐
+│ SESSION │ AGENTS │ TRACES │ GRAPH │ FILES │ SKILLS │ MCP │ ISSUES │ SETTINGS                                                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ ? lead  ·  needs input   0:00:00
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx 5.1k/200k · spend $0.01 · scope apps/api/routes/v1/**
+     ⚒ search_code trigger
+     returns: wire automations triggers API → lead inbox
+└─ ◆ sub:ci  subagent · running                                                                                                                             5:12
+     model glm-5.2-air · ctx 3.0k/200k · spend $0.00
+     ⚒ no tool calls yet
+     returns: watch CI + open PR → lead inbox
+┌ stella ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│stage execute   model —   turn $0.0390 / $2.50  ·  observed                                                                                                   │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ transcript · 22 lines · following ───────────────────────────────────────────────────────────────────────────────────┐┌ PLAN ○ pending approval 0/3 ─────────┐
+│    ⋯ ctrl+o for provenance and budget                                                                                ││Refactor the automations store into a…│
+│                                                                                                                      ││○ 1. extract types                    │
+│── PLAN ──────────────────────────────────────────────────────────────────────────────────────────────────────────────││○ 2. move hooks                       │
+│                                                                                                                      ││○ 3. update 9 imports                 │
+│  Planning the automations cluster: list, editor, triggers, workflows.                                                ││                                      │
+│                                                                                                                      ││                                      │
+│☰  plan  4/7  ·  Wire the triggers API                                                                                ││                                      │
+│                                                                                                                      ││                                      │
+│── EXECUTE ──────────────────────────────┌ approval ──────────────────────────── ⏎ deny with these words · esc back ┐─││                                      │
+│                                         │bash  mutating                                                            │ ││                                      │
+│ │ ● apps/app/automations/page.tsx       │  rm -rf build/                                                           │ ││                                      │
+│ │ ⎿ 312 lines                           │                                                                          │s││                                      │
+│                                         │gate    command.started                                                   │ ││                                      │
+│☰  plan  5/7  ·  Workflows canvas        │reason  matched rule no-destructive-shell                                 │ ││                                      │
+│                                         │                                                                          │ ││                                      │
+│⏸ plan  Refactor the automations store in│  denying — say why (the model is told, verbatim):                        │ ││                                      │
+│                                         │  use the staging bucket instead▏                                         │ ││                                      │
+└─────────────────────────────────────────└──────────────────────────────────────────────────────────────────────────┘ ┘└────────────────────── /plan reads it ┘
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ▸ stage  Refactor the automations store into a shared workspace package
+✓ plan   ▸ execute ████████████░░░░░░░░░░░░ 50%   · verify
+>>>
+ ⌘⏎ new line  ·  ⏎ queue (never blocks)  ·  ! shell  ·  / commands                                                      turn $0.0390  ·  1 line  ·  queue empty
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
#4220 gave the Command Deck both mid-turn asks. The `ask_question` half got a
purpose-built overlay; the **approval** half was wired through the deck's
pre-existing generic `AskUser` card, because that closed the dead-end with one
declaration and no second mechanism.

It worked — a `RequireApproval` on the deck parked on a real human yes/no —
but the card was worse than the request it was rendering.
`AskUserApprovalResponder::question` flattens a five-field `ApprovalRequest`
into one line of prose, and two fields never reached the person deciding at
all:

- **`read_only`** — the bit that separates *this reads something* from *this
  writes something*.
- **`gate`** — which rule or hook raised the demand, and so the context that
  makes a deny defensible.

> Stacked on #4239 (#4220), which this is based on. GitHub retargets to `main`
> when that merges.

## What landed

**`crates/stella-tui/src/views/approval.rs`** — the card, a pure fold like the
question overlay. Fields render as fields: tool, a `mutating`/`read-only`
mark, subject, gate, reason. Both mark values are **words, not colours**, so
the style-stripped goldens can pin them — the whole point is that these stop
being droppable.

**`Inbound::ApprovalAsked` / `ApprovalWithdrawn`, `WorkspaceInput::ApprovalAnswered`**
— the round trip, and **`DeckApprovalResponder`** in `mid_turn_ask.rs` in
place of wrapping `DeckAskUserIo`. That io stays: slash commands (`/init`'s
confirmations) still ask through the generic card. It is just no longer what
answers approvals.

## Default-deny is structural, not a preference

The cursor starts on **Deny**, and every exit that is not an explicit choice
of *Allow* denies — Esc, a withdrawn card, a closed deck, the broker's TTL, a
decision stranded by a cancelled turn. There is no path in the responder or
the fold that produces `Approve` without the driver having chosen it.

Two smaller consequences of the same reasoning:

- **No bare `y`/`n` hotkeys.** The plain-TTY responder accepts them because a
  line prompt has nothing else; a modal card does. On a gate whose wrong
  answer runs somebody's `rm -rf`, one keystroke should not be the whole
  decision.
- **Re-opening re-lands on Deny**, so a card raised while the driver's hand is
  on `⏎` cannot inherit a permissive cursor from the last one they answered.

A deny can still carry words (`ApprovalResponse::Deny { reason }`, forwarded
to the model verbatim) — "use the staging bucket instead" is a redirection the
turn can act on, where a bare refusal is a wall it guesses its way around.
That is the third row, and the only reason this card has a text mode.

## Precedence

Approval outranks the question overlay for the keyboard, and draws on top so
the two agree. It gates a call about to execute where a question is a decision
still being deliberated — and its TTL is `DEFAULT_APPROVAL_TTL`, **two
minutes** against the question's thirty, so it is the one that expires out
from under a driver made to wait its turn.

## Evidence

**Fold witnesses** (`views/approval.rs`, 8): allowing takes a deliberate move
off the deny row; **every exit that is not an explicit allow denies**,
hotkeys included; deny carries the driver's words; Esc in the reason editor
keeps the card up; an empty reason is still a deny; re-opening never inherits
a permissive cursor; Ctrl-C is always declined; `ingest` both directions.

**Transport witnesses** (`command_deck/mid_turn_ask.rs`, 3 new): the whole
structured request reaches the card with `read_only` and `gate` intact — the
regression this PR exists to prevent; **every failed approval wait denies**
(closed deck, and a stale `Approve` stranded by a cancelled turn not
answering the next card); an abandoned wait withdraws the card.

**Routing witnesses** (`deck_ui/parked.rs`, 3): nothing parked claims nothing;
an approval takes the keyboard from a parked question and leaves it standing;
Ctrl-C is declined by both.

**Three goldens**: the card, the reason editor mid-typing, and a read-only
call — the last so the mark's *other* value is pinned too, since nothing else
in the frame distinguishes a read from a write.

**Gate:** `cargo test -p stella-tui -p stella-cli` green · clippy
`-D warnings` clean · rustdoc `-D warnings` clean · `make guards-fast` green ·
`cargo fmt --check` clean.

## God files

`deck_ui.rs` (+19) and `deck_render.rs` (+8) went over on the first pass. **No
baseline was raised.** Key routing for both parked asks moved to
`deck_ui/parked.rs` (matching `dispatch::handle_key` right beside it in the
routing order) and drawing to `deck_render/parked.rs`. Both files end up
*below* where they started, and the precedence rule now lives in one place
with tests instead of spread across two god files.

## Deleted tests

None.

## New dependencies

None.

Closes #4240

## Summary by Sourcery

Replace the generic approval prompt with a structured, default-deny approval card in the Command Deck.

New Features:
- Add a dedicated Command Deck approval card that displays the complete approval request, including tool, mutation status, subject, gate, and reason.
- Support structured approval responses with explicit allow, deny, and deny-with-reason interactions.],
- bug_fixes[]    
- enhancements[]    
- build[]    
- ci[]    
- deployment[]    
- docs[]    
- tests[]    
- chores[]    
- overview    

Enhancements:
- Route approval requests through a dedicated responder and card while retaining the generic AskUser card for other confirmations.
- Enforce structural default-deny behavior for unanswered, dismissed, expired, or otherwise failed approval waits.
- Give approval overlays keyboard and rendering precedence over parked questions and modularize parked-ask routing and rendering.

Tests:
- Add unit, transport, routing, and snapshot coverage for approval rendering, response handling, precedence, withdrawal, and default-deny behavior.