### PR TITLE
fix(stella-tui): an inline diff stops opening with three rows of git plumbing

### DIFF
--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -148,25 +148,68 @@ pub fn body_lines_capped(
     cap: usize,
     fold_hint: Option<&str>,
 ) -> (Vec<Line<'static>>, usize) {
-    render_body(diff, path, cap, true, fold_hint)
+    render_body(diff, path, cap, Chrome::VIEWER, fold_hint)
 }
 
 /// [`body_lines_capped`] for the transcript's inline diffs, which drop a lone
-/// `@@ -a,b +c,d @@` header.
+/// `@@ -a,b +c,d @@` header and a single file's `diff`/`index`/`---`/`+++`
+/// preamble.
 ///
-/// In a diff *viewer* the hunk header is orientation. Inline under a tool call
-/// it is a row of chrome restating what the line-number gutter beside it
-/// already says, and a two-line change should not cost three rows. With more
-/// than one hunk the headers stay: there they earn their space as the boundary
-/// between two disjoint regions of the file.
+/// In a diff *viewer* both are orientation. Inline under a tool call both are
+/// chrome restating what the row above and the gutter beside already say, and a
+/// two-line change should not cost six rows to read. The thresholds differ
+/// because what makes each one earn its space differs: a hunk header is a
+/// boundary between disjoint regions of one file, so it survives from two hunks
+/// up; a file preamble is a boundary between files, so it survives from two
+/// files up.
+///
+/// The preamble is what a real turn actually folds — `WorkJournal`'s
+/// `split_patch_per_file` cuts git's patch on the `diff --git` header and hands
+/// on everything after it, so `index <a>..<b> <mode>` / `--- a/p` / `+++ b/p`
+/// leads every inline diff in the deck. Three rows, on every mutating call,
+/// naming a path the call row already names and a blob hash nobody reads.
 pub fn body_lines_inline(
     diff: &str,
     path: Option<&str>,
     cap: usize,
     fold_hint: Option<&str>,
 ) -> (Vec<Line<'static>>, usize) {
-    let multi = diff.lines().filter(|l| l.starts_with("@@")).count() > 1;
-    render_body(diff, path, cap, multi, fold_hint)
+    render_body(diff, path, cap, Chrome::inline_for(diff), fold_hint)
+}
+
+/// Which of a diff's structural rows earn their space in this rendering.
+///
+/// A pair of bools rather than one: they answer different questions (how many
+/// hunks? how many files?) and a single "is this inline" flag would have to
+/// re-derive both at the point of use, which is where the two would drift.
+#[derive(Clone, Copy)]
+struct Chrome {
+    /// Draw `@@ -a,b +c,d @@`.
+    hunk_headers: bool,
+    /// Draw the per-file preamble (`diff `, `index `, `--- `, `+++ `).
+    file_headers: bool,
+}
+
+impl Chrome {
+    /// Everything, for the standalone viewer — a reader navigating a patch
+    /// needs the boundaries even when there is only one of them.
+    const VIEWER: Self = Self {
+        hunk_headers: true,
+        file_headers: true,
+    };
+
+    /// Keep only the boundaries that separate more than one of something.
+    fn inline_for(diff: &str) -> Self {
+        Self {
+            hunk_headers: diff.lines().filter(|l| l.starts_with("@@")).count() > 1,
+            // `diff `-prefixed lines are the only unambiguous per-file
+            // boundary; the count is 0 for the split-per-file shape the event
+            // path folds and 1 for a whole single-file patch, and both are one
+            // file. Counting `+++ ` instead would miscount, because added
+            // source text starting `++ ` is textually identical to a header.
+            file_headers: diff.lines().filter(|l| l.starts_with("diff ")).count() > 1,
+        }
+    }
 }
 
 /// [`body_lines_inline`] dressed as ANSI strings for the plain surface
@@ -197,7 +240,7 @@ fn render_body(
     diff: &str,
     path: Option<&str>,
     cap: usize,
-    hunk_headers: bool,
+    chrome: Chrome,
     fold_hint: Option<&str>,
 ) -> (Vec<Line<'static>>, usize) {
     let lang = match path {
@@ -221,6 +264,12 @@ fn render_body(
         // Every line advances the gutter counters, shown or not — skipping a
         // line must not renumber the ones after it, and the numbers on the
         // far side of an elision have to be the file's real ones.
+        // Read *before* `body_line` runs, because that call is what moves the
+        // state this asks about. The same structural rule `body_line` itself
+        // applies (only before a file's first hunk is `+++ `/`--- ` a header):
+        // inside a hunk those bytes are added or removed source text, and
+        // dropping them would delete a line of the change.
+        let preamble = !in_hunk && is_meta(text);
         let line = body_line(
             text,
             lang,
@@ -229,7 +278,15 @@ fn render_body(
             &mut in_hunk,
             emphasis.get(&i).copied(),
         );
-        if plan.shows(i) && (hunk_headers || !text.starts_with("@@")) {
+        // Chrome is suppressed after planning rather than before it, so an
+        // elided row's `⋯ n lines` count stays the one `stella_diff::view`
+        // computed and every surface reports the same number for one change.
+        // The cost is a dropped row's slot in the cap; the alternative is the
+        // deck and the export disagreeing about the size of an edit.
+        if plan.shows(i)
+            && (chrome.hunk_headers || !text.starts_with("@@"))
+            && (chrome.file_headers || !preamble)
+        {
             lines.push(line);
         }
     }

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -26,6 +26,7 @@ use stella_protocol::{
 
 mod block_rail;
 mod inline_diff;
+mod mutation_diff_e2e;
 mod palette;
 mod result_row;
 mod slash;

--- a/crates/stella-tui/src/render/tests/mutation_diff_e2e.rs
+++ b/crates/stella-tui/src/render/tests/mutation_diff_e2e.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! **The join nothing covered: fold a real event stream, then render it.**
+//!
+//! Two suites already sit on either side of this seam and both are green:
+//! [`super::super::tests::producer_seq`]'s siblings in `model::tests` prove the
+//! fold stamps a resolvable [`InlineDiffRef`], and [`super::inline_diff`] proves
+//! the renderer draws a capped, styled diff. Neither proves the pair works
+//! *together*, because each supplies by hand what the other would have had to
+//! produce — `producer_seq` reads the ref and stops, and `inline_diff` builds
+//! its [`FileState`] literally, including a `latest_diff` that starts at `@@`.
+//!
+//! That gap is not academic. The diff a real turn folds does **not** start at
+//! `@@`: `WorkJournal::split_patch_per_file` cuts git's multi-file patch on the
+//! `diff --git` header and keeps everything *after* it, so what reaches the fold
+//! is `index <a>..<b> <mode>` / `--- a/p` / `+++ b/p` / `@@ …`. Captured from
+//! `stella run --output-format stream-json` on 2026-08-21 against `b5f1443a0`:
+//!
+//! ```text
+//! {"type":"file_change","path":"main.rs","kind":"modified","added":1,"removed":1,
+//!  "diff":"index a448d2f..993ccff 100644\n--- a/main.rs\n+++ b/main.rs\n@@ -1,3 +1,3 @@\n …"}
+//! ```
+//!
+//! So a header-handling regression in [`crate::diff`] — or any change that
+//! breaks the fold's seq derivation — would leave both existing suites green
+//! while every `edit_file` row in the product rendered with no diff under it.
+//! That is the exact symptom #4155 and #4175 were each reported as, twice, and
+//! it is what this file exists to make loud.
+//!
+//! The event ordering here is the product's own and is load-bearing: the
+//! registry measures a solo mutating call the moment it returns and publishes on
+//! the channel the engine then sends `ToolResult` on, so `FileChange` folds
+//! **before** the row that made it (`stella_tools::call_measure`, #4175).
+
+use super::*;
+
+const WIDTH: usize = 100;
+
+/// Git's real per-file patch shape, header lines included — the bytes
+/// `split_patch_per_file` actually hands the fold, not a hand-trimmed hunk.
+const REAL_PATCH: &str = "index a448d2f..993ccff 100644\n\
+     --- a/main.rs\n\
+     +++ b/main.rs\n\
+     @@ -1,3 +1,3 @@\n \
+     fn main() {\n\
+     -    println!(\"alpha\");\n\
+     +    println!(\"bravo\");\n \
+     }\n";
+
+/// Drive one mutating call through the fold in the order the product emits it.
+fn fold_one_call(model: &mut SessionModel, name: &str, path: &str) {
+    model.apply(&AgentEvent::ToolStart {
+        call: stella_protocol::ToolCall {
+            call_id: "c1".into(),
+            name: name.into(),
+            input: serde_json::json!({ "path": path }),
+        },
+    });
+    // The per-call work-tree measurement, before the result — see the module
+    // doc. Reordering these two is itself the #4155 defect.
+    model.apply(&AgentEvent::FileChange {
+        path: path.into(),
+        kind: FileChangeKind::Modified,
+        added: 1,
+        removed: 1,
+        diff: Some(REAL_PATCH.into()),
+    });
+    model.apply(&AgentEvent::ToolResult {
+        call_id: "c1".into(),
+        output: stella_protocol::ToolOutput::Ok {
+            content: format!("replaced 1 occurrence(s) in {path}"),
+            data: None,
+        },
+        duration_ms: 8,
+        speculated: false,
+    });
+}
+
+/// Render the transcript's last entry against the model's own file state —
+/// the same two arguments the deck passes, sourced the same way.
+fn render_last(model: &SessionModel) -> String {
+    let idx = model.transcript.len() - 1;
+    let mut out = Vec::new();
+    entry_lines(
+        &model.transcript[idx],
+        EntryView::at(&model.files, &model.transcript, idx),
+        false,
+        false,
+        false,
+        WIDTH,
+        &mut out,
+    );
+    out.iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// **Witness.** A folded `edit_file` call renders the change it made, as a
+/// diff, from the bytes the product actually emits.
+///
+/// Fails on any of the three independent breaks that each produce the same
+/// blank row: the fold stamping an unresolvable seq, `FileState` not
+/// remembering the patch at it, or [`crate::diff`] mishandling git's `index`/
+/// `---`/`+++` preamble.
+#[test]
+fn a_folded_edit_renders_its_own_diff() {
+    let mut model = SessionModel::default();
+    fold_one_call(&mut model, "edit_file", "main.rs");
+    let text = render_last(&model);
+
+    assert!(
+        text.contains("println!(\"bravo\")"),
+        "the added line is drawn:\n{text}"
+    );
+    assert!(
+        text.contains("println!(\"alpha\")"),
+        "the removed line is drawn:\n{text}"
+    );
+    assert!(
+        text.contains("+1") && text.contains("−1"),
+        "the metric column states the measured delta:\n{text}"
+    );
+}
+
+/// **Witness.** `write_file` is not a second-class citizen of the same path.
+///
+/// It folds through `is_file_mutation` exactly as `edit_file` does, and the
+/// user-visible complaint that started #4155 named both verbs. Pinning only the
+/// one that happened to be debugged is how the other regresses unnoticed.
+#[test]
+fn a_folded_write_renders_its_own_diff() {
+    let mut model = SessionModel::default();
+    fold_one_call(&mut model, "write_file", "main.rs");
+    let text = render_last(&model);
+
+    assert!(
+        text.contains("println!(\"bravo\")"),
+        "write_file renders a diff too:\n{text}"
+    );
+}
+
+/// **Witness.** Git's patch preamble is chrome, not content.
+///
+/// `index a448d2f..993ccff 100644` is a blob-hash line no reader of a
+/// transcript wants, and `--- a/main.rs` / `+++ b/main.rs` restate the path the
+/// call row above already names. Worse, drawn as body they would be scored as a
+/// removal and an addition — `+1 −1` becoming `+2 −2` on a one-line edit.
+#[test]
+fn the_patch_preamble_is_not_drawn_as_diff_body() {
+    let mut model = SessionModel::default();
+    fold_one_call(&mut model, "edit_file", "main.rs");
+    let text = render_last(&model);
+
+    assert!(
+        !text.contains("index a448d2f"),
+        "git's blob-hash line is not a transcript row:\n{text}"
+    );
+    assert!(
+        !text.contains("+++ b/main.rs"),
+        "the path is named once, by the call row:\n{text}"
+    );
+}


### PR DESCRIPTION
## What

Every mutating row in the deck opened with three rows of git plumbing before reaching a line of the change:

```
 │ ⎿                                                    +1 −1 · 8ms
 │        index a448d2f..993ccff 100644
 │        --- a/main.rs
 │        +++ b/main.rs
 │      1  fn main() {
 │      2 -    println!("alpha");
 │      2 +    println!("bravo");
 │      3  }
```

A blob hash no reader wants, and a path the call row directly above already names — on every `edit_file` and `write_file` result.

## Why it looks like that

The preamble is what a real turn actually folds. `WorkJournal::split_patch_per_file` cuts git's multi-file patch on the `diff --git` header and hands on everything *after* it, so the bytes reaching the transcript begin at `index `, not at `@@`. Captured from `stella run --output-format stream-json` against `b5f1443a0`:

```json
{"type":"file_change","path":"main.rs","kind":"modified","added":1,"removed":1,
 "diff":"index a448d2f..993ccff 100644\n--- a/main.rs\n+++ b/main.rs\n@@ -1,3 +1,3 @@\n …"}
```

## The fix

`body_lines_inline` already dropped a lone `@@` header for exactly this reason — inline under a call it restates what the line-number gutter beside it says. The file preamble is the same judgement one level up, so it is made the same way and at the matching threshold:

| row | earns its space from |
|---|---|
| `@@ -a,b +c,d @@` | two hunks — a boundary between disjoint regions of one file |
| `diff`/`index`/`---`/`+++` | two files — a boundary between files |

The standalone diff viewer (`body_lines_capped`, the `/diff` panel) keeps both, unchanged: there, boundaries are what a reader is navigating by.

Two details worth review:

- **Suppression happens after `stella_diff::view::plan`, not before it**, so an elision's `⋯ n lines` stays the number every surface computes for that change. The cost is a dropped row's slot in the cap; the alternative is the deck and the export disagreeing about the size of one edit. This matches how the existing `@@` suppression already works.
- **Header-ness is read from `in_hunk` *before* `body_line` moves it** — the same structural rule that distinguishes a real `+++ ` header from added source text starting `++ `, which is textually identical and inside a hunk must render as content, or a line of the change is deleted.

The two flags travel as a `Chrome` struct rather than a second positional bool: they answer different questions (how many hunks? how many files?), and a single "is this inline" flag would have to re-derive both at the point of use, which is where the two would drift.

## Witness

`crates/stella-tui/src/render/tests/mutation_diff_e2e.rs` — three tests, new file.

It closes a join nothing covered. `model::tests::producer_seq` proves the fold stamps a resolvable `InlineDiffRef` and stops there; `render/tests/inline_diff` proves the renderer draws a capped, styled diff from a hand-built `FileState` whose text starts at `@@`. **Each supplies by hand what the other would have had to produce**, so both suites stayed green while the product rendered plumbing on every edit.

The new tests fold the real event ordering — `ToolStart` → `FileChange` → `ToolResult`, the order `stella_tools::call_measure` publishes in (#4175) — and render the result against the model's own `files`, over git's real patch bytes.

- `the_patch_preamble_is_not_drawn_as_diff_body` — **fails on the parent commit, passes here** (verified by running it before the fix; output above is its failure message).
- `a_folded_edit_renders_its_own_diff` / `a_folded_write_renders_its_own_diff` — pass on both. They are not the flip; they pin that both verbs reach a diff at all, which is the regression the two suites above could not catch between them.

## Verification

- `cargo test -p stella-tui` — 915 unit + every integration suite, deck golden frames included
- `cargo test -p stella-diff -p stella-transcript` — the shared renderers, unchanged
- `cargo clippy -p stella-tui --all-targets -- -D warnings`, `cargo fmt --all --check`
- `scripts/check-file-size.sh`, `scripts/check-left-behind.sh`

## Deleted tests

None.

## Not in scope

Found while verifying this, already tracked, not touched here: #4227 (a successful call that measured nothing stamps a reference to a future change), #4213 (`bash`/MCP mutations are measured but `is_file_mutation`'s four-name list means no row can claim them), #4214 (a multi-path call can render only one).

## Summary by Sourcery

Hide redundant Git patch metadata from inline mutation diffs while retaining full context in the standalone diff viewer.

Bug Fixes:
- Remove single-file Git diff preamble rows from inline mutation diffs so edit and write results no longer display blob hashes and redundant file paths as diff content.

Enhancements:
- Preserve structural headers in the standalone diff viewer while independently applying hunk and file-header visibility rules to inline diffs.
- Add end-to-end coverage that folds real mutation events and verifies edit and write diffs render correctly without Git preamble noise.

Tests:
- Add integration tests covering folded edit and write mutations rendered from realistic Git patch data, including suppression of the patch preamble.