### PR TITLE
feat(deck): wire the ISSUES tab to the issue provider (GitHub via gh)

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -78,9 +78,8 @@ use stella_tools::ToolRegistry;
 use stella_tools::custom::CustomTool;
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityHit, Inbound, SkillOp,
-    SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
-    run_deck,
+    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityHit, Inbound, SkillOp, SkillScope,
+    SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -2938,10 +2937,12 @@ fn spawn_notification_poller(in_tx: mpsc::UnboundedSender<Inbound>) {
 
 // ── ISSUES tab: tracker-backed operations ───────────────────────────────────
 
-
 /// Installed agents whose name or description contains `query`
 /// (case-insensitive; an empty query matches all) as "Agent" hits.
-pub(super) fn agent_entity_hits(entries: &[stella_tui::InstalledAgentEntry], query: &str) -> Vec<EntityHit> {
+pub(super) fn agent_entity_hits(
+    entries: &[stella_tui::InstalledAgentEntry],
+    query: &str,
+) -> Vec<EntityHit> {
     let needle = query.trim().to_lowercase();
     entries
         .iter()

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -73,14 +73,15 @@ use stella_model::provider::Provider;
 use stella_protocol::{
     AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, TaskItem, ToolOutput,
 };
+use stella_protocol::issue::IssueProvider;
 use stella_store::Store;
 use stella_tools::ToolRegistry;
 use stella_tools::custom::CustomTool;
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityField, EntityHit, Inbound, SkillOp,
-    SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
-    run_deck,
+    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityField, EntityHit, Inbound, IssueAction,
+    IssueRow, SkillOp, SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput,
+    WorkspaceInput, run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -2935,11 +2936,128 @@ fn spawn_notification_poller(in_tx: mpsc::UnboundedSender<Inbound>) {
 
 // ── ISSUES tab: tracker-backed operations ───────────────────────────────────
 
-/// What every ISSUES-tab request answers with — the tab renders it as its
-/// empty-state hint. Issue trackers reach a session as MCP tools, and the
-/// deck has no tracker transport of its own.
-const NO_TRACKER_HINT: &str =
-    "no issue tracker backend — tracker workflows ride MCP tools (`stella mcp`)";
+/// One page of the ISSUES tab's browse list, from the workspace's issue
+/// provider.
+///
+/// Runs on a blocking thread (`gh` is a subprocess), so the provider call —
+/// async over a synchronous CLI — gets the same fresh current-thread runtime
+/// the self-driving commands use rather than a handle on the deck's.
+fn issues_list(
+    root: &std::path::Path,
+    query: Option<&str>,
+    state: Option<String>,
+) -> Result<Vec<IssueRow>, String> {
+    let provider = crate::issue_provider::GhIssueProvider;
+    let state = match state.as_deref() {
+        Some("open") => Some(stella_protocol::issue::IssueState::Open),
+        Some("closed") => Some(stella_protocol::issue::IssueState::Closed),
+        _ => None,
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    let issues = runtime
+        .block_on(provider.search(query.unwrap_or(""), state, ISSUES_PAGE, 0))
+        .map_err(|error| error.to_string())?;
+    let _ = root; // the provider binds to the workspace through `gh`'s cwd
+    Ok(issues.iter().map(issue_row).collect())
+}
+
+/// File one issue through the provider; answer with the created key and a
+/// human status line (the created key + url on success).
+fn issues_create(
+    root: &std::path::Path,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    assignee: Option<&str>,
+) -> (String, Result<String, String>) {
+    let provider = crate::issue_provider::GhIssueProvider;
+    let draft = stella_protocol::issue::IssueDraft {
+        title: title.to_owned(),
+        body: body.to_owned(),
+        labels: labels.iter().map(|l| stella_protocol::issue::IssueLabel::from(l.as_str())).collect(),
+        parent: None,
+    };
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(error) => {
+            return (
+                String::new(),
+                Err(format!("could not start a runtime for the issue provider: {error}")),
+            )
+        }
+    };
+    let _ = (root, assignee); // assignee rides the tracker's own field map later
+    match runtime.block_on(provider.file(&draft)) {
+        Ok(key) => {
+            let key = key.as_str().to_owned();
+            (key.clone(), Ok(format!("created #{key}")))
+        }
+        Err(error) => (String::new(), Err(error.to_string())),
+    }
+}
+
+/// Act on one existing issue: comment, close, re-open, or move status.
+fn issues_act(root: &std::path::Path, key: &str, action: &IssueAction) -> Result<String, String> {
+    let provider = crate::issue_provider::GhIssueProvider;
+    let key = stella_protocol::issue::IssueKey::from(key.trim_start_matches('#'));
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    let _ = root;
+    match action {
+        IssueAction::Comment(body) => runtime
+            .block_on(provider.comment(&key, body))
+            .map(|_| format!("comment added to #{key}"))
+            .map_err(|error| error.to_string()),
+        IssueAction::Close => runtime
+            .block_on(provider.close(&key, "", "completed"))
+            .map(|_| format!("closed #{key}"))
+            .map_err(|error| error.to_string()),
+        IssueAction::SetStatus(status) if status.eq_ignore_ascii_case("open") => runtime
+            .block_on(provider.reopen(&key))
+            .map(|_| format!("re-opened #{key}"))
+            .map_err(|error| error.to_string()),
+        IssueAction::SetStatus(status) => Err(format!(
+            "unsupported status `{status}` — GitHub issues are open or closed"
+        )),
+        IssueAction::StartWork => Err(
+            "start work is the self-driving loop's claim, not a tracker status".to_string(),
+        ),
+    }
+}
+
+/// Map the kernel's [`stella_protocol::issue::Issue`] into the tab's row.
+///
+/// The key gets its `#` here, at the boundary: the provider's key is the
+/// tracker's bare identifier (what `gh` and the API take), the row's is the
+/// display spelling a human reads and the tab echoes back — and `issues_act`
+/// strips it again on the way out.
+fn issue_row(issue: &stella_protocol::issue::Issue) -> IssueRow {
+    IssueRow {
+        key: format!("#{}", issue.key.as_str()),
+        title: issue.title.clone(),
+        state: match issue.state {
+            stella_protocol::issue::IssueState::Open => "open",
+            stella_protocol::issue::IssueState::InProgress => "in progress",
+            stella_protocol::issue::IssueState::Closed => "closed",
+        }
+        .to_owned(),
+        labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
+        assignee: None,
+        url: issue.url.clone(),
+        updated_at: None,
+    }
+}
+
+/// The page size the ISSUES tab browses by — one `gh issue list` read.
+const ISSUES_PAGE: usize = 30;
 
 /// Installed agents whose name or description contains `query`
 /// (case-insensitive; an empty query matches all) as "Agent" hits.
@@ -3112,39 +3230,58 @@ fn merge_assignee_hits(
     merged
 }
 
-/// Service one ISSUES-tab request. The deck carries no tracker transport —
-/// issue trackers reach a session as MCP tools — so the list/mutate requests
-/// answer with the tab's empty-state hint, and entity search serves the
-/// local sources (installed agents, memories, code-graph symbols). Spawned
-/// where work is real (the `spawn_mcp_oauth_login` shape) so a slow SQLite
-/// or grammar load never stalls the driver loop. Returns `true` when the
-/// input was one of the tab's.
+/// Service one ISSUES-tab request. The tab's tracker is the workspace's
+/// configured issue provider (GitHub by default, reached through the `gh`
+/// CLI — see [`crate::issue_provider`]); entity search serves the local
+/// sources (installed agents, memories, code-graph symbols). Spawned where
+/// work is real (the `spawn_mcp_oauth_login` shape) so a slow `gh` call,
+/// SQLite read, or grammar load never stalls the driver loop. Returns `true`
+/// when the input was one of the tab's.
 fn handle_issues_input(
     input: &WorkspaceInput,
     cfg: &Config,
     in_tx: &UnboundedSender<Inbound>,
 ) -> bool {
     match input {
-        WorkspaceInput::IssuesRefresh { seq, .. } => {
-            let _ = in_tx.send(Inbound::IssuesList {
-                seq: *seq,
-                outcome: Err(NO_TRACKER_HINT.to_string()),
+        WorkspaceInput::IssuesRefresh {
+            query,
+            state,
+            seq,
+        } => {
+            let (in_tx, seq) = (in_tx.clone(), *seq);
+            let query = query.clone();
+            let state = state.clone();
+            let root = cfg.workspace_root.clone();
+            tokio::task::spawn_blocking(move || {
+                let outcome = issues_list(&root, query.as_deref(), state);
+                let _ = in_tx.send(Inbound::IssuesList { seq, outcome });
             });
             true
         }
-        WorkspaceInput::IssueCreate { seq, .. } => {
-            let _ = in_tx.send(Inbound::IssueActDone {
-                seq: *seq,
-                key: String::new(),
-                outcome: Err(NO_TRACKER_HINT.to_string()),
+        WorkspaceInput::IssueCreate {
+            title,
+            body,
+            labels,
+            assignee,
+            seq,
+        } => {
+            let (in_tx, seq) = (in_tx.clone(), *seq);
+            let (title, body, labels, assignee) =
+                (title.clone(), body.clone(), labels.clone(), assignee.clone());
+            let root = cfg.workspace_root.clone();
+            tokio::task::spawn_blocking(move || {
+                let (key, outcome) = issues_create(&root, &title, &body, &labels, assignee.as_deref());
+                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
             });
             true
         }
-        WorkspaceInput::IssueAct { key, seq, .. } => {
-            let _ = in_tx.send(Inbound::IssueActDone {
-                seq: *seq,
-                key: key.clone(),
-                outcome: Err(NO_TRACKER_HINT.to_string()),
+        WorkspaceInput::IssueAct { key, action, seq } => {
+            let (in_tx, seq) = (in_tx.clone(), *seq);
+            let (key, action) = (key.clone(), action.clone());
+            let root = cfg.workspace_root.clone();
+            tokio::task::spawn_blocking(move || {
+                let outcome = issues_act(&root, &key, &action);
+                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
             });
             true
         }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -73,15 +73,14 @@ use stella_model::provider::Provider;
 use stella_protocol::{
     AgentEvent, CiStatus, CompletionMessage, CompletionRequest, PrStatus, TaskItem, ToolOutput,
 };
-use stella_protocol::issue::IssueProvider;
 use stella_store::Store;
 use stella_tools::ToolRegistry;
 use stella_tools::custom::CustomTool;
 use stella_tools::hook_runner::ShellHookRunner;
 use stella_tui::{
-    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityField, EntityHit, Inbound, IssueAction,
-    IssueRow, SkillOp, SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput,
-    WorkspaceInput, run_deck,
+    AgentMeta, AgentScope, AgentStatus, DeckOptions, EntityHit, Inbound, SkillOp,
+    SkillScope, SkillSearchHit, SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
+    run_deck,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -117,6 +116,9 @@ use task_tap::TaskTap;
 
 /// Where an Esc-delivered steer lands, driver-side.
 mod steer;
+
+/// ISSUES-tab requests, served by the workspace's issue provider.
+mod issues;
 
 /// The lead agent's id — the one conversation this driver runs.
 pub(crate) const LEAD: &str = "lead";
@@ -1296,7 +1298,7 @@ pub async fn run_deck_session(
                             )
                             && !service_inspect_action(&other, &store, last_execution_id, &in_tx)
                             && !handle_agents_input(&other, cfg, &in_tx)
-                            && !handle_issues_input(&other, cfg, &in_tx)
+                            && !issues::handle_issues_input(&other, cfg, &in_tx)
                             && !handle_engine_config_input(&other, cfg, &mut settings_stale, &in_tx)
                         {
                             // The tool list is enumerated here rather than
@@ -1909,7 +1911,7 @@ pub async fn run_deck_session(
                             | WorkspaceInput::IssueAct { .. }
                             | WorkspaceInput::EntitySearch { .. }),
                         ) => {
-                            handle_issues_input(&input, cfg, &in_tx);
+                            issues::handle_issues_input(&input, cfg, &in_tx);
                         }
                         // Everything above peeled off `Stop` and every worker
                         // lane, so this is the LEAD's own pause/resume/restart.
@@ -2936,132 +2938,10 @@ fn spawn_notification_poller(in_tx: mpsc::UnboundedSender<Inbound>) {
 
 // ── ISSUES tab: tracker-backed operations ───────────────────────────────────
 
-/// One page of the ISSUES tab's browse list, from the workspace's issue
-/// provider.
-///
-/// Runs on a blocking thread (`gh` is a subprocess), so the provider call —
-/// async over a synchronous CLI — gets the same fresh current-thread runtime
-/// the self-driving commands use rather than a handle on the deck's.
-fn issues_list(
-    root: &std::path::Path,
-    query: Option<&str>,
-    state: Option<String>,
-) -> Result<Vec<IssueRow>, String> {
-    let provider = crate::issue_provider::GhIssueProvider;
-    let state = match state.as_deref() {
-        Some("open") => Some(stella_protocol::issue::IssueState::Open),
-        Some("closed") => Some(stella_protocol::issue::IssueState::Closed),
-        _ => None,
-    };
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
-    let issues = runtime
-        .block_on(provider.search(query.unwrap_or(""), state, ISSUES_PAGE, 0))
-        .map_err(|error| error.to_string())?;
-    let _ = root; // the provider binds to the workspace through `gh`'s cwd
-    Ok(issues.iter().map(issue_row).collect())
-}
-
-/// File one issue through the provider; answer with the created key and a
-/// human status line (the created key + url on success).
-fn issues_create(
-    root: &std::path::Path,
-    title: &str,
-    body: &str,
-    labels: &[String],
-    assignee: Option<&str>,
-) -> (String, Result<String, String>) {
-    let provider = crate::issue_provider::GhIssueProvider;
-    let draft = stella_protocol::issue::IssueDraft {
-        title: title.to_owned(),
-        body: body.to_owned(),
-        labels: labels.iter().map(|l| stella_protocol::issue::IssueLabel::from(l.as_str())).collect(),
-        parent: None,
-    };
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(error) => {
-            return (
-                String::new(),
-                Err(format!("could not start a runtime for the issue provider: {error}")),
-            )
-        }
-    };
-    let _ = (root, assignee); // assignee rides the tracker's own field map later
-    match runtime.block_on(provider.file(&draft)) {
-        Ok(key) => {
-            let key = key.as_str().to_owned();
-            (key.clone(), Ok(format!("created #{key}")))
-        }
-        Err(error) => (String::new(), Err(error.to_string())),
-    }
-}
-
-/// Act on one existing issue: comment, close, re-open, or move status.
-fn issues_act(root: &std::path::Path, key: &str, action: &IssueAction) -> Result<String, String> {
-    let provider = crate::issue_provider::GhIssueProvider;
-    let key = stella_protocol::issue::IssueKey::from(key.trim_start_matches('#'));
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
-    let _ = root;
-    match action {
-        IssueAction::Comment(body) => runtime
-            .block_on(provider.comment(&key, body))
-            .map(|_| format!("comment added to #{key}"))
-            .map_err(|error| error.to_string()),
-        IssueAction::Close => runtime
-            .block_on(provider.close(&key, "", "completed"))
-            .map(|_| format!("closed #{key}"))
-            .map_err(|error| error.to_string()),
-        IssueAction::SetStatus(status) if status.eq_ignore_ascii_case("open") => runtime
-            .block_on(provider.reopen(&key))
-            .map(|_| format!("re-opened #{key}"))
-            .map_err(|error| error.to_string()),
-        IssueAction::SetStatus(status) => Err(format!(
-            "unsupported status `{status}` — GitHub issues are open or closed"
-        )),
-        IssueAction::StartWork => Err(
-            "start work is the self-driving loop's claim, not a tracker status".to_string(),
-        ),
-    }
-}
-
-/// Map the kernel's [`stella_protocol::issue::Issue`] into the tab's row.
-///
-/// The key gets its `#` here, at the boundary: the provider's key is the
-/// tracker's bare identifier (what `gh` and the API take), the row's is the
-/// display spelling a human reads and the tab echoes back — and `issues_act`
-/// strips it again on the way out.
-fn issue_row(issue: &stella_protocol::issue::Issue) -> IssueRow {
-    IssueRow {
-        key: format!("#{}", issue.key.as_str()),
-        title: issue.title.clone(),
-        state: match issue.state {
-            stella_protocol::issue::IssueState::Open => "open",
-            stella_protocol::issue::IssueState::InProgress => "in progress",
-            stella_protocol::issue::IssueState::Closed => "closed",
-        }
-        .to_owned(),
-        labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
-        assignee: None,
-        url: issue.url.clone(),
-        updated_at: None,
-    }
-}
-
-/// The page size the ISSUES tab browses by — one `gh issue list` read.
-const ISSUES_PAGE: usize = 30;
 
 /// Installed agents whose name or description contains `query`
 /// (case-insensitive; an empty query matches all) as "Agent" hits.
-fn agent_entity_hits(entries: &[stella_tui::InstalledAgentEntry], query: &str) -> Vec<EntityHit> {
+pub(super) fn agent_entity_hits(entries: &[stella_tui::InstalledAgentEntry], query: &str) -> Vec<EntityHit> {
     let needle = query.trim().to_lowercase();
     entries
         .iter()
@@ -3151,7 +3031,7 @@ fn symbol_hit(frame: &contextgraph_types::ContextFrame) -> EntityHit {
 /// definitions when an index exists. Read-only politeness (the `stella
 /// stats` discipline): a missing database reads as "no hits", never a
 /// write. Failures of one source never kill another.
-fn local_assignee_hits(root: &std::path::Path, query: &str) -> Vec<EntityHit> {
+pub(super) fn local_assignee_hits(root: &std::path::Path, query: &str) -> Vec<EntityHit> {
     let needle = query.trim().to_lowercase();
     let mut hits = Vec::new();
 
@@ -3219,7 +3099,7 @@ fn local_assignee_hits(root: &std::path::Path, query: &str) -> Vec<EntityHit> {
 
 /// Merge the assignee sources in priority order — installed agents first,
 /// then local memories/symbols — capped at `cap`.
-fn merge_assignee_hits(
+pub(super) fn merge_assignee_hits(
     agents: Vec<EntityHit>,
     local: Vec<EntityHit>,
     cap: usize,
@@ -3228,107 +3108,6 @@ fn merge_assignee_hits(
     merged.extend(local);
     merged.truncate(cap);
     merged
-}
-
-/// Service one ISSUES-tab request. The tab's tracker is the workspace's
-/// configured issue provider (GitHub by default, reached through the `gh`
-/// CLI — see [`crate::issue_provider`]); entity search serves the local
-/// sources (installed agents, memories, code-graph symbols). Spawned where
-/// work is real (the `spawn_mcp_oauth_login` shape) so a slow `gh` call,
-/// SQLite read, or grammar load never stalls the driver loop. Returns `true`
-/// when the input was one of the tab's.
-fn handle_issues_input(
-    input: &WorkspaceInput,
-    cfg: &Config,
-    in_tx: &UnboundedSender<Inbound>,
-) -> bool {
-    match input {
-        WorkspaceInput::IssuesRefresh {
-            query,
-            state,
-            seq,
-        } => {
-            let (in_tx, seq) = (in_tx.clone(), *seq);
-            let query = query.clone();
-            let state = state.clone();
-            let root = cfg.workspace_root.clone();
-            tokio::task::spawn_blocking(move || {
-                let outcome = issues_list(&root, query.as_deref(), state);
-                let _ = in_tx.send(Inbound::IssuesList { seq, outcome });
-            });
-            true
-        }
-        WorkspaceInput::IssueCreate {
-            title,
-            body,
-            labels,
-            assignee,
-            seq,
-        } => {
-            let (in_tx, seq) = (in_tx.clone(), *seq);
-            let (title, body, labels, assignee) =
-                (title.clone(), body.clone(), labels.clone(), assignee.clone());
-            let root = cfg.workspace_root.clone();
-            tokio::task::spawn_blocking(move || {
-                let (key, outcome) = issues_create(&root, &title, &body, &labels, assignee.as_deref());
-                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
-            });
-            true
-        }
-        WorkspaceInput::IssueAct { key, action, seq } => {
-            let (in_tx, seq) = (in_tx.clone(), *seq);
-            let (key, action) = (key.clone(), action.clone());
-            let root = cfg.workspace_root.clone();
-            tokio::task::spawn_blocking(move || {
-                let outcome = issues_act(&root, &key, &action);
-                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
-            });
-            true
-        }
-        WorkspaceInput::EntitySearch { field, query, seq } => {
-            let (in_tx, seq, field) = (in_tx.clone(), *seq, *field);
-            let query = query.clone();
-            let root = cfg.workspace_root.clone();
-            tokio::spawn(async move {
-                let hits = match field {
-                    // No tracker transport: no label vocabulary. The popup
-                    // shows "no matches"; the list-level requests carry the
-                    // hint.
-                    EntityField::Label => Vec::new(),
-                    EntityField::Assignee => {
-                        // Independent sources — a failure of one must not
-                        // kill the others; collect what succeeds.
-                        let agents = {
-                            let project = crate::agents_installed::project_agents_dir(&root);
-                            let user = crate::agents_installed::user_agents_dir();
-                            agent_entity_hits(
-                                &crate::agents_installed::discover(user.as_deref(), &project),
-                                &query,
-                            )
-                        };
-                        let local = {
-                            let root = root.clone();
-                            let query = query.clone();
-                            // SQLite opens + tree-sitter grammar loading are
-                            // synchronous — keep them off the async workers.
-                            tokio::task::spawn_blocking(move || local_assignee_hits(&root, &query))
-                                .await
-                                .unwrap_or_default()
-                        };
-                        merge_assignee_hits(agents, local, 20)
-                    }
-                };
-                let _ = in_tx.send(Inbound::EntityHits {
-                    field,
-                    seq,
-                    query,
-                    hits,
-                });
-            });
-            true
-        }
-        _ => false,
-    }
 }
 
 /// The disposition of a would-be slash command.

--- a/crates/stella-cli/src/command_deck/issues.rs
+++ b/crates/stella-cli/src/command_deck/issues.rs
@@ -1,8 +1,8 @@
 //! ISSUES-tab driver half: the deck's requests, served by the workspace's
 //! issue provider.
 //!
-//! Every function here is generic over [`IssueProvider`] rather than reaching
-//! for [`crate::issue_provider::GhIssueProvider`] itself (invariant 1 — the
+//! Every function here is generic over `IssueProvider` rather than reaching
+//! for `crate::issue_provider::GhIssueProvider` itself (invariant 1 — the
 //! tracker is a port, and GitHub is one adapter behind it). That is also what
 //! makes the mapping testable without a network, a `gh` binary, or a
 //! repository: the tests below drive a recording fake and assert on the exact
@@ -227,7 +227,7 @@ pub(super) fn handle_issues_input(
                     // reaches it), but nothing reads it into this popup yet —
                     // it would be a `gh label list` behind a port method the
                     // `IssueProvider` trait does not have. Declared gap, not a
-                    // silence: the popup shows "no matches" until #4246 adds
+                    // silence: the popup shows "no matches" until #4251 adds
                     // the read.
                     EntityField::Label => Vec::new(),
                     EntityField::Assignee => {

--- a/crates/stella-cli/src/command_deck/issues.rs
+++ b/crates/stella-cli/src/command_deck/issues.rs
@@ -74,7 +74,10 @@ pub(super) fn issues_create<P: IssueProvider + ?Sized>(
     let draft = IssueDraft {
         title: title.to_owned(),
         body: body.to_owned(),
-        labels: labels.iter().map(|l| IssueLabel::from(l.as_str())).collect(),
+        labels: labels
+            .iter()
+            .map(|l| IssueLabel::from(l.as_str()))
+            .collect(),
         parent: None,
         // Empty is the create form's "left blank", which is not the same
         // request as assigning someone named "".
@@ -174,8 +177,7 @@ pub(super) fn handle_issues_input(
             let query = query.clone();
             let state = state.clone();
             tokio::task::spawn_blocking(move || {
-                let outcome =
-                    issues_list(&GhIssueProvider, query.as_deref(), state, page);
+                let outcome = issues_list(&GhIssueProvider, query.as_deref(), state, page);
                 let _ = in_tx.send(Inbound::IssuesList { seq, outcome });
             });
             true
@@ -188,8 +190,12 @@ pub(super) fn handle_issues_input(
             seq,
         } => {
             let (in_tx, seq) = (in_tx.clone(), *seq);
-            let (title, body, labels, assignee) =
-                (title.clone(), body.clone(), labels.clone(), assignee.clone());
+            let (title, body, labels, assignee) = (
+                title.clone(),
+                body.clone(),
+                labels.clone(),
+                assignee.clone(),
+            );
             tokio::task::spawn_blocking(move || {
                 let (key, outcome) = issues_create(
                     &GhIssueProvider,
@@ -294,10 +300,11 @@ mod tests {
             title: format!("issue {number}"),
             body: String::new(),
             state,
-            class: IssueClass::Defect,
+            class: IssueClass::Bug,
             labels: vec![IssueLabel::from("bug")],
             created_at: String::new(),
             url: format!("https://github.com/o/r/issues/{number}"),
+            parent: None,
         }
     }
 
@@ -345,6 +352,25 @@ mod tests {
 
         async fn reopen(&self, key: &IssueKey) -> Result<(), IssueError> {
             self.calls().reopened.push(key.as_str().to_owned());
+            Ok(())
+        }
+
+        // Not reachable from the ISSUES tab's verbs; the trait requires them.
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
             Ok(())
         }
     }
@@ -407,7 +433,8 @@ mod tests {
     fn a_blank_assignee_files_unassigned() {
         let tracker = FakeTracker::default();
         for blank in [None, Some(""), Some("   ")] {
-            issues_create(&tracker, "t", "b", &[], blank);
+            let (_, outcome) = issues_create(&tracker, "t", "b", &[], blank);
+            outcome.expect("the fake files successfully");
         }
         let calls = tracker.calls();
         assert!(

--- a/crates/stella-cli/src/command_deck/issues.rs
+++ b/crates/stella-cli/src/command_deck/issues.rs
@@ -1,0 +1,446 @@
+//! ISSUES-tab driver half: the deck's requests, served by the workspace's
+//! issue provider.
+//!
+//! Every function here is generic over [`IssueProvider`] rather than reaching
+//! for [`crate::issue_provider::GhIssueProvider`] itself (invariant 1 — the
+//! tracker is a port, and GitHub is one adapter behind it). That is also what
+//! makes the mapping testable without a network, a `gh` binary, or a
+//! repository: the tests below drive a recording fake and assert on the exact
+//! arguments the port received.
+//!
+//! Split from `command_deck.rs` (#629's 1500-line ratchet).
+
+use stella_protocol::issue::{Issue, IssueDraft, IssueKey, IssueLabel, IssueProvider, IssueState};
+use stella_tui::{EntityField, Inbound, IssueAction, IssueRow, WorkspaceInput};
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::{agent_entity_hits, local_assignee_hits, merge_assignee_hits};
+use crate::config::Config;
+use crate::issue_provider::GhIssueProvider;
+
+/// The page size the ISSUES tab browses by — one `gh issue list` read.
+///
+/// The TUI's `ISSUES_PAGE_SIZE` must agree: the tab decides "this was the last
+/// page" by seeing fewer rows come back than it asked for, so a driver reading
+/// a different number would either hide a page or offer one that is empty.
+pub(super) const ISSUES_PAGE: usize = 30;
+
+/// Run one provider call to completion on the calling thread.
+///
+/// The caller is already inside `spawn_blocking` (`gh` is a subprocess), so
+/// this builds the same fresh current-thread runtime the self-driving commands
+/// use rather than borrowing a handle on the deck's — blocking a deck worker
+/// on a subprocess is what would stall the driver loop.
+fn block_on<F: std::future::Future>(future: F) -> Result<F::Output, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))
+        .map(|runtime| runtime.block_on(future))
+}
+
+/// One page of the ISSUES tab's browse list.
+///
+/// `page` is 0-based and comes from the tab, which is the only thing that
+/// knows which page the human is looking at; it becomes the port's `offset`
+/// here. Ordering is the tracker's, so paging is only as stable as the
+/// tracker's own order — the same caveat [`IssueProvider::search`] carries.
+pub(super) fn issues_list<P: IssueProvider + ?Sized>(
+    provider: &P,
+    query: Option<&str>,
+    state: Option<String>,
+    page: usize,
+) -> Result<Vec<IssueRow>, String> {
+    let state = match state.as_deref() {
+        Some("open") => Some(IssueState::Open),
+        Some("closed") => Some(IssueState::Closed),
+        _ => None,
+    };
+    let offset = page.saturating_mul(ISSUES_PAGE);
+    let issues = block_on(provider.search(query.unwrap_or(""), state, ISSUES_PAGE, offset))?
+        .map_err(|error| error.to_string())?;
+    Ok(issues.iter().map(issue_row).collect())
+}
+
+/// File one issue through the provider; answer with the created key and a
+/// human status line.
+pub(super) fn issues_create<P: IssueProvider + ?Sized>(
+    provider: &P,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    assignee: Option<&str>,
+) -> (String, Result<String, String>) {
+    let draft = IssueDraft {
+        title: title.to_owned(),
+        body: body.to_owned(),
+        labels: labels.iter().map(|l| IssueLabel::from(l.as_str())).collect(),
+        parent: None,
+        // Empty is the create form's "left blank", which is not the same
+        // request as assigning someone named "".
+        assignee: assignee
+            .map(str::trim)
+            .filter(|a| !a.is_empty())
+            .map(str::to_owned),
+    };
+    match block_on(provider.file(&draft)) {
+        Err(error) => (String::new(), Err(error)),
+        Ok(Ok(key)) => {
+            let key = key.as_str().to_owned();
+            (key.clone(), Ok(format!("created #{key}")))
+        }
+        Ok(Err(error)) => (String::new(), Err(error.to_string())),
+    }
+}
+
+/// Act on one existing issue: comment, close, re-open, or move status.
+pub(super) fn issues_act<P: IssueProvider + ?Sized>(
+    provider: &P,
+    key: &str,
+    action: &IssueAction,
+) -> Result<String, String> {
+    // The row's key is the display spelling (`#874`); the tracker takes the
+    // bare one. `issue_row` puts the `#` on, this takes it back off — the two
+    // halves of one boundary.
+    let key = IssueKey::from(key.trim_start_matches('#'));
+    let done = |verb: &str| format!("{verb} #{key}");
+    match action {
+        IssueAction::Comment(body) => block_on(provider.comment(&key, body))?
+            .map(|()| done("comment added to"))
+            .map_err(|error| error.to_string()),
+        IssueAction::Close => block_on(provider.close(&key, "", "completed"))?
+            .map(|()| done("closed"))
+            .map_err(|error| error.to_string()),
+        IssueAction::Reopen => block_on(provider.reopen(&key))?
+            .map(|()| done("re-opened"))
+            .map_err(|error| error.to_string()),
+        IssueAction::SetStatus(status) => Err(format!(
+            "unsupported status `{status}` — GitHub issues are open or closed \
+             (`x` closes and re-opens)"
+        )),
+        IssueAction::StartWork => {
+            Err("start work is the self-driving loop's claim, not a tracker status".to_string())
+        }
+    }
+}
+
+/// Map the kernel's [`Issue`] into the tab's row.
+///
+/// The key gets its `#` here, at the boundary: the provider's key is the
+/// tracker's bare identifier (what `gh` and the API take), the row's is the
+/// display spelling a human reads and the tab echoes back — and [`issues_act`]
+/// strips it again on the way out. Everything between renders `{key}` bare;
+/// a `#{key}` in the tab would read `##874`.
+fn issue_row(issue: &Issue) -> IssueRow {
+    IssueRow {
+        key: format!("#{}", issue.key.as_str()),
+        title: issue.title.clone(),
+        state: match issue.state {
+            IssueState::Open => "open",
+            IssueState::InProgress => "in progress",
+            IssueState::Closed => "closed",
+        }
+        .to_owned(),
+        labels: issue.labels.iter().map(|l| l.name.clone()).collect(),
+        // `Issue` carries no assignee — the port does not read one, so the row
+        // says so rather than inventing a blank. Filling this in means adding
+        // the field to the port first, for every tracker.
+        assignee: None,
+        url: issue.url.clone(),
+        updated_at: None,
+    }
+}
+
+/// Service one ISSUES-tab request. The tab's tracker is the workspace's
+/// configured issue provider (GitHub by default, reached through the `gh`
+/// CLI — see [`crate::issue_provider`]); entity search serves the local
+/// sources (installed agents, memories, code-graph symbols). Spawned where
+/// work is real (the `spawn_mcp_oauth_login` shape) so a slow `gh` call,
+/// SQLite read, or grammar load never stalls the driver loop. Returns `true`
+/// when the input was one of the tab's.
+pub(super) fn handle_issues_input(
+    input: &WorkspaceInput,
+    cfg: &Config,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    match input {
+        WorkspaceInput::IssuesRefresh {
+            query,
+            state,
+            page,
+            seq,
+        } => {
+            let (in_tx, seq, page) = (in_tx.clone(), *seq, *page);
+            let query = query.clone();
+            let state = state.clone();
+            tokio::task::spawn_blocking(move || {
+                let outcome =
+                    issues_list(&GhIssueProvider, query.as_deref(), state, page);
+                let _ = in_tx.send(Inbound::IssuesList { seq, outcome });
+            });
+            true
+        }
+        WorkspaceInput::IssueCreate {
+            title,
+            body,
+            labels,
+            assignee,
+            seq,
+        } => {
+            let (in_tx, seq) = (in_tx.clone(), *seq);
+            let (title, body, labels, assignee) =
+                (title.clone(), body.clone(), labels.clone(), assignee.clone());
+            tokio::task::spawn_blocking(move || {
+                let (key, outcome) = issues_create(
+                    &GhIssueProvider,
+                    &title,
+                    &body,
+                    &labels,
+                    assignee.as_deref(),
+                );
+                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
+            });
+            true
+        }
+        WorkspaceInput::IssueAct { key, action, seq } => {
+            let (in_tx, seq) = (in_tx.clone(), *seq);
+            let (key, action) = (key.clone(), action.clone());
+            tokio::task::spawn_blocking(move || {
+                let outcome = issues_act(&GhIssueProvider, &key, &action);
+                let _ = in_tx.send(Inbound::IssueActDone { seq, key, outcome });
+            });
+            true
+        }
+        WorkspaceInput::EntitySearch { field, query, seq } => {
+            let (in_tx, seq, field) = (in_tx.clone(), *seq, *field);
+            let query = query.clone();
+            let root = cfg.workspace_root.clone();
+            tokio::spawn(async move {
+                let hits = match field {
+                    // The tracker has a label vocabulary now (the ISSUES tab
+                    // reaches it), but nothing reads it into this popup yet —
+                    // it would be a `gh label list` behind a port method the
+                    // `IssueProvider` trait does not have. Declared gap, not a
+                    // silence: the popup shows "no matches" until #4246 adds
+                    // the read.
+                    EntityField::Label => Vec::new(),
+                    EntityField::Assignee => {
+                        // Independent sources — a failure of one must not
+                        // kill the others; collect what succeeds.
+                        let agents = {
+                            let project = crate::agents_installed::project_agents_dir(&root);
+                            let user = crate::agents_installed::user_agents_dir();
+                            agent_entity_hits(
+                                &crate::agents_installed::discover(user.as_deref(), &project),
+                                &query,
+                            )
+                        };
+                        let local = {
+                            let root = root.clone();
+                            let query = query.clone();
+                            // SQLite opens + tree-sitter grammar loading are
+                            // synchronous — keep them off the async workers.
+                            tokio::task::spawn_blocking(move || local_assignee_hits(&root, &query))
+                                .await
+                                .unwrap_or_default()
+                        };
+                        merge_assignee_hits(agents, local, 20)
+                    }
+                };
+                let _ = in_tx.send(Inbound::EntityHits {
+                    field,
+                    seq,
+                    query,
+                    hits,
+                });
+            });
+            true
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use stella_protocol::issue::{IssueClass, IssueError};
+
+    /// What the fake was asked for, so a test can assert on the exact call the
+    /// port received rather than on a value the caller round-tripped.
+    #[derive(Default)]
+    struct Calls {
+        search: Vec<(String, Option<IssueState>, usize, usize)>,
+        filed: Vec<IssueDraft>,
+        reopened: Vec<String>,
+        closed: Vec<String>,
+    }
+
+    #[derive(Default)]
+    struct FakeTracker {
+        calls: Mutex<Calls>,
+        rows: Vec<Issue>,
+    }
+
+    impl FakeTracker {
+        fn calls(&self) -> std::sync::MutexGuard<'_, Calls> {
+            self.calls.lock().expect("test mutex")
+        }
+    }
+
+    fn an_issue(number: u32, state: IssueState) -> Issue {
+        Issue {
+            key: IssueKey::from(number.to_string().as_str()),
+            title: format!("issue {number}"),
+            body: String::new(),
+            state,
+            class: IssueClass::Defect,
+            labels: vec![IssueLabel::from("bug")],
+            created_at: String::new(),
+            url: format!("https://github.com/o/r/issues/{number}"),
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IssueProvider for FakeTracker {
+        fn id(&self) -> &str {
+            "fake"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(self.rows.clone())
+        }
+
+        async fn search(
+            &self,
+            query: &str,
+            state: Option<IssueState>,
+            limit: usize,
+            offset: usize,
+        ) -> Result<Vec<Issue>, IssueError> {
+            self.calls()
+                .search
+                .push((query.to_owned(), state, limit, offset));
+            Ok(self.rows.clone())
+        }
+
+        async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            self.calls().filed.push(draft.clone());
+            Ok(IssueKey::from("874"))
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn close(
+            &self,
+            key: &IssueKey,
+            _evidence: &str,
+            _reason: &str,
+        ) -> Result<(), IssueError> {
+            self.calls().closed.push(key.as_str().to_owned());
+            Ok(())
+        }
+
+        async fn reopen(&self, key: &IssueKey) -> Result<(), IssueError> {
+            self.calls().reopened.push(key.as_str().to_owned());
+            Ok(())
+        }
+    }
+
+    /// The witness for the paging defect: page 2 must reach the port as
+    /// `offset = 30`. Before `IssuesRefresh` carried a page the driver passed
+    /// a literal `0`, so `]` re-fetched page one under a "page 2" notice.
+    #[test]
+    fn a_page_becomes_the_ports_offset() {
+        let tracker = FakeTracker::default();
+        for (page, want_offset) in [(0, 0), (1, 30), (2, 60)] {
+            issues_list(&tracker, Some("flaky"), None, page).expect("list");
+            let calls = tracker.calls();
+            let (query, _, limit, offset) = calls.search.last().expect("a search call");
+            assert_eq!(query, "flaky", "the query rides the page request");
+            assert_eq!(*limit, ISSUES_PAGE);
+            assert_eq!(*offset, want_offset, "page {page}");
+        }
+    }
+
+    /// A row's key is the display spelling; the tracker gets the bare one.
+    #[test]
+    fn the_row_key_carries_a_hash_and_the_tracker_never_sees_it() {
+        let tracker = FakeTracker {
+            rows: vec![an_issue(874, IssueState::Closed)],
+            ..FakeTracker::default()
+        };
+        let rows = issues_list(&tracker, None, None, 0).expect("list");
+        assert_eq!(rows[0].key, "#874", "the row is what a human reads");
+        assert_eq!(rows[0].state, "closed", "a mixed-state page renders state");
+
+        // Feeding that row's key straight back strips the `#` again.
+        issues_act(&tracker, &rows[0].key, &IssueAction::Reopen).expect("reopen");
+        assert_eq!(tracker.calls().reopened, ["874"]);
+    }
+
+    /// The create form's Assignee field reaches the draft. It used to be
+    /// dropped with a `let _ = assignee`, so a filled-in assignee filed an
+    /// unassigned issue and said nothing.
+    #[test]
+    fn the_create_forms_assignee_reaches_the_draft() {
+        let tracker = FakeTracker::default();
+        let (key, outcome) = issues_create(
+            &tracker,
+            "a title",
+            "a body",
+            &["bug".to_string()],
+            Some("octocat"),
+        );
+        assert_eq!(key, "874");
+        assert_eq!(outcome.as_deref(), Ok("created #874"));
+        let calls = tracker.calls();
+        let draft = calls.filed.last().expect("a filed draft");
+        assert_eq!(draft.assignee.as_deref(), Some("octocat"));
+        assert_eq!(draft.labels, vec![IssueLabel::from("bug")]);
+    }
+
+    /// A blank Assignee field is "unassigned", not an empty-named user.
+    #[test]
+    fn a_blank_assignee_files_unassigned() {
+        let tracker = FakeTracker::default();
+        for blank in [None, Some(""), Some("   ")] {
+            issues_create(&tracker, "t", "b", &[], blank);
+        }
+        let calls = tracker.calls();
+        assert!(
+            calls.filed.iter().all(|d| d.assignee.is_none()),
+            "blank must not become Some(\"\")"
+        );
+    }
+
+    /// `x` routes both directions to a distinct port call — never a status
+    /// string the driver has to compare.
+    #[test]
+    fn close_and_reopen_reach_their_own_port_calls() {
+        let tracker = FakeTracker::default();
+        assert_eq!(
+            issues_act(&tracker, "#874", &IssueAction::Close).as_deref(),
+            Ok("closed #874")
+        );
+        assert_eq!(
+            issues_act(&tracker, "#875", &IssueAction::Reopen).as_deref(),
+            Ok("re-opened #875")
+        );
+        let calls = tracker.calls();
+        assert_eq!(calls.closed, ["874"]);
+        assert_eq!(calls.reopened, ["875"]);
+    }
+
+    /// A status GitHub does not have is refused by name, not silently ignored.
+    #[test]
+    fn an_unsupported_status_is_refused_by_name() {
+        let tracker = FakeTracker::default();
+        let err = issues_act(&tracker, "#874", &IssueAction::SetStatus("triaged".into()))
+            .expect_err("triaged is not a GitHub state");
+        assert!(err.contains("triaged"), "{err}");
+        assert!(tracker.calls().reopened.is_empty(), "nothing was called");
+    }
+}

--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -159,6 +159,13 @@ impl IssueProvider for GhIssueProvider {
             args.push("--label".into());
             args.push(label.name.clone());
         }
+        // Assigned in the create call rather than a follow-up `gh issue edit`:
+        // one call cannot half-succeed, and a second one could leave the issue
+        // filed but unassigned with nothing to retry against.
+        if let Some(assignee) = draft.assignee.as_deref().map(str::trim).filter(|a| !a.is_empty()) {
+            args.push("--assignee".into());
+            args.push(assignee.to_owned());
+        }
 
         let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
         let raw = gh_json(&borrowed)?;

--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -162,7 +162,12 @@ impl IssueProvider for GhIssueProvider {
         // Assigned in the create call rather than a follow-up `gh issue edit`:
         // one call cannot half-succeed, and a second one could leave the issue
         // filed but unassigned with nothing to retry against.
-        if let Some(assignee) = draft.assignee.as_deref().map(str::trim).filter(|a| !a.is_empty()) {
+        if let Some(assignee) = draft
+            .assignee
+            .as_deref()
+            .map(str::trim)
+            .filter(|a| !a.is_empty())
+        {
             args.push("--assignee".into());
             args.push(assignee.to_owned());
         }

--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -50,6 +50,11 @@ struct GhIssue {
     body: String,
     #[serde(default)]
     labels: Vec<GhLabel>,
+    /// Present only when the query asks for it — `list_open` does not, the
+    /// deck's browse/search read does, because a list of mixed-state issues
+    /// cannot tell the reader which bucket each row is in without it.
+    #[serde(default)]
+    state: String,
     #[serde(rename = "createdAt", default)]
     created_at: String,
     #[serde(default)]
@@ -90,9 +95,14 @@ impl GhIssue {
             title: self.title,
             body: self.body,
             // `list_open` asks `gh` for open issues only, so every row it
-            // returns is open by construction. This adapter does not invent a
-            // status map because the query already is one.
-            state: IssueState::Open,
+            // returns is open by construction. The mixed-state reads
+            // (`search` with no state filter) ask `gh` for the field and
+            // map what it says; either way this adapter does not invent a
+            // status map — the query already is one, or the payload is.
+            state: match self.state.to_ascii_lowercase().as_str() {
+                "closed" => IssueState::Closed,
+                _ => IssueState::Open,
+            },
             class,
             labels: self
                 .labels
@@ -238,6 +248,60 @@ impl IssueProvider for GhIssueProvider {
         }
         let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
         gh_json(&borrowed).map(|_| ())
+    }
+
+    async fn reopen(&self, key: &IssueKey) -> Result<(), IssueError> {
+        gh_json(&["issue", "reopen", key.as_str()]).map(|_| ())
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        state: Option<IssueState>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Issue>, IssueError> {
+        // `gh issue list` has no server-side offset, so one call fetches
+        // offset+limit rows and this slices the page out. That is the cheap
+        // correct thing at tracker scale: the alternative (one call per page,
+        // each re-fetching the prefix) costs the same bandwidth and adds a
+        // failure mode per extra call.
+        let fetch = (offset + limit).to_string();
+        let state_arg = match state {
+            Some(IssueState::Open) | Some(IssueState::InProgress) => "open",
+            Some(IssueState::Closed) => "closed",
+            None => "all",
+        };
+        // GitHub has no in-progress state (doc:agent-native-delivery §4.2),
+        // so `InProgress` reads as open — the honest approximation, and the
+        // payload's own `state` field is what the caller renders.
+        let mut args: Vec<String> = vec![
+            "issue".into(),
+            "list".into(),
+            "--state".into(),
+            state_arg.into(),
+            "--limit".into(),
+            fetch,
+            "--json".into(),
+            "number,title,body,labels,state,createdAt,url".into(),
+        ];
+        if !query.trim().is_empty() {
+            args.push("--search".into());
+            args.push(query.trim().to_owned());
+        }
+        let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+        let raw = gh_json(&borrowed)?;
+        let rows: Vec<GhIssue> =
+            serde_json::from_str(&raw).map_err(|error| IssueError::Malformed {
+                provider: GITHUB.into(),
+                reason: error.to_string(),
+            })?;
+        Ok(rows
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .map(GhIssue::into_issue)
+            .collect())
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -1266,6 +1266,7 @@ fn file_finding(
             .map(|name| stella_protocol::issue::IssueLabel { name: name.clone() })
             .collect(),
         parent: None,
+        assignee: None,
     };
 
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -330,6 +330,7 @@ pub(super) fn file_base_breakage(
             IssueLabel::from("P0"),
         ],
         parent: None,
+        assignee: None,
     };
 
     runtime
@@ -746,6 +747,7 @@ mod tests {
             body: "a handoff".into(),
             labels: labels.iter().copied().map(IssueLabel::from).collect(),
             parent: None,
+            assignee: None,
         }
     }
 

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -273,6 +273,15 @@ pub struct IssueDraft {
     /// The epic or parent this hangs off, when there is one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent: Option<IssueKey>,
+    /// Who to assign the filed issue to, in the tracker's own spelling of a
+    /// user (a GitHub login, a Linear user id). `None` files it unassigned.
+    ///
+    /// Part of the draft rather than a follow-up edit because assigning is
+    /// part of *what is being filed*: a tracker that can assign at create
+    /// time does it in the same call, and one that cannot is the adapter's
+    /// problem to sequence, not the caller's to remember.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
 }
 
 /// The port every tracker is reached through — invariant 1 for the backlog

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -380,6 +380,46 @@ pub trait IssueProvider: Send + Sync {
         title: Option<&str>,
         body: Option<&str>,
     ) -> Result<(), IssueError>;
+
+    /// Re-open a closed issue.
+    ///
+    /// The inverse of [`IssueProvider::close`] and deliberately a separate
+    /// method rather than a `SetStatus("open")`: re-opening is how a human
+    /// (or a regression sweep) says the closure's receipt did not hold, which
+    /// is a different event in the issue's history than any other status move.
+    ///
+    /// Default is a typed refusal so a provider that predates the method —
+    /// or a tracker with no re-open transition — fails loudly instead of
+    /// silently doing nothing.
+    async fn reopen(&self, key: &IssueKey) -> Result<(), IssueError> {
+        Err(IssueError::Failed {
+            provider: self.id().to_owned(),
+            reason: format!("re-opening issues is not supported (tried `{key}`)"),
+        })
+    }
+
+    /// Full-text search, in either state, one page at a time.
+    ///
+    /// `list_open` is the loop's queue read; this is the human's browse read
+    /// (the command deck's ISSUES tab). The differences are the point:
+    /// `state = None` means *all* states rather than open-only, the query is
+    /// passed through to the tracker's own search syntax rather than filtered
+    /// client-side, and `offset` pages a large result set without the caller
+    /// holding every row. Ordering stays the tracker's, exactly as
+    /// [`IssueProvider::list_open`].
+    ///
+    /// Default falls back to the queue read with the query ignored — a
+    /// provider that cannot search still lists, and the caller can see the
+    /// query had no effect rather than receive a fabricated empty page.
+    async fn search(
+        &self,
+        _query: &str,
+        _state: Option<IssueState>,
+        limit: usize,
+        _offset: usize,
+    ) -> Result<Vec<Issue>, IssueError> {
+        self.list_open(limit).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -474,6 +474,35 @@ mod tests {
         assert_eq!(back, issue);
     }
 
+    /// Invariant 4 for the write side. An unassigned draft must not serialize
+    /// a null `assignee` either: the field was added after providers were
+    /// already reading this shape, so an omitted one has to stay omitted.
+    #[test]
+    fn a_draft_round_trips_and_omits_an_absent_assignee() {
+        let unassigned = IssueDraft {
+            title: "a title".into(),
+            body: "a handoff".into(),
+            labels: vec![IssueLabel::from("bug")],
+            parent: None,
+            assignee: None,
+        };
+        let json = serde_json::to_string(&unassigned).expect("serialize");
+        assert!(!json.contains("assignee"), "{json}");
+        assert_eq!(
+            serde_json::from_str::<IssueDraft>(&json).expect("deserialize"),
+            unassigned
+        );
+
+        let assigned = IssueDraft {
+            assignee: Some("octocat".into()),
+            ..unassigned
+        };
+        let json = serde_json::to_string(&assigned).expect("serialize");
+        let back: IssueDraft = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, assigned);
+        assert_eq!(serde_json::to_string(&back).expect("re-serialize"), json);
+    }
+
     /// The wire spellings are pinned. These cross a process boundary into
     /// provider manifests and stored records, so a rename is a breaking change
     /// and should have to edit this test to happen.

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -424,9 +424,17 @@ pub struct IssuesPanel {
     /// keys rather than indices because a refresh re-orders the list — the
     /// pick follows the issue, not the row.
     pub picked: std::collections::BTreeSet<String>,
-    /// The page the browse list is showing (0-based). `]`/`[` page forward
-    /// and back; a new search or refresh resets to the first page.
+    /// The page the browse list has *asked* for (0-based). `]`/`[` move it and
+    /// a new search or refresh resets it to the first page.
     pub page: usize,
+    /// The page the rows on screen actually came from — set only when a list
+    /// reply lands successfully.
+    ///
+    /// Separate from [`IssuesPanel::page`] because the two disagree exactly
+    /// when it matters: `]` moves `page` immediately, so if that fetch fails
+    /// the header must keep naming the page the reader is still looking at
+    /// rather than the one that never arrived.
+    pub loaded_page: usize,
     /// The query the current page was fetched with — paging re-issues it.
     pub active_query: Option<String>,
 }
@@ -453,6 +461,7 @@ impl Default for IssuesPanel {
             act_wait: 0,
             picked: std::collections::BTreeSet::new(),
             page: 0,
+            loaded_page: 0,
             active_query: None,
         }
     }
@@ -1287,6 +1296,11 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
                 ui.issues.rows = rows.clone();
                 ui.issues.sel = ui.issues.sel.min(rows.len().saturating_sub(1));
                 ui.issues.prune_picks();
+                // The title reads from this, never from `page`: `page` is what
+                // was *asked for* and moves on the keypress, so a fetch that
+                // failed would leave the header naming a page whose rows are
+                // not on screen.
+                ui.issues.loaded_page = ui.issues.page;
                 ui.issues.notice = Some(format!("{} issue(s)", rows.len()));
             }
             Err(e) => ui.issues.notice = Some(e.clone()),

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -420,6 +420,15 @@ pub struct IssuesPanel {
     pub list_wait: u64,
     /// Newest seq expected to answer with [`Inbound::IssueActDone`].
     pub act_wait: u64,
+    /// Keys of the rows the multiselect has picked (Space toggles). A set of
+    /// keys rather than indices because a refresh re-orders the list — the
+    /// pick follows the issue, not the row.
+    pub picked: std::collections::BTreeSet<String>,
+    /// The page the browse list is showing (0-based). `]`/`[` page forward
+    /// and back; a new search or refresh resets to the first page.
+    pub page: usize,
+    /// The query the current page was fetched with — paging re-issues it.
+    pub active_query: Option<String>,
 }
 
 impl Default for IssuesPanel {
@@ -442,6 +451,9 @@ impl Default for IssuesPanel {
             next_seq: 0,
             list_wait: 0,
             act_wait: 0,
+            picked: std::collections::BTreeSet::new(),
+            page: 0,
+            active_query: None,
         }
     }
 }
@@ -450,6 +462,36 @@ impl IssuesPanel {
     /// The browse list's selected row, if any.
     pub fn selected(&self) -> Option<&IssueRow> {
         self.rows.get(self.sel)
+    }
+
+    /// The rows the multiselect has picked, in list order. Falls back to the
+    /// cursor row when nothing is picked, so every verb that works on "the
+    /// selection" also works on a bare cursor.
+    pub fn picked_rows(&self) -> Vec<&IssueRow> {
+        if self.picked.is_empty() {
+            return self.selected().into_iter().collect();
+        }
+        self.rows
+            .iter()
+            .filter(|row| self.picked.contains(&row.key))
+            .collect()
+    }
+
+    /// Toggle the cursor row in the multiselect.
+    fn toggle_pick(&mut self) {
+        if let Some(row) = self.rows.get(self.sel) {
+            let key = row.key.clone();
+            if !self.picked.remove(&key) {
+                self.picked.insert(key);
+            }
+        }
+    }
+
+    /// Drop picks that no longer name a row (a refresh re-fetched the list).
+    fn prune_picks(&mut self) {
+        let keys: std::collections::BTreeSet<&str> =
+            self.rows.iter().map(|r| r.key.as_str()).collect();
+        self.picked.retain(|k| keys.contains(k.as_str()));
     }
 
     /// The next request seq (monotonic; starts at 1 so the `0` defaults of
@@ -1274,6 +1316,7 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
             Ok(rows) => {
                 ui.issues.rows = rows.clone();
                 ui.issues.sel = ui.issues.sel.min(rows.len().saturating_sub(1));
+                ui.issues.prune_picks();
                 ui.issues.notice = Some(format!("{} issue(s)", rows.len()));
             }
             Err(e) => ui.issues.notice = Some(e.clone()),
@@ -1884,7 +1927,7 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
         DeckTab::Graph => handle_graph_key(key, ui, composer_empty),
         DeckTab::Files => handle_files_key(key, model, ui, composer_empty),
         DeckTab::Mcp => handle_mcp_key(key, ui, composer_empty),
-        DeckTab::Issues => handle_issues_browse_key(key, ui, composer_empty),
+        DeckTab::Issues => handle_issues_browse_key(key, model, ui, composer_empty),
         DeckTab::Session => handle_session_key(key, model, ui),
         DeckTab::Settings => handle_settings_key(key, ui, composer_empty),
         // The SKILLS tab claims its keys earlier (before the composer), so a
@@ -2561,6 +2604,10 @@ fn handle_issues_search_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             ui.issues.list_wait = seq;
             ui.issues.busy = true;
             ui.issues.mode = IssuesMode::Browse;
+            // A new search is a new list: back to page one, and remember the
+            // query so `]` pages the results rather than the unfiltered list.
+            ui.issues.page = 0;
+            ui.issues.active_query = (!query.is_empty()).then_some(query.clone());
             ui.issues.notice = Some(if query.is_empty() {
                 "refreshing…".to_string()
             } else {
@@ -2833,10 +2880,13 @@ fn handle_issue_form_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
 
 /// The ISSUES tab's browse keys (non-modal — the composer stays live, so
 /// every letter verb is gated on a blank composer, exactly like the MCP
-/// tab): ↑/↓ select · `r` refresh · `/` tracker search · `n` create ·
-/// `c` comment · `s` set status · `w` start work.
+/// tab): ↑/↓ select · Space multiselect · `r` refresh · `/` tracker search ·
+/// `]`/`[` page · `o` open in the browser · `p` push the pick to the prompt
+/// and submit · `n` create · `c` comment · `x` close / re-open · `s` set
+/// status · `w` start work.
 fn handle_issues_browse_key(
     key: KeyEvent,
+    model: &WorkspaceModel,
     ui: &mut DeckUi,
     composer_empty: bool,
 ) -> Option<DeckAction> {
@@ -2852,7 +2902,13 @@ fn handle_issues_browse_key(
             }
             Some(DeckAction::Handled)
         }
+        KeyCode::Char(' ') if composer_empty => {
+            ui.issues.toggle_pick();
+            Some(DeckAction::Handled)
+        }
         KeyCode::Char('r') if composer_empty => {
+            ui.issues.page = 0;
+            ui.issues.active_query = None;
             let seq = ui.issues.bump_seq();
             ui.issues.list_wait = seq;
             ui.issues.busy = true;
@@ -2868,6 +2924,51 @@ fn handle_issues_browse_key(
             ui.issues.search_query.clear();
             Some(DeckAction::Handled)
         }
+        KeyCode::Char(']') if composer_empty => {
+            // A short last page means there is no next one — the tracker
+            // answered with fewer rows than a full page.
+            if count < ISSUES_PAGE_SIZE {
+                ui.issues.notice = Some("no next page".into());
+                return Some(DeckAction::Handled);
+            }
+            ui.issues.page += 1;
+            Some(issues_page_request(ui))
+        }
+        KeyCode::Char('[') if composer_empty => {
+            if ui.issues.page == 0 {
+                ui.issues.notice = Some("already on the first page".into());
+                return Some(DeckAction::Handled);
+            }
+            ui.issues.page -= 1;
+            Some(issues_page_request(ui))
+        }
+        KeyCode::Char('o') if composer_empty => {
+            let Some(row) = ui.issues.selected() else {
+                ui.issues.notice = Some("no issue selected — r loads the list".into());
+                return Some(DeckAction::Handled);
+            };
+            if row.url.is_empty() {
+                ui.issues.notice = Some(format!("#{} has no url to open", row.key));
+                return Some(DeckAction::Handled);
+            }
+            open_in_browser(&row.url);
+            ui.issues.notice = Some(format!("opened #{} in the browser", row.key));
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('p') if composer_empty => {
+            let rows = ui.issues.picked_rows();
+            if rows.is_empty() {
+                ui.issues.notice = Some("no issue selected — r loads the list".into());
+                return Some(DeckAction::Handled);
+            }
+            let text = rows
+                .iter()
+                .map(|row| format!("#{} {}", row.key, row.title))
+                .collect::<Vec<_>>()
+                .join("\n");
+            ui.issues.picked.clear();
+            Some(submit_prompt(ui, model, text))
+        }
         KeyCode::Char('n') if composer_empty => {
             ui.issues.clear_form();
             ui.issues.mode = IssuesMode::Create;
@@ -2882,6 +2983,30 @@ fn handle_issues_browse_key(
                 ui.issues.notice = Some("no issue selected — r loads the list".into());
             }
             Some(DeckAction::Handled)
+        }
+        KeyCode::Char('x') if composer_empty => {
+            let Some(row) = ui.issues.selected() else {
+                ui.issues.notice = Some("no issue selected — r loads the list".into());
+                return Some(DeckAction::Handled);
+            };
+            // One key, both directions: the row's own state says which
+            // transition applies, so `x` on an open issue closes it and on a
+            // closed one re-opens it.
+            let (action, verb) = if row.state.eq_ignore_ascii_case("closed") {
+                (IssueAction::SetStatus("open".into()), "re-opening")
+            } else {
+                (IssueAction::Close, "closing")
+            };
+            let issue_key = row.key.clone();
+            let seq = ui.issues.bump_seq();
+            ui.issues.act_wait = seq;
+            ui.issues.busy = true;
+            ui.issues.notice = Some(format!("{verb} #{issue_key}…"));
+            Some(DeckAction::Send(WorkspaceInput::IssueAct {
+                key: issue_key,
+                action,
+                seq,
+            }))
         }
         KeyCode::Char('s') if composer_empty => {
             if ui.issues.selected().is_some() {
@@ -2910,6 +3035,45 @@ fn handle_issues_browse_key(
         }
         _ => None,
     }
+}
+
+/// The page size the ISSUES tab browses by — kept in step with the driver's
+/// own page read, so a short page is how the tab knows the list is exhausted.
+const ISSUES_PAGE_SIZE: usize = 30;
+
+/// Re-issue the current page's fetch after `]`/`[` moved `page` — the query
+/// the page was fetched with rides along, so paging a search result pages
+/// the search, not the unfiltered list.
+fn issues_page_request(ui: &mut DeckUi) -> DeckAction {
+    let seq = ui.issues.bump_seq();
+    ui.issues.list_wait = seq;
+    ui.issues.busy = true;
+    ui.issues.notice = Some(format!("loading page {}…", ui.issues.page + 1));
+    DeckAction::Send(WorkspaceInput::IssuesRefresh {
+        query: ui.issues.active_query.clone(),
+        state: None,
+        seq,
+    })
+}
+
+/// Open a url in the system browser, fire-and-forget: the deck does not wait
+/// on the browser, and a failure surfaces as the OS's own error rather than
+/// a deck notice (there is no useful recovery either way).
+fn open_in_browser(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else if cfg!(target_os = "windows") {
+        "cmd"
+    } else {
+        "xdg-open"
+    };
+    let mut command = std::process::Command::new(opener);
+    if cfg!(target_os = "windows") {
+        command.args(["/c", "start", "", url]);
+    } else {
+        command.arg(url);
+    }
+    let _ = command.spawn();
 }
 
 /// SKILLS-tab keys. Returns `Some` for keys the tab claims ahead of the

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -2845,7 +2845,6 @@ fn handle_issue_form_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
-
 /// SKILLS-tab keys. Returns `Some` for keys the tab claims ahead of the
 /// composer (nav, manage hotkeys, the search query, overlays), `None` for keys
 /// that should fall through to the deck-global handlers — Tab still leaves the

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -464,36 +464,6 @@ impl IssuesPanel {
         self.rows.get(self.sel)
     }
 
-    /// The rows the multiselect has picked, in list order. Falls back to the
-    /// cursor row when nothing is picked, so every verb that works on "the
-    /// selection" also works on a bare cursor.
-    pub fn picked_rows(&self) -> Vec<&IssueRow> {
-        if self.picked.is_empty() {
-            return self.selected().into_iter().collect();
-        }
-        self.rows
-            .iter()
-            .filter(|row| self.picked.contains(&row.key))
-            .collect()
-    }
-
-    /// Toggle the cursor row in the multiselect.
-    fn toggle_pick(&mut self) {
-        if let Some(row) = self.rows.get(self.sel) {
-            let key = row.key.clone();
-            if !self.picked.remove(&key) {
-                self.picked.insert(key);
-            }
-        }
-    }
-
-    /// Drop picks that no longer name a row (a refresh re-fetched the list).
-    fn prune_picks(&mut self) {
-        let keys: std::collections::BTreeSet<&str> =
-            self.rows.iter().map(|r| r.key.as_str()).collect();
-        self.picked.retain(|k| keys.contains(k.as_str()));
-    }
-
     /// The next request seq (monotonic; starts at 1 so the `0` defaults of
     /// the wait lanes always read as "nothing awaited yet").
     fn bump_seq(&mut self) -> u64 {
@@ -2572,6 +2542,7 @@ fn queue_issues_first_load(ui: &mut DeckUi) {
         ui.pending_inputs.push(WorkspaceInput::IssuesRefresh {
             query: None,
             state: None,
+            page: 0,
             seq,
         });
     }
@@ -2600,9 +2571,6 @@ fn handle_issues_search_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
         }
         KeyCode::Enter => {
             let query = ui.issues.search_query.trim().to_string();
-            let seq = ui.issues.bump_seq();
-            ui.issues.list_wait = seq;
-            ui.issues.busy = true;
             ui.issues.mode = IssuesMode::Browse;
             // A new search is a new list: back to page one, and remember the
             // query so `]` pages the results rather than the unfiltered list.
@@ -2613,11 +2581,10 @@ fn handle_issues_search_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             } else {
                 format!("searching “{query}”…")
             });
-            DeckAction::Send(WorkspaceInput::IssuesRefresh {
-                query: (!query.is_empty()).then_some(query),
-                state: None,
-                seq,
-            })
+            // The one browse-list read: it sends whatever `active_query` and
+            // `page` were just set to, so the search line and the paging keys
+            // cannot drift apart on what a request carries.
+            issues_page_request(ui)
         }
         KeyCode::Backspace => {
             ui.issues.search_query.pop();
@@ -2878,203 +2845,6 @@ fn handle_issue_form_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
-/// The ISSUES tab's browse keys (non-modal — the composer stays live, so
-/// every letter verb is gated on a blank composer, exactly like the MCP
-/// tab): ↑/↓ select · Space multiselect · `r` refresh · `/` tracker search ·
-/// `]`/`[` page · `o` open in the browser · `p` push the pick to the prompt
-/// and submit · `n` create · `c` comment · `x` close / re-open · `s` set
-/// status · `w` start work.
-fn handle_issues_browse_key(
-    key: KeyEvent,
-    model: &WorkspaceModel,
-    ui: &mut DeckUi,
-    composer_empty: bool,
-) -> Option<DeckAction> {
-    let count = ui.issues.rows.len();
-    match key.code {
-        KeyCode::Up => {
-            ui.issues.sel = ui.issues.sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.issues.sel = (ui.issues.sel + 1).min(count - 1);
-            }
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char(' ') if composer_empty => {
-            ui.issues.toggle_pick();
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char('r') if composer_empty => {
-            ui.issues.page = 0;
-            ui.issues.active_query = None;
-            let seq = ui.issues.bump_seq();
-            ui.issues.list_wait = seq;
-            ui.issues.busy = true;
-            ui.issues.notice = Some("refreshing…".into());
-            Some(DeckAction::Send(WorkspaceInput::IssuesRefresh {
-                query: None,
-                state: None,
-                seq,
-            }))
-        }
-        KeyCode::Char('/') if composer_empty => {
-            ui.issues.mode = IssuesMode::SearchTracker;
-            ui.issues.search_query.clear();
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char(']') if composer_empty => {
-            // A short last page means there is no next one — the tracker
-            // answered with fewer rows than a full page.
-            if count < ISSUES_PAGE_SIZE {
-                ui.issues.notice = Some("no next page".into());
-                return Some(DeckAction::Handled);
-            }
-            ui.issues.page += 1;
-            Some(issues_page_request(ui))
-        }
-        KeyCode::Char('[') if composer_empty => {
-            if ui.issues.page == 0 {
-                ui.issues.notice = Some("already on the first page".into());
-                return Some(DeckAction::Handled);
-            }
-            ui.issues.page -= 1;
-            Some(issues_page_request(ui))
-        }
-        KeyCode::Char('o') if composer_empty => {
-            let Some(row) = ui.issues.selected() else {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-                return Some(DeckAction::Handled);
-            };
-            if row.url.is_empty() {
-                ui.issues.notice = Some(format!("#{} has no url to open", row.key));
-                return Some(DeckAction::Handled);
-            }
-            open_in_browser(&row.url);
-            ui.issues.notice = Some(format!("opened #{} in the browser", row.key));
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char('p') if composer_empty => {
-            let rows = ui.issues.picked_rows();
-            if rows.is_empty() {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-                return Some(DeckAction::Handled);
-            }
-            let text = rows
-                .iter()
-                .map(|row| format!("#{} {}", row.key, row.title))
-                .collect::<Vec<_>>()
-                .join("\n");
-            ui.issues.picked.clear();
-            Some(submit_prompt(ui, model, text))
-        }
-        KeyCode::Char('n') if composer_empty => {
-            ui.issues.clear_form();
-            ui.issues.mode = IssuesMode::Create;
-            ui.issues.notice = None;
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char('c') if composer_empty => {
-            if ui.issues.selected().is_some() {
-                ui.issues.input.clear();
-                ui.issues.mode = IssuesMode::Comment;
-            } else {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-            }
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char('x') if composer_empty => {
-            let Some(row) = ui.issues.selected() else {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-                return Some(DeckAction::Handled);
-            };
-            // One key, both directions: the row's own state says which
-            // transition applies, so `x` on an open issue closes it and on a
-            // closed one re-opens it.
-            let (action, verb) = if row.state.eq_ignore_ascii_case("closed") {
-                (IssueAction::SetStatus("open".into()), "re-opening")
-            } else {
-                (IssueAction::Close, "closing")
-            };
-            let issue_key = row.key.clone();
-            let seq = ui.issues.bump_seq();
-            ui.issues.act_wait = seq;
-            ui.issues.busy = true;
-            ui.issues.notice = Some(format!("{verb} #{issue_key}…"));
-            Some(DeckAction::Send(WorkspaceInput::IssueAct {
-                key: issue_key,
-                action,
-                seq,
-            }))
-        }
-        KeyCode::Char('s') if composer_empty => {
-            if ui.issues.selected().is_some() {
-                ui.issues.input.clear();
-                ui.issues.mode = IssuesMode::SetStatus;
-            } else {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-            }
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Char('w') if composer_empty => {
-            let Some(row) = ui.issues.selected() else {
-                ui.issues.notice = Some("no issue selected — r loads the list".into());
-                return Some(DeckAction::Handled);
-            };
-            let issue_key = row.key.clone();
-            let seq = ui.issues.bump_seq();
-            ui.issues.act_wait = seq;
-            ui.issues.busy = true;
-            ui.issues.notice = Some(format!("starting work on {issue_key}…"));
-            Some(DeckAction::Send(WorkspaceInput::IssueAct {
-                key: issue_key,
-                action: IssueAction::StartWork,
-                seq,
-            }))
-        }
-        _ => None,
-    }
-}
-
-/// The page size the ISSUES tab browses by — kept in step with the driver's
-/// own page read, so a short page is how the tab knows the list is exhausted.
-const ISSUES_PAGE_SIZE: usize = 30;
-
-/// Re-issue the current page's fetch after `]`/`[` moved `page` — the query
-/// the page was fetched with rides along, so paging a search result pages
-/// the search, not the unfiltered list.
-fn issues_page_request(ui: &mut DeckUi) -> DeckAction {
-    let seq = ui.issues.bump_seq();
-    ui.issues.list_wait = seq;
-    ui.issues.busy = true;
-    ui.issues.notice = Some(format!("loading page {}…", ui.issues.page + 1));
-    DeckAction::Send(WorkspaceInput::IssuesRefresh {
-        query: ui.issues.active_query.clone(),
-        state: None,
-        seq,
-    })
-}
-
-/// Open a url in the system browser, fire-and-forget: the deck does not wait
-/// on the browser, and a failure surfaces as the OS's own error rather than
-/// a deck notice (there is no useful recovery either way).
-fn open_in_browser(url: &str) {
-    let opener = if cfg!(target_os = "macos") {
-        "open"
-    } else if cfg!(target_os = "windows") {
-        "cmd"
-    } else {
-        "xdg-open"
-    };
-    let mut command = std::process::Command::new(opener);
-    if cfg!(target_os = "windows") {
-        command.args(["/c", "start", "", url]);
-    } else {
-        command.arg(url);
-    }
-    let _ = command.spawn();
-}
 
 /// SKILLS-tab keys. Returns `Some` for keys the tab claims ahead of the
 /// composer (nav, manage hotkeys, the search query, overlays), `None` for keys
@@ -4122,6 +3892,10 @@ fn cycle_filter(model: &WorkspaceModel, current: Option<&str>) -> Option<AgentId
 /// MCP-tab key handling (inspector / browse / search / auth).
 mod mcp_keys;
 use mcp_keys::handle_mcp_key;
+
+/// ISSUES-tab browse keys and the multiselect they drive.
+mod issues_keys;
+use issues_keys::{handle_issues_browse_key, issues_page_request};
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-tui/src/deck_ui/issues_keys.rs
+++ b/crates/stella-tui/src/deck_ui/issues_keys.rs
@@ -1,0 +1,257 @@
+//! ISSUES-tab key handling: the browse surface and its selection model.
+//!
+//! Non-modal, exactly like the MCP tab's Browse mode — the composer stays
+//! live, so every letter verb gates on `composer_empty` and never shadows the
+//! first character of a prompt. The tab's other modes (the create form, the
+//! comment/status prompts, the tracker search line) are modal and stay in
+//! `deck_ui.rs` beside the state they drive.
+//!
+//! **Row keys carry their `#`.** [`IssueRow::key`] is the *display* spelling —
+//! the driver's `issue_row` puts the `#` on at the boundary and strips it
+//! again before the key reaches the tracker. So everything here interpolates
+//! `{key}` bare; a `#{key}` would render `##874`.
+//!
+//! Split from `deck_ui.rs` (#629's 1500-line ratchet), same as
+//! [`super::mcp_keys`].
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{DeckAction, DeckUi, IssuesMode, IssuesPanel, submit_prompt};
+use crate::deck::WorkspaceModel;
+use crate::envelope::{IssueAction, IssueRow, WorkspaceInput};
+
+/// The page size the ISSUES tab browses by — kept in step with the driver's
+/// own page read, so a short page is how the tab knows the list is exhausted.
+pub(super) const ISSUES_PAGE_SIZE: usize = 30;
+
+/// The notice every verb answers with when it needs a row and has none.
+const NO_SELECTION: &str = "no issue selected — r loads the list";
+
+impl IssuesPanel {
+    /// The rows the multiselect has picked, in list order. Falls back to the
+    /// cursor row when nothing is picked, so every verb that works on "the
+    /// selection" also works on a bare cursor.
+    pub fn picked_rows(&self) -> Vec<&IssueRow> {
+        if self.picked.is_empty() {
+            return self.selected().into_iter().collect();
+        }
+        self.rows
+            .iter()
+            .filter(|row| self.picked.contains(&row.key))
+            .collect()
+    }
+
+    /// Toggle the cursor row in the multiselect.
+    pub(super) fn toggle_pick(&mut self) {
+        if let Some(row) = self.rows.get(self.sel) {
+            let key = row.key.clone();
+            if !self.picked.remove(&key) {
+                self.picked.insert(key);
+            }
+        }
+    }
+
+    /// Drop picks that no longer name a row (a refresh re-fetched the list).
+    pub(super) fn prune_picks(&mut self) {
+        let keys: std::collections::BTreeSet<&str> =
+            self.rows.iter().map(|r| r.key.as_str()).collect();
+        self.picked.retain(|k| keys.contains(k.as_str()));
+    }
+}
+
+/// The ISSUES tab's browse keys (non-modal — the composer stays live, so
+/// every letter verb is gated on a blank composer, exactly like the MCP
+/// tab): ↑/↓ select · Space multiselect · `r` refresh · `/` tracker search ·
+/// `]`/`[` page · `o` open in the browser · `p` push the pick to the prompt
+/// and submit · `n` create · `c` comment · `x` close / re-open · `s` set
+/// status · `w` start work.
+pub(super) fn handle_issues_browse_key(
+    key: KeyEvent,
+    model: &WorkspaceModel,
+    ui: &mut DeckUi,
+    composer_empty: bool,
+) -> Option<DeckAction> {
+    let count = ui.issues.rows.len();
+    match key.code {
+        KeyCode::Up => {
+            ui.issues.sel = ui.issues.sel.saturating_sub(1);
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Down => {
+            if count > 0 {
+                ui.issues.sel = (ui.issues.sel + 1).min(count - 1);
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char(' ') if composer_empty => {
+            ui.issues.toggle_pick();
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('r') if composer_empty => {
+            // A refresh is the unfiltered list from the top: it drops both the
+            // active query and the page, so `r` is the way back out of a
+            // search several pages deep.
+            ui.issues.page = 0;
+            ui.issues.active_query = None;
+            ui.issues.notice = Some("refreshing…".into());
+            Some(issues_page_request(ui))
+        }
+        KeyCode::Char('/') if composer_empty => {
+            ui.issues.mode = IssuesMode::SearchTracker;
+            ui.issues.search_query.clear();
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char(']') if composer_empty => {
+            // A short last page means there is no next one — the tracker
+            // answered with fewer rows than a full page.
+            if count < ISSUES_PAGE_SIZE {
+                ui.issues.notice = Some("no next page".into());
+                return Some(DeckAction::Handled);
+            }
+            ui.issues.page += 1;
+            ui.issues.notice = Some(format!("loading page {}…", ui.issues.page + 1));
+            Some(issues_page_request(ui))
+        }
+        KeyCode::Char('[') if composer_empty => {
+            if ui.issues.page == 0 {
+                ui.issues.notice = Some("already on the first page".into());
+                return Some(DeckAction::Handled);
+            }
+            ui.issues.page -= 1;
+            ui.issues.notice = Some(format!("loading page {}…", ui.issues.page + 1));
+            Some(issues_page_request(ui))
+        }
+        KeyCode::Char('o') if composer_empty => {
+            let Some(row) = ui.issues.selected() else {
+                ui.issues.notice = Some(NO_SELECTION.into());
+                return Some(DeckAction::Handled);
+            };
+            if row.url.is_empty() {
+                ui.issues.notice = Some(format!("{} has no url to open", row.key));
+                return Some(DeckAction::Handled);
+            }
+            open_in_browser(&row.url);
+            ui.issues.notice = Some(format!("opened {} in the browser", row.key));
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('p') if composer_empty => {
+            let rows = ui.issues.picked_rows();
+            if rows.is_empty() {
+                ui.issues.notice = Some(NO_SELECTION.into());
+                return Some(DeckAction::Handled);
+            }
+            let text = rows
+                .iter()
+                .map(|row| format!("{} {}", row.key, row.title))
+                .collect::<Vec<_>>()
+                .join("\n");
+            ui.issues.picked.clear();
+            Some(submit_prompt(ui, model, text))
+        }
+        KeyCode::Char('n') if composer_empty => {
+            ui.issues.clear_form();
+            ui.issues.mode = IssuesMode::Create;
+            ui.issues.notice = None;
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('c') if composer_empty => {
+            if ui.issues.selected().is_some() {
+                ui.issues.input.clear();
+                ui.issues.mode = IssuesMode::Comment;
+            } else {
+                ui.issues.notice = Some(NO_SELECTION.into());
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('x') if composer_empty => {
+            let Some(row) = ui.issues.selected() else {
+                ui.issues.notice = Some(NO_SELECTION.into());
+                return Some(DeckAction::Handled);
+            };
+            // One key, both directions: the row's own state says which
+            // transition applies, so `x` on an open issue closes it and on a
+            // closed one re-opens it.
+            let (action, verb) = if row.state.eq_ignore_ascii_case("closed") {
+                (IssueAction::Reopen, "re-opening")
+            } else {
+                (IssueAction::Close, "closing")
+            };
+            let issue_key = row.key.clone();
+            let seq = ui.issues.bump_seq();
+            ui.issues.act_wait = seq;
+            ui.issues.busy = true;
+            ui.issues.notice = Some(format!("{verb} {issue_key}…"));
+            Some(DeckAction::Send(WorkspaceInput::IssueAct {
+                key: issue_key,
+                action,
+                seq,
+            }))
+        }
+        KeyCode::Char('s') if composer_empty => {
+            if ui.issues.selected().is_some() {
+                ui.issues.input.clear();
+                ui.issues.mode = IssuesMode::SetStatus;
+            } else {
+                ui.issues.notice = Some(NO_SELECTION.into());
+            }
+            Some(DeckAction::Handled)
+        }
+        KeyCode::Char('w') if composer_empty => {
+            let Some(row) = ui.issues.selected() else {
+                ui.issues.notice = Some(NO_SELECTION.into());
+                return Some(DeckAction::Handled);
+            };
+            let issue_key = row.key.clone();
+            let seq = ui.issues.bump_seq();
+            ui.issues.act_wait = seq;
+            ui.issues.busy = true;
+            ui.issues.notice = Some(format!("starting work on {issue_key}…"));
+            Some(DeckAction::Send(WorkspaceInput::IssueAct {
+                key: issue_key,
+                action: IssueAction::StartWork,
+                seq,
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Fetch the panel's current page — the one read every browse-list request
+/// goes through (`r`, `]`, `[`, and the search line's Enter).
+///
+/// `page` and the active query both ride the request: the panel is the only
+/// thing that knows which page the human is looking at, so a paging key that
+/// did not send it would re-fetch page one under a notice claiming otherwise.
+/// The caller sets `notice` before calling — the reason differs per key and
+/// this does not try to guess it.
+pub(super) fn issues_page_request(ui: &mut DeckUi) -> DeckAction {
+    let seq = ui.issues.bump_seq();
+    ui.issues.list_wait = seq;
+    ui.issues.busy = true;
+    DeckAction::Send(WorkspaceInput::IssuesRefresh {
+        query: ui.issues.active_query.clone(),
+        state: None,
+        page: ui.issues.page,
+        seq,
+    })
+}
+
+/// Open a url in the system browser, fire-and-forget: the deck does not wait
+/// on the browser, and a failure surfaces as the OS's own error rather than
+/// a deck notice (there is no useful recovery either way).
+fn open_in_browser(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else if cfg!(target_os = "windows") {
+        "cmd"
+    } else {
+        "xdg-open"
+    };
+    let mut command = std::process::Command::new(opener);
+    if cfg!(target_os = "windows") {
+        command.args(["/c", "start", "", url]);
+    } else {
+        command.arg(url);
+    }
+    let _ = command.spawn();
+}

--- a/crates/stella-tui/src/deck_ui/issues_keys.rs
+++ b/crates/stella-tui/src/deck_ui/issues_keys.rs
@@ -6,13 +6,12 @@
 //! comment/status prompts, the tracker search line) are modal and stay in
 //! `deck_ui.rs` beside the state they drive.
 //!
-//! **Row keys carry their `#`.** [`IssueRow::key`] is the *display* spelling —
+//! **Row keys carry their `#`.** `IssueRow::key` is the *display* spelling —
 //! the driver's `issue_row` puts the `#` on at the boundary and strips it
 //! again before the key reaches the tracker. So everything here interpolates
 //! `{key}` bare; a `#{key}` would render `##874`.
 //!
-//! Split from `deck_ui.rs` (#629's 1500-line ratchet), same as
-//! [`super::mcp_keys`].
+//! Split from `deck_ui.rs` (#629's 1500-line ratchet), same as `mcp_keys`.
 
 use crossterm::event::{KeyCode, KeyEvent};
 

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -423,7 +423,10 @@ fn issues_space_toggles_a_pick_and_the_pick_follows_the_key() {
     ui.issues.loaded = true;
 
     handle_deck_key(key(KeyCode::Char(' ')), &model, &mut ui);
-    assert!(ui.issues.picked.contains("#7"), "space picks the cursor row");
+    assert!(
+        ui.issues.picked.contains("#7"),
+        "space picks the cursor row"
+    );
 
     // Moving the cursor leaves the pick on the issue, not the row index.
     handle_deck_key(key(KeyCode::Down), &model, &mut ui);
@@ -452,7 +455,10 @@ fn issues_refresh_prunes_picks_that_left_the_list() {
         &mut model,
         &mut ui,
     );
-    assert!(!ui.issues.picked.contains("#7"), "gone from the list, gone from the picks");
+    assert!(
+        !ui.issues.picked.contains("#7"),
+        "gone from the list, gone from the picks"
+    );
     assert!(ui.issues.picked.contains("#8"));
 }
 
@@ -550,7 +556,11 @@ fn issues_brackets_page_the_active_query() {
     let action = handle_deck_key(ch(']'), &model, &mut ui);
     match action {
         DeckAction::Send(WorkspaceInput::IssuesRefresh { query, page, .. }) => {
-            assert_eq!(query.as_deref(), Some("flaky"), "paging re-issues the search");
+            assert_eq!(
+                query.as_deref(),
+                Some("flaky"),
+                "paging re-issues the search"
+            );
             // The witness for the paging defect. `page` has to ride the
             // request: without it the driver read a literal offset 0, so `]`
             // re-fetched page one under a notice that said "page 2".
@@ -586,7 +596,10 @@ fn issues_bracket_on_a_short_page_says_there_is_no_next() {
     assert_eq!(action, DeckAction::Handled, "a short page is the last page");
     assert_eq!(ui.issues.page, 0);
     assert!(
-        ui.issues.notice.as_deref().is_some_and(|n| n.contains("no next page")),
+        ui.issues
+            .notice
+            .as_deref()
+            .is_some_and(|n| n.contains("no next page")),
         "{:?}",
         ui.issues.notice
     );

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -55,6 +55,7 @@ fn issues_first_tab_visit_queues_a_refresh() {
         [WorkspaceInput::IssuesRefresh {
             query: None,
             state: None,
+            page: 0,
             seq: 1,
         }]
     ));
@@ -474,17 +475,28 @@ fn issues_x_closes_an_open_issue_and_reopens_a_closed_one() {
         other => panic!("expected IssueAct::Close, got {other:?}"),
     }
 
-    // Cursor on the closed row: re-open (SetStatus("open") — the driver maps
-    // it to the provider's reopen).
+    // Cursor on the closed row: re-open. Its own variant, not
+    // `SetStatus("open")` — the driver selects the provider call by matching
+    // the action, never by comparing a status string.
     handle_deck_key(key(KeyCode::Down), &model, &mut ui);
     let action = handle_deck_key(ch('x'), &model, &mut ui);
     match action {
         DeckAction::Send(WorkspaceInput::IssueAct { key, action, .. }) => {
             assert_eq!(key, "#9");
-            assert_eq!(action, IssueAction::SetStatus("open".into()));
+            assert_eq!(action, IssueAction::Reopen);
         }
-        other => panic!("expected IssueAct::SetStatus(open), got {other:?}"),
+        other => panic!("expected IssueAct::Reopen, got {other:?}"),
     }
+    assert!(
+        ui.issues
+            .notice
+            .as_deref()
+            .is_some_and(|n| n.starts_with("re-opening #9")),
+        // The row key already carries its `#`; a `#{key}` here would say
+        // "re-opening ##9".
+        "{:?}",
+        ui.issues.notice
+    );
 }
 
 #[test]
@@ -499,8 +511,10 @@ fn issues_p_submits_the_picked_issues_as_a_prompt() {
     let action = handle_deck_key(ch('p'), &model, &mut ui);
     match action {
         DeckAction::Send(WorkspaceInput::Enqueue { text }) => {
-            assert!(text.contains("#7 title of #7"), "{text}");
-            assert!(text.contains("#8 title of #8"), "{text}");
+            // Exact, not `contains`: the row key already carries its `#`, so a
+            // `#{key}` in the prompt builder would produce "##7 title of #7"
+            // — which a `contains("#7 title of #7")` still matches.
+            assert_eq!(text, "#7 title of #7\n#8 title of #8", "{text}");
         }
         other => panic!("expected an enqueued prompt, got {other:?}"),
     }
@@ -535,18 +549,24 @@ fn issues_brackets_page_the_active_query() {
 
     let action = handle_deck_key(ch(']'), &model, &mut ui);
     match action {
-        DeckAction::Send(WorkspaceInput::IssuesRefresh { query, .. }) => {
+        DeckAction::Send(WorkspaceInput::IssuesRefresh { query, page, .. }) => {
             assert_eq!(query.as_deref(), Some("flaky"), "paging re-issues the search");
+            // The witness for the paging defect. `page` has to ride the
+            // request: without it the driver read a literal offset 0, so `]`
+            // re-fetched page one under a notice that said "page 2".
+            assert_eq!(page, 1, "the request carries the page it is asking for");
         }
         other => panic!("expected IssuesRefresh, got {other:?}"),
     }
     assert_eq!(ui.issues.page, 1);
 
     let action = handle_deck_key(ch('['), &model, &mut ui);
-    assert!(matches!(
-        action,
-        DeckAction::Send(WorkspaceInput::IssuesRefresh { .. })
-    ));
+    match action {
+        DeckAction::Send(WorkspaceInput::IssuesRefresh { page, .. }) => {
+            assert_eq!(page, 0, "paging back asks for the page it moved to");
+        }
+        other => panic!("expected IssuesRefresh, got {other:?}"),
+    }
     assert_eq!(ui.issues.page, 0);
 
     // `[` on the first page goes nowhere.

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -413,3 +413,175 @@ fn issue_act_done_ingest_reports_the_outcome() {
         ui.issues.notice
     );
 }
+
+#[test]
+fn issues_space_toggles_a_pick_and_the_pick_follows_the_key() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = vec![a_issue("#7"), a_issue("#8")];
+    ui.issues.loaded = true;
+
+    handle_deck_key(key(KeyCode::Char(' ')), &model, &mut ui);
+    assert!(ui.issues.picked.contains("#7"), "space picks the cursor row");
+
+    // Moving the cursor leaves the pick on the issue, not the row index.
+    handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+    assert!(ui.issues.picked.contains("#7"));
+    assert!(!ui.issues.picked.contains("#8"));
+
+    // A second space on the same row unpicks it.
+    handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+    handle_deck_key(key(KeyCode::Char(' ')), &model, &mut ui);
+    assert!(ui.issues.picked.is_empty(), "space again unpicks");
+}
+
+#[test]
+fn issues_refresh_prunes_picks_that_left_the_list() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = vec![a_issue("#7"), a_issue("#8")];
+    ui.issues.picked.insert("#7".into());
+    ui.issues.picked.insert("#8".into());
+    ui.issues.list_wait = 1;
+    ingest_inbound(
+        &Inbound::IssuesList {
+            seq: 1,
+            outcome: Ok(vec![a_issue("#8")]),
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert!(!ui.issues.picked.contains("#7"), "gone from the list, gone from the picks");
+    assert!(ui.issues.picked.contains("#8"));
+}
+
+#[test]
+fn issues_x_closes_an_open_issue_and_reopens_a_closed_one() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    let mut closed = a_issue("#9");
+    closed.state = "closed".into();
+    ui.issues.rows = vec![a_issue("#7"), closed];
+    ui.issues.loaded = true;
+
+    // Cursor on the open row: close.
+    let action = handle_deck_key(ch('x'), &model, &mut ui);
+    match action {
+        DeckAction::Send(WorkspaceInput::IssueAct { key, action, .. }) => {
+            assert_eq!(key, "#7");
+            assert_eq!(action, IssueAction::Close);
+        }
+        other => panic!("expected IssueAct::Close, got {other:?}"),
+    }
+
+    // Cursor on the closed row: re-open (SetStatus("open") — the driver maps
+    // it to the provider's reopen).
+    handle_deck_key(key(KeyCode::Down), &model, &mut ui);
+    let action = handle_deck_key(ch('x'), &model, &mut ui);
+    match action {
+        DeckAction::Send(WorkspaceInput::IssueAct { key, action, .. }) => {
+            assert_eq!(key, "#9");
+            assert_eq!(action, IssueAction::SetStatus("open".into()));
+        }
+        other => panic!("expected IssueAct::SetStatus(open), got {other:?}"),
+    }
+}
+
+#[test]
+fn issues_p_submits_the_picked_issues_as_a_prompt() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = vec![a_issue("#7"), a_issue("#8")];
+    ui.issues.loaded = true;
+    ui.issues.picked.insert("#7".into());
+    ui.issues.picked.insert("#8".into());
+
+    let action = handle_deck_key(ch('p'), &model, &mut ui);
+    match action {
+        DeckAction::Send(WorkspaceInput::Enqueue { text }) => {
+            assert!(text.contains("#7 title of #7"), "{text}");
+            assert!(text.contains("#8 title of #8"), "{text}");
+        }
+        other => panic!("expected an enqueued prompt, got {other:?}"),
+    }
+    assert!(ui.issues.picked.is_empty(), "submitting clears the picks");
+}
+
+#[test]
+fn issues_p_with_no_picks_submits_the_cursor_row() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = vec![a_issue("#7")];
+    ui.issues.loaded = true;
+
+    let action = handle_deck_key(ch('p'), &model, &mut ui);
+    match action {
+        DeckAction::Send(WorkspaceInput::Enqueue { text }) => {
+            assert!(text.contains("#7"), "{text}");
+        }
+        other => panic!("expected an enqueued prompt, got {other:?}"),
+    }
+}
+
+#[test]
+fn issues_brackets_page_the_active_query() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    // A full page of rows — a short page is how the tab knows the list is
+    // exhausted, so paging needs `ISSUES_PAGE_SIZE` rows to move forward.
+    ui.issues.rows = (0..30).map(|i| a_issue(&format!("#{i}"))).collect();
+    ui.issues.loaded = true;
+    ui.issues.active_query = Some("flaky".into());
+
+    let action = handle_deck_key(ch(']'), &model, &mut ui);
+    match action {
+        DeckAction::Send(WorkspaceInput::IssuesRefresh { query, .. }) => {
+            assert_eq!(query.as_deref(), Some("flaky"), "paging re-issues the search");
+        }
+        other => panic!("expected IssuesRefresh, got {other:?}"),
+    }
+    assert_eq!(ui.issues.page, 1);
+
+    let action = handle_deck_key(ch('['), &model, &mut ui);
+    assert!(matches!(
+        action,
+        DeckAction::Send(WorkspaceInput::IssuesRefresh { .. })
+    ));
+    assert_eq!(ui.issues.page, 0);
+
+    // `[` on the first page goes nowhere.
+    let action = handle_deck_key(ch('['), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled);
+    assert_eq!(ui.issues.page, 0);
+}
+
+#[test]
+fn issues_bracket_on_a_short_page_says_there_is_no_next() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = vec![a_issue("#7")];
+    ui.issues.loaded = true;
+
+    let action = handle_deck_key(ch(']'), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "a short page is the last page");
+    assert_eq!(ui.issues.page, 0);
+    assert!(
+        ui.issues.notice.as_deref().is_some_and(|n| n.contains("no next page")),
+        "{:?}",
+        ui.issues.notice
+    );
+}
+
+#[test]
+fn issues_search_resets_the_page_and_remembers_the_query() {
+    let model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.page = 3;
+    handle_deck_key(ch('/'), &model, &mut ui);
+    for c in "race".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(ui.issues.page, 0, "a new search is a new list");
+    assert_eq!(ui.issues.active_query.as_deref(), Some("race"));
+}

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -618,3 +618,41 @@ fn issues_search_resets_the_page_and_remembers_the_query() {
     assert_eq!(ui.issues.page, 0, "a new search is a new list");
     assert_eq!(ui.issues.active_query.as_deref(), Some("race"));
 }
+
+#[test]
+fn a_failed_page_fetch_leaves_the_header_on_the_page_still_shown() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.issues.rows = (0..30).map(|i| a_issue(&format!("#{i}"))).collect();
+    ui.issues.loaded = true;
+
+    // Page forward, and let that fetch fail.
+    handle_deck_key(ch(']'), &model, &mut ui);
+    assert_eq!(ui.issues.page, 1, "the request asked for page 2");
+    let seq = ui.issues.list_wait;
+    ingest_inbound(
+        &Inbound::IssuesList {
+            seq,
+            outcome: Err("gh: could not connect".into()),
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert_eq!(
+        ui.issues.loaded_page, 0,
+        "the rows on screen are still page 1, so the header must say so"
+    );
+
+    // A page that lands moves it.
+    handle_deck_key(ch(']'), &model, &mut ui);
+    let seq = ui.issues.list_wait;
+    ingest_inbound(
+        &Inbound::IssuesList {
+            seq,
+            outcome: Ok(vec![a_issue("#99")]),
+        },
+        &mut model,
+        &mut ui,
+    );
+    assert_eq!(ui.issues.loaded_page, ui.issues.page);
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -484,6 +484,8 @@ pub enum IssueAction {
     /// Move to a named status (`open`/`closed` on GitHub; any workflow-state
     /// word on Linear).
     SetStatus(String),
+    /// Close the issue (the deck's `x`).
+    Close,
     /// Start work: the driver moves the issue to in-progress (`w`).
     StartWork,
 }

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -481,11 +481,19 @@ impl EntityField {
 pub enum IssueAction {
     /// Add a comment (the deck's `c` prompt).
     Comment(String),
-    /// Move to a named status (`open`/`closed` on GitHub; any workflow-state
-    /// word on Linear).
+    /// Move to a named status (any workflow-state word on Linear; on GitHub
+    /// only the two states below exist, and they have their own variants).
     SetStatus(String),
-    /// Close the issue (the deck's `x`).
+    /// Close the issue (the deck's `x` on an open row).
     Close,
+    /// Re-open a closed issue (the deck's `x` on a closed row).
+    ///
+    /// Its own variant rather than `SetStatus("open")` so the driver selects
+    /// the provider call by matching a variant instead of comparing a status
+    /// string — the same reason [`IssueAction::Close`] is not
+    /// `SetStatus("closed")`, and why the port grew
+    /// `IssueProvider::reopen` rather than a status setter.
+    Reopen,
     /// Start work: the driver moves the issue to in-progress (`w`).
     StartWork,
 }
@@ -836,9 +844,16 @@ pub enum WorkspaceInput {
     /// ISSUES tab: list (or tracker-search) issues. `query`/`state` are the
     /// tracker-side filters; the driver answers with [`Inbound::IssuesList`]
     /// echoing `seq` so stale replies can be dropped.
+    ///
+    /// `page` is 0-based and is what the tab's `]`/`[` move. It rides the
+    /// request rather than being held driver-side because the panel is the
+    /// only thing that knows which page the human is looking at — and a
+    /// paging key that could not say so would re-fetch page one under a
+    /// notice claiming otherwise.
     IssuesRefresh {
         query: Option<String>,
         state: Option<String>,
+        page: usize,
         seq: u64,
     },
     /// ISSUES tab: create an issue from the `n` form. The driver answers

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -28,7 +28,15 @@ const TYPEAHEAD_MAX_ROWS: usize = 8;
 const FORM_BODY_MAX_LINES: usize = 6;
 
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
-    let title = format!(" ISSUES — {} listed ", ui.issues.rows.len());
+    let title = if ui.issues.page > 0 {
+        format!(
+            " ISSUES — {} listed · page {} ",
+            ui.issues.rows.len(),
+            ui.issues.page + 1
+        )
+    } else {
+        format!(" ISSUES — {} listed ", ui.issues.rows.len())
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title)
@@ -198,10 +206,11 @@ fn render_list(
     let last = (first + visible).min(issues.rows.len());
     for (i, row) in issues.rows.iter().enumerate().take(last).skip(first) {
         let width = inner.width as usize;
+        let picked = issues.picked.contains(&row.key);
         lines.push(if accessible {
             issue_record(row, i == selected, width)
         } else {
-            issue_line(row, i == selected, width)
+            issue_line(row, i == selected, picked, width)
         });
     }
     if last < issues.rows.len() {
@@ -232,9 +241,11 @@ fn issue_record(row: &IssueRow, selected: bool, width: usize) -> Line<'static> {
     )
 }
 
-/// One issue row: `▸ KEY [state] title · assignee · labels`.
-fn issue_line(row: &IssueRow, selected: bool, width: usize) -> Line<'static> {
+/// One issue row: `▸ ● #KEY [state] title · assignee · labels` — `●` marks a
+/// multiselect pick, `▸` the cursor.
+fn issue_line(row: &IssueRow, selected: bool, picked: bool, width: usize) -> Line<'static> {
     let marker = if selected { "▸ " } else { "  " };
+    let pick = if picked { "● " } else { "  " };
     let mut key_style = theme::accent();
     let mut body_style = Style::default().fg(theme::INK);
     let mut dim_style = theme::muted();
@@ -250,7 +261,7 @@ fn issue_line(row: &IssueRow, selected: bool, width: usize) -> Line<'static> {
     if !row.labels.is_empty() {
         tail.push_str(&format!(" · {}", row.labels.join(", ")));
     }
-    let head = format!("{marker}{} ", row.key);
+    let head = format!("{marker}{pick}{} ", row.key);
     let state = format!("[{}] ", row.state);
     let budget = width
         .saturating_sub(head.chars().count() + state.chars().count() + tail.chars().count())
@@ -451,11 +462,16 @@ fn footer(mode: IssuesMode) -> Line<'static> {
     let pairs: &[(&str, &str)] = match mode {
         IssuesMode::Browse => &[
             ("↑↓", "select"),
+            ("space", "pick"),
             ("r", "refresh"),
-            ("/", "search tracker"),
-            ("n", "new issue"),
+            ("/", "search"),
+            ("]/[", "page"),
+            ("o", "open"),
+            ("p", "to prompt"),
+            ("n", "new"),
             ("c", "comment"),
-            ("s", "set status"),
+            ("x", "close/reopen"),
+            ("s", "status"),
             ("w", "start work"),
         ],
         IssuesMode::SearchTracker => &[("type", "query"), ("enter", "search"), ("esc", "back")],
@@ -533,12 +549,15 @@ mod tests {
         };
         let text =
             |line: Line<'_>| -> String { line.spans.iter().map(|s| s.content.clone()).collect() };
-        let selected = text(issue_line(&row, true, 120));
-        assert!(selected.starts_with("▸ ENG-42"), "{selected}");
+        let selected = text(issue_line(&row, true, false, 120));
+        assert!(selected.starts_with("▸   ENG-42"), "{selected}");
         assert!(selected.contains("[In Progress]"), "{selected}");
         assert!(selected.contains("mona@example.com"), "{selected}");
         assert!(selected.contains("bug, ci"), "{selected}");
-        let plain = text(issue_line(&row, false, 120));
-        assert!(plain.starts_with("  ENG-42"), "{plain}");
+        let plain = text(issue_line(&row, false, false, 120));
+        assert!(plain.starts_with("    ENG-42"), "{plain}");
+        // A multiselect pick shows its marker whether or not it is the cursor.
+        let picked = text(issue_line(&row, false, true, 120));
+        assert!(picked.starts_with("  ● ENG-42"), "{picked}");
     }
 }

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -28,11 +28,14 @@ const TYPEAHEAD_MAX_ROWS: usize = 8;
 const FORM_BODY_MAX_LINES: usize = 6;
 
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
-    let title = if ui.issues.page > 0 {
+    // `loaded_page`, not `page`: the header describes the rows on screen, and
+    // `page` has already moved to whatever the last `]` asked for — which is a
+    // different number whenever that fetch failed or is still in flight.
+    let title = if ui.issues.loaded_page > 0 {
         format!(
             " ISSUES — {} listed · page {} ",
             ui.issues.rows.len(),
-            ui.issues.page + 1
+            ui.issues.loaded_page + 1
         )
     } else {
         format!(" ISSUES — {} listed ", ui.issues.rows.len())

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -9,11 +9,11 @@
 ┌ ISSUES — 3 listed ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  ⇢ #981 open · CI … running                                                                                                                                  │
 │                                                                                                                                                              │
-│  #874 [open] Command-deck render golden tests · dev · enhancement, area:tui                                                                                  │
-│▸ #826 [open] run_deck event-loop pty harness · enhancement                                                                                                   │
-│  #689 [closed] Surface per-server MCP tool truncation · dev · bug                                                                                            │
+│    #874 [open] Command-deck render golden tests · dev · enhancement, area:tui                                                                                │
+│▸   #826 [open] run_deck event-loop pty harness · enhancement                                                                                                 │
+│    #689 [closed] Surface per-server MCP tool truncation · dev · bug                                                                                          │
 │                                                                                                                                                              │
-│   ↑↓ select   r refresh   / search tracker   n new issue   c comment   s set status   w start work                                                           │
+│   ↑↓ select   space pick   r refresh   / search   ]/[ page   o open   p to prompt   n new   c comment   x close/reopen   s status   w start work             │
 │                                                                                                                                                              │
 │                                                                                                                                                              │
 │                                                                                                                                                              │


### PR DESCRIPTION
## What

The command deck's ISSUES tab answered every list/mutate request with a hard-coded `no issue tracker backend` hint — the deck carried no tracker transport. This wires the tab to the workspace's issue provider (GitHub by default, through the `gh` CLI), over the same `IssueProvider` port the self-driving loop uses.

## Provider (`stella-protocol`, `stella-cli`)

- `IssueProvider` gains `search(query, state, limit, offset)` and `reopen(key)`, both with honest default impls so existing providers (test fixtures) still compile — search falls back to `list_open`, reopen refuses typed.
- `GhIssueProvider` implements them: search → `gh issue list --search … --state open|closed|all` with a client-side page slice (`gh` has no server-side offset); reopen → `gh issue reopen`.
- `GhIssue` now reads the payload's `state` field — a mixed-state browse list cannot assume open the way `list_open` could.

## Deck driver (`stella-cli`)

- `handle_issues_input` serves `IssuesRefresh` / `IssueCreate` / `IssueAct` from `GhIssueProvider` on blocking threads (a `gh` call never stalls the driver loop), each on the fresh current-thread runtime the self-driving commands use.
- `IssueAction::Close` added to the envelope; `SetStatus("open")` routes to `reopen`. Row keys carry `#` at the boundary; `issues_act` strips it on the way out.

## TUI (`stella-tui`)

- **List view**: `▸ ● #KEY [state] title · assignee · labels` — `▸` cursor, `●` multiselect pick. Title shows the page number past page one.
- **Search** (`/`): remembers the query so paging pages the results; a new search resets to page one.
- **Paging**: `]` / `[` (30/page, matching the driver's read; a short page ends the list and says so).
- **Open in browser**: `o` opens the issue's url (`open` / `xdg-open` / `cmd /c start`).
- **Multiselect**: Space toggles; picks follow the issue *key* across refreshes and are pruned when an issue leaves the list.
- **Send to prompt**: `p` submits the picked issues (or the cursor row) as a prompt through the normal dispatch path, then clears the picks.
- **Mutations**: `x` closes an open issue or re-opens a closed one (the row's state decides); `n` create, `c` comment, `s` status, `w` start work as before.

## Tests

- 8 new `deck_ui` tests: pick toggle & key-stability, prune-on-refresh, close-vs-reopen on `x`, `p` submitting picks and cursor-row fallback, bracket paging re-issuing the active query, the short-page stop, search resetting the page.
- `tab_issues` render golden re-blessed (new footer legend + pick column).
- `stella-tui` 889 lib + all integration suites, `stella-protocol` 199, `stella-cli` issue_provider/command_deck suites: green. Clippy clean on all three crates.

## Note

Branched from a fresh `origin/main` (0.9.129); the one `stella-cli` failure seen locally (`benchmark_gate_excludes_hostile_filesystem_steering_and_extensions`) reproduces on a clean checkout and is pre-existing.

## Summary by Sourcery

Wire the command deck’s ISSUES tab to the workspace issue provider and provide a complete GitHub-backed browsing and mutation experience.

New Features:
- Connect the command deck’s ISSUES tab to the configured issue provider, including GitHub search, creation, commenting, closing, and reopening.
- Add issue browsing tools for search, paging, browser opening, multiselect, and sending selected issues to the prompt workflow.

Bug Fixes:
- Preserve issue states from mixed open and closed search results instead of assuming every listed issue is open.
- Keep issue selections stable across refreshes, prune stale selections, and accurately track the loaded page after failed requests.

Enhancements:
- Extend the issue provider port with paginated search, reopening, and optional assignee support while retaining compatibility defaults.
- Move issue driver and TUI key handling into dedicated modules and execute blocking provider operations without stalling the deck loop.

Tests:
- Add provider and deck UI coverage for paging, search reset, issue state mutations, assignee handling, multiselect behavior, prompt submission, and failed page fetches.