### PR TITLE
fix(stella-cli): recall anchors on what the turn touched, not just what its prompt names

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -433,7 +433,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 // Same schedule as the plain prompts above (#1221): one
                 // interleaved sequence per workspace, not one per command.
                 m.arm_recall_control();
-                let recalled = m.recall_block_reported(goal).await;
+                let touched =
+                    stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
+                let recalled = m.recall_block_reported(goal, &touched).await;
                 recall_event = recalled.telemetry_event();
                 inject_recall_block(&mut messages, recalled.text);
             }
@@ -520,7 +522,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             // recalled turns. The suppressed flag rides with the turn for
             // attribution.
             m.arm_recall_control();
-            let recalled = m.recall_block_reported(input).await;
+            let touched =
+                stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
+            let recalled = m.recall_block_reported(input, &touched).await;
             recall_event = recalled.telemetry_event();
             inject_recall_block(&mut messages, recalled.text);
         }

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -258,7 +258,8 @@ pub(crate) async fn run_raw_one_shot(
     // contributes to have been assembled.
     let mut recall_event = None;
     if let Some(m) = &memory {
-        let recalled = m.recall_block_reported(prompt).await;
+        let touched = stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
+        let recalled = m.recall_block_reported(prompt, &touched).await;
         recall_event = recalled.telemetry_event();
         inject_recall_block(&mut messages, recalled.text);
     }
@@ -572,7 +573,8 @@ pub async fn run_goal_cmd(
         // share its arm, and re-arming per round would count one prompt as N
         // turns of the schedule.
         m.arm_recall_control();
-        let recalled = m.recall_block_reported(goal).await;
+        let touched = stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
+        let recalled = m.recall_block_reported(goal, &touched).await;
         recall_event = recalled.telemetry_event();
         inject_recall_block(&mut messages, recalled.text);
     }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -1445,7 +1445,17 @@ pub async fn run_deck_session(
         if let Some(m) = &mut memory {
             // The A/B control, armed before recall (#1221).
             m.arm_recall_control();
-            let recalled = m.recall_block_reported(&prompt).await;
+            // Anchors from what the conversation has already touched, not the
+            // prompt alone. A prompt that names no path used to leave recall
+            // unscoped across the whole index, where a common word matches an
+            // unrelated subtree as well as the file being edited — see #4249.
+            //
+            // The same derivation the mid-turn re-query uses, over the same
+            // messages, so the two cannot disagree about what this turn is
+            // about.
+            let touched =
+                stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
+            let recalled = m.recall_block_reported(&prompt, &touched).await;
             recall_event = recalled.telemetry_event();
             inject_recall_block(&mut messages, recalled.text);
         }

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -751,7 +751,10 @@ async fn worker_recall_block(
         return (None, None);
     };
     memory.arm_recall_control();
-    let recalled = memory.recall_block_reported(prompt).await;
+    // A fleet attempt recalls before its engine has messages, so there is no
+    // conversation to derive touched paths from — the empty anchor set is the
+    // honest argument here, and the same scoping the prompt alone always gave.
+    let recalled = memory.recall_block_reported(prompt, &[]).await;
     let event = recalled.telemetry_event();
     // `memory` is dropped here, and deliberately not carried to the reflection
     // below: this handle is rooted at the attempt's own tree, and a lesson

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -703,7 +703,7 @@ async fn a_worker_mines_its_lesson_into_the_invocation_root_not_its_worktree() {
     let after_the_run =
         crate::memory::SessionMemory::open(&invocation_root, false).expect("primary workspace");
     let recalled = after_the_run
-        .recall_block_reported("a task touches the billing migration")
+        .recall_block_reported("a task touches the billing migration", &[])
         .await
         .text
         .unwrap_or_default();

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -141,7 +141,7 @@ impl SessionMemory {
     /// from production would let the next recall site reintroduce it silently.
     #[cfg(test)]
     pub async fn recall_block(&self, prompt: &str) -> Option<String> {
-        self.recall_block_reported(prompt).await.text
+        self.recall_block_reported(prompt, &[]).await.text
     }
 
     /// The recalled-context block **without throwing the recall away**.
@@ -158,7 +158,13 @@ impl SessionMemory {
     /// reason [`Recall`] itself carries frames and usage together: they are
     /// answers to different questions about one request, and separating them
     /// means either re-running recall to report it or losing it entirely.
-    pub async fn recall_block_reported(&self, prompt: &str) -> RecalledBlock {
+    /// `touched` is what the conversation has already changed — the anchor
+    /// set's second half, and the difference between a scoped recall and one
+    /// that matches a word anywhere in the index. Empty is the honest argument
+    /// for a turn that has touched nothing yet; callers with a live
+    /// conversation should derive it (see
+    /// `stella_core::driver::loop_evidence::turn_evidence`).
+    pub async fn recall_block_reported(&self, prompt: &str, touched: &[String]) -> RecalledBlock {
         // Two switches, one gate. `ab_suppressed` withholds injection for ONE
         // turn to build a control arm; `steering_enabled` withholds it for the
         // session because an operator or their org asked (#3243). Both stop
@@ -170,7 +176,11 @@ impl SessionMemory {
         let RecalledFrames {
             recall,
             dropped: frame_drops,
-        } = self.recalled_frames(prompt).await;
+        } = self
+            .recalled_frames_anchored(prompt, self.anchors_for(prompt, touched), |message| {
+                eprintln!("  {} {message}", "!".yellow())
+            })
+            .await;
 
         let all_skills = self.load_skills();
         let selected = skills::select_skills_reporting(
@@ -262,18 +272,7 @@ impl SessionMemory {
         }
         let prompt = signal.prompt;
 
-        // Anchors: what the goal names, then what the turn touched — capped
-        // so a busy turn cannot turn one re-query into a full-graph walk.
-        const MAX_SIGNAL_ANCHORS: usize = 8;
-        let mut anchors = goal_path_anchors(prompt, &self.workspace_root);
-        for path in signal.touched_paths {
-            if anchors.len() >= MAX_SIGNAL_ANCHORS {
-                break;
-            }
-            if !anchors.contains(path) && self.workspace_root.join(path).is_file() {
-                anchors.push(path.clone());
-            }
-        }
+        let anchors = self.anchors_for(prompt, signal.touched_paths);
         let domains = crate::contextgraph::query_domain_scope(&self.domains, &anchors);
 
         let RecalledFrames {
@@ -445,6 +444,40 @@ impl SessionMemory {
 
     /// Authoritative prompt and pipeline recall, including a fresh quarantine
     /// read so prior-turn feedback applies immediately.
+    /// What this turn is *about*, as paths: what the prompt names, then what
+    /// the conversation has already touched.
+    ///
+    /// Capped so a busy turn cannot turn one query into a full-graph walk, and
+    /// every anchor must be a file that exists — an anchor naming nothing
+    /// scopes nothing.
+    ///
+    /// The second half is what the per-turn recall was missing, and it is why a
+    /// turn could pull five frames of unrelated Python into a Rust task. A
+    /// prompt like *"Upstream renamed `_model` to `model` and added a PR
+    /// strip"* names no path at all, so the anchor set came out empty and
+    /// retrieval ran unscoped across the whole index — where the word `model`
+    /// matches a benchmark harness's `model.py` exactly as well as the file the
+    /// turn is editing. Unscoped, lexical similarity has nothing to lose
+    /// against, so it returns its top-k however weak the top is.
+    ///
+    /// The paths a turn has touched are the strongest available statement of
+    /// what it is working on. `signal_recall_block` has composed anchors this
+    /// way since #3243; this is that composition extracted, so the two callers
+    /// cannot drift into disagreeing about what "about" means.
+    pub(super) fn anchors_for(&self, prompt: &str, touched: &[String]) -> Vec<String> {
+        const MAX_ANCHORS: usize = 8;
+        let mut anchors = goal_path_anchors(prompt, &self.workspace_root);
+        for path in touched {
+            if anchors.len() >= MAX_ANCHORS {
+                break;
+            }
+            if !anchors.contains(path) && self.workspace_root.join(path).is_file() {
+                anchors.push(path.clone());
+            }
+        }
+        anchors
+    }
+
     async fn recalled_frames(&self, goal: &str) -> RecalledFrames {
         let anchors = goal_path_anchors(goal, &self.workspace_root);
         self.recalled_frames_anchored(goal, anchors, |message| {

--- a/crates/stella-cli/src/memory/tests/golden_block.rs
+++ b/crates/stella-cli/src/memory/tests/golden_block.rs
@@ -83,7 +83,7 @@ async fn the_assembled_volatile_block_is_byte_identical_to_the_pinned_bytes() {
     // crosses UTC midnight between the two reads accepts either day.
     let before = render_today_section(unix_now_secs());
     let block = memory
-        .recall_block_reported("review the database migrations")
+        .recall_block_reported("review the database migrations", &[])
         .await
         .text
         .expect("all three sources render");

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -347,3 +347,57 @@ async fn a_frame_the_host_merge_evicted_reaches_the_ledger() {
         set.dropped
     );
 }
+
+/// A prompt naming no path still anchors, on what the turn has touched.
+///
+/// The witness for #4249. A live turn resolving a merge conflict in
+/// `views/issues.rs` asked:
+///
+/// > Upstream renamed `_model` to `model` and added a PR strip.
+///
+/// It names no path, so the anchor set came out empty and retrieval ran
+/// unscoped across the whole index — which returned 1133 tokens of an
+/// unrelated Python benchmark harness, because `model` is a common word and
+/// unscoped lexical similarity has nothing to lose against.
+///
+/// `anchors_for` is the fix and this is what it buys: the same prompt, the same
+/// workspace, and the anchor set is the file the turn is actually editing.
+#[test]
+fn a_pathless_prompt_anchors_on_what_the_turn_touched() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let root = dir.path();
+    let edited = root.join("crates/stella-tui/src/views/issues.rs");
+    std::fs::create_dir_all(edited.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&edited, "fn render() {}").expect("write");
+
+    let memory = session(root);
+    let prompt = "Upstream renamed `_model` to `model` and added a PR strip.";
+
+    assert!(
+        memory.anchors_for(prompt, &[]).is_empty(),
+        "the prompt names no path — unanchored is exactly the state that let \
+         an unrelated subtree answer"
+    );
+
+    let touched = vec!["crates/stella-tui/src/views/issues.rs".to_string()];
+    let anchored = memory.anchors_for(prompt, &touched);
+    assert_eq!(
+        anchored,
+        vec!["crates/stella-tui/src/views/issues.rs".to_string()],
+        "the turn's own file is the anchor the prompt could not contribute"
+    );
+}
+
+/// An anchor has to name a file that exists — one that names nothing scopes
+/// nothing, and would widen the query while looking like it narrowed it.
+#[test]
+fn a_touched_path_that_is_not_a_file_is_not_an_anchor() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let memory = session(dir.path());
+    let touched = vec!["crates/gone/vanished.rs".to_string()];
+    assert!(
+        memory
+            .anchors_for("resolve the conflict", &touched)
+            .is_empty()
+    );
+}

--- a/crates/stella-core/src/driver/loop_evidence.rs
+++ b/crates/stella-core/src/driver/loop_evidence.rs
@@ -88,7 +88,7 @@ pub(super) fn turn_start_index(messages: &[CompletionMessage]) -> usize {
 /// and the error classes it has seen — assembled fresh each step from the
 /// same window [`turn_start_index`] gives loop detection, so the two planes
 /// cannot disagree about what "this turn" means.
-pub(super) struct TurnEvidence {
+pub struct TurnEvidence {
     /// Index of the real user message that bounds this turn, when one exists.
     pub prompt_index: Option<usize>,
     /// Tool names in call order, most recent last.
@@ -111,7 +111,7 @@ pub(super) struct TurnEvidence {
 /// full-graph walk — the same reasoning as recall's own anchor cap.
 const MAX_TOUCHED_PATHS: usize = 16;
 
-pub(super) fn turn_evidence(messages: &[CompletionMessage]) -> TurnEvidence {
+pub fn turn_evidence(messages: &[CompletionMessage]) -> TurnEvidence {
     let start = turn_start_index(messages);
     let mut evidence = TurnEvidence {
         prompt_index: start.checked_sub(1),


### PR DESCRIPTION
Closes #4249.

A live turn resolving a merge conflict in `crates/stella-tui/src/views/issues.rs` asked:

> Upstream renamed `_model` to `model` and added a PR strip.

Recall answered with **1133 tokens of an unrelated Python benchmark harness** — `arenabench/cli.py`, `runner.py`, `oracle_stop_hook.py` — and did it again every turn, because recall runs once per turn.

```
recalled  5 frames · 1133 tok · 172ms
  symbol  fn main (arenabench/arenabench/cl…   …/arenabench/cli.py         677 tok
  symbol  fn create (arenabench/arenabench/…   …/arenabench/runner.py      247 tok
  symbol  fn main (arenabench/hooks/oracle_…   …/hooks/oracle_stop_hook.py  82 tok
```

## Why

`recall_block_reported` anchored only on `goal_path_anchors(prompt, root)` — paths named **in the prompt text**. That prompt names none, so the anchor set came out empty and retrieval ran unscoped across the whole index.

Unscoped, lexical similarity has nothing to lose against: `model` matches a harness's `model.py` exactly as well as the file being edited, and the top-k comes back however weak the top is.

## The fix was one function away

`signal_recall_block` — the mid-turn re-query (#3243) — has always composed anchors as *goal paths, then the paths the turn has touched*, capped at 8. Its own comment says why:

> a drifted turn's best anchors are the paths it has TOUCHED, which the goal string cannot name

The per-turn recall was simply never migrated to it. That composition is now `anchors_for`, **extracted** so the two callers cannot drift into disagreeing about what "about" means, and `recall_block_reported` takes the touched paths it needs.

## Where the paths come from — no new plumbing

`stella_core::driver::loop_evidence::turn_evidence` is a pure function over the conversation's messages, and the deck, goal mode and interactive mode each already hold those at the point they recall. So this is the same derivation the steering plane uses, over the same messages — the two planes cannot disagree about what this turn is about. `turn_evidence`/`TurnEvidence` widen from `pub(super)` to `pub`.

This is what I stopped short of last time: I had reverted a version where every caller passed `&[]`, because shipping the parameter unwired is the pattern this repo keeps paying for. `turn_evidence` is the seam that makes it real, and `command_deck.rs` never needed the `WorkspaceModel` I thought it did.

A fleet attempt recalls *before* its engine has messages, so it passes the empty set — the honest argument there, and the same scoping the prompt alone always gave.

## Witness

`a_pathless_prompt_anchors_on_what_the_turn_touched` uses the real prompt: with no touched paths it anchors nowhere — the exact state that let an unrelated subtree answer — and with the edited file it anchors on that file.

`a_touched_path_that_is_not_a_file_is_not_an_anchor` holds the other half: an anchor naming nothing scopes nothing, and would widen the query while looking like it narrowed it.

## Still open, deliberately

**No relevance floor.** Retrieval returns its top-k regardless of score, so a weak best match still costs a full injection. Anchoring narrows *where* it looks; making "nothing here is relevant" an available answer is a separate decision, and it stays on #4249's follow-up note rather than being smuggled in here.

## Verification

`cargo test --workspace` green, `cargo clippy --workspace --all-targets -D warnings` clean, `make guards` green.

One flake worth naming: `stella-runtime`'s `wrapper_transport_limits` failed once during a run with three parallel cargo processes contending — those tests spawn plugin subprocesses and assert timeouts. All 3 pass on rerun, and this diff touches no runtime code.

## Tests deleted

None.

## Summary by Sourcery

Scope recall to the current turn’s touched files so pathless prompts retrieve relevant context instead of unrelated indexed content.

Bug Fixes:
- Scope per-turn recall to files touched by the current conversation, preventing unrelated indexed content from being injected when prompts name no paths.

Enhancements:
- Unify anchor derivation for per-turn and mid-turn recall, including existing prompt paths and valid touched files with a capped anchor set.
- Expose turn evidence so CLI recall callers can derive touched paths consistently from conversation messages.

Tests:
- Add coverage for pathless prompts anchoring on touched files and for ignoring touched paths that do not identify existing files.