### PR TITLE
fix(stella-tui): main compiles again — one diff condition, not two

### DIFF
--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -264,18 +264,14 @@ fn render_body(
         // Every line advances the gutter counters, shown or not — skipping a
         // line must not renumber the ones after it, and the numbers on the
         // far side of an elision have to be the file's real ones.
-        // Captured before `body_line` advances it: a `--- ` or `+++ ` line is
-        // plumbing only *outside* a hunk. Inside one it is body content that
-        // happens to look like a header — an SQL comment, a diff of a diff —
-        // and hunk position is the only thing that can tell them apart
-        // (`count_diff_lines` makes the same distinction for the same reason).
-        // Stripping on the text alone deletes real removed lines.
-        let was_in_hunk = in_hunk;
+        //
         // Read *before* `body_line` runs, because that call is what moves the
         // state this asks about. The same structural rule `body_line` itself
         // applies (only before a file's first hunk is `+++ `/`--- ` a header):
-        // inside a hunk those bytes are added or removed source text, and
-        // dropping them would delete a line of the change.
+        // inside a hunk those bytes are added or removed source text that
+        // happens to look like a header — an SQL comment, a diff of a diff —
+        // and dropping them would delete a line of the change.
+        // (`count_diff_lines` makes the same distinction for the same reason.)
         let preamble = !in_hunk && is_meta(text);
         let line = body_line(
             text,
@@ -293,12 +289,6 @@ fn render_body(
         // line. The counters above still advance over them, so the gutter's
         // numbers stay the file's own.
         //
-        // `@@` survives on the `hunk_headers` flag: it carries the enclosing
-        // scope (`@@ … const TYPEAHEAD_MAX_ROWS`), which is the one piece of
-        // context a hunk cannot reconstruct from its own lines.
-        if plan.shows(i)
-            && !(!was_in_hunk && is_meta(text))
-            && (hunk_headers || !text.starts_with("@@"))
         // Chrome is suppressed after planning rather than before it, so an
         // elided row's `⋯ n lines` count stays the one `stella_diff::view`
         // computed and every surface reports the same number for one change.
@@ -779,45 +769,38 @@ mod tests {
     fn body_numbers_added_lines_on_the_new_side_and_removed_on_the_old() {
         let lines = body_lines(SAMPLE, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
-        // The `---`/`+++` pair is stripped, so the `@@` header leads and the
-        // first numbered row is at index 1.
         // "@@ -1,3 +1,4 @@" starts old=1/new=1; context takes new 1.
-        assert!(texts[1].starts_with("   1  context"), "{:?}", texts[1]);
+        assert!(texts[3].starts_with("   1  context"), "{:?}", texts[3]);
         // The removal is numbered on the OLD side (old line 2).
-        assert!(texts[2].starts_with("   2 -old line"), "{:?}", texts[2]);
+        assert!(texts[4].starts_with("   2 -old line"), "{:?}", texts[4]);
         // Additions continue on the NEW side (new lines 2, 3).
-        assert!(texts[3].starts_with("   2 +new line"), "{:?}", texts[3]);
-        assert!(texts[4].starts_with("   3 +another add"), "{:?}", texts[4]);
+        assert!(texts[5].starts_with("   2 +new line"), "{:?}", texts[5]);
+        assert!(texts[6].starts_with("   3 +another add"), "{:?}", texts[6]);
     }
 
-    /// Git plumbing does not render at all, and the hunk header — which does —
-    /// carries no line number.
-    ///
-    /// This used to assert the opposite half: that `--- a/x.rs` and
-    /// `+++ b/x.rs` rendered with a blank gutter. They render nowhere now. The
-    /// three rows they cost (`index …` joins them on a real git patch) are most
-    /// of the budget a collapsed diff has, spent restating the path the head
-    /// already names and a pair of blob hashes nobody can act on.
+    /// In the standalone viewer the file preamble and the hunk header both
+    /// render, and neither takes a line number — they are not lines of the
+    /// file. Inline under a tool call they are chrome and go away instead,
+    /// which is what `a_full_git_patch_renders_only_its_hunk` covers.
     #[test]
-    fn plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter() {
+    fn file_headers_and_hunks_get_no_number() {
         let lines = body_lines(SAMPLE, None);
-        let texts: Vec<String> = lines.iter().map(line_text).collect();
-        for meta in ["--- a/x.rs", "+++ b/x.rs"] {
+        for (i, line) in lines.iter().take(3).enumerate() {
             assert!(
-                !texts.iter().any(|t| t.contains(meta)),
-                "{meta:?} still renders: {texts:?}"
+                line_text(line).starts_with("     "),
+                "line {i} has a blank gutter: {:?}",
+                line_text(line)
             );
         }
-        assert!(texts[0].contains("@@ -1,3 +1,4 @@"), "{:?}", texts[0]);
-        assert!(
-            texts[0].starts_with("     "),
-            "the hunk header took a line number: {:?}",
-            texts[0]
-        );
     }
 
     /// A real git patch leads with `diff --git` and `index …` as well, and
-    /// neither reaches the row.
+    /// inline none of it reaches the row — a single-file, single-hunk patch is
+    /// all chrome until its first changed line.
+    ///
+    /// This asks `body_lines_inline` and not `body_lines`: the standalone
+    /// viewer keeps both boundaries on purpose, because there they are what a
+    /// reader navigates by (`Chrome::VIEWER`).
     #[test]
     fn a_full_git_patch_renders_only_its_hunk() {
         let patch = "diff --git a/x.rs b/x.rs\n\
@@ -828,7 +811,8 @@ mod tests {
                       keep\n\
                      -old\n\
                      +new";
-        let texts: Vec<String> = body_lines(patch, None).iter().map(line_text).collect();
+        let (lines, _) = body_lines_inline(patch, None, usize::MAX, None);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
         for meta in ["diff --git", "index 74f38f3", "--- a/", "+++ b/"] {
             assert!(
                 !texts.iter().any(|t| t.contains(meta)),
@@ -875,17 +859,17 @@ mod tests {
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            !texts[1].starts_with("     "),
+            !texts[3].starts_with("     "),
             "removed body line should get a gutter number, not read as a header: {:?}",
-            texts[1]
+            texts[3]
         );
         assert!(
-            !texts[2].starts_with("     "),
+            !texts[4].starts_with("     "),
             "added body line should get a gutter number, not read as a header: {:?}",
-            texts[2]
+            texts[4]
         );
-        assert!(texts[1].contains("was a rule"), "{:?}", texts[1]);
-        assert!(texts[2].contains("is a rule"), "{:?}", texts[2]);
+        assert!(texts[3].contains("was a rule"), "{:?}", texts[3]);
+        assert!(texts[4].contains("is a rule"), "{:?}", texts[4]);
     }
 
     #[test]
@@ -905,12 +889,12 @@ mod tests {
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            texts[2].starts_with("     "),
+            texts[4].starts_with("     "),
             "the marker line itself gets a blank gutter: {:?}",
-            texts[2]
+            texts[4]
         );
         assert!(
-            texts[3].starts_with("   1 +new"),
+            texts[5].starts_with("   1 +new"),
             "the marker must not have consumed a line number: {:?}",
             texts[5]
         );


### PR DESCRIPTION
## What

`main` has not compiled since 04:02 UTC. `crates/stella-tui/src/diff.rs:307`:

```
error: expected `{`, found keyword `if`
```

#4244 and #4248 merged six minutes apart and both fixed the same thing — an
inline diff opening with rows of git plumbing. #4248's branch was cut before
#4244 landed, so it carried its own implementation against the pre-#4244
signature. The merge kept **both**, textually:

```rust
if plan.shows(i)
    && !(!was_in_hunk && is_meta(text))
    && (hunk_headers || !text.starts_with("@@"))
// Chrome is suppressed after planning rather than before it, so an
// elided row's `⋯ n lines` count stays the one `stella_diff::view` computed.
if plan.shows(i)
    && (chrome.hunk_headers || !text.starts_with("@@"))
    && (chrome.file_headers || !preamble)
{
    lines.push(line);
}
```

A condition with no block, followed by a second `if`. Git had no conflict to
report — neither side's text contradicts the other line-for-line.

## Three red checks, one root cause

#4248's own CI failed on **MSRV**, **fmt + clippy + test**, and **docs/tools
still matches the declarations**, and it merged anyway. All three are the same
compile error: `stella-cli` depends on `stella-tui`, so
`scripts/check-tool-docs.sh`'s `cargo test -p stella-cli --bin stella tool_docs`
could not build. That guard prints its "you changed a tool — regenerate"
guidance on any non-zero exit, which is what made a downstream build failure
read as an independent stale-docs break. With the crate compiling,
`./scripts/check-tool-docs.sh` reports `OK` with no regeneration.

## Which side survives

#4244's. It is the structurally complete one:

- `Chrome { hunk_headers, file_headers }` carries the two thresholds as a
  struct, with `Chrome::VIEWER` and `Chrome::inline_for`.
- `preamble` is `!was_in_hunk && is_meta(text)` under a different name — the
  two PRs computed the identical value.
- `chrome.file_headers` is the multi-file escape #4248's unconditional strip
  did not have.

#4248's fragment also referenced `hunk_headers`, a `render_body` parameter
#4244 replaced with `chrome: Chrome` — so it could not have compiled even
with a block added.

## The one thing given up, deliberately

The two PRs disagreed about the **standalone viewer**, not only the inline row:

| | `body_lines_capped` / the `/diff` panel |
|---|---|
| #4244 | keeps both boundaries — "there, boundaries are what a reader is navigating by" |
| #4248 | stripped unconditionally; its tests asserted plumbing "render[s] nowhere now", asked through `body_lines` |

This PR keeps #4244's split and restores the four viewer tests #4248 renumbered
(`body_numbers_added_lines_on_the_new_side_and_removed_on_the_old`,
`file_headers_and_hunks_get_no_number`,
`body_lines_number_hunk_text_matching_header_syntax_instead_of_hiding_it`,
`no_newline_marker_gets_no_number_and_does_not_shift_later_numbering`).

**#4248's actual goal is untouched.** "The transcript shows the diff and nothing
else" is about the inline row, and it is still proven — by #4248's own
`render/tests/{inline_diff,tool_output,result_row}.rs` and by #4244's
`mutation_diff_e2e::the_patch_preamble_is_not_drawn_as_diff_body`, all passing.
#4248's new `a_full_git_patch_renders_only_its_hunk` is **kept**, retargeted
from `body_lines` to `body_lines_inline` — the surface whose claim it is.

Whether the viewer should *also* drop the preamble is a live design question
this PR does not settle. Filed as #4259 so the choice stays a maintainer's.

## Deleted tests

`plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter` is **renamed
back** to `file_headers_and_hunks_get_no_number`, its pre-#4248 name and its
pre-#4248 assertions. No test is removed on net; the count goes up by zero and
`a_full_git_patch_renders_only_its_hunk` survives.

## Witness

```
cargo test -p stella-tui     # 952 passed; 0 failed
./scripts/check-tool-docs.sh # OK — docs/tools/ matches the declarations
```

On the parent commit (`8a2fdf8cc`) the crate does not build at all — that is
the fail half of the flip.

Refs #4259

## Summary by Sourcery

Restore the diff renderer build while preserving the intended distinction between standalone diff viewing and inline tool-output rendering.

Bug Fixes:
- Restore compilation of the diff renderer by removing the duplicate conditional left by the conflicting merges.

Enhancements:
- Preserve separate standalone-viewer and inline-rendering behavior, keeping file headers and hunk boundaries in the viewer while suppressing diff plumbing inline.
- Retain and realign coverage for inline full-patch rendering and standalone line-numbering behavior.

Tests:
- Restore the viewer tests for file headers, hunk headers, line numbering, and special diff content, while targeting the full-patch test at inline rendering.