### PR TITLE
fix(stella-tui): main does not compile — #4248 merged an unresolved conflict

### DIFF
--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -264,13 +264,6 @@ fn render_body(
         // Every line advances the gutter counters, shown or not — skipping a
         // line must not renumber the ones after it, and the numbers on the
         // far side of an elision have to be the file's real ones.
-        // Captured before `body_line` advances it: a `--- ` or `+++ ` line is
-        // plumbing only *outside* a hunk. Inside one it is body content that
-        // happens to look like a header — an SQL comment, a diff of a diff —
-        // and hunk position is the only thing that can tell them apart
-        // (`count_diff_lines` makes the same distinction for the same reason).
-        // Stripping on the text alone deletes real removed lines.
-        let was_in_hunk = in_hunk;
         // Read *before* `body_line` runs, because that call is what moves the
         // state this asks about. The same structural rule `body_line` itself
         // applies (only before a file's first hunk is `+++ `/`--- ` a header):
@@ -285,20 +278,6 @@ fn render_body(
             &mut in_hunk,
             emphasis.get(&i).copied(),
         );
-        // `index 74f38f3..9e6e426 100644`, `--- a/<path>`, `+++ b/<path>`:
-        // three rows of git plumbing at the head of every diff, saying the
-        // path the row above already names and a pair of blob hashes nobody
-        // can act on. They cost three of the handful of rows a collapsed diff
-        // gets, which is most of the budget spent before the first changed
-        // line. The counters above still advance over them, so the gutter's
-        // numbers stay the file's own.
-        //
-        // `@@` survives on the `hunk_headers` flag: it carries the enclosing
-        // scope (`@@ … const TYPEAHEAD_MAX_ROWS`), which is the one piece of
-        // context a hunk cannot reconstruct from its own lines.
-        if plan.shows(i)
-            && !(!was_in_hunk && is_meta(text))
-            && (hunk_headers || !text.starts_with("@@"))
         // Chrome is suppressed after planning rather than before it, so an
         // elided row's `⋯ n lines` count stays the one `stella_diff::view`
         // computed and every surface reports the same number for one change.
@@ -779,64 +758,67 @@ mod tests {
     fn body_numbers_added_lines_on_the_new_side_and_removed_on_the_old() {
         let lines = body_lines(SAMPLE, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
-        // The `---`/`+++` pair is stripped, so the `@@` header leads and the
-        // first numbered row is at index 1.
         // "@@ -1,3 +1,4 @@" starts old=1/new=1; context takes new 1.
-        assert!(texts[1].starts_with("   1  context"), "{:?}", texts[1]);
+        assert!(texts[3].starts_with("   1  context"), "{:?}", texts[3]);
         // The removal is numbered on the OLD side (old line 2).
-        assert!(texts[2].starts_with("   2 -old line"), "{:?}", texts[2]);
+        assert!(texts[4].starts_with("   2 -old line"), "{:?}", texts[4]);
         // Additions continue on the NEW side (new lines 2, 3).
-        assert!(texts[3].starts_with("   2 +new line"), "{:?}", texts[3]);
-        assert!(texts[4].starts_with("   3 +another add"), "{:?}", texts[4]);
+        assert!(texts[5].starts_with("   2 +new line"), "{:?}", texts[5]);
+        assert!(texts[6].starts_with("   3 +another add"), "{:?}", texts[6]);
     }
 
-    /// Git plumbing does not render at all, and the hunk header — which does —
-    /// carries no line number.
-    ///
-    /// This used to assert the opposite half: that `--- a/x.rs` and
-    /// `+++ b/x.rs` rendered with a blank gutter. They render nowhere now. The
-    /// three rows they cost (`index …` joins them on a real git patch) are most
-    /// of the budget a collapsed diff has, spent restating the path the head
-    /// already names and a pair of blob hashes nobody can act on.
     #[test]
-    fn plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter() {
+    fn file_headers_and_hunks_get_no_number() {
         let lines = body_lines(SAMPLE, None);
-        let texts: Vec<String> = lines.iter().map(line_text).collect();
-        for meta in ["--- a/x.rs", "+++ b/x.rs"] {
+        for (i, line) in lines.iter().take(3).enumerate() {
             assert!(
-                !texts.iter().any(|t| t.contains(meta)),
-                "{meta:?} still renders: {texts:?}"
+                line_text(line).starts_with("     "),
+                "line {i} has a blank gutter: {:?}",
+                line_text(line)
             );
         }
-        assert!(texts[0].contains("@@ -1,3 +1,4 @@"), "{:?}", texts[0]);
-        assert!(
-            texts[0].starts_with("     "),
-            "the hunk header took a line number: {:?}",
-            texts[0]
-        );
     }
 
-    /// A real git patch leads with `diff --git` and `index …` as well, and
-    /// neither reaches the row.
+    /// The viewer keeps a single file's preamble (above); inline, the same
+    /// patch opens on its first changed line.
+    ///
+    /// `index 74f38f3..9e6e426 100644`, `--- a/<path>`, `+++ b/<path>`: three
+    /// rows restating the path the call row already names and a pair of blob
+    /// hashes nobody can act on. In a viewer that is orientation. Inline under
+    /// a tool call it is most of the row budget spent before the first changed
+    /// line — which is why `Chrome::inline_for` drops it for a lone file and
+    /// keeps it once a patch spans two.
     #[test]
-    fn a_full_git_patch_renders_only_its_hunk() {
-        let patch = "diff --git a/x.rs b/x.rs\n\
-                     index 74f38f3..9e6e426 100644\n\
-                     --- a/x.rs\n\
-                     +++ b/x.rs\n\
-                     @@ -1,2 +1,2 @@\n\
-                      keep\n\
-                     -old\n\
-                     +new";
-        let texts: Vec<String> = body_lines(patch, None).iter().map(line_text).collect();
+    fn a_full_git_patch_renders_only_its_hunk_inline() {
+        // Spelled with explicit `\n` rather than `\`-continuation: that
+        // continuation eats the *leading* whitespace of each line, which would
+        // silently strip the context line's `' '` marker and leave the fixture
+        // something git never emits.
+        let patch = "diff --git a/x.rs b/x.rs\nindex 74f38f3..9e6e426 100644\n--- a/x.rs\n+++ b/x.rs\n@@ -1,2 +1,2 @@\n keep\n-old\n+new";
+        let (lines, _) = body_lines_inline(patch, None, usize::MAX, None);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
         for meta in ["diff --git", "index 74f38f3", "--- a/", "+++ b/"] {
             assert!(
                 !texts.iter().any(|t| t.contains(meta)),
-                "{meta:?} still renders: {texts:?}"
+                "{meta:?} still renders inline: {texts:?}"
             );
         }
         assert!(texts.iter().any(|t| t.contains("-old")), "{texts:?}");
         assert!(texts.iter().any(|t| t.contains("+new")), "{texts:?}");
+        // The gutter still walked the skipped rows, so the numbering is the
+        // file's own rather than a count of what survived.
+        assert!(
+            texts.iter().any(|t| t.starts_with("   1  keep")),
+            "context keeps its real line number: {texts:?}"
+        );
+
+        // The viewer is the other half of the contract: same patch, preamble
+        // intact, because a reader navigating a patch wants the boundaries.
+        let viewer: Vec<String> = body_lines(patch, None).iter().map(line_text).collect();
+        assert!(
+            viewer.iter().any(|t| t.contains("+++ b/x.rs")),
+            "the viewer keeps the preamble: {viewer:?}"
+        );
     }
 
     #[test]
@@ -875,17 +857,17 @@ mod tests {
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            !texts[1].starts_with("     "),
+            !texts[3].starts_with("     "),
             "removed body line should get a gutter number, not read as a header: {:?}",
-            texts[1]
+            texts[3]
         );
         assert!(
-            !texts[2].starts_with("     "),
+            !texts[4].starts_with("     "),
             "added body line should get a gutter number, not read as a header: {:?}",
-            texts[2]
+            texts[4]
         );
-        assert!(texts[1].contains("was a rule"), "{:?}", texts[1]);
-        assert!(texts[2].contains("is a rule"), "{:?}", texts[2]);
+        assert!(texts[3].contains("was a rule"), "{:?}", texts[3]);
+        assert!(texts[4].contains("is a rule"), "{:?}", texts[4]);
     }
 
     #[test]
@@ -905,12 +887,12 @@ mod tests {
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            texts[2].starts_with("     "),
+            texts[4].starts_with("     "),
             "the marker line itself gets a blank gutter: {:?}",
-            texts[2]
+            texts[4]
         );
         assert!(
-            texts[3].starts_with("   1 +new"),
+            texts[5].starts_with("   1 +new"),
             "the marker must not have consumed a line number: {:?}",
             texts[5]
         );


### PR DESCRIPTION
## What & why

**`main` does not build.** `cargo check -p stella-tui` on `8a2fdf8cc`:

```
error: expected `{`, found keyword `if`
   --> crates/stella-tui/src/diff.rs:307:9
note: the `if` expression is missing a block after this condition
   --> crates/stella-tui/src/diff.rs:299:12
```

#4248 merged `main` into its branch and resolved `render_body` by keeping **both** sides' guard. The first has no block, names a bare `hunk_headers` that stopped existing when #4244 moved it onto `Chrome`, and leaves `was_in_hunk` unused. Everything downstream of `stella-tui` fails with it, so every PR opened since 04:02 UTC is red for a reason that is not its own.

### The conflict underneath

The syntax error is the symptom; the two guards are the disease. #4244 landed this idea first and scoped it:

| | preamble (`diff`/`index`/`---`/`+++`) |
|---|---|
| `Chrome::VIEWER` | **kept** — a reader navigating a patch wants the file boundary |
| `Chrome::inline_for`, one file | **dropped** — three rows is most of a collapsed diff's budget |
| `Chrome::inline_for`, two+ files | **kept** — now it separates more than one of something |

#4248 stripped it everywhere, viewer included, and rewrote five tests to match.

**`Chrome` wins.** It already delivers what #4248's description argues for — *"three of the handful of rows a collapsed diff gets"* is a claim about the **collapsed** surface — without also taking the boundary away from the viewer. So `diff.rs` returns to its pre-#4248 state, which is the entirety of #4248's change to this file. The other six files that PR touched are untouched here and keep working: the quiet-mutation rows, the read-body fold, and the `ToolEntry::label` verbs all stand.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_full_git_patch_renders_only_its_hunk_inline` is #4248's own test retargeted at `body_lines_inline`, where the behaviour actually lives now. It pins **both** halves of the contract in one place — inline opens on the first changed line with the gutter still numbering from the file, and the viewer keeps the preamble. `main` had no in-module test for either; #4244's coverage is all in `mutation_diff_e2e`.

On `main` it does not fail — it cannot compile. That is the witness.

Its fixture is spelled with explicit `\n` rather than `\`-continuation, because that continuation eats each line's **leading** whitespace: #4248's patch literal had a context row with no `' '` marker, a shape git never emits. Its assertions happened not to reach that row; mine does, and caught it.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed — the `Chrome` doc comments are restored intact; no behaviour changes vs. pre-#4248 `main`
- [x] CLA signed
- [x] No `Closes #N` — this fixes a merged PR, not an open issue

`cargo check --workspace --all-targets` goes from **broken** to `Finished`.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

The one loose thread is not code — see below.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The `tui-transcript-body` branch is back on the remote, and it should not be.** GitHub auto-deleted it when #4248 merged; I pushed a fix to it before noticing the merge had happened mid-session, which recreated the ref at `617b22bf9`. That commit is the same resolution as this one but based on pre-merge history — it is superseded and safe to discard. Deleting the branch restores the post-merge state; I left it for you rather than deleting a ref I created by accident.

**Why not revert #4248 wholesale.** Six of its seven files are fine and carry three unrelated, wanted changes. Only `diff.rs` was conflicted, and only its `render_body` guard and five test bodies. Reverting the file is the smallest change that makes `main` build.

**Why not just delete the dead first `if`.** That compiles, and it is the wrong fix: it would leave `Chrome::VIEWER.file_headers` set to `true` while the surviving guard also carries `!preamble` semantics from the other side, so the viewer would keep rendering plumbing that four of the file's own tests assert is gone. The tests and the behaviour have to move together, and moving them means picking a side.

## Summary by Sourcery

Resolve the stella-tui diff rendering conflict and restore the correct per-surface handling of patch preambles.

Bug Fixes:
- Restore the intended diff rendering behavior so stella-tui builds and inline single-file patches omit preamble metadata while the standalone viewer preserves it.

Enhancements:
- Align render_body and its coverage with the Chrome-specific display rules, including preserving real file line numbering for skipped metadata.

Tests:
- Add coverage verifying inline hunk rendering, file line numbering, and viewer preamble preservation.