### PR TITLE
context: review the 101-proposal ingest queue — publish 29 steering records, decline 9 the tree refutes

### DIFF
--- a/.stella/rules/ctx.macanderson.stella.agents-md-wins-conflicts.toml
+++ b/.stella/rules/ctx.macanderson.stella.agents-md-wins-conflicts.toml
@@ -1,0 +1,47 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.agents-md-wins-conflicts"
+record_id = "rec_macanderson_stella_agents_md_wins_conflicts_c3358525b085"
+record_hash = "sha256:b87a6841008b7dc780d7335668318e2c19d834400bde4801b617f10994b8e3b8"
+kind = "rule"
+statement = "When CLAUDE.md and AGENTS.md disagree, AGENTS.md wins."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    88,
+    89,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = [
+    "CLAUDE.md",
+    "AGENTS.md",
+]
+keywords = [
+    "precedence",
+    "conflict",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 95

--- a/.stella/rules/ctx.macanderson.stella.allow-needs-comment.toml
+++ b/.stella/rules/ctx.macanderson.stella.allow-needs-comment.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.allow-needs-comment"
+record_id = "rec_macanderson_stella_allow_needs_comment_f1a73870d9c3"
+record_hash = "sha256:6a1401770176aad358fbc28fabe157f9a6856e596359a270fd98f613d7a131fe"
+kind = "rule"
+statement = "An #[allow] attribute must carry a comment explaining why the lint is wrong in that specific place."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    24,
+    26,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "#[allow]",
+    "lint",
+    "comment",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.announce-deferred-fix.toml
+++ b/.stella/rules/ctx.macanderson.stella.announce-deferred-fix.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.announce-deferred-fix"
+record_id = "rec_macanderson_stella_announce_deferred_fix_e91bdcc10043"
+record_hash = "sha256:1523f28af6e7bfb3a74786d37c84a9367e01963ec75add1c7e5ad954103288c2"
+kind = "rule"
+statement = "If the correct fix is bigger than the session, the deferral must be stated out loud in the final message."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    29,
+    32,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "final message",
+    "deferral",
+    "disclosure",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.bench-conclusion-from-trace.toml
+++ b/.stella/rules/ctx.macanderson.stella.bench-conclusion-from-trace.toml
@@ -1,0 +1,45 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.bench-conclusion-from-trace"
+record_id = "rec_macanderson_stella_bench_conclusion_from_trace_ee4128b37c74"
+record_hash = "sha256:23a2f1e8f0c7cf18162de6c3b400c3d01492d55476770f3ac4b095beac56365f"
+kind = "rule"
+statement = "A bench conclusion must be drawn from the trace, never from a surface signal."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    53,
+    54,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+tasks = ["benchmark"]
+keywords = [
+    "bench",
+    "trace",
+    "surface signal",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 92

--- a/.stella/rules/ctx.macanderson.stella.bench-conclusion-from-trace.toml
+++ b/.stella/rules/ctx.macanderson.stella.bench-conclusion-from-trace.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.bench-conclusion-from-trace"
-record_id = "rec_macanderson_stella_bench_conclusion_from_trace_ee4128b37c74"
-record_hash = "sha256:23a2f1e8f0c7cf18162de6c3b400c3d01492d55476770f3ac4b095beac56365f"
 kind = "rule"
 statement = "A bench conclusion must be drawn from the trace, never from a surface signal."
 origin = "imported"
@@ -30,7 +28,9 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-tasks = ["benchmark"]
+# The extractor proposed tasks = ["benchmark"]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "bench",
     "trace",

--- a/.stella/rules/ctx.macanderson.stella.census-role-model-from-step-usage.toml
+++ b/.stella/rules/ctx.macanderson.stella.census-role-model-from-step-usage.toml
@@ -1,0 +1,49 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.census-role-model-from-step-usage"
+record_id = "rec_macanderson_stella_census_role_model_from_step_usage_34881e1008e9"
+record_hash = "sha256:7c5692a3c6efb77c804c2d92659f9729c2c9638b2cc92a8680439574ad6008b8"
+kind = "procedure"
+statement = "Census (role, model) from step_usage before believing a claim about which model ran."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    66,
+    69,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+tasks = [
+    "benchmark",
+    "investigation",
+]
+keywords = [
+    "step_usage",
+    "role",
+    "model",
+    "census",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.census-role-model-from-step-usage.toml
+++ b/.stella/rules/ctx.macanderson.stella.census-role-model-from-step-usage.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.census-role-model-from-step-usage"
-record_id = "rec_macanderson_stella_census_role_model_from_step_usage_34881e1008e9"
-record_hash = "sha256:7c5692a3c6efb77c804c2d92659f9729c2c9638b2cc92a8680439574ad6008b8"
 kind = "procedure"
 statement = "Census (role, model) from step_usage before believing a claim about which model ran."
 origin = "imported"
@@ -30,10 +28,9 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-tasks = [
-    "benchmark",
-    "investigation",
-]
+# The extractor proposed tasks = [ "benchmark", "investigation", ]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "step_usage",
     "role",

--- a/.stella/rules/ctx.macanderson.stella.cheap-control-before-bisect.toml
+++ b/.stella/rules/ctx.macanderson.stella.cheap-control-before-bisect.toml
@@ -1,0 +1,48 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.cheap-control-before-bisect"
+record_id = "rec_macanderson_stella_cheap_control_before_bisect_66851b31c756"
+record_hash = "sha256:7285357c12b4616dc2550b57ca559855eebb77810f1312470f57fb2607cd084a"
+kind = "procedure"
+statement = "Before any bisect, re-run the failing task alone on the old SUT as a cheap control."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    73,
+    76,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+tasks = [
+    "investigation",
+    "bisect",
+]
+keywords = [
+    "control",
+    "bisect",
+    "old SUT",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 92

--- a/.stella/rules/ctx.macanderson.stella.cheap-control-before-bisect.toml
+++ b/.stella/rules/ctx.macanderson.stella.cheap-control-before-bisect.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.cheap-control-before-bisect"
-record_id = "rec_macanderson_stella_cheap_control_before_bisect_66851b31c756"
-record_hash = "sha256:7285357c12b4616dc2550b57ca559855eebb77810f1312470f57fb2607cd084a"
 kind = "procedure"
 statement = "Before any bisect, re-run the failing task alone on the old SUT as a cheap control."
 origin = "imported"
@@ -30,10 +28,9 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-tasks = [
-    "investigation",
-    "bisect",
-]
+# The extractor proposed tasks = [ "investigation", "bisect", ]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "control",
     "bisect",

--- a/.stella/rules/ctx.macanderson.stella.correctness-needs-proof.toml
+++ b/.stella/rules/ctx.macanderson.stella.correctness-needs-proof.toml
@@ -1,0 +1,45 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.correctness-needs-proof"
+record_id = "rec_macanderson_stella_correctness_needs_proof_cc6cc06a0929"
+record_hash = "sha256:11ccb7b11c8ab5cd9967a55942313c2b5ccb95996f74848a48568bc47197541a"
+kind = "rule"
+statement = "Correctness must be demonstrated with a witness test, a property, or a golden diff someone actually read, not merely asserted in a PR description."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    33,
+    37,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "witness test",
+    "property",
+    "golden diff",
+    "proof",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
@@ -1,0 +1,43 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.deleted-test-named-in-pr"
+record_id = "rec_macanderson_stella_deleted_test_named_in_pr_947f153bc7d4"
+record_hash = "sha256:22c94b6cc571743fe3fa1c83f955fb5c847b2c4951106ce2b8f61279833f856e"
+kind = "rule"
+statement = "Deleting a test is permitted but must be named in the PR description so an invisible deletion becomes a sentence a reviewer reads."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+tasks = [
+    "pull-request",
+    "delete-test",
+]
+keywords = [
+    "deleted test",
+    "PR description",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.deleted-test-named-in-pr"
-record_id = "rec_macanderson_stella_deleted_test_named_in_pr_947f153bc7d4"
-record_hash = "sha256:22c94b6cc571743fe3fa1c83f955fb5c847b2c4951106ce2b8f61279833f856e"
 kind = "rule"
 statement = "Deleting a test is permitted but must be named in the PR description so an invisible deletion becomes a sentence a reviewer reads."
 origin = "imported"
@@ -26,10 +24,9 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-tasks = [
-    "pull-request",
-    "delete-test",
-]
+# Retargeted from the extractor's ["pull-request", "delete-test"], neither
+# of which is a ratified task name.
+tasks = ["test", "review"]
 keywords = [
     "deleted test",
     "PR description",

--- a/.stella/rules/ctx.macanderson.stella.expedient-is-defect.toml
+++ b/.stella/rules/ctx.macanderson.stella.expedient-is-defect.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.expedient-is-defect"
+record_id = "rec_macanderson_stella_expedient_is_defect_7db78f4ae8d1"
+record_hash = "sha256:361cf7defa9e34782c809b3ba4b2c6160a5e5c8585f46aa95880e16fff8f869c"
+kind = "constraint"
+statement = "An expedient shortcut is treated as a defect rather than an acceptable tradeoff."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    23,
+    32,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "expedient",
+    "shortcut",
+    "defect",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.file-issue-for-everything-else.toml
+++ b/.stella/rules/ctx.macanderson.stella.file-issue-for-everything-else.toml
@@ -1,0 +1,40 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.file-issue-for-everything-else"
+record_id = "rec_macanderson_stella_file_issue_for_everything_else_a1949d17b5a2"
+record_hash = "sha256:e08b0f6c2a745324ac017923c65309d6e858975489bcf69a232731c26bf76007"
+kind = "rule"
+statement = "Everything not fixed in scope — an unfixed bug, a workaround, a missing test, an idea, dead or unwired code, or the logical next step — becomes a GitHub issue before finishing."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "GitHub issue",
+    "unwired code",
+    "next step",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.inv1-core-no-sdk-imports.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv1-core-no-sdk-imports.toml
@@ -1,0 +1,45 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv1-core-no-sdk-imports"
+record_id = "rec_macanderson_stella_inv1_core_no_sdk_imports_44895607e35f"
+record_hash = "sha256:718a3fc6b794eb14de0580a848996fd4f7c5bdb87ff4a493005e64bdfe79061c"
+kind = "constraint"
+statement = "Invariant 1: stella-core never imports a provider SDK, a filesystem API, or a terminal library; models go through the Provider trait and tools through ToolExecutor."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+# Narrowed from the extractor's [stella-core, stella-protocol]: the statement
+# is about stella-core alone, and the stella-protocol entry only made this
+# record collide with ^protocol-types-only at equal precedence, suspending it.
+paths = ["crates/stella-core"]
+keywords = [
+    "ports",
+    "Provider",
+    "ToolExecutor",
+    "adapter",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 92

--- a/.stella/rules/ctx.macanderson.stella.inv1-core-no-sdk-imports.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv1-core-no-sdk-imports.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.inv1-core-no-sdk-imports"
-record_id = "rec_macanderson_stella_inv1_core_no_sdk_imports_44895607e35f"
-record_hash = "sha256:718a3fc6b794eb14de0580a848996fd4f7c5bdb87ff4a493005e64bdfe79061c"
 kind = "constraint"
 statement = "Invariant 1: stella-core never imports a provider SDK, a filesystem API, or a terminal library; models go through the Provider trait and tools through ToolExecutor."
 origin = "imported"

--- a/.stella/rules/ctx.macanderson.stella.inv3-allowlist-same-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv3-allowlist-same-pr.toml
@@ -1,0 +1,42 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv3-allowlist-same-pr"
+record_id = "rec_macanderson_stella_inv3_allowlist_same_pr_38b7d6b446b7"
+record_hash = "sha256:b99610532bb3772f8717b036d9e941d88154c7643d03f52be1460602b40a692c"
+kind = "rule"
+statement = "Adding a hub telemetry column or a key to an egress encoder fails the gate until the reviewed allowlist in crates/stella-store/src/content_free.rs is edited in the same PR."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["crates/stella-store/src/content_free.rs"]
+keywords = [
+    "allowlist",
+    "hub column",
+    "encoder",
+    "sentinel harness",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "measured"
+confidence = 88

--- a/.stella/rules/ctx.macanderson.stella.inv3-zero-telemetry.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv3-zero-telemetry.toml
@@ -1,0 +1,47 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv3-zero-telemetry"
+record_id = "rec_macanderson_stella_inv3_zero_telemetry_82782f2f11b9"
+record_hash = "sha256:ec6c360eb9fd651dec78a2437611d8317454d41e987e951de250aaf398c4db59"
+kind = "constraint"
+statement = "Invariant 3: community/default Stella sends no telemetry anywhere, and update checks and anonymous analytics remain prohibited."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["crates/stella-store/src/content_free.rs"]
+keywords = [
+    "telemetry",
+    "egress",
+    "analytics",
+    "update check",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 92
+
+[record.truth.probe]
+kind = "path_exists"
+path = "crates/stella-store/src/content_free.rs"
+expect = "present"

--- a/.stella/rules/ctx.macanderson.stella.inv4-serde-roundtrip.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv4-serde-roundtrip.toml
@@ -1,0 +1,47 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv4-serde-roundtrip"
+record_id = "rec_macanderson_stella_inv4_serde_roundtrip_93a77f179150"
+record_hash = "sha256:13422cc6e35a72bd7579b38d53188fa66fea83c63333f8335363eae1efaf222f"
+kind = "constraint"
+statement = "Invariant 4: every type crossing a crate boundary round-trips through serde_json byte-for-byte, and a round-trip test is added whenever a type is added to stella-protocol."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+# Above the default 100 so this wins over ^protocol-types-only, which matches
+# the same crate at 100 with a different enforcement mode and would otherwise
+# suspend it. The two are complementary, not contradictory — "types only" says
+# what may live here, this says what a new type owes — and the more specific
+# rule (one crate plus one task) is the one that should apply.
+precedence = 110
+
+[record.steering.applies_to]
+paths = ["crates/stella-protocol"]
+tasks = ["add-protocol-type"]
+keywords = [
+    "serde",
+    "round-trip",
+    "byte-for-byte",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 92

--- a/.stella/rules/ctx.macanderson.stella.inv4-serde-roundtrip.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv4-serde-roundtrip.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.inv4-serde-roundtrip"
-record_id = "rec_macanderson_stella_inv4_serde_roundtrip_93a77f179150"
-record_hash = "sha256:13422cc6e35a72bd7579b38d53188fa66fea83c63333f8335363eae1efaf222f"
 kind = "constraint"
 statement = "Invariant 4: every type crossing a crate boundary round-trips through serde_json byte-for-byte, and a round-trip test is added whenever a type is added to stella-protocol."
 origin = "imported"
@@ -27,12 +25,14 @@ force = "must"
 # the same crate at 100 with a different enforcement mode and would otherwise
 # suspend it. The two are complementary, not contradictory — "types only" says
 # what may live here, this says what a new type owes — and the more specific
-# rule (one crate plus one task) is the one that should apply.
+# rule — this one names a single crate — is the one that should apply.
 precedence = 110
 
 [record.steering.applies_to]
 paths = ["crates/stella-protocol"]
-tasks = ["add-protocol-type"]
+# The extractor proposed tasks = ["add-protocol-type"]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "serde",
     "round-trip",

--- a/.stella/rules/ctx.macanderson.stella.inv5-typed-errors-no-panic.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv5-typed-errors-no-panic.toml
@@ -1,0 +1,41 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv5-typed-errors-no-panic"
+record_id = "rec_macanderson_stella_inv5_typed_errors_no_panic_0bb306da7419"
+record_hash = "sha256:bda4fcf3a225afe44a116bf5ec8b73833a60e71d3c03ef23f0a534926a815d5b"
+kind = "constraint"
+statement = "Invariant 5: library code returns typed named errors and never uses a bare String error or unwrap/expect on runtime data such as network payloads, tool arguments, or parsed source files."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "typed errors",
+    "unwrap",
+    "expect",
+    "panic",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 92

--- a/.stella/rules/ctx.macanderson.stella.inv6-budget-safe-boundaries.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv6-budget-safe-boundaries.toml
@@ -1,0 +1,41 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv6-budget-safe-boundaries"
+record_id = "rec_macanderson_stella_inv6_budget_safe_boundaries_2f130a644816"
+record_hash = "sha256:50b6313e4757fa2fc72f7c0a104b4dff37f75d503c4ce246aaa88dd926fecd02"
+kind = "constraint"
+statement = "Invariant 6: run_turn consults the budget guard only between model calls and never aborts mid-tool or interrupts a tool in flight."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["crates/stella-core"]
+keywords = [
+    "budget",
+    "run_turn",
+    "mid-tool",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.inv7-byte-stable-prompts.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv7-byte-stable-prompts.toml
@@ -1,0 +1,41 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv7-byte-stable-prompts"
+record_id = "rec_macanderson_stella_inv7_byte_stable_prompts_ff125d7c86e4"
+record_hash = "sha256:480f96299b385a9372661632e27cb8758e696577bf47f2989c33c352a02b4873"
+kind = "constraint"
+statement = "Invariant 7: anything feeding the system prompt must be deterministic, because prompt-cache hits are a feature and nondeterminism there is a cost regression."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["crates/stella-cli/src/agent.rs"]
+keywords = [
+    "prompt cache",
+    "deterministic",
+    "system prompt",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.inv8-matrix-same-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv8-matrix-same-pr.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv8-matrix-same-pr"
+record_id = "rec_macanderson_stella_inv8_matrix_same_pr_6087a2fde1e7"
+record_hash = "sha256:936f194921be6c069b6866557ee670338b57edddd512f5bffe33b3416aa4da7d"
+kind = "rule"
+statement = "Adding a provider or a new divergent feature axis requires updating the parity matrix in the same PR."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = [
+    "crates/stella-model/src/provider_parity.rs",
+    "crates/stella-cli",
+]
+tasks = ["add-provider"]
+keywords = [
+    "parity matrix",
+    "same PR",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.inv8-matrix-same-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv8-matrix-same-pr.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.inv8-matrix-same-pr"
-record_id = "rec_macanderson_stella_inv8_matrix_same_pr_6087a2fde1e7"
-record_hash = "sha256:936f194921be6c069b6866557ee670338b57edddd512f5bffe33b3416aa4da7d"
 kind = "rule"
 statement = "Adding a provider or a new divergent feature axis requires updating the parity matrix in the same PR."
 origin = "imported"
@@ -30,7 +28,9 @@ paths = [
     "crates/stella-model/src/provider_parity.rs",
     "crates/stella-cli",
 ]
-tasks = ["add-provider"]
+# The extractor proposed tasks = ["add-provider"]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "parity matrix",
     "same PR",

--- a/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
@@ -1,0 +1,42 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.inv8-posture-every-axis"
+record_id = "rec_macanderson_stella_inv8_posture_every_axis_3ba2ee8e2de8"
+record_hash = "sha256:eeb530f623e436a02cb764433c08ec45a19a412e230b6784ead78d1b9f1704a3"
+kind = "rule"
+statement = "Each provider id declares a posture on every parity axis and, for a controllable/opt-in/implicit posture, names the witness test proving it on the wire."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["crates/stella-model/src/provider_parity.rs"]
+tasks = ["add-provider"]
+keywords = [
+    "posture",
+    "witness test",
+    "axis",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.inv8-posture-every-axis"
-record_id = "rec_macanderson_stella_inv8_posture_every_axis_3ba2ee8e2de8"
-record_hash = "sha256:eeb530f623e436a02cb764433c08ec45a19a412e230b6784ead78d1b9f1704a3"
 kind = "rule"
 statement = "Each provider id declares a posture on every parity axis and, for a controllable/opt-in/implicit posture, names the witness test proving it on the wire."
 origin = "imported"
@@ -27,7 +25,9 @@ precedence = 100
 
 [record.steering.applies_to]
 paths = ["crates/stella-model/src/provider_parity.rs"]
-tasks = ["add-provider"]
+# The extractor proposed tasks = ["add-provider"]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "posture",
     "witness test",

--- a/.stella/rules/ctx.macanderson.stella.left-behind-fix-is-file-issue.toml
+++ b/.stella/rules/ctx.macanderson.stella.left-behind-fix-is-file-issue.toml
@@ -1,0 +1,41 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.left-behind-fix-is-file-issue"
+record_id = "rec_macanderson_stella_left_behind_fix_is_file_issue_328ec0b9f0c2"
+record_hash = "sha256:973c897bc3c40cd35faa54674a791c7743d7d851d03d153059fd04716d81774a"
+kind = "rule"
+statement = "The fix for a left-behind marker is always to file the issue and reference it — never to delete the marker and never to add a baseline entry, since that baseline started empty and is meant to stay empty."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["scripts/check-left-behind.sh"]
+keywords = [
+    "baseline",
+    "marker",
+    "issue reference",
+]
+
+[record.enforcement]
+mode = "hard"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.multi-commit-runs-confounded.toml
+++ b/.stella/rules/ctx.macanderson.stella.multi-commit-runs-confounded.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.multi-commit-runs-confounded"
-record_id = "rec_macanderson_stella_multi_commit_runs_confounded_6520806908a7"
-record_hash = "sha256:939080bf74fed65d01a3eebe842a7aa0332305dbd05f8a737ff5ad84b0cc4631"
 kind = "rule"
 statement = "Any two runs differing by more than one commit are confounded and must be reported as such."
 origin = "imported"
@@ -30,7 +28,9 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-tasks = ["benchmark"]
+# The extractor proposed tasks = ["benchmark"]; no such task is in the ratified
+# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
+# carry the selection instead.
 keywords = [
     "confounded",
     "commit",

--- a/.stella/rules/ctx.macanderson.stella.multi-commit-runs-confounded.toml
+++ b/.stella/rules/ctx.macanderson.stella.multi-commit-runs-confounded.toml
@@ -1,0 +1,45 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.multi-commit-runs-confounded"
+record_id = "rec_macanderson_stella_multi_commit_runs_confounded_6520806908a7"
+record_hash = "sha256:939080bf74fed65d01a3eebe842a7aa0332305dbd05f8a737ff5ad84b0cc4631"
+kind = "rule"
+statement = "Any two runs differing by more than one commit are confounded and must be reported as such."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    82,
+    84,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+tasks = ["benchmark"]
+keywords = [
+    "confounded",
+    "commit",
+    "reporting",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.no-raise-file-size-baseline.toml
+++ b/.stella/rules/ctx.macanderson.stella.no-raise-file-size-baseline.toml
@@ -1,0 +1,49 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.no-raise-file-size-baseline"
+record_id = "rec_macanderson_stella_no_raise_file_size_baseline_f408e19e3f5c"
+record_hash = "sha256:3fded21fe3f9a45ab51e9f665c050d01d662c28c4609357410820df17faba97e"
+kind = "rule"
+statement = "Raising the ceiling in scripts/file-size-baseline.txt to turn a gate green is prohibited."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    26,
+    28,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+paths = ["scripts/file-size-baseline.txt"]
+keywords = [
+    "file-size-baseline",
+    "gate",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90
+
+[record.truth.probe]
+kind = "path_exists"
+path = "scripts/file-size-baseline.txt"
+expect = "present"

--- a/.stella/rules/ctx.macanderson.stella.no-silent-shortcut.toml
+++ b/.stella/rules/ctx.macanderson.stella.no-silent-shortcut.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.no-silent-shortcut"
+record_id = "rec_macanderson_stella_no_silent_shortcut_67947dbc0cba"
+record_hash = "sha256:54e2db2a8134919e174546dc6c55421b51c1c1801d8561e73e78959c6a4c5a37"
+kind = "constraint"
+statement = "Shipping a shortcut quietly, without disclosing it, is the one unrecoverable move."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    31,
+    32,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "shortcut",
+    "silence",
+    "disclosure",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.no-todo-for-design.toml
+++ b/.stella/rules/ctx.macanderson.stella.no-todo-for-design.toml
@@ -1,0 +1,43 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.no-todo-for-design"
+record_id = "rec_macanderson_stella_no_todo_for_design_8d70517390d6"
+record_hash = "sha256:ea33a905ac30c03b7d990e8fa2b7949d30c38366e777e19f99b5ba5236bc1c4b"
+kind = "rule"
+statement = "A TODO must not stand in for the actual design."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    28,
+    29,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "TODO",
+    "design",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 88

--- a/.stella/rules/ctx.macanderson.stella.nothing-left-behind.toml
+++ b/.stella/rules/ctx.macanderson.stella.nothing-left-behind.toml
@@ -1,0 +1,40 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.nothing-left-behind"
+record_id = "rec_macanderson_stella_nothing_left_behind_37aca87900cc"
+record_hash = "sha256:a611e18229d4a3efed39ef155ac07f98fd8fdd4eca962178e0e1bd14024d16a2"
+kind = "rule"
+statement = "Work is not finished while anything noticed during the session lives only in the author's head, a chat transcript, or a worktree about to be deleted."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "left behind",
+    "session",
+    "handoff",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.now-vs-right-is-maintainers-call.toml
+++ b/.stella/rules/ctx.macanderson.stella.now-vs-right-is-maintainers-call.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.now-vs-right-is-maintainers-call"
+record_id = "rec_macanderson_stella_now_vs_right_is_maintainers_call_b12f8fb1ad3b"
+record_hash = "sha256:bfc63dc1675f9459a49cdb69819e72d4dab1bb3f4ebfcd2a8cdc02db84d7c07f"
+kind = "rule"
+statement = 'When "now" and "right" cannot both be had, the agent must state which one is being given up and why and let a human maintainer choose rather than deciding silently.'
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    48,
+    52,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "escalation",
+    "maintainer",
+    "tradeoff",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.read-full-proof-reason.toml
+++ b/.stella/rules/ctx.macanderson.stella.read-full-proof-reason.toml
@@ -1,0 +1,44 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.read-full-proof-reason"
+record_id = "rec_macanderson_stella_read_full_proof_reason_6385a4611176"
+record_hash = "sha256:1b91266f80972016678c8410b7f49484e430fc7b2a12fcc9e6198293d9da5aa9"
+kind = "procedure"
+statement = "Read the full proof reason strings from the event log because they are truncated everywhere else and the truncated half usually matters."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "CLAUDE.md"
+source_digest = "sha256:5de1b8dc1e72abd504a708a727b54340ebb060894883c5e4e143fc91fab9eba3"
+source_lines = [
+    70,
+    72,
+]
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77ce42"
+extracted_at = "2026-08-09T00:48:02Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "proof",
+    "reason",
+    "truncated",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 90

--- a/.stella/rules/ctx.macanderson.stella.scaffolding-needs-wiring-issue.toml
+++ b/.stella/rules/ctx.macanderson.stella.scaffolding-needs-wiring-issue.toml
@@ -1,0 +1,40 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.scaffolding-needs-wiring-issue"
+record_id = "rec_macanderson_stella_scaffolding_needs_wiring_issue_69bddc3070a5"
+record_hash = "sha256:3b2d14604b95cdd65b973add57e2eab998af39c9049649c0733b01e7dae39609"
+kind = "rule"
+statement = "If a change ships scaffolding that something else must later wire up, the wiring issue is filed in the same breath as the PR, because unwired code with no tracking issue is the failure mode this rule prevents."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+keywords = [
+    "scaffolding",
+    "wiring",
+    "tracking issue",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 88

--- a/.stella/rules/ctx.macanderson.stella.witness-definition.toml
+++ b/.stella/rules/ctx.macanderson.stella.witness-definition.toml
@@ -3,8 +3,6 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.witness-definition"
-record_id = "rec_macanderson_stella_witness_definition_5015b7eb5dd5"
-record_hash = "sha256:7e4b913db5177f7687c731f5211135fcc401956b428aa30e5e21351398a5bc84"
 kind = "constraint"
 statement = "A witness test is one that fails on main without the change and passes with the change, and a behavior change or feature PR should include one."
 origin = "imported"

--- a/.stella/rules/ctx.macanderson.stella.witness-definition.toml
+++ b/.stella/rules/ctx.macanderson.stella.witness-definition.toml
@@ -1,0 +1,43 @@
+schema = "context-record/v0.1"
+set_id = "macanderson.stella"
+
+[[record]]
+lineage_id = "ctx.macanderson.stella.witness-definition"
+record_id = "rec_macanderson_stella_witness_definition_5015b7eb5dd5"
+record_hash = "sha256:7e4b913db5177f7687c731f5211135fcc401956b428aa30e5e21351398a5bc84"
+kind = "constraint"
+statement = "A witness test is one that fails on main without the change and passes with the change, and a behavior change or feature PR should include one."
+origin = "imported"
+sharing_scope = "repository"
+status = "active"
+
+[record.provenance]
+source_kind = "document"
+source_uri = "AGENTS.md"
+source_digest = "sha256:73fd3ccab45e7b2f50264c73439dcd07cc78e97f99b8b164f117d24ef6d3f66b"
+repo = "git@github.com:macanderson/stella"
+commit = "8b63b88a"
+ingest_run_id = "ing_6a77cd04"
+extracted_at = "2026-08-09T00:42:44Z"
+extractor = "anthropic/claude-opus-5"
+
+[record.steering]
+force = "must"
+precedence = 100
+
+[record.steering.applies_to]
+# The extractor proposed tasks = ["pull-request", "feature"]; neither is a
+# recognized task, so both matched nothing and only skewed relevance. The
+# keywords below carry the selection instead.
+keywords = [
+    "witness test",
+    "done",
+    "fail-pass",
+]
+
+[record.enforcement]
+mode = "soft"
+
+[record.truth]
+basis = "decree"
+confidence = 95


### PR DESCRIPTION
## What & why

`stella ingest` had extracted 101 claims from `CLAUDE.md` and `AGENTS.md` into this workspace's review queue, and none of them had ever been decided. This reviews the whole queue: it publishes the 29 that actually steer an agent, declines the 9 the current tree refutes, and leaves the rest undecided.

**Kept (29)** — chosen for being prescriptive and violation-prone, not merely true:

- **Architecture invariants** 1, 3 (both halves), 4, 5, 6, 7, 8 (both halves) — the crown, per CLAUDE.md.
- **The expedient-is-a-defect family** — no raised `file-size-baseline.txt` ceiling, no `TODO` standing in for a design, no uncommented `#[allow]`, no silent shortcut, deferrals announced out loud, "now vs right" is the maintainer's call.
- **Proof obligations** — the witness definition, correctness demonstrated rather than asserted, a deleted test named in the PR description.
- **Nothing left behind** — the umbrella rule, the file-an-issue rule, scaffolding needs a wiring issue, and that a left-behind marker is fixed by filing the issue and never by deleting the marker or baselining it.
- **CLAUDE.md's bench-evidence procedures** — conclusions from the trace, the cheap control before a bisect, censusing `(role, model)` from `step_usage`, runs differing by more than one commit reported as confounded, and reading the full `proof` reason strings.

**Declined (9)** — each refuted against this tree, not by taste. This is the part worth a reviewer's attention, because **four of them carry a green probe**:

| declined | why |
|---|---|
| `pipeline-stage-order` | cites `crates/stella-pipeline/src/replay.rs`; the crate was deleted in #3865 |
| `inv8-parity-two-axes` | freezes the matrix at two axes; `provider_parity.rs` declares six |
| `crates-directory-layout` | says twenty-one crates; `crates/` holds twenty-six |
| 3 × `verify-done-*` | name `crates/stella-tools/src/verify.rs`, which does not exist — `verify_done` is in `RETIRED_TOOL_NAMES` (`catalog.rs:284`) |
| 3 × witness/flip-oracle | describe the built-in staged pipeline deleted in #3865; that shape now belongs to a verification plugin (`doc:pipeline-as-plugins` §8) |

Publishing any of these would steer a fresh agent toward machinery that is not there. Declining records the refutation and sets a cooldown so the next ingest of the same document does not re-ask.

Note that `verify-done-shadow-worktree` is the same lineage #3837 is about — that record was already deliberately retired (ledger seq 2) and its file deleted by #3244, and #3837 independently confirms the `verify.rs` probe is refuted. The decline is consistent with the decision already taken there.

Everything is kept **without `--enforce`**: keeping a record and authorizing it to deny a tool call are separate grants, so `.stella/rules/promotions.jsonl` is untouched and no record blocks anything.

Refs #4261
Refs #4262
Refs #4263
Refs #4264
Refs #3837

## The witness

- [x] No witness needed (pure policy/data change) — because: this PR adds no Rust and changes no behaviour. It publishes `.stella/rules/*.toml` data. The equivalent proof is the repository's own check for these files, `stella context validate`, which is the CI step in `.github/workflows/ci.yml`:

```console
$ stella context validate; echo "EXIT=$?"
Every loaded record is schema-valid and currently believed.
EXIT=0
$ stella context list | rg -c '\^'
38                     # 9 pre-existing + 29 published here
```

Zero unrecognized tasks, zero `record_hash` mismatches, zero equal-precedence conflicts. The only remaining lines are ten "asks to block but its origin is imported" notes — the system correctly refusing an enforcement grant to an extracted claim, consistent with publishing without `--enforce`.

## The gate

Not run: this PR contains no Rust and no manifest change, so `fmt`/`clippy`/`test` compile the same tree as `main`. `./scripts/check-no-scratch.sh` **was** run and passes — it is the guard that actually bears on this change, since `.stella/*` is gitignored with a tracked exception for `rules/`:

```console
$ ./scripts/check-no-scratch.sh
check-no-scratch: OK — no tracked file is gitignored.
```

- [x] Docs updated where behavior/flags changed — n/a, no behaviour or flags changed
- [x] `Refs #N` appears both above and as commit trailers

## Nothing left behind

Four issues filed, each written as a handoff:

- [x] Filed: #4261, #4262, #4263, #4264

- **#4261** — `stella context review` renders a probe verdict recorded **at ingest time** as if it were current. `.stella/proposals/agents.toml` stores `verdict = "supported"` with `checked_at = "2026-08-09T00:42:44Z"`, and the probe is never re-run, so `review` today prints `probe: supported  path crates/stella-tools/src/verify.rs exists` for a file #3244 deleted. A reviewer trusting that column would have published four records naming deleted code. This is the highest-value finding here.
- **#4262** — a cardinality claim gets a `path_exists` probe, so its green cannot distinguish the claim from its opposite ("twenty-one crates" probed by "`crates/stella-core` exists"). Distinct from #4261: re-running these today still returns `supported`.
- **#4263** — the extractor invented 8 `applies_to.tasks` names and **none** is in `KNOWN_TASKS`; separately, that ratified vocabulary has no name for a benchmark trial or an investigation, which is why seven records here had to drop the selector rather than force-fit `run`.
- **#4264** — there is no supported way to amend a published record's scope or precedence, and a hand-edit strands `record_hash` with nothing to re-stamp it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**One proposal was kept and then removed rather than published.** `read-crate-readme-first` came with `paths = ["crates"]`, matching the whole crate tree, and at the default precedence 100 it **suspended eight of the invariant records above** — `stella context validate` reported each as `^read-crate-readme-first applies and ^inv… is suspended`. One advisory record silencing the invariants across `crates/` is a net loss of steering, which is the thing this review was for. It is dropped, and the underlying "no way to amend a published record's scope" gap is #4264.

**Three records were hand-edited after publishing**, each resolving a finding `stella context validate` reported, and each carrying an in-file comment saying why:

- `inv1-core-no-sdk-imports` dropped `crates/stella-protocol` from `applies_to.paths` — the statement is about `stella-core`, and the extra path only collided with `^protocol-types-only` and suspended the invariant.
- `inv4-serde-roundtrip` raised to precedence 110 — it is the more specific rule and at 100 it was suspended by `^protocol-types-only` on the very crate it governs.
- `witness-definition` dropped `tasks = ["pull-request", "feature"]`, neither of which is a ratified task.

**Hand-edited records drop their `record_id`/`record_hash` pair.** There is no command that re-stamps a hand-edited record (`context edit` rewrites a *proposal's* statement; the loader recomputes on read but never writes back). A stale hash is a false claim about the file's content; an absent one is stamped by the loader on read and reports nothing. This is deliberate and is the subject of #4264 — but it should not stay the supported way to amend a record in a system whose governance rests on a hash chain.

**Deliberately left undecided:** the ~60 remaining proposals, which are mostly encyclopedic `fact`/`memory` rows about CI workflow internals. They are true but already in `AGENTS.md`, and each one publishes into the byte-stable system-prompt prefix, so they cost prompt weight without changing what an agent does. Leaving them pending is a decision, not an oversight — they can be revisited without another ingest.

## Summary by Sourcery

Publish the subset of extracted guidance that remains actionable and supported by the current repository.

New Features:
- Publish 29 validated repository guidance records from CLAUDE.md and AGENTS.md as active soft or hard steering rules without enabling enforcement.

Enhancements:
- Retain only prescriptive guidance and repository invariants that remain relevant to the current tree, while leaving refuted or low-value proposals undecided.

Tests:
- Validate the published context records and confirm the repository contains no tracked gitignored scratch files.

Chores:
- Record hand-applied scope and precedence corrections required to avoid rule conflicts.