### PR TITLE
fix(stella-tui): main compiles again — one condition decides a diff row, not two

### DIFF
--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -110,8 +110,8 @@ pub fn footer_line(added: u32, removed: u32, width: usize) -> Line<'static> {
 /// The styled diff body: one `Line` per diff line, with a line-number gutter
 /// tracked from the `@@ -a,b +c,d @@` hunk headers — added/context lines are
 /// numbered on the new side, removed lines on the old side, exactly like a
-/// PR view. Lines outside any hunk (`diff --git`, `index`, `+++`/`---`
-/// headers, or a diff with no hunk header at all) simply get no number —
+/// PR view. A file's git plumbing (`diff --git`, `index`, `+++`/`---`) does
+/// not render at all; a diff with no hunk header simply gets no numbers —
 /// malformed input degrades to unnumbered styled text, never a panic.
 ///
 /// `path` is the file the diff belongs to (the diffs on stella's event path
@@ -151,23 +151,16 @@ pub fn body_lines_capped(
     render_body(diff, path, cap, Chrome::VIEWER, fold_hint)
 }
 
-/// [`body_lines_capped`] for the transcript's inline diffs, which drop a lone
-/// `@@ -a,b +c,d @@` header and a single file's `diff`/`index`/`---`/`+++`
-/// preamble.
+/// [`body_lines_capped`] for the transcript's inline diffs, which additionally
+/// drop a lone `@@ -a,b +c,d @@` header.
 ///
-/// In a diff *viewer* both are orientation. Inline under a tool call both are
-/// chrome restating what the row above and the gutter beside already say, and a
-/// two-line change should not cost six rows to read. The thresholds differ
-/// because what makes each one earn its space differs: a hunk header is a
-/// boundary between disjoint regions of one file, so it survives from two hunks
-/// up; a file preamble is a boundary between files, so it survives from two
-/// files up.
-///
-/// The preamble is what a real turn actually folds — `WorkJournal`'s
-/// `split_patch_per_file` cuts git's patch on the `diff --git` header and hands
-/// on everything after it, so `index <a>..<b> <mode>` / `--- a/p` / `+++ b/p`
-/// leads every inline diff in the deck. Three rows, on every mutating call,
-/// naming a path the call row already names and a blob hash nobody reads.
+/// The `diff`/`index`/`---`/`+++` preamble is dropped by every surface, not
+/// just this one — see [`render_body`]. What is left to decide here is the hunk
+/// header: in a diff *viewer* it is orientation, but inline under a tool call a
+/// single one restates what the row above and the gutter beside already say,
+/// and a two-line change should not cost six rows to read. It survives from two
+/// hunks up, because a hunk header is a boundary between disjoint regions and
+/// there is no boundary to draw when there is only one region.
 pub fn body_lines_inline(
     diff: &str,
     path: Option<&str>,
@@ -179,35 +172,28 @@ pub fn body_lines_inline(
 
 /// Which of a diff's structural rows earn their space in this rendering.
 ///
-/// A pair of bools rather than one: they answer different questions (how many
-/// hunks? how many files?) and a single "is this inline" flag would have to
-/// re-derive both at the point of use, which is where the two would drift.
+/// A struct around one bool rather than a bare argument: the two entry points
+/// pick between *policies*, and `render_body(.., true, ..)` at a call site says
+/// nothing about which question that `true` answers.
+///
+/// It carried a second bool, `file_headers`, until the per-file preamble
+/// stopped rendering on every surface (#4248) and left nothing for the flag to
+/// decide. Whether the standalone viewer should get it back is #4268.
 #[derive(Clone, Copy)]
 struct Chrome {
     /// Draw `@@ -a,b +c,d @@`.
     hunk_headers: bool,
-    /// Draw the per-file preamble (`diff `, `index `, `--- `, `+++ `).
-    file_headers: bool,
 }
 
 impl Chrome {
-    /// Everything, for the standalone viewer — a reader navigating a patch
-    /// needs the boundaries even when there is only one of them.
-    const VIEWER: Self = Self {
-        hunk_headers: true,
-        file_headers: true,
-    };
+    /// Everything a standalone viewer draws — a reader navigating a patch
+    /// needs the hunk boundaries even when there is only one of them.
+    const VIEWER: Self = Self { hunk_headers: true };
 
     /// Keep only the boundaries that separate more than one of something.
     fn inline_for(diff: &str) -> Self {
         Self {
             hunk_headers: diff.lines().filter(|l| l.starts_with("@@")).count() > 1,
-            // `diff `-prefixed lines are the only unambiguous per-file
-            // boundary; the count is 0 for the split-per-file shape the event
-            // path folds and 1 for a whole single-file patch, and both are one
-            // file. Counting `+++ ` instead would miscount, because added
-            // source text starting `++ ` is textually identical to a header.
-            file_headers: diff.lines().filter(|l| l.starts_with("diff ")).count() > 1,
         }
     }
 }
@@ -264,13 +250,6 @@ fn render_body(
         // Every line advances the gutter counters, shown or not — skipping a
         // line must not renumber the ones after it, and the numbers on the
         // far side of an elision have to be the file's real ones.
-        // Captured before `body_line` advances it: a `--- ` or `+++ ` line is
-        // plumbing only *outside* a hunk. Inside one it is body content that
-        // happens to look like a header — an SQL comment, a diff of a diff —
-        // and hunk position is the only thing that can tell them apart
-        // (`count_diff_lines` makes the same distinction for the same reason).
-        // Stripping on the text alone deletes real removed lines.
-        let was_in_hunk = in_hunk;
         // Read *before* `body_line` runs, because that call is what moves the
         // state this asks about. The same structural rule `body_line` itself
         // applies (only before a file's first hunk is `+++ `/`--- ` a header):
@@ -296,18 +275,13 @@ fn render_body(
         // `@@` survives on the `hunk_headers` flag: it carries the enclosing
         // scope (`@@ … const TYPEAHEAD_MAX_ROWS`), which is the one piece of
         // context a hunk cannot reconstruct from its own lines.
-        if plan.shows(i)
-            && !(!was_in_hunk && is_meta(text))
-            && (hunk_headers || !text.starts_with("@@"))
+        //
         // Chrome is suppressed after planning rather than before it, so an
         // elided row's `⋯ n lines` count stays the one `stella_diff::view`
         // computed and every surface reports the same number for one change.
         // The cost is a dropped row's slot in the cap; the alternative is the
         // deck and the export disagreeing about the size of an edit.
-        if plan.shows(i)
-            && (chrome.hunk_headers || !text.starts_with("@@"))
-            && (chrome.file_headers || !preamble)
-        {
+        if plan.shows(i) && !preamble && (chrome.hunk_headers || !text.starts_with("@@")) {
             lines.push(line);
         }
     }


### PR DESCRIPTION
Closes #4256.
Refs #4268.

## What is broken

`stella-tui` has not compiled since #4248 merged. `make build-release` on `main`:

```
error: expected `{`, found keyword `if`
   --> crates/stella-tui/src/diff.rs:307:9
```

#4248 pasted a replacement for `render_body`'s row-admission condition **above** the existing one and never deleted the old block, leaving two consecutive `if plan.shows(i)` expressions, the first with no body. The pasted draft was stale as well — it reads a bare `hunk_headers`, the parameter `render_body` took before #4244 replaced it with `chrome: Chrome`, so it could not have compiled standing alone either.

`main` has been red since `9c8b5511a`; `f01b2602e` and `8a2fdf8cc` both carried it forward.

## Why this is not a one-character fix

The two blocks disagree about behaviour, not just syntax:

| | preamble (`diff `, `index `, `--- `, `+++ `) |
|---|---|
| #4244's block | conditional on `chrome.file_headers`, which `Chrome::VIEWER` sets **true** |
| #4248's block | stripped **unconditionally** |

Deleting either one alone is wrong:

- **Keep only #4244's** and #4248's two new tests fail. Both call `body_lines`, which is the `Chrome::VIEWER` path, and both assert the plumbing renders nowhere — `plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter`, `a_full_git_patch_renders_only_its_hunk`.
- **Keep only #4248's** and `Chrome::file_headers` is written by both constructors and read by nothing — a `dead_code` denial away from red again.

## What this does

Keeps #4248 — the later decision, and the only one carrying tests — and retires `Chrome::file_headers`, which no longer has anything left to decide. One condition survives:

```rust
if plan.shows(i) && !preamble && (chrome.hunk_headers || !text.starts_with("@@")) {
```

`preamble` is the binding already computed before `body_line` runs, and is the same predicate as the deleted `!was_in_hunk && is_meta(text)` — so the hunk-position rule that stops `--- ` *inside* a hunk being read as plumbing is unchanged, and `body_lines_number_hunk_text_matching_header_syntax_instead_of_hiding_it` still guards it. Docs on `body_lines`, `body_lines_inline` and `Chrome` are updated to match, rather than left describing the flag that is gone.

## The part this deliberately does not decide

Whether the standalone FILES-tab viewer should get a per-file boundary back is a genuine design question between two landed PRs, and picking it silently is not this PR's call. Filed as #4268 — cited from the `Chrome` doc comment it concerns, and naming the two tests any answer has to amend. It also records that `Chrome::inline_for`'s multi-file branch shipped in #4244 with no test covering it.

## Deleted tests

None.

## Witness

No new witness test, and the PR template's escape hatch is not what is being claimed: the tree did not compile, so **every** test in the crate is the witness — none of them could run on `main`.

- `cargo test -p stella-tui` — 1020 pass, 0 fail, 1 ignored, #4248's two included.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean, which is the check that would have caught a retired-but-still-written `file_headers`.
- `make build-release` — running; will report.

## Summary by Sourcery

Restore stella-tui compilation and unify diff chrome handling so Git preambles are hidden while hunk boundaries remain governed by the active rendering policy.

Bug Fixes:
- Restore compilation of stella-tui by consolidating diff-row admission into a single condition.
- Consistently suppress Git diff plumbing rows while preserving hunk-header rendering and line-number behavior.

Enhancements:
- Remove the obsolete Chrome::file_headers policy and update diff-rendering documentation to reflect the unified behavior.

Documentation:
- Update user-facing diff-rendering documentation for viewer and inline modes.