### PR TITLE
fix(stella-cli,stella-tools): the approval deadline belongs to the surface that renders the card

### DIFF
--- a/crates/stella-cli/src/command_deck/mid_turn_ask.rs
+++ b/crates/stella-cli/src/command_deck/mid_turn_ask.rs
@@ -47,6 +47,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use stella_protocol::{AgentEvent, QuestionOutcome, QuestionRequest, ToolOutput};
@@ -61,6 +62,40 @@ use crate::interactive::{AskUserIo, FREE_TEXT_LABEL};
 /// rather than per-session: a stale answer from a cancelled turn must never
 /// match a live card's id.
 static NEXT_DECK_ASK: AtomicU64 = AtomicU64::new(0);
+
+/// How long the driver gets to answer an approval **on the deck** (#4253).
+///
+/// Longer than [`stella_tools::registry::approval::DEFAULT_APPROVAL_TTL`],
+/// which is the number for a line-oriented prompt — one sentence and a `y`.
+/// The deck's card (#4240) is a different question to answer: five fields to
+/// read, a gate to weigh, often a path or command line worth going and
+/// looking at before you decide, and a third row that opens a text editor for
+/// the refusal reason. Two minutes covers reading it and nothing else.
+///
+/// Ten, not thirty. The upper bound is not the driver's patience but the cost
+/// of being wrong in the other direction: this TTL is how long a wedged or
+/// abandoned surface can hold a tool call parked, and an approval — unlike a
+/// question — interrupts someone who is already watching the turn. It stays
+/// **below** [`DECK_QUESTION_TTL`] on purpose; see
+/// `stella_tui::deck_ui::parked`, whose precedence rule leans on the approval
+/// being the tighter of the two deadlines.
+///
+/// An expiry denies, so the failure direction is safe either way. What the
+/// old number cost was not safety but *silence*: the card vanished mid-read
+/// and the turn proceeded on a decision the driver never made.
+pub(crate) const DECK_APPROVAL_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// How long the driver gets to answer a question on the deck.
+///
+/// The same thirty minutes the port defaults to — the deck's overlay presents
+/// what the plain-TTY card presents, so nothing about this surface changes
+/// the reasoning in
+/// [`stella_tools::registry::question::DEFAULT_QUESTION_TTL`]. Named here
+/// anyway rather than reaching for the default at the call site, so both of
+/// the deck's deadlines are stated in one place and a future change to either
+/// is a visible edit rather than a silently inherited constant.
+pub(crate) const DECK_QUESTION_TTL: Duration =
+    stella_tools::registry::question::DEFAULT_QUESTION_TTL;
 
 /// Both of the deck's mid-turn ask responders, as the one posture
 /// `enforce_workspace_rules` consumes — plus the [`DeckAskUserIo`] the
@@ -94,10 +129,12 @@ pub(crate) fn surface(
             inbound: inbound.clone(),
             answers: Arc::new(tokio::sync::Mutex::new(approvals)),
         }),
+        approval_ttl: DECK_APPROVAL_TTL,
         question: Arc::new(DeckQuestionResponder {
             inbound,
             answers: Arc::new(tokio::sync::Mutex::new(questions)),
         }),
+        question_ttl: DECK_QUESTION_TTL,
     };
     (posture, ask_io)
 }
@@ -253,9 +290,8 @@ pub(crate) struct DeckQuestionResponder {
 /// over a call that had already given up on it, and a driver's considered
 /// answer would go into a oneshot nobody was holding.
 ///
-/// Both TTLs need it and they are far apart — thirty minutes for a question,
-/// two for an approval — so the approval card is the one a driver is far more
-/// likely to watch expire.
+/// Both TTLs need it, and [`DECK_APPROVAL_TTL`] is the shorter, so the
+/// approval card is the one a driver is more likely to watch expire.
 struct WithdrawOnDrop {
     inbound: UnboundedSender<Inbound>,
     withdraw: Inbound,
@@ -317,6 +353,50 @@ mod tests {
             gate: "command.started".into(),
             subject: Some("rm -rf build/".into()),
         }
+    }
+
+    /// **The #4253 witness.** The deck asks for more time to answer an
+    /// approval than the line-oriented default allows.
+    ///
+    /// `DEFAULT_APPROVAL_TTL` was chosen for a one-line prompt and a `y`.
+    /// #4240 replaced that with a card carrying five fields and a typed
+    /// refusal, and left the deadline alone — so a driver who went to look at
+    /// what `rm -rf build/` would actually delete could come back to a card
+    /// that had already denied on their behalf, with no signal that it had.
+    ///
+    /// Asserted through `surface()` rather than on the constant, because the
+    /// constant being large proves nothing: the defect was that the *wiring*
+    /// reached past the surface's number for the port default.
+    #[test]
+    fn the_deck_asks_for_longer_than_a_line_oriented_prompt_would() {
+        let (in_tx, _in_rx) = mpsc::unbounded_channel();
+        let (_a, asks) = mpsc::unbounded_channel();
+        let (_b, approvals) = mpsc::unbounded_channel();
+        let (_c, questions) = mpsc::unbounded_channel();
+        let (posture, _io) = surface("lead".into(), in_tx, asks, approvals, questions);
+
+        let crate::rules::MidTurnAsk::Surface {
+            approval_ttl,
+            question_ttl,
+            ..
+        } = posture
+        else {
+            panic!("the deck declares a surface, not a headless or tty posture");
+        };
+
+        assert!(
+            approval_ttl > stella_tools::registry::approval::DEFAULT_APPROVAL_TTL,
+            "the deck's card takes longer to read than the prompt the default was chosen for"
+        );
+        // …and still the tighter of the two. `stella_tui::deck_ui::parked`
+        // gives approval the keyboard ahead of a parked question partly
+        // because it is the deadline that runs out first; flipping this
+        // ordering would make that routing rule wrong without touching it.
+        assert!(
+            approval_ttl < question_ttl,
+            "an approval interrupts someone already watching the turn — it must not \
+             outlast a question, which asks them to go away and think"
+        );
     }
 
     fn approval_responder() -> (
@@ -412,9 +492,9 @@ mod tests {
         assert_eq!(reason, "the real answer");
     }
 
-    /// The approval card comes down when its wait is abandoned, exactly like
-    /// the question overlay's. Its TTL is `DEFAULT_APPROVAL_TTL` — two
-    /// minutes, not thirty — so this is the card a driver is far more likely
+    /// The approval card comes down when its wait is abandoned, exactly
+    /// like the question overlay's. [`DECK_APPROVAL_TTL`] is the shorter of
+    /// the deck's two deadlines, so this is the card a driver is more likely
     /// to watch expire.
     #[tokio::test]
     async fn an_abandoned_approval_withdraws_the_card() {

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -402,11 +402,23 @@ pub(crate) enum MidTurnAsk {
     /// A surface that owns its own input loop and brings its own responders
     /// — the Command Deck. The host builds them over its channels and hands
     /// them in, because only it knows how to reach its own driver.
+    ///
+    /// It brings its own **deadlines** too (#4253). A TTL is how long the
+    /// driver gets to answer, so it is a fact about the thing they are
+    /// answering — and a surface that renders a card with five fields to read
+    /// needs longer than one that prints a line and waits for `y`. Carrying
+    /// them here keeps that number in the same place as the responder whose
+    /// presentation it bounds: `command_deck::mid_turn_ask::surface` builds
+    /// both together, so they cannot drift apart.
     Surface {
         /// Answers a gate's `RequireApproval`.
         approval: std::sync::Arc<dyn stella_tools::registry::approval::ApprovalResponder>,
+        /// How long the driver gets to answer an approval on this surface.
+        approval_ttl: std::time::Duration,
         /// Answers an agent's `ask_question`.
         question: std::sync::Arc<dyn stella_tools::registry::question::QuestionResponder>,
+        /// How long the driver gets to answer a question on this surface.
+        question_ttl: std::time::Duration,
     },
 }
 
@@ -444,15 +456,14 @@ pub(crate) fn enforce_workspace_rules(
             crate::approval::attach_interactive_approvals(registry);
             crate::question::attach_interactive_questions(registry);
         }
-        MidTurnAsk::Surface { approval, question } => {
-            registry.attach_approval_responder(
-                approval,
-                stella_tools::registry::approval::DEFAULT_APPROVAL_TTL,
-            );
-            registry.attach_question_responder(
-                question,
-                stella_tools::registry::question::DEFAULT_QUESTION_TTL,
-            );
+        MidTurnAsk::Surface {
+            approval,
+            approval_ttl,
+            question,
+            question_ttl,
+        } => {
+            registry.attach_approval_responder(approval, approval_ttl);
+            registry.attach_question_responder(question, question_ttl);
         }
     }
     let rules = load_workspace_rules(workspace_root, authority);

--- a/crates/stella-tools/src/registry/approval.rs
+++ b/crates/stella-tools/src/registry/approval.rs
@@ -71,14 +71,42 @@ use stella_protocol::tool::ToolOutput;
 use super::ToolRegistry;
 
 /// How long a parked dispatch waits for a human answer before the flow
-/// resolves to a deny ([`APPROVAL_TIMED_OUT`]). Hosts pass their own TTL to
-/// [`ToolRegistry::attach_approval_responder`]; this is the default they
-/// reach for absent a better-informed number.
+/// resolves to a deny ([`APPROVAL_TIMED_OUT`]).
+///
+/// **This is the number for a line-oriented surface** — a one-line question
+/// and a `y`/`n`, which is what the plain-TTY responder renders and what this
+/// value was chosen against. It is a default, not a policy: a surface that
+/// presents *more* to read needs longer, and says so at attachment time
+/// through [`ToolRegistry::attach_approval_responder`].
+///
+/// The Command Deck is exactly that case (#4253). Its card lays out five
+/// fields and offers a typed refusal, so `stella-cli` attaches it with its
+/// own, longer TTL rather than this one. Two minutes was correct for the
+/// prompt this constant was born with, and quietly wrong for a card you have
+/// to read — which is the shape of bug a "default" hides when nothing says
+/// what it was defaulted *for*.
 pub const DEFAULT_APPROVAL_TTL: Duration = Duration::from_secs(120);
 
-/// The deny reason of a TTL expiry — the exact string, so callers and tests
-/// can match it instead of parsing prose.
-pub const APPROVAL_TIMED_OUT: &str = "approval timed out";
+/// The deny reason of a TTL expiry.
+///
+/// Instructive rather than a bare label, and for the reason this module's
+/// headless refusal and [`super::question::QUESTION_TIMED_OUT`] both give:
+/// a refusal that only says *no* leaves the model to invent a recovery, and
+/// the one it invents is to try the same call again. The recovery here is
+/// **not** the question flow's "decide it yourself" — a gate demanded a human
+/// and did not get one, so the call must not run in any form; what the model
+/// can usefully do is take a route that needs no approval, or stop and report.
+///
+/// Callers and tests match on [`APPROVAL_TIMED_OUT_TAG`], the stable leading
+/// phrase, so the guidance can be reworded without breaking them.
+pub const APPROVAL_TIMED_OUT: &str = "approval timed out — nobody answered in time; this is not a \
+     refusal of the idea, so do not re-request the same approval: either take a route that needs \
+     none, or stop and report what you were about to do and why it needed one";
+
+/// The stable leading phrase of [`APPROVAL_TIMED_OUT`] — what a consumer
+/// matches on, so the instruction after it stays editable prose rather than a
+/// string three tests pin verbatim.
+pub const APPROVAL_TIMED_OUT_TAG: &str = "approval timed out";
 
 /// One approval question, as the responder and the bus both see it. Crosses
 /// the crate boundary (the CLI implements [`ApprovalResponder`] over it),
@@ -574,8 +602,15 @@ mod tests {
         match reg.execute("task_list", &serde_json::json!({})).await {
             ToolOutput::Error { message, .. } => {
                 assert!(
-                    message.contains(APPROVAL_TIMED_OUT),
+                    message.contains(APPROVAL_TIMED_OUT_TAG),
                     "the timeout is named: {message}"
+                );
+                // …and names a next move. A bare "timed out" leaves the
+                // model to invent a recovery, and the one it invents is to
+                // ask for the same approval again.
+                assert!(
+                    message.contains("do not re-request"),
+                    "an expiry must instruct, not just label: {message}"
                 );
             }
             other => panic!("a timed-out approval must deny: {other:?}"),

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -811,8 +811,8 @@ pub struct DeckUi {
     pub question: crate::views::question::QuestionOverlay,
     /// The approval card (#4240): the yes/no a parked **dispatch** waits on.
     /// Outranks `question` for the keyboard — a call about to execute is a
-    /// tighter gate than a decision being deliberated, and its TTL is two
-    /// minutes against the question's thirty.
+    /// tighter gate than a decision being deliberated, and it carries the
+    /// shorter of the two deadlines.
     pub approval: crate::views::approval::ApprovalOverlay,
 }
 

--- a/crates/stella-tui/src/deck_ui/parked.rs
+++ b/crates/stella-tui/src/deck_ui/parked.rs
@@ -30,9 +30,9 @@ use super::{DeckAction, DeckUi};
 /// takes the same line for the same reason).
 ///
 /// **Approval is asked first.** It gates a call that is about to execute,
-/// where a question is a decision still being deliberated; and its TTL is
-/// two minutes against the question's thirty, so it is also the one that
-/// expires out from under the driver if made to wait its turn. Rendering
+/// where a question is a decision still being deliberated; and it carries
+/// the shorter of the two deadlines, so it is also the one that expires out
+/// from under the driver if made to wait its turn. Rendering
 /// mirrors this — `deck_render` draws the approval card last, so it lands on
 /// top of the overlay whose keys it is already taking.
 pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
@@ -104,10 +104,10 @@ mod tests {
         }
     }
 
-    /// **Approval wins the keyboard when both are up.** Its TTL is two
-    /// minutes against the question's thirty, so a card made to wait its turn
-    /// is a card that expires under the driver — and the call it gates is
-    /// about to run either way.
+    /// **Approval wins the keyboard when both are up.** It carries the
+    /// shorter of the two deadlines, so a card made to wait its turn is a
+    /// card that expires under the driver — and the call it gates is about
+    /// to run either way.
     #[test]
     fn an_approval_takes_the_keyboard_from_a_parked_question() {
         let mut ui = DeckUi::default();

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -359,9 +359,9 @@ pub enum Inbound {
     /// siblings so the per-token [`Inbound::Event`] does not grow to the size
     /// of the rarest variant.
     ApprovalAsked(Box<stella_tools::registry::approval::ApprovalRequest>),
-    /// The parked approval is no longer answerable — its TTL expired (a much
-    /// shorter one than a question's: `DEFAULT_APPROVAL_TTL` is two minutes)
-    /// or the turn holding it was cancelled — so take the card down.
+    /// The parked approval is no longer answerable — its TTL expired (the
+    /// shorter of the two deadlines; `stella-cli` sets the deck's) or the turn
+    /// holding it was cancelled — so take the card down.
     ///
     /// The dispatch is denied on that path, never approved, so this is
     /// strictly about not leaving a card up that offers to decide something


### PR DESCRIPTION
`DEFAULT_APPROVAL_TTL` is 120 seconds. That number was chosen when an approval
was one line of prose and a `y`/`n` — the plain-TTY prompt.

#4240 replaced that, on the deck, with a card carrying five fields (tool, a
mutating/read-only mark, subject, gate, reason) and a third row that opens a
text editor for the refusal reason. It did not touch the deadline. Two minutes
covers reading that card and very little else — so a driver who went to check
what `rm -rf build/` would actually delete could come back to a card that had
already denied on their behalf, with no signal that it had.

The failure direction was always safe (an expiry denies; nothing runs). What
it cost was **silence**: the card vanished mid-read and the turn proceeded on
a decision the driver never made.

## The fix: the deadline belongs to the surface

`MidTurnAsk::Surface` now carries both TTLs. That is the option this issue
recommended, and the reasoning is that a TTL is *how long the driver gets to
answer*, which makes it a fact about the thing they are answering — not about
the port. A surface rendering five fields needs longer than one printing a
line.

Concretely it puts the number in the same function that builds the responder
whose presentation it bounds (`command_deck::mid_turn_ask::surface`), so the
card and its deadline cannot drift apart. `rules.rs`'s `Surface` arm was
reaching past the surface for the port default — that one line was the whole
bug.

I considered putting `ttl()` on the `ApprovalResponder` trait instead. It
lands the number in the same place in practice (the deck's responder is built
by the same function), but changes a public trait and churns ~10 call sites to
buy nothing here, and it would leave two sources of truth alongside
`attach_approval_responder`'s existing `ttl` parameter — the exact
"two places for one fact" defect `MidTurnAsk` was introduced to remove.

**Ten minutes for the deck.** Long enough to read the gate, go and look at the
subject, and type a redirection. The upper bound is not the driver's patience
but the other direction's cost: this is how long a wedged or abandoned surface
can hold a tool call parked, and an approval interrupts someone *already
watching the turn*. It stays **below** the question TTL deliberately —
`stella_tui::deck_ui::parked` gives approval the keyboard ahead of a parked
question partly because it is the deadline that runs out first, and flipping
that ordering would make the routing rule wrong without touching it. There is
an assertion for exactly that.

## The expiry now instructs instead of labelling

`APPROVAL_TIMED_OUT` was `"approval timed out"` — distinguishable from a human
deny, but a bare wall. The recovery a model invents at a bare wall is to
request the same approval again, which is precisely wrong here: a gate
demanded a human and did not get one, so the call must not run in any form.
It now says so, and names what *can* be done (take a route needing no
approval, or stop and report). Same argument the headless refusal and
`QUESTION_TIMED_OUT` already make — note the guidance differs from the
question flow's "decide it yourself", because an unanswered approval is not a
decision the model may take over.

`APPROVAL_TIMED_OUT_TAG` is the stable leading phrase consumers match on, so
the guidance stays editable prose rather than a string pinned verbatim by
tests.

`DEFAULT_APPROVAL_TTL` keeps its value and gains the sentence it was missing:
what it was defaulted *for*. A "default" that does not say what it assumes is
how this bug hid.

## Six doc comments de-numbered

#4240's prose said "its TTL is two minutes against the question's thirty" in
six places. A number written in two places is the drift hazard this repo keeps
paying for (`AGENTS.md` makes the argument for gate counts and file-size
ceilings). They state the **relationship** now — "the shorter of the two
deadlines" — which stays true whatever the constants become, and the ordering
itself is asserted.

## Evidence

**Witness — `the_deck_asks_for_longer_than_a_line_oriented_prompt_would`.**
Drives the real `surface()` constructor and asserts the declared
`approval_ttl` exceeds `DEFAULT_APPROVAL_TTL` *and* stays under
`question_ttl`. Asserted through the constructor rather than on the constant
deliberately: the constant being large proves nothing, because the defect was
that the wiring reached past the surface's number.

**The expiry witness** (`registry/approval.rs`) now asserts the message both
names the timeout and carries a next move, not just the former.

**Gate**, all re-run on forced rebuilds: `cargo clippy --workspace
--all-targets -- -D warnings` clean · `cargo test --workspace` **8197 passed /
0 failed** · `make guards-fast` green · `make tool-docs` green · rustdoc
`-D warnings` clean · `cargo fmt --check` clean.

## Deleted tests

None.

## New dependencies

None.

Closes #4253

## Summary by Sourcery

Make approval deadlines surface-specific and give expired approvals clear, non-retry recovery instructions.

Bug Fixes:
- Assign approval and question deadlines to the surface that renders them, giving Command Deck approval cards a longer response window while preserving approval precedence over questions.
- Provide actionable timeout guidance that prevents retrying an unanswered approval and suggests using an un gated route or stopping and reporting.

Enhancements:
- Keep surface-specific deadline configuration and its ordering relationship explicit and covered by tests.

Tests:
- Add coverage verifying the Command Deck approval TTL exceeds the line-oriented default while remaining shorter than the question TTL.
- Update timeout coverage to verify that expired approvals include recovery guidance.