### PR TITLE
fix(stella-core): a public TurnEvidence cannot link to a private helper

### DIFF
--- a/crates/stella-core/src/driver/loop_evidence.rs
+++ b/crates/stella-core/src/driver/loop_evidence.rs
@@ -86,8 +86,13 @@ pub(super) fn turn_start_index(messages: &[CompletionMessage]) -> usize {
 /// The transcript evidence a steering re-query reads (#3243 Phase 3): the
 /// prompt that opened this turn, the tools it has called (most recent last),
 /// and the error classes it has seen — assembled fresh each step from the
-/// same window [`turn_start_index`] gives loop detection, so the two planes
+/// same window `turn_start_index` gives loop detection, so the two planes
 /// cannot disagree about what "this turn" means.
+///
+/// `turn_start_index` is deliberately not linked: it is `pub(super)`, and this
+/// type is `pub` (#4258), so an intra-doc link from here would point a reader
+/// of the public API at an item they cannot reach — which is the error
+/// `cargo doc -D warnings` raises.
 pub struct TurnEvidence {
     /// Index of the real user message that bounds this turn, when one exists.
     pub prompt_index: Option<usize>,


### PR DESCRIPTION
## What

`main` does not document. The exact invocation from `ci.yml:464`:

```
$ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
    --document-private-items --keep-going
error: public documentation for `TurnEvidence` links to private item `turn_start_index`
error: could not document `stella-core`
```

This is the **second** break on today's red `main`, and it was hidden behind
the first. #4248 merged an unresolved conflict that stopped `stella-tui`
compiling (#4256, repaired by #4260 and refined by #4265). While that stood,
`fmt + clippy + test` died at the compile step and never reached `cargo doc`.
With the tree compiling again, the job runs further and finds this.

## Why it is here

#4258 widened two items and left the doc comment above one of them unchanged:

```diff
-pub(super) struct TurnEvidence {
+pub struct TurnEvidence {
-pub(super) fn turn_evidence(messages: &[CompletionMessage]) -> TurnEvidence {
+pub fn turn_evidence(messages: &[CompletionMessage]) -> TurnEvidence {
```

That doc comment links to `` [`turn_start_index`] ``, which stays `pub(super)`.
While `TurnEvidence` was crate-internal the link was private-to-private and
rustdoc was content. The moment the type became public,
`private_intra_doc_links` fires — correctly: a reader of the public API would
be pointed at an item they cannot reach.

#4258's own CI was red when it merged, and red for the *inherited* reason, so
this failure was read as more of the same. AGENTS.md names this exact hazard as
the reason the `main-red-hold` exists: "once `main` is red every PR's checks are
red too, so red stops distinguishing 'your change is broken' from 'the base
is'."

## The fix

`turn_start_index` stays `pub(super)`. It is the internal boundary rule that
loop detection and `driver::confident_zero` share — not API, and widening it to
silence a lint would export an implementation detail to make a doc link legal.

So the link is demoted to a plain code span, and a short note says why it is not
a link, so the next person who widens a type in this file does not rediscover
the rule from a red gate.

## Note on the local gate

`make doc-warnings` runs the same flags as CI (`--document-private-items`
included), so this reproduces locally — it is not a CI-only failure. It simply
requires the tree to compile first, which is why nothing caught it before now.

## Witness

Fails on the parent, passes on this commit:

```
git checkout HEAD~1 -- crates/stella-core/src/driver/loop_evidence.rs
touch crates/stella-core/src/driver/loop_evidence.rs
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps \
  --document-private-items --keep-going
# error: public documentation for `TurnEvidence` links to private item `turn_start_index`
# error: could not document `stella-core`
```

```
$ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
    --document-private-items --keep-going
# clean, whole workspace
```

The `touch` is load-bearing when checking this by hand: cargo replays a cached
success otherwise.

Refs #4256

## Summary by Sourcery

Fix public turn evidence documentation so the workspace builds cleanly with warnings denied.

Bug Fixes:
- Resolve the rustdoc warning caused by public `TurnEvidence` documentation linking to the private `turn_start_index` helper.

Enhancements:
- Clarify why the internal turn-boundary helper is intentionally referenced without a public documentation link.