### PR TITLE
fix(stella-tui,stella-core): the diff tests and doc links say what the code now does

### DIFF
--- a/crates/stella-core/src/driver/loop_evidence.rs
+++ b/crates/stella-core/src/driver/loop_evidence.rs
@@ -86,8 +86,13 @@ pub(super) fn turn_start_index(messages: &[CompletionMessage]) -> usize {
 /// The transcript evidence a steering re-query reads (#3243 Phase 3): the
 /// prompt that opened this turn, the tools it has called (most recent last),
 /// and the error classes it has seen — assembled fresh each step from the
-/// same window [`turn_start_index`] gives loop detection, so the two planes
+/// same window `turn_start_index` gives loop detection, so the two planes
 /// cannot disagree about what "this turn" means.
+///
+/// `turn_start_index` is deliberately not linked: it is `pub(super)`, and this
+/// type is `pub` (#4258), so an intra-doc link from here would point a reader
+/// of the public API at an item they cannot reach — which is the error
+/// `cargo doc -D warnings` raises.
 pub struct TurnEvidence {
     /// Index of the real user message that bounds this turn, when one exists.
     pub prompt_index: Option<usize>,

--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -155,7 +155,8 @@ pub fn body_lines_capped(
 /// drop a lone `@@ -a,b +c,d @@` header.
 ///
 /// The `diff`/`index`/`---`/`+++` preamble is dropped by every surface, not
-/// just this one — see [`render_body`]. What is left to decide here is the hunk
+/// just this one — see `render_body`, which is private, so this names it
+/// rather than linking to it. What is left to decide here is the hunk
 /// header: in a diff *viewer* it is orientation, but inline under a tool call a
 /// single one restates what the row above and the gutter beside already say,
 /// and a two-line change should not cost six rows to read. It survives from two
@@ -755,36 +756,44 @@ mod tests {
     fn body_numbers_added_lines_on_the_new_side_and_removed_on_the_old() {
         let lines = body_lines(SAMPLE, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
+        // The `---`/`+++` preamble is stripped on every surface, so the `@@`
+        // header leads and the first numbered row is at index 1.
         // "@@ -1,3 +1,4 @@" starts old=1/new=1; context takes new 1.
-        assert!(texts[3].starts_with("   1  context"), "{:?}", texts[3]);
+        assert!(texts[1].starts_with("   1  context"), "{:?}", texts[1]);
         // The removal is numbered on the OLD side (old line 2).
-        assert!(texts[4].starts_with("   2 -old line"), "{:?}", texts[4]);
+        assert!(texts[2].starts_with("   2 -old line"), "{:?}", texts[2]);
         // Additions continue on the NEW side (new lines 2, 3).
-        assert!(texts[5].starts_with("   2 +new line"), "{:?}", texts[5]);
-        assert!(texts[6].starts_with("   3 +another add"), "{:?}", texts[6]);
+        assert!(texts[3].starts_with("   2 +new line"), "{:?}", texts[3]);
+        assert!(texts[4].starts_with("   3 +another add"), "{:?}", texts[4]);
     }
 
+    /// The preamble does not render, and the hunk header — which does — carries
+    /// no line number, because it is not a line of the file.
     #[test]
-    fn file_headers_and_hunks_get_no_number() {
-        let lines = body_lines(SAMPLE, None);
-        for (i, line) in lines.iter().take(3).enumerate() {
+    fn plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter() {
+        let texts: Vec<String> = body_lines(SAMPLE, None).iter().map(line_text).collect();
+        for meta in ["--- a/x.rs", "+++ b/x.rs"] {
             assert!(
-                line_text(line).starts_with("     "),
-                "line {i} has a blank gutter: {:?}",
-                line_text(line)
+                !texts.iter().any(|t| t.contains(meta)),
+                "{meta:?} still renders: {texts:?}"
             );
         }
+        assert!(texts[0].contains("@@ -1,3 +1,4 @@"), "{:?}", texts[0]);
+        assert!(
+            texts[0].starts_with("     "),
+            "the hunk header took a line number: {:?}",
+            texts[0]
+        );
     }
 
-    /// The viewer keeps a single file's preamble (above); inline, the same
-    /// patch opens on its first changed line.
+    /// A real git patch leads with `diff --git` and `index …` on top of the
+    /// `---`/`+++` pair, and none of the four reaches a row on either surface.
     ///
     /// `index 74f38f3..9e6e426 100644`, `--- a/<path>`, `+++ b/<path>`: three
-    /// rows restating the path the call row already names and a pair of blob
-    /// hashes nobody can act on. In a viewer that is orientation. Inline under
-    /// a tool call it is most of the row budget spent before the first changed
-    /// line — which is why `Chrome::inline_for` drops it for a lone file and
-    /// keeps it once a patch spans two.
+    /// rows restating the path the row above already names and a pair of blob
+    /// hashes nobody can act on. `render_body` drops them for every caller —
+    /// the viewer included — so this asks both entry points and expects the
+    /// same answer from each.
     #[test]
     fn a_full_git_patch_renders_only_its_hunk_inline() {
         // Spelled with explicit `\n` rather than `\`-continuation: that
@@ -809,13 +818,16 @@ mod tests {
             "context keeps its real line number: {texts:?}"
         );
 
-        // The viewer is the other half of the contract: same patch, preamble
-        // intact, because a reader navigating a patch wants the boundaries.
+        // The viewer is the other half of the contract, and gives the same
+        // answer: the preamble is chrome wherever it is drawn, so one patch
+        // does not look like two different patches across two surfaces.
         let viewer: Vec<String> = body_lines(patch, None).iter().map(line_text).collect();
-        assert!(
-            viewer.iter().any(|t| t.contains("+++ b/x.rs")),
-            "the viewer keeps the preamble: {viewer:?}"
-        );
+        for meta in ["diff --git", "index 74f38f3", "--- a/", "+++ b/"] {
+            assert!(
+                !viewer.iter().any(|t| t.contains(meta)),
+                "{meta:?} still renders in the viewer: {viewer:?}"
+            );
+        }
     }
 
     #[test]
@@ -853,18 +865,19 @@ mod tests {
         let diff = "--- a/x.rs\n+++ b/x.rs\n@@ -1,2 +1,2 @@\n--- was a rule\n+++ is a rule\n";
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
+        // Index 0 is the `@@` header; the real preamble above it is stripped.
         assert!(
-            !texts[3].starts_with("     "),
+            !texts[1].starts_with("     "),
             "removed body line should get a gutter number, not read as a header: {:?}",
-            texts[3]
+            texts[1]
         );
         assert!(
-            !texts[4].starts_with("     "),
+            !texts[2].starts_with("     "),
             "added body line should get a gutter number, not read as a header: {:?}",
-            texts[4]
+            texts[2]
         );
-        assert!(texts[3].contains("was a rule"), "{:?}", texts[3]);
-        assert!(texts[4].contains("is a rule"), "{:?}", texts[4]);
+        assert!(texts[1].contains("was a rule"), "{:?}", texts[1]);
+        assert!(texts[2].contains("is a rule"), "{:?}", texts[2]);
     }
 
     #[test]
@@ -883,15 +896,16 @@ mod tests {
             "--- a/x.rs\n+++ b/x.rs\n@@ -1,1 +1,1 @@\n-old\n\\ No newline at end of file\n+new\n";
         let lines = body_lines(diff, None);
         let texts: Vec<String> = lines.iter().map(line_text).collect();
+        // Index 0 is the `@@` header; the real preamble above it is stripped.
         assert!(
-            texts[4].starts_with("     "),
+            texts[2].starts_with("     "),
             "the marker line itself gets a blank gutter: {:?}",
-            texts[4]
+            texts[2]
         );
         assert!(
-            texts[5].starts_with("   1 +new"),
+            texts[3].starts_with("   1 +new"),
             "the marker must not have consumed a line number: {:?}",
-            texts[5]
+            texts[3]
         );
     }
 


### PR DESCRIPTION
Supersedes #4274 (same first commit, rebased onto `66971dde9` and extended —
the branch could not be updated in place without a force-push).

## What

`main` is red on **five `diff::tests`** and on **rustdoc, at two sites**. All of
it is downstream of one thing: `main` had not compiled since #4248 (#4256), and
while that stood `fmt + clippy + test` died at the compile step — so the tests
and `cargo doc` never ran at all. Four PRs merged onto that tree reading their
own red checks as inherited. Each repair that landed uncovered the next failure
rather than causing it.

## 1. The five diff tests

#4269 settled the design question that #4244 and #4248 had answered differently:
the `diff`/`index`/`---`/`+++` preamble is dropped on **every** surface, viewer
included. It removed `Chrome::file_headers` and made the guard unconditional:

```rust
if plan.shows(i) && !preamble && (chrome.hunk_headers || !text.starts_with("@@")) {
```

That is a real decision and this PR keeps it. What #4269 did not do is update
the five tests still asserting the other answer — that `body_lines` keeps the
preamble. Three of them index into the rendered rows and shift by two when it
goes, so they fail as a panic rather than as a claim:

```
index out of bounds: the len is 3 but the index is 3
```

| test | change |
|---|---|
| `body_numbers_added_lines_on_the_new_side_and_removed_on_the_old` | re-indexed 3‥6 → 1‥4 |
| `body_lines_number_hunk_text_matching_header_syntax_instead_of_hiding_it` | re-indexed 3,4 → 1,2 |
| `no_newline_marker_gets_no_number_and_does_not_shift_later_numbering` | re-indexed 4,5 → 2,3 |
| `file_headers_and_hunks_get_no_number` | renamed to `plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter` |
| `a_full_git_patch_renders_only_its_hunk_inline` | viewer half flipped |

The rename is not cosmetic: file headers no longer get a number *or* a row, so
the old name describes a state that cannot occur. It goes back to the name
#4248 gave it, which is what the code now does.

`a_full_git_patch_renders_only_its_hunk_inline` asserted that the viewer keeps
the preamble. It now asserts the viewer strips it too — which turns "one patch
looks the same on both surfaces" from a comment into a tested claim.

## 2. Two `private_intra_doc_links` failures

Same defect, two sites, both invisible until the tree compiled:

- **`body_lines_inline`** (`pub`) linked to **`render_body`** (private) — added
  by #4269, in the doc comment explaining the new policy.
- **`TurnEvidence`** (`pub` since #4258) linked to **`turn_start_index`**
  (`pub(super)`) — #4258 widened the type and left the link.

```
error: public documentation for `TurnEvidence` links to private item `turn_start_index`
error: public documentation for `body_lines_inline` links to private item `render_body`
```

Neither private item should be widened to make a link legal — `render_body` is
the shared implementation both entry points wrap, and `turn_start_index` is the
internal boundary rule loop detection and `driver::confident_zero` share. Both
links are demoted to code spans that still name the item, each with a line
saying why it is not a link, so the next person who widens a type here does not
rediscover the rule from a red gate.

## Deleted tests

`file_headers_and_hunks_get_no_number` is **renamed**, not removed, to
`plumbing_is_stripped_and_the_hunk_header_keeps_a_blank_gutter`. Net test count
is unchanged.

## Witness

```
cargo test -p stella-tui                                 # 952 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings    # clean
cargo fmt --all --check                                  # clean
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --keep-going                  # clean
```

All fail on the parent (`66971dde9`) and pass here. Note when checking the
rustdoc half by hand that `touch` on the edited file is load-bearing — cargo
replays a cached success otherwise.

Refs #4256
Refs #4259

## Summary by Sourcery

Bring diff tests and public documentation in line with the current rendering and visibility rules.

Bug Fixes:
- Align diff tests with the behavior that strips Git patch preambles on both inline and viewer surfaces.
- Resolve rustdoc warnings caused by public documentation linking to private items.

Enhancements:
- Clarify diff rendering test names and assertions to reflect the current hunk-header and numbering behavior.

Tests:
- Update diff rendering coverage for stripped preambles, hunk gutters, line numbering, and no-newline markers.