### PR TITLE
fix(stella-transcript): one transcript on the plain surface, and a gate step that says which surfaces share it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + diagnostic-codes
                          #   + bench-suites
                          #   + tokens (hue clamp + no retired hex)
+                         #   + transcript-surfaces
                          #   + wire-schema
                          #   + lockfile-sync (cargo metadata --locked)
                          #   + format-check (fmt --check)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ python3 ./scripts/check-dead-code-allows.py
 ./scripts/check-bench-suites.sh
 python3 ./scripts/gen-tokens.py --check
 python3 ./scripts/check-tokens.py
+python3 ./scripts/check-transcript-surfaces.py
 ./scripts/check-wire-schema.sh
 ./scripts/check-lockfile-sync.sh
 cargo fmt --check

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     command-docs brand-case file-size god-files gate-parity left-behind \
                     role-names stat-portability module-reachability typed-errors \
-                    dead-code-allows diagnostic-codes bench-suites tokens
+                    dead-code-allows diagnostic-codes bench-suites tokens \
+                    transcript-surfaces
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The cargo steps that resolve or parse but never build. They are not in
@@ -468,6 +469,14 @@ module-reachability-test: ## Test the module-reachability walker (hermetic; not 
 .PHONY: god-files
 god-files: ## Assert AGENTS.md and the crate READMEs name the baselined god files (#1435)
 	@./scripts/check-god-files.sh
+
+.PHONY: transcript-surfaces
+transcript-surfaces: ## Assert every transcript surface declares whether it draws through stella-transcript (#3764)
+	@./scripts/check-transcript-surfaces.py
+
+.PHONY: transcript-surfaces-test
+transcript-surfaces-test: ## Test the transcript-surface guard's failure directions (hermetic; not part of `gate`)
+	./scripts/test-transcript-surfaces.py
 
 .PHONY: lockfile-sync
 lockfile-sync: ## Assert Cargo.lock resolves against the manifests as committed (#3332)

--- a/crates/stella-cli/src/plain/transcript.rs
+++ b/crates/stella-cli/src/plain/transcript.rs
@@ -1,34 +1,41 @@
-//! The plain surface's transcript frames — the character-grid renderer, on
-//! scrollback.
+//! The plain surface's transcript — the character-grid renderer, streamed onto
+//! scrollback as the turn happens.
 //!
-//! # The tension this module resolves
+//! # One rendering, not two
 //!
-//! [`stella_transcript::grid::render`] draws a *whole* turn: the header rail
-//! states the turn's step count, wall time and cost, and the frame closes with
-//! a matching bottom rail. None of those numbers exist until the turn ends. The
-//! plain surface, by contrast, is append-only — it writes into the user's own
-//! scrollback and can never revisit a line it has printed (see the parent
-//! module's header). A streamed frame is therefore not merely awkward, it is
-//! unrepresentable: the top rail would have to be printed before its own
-//! contents are known.
+//! This surface is append-only: it writes into the user's own scrollback and
+//! can never revisit a line it has printed. That used to be read as "a frame
+//! cannot be streamed", because [`stella_transcript::grid`]'s turn frame put
+//! the turn's status and accounting on its *top* rail and neither exists when
+//! the turn opens. So the frame was emitted once, at `TurnComplete`, and a
+//! terse `· {tool}` progress row was printed per call in the meantime and then
+//! erased.
 //!
-//! So the frame is emitted **once, when the turn completes**, and what happens
-//! before that depends on who is watching:
+//! That produced two renderings of one turn, and the user saw the worse one
+//! for the entire run — minutes of `· bash` on a terminal, while the very same
+//! code printed the real transcript to a daemon's console file, where nobody
+//! was watching it happen. It also could not erase correctly: the cursor-up
+//! that removed the progress rows was unbounded, so a turn with more tool calls
+//! than the terminal had rows walked off the top of the screen and cleared
+//! whatever was there instead.
 //!
-//! - **On a terminal**, a terse progress line per tool call is printed while
-//!   the turn runs, then erased immediately before the frame replaces it. Each
-//!   is truncated to the terminal width so it occupies exactly one physical
-//!   row — the cursor-up erase is only correct if the count of rows printed
-//!   equals the count of lines printed, which wrapping would break.
-//! - **Anywhere else** — a log file, a supervised child's console file, the
-//!   bytes `stella daemon logs` replays — nothing is printed until the frame.
-//!   A reader of those bytes arrives after the fact and wants the transcript,
-//!   not a progress trace that the frame below then repeats.
+//! The frame is streamable now — its status and chips moved to the closing
+//! rail, which is the only place they are knowable
+//! ([`grid::render_turn_lines`]'s contract, pinned by
+//! `render_turn_is_append_only_as_a_turn_grows`). So there is one rendering:
+//! the transcript itself, written a line at a time as the turn produces it. A
+//! terminal and a log file receive the same bytes, which is the property the
+//! two used to differ on most visibly.
 //!
-//! `STELLA_PLAIN_STREAM=1` restores the pre-frame line-by-line rendering for a
-//! caller that genuinely wants tokens as they arrive.
+//! # What "as the turn produces it" means
+//!
+//! Only lines that can never change are written, which is
+//! [`RunBuilder::settled`]'s job: a tool call reaches scrollback when its
+//! result does, not when it dispatches, because the row carries its duration,
+//! output fold and cost. The closing rail is withheld until the turn ends for
+//! the same reason.
 
-use std::io::{IsTerminal, Write};
+use std::io::Write;
 
 use stella_protocol::AgentEvent;
 use stella_transcript::{FoldState, Run, Status, Zoom, grid};
@@ -41,30 +48,37 @@ const FALLBACK_WIDTH: usize = 100;
 /// chips so far from its verb that the row stops reading as one thing.
 const MAX_WIDTH: usize = 120;
 
-/// Accumulates a turn and prints its frame when it closes.
+/// Accumulates a turn and writes its frame to scrollback as it settles.
 pub struct TranscriptPrinter {
     builder: RunBuilder,
-    /// How many progress rows are on screen awaiting erasure. Always `0` when
-    /// not writing to a terminal.
-    progress_rows: usize,
-    interactive: bool,
-    /// How many turns have been printed, so a frame is never re-printed.
+    /// Lines of the turn currently open that are already on scrollback.
+    emitted: usize,
+    /// Turns written in full, so a frame is never written twice.
     printed_turns: usize,
+    /// The column count every frame is drawn to, resolved once.
+    ///
+    /// Read at construction rather than per line, because a streamed frame is
+    /// the one thing that cannot survive a mid-turn resize: the rails and the
+    /// chip column of the lines already written are fixed, and re-measuring
+    /// would close a frame at a width its own top rail was not drawn to. A
+    /// pinned width means a resize takes effect on the next run instead of
+    /// tearing the one in progress.
+    width: usize,
 }
 
 impl TranscriptPrinter {
-    /// A printer for a run, deciding once whether a human is watching.
+    /// A printer for a run, measuring the terminal once.
     #[must_use]
     pub fn new(name: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
             builder: RunBuilder::new(name, model),
-            progress_rows: 0,
-            interactive: std::io::stdout().is_terminal(),
+            emitted: 0,
             printed_turns: 0,
+            width: width(),
         }
     }
 
-    /// Whether the caller asked for the legacy line-by-line rendering.
+    /// Whether the caller asked for the legacy line-by-line card rendering.
     #[must_use]
     pub fn streaming_requested() -> bool {
         std::env::var("STELLA_PLAIN_STREAM").is_ok_and(|v| v == "1")
@@ -73,80 +87,118 @@ impl TranscriptPrinter {
     /// Open a turn around the user's prompt.
     pub fn start_turn(&mut self, prompt: &str) {
         self.builder.start_turn(prompt);
+        self.emitted = 0;
     }
 
-    /// Fold one event in, and show progress if a human is watching.
+    /// Fold one event in and write whatever it settled.
     pub fn observe(&mut self, event: &AgentEvent) {
-        self.builder.push(event);
-        if let AgentEvent::ToolStart { call } = event {
-            self.progress(&call.name);
-        }
-        if matches!(event, AgentEvent::TurnComplete { .. }) {
-            self.flush();
-        }
+        let text = self.observed(event);
+        write(&text);
     }
 
-    /// Close the open turn and print every frame not yet printed.
+    /// Close the open turn and write every line not yet written.
     pub fn flush(&mut self) {
+        let text = self.flushed();
+        write(&text);
+    }
+
+    // The two above are the whole I/O surface of this module: everything that
+    // decides *what* to print is below and returns it, so a test can read the
+    // scrollback this surface would produce without capturing a file
+    // descriptor (invariant #2's discipline, one crate out).
+
+    /// What [`Self::observe`] would write.
+    fn observed(&mut self, event: &AgentEvent) -> String {
+        self.builder.push(event);
+        if matches!(event, AgentEvent::TurnComplete { .. }) {
+            return self.flushed();
+        }
+        // A reasoning or text delta can settle nothing — `settled` withholds
+        // the block each one appends to — so re-rendering the turn for one is
+        // pure work. They are also the two events that arrive at token rate,
+        // which is what makes the exclusion worth stating rather than leaving
+        // to the suffix arithmetic to discover.
+        if matches!(
+            event,
+            AgentEvent::TextDelta { .. } | AgentEvent::Reasoning { .. }
+        ) {
+            return String::new();
+        }
+        self.advance()
+    }
+
+    /// What [`Self::flush`] would write.
+    fn flushed(&mut self) -> String {
         self.builder.finish_turn(Status::Ok);
-        self.erase_progress();
         let run = self.builder.snapshot();
+        let mut out = String::new();
         for index in self.printed_turns..run.turns.len() {
-            print!("{}", frame(&run, index, width()));
+            // The first unwritten turn is the one that was open, so its already
+            // streamed prefix is skipped; any later turn is written whole.
+            let from = if index == self.printed_turns {
+                self.emitted
+            } else {
+                0
+            };
+            append(&mut out, &frame(&run, index, self.width), from);
         }
         self.printed_turns = run.turns.len();
-        let _ = std::io::stdout().flush();
+        self.emitted = 0;
+        out
     }
 
-    fn progress(&mut self, tool: &str) {
-        if !self.interactive {
-            return;
+    /// The lines the open turn has settled since the last call.
+    fn advance(&mut self) -> String {
+        if !self.builder.is_turn_open() {
+            return String::new();
         }
-        // Truncated so the row cannot wrap; see the module doc on why the
-        // erase depends on that.
-        let mut line = format!("  · {tool}");
-        line.truncate(width());
-        println!("{line}");
-        self.progress_rows += 1;
-    }
-
-    fn erase_progress(&mut self) {
-        if self.progress_rows == 0 {
-            return;
-        }
-        // Up N rows, then clear from the cursor to the end of the screen.
-        print!("\x1b[{}A\x1b[J", self.progress_rows);
-        self.progress_rows = 0;
+        let run = self.builder.settled();
+        let Some(index) = run.turns.len().checked_sub(1) else {
+            return String::new();
+        };
+        let lines = frame(&run, index, self.width);
+        // The closing rail is withheld while the turn is open: it carries the
+        // status and the cost, and a turn that is still running has neither.
+        let body = &lines[..lines.len().saturating_sub(1)];
+        let mut out = String::new();
+        append(&mut out, body, self.emitted);
+        self.emitted = body.len();
+        out
     }
 }
 
-/// One turn's frame, as ANSI text ending in a newline.
+/// One turn's frame, as ANSI lines.
 ///
-/// Rendered from a run holding only that turn, because `grid::render` draws
-/// every turn it is given and this surface has already printed the earlier
-/// ones. The trailing status line `grid::render` appends is dropped for the
-/// same reason: it is a whole-run footer, and printing "1 turns" under every
-/// frame would state something false about the session.
-fn frame(run: &Run, index: usize, width: usize) -> String {
-    let Some(turn) = run.turns.get(index) else {
-        return String::new();
-    };
-    let single = Run {
-        name: run.name.clone(),
-        model: run.model.clone(),
-        started_at: run.started_at.clone(),
-        turns: vec![turn.clone()],
-    };
+/// Rendered one turn at a time rather than through `grid::render`, which draws
+/// the whole run and appends a keybinding footer. Both are wrong here: the
+/// earlier turns are already on scrollback and cannot be redrawn, and the
+/// footer describes a fold cursor this surface does not have.
+fn frame(run: &Run, index: usize, width: usize) -> Vec<String> {
     let mut state = FoldState::new();
     state.set_zoom(Zoom::Steps);
-    let mut lines = grid::render(&single, &state, width);
-    lines.pop();
-    let body = grid::to_ansi256(&lines);
-    if body.is_empty() {
-        body
-    } else {
-        format!("{body}\n")
+    grid::render_turn_lines(run, &state, index, width)
+        .iter()
+        .map(|line| grid::to_ansi256(std::slice::from_ref(line)))
+        .collect()
+}
+
+/// Push `lines[from..]` onto `out`, one per row.
+fn append(out: &mut String, lines: &[String], from: usize) {
+    for line in lines.iter().skip(from) {
+        out.push_str(line);
+        out.push('\n');
     }
+}
+
+/// One write per batch. A turn can settle several lines at once, and a partial
+/// line reaching a reader that is tailing the file would tear the frame.
+fn write(text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    let mut stdout = std::io::stdout();
+    let _ = stdout.write_all(text.as_bytes());
+    let _ = stdout.flush();
 }
 
 /// The width to draw at: the terminal's, clamped, or a fixed fallback when

--- a/crates/stella-cli/src/plain/transcript/tests.rs
+++ b/crates/stella-cli/src/plain/transcript/tests.rs
@@ -1,30 +1,43 @@
-//! Witnesses for the plain surface's frames. Each fails before this module
-//! existed, because the plain surface had no path to `grid::render` at all —
-//! the renderer's only callers were its own tests and one example.
+//! Witnesses for the plain surface's transcript.
+//!
+//! The first group fails before this module existed, because the plain surface
+//! had no path to `grid::render` at all. The streaming group fails before
+//! #3764's follow-up, because this surface used to print `· {tool}` per call
+//! for the whole turn and draw the real frame only once the turn was over —
+//! two renderings of one turn, with the worse one on the surface a human was
+//! actually watching.
 
 use super::*;
 use serde_json::json;
 use stella_protocol::{ToolCall, ToolOutput};
 
-fn built(prompt: &str) -> Run {
-    let mut b = RunBuilder::new("latex-proof", "z-ai/glm-5.2");
-    b.start_turn(prompt);
-    b.push(&AgentEvent::ToolStart {
+fn call(id: &str, name: &str, input: serde_json::Value) -> AgentEvent {
+    AgentEvent::ToolStart {
         call: ToolCall {
-            call_id: "c1".to_string(),
-            name: "read_file".to_string(),
-            input: json!({"path": "app/main.tex"}),
+            call_id: id.to_string(),
+            name: name.to_string(),
+            input,
         },
-    });
-    b.push(&AgentEvent::ToolResult {
-        call_id: "c1".to_string(),
+    }
+}
+
+fn result(id: &str, content: &str) -> AgentEvent {
+    AgentEvent::ToolResult {
+        call_id: id.to_string(),
         output: ToolOutput::Ok {
-            content: "\\documentclass{article}\n".to_string(),
+            content: content.to_string(),
             data: None,
         },
         duration_ms: 9,
         speculated: false,
-    });
+    }
+}
+
+fn built(prompt: &str) -> Run {
+    let mut b = RunBuilder::new("latex-proof", "z-ai/glm-5.2");
+    b.start_turn(prompt);
+    b.push(&call("c1", "read_file", json!({"path": "app/main.tex"})));
+    b.push(&result("c1", "\\documentclass{article}\n"));
     b.push(&AgentEvent::Text {
         text: "Read it.".to_string(),
     });
@@ -32,12 +45,35 @@ fn built(prompt: &str) -> Run {
     b.snapshot()
 }
 
+/// The width every test here draws at.
+///
+/// Pinned rather than measured, because
+/// [`the_width_is_clamped_and_then_fixed_for_the_whole_turn`] mutates `COLUMNS`
+/// and the harness runs these in parallel threads of one process: a test that
+/// read the environment would be reading that one's fixture. It is not a
+/// hypothetical — the streaming witness first failed on exactly this, with a
+/// closing rail two dozen cells longer than the top rail it was compared to.
+const W: usize = 100;
+
+/// A printer drawing at [`W`], for the same reason [`W`] exists.
+fn printer() -> TranscriptPrinter {
+    let mut p = TranscriptPrinter::new("latex-proof", "z-ai/glm-5.2");
+    p.width = W;
+    p
+}
+
+/// The frame as one string, the way it reaches scrollback.
+fn frame_text(run: &Run, index: usize) -> String {
+    strip_ansi(&frame(run, index, W).join("\n"))
+}
+
+// ------------------------------------------------------------- the frame
+
 /// The frame is the box-drawing turn frame from the reference mockups — the
 /// thing four previous attempts never got onto a live surface.
 #[test]
 fn a_turn_prints_as_a_box_drawn_frame() {
-    let run = built("fix the overfull hbox warnings");
-    let out = strip_ansi(&frame(&run, 0, 100));
+    let out = frame_text(&built("fix the overfull hbox warnings"), 0);
 
     let first = out.lines().next().expect("a frame has a top rail");
     assert!(
@@ -59,26 +95,23 @@ fn a_turn_prints_as_a_box_drawn_frame() {
 #[test]
 fn every_rail_is_drawn_to_the_requested_width() {
     let run = built("go");
-    for width in [60usize, 100, 120] {
-        let out = strip_ansi(&frame(&run, 0, width));
+    for w in [60usize, 100, 120] {
+        let out = strip_ansi(&frame(&run, 0, w).join("\n"));
         for line in out
             .lines()
             .filter(|l| l.starts_with('╭') || l.starts_with('╰'))
         {
-            assert_eq!(
-                line.chars().count(),
-                width,
-                "rail is not {width} wide: {line:?}"
-            );
+            assert_eq!(line.chars().count(), w, "rail is not {w} wide: {line:?}");
         }
     }
 }
 
 /// A whole-run footer under a single-turn frame would state something false
-/// about the session, so it is dropped.
+/// about the session, so this surface renders one turn at a time rather than
+/// calling `grid::render` and trimming.
 #[test]
 fn a_single_turn_frame_carries_no_whole_run_footer() {
-    let out = strip_ansi(&frame(&built("go"), 0, 100));
+    let out = frame_text(&built("go"), 0);
     let last = out.lines().last().expect("a frame has a last line");
     assert!(
         last.starts_with("╰─"),
@@ -86,17 +119,16 @@ fn a_single_turn_frame_carries_no_whole_run_footer() {
     );
 }
 
-/// Each turn is printed once. A second flush after nothing happened must not
-/// re-print a frame that is already in the user's scrollback.
+/// Each turn is written once. A second flush after nothing happened must not
+/// re-write a frame that is already in the user's scrollback.
 #[test]
 fn a_frame_is_never_printed_twice() {
-    let mut p = TranscriptPrinter::new("run", "m");
-    p.interactive = false;
+    let mut p = printer();
     p.start_turn("first");
-    p.flush();
+    assert!(!p.flushed().is_empty(), "the first flush wrote nothing");
     assert_eq!(p.printed_turns, 1);
-    p.flush();
-    assert_eq!(p.printed_turns, 1, "an idle flush re-printed a turn");
+    assert_eq!(p.flushed(), "", "an idle flush re-wrote a turn");
+    assert_eq!(p.printed_turns, 1);
 }
 
 /// The user-visible half of the fold's terminator bug: `spawn_renderer` flushes
@@ -106,58 +138,189 @@ fn a_frame_is_never_printed_twice() {
 /// every `stella run` ended with one.
 #[test]
 fn the_run_terminator_prints_no_trailing_frame() {
-    let mut p = TranscriptPrinter::new("run", "m");
-    p.interactive = false;
+    let mut p = printer();
     p.start_turn("ship it");
-    p.observe(&AgentEvent::TurnComplete {
+    p.observed(&AgentEvent::TurnComplete {
         model: "m".to_string(),
         cost_usd: 0.01,
     });
     assert_eq!(p.printed_turns, 1, "the real turn should have printed");
-    p.observe(&AgentEvent::RunComplete {
+    p.observed(&AgentEvent::RunComplete {
         model: "m".to_string(),
         cost_usd: 0.01,
     });
     // What `spawn_renderer` does once `rx` closes.
-    p.flush();
     assert_eq!(
-        p.printed_turns, 1,
-        "the run terminator printed a second, promptless frame"
+        p.flushed(),
+        "",
+        "the run terminator wrote a second, promptless frame"
+    );
+    assert_eq!(p.printed_turns, 1);
+}
+
+// --------------------------------------------------------- the streaming
+
+/// Everything one printer writes over a turn, in order.
+fn streamed(events: &[AgentEvent]) -> String {
+    let mut p = printer();
+    p.start_turn("fix the overfull hbox warnings");
+    let mut out = String::new();
+    for event in events {
+        out.push_str(&p.observed(event));
+    }
+    out.push_str(&p.flushed());
+    out
+}
+
+fn turn_events() -> Vec<AgentEvent> {
+    vec![
+        AgentEvent::Reasoning {
+            delta: "I'll read the file first.".to_string(),
+        },
+        call("c1", "read_file", json!({"path": "app/main.tex"})),
+        result("c1", "\\documentclass{article}\n"),
+        call("c2", "bash", json!({"command": "latexmk main.tex"})),
+        result("c2", "Overfull \\hbox (3.1pt too wide)\n"),
+        AgentEvent::Text {
+            text: "Read it.".to_string(),
+        },
+    ]
+}
+
+/// **The property this surface exists to have.** What a human watches scroll
+/// past during the run is, byte for byte, the transcript they are left with —
+/// there is no second, terser rendering and nothing is redrawn.
+///
+/// Fails before the streaming rewrite: the old surface wrote `  · read_file`
+/// and `  · bash` while the turn ran, erased them with a cursor-up, and only
+/// then wrote the frame.
+#[test]
+fn what_scrolls_past_during_the_turn_is_the_transcript_that_remains() {
+    let live = strip_ansi(&streamed(&turn_events()));
+
+    let mut b = RunBuilder::new("latex-proof", "z-ai/glm-5.2");
+    b.start_turn("fix the overfull hbox warnings");
+    for event in turn_events() {
+        b.push(&event);
+    }
+    b.finish_turn(Status::Ok);
+    let finished = format!("{}\n", frame_text(&b.snapshot(), 0));
+
+    assert_eq!(
+        live, finished,
+        "the streamed scrollback and the finished frame are different documents"
     );
 }
 
-/// Nothing is printed before the frame when no human is watching, so a log
-/// file holds the transcript rather than the transcript plus a progress trace
-/// that repeats it.
+/// No placeholder vocabulary reaches scrollback. The `· {tool}` row is the
+/// specific thing being ruled out, and a bare tool name with no digest around
+/// it is the shape of the defect rather than that one glyph.
 #[test]
-fn a_non_interactive_surface_prints_no_progress_rows() {
-    let mut p = TranscriptPrinter::new("run", "m");
-    p.interactive = false;
+fn no_progress_placeholder_is_ever_written() {
+    let live = strip_ansi(&streamed(&turn_events()));
+    for line in live.lines() {
+        assert!(
+            !line.trim_start().starts_with('·'),
+            "a placeholder progress row reached scrollback: {line:?}"
+        );
+    }
+}
+
+/// A terminal and a log file receive the same bytes. This surface used to
+/// branch on `stdout().is_terminal()` and print the progress rows only to a
+/// terminal, which is why `stella run --foreground` and the same run under the
+/// daemon looked like different products.
+#[test]
+fn the_same_bytes_reach_a_terminal_and_a_log_file() {
+    // Stated structurally, because that is the only way to state it: the two
+    // destinations differ if and only if some branch asks which one it is
+    // writing to. Nothing in this module may ask.
+    let source = include_str!("../transcript.rs");
+    assert!(
+        !source.contains("is_terminal"),
+        "the surface grew a terminal-only branch again — that is the divergence"
+    );
+}
+
+/// A dispatched call reaches scrollback when its **result** does, not when it
+/// dispatches. Its row carries the duration, the output fold and the cost, so
+/// writing it at dispatch would mean rewriting a line already committed.
+#[test]
+fn a_call_reaches_scrollback_only_once_it_has_settled() {
+    let mut p = printer();
     p.start_turn("go");
-    p.observe(&AgentEvent::ToolStart {
-        call: ToolCall {
-            call_id: "c1".to_string(),
-            name: "bash".to_string(),
-            input: json!({"command": "ls"}),
-        },
-    });
-    assert_eq!(
-        p.progress_rows, 0,
-        "a log file must not receive progress rows"
+    let on_dispatch = strip_ansi(&p.observed(&call("c1", "bash", json!({"command": "ls -la"}))));
+    assert!(
+        !on_dispatch.contains("ls -la"),
+        "an in-flight call was committed to scrollback: {on_dispatch:?}"
+    );
+    let on_result = strip_ansi(&p.observed(&result("c1", "main.tex\n")));
+    assert!(
+        on_result.contains("ls -la"),
+        "the settled call never arrived: {on_result:?}"
+    );
+}
+
+/// The closing rail is withheld until the turn ends, because it is the one
+/// line carrying facts that do not exist while the turn runs.
+#[test]
+fn the_closing_rail_arrives_only_with_the_turn_it_closes() {
+    let mut p = printer();
+    p.start_turn("go");
+    let during = strip_ansi(&p.observed(&result("c1", "x")));
+    assert!(
+        !during.contains('╰'),
+        "a running turn wrote its closing rail: {during:?}"
+    );
+    assert!(
+        strip_ansi(&p.flushed()).contains('╰'),
+        "the finished turn never closed its frame"
     );
 }
 
 /// The width clamp keeps a frame readable on a very wide terminal and legal on
-/// a narrow one.
+/// a narrow one — and a turn is drawn at **one** width for its whole life.
+///
+/// Both halves live in one test because both mutate `COLUMNS`, which is
+/// process-global while the harness runs tests in parallel threads. Split, they
+/// would read each other's fixture; that is exactly how the streaming witness
+/// first failed, with a rail two dozen cells too long.
+///
+/// The second half is the one that matters at runtime. A streamed frame cannot
+/// be redrawn, so a printer that re-measured the terminal would close a resized
+/// turn at a width its own top rail was never drawn to.
 #[test]
-fn width_is_clamped_at_both_ends() {
-    // SAFETY: single-threaded test process; the var is read, not cached.
+fn the_width_is_clamped_and_then_fixed_for_the_whole_turn() {
+    // SAFETY: the only test in this module that touches `COLUMNS`, by design.
     unsafe { std::env::set_var("COLUMNS", "400") };
     assert_eq!(width(), MAX_WIDTH);
     unsafe { std::env::set_var("COLUMNS", "10") };
     assert_eq!(width(), 40);
     unsafe { std::env::remove_var("COLUMNS") };
     assert_eq!(width(), FALLBACK_WIDTH);
+
+    unsafe { std::env::set_var("COLUMNS", "100") };
+    let mut p = TranscriptPrinter::new("run", "m");
+    p.start_turn("go");
+    let opened = strip_ansi(&p.observed(&result("c1", "x")));
+    unsafe { std::env::set_var("COLUMNS", "60") };
+    let closed = strip_ansi(&p.flushed());
+    unsafe { std::env::remove_var("COLUMNS") };
+
+    let rails: Vec<usize> = opened
+        .lines()
+        .chain(closed.lines())
+        .filter(|l| l.starts_with('╭') || l.starts_with('╰'))
+        .map(|l| l.chars().count())
+        .collect();
+    assert!(
+        rails.len() >= 2,
+        "expected an opening and a closing rail, got {rails:?}"
+    );
+    assert!(
+        rails.iter().all(|&w| w == 100),
+        "the terminal was re-measured mid-turn and the frame tore: {rails:?}"
+    );
 }
 
 /// Strip SGR sequences so an assertion reads the characters, not the paint.

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -239,7 +239,7 @@ pub fn render(run: &Run, state: &FoldState, width: usize) -> Vec<Line> {
 /// printed, and a top rail that claimed them would freeze `running` and a
 /// partial cost into scrollback forever. It is a real constraint on this
 /// function, not a layout preference — moving either back onto
-/// [`turn_frame_top`] makes the frame unstreamable, and
+/// `turn_frame_top` makes the frame unstreamable, and
 /// `render_turn_is_append_only_as_a_turn_grows` fails.
 #[must_use]
 pub fn render_turn_lines(run: &Run, state: &FoldState, index: usize, width: usize) -> Vec<Line> {

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -223,6 +223,34 @@ pub fn render(run: &Run, state: &FoldState, width: usize) -> Vec<Line> {
     lines
 }
 
+/// One turn's frame, top rail to bottom rail, with no whole-run footer.
+///
+/// # The streaming contract
+///
+/// Every line this returns is **final the moment it is produced**, and the
+/// sequence only ever grows at the tail as the turn does. That is what lets an
+/// append-only surface — a terminal's scrollback, a log file — print a turn as
+/// it happens by re-rendering and emitting the suffix it has not printed yet,
+/// instead of inventing a second, terser rendering to show in the meantime
+/// (`stella-cli`'s `plain::transcript` does exactly this).
+///
+/// The contract is why the turn's status and accounting sit on the **bottom**
+/// rail rather than the top: neither exists when the first line has to be
+/// printed, and a top rail that claimed them would freeze `running` and a
+/// partial cost into scrollback forever. It is a real constraint on this
+/// function, not a layout preference — moving either back onto
+/// [`turn_frame_top`] makes the frame unstreamable, and
+/// `render_turn_is_append_only_as_a_turn_grows` fails.
+#[must_use]
+pub fn render_turn_lines(run: &Run, state: &FoldState, index: usize, width: usize) -> Vec<Line> {
+    let ctx = Ctx { run, state, width };
+    let mut lines = Vec::new();
+    if let Some(turn) = run.turns.get(index) {
+        render_turn(&mut lines, &ctx, turn, index);
+    }
+    lines
+}
+
 fn render_turn(out: &mut Vec<Line>, ctx: &Ctx<'_>, turn: &Turn, index: usize) {
     let width = ctx.width;
     let open = ctx.open(NodeId::Turn(index));
@@ -232,7 +260,7 @@ fn render_turn(out: &mut Vec<Line>, ctx: &Ctx<'_>, turn: &Turn, index: usize) {
             Cell::new("│ ", Color::Faint),
             Cell::new("…", Color::Dim),
         ]);
-        out.push(turn_frame_bottom(width));
+        out.push(turn_frame_bottom(turn, width));
         return;
     }
 
@@ -272,19 +300,21 @@ fn render_turn(out: &mut Vec<Line>, ctx: &Ctx<'_>, turn: &Turn, index: usize) {
         out.push(spine_blank());
         role_lines(out, "agent", Color::Violet, answer, width);
     }
-    out.push(turn_frame_bottom(width));
+    out.push(turn_frame_bottom(turn, width));
 }
 
+/// The turn's opening rail: everything about a turn that is knowable before it
+/// runs, and nothing that is not.
+///
+/// Deliberately carries no status and no chips. See [`render_turn_lines`]'s
+/// streaming contract — this is the line a live surface has to print first,
+/// when the only true answers to "how did it go" and "what did it cost" are
+/// "unknown".
 fn turn_frame_top(turn: &Turn, open: bool, width: usize) -> Line {
     let dig = digest::turn_digest(turn, 40, digest::ChipStyle::Tight);
     let mut line = vec![
         Cell::new("╭─ ", Color::Faint),
         Cell::new(&turn.name, Color::Violet).bold(),
-        Cell::new(" ", Color::Faint),
-        Cell::new(
-            format!("{} {}", turn.status.glyph(), status_word(turn.status)),
-            status_color(turn.status),
-        ),
         Cell::new(" ", Color::Faint),
     ];
     // An expanded turn shows its content in full, so a fold marker on its own
@@ -296,24 +326,36 @@ fn turn_frame_top(turn: &Turn, open: bool, width: usize) -> Line {
         line.push(Cell::new(format!("\"{}\" ", dig.prompt_line), Color::Dim));
     }
 
+    // The three cells after the fill — the ` ─╮` cap — are reserved here, not
+    // discovered later: a top rail that reserves less than it emits is longer
+    // than the bottom one it has to meet.
+    let used = line_width(&line) + 3;
+    let fill = width.saturating_sub(used).max(1);
+    line.push(Cell::new("─".repeat(fill), Color::Faint));
+    line.push(Cell::new(" ─╮", Color::Faint));
+    line
+}
+
+/// The turn's closing rail, carrying the two facts that only exist once the
+/// turn is over: how it ended, and what it spent.
+fn turn_frame_bottom(turn: &Turn, width: usize) -> Line {
+    let dig = digest::turn_digest(turn, 40, digest::ChipStyle::Tight);
+    let mut line = vec![
+        Cell::new("╰─ ", Color::Faint),
+        Cell::new(
+            format!("{} {}", turn.status.glyph(), status_word(turn.status)),
+            status_color(turn.status),
+        ),
+        Cell::new(" ", Color::Faint),
+    ];
     let chips = chips_text(&dig.chips);
-    // The four cells after the fill — the separating space and the ` ─╮` cap —
-    // are reserved here, not discovered later: a top rail that reserves less
-    // than it emits is two cells longer than the bottom one it has to meet.
     let used = line_width(&line) + cells(&chips) + 4;
     let fill = width.saturating_sub(used).max(1);
     line.push(Cell::new("─".repeat(fill), Color::Faint));
     line.push(Cell::new(" ", Color::Faint));
     line.push(Cell::new(chips, Color::Dim));
-    line.push(Cell::new(" ─╮", Color::Faint));
+    line.push(Cell::new(" ─╯", Color::Faint));
     line
-}
-
-fn turn_frame_bottom(width: usize) -> Line {
-    vec![Cell::new(
-        format!("╰{}╯", "─".repeat(width.saturating_sub(2))),
-        Color::Faint,
-    )]
 }
 
 fn spine_blank() -> Line {

--- a/crates/stella-transcript/src/html.rs
+++ b/crates/stella-transcript/src/html.rs
@@ -130,8 +130,15 @@ fn turn_block(out: &mut String, run: &Run, state: &FoldState, turn: &Turn, index
             );
         }
         out.push_str("</span>");
+        // Only a collapsed turn puts its accounting on the summary, because
+        // the summary is the only thing a collapsed `<details>` renders — a
+        // turn that showed no cost until you opened it would hide exactly what
+        // a reader scans a transcript for. An expanded turn closes with the
+        // receipt below instead, in the same place `grid`'s bottom rail puts
+        // it, so the two shared renderers agree about where a turn's outcome
+        // is read. Rendering both would state it twice on one open turn.
+        chips(out, &dig.chips);
     }
-    chips(out, &dig.chips);
     out.push_str("</div></summary>");
 
     role_block(out, "you", "YOU", &escape_paragraphs(&turn.prompt), false);
@@ -139,7 +146,30 @@ fn turn_block(out: &mut String, run: &Run, state: &FoldState, turn: &Turn, index
     if let Some(answer) = &turn.answer {
         role_block(out, "agent", "AGENT", &escape_paragraphs(answer), true);
     }
+    if open {
+        turn_receipt(out, turn, &dig.chips);
+    }
     out.push_str("</details>");
+}
+
+/// The expanded turn's closing receipt — `grid::turn_frame_bottom`'s counterpart.
+///
+/// The two renderers deliberately agree on *what* closes a turn (its status
+/// word and its chips) and on *where* (after the last thing the turn did).
+/// `grid` has no choice about it: its frame has to be printable a line at a
+/// time as the turn runs, and neither fact exists when the top rail goes out.
+/// Keeping the web surface in step is what stops a reader who compares
+/// `stella run`'s scrollback with `stella observe` from finding two documents.
+fn turn_receipt(out: &mut String, turn: &Turn, chip_list: &[Chip]) {
+    let _ = write!(
+        out,
+        "<div class=\"turnreceipt\"><span class=\"st {}\">{} {}</span>",
+        turn.status.token(),
+        turn.status.glyph(),
+        status_word(turn.status),
+    );
+    chips(out, chip_list);
+    out.push_str("</div>");
 }
 
 fn steps_and_prose(out: &mut String, run: &Run, state: &FoldState, turn: &Turn, ti: usize) {

--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -263,6 +263,18 @@ details[open] > summary .chev { transform: rotate(90deg); }
 .tdigest .aq { color: var(--ink); }
 .tdigest .sep { color: var(--faint); }
 
+/* An expanded turn's closing receipt — the web counterpart of `grid`'s bottom
+   rail, and placed to match it: status on the left, chips pushed right. */
+.turnreceipt {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  padding: 10px 18px;
+  border-top: 1px solid var(--line);
+  background: var(--raised);
+}
+
 .chips { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
 .chip {
   font-size: 10.5px;

--- a/crates/stella-transcript/src/lib.rs
+++ b/crates/stella-transcript/src/lib.rs
@@ -26,6 +26,29 @@
 //! re-implementing the TUI's renderer in JavaScript, and that copy had silently
 //! drifted to the point of having no diff rendering at all.
 //!
+//! ## Which surfaces actually draw through this crate
+//!
+//! Extracting the crate proved nothing on its own, and the gap between "the
+//! crate exists" and "every surface uses it" went unnoticed for long enough to
+//! close #3578 as completed twice while the deck had never called
+//! [`grid::render`]. The adoption ledger is
+//! `scripts/check-transcript-surfaces.py` (`make transcript-surfaces`): one row
+//! per surface, a row that claims to share must really reference the entry
+//! point, a row that does not must cite the issue deciding it, and the caller
+//! sets must match in both directions. That file is the current answer; this
+//! paragraph deliberately does not repeat a count, because a number in two
+//! places is how the last one died.
+//!
+//! ## A turn closes with its outcome, on both renderers
+//!
+//! Neither a turn's status nor its accounting exists when the turn opens, so
+//! both live at the *end* of a turn — [`grid`]'s bottom rail, and [`html`]'s
+//! receipt. That is a constraint before it is a layout: it is the only thing
+//! that lets an append-only surface write a frame a line at a time as the turn
+//! runs, instead of showing a placeholder until it can draw the whole thing
+//! (see [`grid::render_turn_lines`]). A collapsed `<details>` is the one
+//! exception, and only because it renders nothing but its summary.
+//!
 //! ## Purity
 //!
 //! Nothing here reads a file, spawns a process, formats a timestamp or touches

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -1209,6 +1209,139 @@ fn the_turn_frame_rails_are_the_same_width() {
     assert_eq!(rail('╰'), Some(WIDTH), "the frame's bottom rail");
 }
 
+/// The property an append-only surface streams on: as a turn runs, its frame
+/// only ever grows at the tail. Every line already produced stays byte-for-byte
+/// what it was, so a terminal that has printed the first N can print the rest
+/// without revisiting one — and therefore has no reason to invent a terser
+/// placeholder rendering to show in the meantime.
+///
+/// This is what makes [`grid::render_turn_lines`]'s contract enforceable rather
+/// than aspirational. It fails the moment anything that is unknown at the start
+/// of a turn moves back onto the top rail: `stella run` on a terminal used to
+/// print `· bash` per call for the whole turn and draw the real frame only at
+/// the end, precisely because the frame could not be started before it was
+/// finished.
+///
+/// The closing rail is excluded, and only the closing rail. It carries the two
+/// facts that do not exist until the turn is over — how it ended and what it
+/// spent — which is exactly why they live there.
+#[test]
+fn render_turn_is_append_only_as_a_turn_grows() {
+    const WIDTH: usize = 100;
+    let state = FoldState::new();
+
+    // The turn as it looks after `steps` calls have settled, still running.
+    let growing = |steps: usize| {
+        let mut run = run_with(
+            (0..steps)
+                .map(|i| {
+                    step(
+                        bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
+                        0,
+                    )
+                })
+                .collect(),
+        );
+        let turn = &mut run.turns[0];
+        turn.status = Status::Running;
+        turn.answer = None;
+        run
+    };
+
+    // Every line but the closing rail, which the streaming surface withholds
+    // until the turn ends for the reason in this test's doc comment.
+    let body = |run: &Run| -> Vec<String> {
+        let lines = grid::render_turn_lines(run, &state, 0, WIDTH);
+        lines[..lines.len() - 1]
+            .iter()
+            .map(|l| grid::to_plain(std::slice::from_ref(l)))
+            .collect()
+    };
+
+    let mut previous: Vec<String> = Vec::new();
+    for steps in 0..4 {
+        let next = body(&growing(steps));
+        assert!(
+            next.len() >= previous.len(),
+            "the frame shrank at {steps} steps: {} -> {}",
+            previous.len(),
+            next.len()
+        );
+        for (i, (was, now)) in previous.iter().zip(&next).enumerate() {
+            assert_eq!(
+                was, now,
+                "line {i} was rewritten when the turn reached {steps} steps — \
+                 a surface that had already printed it cannot take it back"
+            );
+        }
+        previous = next;
+    }
+
+    // Ending the turn — an answer arrives and the status settles — still only
+    // appends. Were the status on the top rail, this is the assertion that
+    // would catch `running` frozen into a finished turn's scrollback.
+    let finished = body(&run_with(
+        (0..3)
+            .map(|i| {
+                step(
+                    bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
+                    0,
+                )
+            })
+            .collect(),
+    ));
+    for (i, (was, now)) in previous.iter().zip(&finished).enumerate() {
+        assert_eq!(was, now, "line {i} was rewritten when the turn finished");
+    }
+    assert!(
+        finished.len() > previous.len(),
+        "the answer should have appended lines"
+    );
+}
+
+/// The closing rail is where a turn's outcome is read, on both renderers.
+///
+/// They are allowed to differ in medium — one draws a box rule, the other a
+/// `<div>` — but not in *which end of a turn* answers "how did it go, and what
+/// did it cost". A reader comparing `stella run`'s scrollback against
+/// `stella observe` for the same session must not find that question answered
+/// in two different places (#3764).
+#[test]
+fn both_renderers_close_a_turn_with_its_status_and_accounting() {
+    let run = run_with(vec![step(bash("cargo test", &["ok"], Status::Ok), 0)]);
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+
+    let lines = grid::render_turn_lines(&run, &state, 0, 100);
+    let closing = grid::to_plain(std::slice::from_ref(
+        lines.last().expect("a turn frame has a closing rail"),
+    ));
+    // `done` is `status_word(Status::Ok)`. Spelled out rather than derived so a
+    // change to the vocabulary makes a reader look at both renderers at once,
+    // which is the whole point of the test.
+    assert!(
+        closing.starts_with('╰') && closing.contains("done") && closing.contains('$'),
+        "the grid's closing rail lost the status or the cost: {closing:?}"
+    );
+
+    let markup = html::render_run(&run, &state);
+    let receipt = markup
+        .split("turnreceipt")
+        .nth(1)
+        .expect("an expanded turn closes with a receipt");
+    assert!(
+        receipt.contains("done") && receipt.contains("chip"),
+        "the html receipt lost the status or the chips: {receipt:?}"
+    );
+    // The summary must not also carry them, or an open turn states its cost
+    // twice and the two copies can disagree.
+    let summary = markup.split("</summary>").next().unwrap_or_default();
+    assert!(
+        !summary.contains("class=\"chips\""),
+        "an expanded turn put its chips on the summary as well as the receipt"
+    );
+}
+
 /// The step digest's chips are flush right, and a double-width object must not
 /// move them: the row occupies the grid's width either way.
 #[test]

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -10,6 +10,9 @@
 // a rendered shape, and a property wants room to state itself.
 mod json_reindent;
 
+// The turn frame, and the append-only property the plain surface streams on.
+mod frame;
+
 use crate::digest::{self, format_cost, format_duration, format_tokens};
 use crate::file_diff::{FileDiff, RowKind};
 use crate::fold::{Command, Cursor, FoldState, Zoom, apply};
@@ -1189,156 +1192,6 @@ fn double_width_text_keeps_every_row_inside_the_grid() {
         overruns.len(),
         lines.len(),
         overruns.join("\n")
-    );
-}
-
-/// The turn frame's two rails are one box: a top that reserves fewer cells for
-/// its `─╮` cap than it emits is two cells longer than the bottom it meets.
-#[test]
-fn the_turn_frame_rails_are_the_same_width() {
-    const WIDTH: usize = 100;
-    let run = run_with(vec![step(edit("src/lib.rs", "a\n", "b\n"), 1_000)]);
-    let lines = grid::render(&run, &FoldState::new(), WIDTH);
-    let rail = |corner: char| {
-        lines
-            .iter()
-            .find(|l| l.first().is_some_and(|c| c.text.starts_with(corner)))
-            .map(grid::line_width)
-    };
-    assert_eq!(rail('╭'), Some(WIDTH), "the frame's top rail");
-    assert_eq!(rail('╰'), Some(WIDTH), "the frame's bottom rail");
-}
-
-/// The property an append-only surface streams on: as a turn runs, its frame
-/// only ever grows at the tail. Every line already produced stays byte-for-byte
-/// what it was, so a terminal that has printed the first N can print the rest
-/// without revisiting one — and therefore has no reason to invent a terser
-/// placeholder rendering to show in the meantime.
-///
-/// This is what makes [`grid::render_turn_lines`]'s contract enforceable rather
-/// than aspirational. It fails the moment anything that is unknown at the start
-/// of a turn moves back onto the top rail: `stella run` on a terminal used to
-/// print `· bash` per call for the whole turn and draw the real frame only at
-/// the end, precisely because the frame could not be started before it was
-/// finished.
-///
-/// The closing rail is excluded, and only the closing rail. It carries the two
-/// facts that do not exist until the turn is over — how it ended and what it
-/// spent — which is exactly why they live there.
-#[test]
-fn render_turn_is_append_only_as_a_turn_grows() {
-    const WIDTH: usize = 100;
-    let state = FoldState::new();
-
-    // The turn as it looks after `steps` calls have settled, still running.
-    let growing = |steps: usize| {
-        let mut run = run_with(
-            (0..steps)
-                .map(|i| {
-                    step(
-                        bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
-                        0,
-                    )
-                })
-                .collect(),
-        );
-        let turn = &mut run.turns[0];
-        turn.status = Status::Running;
-        turn.answer = None;
-        run
-    };
-
-    // Every line but the closing rail, which the streaming surface withholds
-    // until the turn ends for the reason in this test's doc comment.
-    let body = |run: &Run| -> Vec<String> {
-        let lines = grid::render_turn_lines(run, &state, 0, WIDTH);
-        lines[..lines.len() - 1]
-            .iter()
-            .map(|l| grid::to_plain(std::slice::from_ref(l)))
-            .collect()
-    };
-
-    let mut previous: Vec<String> = Vec::new();
-    for steps in 0..4 {
-        let next = body(&growing(steps));
-        assert!(
-            next.len() >= previous.len(),
-            "the frame shrank at {steps} steps: {} -> {}",
-            previous.len(),
-            next.len()
-        );
-        for (i, (was, now)) in previous.iter().zip(&next).enumerate() {
-            assert_eq!(
-                was, now,
-                "line {i} was rewritten when the turn reached {steps} steps — \
-                 a surface that had already printed it cannot take it back"
-            );
-        }
-        previous = next;
-    }
-
-    // Ending the turn — an answer arrives and the status settles — still only
-    // appends. Were the status on the top rail, this is the assertion that
-    // would catch `running` frozen into a finished turn's scrollback.
-    let finished = body(&run_with(
-        (0..3)
-            .map(|i| {
-                step(
-                    bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
-                    0,
-                )
-            })
-            .collect(),
-    ));
-    for (i, (was, now)) in previous.iter().zip(&finished).enumerate() {
-        assert_eq!(was, now, "line {i} was rewritten when the turn finished");
-    }
-    assert!(
-        finished.len() > previous.len(),
-        "the answer should have appended lines"
-    );
-}
-
-/// The closing rail is where a turn's outcome is read, on both renderers.
-///
-/// They are allowed to differ in medium — one draws a box rule, the other a
-/// `<div>` — but not in *which end of a turn* answers "how did it go, and what
-/// did it cost". A reader comparing `stella run`'s scrollback against
-/// `stella observe` for the same session must not find that question answered
-/// in two different places (#3764).
-#[test]
-fn both_renderers_close_a_turn_with_its_status_and_accounting() {
-    let run = run_with(vec![step(bash("cargo test", &["ok"], Status::Ok), 0)]);
-    let mut state = FoldState::new();
-    state.set_zoom(Zoom::Everything);
-
-    let lines = grid::render_turn_lines(&run, &state, 0, 100);
-    let closing = grid::to_plain(std::slice::from_ref(
-        lines.last().expect("a turn frame has a closing rail"),
-    ));
-    // `done` is `status_word(Status::Ok)`. Spelled out rather than derived so a
-    // change to the vocabulary makes a reader look at both renderers at once,
-    // which is the whole point of the test.
-    assert!(
-        closing.starts_with('╰') && closing.contains("done") && closing.contains('$'),
-        "the grid's closing rail lost the status or the cost: {closing:?}"
-    );
-
-    let markup = html::render_run(&run, &state);
-    let receipt = markup
-        .split("turnreceipt")
-        .nth(1)
-        .expect("an expanded turn closes with a receipt");
-    assert!(
-        receipt.contains("done") && receipt.contains("chip"),
-        "the html receipt lost the status or the chips: {receipt:?}"
-    );
-    // The summary must not also carry them, or an open turn states its cost
-    // twice and the two copies can disagree.
-    let summary = markup.split("</summary>").next().unwrap_or_default();
-    assert!(
-        !summary.contains("class=\"chips\""),
-        "an expanded turn put its chips on the summary as well as the receipt"
     );
 }
 

--- a/crates/stella-transcript/src/tests/frame.rs
+++ b/crates/stella-transcript/src/tests/frame.rs
@@ -1,0 +1,158 @@
+//! The turn frame: its rails, and the streaming contract they make possible.
+//!
+//! Split out of the parent module for the 1500-line ceiling, and along this
+//! seam because these three hold one property between them — a turn frame that
+//! can be written a line at a time, closing with the two facts that do not
+//! exist until it ends.
+
+use super::*;
+
+/// The turn frame's two rails are one box: a top that reserves fewer cells for
+/// its `─╮` cap than it emits is two cells longer than the bottom it meets.
+#[test]
+fn the_turn_frame_rails_are_the_same_width() {
+    const WIDTH: usize = 100;
+    let run = run_with(vec![step(edit("src/lib.rs", "a\n", "b\n"), 1_000)]);
+    let lines = grid::render(&run, &FoldState::new(), WIDTH);
+    let rail = |corner: char| {
+        lines
+            .iter()
+            .find(|l| l.first().is_some_and(|c| c.text.starts_with(corner)))
+            .map(grid::line_width)
+    };
+    assert_eq!(rail('╭'), Some(WIDTH), "the frame's top rail");
+    assert_eq!(rail('╰'), Some(WIDTH), "the frame's bottom rail");
+}
+
+/// The property an append-only surface streams on: as a turn runs, its frame
+/// only ever grows at the tail. Every line already produced stays byte-for-byte
+/// what it was, so a terminal that has printed the first N can print the rest
+/// without revisiting one — and therefore has no reason to invent a terser
+/// placeholder rendering to show in the meantime.
+///
+/// This is what makes [`grid::render_turn_lines`]'s contract enforceable rather
+/// than aspirational. It fails the moment anything that is unknown at the start
+/// of a turn moves back onto the top rail: `stella run` on a terminal used to
+/// print `· bash` per call for the whole turn and draw the real frame only at
+/// the end, precisely because the frame could not be started before it was
+/// finished.
+///
+/// The closing rail is excluded, and only the closing rail. It carries the two
+/// facts that do not exist until the turn is over — how it ended and what it
+/// spent — which is exactly why they live there.
+#[test]
+fn render_turn_is_append_only_as_a_turn_grows() {
+    const WIDTH: usize = 100;
+    let state = FoldState::new();
+
+    // The turn as it looks after `steps` calls have settled, still running.
+    let growing = |steps: usize| {
+        let mut run = run_with(
+            (0..steps)
+                .map(|i| {
+                    step(
+                        bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
+                        0,
+                    )
+                })
+                .collect(),
+        );
+        let turn = &mut run.turns[0];
+        turn.status = Status::Running;
+        turn.answer = None;
+        run
+    };
+
+    // Every line but the closing rail, which the streaming surface withholds
+    // until the turn ends for the reason in this test's doc comment.
+    let body = |run: &Run| -> Vec<String> {
+        let lines = grid::render_turn_lines(run, &state, 0, WIDTH);
+        lines[..lines.len() - 1]
+            .iter()
+            .map(|l| grid::to_plain(std::slice::from_ref(l)))
+            .collect()
+    };
+
+    let mut previous: Vec<String> = Vec::new();
+    for steps in 0..4 {
+        let next = body(&growing(steps));
+        assert!(
+            next.len() >= previous.len(),
+            "the frame shrank at {steps} steps: {} -> {}",
+            previous.len(),
+            next.len()
+        );
+        for (i, (was, now)) in previous.iter().zip(&next).enumerate() {
+            assert_eq!(
+                was, now,
+                "line {i} was rewritten when the turn reached {steps} steps — \
+                 a surface that had already printed it cannot take it back"
+            );
+        }
+        previous = next;
+    }
+
+    // Ending the turn — an answer arrives and the status settles — still only
+    // appends. Were the status on the top rail, this is the assertion that
+    // would catch `running` frozen into a finished turn's scrollback.
+    let finished = body(&run_with(
+        (0..3)
+            .map(|i| {
+                step(
+                    bash(&format!("cargo test -p crate-{i}"), &["ok"], Status::Ok),
+                    0,
+                )
+            })
+            .collect(),
+    ));
+    for (i, (was, now)) in previous.iter().zip(&finished).enumerate() {
+        assert_eq!(was, now, "line {i} was rewritten when the turn finished");
+    }
+    assert!(
+        finished.len() > previous.len(),
+        "the answer should have appended lines"
+    );
+}
+
+/// The closing rail is where a turn's outcome is read, on both renderers.
+///
+/// They are allowed to differ in medium — one draws a box rule, the other a
+/// `<div>` — but not in *which end of a turn* answers "how did it go, and what
+/// did it cost". A reader comparing `stella run`'s scrollback against
+/// `stella observe` for the same session must not find that question answered
+/// in two different places (#3764).
+#[test]
+fn both_renderers_close_a_turn_with_its_status_and_accounting() {
+    let run = run_with(vec![step(bash("cargo test", &["ok"], Status::Ok), 0)]);
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+
+    let lines = grid::render_turn_lines(&run, &state, 0, 100);
+    let closing = grid::to_plain(std::slice::from_ref(
+        lines.last().expect("a turn frame has a closing rail"),
+    ));
+    // `done` is `status_word(Status::Ok)`. Spelled out rather than derived so a
+    // change to the vocabulary makes a reader look at both renderers at once,
+    // which is the whole point of the test.
+    assert!(
+        closing.starts_with('╰') && closing.contains("done") && closing.contains('$'),
+        "the grid's closing rail lost the status or the cost: {closing:?}"
+    );
+
+    let markup = html::render_run(&run, &state);
+    let receipt = markup
+        .split("turnreceipt")
+        .nth(1)
+        .expect("an expanded turn closes with a receipt");
+    assert!(
+        receipt.contains("done") && receipt.contains("chip"),
+        "the html receipt lost the status or the chips: {receipt:?}"
+    );
+    // The summary must not also carry them, or an open turn states its cost
+    // twice and the two copies can disagree.
+    let summary = markup.split("</summary>").next().unwrap_or_default();
+    assert!(
+        !summary.contains("class=\"chips\""),
+        "an expanded turn put its chips on the summary as well as the receipt"
+    );
+}

--- a/crates/stella-tui/src/transcript_build.rs
+++ b/crates/stella-tui/src/transcript_build.rs
@@ -175,6 +175,51 @@ impl RunBuilder {
         run
     }
 
+    /// Whether a turn is currently accumulating.
+    #[must_use]
+    pub fn is_turn_open(&self) -> bool {
+        self.turn.is_some()
+    }
+
+    /// The run so far, cut back to the part that **cannot change again**.
+    ///
+    /// [`Self::snapshot`] is for a surface that repaints — the deck redraws
+    /// every frame, so a row that is still moving is fine there. An
+    /// append-only surface cannot take a line back once it has written it, so
+    /// it needs the other question answered: what is finished?
+    ///
+    /// Three things are excluded, and each is excluded because it is still
+    /// being written:
+    ///
+    /// - **In-flight calls.** A step's row gains its duration, its output fold
+    ///   and its cost chips when the result arrives, so a row emitted at
+    ///   dispatch would have to be rewritten. `snapshot` shows them as
+    ///   `Running` on purpose; here they are simply not yet part of the turn.
+    /// - **The reasoning block at the frontier.** [`Self::push`] appends
+    ///   `Reasoning` deltas into the block belonging to the current step
+    ///   count, so that one block grows a token at a time. Every earlier block
+    ///   is closed by definition: once a step lands, nothing can append to the
+    ///   prose before it.
+    /// - **The answer.** It streams as `TextDelta` previews that the
+    ///   consolidated `Text` event then *replaces* rather than extends (see
+    ///   `AgentEvent::Text`'s contract), so no prefix of it is safe to commit.
+    ///
+    /// Notes are kept. A note is complete when it is created, and a trailing
+    /// note keeps its position when the frontier advances past it — it renders
+    /// after the same steps either way.
+    #[must_use]
+    pub fn settled(&self) -> Run {
+        let mut run = self.run.clone();
+        if let Some(turn) = &self.turn {
+            let mut turn = turn.clone();
+            let frontier = turn.steps.len();
+            turn.prose.retain(|p| p.before_step < frontier);
+            turn.answer = None;
+            run.turns.push(turn);
+        }
+        run
+    }
+
     /// Close the open turn, if any.
     pub fn finish_turn(&mut self, status: Status) {
         let Some(mut turn) = self.turn.take() else {

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -97,7 +97,8 @@ number_word() {
   23) echo twenty-three ;; 24) echo twenty-four ;; 25) echo twenty-five ;;
   26) echo twenty-six ;; 27) echo twenty-seven ;; 28) echo twenty-eight ;;
   29) echo twenty-nine ;; 30) echo thirty ;; 31) echo thirty-one ;;
-  32) echo thirty-two ;;
+  32) echo thirty-two ;; 33) echo thirty-three ;; 34) echo thirty-four ;;
+  35) echo thirty-five ;; 36) echo thirty-six ;;
   *) echo "" ;;
   esac
 }
@@ -117,12 +118,13 @@ fi
 contributing_alias() {
   case "$1" in
   shellcheck) echo 'shellcheck ' ;;
-  # Five Python guards, so the `.sh` default below does not fit them.
+  # Six Python guards, so the `.sh` default below does not fit them.
   doc-links) echo 'check-doc-links' ;;
   module-reachability) echo 'check-module-reachability' ;;
   typed-errors) echo 'check-typed-errors' ;;
   dead-code-allows) echo 'check-dead-code-allows' ;;
   tokens) echo 'check-tokens' ;;
+  transcript-surfaces) echo 'check-transcript-surfaces' ;;
   doc-warnings) echo 'cargo doc' ;;
   format-check) echo 'cargo fmt' ;;
   lint) echo 'cargo clippy' ;;

--- a/scripts/check-transcript-surfaces.py
+++ b/scripts/check-transcript-surfaces.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Guard: every transcript surface declares whether it renders through the
+shared renderer, and the declaration is checked against the tree.
+
+`crates/stella-transcript` was extracted so that one session transcript would
+render the same way everywhere (#3764). Extracting it proved nothing on its
+own, and that gap is not hypothetical — #3578 ("render the Command Deck's
+session view through stella-transcript") was closed as *completed* twice while
+`grid::render` had zero callers inside `stella-tui`, and the second close was a
+manual one with no commit attached. Nothing in the gate could tell "the shared
+crate exists and two surfaces use it" from "every surface renders the same",
+because both look identical from the outside: the crate builds, its own tests
+pass, and the surfaces that never adopted it are simply absent from the
+evidence.
+
+So the fact this guard checks is *adoption*, and it checks it from both sides,
+the same shape `stella-model`'s provider-parity matrix and
+`stella-protocol`'s event-consumer ledger use:
+
+  - a `SHARED` row names a file that must really reference the shared entry
+    point, so a surface silently regressing to its own painter goes red;
+  - an `OWN` row names a file that must NOT reference it and must cite the
+    issue where the gap is being decided, so a divergence is a declared,
+    tracked gap rather than a silence nobody noticed;
+  - the caller sets must match **exactly**, so a new surface cannot wire
+    itself in without declaring itself, and a row cannot go stale in either
+    direction;
+  - every crate that depends on `stella-transcript` must own at least one row,
+    so a new consumer crate cannot appear undeclared.
+
+An `OWN` row is not permission. It is a debt with an address on it. The
+`Done when` of each cited issue is written as "…and this row reads SHARED".
+
+── Deliberately not checked ─────────────────────────────────────────────────
+
+Whether the *output* of two SHARED surfaces actually looks the same. That is a
+rendering property and belongs in a test that renders one fixture through both
+paths (each cited issue names the one it needs). This guard answers the
+narrower question that kept being answered wrongly: does this surface call the
+shared renderer at all.
+
+Aliased imports (`use stella_transcript::grid::render;` then a bare `render()`)
+are not recognised. Both shipping callers qualify the path, which is the
+neighbourhood idiom; a surface that stops qualifying will fail this guard and
+should re-qualify rather than teach the guard to parse Rust.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# The crate that *defines* the renderers. Its own tests and examples are not
+# surfaces, so nothing under it counts as a caller.
+RENDERER_CRATE = "crates/stella-transcript/"
+
+# The shared entry points a surface is expected to draw through.
+GRID = "stella_transcript::grid::render"
+HTML = "stella_transcript::html::render_page"
+
+# What a reference to each entry point looks like in source, once comments are
+# stripped. The `use stella_transcript::grid;` form means a call site reads
+# `grid::render(...)`, so the crate-qualified prefix cannot be required.
+PATTERNS = {
+    GRID: re.compile(r"\bgrid::render\s*\("),
+    HTML: re.compile(r"\bhtml::render_page\s*\("),
+}
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One place in this workspace that draws a session transcript."""
+
+    ident: str
+    path: str
+    entry: str
+    shared: bool
+    #: The issue deciding the gap. Required for an OWN row, forbidden on SHARED.
+    issue: int | None
+    note: str
+
+
+# ── The ledger ───────────────────────────────────────────────────────────────
+#
+# One row per surface that renders a session transcript to a human. Adding a
+# surface means adding a row; there is no default.
+SURFACES: list[Surface] = [
+    Surface(
+        ident="plain",
+        path="crates/stella-cli/src/plain/transcript.rs",
+        entry=GRID,
+        shared=True,
+        issue=None,
+        note="`stella run` on a terminal and the bytes a daemon child writes "
+        "to its console file are the same code path.",
+    ),
+    Surface(
+        ident="observatory",
+        path="crates/stella-observatory/src/lib.rs",
+        entry=HTML,
+        shared=True,
+        issue=None,
+        note="`stella observe` -> /transcript?id=N.",
+    ),
+    Surface(
+        ident="deck-v1",
+        path="crates/stella-tui/src/render/entry.rs",
+        entry=GRID,
+        shared=False,
+        issue=3578,
+        note="The Command Deck's session view. Paints from its own "
+        "`TranscriptEntry` (28 variants) through `render/entry.rs`, "
+        "`render/row.rs` and `diff.rs`; takes only `syntax::body_paint` and "
+        "`tabs::expand` from the shared crate.",
+    ),
+    Surface(
+        ident="deck-v2",
+        path="crates/stella-tui/src/v2/transcript.rs",
+        entry=GRID,
+        shared=False,
+        issue=4271,
+        note="The v2 deck's SPEC 6 frame. Whether SPEC 6 or `grid.rs` is the "
+        "one frame is an open design decision, not a wiring task.",
+    ),
+    Surface(
+        ident="export-html",
+        path="crates/stella-cli/src/export/transcript.rs",
+        entry=HTML,
+        shared=False,
+        issue=4270,
+        note="The `/export` archive's readable half. Folds "
+        "`Store::session_events` itself and emits its own HTML; carries the "
+        "#817 redaction pass the shared renderer cannot host.",
+    ),
+]
+
+# Surfaces outside the Rust workspace, tracked here so the ledger is the whole
+# answer to "how many ways does this repository draw a transcript". Not
+# mechanically checked against an entry point — they have no Rust to reference
+# one — but the file must exist, so retiring the port makes this row fail.
+FOREIGN: list[tuple[str, str, int, str]] = [
+    (
+        "arenabench",
+        "arenabench/ui/components/arena/transcript-page.tsx",
+        3814,
+        "A hand-maintained TypeScript port of the Rust renderer.",
+    ),
+]
+
+
+def production_sources(repo: Path = REPO) -> list[Path]:
+    """Every tracked Rust file that ships, excluding tests and examples."""
+    out = subprocess.run(
+        ["git", "ls-files", "*.rs"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    keep = []
+    for rel in out:
+        if rel.startswith(RENDERER_CRATE):
+            continue
+        parts = Path(rel).parts
+        if "tests" in parts or "examples" in parts or "benches" in parts:
+            continue
+        if Path(rel).name == "tests.rs":
+            continue
+        keep.append(Path(rel))
+    return keep
+
+
+LINE_COMMENT = re.compile(r"//.*$", re.MULTILINE)
+
+
+def references(path: Path, entry: str, repo: Path = REPO) -> bool:
+    """Whether `path` calls `entry`, ignoring anything inside a line comment.
+
+    Comments are stripped because a doc comment naming the renderer is prose,
+    not adoption — `plain/transcript.rs` explains the renderer in its header
+    and calls it in its body, and only the second one is the fact this guard
+    is about.
+    """
+    try:
+        text = (repo / path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(PATTERNS[entry].search(LINE_COMMENT.sub("", text)))
+
+
+def dependent_crates(repo: Path = REPO) -> set[str]:
+    """Crate directories whose manifest depends on `stella-transcript`."""
+    out = subprocess.run(
+        ["git", "ls-files", "*/Cargo.toml"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    deps = set()
+    for rel in out:
+        if rel.startswith(RENDERER_CRATE):
+            continue
+        text = (repo / rel).read_text(encoding="utf-8", errors="replace")
+        if re.search(r"^stella-transcript\b", text, re.MULTILINE):
+            deps.add(str(Path(rel).parent) + "/")
+    return deps
+
+
+def check(
+    repo: Path = REPO,
+    surfaces: list[Surface] | None = None,
+    foreign: list[tuple[str, str, int, str]] | None = None,
+) -> list[str]:
+    """Every disagreement between the ledger and the tree, as prose.
+
+    Parameterised on the tree and the ledger so `scripts/test-transcript-surfaces.py`
+    can drive it against synthetic ones. A guard whose failure directions are
+    never exercised is a guard nobody has evidence about — which is the same
+    mistake, one level up, that this whole file is here to stop repeating.
+    """
+    surfaces = SURFACES if surfaces is None else surfaces
+    foreign = FOREIGN if foreign is None else foreign
+    problems: list[str] = []
+
+    # 1. Each row's own claim.
+    for s in surfaces:
+        exists = (repo / s.path).exists()
+        if not exists:
+            problems.append(
+                f"{s.ident}: {s.path} does not exist. A surface was moved or "
+                f"retired without updating this ledger."
+            )
+            continue
+        calls = references(Path(s.path), s.entry, repo)
+        if s.shared and not calls:
+            problems.append(
+                f"{s.ident}: declared SHARED but {s.path} does not call "
+                f"{s.entry}. Either the surface regressed to its own painter "
+                f"— fix that, it is the whole point — or the call moved to "
+                f"another file and this row must name it."
+            )
+        if not s.shared and calls:
+            problems.append(
+                f"{s.ident}: declared OWN (#{s.issue}) but {s.path} now calls "
+                f"{s.entry}. If the surface was migrated, flip this row to "
+                f"SHARED, drop the issue, and close #{s.issue}."
+            )
+        if s.shared and s.issue is not None:
+            problems.append(
+                f"{s.ident}: SHARED rows carry no issue; #{s.issue} is either "
+                f"stale or this row should be OWN."
+            )
+        if not s.shared and s.issue is None:
+            problems.append(
+                f"{s.ident}: OWN rows must cite the issue deciding the gap. "
+                f"A divergence with no address is the silence this guard exists "
+                f"to prevent."
+            )
+
+    # 2. Totality: no undeclared caller. The other direction — a SHARED row
+    # whose file does not call the entry point — is rule 1's job, so it is not
+    # restated here; a doubled message reads as two defects.
+    sources = production_sources(repo)
+    for entry in (GRID, HTML):
+        found = {str(p) for p in sources if references(p, entry, repo)}
+        declared = {s.path for s in surfaces if s.entry == entry and s.shared}
+        for extra in sorted(found - declared):
+            problems.append(
+                f"{extra} calls {entry} but declares no row. Add it to "
+                f"SURFACES as SHARED — a transcript surface that nothing "
+                f"declares is one nothing can hold to the charter."
+            )
+
+    # 3. No undeclared consumer crate.
+    owners = {s.path for s in surfaces}
+    for crate in sorted(dependent_crates(repo)):
+        if not any(path.startswith(crate) for path in owners):
+            problems.append(
+                f"{crate} depends on stella-transcript but owns no row in "
+                f"SURFACES. Declare what it draws and how."
+            )
+
+    # 4. Foreign ports still exist where the ledger says.
+    for ident, path, issue, _note in foreign:
+        if not (repo / path).exists():
+            problems.append(
+                f"{ident}: {path} is gone. If the port was retired, drop the "
+                f"row and close #{issue}."
+            )
+
+    return problems
+
+
+def main() -> int:
+    problems = check()
+    if problems:
+        print("transcript-surfaces: the ledger and the tree disagree.\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "\nThe ledger is scripts/check-transcript-surfaces.py; the charter "
+            "it enforces is crates/stella-transcript/src/lib.rs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    shared = sum(1 for s in SURFACES if s.shared)
+    own = len(SURFACES) - shared
+    print(
+        f"transcript-surfaces: {shared} shared, {own} declared gaps, "
+        f"{len(FOREIGN)} foreign port(s) — ledger matches the tree."
+    )
+    for s in SURFACES:
+        if not s.shared:
+            print(f"    gap: {s.ident} -> #{s.issue} ({s.path})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-transcript-surfaces.py
+++ b/scripts/check-transcript-surfaces.py
@@ -60,14 +60,20 @@ REPO = Path(__file__).resolve().parent.parent
 RENDERER_CRATE = "crates/stella-transcript/"
 
 # The shared entry points a surface is expected to draw through.
-GRID = "stella_transcript::grid::render"
+GRID = "stella_transcript::grid::render{,_turn_lines}"
 HTML = "stella_transcript::html::render_page"
 
 # What a reference to each entry point looks like in source, once comments are
 # stripped. The `use stella_transcript::grid;` form means a call site reads
 # `grid::render(...)`, so the crate-qualified prefix cannot be required.
+#
+# `render` and `render_turn_lines` both count, because both are the shared
+# painter: the first draws a finished run, the second one turn of a run that is
+# still going. A live surface has to use the second — an append-only one cannot
+# redraw a whole run per event — and refusing to count it would have read a
+# surface's move *onto* the streaming API as a regression away from sharing.
 PATTERNS = {
-    GRID: re.compile(r"\bgrid::render\s*\("),
+    GRID: re.compile(r"\bgrid::render(_turn_lines)?\s*\("),
     HTML: re.compile(r"\bhtml::render_page\s*\("),
 }
 

--- a/scripts/test-transcript-surfaces.py
+++ b/scripts/test-transcript-surfaces.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Directions `scripts/check-transcript-surfaces.py` must fail in.
+
+A guard is only worth its place in the gate if its failures are demonstrated.
+This one exists because a claim ("every surface renders the same") was believed
+without being checked, so shipping it unexercised would repeat the mistake at
+one remove: a green `make transcript-surfaces` would prove the ledger is
+*self-consistent*, not that the guard can tell a true ledger from a false one.
+
+Each case below builds a synthetic tree, drives `check()` against it, and
+asserts on the message — hermetic, no network, no cargo. Not part of `make
+gate`; run it with `make transcript-surfaces-test`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location(
+    "check_transcript_surfaces", HERE / "check-transcript-surfaces.py"
+)
+assert spec and spec.loader
+guard = importlib.util.module_from_spec(spec)
+# Registered before execution: `@dataclass` resolves the defining module out of
+# `sys.modules`, so a module loaded by path alone raises while processing its
+# own class definitions.
+sys.modules[spec.name] = guard
+spec.loader.exec_module(guard)
+
+Surface = guard.Surface
+GRID = guard.GRID
+HTML = guard.HTML
+
+FAILURES: list[str] = []
+
+
+def scenario(name: str):
+    """Register a case; a raised AssertionError is recorded, not fatal."""
+
+    def wrap(fn):
+        try:
+            fn()
+            print(f"  ok   {name}")
+        except AssertionError as exc:
+            FAILURES.append(f"{name}: {exc}")
+            print(f"  FAIL {name}: {exc}")
+        return fn
+
+    return wrap
+
+
+def tree(files: dict[str, str]) -> Path:
+    """A git-tracked synthetic workspace holding exactly `files`."""
+    root = Path(tempfile.mkdtemp(prefix="transcript-surfaces-"))
+    for rel, body in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    return root
+
+
+CALLS_GRID = "fn draw() { let _ = grid::render(&run, &state, 100); }\n"
+NO_CALL = "fn draw() { self.paint_my_own_way(); }\n"
+MENTIONS_ONLY = "//! See [`stella_transcript::grid::render`].\nfn draw() { mine(); }\n"
+
+
+def only(problems: list[str], needle: str) -> None:
+    assert any(needle in p for p in problems), f"expected {needle!r} in {problems}"
+
+
+@scenario("a SHARED row whose file stopped calling the renderer fails")
+def _():
+    root = tree({"a/src/lib.rs": NO_CALL})
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, None, "")]
+    problems = guard.check(root, rows, [])
+    only(problems, "declared SHARED but")
+
+
+@scenario("a SHARED row whose file does call the renderer passes")
+def _():
+    root = tree({"a/src/lib.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, None, "")]
+    assert guard.check(root, rows, []) == [], "a correct ledger must be silent"
+
+
+@scenario("an OWN row that quietly adopted the renderer fails, naming its issue")
+def _():
+    root = tree({"a/src/lib.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, False, 1234, "")]
+    problems = guard.check(root, rows, [])
+    only(problems, "declared OWN (#1234) but")
+    only(problems, "close #1234")
+
+
+@scenario("an OWN row with no issue fails — a gap must have an address")
+def _():
+    root = tree({"a/src/lib.rs": NO_CALL})
+    rows = [Surface("a", "a/src/lib.rs", GRID, False, None, "")]
+    only(guard.check(root, rows, []), "must cite the issue")
+
+
+@scenario("a SHARED row carrying a stale issue fails")
+def _():
+    root = tree({"a/src/lib.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, 99, "")]
+    only(guard.check(root, rows, []), "SHARED rows carry no issue")
+
+
+@scenario("an undeclared file that calls the renderer fails")
+def _():
+    root = tree({"a/src/lib.rs": CALLS_GRID, "b/src/lib.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, None, "")]
+    only(guard.check(root, rows, []), "b/src/lib.rs calls")
+
+
+@scenario("a doc comment naming the renderer is prose, not adoption")
+def _():
+    root = tree({"a/src/lib.rs": MENTIONS_ONLY})
+    rows = [Surface("a", "a/src/lib.rs", GRID, False, 1234, "")]
+    assert guard.check(root, rows, []) == [], "a doc mention must not read as a call"
+
+
+@scenario("a test file that calls the renderer is not a surface")
+def _():
+    root = tree({"a/src/lib.rs": NO_CALL, "a/src/tests.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, False, 1234, "")]
+    assert guard.check(root, rows, []) == [], "tests.rs must not count as a caller"
+
+
+@scenario("a moved or deleted surface file fails")
+def _():
+    root = tree({"a/src/lib.rs": NO_CALL})
+    rows = [Surface("a", "a/src/gone.rs", GRID, True, None, "")]
+    only(guard.check(root, rows, []), "does not exist")
+
+
+@scenario("a crate depending on stella-transcript with no row fails")
+def _():
+    root = tree(
+        {
+            "a/src/lib.rs": CALLS_GRID,
+            "a/Cargo.toml": "[dependencies]\n",
+            "c/Cargo.toml": "[dependencies]\nstella-transcript.workspace = true\n",
+            "c/src/lib.rs": NO_CALL,
+        }
+    )
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, None, "")]
+    only(guard.check(root, rows, []), "owns no row")
+
+
+@scenario("a retired foreign port fails rather than passing silently")
+def _():
+    root = tree({"a/src/lib.rs": CALLS_GRID})
+    rows = [Surface("a", "a/src/lib.rs", GRID, True, None, "")]
+    problems = guard.check(root, rows, [("port", "ui/port.tsx", 777, "")])
+    only(problems, "is gone")
+
+
+@scenario("the html entry point is checked on the same terms as the grid one")
+def _():
+    root = tree({"a/src/lib.rs": "fn p() { html::render_page(&run, &state) }\n"})
+    rows = [Surface("a", "a/src/lib.rs", HTML, False, 1234, "")]
+    only(guard.check(root, rows, []), "declared OWN (#1234) but")
+
+
+if FAILURES:
+    print(f"\n{len(FAILURES)} scenario(s) failed", file=sys.stderr)
+    sys.exit(1)
+print("\ntranscript-surfaces guard: every failure direction demonstrated")


### PR DESCRIPTION
## Why

`stella run` on a terminal printed `  · bash` per tool call for the whole turn and drew the real frame only at `TurnComplete`. The same code writing to a daemon's console file printed the frame and no placeholder. So the foreground and background of one command looked like different products, and the worse one was on the surface a human was actually watching.

That is the visible half. The larger finding is that `stella-transcript` was extracted to end exactly this drift and **two of five surfaces adopted it**:

| Surface | Painter | |
|---|---|---|
| `stella run` / plain | `stella_transcript::grid` | shared |
| Observatory (`stella observe`) | `stella_transcript::html` | shared |
| Command Deck v1 (`render/entry.rs`, `render/row.rs`, `diff.rs`) | its own | #3578 |
| Command Deck v2 (`v2/transcript.rs`, SPEC 6) | its own | #4271 |
| `stella export` HTML (`export/transcript.rs`) | its own | #4270 |

Before this PR, `grid::render` had **exactly one** production caller in the whole workspace and `html::render_page` had exactly one. Every other reference was `stella-transcript`'s own tests or its example. `crates/stella-tui/src/transcript_build.rs` — the `AgentEvent` → `Run` fold written *for* #3578 — had no in-crate consumer at all.

#3578 was nonetheless closed as `completed` **twice** while none of its three "done when" conditions held; the second close was manual, with no commit attached. Nothing in the gate could distinguish "the shared crate exists" from "every surface renders the same", because both look identical from outside: the crate builds and its own tests pass. That is the gap this PR closes first.

## What changed

**1. A gate step that makes adoption checkable** — `make transcript-surfaces` (`scripts/check-transcript-surfaces.py`), in the shape of `provider_parity.rs` and the event-consumer ledger. One row per surface; a `SHARED` row must really reference the entry point, an `OWN` row must cite the issue deciding it, the caller sets must match **exactly** in both directions, and no crate may depend on `stella-transcript` without owning a row. `scripts/test-transcript-surfaces.py` (`make transcript-surfaces-test`, hermetic) demonstrates all twelve failure directions — a guard whose failures are never exercised only proves the ledger is self-consistent.

It earned its place immediately: it caught this PR's own plain surface when the call moved from `grid::render` to `grid::render_turn_lines`.

**2. The turn frame became streamable.** The blocker was structural: `grid`'s frame put the turn's status and accounting on its *top* rail, and neither exists when the turn opens, so an append-only surface could not begin the frame before it was finished — hence the placeholder. Both facts move to the closing rail, where they are knowable. `grid::render_turn_lines` states the contract: every line is final when produced, the sequence only grows at the tail.

**3. The plain surface has one rendering.** `RunBuilder::settled` decides what is safe to commit: a call reaches scrollback when its **result** does, not when it dispatches, because the row carries its duration, output fold and cost. The `is_terminal` branch is deleted, so a terminal and a log file get the same bytes by construction rather than by intention.

**4. `html` follows onto the same closing receipt**, so a reader comparing `stella run`'s scrollback with `stella observe` does not find "how did it go, what did it cost" answered at opposite ends of a turn. A collapsed `<details>` keeps its chips on the summary — it renders nothing else.

## Two bugs found on the way

- **The erase was unbounded.** `\x1b[{n}A` with `n` = the number of progress rows, no clamp to terminal height. A turn with more tool calls than the terminal had rows walked the cursor off the top of the screen and cleared whatever was there. Gone with the placeholder.
- **The frame was drawn at whatever `COLUMNS` said at that moment**, so a terminal resized mid-turn wrote mismatched rails into scrollback that can never be redrawn. The width is measured once per printer. Found by the streaming witness failing on a rail two dozen cells too long.

## Witnesses

`render_turn_is_append_only_as_a_turn_grows` is the load-bearing one. Checked the artisanal way — restoring status+chips to the top rail and re-running:

```
assertion `left == right` failed: line 0 was rewritten when the turn reached 1 steps
  left:  "╭─ fix-overfull … running ───────────────────────── [0 steps] [0:41] ─╮"
  right: "╭─ fix-overfull … running ───── [1 steps] [0:41] [7.0k→34] [$0.0008] ─╮"
```

That is precisely why the frame could not be streamed before.

Also `what_scrolls_past_during_the_turn_is_the_transcript_that_remains` (streamed bytes == finished frame, exactly), `no_progress_placeholder_is_ever_written`, `the_same_bytes_reach_a_terminal_and_a_log_file` (structural — nothing in the module may read `is_terminal`), `a_call_reaches_scrollback_only_once_it_has_settled`, `the_closing_rail_arrives_only_with_the_turn_it_closes`, `the_width_is_clamped_and_then_fixed_for_the_whole_turn`, and `both_renderers_close_a_turn_with_its_status_and_accounting`.

**No test was deleted.** `a_non_interactive_surface_prints_no_progress_rows` and `width_is_clamped_at_both_ends` are **renamed and widened**, not removed: the first asserted a mode split this PR deletes, and is now `the_same_bytes_reach_a_terminal_and_a_log_file`; the second absorbed the resize case as `the_width_is_clamped_and_then_fixed_for_the_whole_turn`, because both halves mutate `COLUMNS` and split across parallel test threads they read each other's fixture — which is how the streaming witness first failed.

`crates/stella-transcript/src/tests.rs` crossed 1500 lines, so the frame tests were **split** into `tests/frame.rs`. No baseline entry was added and no ceiling was raised.

## Verified

`cargo test -p stella-transcript` (88 + 2), `cargo test -p stella-cli plain::transcript` (11), `cargo test -p stella-observatory`, `cargo test -p stella-cli --test design_token_parity` (11), clippy `-D warnings` on all four touched crates, `make doc-warnings` on the three I own, `make guards-fast`, `make tokens`, `make wire-schema`, `make lockfile-sync`, `make tool-docs`, `make gate-parity` (33 steps), `cargo fmt --check`.

## Not verified, and why

`cargo test -p stella-tui` and `make doc-warnings` for `stella-tui` are **red on `main` already**, in `crates/stella-tui/src/diff.rs`, which this PR does not touch (`git diff origin/main -- crates/stella-tui/` is 45 added lines in `transcript_build.rs` and nothing else). Confirmed on a pristine detached `origin/main` at 069e62d37, not inferred: 5 test failures, two of them index-out-of-bounds panics, plus a private-intra-doc-link error. Filed as #4277 with the evidence; related to #4259 / #4268.

## What this does not fix

Three of five surfaces still paint their own transcript. Each is now a declared row with an issue, and the gate will not let one be quietly closed:

- **#3578** (deck v1) — reopened, with the second false close documented. Not a call swap: 28 `TranscriptEntry` variants against a model expressing ~7, plus a fold/scroll engine `grid::render`'s whole-run redraw does not have.
- **#4271** (deck v2) — a design decision before a refactor: whether SPEC 6 or `grid.rs` is the one frame.
- **#4270** (`stella export` HTML) — blocked on where #817's redaction pass lives, since `stella-transcript` cannot depend on `stella-core`.

Refs #3764, #3578, #4270, #4271, #4277

## Summary by Sourcery

Make transcript rendering consistent across plain output and shared surfaces while adding a gate that tracks renderer adoption.

New Features:
- Add a transcript-surface adoption gate and hermetic tests to verify shared-renderer usage is declared and tracked across production surfaces.
- Stream plain transcript frames incrementally as settled turn content becomes immutable, using the same output for terminals and log files.
- Expose a per-turn grid rendering API suitable for append-only consumers.

Bug Fixes:
- Remove terminal-only progress placeholders and unbounded cursor erasure from plain transcript output.
- Keep streamed frame widths fixed for the duration of a turn to prevent torn output after terminal resizes.
- Align HTML transcript receipts with grid output so turn status and accounting appear at the closing edge.

Enhancements:
- Add settled-run folding support to identify transcript content safe for append-only rendering.
- Reorganize frame tests and add coverage for append-only rendering, settled calls, closing rails, consistent output, and renderer parity.

CI:
- Include transcript-surface validation in the standard gate and gate-parity checks.

Documentation:
- Document transcript renderer adoption, streaming constraints, and closing-rail semantics.

Tests:
- Add comprehensive plain-surface streaming witnesses and transcript renderer parity tests.
- Add twelve hermetic failure-direction scenarios for the transcript-surface guard.