### PR TITLE
fix(stella-tui): main is red — a pub fn cannot link to a private helper

### DIFF
--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -155,7 +155,8 @@ pub fn body_lines_capped(
 /// drop a lone `@@ -a,b +c,d @@` header.
 ///
 /// The `diff`/`index`/`---`/`+++` preamble is dropped by every surface, not
-/// just this one — see [`render_body`]. What is left to decide here is the hunk
+/// just this one — see `render_body` below (not a link: it is private, and
+/// this is a `pub fn`). What is left to decide here is the hunk
 /// header: in a diff *viewer* it is orientation, but inline under a tool call a
 /// single one restates what the row above and the gutter beside already say,
 /// and a two-line change should not cost six rows to read. It survives from two


### PR DESCRIPTION
**`main` is red and every PR inherits it.** `cargo doc -D warnings` has failed
on `main` since #4269:

```
error: public documentation for `body_lines_inline` links to private item `render_body`
  --> crates/stella-tui/src/diff.rs:158
error: could not document `stella-tui`
```

`body_lines_inline` is `pub`; `render_body` is private. CI runs rustdoc with
`--document-private-items` and denies `rustdoc::private_intra_doc_links`, so
the link resolves under a plain `cargo doc` and fails the gate. One line,
un-linked.

## Why this keeps happening

Third instance of the same class in two days — #4274 fixed `TurnEvidence` →
`turn_start_index`, and #4272 carried two of its own before CI caught them.

The tell is identical every time: a `pub` item citing a `pub(crate)` or
private neighbour, written from *inside* the module where the target genuinely
is reachable. It reads correctly, it resolves locally, and it only fails under
the flag combination CI uses. `make doc-warnings` reproduces it exactly;
`cargo doc` alone does not.

Worth knowing when writing docs on a `pub` item: check the visibility of
everything in `[`brackets`]`, or run `make doc-warnings` as the **last** thing
before committing rather than partway through — a run from before the doc was
written proves nothing about it.

## Evidence

- `make doc-warnings` — clean (fails on `main` as quoted above).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — 8093 passed / 0 failed.
- `make guards-fast` — green.
- `cargo fmt --check` — clean.

Documentation only; no behaviour change, so no witness test. The gate itself
is the witness: it fails on `main` and passes here.

## Deleted tests

None.

## New dependencies

None.

## Summary by Sourcery

Remove the invalid private-item documentation link so rustdoc warnings pass without changing behavior.

Bug Fixes:
- Fix the public documentation warning caused by linking from `body_lines_inline` to the private `render_body` helper.

Enhancements:
- Clarify the documentation reference without creating a private intra-documentation link.