### PR TITLE
docs(tui-v2): SPEC 6.4 states the diff-tint constraint, not one mechanism

### DIFF
--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -146,7 +146,9 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
 
 - Engine: `syntect` with a custom theme built from section 3.1 (keywords gold, types silver_type, identifiers text, comments comment, strings silver, primitives silver_type). Two metals plus white is the full syntax palette on purpose.
 - Highlight once when the event arrives, cache `Vec<Line<'static>>`. Never highlight per frame.
-- Diff rows are two-layer: `Line.style` carries the bg tint (`diff_add_bg` or `diff_del_bg`), spans keep syntax fg. ratatui composes them per cell.
+- Diff rows are two-layer: a background tint (`diff_add_bg` or `diff_del_bg`) under foreground spans that keep their syntax colors. The tint covers the **code column, out to the pane edge** — reaching the edge is what makes the ground read as a band rather than tracing the ragged right end of the code — and it covers **nothing to the left of it**. A rail, a line-number gutter, or any other chrome the surface draws in the margin is not part of the diff and never takes the tint.
+
+  Stated as a constraint because the obvious mechanism violates it. `Line.style` is the one-call way to tint a row and is correct only where the row is *nothing but* diff; on any row carrying a margin it paints the whole row's area, so a green band swallows the rail whose metal says which event the diff belongs to (SPEC 6.2) — the two layers then disagree about what the row is. In the transcript every diff row carries that rail, so the tint rides a per-span `bg` on the code plus one trailing padded span to the pane edge. A surface with no margin may use `Line.style`; a surface with one must not. The reference implementation is `push_diff_line` in `crates/stella-tui/src/render/row.rs`, and `a_rust_diff_renders_add_and_remove_rows_per_spec_64` asserts both halves — the band reaches the pane edge, and the rail span's `bg` stays `None`.
 - Line number gutter in `dim`. Sign column (`+`/`-`) is mandatory and colored; color is never the only diff signal.
 
 ## 7. Plan and task contracts


### PR DESCRIPTION
## What & why

SPEC 6.4 specified a diff row's two layers as a **mechanism**:

> Diff rows are two-layer: `Line.style` carries the bg tint (`diff_add_bg` or `diff_del_bg`), spans keep syntax fg. ratatui composes them per cell.

Taken literally that is wrong for the transcript, and #4127 could not implement it as written.

A transcript diff row is not just the diff. `render::row::push_diff_line` prepends the block's rail (`" │"` plus the body indent) to every row, and **the rail carries the call's metal (SPEC 6.2), not the hunk's**. `Line.style` paints the whole row's area, rail included — so a green band swallows the gold or silver rail that says which event the diff belongs to. The two layers then disagree about what the row is.

## Why this is a defect in the SPEC rather than a note in the code

The next person to implement a diff surface from SPEC 6.4 — the plugin panel host (SPEC 12), a second transcript renderer, the Observatory — reads `Line.style`, implements it, and paints over whatever margin their surface has. A spec that names one mechanism teaches that mechanism; it should state the constraint the mechanism was trying to satisfy.

## What changes

The bullet now states the rule in terms that survive a row with a margin:

- the tint covers the **code column, out to the pane edge** — reaching the edge is what makes the ground read as a band rather than tracing the ragged right end of the code;
- it covers **nothing to the left of it**. A rail, a line-number gutter, or any other chrome the surface draws in the margin is not part of the diff and never takes the tint.

`Line.style` is deliberately **kept and named**, because it is the right call where a row is nothing but diff — flagged as wrong wherever a row carries chrome the tint must not cover. A surface with no margin may use it; a surface with one must not. That is more useful to the next implementer than deleting the mechanism outright, which would leave them to rediscover why.

The reference implementation and its assertion are cited inline so the spec points at running code: `push_diff_line` in `crates/stella-tui/src/render/row.rs`, and `a_rust_diff_renders_add_and_remove_rows_per_spec_64` in `crates/stella-tui/src/render/tests/result_row.rs`, which checks **both** halves — the band reaches the pane edge, and the rail span's `bg` stays `None`.

## The witness

- [ ] This PR includes a witness test

**No code changes, so none is required** (AGENTS.md exempts docs). This is the case #4195 anticipated: its definition of done says "No code change is implied — #4127 already renders it correctly, and its test is the reference for what 'correct' means." This PR makes the spec describe the code that already exists rather than the code changing to match a spec that was wrong.

Verified the cited test is real and passing rather than taking the issue's word for it:

```
cargo test -p stella-tui --lib -- a_rust_diff_renders_add_and_remove_rows_per_spec_64
test result: ok
```

## The gate

Docs-only. `make gate` was run for the sibling code PR on this stack and is green; nothing in this diff compiles.

Note for review: a docs-only PR **skips** the required Rust job, and a skipped job satisfies the check — so a green tick here is not evidence any Rust ran.

Closes #4195

## Summary by Sourcery

Clarify the diff tinting contract in SPEC 6.4 so diff backgrounds form a full code-column band without covering surrounding rails or margin chrome.

Enhancements:
- Clarify SPEC 6.4 as a diff-rendering constraint that keeps tint confined to the code column through the pane edge while preserving rail and other margin chrome.
- Document when `Line.style` is appropriate and reference the existing implementation and test that validate the required rendering behavior.

Documentation:
- Update the TUI v2 specification to define diff tinting independently of a single rendering mechanism and explain the margin-related constraint.