### PR TITLE
docs(tui-v2): the P2 plan stops ordering a fourth lexer

### DIFF
--- a/design/tui-v2/IMPLEMENTATION-PLAN.md
+++ b/design/tui-v2/IMPLEMENTATION-PLAN.md
@@ -8,7 +8,12 @@ Companion to `SPEC-stella-tui-v2.md`. Phases are ordered so each ships value alo
 - **State crate boundaries** (adjust names to the existing workspace):
   - `stella-tui-theme`: palette consts, hue clamp tests, glyph consts, 16-color fallback map.
   - `stella-tui-widgets`: transcript, plan panel, task zoom, tabs, palette overlay, plugin panel host. Each widget implements `Widget` or `StatefulWidget` and renders into `Buffer` directly.
-  - `stella-tui-highlight`: syntect wrapper, theme build, per-event cache.
+  - *(no highlighter crate — see below.)* An earlier draft of this plan put a
+    `stella-tui-highlight` here: a syntect wrapper owning the lexer, the theme
+    build and the per-event cache. Only the **cache** was the deck's to build.
+    The lexer is `stella_transcript::syntax`'s, shared with the export grid and
+    the Observatory, and the deck keeps the palette (`syntax::tok_style`) and
+    nothing else (#4036, #4196).
   - `stella-cli`: event loop, key routing, state reduction from AEP events.
 - **Event model**: every transcript event is a struct with `turn_id`, `task_id: Option<TaskId>`, `kind`, timing, and a lazily built `rendered: OnceCell<Vec<Line<'static>>>`. Rendering an event never recomputes highlights.
 - **Async boundary**: registry searches (skills, MCP), tracker sync, and oauth run as tokio tasks that post results back into state between ticks. The draw path never awaits.
@@ -18,7 +23,7 @@ Companion to `SPEC-stella-tui-v2.md`. Phases are ordered so each ships value alo
 | Crate | Purpose | Notes |
 |---|---|---|
 | `ratatui` + `crossterm` | already in use | `BorderType::Rounded` for panels |
-| `syntect` | syntax highlighting | `fancy-regex` feature to avoid oniguruma on Windows |
+| ~~`syntect`~~ | ~~syntax highlighting~~ | **Not taken.** The deck highlights through `stella_transcript::syntax`, which the export grid and Observatory already share. A syntect crate here would be a *fourth* lexer for the same bodies — the drift #3644 and #4036 each closed once (#4196). |
 | `nucleo` | fuzzy matching for the palette | match indices drive gold letters |
 | `insta` | snapshot tests | pairs with `TestBackend` |
 | `tokio` | async registry, tracker, oauth | already likely present |
@@ -47,7 +52,13 @@ Acceptance: snapshots for a scripted turn (begin, skill, read, run, receipt); fo
 
 ### P2: highlighting and code events
 
-- `stella-tui-highlight`: build the syntect theme from the palette (SPEC 6.4), highlight-on-arrival cache, language detection by extension with plain-text fallback.
+- **Highlight cache** (shipped, #4127): highlight-on-arrival with tail reuse in
+  `crates/stella-tui/src/views/session/fold.rs`, witnessed by
+  `an_unchanged_tail_is_highlighted_once_not_once_per_frame`. This was P2's real
+  deliverable. The lexer, theme mapping and extension-based language detection
+  it was going to wrap are `stella_transcript::syntax`'s
+  (`body_paint`/`paint_line`), and the deck supplies only `syntax::tok_style`.
+  Do not fork them (#4036, #4196).
 - Diff rendering: two-layer rows, sign column, line-number gutter.
 - `edit`, `write`, `delete` (with the pre-execution graph check line), and expanded `read` bodies.
 
@@ -103,7 +114,14 @@ Acceptance: palette snapshot for query `ga` during a verify turn showing `/gates
 
 ## 5. Risks and mitigations
 
-- **syntect grammar accuracy**: good for Rust and TS, not tree-sitter grade. Mitigation: highlighter is behind a trait; swap to tree-sitter per-language later without touching widgets.
+- **Lexer accuracy**: `stella_transcript::syntax` is hand-written and covers a
+  fixed `Lang` set, so it is heuristic where a grammar-based lexer (syntect,
+  tree-sitter) would be accurate, and silent on languages it does not know.
+  That is a real cost and it is accepted for now. Mitigation is about **where** a
+  better lexer lands, not whether: it goes into `stella-transcript`, so the deck,
+  the export grid and the Observatory gain it together. A deck-local highlighter
+  buys the deck accuracy by making the three surfaces disagree again, which is
+  the one outcome #4036 forbade (#4196).
 - **Terminal variance on Windows**: legacy conhost degrades truecolor. Mitigation: fallback map plus recommending Windows Terminal; the desktop shell solves it permanently later.
 - **Registry and tracker latency**: never block the draw path; all remote work is async with visible `◐` states and stale-data tags.
 - **Scope creep in tabs**: AGENTS and SETTINGS are restyle-only in this cycle (SPEC 9.5).


### PR DESCRIPTION
## What & why

`design/tui-v2/IMPLEMENTATION-PLAN.md` ordered a `stella-tui-highlight` crate — a syntect wrapper owning the lexer, the theme build and a per-event cache — in **four** places (§1 crate boundaries, §2 dependencies, §3 P2, §5 risks).

#4127 shipped P2 and deliberately did not build it, because `stella_transcript::syntax` (`body_paint`/`paint_line`) already lexes those exact bodies for the deck, the export grid and the Observatory HTML renderer. A syntect crate here would have been a **fourth lexer for one rendering decision** — precisely the drift #3644 and #4036 each closed once.

The plan and the code could not both be followed, and the plan is the half that is wrong. It stays wrong in a way that costs something: the next agent picking up a later phase reads the plan and builds the crate. #4196 was filed for exactly that.

## What changes

Nothing is silently deleted — each site records the decision, because "the plan no longer mentions syntect" and "the plan says why syntect was not taken" read identically to a fresh agent right up until they propose it again.

- **§1** — the `stella-tui-highlight` bullet is struck and replaced with the split it got wrong: only the **cache** was the deck's to build. The lexer is `stella-transcript`'s; the deck keeps the palette (`syntax::tok_style`) and nothing else.
- **§2** — the `syntect` dependency row is struck through with the reason inline, rather than removed from the table. A dependency the project considered and rejected is worth more in the table than absent from it.
- **§3 P2** — the deliverable is restated as what actually shipped: the highlight-on-arrival cache with tail reuse in `crates/stella-tui/src/views/session/fold.rs`, witnessed by `an_unchanged_tail_is_highlighted_once_not_once_per_frame`.
- **§5** — the risk is re-aimed rather than dropped. It said "syntect grammar accuracy"; syntect is not in the tree, so as written it warned about a risk the project does not carry while staying silent on the one it does. The shared lexer being hand-written, heuristic and limited to a fixed `Lang` set **is** a real cost, and it is accepted. The mitigation is about **where** a better lexer lands, not whether: it goes into `stella-transcript` so the deck, the export grid and the Observatory gain it together. A deck-local highlighter buys the deck accuracy by making the three surfaces disagree again — the one outcome #4036 forbade.

## What this PR deliberately does not do

#4196's definition of done offers two paths and they are not exclusive in spirit, but only the first is settled: **the plan changes to record the decision.** The second — actually upgrading the lexer — is a real open question (syntect is grammar-accurate where the hand-written lexer is heuristic, and silent on languages it does not know) and #4196 is explicit that it must be filed against `stella-transcript` so all three renderers gain it at once, never as a deck-local crate. That issue is **not** filed by this PR because the decision to upgrade has not been made; §5 now carries the constraint any future upgrade has to satisfy, which is what stops the wrong version of it being built.

## The witness

- [ ] This PR includes a witness test

**Docs only, no code changes** — AGENTS.md exempts it. The claim the plan now makes about the code was checked rather than assumed:

- `stella-tui-highlight` does not exist in the workspace and `syntect` is not a dependency of it.
- `an_unchanged_tail_is_highlighted_once_not_once_per_frame` exists in `crates/stella-tui/src/views/session/fold.rs` and passes.

## The gate

Docs-only; nothing here compiles. Note that a docs-only PR **skips** the required Rust job and a skipped job satisfies the check — a green tick on this PR is not evidence that any Rust ran.

Closes #4196

## Summary by Sourcery

Correct the TUI v2 implementation plan to reflect the shared syntax highlighting architecture and prevent a separate deck-local lexer from being introduced.

Enhancements:
- Update the TUI v2 implementation plan to document the shared transcript lexer and retain only the deck-local highlight cache.
- Align the P2 deliverable and risk guidance with the shipped implementation, directing future lexer improvements to the shared transcript layer.

Documentation:
- Clarify that a deck-local syntect highlighter is intentionally not planned, preserving consistent highlighting across the deck, export grid, and Observatory.