### PR TITLE
docs(stella-transcript): record which frame is the one frame

### DIFF
--- a/crates/stella-transcript/src/lib.rs
+++ b/crates/stella-transcript/src/lib.rs
@@ -26,6 +26,58 @@
 //! re-implementing the TUI's renderer in JavaScript, and that copy had silently
 //! drifted to the point of having no diff rendering at all.
 //!
+//! ## Which frame is the one frame: SPEC 6, and [`grid`] is where it lands
+//!
+//! Settled 2026-08-22, owner's call, recorded here because #4271 asked for it
+//! in this charter specifically — a decision that lives only in an issue is one
+//! the next author re-litigates.
+//!
+//! Two frames were drawing the same information. [`grid`] draws a
+//! `╭─ … ─╮` / `│` / `╰──╯` box with [`digest::Chip`] right-aligned;
+//! `stella-tui`'s `v2::transcript` draws `design/tui-v2/SPEC.md` §6 — a
+//! full-width labelled rule, a run of railed event rows, a closing rule and a
+//! one-line receipt. Neither was wrong, and the deck's was written without
+//! reference to this crate at all.
+//!
+//! **SPEC 6 wins, and [`grid`] is changed to draw it** rather than the deck
+//! being bent onto the box. Three reasons, in order of weight:
+//!
+//! 1. SPEC 6 is the *authored product design*; the box frame is an artifact of
+//!    this crate's extraction (#3764) and was never designed against it. When a
+//!    spec and an implementation disagree about a product decision, the spec is
+//!    the side that was decided on purpose.
+//! 2. The box cannot carry SPEC 2's **two-metal rule**. [`grid::Color`]'s roles
+//!    are `Ink`/`Dim`/`Faint`/`Cyan`/`Green`/`Red`/…, and `Cyan` for "tool
+//!    identity" is exactly the per-class hue SPEC 3.2's clamp rejects and #4125
+//!    is about removing. Adopting the box would mean relaxing the palette rule
+//!    the whole v2 theme is built on.
+//! 3. The blast radius is one surface. [`grid`] has exactly one shipping caller
+//!    — the plain `stella run` transcript
+//!    (`crates/stella-cli/src/plain/transcript.rs`). The Observatory renders
+//!    through [`html`] and is untouched by the frame decision. So "one frame"
+//!    costs a changed appearance on one terminal surface, not three.
+//!
+//! ### Where the theme sits, which is the other half of the question
+//!
+//! [`grid`] does **not** gain a dependency on `stella-tui-theme`, and the deck
+//! does not stop using it. The existing seam already answers this: this crate
+//! emits a *role* and encodes at the very end, which is what keeps it free of a
+//! terminal dependency. So the rule is **[`grid`] owns the role, the surface
+//! owns the pigment** — [`grid::Color`] gains the two metals as roles, and the
+//! deck maps role → `stella_tui_theme::token` RGB at its own encode step. A
+//! warm gray cannot be smuggled in that way, because the deck's hue clamp still
+//! guards every token the mapping can produce.
+//!
+//! ### The gap this exposes, which is real and is not the frame
+//!
+//! `v2::transcript`'s file-event fields are all `Option` because a head row
+//! renders before anything is measured, and a `+0 -0` beside a path is a
+//! different and louder claim than "not measured yet". [`model`] has no
+//! equivalent notion of an unmeasured row. That is a genuine hole in the shared
+//! model — the same one #4181 describes from the accessibility side — and it
+//! has to be closed *before* the deck can render through [`grid`], not after,
+//! or the migration silently reintroduces the fabricated zero.
+//!
 //! ## Which surfaces actually draw through this crate
 //!
 //! Extracting the crate proved nothing on its own, and the gap between "the

--- a/scripts/check-transcript-surfaces.py
+++ b/scripts/check-transcript-surfaces.py
@@ -129,9 +129,15 @@ SURFACES: list[Surface] = [
         path="crates/stella-tui/src/v2/transcript.rs",
         entry=GRID,
         shared=False,
-        issue=4271,
-        note="The v2 deck's SPEC 6 frame. Whether SPEC 6 or `grid.rs` is the "
-        "one frame is an open design decision, not a wiring task.",
+        issue=4289,
+        note="The v2 deck's SPEC 6 frame. The design question is settled — "
+        "SPEC 6 is the one frame and `grid.rs` is changed to draw it, not the "
+        "other way round (#4271, recorded in stella-transcript's charter). "
+        "What is left is the migration, and its first step is a correctness "
+        "precondition rather than wiring: `model` has no notion of an "
+        "*unmeasured* row, so moving the deck across before that lands would "
+        "reintroduce the fabricated `+0 -0` its `Option` fields exist to "
+        "prevent.",
     ),
     Surface(
         ident="export-html",


### PR DESCRIPTION
## What & why

#4271 filed a **design decision**, explicitly not a refactor: the workspace draws one session four ways, and two of those four draw the same information in two different shapes — `grid.rs`'s `╭─ … ─╮` box with right-aligned `digest::Chip`s, and `stella-tui`'s `v2::transcript` drawing SPEC 6's full-width labelled rule, railed event rows and one-line receipt. Neither is wrong. The deck's was written without reference to the shared one.

The issue is clear that this "should not be closed by picking whichever is easier to call", so this PR records the call and its reasoning where the next author will hit it.

## The decision

**SPEC 6 is the one frame, and `grid.rs` is changed to draw it** — not the deck bent onto the box. Owner's call, 2026-08-22. Recorded in `crates/stella-transcript/src/lib.rs`'s charter, which is where #4271 asked for it: a decision that lives only in an issue is one the next author re-litigates.

Three reasons, in order of weight:

1. **SPEC 6 is the authored product design.** The box frame is an artifact of this crate's extraction (#3764) and was never designed against it. When a spec and an implementation disagree about a *product* decision, the spec is the side that was decided on purpose.
2. **The box cannot carry SPEC 2's two-metal rule.** `grid::Color`'s roles are `Ink`/`Dim`/`Faint`/`Cyan`/`Green`/`Red`/…, and `Cyan` for "bash and tool identity" is precisely the per-class hue SPEC 3.2's clamp rejects and #4125 is about removing. Adopting the box would mean relaxing the palette rule the whole v2 theme is built on, to keep a frame nobody designed.
3. **The blast radius is one surface, not three.** This is the fact that most changed the shape of the decision, and it is not in the issue: `grid` has **exactly one shipping caller**, the plain `stella run` transcript (`crates/stella-cli/src/plain/transcript.rs`). The Observatory renders through `html::render_page` and is untouched by the frame question entirely. So "one frame everywhere" costs a changed appearance on one terminal surface.

## The other half of #4271's question, also settled

**Where `stella_tui_theme` sits.** `grid` does **not** gain a dependency on it, and the deck does not stop using it. The seam `grid` already documents answers this — it emits a *role* and encodes at the very end, which is what keeps this crate free of a terminal dependency. So: **`grid` owns the role, the surface owns the pigment.** `grid::Color` gains the two metals as roles; the deck maps role → `stella_tui_theme::token` at its own encode step, the plain surface to its ANSI codes. A warm gray cannot be smuggled in that way, because the deck's hue clamp still guards every token the mapping can produce.

## The gap this exposes, which is the part worth reading

#4271 §3 is right that `v2::transcript`'s `Option` fields have no equivalent in `stella_transcript::model`, and I want to be explicit that this is a **correctness precondition, not a wiring detail**. A head row renders the moment its call dispatches, before anything is measured; `+0 -0` beside a path asserts the edit changed nothing, which is a louder and entirely different claim than "not measured yet". That fabricated zero has already shipped twice as a defect (#2290, #4156).

Migrating the deck onto `grid` before `model` can express "unmeasured" would reintroduce it silently — turning the whole migration into a regression. So it is sequenced first in #4289, not last.

## What this PR does not do

It does not migrate anything. `deck-v2` stays a declared gap in the adoption ledger; what changes is the address on the debt — the row now cites **#4289** (the migration, filed with this PR as a four-step handoff) instead of #4271 (the question, now answered).

`make transcript-surfaces` still reports it as a gap, deliberately:

```
transcript-surfaces: 2 shared, 3 declared gaps, 1 foreign port(s) — ledger matches the tree.
    gap: deck-v1 -> #3578
    gap: deck-v2 -> #4289
    gap: export-html -> #4270
```

I have used `Refs #4271` rather than `Closes`, because #4271's definition of done has three parts and this PR delivers one: the decision is recorded in the charter, but `v2/transcript.rs` does not yet draw through `grid` and the row does not yet read `Shared`. #4289 closes it.

## The witness

- [ ] This PR includes a witness test

Docs plus one guard-data note; nothing here compiles. Two checks that do apply were run rather than assumed:

- `make transcript-surfaces` — **exit 0**, output above. This matters: the guard requires an `OWN` row to cite an issue, so a re-pointed citation is exactly the kind of edit that can go stale silently.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-transcript --no-deps` — **exit 0**. The charter addition adds a dozen intra-doc links (`grid::Color`, `digest::Chip`, `model`, `html`) and an unresolved one is a gate failure, not a cosmetic issue.

Refs #4271

## Summary by Sourcery

Record SPEC 6 as the canonical transcript frame and redirect the remaining deck migration work to #4289 without changing rendering behavior.

Enhancements:
- Record the decision that SPEC 6 is the canonical transcript frame and that the shared grid renderer will be migrated to it.
- Document the role-versus-pigment boundary and the unmeasured-row model requirement as prerequisites for the future deck migration.

Documentation:
- Add the transcript charter rationale for the canonical frame, theme ownership, affected surfaces, and migration prerequisites.

Chores:
- Update the transcript-surface adoption ledger to track the remaining deck migration under #4289 instead of the resolved design question #4271.