### PR TITLE
fix(stella-tui): a v2 call head dims the directory and lights the basename

### DIFF
--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -207,12 +207,57 @@ impl EventKind {
     }
 }
 
+/// The object of a head's verb, and whether it is a **path**.
+///
+/// The flag rides the subject rather than being re-derived from the string at
+/// render time, because "contains a slash" is not the same question. A `bash`
+/// head's subject is a command line, and `sed -n '1,20p' foo/bar.rs` contains a
+/// slash while being no more a path than `grep -r foo/ .` is. Brightening the
+/// tail of either would spend the row's emphasis on the text least able to use
+/// it.
+///
+/// The distinction is free where it is decided: `transcript_source::subject_for`
+/// (module-private, so named rather than linked) already branches on
+/// `path: Option<&str>` and falls back to the raw input only when there is
+/// none, so it *knows* — it simply used to discard the answer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Subject {
+    /// The rendered text.
+    pub text: String,
+    /// Whether [`Self::text`] is a filesystem path, and so gets the
+    /// dim-directory / bright-basename split (SPEC 6.2).
+    pub is_path: bool,
+}
+
+impl Subject {
+    /// A subject that is a path.
+    #[must_use]
+    pub fn path(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            is_path: true,
+        }
+    }
+}
+
+/// Anything string-shaped is a **non-path** subject. Deliberately the default:
+/// a command line, a skill name or a tool's own label is the common case, and
+/// the emphasis split is the exception that has to be asked for.
+impl<T: Into<String>> From<T> for Subject {
+    fn from(text: T) -> Self {
+        Self {
+            text: text.into(),
+            is_path: false,
+        }
+    }
+}
+
 /// One transcript event, already projected — no borrowed model state.
 #[derive(Clone, Debug)]
 pub struct Event {
     pub kind: EventKind,
     /// The object of the verb: a path, a command line, a skill name.
-    pub subject: String,
+    pub subject: Subject,
     /// Wall time, rendered `⚡3ms`. Zero suppresses the metric.
     pub duration_ms: u64,
     /// The task this event is attributed to, rendered `→ task 3` when a plan
@@ -229,7 +274,7 @@ pub struct Event {
 impl Event {
     /// A minimal event; the builders below are for tests and the live source.
     #[must_use]
-    pub fn new(kind: EventKind, subject: impl Into<String>) -> Self {
+    pub fn new(kind: EventKind, subject: impl Into<Subject>) -> Self {
         Self {
             kind,
             subject: subject.into(),
@@ -445,10 +490,44 @@ pub fn rail_span(metal: Color) -> Span<'static> {
     Span::styled(" │", Style::new().fg(metal))
 }
 
+/// The subject, split so a **path**'s basename carries the emphasis.
+///
+/// In a scan down the margin the eye is hunting the file *identity*; the
+/// directory is context that only matters once the file is found, so it
+/// recedes. Without this a column of calls in one workspace reads as a column
+/// of near-identical `crates/stella-tui/src/render/…` strings, all the same
+/// weight, differing only in the last few cells (#4168).
+///
+/// Non-path text is deliberately left as one unemphasised span. The subject of
+/// a `bash` head is a command, not a file, and brightening its tail would spend
+/// the contrast on the rows least able to use it — the rule the v1 row encoded
+/// in `render::row::path_spans` before it was deleted, third arm included.
+///
+/// `lead` is the separator owned by whatever precedes the subject, carried into
+/// the first span rather than pushed as one of its own: an empty span would
+/// still occupy an index the palette tests count past.
+fn subject_spans(subject: &Subject, lead: &str) -> Vec<Span<'static>> {
+    let text = Style::new().fg(token::TEXT);
+    // Byte-index slicing is safe on the result of `rfind('/')`: `/` is ASCII,
+    // so `cut` and `cut + 1` are both char boundaries whatever else the path
+    // holds.
+    match subject.text.rfind('/').filter(|_| subject.is_path) {
+        Some(cut) => vec![
+            Span::styled(
+                format!("{lead}{}", &subject.text[..=cut]),
+                Style::new().fg(token::DIM),
+            ),
+            Span::styled(subject.text[cut + 1..].to_owned(), text),
+        ],
+        // A basename with no directory is already the identity — bright, whole,
+        // and nothing to recede. A non-path renders exactly as it did before.
+        _ => vec![Span::styled(format!("{lead}{}", subject.text), text)],
+    }
+}
+
 /// `<rail> <glyph> <verb> <subject> … <metrics right-aligned>`.
 fn head_row(event: &Event, metal: Color, width: usize) -> Line<'static> {
     let dim = Style::new().fg(token::DIM);
-    let text = Style::new().fg(token::TEXT);
 
     let mut left = vec![
         rail_span(metal),
@@ -467,11 +546,11 @@ fn head_row(event: &Event, metal: Color, width: usize) -> Line<'static> {
             event.kind.verb().to_string(),
             Style::new().fg(metal).add_modifier(Modifier::BOLD),
         ));
-        if !event.subject.is_empty() {
-            left.push(Span::styled(format!(" {}", event.subject), text));
+        if !event.subject.text.is_empty() {
+            left.extend(subject_spans(&event.subject, " "));
         }
-    } else if !event.subject.is_empty() {
-        left.push(Span::styled(event.subject.clone(), text));
+    } else if !event.subject.text.is_empty() {
+        left.extend(subject_spans(&event.subject, ""));
     }
     left.extend(kind_detail(&event.kind));
 

--- a/crates/stella-tui/src/v2/transcript/tests.rs
+++ b/crates/stella-tui/src/v2/transcript/tests.rs
@@ -304,6 +304,72 @@ fn a_partial_test_pass_is_not_green() {
     assert_eq!(span.style.fg, Some(token::RED));
 }
 
+/// #4168: a path's basename carries the emphasis, the directory recedes.
+///
+/// The rule the v1 call row encoded in `render::row::path_spans`, deleted along
+/// with the unreachable arm that was keeping it alive. In a scan down the
+/// margin the eye hunts the file *identity*; without the split, a column of
+/// calls in one workspace is a column of near-identical
+/// `crates/stella-tui/src/render/…` strings differing only in their last cells.
+#[test]
+fn a_path_subject_dims_its_directory_and_brightens_its_basename() {
+    let mut event = Event::new(
+        EventKind::Read {
+            extent: Extent::default(),
+        },
+        Subject::path("a/b/c.rs"),
+    );
+    event.collapsed = Some(false);
+    let spans = head_row(&event, token::SILVER, W).spans;
+
+    let dir = spans
+        .iter()
+        .find(|s| s.content.contains("a/b/"))
+        .expect("the directory renders");
+    let base = spans
+        .iter()
+        .find(|s| s.content == "c.rs")
+        .expect("the basename is its own span");
+
+    assert_eq!(dir.style.fg, Some(token::DIM), "the directory is not dim");
+    assert_eq!(base.style.fg, Some(token::TEXT), "the basename is not lit");
+    assert_ne!(
+        dir.style.fg, base.style.fg,
+        "directory and basename render in one style — the split did not happen"
+    );
+}
+
+/// The other half, and the reason it is a separate test: the fix must not
+/// over-reach.
+///
+/// A `bash` head's subject is a command line, and `grep -r foo/ .` contains a
+/// slash while being no more a path than any other argument list. Brightening
+/// its tail would spend the row's contrast on the rows least able to use it.
+/// Deriving path-ness from the string instead of carrying it on the subject is
+/// precisely the implementation this rejects — that version passes the test
+/// above and fails this one.
+#[test]
+fn a_command_subject_stays_one_unemphasised_span() {
+    let mut event = Event::new(EventKind::Run, Subject::from("grep -r foo/ ."));
+    event.collapsed = Some(false);
+    let spans = head_row(&event, token::GOLD, W).spans;
+
+    let subject: Vec<_> = spans
+        .iter()
+        .filter(|s| s.content.contains("grep") || s.content.contains("foo/"))
+        .collect();
+    assert_eq!(
+        subject.len(),
+        1,
+        "a command line was split as though it were a path: {subject:?}"
+    );
+    assert_eq!(
+        subject[0].style.fg,
+        Some(token::TEXT),
+        "a command subject changed tone"
+    );
+}
+
 /// prompt.md rule 3: no hex literal outside the theme crate.
 #[test]
 fn no_hex_literals_in_v2_transcript_code() {

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -29,7 +29,7 @@ use ratatui::style::Color;
 use ratatui::text::Line;
 
 use super::transcript::{
-    Event, EventKind, Extent, Receipt, TurnHead, event_rows, receipt, turn_begin, turn_end,
+    Event, EventKind, Extent, Receipt, Subject, TurnHead, event_rows, receipt, turn_begin, turn_end,
 };
 use crate::model::{FileState, TranscriptEntry};
 
@@ -187,10 +187,13 @@ fn kind_for(name: &str, measured: Option<(u32, u32)>) -> EventKind {
 
 /// The object of the verb: the path for a file tool, the command for `bash`,
 /// the raw input for anything else.
-fn subject_for(name: &str, path: Option<&str>, input: &str) -> String {
+fn subject_for(name: &str, path: Option<&str>, input: &str) -> Subject {
     match (name, path) {
-        (_, Some(p)) if !p.is_empty() => p.to_string(),
-        ("bash", _) => first_line(input).to_string(),
+        // The one arm that yields a path, and the only one that may: the caller
+        // handed us `path`, so this is not a guess about the string's shape.
+        (_, Some(p)) if !p.is_empty() => Subject::path(p),
+        // A command line, not a file — even when it contains a slash.
+        ("bash", _) => first_line(input).into(),
         _ => {
             // A tool this host has no verb for is named by its own label, which
             // for an MCP tool is its trailing segment: the row read
@@ -204,9 +207,9 @@ fn subject_for(name: &str, path: Option<&str>, input: &str) -> String {
             let label = stella_tools::catalog::label_for(name);
             let head = first_line(input);
             if head.is_empty() {
-                label.to_string()
+                label.into()
             } else {
-                format!("{label} {head}")
+                format!("{label} {head}").into()
             }
         }
     }


### PR DESCRIPTION
## What & why

A v2 call row drew its path as **one flat span**, so a column of calls in one workspace read as a column of near-identical `crates/stella-tui/src/render/…` strings — same weight end to end, differing only in their last few cells.

```
" │ ● read crates/stella-tui/src/render/row.rs · 0 lines"
  spans: [" │", " ● ", "read", " crates/stella-tui/src/render/row.rs", " · 0 lines"]
```

v1's call row split it, and the rule lived in `render::row::path_spans`:

> Split a path into (directory, basename) spans so the basename carries the emphasis. In a scan, the file *identity* is what the eye is hunting; the directory is context that only matters once you've found the file, so it recedes.

That function was deleted along with the unreachable v1 arm that had been keeping it alive (#4157). Dead code is not a specification, so this restores the **rule**, not the function.

## The design decision, which is the whole of the PR

**Path-ness rides the subject; it is never re-derived from the string.**

`transcript_source::subject_for` already branches on `path: Option<&str>` and falls back to the raw input only when there is none — it *knows*, and simply discarded the answer. So:

```rust
pub struct Subject { pub text: String, pub is_path: bool }
impl<T: Into<String>> From<T> for Subject { /* is_path: false */ }
```

`From` makes **non-path the default**, which is why every existing construction (`Event::new(kind, String::new())`, the compaction row, the tests) keeps compiling untouched and the split is the case that has to be asked for via `Subject::path(…)`. One arm of `subject_for` opts in — the one the caller handed a `path`.

The tempting shortcut is "brighten after the last `/` if the subject contains one", with no new field. It is wrong: a `bash` head's subject is a **command line**, and `sed -n '1,20p' foo/bar.rs` contains a slash while being no more a path than `grep -r foo/ .`. Brightening either tail spends the row's scarcest resource on the rows least able to use it. That is v1's third arm and it is preserved deliberately.

## The witness

- [x] This PR includes a witness test

Two, and **they are complementary by construction** — which is the part worth reviewing, because it is what makes the second one load-bearing rather than decorative. I ran each disarm rather than asserting it:

| `subject_spans` does… | `…dims_its_directory_and_brightens_its_basename` | `…stays_one_unemphasised_span` |
|---|---|---|
| ignore `is_path` (**the behaviour on `main`**) | **FAILED** | ok |
| derive path-ness from the string (the shortcut) | ok | **FAILED** |
| carry `is_path` (**this PR**) | ok | ok |

Only carrying the flag passes both. Verbatim from the disarmed runs:

```
# .filter(|_| false)  — the main behaviour
test a_command_subject_stays_one_unemphasised_span ... ok
test a_path_subject_dims_its_directory_and_brightens_its_basename ... FAILED

# .filter(|_| true)   — derived from the string
test a_path_subject_dims_its_directory_and_brightens_its_basename ... ok
test a_command_subject_stays_one_unemphasised_span ... FAILED
```

This is exactly what #4168 asked for: "Both halves fail on `main` today — the first because the path is one span, the second because it would pass trivially and is there to stop the fix over-reaching."

## Constraints from the issue, each checked

- **Colour through the theme.** `token::DIM` and `token::TEXT`; no hex literal under `src/v2/`. Both guards pass — `no_hex_literals_in_v2_render_code` and `no_hex_literals_in_v2_transcript_code`.
- **Block geometry unmoved.** `render/tests/block_rail.rs` pins the rail at column 1 and content at column 5; adding spans *inside* the subject does not move it, and the suite passes. The palette tests index `spans[2]` (the verb) and the split only adds indices after it.
- **Goldens untouched.** `deck_render_snapshots` passes with no `BLESS`. They compare characters, and this is a pure re-styling — so a moved snapshot would have meant the fix changed the *text*, which would be a bug in the fix. None moved.

## The gate

Each with its exit code, `--color=never`, not a grep of coloured output:

- `cargo test -p stella-tui` — **0**. 954 lib tests (952 + these 2), every integration suite green.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — **0**
- `cargo fmt -p stella-tui -- --check` — **0**
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` — **0**, and worth a note: it caught a real one. My first draft documented `Subject` with an intra-doc link to `subject_for`, which is module-private — `error: public documentation for Subject links to private item`, the same shape that made `main` red in #4279. Fixed by naming it in backticks rather than linking, the idiom `measured_delta`'s doc comment already uses for `render::resolve_inline_delta`. I had also widened `subject_for` to `pub(super)` for no reason; it is private again.

No test deleted or renamed by this PR.

Closes #4168

## Summary by Sourcery

Restore distinct visual emphasis for filesystem paths in v2 transcript call rows while keeping command subjects unchanged.

New Features:
- Highlight filesystem path subjects by dimming their directory and emphasizing their basename in v2 transcript rows.

Bug Fixes:
- Prevent command-line subjects containing slashes from being incorrectly styled as filesystem paths.

Enhancements:
- Preserve path identity explicitly on transcript subjects instead of inferring it from rendered text.
- Add complementary tests covering path emphasis and non-path command rendering.

Tests:
- Add regression coverage for path and command subject styling, including protection against slash-based path inference.