### PR TITLE
fix(stella-tui): the opening rule names the model that is answering the turn

### DIFF
--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -1156,12 +1156,13 @@ impl SessionModel {
     ///
     /// * an earlier turn's rule is already settled and must not be rewritten by
     ///   a later turn's call;
-    /// * a sub-agent's calls also carry [`ModelCallRole::Worker`], and a child
-    ///   may well run on a different model. The lead has to call the model
-    ///   before it can decide to delegate, so the lead's own first worker call
-    ///   always precedes any child's and has already claimed the rule by the
-    ///   time one arrives. Depth is not on the wire here, so the ordering is the
-    ///   guarantee rather than a filter.
+    /// * a sub-agent's calls also carry
+    ///   [`stella_protocol::ModelCallRole::Worker`], and a child may well run on
+    ///   a different model. The lead has to call the model before it can decide
+    ///   to delegate, so the lead's own first worker call always precedes any
+    ///   child's and has already claimed the rule by the time one arrives. Depth
+    ///   is not on the wire here, so the ordering is the guarantee rather than a
+    ///   filter.
     ///
     /// A turn whose rule was never stamped (`turn_head_stamped` false — no stage
     /// boundary yet) simply finds nothing and leaves `hud.model` to carry it.

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -339,7 +339,12 @@ impl SessionModel {
                     self.turn_head_stamped = true;
                     Some(TurnOpening {
                         turn: self.turns_completed.saturating_add(1),
-                        model: self.hud.model.clone(),
+                        // Deliberately not `self.hud.model`: that field is
+                        // written only by `TurnComplete`/`RunComplete`, so at
+                        // this instant it holds either nothing (turn 1) or the
+                        // *previous* turn's model. The turn's own first worker
+                        // call back-fills it — see `TurnOpening::model`.
+                        model: None,
                         budget_usd: self.hud.limit_usd,
                     })
                 };
@@ -850,8 +855,28 @@ impl SessionModel {
             // (#3511), and the crate itself was deleted in #3865, so nothing
             // emits `Proof` today. The step survives in the traces tab and the transcript
             // export, which read the raw stream.
-            | AgentEvent::Proof { .. }
-            | AgentEvent::StepManifest { .. } => {}
+            | AgentEvent::Proof { .. } => {}
+            // The one field of a manifest the deck folds: **which model is
+            // answering this turn**. Its token, cost and block fields are
+            // pointedly still ignored, for the reason the group above states —
+            // the live spend is `BudgetTick`'s and folding a second source
+            // would double-count it.
+            //
+            // The manifest is emitted immediately *before* its call commits,
+            // which is what makes it early enough to label a turn that has only
+            // just started — the whole point, since `Hud::model`'s existing
+            // writers are both terminal (#4183).
+            AgentEvent::StepManifest {
+                role,
+                model,
+                call_seq,
+                ..
+            } => {
+                if turn::supplies_the_turns_model(*role, *call_seq) {
+                    self.hud.model = Some(model.clone());
+                    self.name_the_open_turns_model(model);
+                }
+            }
             AgentEvent::Error { message, retryable } => {
                 // A terminal error ends the turn without a `Complete`, so the
                 // plan has to close here too: a step left `working` on a turn
@@ -1120,6 +1145,39 @@ impl SessionModel {
                 _ => None,
             })
             .and_then(|(name, path)| is_file_mutation(&name).then_some(path).flatten())
+    }
+
+    /// Name `model` on the opening rule of the turn now in flight, if that rule
+    /// has not been given one yet.
+    ///
+    /// Walks back to the **nearest** stage boundary that opened a turn and stops
+    /// there, whether or not it fills anything. That single stop is what makes
+    /// this first-write-wins per turn, and it is doing two jobs:
+    ///
+    /// * an earlier turn's rule is already settled and must not be rewritten by
+    ///   a later turn's call;
+    /// * a sub-agent's calls also carry [`ModelCallRole::Worker`], and a child
+    ///   may well run on a different model. The lead has to call the model
+    ///   before it can decide to delegate, so the lead's own first worker call
+    ///   always precedes any child's and has already claimed the rule by the
+    ///   time one arrives. Depth is not on the wire here, so the ordering is the
+    ///   guarantee rather than a filter.
+    ///
+    /// A turn whose rule was never stamped (`turn_head_stamped` false — no stage
+    /// boundary yet) simply finds nothing and leaves `hud.model` to carry it.
+    fn name_the_open_turns_model(&mut self, model: &str) {
+        if let Some(TranscriptEntry::Stage {
+            opens: Some(opening),
+            ..
+        }) = self
+            .transcript
+            .iter_mut()
+            .rev()
+            .find(|e| matches!(e, TranscriptEntry::Stage { opens: Some(_), .. }))
+            && opening.model.is_none()
+        {
+            opening.model = Some(model.to_owned());
+        }
     }
 
     /// Drop the inline-diff reference from every earlier result that pointed

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -12,8 +12,8 @@ use super::*;
 // them (#4217). Naming them keeps the tests independent of what the fold
 // happens to need.
 use stella_protocol::{
-    BudgetMode, ContextFrameRef, MediaArtifactRef, MediaJobState, MediaKind, PrStatus,
-    ProviderShare, ToolCall, VerdictEvidence,
+    BudgetMode, ContextFrameRef, MediaArtifactRef, MediaJobState, MediaKind, ModelCallRole,
+    PrStatus, ProviderShare, ToolCall, VerdictEvidence,
 };
 
 fn text(delta: &str) -> AgentEvent {
@@ -229,9 +229,27 @@ fn only_the_first_stage_of_a_turn_opens_a_turn_rule() {
     );
 }
 
+/// One model call, for the opening-rule tests below.
+fn manifest(role: ModelCallRole, call_seq: u64, model: &str) -> AgentEvent {
+    AgentEvent::StepManifest {
+        turn_instance: 0,
+        step: 0,
+        call_seq,
+        role,
+        provider: "openrouter".into(),
+        model: model.into(),
+        blocks: Vec::new(),
+        effective_budget_tokens: 100_000,
+        calibration_factor: 1.0,
+        estimated_input_tokens: 40,
+        compiled_frame: None,
+    }
+}
+
 /// The opening rule states the budget the last `BudgetTick` reported and the
-/// model the HUD has observed — and states neither before anything reported
-/// one. `None` is "nobody said", not `$0.00` and not the configured default.
+/// model of the turn's own first worker call — and states neither before
+/// anything reported one. `None` is "nobody said", not `$0.00` and not the
+/// configured default.
 #[test]
 fn an_opening_rule_carries_only_facts_the_fold_was_given() {
     let mut model = SessionModel::new();
@@ -239,9 +257,25 @@ fn an_opening_rule_carries_only_facts_the_fold_was_given() {
     let first = openings(&model)[0].clone();
     assert_eq!(
         first.model, None,
-        "no turn has settled, so no model is known"
+        "no call has committed, so no model has answered"
     );
     assert_eq!(first.budget_usd, None, "no tick has armed a budget");
+
+    // The two facts reach the rule by different routes, and the difference is
+    // deliberate. A budget is armed before the turn opens, so it is *stamped*
+    // when the boundary is pushed. A model is not known until a call commits,
+    // which is strictly after that, so it is *back-filled* onto the same rule.
+    model.apply(&manifest(ModelCallRole::Worker, 0, "kimi-k3"));
+    assert_eq!(
+        openings(&model)[0].model.as_deref(),
+        Some("kimi-k3"),
+        "the turn's first worker call did not reach its own rule"
+    );
+    assert_eq!(
+        openings(&model)[0].budget_usd,
+        None,
+        "no tick armed a budget before this turn opened"
+    );
 
     model.apply(&AgentEvent::TurnComplete {
         model: "kimi-k3".into(),
@@ -257,8 +291,109 @@ fn an_opening_rule_carries_only_facts_the_fold_was_given() {
     });
     model.apply(&stage(StageKind::Execute));
     let second = openings(&model)[1].clone();
-    assert_eq!(second.model.as_deref(), Some("kimi-k3"));
-    assert_eq!(second.budget_usd, Some(0.60));
+    assert_eq!(second.budget_usd, Some(0.60), "the armed budget is stamped");
+    assert_eq!(
+        second.model, None,
+        "a settled TurnComplete is not evidence about the turn now opening — \
+         naming its model here is the defect #4183 closed"
+    );
+}
+
+/// #4183: the **first** turn names its model, which is the whole point.
+///
+/// `Hud::model`'s only writers are `TurnComplete` and `RunComplete`, both
+/// terminal, so sourcing the rule from it left turn 1 permanently blank and
+/// made every later turn name its predecessor's model. The manifest arrives
+/// *before* its call commits, which is what makes it early enough to label the
+/// turn it belongs to.
+#[test]
+fn the_first_turns_rule_names_the_model_that_is_answering_it() {
+    let mut model = SessionModel::new();
+    model.apply(&stage(StageKind::Execute));
+    assert_eq!(
+        openings(&model)[0].model,
+        None,
+        "nothing has committed a call yet"
+    );
+
+    model.apply(&manifest(ModelCallRole::Worker, 0, "kimi-k3"));
+
+    assert_eq!(
+        openings(&model)[0].model.as_deref(),
+        Some("kimi-k3"),
+        "the turn's own first worker call did not reach its opening rule"
+    );
+}
+
+/// The trap the fold has to design around: a manifest is emitted for *every*
+/// model call, and an auxiliary one is not the turn's answer.
+///
+/// An unfiltered fold would let the overflow summarizer's model label the turn
+/// — a rule naming a model that never answered it, which is worse than the
+/// blank it replaces. Both halves of the predicate are exercised: a wrong role
+/// at the worker's `call_seq`, and the worker's own role at an auxiliary seq.
+#[test]
+fn an_auxiliary_call_never_supplies_the_opening_rules_model() {
+    for (role, call_seq) in [
+        (ModelCallRole::Summarization, 0),
+        (ModelCallRole::Verdict, 0),
+        // Legacy sessions recorded no role at all. A call this build cannot
+        // identify must not name the turn either — eliding beats asserting a
+        // routing decision nothing recorded.
+        (ModelCallRole::Unknown, 0),
+        // The worker's role riding an auxiliary seq is still not the engine's
+        // own call for the step.
+        (ModelCallRole::Worker, 1),
+    ] {
+        let mut model = SessionModel::new();
+        model.apply(&stage(StageKind::Execute));
+        model.apply(&manifest(role, call_seq, "cheap-summarizer"));
+        assert_eq!(
+            openings(&model)[0].model,
+            None,
+            "{role:?} at call_seq {call_seq} labelled the turn"
+        );
+    }
+}
+
+/// A later turn's call must not rewrite a settled rule, and a sub-agent's must
+/// not overwrite the lead's.
+///
+/// Both fall out of the same stop: the back-fill walks to the *nearest* opened
+/// turn and stops there whether or not it fills anything, so the first worker
+/// call of each turn claims that turn's rule and nothing later can take it.
+#[test]
+fn a_later_call_cannot_rewrite_a_rule_another_turn_already_claimed() {
+    let mut model = SessionModel::new();
+    model.apply(&stage(StageKind::Execute));
+    model.apply(&manifest(ModelCallRole::Worker, 0, "kimi-k3"));
+    // A delegated child's calls carry the worker role too, and may run on a
+    // different model.
+    model.apply(&manifest(ModelCallRole::Worker, 0, "child-model"));
+    assert_eq!(
+        openings(&model)[0].model.as_deref(),
+        Some("kimi-k3"),
+        "a second worker call overwrote the turn's model"
+    );
+
+    model.apply(&AgentEvent::TurnComplete {
+        model: "kimi-k3".into(),
+        cost_usd: 0.11,
+    });
+    model.apply(&stage(StageKind::Execute));
+    model.apply(&manifest(ModelCallRole::Worker, 0, "glm-5"));
+
+    let opened = openings(&model);
+    assert_eq!(
+        opened[0].model.as_deref(),
+        Some("kimi-k3"),
+        "turn 1's settled rule was rewritten by turn 2's call"
+    );
+    assert_eq!(
+        opened[1].model.as_deref(),
+        Some("glm-5"),
+        "turn 2's rule did not take its own turn's model"
+    );
 }
 
 /// A turn that died never emits `TurnComplete`, so nothing else clears the

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -13,7 +13,39 @@
 //! the same cut `file_state` and `recall` already make, and along the same
 //! seam: a `TranscriptEntry`'s supporting types live beside it, not in it.
 
-use stella_protocol::{BudgetMode, StageKind, StageName};
+use stella_protocol::{BudgetMode, ModelCallRole, StageKind, StageName};
+
+/// Whether one model call is the one **answering the turn**, and so may supply
+/// the model name on SPEC 6.1's opening rule.
+///
+/// The one named place the fold asks this, deliberately. The role vocabulary is
+/// in flux — see the roleless-core work (#3903) — and a predicate spelled out at
+/// each call site is a predicate that gets updated at some of them.
+///
+/// Two conditions, and each excludes a different wrong answer:
+///
+/// * **[`ModelCallRole::Worker`]** is the ordinary execution role
+///   (`stella-core`'s `driver::capabilities`: "every call has a role, and
+///   `Worker` is the ordinary"). Every other role is auxiliary to the turn
+///   rather than the turn — a `Summarization` call is the overflow summarizer,
+///   a `Verdict` call is a verifier — and naming one of those on the rule would
+///   say the turn was answered by a model that never answered it.
+/// * **`call_seq == 0`** is the engine's own call for the step. Auxiliary calls
+///   riding the same `(turn_instance, step)` take 1, 2, … from a per-execution
+///   counter, so the zero is what separates the worker from whatever shared its
+///   step.
+///
+/// [`ModelCallRole::Unknown`] is deliberately **not** accepted, even though it
+/// is the `serde` default for an absent role and so covers every session
+/// recorded before call-role attribution existed. Naming a model from a call
+/// this build cannot identify is the same move #4124 refused when it declined
+/// to substitute the configured default: the rule would assert a routing
+/// decision nothing recorded. A replayed legacy session therefore keeps the
+/// blank it has today, which is the honest outcome rather than a regression.
+#[must_use]
+pub(crate) fn supplies_the_turns_model(role: ModelCallRole, call_seq: u64) -> bool {
+    matches!(role, ModelCallRole::Worker) && call_seq == 0
+}
 
 /// What SPEC 6.1's opening rule says out loud, stamped onto the stage boundary
 /// that opens a turn.
@@ -43,13 +75,26 @@ pub struct TurnOpening {
     /// ordinal — which is the honest reading of a counter that means "turns
     /// this session has finished", not a renumbering.
     pub turn: u32,
-    /// The model answering, as [`Hud::model`] last observed it.
+    /// The model answering **this** turn, from a call that actually happened.
     ///
-    /// `None` for the whole first turn of a session: `Hud::model` is fed by
-    /// `AgentEvent::TurnComplete`, which by definition has not arrived yet.
-    /// Elided rather than substituted — the configured default is not evidence
-    /// of what a router picked, and the rule would be asserting a routing
-    /// decision nothing recorded (#4183).
+    /// Opens as `None` and is back-filled by the turn's own first worker call
+    /// (`AgentEvent::StepManifest`, gated on `supplies_the_turns_model` below —
+    /// crate-private, so named rather than linked),
+    /// rather than being stamped from [`Hud::model`] when the boundary is
+    /// pushed. Two defects made that the wrong source (#4183): `Hud::model` is
+    /// written only by `TurnComplete` and `RunComplete`, both of which are
+    /// terminal, so it was empty for the whole of turn 1 and named *the
+    /// previous turn's* model from turn 2 on.
+    ///
+    /// Back-filled rather than deferred because the boundary is a settled
+    /// transcript entry: the rule renders the moment the stage lands, and the
+    /// deck's settled-prefix fold re-renders it when the manifest arrives — the
+    /// same shape the head's measured size uses (#4154).
+    ///
+    /// Still `None` when nothing has committed a worker call, which is honest:
+    /// a turn that ended before reaching the model has no model to name, and
+    /// eliding beats substituting the configured default, which is not evidence
+    /// of what a router picked (#4124).
     pub model: Option<String>,
     /// This turn's spend ceiling, from [`Hud::limit_usd`].
     ///


### PR DESCRIPTION
## What & why

SPEC 6.1's opening rule is `── turn N <stage> · <model> · budget $X ──`. The model half was **blank for the whole first turn of every session**, and named the *previous* turn's model from turn 2 on.

`TurnOpening::model` was stamped from `Hud::model`, and that field has exactly two writers — `AgentEvent::TurnComplete` and `AgentEvent::RunComplete` — **both terminal**. So at the instant a rule is pushed it holds either nothing at all, or a fact about a turn that has already ended.

#4124 elided rather than substituting the configured default, and that was right: naming a default over a routed call is the rule asserting a routing decision nothing recorded. But eliding is a placeholder, not an answer.

## The producer already existed

`AgentEvent::StepManifest` carries `role`, `provider`, `model` and `call_seq`, and is emitted **immediately before each call commits** — which is what makes it early enough to label the turn it belongs to, and why I took it over `StepUsage`.

The deck folded neither manifest nor usage, deliberately: their token and cost fields would double-count the spend `BudgetTick` already drives. So this folds **the model name and nothing else**, and the comment at the new arm says so, because the next reader's first question is why this event left the no-op group.

## Two things that needed designing, not just wiring

**1. The rule is a settled transcript entry, so the fact has to be back-filled.** The boundary renders the moment the stage lands, which is strictly before any call commits. So `TurnOpening::model` now opens as `None` and the turn's own first worker call fills it — the same settled-prefix re-render the head's measured size already uses (#4154). Budget still *stamps* at open, because a budget is armed before the turn starts while a model is not known until a call commits. Two facts, one rule, two routes; the test says why out loud rather than leaving it to look like an inconsistency.

**2. The predicate has to exclude two different wrong answers, and lives in one named place.** #4183 warns the role vocabulary is in flux (#3903), so `turn::supplies_the_turns_model(role, call_seq)` is the single site the fold cites:

- **`Worker`** — `stella-core`'s `driver::capabilities` states it is the ordinary execution role. Every other role is auxiliary *to* the turn rather than *being* the turn; a `Summarization` call is the overflow summarizer and a `Verdict` call is a verifier, and naming either on the rule says the turn was answered by a model that never answered it.
- **`call_seq == 0`** — the engine's own call for the step. Auxiliary calls riding the same `(turn_instance, step)` take 1, 2, … from a per-execution counter.
- **`Unknown` is refused**, though it is the `serde` default for an absent role and so covers every pre-attribution session. Naming a model from a call this build cannot identify is the same move #4124 declined. A replayed legacy session keeps the blank it has today — no improvement, but no invention either.

**The sub-agent hazard, which is not in the issue.** A delegated child's calls also carry `ModelCallRole::Worker` (`stella-core`'s `SubAgentSpec`) and may run on a different model, and `StepManifest` carries no depth to filter on. The back-fill walks to the **nearest** opened turn and stops there whether or not it fills anything, making it first-write-wins per turn — and the lead must call the model before it can decide to delegate, so the lead's own call has always claimed the rule by the time a child's arrives. Ordering is the guarantee; that argument is written on the helper rather than left implicit.

## The witness

- [x] This PR includes a witness test

Four, and **every one was disarmed and re-run** rather than asserted:

| Disarm | Result |
|---|---|
| remove the fold (`if false && …`) | `an_opening_rule_carries_only_facts_the_fold_was_given` **FAILED**, `the_first_turns_rule_names_the_model_that_is_answering_it` **FAILED**, `a_later_call_cannot_rewrite_a_rule_another_turn_already_claimed` **FAILED** |
| widen the predicate to accept everything | `an_auxiliary_call_never_supplies_the_opening_rules_model` **FAILED** — `Summarization at call_seq 0 labelled the turn` |

The second row is the point of doing both. The auxiliary guard *passes* under the first disarm, so on its own it proves nothing; it is load-bearing only against a fold that over-reaches, which is the failure this feature invites.

`an_opening_rule_names_no_model_or_budget_it_was_never_told` still holds for the genuinely-unknown case, as #4183 requires.

## A test is rewritten — naming it explicitly

`an_opening_rule_carries_only_facts_the_fold_was_given` keeps its name and its budget half. Its **model half asserted the defect**: `second.model == Some("kimi-k3")` on a turn whose model came from the *previous* turn's `TurnComplete`. #4183 calls that assertion "the witness, inverted", and it now asserts the opposite with a message saying which defect it is. **No test is deleted or renamed by this PR** (`check-deleted-tests` runs on `pull_request` only, so stating it here).

## The gate

Exit codes, `--color=never`:

- `cargo test -p stella-tui` — **0**; 955 lib tests (952 + 3 new), every integration suite green
- `cargo test -p stella-cli` — **0**. Run deliberately: `stella-cli` links `stella-tui`, and this changes fold behaviour rather than only rendering, so the crate-scoped run is not sufficient evidence on its own.
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — **0**
- `cargo fmt -p stella-tui -- --check` — **0**
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` — **0**, after fixing one it caught: `TurnOpening::model`'s doc linked `[supplies_the_turns_model]`, which is `pub(crate)` — `error: public documentation for model links to private item`, the shape that made `main` red in #4279. Named in backticks instead.

Closes #4183

## Summary by Sourcery

Attribute each opening rule to the current turn’s primary worker model without inventing routing information or rewriting settled transcript entries.

Bug Fixes:
- Ensure opening rules name the model answering the current turn, including on the first turn, instead of retaining a blank or previous-turn model.

Enhancements:
- Back-fill opening-rule model names from the first primary worker call while excluding auxiliary, unknown, and subsequent calls.
- Preserve first-write-wins behavior so later turns and delegated calls cannot rewrite settled opening rules.

Tests:
- Add coverage for first-turn model attribution, auxiliary-call exclusion, per-turn first-write-wins behavior, and genuinely unknown model data.