### PR TITLE
fix(stella-cli,stella-tools,stella-plugin,stella-autonomy): six plugin and self-driving defects, and one issue that was already fixed

### DIFF
--- a/crates/stella-autonomy/src/doctrine.rs
+++ b/crates/stella-autonomy/src/doctrine.rs
@@ -28,9 +28,10 @@
 //!   "match the neighbourhood", "no new dependencies casually" — that is
 //!   instruction for the judgement half, it already has a home in the context
 //!   record plane (`.stella/rules/*.toml`, `doc:context-pr`),
-//!   and duplicating it here would create the fifth plane. A `[doctrine]` block
-//!   that wanted to say something prose-shaped is a context record, and this
-//!   module's answer to that request is a pointer, not a field.
+//!   and duplicating it here would create the fifth plane. A
+//!   `[self_driving.doctrine]` block that wanted to say something prose-shaped
+//!   is a context record, and this module's answer to that request is a
+//!   pointer, not a field.
 //!
 //! The test for whether something belongs here is the same one invariant 5
 //! applies to error types: **does a caller branch on it?** A pure machine
@@ -114,9 +115,9 @@ pub enum ContentionPolicy {
 
 /// The operator's declared decision system.
 ///
-/// Source-tracked beside the provider and convention manifests under
-/// `.stella/issues/`, for the same reason: **the person who starts the loop is
-/// the person who decides how it decides**, and that is only true if what it
+/// Declared in `[self_driving.doctrine]` in `stella.toml`, source-tracked with
+/// the rest of the workspace's configuration: **the person who starts the loop
+/// is the person who decides how it decides**, and that is only true if what it
 /// will do is legible before it does it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -277,6 +278,49 @@ mod tests {
         assert_eq!(d.foreign_breakage, ForeignBreakage::FileAndAdopt);
         assert_eq!(d.contention, ContentionPolicy::Defer);
         assert!(!d.abandon_escalated);
+    }
+
+    /// ...and the spec says the same thing, on the one axis where saying the
+    /// other thing changes what the loop does to a red base.
+    ///
+    /// `doc:backlog-self-driving` §6.5 marked `file_and_wait` *(default)* for as
+    /// long as this crate shipped [`ForeignBreakage::FileAndAdopt`], so a reader
+    /// of the spec expected a loop that reports a base somebody else broke and
+    /// stops. The default is the operator-visible contract, and it is stated in
+    /// two places; this is the assertion that keeps them one answer.
+    ///
+    /// The predicate reads only the bullets naming a `foreign_breakage`
+    /// spelling and asks which carries the `*(default)*` marker. That marker
+    /// sits immediately after the code span, so it stays on the bullet's first
+    /// line however the prose after it is reflowed.
+    #[test]
+    fn doctrine_default_matches_the_spec() {
+        let spec = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("docs/spec/backlog-self-driving.md");
+        let text = std::fs::read_to_string(&spec)
+            .unwrap_or_else(|e| panic!("read {}: {e}", spec.display()));
+
+        let marked: Vec<&str> = ["file_and_wait", "file_and_adopt", "ignore"]
+            .into_iter()
+            .filter(|spelling| {
+                let bullet = format!("- `{spelling}`");
+                text.lines().any(|line| {
+                    line.trim_start().starts_with(&bullet) && line.contains("*(default)*")
+                })
+            })
+            .collect();
+
+        let shipped = serde_json::to_value(Doctrine::default().foreign_breakage)
+            .expect("serialize the default");
+        let shipped = shipped.as_str().expect("a snake_case string");
+
+        assert_eq!(
+            marked,
+            vec![shipped],
+            "exactly one `foreign_breakage` bullet in §6.5 is marked *(default)*, \
+             and it is the one `Doctrine::default()` ships"
+        );
     }
 
     /// The witness for collision avoidance: a worktree on this machine defers

--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -72,6 +72,12 @@ pub struct SessionStats {
     /// are different grades of evidence and a dashboard that merged them
     /// would hide which merges rested on which.
     pub verified_locally: u32,
+    /// Filings attempted, however they ended.
+    ///
+    /// The denominator `issues_created`, `filings_refused` and
+    /// `filings_duplicate` share, which is what makes
+    /// [`SessionStats::filings_balance`] a check rather than an assumption.
+    pub filings_attempted: u32,
     /// Filings refused for not matching the workspace's convention.
     pub filings_refused: u32,
     /// Filings skipped because the finding was already in the seen set.
@@ -106,9 +112,18 @@ pub struct SessionStats {
     pub base_broken_waits: u32,
 
     // -- what the loop learned ----------------------------------------------
-    /// Reflections written to the reflection log.
+    //
+    // A turn runs in a child process, so these three are deltas over the
+    // durable state it leaves behind rather than events this process saw. The
+    // writer is `stella-cli`'s `self_driving_cmd::learning`, which names the
+    // artifact each one is read from.
+    /// Lessons written to the reflection log, restatements included — a lesson
+    /// the loop keeps re-learning is the recurrence the miners exist to count.
     pub reflections_logged: u32,
-    /// Memories created.
+    /// Memories created: distinct memory lineages the context store gained.
+    ///
+    /// Lower than `reflections_logged` by design — a restated lesson reaches
+    /// the log and claims no memory.
     pub memories_created: u32,
     /// Proposals emitted for a human to accept or decline.
     pub proposals_made: u32,
@@ -186,11 +201,143 @@ impl SessionStats {
             _ => {}
         }
     }
+
+    /// Whether the filing counts add up.
+    ///
+    /// The companion to [`SessionStats::closures_balance`], for the same
+    /// reason: three outcomes rendered beside a total that disagrees with them
+    /// is worse than either alone, because a reader believes whichever they
+    /// read first.
+    #[must_use]
+    pub fn filings_balance(&self) -> bool {
+        self.issues_created + self.filings_refused + self.filings_duplicate
+            == self.filings_attempted
+    }
+
+    /// Record a filing by its canonical outcome.
+    ///
+    /// A `&str` rather than the caller's own enum, exactly as
+    /// [`SessionStats::record_closure`]: this is a leaf crate, and the
+    /// vocabulary of *why a filing did not happen* belongs to the surface that
+    /// tried. An unrecognised outcome still counts toward the attempts, so
+    /// [`SessionStats::filings_balance`] reports it rather than the number
+    /// silently going missing.
+    pub fn record_filing(&mut self, canonical: &str) {
+        self.filings_attempted += 1;
+        match canonical {
+            "new" => self.issues_created += 1,
+            "refused" => self.filings_refused += 1,
+            "duplicate" => self.filings_duplicate += 1,
+            _ => {}
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every counter, and the code that writes it.
+    ///
+    /// A counter with a printer and no producer renders `0` forever, and a
+    /// reader cannot tell that from "the session did none of that" — five of
+    /// them shipped that way (#4118). The compiler cannot catch it: a `pub`
+    /// field that nothing assigns is neither dead code nor a warning.
+    ///
+    /// This is the discipline of invariant #10's consumer ledger
+    /// (`stella_protocol::event::consumers`) pointed at production instead of
+    /// consumption, and it enforces the same half: a field cannot be added
+    /// without a line naming where it is written, which a reviewer reads. It
+    /// does not prove the named site still exists — that string is prose. The
+    /// test below proves totality, which is what makes the question
+    /// unavoidable at the moment a field is added.
+    const PRODUCERS: &[(&str, &str)] = &[
+        ("issues_claimed", "drive.rs — taken off the ranked queue"),
+        ("issues_attempted", "drive.rs — a turn was spent on it"),
+        ("issues_changed", "drive.rs — WorkOutcome::Changed"),
+        ("issues_no_change", "drive.rs — WorkOutcome::NoChange"),
+        ("issues_failed", "drive.rs — WorkOutcome::Failed"),
+        ("issues_escalated", "drive.rs — handed back to a human"),
+        (
+            "issues_deferred",
+            "drive.rs — a peer had it, or it would not start",
+        ),
+        (
+            "issues_created",
+            "SessionStats::record_filing, from self_driving_cmd.rs",
+        ),
+        ("issues_triaged", "drive.rs — placed on the ladder"),
+        (
+            "verified_locally",
+            "drive.rs — the project's own checks passed here",
+        ),
+        ("filings_attempted", "SessionStats::record_filing"),
+        ("filings_refused", "SessionStats::record_filing"),
+        ("filings_duplicate", "SessionStats::record_filing"),
+        (
+            "closed_total",
+            "SessionStats::record_closure, from lifecycle.rs",
+        ),
+        ("closed_completed", "SessionStats::record_closure"),
+        ("closed_not_planned", "SessionStats::record_closure"),
+        ("closed_duplicate", "SessionStats::record_closure"),
+        ("prs_opened", "drive.rs — delivery opened one"),
+        ("prs_merged", "drive.rs — the forge reported a merge"),
+        ("prs_escalated", "drive.rs — handed to a human instead"),
+        ("fixes_pushed", "drive.rs — a red build was answered"),
+        ("rebases", "drive.rs — a conflict was answered"),
+        (
+            "base_broken_waits",
+            "drive.rs — the red reproduced on the base",
+        ),
+        (
+            "reflections_logged",
+            "self_driving_cmd/learning.rs — reflection-log delta",
+        ),
+        (
+            "memories_created",
+            "self_driving_cmd/learning.rs — memory-lineage delta",
+        ),
+        (
+            "proposals_made",
+            "self_driving_cmd/learning.rs — proposal-record delta",
+        ),
+        ("turns_run", "drive.rs — a turn reached the model"),
+        (
+            "turns_over_budget",
+            "drive.rs — a turn hit its spend ceiling",
+        ),
+    ];
+
+    /// **The witness.** Every field the report renders names the code that
+    /// writes it. A counter added with a printer and no producer fails here
+    /// instead of shipping a zero somebody reads as a fact.
+    #[test]
+    fn every_counter_names_its_producer() {
+        let rendered = serde_json::to_value(SessionStats::default()).expect("serialize");
+        let fields: std::collections::BTreeSet<String> = rendered
+            .as_object()
+            .expect("a struct serializes to an object")
+            .keys()
+            .cloned()
+            .collect();
+        let declared: std::collections::BTreeSet<String> = PRODUCERS
+            .iter()
+            .map(|(field, _)| (*field).to_owned())
+            .collect();
+
+        let undeclared: Vec<&String> = fields.difference(&declared).collect();
+        assert!(
+            undeclared.is_empty(),
+            "these counters have a printer and no declared producer: {undeclared:?} \
+             — name the code that writes each one in PRODUCERS, or delete the field"
+        );
+        let stale: Vec<&String> = declared.difference(&fields).collect();
+        assert!(
+            stale.is_empty(),
+            "PRODUCERS names counters that no longer exist: {stale:?}"
+        );
+    }
 
     /// **The witness.** A loop filing faster than it finishes is losing ground,
     /// and the number that says so must be on the dashboard — the raw counts
@@ -252,6 +399,39 @@ mod tests {
         assert!(
             !stats.closures_balance(),
             "an unrecognised resolution must show up as an imbalance, not disappear"
+        );
+    }
+
+    /// The three outcomes must sum to the attempts, and `record_filing` is
+    /// what makes that true by construction. A refusal and a duplicate are
+    /// real outcomes of a filing, not silences.
+    #[test]
+    fn recording_filings_keeps_the_counts_balanced() {
+        let mut stats = SessionStats::default();
+        stats.record_filing("new");
+        stats.record_filing("refused");
+        stats.record_filing("duplicate");
+        stats.record_filing("duplicate");
+
+        assert_eq!(stats.filings_attempted, 4);
+        assert_eq!(stats.issues_created, 1);
+        assert_eq!(stats.filings_refused, 1);
+        assert_eq!(stats.filings_duplicate, 2);
+        assert!(stats.filings_balance());
+    }
+
+    /// A filing outcome this build does not know still counts toward the
+    /// attempts, so the balance check reports the gap rather than the number
+    /// vanishing — the same contract `record_closure` holds.
+    #[test]
+    fn an_unknown_filing_outcome_is_visible_rather_than_lost() {
+        let mut stats = SessionStats::default();
+        stats.record_filing("rate_limited");
+
+        assert_eq!(stats.filings_attempted, 1);
+        assert!(
+            !stats.filings_balance(),
+            "an unrecognised filing outcome must show up as an imbalance, not disappear"
         );
     }
 

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -574,8 +574,14 @@ fn remove(workspace_root: &Path, name: &str) -> Result<(), String> {
 /// (there can be more than one — see
 /// [`roster::read_tier`]'s collision notice, where only the last is in force
 /// and the others are installed and inert), plus the literal `<tier>/<name>`
-/// when it exists, which is how a package whose manifest no longer parses is
-/// still reachable.
+/// when it is a real directory, which is how a package whose manifest no
+/// longer parses is still reachable.
+///
+/// `symlink_metadata`, not `Path::is_dir`, which follows the link: a symlinked
+/// tier entry is not a plugin — [`roster::read_tier`] skips it and says so —
+/// so `remove` must not collect one either (#3530). Collected, it reached
+/// [`remove_plugin_dir`]'s refusal and turned an unremarkable "not installed"
+/// into a hard error about a package this CLI never installed.
 fn removable_dirs(tier: &Path, name: &str, installs: &[roster::InstalledPlugin]) -> Vec<PathBuf> {
     let mut dirs: Vec<PathBuf> = installs
         .iter()
@@ -583,7 +589,9 @@ fn removable_dirs(tier: &Path, name: &str, installs: &[roster::InstalledPlugin])
         .map(|plugin| plugin.dir.clone())
         .collect();
     let by_path = tier.join(name);
-    if by_path.is_dir() && !dirs.contains(&by_path) {
+    let is_real_dir =
+        std::fs::symlink_metadata(&by_path).is_ok_and(|meta| meta.file_type().is_dir());
+    if is_real_dir && !dirs.contains(&by_path) {
         dirs.push(by_path);
     }
     dirs

--- a/crates/stella-cli/src/plugin_cmd/package.rs
+++ b/crates/stella-cli/src/plugin_cmd/package.rs
@@ -113,6 +113,12 @@ pub(crate) struct ContributedDir {
     /// The contributing plugin's manifest `name` — the provenance, and the
     /// string `Principal::Plugin` carries for its tools.
     pub(crate) plugin: String,
+    /// The installed package's own root — `<plugin_dir>`, which [`Self::dir`]
+    /// sits inside. It is what `${plugin_dir}` expands to in a contributed
+    /// manifest, and it is carried explicitly so the layout is stated once,
+    /// here in [`dirs_of`], rather than re-derived from a parent path by every
+    /// surface that needs it.
+    pub(crate) package_dir: PathBuf,
     /// The directory itself. It may not exist: a plugin shipping no skills
     /// has no `skills/`, and every loader here treats an absent directory as
     /// an empty one rather than an error.
@@ -135,6 +141,7 @@ fn dirs_of(roster: &PluginRoster, kind: &str) -> Vec<ContributedDir> {
         .filter(|plugin| reconciles_with_disk(plugin))
         .map(|plugin| ContributedDir {
             plugin: plugin.manifest.name.clone(),
+            package_dir: plugin.dir.clone(),
             dir: plugin.dir.join(kind),
         })
         .collect()
@@ -191,6 +198,13 @@ fn session_roster(workspace_root: &Path) -> PluginRoster {
 /// Handed to [`stella_tools::custom::discover_with_plugins`], which scans
 /// them **last** so the user's own manifests keep their names — see that
 /// function for the precedence argument.
+///
+/// The package root rides along because a contributed manifest may name a
+/// script the package ships, and the child still runs from the *workspace*
+/// root — a linter a plugin contributes acts on the user's repository. So the
+/// package's own paths arrive as `${plugin_dir}`, which discovery expands
+/// against this directory (#3579), the same way [`super::roster`] expands it
+/// in a plugin's hook argv.
 pub(crate) fn contributed_tool_dirs(
     workspace_root: &Path,
 ) -> Vec<stella_tools::custom::PluginToolDir> {
@@ -198,6 +212,7 @@ pub(crate) fn contributed_tool_dirs(
         .into_iter()
         .map(|contributed| stella_tools::custom::PluginToolDir {
             plugin: contributed.plugin,
+            package_dir: contributed.package_dir,
             dir: contributed.dir,
         })
         .collect()

--- a/crates/stella-cli/src/plugin_cmd/roster.rs
+++ b/crates/stella-cli/src/plugin_cmd/roster.rs
@@ -332,6 +332,17 @@ fn read_project_tier(workspace_root: &Path, notices: &mut Vec<String>) -> Vec<In
 /// a plugin sitting in a workspace the operator has *not* trusted — deleting a
 /// package is the one operation an untrusted tier must never be able to
 /// refuse. Reading a manifest parses TOML; it spawns nothing.
+///
+/// # Why a symlinked entry is not a plugin
+///
+/// A tier holds packages `stella plugin install` copied there, and install
+/// refuses a symlink inside one (`super::copy_tree`) because a link is a
+/// request to run something the package's author does not ship. A link *as*
+/// the entry is the same request one level up, so it gets the same answer:
+/// skipped, and said out loud (#3530). Admitted, it loaded, listed, and
+/// routed an `argv` with `${plugin_dir}` interpolated to the link path —
+/// while `super::remove_plugin_dir` refused to delete it, leaving a package
+/// that ran and could not be uninstalled.
 pub(crate) fn read_tier(
     dir: &Path,
     scope: PluginScope,
@@ -347,23 +358,51 @@ pub(crate) fn read_tier(
     };
     // Collected and sorted rather than taken in readdir order: the roster is
     // shown to humans and folded into routes, and directory order is not
-    // stable across filesystems.
-    let mut dirs: Vec<PathBuf> = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
+    // stable across filesystems. Both lists are sorted for the same reason —
+    // the notices are read by a human too.
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let mut links: Vec<PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
         // A leading dot is never a plugin: `super::checked_name` refuses such
         // a manifest name, so no install can produce one — and `install`
         // stages its copy under exactly that spelling, so this is what keeps a
         // half-copied tree from being loaded and routed in the window before
-        // it is renamed into place.
-        .filter(|path| {
-            !path
-                .file_name()
-                .is_some_and(|name| name.to_string_lossy().starts_with('.'))
-        })
-        .collect();
+        // it is renamed into place. Checked first, so a staging directory is
+        // skipped in silence whatever it turns out to be.
+        if path
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().starts_with('.'))
+        {
+            continue;
+        }
+        // `DirEntry::file_type` describes the entry; `Path::is_dir` describes
+        // whatever it resolves to, which is how a link to a directory was read
+        // as an installed package. An entry whose type cannot be read is
+        // skipped like any other non-directory.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            links.push(path);
+        } else if file_type.is_dir() {
+            dirs.push(path);
+        }
+    }
     dirs.sort();
+    links.sort();
+    // Spoken, not silent, for the reason [`read_project_tier`] argues: a
+    // plugin that vanishes with no message is indistinguishable from a broken
+    // one, and a hand-linked entry is exactly the case where the user believes
+    // they installed something. A stray *file* stays silent — nobody links a
+    // regular file into a tier meaning it as a package.
+    for path in links {
+        notices.push(format!(
+            "  ! {} is a symlink, not an installed package — it is not loaded or routed; \
+             `stella plugin install` copies packages, it never links them",
+            path.display()
+        ));
+    }
 
     let mut found: Vec<InstalledPlugin> = Vec::new();
     for path in dirs {

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -57,29 +57,14 @@ fn roster_at(root: &Path) -> PluginRoster {
 
 /// `PluginRoster::load` reads the *user* tier through `crate::paths`, which a
 /// unit test must not touch — so the project tier is read directly here.
+///
+/// Through `roster::read_tier`, never a second scan of its own: what a tier
+/// admits is the policy under test in more than one place here, and a helper
+/// with a private copy of that filter would answer for a build that does not
+/// have it (#3530).
 fn read_project_tier(root: &Path) -> Vec<super::roster::InstalledPlugin> {
     let dir = stella_home::resolve_project_plugins_dir(root);
-    let mut found = Vec::new();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return found;
-    };
-    let mut paths: Vec<PathBuf> = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
-    paths.sort();
-    for path in paths {
-        if let Some(manifest) = roster::load_manifest(&path).expect("a fixture manifest must load")
-        {
-            found.push(super::roster::InstalledPlugin {
-                manifest,
-                dir: path,
-                scope: PluginScope::Project,
-            });
-        }
-    }
-    found
+    roster::read_tier(&dir, PluginScope::Project, &mut Vec::new())
 }
 
 /// **Witness (c).** install → list → remove round-trips, and the removed
@@ -322,6 +307,75 @@ fn an_untrusted_projects_plugins_do_not_load_are_not_listed_and_dispatch_no_hook
         trusted.hook_routes().len(),
         2,
         "one route per declared hook, once trusted"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The symlink witness (#3530).** A symlinked tier entry is **not** a
+/// plugin: it is not loaded, not listed, dispatches no hook, and `remove`
+/// reports it as not installed instead of erroring on it.
+///
+/// The route assertion is the load-bearing one — a route is an `argv` a host
+/// spawns, with `${plugin_dir}` interpolated to the *link* path, so a test
+/// asserting only on the roster would pass against a build that still handed
+/// out dispatchable commands into a tree this CLI never copied. `install` has
+/// always refused a symlink (`a_symlink_in_a_package_is_refused`); the tier
+/// reader now holds the same line, so the two can no longer disagree in the
+/// direction that left a package loadable, routable and un-uninstallable.
+///
+/// Driven through `PluginRoster::load` rather than the `roster_at` helper on
+/// purpose: `load` is what the binary calls, so the trust gate and the user
+/// tier are in the picture and nothing here can be answered by a fixture's
+/// own reading of the directory.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_tier_entry_is_not_loaded_listed_or_routed() {
+    let _env = crate::test_env::lock();
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
+    let root = temp_root("symlinked-entry");
+    // A home of our own, so the developer's `~/.stella/plugins` cannot answer.
+    let _paths = crate::paths::test_user_home(root.join("home"));
+
+    // A complete, loadable package that lives *outside* the tier, reachable
+    // only through the link — what a hand-run `ln -s` produces.
+    let source = package(&root, "vera");
+    let tier = stella_home::resolve_project_plugins_dir(&root);
+    std::fs::create_dir_all(&tier).expect("fixture tier");
+    std::os::unix::fs::symlink(&source, tier.join("vera")).expect("fixture symlink");
+
+    // Trusted, so the project-tier gate cannot be what refuses it (#3509).
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe {
+        std::env::set_var("STELLA_TRUST_PROJECT", "1");
+        std::env::remove_var("STELLA_PROJECT_HOOKS");
+    }
+    let (roster, notices) = PluginRoster::load(&root, &Settings::default());
+    assert!(roster.get("vera").is_none(), "not loaded");
+    assert!(
+        roster.plugins().is_empty(),
+        "not listed: {:?}",
+        roster.plugins()
+    );
+    assert!(
+        roster.hook_routes().is_empty(),
+        "and above all dispatches nothing — a route is an argv the host spawns: {:?}",
+        roster.hook_routes()
+    );
+    assert!(
+        notices.iter().any(|notice| notice.contains("symlink")),
+        "the skip is spoken, not silent: {notices:?}"
+    );
+
+    let error = remove(&root, "vera").expect_err("there is nothing installed to remove");
+    assert!(
+        error.contains("is not installed in either scope"),
+        "the link is reported as not installed, not refused as a removal: {error}"
+    );
+    assert!(
+        std::fs::symlink_metadata(tier.join("vera")).is_ok(),
+        "and the link itself is left for the operator to delete by hand"
     );
 
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -25,6 +25,7 @@ mod convention;
 mod deliver;
 mod drive;
 mod hooks;
+mod learning;
 mod lifecycle;
 pub(crate) mod probes;
 mod report;
@@ -1283,9 +1284,14 @@ fn file_finding(
         ))
         .map_err(|error| error.to_string())?;
 
+    // Every outcome is counted, not just the one that reached the tracker: a
+    // refusal and a duplicate are what a filing *did*, and a report that showed
+    // only `created` beside two permanent zeros made a loop whose findings were
+    // all being refused look like a loop that found nothing (#4118).
+    st.update_stats(|s| s.record_filing(outcome.canonical()));
+
     if let backlog::Filed::New(key) = &outcome {
         st.add_seen(&stella_autonomy::finding_digest(title))?;
-        st.update_stats(|s| s.issues_created += 1);
         if format == QueryFormat::Json {
             println!(r#"{{"filed":"{key}"}}"#);
         } else {

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -1,9 +1,11 @@
 //! The backlog half of the self-driving verbs, read through the issue port.
 //!
 //! `doc:backlog-self-driving` B1. Split out of `self_driving_cmd.rs` rather
-//! than added to it: that file is 1005 lines and #3599 records it as closed to
-//! growth, with new logic landing in siblings here (AGENTS.md § *God files* —
-//! plan around them, never into them).
+//! than added to it: that file is close enough to the 1500-line ceiling
+//! `make file-size` enforces that new logic lands in siblings here, and it
+//! carries no baseline entry, so a crossing fails the gate outright rather
+//! than being grandfathered (AGENTS.md § *God files* — plan around them,
+//! never into them).
 //!
 //! The parent keeps the two verb entry points, which name the concrete
 //! provider. Everything below takes a `&dyn IssueProvider` and has never heard
@@ -163,6 +165,22 @@ pub(super) enum Filed {
         /// Every violation, so a human fixes them in one pass.
         violations: Vec<Violation>,
     },
+}
+
+impl Filed {
+    /// This outcome's canonical name, for
+    /// [`stella_autonomy::SessionStats::record_filing`].
+    ///
+    /// A `&str` rather than the enum, because `stella-autonomy` is a leaf crate
+    /// with no workspace dependencies and must not learn what a `Filed` is —
+    /// the same boundary `record_closure` takes a resolution across.
+    pub(super) fn canonical(&self) -> &'static str {
+        match self {
+            Filed::New(_) => "new",
+            Filed::Duplicate { .. } => "duplicate",
+            Filed::Refused { .. } => "refused",
+        }
+    }
 }
 
 /// File a finding, if it is both novel and conformant.
@@ -805,6 +823,50 @@ mod tests {
 
         assert_eq!(outcome, Filed::New(IssueKey::from("1001")));
         assert_eq!(provider.filed().len(), 1);
+    }
+
+    /// **The witness.** Every filing outcome reaches the session's counters,
+    /// not just the one that got a key.
+    ///
+    /// `filings_refused` and `filings_duplicate` had a `println!` and no write
+    /// site anywhere in the workspace, so a loop whose every finding was being
+    /// refused rendered identically to a loop that found nothing — beside a
+    /// live `created` in the same block (#4118).
+    #[test]
+    fn every_filing_outcome_reaches_the_session_counters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let st = super::super::state::LoopState {
+            dir: dir.path().to_path_buf(),
+            repo_root: dir.path().to_path_buf(),
+        };
+        let provider = FixtureProvider::default();
+        let title = "the retry counter survives a goal round";
+
+        for (seen, labels) in [
+            // conformant and novel — filed
+            (Vec::new(), &["bug", "P1"][..]),
+            // conformant but already filed — duplicate
+            (vec![finding_digest(title)], &["bug", "P1"][..]),
+            // novel but off-convention — refused
+            (Vec::new(), &["P1"][..]),
+        ] {
+            let outcome = block_on(file_finding(
+                &provider,
+                &convention(),
+                &seen,
+                &draft(title, labels),
+                "Created by stella.",
+            ))
+            .expect("the port was reachable");
+            st.update_stats(|s| s.record_filing(outcome.canonical()));
+        }
+
+        let stats = st.stats();
+        assert_eq!(stats.filings_attempted, 3);
+        assert_eq!(stats.issues_created, 1);
+        assert_eq!(stats.filings_duplicate, 1);
+        assert_eq!(stats.filings_refused, 1);
+        assert!(stats.filings_balance());
     }
 
     /// Re-filing what the loop already filed is the fastest way to make a

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -280,6 +280,43 @@ body = "description"
         assert!(load(ws.path()).vocabulary.is_open("To Do"));
     }
 
+    /// The doctrine is read from `stella.toml`, like everything else
+    /// configurable about stella, and an unconfigured workspace gets the
+    /// shipped default.
+    ///
+    /// A regression guard on a seam nothing asserted, not a witness — `load`
+    /// already carries the value. It is worth pinning because this axis decides
+    /// whether the loop repairs a base somebody else broke, and because #3943
+    /// proposes reading it from a `.stella/issues/` manifest instead: a second
+    /// place to declare it is how the two would come to disagree.
+    #[test]
+    fn the_doctrine_is_read_from_stella_toml() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            r#"
+[meta]
+schema_version = 1
+scope = "project"
+
+[self_driving.doctrine]
+foreign_breakage = "file_and_wait"
+"#,
+        );
+
+        assert_eq!(
+            load(ws.path()).doctrine.foreign_breakage,
+            stella_autonomy::ForeignBreakage::FileAndWait,
+            "an operator's declared axis must reach the loop"
+        );
+        assert_eq!(
+            load(workspace().path()).doctrine,
+            stella_autonomy::Doctrine::default(),
+            "and a workspace that declares nothing gets the shipped default"
+        );
+    }
+
     /// A malformed manifest falls back to a working vocabulary rather than
     /// stopping the loop, and the operator is told.
     #[test]

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -784,18 +784,29 @@ pub(super) fn base_is_broken(branch: &str) -> bool {
     ci_from(&checks) == CiConclusion::Red
 }
 
-/// What else on this machine or this forge looks like a fix already in flight.
+/// What else on this machine or this forge looks like work on `key` already in
+/// flight.
 ///
 /// Four signals, and the doctrine decides what they mean — this only gathers
 /// them. Cheap reads, all of them, because this runs on every poll while the
-/// base is red.
+/// base is red, and once per candidate before an issue is claimed.
+///
+/// Nothing here is about the *subject* of the issue: `key` is only ever matched
+/// as text against branch names, pull-request search results, worktree paths and
+/// the ledger's `issue:<key>` claim key. That is what lets one function serve
+/// both the base-breakage adoption and the claim queue.
 ///
 /// `local_worktrees` is the one nobody checks, and the one most likely to
 /// matter: two self-driving processes against one clone each see the other's
 /// worktree here, and without it they would both adopt the same breakage and
 /// race to fix it.
+///
+/// `ledger_claims` is the only **authoritative** one — a lease with an owner and
+/// an expiry rather than a name that resembles the work — and the only one
+/// `ContentionPolicy::ClaimsOnly` reads. Until it was gathered, that policy
+/// selected an always-empty set and so meant *proceed regardless*.
 #[must_use]
-pub(super) fn base_fix_contention(root: &std::path::Path, key: &str) -> Contention {
+pub(super) fn contention_for_issue(root: &std::path::Path, key: &str) -> Contention {
     let mut contention = Contention::default();
 
     // A branch whose name carries the issue key. Remote only: a local branch
@@ -831,7 +842,48 @@ pub(super) fn base_fix_contention(root: &std::path::Path, key: &str) -> Contenti
             .collect();
     }
 
+    // A dispatch lease another worker is holding on this exact issue.
+    contention.ledger_claims = live_issue_claims(root, key);
+
     contention
+}
+
+/// Owners of live dispatch leases on `issue:<key>`.
+///
+/// The same read `stella fleet claims` performs (`crate::fleet_claims`), narrowed
+/// to one claim key and reporting the owner, because a run id embeds the minting
+/// process's pid and so names a session a human can go and look at.
+///
+/// **Fails open, in every direction**: a workspace with no ledger has never run
+/// a fan-out, and one whose ledger cannot be opened or read is a workspace this
+/// probe knows nothing about. Neither is evidence that somebody else is working
+/// the issue, and reporting one as if it were would deadlock the loop against a
+/// file it cannot read. That is the stance the other three signals already take.
+fn live_issue_claims(root: &std::path::Path, key: &str) -> Vec<String> {
+    let Ok(ledger_path) = stella_store::workspace_private_sqlite_path(root, "fleet.db") else {
+        return Vec::new();
+    };
+    if !ledger_path.exists() {
+        return Vec::new();
+    }
+    let Ok(now_ms) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) else {
+        return Vec::new();
+    };
+    let now_ms = now_ms.as_millis().min(u128::from(u64::MAX)) as u64;
+
+    let Ok(ledger) = stella_fleet::Ledger::open(&ledger_path) else {
+        return Vec::new();
+    };
+    let Ok(claims) = ledger.live_dispatch_claims(now_ms) else {
+        return Vec::new();
+    };
+
+    let wanted = format!("issue:{key}");
+    claims
+        .into_iter()
+        .filter(|claim| claim.claim_key == wanted)
+        .map(|claim| claim.owner)
+        .collect()
 }
 
 /// Open pull requests that say they close `key`.

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -60,9 +60,9 @@
 use std::collections::HashMap;
 
 use stella_autonomy::{
-    Action, Attempts, CarriedPr, CiConclusion, Contention, DeliverPolicy, IssueRef,
-    LoopObservation, LoopState, LoopStep, PrDisposition, PrRef, PrState, UnblockAttempt,
-    deliver_next, step,
+    Action, Attempts, CarriedPr, CiConclusion, Contention, ContentionPolicy, ContentionVerdict,
+    DeliverPolicy, IssueRef, LoopObservation, LoopState, LoopStep, PrDisposition, PrRef, PrState,
+    UnblockAttempt, contention_verdict, deliver_next, step,
 };
 
 use super::audit::{self, Action as Audit};
@@ -301,6 +301,20 @@ pub(super) fn drive(
                 // One per pass. Triage is a model call, and draining a
                 // hundred unlabelled issues before touching any work would
                 // turn a delivery loop into a labelling bot.
+                //
+                // Ranked is then filtered by contention as well as by what
+                // this run already holds — see [`next_claimable`]. Before
+                // that the branch-collision guard in `work::start` was the
+                // only thing that noticed a peer, which is a git failure
+                // after git state exists rather than a look before it (#4002).
+                //
+                // The two guards see different things and the order matters:
+                // a claim-time probe reads names, while `work::start` has a
+                // specific git error and asks the forge, which is what lets
+                // it tell the loop's own dead run from a live peer. An
+                // operator whose clone is full of their own leftovers wants
+                // `ContentionPolicy::ClaimsOnly`, which is what that policy
+                // is for (`stella_autonomy::ContentionPolicy`).
                 if let Err(error) =
                     assess_one(durable, &root, &provider, &cfg, spend_limit, &mut triaged)
                 {
@@ -330,10 +344,29 @@ pub(super) fn drive(
                     }
                 };
 
-                let Some(key) = ranked
-                    .into_iter()
-                    .find(|k| !state.claimed.iter().any(|c| &c.0 == k) && !spent.contains_key(k))
-                else {
+                let mut deferrals = 0_u32;
+                let pick = next_claimable(
+                    ranked,
+                    |k| state.claimed.iter().any(|c| c.0 == k) || spent.contains_key(k),
+                    doctrine.contention,
+                    |k| super::deliver::contention_for_issue(&root, k),
+                    |k, evidence| {
+                        deferrals += 1;
+                        audit::record(
+                            durable,
+                            Audit::Deferred,
+                            Some(k),
+                            &format!(
+                                "somebody else is already on it ({}); taking the next candidate \
+                                 rather than duplicating",
+                                evidence.join(", ")
+                            ),
+                        );
+                        durable.update_stats(|s| s.issues_deferred += 1);
+                    },
+                );
+
+                let Pick::Take(key) = pick else {
                     // An empty queue is a state, not an ending.
                     //
                     // Returning here made "there is nothing to do right now"
@@ -347,12 +380,18 @@ pub(super) fn drive(
                     // Waiting costs one queue read per poll and is the whole
                     // difference between a batch job and a loop somebody can
                     // walk away from.
+                    //
+                    // The deferral count is on this line because without it an
+                    // exhausted queue and a queue whose every candidate went to
+                    // a peer read identically, and the second is the one where
+                    // something is happening.
                     audit::record(
                         durable,
                         Audit::Waited,
                         None,
                         &format!(
-                            "the queue offers nothing this run has not already taken; \
+                            "the queue offers nothing this run has not already taken \
+                             ({deferrals} deferred to another actor this pass); \
                              re-asking in {poll_secs}s — a new issue, or an escalation \
                              label removed, is all it takes"
                         ),
@@ -1043,6 +1082,46 @@ fn advance(
     }
 }
 
+/// What the ranked queue yielded.
+#[derive(Debug, PartialEq, Eq)]
+enum Pick {
+    /// The first candidate that is neither already taken nor contended.
+    Take(String),
+    /// Every candidate was taken or deferred.
+    Exhausted,
+}
+
+/// The first issue on the ranked queue this run may actually start.
+///
+/// Pure: no I/O and no clock, so the decision has a test seam of its own rather
+/// than only being reachable through `drive`'s network loop. `seen` and
+/// `deferred` are the two edges — the caller supplies the probe and the ledger
+/// write, and this supplies the walk.
+///
+/// **A deferral advances to the next candidate; it does not end the search.**
+/// The queue is priority-ordered, so stopping at the first contended issue would
+/// hand one peer's branch the power to stall the whole run — which is exactly
+/// what the loop did on #3691 by discovering the collision as a `git worktree
+/// add` failure and only then moving on (#4002).
+fn next_claimable(
+    ranked: impl IntoIterator<Item = String>,
+    taken: impl Fn(&str) -> bool,
+    policy: ContentionPolicy,
+    seen: impl Fn(&str) -> Contention,
+    mut deferred: impl FnMut(&str, &[String]),
+) -> Pick {
+    for key in ranked {
+        if taken(&key) {
+            continue;
+        }
+        match contention_verdict(policy, &seen(&key)) {
+            ContentionVerdict::Proceed => return Pick::Take(key),
+            ContentionVerdict::Defer { evidence } => deferred(&key, &evidence),
+        }
+    }
+    Pick::Exhausted
+}
+
 /// What the world looks like, in the shape the machine decides over.
 ///
 /// The bound is expressed as an exhausted queue rather than as a special case
@@ -1079,7 +1158,7 @@ fn observe(
     let filed = super::backlog::open_base_breakage(provider);
     let contention = filed
         .as_ref()
-        .map(|key| super::deliver::base_fix_contention(root, key))
+        .map(|key| super::deliver::contention_for_issue(root, key))
         .unwrap_or_default();
 
     LoopObservation {
@@ -1117,4 +1196,81 @@ fn report(durable: &Durable, tally: &Tally) -> Result<(), String> {
         ),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A ranked queue whose top entry a peer is holding yields the next one,
+    /// and says why it skipped.
+    ///
+    /// The second half is what stops this passing vacuously: the identical
+    /// input under [`ContentionPolicy::Proceed`] must take the contended
+    /// candidate, so a `next_claimable` that ignored the verdict entirely
+    /// would fail the first half rather than satisfy both.
+    #[test]
+    fn a_candidate_a_peer_is_working_is_skipped_with_evidence() {
+        let ranked = || ["3691".to_owned(), "3702".to_owned()];
+        let seen = |key: &str| {
+            if key == "3691" {
+                Contention {
+                    local_worktrees: vec!["/tmp/wip-3691-preserved".to_owned()],
+                    ..Contention::default()
+                }
+            } else {
+                Contention::default()
+            }
+        };
+
+        let mut skipped: Vec<(String, Vec<String>)> = Vec::new();
+        let pick = next_claimable(
+            ranked(),
+            |_| false,
+            ContentionPolicy::Defer,
+            seen,
+            |key, evidence| skipped.push((key.to_owned(), evidence.to_vec())),
+        );
+
+        assert_eq!(pick, Pick::Take("3702".to_owned()));
+        assert_eq!(
+            skipped,
+            vec![(
+                "3691".to_owned(),
+                vec!["local worktree: /tmp/wip-3691-preserved".to_owned()]
+            )]
+        );
+
+        let mut skipped_under_proceed: Vec<String> = Vec::new();
+        let pick = next_claimable(
+            ranked(),
+            |_| false,
+            ContentionPolicy::Proceed,
+            seen,
+            |key, _| skipped_under_proceed.push(key.to_owned()),
+        );
+
+        assert_eq!(pick, Pick::Take("3691".to_owned()));
+        assert!(skipped_under_proceed.is_empty());
+    }
+
+    /// A queue whose every candidate is contended is exhausted, not merely
+    /// stalled on the first one.
+    #[test]
+    fn a_fully_contended_queue_defers_every_candidate() {
+        let mut skipped: Vec<String> = Vec::new();
+        let pick = next_claimable(
+            ["1".to_owned(), "2".to_owned()],
+            |_| false,
+            ContentionPolicy::Defer,
+            |_| Contention {
+                ledger_claims: vec!["fleet-run-7".to_owned()],
+                ..Contention::default()
+            },
+            |key, _| skipped.push(key.to_owned()),
+        );
+
+        assert_eq!(pick, Pick::Exhausted);
+        assert_eq!(skipped, vec!["1".to_owned(), "2".to_owned()]);
+    }
 }

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -441,6 +441,12 @@ pub(super) fn drive(
                     &format!("began work — {}", resolved.title),
                 );
 
+                // What the turn is about to learn, measured either side of it.
+                // The turn is a child process writing into the repository's
+                // own state root, so a delta over that state is the only
+                // producer these counters can have — see `learning`.
+                let learned_before = super::learning::tally(&root);
+
                 // A `work` that cannot start is one issue's problem, not the
                 // loop's: a single leftover branch must not halt a run that has
                 // other issues to get on with.
@@ -458,10 +464,12 @@ pub(super) fn drive(
                             continue;
                         }
                     };
+                let learned = super::learning::tally(&root).since(learned_before);
 
                 durable.update_stats(|s| {
                     s.issues_attempted += 1;
                     s.turns_run += 1;
+                    learned.add_to(s);
                 });
 
                 match outcome {

--- a/crates/stella-cli/src/self_driving_cmd/learning.rs
+++ b/crates/stella-cli/src/self_driving_cmd/learning.rs
@@ -1,0 +1,134 @@
+//! What a turn taught, counted from the state it leaves behind.
+//!
+//! The loop cannot observe a turn learning something. A turn runs in a child
+//! process ([`super::work::run_turn`] spawns `stella run --output-format json`),
+//! so no event reaches this process as it happens — and none reaches it on the
+//! wire either, because a machine-format turn deliberately emits no reflection
+//! frame so `Complete` stays the unique final one
+//! (`crate::agent::goal::surface_reflection`).
+//!
+//! What *is* observable is durable. `run_turn` points the child's workspace
+//! state root at the repository rather than the throwaway worktree precisely so
+//! the reflection log, the context store and the telemetry store outlive the
+//! unit of work — so the honest producer for the learning counters is a delta:
+//! read the artifacts before the turn, read them after, and report the
+//! difference.
+//!
+//! The three artifacts are deliberately three different questions. Every
+//! lesson reaches the reflection log, restatements included; only a *novel*
+//! lesson becomes a memory; only a recurring one becomes a proposal. Counting
+//! one number three times would be worse than counting none.
+
+use std::path::Path;
+
+use stella_core::context_record::ContextRecordKind;
+
+/// The learning artifacts under one state root, counted at one instant.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct LearningTally {
+    /// Lessons in the reflection mining log, novel and restated alike.
+    pub reflections: u32,
+    /// Distinct memory lineages — memories, as a user counts them.
+    pub memories: u32,
+    /// Record-proposal revisions the context ledger holds.
+    pub proposals: u32,
+}
+
+impl LearningTally {
+    /// What `self` holds beyond `earlier`.
+    ///
+    /// Saturating in every field, because retention runs: a prune or a
+    /// `stella memory forget` between the two readings can lower a count, and
+    /// "this turn taught minus three lessons" is not a thing to report.
+    #[must_use]
+    pub(super) fn since(self, earlier: Self) -> Self {
+        Self {
+            reflections: self.reflections.saturating_sub(earlier.reflections),
+            memories: self.memories.saturating_sub(earlier.memories),
+            proposals: self.proposals.saturating_sub(earlier.proposals),
+        }
+    }
+
+    /// Fold this delta into the session's counters.
+    pub(super) fn add_to(self, stats: &mut stella_autonomy::SessionStats) {
+        stats.reflections_logged += self.reflections;
+        stats.memories_created += self.memories;
+        stats.proposals_made += self.proposals;
+    }
+}
+
+/// Count what the workspace at `state_root` has learned so far.
+///
+/// Reads only what already exists. A workspace that has never reflected must
+/// read as zero rather than gain an empty database as a side effect of being
+/// counted — the rule `stella memory index` states and this shares, with the
+/// added reason that this runs twice per turn on somebody's live repository.
+///
+/// Unreadable state is zero rather than an error for the same reason every
+/// other write on this path is best-effort: a counter must never be able to
+/// stop a turn.
+pub(super) fn tally(state_root: &Path) -> LearningTally {
+    let (memories, proposals) = context_tally(state_root);
+    LearningTally {
+        reflections: reflection_lines(state_root),
+        memories,
+        proposals,
+    }
+}
+
+/// Lessons in `.stella/private/reflections.jsonl` — one line each.
+///
+/// The log rather than the `reflections` table in `store.db`: they mirror each
+/// other, and the log is the surface the field is named after and the one the
+/// skill and rule miners actually read.
+fn reflection_lines(state_root: &Path) -> u32 {
+    let Ok(Some(path)) =
+        stella_store::existing_workspace_private_state_path(state_root, "reflections.jsonl")
+    else {
+        return 0;
+    };
+    let count = std::fs::read_to_string(&path)
+        .map(|text| text.lines().filter(|line| !line.trim().is_empty()).count())
+        .unwrap_or(0);
+    clamp(count)
+}
+
+/// Memory lineages and record proposals, from `.stella/private/context.db`.
+///
+/// One open serves both, because both are the same store answering two
+/// questions and opening it twice per reading would double the only cost here.
+fn context_tally(state_root: &Path) -> (u32, u32) {
+    let Ok(Some(path)) =
+        stella_store::existing_workspace_private_sqlite_path(state_root, "context.db")
+    else {
+        return (0, 0);
+    };
+    let Ok(store) = stella_context::ContextStore::open(&path) else {
+        return (0, 0);
+    };
+
+    // Lineages, not live rows: a lineage is one memory however many times it
+    // has been revised, and a revision is not a memory created.
+    let memories = store
+        .memory_lineage_stats()
+        .map_or(0, |stats| clamp(stats.lineages));
+
+    // `record_counts` rather than a bounded `records_of_kind` read: the ledger
+    // is append-only, so a capped read stops moving once the log passes the
+    // cap, and a delta over a frozen number is silently zero forever.
+    let proposals = store.record_counts().map_or(0, |counts| {
+        counts
+            .into_iter()
+            .find(|(kind, _)| kind == ContextRecordKind::RecordProposal.as_str())
+            .map_or(0, |(_, n)| u32::try_from(n).unwrap_or(u32::MAX))
+    });
+
+    (memories, proposals)
+}
+
+fn clamp(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
@@ -1,0 +1,158 @@
+//! What a turn taught, read back off durable state.
+//!
+//! The helper is exercised directly rather than through `work::run_turn`: that
+//! spawns a real `stella run` child process, which is minutes and a provider
+//! key, and the thing under test is the delta, not the spawn.
+
+use std::path::Path;
+
+use stella_context::{ContextDelta, ContextStore, MemoryInput};
+use stella_core::context_record::{
+    ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus, confidence_from_score,
+};
+
+use super::{LearningTally, tally};
+
+fn block_on<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+        .block_on(f)
+}
+
+/// Open the context store where [`tally`] will look for it.
+fn context_store(root: &Path) -> ContextStore {
+    let path = stella_store::workspace_private_sqlite_path(root, "context.db")
+        .expect("resolve context.db");
+    ContextStore::open(&path).expect("open context.db")
+}
+
+fn log_lesson(root: &Path, lesson: &str) {
+    stella_store::append_workspace_private_line(
+        root,
+        "reflections.jsonl",
+        &format!(r#"{{"lesson":"{lesson}"}}"#),
+    )
+    .expect("append a lesson");
+}
+
+fn remember(store: &ContextStore, content: &str) {
+    let delta = ContextDelta {
+        memories: vec![MemoryInput::reflection(content, ["testing".to_owned()])],
+        ..Default::default()
+    };
+    block_on(store.upsert(delta)).expect("upsert a memory");
+}
+
+fn propose(store: &ContextStore, candidate_id: &str) {
+    let score = ProposalScore {
+        occurrences: 3,
+        distinct_tasks: 3,
+        salient: false,
+        rank: 30.0,
+    };
+    let proposal = ProposalRecord::new(
+        RecordProposalKind::Knowledge,
+        RecordProposalStatus::Eligible,
+        candidate_id,
+        "Prefer rg over grep",
+        "Use ripgrep instead of grep in this repository.",
+        vec!["tooling".into()],
+        vec!["obs_a".into(), "obs_b".into(), "obs_c".into()],
+        score,
+        confidence_from_score(&score).expect("confidence"),
+        "2026-07-26T12:00:00Z",
+    )
+    .expect("proposal");
+    crate::memory::proposals::record_proposal(store, &proposal).expect("record a proposal");
+}
+
+/// **The witness.** A turn that reflects, remembers, and proposes moves all
+/// three learning counters, and each moves by its own number.
+///
+/// Before this existed the three fields had a `println!` and no write site
+/// anywhere in the workspace, so `stella self-driving stats` reported a session
+/// that learned nothing however much it learned (#4118).
+#[test]
+fn a_turn_that_learns_moves_all_three_counters() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let store = context_store(root);
+
+    let before = tally(root);
+
+    log_lesson(root, "a restated lesson still reaches the log");
+    log_lesson(root, "read the trace, never a surface signal");
+    log_lesson(root, "read the trace, never a surface signal");
+    remember(&store, "read the trace, never a surface signal");
+    propose(&store, "read-the-trace-aaaa1111");
+
+    let learned = tally(root).since(before);
+
+    assert_eq!(
+        learned.reflections, 3,
+        "every lesson reaches the log, restatements included"
+    );
+    assert_eq!(learned.memories, 1, "only the novel lesson became a memory");
+    assert_eq!(learned.proposals, 1);
+
+    let mut stats = stella_autonomy::SessionStats::default();
+    learned.add_to(&mut stats);
+    assert_eq!(stats.reflections_logged, 3);
+    assert_eq!(stats.memories_created, 1);
+    assert_eq!(stats.proposals_made, 1);
+}
+
+/// Reflections and memories are different questions, and a turn whose lessons
+/// were all restatements proves it: the log grows, no memory is created.
+#[test]
+fn a_restatement_only_turn_logs_a_reflection_and_claims_no_memory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let store = context_store(root);
+    remember(&store, "already known");
+
+    let before = tally(root);
+    log_lesson(root, "already known");
+    let learned = tally(root).since(before);
+
+    assert_eq!(learned.reflections, 1);
+    assert_eq!(learned.memories, 0);
+}
+
+/// Counting must never create what it counts. A workspace that has learned
+/// nothing reads as zero and gains no database for having been asked — this
+/// runs twice per turn on somebody's live repository.
+#[test]
+fn counting_an_untouched_workspace_creates_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    assert_eq!(tally(root), LearningTally::default());
+    assert!(
+        !root
+            .join(".stella")
+            .join("private")
+            .join("context.db")
+            .exists(),
+        "the tally must not create a context store"
+    );
+}
+
+/// Retention runs. A prune between the two readings lowers a count, and "this
+/// turn taught minus three lessons" is not a thing to report.
+#[test]
+fn a_shrinking_count_reports_nothing_learned_rather_than_a_negative() {
+    let later = LearningTally {
+        reflections: 1,
+        memories: 0,
+        proposals: 2,
+    };
+    let earlier = LearningTally {
+        reflections: 9,
+        memories: 4,
+        proposals: 2,
+    };
+    assert_eq!(later.since(earlier), LearningTally::default());
+}

--- a/crates/stella-cli/src/self_driving_cmd/stats.rs
+++ b/crates/stella-cli/src/self_driving_cmd/stats.rs
@@ -5,9 +5,10 @@
 //! module is only the rendering.
 //!
 //! Split out of `self_driving_cmd.rs` rather than added to it: that file is
-//! over the 1500-line limit and `doc:backlog-self-driving` §9 records it as
-//! closed to growth (AGENTS.md § *God files* — plan around them, never into
-//! them).
+//! within a couple of hundred lines of the 1500-line ceiling `make file-size`
+//! enforces, and it carries no entry in `scripts/file-size-baseline.txt` — so
+//! a crossing fails the gate outright rather than being grandfathered
+//! (AGENTS.md § *God files* — plan around them, never into them).
 
 use crate::query_format::QueryFormat;
 
@@ -46,9 +47,16 @@ pub(super) fn session_stats(st: &LoopState, format: QueryFormat) -> Result<(), S
     println!("  deferred        {:>5}", stats.issues_deferred);
 
     println!("\nfiled");
+    println!("  attempted       {:>5}", stats.filings_attempted);
     println!("  created         {:>5}", stats.issues_created);
     println!("  refused         {:>5}", stats.filings_refused);
     println!("  duplicate       {:>5}", stats.filings_duplicate);
+    if !stats.filings_balance() {
+        eprintln!(
+            "  warning: the three outcomes do not sum to the attempts — a filing \
+             outcome this build does not recognise was recorded"
+        );
+    }
 
     println!("\nclosed");
     println!("  total           {:>5}", stats.closed_total);

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -45,6 +45,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::ManifestError;
 use crate::host_call::HostCall;
 use crate::manifest::{OracleProcessSource, Participation, PluginManifest};
+use crate::wire::{WIRE_FIELDS, WrapperPoint};
 
 /// How bad one honest call of a tool is — re-exported from
 /// [`stella_protocol`], which is where the vocabulary lives.
@@ -195,6 +196,7 @@ pub fn consent_text(manifest: &PluginManifest) -> String {
     lines.extend(loop_say(manifest));
     lines.extend(driver_say(manifest));
     lines.extend(oracle_self_report(manifest));
+    lines.extend(data_that_leaves_the_process(manifest));
     lines.push(String::new());
     lines.extend(capability_grant(manifest));
     lines.extend(package_contributions(manifest));
@@ -345,6 +347,7 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
             stages.join(", ")
         ));
     }
+    lines.extend(role_spend(manifest));
 
     if let Some(wrapper) = &manifest.wrapper {
         // A contributed stage is named as the plugin's own rather than listed
@@ -371,6 +374,52 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
         ));
     }
 
+    lines
+}
+
+/// What each declared stage costs: the model tier its `[roles.<name>]` intent
+/// asks to be routed at (#3514).
+///
+/// Empty for a manifest declaring no `[roles]`, on
+/// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s reasoning —
+/// a manifest written before this section renders byte-for-byte what it
+/// rendered before.
+///
+/// # Why the omission was a defect rather than a gap
+///
+/// `WrapperError::UndeclaredRole` refuses a role intent the manifest never
+/// declared, and justifies the refusal with "the roles a human consented to at
+/// install are the roles a wrapper may spend". That cited a document which
+/// named the stages and nothing about what they cost, so a user consented to a
+/// stage list without being told any of it spends at a premium tier — on their
+/// own BYOK key.
+///
+/// The tier is stated as the plugin's *ask*, not as a model, because that is
+/// what it is: [`crate::Role`] is a routing intent an open-vocabulary host
+/// resolves against the user's own providers, soft-failing to the session
+/// default. Rendering it as a model would be `capability_grant`'s claimed-limit
+/// error in the other direction — a promise this crate cannot keep.
+fn role_spend(manifest: &PluginManifest) -> Vec<String> {
+    let Some(roles) = &manifest.roles else {
+        return Vec::new();
+    };
+    if roles.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec!["  - spends each stage's model calls at a tier it names:".into()];
+    // A `BTreeMap`, so the order is the manifest's own and is stable.
+    for (name, role) in roles {
+        lines.push(format!(
+            "      {}: the `{}` tier",
+            one_line(name),
+            one_line(&role.tier)
+        ));
+    }
+    lines.push(
+        "      A tier is the name this plugin asks for, never a model: your own provider \
+         configuration decides what each one resolves to, and your key pays for it."
+            .into(),
+    );
     lines
 }
 
@@ -479,6 +528,85 @@ fn oracle_self_report(manifest: &PluginManifest) -> Vec<String> {
              own work."
         ),
     ]
+}
+
+/// What of the user's own work is handed to the plugin's process, at each
+/// point it is granted (#3514).
+///
+/// # The disclosure that matters most for a BYOK product
+///
+/// Every other section here enumerates a *power* — a grade, a hook, an argv, an
+/// environment slice, a capability. None of them names the **data**, and the
+/// wire ships the user's prompt, the model's whole reply, the tools the turn
+/// ran and the files it changed, as JSON on a third party's standard input. A
+/// plugin declaring no `[[capabilities]]` renders "It asks for no tool
+/// capabilities.", which reads as harmless and left a prompt-exfiltrating
+/// plugin indistinguishable from a benign one at the one moment a user gets to
+/// refuse.
+///
+/// # It reads off [`WIRE_FIELDS`] because a hand-written list rots
+///
+/// The sentences belong to [`crate::wire`], beside the types they describe, and
+/// `every_wire_field_is_in_the_table` destructures those types against the table
+/// — so a field added to the wire and disclosed to nobody fails a test. Spelling
+/// the list out here would make this document complete exactly until the next
+/// field landed.
+///
+/// # Empty when nothing is dispatched, per point
+///
+/// `LoopGrant::permits_point` is the filter `stella_runtime::wrapper` actually
+/// dispatches on, so it is the filter here: telling a user their prompt crosses
+/// to a plugin that answers no point would disclose something that does not
+/// happen, which is `a_declared_scope_is_labelled_as_the_plugins_claim`'s error
+/// with the sign flipped.
+fn data_that_leaves_the_process(manifest: &PluginManifest) -> Vec<String> {
+    // No `[runtime]` and no `[wrapper]` is no process of the plugin's own, so
+    // there is no other end of a pipe for any of this to reach.
+    if manifest.runtime.is_none() && manifest.wrapper.is_none() {
+        return Vec::new();
+    }
+    let disclosed: Vec<(WrapperPoint, &'static str)> = WIRE_FIELDS
+        .iter()
+        .filter(|field| manifest.loop_grant.permits_point(field.point))
+        .filter_map(|field| field.disclosure.map(|sentence| (field.point, sentence)))
+        .collect();
+    if disclosed.is_empty() {
+        return Vec::new();
+    }
+
+    let name = one_line(&manifest.name);
+    let mut lines = vec![
+        String::new(),
+        format!(
+            "Stella hands `{name}`'s own process your work, as JSON on that process's \
+             standard input. What crosses:"
+        ),
+    ];
+    let mut rendering = None;
+    for (point, sentence) in disclosed {
+        if rendering != Some(point) {
+            lines.push(format!("  - {} (`{point}`):", point_moment(point)));
+            rendering = Some(point);
+        }
+        lines.push(format!("      - {sentence}"));
+    }
+    lines.push(
+        "  Once it has been handed over, nothing in Stella bounds what that process does \
+         with it: a plugin asking for no tool capability at all can still send every line \
+         of it anywhere it can reach."
+            .into(),
+    );
+    lines
+}
+
+/// When each point's request is sent, in a reader's terms rather than the
+/// socket's. Exhaustive by construction: a third [`WrapperPoint`] does not
+/// compile until it has words here.
+fn point_moment(point: WrapperPoint) -> &'static str {
+    match point {
+        WrapperPoint::BeforeTurn => "before each turn runs",
+        WrapperPoint::AfterTurn => "once each turn has finished",
+    }
 }
 
 /// The "what it may reach outside your turn" half — the capability list, its
@@ -1011,6 +1139,95 @@ mod tests {
             !hostile_text.chars().any(|ch| ch.is_control() && ch != '\n'),
             "a control character survived into the prompt: {hostile_text:?}"
         );
+    }
+
+    /// **The #3514 tier witness.** A stage list says what a plugin spends
+    /// model calls on and said nothing about what those calls cost, so a user
+    /// consented to `triage` without being told it runs at a premium tier on
+    /// their own key — while `WrapperError::UndeclaredRole` cited this very
+    /// document as the thing that authorised the role.
+    ///
+    /// Anti-vacuity is the second half, on
+    /// [`the_scope_disclaimer_appears_only_when_a_scope_was_declared`]'s
+    /// reasoning: a manifest declaring no `[roles]` renders none of it.
+    #[test]
+    fn the_consent_prompt_names_the_tier_a_role_spends_at() {
+        let text = consent_text(&parse(
+            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+             [subloop]\nstages = [\"triage\"]\n\n\
+             [roles.triage]\ntier = \"premium\"\n",
+        ));
+        assert!(
+            text.contains("spends each stage's model calls at a tier it names:"),
+            "{text}"
+        );
+        assert!(text.contains("triage: the `premium` tier"), "{text}");
+        assert!(
+            text.contains("your own provider configuration decides what each one resolves to"),
+            "a tier is the plugin's ask, not a model this crate can promise: {text}"
+        );
+
+        let tierless = consent_text(&parse(
+            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n[subloop]\nstages = [\"triage\"]\n",
+        ));
+        assert!(
+            !tierless.contains("at a tier it names"),
+            "a manifest with no [roles] must render what it always did: {tierless}"
+        );
+    }
+
+    /// **The #3514 disclosure witness.** The document enumerated powers and
+    /// never the data, so a plugin whose process is handed the user's prompt
+    /// and the model's whole reply rendered "It asks for no tool
+    /// capabilities." — which reads as harmless. For a BYOK product whose
+    /// promise is that prompts stay on the machine, this is the disclosure
+    /// that matters most.
+    ///
+    /// The assertions are on the disclosure's own fixed phrasing, which lives
+    /// in [`crate::wire::WIRE_FIELDS`] beside the fields it describes.
+    #[test]
+    fn a_wrapper_prompt_says_what_leaves_the_machine() {
+        let text = consent_text(&parse(
+            "name = \"vera\"\n[loop]\nparticipation = \"steering\"\n\
+             points = [\"before_turn\", \"after_turn\"]\n\n\
+             [wrapper]\nid = \"lite-v1\"\n[[wrapper.stages]]\nname = \"execute\"\n\n\
+             [runtime]\nargv = [\"python3\", \"main.py\"]\ntimeout_secs = 30\n",
+        ));
+        for expected in [
+            "Stella hands `vera`'s own process your work, as JSON on that process's standard \
+             input. What crosses:",
+            "before each turn runs (`before_turn`):",
+            "the goal you typed for this turn, in full",
+            "once each turn has finished (`after_turn`):",
+            "the model's full reply for the turn — the same text you were shown",
+            "the name of every tool the turn ran, in call order",
+            "the workspace-relative path of every file the turn changed",
+            "can still send every line of it anywhere it can reach",
+        ] {
+            assert!(text.contains(expected), "missing {expected:?} in:\n{text}");
+        }
+
+        let no_process = consent_text(&parse(
+            "name = \"p\"\n[loop]\nparticipation = \"steering\"\npoints = [\"before_turn\"]\n",
+        ));
+        assert!(
+            !no_process.contains("as JSON on that process's standard input"),
+            "a plugin with no process of its own is handed nothing: {no_process}"
+        );
+    }
+
+    /// The other half of the filter: `permits_point` is what
+    /// `stella_runtime::wrapper` dispatches on, so a plugin that declares a
+    /// process and answers no point is handed none of this — and must not be
+    /// disclosed as though it were.
+    #[test]
+    fn a_process_that_answers_no_point_discloses_no_data() {
+        let text = consent_text(&parse(
+            "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n\
+             [runtime]\nargv = [\"node\"]\ntimeout_secs = 5\n",
+        ));
+        assert!(!text.contains("What crosses:"), "{text}");
+        assert!(!text.contains("the goal you typed for this turn"), "{text}");
     }
 
     #[test]

--- a/crates/stella-plugin/src/wire.rs
+++ b/crates/stella-plugin/src/wire.rs
@@ -690,6 +690,140 @@ pub struct TurnOutcome {
     pub changed_files: Option<Vec<String>>,
 }
 
+/// One field of a request that crosses to a plugin's own process, and what a
+/// consent prompt tells a human about it.
+///
+/// [`crate::consent_text`] renders [`Self::disclosure`] verbatim (#3514). A
+/// user deciding whether to install a plugin that runs as a process is deciding
+/// what of their work that process gets to see, and the answer is a property of
+/// *this* module: writing the sentences out beside the prompt instead would put
+/// a copy of the request shape in a file that does not change when the request
+/// does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WireField {
+    /// The point whose request carries it.
+    pub point: WrapperPoint,
+    /// The field's path, as serde writes it — dotted for a field of the nested
+    /// [`TurnOutcome`].
+    pub path: &'static str,
+    /// What crosses, in the words a human reads before granting the point, or
+    /// `None` for a field carrying nothing of the user's.
+    ///
+    /// `None` is a **decision, not an omission**: every field of the two
+    /// requests has a row here, so a field that crosses the process boundary
+    /// and is disclosed to nobody is a line somebody wrote rather than one
+    /// nobody noticed.
+    pub disclosure: Option<&'static str>,
+}
+
+/// Every field of the two request messages, and what the consent prompt says
+/// about each.
+///
+/// In wire order, grouped by point, because the prompt renders it in table
+/// order and is showing a reader a message rather than a set.
+///
+/// The leaves stop at [`BeforeTurnRequest`], [`AfterTurnRequest`] and
+/// [`TurnOutcome`] — the three types `every_wire_field_is_in_the_table`
+/// destructures, so a field added to any of them stops that test compiling
+/// until it has a row here. A nested grant is disclosed whole, in one sentence
+/// naming what it carries, rather than expanded field by field.
+pub const WIRE_FIELDS: &[WireField] = &[
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "protocol_version",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "wrapper",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "stage",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "round",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "goal",
+        disclosure: Some("the goal you typed for this turn, in full"),
+    },
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "candidate",
+        disclosure: Some(
+            "when the host has made one, the absolute path of the scratch workspace the turn \
+             will run in, and the test command it would run there",
+        ),
+    },
+    // The plugin's own words handed back: `published` carries what an earlier
+    // stage of this same plugin published this turn, never something the host
+    // measured of the user's.
+    WireField {
+        point: WrapperPoint::BeforeTurn,
+        path: "published",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "protocol_version",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "wrapper",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "stage",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "round",
+        disclosure: None,
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "goal",
+        disclosure: Some("the goal you typed for this turn, in full"),
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "candidate",
+        disclosure: Some(
+            "when the host has made one, the absolute path of the scratch workspace the turn \
+             ran in, and the test command it would run there",
+        ),
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "turn.completed",
+        disclosure: Some("whether the turn finished or was aborted"),
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "turn.answer",
+        disclosure: Some("the model's full reply for the turn — the same text you were shown"),
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "turn.tools",
+        disclosure: Some("the name of every tool the turn ran, in call order"),
+    },
+    WireField {
+        point: WrapperPoint::AfterTurn,
+        path: "turn.changed_files",
+        disclosure: Some("the workspace-relative path of every file the turn changed"),
+    },
+];
+
 /// The evidence a wrapper gathered.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1095,6 +1229,7 @@ pub enum StopReason {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::wrapper::HostStage;
 
     /// The one exit from [`VolatileContext`] is a non-system message, which is
     /// invariant 7 held structurally rather than by review. If a future edit
@@ -1129,6 +1264,136 @@ mod tests {
             }
             .is_well_typed()
         );
+    }
+
+    /// Names one destructured field, consuming its binding.
+    ///
+    /// The consumption is the point: a field added to a pattern below and then
+    /// left out of the list beside it is an unused binding, which the
+    /// workspace's clippy step (`--all-targets -D warnings`) refuses.
+    fn named<T>(path: &'static str, _value: T) -> &'static str {
+        path
+    }
+
+    /// How many rows [`WIRE_FIELDS`] holds for this field. One is the contract.
+    fn rows_for(point: WrapperPoint, path: &str) -> usize {
+        WIRE_FIELDS
+            .iter()
+            .filter(|field| field.point == point && field.path == path)
+            .count()
+    }
+
+    /// **The anti-drift guard for #3514.** The consent prompt's data
+    /// disclosure is only as complete as [`WIRE_FIELDS`], and a list of
+    /// sentences maintained by hand is complete exactly until the next field
+    /// lands. So the table is checked against the types themselves: adding a
+    /// field to either request — or to [`TurnOutcome`] — stops the patterns
+    /// below compiling (`E0027`), and a row naming a field neither request has
+    /// fails here.
+    #[test]
+    fn every_wire_field_is_in_the_table() {
+        let BeforeTurnRequest {
+            protocol_version,
+            wrapper,
+            stage,
+            round,
+            goal,
+            candidate,
+            published,
+        } = BeforeTurnRequest {
+            protocol_version: PROTOCOL_VERSION,
+            wrapper: "lite-v1".to_string(),
+            stage: StageName::Host(HostStage::Execute),
+            round: 0,
+            goal: "make the failing test pass".to_string(),
+            candidate: Some(CandidateGrant::new(
+                CandidateHandle::new("candidate-1"),
+                "/tmp/candidate-1",
+            )),
+            published: Vec::new(),
+        };
+        let before_paths = [
+            named("protocol_version", protocol_version),
+            named("wrapper", wrapper),
+            named("stage", stage),
+            named("round", round),
+            named("goal", goal),
+            named("candidate", candidate),
+            named("published", published),
+        ];
+
+        let AfterTurnRequest {
+            protocol_version,
+            wrapper,
+            stage,
+            round,
+            goal,
+            candidate,
+            turn,
+        } = AfterTurnRequest {
+            protocol_version: PROTOCOL_VERSION,
+            wrapper: "lite-v1".to_string(),
+            stage: None,
+            round: 0,
+            goal: "make the failing test pass".to_string(),
+            candidate: None,
+            turn: TurnOutcome::default(),
+        };
+        // `turn` is not a leaf — its own fields cross the same pipe, so each is
+        // named on its own and the struct itself is not.
+        let TurnOutcome {
+            completed,
+            answer,
+            tools,
+            changed_files,
+        } = turn;
+        let after_paths = [
+            named("protocol_version", protocol_version),
+            named("wrapper", wrapper),
+            named("stage", stage),
+            named("round", round),
+            named("goal", goal),
+            named("candidate", candidate),
+            named("turn.completed", completed),
+            named("turn.answer", answer),
+            named("turn.tools", tools),
+            named("turn.changed_files", changed_files),
+        ];
+
+        let wire: Vec<(WrapperPoint, &str)> = before_paths
+            .iter()
+            .map(|path| (WrapperPoint::BeforeTurn, *path))
+            .chain(
+                after_paths
+                    .iter()
+                    .map(|path| (WrapperPoint::AfterTurn, *path)),
+            )
+            .collect();
+
+        for (point, path) in &wire {
+            assert_eq!(
+                rows_for(*point, path),
+                1,
+                "`{point}.{path}` crosses to a plugin's process and has no single row in \
+                 WIRE_FIELDS: give it one, disclosing it or saying `None` on purpose"
+            );
+        }
+        for field in WIRE_FIELDS {
+            assert!(
+                wire.contains(&(field.point, field.path)),
+                "WIRE_FIELDS names `{}.{}`, which is not a field of that request",
+                field.point,
+                field.path
+            );
+            assert!(
+                field
+                    .disclosure
+                    .is_none_or(|sentence| !sentence.trim().is_empty()),
+                "`{}.{}` is disclosed with no sentence to disclose it in",
+                field.point,
+                field.path
+            );
+        }
     }
 
     /// A host that could not gather evidence must not hand `judge` a set that

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -40,6 +40,15 @@
 //!   write `.stella/tools/` can already run code in the repo.
 //! - Sets the child's working directory to the **workspace root**, so a
 //!   relative `command[0]` like `./scripts/lint-fix.sh` resolves against it.
+//!   That holds for a plugin's tool too, because a contributed linter acts on
+//!   the *user's* repository. A package therefore names the scripts it ships
+//!   itself with `${plugin_dir}`, which discovery expands to the installed
+//!   package directory in every `command` element and every `[env]` value
+//!   before the tool is advertised — the same placeholder, expanded by the
+//!   same host, that `stella_plugin`'s `Runtime::argv` already documents for a
+//!   plugin's own process. The expansion is **only** for a contributed
+//!   manifest: under `.stella/tools/` there is no package for it to name, so
+//!   it is left verbatim rather than quietly becoming the empty string.
 //! - Delivers the model's input JSON to the child **two ways**, so trivial
 //!   scripts need no JSON parser:
 //!   1. The whole input object is written to the child's **stdin** as one JSON
@@ -133,12 +142,17 @@ pub struct CustomTool {
     /// Human description advertised to the model.
     pub description: String,
     /// argv to spawn directly (no shell). `command[0]` is the program.
+    ///
+    /// On a tool a package contributed, `${plugin_dir}` is already expanded
+    /// here — discovery resolves it against [`PluginToolDir::package_dir`], so
+    /// nothing downstream has to know a placeholder existed.
     pub command: Vec<String>,
     /// Resolved timeout (default applied, clamped to [`MAX_TIMEOUT_MS`]).
     pub timeout_ms: u64,
     /// JSON Schema for the tool's input, converted verbatim from TOML.
     pub input_schema: Value,
-    /// Extra environment variables applied to the child process.
+    /// Extra environment variables applied to the child process. Values carry
+    /// the same `${plugin_dir}` expansion [`Self::command`] does.
     pub env: HashMap<String, String>,
     /// Manifest file this tool was loaded from (for diagnostics / listing).
     pub source: PathBuf,
@@ -553,7 +567,8 @@ pub fn discover_in_scopes(
 }
 
 /// One installed plugin's contributed tool directory: the manifest `name`
-/// every tool found under it is attributed to, and `<plugin_dir>/tools`.
+/// every tool found under it is attributed to, the package it was installed
+/// as, and `<plugin_dir>/tools`.
 ///
 /// The host resolves these — only it knows what is installed, which tier a
 /// package came from, whether the workspace is trusted to run its code, and
@@ -564,9 +579,41 @@ pub struct PluginToolDir {
     /// The plugin's manifest `name`, as [`CustomTool::contributed_by`] and
     /// [`stella_core::ports::Principal::Plugin`] spell it.
     pub plugin: String,
+    /// `<plugin_dir>` — the installed package's own root, and what
+    /// `${plugin_dir}` expands to in the manifests found under [`Self::dir`].
+    ///
+    /// Carried alongside `dir` rather than derived from its parent: the host
+    /// is the one that knows where a package was installed, and a layout
+    /// re-derived here would be a second place to keep it true.
+    pub package_dir: PathBuf,
     /// `<plugin_dir>/tools`. A missing directory is a plugin that ships no
     /// tools, which is the ordinary case and not a diagnostic.
     pub dir: PathBuf,
+}
+
+/// The placeholder a package writes where its own installed directory
+/// belongs — the convention `stella_plugin`'s `Runtime::argv` documents for a
+/// plugin's process argv, applied to the tools that package ships. Expanding
+/// it is the host's job in both cases, because the plugin crate resolves no
+/// paths.
+const PLUGIN_DIR_PLACEHOLDER: &str = "${plugin_dir}";
+
+/// Expand [`PLUGIN_DIR_PLACEHOLDER`] through a contributed tool's `command`
+/// argv and `[env]` values.
+///
+/// Called only for a manifest read out of a package directory. A user's own
+/// `.stella/tools/` manifest is left verbatim: no package is in scope there,
+/// and expanding the placeholder to nothing would silently turn
+/// `${plugin_dir}/x.sh` into a different path rather than leaving a visible
+/// spawn failure naming what the manifest actually asked for.
+fn expand_package_dir(tool: &mut CustomTool, package_dir: &Path) {
+    let dir = package_dir.to_string_lossy();
+    for arg in &mut tool.command {
+        *arg = arg.replace(PLUGIN_DIR_PLACEHOLDER, &dir);
+    }
+    for value in tool.env.values_mut() {
+        *value = value.replace(PLUGIN_DIR_PLACEHOLDER, &dir);
+    }
 }
 
 /// [`discover_in_scopes`], plus the tools installed plugins contribute
@@ -601,7 +648,7 @@ pub fn discover_with_plugins(
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     // Workspace first so it wins collisions, then user-global.
-    let mut dirs: Vec<(PathBuf, Option<&str>)> = Vec::new();
+    let mut dirs: Vec<(PathBuf, Option<&PluginToolDir>)> = Vec::new();
     if include_workspace {
         dirs.push((workspace_root.join(".stella").join("tools"), None));
     }
@@ -610,11 +657,11 @@ pub fn discover_with_plugins(
     }
     // Last, so a plugin never takes a name the user's own manifests defined.
     for contributed in plugin_dirs {
-        dirs.push((contributed.dir.clone(), Some(contributed.plugin.as_str())));
+        dirs.push((contributed.dir.clone(), Some(contributed)));
     }
 
-    for (dir, plugin) in dirs {
-        load_dir(&dir, plugin, &mut seen, &mut report);
+    for (dir, contributor) in dirs {
+        load_dir(&dir, contributor, &mut seen, &mut report);
     }
     report
 }
@@ -623,13 +670,16 @@ pub fn discover_with_plugins(
 /// to `report`. Absent directories are silently ignored (having no tools dir is
 /// normal); files are processed in sorted order for deterministic output.
 ///
-/// `plugin` is the package this directory belongs to, or `None` for the
-/// user's own scopes — it becomes [`CustomTool::contributed_by`] on
+/// `contributor` is the package this directory belongs to, or `None` for the
+/// user's own scopes. Its `plugin` becomes [`CustomTool::contributed_by`] on
 /// everything found here, which is why provenance cannot be forged: it comes
-/// from the directory being read, not from anything inside the file.
+/// from the directory being read, not from anything inside the file. Its
+/// `package_dir` is what [`expand_package_dir`] resolves `${plugin_dir}`
+/// against, so the same fact decides both, and neither can apply to a
+/// manifest the user wrote.
 fn load_dir(
     dir: &Path,
-    plugin: Option<&str>,
+    contributor: Option<&PluginToolDir>,
     seen: &mut std::collections::HashSet<String>,
     report: &mut UngatedDiscovery,
 ) {
@@ -660,17 +710,18 @@ fn load_dir(
                 if seen.contains(&tool.name) {
                     report.diagnostics.push(ToolDiagnostic {
                         path: path.clone(),
-                        reason: match plugin {
+                        reason: match contributor {
                             // Never "and the plugin's copy won": a package
                             // silently replacing a name the user already
                             // defined is the one outcome the precedence rule
                             // exists to forbid, so the message says whose
                             // copy is running.
-                            Some(plugin) => format!(
+                            Some(contributor) => format!(
                                 "tool `{}` is already defined by a manifest you installed \
                                  yourself — the copy the `{plugin}` plugin ships is ignored, \
                                  and yours is the one that runs",
-                                tool.name
+                                tool.name,
+                                plugin = contributor.plugin
                             ),
                             None => format!(
                                 "tool `{}` already defined by an earlier (workspace) manifest \
@@ -682,7 +733,10 @@ fn load_dir(
                     continue;
                 }
                 seen.insert(tool.name.clone());
-                tool.contributed_by = plugin.map(str::to_string);
+                if let Some(contributor) = contributor {
+                    tool.contributed_by = Some(contributor.plugin.clone());
+                    expand_package_dir(&mut tool, &contributor.package_dir);
+                }
                 report.tools.push(tool);
             }
             Err(reason) => report.diagnostics.push(ToolDiagnostic { path, reason }),

--- a/crates/stella-tools/src/custom/tests.rs
+++ b/crates/stella-tools/src/custom/tests.rs
@@ -1055,6 +1055,7 @@ fn a_plugin_contributes_a_tool_and_it_carries_the_plugin_name() {
         true,
         &[PluginToolDir {
             plugin: "vera".into(),
+            package_dir: root.path().join("plugins").join("vera"),
             dir: plugin_dir,
         }],
     );
@@ -1078,6 +1079,7 @@ fn a_contributed_tool_is_authorized_as_the_plugin_and_a_users_own_is_not() {
         true,
         &[PluginToolDir {
             plugin: "vera".into(),
+            package_dir: root.path().join("pkg"),
             dir: plugin_dir,
         }],
     )
@@ -1118,6 +1120,7 @@ fn a_plugin_never_takes_a_name_the_user_already_defined() {
         true,
         &[PluginToolDir {
             plugin: "vera".into(),
+            package_dir: root.path().join("pkg"),
             dir: plugin_dir,
         }],
     );
@@ -1157,10 +1160,12 @@ fn two_plugins_claiming_one_name_resolve_in_roster_order() {
         &[
             PluginToolDir {
                 plugin: "alpha".into(),
+                package_dir: root.path().join("alpha"),
                 dir: first,
             },
             PluginToolDir {
                 plugin: "zeta".into(),
+                package_dir: root.path().join("zeta"),
                 dir: second,
             },
         ],
@@ -1181,6 +1186,87 @@ fn a_manifest_cannot_claim_to_have_been_shipped_by_a_plugin() {
     )
     .expect("unknown fields are ignored, as they always have been");
     assert_eq!(tool.contributed_by, None);
+}
+
+/// **Witness for #3579: a package's tool can run a script the package ships.**
+///
+/// The child's working directory stays the workspace root — a linter a plugin
+/// contributes acts on the *user's* repository — so a package names its own
+/// files with `${plugin_dir}` and discovery resolves it against the installed
+/// package. Without that expansion `command[0]` resolved inside the user's
+/// repo, where the script is not, and the only shapes that could ever run were
+/// a program already on `PATH` or an absolute path a package cannot know when
+/// it is written.
+///
+/// The user's own manifest is the other half: `${plugin_dir}` names nothing
+/// under `.stella/tools/`, so it must survive verbatim rather than expand to
+/// the empty string and become a different path.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_contributed_tool_runs_a_script_its_own_package_ships() {
+    let root = tempfile::tempdir().unwrap();
+    let package = root.path().join("plugins").join("vera");
+    let script = package.join("scripts").join("x.sh");
+    std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+    std::fs::write(&script, "#!/bin/sh\necho shipped_script_ran\n").unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    // One manifest text, written into both scopes — so the only difference
+    // between the two tools below is the directory each was read from.
+    let manifest = |name: &str| {
+        format!(
+            "name = \"{name}\"\n\
+             description = \"d\"\n\
+             command = [\"${{plugin_dir}}/scripts/x.sh\"]\n\
+             \n\
+             [env]\n\
+             PKG_DATA = \"${{plugin_dir}}/data\"\n"
+        )
+    };
+    let contributed = package.join("tools");
+    std::fs::create_dir_all(&contributed).unwrap();
+    std::fs::write(contributed.join("theirs.toml"), manifest("theirs")).unwrap();
+    let own = root.path().join(".stella").join("tools");
+    std::fs::create_dir_all(&own).unwrap();
+    std::fs::write(own.join("mine.toml"), manifest("mine")).unwrap();
+
+    let (tools, _) = discover_with_plugins(
+        root.path(),
+        None,
+        true,
+        &[PluginToolDir {
+            plugin: "vera".into(),
+            package_dir: package.clone(),
+            dir: contributed,
+        }],
+    )
+    .into_parts();
+
+    let mine = tools.iter().find(|t| t.name == "mine").expect("mine");
+    assert_eq!(
+        mine.command[0], "${plugin_dir}/scripts/x.sh",
+        "no package is in scope for a manifest the user wrote"
+    );
+    assert_eq!(mine.env["PKG_DATA"], "${plugin_dir}/data");
+
+    let theirs = tools.iter().find(|t| t.name == "theirs").expect("theirs");
+    assert_eq!(theirs.command[0], script.to_string_lossy());
+    assert_eq!(
+        theirs.env["PKG_DATA"],
+        package.join("data").to_string_lossy()
+    );
+
+    // Run it from the workspace root, which is where it does NOT live.
+    match run_custom(theirs, &serde_json::json!({}), root.path()).await {
+        ToolOutput::Ok { content, .. } => {
+            assert!(content.contains("shipped_script_ran"), "{content}");
+        }
+        ToolOutput::Error { message, .. } => {
+            panic!("a package's own script must run: {message}")
+        }
+    }
 }
 
 // the shared dispatch gate (#2793)

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -707,25 +707,28 @@ repository's, and it is written down in `CLAUDE.md`. Another's is *"ship the
 smallest diff that closes the ticket"*. **Both are legitimate, and a loop that
 hardcodes either is a loop that can only replace one of them.**
 
-So the tie-breakers are configuration: a `[doctrine]` manifest, source-tracked
-beside the provider and convention manifests under `.stella/issues/`, because the
-person who starts the loop is the person who decides how it decides — and that is
-only true if what it will do is legible *before* it does it.
+So the tie-breakers are configuration: a `[self_driving.doctrine]` block in
+`stella.toml`, source-tracked with the rest of the workspace's configuration,
+because the person who starts the loop is the person who decides how it decides —
+and that is only true if what it will do is legible *before* it does it. It is
+not a manifest under `.stella/issues/` beside the provider and convention ones:
+everything configurable about stella comes from `stella.toml`, and a second
+config system is a second place to search.
 
 **The line is machine-readability, and it is drawn to avoid a fifth steering
 plane.** This repository already carries four that do not know about each other
 (#3243), and the fastest way to make it five is a free-text "how should I decide
 things" field. So:
 
-| Belongs in `[doctrine]` | Belongs in a context record |
+| Belongs in `[self_driving.doctrine]` | Belongs in a context record |
 |---|---|
 | Closed enums and numbers a **pure machine** branches on — `foreign_breakage`, `contention`, `queue_order`, `abandon_escalated`, the `deliver` ceilings | Prose instruction for the **judgement half** — "prefer the architecturally sound option", "match the neighbourhood", "no new dependencies casually" |
 | No model ever reads it. An operator's declared preference becomes *testable*: you can assert `FileAndWait` does not adopt, and the assertion cannot be talked out of. | Already has a home (`.stella/rules/*.toml`, `doc:context-pr`), already governed, already versioned. |
 
 The test is invariant 5's: **does a caller branch on it?** A pure machine
 branching on a closed enum belongs; a sentence a model reads does not. A
-`[doctrine]` field that wants to say something prose-shaped **is** a context
-record, and the answer to that request is a pointer, not a field.
+`[self_driving.doctrine]` field that wants to say something prose-shaped **is** a
+context record, and the answer to that request is a pointer, not a field.
 
 #### The loop exhausts its permitted channels before it parks
 
@@ -735,8 +738,10 @@ for its author has a throughput equal to somebody else's response time. But a
 loop wandering into unrelated code is also how an autonomous system becomes a
 liability — so this is exactly a doctrine axis, not a rule:
 
-- `file_and_wait` *(default)* — make it visible, leave the fix to a human.
-- `file_and_adopt` — make it visible, then fix it at the top of the queue.
+- `file_and_adopt` *(default)* — make it visible, then fix it at the top of the
+  queue. A loop that files and waits has handed its own throughput to somebody
+  else's response time.
+- `file_and_wait` — make it visible, leave the fix to a human.
 - `ignore` — neither. Present for the operator who wants a silent loop, and
   deliberately **not** the default: a system that notices breakage and says
   nothing is the worst of the three.
@@ -751,8 +756,9 @@ Three orderings inside that are load-bearing:
 3. **Unblock before claiming.** A red base makes every PR the loop produces fail
    CI, so it is dealt with before more are made.
 
-And a red base stops *merges*, not *authoring* — so under `file_and_wait`, once
-filed, the loop carries on with ordinary work rather than parking.
+And a red base stops *merges*, not *authoring* — so even under `file_and_wait`,
+where the fix is somebody else's, the loop carries on with ordinary work once it
+has filed rather than parking.
 
 #### Collision avoidance, and the signal nobody checks
 

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -884,7 +884,7 @@ drew its batch from. Both numbers are now folds of one ranking of one read.
 | `Issue`, `IssueState`, `IssueClass`, `PrId`, receipts | `stella-protocol` (types only) |
 | Residue detection, discharge rules | `stella-core` (pure, no I/O) |
 | The residue gate stage | **Homeless.** `stella-pipeline` is deleted (#3852/#3865) and this row named it; B5 has to pick a home before it can be built — a wrapper plugin's own side, or a `stella-cli` check over the turn's transcript. Tracked in #3901's sweep of the same stale claim. |
-| `backlog`/`work`/`deliver`/`sweep`/`curate` verbs, the forge adapter, provider manifests | `stella-cli` (`self_driving_cmd/` — note `self_driving_cmd.rs` is 1005 lines and new logic lands in siblings) |
+| `backlog`/`work`/`deliver`/`sweep`/`curate` verbs, the forge adapter, provider manifests | `stella-cli` (`self_driving_cmd/` — `self_driving_cmd.rs` is close enough to the 1500-line ceiling that new logic lands in siblings; it carries no baseline entry, so a crossing fails the gate rather than being grandfathered) |
 | Issue claims | `stella-fleet` ledger |
 | The driver channel: dispatch context, `[driver]` block, `permits_call` | `stella-plugin` (wire + gate), `stella-runtime` (`src/wrapper/`, beside the existing host-call dispatch) |
 | The policy loop | `plugins/stella-selfdriving/` |


### PR DESCRIPTION
Six confirmed defects in the plugin surface and the self-driving loop, found by triaging every open P0/P1 issue tagged `area:plugin` or `area:autonomy` against the current tree.

Ten issues were triaged in parallel. One (**#3500**) turned out to be **already fixed** and is closed with evidence rather than re-fixed. Six were real and are fixed here. The rest needed owner decisions and got correction comments, because three of them assert defects that are partly or wholly already shipped — a fresh agent reading them today would rebuild working code.

---

## The fixes

### #3579 — a plugin-contributed tool could not run a script its own package ships

`${plugin_dir}` was never interpolated for custom tools, so a contributed tool's `command[0]` resolved against the **user's** workspace root and failed. The convention already existed, was already specified as the host's job (`crates/stella-plugin/src/runtime.rs:61-77`), and was already implemented for hook argv (`plugin_cmd/roster.rs:277`) — it just never reached `tools/*.toml`.

Chose **interpolation** over re-rooting the child's cwd, and the reason is the interesting part: the workspace root is the *correct* cwd for a contributed tool. A linter a package ships acts on the user's repository, so re-rooting breaks the common case and then needs an env var to hand the workspace back — a second concept for one problem. Interpolation keeps `custom.rs`'s documented "cwd is the workspace root" contract true for every tool.

A user's own `.stella/tools/` is deliberately left **verbatim**: `${plugin_dir}` names nothing there, and silently expanding it to empty is worse than leaving it alone. `parse_manifest` is untouched, so `plugin_cmd/package.rs::tool_names` (#3565 reconciliation) still answers identically and `a_manifest_cannot_claim_to_have_been_shipped_by_a_plugin` stays true — provenance still comes only from the directory.

### #3530 — a symlinked plugin loaded and routed, and could not be uninstalled

`stella plugin install` already refuses symlinks, with a witness. The tier reader held the weaker line: `read_tier` filtered on `Path::is_dir()` and `removable_dirs` on `by_path.is_dir()`, both of which **follow** the link. So a hand-linked entry loaded, listed, and routed an argv with `${plugin_dir}` interpolated to the link path — while `remove_plugin_dir` refused to delete it. A package that ran and could not be uninstalled.

All three sites now agree that a symlinked tier entry is not a plugin. `DirEntry::file_type()` and `symlink_metadata` describe the **entry**, not what it resolves to. A skipped symlink is **reported**, not silently dropped, on the reasoning `read_project_tier`'s own doc comment already gives: a plugin that vanishes with no message is indistinguishable from a broken one.

### #4002 — the self-driving loop claimed an issue a peer was already working

The `LoopStep::Claim` arm consulted **no** contention signal, while the base-fix path in the same loop did. Two paths, two different lines. Separately, `Contention::ledger_claims` was never populated by anything, so `ContentionPolicy::ClaimsOnly` selected an always-empty set and meant "proceed regardless" on every path.

- `base_fix_contention` → `contention_for_issue(root, key)` (its body was already key-generic), rename chased through the comments.
- Added the fourth signal — fleet-ledger dispatch claims on `issue:<key>` — which is what makes `ClaimsOnly` select a non-empty set. It fails open in every direction, matching the stance of the other three probes. `stella-fleet` was already a dependency; no new edge.
- New **pure** `next_claimable` selector plus `Pick`: no I/O, no clock, so the decision finally has a test seam instead of being buried in `drive()`'s network loop. A contended candidate is audited and skipped, and the loop takes the next one rather than stalling.
- The exhausted-queue message now names the deferral count, so a pass where every candidate went to a peer no longer reads identically to an empty backlog.

### #4118 — five session-stats counters had a printer and no producer

`stella self-driving stats` reported a session that learned nothing however much it learned. The issue names three counters; **it is five** — `filings_refused` and `filings_duplicate` sit under the same `filed` heading beside a live `issues_created`, so a reader saw one true number next to two dead ones.

**Filings.** `record_filing(canonical)` mirrors the existing `record_closure`, with a new `filings_attempted` denominator so `filings_balance()` is a check rather than an assumption. `stella-autonomy` stays a leaf: it takes a `&str`, never the CLI's `Filed` enum.

**Learning.** A turn runs in a **child process** (`work::run_turn` spawns `stella run --output-format json`), and a machine-format turn deliberately emits no reflection frame so `Complete` stays the unique final one. So no event can reach the loop as it happens. What *is* observable is durable: `run_turn` already points the child's state root at the repository rather than the throwaway worktree. The new `self_driving_cmd::learning` module reads a **delta** over that state. The three counters read three **different** artifacts, so they mean different things rather than being one number counted thrice; counting never creates a store; unreadable state is zero rather than an error, because a counter must not be able to stop a turn.

### #3514 (first half) — the consent prompt hid the model tier and the data egress

A `[wrapper]` manifest rendered *"It asks for no tool capabilities."* — actively misleading about a process that is handed the goal, the model's full reply, every tool name, and every changed-file path. And a `[roles.x] tier = "premium"` was never named, so a user consented without being told what the plugin would spend at.

The disclosure is **compiler-enforced** rather than a comment that rots: `WIRE_FIELDS` carries one row per (point, field), and an exhaustive destructure means a new wire field **does not compile** until it is disclosed. Data is filtered by `LoopGrant::permits_point`, so the prompt describes what is actually dispatched rather than what the manifest merely mentions.

The consent-receipt / manifest-digest half of #3514 (a plugin widening its own grant by rewriting its manifest after consent) is **not** in this change and stays open.

### #3943 — the doctrine loader already shipped; the docs drifted

The loader this issue asks for **exists** (`toml_config.rs:353` → `config.rs:92`, landed under #4078). Building the `.stella/issues/doctrine.json` manifest it prescribes would create exactly the two-settings-that-disagree failure `config.rs`'s own module doc forbids. Fixed the drift instead — including the sharpest error: the spec marked `file_and_wait` as the **default** when the shipped default is `FileAndAdopt`, i.e. the wrong default stated on the exact axis that decides whether the loop repairs a red `main`.

Also corrected three stale line-count claims that were copies of one another.

---

## Witness tests

| Issue | Test | Flip |
|---|---|---|
| #3579 | `custom::tests::a_contributed_tool_runs_a_script_its_own_package_ships` | **Observed** — with the expansion neutered it fails on the raw `${plugin_dir}/scripts/x.sh` |
| #3530 | `plugin_cmd::tests::a_symlinked_tier_entry_is_not_loaded_listed_or_routed` | **Observed twice**, once per half — each site reverted independently gives a distinct failure |
| #4002 | `self_driving_cmd::drive::tests::a_candidate_a_peer_is_working_is_skipped_with_evidence` | **Observed** — the pre-change bare `find` reproduced in the seam fails both assertions |
| #3943 | `doctrine::tests::doctrine_default_matches_the_spec` | **Observed** — reads the spec at runtime; restoring the stale line gives `left: ["file_and_wait"] / right: ["file_and_adopt"]` |
| #3514 | `the_consent_prompt_names_the_tier_a_role_spends_at`, `a_wrapper_prompt_says_what_leaves_the_machine` | **Observed** — each call site deleted in place fails, restored passes |
| #4118 | `every_counter_names_its_producer` | **Observed** — deleting one `PRODUCERS` entry fails naming the orphan |

### Stated plainly, because it matters

**#4118's producer tests have a compile-level flip, not an assertion-level one.** Fixing "a field with no producer" is purely additive, so no test of the producer can compile against the old tree — reverting yields `error[E0599]: no method named record_filing`, not a failed assertion. That was not faked into an assertion flip. The **structural guard** above is the one with a real assertion-level flip, and it is the part that stops the next field shipping a zero.

Three additions are **regression guards, not witnesses**, and say so in-band: `the_doctrine_is_read_from_stella_toml` (passes on `main` already), `a_process_that_answers_no_point_discloses_no_data`, and `every_wire_field_is_in_the_table`. The last was shown to have teeth a different way: adding a probe field to `TurnOutcome` produces `error[E0027]: pattern does not mention field` — a new wire field genuinely cannot ship undisclosed.

The prose corrections in `doctrine.rs` and the spec's path/rename have no flip available and are not claimed to.

---

## Verification

- `cargo test --workspace --no-fail-fast` — green except **two known pre-existing failures**, both tracked by **#3996/#3982**: `settings::tests::untrusted_project_cannot_enable_tools_or_replace_an_agent_prompt` and `tool_switches::tests::a_saved_switch_round_trips_through_the_settings_chain_under_the_managed_ceiling`. Both override `HOME` but not `STELLA_HOME`, so they fail whenever the home is isolated and pass when they read the developer's real `~/.stella`. Demonstrated both ways. #3996 predicts exactly two such tests. **This branch touches neither `crates/stella-cli/src/settings/` nor `tool_switches.rs`.**
- `cargo clippy -p stella-cli -p stella-tools -p stella-autonomy -p stella-plugin --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `make guards-fast` — every guard OK, including `check-file-size` ("nothing went over by this change"), `check-god-files`, `check-left-behind`, `check-dead-code-allows` (9 suppressions, **none added by this change**), `check-invariants`, `check-doc-links`, `check-lockfile-sync`.
- `make wire-schema` — `docs/wire/` unchanged. The new `pub const` table alters no serialized shape; confirmed by running it, not assumed.

**No new dependencies.**

---

## Issues filed from this work

Per AGENTS.md § *Nothing left behind*:

- **#4300** — a crashed run's leftover worktree now defers its own issue forever under the default policy, blocking a recovery `work::start` used to perform. **This is the direct cost of the #4002 fix in this PR, stated rather than shipped quietly**, and it also corrects `doctrine.rs:104`'s "a deferred one costs a poll interval", which is false for that case.
- **#4303** — `ContentionPolicy::ClaimsOnly` is inert: the loop never mints a lease, so two drives claim one issue and the second deletes the first's **live** worktree.
- **#4310** — a hooks-only plugin is told it "asks for nothing" while its process receives the user's tool inputs; the hook channel has no disclosure table.
- **#4306** — `stella self-driving work` records no session stats at all (a literal `let _ = st;`).
- **#4301** — `${plugin_dir}` now has two implementations; the docs describe only one, and the end-to-end install→dispatch witness is still unwritten.
- **#4302** — `plugin remove`: a project-tier failure aborts before the user tier is read, leaving a copy that still dispatches hooks.
- **#4304** — `QueueCriterion` has zero consumers, and the doctrine spec table promises two axes `Doctrine` does not carry.

Correction comments posted on **#4119**, **#3547**, **#3943** and **#3482**, each of which asserts something already partly shipped. #3482's fix in particular is **already written** on an unmerged branch (`feat-3482-plugin-capability-gate`) and should be cherry-picked, not rewritten.

**#3500 closed** with evidence.

---

## Tests deleted

None.

Closes #3579
Closes #3530
Closes #4002
Closes #4118
Refs #3514
Refs #3943
