### PR TITLE
feat(stella-tui,stella-tui-theme): four SPEC 4 glyphs so a tool call's class is legible again

### DIFF
--- a/crates/stella-tui-theme/src/glyph.rs
+++ b/crates/stella-tui-theme/src/glyph.rs
@@ -14,6 +14,14 @@
 //! character specifically; a layout that budgets one cell for it will shear
 //! the row to its right, so [`width`] states the width rather than leaving
 //! each call site to measure. Nothing else here is fullwidth.
+//!
+//! Three glyphs — [`QUEUED`], [`MEMORY`] and [`TOOL_EXECUTE`] — carry East
+//! Asian Width `A` (*ambiguous*) rather than `N`, so a terminal configured for
+//! CJK double-width ambiguity draws them in two cells. [`width`] answers one
+//! for them because that is what every non-CJK configuration draws and what
+//! the layout budgets. The hazard is named here rather than silently
+//! inherited; it predates the tool-class rows below rather than arriving with
+//! them.
 
 /// Done, pass. Green.
 pub const DONE: char = '✓';
@@ -72,6 +80,54 @@ pub const NODE_TYPE: char = '▢';
 /// Graph node: function. Silver.
 pub const NODE_FN: char = 'ƒ';
 
+// ── Tool class (SPEC 4) ─────────────────────────────────────────────────────
+//
+// Four glyphs for the four classes a tool call falls into, drawn on the head
+// of a call this renderer has no verb of its own for. They take the metal of
+// the row they head and add none of their own: SPEC 2 spends its two metals on
+// *kind*, and re-adding *class* as a third hue would erode the rule the whole
+// scheme rests on. Shape carries class instead, which is what SPEC 2's "never
+// colour alone" already points at (#4125).
+//
+// All four are drawn from the circle and arrow families rather than invented,
+// and each was checked against the shipped `cmap` of the brand font before it
+// was chosen — see the per-glyph notes. That check is why `TOOL_EXECUTE` is
+// U+2299 and not U+2317 VIEWDATA SQUARE, which the design first named.
+
+/// Tool class: a look — nothing changed. Outline, unfilled.
+///
+/// U+25CC DOTTED CIRCLE, native to JetBrains Mono (SPEC 3.4).
+pub const TOOL_INSPECT: char = '◌';
+
+/// Tool class: written — filled and marked.
+///
+/// U+25C9 FISHEYE, native to JetBrains Mono (SPEC 3.4).
+pub const TOOL_MUTATE: char = '◉';
+
+/// Tool class: external, opaque — a call this table cannot vouch for.
+///
+/// U+2299 CIRCLED DOT OPERATOR. The design's first choice was U+2317 VIEWDATA
+/// SQUARE, which reads better for "external" and is width `N` rather than this
+/// character's ambiguous `A`. It was rejected on coverage: U+2317 is absent
+/// from the `cmap` of *every* monospace face checked — JetBrains Mono, DejaVu
+/// Sans Mono, Fira Code, Cascadia Mono, Hack, Ubuntu Mono and Menlo — so it
+/// resolves through CoreText to the proportional Apple Symbols on macOS and
+/// has nothing to resolve to on a bare Linux terminal. A glyph whose entire
+/// job is to be recognised may not ship as a tofu box (SPEC 2, cell-grid
+/// honest). This character is present in JetBrains Mono itself.
+pub const TOOL_EXECUTE: char = '⊙';
+
+/// Tool class: handed to another agent.
+///
+/// U+21B3 DOWNWARDS ARROW WITH TIP RIGHTWARDS — width `N`, and the one glyph
+/// here whose shape states the relation rather than naming it. Absent from
+/// JetBrains Mono, so it resolves to Menlo, which is exactly what the shipped
+/// [`RUNNING`] spinner already does and therefore no new hazard. The
+/// circle-family alternative (U+25D1) was declined because it is
+/// [`SPINNER`]`[2]`: a delegation would be indistinguishable from a call
+/// caught mid-spin.
+pub const TOOL_DELEGATE: char = '↳';
+
 /// The eighth-block ramp, empty through full — the only sub-cell precision
 /// this design allows itself (SPEC 2: cell-grid honest).
 ///
@@ -87,7 +143,7 @@ pub const METER_TRACK: char = '░';
 ///
 /// The tests walk this instead of a second list, so a glyph added without a
 /// stated width is caught rather than assumed.
-pub const ALL: [(&str, char); 16] = [
+pub const ALL: [(&str, char); 20] = [
     ("done", DONE),
     ("running", RUNNING),
     ("queued", QUEUED),
@@ -102,6 +158,10 @@ pub const ALL: [(&str, char); 16] = [
     ("node_file", NODE_FILE),
     ("node_type", NODE_TYPE),
     ("node_fn", NODE_FN),
+    ("tool_inspect", TOOL_INSPECT),
+    ("tool_mutate", TOOL_MUTATE),
+    ("tool_execute", TOOL_EXECUTE),
+    ("tool_delegate", TOOL_DELEGATE),
     ("block_full", BLOCK_EIGHTHS[8]),
     ("meter_track", METER_TRACK),
 ];

--- a/crates/stella-tui-theme/src/glyph.rs
+++ b/crates/stella-tui-theme/src/glyph.rs
@@ -15,13 +15,17 @@
 //! the row to its right, so [`width`] states the width rather than leaving
 //! each call site to measure. Nothing else here is fullwidth.
 //!
-//! Three glyphs — [`QUEUED`], [`MEMORY`] and [`TOOL_EXECUTE`] — carry East
-//! Asian Width `A` (*ambiguous*) rather than `N`, so a terminal configured for
-//! CJK double-width ambiguity draws them in two cells. [`width`] answers one
-//! for them because that is what every non-CJK configuration draws and what
-//! the layout budgets. The hazard is named here rather than silently
-//! inherited; it predates the tool-class rows below rather than arriving with
-//! them.
+//! [`WRITE`] is the only *unconditionally* wide one. Seven others carry East
+//! Asian Width `A` (**ambiguous**) rather than `N`, so a terminal configured
+//! for CJK double-width ambiguity draws them in two cells: [`RUNNING`],
+//! [`QUEUED`], [`GATE`], [`MEMORY`], [`NODE_FILE`], [`TOOL_EXECUTE`], and
+//! `BLOCK_EIGHTHS[8]`. [`width`] answers one for all of them, because that is
+//! what every non-CJK configuration draws and what the layout budgets.
+//!
+//! The hazard is named rather than silently inherited, and it predates the
+//! tool-class rows below: six of those seven shipped before them. It is not
+//! guarded, because nothing here knows the terminal's ambiguous-width setting
+//! — a real fix means asking the terminal, not asserting a number.
 
 /// Done, pass. Green.
 pub const DONE: char = '✓';

--- a/crates/stella-tui/src/v2/transcript.rs
+++ b/crates/stella-tui/src/v2/transcript.rs
@@ -35,6 +35,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use stella_tui_theme::{glyph, token};
 
+use crate::tool_class::ToolClass;
+
 /// Cells the coloured rail occupies at the head of every event row (SPEC 6.2).
 pub const RAIL_W: usize = 2;
 
@@ -144,8 +146,19 @@ pub enum EventKind {
         evicted: u32,
         deduped: u32,
     },
-    /// Anything this renderer has not been taught.
-    Other,
+    /// Anything this renderer has not been taught — an MCP server's tool, a
+    /// workspace custom tool, a built-in with no verb of its own.
+    ///
+    /// The `class` is the only thing that distinguishes one such row from
+    /// another, and it is carried as a **glyph**, never as a hue. Every
+    /// `Other` rails gold because every one of them is *stella acting*
+    /// ([`EventKind::metal`]), which under v1's class-coloured names left
+    /// `get_state`, `mcp__github__create_pull_request` and `delegate`
+    /// rendering identically — one `●` on one gold rail, the confusion #4125
+    /// was filed about. Restoring the distinction as a third colour channel
+    /// would erode SPEC 2's two-metal rule; restoring it as shape does not,
+    /// which is what SPEC 2's "never colour alone" already asks for.
+    Other { class: ToolClass },
 }
 
 impl EventKind {
@@ -167,13 +180,17 @@ impl EventKind {
             // bookkeeping tier and belongs to compaction alone: a call the
             // renderer has not been taught is not thereby less of an action,
             // and dimming it would hide exactly the rows a user added.
-            EventKind::Other => token::GOLD,
+            EventKind::Other { .. } => token::GOLD,
             EventKind::Compaction { .. } => token::DIM,
         }
     }
 
     /// The head glyph (SPEC 4). A collapsed event takes `▸` regardless of kind
     /// — the toggle state outranks the kind on the one cell that shows it.
+    ///
+    /// [`EventKind::Other`] is the one arm that reads a second field: every
+    /// such row rails gold, so the glyph is the only cell left that can say
+    /// which of them this is (#4125).
     #[must_use]
     pub fn head_glyph(&self, collapsed: bool) -> char {
         if collapsed {
@@ -187,6 +204,12 @@ impl EventKind {
             EventKind::Gate { .. } => glyph::GATE,
             EventKind::Model { .. } => glyph::RUNNING,
             EventKind::Compaction { .. } => '↓',
+            EventKind::Other { class } => match class {
+                ToolClass::Inspect => glyph::TOOL_INSPECT,
+                ToolClass::Mutate => glyph::TOOL_MUTATE,
+                ToolClass::Execute => glyph::TOOL_EXECUTE,
+                ToolClass::Delegate => glyph::TOOL_DELEGATE,
+            },
             _ => '●',
         }
     }
@@ -205,7 +228,7 @@ impl EventKind {
             EventKind::Gate { .. } => "gate",
             EventKind::Model { .. } => "model",
             EventKind::Compaction { .. } => "compacted",
-            EventKind::Other => "",
+            EventKind::Other { .. } => "",
         }
     }
 

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -182,7 +182,15 @@ fn kind_for(name: &str, measured: Option<(u32, u32)>) -> EventKind {
         // not necessarily this workspace's `read`, and a familiar verb on a row
         // that did something else is the one error a transcript cannot afford.
         // It keeps its name as the subject instead — see `subject_for`.
-        _ => EventKind::Other,
+        //
+        // The class is the one thing that *can* be said about it without
+        // claiming a verb, and it comes off the same gate-enforced catalog the
+        // policy layer reads rather than a second table here, so a tool cannot
+        // be filed under one family for `tools.<group>: "off"` and a different
+        // one on screen. It renders as a glyph, never as a hue (#4125).
+        _ => EventKind::Other {
+            class: crate::tool_class::classify(name),
+        },
     }
 }
 
@@ -306,7 +314,7 @@ mod tests {
     use super::*;
     use crate::model::SessionModel;
     use stella_protocol::{AgentEvent, FileChangeKind, ToolCall, ToolOutput};
-    use stella_tui_theme::token;
+    use stella_tui_theme::{glyph, token};
 
     fn text_of(line: &Line<'static>) -> String {
         line.spans.iter().map(|s| s.content.clone()).collect()
@@ -665,6 +673,116 @@ mod tests {
                  (declares: {declares_a_size}), so the row states the same \
                  thing measured as unmeasured: {measured}"
             );
+        }
+    }
+
+    /// The three calls #4125 named, and the three cells that have to tell them
+    /// apart.
+    ///
+    /// `get_state` is an inspection, `mcp__github__create_pull_request` an
+    /// opaque external call and `delegate` a hand-off. All three are
+    /// `EventKind::Other`, so all three rail gold — which under v1's
+    /// class-coloured tool names was the whole signal, and under v2 left every
+    /// one of them drawing the same `●`. The glyph is the only cell left that
+    /// can carry the distinction.
+    const CLASS_CASES: [(&str, char); 4] = [
+        ("get_state", glyph::TOOL_INSPECT),
+        ("save_state", glyph::TOOL_MUTATE),
+        ("mcp__github__create_pull_request", glyph::TOOL_EXECUTE),
+        ("delegate", glyph::TOOL_DELEGATE),
+    ];
+
+    /// The glyph cell of a head row: the rail is span 0, the glyph span 1
+    /// (`" x "`), which `head_row` composes in that order.
+    fn head_glyph_of(name: &str) -> char {
+        let rows = head_rows(name, None, "{}", None, 120);
+        let row = rows
+            .first()
+            .expect("a head always renders at least one row");
+        let cell = row.spans[1].content.trim().to_string();
+        let mut chars = cell.chars();
+        let glyph = chars
+            .next()
+            .unwrap_or_else(|| panic!("`{name}` drew no glyph"));
+        assert_eq!(
+            chars.next(),
+            None,
+            "`{name}` drew more than one glyph: {cell:?}"
+        );
+        glyph
+    }
+
+    /// **The witness (#4125).** A look, a write, an opaque external call and a
+    /// hand-off render four *different* glyphs.
+    ///
+    /// Before this they were four `●`, so a reader scanning the margin could
+    /// not tell a `get_state` from an MCP pull-request call from a sub-agent
+    /// delegation — the exact confusion the issue was filed about.
+    #[test]
+    fn a_tool_calls_class_is_legible_from_its_glyph_alone() {
+        let mut seen: Vec<(char, &str)> = Vec::new();
+        for (name, want) in CLASS_CASES {
+            let got = head_glyph_of(name);
+            assert_eq!(
+                got, want,
+                "`{name}` drew {got:?} rather than its class glyph {want:?}"
+            );
+            if let Some((_, other)) = seen.iter().find(|(ch, _)| *ch == got) {
+                panic!(
+                    "`{name}` and `{other}` both drew {got:?} — the class is \
+                     illegible in the one cell that carries it (#4125)"
+                );
+            }
+            seen.push((got, name));
+        }
+    }
+
+    /// The other half of the law, and the reason this fix is a *glyph* and not
+    /// a hue: the four classes still share one rail and spend no colour.
+    ///
+    /// SPEC 2 gives the scheme two metals and spends them on **kind**. #4125
+    /// declined a third colour channel for class precisely because it would
+    /// erode that rule, so a future change that re-reaches for
+    /// `ToolClass::color` — v1's categorical `data-*` hues, which SPEC 3.2's
+    /// clamp rejects outright — has to fail here rather than pass quietly.
+    #[test]
+    fn a_tool_classs_glyph_spends_no_colour() {
+        let banned = [
+            ("teal", crate::theme::TEAL),
+            ("magenta", crate::theme::MAGENTA),
+            ("violet", crate::theme::VIOLET),
+            ("orchid", crate::theme::ORCHID),
+        ];
+        for (name, _) in CLASS_CASES {
+            let rows = head_rows(name, None, "{}", None, 120);
+            let row = rows
+                .first()
+                .expect("a head always renders at least one row");
+
+            // One rail, one metal, for every class alike.
+            assert_eq!(
+                row.spans[0].style.fg,
+                Some(token::GOLD),
+                "`{name}` moved off the shared gold rail — class is not a metal"
+            );
+            // The glyph takes the row's metal and adds none of its own.
+            assert_eq!(
+                row.spans[1].style.fg,
+                Some(token::GOLD),
+                "`{name}`'s class glyph wears a colour of its own"
+            );
+            for span in &row.spans {
+                for (hue, colour) in banned {
+                    assert_ne!(
+                        span.style.fg,
+                        Some(colour),
+                        "`{name}` paints {:?} in the categorical `{hue}` — \
+                         class came back as a hue, which #4125 declined and \
+                         SPEC 3.2's clamp rejects",
+                        span.content
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -29,7 +29,7 @@
 │                                                                                                                      ││                                      │
 │── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
 │                                                                                                                      ││                                      │
-│ │ ● apps/app/automations/page.tsx                                                                                    ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx                                                                                    ││                                      │
 │ │ ⎿ 312 lines                                                                                                    42ms││                                      │
 │                                                                                                                      ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                  ┌ budget  session spend cap ⏎ set · ⌫ edit · esc close ┐           ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -29,7 +29,7 @@
 │                                           │          low · thinking off · from agents.triage.model               │   ││                                      │
 │── EXECUTE ────────────────────────────────│research  zai/glm-5.2-air                                             │───││                                      │
 │                                           │          low · thinking off · from default_model                     │   ││                                      │
-│ │ ● apps/app/automations/page.tsx         │plan      zai/glm-5.2-air                                             │   ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx         │plan      zai/glm-5.2-air                                             │   ││                                      │
 │ │ ⎿ 312 lines                             │          medium · thinking on · from default_model                   │2ms││                                      │
 │                                           │work      zai/glm-5.2-air                                     served  │   ││                                      │
 │☰  plan  5/7  ·  Workflows canvas          │          medium · thinking on · from default_model                   │   ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -29,7 +29,7 @@
 │                                                   │▸ ○ 1. extract types                                  │           ││                                      │
 │── EXECUTE ────────────────────────────────────────│  ○ 2. move hooks                                     │───────────││                                      │
 │                                                   │  ○ 3. update 9 imports                               │           ││                                      │
-│ │ ● apps/app/automations/page.tsx                 │                                                      │           ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx                 │                                                      │           ││                                      │
 │ │ ⎿ 312 lines                                     │repo      macanderson/web-app ⎇ feat/automations-store│       42ms││                                      │
 │                                                   │write     packages/automations/** · apps/app/automatio│           ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                  │read      apps/** · packages/**  (2 globs)            │           ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
@@ -29,7 +29,7 @@
 │                                         ┌ approval ─────────────────────────────── ↑↓ move · ⏎ choose · esc denies ┐ ││                                      │
 │── EXECUTE ──────────────────────────────│bash  mutating                                                            │─││                                      │
 │                                         │  rm -rf build/                                                           │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │                                                                          │ ││                                      │
 │ │ ⎿ 312 lines                           │gate    command.started                                                   │s││                                      │
 │                                         │reason  matched rule no-destructive-shell                                 │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
@@ -29,7 +29,7 @@
 │                                         ┌ approval ─────────────────────────────── ↑↓ move · ⏎ choose · esc denies ┐ ││                                      │
 │── EXECUTE ──────────────────────────────│read_file  read-only                                                      │─││                                      │
 │                                         │  .stella/private/credentials.toml                                        │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │                                                                          │ ││                                      │
 │ │ ⎿ 312 lines                           │gate    tool.call.requested                                               │s││                                      │
 │                                         │reason  matched rule secrets-are-off-limits                               │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
@@ -29,7 +29,7 @@
 │                                                                                                                      ││                                      │
 │── EXECUTE ──────────────────────────────┌ approval ──────────────────────────── ⏎ deny with these words · esc back ┐─││                                      │
 │                                         │bash  mutating                                                            │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │  rm -rf build/                                                           │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │  rm -rf build/                                                           │ ││                                      │
 │ │ ⎿ 312 lines                           │                                                                          │s││                                      │
 │                                         │gate    command.started                                                   │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │reason  matched rule no-destructive-shell                                 │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -29,7 +29,7 @@
 │                                         ┌ question ───────────────────────────────────── ⏎ save note · esc discard ┐ ││                                      │
 │── EXECUTE ──────────────────────────────│from the `research-child` sub-agent                                       │─││                                      │
 │                                         │                                                                          │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │Which auth should the new endpoint use?                                   │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │Which auth should the new endpoint use?                                   │ ││                                      │
 │ │ ⎿ 312 lines                           │                                                                          │s││                                      │
 │                                         │  [ ] Session cookie — Matches the rest of the app                        │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │  [x] Bearer token                                                        │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -29,7 +29,7 @@
 │                                         │  • Which auth should the new endpoint use?                               │ ││                                      │
 │── EXECUTE ──────────────────────────────│      → Session cookie                                                    │─││                                      │
 │                                         │        note: admin routes only                                           │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │                                                                          │ ││                                      │
 │ │ ⎿ 312 lines                           │  • Which environments should it reach first?                             │s││                                      │
 │                                         │      → staging                                                           │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -29,7 +29,7 @@
 │                                                                                                                      ││                                      │
 │── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
 │                                         ┌ question ──── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │from the `research-child` sub-agent                                       │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │from the `research-child` sub-agent                                       │ ││                                      │
 │ │ ⎿ 312 lines                           │                                                                          │s││                                      │
 │                                         │Which auth should the new endpoint use?                                   │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -29,7 +29,7 @@
 │                                         │from the `research-child` sub-agent                                       │ ││                                      │
 │── EXECUTE ──────────────────────────────│                                                                          │─││                                      │
 │                                         │● Auth method  ○ Rollout                                                  │ ││                                      │
-│ │ ● apps/app/automations/page.tsx       │                                                                          │ ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx       │                                                                          │ ││                                      │
 │ │ ⎿ 312 lines                           │[2/2] Which environments should it reach first?                           │s││                                      │
 │                                         │several answers may be chosen                                             │ ││                                      │
 │☰  plan  5/7  ·  Workflows canvas        │                                                                          │ ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
@@ -26,7 +26,7 @@
 │ │   crates/stella-observatory/src/lib.rs:212                                                                         ││                                      │
 │ │   ⋯ 2 lines · ctrl+o                                                                                               ││                                      │
 │                                                                                                                      ││                                      │
-│ │ ● get_state {"key":"verify"}                                                                                       ││                                      │
+│ │ ◌ get_state {"key":"verify"}                                                                                       ││                                      │
 │ │ ⎿                                                                                                               8ms││                                      │
 │ │   {                                                                                                                ││                                      │
 │ │     "flip": true,                                                                                                  ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -29,7 +29,7 @@
 │                                                                                                                      ││                                      │
 │── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
 │                                                                                                                      ││                                      │
-│ │ ● apps/app/automations/page.tsx                                                                                    ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx                                                                                    ││                                      │
 │ │ ⎿ 312 lines                                                                                                    42ms││                                      │
 │                                                                                                                      ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                                                                                     ││                                      │

--- a/crates/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -29,7 +29,7 @@
 │                                                                                                                      ││                                      │
 │── EXECUTE ───────────────────────────────────────────────────────────────────────────────────────────────────────────││                                      │
 │                                                                                                                      ││                                      │
-│ │ ● apps/app/automations/page.tsx                                                                                    ││                                      │
+│ │ ⊙ apps/app/automations/page.tsx                                                                                    ││                                      │
 │ │ ⎿ 312 lines                                                                                                    42ms││                                      │
 │                                                                                                                      ││                                      │
 │☰  plan  5/7  ·  Workflows canvas                                                                                     ││                                      │

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -95,6 +95,50 @@ One vocabulary across every panel, including plugin-drawn UI:
 | `◆` | memory | silver |
 | `✦` | skill | silver |
 | `▤ ▢ ƒ` | graph node kinds: file, type, fn | silver |
+| `◌` | tool class: inspect — a look, nothing changed | takes the row's metal |
+| `◉` | tool class: mutate — written | takes the row's metal |
+| `⊙` | tool class: execute — external, opaque | takes the row's metal |
+| `↳` | tool class: delegate — handed to another agent | takes the row's metal |
+
+### 4.1 Tool class is a shape, never a hue
+
+The four rows above are drawn on the head of a call the transcript has no verb
+of its own for — an MCP tool, a workspace custom tool, a built-in like
+`get_state` or `delegate`. They add **no colour**: they take the metal of the
+row they head, which §6.2 makes gold for all of them alike, because every one
+of them is stella acting.
+
+v1 hued the tool *name* by its class, using four categorical `data-*` hues.
+§3.2's clamp rejects those outright, so v2 dropped the signal, and
+`get_state`, `mcp__github__create_pull_request` and `delegate` all collapsed
+onto one `●` on one gold rail — a reader could no longer tell a look from an
+opaque external call from a hand-off (#4125). Restoring the distinction as a
+third colour channel was declined: it would erode the two-metal rule the whole
+scheme rests on. Shape carries it instead, which is what §2's *never colour
+alone* already asks for.
+
+**Font coverage decided two of the four.** A glyph whose entire job is to be
+recognised may not ship as a tofu box (§2, cell-grid honest), so each candidate
+was checked against the shipped `cmap` of the brand font (§3.4) and of six
+other common monospace faces:
+
+- `◌` U+25CC and `◉` U+25C9 are **native to JetBrains Mono**. Both are East
+  Asian Width `N` — unambiguously one cell, which is stricter than `○` U+25CB
+  and `◆` U+25C6 above already are (both `A`).
+- `⊙` U+2299 replaces the design's first choice, `⌗` U+2317 VIEWDATA SQUARE.
+  U+2317 reads better for *external* and is width `N`, but it is absent from
+  **every** monospace face checked — JetBrains Mono, DejaVu Sans Mono, Fira
+  Code, Cascadia Mono, Hack, Ubuntu Mono, Menlo — resolving to the proportional
+  Apple Symbols on macOS and to nothing on a bare Linux terminal. U+2299 is
+  present in JetBrains Mono itself. Its cost is width `A`.
+- `↳` U+21B3 is width `N` and absent from JetBrains Mono, resolving to Menlo —
+  exactly what the shipped `◐` spinner above already does, so it is no new
+  hazard. The circle-family alternative U+25D1 was declined because it is the
+  third frame of that spinner: a delegation would be indistinguishable from a
+  call caught mid-spin.
+
+The 16-colour fallback (§3.5) needs no work here: these carry meaning by shape,
+so a colour-degraded terminal loses nothing.
 
 ## 5. Layout
 

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -123,8 +123,9 @@ was checked against the shipped `cmap` of the brand font (§3.4) and of six
 other common monospace faces:
 
 - `◌` U+25CC and `◉` U+25C9 are **native to JetBrains Mono**. Both are East
-  Asian Width `N` — unambiguously one cell, which is stricter than `○` U+25CB
-  and `◆` U+25C6 above already are (both `A`).
+  Asian Width `N` — unambiguously one cell, which is stricter than seven rows
+  above them already are: `◐`, `○`, `◇`, `◆`, `▤` and the full block are all
+  width `A`, and `＋` is fullwidth outright.
 - `⊙` U+2299 replaces the design's first choice, `⌗` U+2317 VIEWDATA SQUARE.
   U+2317 reads better for *external* and is width `N`, but it is absent from
   **every** monospace face checked — JetBrains Mono, DejaVu Sans Mono, Fira


### PR DESCRIPTION
Closes #4125

Implements the owner's decision of 2026-08-22: **option 2, as four new SPEC 4
glyphs**. Options 1 (accept the loss) and 3 (a third colour channel) are
declined. The two-metal rule is untouched — this is the glyph column only, no
new colour token, no rail change.

## The problem

`get_state`, `mcp__github__create_pull_request` and `delegate` are all
`EventKind::Other`. All three rail gold, and all three drew the same `●`. v1
carried the distinction as a categorical hue on the tool name; SPEC 3.2's clamp
rejects those hues outright, so v2 dropped the signal entirely.

Class comes back as **shape**, which is what SPEC 2's *never colour alone*
already points at.

## The set

| Glyph | Class | Codepoint | EAW | In JetBrains Mono |
|---|---|---|---|---|
| `◌` | `Inspect` | U+25CC | `N` | yes |
| `◉` | `Mutate` | U+25C9 | `N` | yes |
| `⊙` | `Execute` | U+2299 | `A` | yes |
| `↳` | `Delegate` | U+21B3 | `N` | no → Menlo |

`crates/stella-tui/src/tool_class.rs` gains its first v2 consumer, reading the
same gate-enforced catalog the policy layer does, so a tool cannot be filed
under one family for `tools.<group>: "off"` and a different one on screen.

## The font check — and it changed one glyph

This was the open item. **I am not shipping `⌗` U+2317.** It is absent from the
`cmap` of **every** monospace face I checked — JetBrains Mono, DejaVu Sans
Mono, Fira Code, Cascadia Mono, Hack, Ubuntu Mono, Menlo, 0 for 7. On macOS
CoreText resolves it to **Apple Symbols**, which is proportional and macOS-only;
on a bare Linux terminal with any of those faces there is nothing to fall back
to and it is a tofu box. SPEC 2's cell-grid-honest rule is not negotiable for a
glyph whose entire job is to be recognised, so I took the owner's
pre-approved circle-family alternative, `⊙` U+2299, which is **native to
JetBrains Mono**.

Its cost is real and I am not glossing it: `⊙` is East Asian Width `A`
(ambiguous) where `⌗` is `N`, so it draws in two cells under a terminal
configured for CJK double-width ambiguity. That means **the issue's "all four
are width `N`" claim no longer holds for the shipped set**, and SPEC 4 now says
so rather than repeating it. It is still no worse than `○` U+25CB and `◆`
U+25C6, which are `A` and already ship.

**I kept `↳` and declined the pre-approved `◑` U+25D1.** `↳` is not tofu — it
is absent from JetBrains Mono but resolves to Menlo, which is exactly what the
shipped `◐` `RUNNING` spinner already does, so it is no new hazard, and it is
width `N`. `◑` is worse on two independent counts: it is `SPINNER[2]`, so a
delegation would be indistinguishable from a call caught mid-spin, and it is
also EAW `A`.

Method, so it is reproducible rather than asserted: `cmap` membership via
`fontTools`, cross-checked against a hand-written TTF `cmap` parser that agreed
exactly; macOS substitution via `CTFontCreateForString` with a base font of
`JetBrains Mono`.

## Witnesses, and both disarms

Two tests, each disarmed in its own direction, each leaving the other green —
so neither is a restatement of the other.

**`a_tool_calls_class_is_legible_from_its_glyph_alone`** — the witness. Disarmed
by reverting `head_glyph`'s new arm to `_ => '●'`:

```
running 1 test
test v2::transcript_source::tests::a_tool_calls_class_is_legible_from_its_glyph_alone ... FAILED

---- v2::transcript_source::tests::a_tool_calls_class_is_legible_from_its_glyph_alone stdout ----
thread '...' panicked at crates/stella-tui/src/v2/transcript_source.rs:718:13:
assertion `left == right` failed: `get_state` drew '●' rather than its class glyph '◌'
  left: '●'
 right: '◌'

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 982 filtered out
```

Exit code `101`. The other test stayed green under this disarm (exit `0`).

**`a_tool_classs_glyph_spends_no_colour`** — the anti-over-reach half, which
stops the fix re-adding class as a hue. Disarmed in the **opposite** direction,
by painting the glyph span with `ToolClass::color()`:

```
running 1 test
test v2::transcript_source::tests::a_tool_classs_glyph_spends_no_colour ... FAILED

---- v2::transcript_source::tests::a_tool_classs_glyph_spends_no_colour stdout ----
thread '...' panicked at crates/stella-tui/src/v2/transcript_source.rs:759:13:
assertion `left == right` failed: `get_state`'s class glyph wears a colour of its own
  left: Some(Rgb(47, 211, 198))
 right: Some(Rgb(239, 197, 63))

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 982 filtered out
```

Exit code `101`; `Rgb(47, 211, 198)` is v1's categorical teal against gold
`Rgb(239, 197, 63)`. The witness stayed green under this disarm (exit `0`).

Both arms restored; `rg DISARM` over the diff returns nothing.

## Goldens — read, not blessed blind

13 deck goldens moved, **one character each, with no column shift** — the
closing `│` borders line up on the `-` and `+` lines, which is the width
evidence:

```
-│ │ ● get_state {"key":"verify"}                     ││
+│ │ ◌ get_state {"key":"verify"}                     ││
-│ │ ● apps/app/automations/page.tsx                  ││
+│ │ ⊙ apps/app/automations/page.tsx                  ││
```

The second row is `mcp__fs__read_file`, which `classify` files as `Execute`
rather than `Inspect` — deliberate and already tested by
`an_unknown_tool_promises_the_least`: the renderer cannot vouch that a server's
`read_file` only read.

To be precise about what the goldens do and do not show: the two rows live in
**different** frames, not one. `session_tool_result_multiline.txt` line 29 is
the `◌ get_state` row; the other 12 goldens carry the `⊙` MCP row. Both drew
`●` before this change, so the golden set is evidence that the two classes now
diverge — but no committed frame contains both side by side. The
three-different-glyphs-on-one-gold-rail claim from the issue is proved by the
witness test, not by a golden.

## Gate

Scoped, exit codes recorded, `--color=never` throughout.

| Command | Exit |
|---|---|
| `cargo test -p stella-tui` | 0 |
| `cargo test -p stella-tui-theme` | 0 (19 passed, clamp + glyph tests intact) |
| `cargo clippy -p stella-tui -p stella-tui-theme --all-targets -- -D warnings` | 0 |
| `cargo fmt -p stella-tui -p stella-tui-theme -- --check` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui-theme --no-deps` | 0 |
| `make guards-fast` | 0 |
| `make doc-links` | 0 |
| `make invariants` | 0 |

`no_hex_literals_in_v2_render_code` and the theme crate's hue-clamp tests pass
unchanged — neither was weakened. No file-size baseline raised, no god file
touched, no `#[allow]` added, no `TODO` introduced. No test was deleted.

## SPEC amendment

`design/tui-v2/SPEC.md` §4 gains the four rows plus a new **§4.1 "Tool class is
a shape, never a hue"**, recording *why* the colour options were declined and
the full font-coverage reasoning — the record the DoD asks for, so the next
reader does not have to re-derive it.

## Filed, not left behind

The font check turned up pre-existing debt outside this change's scope:

- **#4318** — six already-shipped SPEC 4 glyphs are absent from JetBrains Mono,
  and `DRIFT_FALLBACK` `↯` is *itself* missing from the brand font, so SPEC 4's
  stated remedy for `⑂` does not work on the one font the design names. Also
  proposes the coverage guard that would have caught all of this.
- **#4320** — `head_glyph` draws `●` and `↓`, neither of which is in
  `glyph::ALL`, so the deck's most-drawn glyphs escape both `glyphs_are_distinct`
  and the width test.

Neither is a regression from this PR; both were found by doing the check this
issue asked for.

## Summary by Sourcery

Make tool-call classes legible through distinct shape-based glyphs while preserving the TUI's two-metal colour system.

New Features:
- Add four glyphs that distinguish inspect, mutate, execute, and delegate tool calls in the transcript.

Bug Fixes:
- Restore tool-class legibility for previously indistinguishable gold-railed tool calls without reintroducing categorical colour.

Enhancements:
- Use the shared gate-enforced tool classification catalog for transcript rendering.
- Document the new tool-class glyph vocabulary, font coverage decisions, and shape-over-colour rule in the TUI specification.

Documentation:
- Amend the TUI v2 specification with the four tool-class glyphs and their accessibility and width considerations.

Tests:
- Add coverage proving tool classes render distinct glyphs and share the row's gold colour.
- Update transcript snapshots for the new tool-class glyphs.