### PR TITLE
feat(stella-transcript): the shared lexer is grammar-backed, so every surface gains it at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,15 @@ dependencies = [
  "serde",
  "serde_json",
  "stella-diff",
+ "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-sequel",
+ "tree-sitter-typescript",
  "unicode-width",
 ]
 

--- a/crates/stella-transcript/Cargo.toml
+++ b/crates/stella-transcript/Cargo.toml
@@ -23,6 +23,31 @@ serde = { workspace = true }
 # reason, so it is resident in the tree rather than new supply chain, and it is
 # a pure table lookup over `&str` — no I/O, no allocation, invariant #2 intact.
 unicode-width = { workspace = true }
+# The grammar-backed half of the shared lexer (#4283). The near-leaf contract
+# above is weakened by this, not waived, and three things pay for it:
+#
+# - **It is resident supply chain, not new.** Every crate below is already in
+#   the root `[workspace.dependencies]` and is a *default* feature of
+#   `stella-graph`, which `stella-cli` takes with defaults — so the shipping
+#   binary already compiles this exact C, and `cargo deny check licenses` has
+#   already passed on all of it. `stella-observatory` is the one consumer that
+#   newly pays a compile cost, and it pays it to stop rendering Go, Java, C,
+#   SQL and PHP as flat text.
+# - **It lands here or nowhere.** A deck-local highlighter would buy the deck
+#   accuracy by making the three transcript surfaces disagree on classification
+#   again — the drift #3644 and #4036 each closed once, and #4196 forbade.
+# - **Grammars are compiled in, so nothing is loaded at runtime** (which is why
+#   syntect was declined): the lexer stays a pure function over borrowed text,
+#   invariant #2 intact.
+tree-sitter = { workspace = true }
+tree-sitter-rust = { workspace = true }
+tree-sitter-typescript = { workspace = true }
+tree-sitter-python = { workspace = true }
+tree-sitter-go = { workspace = true }
+tree-sitter-java = { workspace = true }
+tree-sitter-c = { workspace = true }
+tree-sitter-sequel = { workspace = true }
+tree-sitter-php = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -58,6 +58,13 @@ pub enum Color {
     Violet,
     /// Hunk headers.
     Blue,
+    /// Function and method names in highlighted source.
+    ///
+    /// The deck spends `theme::MAGENTA` here, and this is the entry that lets
+    /// the grid say the same thing — `Tok::Function` arrived with the
+    /// grammar-backed lexer (#4283) and had no hue in this palette's
+    /// vocabulary.
+    Magenta,
 }
 
 impl Color {
@@ -74,6 +81,8 @@ impl Color {
             Color::Amber => 179,
             Color::Violet => 141,
             Color::Blue => 111,
+            // 168 is the cube entry `theme::MAGENTA` already falls back to.
+            Color::Magenta => 168,
         }
     }
 
@@ -89,6 +98,7 @@ impl Color {
             Color::Amber => 33,
             Color::Violet => 35,
             Color::Blue => 34,
+            Color::Magenta => 35,
         }
     }
 }
@@ -637,6 +647,11 @@ fn tok_color(t: syntax::Tok) -> Color {
         syntax::Tok::Str => Color::Green,
         syntax::Tok::Number => Color::Violet,
         syntax::Tok::Comment => Color::Faint,
+        // The two classes the grammar-backed lexer added (#4283), on the deck's
+        // own hues for them: `theme::TEAL` for a type, `theme::MAGENTA` for a
+        // function name.
+        syntax::Tok::Type => Color::Cyan,
+        syntax::Tok::Function => Color::Magenta,
     }
 }
 

--- a/crates/stella-transcript/src/html.rs
+++ b/crates/stella-transcript/src/html.rs
@@ -506,6 +506,9 @@ fn tok_class(t: syntax::Tok) -> &'static str {
         syntax::Tok::Str => "ts",
         syntax::Tok::Number => "tn",
         syntax::Tok::Comment => "tc",
+        // The two classes the grammar-backed lexer added (#4283).
+        syntax::Tok::Type => "ty",
+        syntax::Tok::Function => "tf",
     }
 }
 

--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -83,6 +83,7 @@
      and deliberately outside the parity matrix. */
   --cyan: #4ed6e0;
   --violet: #a8a3f5;
+  --magenta: #e08ac0;
   /* The three semantic colours: instrument `--ok` / `--bad` / `--warn`. */
   --green: #74c991;
   --red: #e0687a;
@@ -520,3 +521,9 @@ table.diff { border-collapse: collapse; width: 100%; font: 12.5px/1.65 var(--mon
 .out .ts { color: var(--green); }
 .out .tn { color: var(--violet); }
 .out .tc { color: var(--faint); font-style: italic; }
+/* The two classes the grammar-backed lexer added (#4283). They ride `--cyan`
+   and `--magenta`, the categorical pair that is deliberately scheme-invariant
+   (see the header note), so a type and a function name read the same on paper
+   as they do on the dark ground. */
+.out .ty { color: var(--cyan); }
+.out .tf { color: var(--magenta); }

--- a/crates/stella-transcript/src/syntax.rs
+++ b/crates/stella-transcript/src/syntax.rs
@@ -24,6 +24,26 @@
 //! lexer, three palettes — and no surface can differ on *classification* any
 //! more, only on hue.
 //!
+//! ## The grammar, and why it landed here too (#4283)
+//!
+//! The lexer that arrived by those two moves was hand-written, knew six
+//! languages, and guessed inside them. #4283 asked whether to replace it with a
+//! grammar-backed one and — the part that mattered — *where* such a thing may
+//! land. The answer was the same as above, for the same reason: here, so all
+//! three surfaces gain it at once. A deck-local highlighting crate would have
+//! been a fourth copy of a rendering decision this tree has already
+//! de-duplicated twice.
+//!
+//! What shipped is tree-sitter in the private `grammar` module, covering the
+//! eight languages whose grammars this workspace already compiles for
+//! `stella-graph`, and the hand-written scans in `lang` surviving for the
+//! three with no resident
+//! grammar (Markdown, TOML, JSON). syntect was declined: it loads grammar and
+//! theme assets at runtime, which invariant #2 forbids in this layer. The two
+//! token classes only a grammar can produce — [`Tok::Type`] and
+//! [`Tok::Function`] — grew the shared vocabulary, so all three palettes moved
+//! in that same change.
+//!
 //! ## Contract
 //!
 //! Carried over verbatim from the original, because three surfaces now depend
@@ -36,6 +56,7 @@
 //! - **Panic-free.** An unterminated string runs to end of line; a trailing
 //!   lone backslash cannot step past the end.
 
+mod grammar;
 mod lang;
 
 pub use lang::{Highlighter, Lang, lang_from_ext, lang_from_fence, lang_from_path, tokenize};
@@ -59,6 +80,22 @@ pub enum Tok {
     Number,
     /// Line comments. JSON has none; the other lexers do.
     Comment,
+    /// Type positions — a declared type, a primitive, a type parameter.
+    ///
+    /// Grammar-only, and one of the two reasons the grammar was worth taking
+    /// (#4283): a keyword table sees `Duration` and an ordinary variable as the
+    /// same identifier, so the hand-written scan could never have produced this
+    /// class. Languages still lexed by hand (Markdown, TOML, JSON) never emit
+    /// it, which is not a gap — none of the three has type syntax.
+    Type,
+    /// A function or method *name* — the one being declared, or the one being
+    /// called.
+    ///
+    /// The other grammar-only class. It earns a palette entry because in Java,
+    /// C and Go most lines are declarations or calls, and without it the name
+    /// that says what the line *does* wears the same tone as every local around
+    /// it.
+    Function,
 }
 
 /// The tagged runs for one source line: consecutive text slices, each with an

--- a/crates/stella-transcript/src/syntax/grammar.rs
+++ b/crates/stella-transcript/src/syntax/grammar.rs
@@ -1,0 +1,501 @@
+//! The grammar-backed half of the shared lexer: tree-sitter over one line.
+//!
+//! ## Why a grammar, and why here
+//!
+//! The hand-written scan in [`super::lang`] recognised six languages and no
+//! more, so a `read_file` of a Go, Java, C, SQL or PHP file rendered as flat
+//! text on all three transcript surfaces, and even inside the six it guessed —
+//! a keyword table cannot tell a type from a variable, or a call from a
+//! reference. #4283 decided the upgrade and, more importantly, decided *where*
+//! it lands: here, at the bottom, so the deck, the export grid and the
+//! Observatory gain it in one change. A deck-local highlighter would have
+//! bought the deck accuracy by making the three surfaces disagree again, which
+//! is the drift #3644 and #4036 each closed once.
+//!
+//! ## Why tree-sitter and not syntect
+//!
+//! Two reasons, and the second is the one that settles it:
+//!
+//! - **It is already resident.** The root `[workspace.dependencies]` carries
+//!   `tree-sitter` and all eight grammar crates used here, because
+//!   `stella-graph` indexes the code graph with them — every one is a default
+//!   feature of that crate, and `stella-cli` takes it with defaults, so the
+//!   shipping binary already compiles this exact C. `cargo deny check licenses`
+//!   has therefore already passed on all of it.
+//! - **Grammars are compiled in, so there is no runtime asset load.**
+//!   syntect's default path reads grammar and theme files at startup, which
+//!   invariant #2 forbids in this layer. Everything below is a pure function
+//!   over borrowed text.
+//!
+//! ## Why per line, and why that is not a parser instantiation per line
+//!
+//! [`super::tokenize`]'s contract is stateless and line-oriented, because a
+//! diff hunk can slice a file anywhere and a transcript body is middle-elided
+//! before anything renders it. That contract is kept: each line is parsed on
+//! its own. Tree-sitter is error-tolerant by construction — a fragment that is
+//! not a whole item still lexes its leaves correctly, wrapped in an `ERROR`
+//! node whose children keep their token kinds — so a line taken out of context
+//! degrades to slightly-off *structure*, never to wrong tokens.
+//!
+//! What would have made that ruinous is `Parser::new()` per line: constructing
+//! a parser and installing a language dwarfs the parse itself. So parsers are
+//! built once per grammar per thread and reused ([`with_parser`]). This matters
+//! more than it looks — the deck caches highlighted tail rows across frames
+//! (`an_unchanged_tail_is_highlighted_once_not_once_per_frame`), and a
+//! per-frame parser build would have made a cache that still holds look like
+//! one that does not.
+//!
+//! ## Losslessness, structurally
+//!
+//! The contract every surface leans on is that concatenating the run texts
+//! reproduces the line. That is not asserted here, it is *constructed*:
+//! [`runs`] walks the leaves in source order and fills every byte between them,
+//! so the output covers `[0, code.len())` exactly once. A leaf that fails a
+//! sanity check (zero width, out of order, not on a `char` boundary) is skipped
+//! without advancing the cursor, so its bytes are still emitted — untagged
+//! rather than dropped.
+
+use std::cell::RefCell;
+
+use tree_sitter::{Node, Parser};
+
+use super::{Runs, Tok};
+
+/// A grammar compiled into this crate.
+///
+/// Deliberately *not* one-to-one with [`super::Lang`]: several languages share
+/// a grammar (every TypeScript/JavaScript dialect takes the TSX one), and the
+/// three languages with no resident grammar — Markdown, TOML, JSON — have no
+/// variant here at all and stay with the hand-written scan.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum Grammar {
+    Rust,
+    /// TypeScript, TSX, JavaScript and JSX.
+    ///
+    /// One grammar for all four rather than `LANGUAGE_TYPESCRIPT` beside
+    /// `LANGUAGE_TSX`: this crate holds a single `Lang::TsJs` because the
+    /// palettes downstream cannot tell the dialects apart anyway, and TSX is
+    /// the choice that keeps JSX prose from lexing as an unterminated string —
+    /// the failure `a_contraction_apostrophe_does_not_swallow_the_line_as_a_string`
+    /// pins. The cost is the `<T>expr` type assertion, which TSX reads as a JSX
+    /// element; it is rare, and it mis-tints rather than mis-renders.
+    Tsx,
+    Python,
+    Go,
+    Java,
+    C,
+    Sql,
+    Php,
+}
+
+impl Grammar {
+    /// Every grammar, for the tests that assert each one arms and holds its own
+    /// parser slot.
+    ///
+    /// `#[cfg(test)]` rather than `#[allow(dead_code)]`: nothing ships a call to
+    /// it, so the allow would be asserting the lint is wrong when it is right
+    /// (AGENTS.md § "Code style"). A later production caller becomes a build
+    /// error here rather than silently re-justifying a suppression.
+    #[cfg(test)]
+    pub(super) const ALL: [Grammar; 8] = [
+        Grammar::Rust,
+        Grammar::Tsx,
+        Grammar::Python,
+        Grammar::Go,
+        Grammar::Java,
+        Grammar::C,
+        Grammar::Sql,
+        Grammar::Php,
+    ];
+
+    /// This grammar's slot in the per-thread parser cache.
+    fn slot(self) -> usize {
+        match self {
+            Grammar::Rust => 0,
+            Grammar::Tsx => 1,
+            Grammar::Python => 2,
+            Grammar::Go => 3,
+            Grammar::Java => 4,
+            Grammar::C => 5,
+            Grammar::Sql => 6,
+            Grammar::Php => 7,
+        }
+    }
+
+    /// The tree-sitter language.
+    ///
+    /// `LANGUAGE_PHP` rather than `LANGUAGE_PHP_ONLY` for the same reason
+    /// `stella-graph` picks it: a real `.php` file opens in HTML and the
+    /// PHP-only grammar cannot parse it.
+    fn language(self) -> tree_sitter::Language {
+        match self {
+            Grammar::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Grammar::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+            Grammar::Python => tree_sitter_python::LANGUAGE.into(),
+            Grammar::Go => tree_sitter_go::LANGUAGE.into(),
+            Grammar::Java => tree_sitter_java::LANGUAGE.into(),
+            Grammar::C => tree_sitter_c::LANGUAGE.into(),
+            Grammar::Sql => tree_sitter_sequel::LANGUAGE.into(),
+            Grammar::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+        }
+    }
+}
+
+thread_local! {
+    /// One parser per grammar per thread, built on first use.
+    ///
+    /// `RefCell` rather than a lock because a `Parser` is not `Sync` and does
+    /// not need to be: nothing here escapes the call, so the borrow is taken
+    /// and released inside [`with_parser`] and can never be held across one.
+    static PARSERS: RefCell<[Option<Parser>; 8]> =
+        RefCell::new(std::array::from_fn(|_| None));
+}
+
+/// Run `f` against this thread's parser for `g`, building it on first use.
+///
+/// `None` when the grammar will not install — a version skew between
+/// `tree-sitter` and a grammar crate is the only way that happens, and it is a
+/// build-time fact rather than a runtime one, so the caller renders the line
+/// plain rather than treating it as an error worth naming.
+fn with_parser<T>(g: Grammar, f: impl FnOnce(&mut Parser) -> T) -> Option<T> {
+    PARSERS.with(|cell| {
+        let mut slots = cell.borrow_mut();
+        let slot = &mut slots[g.slot()];
+        if slot.is_none() {
+            let mut parser = Parser::new();
+            if parser.set_language(&g.language()).is_err() {
+                return None;
+            }
+            *slot = Some(parser);
+        }
+        slot.as_mut().map(f)
+    })
+}
+
+/// Tokenize one line under `g`, or `None` when the grammar would not install.
+///
+/// Lossless and panic-free by construction — see the module doc.
+pub(super) fn runs(code: &str, g: Grammar) -> Option<Runs> {
+    let tree = with_parser(g, |parser| parser.parse(code.as_bytes(), None))??;
+
+    let mut out = Emit::new(code);
+    let mut cursor = tree.walk();
+    // Depth-first, leaves in source order. `goto_first_child` descends while
+    // there is one; at a leaf we emit, then climb until a sibling exists.
+    // Failing to climb means we are back at the root and the walk is done.
+    loop {
+        if cursor.goto_first_child() {
+            continue;
+        }
+        out.leaf(cursor.node());
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return Some(out.finish());
+            }
+        }
+    }
+}
+
+/// Accumulates runs over the source, filling the gaps between leaves.
+struct Emit<'a> {
+    code: &'a str,
+    runs: Runs,
+    /// Bytes before this are already emitted. The invariant that makes the
+    /// output lossless: it only ever moves forward, and it reaches
+    /// `code.len()` in [`Emit::finish`].
+    cursor: usize,
+    /// Untagged text awaiting a tagged run to interrupt it, so punctuation and
+    /// indentation cost one run rather than one per token.
+    plain: String,
+}
+
+impl<'a> Emit<'a> {
+    fn new(code: &'a str) -> Self {
+        Self {
+            code,
+            runs: Runs::new(),
+            cursor: 0,
+            plain: String::new(),
+        }
+    }
+
+    fn flush(&mut self) {
+        if !self.plain.is_empty() {
+            self.runs.push((std::mem::take(&mut self.plain), None));
+        }
+    }
+
+    /// Emit one leaf, plus whatever untagged text precedes it.
+    fn leaf(&mut self, node: Node<'_>) {
+        let (start, end) = (node.start_byte(), node.end_byte());
+        // Zero-width (a `MISSING` node tree-sitter inserted to recover), out of
+        // order, past the end, or off a `char` boundary. Skipping without
+        // moving the cursor leaves the bytes to the next gap fill or to
+        // `finish`, so the line still round-trips.
+        if end <= start
+            || start < self.cursor
+            || end > self.code.len()
+            || !self.code.is_char_boundary(start)
+            || !self.code.is_char_boundary(end)
+        {
+            return;
+        }
+        if start > self.cursor {
+            self.plain.push_str(&self.code[self.cursor..start]);
+        }
+        match classify(node) {
+            Some(tok) => {
+                self.flush();
+                // Coalesce with the previous run when it wears the same class.
+                // Grammars split one literal into several leaves — `'` +
+                // `string_fragment` + `'` in TypeScript, `string_start` +
+                // `string_content` + `string_end` in Python — and a reader
+                // wants `'ok'`, not three runs that happen to abut. It also
+                // keeps the run list short, which every surface pays for by
+                // the cell.
+                match self.runs.last_mut() {
+                    Some((text, last)) if *last == Some(tok) => {
+                        text.push_str(&self.code[start..end]);
+                    }
+                    _ => self
+                        .runs
+                        .push((self.code[start..end].to_string(), Some(tok))),
+                }
+            }
+            None => self.plain.push_str(&self.code[start..end]),
+        }
+        self.cursor = end;
+    }
+
+    fn finish(mut self) -> Runs {
+        if self.cursor < self.code.len() {
+            let rest = self.code[self.cursor..].to_string();
+            self.plain.push_str(&rest);
+        }
+        self.flush();
+        self.runs
+    }
+}
+
+/// The token class for one leaf, or `None` to leave it untinted.
+///
+/// The rules are stated over tree-sitter *node kinds* rather than over a
+/// per-language word list, which is what makes one function serve eight
+/// grammars — and what makes it keep serving a ninth nobody has added yet.
+fn classify(node: Node<'_>) -> Option<Tok> {
+    let kind = node.kind();
+
+    // Anonymous leaves are the grammar's literal tokens, and their `kind` *is*
+    // their text: `fn`, `let`, `if`, `{`, `->`. So "a keyword is an anonymous
+    // leaf that reads as a word" replaces every hand-maintained keyword table
+    // at once — the single largest thing a grammar buys here.
+    if !node.is_named() {
+        // ...with one exception, and it is the quote marks. Several grammars
+        // spell a literal as `'` + `string_fragment` + `'`, so the delimiters
+        // arrive here as anonymous leaves of a string parent. Tinting only the
+        // fragment would leave `'ok'` reading as `ok` in string green with two
+        // bare quotes around it — visibly worse than the hand-written scan this
+        // replaced, which is how the case was found.
+        if let Some(parent) = node.parent() {
+            if is_str_kind(parent.kind()) {
+                return Some(Tok::Str);
+            }
+            // The same shape once more, for a primitive type spelled as a
+            // reserved word: TypeScript's `predefined_type` and PHP's
+            // `primitive_type` wrap an anonymous `string`/`number` leaf, where
+            // Java and C name theirs. Without this the identical `string` reads
+            // as a type in one file and a keyword in the next.
+            //
+            // Words only, unlike the string rule above. A type *expression*
+            // also holds punctuation — the `.` of Go's `time.Duration`, the
+            // brackets of a slice or array type — and tinting those pulls the
+            // separator into the type's colour while the package name beside it
+            // stays plain, which reads as a mis-parse rather than as structure.
+            if is_word(kind) && is_type_kind(parent.kind()) {
+                return Some(Tok::Type);
+            }
+        }
+        return is_word(kind).then_some(Tok::Keyword);
+    }
+
+    // `keyword_select`, `keyword_from`, … — the SQL grammar names its keywords
+    // rather than leaving them anonymous.
+    if kind.starts_with("keyword_") {
+        return Some(Tok::Keyword);
+    }
+
+    // Strings before numbers, and both before anything else: several string
+    // kinds spell an integer word inside themselves
+    // (`interpreted_string_literal`), and reversing these two arms would tint
+    // half a Go literal as a number.
+    if kind.contains("comment") {
+        return Some(Tok::Comment);
+    }
+    if is_str_kind(kind) {
+        return Some(Tok::Str);
+    }
+    if is_number_kind(kind) {
+        return Some(Tok::Number);
+    }
+    if is_type_kind(kind) {
+        return Some(Tok::Type);
+    }
+    if is_function(node) {
+        return Some(Tok::Function);
+    }
+    None
+}
+
+/// String and character literals, and the pieces grammars split them into
+/// (`string_fragment`, `string_content`, `string_start`/`string_end`).
+fn is_str_kind(kind: &str) -> bool {
+    kind.contains("string") || kind.contains("char") || kind == "heredoc_body"
+}
+
+/// Whether a literal token reads as a word — the test that separates a keyword
+/// from punctuation without knowing the language.
+fn is_word(kind: &str) -> bool {
+    kind.starts_with(|c: char| c.is_alphabetic())
+        && kind.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Numeric literals, and the scalar constants that stand where a number stands.
+///
+/// The constants earn [`Tok::Number`] rather than a keyword hue for the reason
+/// `json_runs` gives: they are values, and colouring them like structure makes
+/// a body's shape unreadable at exactly the glance this colouring exists for.
+fn is_number_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "integer"
+            | "integer_literal"
+            | "int_literal"
+            | "float"
+            | "float_literal"
+            | "number"
+            | "number_literal"
+            | "numeric_literal"
+            | "imaginary_literal"
+            | "decimal_integer_literal"
+            | "decimal_floating_point_literal"
+            | "hex_integer_literal"
+            | "octal_integer_literal"
+            | "binary_integer_literal"
+            | "boolean_literal"
+            | "true"
+            | "false"
+            | "null"
+            | "null_literal"
+            | "nil"
+            | "none"
+            | "undefined"
+    )
+}
+
+/// Type positions.
+///
+/// The `_type` suffix is the generalisation — Java spells `integral_type` and
+/// `void_type`, Go and Rust `primitive_type`, TypeScript `predefined_type` —
+/// and it is safe against non-type nodes because only *leaves* reach here, so a
+/// `generic_type` or a `union_type` (both interior) never tests it.
+fn is_type_kind(kind: &str) -> bool {
+    kind == "type_identifier"
+        || kind == "primitive_type"
+        || kind == "predefined_type"
+        || kind == "sized_type_specifier"
+        || kind == "type_parameter"
+        || kind.ends_with("_type")
+}
+
+/// Whether this leaf names a function — either the one being declared or the
+/// one being called.
+///
+/// The distinction a keyword table cannot make, and the reason [`Tok::Function`]
+/// is worth a palette entry: in Java or C most lines are declarations, and
+/// without this the name of the thing being declared reads exactly like every
+/// local variable around it.
+fn is_function(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let pk = parent.kind();
+
+    // The declared name. `function`/`method` covers `function_item` (Rust),
+    // `function_declaration` (Go/JS), `method_declaration` (Java/Go),
+    // `function_definition` (C/Python/PHP), `method_definition` (JS).
+    if (pk.contains("function") || pk.contains("method")) && is_field(parent, "name", node) {
+        return true;
+    }
+    // C spells the declared name through a declarator rather than a `name`
+    // field: `function_definition` → `function_declarator` → `identifier`.
+    if pk == "function_declarator" && is_field(parent, "declarator", node) {
+        return true;
+    }
+    // The callee. Either directly (`foo()`), or through the field of a
+    // selector when the call is `pkg.Foo()` / `obj.method()` — the shape most
+    // Go, Java and TypeScript lines actually take.
+    if is_call(pk) && (is_field(parent, "function", node) || is_field(parent, "name", node)) {
+        return true;
+    }
+    if matches!(
+        pk,
+        "selector_expression" | "field_expression" | "member_expression" | "attribute"
+    ) && (is_field(parent, "field", node)
+        || is_field(parent, "property", node)
+        || is_field(parent, "attribute", node))
+    {
+        return parent
+            .parent()
+            .is_some_and(|gp| is_call(gp.kind()) && is_field(gp, "function", parent));
+    }
+    false
+}
+
+/// Whether `kind` is a call expression in any of the eight grammars.
+fn is_call(kind: &str) -> bool {
+    kind == "call" || kind.contains("call_expression") || kind == "method_invocation"
+}
+
+/// Whether `parent`'s `field` is exactly `node`.
+fn is_field(parent: Node<'_>, field: &str, node: Node<'_>) -> bool {
+    parent
+        .child_by_field_name(field)
+        .is_some_and(|n| n.id() == node.id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every grammar installs.
+    ///
+    /// A version skew between `tree-sitter` and a grammar crate is a silent
+    /// failure otherwise: [`runs`] returns `None`, the caller renders the line
+    /// plain, and the surface looks exactly like the flat text this whole
+    /// change exists to stop rendering.
+    #[test]
+    fn every_grammar_arms() {
+        for g in Grammar::ALL {
+            assert!(
+                runs("x", g).is_some(),
+                "{g:?} did not install — a tree-sitter/grammar version skew"
+            );
+        }
+    }
+
+    /// Distinct cache slots, so no grammar parses with another's parser.
+    #[test]
+    fn every_grammar_holds_its_own_parser_slot() {
+        let mut slots: Vec<usize> = Grammar::ALL.iter().map(|g| g.slot()).collect();
+        slots.sort_unstable();
+        slots.dedup();
+        assert_eq!(slots.len(), Grammar::ALL.len(), "two grammars share a slot");
+        assert!(
+            slots.iter().all(|s| *s < Grammar::ALL.len()),
+            "a slot is out of the cache's range: {slots:?}"
+        );
+    }
+}

--- a/crates/stella-transcript/src/syntax/lang.rs
+++ b/crates/stella-transcript/src/syntax/lang.rs
@@ -1,12 +1,24 @@
-//! Lightweight syntax highlighting — the one source-coloring engine every
-//! transcript surface lexes with.
+//! Syntax highlighting — the one source-coloring engine every transcript
+//! surface lexes with.
 //!
-//! A compact, dependency-free lexer (no `syntect`, no tree-sitter) that colors
-//! keywords, string/char literals, line comments, and numbers for the languages
-//! this workspace edits most, plus structural coloring for Markdown and TOML
-//! sources. It is intentionally *not* a parser: one left-to-right scan per line,
-//! so a line sliced out of context (a diff hunk cutting a block comment in half)
-//! degrades to slightly-off coloring, never a wrong render or a panic.
+//! **Two engines, and the line between them is which grammars are resident.**
+//! Eleven languages are covered. Eight of them — Rust, TypeScript/JavaScript,
+//! Python, Go, Java, C, SQL, PHP — go through tree-sitter in [`super::grammar`],
+//! which is where the accuracy and every language added after #4283 lives. The
+//! remaining three — Markdown, TOML, JSON — have no grammar in this workspace
+//! and are lexed by the hand-written scans below; adding a grammar for them
+//! would be new supply chain, which is exactly what the resident-grammar
+//! argument in `Cargo.toml` does not license.
+//!
+//! That split is a fact about the dependency tree, not a taste: a language is
+//! grammar-backed here if and only if `stella-graph` already compiles its
+//! grammar. See [`super::grammar`] for why tree-sitter rather than syntect, and
+//! for how per-line parsing stays cheap.
+//!
+//! Both engines keep the same contract: one line at a time, no state carried
+//! between lines, so a line sliced out of context (a diff hunk cutting a block
+//! comment in half) degrades to slightly-off coloring, never a wrong render or
+//! a panic.
 //!
 //! ## Why this lives here and not in `stella-tui`
 //!
@@ -31,6 +43,7 @@
 //! [`Highlighter`], which tracks that state and lights fence interiors up in
 //! their own language.
 
+use super::grammar::{self, Grammar};
 use super::{Runs, Tok};
 
 /// A language we can syntax-highlight.
@@ -42,6 +55,16 @@ pub enum Lang {
     TsJs,
     /// Python.
     Python,
+    /// Go.
+    Go,
+    /// Java.
+    Java,
+    /// C (and the C-family headers a `read_file` most often lands on).
+    C,
+    /// SQL.
+    Sql,
+    /// PHP.
+    Php,
     /// Markdown *source* (headings, list markers, fences, inline code) — the
     /// skills/agents definition format.
     Markdown,
@@ -60,6 +83,16 @@ pub fn lang_from_ext(ext: &str) -> Option<Lang> {
         "rs" => Some(Lang::Rust),
         "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "mts" | "cts" => Some(Lang::TsJs),
         "py" | "pyi" => Some(Lang::Python),
+        "go" => Some(Lang::Go),
+        "java" => Some(Lang::Java),
+        // The C-family extensions `stella-graph` routes to the same grammar.
+        // C++ is a genuine approximation rather than a match — the C grammar
+        // recovers through what it cannot parse, so a `.cpp` file lexes its
+        // strings, comments, numbers and keywords and mis-structures the rest,
+        // which is strictly more than the flat text it rendered as before.
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx" => Some(Lang::C),
+        "sql" => Some(Lang::Sql),
+        "php" => Some(Lang::Php),
         "md" | "markdown" => Some(Lang::Markdown),
         "toml" => Some(Lang::Toml),
         "json" | "jsonl" | "ndjson" => Some(Lang::Json),
@@ -92,10 +125,37 @@ pub fn lang_from_fence(tag: &str) -> Option<Lang> {
             Some(Lang::TsJs)
         }
         "py" | "python" | "python3" => Some(Lang::Python),
+        "go" | "golang" => Some(Lang::Go),
+        "java" => Some(Lang::Java),
+        "c" | "h" | "cpp" | "c++" | "cc" => Some(Lang::C),
+        "sql" | "postgres" | "postgresql" | "mysql" | "sqlite" => Some(Lang::Sql),
+        "php" => Some(Lang::Php),
         "md" | "markdown" => Some(Lang::Markdown),
         "toml" => Some(Lang::Toml),
         "json" | "jsonl" | "ndjson" => Some(Lang::Json),
         _ => None,
+    }
+}
+
+impl Lang {
+    /// The grammar that lexes this language, or `None` when it is one of the
+    /// three lexed by hand.
+    ///
+    /// The whole of the two-engine split, in one function. `None` is a claim
+    /// about this workspace's dependency tree — no resident grammar — and not
+    /// about the language being simple.
+    fn grammar(self) -> Option<Grammar> {
+        match self {
+            Lang::Rust => Some(Grammar::Rust),
+            Lang::TsJs => Some(Grammar::Tsx),
+            Lang::Python => Some(Grammar::Python),
+            Lang::Go => Some(Grammar::Go),
+            Lang::Java => Some(Grammar::Java),
+            Lang::C => Some(Grammar::C),
+            Lang::Sql => Some(Grammar::Sql),
+            Lang::Php => Some(Grammar::Php),
+            Lang::Markdown | Lang::Toml | Lang::Json => None,
+        }
     }
 }
 
@@ -105,11 +165,22 @@ pub fn lang_from_fence(tag: &str) -> Option<Lang> {
 /// panic-free. Stateless: markdown scans as body prose (fence lines read as
 /// markers, but their interiors are unknown here — [`Highlighter`] knows).
 pub fn tokenize(code: &str, lang: Lang) -> Runs {
+    if let Some(g) = lang.grammar() {
+        // `None` only when a grammar will not install, which is a build-time
+        // version skew rather than anything about this line. One untinted line
+        // is the right degradation for it, and `every_grammar_arms` is what
+        // stops it being discovered on a user's screen.
+        return grammar::runs(code, g).unwrap_or_else(|| vec![(code.to_string(), None)]);
+    }
     match lang {
         Lang::Markdown => md_line(code).0,
         Lang::Toml => toml_runs(code),
         Lang::Json => super::json_runs(code),
-        Lang::Rust | Lang::TsJs | Lang::Python => code_runs(code, lang),
+        // Unreachable: every remaining variant answered `Some` above. Stated as
+        // a plain fallback rather than an `unreachable!` because this is a
+        // rendering path, and a panic here would take the deck down over a
+        // token colour.
+        _ => vec![(code.to_string(), None)],
     }
 }
 
@@ -307,10 +378,10 @@ fn frontmatter_runs(line: &str) -> Runs {
         }
         runs.push((key.to_string(), Some(Tok::Keyword)));
         runs.push((":".to_string(), None));
-        runs.extend(code_runs(rest, Lang::Toml));
+        runs.extend(value_runs(rest));
         return runs;
     }
-    code_runs(line, Lang::Toml)
+    value_runs(line)
 }
 
 /// A horizontal rule: 3+ of the same `-`/`*`/`_` (spaces allowed between).
@@ -383,7 +454,7 @@ fn toml_runs(code: &str) -> Runs {
             runs.push((chars[..end].iter().collect(), Some(Tok::Keyword)));
             let rest: String = chars[end..].iter().collect();
             if !rest.is_empty() {
-                runs.extend(code_runs(&rest, Lang::Toml));
+                runs.extend(value_runs(&rest));
             }
             return runs;
         }
@@ -404,18 +475,25 @@ fn toml_runs(code: &str) -> Runs {
             }
             runs.push((key.to_string(), Some(Tok::Keyword)));
             runs.push((format!("{}=", &key_part[key.len()..]), None));
-            runs.extend(code_runs(&lead[eq + 1..], Lang::Toml));
+            runs.extend(value_runs(&lead[eq + 1..]));
             return runs;
         }
     }
-    code_runs(code, Lang::Toml)
+    value_runs(code)
 }
 
-// ── The generic code scan ───────────────────────────────────────────────────
+// ── The value scan ──────────────────────────────────────────────────────────
 
-/// The left-to-right run scan for code-shaped languages (Rust, TS/JS, Python,
-/// and TOML values): line comments, string/char literals, numbers, keywords.
-fn code_runs(code: &str, lang: Lang) -> Runs {
+/// The left-to-right run scan for a **config value**: `#` line comments,
+/// quoted strings, numbers, and the four TOML scalar constants.
+///
+/// This is all that is left of the hand-written scan that once served Rust,
+/// TS/JS and Python too. Those three are grammar-backed now (#4283), and their
+/// keyword tables went with them — a keyword table is precisely what a grammar
+/// replaces. What survives is the half no grammar in this workspace covers:
+/// TOML values, and the YAML frontmatter values [`frontmatter_runs`] lexes by
+/// the same rules because the two scalar syntaxes agree closely enough.
+fn value_runs(code: &str) -> Runs {
     let chars: Vec<char> = code.chars().collect();
     let n = chars.len();
     let mut runs: Runs = Vec::new();
@@ -425,21 +503,21 @@ fn code_runs(code: &str, lang: Lang) -> Runs {
     while i < n {
         let c = chars[i];
 
-        // Line comment: `//` (Rust/TS/JS) or `#` (Python/TOML) to end of line.
-        if is_comment_start(&chars, i, lang) {
+        // Line comment: `#` to end of line, in TOML and YAML alike.
+        if c == '#' {
             flush(&mut plain, &mut runs);
             runs.push((chars[i..].iter().collect(), Some(Tok::Comment)));
             return runs;
         }
 
-        // String / char literal.
-        if is_string_start(&chars, i, lang) {
+        // String literal.
+        if matches!(c, '"' | '\'') {
             let (end, closed) = scan_string(&chars, i);
-            // An unterminated single quote is far more often a contraction in
-            // prose ("Don't" in JSX text or a docstring) than a string the
-            // hunk cut in half — leave it plain instead of swallowing the
-            // rest of the line. Double quotes and backticks keep the
-            // string-to-end-of-line reading (a cut hunk is the likely cause).
+            // An unterminated single quote is far more often an apostrophe in
+            // a prose value than a string a hunk cut in half — leave it plain
+            // instead of swallowing the rest of the line. A double quote keeps
+            // the string-to-end-of-line reading (a cut hunk is the likely
+            // cause).
             if closed || c != '\'' {
                 flush(&mut plain, &mut runs);
                 runs.push((chars[i..end].iter().collect(), Some(Tok::Str)));
@@ -468,7 +546,7 @@ fn code_runs(code: &str, lang: Lang) -> Runs {
                 j += 1;
             }
             let word: String = chars[i..j].iter().collect();
-            if is_keyword(&word, lang) {
+            if TOML_KEYWORDS.contains(&word.as_str()) {
                 flush(&mut plain, &mut runs);
                 runs.push((word, Some(Tok::Keyword)));
             } else {
@@ -490,43 +568,6 @@ fn code_runs(code: &str, lang: Lang) -> Runs {
 fn flush(plain: &mut String, runs: &mut Runs) {
     if !plain.is_empty() {
         runs.push((std::mem::take(plain), None));
-    }
-}
-
-fn is_comment_start(chars: &[char], i: usize, lang: Lang) -> bool {
-    match lang {
-        Lang::Python | Lang::Toml => chars[i] == '#',
-        Lang::Rust | Lang::TsJs => chars[i] == '/' && chars.get(i + 1) == Some(&'/'),
-        // Markdown and JSON never reach the generic scan ([`tokenize`]
-        // dispatches them to [`md_line`] and [`json_runs`]); the arms exist for
-        // exhaustiveness only. JSON has no comment syntax in any case.
-        Lang::Markdown | Lang::Json => false,
-    }
-}
-
-/// Whether position `i` opens a string/char literal. Double quotes (and TS/JS
-/// template backticks) always do; the single quote is ambiguous in Rust
-/// (lifetimes like `&'a T`, `derive('...')`), so there it only counts when it
-/// matches a char-literal shape — otherwise the whole line would mis-color.
-fn is_string_start(chars: &[char], i: usize, lang: Lang) -> bool {
-    match chars[i] {
-        '"' => true,
-        '`' => lang == Lang::TsJs,
-        '\'' => match lang {
-            Lang::Rust => is_rust_char_literal(chars, i),
-            Lang::Markdown => false,
-            _ => true,
-        },
-        _ => false,
-    }
-}
-
-/// A Rust char literal at `i`: `'x'` or an escaped `'\n'` / `'\''` / `'\\'`.
-fn is_rust_char_literal(chars: &[char], i: usize) -> bool {
-    if chars.get(i + 1) == Some(&'\\') {
-        chars.get(i + 3) == Some(&'\'')
-    } else {
-        matches!(chars.get(i + 1), Some(c) if *c != '\'') && chars.get(i + 2) == Some(&'\'')
     }
 }
 
@@ -575,83 +616,6 @@ fn is_ident_continue(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
 
-/// Whether `word` is a keyword in `lang`. Linear scans over small, fixed
-/// slices — cheap enough for the handful of identifiers on a line.
-fn is_keyword(word: &str, lang: Lang) -> bool {
-    let table: &[&str] = match lang {
-        Lang::Rust => &RUST_KEYWORDS,
-        Lang::TsJs => &TSJS_KEYWORDS,
-        Lang::Python => &PYTHON_KEYWORDS,
-        Lang::Toml => &TOML_KEYWORDS,
-        // Neither reaches the generic scan; JSON's three bare words are
-        // classified by [`json_runs`] as the scalar constants they are.
-        Lang::Markdown | Lang::Json => &[],
-    };
-    table.contains(&word)
-}
-
-const RUST_KEYWORDS: [&str; 39] = [
-    "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
-    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub",
-    "ref", "return", "self", "Self", "static", "struct", "super", "trait", "true", "type",
-    "unsafe", "use", "where", "while", "yield",
-];
-
-const TSJS_KEYWORDS: [&str; 45] = [
-    "as",
-    "async",
-    "await",
-    "break",
-    "case",
-    "catch",
-    "class",
-    "const",
-    "continue",
-    "debugger",
-    "default",
-    "delete",
-    "do",
-    "else",
-    "enum",
-    "export",
-    "extends",
-    "false",
-    "finally",
-    "for",
-    "from",
-    "function",
-    "if",
-    "implements",
-    "import",
-    "in",
-    "instanceof",
-    "interface",
-    "let",
-    "new",
-    "null",
-    "of",
-    "readonly",
-    "return",
-    "super",
-    "switch",
-    "this",
-    "throw",
-    "true",
-    "try",
-    "typeof",
-    "undefined",
-    "var",
-    "void",
-    "while",
-];
-
-const PYTHON_KEYWORDS: [&str; 35] = [
-    "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif",
-    "else", "except", "False", "finally", "for", "from", "global", "if", "import", "in", "is",
-    "lambda", "None", "nonlocal", "not", "or", "pass", "raise", "return", "True", "try", "while",
-    "with", "yield",
-];
-
 /// TOML value constants (booleans and the special floats).
 const TOML_KEYWORDS: [&str; 4] = ["true", "false", "inf", "nan"];
 
@@ -688,12 +652,22 @@ mod tests {
         }
     }
 
-    const ALL_LANGS: [Lang; 5] = [
+    /// Every language, both engines. The grammar-backed ones joined this list
+    /// with #4283, which matters more than it looks: the losslessness property
+    /// below is the one contract a tree-sitter walk could plausibly break, and
+    /// it now runs over arbitrary text through all eight grammars.
+    const ALL_LANGS: [Lang; 11] = [
         Lang::Rust,
         Lang::TsJs,
         Lang::Python,
+        Lang::Go,
+        Lang::Java,
+        Lang::C,
+        Lang::Sql,
+        Lang::Php,
         Lang::Markdown,
         Lang::Toml,
+        Lang::Json,
     ];
 
     // Losslessness as a property, not a list of examples.
@@ -806,6 +780,118 @@ mod tests {
         }
     }
 
+    /// **The #4283 witness, one row per language the upgrade added.**
+    ///
+    /// Each row is a `read_file` of a real source line, reached the way a
+    /// surface reaches it: extension → [`Lang`] → [`tokenize`]. On the
+    /// hand-written lexer every one of these fails at the *first* step —
+    /// `lang_from_ext` answered `None` for `go`, `java`, `c`, `sql` and `php`,
+    /// so `BodyPaint::lang` was `None` and the body rendered as flat text on
+    /// the deck, the export grid and the Observatory alike. That is the cost
+    /// this issue named, and this is the test that says it is paid.
+    #[test]
+    fn every_newly_supported_language_lexes_where_the_old_lexer_saw_nothing() {
+        for (ext, src, want) in [
+            (
+                "go",
+                "func Sum(a int) error { return fmt.Errorf(\"x\", 1) }",
+                &["func", "Sum", "int", "Errorf", "\"x\"", "1"][..],
+            ),
+            (
+                "java",
+                "public static void main(String[] args) { System.out.println(\"hi\"); }",
+                &["public", "void", "main", "String", "println", "\"hi\""][..],
+            ),
+            (
+                "c",
+                "static int add(int a) { /* c */ return 0x1F; }",
+                &["static", "int", "add", "/* c */", "return", "0x1F"][..],
+            ),
+            (
+                "sql",
+                "SELECT id FROM users WHERE age > 21",
+                &["SELECT", "FROM", "WHERE"][..],
+            ),
+            (
+                "php",
+                "<?php function greet(string $n) { return \"hi\"; }",
+                &["function", "greet", "string", "return", "\"hi\""][..],
+            ),
+        ] {
+            let lang = lang_from_ext(ext)
+                .unwrap_or_else(|| panic!(".{ext} maps to no language, so its body renders flat"));
+            let runs = tokenize(src, lang);
+            assert_eq!(rebuilt(&runs), src, ".{ext} lexed lossily: {runs:?}");
+            for text in want {
+                assert!(
+                    runs.iter().any(|(t, tok)| t == text && tok.is_some()),
+                    ".{ext} left {text:?} untinted — the grammar is not reaching this line: {runs:?}"
+                );
+            }
+        }
+    }
+
+    /// The two token classes a keyword table cannot produce.
+    ///
+    /// This is what justifies growing [`Tok`] — and growing it is a three-site
+    /// change (`tok_style`, `tok_color`, `tok_class`), so the payoff had better
+    /// be visible. A hand-written scan sees `Duration`, `total` and `compute`
+    /// as one thing: an identifier.
+    #[test]
+    fn the_grammar_names_types_and_functions_a_keyword_table_could_not() {
+        let runs = tokenize("fn main() { let s = parse(x); }", Lang::Rust);
+        assert_eq!(
+            run_tok(&runs, "main"),
+            Some(&Some(Tok::Function)),
+            "the declared name: {runs:?}"
+        );
+        assert_eq!(
+            run_tok(&runs, "parse"),
+            Some(&Some(Tok::Function)),
+            "the callee: {runs:?}"
+        );
+        // ...and the identifier beside them stays plain, which is the half that
+        // makes the distinction worth a colour.
+        assert_eq!(run_tok(&runs, "x"), None, "a bare identifier: {runs:?}");
+
+        let runs = tokenize("var d time.Duration = readAll(f)", Lang::Go);
+        assert_eq!(
+            run_tok(&runs, "Duration"),
+            Some(&Some(Tok::Type)),
+            "a named type: {runs:?}"
+        );
+        assert_eq!(
+            run_tok(&runs, "readAll"),
+            Some(&Some(Tok::Function)),
+            "a callee through a package selector: {runs:?}"
+        );
+    }
+
+    /// A fragment lexes as a fragment.
+    ///
+    /// The stateless, one-line contract survives the move to a whole-file
+    /// parser only because tree-sitter recovers: a line sliced out of a body —
+    /// which is every line of a middle-elided tool result — still lexes its
+    /// leaves correctly inside the `ERROR` node wrapping them. If this ever
+    /// regresses, every transcript body loses its colour below the first line
+    /// that is not a complete item.
+    #[test]
+    fn a_line_sliced_out_of_a_body_still_lexes_its_tokens() {
+        for (src, lang, want) in [
+            ("    let total = compute(items);", Lang::Rust, "let"),
+            ("} else if (x) {", Lang::TsJs, "else"),
+            ("        return helper(n)  # tail", Lang::Python, "# tail"),
+            ("    } // close", Lang::Java, "// close"),
+        ] {
+            let runs = tokenize(src, lang);
+            assert_eq!(rebuilt(&runs), src, "{lang:?} lexed lossily: {runs:?}");
+            assert!(
+                runs.iter().any(|(t, tok)| t == want && tok.is_some()),
+                "{lang:?} left {want:?} untinted in a fragment: {runs:?}"
+            );
+        }
+    }
+
     #[test]
     fn markdown_and_toml_map_from_extensions_and_fence_tags() {
         assert_eq!(lang_from_fence("json"), Some(Lang::Json));
@@ -820,6 +906,21 @@ mod tests {
         assert_eq!(lang_from_fence("rust ignore"), Some(Lang::Rust));
         assert_eq!(lang_from_fence(""), None);
         assert_eq!(lang_from_fence("mermaid"), None);
+        // The languages #4283 added reach both doors, so a fenced block in a
+        // SKILL.md lights up the same way a `read_file` of the same source
+        // does.
+        assert_eq!(lang_from_fence("go"), Some(Lang::Go));
+        assert_eq!(lang_from_fence("java"), Some(Lang::Java));
+        assert_eq!(lang_from_fence("sql"), Some(Lang::Sql));
+        assert_eq!(lang_from_fence("php"), Some(Lang::Php));
+        assert_eq!(lang_from_path("cmd/serve/main.go"), Some(Lang::Go));
+        assert_eq!(lang_from_path("src/Main.java"), Some(Lang::Java));
+        assert_eq!(lang_from_path("lib/parse.h"), Some(Lang::C));
+        assert_eq!(lang_from_path("migrations/001.sql"), Some(Lang::Sql));
+        // Still not covered, and saying so is the point: a language with no
+        // resident grammar renders plain rather than wrong.
+        assert_eq!(lang_from_fence("yaml"), None);
+        assert_eq!(lang_from_fence("bash"), None);
     }
 
     #[test]

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -258,6 +258,47 @@ fn an_exported_read_of_an_unknown_extension_is_numbered_but_not_coloured() {
     }
 }
 
+/// **Both export renderers gain the grammar in one change (#4283).**
+///
+/// The issue's whole point was *where* the upgrade lands. A deck-local
+/// highlighter would have left this test impossible to write: a Go body would
+/// light up on the deck and stay flat in an exported transcript and in the
+/// Observatory, which is the drift #3644 and #4036 each closed once. So the
+/// witness is stated against the two surfaces that are not the deck, and it
+/// covers both classes the upgrade added — a class with no palette entry in one
+/// renderer is a surface disagreeing about hue, which is the other half of what
+/// the palette split is allowed to differ on.
+#[test]
+fn a_go_read_reaches_both_export_renderers_with_the_grammars_classes() {
+    let source = numbered(1, &["func Sum(a int) error {", "\treturn nil", "}"]);
+    let (_, markup) = rendered(read_call("cmd/serve/main.go", source.clone()));
+    for (class, what) in [
+        ("\"tk\"", "the `func` keyword"),
+        ("\"ty\"", "the `int` type"),
+        ("\"tf\"", "the `Sum` function name"),
+    ] {
+        assert!(
+            markup.contains(class),
+            "the Observatory renderer lost {what} ({class}):\n{markup}"
+        );
+    }
+
+    let run = run_with(vec![step(read_call("cmd/serve/main.go", source), 0)]);
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+    let lines = grid::render(&run, &state, 100);
+    for (color, what) in [
+        (grid::Color::Cyan, "a type"),
+        (grid::Color::Magenta, "a function name"),
+    ] {
+        assert!(
+            lines.iter().flatten().any(|cell| cell.fg == color),
+            "the export grid painted no cell as {what} ({color:?}) — a Go body \
+             reached it uncoloured"
+        );
+    }
+}
+
 /// A grid row's measured width is the width it draws at.
 ///
 /// A tab is zero columns to `unicode-width` and a real stop to a terminal, so a

--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -1233,10 +1233,22 @@ mod tests {
              changed from unchanged: {:?}",
             context.spans
         );
-        // The un-tokenized remainder falls back to the muted body colour, so
-        // context still reads a shade quieter than a changed line overall.
+        // The function's *name* is a token now, not part of the remainder —
+        // the grammar-backed lexer classifies it where the keyword table could
+        // only see an identifier (#4283).
         assert_eq!(
-            span_with(context, " unchanged() {}").map(|s| s.style.fg),
+            span_with(context, "unchanged").map(|s| s.style.fg),
+            Some(Some(theme::SYNTAX_FUNCTION)),
+            "the declared name is a function token: {:?}",
+            context.spans
+        );
+        // The un-tokenized remainder still falls back to the muted body colour,
+        // so context reads a shade quieter than a changed line overall. This is
+        // the assertion the line above narrowed: it used to name
+        // `" unchanged() {}"` as one plain run, and only the punctuation is
+        // plain now.
+        assert_eq!(
+            span_with(context, "() {}").map(|s| s.style.fg),
             Some(Some(theme::MUTED)),
             "plain runs stay muted: {:?}",
             context.spans

--- a/crates/stella-tui/src/syntax.rs
+++ b/crates/stella-tui/src/syntax.rs
@@ -35,6 +35,8 @@ pub fn tok_style(t: Tok) -> Style {
         Tok::Comment => Style::default()
             .fg(theme::SYNTAX_COMMENT)
             .add_modifier(Modifier::ITALIC),
+        Tok::Type => Style::default().fg(theme::SYNTAX_TYPE),
+        Tok::Function => Style::default().fg(theme::SYNTAX_FUNCTION),
     }
 }
 
@@ -126,10 +128,17 @@ mod tests {
     /// would have closed half the gap #3644 and #4036 exist to close.
     #[test]
     fn every_token_class_wears_its_own_colour() {
-        let hues: Vec<_> = [Tok::Keyword, Tok::Str, Tok::Number, Tok::Comment]
-            .into_iter()
-            .map(|t| tok_style(t).fg)
-            .collect();
+        let hues: Vec<_> = [
+            Tok::Keyword,
+            Tok::Str,
+            Tok::Number,
+            Tok::Comment,
+            Tok::Type,
+            Tok::Function,
+        ]
+        .into_iter()
+        .map(|t| tok_style(t).fg)
+        .collect();
         for (i, a) in hues.iter().enumerate() {
             for b in hues.iter().skip(i + 1) {
                 assert_ne!(a, b, "two token classes share a colour: {hues:?}");

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -389,6 +389,14 @@ pub const SYNTAX_NUMBER: Color = VIOLET;
 /// Line comment (rendered dimmed + italic) — the caption tier, which is
 /// "comments dim toward the caption tier" made literal.
 pub const SYNTAX_COMMENT: Color = palette::TEXT_TERTIARY;
+/// A type position — teal, the categorical hue already carried for
+/// [`SUBAGENT`]. Arrived with the grammar-backed lexer (#4283), which is the
+/// first thing here able to tell a type from any other identifier.
+pub const SYNTAX_TYPE: Color = TEAL;
+/// A function or method *name* — magenta, the remaining categorical hue, and
+/// the one furthest from both the neutral keyword stop and the violet
+/// literals it will sit beside on the same line.
+pub const SYNTAX_FUNCTION: Color = MAGENTA;
 
 /// Inline code spans and fenced-code plain runs (`crate::markdown`). A calm
 /// sage green — quiet enough that a backticked word reads as *technical*

--- a/design/tui-v2/IMPLEMENTATION-PLAN.md
+++ b/design/tui-v2/IMPLEMENTATION-PLAN.md
@@ -114,15 +114,26 @@ Acceptance: palette snapshot for query `ga` during a verify turn showing `/gates
 
 ## 5. Risks and mitigations
 
-- **Lexer accuracy**: `stella_transcript::syntax` is hand-written and covers a
-  fixed `Lang` set, so it is heuristic where a grammar-based lexer (syntect,
-  tree-sitter) would be accurate, and silent on languages it does not know.
-  That is a real cost and it is accepted for now. Mitigation is about **where** a
-  better lexer lands, not whether: it goes into `stella-transcript`, so the deck,
-  the export grid and the Observatory gain it together — that upgrade is tracked
-  as #4283, and it lands there or not at all. A deck-local highlighter buys the
-  deck accuracy by making the three surfaces disagree again, which is the one
-  outcome #4036 forbade (#4196).
+- **Lexer accuracy**: ~~a real cost, accepted for now~~ — **paid, in
+  `stella-transcript`, by #4283.** `stella_transcript::syntax` is now
+  grammar-backed: tree-sitter lexes Rust, TypeScript/JavaScript, Python, Go,
+  Java, C, SQL and PHP, and the hand-written scans survive only for Markdown,
+  TOML and JSON, which have no grammar resident in this workspace. Two token
+  classes a keyword table cannot produce — `Tok::Type` and `Tok::Function` —
+  joined the shared vocabulary, and all three palettes (`tok_style`,
+  `tok_color`, `tok_class`) moved in the same PR.
+
+  The mitigation held as written: it landed **in `stella-transcript`**, so the
+  deck, the export grid and the Observatory gained it together rather than a
+  deck-local highlighter buying the deck accuracy by making the three surfaces
+  disagree again (#4036, #4196). syntect was declined — it loads grammar and
+  theme assets at runtime, which invariant #2 forbids in this layer — and
+  tree-sitter cost no new supply chain, because `stella-graph` already compiles
+  every one of those grammars as a default feature.
+
+  What is still flat: any language with no grammar in this tree, shell, YAML
+  and HTML among them. Adding one is new supply chain and a fresh
+  `cargo deny check licenses` decision, not a change this bullet pre-approves.
 - **Terminal variance on Windows**: legacy conhost degrades truecolor. Mitigation: fallback map plus recommending Windows Terminal; the desktop shell solves it permanently later.
 - **Registry and tracker latency**: never block the draw path; all remote work is async with visible `◐` states and stale-data tags.
 - **Scope creep in tabs**: AGENTS and SETTINGS are restyle-only in this cycle (SPEC 9.5).


### PR DESCRIPTION
Closes #4283.

`stella_transcript::syntax` is now grammar-backed. tree-sitter lexes eight
languages — Rust, TypeScript/JavaScript, Python, Go, Java, C, SQL, PHP — and the
hand-written scans survive only for the three with no grammar resident in this
workspace (Markdown, TOML, JSON).

The issue's question was **where** such an upgrade may land, not whether. It
landed in `stella-transcript`, so the deck, the export grid and the Observatory
gained it in one change. A deck-local highlighting crate would have been a
fourth copy of a rendering decision this tree already de-duplicated twice
(#3644, #4036) and that #4196 forbade.

## The dependency sentence AGENTS.md asks for

`stella-transcript` is a near-leaf by contract, and this weakens that, so it
owes an argument:

- **It is resident supply chain, not new.** `tree-sitter` and all eight grammar
  crates are already in the root `[workspace.dependencies]`, and every one is a
  **default feature** of `stella-graph`, which `stella-cli` takes with defaults.
  The shipping binary already compiles this exact C. `cargo deny check licenses`
  passes (`licenses ok`) and no `deny.toml` allow-list was touched.
- **`stella-observatory` is the one consumer that newly pays** a compile cost —
  it links `stella-transcript` but not `stella-graph`. It pays it to stop
  rendering Go, Java, C, SQL and PHP as flat text. Stated plainly rather than
  buried: this is the real cost of the change.
- **syntect was declined**, as the issue anticipated: its default path loads
  grammar and theme assets at runtime, which invariant #2 forbids in this layer.
  tree-sitter grammars are compiled in, so the lexer stays a pure function over
  borrowed text.

Exemplar followed: `stella-graph`'s `lang.rs`/`parse.rs` — same grammar
selection (`LANGUAGE_TSX`, `LANGUAGE_PHP` and not `LANGUAGE_PHP_ONLY`), same
extension routing.

## `Tok` grew by two, and all three palettes moved

`Type` and `Function` are the classes a keyword table cannot produce — it sees
`Duration`, `total` and `compute` as one thing. Per the issue's constraint, all
three palettes moved in this PR:

| Class | `tok_style` (deck) | `tok_color` (grid) | `tok_class` (html) |
|---|---|---|---|
| `Type` | `SYNTAX_TYPE` = `TEAL` | `Color::Cyan` | `.ty` → `--cyan` |
| `Function` | `SYNTAX_FUNCTION` = `MAGENTA` | `Color::Magenta` (new) | `.tf` → `--magenta` (new) |

`TEAL` and `MAGENTA` were chosen because both already carry full 256/16
fallback and light-mode entries in `theme.rs`, so they inherit contrast work
rather than needing fresh AA measurement. `--cyan`/`--magenta` are
scheme-invariant categoricals, matching the convention `transcript.css`'s own
header states.

## How the per-line contract survived a whole-file parser

`tokenize` is stateless and line-oriented because a diff hunk can slice a file
anywhere and tool bodies are middle-elided. Kept: each line is parsed alone, and
tree-sitter's error recovery keeps leaf token kinds inside the `ERROR` node
wrapping a fragment. `a_line_sliced_out_of_a_body_still_lexes_its_tokens` is the
witness.

**Parsers are built once per grammar per thread, never per line.** The issue
warned a per-frame parser instantiation would silently defeat the deck's tail
cache; `with_parser` is why it does not.

Losslessness is **constructed, not asserted**: the walk fills every byte between
leaves, so output covers `[0, code.len())` exactly once, and a leaf failing a
sanity check is skipped *without advancing the cursor*. The existing proptest
now runs over all eleven languages.

## Verification

| Check | Result |
|---|---|
| `cargo test -p stella-transcript` | 98 passed, 0 failed |
| `cargo test -p stella-tui` | 1043 passed, 0 failed |
| `an_unchanged_tail_is_highlighted_once_not_once_per_frame` | **green** |
| `deck_render_snapshots` (golden frames) | 17 passed, **no re-blessing** |
| `cargo deny check licenses` | `licenses ok` |
| `make guards` | exit 0 |
| clippy `-D warnings` (transcript, tui, observatory, cli) | clean |
| rustdoc `-D warnings` | clean |

Golden frames needed no re-blessing, which is itself evidence: they compare the
character grid, and the lexer is lossless, so a classification change cannot
move them.

Witness per newly supported language:
`every_newly_supported_language_lexes_where_the_old_lexer_saw_nothing` — one row
each for Go, Java, C, SQL and PHP, reached the way a surface reaches it
(extension → `Lang` → `tokenize`). On `main` every row fails at the *first*
step, because `lang_from_ext` answered `None` for all five.

`a_go_read_reaches_both_export_renderers_with_the_grammars_classes` states the
cross-surface half against the two renderers that are **not** the deck.

## Tests changed (no deletions)

`stella-tui`'s `context_lines_keep_their_syntax_colors` kept its name and
intent; two assertions moved. It asserted `" unchanged() {}"` was one plain run,
and the function name is a token now — so it asserts `unchanged` is
`SYNTAX_FUNCTION` and only `"() {}"` stays muted. No test was deleted.

## Also in this PR

- `design/tui-v2/IMPLEMENTATION-PLAN.md` §5's risk bullet amended to say what
  shipped, as the issue required — including what is *still* flat.
- The hand-written scan was narrowed to what it still serves (`value_runs`), and
  the Rust/TS/Python keyword tables deleted. A grammar is exactly what replaces
  a keyword table; leaving three dead ones behind in a file whose doc claims to
  be "the one source-coloring engine" is the stale-comment-as-bug case.

## Still flat, deliberately

Shell, YAML and HTML have no grammar resident in this workspace, and `.cpp` is
routed to the C grammar as a documented approximation. Adding any of them is new
supply chain and a fresh licence decision, not something this PR pre-approves —
the plan bullet now says so rather than leaving it implied.

Filed as **#4325**, written as a handoff: the per-grammar decision, why the
"already resident" argument does not transfer, the YAML/frontmatter wrinkle, and
the `.ts`-lexed-as-TSX approximation noted so it is not lost.
