### PR TITLE
feat(stella-protocol,stella-tui): a steer names its cause, and the rule names the person's (#3622, #4185)

### DIFF
--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -390,7 +390,7 @@ impl<'a> Fold<'a> {
                 let prose = self.clean(reason);
                 self.note_row("err", "RETRY", &format!("attempt {attempt}"), Some(&prose));
             }
-            AgentEvent::Steered { text } => {
+            AgentEvent::Steered { text, .. } => {
                 let prose = self.clean(text);
                 self.prose_row("user", "STEER", &prose);
             }

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -42,7 +42,7 @@
 //! `crate::step::TurnState` can hold the budget it checkpoints; the ladder's
 //! policy belongs beside the ladder, not in the state container.
 
-use stella_protocol::{AgentEvent, CompletionMessage, MessageRole};
+use stella_protocol::{AgentEvent, CompletionMessage, MessageRole, SteerCause};
 
 use crate::event_sender::EventSender;
 use crate::loop_detect::{CallRecord, LoopIdentity, LoopVerdict, detect_loop};
@@ -276,7 +276,10 @@ pub(super) fn check_loop_detection(
             None,
             loop_steer.remaining(),
         );
-        let _ = events.send(AgentEvent::Steered { text: text.clone() });
+        let _ = events.send(AgentEvent::Steered {
+            text: text.clone(),
+            cause: SteerCause::Loop,
+        });
         messages.push(CompletionMessage::user(text));
         return None;
     };
@@ -500,7 +503,10 @@ fn steer_stalled_turn(
         return;
     }
     let text = stall_steer_text(stall_secs);
-    let _ = events.send(AgentEvent::Steered { text: text.clone() });
+    let _ = events.send(AgentEvent::Steered {
+        text: text.clone(),
+        cause: SteerCause::Stall,
+    });
     messages.push(CompletionMessage::user(text));
 }
 
@@ -1148,7 +1154,7 @@ mod tests {
         use proptest::prelude::*;
         use std::borrow::Cow;
         use stella_protocol::tool::{ToolCall, ToolOutput, ToolResult};
-        use stella_protocol::{AgentEvent, CompletionMessage, MessageRole};
+        use stella_protocol::{AgentEvent, CompletionMessage, MessageRole, SteerCause};
 
         /// One resolved `bash` call and the bytes it produced, as the pair of
         /// transcript messages the driver would have accumulated.
@@ -1252,10 +1258,13 @@ mod tests {
                 steer.content
             );
             assert!(
-                drained
-                    .iter()
-                    .any(|e| matches!(e, AgentEvent::Steered { text } if text == &steer.content)),
-                "the steer is on the transcript AND on the wire: {drained:?}"
+                drained.iter().any(|e| matches!(
+                    e,
+                    AgentEvent::Steered { text, cause }
+                        if text == &steer.content && *cause == SteerCause::Stall
+                )),
+                "the steer is on the transcript AND on the wire, named as the \
+                 stall rung rather than left for a prose match (#3622): {drained:?}"
             );
 
             // Warn once: a second pass over the same (still stalling) window

--- a/crates/stella-core/src/driver/step_boundary.rs
+++ b/crates/stella-core/src/driver/step_boundary.rs
@@ -13,7 +13,7 @@
 //! a user steer landed this step is part of what the next query answers to
 //! rather than something it races.
 
-use stella_protocol::{AgentEvent, CompletionMessage};
+use stella_protocol::{AgentEvent, CompletionMessage, SteerCause};
 
 use crate::event_sender::EventSender;
 use crate::step::{StepOutcome, TurnState};
@@ -32,7 +32,15 @@ pub(super) async fn consult_hosts(
 ) -> Option<StepOutcome> {
     if let Some(steering) = steering {
         for text in steering.drain_steering() {
-            let _ = events.send(AgentEvent::Steered { text: text.clone() });
+            // The port's queue is fed by a host on a person's behalf — the
+            // deck's `>` steer, `stella-serve`'s control channel — and by
+            // nothing else. The engine's own two rungs push their text
+            // straight onto `messages` in `loop_escalation`, so this is the
+            // one site that may claim `User`.
+            let _ = events.send(AgentEvent::Steered {
+                text: text.clone(),
+                cause: SteerCause::User,
+            });
             state.messages.push(CompletionMessage::user(text));
         }
         if steering.soft_stop_requested() {

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::event::BudgetMode;
-use stella_protocol::{CompletionUsage, ToolSchema};
+use stella_protocol::{CompletionUsage, SteerCause, ToolSchema};
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
@@ -1002,9 +1002,11 @@ async fn steered_messages_inject_before_the_next_model_call() {
     );
     let events = drain_events(&mut rx);
     assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, AgentEvent::Steered { text } if text == "also check the tests")),
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Steered { text, cause }
+                if text == "also check the tests" && *cause == SteerCause::User
+        )),
         "steering must be visible in the event stream: {events:?}"
     );
 }
@@ -1756,7 +1758,7 @@ async fn stuck_loop_steers_once_then_aborts_on_re_detection() {
     assert_eq!(steers.len(), 1, "one warning per loop; one loop here");
     assert!(matches!(
         steers[0],
-        AgentEvent::Steered { text } if text.contains("looping")
+        AgentEvent::Steered { text, .. } if text.contains("looping")
     ));
     // Typed decisions (receipts spec §6.3): each detection also lands as a
     // parseable LoopDetected — the steer with `aborted: false`, the kill

--- a/crates/stella-core/src/driver/tests/loop_abort.rs
+++ b/crates/stella-core/src/driver/tests/loop_abort.rs
@@ -240,7 +240,7 @@ async fn a_second_distinct_loop_earns_its_own_steer_before_the_turn_dies() {
     let steers: Vec<&String> = events
         .iter()
         .filter_map(|e| match e {
-            AgentEvent::Steered { text } => Some(text),
+            AgentEvent::Steered { text, .. } => Some(text),
             _ => None,
         })
         .collect();
@@ -645,4 +645,72 @@ async fn a_terminated_short_answer_after_investigation_still_completes() {
         "a stated, punctuated result must not be gated: {outcome:?}"
     );
     drain_events(&mut rx);
+}
+
+/// #3622: the stuck-loop rung stamps `SteerCause::Loop` on the wire, so a
+/// consumer separates it from a user steer without reading the prose.
+///
+/// Before the field there was nothing on the event but `text`, and the only
+/// available test was `text.starts_with(LOOP_STEER_PREFIX)` — a substring test
+/// on English, which is exactly what `AgentEvent::LoopDetected` was introduced
+/// to end for this rung.
+///
+/// The paired `LoopDetected` is asserted alongside deliberately: it is what
+/// establishes that the steer under inspection really came from the loop rung,
+/// so the cause assertion is about the emitter and not about this test's setup.
+#[tokio::test]
+async fn a_stuck_loop_steer_names_the_loop_rung_as_its_cause() {
+    let grep_open = |call_id: &str| {
+        call_of(
+            call_id,
+            "grep",
+            serde_json::json!({"pattern": "fn open", "path": "src/store.rs"}),
+        )
+    };
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![
+            Ok(grep_open("c1")),
+            Ok(grep_open("c2")),
+            Ok(grep_open("c3")),
+        ]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = ConstantTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, exact_repeat_only(30), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("where is the store opened?"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let _ = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::LoopDetected { .. })),
+        "the loop rung must actually have fired: {events:?}"
+    );
+    let causes: Vec<SteerCause> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::Steered { cause, .. } => Some(*cause),
+            _ => None,
+        })
+        .collect();
+    assert!(!causes.is_empty(), "the loop rung steers: {events:?}");
+    assert!(
+        causes.iter().all(|c| *c == SteerCause::Loop),
+        "the engine's own nudge is not the user speaking: {causes:?}"
+    );
+    assert!(
+        !causes.iter().any(|c| c.is_from_a_person()),
+        "no loop steer may be attributed to a person"
+    );
 }

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -252,9 +252,11 @@ pub enum PolicyKind {
 mod call_role;
 pub mod consumers;
 mod payload;
+mod steer_cause;
 mod tags;
 
 pub use call_role::ModelCallRole;
+pub use steer_cause::SteerCause;
 // Re-exported so `KNOWN_TYPE_TAGS` keeps its path through this module and
 // `crate::KNOWN_TYPE_TAGS`: the table moved to a submodule (#2730), the
 // public name did not.
@@ -445,10 +447,21 @@ pub enum AgentEvent {
         attempt: u32,
         reason: String,
     },
-    /// A user message queued mid-turn was injected at a step boundary
-    /// (`stella-core` steering) — the transcript's record that the model
-    /// was steered, and when.
-    Steered { text: String },
+    /// A message was injected into the turn at a step boundary — the
+    /// transcript's record that the model was steered, and when.
+    ///
+    /// Three rungs emit this and `cause` is what tells them apart: a person's
+    /// mid-turn message, the stuck-loop nudge, and the stalled-turn nudge.
+    /// Before it, a consumer could only match the English prose (#3622).
+    Steered {
+        text: String,
+        /// Who or what steered. `serde(default)` so streams recorded before
+        /// this field parse — as [`SteerCause::Unknown`], never as
+        /// [`SteerCause::User`], which would relabel the whole recorded
+        /// history as human input.
+        #[serde(default)]
+        cause: SteerCause,
+    },
     /// The turn parked on an engine-side wait (#1471, #1857): a tool
     /// deposited a wait request and the engine is now probing on its own
     /// clock — zero model calls until the watched state changes or the

--- a/crates/stella-protocol/src/event/steer_cause.rs
+++ b/crates/stella-protocol/src/event/steer_cause.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Why a turn was steered.
+//!
+//! Split out of `event.rs` for the reason [`super::ModelCallRole`]'s module
+//! gives: the parent is a god file under the size ratchet, and a vocabulary
+//! belongs beside its own enumeration rather than in the middle of the variant
+//! list.
+
+use serde::{Deserialize, Serialize};
+
+// Doc-link target only: the variant is named in this module's docs but not
+// used in its code. `cfg(doc)` keeps rustdoc's intra-doc link resolving
+// without an import a normal build would flag as unused.
+#[cfg(doc)]
+use super::AgentEvent;
+
+/// What put the message into the turn, for [`AgentEvent::Steered`].
+///
+/// Three different things emit that event and they are different pathologies
+/// with different remedies: a person interrupting, the stuck-loop rung, and
+/// the stalled-turn rung (#2022). Before this field the only way to tell them
+/// apart was to match the English prose — and `STALL_STEER_PREFIX` *extends*
+/// `LOOP_STEER_PREFIX`, so even the prefix test was a substring test on a
+/// sentence (#3622). That is precisely the practice
+/// [`AgentEvent::LoopDetected`] was introduced to end for the loop rung.
+///
+/// The consequence was that "the turn was steered" was one bucket, so no
+/// consumer could answer *how often does the stall rung actually fire* — the
+/// question that decides whether the rung earns its keep.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SteerCause {
+    /// Not recorded: an event written before this field existed.
+    ///
+    /// The default for an **absent** `cause` only, matching
+    /// [`super::ModelCallRole::Unknown`]'s precedent for exactly this
+    /// situation.
+    ///
+    /// [`Self::User`] would have been the cheaper default and is the wrong
+    /// one: every `Steered` recorded before this field came from one of the
+    /// two automatic rungs, so defaulting to `User` would relabel the entire
+    /// recorded history as human input — and the tallies that read it would
+    /// be wrong in the one direction that matters.
+    // The doc above links a Rust path, and schemars publishes a doc comment
+    // verbatim as the schema `description` — where no consumer of
+    // `--output-format stream-json` can resolve one. So the wire reader gets a
+    // description written for them, and the Rust reader keeps the link.
+    #[cfg_attr(
+        feature = "schema",
+        schemars(
+            description = "Not recorded: an event written before this field existed. The default for an absent `cause` only — never `user`, which would relabel a whole recorded history as human input."
+        )
+    )]
+    #[default]
+    Unknown,
+    /// A person's mid-turn message, drained from
+    /// `stella_core::ports::TurnSteering` at a step boundary.
+    User,
+    /// The stuck-loop rung's nudge, following a `LoopVerdict`. Paired with an
+    /// [`AgentEvent::LoopDetected`] carrying the same evidence.
+    Loop,
+    /// The stalled-turn rung's nudge (#2022): no loop, but the turn has spent
+    /// too long waiting. Has no typed twin, which is why it was
+    /// indistinguishable from [`Self::Loop`] on the wire.
+    Stall,
+}
+
+impl SteerCause {
+    /// Whether this steer is something a person did.
+    ///
+    /// The one predicate a surface should ask before attributing a steer to
+    /// the user — SPEC 6.1's opening rule labels a queued steer, and a rule
+    /// that named a stall-rung auto-steer as something the user typed would be
+    /// worse than the blank it replaces (#4185).
+    ///
+    /// [`Self::Unknown`] is **not** a person: a replayed legacy session keeps
+    /// the blank it has today, which is the honest outcome rather than a
+    /// guess.
+    #[must_use]
+    pub fn is_from_a_person(self) -> bool {
+        matches!(self, Self::User)
+    }
+}

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -1237,4 +1237,67 @@ fn unknown_block_kind_degrades_to_other_not_a_parse_error() {
     assert_eq!(zone, CacheZone::Other);
 }
 
+/// #3622: the three rungs that emit `Steered` are now separable on the wire,
+/// and the field round-trips (invariant #4).
+///
+/// The failing half before this field existed is not subtle — there was
+/// nothing to read but `text`, and `stall_steer_text`'s prefix *extends*
+/// `steer_text`'s, so even a prefix test was a substring test on English.
+#[test]
+fn a_steer_names_its_cause_on_the_wire() {
+    for cause in [
+        SteerCause::User,
+        SteerCause::Loop,
+        SteerCause::Stall,
+        SteerCause::Unknown,
+    ] {
+        let event = AgentEvent::Steered {
+            text: "do the other thing".into(),
+            cause,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"type\":\"steered\""), "{json}");
+        match serde_json::from_str::<AgentEvent>(&json).unwrap() {
+            AgentEvent::Steered { cause: back, .. } => assert_eq!(back, cause),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+    // The two automatic rungs are distinguishable without reading the prose,
+    // which is the whole point of the field.
+    let loop_json = serde_json::to_string(&AgentEvent::Steered {
+        text: "same words".into(),
+        cause: SteerCause::Loop,
+    })
+    .unwrap();
+    let stall_json = serde_json::to_string(&AgentEvent::Steered {
+        text: "same words".into(),
+        cause: SteerCause::Stall,
+    })
+    .unwrap();
+    assert_ne!(loop_json, stall_json);
+}
+
+/// An event recorded before `cause` existed decodes as `Unknown` — **never**
+/// as `User`.
+///
+/// The direction is the assertion. Every `Steered` in the recorded history
+/// came from one of the two automatic rungs (the user path did not emit
+/// through here at all until this change), so a `User` default would relabel
+/// the whole of it as human input and every tally reading it would be wrong in
+/// the one direction that matters (#3622).
+#[test]
+fn a_steer_recorded_before_the_cause_existed_is_not_called_the_user() {
+    let old = r#"{"type":"steered","text":"you have repeated the same tool call"}"#;
+    match serde_json::from_str::<AgentEvent>(old).unwrap() {
+        AgentEvent::Steered { cause, .. } => {
+            assert_eq!(cause, SteerCause::Unknown, "missing cause must not guess");
+            assert!(
+                !cause.is_from_a_person(),
+                "a legacy steer must not be attributed to the user"
+            );
+        }
+        other => panic!("old stream must parse: {other:?}"),
+    }
+}
+
 mod tag_table;

--- a/crates/stella-protocol/src/event/tests/tag_table.rs
+++ b/crates/stella-protocol/src/event/tests/tag_table.rs
@@ -35,7 +35,10 @@ fn type_tag_matches_the_serde_type_wire_tag() {
             attempt: 1,
             reason: "x".into(),
         },
-        AgentEvent::Steered { text: "s".into() },
+        AgentEvent::Steered {
+            text: "s".into(),
+            cause: SteerCause::Loop,
+        },
         AgentEvent::TurnParked {
             description: "CI settles".into(),
             poll_interval_secs: 5,

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -111,7 +111,7 @@ pub use event::{
     ContextFrameRef, ContextProviderUsage, ContextUsage, FileChangeKind, HunkProposal,
     KNOWN_TYPE_TAGS, MODEL_CALL_FAILED_PREFIX, ManifestEntry, MediaArtifactRef, MediaJobState,
     MediaKind, ModelCallRole, PolicyKind, PrStatus, ProofStep, ProposedHunk, ProviderShare,
-    ScopeProposal, StageKind, StageScope, TaskItem, TaskStatus, UNKNOWN_MODEL,
+    ScopeProposal, StageKind, StageScope, SteerCause, TaskItem, TaskStatus, UNKNOWN_MODEL,
     UsageIncompleteReason, VerdictEvidence,
 };
 // The *open* stage vocabulary (`doc:roleless-core`). `StageKind` above stays

--- a/crates/stella-protocol/tests/wire_contract.rs
+++ b/crates/stella-protocol/tests/wire_contract.rs
@@ -470,6 +470,7 @@ fn every_nested_vocabulary_is_fully_sampled() {
         ("BudgetScope", all_budget_scopes().len()),
         ("PolicyKind", all_policy_kinds().len()),
         ("ModelCallRole", all_model_call_roles().len()),
+        ("SteerCause", all_steer_causes().len()),
         (
             "UsageIncompleteReason",
             all_usage_incomplete_reasons().len(),
@@ -524,6 +525,7 @@ fn every_nested_vocabulary_is_fully_sampled() {
         "BudgetScope",
         "PolicyKind",
         "ModelCallRole",
+        "SteerCause",
         "UsageIncompleteReason",
         "FinishReason",
         "FileChangeKind",

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -13,8 +13,8 @@ use stella_protocol::completion::FinishReason;
 use stella_protocol::delivery_event::{DeliveryDecline, DeliveryOutcome};
 use stella_protocol::event::{
     BudgetMode, BudgetScope, CiStatus, FileChangeKind, MediaJobState, MediaKind, ModelCallRole,
-    PolicyKind, PrStatus, ProofStep, ProofTree, ScopeProposal, StageKind, TaskItem, TaskStatus,
-    UsageIncompleteReason,
+    PolicyKind, PrStatus, ProofStep, ProofTree, ScopeProposal, StageKind, SteerCause, TaskItem,
+    TaskStatus, UsageIncompleteReason,
 };
 use stella_protocol::ladder::{FlipOutcome, LadderRung, LadderSnapshot, OracleObservation};
 use stella_protocol::receipt::{
@@ -308,6 +308,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
         },
         AgentEvent::Steered {
             text: "actually, use the other file".into(),
+            cause: SteerCause::User,
         },
         AgentEvent::TurnParked {
             description: "CI for branch main settles".into(),

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -63,6 +63,16 @@ pub(crate) fn all_delivery_declines() -> Vec<DeliveryDecline> {
     vec![NothingCreated, IntegrityRefusal, AdoptFailed]
 }
 
+/// Every reason a turn can be steered (#3622).
+///
+/// `Unknown` is in the list because it is the wire value a stream recorded
+/// before the field existed decodes to, so it reaches consumers exactly as the
+/// three real causes do.
+pub(crate) fn all_steer_causes() -> Vec<SteerCause> {
+    use SteerCause::*;
+    vec![Unknown, User, Loop, Stall]
+}
+
 pub(crate) fn all_policy_kinds() -> Vec<PolicyKind> {
     use PolicyKind::*;
     vec![Evaluated, Blocked, ApprovalRequested, SecretDetected]
@@ -305,10 +315,6 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
         AgentEvent::Retry {
             attempt: 1,
             reason: "429 from the provider".into(),
-        },
-        AgentEvent::Steered {
-            text: "actually, use the other file".into(),
-            cause: SteerCause::User,
         },
         AgentEvent::TurnParked {
             description: "CI for branch main settles".into(),
@@ -762,6 +768,14 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
             delivery: DeliveryOutcome::Declined { reason },
         }
     }));
+    events.extend(
+        all_steer_causes()
+            .into_iter()
+            .map(|cause| AgentEvent::Steered {
+                text: "actually, use the other file".into(),
+                cause,
+            }),
+    );
     events.extend(
         all_policy_kinds()
             .into_iter()

--- a/crates/stella-serve/src/observe/tally.rs
+++ b/crates/stella-serve/src/observe/tally.rs
@@ -214,6 +214,7 @@ mod tests {
         });
         fold.observe(&AgentEvent::Steered {
             text: "secret".to_string(),
+            cause: stella_protocol::SteerCause::User,
         });
         assert_eq!(fold.finish(), TurnTally::default());
     }

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -103,7 +103,11 @@ async fn main() -> std::io::Result<()> {
                     for text in texts {
                         let _ = react_tx.send(Inbound::Event {
                             agent: agent.clone(),
-                            event: stella_protocol::AgentEvent::Steered { text },
+                            event: stella_protocol::AgentEvent::Steered {
+                                text,
+                                // The demo shell's `>` steer is a person's.
+                                cause: stella_protocol::SteerCause::User,
+                            },
                         });
                     }
                 }

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -801,10 +801,12 @@ impl WorkspaceModel {
     /// the one that left. Oldest match first, so two identical steers claim
     /// two rows rather than one row twice.
     ///
-    /// No match is the ordinary case, not a failure: `Steered` is also how the
-    /// engine narrates its OWN injections — the loop-escalation nudge — which
-    /// were never in anyone's queue and must leave the backlog untouched. That
-    /// is the same guard `PromptStarted` applies to a driver-side prompt.
+    /// No match is still an ordinary outcome, not a failure — a `>` steer the
+    /// deck did not originate leaves the backlog untouched. What no longer
+    /// reaches here at all is the engine narrating its OWN injections: the
+    /// loop and stall rungs were never in anyone's queue, and the caller now
+    /// filters them on [`stella_protocol::SteerCause`] rather than relying on
+    /// their text failing to match (#3622).
     fn claim_steered(&mut self, text: &str) {
         let steered = text.trim();
         let position = self.queue.items.iter().position(|queued| {
@@ -842,7 +844,9 @@ impl WorkspaceModel {
         // queue mirror of it, and the row would sit there as "waiting"
         // forever while the words it holds were long since delivered. This
         // ack is the only signal that says they were.
-        if let AgentEvent::Steered { text } = event {
+        if let AgentEvent::Steered { text, cause } = event
+            && cause.is_from_a_person()
+        {
             self.claim_steered(text);
         }
 

--- a/crates/stella-tui/src/deck/classify.rs
+++ b/crates/stella-tui/src/deck/classify.rs
@@ -287,7 +287,7 @@ pub(super) fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
             (TraceKind::Other, format!("fallback {from}→{to}"))
         }
         AgentEvent::Retry { attempt, .. } => (TraceKind::Other, format!("retry #{attempt}")),
-        AgentEvent::Steered { text } => (
+        AgentEvent::Steered { text, .. } => (
             TraceKind::Other,
             format!("steer: {}", text.chars().take(40).collect::<String>()),
         ),

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use stella_protocol::{StageKind, ToolCall, ToolOutput};
+use stella_protocol::{StageKind, SteerCause, ToolCall, ToolOutput};
 
 fn reg(id: &str) -> Inbound {
     Inbound::Register(AgentMeta::new(id, format!("goal for {id}"), 0))
@@ -696,6 +696,7 @@ fn a_steered_ack_claims_the_prompt_that_carried_it() {
         "lead",
         AgentEvent::Steered {
             text: "fix the tests".into(),
+            cause: SteerCause::User,
         },
     ));
     assert_eq!(w.queue.pending(), 2, "the steer's own row is gone");
@@ -721,9 +722,37 @@ fn an_engine_authored_steer_never_claims_someone_elses_prompt() {
         "lead",
         AgentEvent::Steered {
             text: "you have repeated the same tool call three times".into(),
+            cause: SteerCause::Loop,
         },
     ));
     assert_eq!(w.queue.pending(), 1);
+}
+
+/// …and it is the **cause** that says so, not a lucky text mismatch.
+///
+/// `an_engine_authored_steer_never_claims_someone_elses_prompt` above passes
+/// on either code, because the nudge's prose happens not to match the queued
+/// row. This is the same shape with the coincidence removed: an engine steer
+/// whose text is byte-identical to a waiting prompt. Before the cause was on
+/// the wire (#3622) the deck had nothing else to read, so it dropped the
+/// user's still-waiting row and told them it had been delivered.
+#[test]
+fn a_loop_steer_never_claims_a_prompt_whose_text_it_matches() {
+    let mut w = WorkspaceModel::new();
+    w.apply_inbound(&reg("lead"));
+    w.queue.enqueue("> retry the build".into(), 1);
+    w.apply_inbound(&ev(
+        "lead",
+        AgentEvent::Steered {
+            text: "retry the build".into(),
+            cause: SteerCause::Loop,
+        },
+    ));
+    assert_eq!(
+        w.queue.pending(),
+        1,
+        "the engine's own nudge consumed a prompt the user is still waiting on"
+    );
 }
 
 /// Two identical steers are two prompts the user typed twice, so the first
@@ -739,6 +768,7 @@ fn identical_steers_claim_one_row_each() {
         "lead",
         AgentEvent::Steered {
             text: "again".into(),
+            cause: SteerCause::User,
         },
     );
     w.apply_inbound(&ack);

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -392,6 +392,11 @@ impl SessionModel {
                         // call back-fills it — see `TurnOpening::model`.
                         model: None,
                         budget_usd: self.hud.limit_usd,
+                        // Same shape, same reason: a steer is consumed mid-turn,
+                        // after this rule is drawn. The turn's own first
+                        // `SteerCause::User` steer back-fills it — see
+                        // `TurnOpening::queued_steer`.
+                        queued_steer: None,
                     })
                 };
                 self.transcript.push(TranscriptEntry::Stage {
@@ -594,12 +599,18 @@ impl SessionModel {
                     reason: reason.clone(),
                 });
             }
-            AgentEvent::Steered { text } => {
+            AgentEvent::Steered { text, cause } => {
                 // A steered message IS a user message — it entered the
                 // conversation mid-turn; the prefix is what tells the
                 // reader (and a replay) it landed at a step boundary.
                 self.transcript
                     .push(TranscriptEntry::User(format!("(steered mid-turn) {text}")));
+                // …and only a person's steer is the payoff SPEC 6.1's rule
+                // promises. The engine's loop and stall nudges keep their row
+                // and get no label (#4185).
+                if cause.is_from_a_person() {
+                    self.name_the_open_turns_steer(text);
+                }
             }
             AgentEvent::TurnParked {
                 description,
@@ -1262,6 +1273,33 @@ impl SessionModel {
             && opening.model.is_none()
         {
             opening.model = Some(model.to_owned());
+        }
+    }
+
+    /// Name the steer a person made on the opening rule of the turn now in
+    /// flight, if that rule has not been given one yet.
+    ///
+    /// The same walk as [`Self::name_the_open_turns_model`], and for the same
+    /// reason: the nearest stage boundary that opened a turn, stop there
+    /// whether or not it fills anything. That single stop is what makes this
+    /// first-write-wins per turn — an earlier turn's rule is settled and a
+    /// second steer in this turn does not rewrite what the turn opened by
+    /// consuming.
+    ///
+    /// A turn whose rule was never stamped simply finds nothing, and the steer
+    /// keeps the `(steered mid-turn)` transcript row it always had.
+    fn name_the_open_turns_steer(&mut self, text: &str) {
+        if let Some(TranscriptEntry::Stage {
+            opens: Some(opening),
+            ..
+        }) = self
+            .transcript
+            .iter_mut()
+            .rev()
+            .find(|e| matches!(e, TranscriptEntry::Stage { opens: Some(_), .. }))
+            && opening.queued_steer.is_none()
+        {
+            opening.queued_steer = Some(text.to_owned());
         }
     }
 

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -15,6 +15,12 @@
 
 use stella_protocol::{BudgetMode, ModelCallRole, StageKind, StageName};
 
+// Doc-link target only: named in `TurnOpening::queued_steer`'s docs, gated by
+// the fold in `super`. `cfg(doc)` keeps the intra-doc link resolving without
+// an import a normal build would flag as unused.
+#[cfg(doc)]
+use stella_protocol::SteerCause;
+
 /// Whether one model call is the one **answering the turn**, and so may supply
 /// the model name on SPEC 6.1's opening rule.
 ///
@@ -109,6 +115,30 @@ pub struct TurnOpening {
     /// same reason: a rule printing `budget $0.00` over an uncapped run would
     /// state a cap nobody set.
     pub budget_usd: Option<f64>,
+    /// The steer **a person** made mid-turn that this turn consumed (SPEC
+    /// 6.1's `queued:` label).
+    ///
+    /// The composer promises `⏎ queue (never blocks)`, and a queue that never
+    /// blocks needs a visible payoff — the moment what you typed mid-turn
+    /// actually got picked up. That is what this names (#4185).
+    ///
+    /// Back-filled by the turn's own first
+    /// [`stella_protocol::AgentEvent::Steered`] whose
+    /// [`SteerCause::is_from_a_person`] holds, exactly as [`Self::model`] is
+    /// back-filled by the turn's first worker call (#4183) — a steer is
+    /// consumed *after* the rule is drawn, so the field opens as `None` and
+    /// the deck's settled-prefix fold re-renders the rule when it arrives.
+    /// First write wins, for the same reason: a second steer does not rewrite
+    /// what the turn opened by consuming.
+    ///
+    /// The [`SteerCause`] gate is the whole point of the field's existence.
+    /// The engine's loop and stall rungs emit the same event, and a rule that
+    /// labelled a stall-rung auto-steer as something the user queued would be
+    /// worse than the blank it replaces — which is why this label sat unfed
+    /// until the cause was on the wire (#3622). A legacy event decoding as
+    /// [`SteerCause::Unknown`] keeps the blank, which is honest rather than a
+    /// guess.
+    pub queued_steer: Option<String>,
 }
 
 /// What SPEC 6.1's receipt says, stamped onto the entry that closes a turn.

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -258,6 +258,7 @@ fn v2_rows(
                 stage_label(name),
                 opening.model.as_deref(),
                 opening.budget_usd,
+                opening.queued_steer.as_deref(),
                 width,
             ));
             true

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -21,7 +21,7 @@ use ratatui::layout::Rect;
 use ratatui::text::Line;
 use stella_protocol::{
     AgentEvent, BudgetMode, CiStatus, FileChangeKind, MediaJobState, MediaKind, PrStatus,
-    StageKind, SubAgentStatus,
+    StageKind, SteerCause, SubAgentStatus,
 };
 
 mod block_rail;
@@ -600,6 +600,7 @@ fn a_turn_opens_on_a_labelled_rule() {
             turn: 4,
             model: Some("kimi-k3".into()),
             budget_usd: Some(0.60),
+            queued_steer: None,
         }),
     };
     let text = recall_text(&entry, false, 100);
@@ -634,6 +635,7 @@ fn an_opening_rule_names_no_model_or_budget_it_was_never_told() {
                 turn: 1,
                 model: None,
                 budget_usd: None,
+                queued_steer: None,
             }),
         },
         false,
@@ -1257,4 +1259,99 @@ fn an_unmeasured_recall_latency_is_omitted_not_printed_as_zero() {
     *latency_ms = 0;
     let text = recall_text(&entry, false, 100);
     assert!(!text.contains("0ms"), "{text}");
+}
+
+/// Fold a turn that opens and is then steered, and hand back what the opening
+/// rule renders on the live path — `SessionModel::apply` → `entry_lines`, not
+/// a hand-built [`crate::model::TurnOpening`].
+///
+/// The renderer half has been covered since #4123
+/// (`v2::transcript::tests::a_consumed_steer_is_named_on_the_turn_rule`); what
+/// was missing, and what the two tests below are, is the producer.
+fn opening_rule_of_a_steered_turn(cause: SteerCause) -> String {
+    let mut model = SessionModel::new();
+    model.apply(&AgentEvent::Stage {
+        name: StageKind::Execute.into(),
+        scope: stella_protocol::StageScope::Run,
+    });
+    model.apply(&AgentEvent::Steered {
+        text: "also fix the flake".into(),
+        cause,
+    });
+    let entry = model
+        .transcript
+        .iter()
+        .find(|e| matches!(e, TranscriptEntry::Stage { opens: Some(_), .. }))
+        .expect("the turn opened on a rule");
+    recall_text(entry, false, 120)
+}
+
+/// SPEC 6.1: the steer a turn consumed is named on that turn's opening rule.
+///
+/// This is the payoff the composer's `⏎ queue (never blocks)` promises, and it
+/// is the witness for #4185. Before it, `turn_begin_rows` passed
+/// `queued_steer: None` unconditionally — the renderer worked and nothing on
+/// the live path could ever reach it, so the label was a field with no
+/// producer.
+///
+/// Back-filled after the rule is drawn, exactly as `TurnOpening::model` is
+/// (#4183): a steer lands mid-turn, so there is nothing to stamp at the
+/// boundary.
+#[test]
+fn a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it() {
+    let text = opening_rule_of_a_steered_turn(SteerCause::User);
+    assert!(
+        text.contains("queued: \"also fix the flake\""),
+        "the rule did not name the steer this turn consumed:\n{text}"
+    );
+}
+
+/// …and **only** a person's steer.
+///
+/// The engine's two automatic rungs emit the same `AgentEvent::Steered`, and a
+/// rule labelling a stall-rung auto-steer as something the user queued would be
+/// worse than the blank it replaces — which is exactly why #4185 sat blocked on
+/// #3622 rather than guessing.
+///
+/// `Unknown` is in the sweep for the same reason: a session recorded before the
+/// cause existed must keep its blank rather than be attributed to a person.
+///
+/// This is the half that would pass trivially against a fix that never fed the
+/// label at all, so it is evidence only when read beside its twin above.
+#[test]
+fn an_engine_authored_steer_leaves_the_turn_rule_blank() {
+    for cause in [SteerCause::Loop, SteerCause::Stall, SteerCause::Unknown] {
+        let text = opening_rule_of_a_steered_turn(cause);
+        assert!(
+            !text.contains("queued:"),
+            "{cause:?} is not the user speaking, and the rule said it was:\n{text}"
+        );
+    }
+}
+
+/// The steer keeps its own `(steered mid-turn)` transcript row either way.
+///
+/// The rule says what the turn opened by consuming; the row says when it
+/// landed. Dropping the row in favour of the label would lose the position,
+/// and the two rungs that get no label would lose their record entirely.
+#[test]
+fn a_steer_keeps_its_own_row_whatever_its_cause() {
+    for cause in [SteerCause::User, SteerCause::Loop] {
+        let mut model = SessionModel::new();
+        model.apply(&AgentEvent::Stage {
+            name: StageKind::Execute.into(),
+            scope: stella_protocol::StageScope::Run,
+        });
+        model.apply(&AgentEvent::Steered {
+            text: "also fix the flake".into(),
+            cause,
+        });
+        assert!(
+            model.transcript.iter().any(|e| matches!(
+                e,
+                TranscriptEntry::User(t) if t.starts_with("(steered mid-turn)")
+            )),
+            "{cause:?} lost its transcript row"
+        );
+    }
 }

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -638,7 +638,7 @@ pub fn event_line(event: &AgentEvent) -> Option<EventLine> {
         AgentEvent::Unknown { event_type, .. } => Some(unknown_event(event_type)),
         AgentEvent::SubAgent { phase } => Some(sub_agent(phase)),
         AgentEvent::Retry { attempt, reason } => Some(retry(*attempt, reason)),
-        AgentEvent::Steered { text } => Some(steered(text)),
+        AgentEvent::Steered { text, .. } => Some(steered(text)),
         AgentEvent::TurnParked {
             description,
             poll_interval_secs,

--- a/crates/stella-tui/src/v2/transcript_source.rs
+++ b/crates/stella-tui/src/v2/transcript_source.rs
@@ -236,19 +236,26 @@ fn first_line(text: &str) -> &str {
 /// [`crate::model::TurnOpening`] for why a wrapped run's four inner stages do
 /// not each announce the same turn number.
 ///
-/// `queued_steer` is deliberately never fed here. A steer that landed is
-/// already its own transcript row ([`crate::TranscriptEntry::User`], prefixed
-/// `(steered mid-turn)`), so naming it a second time on the rule above it would
-/// report one interruption twice; and a steer *queued before* the turn opened
-/// arrives as an ordinary prompt, which the deck cannot tell apart from any
-/// other. The label stays unfed rather than fed something that is not it
-/// (#4185).
+/// `queued_steer` names the mid-turn steer **a person** made that this turn
+/// consumed — the visible payoff the composer's `⏎ queue (never blocks)`
+/// promises. It is back-filled onto [`crate::model::TurnOpening`] by the fold,
+/// gated on [`stella_protocol::SteerCause::is_from_a_person`], so the engine's
+/// own loop and stall nudges never reach it: a rule labelling a stall-rung
+/// auto-steer as something the user queued would be worse than the blank it
+/// replaces, which is why this stayed unfed until the cause was on the wire
+/// (#4185, #3622).
+///
+/// The steer also keeps its own `(steered mid-turn)` transcript row
+/// ([`crate::TranscriptEntry::User`]). The two are not one fact said twice:
+/// the row is *when* it landed, the rule is *what this turn opened by
+/// consuming* — the same relationship `model` has with the closing receipt.
 #[must_use]
 pub fn turn_begin_rows(
     turn: u32,
     stage: &str,
     model: Option<&str>,
     budget_usd: Option<f64>,
+    queued_steer: Option<&str>,
     width: usize,
 ) -> Vec<Line<'static>> {
     vec![turn_begin(
@@ -257,7 +264,7 @@ pub fn turn_begin_rows(
             stage: stage.to_string(),
             model: model.map(str::to_string),
             budget_usd,
-            queued_steer: None,
+            queued_steer: queued_steer.map(str::to_string),
         },
         width,
     )]

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1047,6 +1047,23 @@ export type StageName = string;
 export type StageScope = "turn" | "run";
 
 /**
+ * What put the message into the turn, for [`AgentEvent::Steered`].
+ *
+ * Three different things emit that event and they are different pathologies
+ * with different remedies: a person interrupting, the stuck-loop rung, and
+ * the stalled-turn rung (#2022). Before this field the only way to tell them
+ * apart was to match the English prose — and `STALL_STEER_PREFIX` *extends*
+ * `LOOP_STEER_PREFIX`, so even the prefix test was a substring test on a
+ * sentence (#3622). That is precisely the practice
+ * [`AgentEvent::LoopDetected`] was introduced to end for the loop rung.
+ *
+ * The consequence was that "the turn was steered" was one bucket, so no
+ * consumer could answer *how often does the stall rung actually fire* — the
+ * question that decides whether the rung earns its keep.
+ */
+export type SteerCause = "unknown" | "user" | "loop" | "stall";
+
+/**
  * One point in a sub-agent's lifecycle. Exactly one `Started` and exactly
  * one `Finished` are emitted per spawn, in that order, even when the child
  * is refused before its first model call (a refusal still brackets, so a
@@ -1384,6 +1401,13 @@ export type AgentEvent = {
   ts?: number;
   type: "retry";
 } | {
+  /**
+   * Who or what steered. `serde(default)` so streams recorded before
+   * this field parse — as [`SteerCause::Unknown`], never as
+   * [`SteerCause::User`], which would relabel the whole recorded
+   * history as human input.
+   */
+  cause?: SteerCause;
   text: string;
   /**
    * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1684,6 +1684,31 @@
         }
       ]
     },
+    "SteerCause": {
+      "description": "What put the message into the turn, for [`AgentEvent::Steered`].\n\nThree different things emit that event and they are different pathologies\nwith different remedies: a person interrupting, the stuck-loop rung, and\nthe stalled-turn rung (#2022). Before this field the only way to tell them\napart was to match the English prose — and `STALL_STEER_PREFIX` *extends*\n`LOOP_STEER_PREFIX`, so even the prefix test was a substring test on a\nsentence (#3622). That is precisely the practice\n[`AgentEvent::LoopDetected`] was introduced to end for the loop rung.\n\nThe consequence was that \"the turn was steered\" was one bucket, so no\nconsumer could answer *how often does the stall rung actually fire* — the\nquestion that decides whether the rung earns its keep.",
+      "oneOf": [
+        {
+          "const": "unknown",
+          "description": "Not recorded: an event written before this field existed. The default for an absent `cause` only — never `user`, which would relabel a whole recorded history as human input.",
+          "type": "string"
+        },
+        {
+          "const": "user",
+          "description": "A person's mid-turn message, drained from\n`stella_core::ports::TurnSteering` at a step boundary.",
+          "type": "string"
+        },
+        {
+          "const": "loop",
+          "description": "The stuck-loop rung's nudge, following a `LoopVerdict`. Paired with an\n[`AgentEvent::LoopDetected`] carrying the same evidence.",
+          "type": "string"
+        },
+        {
+          "const": "stall",
+          "description": "The stalled-turn rung's nudge (#2022): no loop, but the turn has spent\ntoo long waiting. Has no typed twin, which is why it was\nindistinguishable from [`Self::Loop`] on the wire.",
+          "type": "string"
+        }
+      ]
+    },
     "SubAgentPhase": {
       "description": "One point in a sub-agent's lifecycle. Exactly one `Started` and exactly\none `Finished` are emitted per spawn, in that order, even when the child\nis refused before its first model call (a refusal still brackets, so a\nconsumer folding these never sees an unclosed child).",
       "oneOf": [
@@ -2285,8 +2310,13 @@
       "type": "object"
     },
     {
-      "description": "A user message queued mid-turn was injected at a step boundary\n(`stella-core` steering) — the transcript's record that the model\nwas steered, and when.",
+      "description": "A message was injected into the turn at a step boundary — the\ntranscript's record that the model was steered, and when.\n\nThree rungs emit this and `cause` is what tells them apart: a person's\nmid-turn message, the stuck-loop nudge, and the stalled-turn nudge.\nBefore it, a consumer could only match the English prose (#3622).",
       "properties": {
+        "cause": {
+          "$ref": "#/$defs/SteerCause",
+          "default": "unknown",
+          "description": "Who or what steered. `serde(default)` so streams recorded before\nthis field parse — as [`SteerCause::Unknown`], never as\n[`SteerCause::User`], which would relabel the whole recorded\nhistory as human input."
+        },
         "text": {
           "type": "string"
         },

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -68,6 +68,13 @@ export type AgentEvent = {
   reason: string;
   type: "retry";
 } | {
+  /**
+   * Who or what steered. `serde(default)` so streams recorded before
+   * this field parse — as [`SteerCause::Unknown`], never as
+   * [`SteerCause::User`], which would relabel the whole recorded
+   * history as human input.
+   */
+  cause?: SteerCause;
   text: string;
   type: "steered";
 } | {
@@ -1847,6 +1854,23 @@ export type StageName = string;
  * rather than guessing wrong.
  */
 export type StageScope = "turn" | "run";
+
+/**
+ * What put the message into the turn, for [`AgentEvent::Steered`].
+ *
+ * Three different things emit that event and they are different pathologies
+ * with different remedies: a person interrupting, the stuck-loop rung, and
+ * the stalled-turn rung (#2022). Before this field the only way to tell them
+ * apart was to match the English prose — and `STALL_STEER_PREFIX` *extends*
+ * `LOOP_STEER_PREFIX`, so even the prefix test was a substring test on a
+ * sentence (#3622). That is precisely the practice
+ * [`AgentEvent::LoopDetected`] was introduced to end for the loop rung.
+ *
+ * The consequence was that "the turn was steered" was one bucket, so no
+ * consumer could answer *how often does the stall rung actually fire* — the
+ * question that decides whether the rung earns its keep.
+ */
+export type SteerCause = "unknown" | "user" | "loop" | "stall";
 
 /**
  * One point in a sub-agent's lifecycle. Exactly one `Started` and exactly

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -175,8 +175,13 @@
           "type": "object"
         },
         {
-          "description": "A user message queued mid-turn was injected at a step boundary\n(`stella-core` steering) — the transcript's record that the model\nwas steered, and when.",
+          "description": "A message was injected into the turn at a step boundary — the\ntranscript's record that the model was steered, and when.\n\nThree rungs emit this and `cause` is what tells them apart: a person's\nmid-turn message, the stuck-loop nudge, and the stalled-turn nudge.\nBefore it, a consumer could only match the English prose (#3622).",
           "properties": {
+            "cause": {
+              "$ref": "#/$defs/SteerCause",
+              "default": "unknown",
+              "description": "Who or what steered. `serde(default)` so streams recorded before\nthis field parse — as [`SteerCause::Unknown`], never as\n[`SteerCause::User`], which would relabel the whole recorded\nhistory as human input."
+            },
             "text": {
               "type": "string"
             },
@@ -3414,6 +3419,31 @@
         {
           "const": "run",
           "description": "A wrapper's stages over the whole run: triage, plan, witness, verify.",
+          "type": "string"
+        }
+      ]
+    },
+    "SteerCause": {
+      "description": "What put the message into the turn, for [`AgentEvent::Steered`].\n\nThree different things emit that event and they are different pathologies\nwith different remedies: a person interrupting, the stuck-loop rung, and\nthe stalled-turn rung (#2022). Before this field the only way to tell them\napart was to match the English prose — and `STALL_STEER_PREFIX` *extends*\n`LOOP_STEER_PREFIX`, so even the prefix test was a substring test on a\nsentence (#3622). That is precisely the practice\n[`AgentEvent::LoopDetected`] was introduced to end for the loop rung.\n\nThe consequence was that \"the turn was steered\" was one bucket, so no\nconsumer could answer *how often does the stall rung actually fire* — the\nquestion that decides whether the rung earns its keep.",
+      "oneOf": [
+        {
+          "const": "unknown",
+          "description": "Not recorded: an event written before this field existed. The default for an absent `cause` only — never `user`, which would relabel a whole recorded history as human input.",
+          "type": "string"
+        },
+        {
+          "const": "user",
+          "description": "A person's mid-turn message, drained from\n`stella_core::ports::TurnSteering` at a step boundary.",
+          "type": "string"
+        },
+        {
+          "const": "loop",
+          "description": "The stuck-loop rung's nudge, following a `LoopVerdict`. Paired with an\n[`AgentEvent::LoopDetected`] carrying the same evidence.",
+          "type": "string"
+        },
+        {
+          "const": "stall",
+          "description": "The stalled-turn rung's nudge (#2022): no loop, but the turn has spent\ntoo long waiting. Has no typed twin, which is why it was\nindistinguishable from [`Self::Loop`] on the wire.",
           "type": "string"
         }
       ]


### PR DESCRIPTION
Closes #3622
Closes #4185

## Why these are one PR

#3622's definition of done was extended by the owner on 2026-08-22 to require
that **the `User` arm has a producer**: a `cause` field with no site emitting
`SteerCause::User` is a declared-but-inert value, the shape invariant #10 exists
to prevent — and #4185 cannot proceed on an arm nothing sets. So the wire field,
its producer, and the label that consumes it are one change. Splitting them
would land either an inert enum arm or a rule fed by a value nothing writes.

## Part 1 — the wire (#3622)

`AgentEvent::Steered { text }` became `Steered { text, cause }`, with
`SteerCause::{Unknown, User, Loop, Stall}` in a new
`crates/stella-protocol/src/event/steer_cause.rs`. Sibling module rather than a
line in `event.rs`, following `event/call_role.rs`'s own precedent (its module
doc gives the reason: the parent is a god file under the size ratchet, and a
vocabulary belongs beside its own enumeration).

**Shape 1, not the typed twin** — the owner's decision, taken as settled. No new
`AgentEvent` variant means invariant #10's `E0004` never fires; and a typed twin
would distinguish loop from stall while still saying nothing about *user*, which
is the discriminator #4185 needs.

**The default.** `Unknown` is `#[default]`, matching `ModelCallRole::Unknown`'s
precedent for exactly this situation. `User` is emphatically not: every `Steered`
in the recorded history came from one of the two automatic rungs, so a `User`
default would relabel all of it as human input.

I could **not** check the three-value alternative against the store, and say so
rather than assert the shape it would have justified: this machine's
`.stella/private/store.db` returns `Error: stepping, database disk image is
malformed (11)` on `select count(*) from events where event_type='steered'`.
That is a reason to prefer the option that needs no census, which is the one
that shipped — not evidence about what the history contains.

Emit sites, all three:

| site | cause |
|---|---|
| `driver/loop_escalation.rs` `check_loop_detection` (`steer_text`) | `Loop` |
| `driver/loop_escalation.rs` `steer_stalled_turn` (`stall_steer_text`) | `Stall` |
| `driver/step_boundary.rs` `consult_hosts` (`TurnSteering::drain_steering`) | `User` |

`loop_escalation.rs` went 1461 → 1472 lines against its 1500 ceiling and
**gained no baseline entry**; the whole diff there is two struct literals and one
strengthened assertion.

All four arms are sampled in `tests/wire_contract/samples.rs` via a new
`all_steer_causes()`, with the matching rows in
`every_nested_vocabulary_is_fully_sampled`'s count table and its staleness set.
Worth naming how that was found, because it is the failure mode this repo keeps
writing down: a scoped `cargo test -p stella-protocol` ran **green** before the
schema was regenerated — the arm-coverage test reads the *committed* schema, so
at that moment it was asking a question `SteerCause` was not yet part of. The
full-workspace run after regeneration is what failed
(`SteerCause: Value("loop")`, `Value("stall")` never serialized by any sample).
The green was real and answered an adjacent question.

`docs/wire/` regenerated with `bash scripts/export-agentevent-schema.sh`. The
change is additive — `cause?: SteerCause` optional in `agentevent.d.ts` /
`serveframe.d.ts` — so no consumer of `--output-format stream-json` or the SSE
stream breaks. `wire-schema` first rejected the artifact for publishing a Rust
path (`super::ModelCallRole::Unknown`, which schemars copies verbatim into
`description`); fixed the way the guard's own message prescribes, with a
`schemars(description = ...)` written for the wire reader, keeping the intra-doc
link for the Rust one.

### `ConsumerPosture`: verified, not assumed

Checked rather than taken on faith. `event/tags.rs` keys the ledger by **wire
tag**, and no tag was added — `Steered => "steered"` keeps its existing
`ConsumerPosture::Unclassified { issue: "#2703" }` row, `MAX_UNCLASSIFIED` is
untouched, and nothing recompiles into an `E0004`. Its posture is left alone
deliberately: reclassifying `Steered` is #2703's audit, and `Steered` already had
surfaces before this PR while sitting in that backlog.

### `receipts.rs` — named in the issue, deliberately not changed

`user_block_kind` takes `&str` content off a `CompletionMessage`, which carries
`role` and `content` and nothing else. The cause is on the event stream, which
the receipt builder never sees, so "read the field" there is a wire decision
about the model-facing message type, not a one-line change — and both rungs file
as the same `BlockKind::Steered` either way, so nothing is misattributed today.
Filed as **#4323** with the three candidate shapes written out, rather than left
as an omission.

## Part 2 — the producer and the label (#4185)

`TurnOpening` gains `queued_steer: Option<String>`, back-filled by
`SessionModel::name_the_open_turns_steer` — the same walk
`name_the_open_turns_model` does for #4183's `model` field: nearest stage
boundary that opened a turn, stop there whether or not it fills anything, which
is what makes it first-write-wins per turn. A steer is consumed *after* the rule
is drawn, so this is exactly the mechanism the owner pointed at, not a second one
invented for it.

`turn_begin_rows` stops hardcoding `queued_steer: None` and takes the value;
`render/entry.rs` passes `opening.queued_steer.as_deref()`. The fold gates on
`cause.is_from_a_person()`, so `Loop`, `Stall` and `Unknown` all leave the label
blank.

The deck's `claim_steered` now gates on the same predicate. It previously relied
on an engine nudge's prose failing to match a queued row — true in practice,
guaranteed by nothing.

**One judgement call, stated out loud.** The `(steered mid-turn)` transcript row
is kept for every cause, so a user steer appears on the rule *and* as its own
row. #4185's body offers deleting one of them as "two renderings of one event",
under the reading "any steer this turn consumed". Under the reading the owner
settled — *a steer a person made* — the two say different things: the row is
**when** it landed, the rule is **what this turn opened by consuming**. Deleting
the row would also have to keep it for the two rungs that get no label, which is
an inconsistency worse than the redundancy. `a_steer_keeps_its_own_row_whatever_its_cause`
pins the choice so a later change to it is deliberate.

## Witnesses, and the disarm that proves each one

Nine tests; the two #4185 ones are complementary and were disarmed in **opposite**
directions, as the issue requires.

| test | crate |
|---|---|
| `render::tests::a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it` | stella-tui |
| `render::tests::an_engine_authored_steer_leaves_the_turn_rule_blank` | stella-tui |
| `render::tests::a_steer_keeps_its_own_row_whatever_its_cause` | stella-tui |
| `deck::tests::a_loop_steer_never_claims_a_prompt_whose_text_it_matches` | stella-tui |
| `event::tests::a_steer_names_its_cause_on_the_wire` | stella-protocol |
| `event::tests::a_steer_recorded_before_the_cause_existed_is_not_called_the_user` | stella-protocol |
| `driver::tests::loop_abort::a_stuck_loop_steer_names_the_loop_rung_as_its_cause` | stella-core |
| `driver::tests::steered_messages_inject_before_the_next_model_call` (strengthened) | stella-core |
| `driver::loop_escalation::tests::stall::a_turn_that_sleeps_away_its_budget_is_steered_though_no_loop_fires` (strengthened) | stella-core |

### Disarm 1 — `turn_begin_rows` drops the label again (the #4124 status quo)

`queued_steer: queued_steer.map(str::to_string)` → `queued_steer: None`

```
running 2 tests
test render::tests::an_engine_authored_steer_leaves_the_turn_rule_blank ... ok
test render::tests::a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it ... FAILED

---- render::tests::a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it stdout ----
thread 'render::tests::a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it' panicked at crates/stella-tui/src/render/tests.rs:1303:5:
the rule did not name the steer this turn consumed:
── turn 1 execute ──────────────────────────────────────────────────────────────────────────────────────────────────────

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 983 filtered out
```

Note which one held: the negative twin passes here. That is why it is not
evidence on its own.

### Disarm 2 — the `SteerCause` gate removed (the fix over-reaching)

`if cause.is_from_a_person() {` → `if true {`

```
running 3 tests
test deck::tests::a_loop_steer_never_claims_a_prompt_whose_text_it_matches ... ok
test render::tests::a_user_steer_is_named_on_the_rule_of_the_turn_that_consumed_it ... ok
test render::tests::an_engine_authored_steer_leaves_the_turn_rule_blank ... FAILED

---- render::tests::an_engine_authored_steer_leaves_the_turn_rule_blank stdout ----
thread 'render::tests::an_engine_authored_steer_leaves_the_turn_rule_blank' panicked at crates/stella-tui/src/render/tests.rs:1325:9:
Loop is not the user speaking, and the rule said it was:
── turn 1 execute · queued: "also fix the flake" ───────────────────────────────────────────────────────────────────────

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 982 filtered out
```

The two disarms fail disjoint tests in opposite directions, which is what makes
the pair evidence rather than a coincidence.

### Disarm 3 — the deck's claim gate removed

`if let AgentEvent::Steered { text, cause } = event && cause.is_from_a_person()`
→ `if let AgentEvent::Steered { text, .. } = event`

```
---- deck::tests::a_loop_steer_never_claims_a_prompt_whose_text_it_matches stdout ----
thread 'deck::tests::a_loop_steer_never_claims_a_prompt_whose_text_it_matches' panicked at crates/stella-tui/src/deck/tests.rs:751:5:
assertion `left == right` failed: the engine's own nudge consumed a prompt the user is still waiting on
  left: 0
 right: 1
```

### Disarm 4 — the serde default moved to `User`

`#[default]` moved from `Unknown` to `User`

```
---- event::tests::a_steer_recorded_before_the_cause_existed_is_not_called_the_user stdout ----
thread 'event::tests::a_steer_recorded_before_the_cause_existed_is_not_called_the_user' panicked at crates/stella-protocol/src/event/tests.rs:1293:13:
assertion `left == right` failed: missing cause must not guess
  left: User
 right: Unknown
```

### Disarm 5+6 — both core emit sites given the wrong cause

`SteerCause::Loop` → `Stall` in `loop_escalation.rs`; `SteerCause::User` →
`Unknown` in `step_boundary.rs`

```
---- driver::tests::loop_abort::a_stuck_loop_steer_names_the_loop_rung_as_its_cause stdout ----
thread '...' panicked at crates/stella-core/src/driver/tests/loop_abort.rs:708:5:
the engine's own nudge is not the user speaking: [Stall]

---- driver::tests::steered_messages_inject_before_the_next_model_call stdout ----
thread '...' panicked at crates/stella-core/src/driver/tests.rs:1004:5:
steering must be visible in the event stream: [Steered { text: "also check the tests", cause: Unknown }, BudgetTick { … }]

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1354 filtered out
```

Every disarm was reverted and the suites re-run green before this branch was
pushed.

## Goldens

`crates/stella-tui/tests/snapshots/deck/` is **unchanged** — read, not blessed,
and `deck_render_snapshots` passes as committed. No fixture folds a
`SteerCause::User` steer, so no rule in a snapshot gains a `queued:` segment.
The label's rendering is covered by
`v2::transcript::tests::a_consumed_steer_is_named_on_the_turn_rule` (which
predates this PR) and now by the live-path witnesses above.

## What I ran

```
cargo fmt --all -- --check                                    exit 0
cargo clippy -p stella-protocol -p stella-core -p stella-tui \
             -p stella-cli -p stella-serve --all-targets -- -D warnings   exit 0
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol -p stella-core \
             -p stella-tui --no-deps                          exit 0
cargo test --workspace                                        exit 0
make gate                                                     exit 0
```

No `#[allow]` was added. No file-size baseline was raised. No `TODO` without an
issue number. `deck_ui.rs` and `views/engine.rs` are untouched.

## Left behind, filed

- **#4323** — `receipts::user_block_kind` still separates the two rungs by prose
  and structurally cannot read `SteerCause`; the three candidate shapes and the
  invariant-#4/#7 constraints are written out there as a handoff.

## Summary by Sourcery

Add explicit steering attribution across the protocol and TUI so user steers are labeled accurately without misclassifying engine-generated nudges.

New Features:
- Add a typed cause to steering events, distinguishing user input from loop and stall automation while preserving compatibility with older streams.
- Display user-authored mid-turn steering on the opening rule of the turn that consumes it.
- Prevent engine-generated steering events from claiming queued user prompts.

Bug Fixes:
- Ensure legacy steering events without a cause are treated as unknown rather than incorrectly attributed to a user.
- Replace text-based identification of engine steering with explicit cause-based attribution.

Enhancements:
- Preserve the existing transcript row for every steering event while adding the user-steer rule label only when appropriate.

Documentation:
- Regenerate the TypeScript wire definitions and JSON schemas with the new optional steering cause field.

Tests:
- Expand protocol wire-contract coverage to sample every steering cause.
- Add coverage for cause serialization, legacy decoding, producer attribution, user-rule labeling, and prompt-claim behavior.