### PR TITLE
feat(stella-tui,stella-cli): a mid-turn prompt queues for the lead, and Esc steers the queue

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -299,19 +299,6 @@ impl HoldState {
     }
 }
 
-/// The persisted `ui.mid_turn_prompt` policy, or the deck's default
-/// (`queue`) when the key is absent, unreadable, or names a slug the deck does
-/// not know — chrome, never fatal, like `ui.theme`.
-fn mid_turn_prompt_policy(cfg: &Config) -> stella_tui::deck_ui::MidTurnPrompt {
-    crate::settings::Settings::load(&cfg.workspace_root)
-        .ok()
-        .and_then(|s| {
-            s.ui_mid_turn_prompt()
-                .and_then(stella_tui::deck_ui::MidTurnPrompt::parse)
-        })
-        .unwrap_or_default()
-}
-
 /// Return cancelled prompts to the FRONT of the backlog (push order:
 /// front-most last) and mirror each front-insert into the deck's queue view
 /// (`Inbound::PromptRequeued` is the exact inverse of `PromptStarted`'s
@@ -695,7 +682,7 @@ pub async fn run_deck_session(
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         no_anim,
         accessible,
-        mid_turn_prompt: mid_turn_prompt_policy(cfg),
+        mid_turn_prompt: steer::mid_turn_prompt_policy(cfg),
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering
@@ -963,10 +950,8 @@ pub async fn run_deck_session(
                     // Any submission releases a hold and runs NOW — ahead of the
                     // parked backlog. `EnqueueFront` is the deck's explicit
                     // front-insert (sent while it knows dispatch is held); a
-                    // plain `Enqueue` behaves identically here because running
-                    // the text immediately IS the front of the queue, and so
-                    // does `EnqueueNext` — at rest there is no turn to wait
-                    // behind.
+                    // plain `Enqueue` and an `EnqueueNext` behave identically
+                    // here because running the text immediately IS the front.
                     Some(WorkspaceInput::Enqueue { text })
                     | Some(WorkspaceInput::EnqueueFront { text })
                     | Some(WorkspaceInput::EnqueueNext { text })
@@ -1657,12 +1642,7 @@ pub async fn run_deck_session(
                         // if a turn started before it arrived — the deck's
                         // queue view already shows it first.
                         Some(WorkspaceInput::EnqueueFront { text }) => queue.push_front(text),
-                        // The deck's default for a plain mid-turn prompt: wait
-                        // in the backlog as the lead's next turn. Deliberately
-                        // NOT drained to a sidecar — the backlog is what an
-                        // Esc-steer delivers into this turn (`steer`), and a
-                        // prompt already running on a stranger lane cannot be
-                        // steered anywhere.
+                        // Waits its turn; never drained to a sidecar (see `steer`).
                         Some(WorkspaceInput::EnqueueNext { text }) => queue.push_back(text),
                         // The deck's queue editor mutates its own view of the
                         // backlog and mirrors each edit here so the dispatch

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -299,6 +299,19 @@ impl HoldState {
     }
 }
 
+/// The persisted `ui.mid_turn_prompt` policy, or the deck's default
+/// (`queue`) when the key is absent, unreadable, or names a slug the deck does
+/// not know — chrome, never fatal, like `ui.theme`.
+fn mid_turn_prompt_policy(cfg: &Config) -> stella_tui::deck_ui::MidTurnPrompt {
+    crate::settings::Settings::load(&cfg.workspace_root)
+        .ok()
+        .and_then(|s| {
+            s.ui_mid_turn_prompt()
+                .and_then(stella_tui::deck_ui::MidTurnPrompt::parse)
+        })
+        .unwrap_or_default()
+}
+
 /// Return cancelled prompts to the FRONT of the backlog (push order:
 /// front-most last) and mirror each front-insert into the deck's queue view
 /// (`Inbound::PromptRequeued` is the exact inverse of `PromptStarted`'s
@@ -682,6 +695,7 @@ pub async fn run_deck_session(
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
         no_anim,
         accessible,
+        mid_turn_prompt: mid_turn_prompt_policy(cfg),
         ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering
@@ -950,9 +964,12 @@ pub async fn run_deck_session(
                     // parked backlog. `EnqueueFront` is the deck's explicit
                     // front-insert (sent while it knows dispatch is held); a
                     // plain `Enqueue` behaves identically here because running
-                    // the text immediately IS the front of the queue.
+                    // the text immediately IS the front of the queue, and so
+                    // does `EnqueueNext` — at rest there is no turn to wait
+                    // behind.
                     Some(WorkspaceInput::Enqueue { text })
                     | Some(WorkspaceInput::EnqueueFront { text })
+                    | Some(WorkspaceInput::EnqueueNext { text })
                     | Some(WorkspaceInput::ToAgent {
                         input: UserInput::Prompt { text, .. },
                         ..
@@ -1640,6 +1657,13 @@ pub async fn run_deck_session(
                         // if a turn started before it arrived — the deck's
                         // queue view already shows it first.
                         Some(WorkspaceInput::EnqueueFront { text }) => queue.push_front(text),
+                        // The deck's default for a plain mid-turn prompt: wait
+                        // in the backlog as the lead's next turn. Deliberately
+                        // NOT drained to a sidecar — the backlog is what an
+                        // Esc-steer delivers into this turn (`steer`), and a
+                        // prompt already running on a stranger lane cannot be
+                        // steered anywhere.
+                        Some(WorkspaceInput::EnqueueNext { text }) => queue.push_back(text),
                         // The deck's queue editor mutates its own view of the
                         // backlog and mirrors each edit here so the dispatch
                         // queue never drifts from what the user is looking at.

--- a/crates/stella-cli/src/command_deck/settle.rs
+++ b/crates/stella-cli/src/command_deck/settle.rs
@@ -474,6 +474,50 @@ mod tests {
         );
     }
 
+    /// The deck's default mid-turn verb waits its turn: an `EnqueueNext` that
+    /// lands in the settle window parks BEHIND what is already waiting, where
+    /// `EnqueueFront` jumps ahead of it. Before the arm existed this input
+    /// was deferred out of the window and never reached the backlog at all.
+    #[tokio::test(start_paused = true)]
+    async fn enqueue_next_during_the_settle_window_waits_behind_the_backlog() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let dir = std::env::temp_dir().join(format!("stella-settle-next-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut queue = crate::session_persist::DurableQueue::fresh(dir.clone());
+        queue.push_back("already waiting".to_string());
+
+        tx.send(WorkspaceInput::EnqueueNext {
+            text: "after it".to_string(),
+        })
+        .unwrap();
+        tx.send(WorkspaceInput::EnqueueFront {
+            text: "before both".to_string(),
+        })
+        .unwrap();
+        drop(tx);
+
+        let deferred = run_while_listening(
+            tokio::time::sleep(std::time::Duration::from_secs(30)),
+            &mut rx,
+            &mut queue,
+        )
+        .await;
+
+        assert_eq!(
+            stella_store::journal::read_queue(&dir),
+            vec![
+                "before both".to_string(),
+                "already waiting".to_string(),
+                "after it".to_string(),
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            deferred.is_empty(),
+            "a queue input is serviced, not deferred"
+        );
+    }
+
     #[test]
     fn a_turn_with_no_assistant_prose_is_not_a_question() {
         assert!(!ends_with_a_question(&[user("go")]));

--- a/crates/stella-cli/src/command_deck/settle.rs
+++ b/crates/stella-cli/src/command_deck/settle.rs
@@ -131,6 +131,7 @@ where
                     }
                 }
                 Some(WorkspaceInput::EnqueueFront { text }) => queue.push_front(text),
+                Some(WorkspaceInput::EnqueueNext { text }) => queue.push_back(text),
                 Some(WorkspaceInput::QueueRemove { index }) => {
                     if index < queue.len() {
                         queue.remove(index);

--- a/crates/stella-cli/src/command_deck/steer.rs
+++ b/crates/stella-cli/src/command_deck/steer.rs
@@ -9,8 +9,22 @@
 //! whole change is `stella_tui::envelope::steering`; this file is only what
 //! the driver does with the texts once they arrive.
 
+use crate::config::Config;
 use crate::session_persist::DurableQueue;
 use crate::subsession::SteeringTap;
+
+/// The persisted `ui.mid_turn_prompt` policy, or the deck's default (`queue`)
+/// when the key is absent, unreadable, or names a slug the deck does not know
+/// — chrome, never fatal, like `ui.theme`.
+pub(super) fn mid_turn_prompt_policy(cfg: &Config) -> stella_tui::deck_ui::MidTurnPrompt {
+    crate::settings::Settings::load(&cfg.workspace_root)
+        .ok()
+        .and_then(|s| {
+            s.ui_mid_turn_prompt()
+                .and_then(stella_tui::deck_ui::MidTurnPrompt::parse)
+        })
+        .unwrap_or_default()
+}
 
 /// One leading `>` marker off a text, and nothing else.
 ///

--- a/crates/stella-cli/src/command_deck/theme_cmd.rs
+++ b/crates/stella-cli/src/command_deck/theme_cmd.rs
@@ -91,9 +91,15 @@ pub fn current_summary(cfg: &Config) -> String {
 pub fn set_theme(name: ThemeName) -> Result<String, String> {
     // Live switch first — the next frame is already this theme.
     stella_tui::theme::set_active_theme(name);
-    let ui = crate::settings::UiSettings {
-        theme: Some(name.slug().to_string()),
-    };
+    // Read-modify-write on the section, not just the file: `[ui]` also
+    // carries `mid_turn_prompt`, and a fresh struct here would erase it.
+    // An unreadable user scope falls back to a section holding only the
+    // theme — the write below then reports the same problem in its own words.
+    let mut ui = crate::settings::Settings::load_user_scope(&mut Vec::new())
+        .ok()
+        .and_then(|s| s.ui)
+        .unwrap_or_default();
+    ui.theme = Some(name.slug().to_string());
     let Some(path) = crate::settings::user_config_path() else {
         return Err(format!(
             "theme → {} for this session, but it could not be saved for next time: \

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -622,6 +622,22 @@ pub struct UiSettings {
     /// `crates/stella-tui/src/palette.rs`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<String>,
+    /// What a plain prompt typed at a running agent does: `queue` (the
+    /// default — wait as the lead's next turn, so Esc can steer the backlog
+    /// into the running turn), `ask` (raise the routing card), or `spawn`
+    /// (fork a sidecar lane, the original behaviour). Unset or unrecognised
+    /// keeps the default; the reader validates
+    /// ([`stella_tui::deck_ui::MidTurnPrompt::parse`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mid_turn_prompt: Option<String>,
+}
+
+impl UiSettings {
+    /// Whether every field is unset — the section would serialize to `{}`,
+    /// and the writers drop the key instead.
+    pub fn is_empty(&self) -> bool {
+        self.theme.is_none() && self.mid_turn_prompt.is_none()
+    }
 }
 
 impl UiSettings {
@@ -634,7 +650,7 @@ impl UiSettings {
     pub fn save_to(&self, path: &Path) -> Result<(), String> {
         if toml_config::path_is_toml(path) {
             let user_private = user_config_path().as_deref() == Some(path);
-            let value = self.theme.is_some().then_some(self);
+            let value = (!self.is_empty()).then_some(self);
             return toml_io::save_section(path, "ui", value, user_private);
         }
         private::reject_symlink(path)?;
@@ -647,7 +663,7 @@ impl UiSettings {
         let object = root
             .as_object_mut()
             .ok_or_else(|| format!("settings file {} is not a JSON object", path.display()))?;
-        if self.theme.is_none() {
+        if self.is_empty() {
             object.remove("ui");
         } else {
             let value =
@@ -732,6 +748,13 @@ impl Settings {
     /// the raw slug; validation is the reader's job ([`stella_tui::theme`]).
     pub fn ui_theme(&self) -> Option<&str> {
         self.ui.as_ref().and_then(|u| u.theme.as_deref())
+    }
+
+    /// The persisted mid-turn prompt policy slug (`ui.mid_turn_prompt`), if
+    /// any. Raw like [`Settings::ui_theme`]: the deck parses and applies its
+    /// default ([`stella_tui::deck_ui::MidTurnPrompt`]).
+    pub fn ui_mid_turn_prompt(&self) -> Option<&str> {
+        self.ui.as_ref().and_then(|u| u.mid_turn_prompt.as_deref())
     }
 
     /// The configured MCP registry URL, or the official default. Applied at the

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -117,6 +117,23 @@ impl Settings {
         Ok(loaded.settings)
     }
 
+    /// The user scope alone, unmerged — what `~/.stella/stella.toml` (or the
+    /// JSON it shadows) says and nothing else. A writer that edits one field
+    /// of a user-scope section reads through this first, so it rewrites the
+    /// section it found rather than a fresh one that drops every sibling key
+    /// (`/theme` and `ui.mid_turn_prompt` share `[ui]`).
+    pub(crate) fn load_user_scope(notices: &mut Vec<String>) -> Result<Self, String> {
+        Ok(
+            match (user_settings_path(), toml_config::user_toml_path()) {
+                (Some(json), Some(toml)) => {
+                    Self::load_scope_dual(&toml, &json, ConfigScope::User, notices)?
+                }
+                (Some(json), None) => Self::load_scope(&json)?,
+                (None, _) => Self::default(),
+            },
+        )
+    }
+
     /// The managed tier's dual read.
     ///
     /// Differs from the other two scopes in one way that matters: when
@@ -446,13 +463,7 @@ impl Settings {
 
         let mut notices: Vec<String> = Vec::new();
 
-        let user = match (user_settings_path(), toml_config::user_toml_path()) {
-            (Some(json), Some(toml)) => {
-                Self::load_scope_dual(&toml, &json, ConfigScope::User, &mut notices)?
-            }
-            (Some(json), None) => Self::load_scope(&json)?,
-            (None, _) => Self::default(),
-        };
+        let user = Self::load_user_scope(&mut notices)?;
         let (_managed_path, managed) = Self::load_managed_scope_dual(&mut notices)?;
         let project_json = project_settings_path(workspace_root);
         let project_toml = toml_config::project_toml_path(workspace_root);

--- a/crates/stella-cli/src/settings/migrate.rs
+++ b/crates/stella-cli/src/settings/migrate.rs
@@ -91,7 +91,7 @@ pub fn render(settings: &Settings, scope: ConfigScope) -> Result<String, String>
             toml_io::item_for(&settings.context_providers, "context_providers")?;
     }
     if let Some(ui) = &settings.ui
-        && ui.theme.is_some()
+        && !ui.is_empty()
     {
         doc["ui"] = toml_io::item_for(ui, "ui")?;
     }

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -409,6 +409,36 @@ fn ui_theme_save_preserves_other_keys_and_roundtrips() {
     assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
 }
 
+/// `ui.mid_turn_prompt` is read raw and written beside `theme`; a section
+/// holding only the policy is not "empty", so it is neither dropped on save
+/// nor left behind by the TOML migration's emptiness check.
+#[test]
+fn ui_mid_turn_prompt_roundtrips_and_keeps_the_section_alive_without_a_theme() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write(
+        dir.path(),
+        "settings.json",
+        r#"{"ui": {"mid_turn_prompt": "ask"}}"#,
+    );
+    let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+    assert_eq!(merged.ui_mid_turn_prompt(), Some("ask"));
+    assert_eq!(merged.ui_theme(), None);
+
+    let ui = UiSettings {
+        theme: None,
+        mid_turn_prompt: Some("spawn".to_string()),
+    };
+    assert!(!ui.is_empty());
+    ui.save_to(&path).unwrap();
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(raw["ui"]["mid_turn_prompt"], "spawn");
+    assert!(
+        raw["ui"].get("theme").is_none(),
+        "unset fields are not written"
+    );
+}
+
 /// **Witness for the shipped default.** With no settings at all — no file,
 /// no `tools` key, an empty `tools` object — every tool is on.
 #[test]

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -376,6 +376,7 @@ fn ui_theme_save_preserves_other_keys_and_roundtrips() {
     );
     let ui = UiSettings {
         theme: Some("stella-light".to_string()),
+        ..Default::default()
     };
     ui.save_to(&path).unwrap();
 

--- a/crates/stella-cli/src/settings/tests/toml.rs
+++ b/crates/stella-cli/src/settings/tests/toml.rs
@@ -969,6 +969,7 @@ fn a_migrated_file_round_trips_through_a_section_save() {
 
     let ui = UiSettings {
         theme: Some("stella-light".to_string()),
+        ..Default::default()
     };
     ui.save_to(&toml_path).unwrap();
 

--- a/crates/stella-cli/src/settings/toml_io.rs
+++ b/crates/stella-cli/src/settings/toml_io.rs
@@ -304,6 +304,7 @@ bash = "off"
 
         let ui = UiSettings {
             theme: Some("stella-light".to_string()),
+            ..Default::default()
         };
         save_section(&path, "ui", Some(&ui), false).unwrap();
 
@@ -344,6 +345,7 @@ bash = "off"
         let path = dir.path().join("nested").join("stella.toml");
         let ui = UiSettings {
             theme: Some("stella-light".to_string()),
+            ..Default::default()
         };
         save_section(&path, "ui", Some(&ui), false).unwrap();
         let after = std::fs::read_to_string(&path).unwrap();
@@ -374,6 +376,7 @@ bash = "off"
         std::fs::write(&path, "[ui\ntheme = broken").unwrap();
         let ui = UiSettings {
             theme: Some("stella-light".to_string()),
+            ..Default::default()
         };
         let err = save_section(&path, "ui", Some(&ui), false).unwrap_err();
         assert!(err.contains("invalid config file"), "{err}");

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -95,7 +95,7 @@ pub(super) const PROVIDER_FIELDS: &[&str] = &[
 const MCP_FIELDS: &[&str] = &["registry_url"];
 
 /// `ui` — [`super::UiSettings`].
-const UI_FIELDS: &[&str] = &["theme"];
+const UI_FIELDS: &[&str] = &["theme", "mid_turn_prompt"];
 
 /// `reward` — [`super::RewardSettings`]. Closed: a mistyped weight key is the
 /// exact failure this walker exists for, because the typo and the correct key

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -83,9 +83,12 @@ async fn main() -> std::io::Result<()> {
         while let Some(input) = sub_rx.recv().await {
             match input {
                 // The demo has no real dispatch queue, so a front-insert
-                // (the first submission after a double-Esc hold) starts a
-                // scripted run just like a plain enqueue.
-                WorkspaceInput::Enqueue { text } | WorkspaceInput::EnqueueFront { text } => {
+                // (the first submission after a double-Esc hold) and a
+                // wait-your-turn queue both start a scripted run just like a
+                // plain enqueue.
+                WorkspaceInput::Enqueue { text }
+                | WorkspaceInput::EnqueueFront { text }
+                | WorkspaceInput::EnqueueNext { text } => {
                     n += 1;
                     let id = format!("you:{n}");
                     let _ = react_tx.send(Inbound::Register(

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -97,6 +97,10 @@ pub struct DeckOptions {
     ///
     /// `--plain` is unaffected and stays what it is: the no-terminal path.
     pub accessible: bool,
+    /// What a plain prompt typed at a running agent does (`ui.mid_turn_prompt`):
+    /// queue for the lead so Esc can steer it (the default), raise the routing
+    /// card, or fork a sidecar. See [`crate::deck_ui::MidTurnPrompt`].
+    pub mid_turn_prompt: crate::deck_ui::MidTurnPrompt,
 }
 
 fn now_ms() -> u64 {
@@ -528,6 +532,7 @@ pub async fn run_deck(
     ui.color_mode = color_mode;
     ui.no_anim = no_anim;
     ui.accessible = opts.accessible;
+    ui.mid_turn_prompt = opts.mid_turn_prompt;
     ui.scrollback.set_live(inline);
     // A degraded accessible session must say so. The whole promise of the mode
     // is that finished messages become durable terminal output; if the inline
@@ -674,7 +679,8 @@ pub async fn run_deck(
                                 // queue is the labeled out-of-band fold of the
                                 // OUTBOUND stream; this is its one mutation site.)
                                 match &input {
-                                    WorkspaceInput::Enqueue { text } => {
+                                    WorkspaceInput::Enqueue { text }
+                                    | WorkspaceInput::EnqueueNext { text } => {
                                         model.queue.enqueue(text.clone(), model.now_ms);
                                     }
                                     // The first submission after a double-Esc

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -587,8 +587,7 @@ pub struct DeckUi {
     /// to say whether it steers the running turn, continues the thread, or
     /// forks a sidecar. See [`dispatch`].
     pub pending_dispatch: Option<PendingDispatch>,
-    /// What a plain mid-turn prompt does — queue for the lead (the default),
-    /// raise that card, or fork a sidecar. `ui.mid_turn_prompt` in settings.
+    /// What a plain mid-turn prompt does (`ui.mid_turn_prompt`); see [`dispatch`].
     pub mid_turn_prompt: MidTurnPrompt,
     pub splash: SplashState,
     /// Startup system notifications, shown as a transient dialog rather than

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -587,8 +587,9 @@ pub struct DeckUi {
     /// to say whether it steers the running turn, continues the thread, or
     /// forks a sidecar. See [`dispatch`].
     pub pending_dispatch: Option<PendingDispatch>,
-    /// Whether that card is raised at all (default: yes).
-    pub ask_before_spawn: AskBeforeSpawn,
+    /// What a plain mid-turn prompt does — queue for the lead (the default),
+    /// raise that card, or fork a sidecar. `ui.mid_turn_prompt` in settings.
+    pub mid_turn_prompt: MidTurnPrompt,
     pub splash: SplashState,
     /// Startup system notifications, shown as a transient dialog rather than
     /// as transcript rows (see [`crate::notice`]).
@@ -827,7 +828,7 @@ impl Default for DeckUi {
             issues: IssuesPanel::default(),
             composer: Composer::with_paste_threshold(crate::composer::DECK_PASTE_LINE_THRESHOLD),
             pending_dispatch: None,
-            ask_before_spawn: AskBeforeSpawn::default(),
+            mid_turn_prompt: MidTurnPrompt::default(),
             splash: SplashState::new(),
             notice: NoticeState::new(),
             index_readiness: IndexReadiness::unknown(),
@@ -1551,7 +1552,7 @@ mod steer;
 pub use gates::HunkMarks;
 mod nav;
 mod queue_editor;
-pub use dispatch::{AskBeforeSpawn, DispatchRoute, PendingDispatch};
+pub use dispatch::{DispatchRoute, MidTurnPrompt, PendingDispatch};
 pub use nav::TranscriptSearch;
 pub(crate) use nav::is_folded;
 use nav::{handle_search_key, reveal_current_match, seek_failure, toggle_fold};

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -1,17 +1,22 @@
-//! Where a prompt submitted while a turn is running should go — asked, not
-//! assumed.
+//! Where a prompt submitted while a turn is running should go.
 //!
 //! The deck used to answer this silently: any mid-turn prompt without a `>`
 //! marker became a sidecar sub-session. That is a defensible default for a
 //! *concurrent* request and a bad one for the far more common case, which is
 //! the next thing the user wants to say to the agent they are already talking
-//! to. The two are indistinguishable from the text, so the deck stops
-//! guessing and asks — three routes, one keystroke each.
+//! to. So the default is now [`MidTurnPrompt::Queue`]: the prompt waits in the
+//! backlog as the lead's next turn, and Esc delivers the whole backlog into
+//! the running turn (`deck_ui::steer`) — type, type, type, Esc, and the agent
+//! keeps working with everything you said. Nothing completes, nothing is
+//! cancelled, no stranger lane starts.
 //!
-//! Only genuinely ambiguous submissions raise the card. An explicit `>`, a
-//! slash command, a `!` shell line, and the first prompt after a double-Esc
-//! hold all carry their own intent already, and a card over intent the user
-//! has stated is just a keystroke tax.
+//! The other two answers stay reachable through `ui.mid_turn_prompt`:
+//! [`MidTurnPrompt::Ask`] raises a routing card (three routes, one keystroke
+//! each), and [`MidTurnPrompt::AlwaysSpawn`] is the old silent fork.
+//!
+//! Whatever the policy, a submission that states its own routing is never
+//! second-guessed: an explicit `>`, a slash command, a `!` shell line, and
+//! the first prompt after a double-Esc hold all carry their own intent.
 
 use super::*;
 
@@ -73,15 +78,20 @@ fn carries_its_own_intent(text: &str) -> bool {
 /// card was raised and the caller should treat the key as handled.
 ///
 /// The running check is the focused agent's own status, so a prompt typed at
-/// an idle agent — including one whose turn just finished — never sees the
-/// card. That is the same boundary the driver enforces on its side
-/// (`SteeringTap::is_settling`), which is what keeps the two layers agreeing
-/// about what "still running" means.
+/// an idle agent — including one whose turn just finished — never queues or
+/// sees the card: it is simply the next turn. That is the same boundary the
+/// driver enforces on its side (`SteeringTap::is_settling`), which is what
+/// keeps the two layers agreeing about what "still running" means.
 pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<WorkspaceInput> {
     let focused = model.agents.get(ui.focused);
     let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
-    if !running || carries_its_own_intent(&text) || ui.ask_before_spawn.not_asking() {
+    if !running || carries_its_own_intent(&text) {
         return Some(WorkspaceInput::Enqueue { text });
+    }
+    match ui.mid_turn_prompt {
+        MidTurnPrompt::Queue => return Some(WorkspaceInput::EnqueueNext { text }),
+        MidTurnPrompt::AlwaysSpawn => return Some(WorkspaceInput::Enqueue { text }),
+        MidTurnPrompt::Ask => {}
     }
     let live = model
         .agents
@@ -180,24 +190,37 @@ pub fn release_if_settled(ui: &mut DeckUi, agent: &str, event: &stella_protocol:
     ui.composer.load(text);
 }
 
-/// Whether the deck asks before forking a turn into a sidecar.
+/// What a plain prompt submitted at a running agent does — the
+/// `ui.mid_turn_prompt` setting.
 ///
 /// A preference rather than a constant because the answer is genuinely
-/// personal: someone dispatching many independent requests at one agent wants
-/// the old silent spawn, and someone in a long single-threaded collaboration
-/// wants never to be forked at all. Both are reachable without editing code.
+/// personal: someone in a long single-threaded collaboration wants the
+/// backlog-then-Esc rhythm and never to be forked; someone dispatching many
+/// independent requests at one agent wants the old silent spawn; someone who
+/// does both wants to be asked. All three are reachable from settings
+/// (`"queue"` / `"ask"` / `"spawn"`).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum AskBeforeSpawn {
-    /// Raise the card (the default — the deck does not guess).
+pub enum MidTurnPrompt {
+    /// Wait in the backlog as the lead's next turn; Esc steers the backlog
+    /// into the running turn. The default.
     #[default]
+    Queue,
+    /// Raise the routing card (`s` steer / `n` next / `p` sidecar).
     Ask,
-    /// Never ask; a mid-turn prompt always forks, as it did before.
+    /// Never ask; a mid-turn prompt always forks to a sidecar lane.
     AlwaysSpawn,
 }
 
-impl AskBeforeSpawn {
-    fn not_asking(self) -> bool {
-        matches!(self, Self::AlwaysSpawn)
+impl MidTurnPrompt {
+    /// Parse the settings slug. `None` for an unrecognised value, so the
+    /// reader keeps the default rather than failing the file.
+    pub fn parse(slug: &str) -> Option<Self> {
+        match slug.trim() {
+            "queue" => Some(Self::Queue),
+            "ask" => Some(Self::Ask),
+            "spawn" => Some(Self::AlwaysSpawn),
+            _ => None,
+        }
     }
 }
 
@@ -224,12 +247,49 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
-    /// The whole point: a prompt typed at a running agent parks on the card
-    /// instead of silently becoming someone else's problem.
+    /// A deck under the routing-card policy.
+    fn asking_ui() -> DeckUi {
+        DeckUi {
+            mid_turn_prompt: MidTurnPrompt::Ask,
+            ..Default::default()
+        }
+    }
+
+    /// **The witness for the default.** A plain prompt typed at a running
+    /// agent waits in the backlog as the lead's next turn — no card, no
+    /// sidecar lane — which is exactly what an Esc then steers into the turn.
     #[test]
-    fn a_prompt_at_a_running_agent_raises_the_card_and_sends_nothing_yet() {
+    fn by_default_a_prompt_at_a_running_agent_queues_for_the_lead() {
         let model = model_with_lead(crate::AgentStatus::Running);
         let mut ui = DeckUi::default();
+        assert_eq!(ui.mid_turn_prompt, MidTurnPrompt::Queue);
+        assert_eq!(
+            route(&mut ui, &model, "add the tests".into()),
+            Some(WorkspaceInput::EnqueueNext {
+                text: "add the tests".into()
+            })
+        );
+        assert!(ui.pending_dispatch.is_none(), "no card under the default");
+    }
+
+    /// The settings slugs, and that an unknown one keeps the default.
+    #[test]
+    fn the_policy_parses_its_three_slugs_and_nothing_else() {
+        assert_eq!(MidTurnPrompt::parse("queue"), Some(MidTurnPrompt::Queue));
+        assert_eq!(MidTurnPrompt::parse(" ask "), Some(MidTurnPrompt::Ask));
+        assert_eq!(
+            MidTurnPrompt::parse("spawn"),
+            Some(MidTurnPrompt::AlwaysSpawn)
+        );
+        assert_eq!(MidTurnPrompt::parse("sidecar"), None);
+    }
+
+    /// Under `ask`, a prompt typed at a running agent parks on the card
+    /// instead of silently becoming someone else's problem.
+    #[test]
+    fn under_ask_a_prompt_at_a_running_agent_raises_the_card_and_sends_nothing_yet() {
+        let model = model_with_lead(crate::AgentStatus::Running);
+        let mut ui = asking_ui();
         assert_eq!(route(&mut ui, &model, "add the tests".into()), None);
         assert_eq!(
             ui.pending_dispatch.as_ref().map(|p| p.text.as_str()),
@@ -274,7 +334,7 @@ mod tests {
         ];
         for (code, expected) in cases {
             let model = model_with_lead(crate::AgentStatus::Running);
-            let mut ui = DeckUi::default();
+            let mut ui = asking_ui();
             route(&mut ui, &model, "go".into());
             assert_eq!(
                 handle_key(key(code), &mut ui),
@@ -291,7 +351,7 @@ mod tests {
     #[test]
     fn esc_returns_the_text_to_the_composer_instead_of_dropping_it() {
         let model = model_with_lead(crate::AgentStatus::Running);
-        let mut ui = DeckUi::default();
+        let mut ui = asking_ui();
         route(&mut ui, &model, "a careful question".into());
         assert_eq!(
             handle_key(key(KeyCode::Esc), &mut ui),
@@ -306,7 +366,7 @@ mod tests {
     #[test]
     fn an_unrelated_key_is_swallowed_and_leaves_the_card_up() {
         let model = model_with_lead(crate::AgentStatus::Running);
-        let mut ui = DeckUi::default();
+        let mut ui = asking_ui();
         route(&mut ui, &model, "held".into());
         assert_eq!(
             handle_key(key(KeyCode::Char('z')), &mut ui),
@@ -316,12 +376,12 @@ mod tests {
         assert_eq!(ui.composer.buffer(), "", "nothing leaked into the composer");
     }
 
-    /// With the preference off, the deck behaves exactly as it did before.
+    /// Under `spawn`, the deck behaves exactly as it originally did.
     #[test]
     fn always_spawn_restores_the_old_silent_fork() {
         let model = model_with_lead(crate::AgentStatus::Running);
         let mut ui = DeckUi {
-            ask_before_spawn: AskBeforeSpawn::AlwaysSpawn,
+            mid_turn_prompt: MidTurnPrompt::AlwaysSpawn,
             ..Default::default()
         };
         assert_eq!(

--- a/crates/stella-tui/src/deck_ui/tests/esc.rs
+++ b/crates/stella-tui/src/deck_ui/tests/esc.rs
@@ -123,6 +123,49 @@ fn esc_delivers_the_whole_prompt_queue_in_order() {
     );
 }
 
+/// **The rhythm this exists for**, end to end on the deck's side: type a
+/// prompt at a running agent and press ⏎ — it queues for the lead (no routing
+/// card, no sidecar lane); type another, ⏎ — it queues behind the first; then
+/// Esc delivers both into the running turn, in order, as one steer. The turn
+/// never completes or cancels on the way: nothing here is a `Stop`.
+///
+/// Before this the deck raised a card on the first ⏎ and the second test
+/// keystrokes would have been swallowed by it, so this fails on the old code
+/// at the first assertion.
+#[test]
+fn a_mid_turn_enter_queues_for_the_lead_and_the_next_esc_steers_the_queue() {
+    let mut model = running_model();
+    let mut ui = ready_ui();
+    for (i, prompt) in ["first correction", "second correction"]
+        .iter()
+        .enumerate()
+    {
+        for c in prompt.chars() {
+            handle_deck_key(ch(c), &model, &mut ui);
+        }
+        let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(
+            action,
+            DeckAction::Send(WorkspaceInput::EnqueueNext {
+                text: (*prompt).into()
+            }),
+            "⏎ at a running agent queues for the lead, with no card raised"
+        );
+        assert!(ui.pending_dispatch.is_none());
+        // The shell mirrors every queue input into the model the instant it
+        // is sent (`deck_shell`'s one mutation site); do the same here.
+        model.queue.enqueue((*prompt).into(), i as u64);
+    }
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Steer {
+            agent: "lead".into(),
+            texts: vec!["first correction".into(), "second correction".into()],
+        }),
+        "Esc steers the whole backlog into the running turn, in order"
+    );
+}
+
 /// And the case where Esc still means stop: nothing typed, nothing queued.
 /// With no guidance to deliver, an interrupt is the only thing the keystroke
 /// can mean — so the escape hatch never moved.

--- a/crates/stella-tui/src/deck_ui/tests/esc.rs
+++ b/crates/stella-tui/src/deck_ui/tests/esc.rs
@@ -136,10 +136,7 @@ fn esc_delivers_the_whole_prompt_queue_in_order() {
 fn a_mid_turn_enter_queues_for_the_lead_and_the_next_esc_steers_the_queue() {
     let mut model = running_model();
     let mut ui = ready_ui();
-    for (i, prompt) in ["first correction", "second correction"]
-        .iter()
-        .enumerate()
-    {
+    for (i, prompt) in ["first correction", "second correction"].iter().enumerate() {
         for c in prompt.chars() {
             handle_deck_key(ch(c), &model, &mut ui);
         }

--- a/crates/stella-tui/src/deck_ui/tests/routing_card.rs
+++ b/crates/stella-tui/src/deck_ui/tests/routing_card.rs
@@ -4,6 +4,15 @@
 
 use super::*;
 
+/// A deck under the `ask` policy: the card is raised only there, so every
+/// card test opts into it. The default policy queues instead
+/// ([`MidTurnPrompt::Queue`]); `tests/queue.rs` covers that rhythm.
+fn asking_ui() -> DeckUi {
+    let mut ui = ready_ui();
+    ui.mid_turn_prompt = MidTurnPrompt::Ask;
+    ui
+}
+
 #[test]
 fn ask_user_answer_latches_until_a_fresh_question_rearms() {
     let ask = Inbound::Event {
@@ -68,7 +77,7 @@ fn a_finished_turn_releases_a_routing_card_stuck_on_its_prompt() {
         agent: "lead".into(),
         status: crate::AgentStatus::Running,
     });
-    let mut ui = ready_ui();
+    let mut ui = asking_ui();
 
     for c in "and now the tests".chars() {
         handle_deck_key(ch(c), &model, &mut ui);
@@ -122,7 +131,7 @@ fn a_finished_turn_on_another_agent_does_not_release_someone_elses_card() {
         agent: "lead".into(),
         status: crate::AgentStatus::Running,
     });
-    let mut ui = ready_ui();
+    let mut ui = asking_ui();
 
     for c in "keep me".chars() {
         handle_deck_key(ch(c), &model, &mut ui);

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -720,6 +720,18 @@ pub enum WorkspaceInput {
     /// prompt runs before the prompt the hold returned to the queue — and
     /// receiving it is what releases the hold.
     EnqueueFront { text: String },
+    /// Queue a prompt as the lead's NEXT turn, behind whatever is already
+    /// waiting, and never fork it to a sidecar lane. The deck sends this for
+    /// a plain prompt typed while the lead is running under the default
+    /// [`MidTurnPrompt::Queue`](crate::deck_ui::MidTurnPrompt) policy, so the
+    /// backlog is exactly what an Esc then steers into the running turn
+    /// ([`WorkspaceInput::Steer`]). At rest it dispatches like
+    /// [`WorkspaceInput::Enqueue`].
+    ///
+    /// A third verb rather than a flag on `Enqueue` because the driver's
+    /// mid-turn arm routes a plain `Enqueue` to a sidecar (`route_mid_turn`)
+    /// and `EnqueueFront` jumps the backlog; neither is "wait your turn".
+    EnqueueNext { text: String },
     /// Remove one not-yet-dispatched prompt from the queue (0 = oldest). The
     /// deck's queue editor sends this for `ctrl+x` delete and for pulling a
     /// prompt back into the composer to edit it.

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -248,12 +248,14 @@ Two things are unique to deck turns:
 - **Cooperative claims.** The lead claims files on first write, so parallel
   workers in the same tree never fight over a file.
 - **Mid-turn steering & soft-cancel.** You don't have to wait for a turn to
-  finish to correct it. Type `>your note` and it lands at the next step
-  boundary as a real user message — a course-correction the model reads before
-  its next action, not an interrupt that throws away work. `Esc` is a *soft
-  stop*: it halts at the next boundary and keeps everything already completed.
-  `Esc Esc` cancels immediately and holds the queue. Steering beats
-  restarting: you keep the cache-warm context and only redirect it.
+  finish to correct it. Prompts typed while it runs queue; `Esc` delivers the
+  whole queue plus the composer into the running turn at its next step
+  boundary as real user messages — course-corrections the model reads before
+  its next action, with nothing thrown away. `>your note` skips the queue and
+  lands at the next boundary on its own. `Esc` with nothing to deliver is a
+  *soft stop*: it halts at the next boundary and keeps everything already
+  completed. `Esc Esc` cancels immediately and holds the queue. Steering
+  beats restarting: you keep the cache-warm context and only redirect it.
 
 `stella --plain` (or any non-TTY stdin/stdout, or `STELLA_PLAIN=1`) falls
 back to the **plain REPL**: the same per-prompt raw turns and the same

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -52,31 +52,41 @@ a cursor-position request, and how to tell the mode is working — are on the
 
 ### Typing while a turn is running
 
-You never have to wait for a turn to finish, and what happens to your text depends on one character:
+You never have to wait for a turn to finish. A plain prompt **queues** — it waits as the
+lead's next turn, behind anything already waiting, and the turn in flight is not touched.
+Press `Esc` and everything waiting — the queue, in order, plus whatever is in the composer —
+is delivered into the **running** turn at its next step boundary, and the turn keeps going.
+A `Steered` line per message is the acknowledgement; nothing completes, nothing is cancelled,
+and no second agent starts.
+
+```text
+fix the flaky login test           ⏎   ← queued
+also update the changelog          ⏎   ← queued behind it
+                                   Esc ← both land in the running turn, in that order
+```
+
+Two prefixes skip the queue:
 
 <CardGrid size="md">
-  <SpecCard title="Steer this turn — `> …`">
-    A message prefixed `>` is injected into the **running** turn at its next step boundary.
-    A `Steered` line in the transcript is the acknowledgement.
+  <SpecCard title="Steer now — `> …`">
+    A message prefixed `>` goes into the running turn at its next step boundary without
+    waiting for `Esc`.
   </SpecCard>
-  <SpecCard title="Anything else — a new sub-session">
-    A plain prompt does **not** interrupt the turn. It becomes its own sub-session, dispatched
-    alongside the one already running, and the deck says so rather than leaving you guessing
-    whether your text landed. Only slot exhaustion or a slash command leaves it queued for the
-    lead instead.
+  <SpecCard title="Shell — `! …`">
+    A `!` line runs immediately as a shell command, inline in the transcript, never queued.
   </SpecCard>
 </CardGrid>
 
-```text
-> also update the changelog        ← steers the turn in flight
-fix the flaky login test           ← starts a separate sub-session
-```
+`ui.mid_turn_prompt` in [settings](/docs/configuration/settings#the-ui-section) changes what
+a plain prompt does at a running agent: `queue` (the default above), `ask` (a card offers
+`s` steer / `n` next turn / `p` sidecar sub-session per prompt), or `spawn` (every plain
+prompt forks a sidecar sub-session, dispatched alongside the running turn).
 
 <Callout type="info">
-A bare `⏎` **always** submits, even while an agent is busy — that is what makes the two
-behaviors above possible without waiting. The one exception is a **pending gate on the focused
-agent** (a scope review, a hunk review, or a question the approvals plane put to you): there the
-submit answers the gate rather than steering or starting anything. Answer it first, then steer.
+A bare `⏎` **always** submits, even while an agent is busy — that is what makes queueing
+possible without waiting. The one exception is a **pending gate on the focused agent** (a
+scope review, a hunk review, or a question the approvals plane put to you): there the submit
+answers the gate rather than queueing or steering anything. Answer it first, then steer.
 </Callout>
 
 ### Reviewing a write hunk by hunk — not yet reachable
@@ -114,7 +124,8 @@ A *modified* `⏎` (`⌘⏎` / `⌃⏎` / `⌥⏎`) inserts a line break instead
 is kept verbatim in the prompt. On a terminal that cannot report the chord it folds back to a
 plain submit.
 
-Esc soft-stops the current turn without ending the session. See
+Esc with nothing queued and nothing typed soft-stops the current turn without ending the
+session; `Esc Esc` cancels it immediately and holds the queue until your next submission. See
 [Agent engine paths](/docs/agent-engine-paths) for how steering interacts with each execution
 path.
 

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -487,11 +487,18 @@ section behaves exactly as the defaults.
     `dark` and `light` also resolve. An unrecognised value falls back to the default
     rather than failing the file.
   </OptionCard>
+  <OptionCard name="mid_turn_prompt" defaultValue="queue">
+    What a plain prompt typed at a **running** agent does. `queue` waits as the lead's
+    next turn, so `Esc` can steer the whole backlog into the turn in flight. `ask` raises
+    a routing card per prompt (`s` steer / `n` next turn / `p` sidecar). `spawn` forks every
+    plain prompt to a sidecar sub-session. An unrecognised value keeps the default.
+    See [Typing while a turn is running](/docs/commands/chat#typing-while-a-turn-is-running).
+  </OptionCard>
 </CardGrid>
 
 ```json title="<workspace>/.stella/settings.json"
 {
-  "ui": { "theme": "stella-light" }
+  "ui": { "theme": "stella-light", "mid_turn_prompt": "ask" }
 }
 ```
 

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -317,6 +317,7 @@ Unchanged — see [The ui section](/docs/configuration/settings#the-ui-section).
 ```toml title="stella.toml"
 [ui]
 theme = "stella-light"
+mid_turn_prompt = "queue"   # queue | ask | spawn
 ```
 
 ### `[reward]`


### PR DESCRIPTION
## What & why

Steering from the deck was designed (#2904) as: type while the turn runs, press Esc, every waiting prompt goes into the running turn at its next step boundary and the turn keeps going. In practice it never fired that way, because a plain prompt typed at a running lead did not *queue*. `deck_ui/dispatch.rs` raised a routing card on every ⏎ (`s`/`n`/`p`), and the only other policy, `AskBeforeSpawn::AlwaysSpawn`, forked each prompt to a stranger sidecar lane — and was reachable from no setting despite its doc claiming otherwise. So the backlog an Esc-steer drains was empty in the ordinary case, Esc degraded to a soft stop, and the user watched each prompt complete as its own turn.

This PR makes the rhythm the default:

- ⏎ at a running lead sends a new `WorkspaceInput::EnqueueNext`, which the driver parks **behind** the backlog without draining it to a sidecar (`command_deck.rs` mid-turn arm, `settle.rs` window; at rest it dispatches like `Enqueue`).
- Esc delivers the whole backlog plus the composer into the running turn — the unchanged `Steer` path — so nothing completes, nothing is cancelled, no second agent starts. Esc with nothing to say is still the soft stop; Esc Esc is still stop-and-hold.
- The policy is `ui.mid_turn_prompt = "queue" | "ask" | "spawn"` (`MidTurnPrompt`, default `Queue`); the card and the silent fork both remain reachable, now from a setting that exists.
- `/theme` reads the user scope's `[ui]` section before rewriting it (`Settings::load_user_scope`), so setting a theme no longer erases `mid_turn_prompt`.

Exemplar for the verb split: `EnqueueFront` already exists as "jump the backlog"; `EnqueueNext` is its "wait your turn" sibling rather than a flag on `Enqueue`, following the single-purpose rule (AGENTS.md invariant #9).

## The witness

- [x] Witness tests (fail on `main`, pass here):
  - `stella-tui` `deck_ui::tests::esc::a_mid_turn_enter_queues_for_the_lead_and_the_next_esc_steers_the_queue` — ⏎, ⏎, Esc → one `Steer` with both prompts in order; on `main` the first ⏎ raises the card and the assertion fails.
  - `stella-tui` `deck_ui::dispatch::tests::by_default_a_prompt_at_a_running_agent_queues_for_the_lead`, `the_policy_parses_its_three_slugs_and_nothing_else`.
  - `stella-cli` `command_deck::settle::tests::enqueue_next_during_the_settle_window_waits_behind_the_backlog` — order `[front, already-waiting, next]`; on `main` the input is deferred and never reaches the backlog.
  - `stella-cli` `settings::tests::ui_mid_turn_prompt_roundtrips_and_keeps_the_section_alive_without_a_theme`.
  - The in-turn `select!` arm for `EnqueueNext` is a one-line `push_back` inside `run_deck_session`; its witness is exhaustiveness (the match would not compile without it) plus the settle-window test of the identical arm.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` (the only crates that match on `WorkspaceInput`)
- [x] `cargo test -p stella-tui -p stella-cli` — 994 + 1980 passed
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p stella-tui -p stella-cli --no-deps`
- [x] `check-file-size`: OK. `command_deck.rs` (grandfathered) nets +4 lines — the two new match arms must live in its `select!`; the policy reader went to `command_deck/steer.rs` instead. `deck_ui.rs` nets 0.
- [x] `make prose`: red on `main` independently of this branch (#4343); none of the four files it names are in this diff.
- [x] Docs: `commands/chat.mdx`, `agent-engine-paths.mdx`, `configuration/settings.mdx`, `configuration/stella-toml.mdx`

## Nothing left behind

- [x] There is nothing new: a steer aimed at a focused **worker** lane still re-parks rather than injecting (pre-existing, tracked in #2899).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- `WorkspaceInput` is deck↔driver in-process, not a serde wire type; no round-trip test applies.

## Anything reviewers should know?

The default changed from "ask" to "queue". The card was added so the deck would stop guessing between "next thing to say" and "concurrent request"; this PR takes the position that the far more common case is the former, and that Esc-to-steer only works as designed if queueing is what ⏎ does. `ask` and `spawn` are one settings line away.

## Summary by Sourcery

Make mid-turn prompt queueing and Esc-based steering the default while retaining configurable routing and sidecar behaviors.

New Features:
- Queue prompts submitted during a running turn for the lead by default and let Esc steer the accumulated backlog into that turn without starting another agent.
- Add the configurable `ui.mid_turn_prompt` policy with `queue`, `ask`, and `spawn` modes.
- Add `WorkspaceInput::EnqueueNext` for preserving prompt order behind existing queued work.

Bug Fixes:
- Preserve existing UI settings, including `mid_turn_prompt`, when changing the theme.
- Ensure prompts queued during the driver's settle window are retained in the correct order.

Enhancements:
- Align deck routing, driver queue handling, and steering behavior around explicit mid-turn prompt policies.

Documentation:
- Update chat, agent-engine, and configuration documentation for queued mid-turn prompts, steering, and the new setting.

Tests:
- Add coverage for default queueing, policy parsing, Esc steering order, settle-window ordering, and settings round trips.