### PR TITLE
docs: delete the nine content-free constructions that turned main's prose gate red (#4343)

### DIFF
--- a/crates/stella-transcript/src/syntax/grammar.rs
+++ b/crates/stella-transcript/src/syntax/grammar.rs
@@ -14,8 +14,6 @@
 //!
 //! ## Why tree-sitter and not syntect
 //!
-//! Two reasons, and the second is the one that settles it:
-//!
 //! - **It is already resident.** The root `[workspace.dependencies]` carries
 //!   `tree-sitter` and all eight grammar crates used here, because
 //!   `stella-graph` indexes the code graph with them — every one is a default
@@ -156,7 +154,7 @@ thread_local! {
 /// `None` when the grammar will not install — a version skew between
 /// `tree-sitter` and a grammar crate is the only way that happens, and it is a
 /// build-time fact rather than a runtime one, so the caller renders the line
-/// plain rather than treating it as an error worth naming.
+/// plain rather than treating it as an error.
 fn with_parser<T>(g: Grammar, f: impl FnOnce(&mut Parser) -> T) -> Option<T> {
     PARSERS.with(|cell| {
         let mut slots = cell.borrow_mut();

--- a/crates/stella-transcript/src/syntax/lang.rs
+++ b/crates/stella-transcript/src/syntax/lang.rs
@@ -850,8 +850,8 @@ mod tests {
             Some(&Some(Tok::Function)),
             "the callee: {runs:?}"
         );
-        // ...and the identifier beside them stays plain, which is the half that
-        // makes the distinction worth a colour.
+        // ...and the identifier beside them stays plain — that contrast is
+        // what makes the distinction worth a colour.
         assert_eq!(run_tok(&runs, "x"), None, "a bare identifier: {runs:?}");
 
         let runs = tokenize("var d time.Duration = readAll(f)", Lang::Go);

--- a/crates/stella-tui-theme/src/glyph.rs
+++ b/crates/stella-tui-theme/src/glyph.rs
@@ -2,7 +2,7 @@
 //! plugin-drawn UI.
 //!
 //! Glyphs exist so colour is never the only carrier of state (SPEC 2, SPEC
-//! 13). That makes them load-bearing under `NO_COLOR`, on a 16-color
+//! 13). They are the only carrier under `NO_COLOR`, on a 16-color
 //! terminal where the metals collapse toward each other, and for red/green
 //! colour blindness — which is why they live beside the palette rather than
 //! inside whichever widget first needed one.
@@ -22,9 +22,9 @@
 //! `BLOCK_EIGHTHS[8]`. [`width`] answers one for all of them, because that is
 //! what every non-CJK configuration draws and what the layout budgets.
 //!
-//! The hazard is named rather than silently inherited, and it predates the
-//! tool-class rows below: six of those seven shipped before them. It is not
-//! guarded, because nothing here knows the terminal's ambiguous-width setting
+//! The hazard predates the tool-class rows below: six of those seven shipped
+//! before them. It is not guarded, because nothing here knows the terminal's
+//! ambiguous-width setting
 //! — a real fix means asking the terminal, not asserting a number.
 
 /// Done, pass. Green.

--- a/crates/stella-tui-theme/src/glyph.rs
+++ b/crates/stella-tui-theme/src/glyph.rs
@@ -24,8 +24,8 @@
 //!
 //! The hazard predates the tool-class rows below: six of those seven shipped
 //! before them. It is not guarded, because nothing here knows the terminal's
-//! ambiguous-width setting
-//! — a real fix means asking the terminal, not asserting a number.
+//! ambiguous-width setting — a real fix means asking the terminal, not
+//! asserting a number.
 
 /// Done, pass. Green.
 pub const DONE: char = '✓';

--- a/docs/spec/oxagen-trace-drain.md
+++ b/docs/spec/oxagen-trace-drain.md
@@ -28,7 +28,7 @@ optimism. They are called out individually rather than smoothed over.
 > Does Stella have a way for Oxagen to be fed the full trace for every agent
 > execution?
 
-**No — and the absence is deliberate, enforced, and load-bearing.**
+**No — and the absence is deliberate and enforced.**
 
 Three egress paths exist today. All three are either **content-free by
 construction** or **local-only**:
@@ -185,7 +185,7 @@ document and an active enrollment.
 ### 3.3 The guard that makes both of those true
 
 `crates/stella-store/src/content_free.rs` is why §3.1 and §3.2 can be stated as
-fact rather than intent. Two halves:
+fact rather than intent:
 
 1. **A schema allowlist.** `HUB_TELEMETRY_COLUMNS` is compared against the live
    `PRAGMA table_info`, so adding a hub column fails the build until a human
@@ -512,7 +512,7 @@ becomes semantically searchable for free.
 | `sub_agent` events | `-[:BRANCHED_TO_SUBAGENT]->(:Execution)` | |
 | `reflections` | `-[:REMEMBERS]->(:AgentMemory)` | |
 | `commit`, `pr` | `(:EntityNode)` + `IMPLEMENTS` / `PART_OF` / `AUTHORED_BY` | the GitHub connector's existing vocabulary |
-| `file_locks` | `-[:LOCKED]->(:SourceFile)` | already a declared *lineage-only* projection — explicitly **not** load-bearing for mutual exclusion (ADR-021 §5) |
+| `file_locks` | `-[:LOCKED]->(:SourceFile)` | already a declared *lineage-only* projection — explicitly **not** relied on for mutual exclusion (ADR-021 §5) |
 
 ### 8.2 What Stella justifies adding
 


### PR DESCRIPTION
## What

`make prose` fails on `origin/main` at 94bfc6c14 (#4343): nine constructions in four files with no baseline allowance — `crates/stella-transcript/src/syntax/grammar.rs`, `crates/stella-transcript/src/syntax/lang.rs`, `crates/stella-tui-theme/src/glyph.rs`, `docs/spec/oxagen-trace-drain.md`. Each is deleted or replaced with the plain word; no baseline entry is added.

## Evidence

- `python3 scripts/check-prose.py` on this branch: `OK -- 728 grandfathered construction(s) in 480 file(s), none added.`
- `cargo fmt --all --check` clean. Comment-only and markdown-only changes; no witness test applies.

Closes #4343

## Summary by Sourcery

Enhancements:
- Remove nine content-free prose constructions from Rust comments and specification text without changing behavior or adding baseline allowances.