### PR TITLE
fix(stella-cli): keep the deck's input serviced while a slash command asks a question (#4357)

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -101,6 +101,7 @@ mod session_clear;
 mod sessions_view;
 mod settings_io;
 mod settle;
+mod slash_pump;
 mod task_tap;
 mod theme_cmd;
 use pr_observe::{ci_status_token, observe_pr, pr_status_token};
@@ -1404,6 +1405,9 @@ pub async fn run_deck_session(
         // Session-level slash commands are the driver's, never the model's —
         // the deck's popup enqueues them like any prompt (tab switches and
         // the help overlay were already handled TUI-side and never reach us).
+        // Awaited through the pump, not directly: a command that raises a
+        // question (`/init`) is answered on `sub_rx`, and nothing else reads
+        // that channel until the command returns (#4357).
         let command = run_deck_command(
             &prompt,
             &in_tx,
@@ -1416,8 +1420,18 @@ pub async fn run_deck_session(
             agent::remaining_budget(&budget),
             &session_record.id,
             &ask_io,
+        );
+        let command = match slash_pump::await_answerable(
+            command,
+            &mut sub_rx,
+            &ask_tx,
+            &mut deferred,
         )
-        .await;
+        .await
+        {
+            slash_pump::CommandWake::Finished(command) => command,
+            slash_pump::CommandWake::Quit => break 'session,
+        };
         if matches!(command, DeckCommand::Handled | DeckCommand::InitCompleted) {
             // A handled command emits its answer as `Text`, which flips the
             // lead to `Running` in the deck's fold — but no turn is in flight.

--- a/crates/stella-cli/src/command_deck/slash_pump.rs
+++ b/crates/stella-cli/src/command_deck/slash_pump.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Keep the deck's input channel serviced while a slash command runs.
+//!
+//! A slash command is awaited by the driver between turns, outside the turn
+//! loop's `select!` — and that `select!` is the only place an
+//! [`UserInput::AskUserAnswer`] was forwarded to the channel
+//! [`super::mid_turn_ask::DeckAskUserIo`] parks on. So a slash command that
+//! raised a question (`/init`'s markdown→TOML conversion offer, #3642) could
+//! never receive the answer: the deck sent it, nothing read it, the card's
+//! `ToolResult` never came back to clear the gate, and every key after that
+//! was swallowed by the pending question. Ctrl-C was the only way out.
+//!
+//! [`await_answerable`] is the missing arm. It races the command against the
+//! deck's channel: an answer is forwarded, a quit aborts the command, and any
+//! other input is *deferred* — pushed onto the idle arm's replay buffer so a
+//! prompt typed during `/init` keeps its place ahead of anything typed after
+//! it, exactly as the turn loop's `deferred` queue already promises.
+//!
+//! Separate from `command_deck.rs` because that file is a god file closed to
+//! growth (`scripts/file-size-baseline.txt`); the call site there is one
+//! expression.
+
+use std::collections::VecDeque;
+use std::future::Future;
+
+use stella_tui::{UserInput, WorkspaceInput};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// How a slash command awaited through [`await_answerable`] ended.
+#[derive(Debug)]
+pub(super) enum CommandWake<T> {
+    /// The command ran to completion.
+    Finished(T),
+    /// The deck quit (or its channel closed) mid-command; the command's
+    /// future was dropped unfinished.
+    Quit,
+}
+
+/// Await `command` while forwarding the deck's ask answers to `ask_tx`.
+///
+/// Every [`WorkspaceInput`] that arrives on `sub_rx` during the command is
+/// handled in one of three ways:
+///
+/// - [`UserInput::AskUserAnswer`] → its text goes to `ask_tx`, which is the
+///   channel the pending question's `prompt()` is blocked on;
+/// - [`WorkspaceInput::Quit`], or the channel closing → the command is
+///   dropped and [`CommandWake::Quit`] returned;
+/// - anything else → `deferred.push_back`, for the idle arm to replay in
+///   arrival order once the command returns.
+pub(super) async fn await_answerable<F, T>(
+    command: F,
+    sub_rx: &mut UnboundedReceiver<WorkspaceInput>,
+    ask_tx: &UnboundedSender<String>,
+    deferred: &mut VecDeque<WorkspaceInput>,
+) -> CommandWake<T>
+where
+    F: Future<Output = T>,
+{
+    tokio::pin!(command);
+    loop {
+        tokio::select! {
+            outcome = &mut command => return CommandWake::Finished(outcome),
+            input = sub_rx.recv() => match input {
+                None | Some(WorkspaceInput::Quit) => return CommandWake::Quit,
+                Some(WorkspaceInput::ToAgent {
+                    input: UserInput::AskUserAnswer { answer, .. },
+                    ..
+                }) => {
+                    let _ = ask_tx.send(answer);
+                }
+                Some(other) => deferred.push_back(other),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn answer(text: &str) -> WorkspaceInput {
+        WorkspaceInput::ToAgent {
+            agent: "lead".to_string(),
+            input: UserInput::AskUserAnswer {
+                id: "deck-ask-0".to_string(),
+                answer: text.to_string(),
+            },
+        }
+    }
+
+    /// The witness for the deadlock: a command parked on the ask channel
+    /// completes once the deck's answer arrives on the input channel.
+    #[tokio::test]
+    async fn an_answer_sent_during_the_command_reaches_the_parked_question() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        // Stands in for `/init`: blocked until an answer lands on `ask_rx`,
+        // exactly as `DeckAskUserIo::prompt` is.
+        let command = async move { ask_rx.recv().await };
+        sub_tx.send(answer("2")).expect("deck input channel open");
+
+        let wake = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred),
+        )
+        .await
+        .expect("the command must not hang once the answer is sent");
+
+        match wake {
+            CommandWake::Finished(Some(text)) => assert_eq!(text, "2"),
+            other => panic!("expected the forwarded answer, got {other:?}"),
+        }
+        assert!(deferred.is_empty(), "an answer is consumed, never deferred");
+    }
+
+    /// A prompt typed while the command runs is neither lost nor acted on
+    /// early: it waits in `deferred`, in arrival order.
+    #[tokio::test]
+    async fn other_input_is_deferred_in_arrival_order() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        sub_tx
+            .send(WorkspaceInput::Enqueue {
+                text: "first".to_string(),
+            })
+            .expect("open");
+        sub_tx
+            .send(WorkspaceInput::Enqueue {
+                text: "second".to_string(),
+            })
+            .expect("open");
+        sub_tx.send(answer("1")).expect("open");
+
+        let command = async move { ask_rx.recv().await };
+        let wake = await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred).await;
+        assert!(matches!(wake, CommandWake::Finished(Some(ref t)) if t == "1"));
+
+        let texts: Vec<String> = deferred
+            .iter()
+            .map(|input| match input {
+                WorkspaceInput::Enqueue { text } => text.clone(),
+                other => panic!("unexpected deferred input {other:?}"),
+            })
+            .collect();
+        assert_eq!(texts, ["first", "second"]);
+    }
+
+    /// Quit aborts the command rather than leaving the driver parked on a
+    /// question nobody will answer.
+    #[tokio::test]
+    async fn quit_drops_the_command() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        sub_tx.send(WorkspaceInput::Quit).expect("open");
+        let command = async move { ask_rx.recv().await };
+        let wake = await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred).await;
+        assert!(matches!(wake, CommandWake::Quit));
+    }
+}


### PR DESCRIPTION
## What

`/init` on the Command Deck raises the markdown→TOML conversion offer as an `AskUser` card and then deadlocks: the answer is sent by the deck but nothing forwards it, the card never clears, and every key after that is swallowed. Only Ctrl-C gets out (observed 2026-08-22 on 0.9.143).

`run_deck_command` was awaited directly in the session loop, outside the turn loop's `select!` — the only place an `AskUserAnswer` was forwarded to the channel `DeckAskUserIo::prompt` parks on.

## Fix

New sibling module `command_deck/slash_pump.rs` (the god file gets a one-expression call-site swap): `await_answerable` races the command against `sub_rx`. Answers forward to `ask_tx`; `Quit` drops the command; any other input joins the idle arm's existing `deferred` buffer so it replays in arrival order. Exemplar: the turn loop's own `sub_rx` arm in `command_deck.rs`, which this mirrors for the between-turns path.

## Evidence

- `cargo test -p stella-cli slash_pump` — 3 passed: a command parked on the ask channel completes once the deck's answer arrives; other input is deferred in order; Quit aborts.
- Witness is compile-level on `main`: the module and the pump do not exist there, so the test cannot build (`stella-cli` is binary-only; the deadlock sits in the session loop with no seam a test could reach before this change).
- `cargo clippy -p stella-cli --all-targets -- -D warnings`, `make doc-warnings CARGO_SCOPE="-p stella-cli"`, `make file-size prose left-behind` — all green.
- Not yet verified by hand on a live deck (the binary on this machine is the installed 0.9.143); the manual check is `/init` on a workspace with `.claude/commands/*.md`, answer `2`, then type a prompt.

Closes #4357

## Summary by Sourcery

Service deck input while slash commands are running so interactive prompts complete without swallowing subsequent input.

Bug Fixes:
- Keep slash commands responsive to deck input so interactive questions can receive answers and complete instead of deadlocking.
- Preserve non-answer input received during a slash command for replay in arrival order, while allowing quit input to abort the command.

Enhancements:
- Isolate slash-command input servicing in a dedicated module and add focused coverage for answer forwarding, input deferral, and quit handling.

Tests:
- Add asynchronous tests covering answer delivery, ordered input deferral, and command cancellation on quit.