### PR TITLE
feat(stella-tools): write_file and edit_file always carry their diff — published where the tree measurement saw nothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,6 +3291,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "stella-core",
+ "stella-diff",
  "stella-embed",
  "stella-graph",
  "stella-home",

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -64,6 +64,7 @@ use stella_core::TurnOutcome;
 use stella_protocol::event::{AgentEvent, FileChangeKind};
 use stella_store::work_journal::{JournalChange, JournalChangeKind};
 use stella_store::{FileTouchRow, Store};
+use stella_tools::own_change::{OwnChange, OwnChangeKind};
 
 use crate::config::Config;
 use crate::durability::SessionDurability;
@@ -109,8 +110,65 @@ impl stella_tools::call_measure::CallMeasure for TurnCallMeasure {
     /// this reading and the boundary's partition the turn between them. That
     /// is the property the counters downstream depend on, and it is why this
     /// calls the boundary's own function rather than a per-call variant of it.
-    fn measure_and_publish(&self) {
-        emit_measured_tree_changes(&self.durability, &self.tx, self.execution.as_ref());
+    fn measure_and_publish(&self, own: &[OwnChange]) {
+        let measured =
+            emit_measured_tree_changes(&self.durability, &self.tx, self.execution.as_ref());
+        emit_own_changes(&self.tx, self.execution.as_ref(), own, &measured);
+    }
+}
+
+/// Publish a call's own reading for every path the tree reading left out.
+///
+/// The tree reading is git's, and git does not see a gitignored path or a
+/// workspace with no journal bound — which is how a `write_file` into
+/// `.stella/agents/…` rendered as `wrote 9214 bytes` with no diff under it.
+/// The tool's own diff (`stella_tools::own_change`) fills exactly that gap, and
+/// only that gap: a path the snapshot reported keeps the snapshot's event, so
+/// the Files tab still counts each change once.
+///
+/// Both projections are written, as for a measured change: the event the
+/// transcript folds, and the `files_touched` row the reflection loop reads.
+fn emit_own_changes(
+    tx: &EventSender,
+    execution: Option<&(Arc<Store>, i64)>,
+    own: &[OwnChange],
+    measured: &[String],
+) {
+    let unmeasured: Vec<&OwnChange> = own
+        .iter()
+        .filter(|change| !measured.contains(&change.path))
+        .collect();
+    if unmeasured.is_empty() {
+        return;
+    }
+    if let Some((store, execution_id)) = execution {
+        let rows: Vec<FileTouchRow> = unmeasured.iter().map(|c| own_touch_row(c)).collect();
+        let _ = store.record_files_touched(*execution_id, &rows);
+    }
+    for change in unmeasured {
+        let _ = tx.send(stella_tools::own_change::file_change(change.clone()));
+    }
+}
+
+/// The durable row for a change the call itself read, in the same CRUD
+/// alphabet as [`file_touch_row`] and with its provenance named.
+fn own_touch_row(change: &OwnChange) -> FileTouchRow {
+    FileTouchRow {
+        path: change.path.clone(),
+        ops: match change.kind {
+            OwnChangeKind::Created => "C",
+            OwnChangeKind::Modified => "U",
+        }
+        .to_string(),
+        lines_added: u64::from(change.added),
+        lines_removed: u64::from(change.removed),
+        events_json: serde_json::json!([{
+            "event": "measured",
+            "reason": "the call's own before/after reading",
+            "lines_added": change.added,
+            "lines_removed": change.removed,
+        }])
+        .to_string(),
     }
 }
 
@@ -240,7 +298,9 @@ pub(crate) fn emit_shared_tree_changes(
     tx: &EventSender,
     execution: Option<&(Arc<Store>, i64)>,
 ) {
-    emit_measured_tree_changes(&cfg.durability, tx, execution);
+    // The boundary sweep has no call's own reading to reconcile against, so
+    // the published paths are not needed here.
+    let _ = emit_measured_tree_changes(&cfg.durability, tx, execution);
 }
 
 /// [`emit_shared_tree_changes`] over the durability handle alone.
@@ -251,14 +311,18 @@ pub(crate) fn emit_shared_tree_changes(
 /// then run the *same* function, which is the load-bearing half of the
 /// no-double-counting argument in `stella_tools::call_measure`: there is one
 /// measurement, called more or less often, not two that have to agree.
+///
+/// Returns the paths it published, so a per-call reading the tool supplied
+/// itself ([`emit_own_changes`]) can be published for the rest and no path
+/// gets two events.
 pub(crate) fn emit_measured_tree_changes(
     durability: &SessionDurability,
     tx: &EventSender,
     execution: Option<&(Arc<Store>, i64)>,
-) {
+) -> Vec<String> {
     let measured = durability.snapshot_worktree();
     if measured.is_empty() {
-        return;
+        return Vec::new();
     }
     if let Some((store, execution_id)) = execution {
         let rows: Vec<FileTouchRow> = measured.iter().map(file_touch_row).collect();
@@ -267,9 +331,11 @@ pub(crate) fn emit_measured_tree_changes(
         // fail a turn whose bytes are already on disk.
         let _ = store.record_files_touched(*execution_id, &rows);
     }
+    let paths = measured.iter().map(|c| c.path.clone()).collect();
     for change in measured {
         let _ = tx.send(file_change(change));
     }
+    paths
 }
 
 /// One measured delta as a durable row.
@@ -452,6 +518,59 @@ mod tests {
              exactly how the deck's Files tab stayed empty for every session. \
              Use `turn_files::close_turn_boundary_raw`, which pays both."
         );
+    }
+
+    /// **Witness.** A path the tree reading cannot see still reaches the
+    /// stream with its diff, from the call's own reading.
+    ///
+    /// An unbound durability is the no-journal case exactly, and it is also
+    /// what a gitignored path looks like from the snapshot's side: nothing
+    /// measured. Before this, `measure_and_publish` sent nothing here and the
+    /// row rendered `wrote N bytes` with no diff and no line count.
+    #[test]
+    fn a_call_s_own_reading_is_published_where_the_tree_saw_nothing() {
+        use stella_tools::call_measure::CallMeasure as _;
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let measure =
+            TurnCallMeasure::new(SessionDurability::default(), EventSender::new(tx), None);
+        let own = stella_tools::own_change::own_change(
+            ".stella/agents/kfc/spec-tasks.md",
+            None,
+            "# tasks\n- one\n",
+        );
+        measure.measure_and_publish(std::slice::from_ref(&own));
+
+        let Ok(AgentEvent::FileChange {
+            path,
+            kind,
+            added,
+            removed,
+            diff,
+        }) = rx.try_recv()
+        else {
+            panic!("the call's own reading must be published when nothing was measured");
+        };
+        assert_eq!(path, ".stella/agents/kfc/spec-tasks.md");
+        assert_eq!(kind, FileChangeKind::Created);
+        assert_eq!((added, removed), (2, 0));
+        assert!(
+            diff.as_deref().is_some_and(|d| d.contains("+- one")),
+            "the diff rides the event: {diff:?}"
+        );
+        assert!(rx.try_recv().is_err(), "one change, one event");
+    }
+
+    /// The durable row a self-read change writes uses the CRUD letters both
+    /// reader queries grep for, like a measured one.
+    #[test]
+    fn a_self_read_change_writes_a_crud_lettered_row() {
+        let created = stella_tools::own_change::own_change("a.md", None, "x\n");
+        let modified = stella_tools::own_change::own_change("b.md", Some("x\n"), "y\n");
+        assert_eq!(own_touch_row(&created).ops, "C");
+        let row = own_touch_row(&modified);
+        assert_eq!(row.ops, "U");
+        assert_eq!((row.lines_added, row.lines_removed), (1, 1));
     }
 
     fn measured(kind: JournalChangeKind) -> JournalChange {

--- a/crates/stella-tools/Cargo.toml
+++ b/crates/stella-tools/Cargo.toml
@@ -25,6 +25,11 @@ stella-graph = { path = "../stella-graph" }
 # crate is where the network is allowed to live: `stella-graph` stores vectors
 # and ranks them, and never learns what produced them (invariant 1).
 stella-embed = { path = "../stella-embed", features = ["http"] }
+# The differ `write_file` and `edit_file` run over the bytes they read and the
+# bytes they wrote (`own_change`), so a mutation the work-tree measurement
+# cannot see — a gitignored path, a workspace with no journal — still renders
+# its diff. A leaf with no dependencies, so linking it costs nothing (#1511).
+stella-diff = { path = "../stella-diff" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/stella-tools/README.md
+++ b/crates/stella-tools/README.md
@@ -105,8 +105,11 @@ every spawn path shares ([`src/subprocess_env.rs`](src/subprocess_env.rs),
 
 Depends on `stella-protocol` (`ToolOutput`/`ToolSchema`), `stella-core` (the
 `ToolExecutor` port, the hook bus, the task board, the MCP-usage ledger),
-`stella-store` (the foundry adoption ledger), and `stella-home` (the
-user-global custom-tools directory). It builds no binary.
+`stella-store` (the foundry adoption ledger), `stella-home` (the
+user-global custom-tools directory), and `stella-diff` (the differ
+`write_file` and `edit_file` run over the bytes they read and wrote —
+[`src/own_change.rs`](src/own_change.rs) — so a change the work-tree
+measurement cannot see still carries its diff). It builds no binary.
 
 `stella-cli` is the real consumer: it constructs the registry and layers
 custom script tools and MCP tools around it. `stella-tui` and `stella-fleet`

--- a/crates/stella-tools/src/call_measure.rs
+++ b/crates/stella-tools/src/call_measure.rs
@@ -72,6 +72,21 @@
 //! MCP and custom tool — runs alone in its own dispatch group, which is
 //! precisely when a before/after snapshot means what it says.
 //!
+//! # What the tree cannot see, the call reports itself
+//!
+//! A snapshot is git's reading, and git does not read a gitignored path or a
+//! workspace with no journal bound. A `write_file` into `.stella/agents/…`
+//! under a `/.stella/*` ignore rule measured nothing, so its row rendered with
+//! no diff and no line count — the exact shape of a call that changed nothing.
+//! `write_file` and `edit_file` therefore carry their **own reading**
+//! ([`crate::own_change`]): a diff over the bytes they read and the bytes they
+//! wrote, which is a measurement of what landed and not the argument-derived
+//! guess the reasons above rule out. The registry hands it to
+//! [`CallMeasure::measure_and_publish`] beside the snapshot, and the host
+//! publishes it for every path the snapshot did not cover. Where both saw the
+//! path the snapshot's reading is the one published, so the
+//! one-change-one-event property above is kept.
+//!
 //! # This is observability, never evidence
 //!
 //! Unchanged from `FileChange`'s standing contract, and it has teeth at this
@@ -100,11 +115,17 @@ pub trait CallMeasure: Send + Sync {
     /// an implementation that reported a cumulative delta would make every
     /// counter downstream sum a prefix of itself once per call.
     ///
+    /// `own` is the call's own reading of what it changed
+    /// ([`crate::own_change`]), empty for a tool that carries none. An
+    /// implementation publishes each entry whose path the tree reading did
+    /// not report — never one it did, or the Files tab counts that change
+    /// twice.
+    ///
     /// Best-effort and infallible by signature, like every other
     /// turn-boundary write: a call whose bytes are already on disk is not made
     /// less done by an unmeasurable tree, and a measurement failure must never
     /// become a tool failure.
-    fn measure_and_publish(&self);
+    fn measure_and_publish(&self, own: &[crate::own_change::OwnChange]);
 }
 
 /// The registry's slot for a host-supplied [`CallMeasure`].
@@ -143,7 +164,7 @@ mod tests {
     fn attaching_twice_leaves_only_the_second_measurer() {
         struct Counting(Arc<AtomicUsize>);
         impl CallMeasure for Counting {
-            fn measure_and_publish(&self) {
+            fn measure_and_publish(&self, _own: &[crate::own_change::OwnChange]) {
                 self.0.fetch_add(1, Ordering::Relaxed);
             }
         }
@@ -156,7 +177,7 @@ mod tests {
         *slot.write().unwrap() = Some(Arc::new(Counting(second.clone())));
 
         let measurer = slot.read().unwrap().clone().expect("attached");
-        measurer.measure_and_publish();
+        measurer.measure_and_publish(&[]);
 
         assert_eq!(
             first.load(Ordering::Relaxed),

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -230,6 +230,9 @@ fn edit_target(value: &Value) -> Result<EditTarget, crate::input::InputError> {
 struct Pending {
     scope_root: std::path::PathBuf,
     path: String,
+    /// The bytes on disk when the batch first loaded this file — the old side
+    /// of the change the batch reports once it lands.
+    original: String,
     content: String,
     edits: usize,
 }
@@ -439,10 +442,18 @@ impl EditFile {
                 // deterministic — never a timestamp, which broke the detector
                 // in the opposite direction once.
                 let digest = crate::staleness::sha256_8(new_content.as_bytes());
-                ToolOutput::ok(format!(
-                    "replaced {replaced} occurrence(s) in {path} at byte {offset} \
-                     (file sha256/8 {digest})"
-                ))
+                let change = crate::own_change::own_change(
+                    &crate::own_change::workspace_path(root, &scope_root, path),
+                    Some(&content),
+                    &new_content,
+                );
+                crate::own_change::attach(
+                    ToolOutput::ok(format!(
+                        "replaced {replaced} occurrence(s) in {path} at byte {offset} \
+                         (file sha256/8 {digest})"
+                    )),
+                    &[change],
+                )
             }
             Err(e) => ToolOutput::error(format!("failed to write `{path}`: {e}")),
         }
@@ -517,6 +528,7 @@ impl EditFile {
                     pending.push(Pending {
                         scope_root,
                         path,
+                        original: content.clone(),
                         content,
                         edits: 0,
                     });
@@ -559,6 +571,7 @@ impl EditFile {
         // Every edit validated against the composed content. Only now does
         // anything reach the disk.
         let mut report = Vec::with_capacity(pending.len());
+        let mut changes = Vec::with_capacity(pending.len());
         for file in &pending {
             let handle = match crate::rootfd::RootHandle::open(&file.scope_root) {
                 Ok(handle) => Arc::new(handle),
@@ -583,17 +596,25 @@ impl EditFile {
                 file.edits,
                 crate::staleness::sha256_8(file.content.as_bytes())
             ));
+            changes.push(crate::own_change::own_change(
+                &crate::own_change::workspace_path(root, &file.scope_root, &file.path),
+                Some(&file.original),
+                &file.content,
+            ));
         }
         // The per-file digests are the batch's identity stamp, for the same
         // reason the single form carries one (#3176): N distinct batches must
         // not produce byte-identical output, or the stagnation detector reads
         // correct work as a stuck loop.
-        ToolOutput::ok(format!(
-            "applied {} edit(s) across {} file(s), all or nothing:\n{}",
-            targets.len(),
-            pending.len(),
-            report.join("\n")
-        ))
+        crate::own_change::attach(
+            ToolOutput::ok(format!(
+                "applied {} edit(s) across {} file(s), all or nothing:\n{}",
+                targets.len(),
+                pending.len(),
+                report.join("\n")
+            )),
+            &changes,
+        )
     }
 
     /// Attribute a miss inside a batch, in the vocabulary the single form uses.

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -59,6 +59,7 @@ pub mod gated;
 pub mod hook_bridge;
 pub mod hook_runner;
 pub mod input;
+pub mod own_change;
 pub mod policy;
 pub mod read;
 pub mod registry;

--- a/crates/stella-tools/src/own_change.rs
+++ b/crates/stella-tools/src/own_change.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A mutating call's **own reading** of what it changed — the diff `write_file`
+//! and `edit_file` compute from the bytes they read and the bytes they wrote.
+//!
+//! # Why the work-tree measurement is not enough
+//!
+//! The transcript's inline diff under a file call resolves through an
+//! [`AgentEvent::FileChange`](stella_protocol::AgentEvent::FileChange) that
+//! folded inside the call's window, and until this existed that event had one
+//! producer: the per-call work-tree snapshot (`stella_tools::call_measure`,
+//! bound by `stella-cli`'s `turn_files`). A snapshot is git's reading of the
+//! tree, which is the right authority for everything a `bash` or an MCP server
+//! moves — and it has holes no amount of care closes:
+//!
+//! - **A gitignored path is invisible to it.** The journal honours
+//!   `.gitignore` by design, so a `write_file` into `.stella/agents/…` under a
+//!   `/.stella/*` rule produced no measurement at all, and the row rendered
+//!   `wrote 9214 bytes to …` with no diff and no line count — the shape of a
+//!   call that changed nothing.
+//! - **A workspace with no journal measures nothing.** A session whose
+//!   durability never bound (no work store, a read-only home) has no snapshot
+//!   to take.
+//!
+//! `write_file` and `edit_file` hold both sides of every change they make: the
+//! content they were handed, and the content they read before replacing it. A
+//! diff over those two is a measurement of the bytes, not an inference from
+//! the arguments (the #2290 defect the counts contract forbids — a tool's
+//! *arguments* are a request, and these are the bytes that landed). So the
+//! tools report it, and the turn's measurer publishes it for any path the
+//! tree reading did not cover. Where the snapshot *did* see the path, its
+//! reading stays the one published: one change, one event.
+//!
+//! # Transport
+//!
+//! The reading rides [`ToolOutput::Ok`]'s `data` under [`DATA_KEY`] — the
+//! declared seam for a result's structured half (#3285). The model never sees
+//! it; `content` is untouched, so the byte-identical success strings the
+//! stagnation detector keys on (#3176) are preserved.
+//!
+//! # Shape
+//!
+//! The diff text is the per-file body the journal hands the same event —
+//! everything after git's `diff --git` line: `--- a/path`, `+++ b/path`, then
+//! `@@` hunks — so every consumer that already renders a measured change
+//! renders this one through the same parser, unchanged.
+
+use serde::{Deserialize, Serialize};
+use stella_protocol::tool::ToolOutput;
+
+/// The key under which a call's own changes ride `ToolOutput::Ok::data`.
+pub const DATA_KEY: &str = "changes";
+
+/// Context lines on either side of a hunk — git's default, so a diff here and
+/// a diff the journal measured read alike.
+const CONTEXT: usize = 3;
+
+/// What a call did to one path, as the call itself saw it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnChange {
+    /// Workspace-relative when the path is inside the session root — the same
+    /// spelling the work-tree measurement uses, so the two can be matched —
+    /// and absolute otherwise.
+    pub path: String,
+    /// Whether the path existed before the call.
+    pub kind: OwnChangeKind,
+    /// Lines present only after the call.
+    pub added: u32,
+    /// Lines present only before the call.
+    pub removed: u32,
+    /// The unified diff, in the shape described in the module docs.
+    pub diff: String,
+}
+
+/// Whether the call created the path or changed one that was there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnChangeKind {
+    Created,
+    Modified,
+}
+
+/// Diff `before` against `after` for `path`.
+///
+/// `None` for `before` means the path did not exist: the change is
+/// [`OwnChangeKind::Created`] and the diff is all-green. `Some("")` is an
+/// existing empty file, which is a modification — the distinction git draws
+/// with `new file mode`, and the one the deck draws with `new file`.
+#[must_use]
+pub fn own_change(path: &str, before: Option<&str>, after: &str) -> OwnChange {
+    let kind = match before {
+        Some(_) => OwnChangeKind::Modified,
+        None => OwnChangeKind::Created,
+    };
+    let diff = stella_diff::unified_diff(before.unwrap_or_default(), after, CONTEXT);
+    OwnChange {
+        path: path.to_string(),
+        kind,
+        // Counts are `usize` in the differ and `u32` on the wire; a file with
+        // more than four billion lines is not a file this tool writes.
+        added: u32::try_from(diff.added).unwrap_or(u32::MAX),
+        removed: u32::try_from(diff.removed).unwrap_or(u32::MAX),
+        diff: patch_text(path, kind, &diff),
+    }
+}
+
+/// The workspace-relative spelling of a path the write scope resolved.
+///
+/// [`crate::ctx::ToolCtx::resolve_for_write`] hands back a path relative to
+/// whichever allowed root it landed in, which is the session root for every
+/// ordinary call and a nested or sibling root for a scoped one. The
+/// measurement names paths relative to the session root, so a change has to be
+/// spelled the same way to be matched against it; a path outside the session
+/// root keeps its absolute form, which the measurement can never name anyway.
+///
+/// The scope's roots are canonical (`ToolRegistry::write_scope`) and the
+/// session root is as the host gave it, so on a machine where the two spell
+/// one directory differently — macOS's `/var` → `/private/var` — the prefix
+/// is tried in both spellings. Failing that match would leave every path
+/// absolute, which the measurement could never match and the deck would
+/// render as a file outside the workspace.
+#[must_use]
+pub fn workspace_path(root: &std::path::Path, scope_root: &std::path::Path, rel: &str) -> String {
+    let absolute = scope_root.join(rel);
+    if let Ok(inside) = absolute.strip_prefix(root) {
+        return inside.to_string_lossy().into_owned();
+    }
+    if let Ok(canonical) = root.canonicalize()
+        && let Ok(inside) = absolute.strip_prefix(&canonical)
+    {
+        return inside.to_string_lossy().into_owned();
+    }
+    absolute.to_string_lossy().into_owned()
+}
+
+/// The per-file patch body, in git's shape minus the `diff --git` line the
+/// journal strips before attaching (`work_journal::snapshot::attach_diffs`).
+fn patch_text(path: &str, kind: OwnChangeKind, diff: &stella_diff::Diff) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    match kind {
+        OwnChangeKind::Created => {
+            out.push_str("--- /dev/null\n");
+        }
+        OwnChangeKind::Modified => {
+            let _ = writeln!(out, "--- a/{path}");
+        }
+    }
+    let _ = writeln!(out, "+++ b/{path}");
+    for hunk in &diff.hunks {
+        out.push_str(&hunk.header());
+        out.push('\n');
+        for line in &hunk.lines {
+            out.push(line.op.sigil());
+            out.push_str(&line.text);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// One reading as the wire event every transcript surface folds.
+///
+/// The counts and the diff are carried, never recounted from the text — the
+/// #2290 contract at this seam, the same one `turn_files::file_change` holds
+/// for a measured change.
+#[must_use]
+pub fn file_change(change: OwnChange) -> stella_protocol::AgentEvent {
+    stella_protocol::AgentEvent::FileChange {
+        path: change.path,
+        kind: match change.kind {
+            OwnChangeKind::Created => stella_protocol::FileChangeKind::Created,
+            OwnChangeKind::Modified => stella_protocol::FileChangeKind::Modified,
+        },
+        added: change.added,
+        removed: change.removed,
+        diff: Some(change.diff),
+    }
+}
+
+/// Attach `changes` to a successful output under [`DATA_KEY`].
+///
+/// An error output is returned untouched: a failed call reports no change,
+/// whatever it may have left behind (the next measurement still sees that).
+/// Other keys already in `data` are kept.
+#[must_use]
+pub fn attach(output: ToolOutput, changes: &[OwnChange]) -> ToolOutput {
+    let ToolOutput::Ok { content, data } = output else {
+        return output;
+    };
+    let mut data = match data {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+    // Serializing a plain struct of strings and integers cannot fail; the
+    // fallback keeps the signature infallible rather than hiding a panic.
+    let value = serde_json::to_value(changes).unwrap_or(serde_json::Value::Array(Vec::new()));
+    data.insert(DATA_KEY.to_string(), value);
+    ToolOutput::Ok {
+        content,
+        data: Some(serde_json::Value::Object(data)),
+    }
+}
+
+/// The changes a successful output carries under [`DATA_KEY`], or none.
+///
+/// Lenient on purpose: a tool that carries no reading, or a reading in a shape
+/// this version does not parse, is a call with nothing to report — never an
+/// error at the seam that publishes it.
+#[must_use]
+pub fn from_output(output: &ToolOutput) -> Vec<OwnChange> {
+    let ToolOutput::Ok {
+        data: Some(data), ..
+    } = output
+    else {
+        return Vec::new();
+    };
+    data.get(DATA_KEY)
+        .cloned()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A created file is all-green, counted, and headed `/dev/null` on the old
+    /// side — the git spelling every consumer keys "new file" on.
+    #[test]
+    fn a_created_file_is_an_all_green_diff_from_dev_null() {
+        let change = own_change("notes/spec.md", None, "# Spec\n\nbody\n");
+        assert_eq!(change.kind, OwnChangeKind::Created);
+        assert_eq!((change.added, change.removed), (3, 0));
+        assert!(
+            change
+                .diff
+                .starts_with("--- /dev/null\n+++ b/notes/spec.md\n@@ -0,0 +1,3 @@\n")
+        );
+        assert!(change.diff.contains("+# Spec\n"));
+        assert!(
+            !change.diff.contains("\n-"),
+            "nothing removed: {}",
+            change.diff
+        );
+    }
+
+    /// A modification names both sides and frames the change with git's three
+    /// lines of context.
+    #[test]
+    fn a_modification_is_a_hunk_over_both_sides() {
+        let before = "a\nb\nc\nd\ne\nf\ng\n";
+        let after = "a\nb\nc\nD\ne\nf\ng\n";
+        let change = own_change("src/lib.rs", Some(before), after);
+        assert_eq!(change.kind, OwnChangeKind::Modified);
+        assert_eq!((change.added, change.removed), (1, 1));
+        assert!(
+            change
+                .diff
+                .starts_with("--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,7 +1,7 @@\n")
+        );
+        assert!(change.diff.contains("\n-d\n+D\n"), "{}", change.diff);
+    }
+
+    /// An existing empty file is modified, not created: the distinction the
+    /// deck renders as `new file`, so it must not be guessed from content.
+    #[test]
+    fn an_empty_existing_file_is_a_modification() {
+        let change = own_change("x", Some(""), "one\n");
+        assert_eq!(change.kind, OwnChangeKind::Modified);
+        assert!(change.diff.starts_with("--- a/x\n"));
+    }
+
+    /// The reading round-trips through `data` untouched, beside whatever the
+    /// tool already put there, and never touches `content`.
+    #[test]
+    fn attach_then_from_output_round_trips_beside_existing_data() {
+        let change = own_change("a.txt", None, "hi\n");
+        let output =
+            ToolOutput::ok_with_data("wrote 3 bytes to a.txt", serde_json::json!({ "keep": 1 }));
+        let output = attach(output, std::slice::from_ref(&change));
+        let ToolOutput::Ok { content, data } = &output else {
+            panic!("attach must keep the Ok arm");
+        };
+        assert_eq!(content, "wrote 3 bytes to a.txt");
+        assert_eq!(data.as_ref().unwrap()["keep"], 1);
+        assert_eq!(from_output(&output), vec![change]);
+    }
+
+    /// A failed call carries no reading, and an output without one reads as
+    /// empty rather than as an error.
+    #[test]
+    fn errors_and_readingless_outputs_carry_nothing() {
+        let change = own_change("a.txt", None, "hi\n");
+        let err = attach(ToolOutput::error("no"), &[change]);
+        assert!(err.is_error());
+        assert!(from_output(&err).is_empty());
+        assert!(from_output(&ToolOutput::ok("plain")).is_empty());
+    }
+
+    /// A scoped root's relative path is re-spelled against the session root,
+    /// and a path outside it stays absolute.
+    #[test]
+    fn workspace_path_is_session_relative_inside_and_absolute_outside() {
+        let root = std::path::Path::new("/ws");
+        assert_eq!(workspace_path(root, root, "src/a.rs"), "src/a.rs");
+        assert_eq!(
+            workspace_path(root, std::path::Path::new("/ws/nested"), "b.rs"),
+            "nested/b.rs"
+        );
+        assert_eq!(
+            workspace_path(root, std::path::Path::new("/elsewhere"), "c.rs"),
+            "/elsewhere/c.rs"
+        );
+    }
+
+    /// The scope root is canonical and the session root is as given; where
+    /// the two spell one directory differently the path is still relative.
+    /// On macOS a tempdir is the live case (`/var` → `/private/var`); on a
+    /// filesystem with no such alias both spellings agree and this is the
+    /// plain case again.
+    #[test]
+    fn workspace_path_matches_a_canonical_scope_root_to_the_given_session_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let given = dir.path();
+        let canonical = given.canonicalize().unwrap();
+        assert_eq!(workspace_path(given, &canonical, "src/a.rs"), "src/a.rs");
+    }
+}

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -613,14 +613,31 @@ impl ToolRegistry {
         // lost — the next measurement, per-call or at the boundary, still
         // reports it, because a snapshot reports everything since the last
         // one rather than everything one call did.
+        //
+        // The call's own reading (`crate::own_change`) rides beside the tree
+        // measurement, for the paths that reading cannot see — a gitignored
+        // file, a workspace with no journal. With no measurer attached it is
+        // published on the event stream directly: a host that folds the
+        // stream without binding a journal still owes every `write_file` its
+        // diff.
         if matches!(output, ToolOutput::Ok { .. }) && self.measures_alone(name) {
+            let own = crate::own_change::from_output(&output);
             let measure = self
                 .call_measure
                 .read()
                 .unwrap_or_else(|p| p.into_inner())
                 .clone();
-            if let Some(measure) = measure {
-                measure.measure_and_publish();
+            match measure {
+                Some(measure) => measure.measure_and_publish(&own),
+                None => {
+                    if let Some(events) = self.events() {
+                        for change in own {
+                            // A closed channel means the renderer is gone,
+                            // which is not this call's failure to report.
+                            let _ = events.send(crate::own_change::file_change(change));
+                        }
+                    }
+                }
             }
         }
         if let Some(bus) = &bus {

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -31,10 +31,14 @@ async fn only_a_successful_solo_mutating_call_is_measured_on_its_own() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Default)]
-    struct Counting(AtomicUsize);
+    struct Counting(
+        AtomicUsize,
+        std::sync::Mutex<Vec<crate::own_change::OwnChange>>,
+    );
     impl CallMeasure for Counting {
-        fn measure_and_publish(&self) {
+        fn measure_and_publish(&self, own: &[crate::own_change::OwnChange]) {
             self.0.fetch_add(1, Ordering::Relaxed);
+            self.1.lock().unwrap().extend_from_slice(own);
         }
     }
 
@@ -79,6 +83,16 @@ async fn only_a_successful_solo_mutating_call_is_measured_on_its_own() {
         1,
         "a successful write measures the change it made"
     );
+    {
+        // The write's own reading reaches the measurer beside the tree
+        // reading, so a path git cannot see still gets its diff.
+        let own = counter.1.lock().unwrap();
+        assert_eq!(own.len(), 1, "one written file, one own reading");
+        assert_eq!(own[0].path, "a.txt");
+        assert_eq!(own[0].kind, crate::own_change::OwnChangeKind::Created);
+        assert_eq!((own[0].added, own[0].removed), (1, 0));
+        assert!(own[0].diff.contains("+hello"), "{}", own[0].diff);
+    }
 
     reg.execute("read_file", &serde_json::json!({"path": "a.txt"}))
         .await;
@@ -113,7 +127,7 @@ async fn detaching_the_event_stream_drops_the_call_measurer_too() {
 
     struct Noop;
     impl CallMeasure for Noop {
-        fn measure_and_publish(&self) {}
+        fn measure_and_publish(&self, _own: &[crate::own_change::OwnChange]) {}
     }
 
     let (_root, reg) = bare_registry();
@@ -129,6 +143,58 @@ async fn detaching_the_event_stream_drops_the_call_measurer_too() {
         "and gone when the turn's stream closes — a live one would hold the \
          channel open after the renderer was meant to finish"
     );
+}
+
+/// **Witness.** A registry with an event stream and no measurer still
+/// publishes a file tool's own reading as a `FileChange`, diff included.
+///
+/// A host that never binds a journal had no `FileChange` producer at all, so
+/// every `write_file` and `edit_file` it rendered was diffless. Fails before
+/// the own reading existed: nothing was sent on the stream.
+#[tokio::test]
+async fn a_file_tool_s_own_reading_is_published_without_a_measurer() {
+    use stella_protocol::{AgentEvent, FileChangeKind};
+
+    let (_root, reg) = bare_registry();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    reg.attach_events(stella_core::EventSender::new(tx));
+
+    let write = serde_json::json!({ "path": "notes.md", "content": "one\ntwo\n" });
+    assert!(!reg.execute("write_file", &write).await.is_error());
+    let Ok(AgentEvent::FileChange {
+        path,
+        kind,
+        added,
+        removed,
+        diff,
+    }) = rx.try_recv()
+    else {
+        panic!("the write's own reading must reach the stream");
+    };
+    assert_eq!(path, "notes.md");
+    assert_eq!(kind, FileChangeKind::Created);
+    assert_eq!((added, removed), (2, 0));
+    assert!(diff.as_deref().is_some_and(|d| d.contains("+two")));
+
+    // An edit on the file the session just authored reads as a modification
+    // of it, with both sides of the change on the wire.
+    let edit =
+        serde_json::json!({ "path": "notes.md", "old_string": "two", "new_string": "three" });
+    assert!(!reg.execute("edit_file", &edit).await.is_error());
+    let Ok(AgentEvent::FileChange {
+        kind,
+        added,
+        removed,
+        diff,
+        ..
+    }) = rx.try_recv()
+    else {
+        panic!("the edit's own reading must reach the stream");
+    };
+    assert_eq!(kind, FileChangeKind::Modified);
+    assert_eq!((added, removed), (1, 1));
+    let diff = diff.expect("an edit carries its diff");
+    assert!(diff.contains("-two\n+three\n"), "{diff}");
 }
 
 #[tokio::test]

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -106,6 +106,23 @@ fn write_target(value: &Value) -> Result<WriteTarget, crate::input::InputError> 
     })
 }
 
+/// What is at `path` before this call replaces it — `None` when nothing is.
+///
+/// Read through the descriptor the write is about to walk (#938), so the old
+/// side of the diff and the file being overwritten are one file. The bytes are
+/// decoded lossily: the new side is a `String` by construction, and a diff
+/// over a lossy old side still states every line that changed, where refusing
+/// to diff would state nothing.
+fn before(handle: &crate::rootfd::RootHandle, path: &str) -> Option<String> {
+    if handle.stat(path).is_err() {
+        return None;
+    }
+    handle
+        .read(path)
+        .ok()
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+}
+
 impl WriteFile {
     /// Write several files as one change.
     ///
@@ -145,12 +162,14 @@ impl WriteFile {
                      `edit_file` to change part of it in place. Nothing was written."
                 ));
             }
-            planned.push((handle, path, target.content.as_str()));
+            planned.push((handle, scope_root, path, target.content.as_str()));
         }
 
         // Pass two: every check passed, so commit.
         let mut report = Vec::with_capacity(planned.len());
-        for (handle, path, content) in planned {
+        let mut changes = Vec::with_capacity(planned.len());
+        for (handle, scope_root, path, content) in planned {
+            let previous = before(&handle, &path);
             match crate::durable_write::write_file_durably_at(
                 handle,
                 path.clone(),
@@ -163,15 +182,23 @@ impl WriteFile {
                     self.ledger.record_known(root, &path, content);
                     self.ledger.record_coverage(root, &path, true);
                     report.push(format!("{path} — {} bytes", content.len()));
+                    changes.push(crate::own_change::own_change(
+                        &crate::own_change::workspace_path(root, &scope_root, &path),
+                        previous.as_deref(),
+                        content,
+                    ));
                 }
                 Err(e) => return ToolOutput::error(format!("failed to write `{path}`: {e}")),
             }
         }
-        ToolOutput::ok(format!(
-            "wrote {} file(s):\n{}",
-            report.len(),
-            report.join("\n")
-        ))
+        crate::own_change::attach(
+            ToolOutput::ok(format!(
+                "wrote {} file(s):\n{}",
+                report.len(),
+                report.join("\n")
+            )),
+            &changes,
+        )
     }
 
     async fn write_one(&self, input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
@@ -226,6 +253,7 @@ impl WriteFile {
             ));
         }
 
+        let previous = before(&handle, path);
         match crate::durable_write::write_file_durably_at(
             handle,
             path.to_string(),
@@ -242,7 +270,15 @@ impl WriteFile {
                 // what the content is, this says the model has seen all of it.
                 self.ledger.record_coverage(root, path, true);
                 let bytes = content.len();
-                ToolOutput::ok(format!("wrote {bytes} bytes to {path}"))
+                let change = crate::own_change::own_change(
+                    &crate::own_change::workspace_path(root, &scope_root, path),
+                    previous.as_deref(),
+                    content,
+                );
+                crate::own_change::attach(
+                    ToolOutput::ok(format!("wrote {bytes} bytes to {path}")),
+                    &[change],
+                )
             }
             Err(e) if e.is_escape() => {
                 ToolOutput::error(format!("path `{path}` escapes workspace root ({e})"))


### PR DESCRIPTION
## What & why

A `write_file` into `.stella/agents/kfc/spec-tasks.md` rendered in the deck as `＋ write … · new file` over `wrote 9214 bytes to …` — no diff, no line count. The rule for this surface is that `write_file` and `edit_file` show their diff, no exceptions; this PR closes the producer-side exceptions.

**Root cause.** The deck paints a diff under a file call only from a `FileChange` that folded inside the call's window, and that event had one producer: the work journal's git snapshot (`stella-cli/src/turn_files.rs` → `stella-store/src/work_journal/snapshot.rs`). git's reading has holes nothing downstream can fill:

- a **gitignored path** is invisible to it — this repository's `.gitignore:63` is `/.stella/*`, which is the screenshot;
- a session with **no journal bound** measures nothing;
- the session's **first snapshot is baseline-only** (`snapshot.rs:137-140` returns nothing), so the first mutating call of every session was diffless too.

**Fix.** `write_file` and `edit_file` hold both sides of every change they make. They now diff the bytes they read against the bytes they wrote (`stella-diff`, the leaf crate, #1511) and carry the result in `ToolOutput::Ok.data["changes"]` — the declared seam for a result's structured half (#3285); `content` is untouched, so the identity stamps the stagnation detector keys on (#3176) are preserved. This is a measurement of what landed, not the argument-derived guess #2290 forbids.

The registry hands that reading to `CallMeasure::measure_and_publish` beside the tree reading. `turn_files` publishes it — event and `files_touched` row — **only for paths the snapshot did not report**, so every change still gets exactly one event (the no-double-counting argument in `stella_tools::call_measure` holds). A registry with an event stream and no measurer publishes it directly.

The diff text is the per-file body the journal already hands the same event (`--- a/p`, `+++ b/p`, `@@` hunks; `--- /dev/null` for a created file), so the deck, `stella export` and the Observatory render it through the parser they already have. No TUI change.

Exemplar followed: the change is shaped like `turn_files.rs` itself — one producer function, one wire mapping, both projections from one reading.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here):
  - `stella-tools` `registry::tests::a_file_tool_s_own_reading_is_published_without_a_measurer` — attach only an event stream, run `write_file` then `edit_file`, assert one `FileChange` each with kind, counts and diff. On `main` nothing reaches the channel.
  - `stella-cli` `turn_files::tests::a_call_s_own_reading_is_published_where_the_tree_saw_nothing` — unbound durability (the no-journal / gitignored shape from the snapshot's side) still publishes the reading with its diff, and exactly one event.
  - `own_change` unit tests: created vs modified vs empty-existing, the `/dev/null` header, round-trip through `data`, and the canonical-root path match (macOS `/var` → `/private/var`, which made every path absolute on the first run).

## The gate

- [x] `cargo fmt --check`
- [x] `make check CARGO_SCOPE="-p stella-tools -p stella-cli"` — every guard + clippy `-D warnings`
- [x] `make doc-warnings` on both crates
- [x] `cargo test -p stella-tools` (515 lib + integration) · `cargo test -p stella-cli --no-fail-fast` (1990 lib + every integration binary)
- [x] Docs: `call_measure.rs` and `own_change.rs` module docs, `stella-tools/README.md` names the new edge
- [ ] CLA signed
- [x] No issue to close; `Refs` trailers on the docs commit

## Nothing left behind

- [x] Filed: #4365 (consumer side — `DIFF_HISTORY = 8` / `MAX_TRACKED_FILES = 256` still drop a row's diff after the 9th edit to one path), #4366 (`delete_file` carries no own reading)

## Ground-rule check

- [x] No I/O added to `stella-core`. New dep: `stella-tools` → `stella-diff`, a leaf with no dependencies, already linked by `stella-cli`/`stella-tui`/`stella-transcript`; justified in `Cargo.toml`.
- [x] No new outbound network calls
- [x] `OwnChange` crosses no crate boundary on the wire (it rides inside `ToolOutput.data` as JSON; `attach_then_from_output_round_trips_beside_existing_data` covers the round-trip)

## Anything reviewers should know?

- A `write_file` whose content is byte-identical to what was on disk now publishes a `Modified` change with `+0 −0` and a header-only diff. That is the true reading — the call changed nothing — and the snapshot would have said nothing at all. If the row should instead say nothing, that is a one-line `changed()` check in `own_change::attach` callers; I kept it because "no exceptions" was the ask.
- Non-UTF-8 old bytes on an overwrite are decoded lossily for the old side; the new side is a `String` by construction.
- `emit_measured_tree_changes` now returns the published paths; the turn-boundary caller discards them (it has no own reading to reconcile).

## Summary by Sourcery

Publish reliable diffs and line counts for `write_file` and `edit_file` mutations even when worktree measurement cannot observe the changed paths.

New Features:
- Make `write_file` and `edit_file` carry structured before-and-after file changes, including unified diffs and line counts, in successful tool outputs.
- Publish tool-provided file changes through event streams and durable file-touch records when tree measurement does not report the paths.

Bug Fixes:
- Ensure diffs are available for file mutations involving gitignored paths, unbound journals, first-session snapshots, or hosts without a measurer.
- Prevent duplicate file-change events by preferring tree measurements for paths they already cover.

Enhancements:
- Add shared own-change generation, serialization, path normalization, and event conversion for file mutation observability.
- Preserve existing tool output content and structured data while attaching change metadata.

Build:
- Add the `stella-diff` dependency to `stella-tools`.

Documentation:
- Document call-owned file readings and the new `stella-diff` dependency in the tools documentation.

Tests:
- Add coverage for created, modified, empty-existing, round-tripped, scoped, and canonicalized file changes.
- Add witness tests for publishing changes without a measurer and when tree measurement sees no changes.