### PR TITLE
feat(stella-tui): one navigation vocabulary — the focus tree, the pulse row, and a sub-agents overlay that can nudge and flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-autonomy"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "proptest",
  "serde",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "stella-cli"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "clap",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "proptest",
  "serde",
@@ -3017,14 +3017,14 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "stella-embed"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "stella-engine"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "serde",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3098,11 +3098,11 @@ dependencies = [
 
 [[package]]
 name = "stella-home"
-version = "0.9.145"
+version = "0.9.146"
 
 [[package]]
 name = "stella-mcp"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "libc",
  "rusqlite",
@@ -3192,14 +3192,14 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "stella-serve",
 ]
 
 [[package]]
 name = "stella-plugin"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "proptest",
  "serde",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "schemars",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "base64 0.23.1",
  "libc",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "stella-transcript"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "proptest",
  "serde",
@@ -3324,11 +3324,11 @@ dependencies = [
 
 [[package]]
 name = "stella-tty"
-version = "0.9.145"
+version = "0.9.146"
 
 [[package]]
 name = "stella-tui"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "arboard",
  "crossterm",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui-theme"
-version = "0.9.145"
+version = "0.9.146"
 dependencies = [
  "ratatui",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-autonomy"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "proptest",
  "serde",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "stella-cli"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "clap",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "stella-context"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "stella-core"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "stella-diag"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "proptest",
  "serde",
@@ -3017,14 +3017,14 @@ dependencies = [
 
 [[package]]
 name = "stella-diff"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "stella-embed"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "stella-engine"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "serde",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "stella-fleet"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "stella-graph"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -3098,11 +3098,11 @@ dependencies = [
 
 [[package]]
 name = "stella-home"
-version = "0.9.146"
+version = "0.9.147"
 
 [[package]]
 name = "stella-mcp"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "stella-media"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "stella-model"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "stella-observatory"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "libc",
  "rusqlite",
@@ -3192,14 +3192,14 @@ dependencies = [
 
 [[package]]
 name = "stella-parity"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "stella-serve",
 ]
 
 [[package]]
 name = "stella-plugin"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "proptest",
  "serde",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "stella-protocol"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "schemars",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "stella-runtime"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "stella-serve"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "stella-store"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "base64 0.23.1",
  "libc",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tools"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "stella-transcript"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "proptest",
  "serde",
@@ -3324,11 +3324,11 @@ dependencies = [
 
 [[package]]
 name = "stella-tty"
-version = "0.9.146"
+version = "0.9.147"
 
 [[package]]
 name = "stella-tui"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "arboard",
  "crossterm",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "stella-tui-theme"
-version = "0.9.146"
+version = "0.9.147"
 dependencies = [
  "ratatui",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 exclude = [".stella-examples"]
 
 [workspace.package]
-version = "0.9.145"
+version = "0.9.146"
 edition = "2024"
 rust-version = "1.90"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 exclude = [".stella-examples"]
 
 [workspace.package]
-version = "0.9.146"
+version = "0.9.147"
 edition = "2024"
 rust-version = "1.90"
 license = "AGPL-3.0-only"

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -705,8 +705,8 @@ pub(crate) enum Command {
     ///
     /// Reopen a previous session exactly where it stood — transcript,
     /// conversation, pending prompts. Sessions are durable (quit, crash, and
-    /// power loss included); the deck's SESSIONS overlay (`←` on an empty
-    /// prompt, `⏎` on a row) is the same navigation from inside a session.
+    /// power loss included); the deck's SESSIONS overlay (`ctrl-e`, `⏎` on a
+    /// row) is the same navigation from inside a session.
     Resume {
         /// Registry id (`ses-…`) of the session to reopen. Omitted: the most
         /// recently active resumable session of this workspace.

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -2475,6 +2475,10 @@ pub(crate) fn prompt_line(prompt: &str, max_chars: usize) -> String {
 /// Service a session-registry / inbox verb from the deck. Returns `true` if
 /// `input` was one (so the caller skips its own dispatch). All of these are
 /// cheap local file ops, serviced identically idle or mid-turn.
+// Every argument is a distinct handle the verbs need (registry, store, config,
+// budget, the two identities, the channel) — bundling them into a struct would
+// move the same list one hop away from the one call site.
+#[allow(clippy::too_many_arguments)]
 fn service_registry_action(
     input: &WorkspaceInput,
     scope: &sessions_view::SessionScope<'_>,
@@ -3553,7 +3557,7 @@ async fn run_deck_command(
         // but a queued one reaches here — accept it as handled (a no-op)
         // rather than calling it "unknown".
         "/files" | "/diff" | "/graph" | "/agents" | "/skills" | "/mcp" | "/mcp-search"
-        | "/settings" | "/sessions" | "/context" | "/inspect" | "/inbox" => {}
+        | "/settings" | "/sessions" | "/subagents" | "/context" | "/inspect" | "/inbox" => {}
         _ => {
             if let Some(reply) = add_dir::handle(trimmed, cfg, registry) {
                 say(reply);

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -653,8 +653,8 @@ pub async fn run_deck_session(
         // A fresh session in a workspace that has something to go back to:
         // one pointer, so "navigate back in" is discoverable.
         let _ = deck_tx.send(system_notice(
-            "◂ a previous session is resumable — ← (on an empty prompt) opens SESSIONS, ⏎ \
-             reopens one; or run `stella resume`."
+            "◂ a previous session is resumable — ctrl-e opens SESSIONS, ⏎ reopens one; \
+             or run `stella resume`."
                 .to_string(),
         ));
     }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -101,6 +101,7 @@ mod session_clear;
 mod sessions_view;
 mod settings_io;
 mod settle;
+mod slash_pump;
 mod task_tap;
 mod theme_cmd;
 use pr_observe::{ci_status_token, observe_pr, pr_status_token};
@@ -1404,6 +1405,9 @@ pub async fn run_deck_session(
         // Session-level slash commands are the driver's, never the model's —
         // the deck's popup enqueues them like any prompt (tab switches and
         // the help overlay were already handled TUI-side and never reach us).
+        // Awaited through the pump, not directly: a command that raises a
+        // question (`/init`) is answered on `sub_rx`, and nothing else reads
+        // that channel until the command returns (#4357).
         let command = run_deck_command(
             &prompt,
             &in_tx,
@@ -1416,8 +1420,18 @@ pub async fn run_deck_session(
             agent::remaining_budget(&budget),
             &session_record.id,
             &ask_io,
+        );
+        let command = match slash_pump::await_answerable(
+            command,
+            &mut sub_rx,
+            &ask_tx,
+            &mut deferred,
         )
-        .await;
+        .await
+        {
+            slash_pump::CommandWake::Finished(command) => command,
+            slash_pump::CommandWake::Quit => break 'session,
+        };
         if matches!(command, DeckCommand::Handled | DeckCommand::InitCompleted) {
             // A handled command emits its answer as `Text`, which flips the
             // lead to `Running` in the deck's fold — but no turn is in flight.

--- a/crates/stella-cli/src/command_deck/skills.rs
+++ b/crates/stella-cli/src/command_deck/skills.rs
@@ -58,11 +58,11 @@ pub(super) const DECK_BUILTINS: &[(&str, &str)] = &[
     ("/mcp", "open the MCP servers tab"),
     (
         "/sessions",
-        "every stella session on this machine, grouped by status (also: ← on an empty prompt)",
+        "every stella session on this machine, grouped by status (also: ctrl-e)",
     ),
     (
         "/context",
-        "this session's active skills + MCP servers (also: → on an empty prompt)",
+        "this session's active skills + MCP servers (also: ctrl-k)",
     ),
     (
         "/subagents",

--- a/crates/stella-cli/src/command_deck/skills.rs
+++ b/crates/stella-cli/src/command_deck/skills.rs
@@ -65,6 +65,10 @@ pub(super) const DECK_BUILTINS: &[(&str, &str)] = &[
         "this session's active skills + MCP servers (also: → on an empty prompt)",
     ),
     (
+        "/subagents",
+        "every dispatched sub-agent: purpose, where it is, stop · pause · restart (also: ctrl-a)",
+    ),
+    (
         "/plan",
         "the plan — every step, with where it may write and spend",
     ),

--- a/crates/stella-cli/src/command_deck/slash_pump.rs
+++ b/crates/stella-cli/src/command_deck/slash_pump.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Keep the deck's input channel serviced while a slash command runs.
+//!
+//! A slash command is awaited by the driver between turns, outside the turn
+//! loop's `select!` — and that `select!` is the only place an
+//! [`UserInput::AskUserAnswer`] was forwarded to the channel
+//! [`super::mid_turn_ask::DeckAskUserIo`] parks on. So a slash command that
+//! raised a question (`/init`'s markdown→TOML conversion offer, #3642) could
+//! never receive the answer: the deck sent it, nothing read it, the card's
+//! `ToolResult` never came back to clear the gate, and every key after that
+//! was swallowed by the pending question. Ctrl-C was the only way out.
+//!
+//! [`await_answerable`] is the missing arm. It races the command against the
+//! deck's channel: an answer is forwarded, a quit aborts the command, and any
+//! other input is *deferred* — pushed onto the idle arm's replay buffer so a
+//! prompt typed during `/init` keeps its place ahead of anything typed after
+//! it, exactly as the turn loop's `deferred` queue already promises.
+//!
+//! Separate from `command_deck.rs` because that file is a god file closed to
+//! growth (`scripts/file-size-baseline.txt`); the call site there is one
+//! expression.
+
+use std::collections::VecDeque;
+use std::future::Future;
+
+use stella_tui::{UserInput, WorkspaceInput};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// How a slash command awaited through [`await_answerable`] ended.
+#[derive(Debug)]
+pub(super) enum CommandWake<T> {
+    /// The command ran to completion.
+    Finished(T),
+    /// The deck quit (or its channel closed) mid-command; the command's
+    /// future was dropped unfinished.
+    Quit,
+}
+
+/// Await `command` while forwarding the deck's ask answers to `ask_tx`.
+///
+/// Every [`WorkspaceInput`] that arrives on `sub_rx` during the command is
+/// handled in one of three ways:
+///
+/// - [`UserInput::AskUserAnswer`] → its text goes to `ask_tx`, which is the
+///   channel the pending question's `prompt()` is blocked on;
+/// - [`WorkspaceInput::Quit`], or the channel closing → the command is
+///   dropped and [`CommandWake::Quit`] returned;
+/// - anything else → `deferred.push_back`, for the idle arm to replay in
+///   arrival order once the command returns.
+pub(super) async fn await_answerable<F, T>(
+    command: F,
+    sub_rx: &mut UnboundedReceiver<WorkspaceInput>,
+    ask_tx: &UnboundedSender<String>,
+    deferred: &mut VecDeque<WorkspaceInput>,
+) -> CommandWake<T>
+where
+    F: Future<Output = T>,
+{
+    tokio::pin!(command);
+    loop {
+        tokio::select! {
+            outcome = &mut command => return CommandWake::Finished(outcome),
+            input = sub_rx.recv() => match input {
+                None | Some(WorkspaceInput::Quit) => return CommandWake::Quit,
+                Some(WorkspaceInput::ToAgent {
+                    input: UserInput::AskUserAnswer { answer, .. },
+                    ..
+                }) => {
+                    let _ = ask_tx.send(answer);
+                }
+                Some(other) => deferred.push_back(other),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn answer(text: &str) -> WorkspaceInput {
+        WorkspaceInput::ToAgent {
+            agent: "lead".to_string(),
+            input: UserInput::AskUserAnswer {
+                id: "deck-ask-0".to_string(),
+                answer: text.to_string(),
+            },
+        }
+    }
+
+    /// The witness for the deadlock: a command parked on the ask channel
+    /// completes once the deck's answer arrives on the input channel.
+    #[tokio::test]
+    async fn an_answer_sent_during_the_command_reaches_the_parked_question() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        // Stands in for `/init`: blocked until an answer lands on `ask_rx`,
+        // exactly as `DeckAskUserIo::prompt` is.
+        let command = async move { ask_rx.recv().await };
+        sub_tx.send(answer("2")).expect("deck input channel open");
+
+        let wake = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred),
+        )
+        .await
+        .expect("the command must not hang once the answer is sent");
+
+        match wake {
+            CommandWake::Finished(Some(text)) => assert_eq!(text, "2"),
+            other => panic!("expected the forwarded answer, got {other:?}"),
+        }
+        assert!(deferred.is_empty(), "an answer is consumed, never deferred");
+    }
+
+    /// A prompt typed while the command runs is neither lost nor acted on
+    /// early: it waits in `deferred`, in arrival order.
+    #[tokio::test]
+    async fn other_input_is_deferred_in_arrival_order() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        sub_tx
+            .send(WorkspaceInput::Enqueue {
+                text: "first".to_string(),
+            })
+            .expect("open");
+        sub_tx
+            .send(WorkspaceInput::Enqueue {
+                text: "second".to_string(),
+            })
+            .expect("open");
+        sub_tx.send(answer("1")).expect("open");
+
+        let command = async move { ask_rx.recv().await };
+        let wake = await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred).await;
+        assert!(matches!(wake, CommandWake::Finished(Some(ref t)) if t == "1"));
+
+        let texts: Vec<String> = deferred
+            .iter()
+            .map(|input| match input {
+                WorkspaceInput::Enqueue { text } => text.clone(),
+                other => panic!("unexpected deferred input {other:?}"),
+            })
+            .collect();
+        assert_eq!(texts, ["first", "second"]);
+    }
+
+    /// Quit aborts the command rather than leaving the driver parked on a
+    /// question nobody will answer.
+    #[tokio::test]
+    async fn quit_drops_the_command() {
+        let (sub_tx, mut sub_rx) = unbounded_channel::<WorkspaceInput>();
+        let (ask_tx, mut ask_rx) = unbounded_channel::<String>();
+        let mut deferred = VecDeque::new();
+
+        sub_tx.send(WorkspaceInput::Quit).expect("open");
+        let command = async move { ask_rx.recv().await };
+        let wake = await_answerable(command, &mut sub_rx, &ask_tx, &mut deferred).await;
+        assert!(matches!(wake, CommandWake::Quit));
+    }
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -423,7 +423,7 @@ fn run_resume_list() -> Result<(), String> {
     }
     println!(
         "\n↩ resumable here (`stella resume [ID]`) · resumable from its own workspace\n\
-         inside the deck: `←` on an empty prompt opens SESSIONS, `⏎` reopens a session"
+         inside the deck: `ctrl-e` opens SESSIONS, `⏎` reopens a session"
     );
     Ok(())
 }

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -151,6 +151,12 @@ pub fn replay_inbound(record: JournalRecord, started_ms: u64) -> Option<Inbound>
         } => {
             let mut meta = AgentMeta::new(agent, title, started_ms).with_role(role);
             meta.model = model;
+            // The journal's `Register` record carries no dispatcher; every
+            // lane this driver has ever spawned was the lead's
+            // (`subsession::spawn`), so the replayed row says the same.
+            if meta.role == "subagent" {
+                meta = meta.with_parent(crate::command_deck::LEAD);
+            }
             Some(Inbound::Register(meta))
         }
         JournalRecord::Event { agent, event } => Some(Inbound::Event { agent, event }),

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -669,10 +669,14 @@ pub(crate) fn spawn(
     pause_rx: watch::Receiver<bool>,
     tap: Arc<SteeringTap>,
 ) {
+    // Delegation runs from the lead session only (see the stranded
+    // `task_assign` note in `run_worker`), so the lead is every lane's
+    // dispatcher — stated on the row rather than assumed by the deck.
     let mut meta = AgentMeta::new(spec.lane.clone(), spec.title.clone(), now_ms())
         .with_role("subagent")
         .with_pid(std::process::id())
-        .with_purpose(spec.purpose.clone());
+        .with_purpose(spec.purpose.clone())
+        .with_parent(crate::command_deck::LEAD);
     meta.model = Some(format!("{}/{}", cfg.provider.id, cfg.model_id));
     meta.effort = pinned_effort(cfg).map(str::to_string);
     let _ = in_tx.send(Inbound::Register(meta));

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -173,6 +173,7 @@ impl SubSessions {
             SubSessionSpec {
                 lane: lane.to_string(),
                 title: lane.to_string(),
+                purpose: String::new(),
                 prompt: String::new(),
                 notify_title: String::new(),
             },
@@ -448,6 +449,10 @@ pub(crate) struct SubSessionSpec {
     pub lane: String,
     /// Dashboard row title.
     pub title: String,
+    /// One sentence on what the lane is for, in the words it was handed —
+    /// the task's description or subject for an assigned task, the prompt's
+    /// first line for a dispatched one. The SUB-AGENTS overlay's second row.
+    pub purpose: String,
     /// The full prompt the worker's model receives.
     pub prompt: String,
     /// Notification title on completion (the body is the outcome).
@@ -473,6 +478,61 @@ pub(crate) fn task_prompt(req: &SpawnRequest) -> String {
         req.briefing
     ));
     prompt
+}
+
+/// The sentence the SUB-AGENTS overlay shows for an assigned task: the
+/// description's first sentence when the lead wrote one, the subject
+/// otherwise. The briefing is deliberately not used — it is instructions to
+/// the worker, and a row is about what the task *is*.
+pub(crate) fn task_purpose(req: &SpawnRequest) -> String {
+    req.description
+        .as_deref()
+        .map(first_sentence)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| first_sentence(&req.subject))
+}
+
+/// Most characters a purpose sentence spends.
+const PURPOSE_CAP: usize = 160;
+
+/// The first sentence of `text`, on one line: cut at the first sentence
+/// break or newline, whitespace collapsed, capped at [`PURPOSE_CAP`].
+pub(crate) fn first_sentence(text: &str) -> String {
+    let first_line = text.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+    let mut sentence = first_line;
+    // `. ` rather than `.`, so a file name like `lib.rs` does not end the
+    // sentence.
+    for mark in [". ", "! ", "? "] {
+        if let Some(i) = sentence.find(mark) {
+            sentence = &sentence[..i + 1];
+        }
+    }
+    let joined = sentence.split_whitespace().collect::<Vec<_>>().join(" ");
+    if joined.chars().count() <= PURPOSE_CAP {
+        joined
+    } else {
+        let head: String = joined.chars().take(PURPOSE_CAP - 1).collect();
+        format!("{head}…")
+    }
+}
+
+/// The reasoning effort a worker's calls are pinned to, as the word the
+/// settings spell it — resolved through `engine_config::tuning_for`, the same
+/// helper the engine builder applies (`agent::engine`), with the builder's
+/// capability clamp: a catalog-confirmed non-reasoning model carries no
+/// effort, so none is shown. `None` when nothing pins one. A provider that
+/// ignores the pin still receives it and says so at boot (AGENTS.md
+/// invariant 8's `ReasoningPosture`), so the word here is what the request
+/// carries, not a promise the model honours it.
+pub(crate) fn pinned_effort(cfg: &Config) -> Option<&'static str> {
+    if crate::engine_config::model_supports_reasoning(cfg.provider.id, &cfg.model_id) == Some(false)
+    {
+        return None;
+    }
+    cfg.engine_settings
+        .as_ref()
+        .and_then(|engine| crate::engine_config::tuning_for(engine).effort)
+        .map(crate::engine_config::effort_to_str)
 }
 
 /// The panic text a caught worker payload carries (`panic!("…")` is a
@@ -534,8 +594,10 @@ pub(crate) fn spawn(
 ) {
     let mut meta = AgentMeta::new(spec.lane.clone(), spec.title.clone(), now_ms())
         .with_role("subagent")
-        .with_pid(std::process::id());
+        .with_pid(std::process::id())
+        .with_purpose(spec.purpose.clone());
     meta.model = Some(format!("{}/{}", cfg.provider.id, cfg.model_id));
+    meta.effort = pinned_effort(cfg).map(str::to_string);
     let _ = in_tx.send(Inbound::Register(meta));
     let _ = in_tx.send(Inbound::Status {
         agent: spec.lane.clone(),
@@ -871,6 +933,7 @@ pub(crate) fn drain_queue(
         let spec = SubSessionSpec {
             lane: lane.clone(),
             title: prompt_line(&text, 48),
+            purpose: first_sentence(&text),
             notify_title: format!("reply ready — {}", prompt_line(&text, 40)),
             prompt: text,
         };
@@ -970,6 +1033,7 @@ pub(crate) fn spawn_task_worker(
     let spec = SubSessionSpec {
         lane: lane.clone(),
         title: format!("task #{}: {}", req.task_id, prompt_line(&req.subject, 40)),
+        purpose: task_purpose(req),
         prompt: task_prompt(req),
         notify_title: format!(
             "task #{} done — {}",
@@ -1025,429 +1089,4 @@ pub(crate) async fn shutdown_workers(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The spawn notice is the only thing standing between a mid-turn prompt
-    /// and looking like it did nothing, so its four jobs are pinned: name the
-    /// lane, say this turn is unaffected, say how to open the lane, and say
-    /// how to get back. A prettier wording is fine; a wording that drops one
-    /// of these is the regression.
-    #[test]
-    fn the_spawn_notice_names_the_lane_and_the_keys_in_and_out() {
-        let notice = spawn_notice("req:1", "fix the flaky witness test");
-
-        assert!(
-            notice.contains("req:1"),
-            "the notice must name the lane that took the prompt: {notice}"
-        );
-        assert!(
-            notice.contains("fix the flaky witness test"),
-            "the notice must echo the prompt so the user can tell which one it \
-             was: {notice}"
-        );
-        assert!(
-            notice.contains("does not block"),
-            "the notice must say the running turn is unaffected — that is the \
-             whole point of dispatching to a worker: {notice}"
-        );
-        assert!(
-            notice.contains("AGENTS"),
-            "the notice must name the tab that reaches the lane: {notice}"
-        );
-        assert!(
-            notice.contains(LEAD),
-            "the notice must say how to get BACK to the lead, not just in: \
-             {notice}"
-        );
-    }
-
-    /// A long prompt is truncated rather than dumped into the transcript — the
-    /// notice is a signpost, not a second copy of the prompt.
-    #[test]
-    fn the_spawn_notice_truncates_a_long_prompt() {
-        let long = "x".repeat(400);
-        let notice = spawn_notice("req:2", &long);
-        assert!(
-            !notice.contains(&long),
-            "the full prompt must not be inlined verbatim"
-        );
-        assert!(
-            notice.lines().count() <= 4,
-            "the notice must stay a few lines — it prints on every spawn: {notice}"
-        );
-    }
-
-    fn dummy_spec(lane: &str) -> SubSessionSpec {
-        SubSessionSpec {
-            lane: lane.to_string(),
-            title: "t".into(),
-            prompt: "p".into(),
-            notify_title: "n".into(),
-        }
-    }
-
-    #[tokio::test]
-    async fn watch_gate_parks_while_paused_and_releases_on_resume_or_teardown() {
-        use stella_core::ports::TurnGate;
-        let (tx, rx) = watch::channel(true);
-        let gate = WatchGate(rx);
-        let wait = gate.wait_if_paused();
-        tokio::pin!(wait);
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), &mut wait)
-                .await
-                .is_err(),
-            "a paused gate must park"
-        );
-        tx.send(false).unwrap();
-        tokio::time::timeout(std::time::Duration::from_millis(500), wait)
-            .await
-            .expect("resume releases the gate");
-
-        // A dropped sender (driver teardown) must release, never park forever.
-        let (tx2, rx2) = watch::channel(true);
-        let gate2 = WatchGate(rx2);
-        drop(tx2);
-        tokio::time::timeout(
-            std::time::Duration::from_millis(500),
-            gate2.wait_if_paused(),
-        )
-        .await
-        .expect("teardown releases the gate");
-    }
-
-    #[test]
-    fn pause_resume_flips_the_watch_and_restart_needs_a_dead_lane() {
-        let mut subs = SubSessions::new();
-        let (stop_tx, _stop_rx) = oneshot::channel();
-        let (pause_tx, pause_rx) = watch::channel(false);
-        let generation = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
-        assert!(subs.set_paused("req:1", true));
-        assert!(*pause_rx.borrow());
-        assert!(subs.set_paused("req:1", false));
-        assert!(!*pause_rx.borrow());
-        assert!(!subs.set_paused("req:404", true), "unknown lane is a no-op");
-        // A live lane refuses respawn; its spec survives its end.
-        assert!(subs.is_live("req:1"));
-        assert!(subs.ended("req:1", generation));
-        assert!(!subs.is_live("req:1"));
-        assert!(subs.spec("req:1").is_some(), "spec retained for Restart");
-    }
-
-    #[test]
-    fn slot_bookkeeping_caps_and_recovers() {
-        let mut subs = SubSessions::new();
-        let mut generations = Vec::new();
-        for i in 0..MAX_CONCURRENT {
-            assert!(subs.has_slot());
-            let (stop_tx, _stop_rx) = oneshot::channel();
-            let (pause_tx, _pause_rx) = watch::channel(false);
-            generations.push(subs.started(
-                &format!("req:{i}"),
-                stop_tx,
-                pause_tx,
-                dummy_spec(&format!("req:{i}")),
-            ));
-        }
-        assert!(!subs.has_slot());
-        assert!(subs.ended("req:0", generations[0]));
-        assert!(subs.has_slot());
-        // An Ended nothing started must free nothing (and never underflow).
-        let mut fresh = SubSessions::new();
-        assert!(!fresh.ended("req:none", 0));
-        assert!(fresh.has_slot());
-    }
-
-    #[test]
-    fn stop_signals_a_live_worker_once_and_only_once() {
-        let mut subs = SubSessions::new();
-        let (stop_tx, mut stop_rx) = oneshot::channel();
-        let (pause_tx, _pause_rx) = watch::channel(false);
-        subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
-        assert!(subs.stop("req:1"), "a live worker accepts the signal");
-        assert_eq!(stop_rx.try_recv(), Ok(()));
-        assert!(!subs.stop("req:1"), "a second stop is a stale no-op");
-        assert!(!subs.stop("req:404"), "an unknown lane is a no-op");
-    }
-
-    #[test]
-    fn a_stopped_lane_winds_down_until_its_ended_arrives() {
-        // stop() must NOT free the lane: the worker thread is still
-        // draining. The lane stays live (so Restart defers via
-        // pending_restarts instead of respawning into a second worker), the
-        // slot stays occupied, and only the matching Ended frees both.
-        let mut subs = SubSessions::new();
-        let (stop_tx, _stop_rx) = oneshot::channel();
-        let (pause_tx, _pause_rx) = watch::channel(false);
-        let generation = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
-        assert!(subs.stop("req:1"));
-        assert!(subs.is_live("req:1"), "winding down still counts as live");
-        assert_eq!(subs.live(), 1, "the slot is not free until Ended");
-        assert!(
-            !subs.set_paused("req:1", true),
-            "a winding-down worker cannot be paused"
-        );
-        assert!(subs.ended("req:1", generation));
-        assert!(!subs.is_live("req:1"));
-        assert_eq!(subs.live(), 0);
-    }
-
-    /// `/clear` (#1631) reports the lanes it left running, and this is what
-    /// it reports: running workers and winding-down ones, never a lane whose
-    /// worker has already ended. A retained spec is a Restart target, not
-    /// something the user needs warning about — so `live_lanes` and `lanes`
-    /// must diverge the moment a worker settles.
-    #[test]
-    fn live_lanes_are_the_running_and_winding_down_ones_only() {
-        let mut subs = SubSessions::new();
-        let (stop_a, _rx_a) = oneshot::channel();
-        let (pause_a, _p_a) = watch::channel(false);
-        let gen_a = subs.started("req:1", stop_a, pause_a, dummy_spec("req:1"));
-        let (stop_b, _rx_b) = oneshot::channel();
-        let (pause_b, _p_b) = watch::channel(false);
-        subs.started("req:2", stop_b, pause_b, dummy_spec("req:2"));
-
-        assert_eq!(subs.live_lanes(), vec!["req:1", "req:2"], "both running");
-
-        assert!(subs.stop("req:1"));
-        assert_eq!(
-            subs.live_lanes(),
-            vec!["req:1", "req:2"],
-            "a winding-down lane is still writing, so it is still reported"
-        );
-
-        assert!(subs.ended("req:1", gen_a));
-        assert_eq!(subs.live_lanes(), vec!["req:2"], "an ended lane drops out");
-        assert_eq!(
-            subs.lanes(),
-            vec!["req:1", "req:2"],
-            "…while `lanes` still carries it for Restart"
-        );
-    }
-
-    #[test]
-    fn stop_then_restart_leaves_one_worker_with_working_channels() {
-        // The full stop→Ended→respawn sequence, then a stale Ended for the
-        // replaced generation: exactly one live worker must remain, with ITS
-        // stop/pause channels registered and the active count intact.
-        let mut subs = SubSessions::new();
-        let (stop_tx, _stop_rx) = oneshot::channel();
-        let (pause_tx, _pause_rx) = watch::channel(false);
-        let old = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
-        subs.stop("req:1");
-        assert!(subs.ended("req:1", old));
-        // The respawn (what pending_restarts triggers on the Ended).
-        let (stop_tx2, mut stop_rx2) = oneshot::channel();
-        let (pause_tx2, pause_rx2) = watch::channel(false);
-        let new = subs.started("req:1", stop_tx2, pause_tx2, dummy_spec("req:1"));
-        assert_ne!(old, new, "each spawn gets its own generation");
-        assert_eq!(subs.live(), 1);
-        // A late Ended from the replaced worker frees nothing.
-        assert!(!subs.ended("req:1", old), "stale Ended must be ignored");
-        assert_eq!(subs.live(), 1, "active count survives the stale Ended");
-        assert!(
-            subs.set_paused("req:1", true),
-            "replacement's pause channel is intact"
-        );
-        assert!(*pause_rx2.borrow());
-        assert!(subs.stop("req:1"), "replacement's stop channel is intact");
-        assert_eq!(stop_rx2.try_recv(), Ok(()));
-        assert!(subs.ended("req:1", new));
-        assert_eq!(subs.live(), 0);
-    }
-
-    #[test]
-    fn a_panicking_worker_body_ends_as_failed_never_silence() {
-        // The supervisor must receive Ended whatever a tool does — a panic
-        // synthesizes Failed with the payload's message, both payload kinds.
-        let (id, cost, end) = run_caught(|| panic!("tool blew up"));
-        assert_eq!(id, None);
-        assert_eq!(cost, 0.0);
-        match end {
-            WorkerEnd::Failed(reason) => {
-                assert!(reason.contains("worker panicked"), "{reason}");
-                assert!(reason.contains("tool blew up"), "{reason}");
-            }
-            _ => panic!("a panic must synthesize WorkerEnd::Failed"),
-        }
-        let (_, _, end) = run_caught(|| panic!("{}", format!("dynamic {}", 7)));
-        match end {
-            WorkerEnd::Failed(reason) => assert!(reason.contains("dynamic 7"), "{reason}"),
-            _ => panic!("a String panic payload must synthesize Failed too"),
-        }
-        // A body that returns normally passes through untouched.
-        let (id, cost, end) = run_caught(|| (Some(7), 1.25, WorkerEnd::Done));
-        assert_eq!(id, Some(7));
-        assert_eq!(cost, 1.25);
-        assert!(matches!(end, WorkerEnd::Done));
-    }
-
-    #[tokio::test]
-    async fn quit_shutdown_stops_workers_and_reaps_their_endings() {
-        // Quit-time teardown: every live worker sees its stop signal and the
-        // drain waits for their Ended messages — no orphaned bookkeeping.
-        let mut subs = SubSessions::new();
-        let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
-        for lane in ["req:1", "sub:9"] {
-            let (stop_tx, stop_rx) = oneshot::channel();
-            let (pause_tx, _pause_rx) = watch::channel(false);
-            let generation = subs.started(lane, stop_tx, pause_tx, dummy_spec(lane));
-            let sup = sup_tx.clone();
-            let lane = lane.to_string();
-            // A worker's whole quit obligation: see the stop, close out,
-            // send Ended.
-            tokio::spawn(async move {
-                let _ = stop_rx.await;
-                let _ = sup.send(SupervisorMsg::Ended {
-                    lane,
-                    generation,
-                    execution_id: None,
-                    cost_usd: 0.0,
-                    end: WorkerEnd::Stopped,
-                });
-            });
-        }
-        shutdown_workers(&mut subs, &mut sup_rx, std::time::Duration::from_secs(5)).await;
-        assert_eq!(subs.live(), 0, "every worker settled before the deadline");
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn quit_shutdown_abandons_a_hung_worker_at_the_deadline() {
-        // A worker that never answers its stop must not hold the exit
-        // hostage — the drain returns at the deadline with the lane still
-        // accounted (abandoned, exactly the pre-teardown behavior).
-        let mut subs = SubSessions::new();
-        let (stop_tx, _stop_rx) = oneshot::channel();
-        let (pause_tx, _pause_rx) = watch::channel(false);
-        subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
-        let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
-        shutdown_workers(
-            &mut subs,
-            &mut sup_rx,
-            std::time::Duration::from_millis(100),
-        )
-        .await;
-        assert_eq!(subs.live(), 1, "abandoned, not freed — and no hang");
-    }
-
-    #[test]
-    fn req_lanes_are_sequential() {
-        let mut subs = SubSessions::new();
-        assert_eq!(subs.next_req_lane(), "req:1");
-        assert_eq!(subs.next_req_lane(), "req:2");
-    }
-
-    #[test]
-    fn lanes_names_every_worker_ever_started_live_or_ended() {
-        // The session-switch site deregisters exactly this set — a lane's
-        // dashboard row outlives its worker, so `lanes` must too.
-        let mut subs = SubSessions::new();
-        assert!(subs.lanes().is_empty());
-        let mut generations = std::collections::HashMap::new();
-        for lane in ["req:2", "req:1", "sub:7"] {
-            let (stop_tx, _stop_rx) = oneshot::channel();
-            let (pause_tx, _pause_rx) = watch::channel(false);
-            generations.insert(
-                lane,
-                subs.started(lane, stop_tx, pause_tx, dummy_spec(lane)),
-            );
-        }
-        assert!(subs.ended("req:1", generations["req:1"]));
-        assert_eq!(
-            subs.lanes(),
-            vec![
-                "req:1".to_string(),
-                "req:2".to_string(),
-                "sub:7".to_string()
-            ],
-            "ended lanes stay listed; order is deterministic (sorted)"
-        );
-    }
-
-    /// The reported bug. The deck paints `✓ done · stage complete · 100%` the
-    /// moment `AgentEvent::TurnComplete` leaves the driver, but `run_lead_turn`
-    /// keeps running — and its `select!` keeps reading input — while it
-    /// persists the turn. A follow-up typed into that window used to be read
-    /// as a brand-new request and spawned `req:1`, so a long collaboration
-    /// silently forked into a stranger agent every time the user answered
-    /// promptly. Once settling, every submission continues the thread.
-    #[test]
-    fn a_prompt_typed_after_the_turn_is_done_continues_the_thread() {
-        assert_eq!(
-            route_mid_turn("and now add the tests".into(), true),
-            MidTurnRoute::NextTurn("and now add the tests".into()),
-            "a settling turn has no work left to run something alongside"
-        );
-    }
-
-    /// While the turn is genuinely running, the two routes stay as they were:
-    /// `>` is the steer marker, everything else is a concurrent request.
-    #[test]
-    fn a_live_turn_still_steers_on_the_marker_and_spawns_otherwise() {
-        assert_eq!(
-            route_mid_turn("> only the parser".into(), false),
-            MidTurnRoute::Steer("only the parser".into()),
-            "the marker and its padding are stripped before injection"
-        );
-        assert_eq!(
-            route_mid_turn("unrelated question".into(), false),
-            MidTurnRoute::Sidecar("unrelated question".into()),
-        );
-    }
-
-    /// A `>` aimed at a settling turn cannot be injected — there is no step
-    /// boundary left to inject at, and pushing it to the tap would drop it on
-    /// the floor. It becomes the next turn instead, marker stripped: the user
-    /// asked to influence the work, and continuing the thread is the closest
-    /// thing still on offer.
-    #[test]
-    fn a_steer_that_arrives_too_late_becomes_the_next_turn_not_silence() {
-        assert_eq!(
-            route_mid_turn(">  narrow it down".into(), true),
-            MidTurnRoute::NextTurn("narrow it down".into()),
-        );
-    }
-
-    #[test]
-    fn task_prompt_carries_identity_and_briefing_verbatim() {
-        let req = SpawnRequest {
-            task_id: "3".into(),
-            subject: "Fix the redirect loop".into(),
-            description: Some("token refresh races the redirect".into()),
-            briefing: "Start from auth/callback.rs; the witness test is half-written.".into(),
-        };
-        let prompt = task_prompt(&req);
-        assert!(prompt.contains("Task #3: Fix the redirect loop"));
-        assert!(prompt.contains("token refresh races the redirect"));
-        assert!(prompt.contains("Start from auth/callback.rs; the witness test is half-written."));
-    }
-
-    #[test]
-    fn drain_stops_at_slash_commands_and_respects_hold() {
-        // Contract-level test of the pure gating conditions: a held dispatch
-        // or a slash front entry must leave the queue untouched. (Spawning
-        // itself needs a provider key + threads — exercised in integration,
-        // not here — so this asserts the *refusals*, which are what protect
-        // the deck's FIFO view.)
-        let queue: std::collections::VecDeque<String> =
-            std::collections::VecDeque::from(["/models".to_string()]);
-        let subs = SubSessions::new();
-        assert!(subs.has_slot());
-        assert!(
-            queue
-                .front()
-                .is_some_and(|t| t.trim_start().starts_with('/')),
-            "slash front entry must gate the drain"
-        );
-        // Simulate the drain's gate exactly as `drain_queue` evaluates it.
-        let held = false;
-        let would_take = !held
-            && subs.has_slot()
-            && queue
-                .front()
-                .is_some_and(|t| !t.trim_start().starts_with('/'));
-        assert!(!would_take);
-        assert_eq!(queue.len(), 1);
-    }
-}
+mod tests;

--- a/crates/stella-cli/src/subsession/tests.rs
+++ b/crates/stella-cli/src/subsession/tests.rs
@@ -1,0 +1,456 @@
+//! Tests for the sub-session supervisor: the spawn notice, mid-turn
+//! routing, the task prompt and purpose, the pinned effort, and the
+//! worker lifecycle.
+
+use super::*;
+
+/// The spawn notice is the only thing standing between a mid-turn prompt
+/// and looking like it did nothing, so its four jobs are pinned: name the
+/// lane, say this turn is unaffected, say how to open the lane, and say
+/// how to get back. A prettier wording is fine; a wording that drops one
+/// of these is the regression.
+#[test]
+fn the_spawn_notice_names_the_lane_and_the_keys_in_and_out() {
+    let notice = spawn_notice("req:1", "fix the flaky witness test");
+
+    assert!(
+        notice.contains("req:1"),
+        "the notice must name the lane that took the prompt: {notice}"
+    );
+    assert!(
+        notice.contains("fix the flaky witness test"),
+        "the notice must echo the prompt so the user can tell which one it \
+         was: {notice}"
+    );
+    assert!(
+        notice.contains("does not block"),
+        "the notice must say the running turn is unaffected — that is the \
+         whole point of dispatching to a worker: {notice}"
+    );
+    assert!(
+        notice.contains("AGENTS"),
+        "the notice must name the tab that reaches the lane: {notice}"
+    );
+    assert!(
+        notice.contains(LEAD),
+        "the notice must say how to get BACK to the lead, not just in: \
+         {notice}"
+    );
+}
+
+/// A long prompt is truncated rather than dumped into the transcript — the
+/// notice is a signpost, not a second copy of the prompt.
+#[test]
+fn the_spawn_notice_truncates_a_long_prompt() {
+    let long = "x".repeat(400);
+    let notice = spawn_notice("req:2", &long);
+    assert!(
+        !notice.contains(&long),
+        "the full prompt must not be inlined verbatim"
+    );
+    assert!(
+        notice.lines().count() <= 4,
+        "the notice must stay a few lines — it prints on every spawn: {notice}"
+    );
+}
+
+fn dummy_spec(lane: &str) -> SubSessionSpec {
+    SubSessionSpec {
+        lane: lane.to_string(),
+        title: "t".into(),
+        purpose: String::new(),
+        prompt: "p".into(),
+        notify_title: "n".into(),
+    }
+}
+
+#[tokio::test]
+async fn watch_gate_parks_while_paused_and_releases_on_resume_or_teardown() {
+    use stella_core::ports::TurnGate;
+    let (tx, rx) = watch::channel(true);
+    let gate = WatchGate(rx);
+    let wait = gate.wait_if_paused();
+    tokio::pin!(wait);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut wait)
+            .await
+            .is_err(),
+        "a paused gate must park"
+    );
+    tx.send(false).unwrap();
+    tokio::time::timeout(std::time::Duration::from_millis(500), wait)
+        .await
+        .expect("resume releases the gate");
+
+    // A dropped sender (driver teardown) must release, never park forever.
+    let (tx2, rx2) = watch::channel(true);
+    let gate2 = WatchGate(rx2);
+    drop(tx2);
+    tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        gate2.wait_if_paused(),
+    )
+    .await
+    .expect("teardown releases the gate");
+}
+
+#[test]
+fn pause_resume_flips_the_watch_and_restart_needs_a_dead_lane() {
+    let mut subs = SubSessions::new();
+    let (stop_tx, _stop_rx) = oneshot::channel();
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let generation = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+    assert!(subs.set_paused("req:1", true));
+    assert!(*pause_rx.borrow());
+    assert!(subs.set_paused("req:1", false));
+    assert!(!*pause_rx.borrow());
+    assert!(!subs.set_paused("req:404", true), "unknown lane is a no-op");
+    // A live lane refuses respawn; its spec survives its end.
+    assert!(subs.is_live("req:1"));
+    assert!(subs.ended("req:1", generation));
+    assert!(!subs.is_live("req:1"));
+    assert!(subs.spec("req:1").is_some(), "spec retained for Restart");
+}
+
+#[test]
+fn slot_bookkeeping_caps_and_recovers() {
+    let mut subs = SubSessions::new();
+    let mut generations = Vec::new();
+    for i in 0..MAX_CONCURRENT {
+        assert!(subs.has_slot());
+        let (stop_tx, _stop_rx) = oneshot::channel();
+        let (pause_tx, _pause_rx) = watch::channel(false);
+        generations.push(subs.started(
+            &format!("req:{i}"),
+            stop_tx,
+            pause_tx,
+            dummy_spec(&format!("req:{i}")),
+        ));
+    }
+    assert!(!subs.has_slot());
+    assert!(subs.ended("req:0", generations[0]));
+    assert!(subs.has_slot());
+    // An Ended nothing started must free nothing (and never underflow).
+    let mut fresh = SubSessions::new();
+    assert!(!fresh.ended("req:none", 0));
+    assert!(fresh.has_slot());
+}
+
+#[test]
+fn stop_signals_a_live_worker_once_and_only_once() {
+    let mut subs = SubSessions::new();
+    let (stop_tx, mut stop_rx) = oneshot::channel();
+    let (pause_tx, _pause_rx) = watch::channel(false);
+    subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+    assert!(subs.stop("req:1"), "a live worker accepts the signal");
+    assert_eq!(stop_rx.try_recv(), Ok(()));
+    assert!(!subs.stop("req:1"), "a second stop is a stale no-op");
+    assert!(!subs.stop("req:404"), "an unknown lane is a no-op");
+}
+
+#[test]
+fn a_stopped_lane_winds_down_until_its_ended_arrives() {
+    // stop() must NOT free the lane: the worker thread is still
+    // draining. The lane stays live (so Restart defers via
+    // pending_restarts instead of respawning into a second worker), the
+    // slot stays occupied, and only the matching Ended frees both.
+    let mut subs = SubSessions::new();
+    let (stop_tx, _stop_rx) = oneshot::channel();
+    let (pause_tx, _pause_rx) = watch::channel(false);
+    let generation = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+    assert!(subs.stop("req:1"));
+    assert!(subs.is_live("req:1"), "winding down still counts as live");
+    assert_eq!(subs.live(), 1, "the slot is not free until Ended");
+    assert!(
+        !subs.set_paused("req:1", true),
+        "a winding-down worker cannot be paused"
+    );
+    assert!(subs.ended("req:1", generation));
+    assert!(!subs.is_live("req:1"));
+    assert_eq!(subs.live(), 0);
+}
+
+/// `/clear` (#1631) reports the lanes it left running, and this is what
+/// it reports: running workers and winding-down ones, never a lane whose
+/// worker has already ended. A retained spec is a Restart target, not
+/// something the user needs warning about — so `live_lanes` and `lanes`
+/// must diverge the moment a worker settles.
+#[test]
+fn live_lanes_are_the_running_and_winding_down_ones_only() {
+    let mut subs = SubSessions::new();
+    let (stop_a, _rx_a) = oneshot::channel();
+    let (pause_a, _p_a) = watch::channel(false);
+    let gen_a = subs.started("req:1", stop_a, pause_a, dummy_spec("req:1"));
+    let (stop_b, _rx_b) = oneshot::channel();
+    let (pause_b, _p_b) = watch::channel(false);
+    subs.started("req:2", stop_b, pause_b, dummy_spec("req:2"));
+
+    assert_eq!(subs.live_lanes(), vec!["req:1", "req:2"], "both running");
+
+    assert!(subs.stop("req:1"));
+    assert_eq!(
+        subs.live_lanes(),
+        vec!["req:1", "req:2"],
+        "a winding-down lane is still writing, so it is still reported"
+    );
+
+    assert!(subs.ended("req:1", gen_a));
+    assert_eq!(subs.live_lanes(), vec!["req:2"], "an ended lane drops out");
+    assert_eq!(
+        subs.lanes(),
+        vec!["req:1", "req:2"],
+        "…while `lanes` still carries it for Restart"
+    );
+}
+
+#[test]
+fn stop_then_restart_leaves_one_worker_with_working_channels() {
+    // The full stop→Ended→respawn sequence, then a stale Ended for the
+    // replaced generation: exactly one live worker must remain, with ITS
+    // stop/pause channels registered and the active count intact.
+    let mut subs = SubSessions::new();
+    let (stop_tx, _stop_rx) = oneshot::channel();
+    let (pause_tx, _pause_rx) = watch::channel(false);
+    let old = subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+    subs.stop("req:1");
+    assert!(subs.ended("req:1", old));
+    // The respawn (what pending_restarts triggers on the Ended).
+    let (stop_tx2, mut stop_rx2) = oneshot::channel();
+    let (pause_tx2, pause_rx2) = watch::channel(false);
+    let new = subs.started("req:1", stop_tx2, pause_tx2, dummy_spec("req:1"));
+    assert_ne!(old, new, "each spawn gets its own generation");
+    assert_eq!(subs.live(), 1);
+    // A late Ended from the replaced worker frees nothing.
+    assert!(!subs.ended("req:1", old), "stale Ended must be ignored");
+    assert_eq!(subs.live(), 1, "active count survives the stale Ended");
+    assert!(
+        subs.set_paused("req:1", true),
+        "replacement's pause channel is intact"
+    );
+    assert!(*pause_rx2.borrow());
+    assert!(subs.stop("req:1"), "replacement's stop channel is intact");
+    assert_eq!(stop_rx2.try_recv(), Ok(()));
+    assert!(subs.ended("req:1", new));
+    assert_eq!(subs.live(), 0);
+}
+
+#[test]
+fn a_panicking_worker_body_ends_as_failed_never_silence() {
+    // The supervisor must receive Ended whatever a tool does — a panic
+    // synthesizes Failed with the payload's message, both payload kinds.
+    let (id, cost, end) = run_caught(|| panic!("tool blew up"));
+    assert_eq!(id, None);
+    assert_eq!(cost, 0.0);
+    match end {
+        WorkerEnd::Failed(reason) => {
+            assert!(reason.contains("worker panicked"), "{reason}");
+            assert!(reason.contains("tool blew up"), "{reason}");
+        }
+        _ => panic!("a panic must synthesize WorkerEnd::Failed"),
+    }
+    let (_, _, end) = run_caught(|| panic!("{}", format!("dynamic {}", 7)));
+    match end {
+        WorkerEnd::Failed(reason) => assert!(reason.contains("dynamic 7"), "{reason}"),
+        _ => panic!("a String panic payload must synthesize Failed too"),
+    }
+    // A body that returns normally passes through untouched.
+    let (id, cost, end) = run_caught(|| (Some(7), 1.25, WorkerEnd::Done));
+    assert_eq!(id, Some(7));
+    assert_eq!(cost, 1.25);
+    assert!(matches!(end, WorkerEnd::Done));
+}
+
+#[tokio::test]
+async fn quit_shutdown_stops_workers_and_reaps_their_endings() {
+    // Quit-time teardown: every live worker sees its stop signal and the
+    // drain waits for their Ended messages — no orphaned bookkeeping.
+    let mut subs = SubSessions::new();
+    let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+    for lane in ["req:1", "sub:9"] {
+        let (stop_tx, stop_rx) = oneshot::channel();
+        let (pause_tx, _pause_rx) = watch::channel(false);
+        let generation = subs.started(lane, stop_tx, pause_tx, dummy_spec(lane));
+        let sup = sup_tx.clone();
+        let lane = lane.to_string();
+        // A worker's whole quit obligation: see the stop, close out,
+        // send Ended.
+        tokio::spawn(async move {
+            let _ = stop_rx.await;
+            let _ = sup.send(SupervisorMsg::Ended {
+                lane,
+                generation,
+                execution_id: None,
+                cost_usd: 0.0,
+                end: WorkerEnd::Stopped,
+            });
+        });
+    }
+    shutdown_workers(&mut subs, &mut sup_rx, std::time::Duration::from_secs(5)).await;
+    assert_eq!(subs.live(), 0, "every worker settled before the deadline");
+}
+
+#[tokio::test(start_paused = true)]
+async fn quit_shutdown_abandons_a_hung_worker_at_the_deadline() {
+    // A worker that never answers its stop must not hold the exit
+    // hostage — the drain returns at the deadline with the lane still
+    // accounted (abandoned, exactly the pre-teardown behavior).
+    let mut subs = SubSessions::new();
+    let (stop_tx, _stop_rx) = oneshot::channel();
+    let (pause_tx, _pause_rx) = watch::channel(false);
+    subs.started("req:1", stop_tx, pause_tx, dummy_spec("req:1"));
+    let (_sup_tx, mut sup_rx) = mpsc::unbounded_channel();
+    shutdown_workers(
+        &mut subs,
+        &mut sup_rx,
+        std::time::Duration::from_millis(100),
+    )
+    .await;
+    assert_eq!(subs.live(), 1, "abandoned, not freed — and no hang");
+}
+
+#[test]
+fn req_lanes_are_sequential() {
+    let mut subs = SubSessions::new();
+    assert_eq!(subs.next_req_lane(), "req:1");
+    assert_eq!(subs.next_req_lane(), "req:2");
+}
+
+#[test]
+fn lanes_names_every_worker_ever_started_live_or_ended() {
+    // The session-switch site deregisters exactly this set — a lane's
+    // dashboard row outlives its worker, so `lanes` must too.
+    let mut subs = SubSessions::new();
+    assert!(subs.lanes().is_empty());
+    let mut generations = std::collections::HashMap::new();
+    for lane in ["req:2", "req:1", "sub:7"] {
+        let (stop_tx, _stop_rx) = oneshot::channel();
+        let (pause_tx, _pause_rx) = watch::channel(false);
+        generations.insert(
+            lane,
+            subs.started(lane, stop_tx, pause_tx, dummy_spec(lane)),
+        );
+    }
+    assert!(subs.ended("req:1", generations["req:1"]));
+    assert_eq!(
+        subs.lanes(),
+        vec![
+            "req:1".to_string(),
+            "req:2".to_string(),
+            "sub:7".to_string()
+        ],
+        "ended lanes stay listed; order is deterministic (sorted)"
+    );
+}
+
+/// The reported bug. The deck paints `✓ done · stage complete · 100%` the
+/// moment `AgentEvent::TurnComplete` leaves the driver, but `run_lead_turn`
+/// keeps running — and its `select!` keeps reading input — while it
+/// persists the turn. A follow-up typed into that window used to be read
+/// as a brand-new request and spawned `req:1`, so a long collaboration
+/// silently forked into a stranger agent every time the user answered
+/// promptly. Once settling, every submission continues the thread.
+#[test]
+fn a_prompt_typed_after_the_turn_is_done_continues_the_thread() {
+    assert_eq!(
+        route_mid_turn("and now add the tests".into(), true),
+        MidTurnRoute::NextTurn("and now add the tests".into()),
+        "a settling turn has no work left to run something alongside"
+    );
+}
+
+/// While the turn is genuinely running, the two routes stay as they were:
+/// `>` is the steer marker, everything else is a concurrent request.
+#[test]
+fn a_live_turn_still_steers_on_the_marker_and_spawns_otherwise() {
+    assert_eq!(
+        route_mid_turn("> only the parser".into(), false),
+        MidTurnRoute::Steer("only the parser".into()),
+        "the marker and its padding are stripped before injection"
+    );
+    assert_eq!(
+        route_mid_turn("unrelated question".into(), false),
+        MidTurnRoute::Sidecar("unrelated question".into()),
+    );
+}
+
+/// A `>` aimed at a settling turn cannot be injected — there is no step
+/// boundary left to inject at, and pushing it to the tap would drop it on
+/// the floor. It becomes the next turn instead, marker stripped: the user
+/// asked to influence the work, and continuing the thread is the closest
+/// thing still on offer.
+#[test]
+fn a_steer_that_arrives_too_late_becomes_the_next_turn_not_silence() {
+    assert_eq!(
+        route_mid_turn(">  narrow it down".into(), true),
+        MidTurnRoute::NextTurn("narrow it down".into()),
+    );
+}
+
+/// The overlay's purpose row is the task's own description, one sentence,
+/// never the briefing — and the subject when there is no description.
+#[test]
+fn task_purpose_is_the_descriptions_first_sentence_or_the_subject() {
+    let mut req = SpawnRequest {
+        task_id: "3".into(),
+        subject: "Fix the redirect loop".into(),
+        description: Some(
+            "Token refresh races the redirect in auth/login.rs. Repro: log in twice.\n\
+             Then read the trace."
+                .into(),
+        ),
+        briefing: "Start from the failing test.".into(),
+    };
+    assert_eq!(
+        task_purpose(&req),
+        "Token refresh races the redirect in auth/login.rs."
+    );
+    req.description = None;
+    assert_eq!(task_purpose(&req), "Fix the redirect loop");
+    assert_eq!(
+        first_sentence("  \n\nSimplify   docs/spec.md so it reads plainly\nmore"),
+        "Simplify docs/spec.md so it reads plainly",
+        "a dotted path is not a sentence break; the newline is"
+    );
+}
+
+#[test]
+fn task_prompt_carries_identity_and_briefing_verbatim() {
+    let req = SpawnRequest {
+        task_id: "3".into(),
+        subject: "Fix the redirect loop".into(),
+        description: Some("token refresh races the redirect".into()),
+        briefing: "Start from auth/callback.rs; the witness test is half-written.".into(),
+    };
+    let prompt = task_prompt(&req);
+    assert!(prompt.contains("Task #3: Fix the redirect loop"));
+    assert!(prompt.contains("token refresh races the redirect"));
+    assert!(prompt.contains("Start from auth/callback.rs; the witness test is half-written."));
+}
+
+#[test]
+fn drain_stops_at_slash_commands_and_respects_hold() {
+    // Contract-level test of the pure gating conditions: a held dispatch
+    // or a slash front entry must leave the queue untouched. (Spawning
+    // itself needs a provider key + threads — exercised in integration,
+    // not here — so this asserts the *refusals*, which are what protect
+    // the deck's FIFO view.)
+    let queue: std::collections::VecDeque<String> =
+        std::collections::VecDeque::from(["/models".to_string()]);
+    let subs = SubSessions::new();
+    assert!(subs.has_slot());
+    assert!(
+        queue
+            .front()
+            .is_some_and(|t| t.trim_start().starts_with('/')),
+        "slash front entry must gate the drain"
+    );
+    // Simulate the drain's gate exactly as `drain_queue` evaluates it.
+    let held = false;
+    let would_take = !held
+        && subs.has_slot()
+        && queue
+            .front()
+            .is_some_and(|t| !t.trim_start().starts_with('/'));
+    assert!(!would_take);
+    assert_eq!(queue.len(), 1);
+}

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -696,7 +696,9 @@ mod tests {
             // away from being invisible to this sweep.
             include_str!("../../stella-cli/src/agent/tests/engine_wiring.rs"),
             include_str!("../../stella-cli/src/subagent/tests.rs"),
-            include_str!("../../stella-cli/src/subsession.rs"),
+            // `subsession.rs` crossed the ratchet with #4334 and its tests
+            // moved out the same way — the `turn.steer` witness lives here.
+            include_str!("../../stella-cli/src/subsession/tests.rs"),
             include_str!("../../stella-cli/src/command_deck/tests.rs"),
             include_str!("../../stella-cli/src/session_persist.rs"),
             include_str!("../../stella-cli/src/engine_config.rs"),

--- a/crates/stella-tui/README.md
+++ b/crates/stella-tui/README.md
@@ -167,7 +167,9 @@ escape hatch for an irreducible line (a module declaration in an oversized
 | [`src/v2/status_source.rs`](src/v2/status_source.rs) | `WorkspaceModel` → the v2 status bar's input struct. The **one** projection of SPEC 5's six values, since #4187 deleted the second one — which was the one that drew, and which printed the wire string `context_recall` where SPEC 5 says `context recall`. |
 | [`src/progress.rs`](src/progress.rs), [`src/cache_panel.rs`](src/cache_panel.rs), [`src/splash.rs`](src/splash.rs) | Chrome widgets: the unified stage stepper + progress row, the cache formatters behind the status bar's `saved` cell / context overlay, and the launch mark held over session init. |
 | [`src/views/cards.rs`](src/views/cards.rs) + [`plan_card`](src/views/plan_card.rs) · [`models_card`](src/views/models_card.rs) · [`budget_card`](src/views/budget_card.rs) | The three floating cards over one shared chrome; their modal key handlers live in [`src/deck_ui/cards.rs`](src/deck_ui/cards.rs). |
-| [`src/v2/subagents.rs`](src/v2/subagents.rs) | The SUB-AGENTS overlay (`↓` from an empty prompt, `ctrl-a`, `/subagents`): every dispatched lane with its vitals, purpose and place, and the controls — `→`/`⏎` open, `ctrl-x ctrl-x` kill, `p` pause/resume, `r` restart, `l` back to the lead. The one place the lanes are drawn; the SESSION tab stacks nothing above the transcript for them. |
+| [`src/v2/subagents.rs`](src/v2/subagents.rs) | The SUB-AGENTS overlay (`↓` from an empty prompt, `ctrl-a`, `/subagents`): every dispatched lane and every `delegate` child with its vitals (quiet time first), purpose and place, and the controls — `→`/`⏎` open, `n` nudge, `f` flag to the dispatcher, `ctrl-x ctrl-x` kill, `p` pause/resume, `r` restart, `l` back to the lead. `lifecycle.rs` is the place sentence the pulse row shares; `rows.rs` is the row model and the two messages. The one place the sub-agents are drawn; the SESSION tab stacks nothing above the transcript for them. |
+| [`src/v2/pulse.rs`](src/v2/pulse.rs) | The pulse row: the live agent's status, quiet time, place and last words, drawn in the air row above the composer on every tab but SESSION (and at an opened lane, where it is the lead). |
+| [`src/keymap.rs`](src/keymap.rs) | The one keymap table. The `?` sheet and the hint row render it; a row is a claim the witness tests under `src/deck_ui/tests/` establish. |
 | [`src/scroll.rs`](src/scroll.rs), [`src/input.rs`](src/input.rs), [`src/graph.rs`](src/graph.rs), [`src/resource.rs`](src/resource.rs), [`src/attach.rs`](src/attach.rs), [`src/clipboard.rs`](src/clipboard.rs) | Small leaf modules: line-exact viewport math, the outbound message enum, the graph snapshot types, CPU/MEM sampling, pasted-path detection, `⌃V` clipboard capture. |
 | [`src/fleet_dashboard.rs`](src/fleet_dashboard.rs) | A separate full-screen surface for `stella fleet` — its own fold (`FleetMsg`), its own `run`, monotonic `Instant` clocks only. |
 | [`src/scenario.rs`](src/scenario.rs) | A deterministic scripted multi-agent scenario, driving both `examples/deck_demo.rs` and the snapshot test. |
@@ -202,10 +204,32 @@ shell was deleted in #936 — see [`src/lib.rs`](src/lib.rs)'s module header.
 ([`src/deck_ui.rs`](src/deck_ui.rs)) runs modal contexts first (splash,
 help, installed-agent editors, issues forms, queue editor, graph picker, engine
 panel, overlays), then tab navigation, then focused-agent gates, then composer
-editing, then per-tab keys, then Esc. Two rules hold throughout: bare-letter
-hotkeys (`s`/`p`/`r` on AGENTS, `?` for help) only fire from an **empty
-composer**, so they never eat a keystroke meant for a prompt; and the composer
-never claims Esc, so a typed draft survives an interrupt.
+editing, then per-tab keys, then the focus tree, then Esc. Two rules hold
+throughout: bare-letter hotkeys (`s`/`p`/`r` on AGENTS, `?` for help) only
+fire from an **empty composer**, so they never eat a keystroke meant for a
+prompt; and the composer never claims Esc, so a typed draft survives an
+interrupt.
+
+**One navigation vocabulary, at every level** ([`src/deck_ui/focus.rs`](src/deck_ui/focus.rs)).
+From an empty composer `←`/`→` move to the sibling — the pane beside this
+one, or, when the tab has none that way, the tab beside it: a key the active
+tab declines *bubbles* to the tab strip, the DOM's model, so no tab spells
+its own arrows. `↑`/`↓` (and `j`/`k`) walk the list under the cursor, `⏎`
+opens what is under it, and `⌫` backs up one level and never reaches a
+running turn — Esc keeps its peel-then-interrupt chain, `⌫` is the half of it
+that cannot also mean *stop*. Every list and scrolling body takes the same
+keys through [`src/deck_ui/list_nav.rs`](src/deck_ui/list_nav.rs), and every
+overlay closes on `q` or Esc. The table every help surface renders is
+[`src/keymap.rs`](src/keymap.rs): the `?` sheet and the hint row under the
+composer both read it, so neither can drift from the other.
+
+**Sub-agents are a tree.** `AgentMeta::parent` names the agent that
+dispatched each lane; the SESSION breadcrumb prints the path
+(`lead ▸ sub:2`), `⌫` walks back up it, and the SUB-AGENTS overlay's `f`
+flags a lane to whoever dispatched it. Off the SESSION tab the one row of
+air above the composer is the **pulse row**
+([`src/v2/pulse.rs`](src/v2/pulse.rs)): the live agent's status, quiet time,
+place and last words, so no tab is blind to the turn.
 
 **Slash commands are an input, not a hard-coded set.** The vocabulary arrives
 as `RunOptions::slash_commands` / `DeckOptions::slash_commands`, so the CLI owns
@@ -247,9 +271,9 @@ every panic on every thread, including panel panics the session survives.
   being true.
 - **Digits never switch tabs, deliberately.** They quick-pick answers on a
   pending question card and must stay typeable as a prompt's first character,
-  so `Tab` / `Shift-Tab` are the only tab navigation
-  ([`src/deck_ui.rs`](src/deck_ui.rs)). Adding a digit hotkey would eat a
-  keystroke meant for the composer.
+  so `←`/`→` (empty composer) and `Tab` / `Shift-Tab` are the only tab
+  navigation ([`src/deck_ui/focus.rs`](src/deck_ui/focus.rs)). Adding a digit
+  hotkey would eat a keystroke meant for the composer.
 - Mouse capture is off by default in both `RunOptions` and `DeckOptions` so
   native terminal selection and copy keep working. The deck's event loop
   discards mouse events entirely today — turning the flag on currently costs

--- a/crates/stella-tui/src/accessible/announce.rs
+++ b/crates/stella-tui/src/accessible/announce.rs
@@ -30,13 +30,22 @@ use crate::deck_ui::DeckUi;
 /// it opens and closes on almost every keystroke, and announcing it would bury
 /// the moves that matter.
 fn overlay(ui: &DeckUi) -> Option<&'static str> {
+    // The parked asks first: they own the keyboard ahead of everything
+    // (`deck_ui::parked`), so they are what a reader is answering.
     let candidates = [
+        (ui.approval.is_open(), "approval card"),
+        (ui.question.is_open(), "question card"),
+        (ui.pending_dispatch.is_some(), "routing card"),
         (ui.help_open, "help"),
+        (ui.subagents.open, "sub-agents"),
         (ui.queue_open, "queue editor"),
         (ui.sessions_open, "sessions"),
         (ui.context_open, "context"),
         (ui.inbox_open, "inbox"),
         (ui.inspect_open, "inspect"),
+        (ui.cards.is_open(), "card"),
+        (ui.skills.preview.is_some(), "skill preview"),
+        (ui.mcp.inspector.is_some(), "server inspector"),
         (ui.search.open, "transcript search"),
         (ui.graph_picker_open, "graph file picker"),
     ];
@@ -177,6 +186,25 @@ mod tests {
         assert_eq!(ui.scrollback.take_announcements(), vec!["▸ help opened"]);
         announcing(&model, &mut ui, |ui| ui.help_open = false);
         assert_eq!(ui.scrollback.take_announcements(), vec!["▸ help closed"]);
+    }
+
+    /// The SUB-AGENTS overlay and the floating cards were silent: a reader
+    /// pressed `ctrl-a` and was told nothing. Every modal surface announces.
+    #[test]
+    fn the_sub_agents_overlay_and_the_cards_announce_too() {
+        let model = model_with(&["lead"]);
+        let mut ui = ui();
+        announcing(&model, &mut ui, |ui| ui.subagents.open = true);
+        assert_eq!(
+            ui.scrollback.take_announcements(),
+            vec!["▸ sub-agents opened"]
+        );
+        announcing(&model, &mut ui, |ui| ui.subagents.open = false);
+        ui.scrollback.take_announcements();
+        announcing(&model, &mut ui, |ui| {
+            ui.cards.raise(crate::deck_ui::cards::Card::Plan)
+        });
+        assert_eq!(ui.scrollback.take_announcements(), vec!["▸ card opened"]);
     }
 
     #[test]

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -538,6 +538,47 @@ impl WorkspaceModel {
         self.agents.len() - self.subagent_count()
     }
 
+    /// The index of the agent that dispatched `agents[idx]`, following
+    /// [`AgentMeta::parent`]. A lane registered without a parent — an older
+    /// driver, a replayed journal that predates the field — falls back to
+    /// the first non-subagent row, which is the lead in every session this
+    /// deck has ever drawn; a root returns `None`.
+    pub fn parent_of(&self, idx: usize) -> Option<usize> {
+        let entry = self.agents.get(idx)?;
+        match &entry.meta.parent {
+            Some(parent) => self.index_of(parent),
+            None if entry.is_subagent() => self
+                .agents
+                .iter()
+                .position(|a| !a.is_subagent())
+                .filter(|&lead| lead != idx),
+            None => None,
+        }
+    }
+
+    /// The agents `agents[idx]` dispatched, in registration order.
+    pub fn children_of(&self, idx: usize) -> Vec<usize> {
+        (0..self.agents.len())
+            .filter(|&i| i != idx && self.parent_of(i) == Some(idx))
+            .collect()
+    }
+
+    /// The path from the root to `agents[idx]`, as ids — what the breadcrumb
+    /// prints (`lead ▸ sub:2`). Bounded by the agent count so a malformed
+    /// parent cycle cannot spin it.
+    pub fn ancestry(&self, idx: usize) -> Vec<&AgentId> {
+        let mut path = Vec::new();
+        let mut cur = Some(idx);
+        while let Some(i) = cur
+            && path.len() < self.agents.len()
+        {
+            path.push(&self.agents[i].meta.id);
+            cur = self.parent_of(i);
+        }
+        path.reverse();
+        path
+    }
+
     /// The summed live-turn token rate across every running lane, plus how
     /// many lanes contributed. More than one contributor means the honest
     /// figure is the workspace's combined rate, labelled `combined` (D5) —

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -150,6 +150,11 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
             crate::v2::sessions::render(model, ui, area, b)
         });
     }
+    if ui.subagents.open {
+        guarded_overlay(buf, area, "sub-agents", |b| {
+            crate::v2::subagents::render(model, ui, area, b)
+        });
+    }
     if ui.inbox_open {
         guarded_overlay(buf, area, "inbox", |b| {
             render_inbox_overlay(model, ui, area, b)
@@ -215,6 +220,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         || parked::owns_keyboard(ui)
         || ui.queue_open
         || ui.graph_picker_open
+        || ui.subagents.open
         || ui.sessions_open
         || ui.inbox_open
         || ui.context_open

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -80,7 +80,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     let bands = Layout::vertical([
         Constraint::Length(1),          // tab row / breadcrumb
         Constraint::Min(1),             // active view
-        Constraint::Length(1),          // air above the prompt
+        Constraint::Length(1),          // air above the prompt, or the pulse row
         Constraint::Length(composer_h), // composer
         Constraint::Length(1),          // keybinding hint row
         Constraint::Length(statline_h), // status bar (+ diagnosis)
@@ -105,6 +105,12 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         DeckTab::Settings => views::settings::render(model, ui, content, b),
     });
 
+    // The pulse row (`v2::pulse`) draws in the air row off the SESSION tab,
+    // and at an opened lane: the live agent's status, quiet time, place and
+    // last words, so no tab is blind to the turn.
+    guarded_band(buf, bands[2], "pulse", |b| {
+        crate::v2::pulse::render_row(model, ui, bands[2], b)
+    });
     guarded_band(buf, bands[3], "composer", |b| {
         render_composer(&c_layout, bands[3], b)
     });

--- a/crates/stella-tui/src/deck_render/help.rs
+++ b/crates/stella-tui/src/deck_render/help.rs
@@ -1,5 +1,8 @@
 //! The `?` overlay: SPEC 11's help sheet and SPEC 5's metric detail view.
 //!
+//! The keys come from [`crate::keymap`] — this file renders the table and
+//! owns none of its rows, so the sheet cannot drift from the hint row.
+//!
 //! Split out of `deck_render.rs` because that file is a grandfathered god file
 //! and closed to growth (AGENTS.md, "God files — plan around them, never into
 //! them"). It sat at 1514 lines against a 1518 ceiling — four lines of
@@ -25,6 +28,7 @@
 //! *role* is pinned to.
 
 use super::*;
+use crate::keymap::{self, Scope};
 
 /// A pipeline role as this overlay names it.
 ///
@@ -124,141 +128,6 @@ fn help_row(key: &str, desc: &str) -> Line<'static> {
     ])
 }
 
-/// The shortcuts specific to one deck tab, as `(key, description)` pairs.
-/// Keyed off [`DeckTab`] so the overlay only ever shows keys that work where
-/// the user actually is — the per-tab handlers in `deck_ui` are the behavior
-/// these rows must mirror.
-fn tab_shortcuts(tab: DeckTab) -> &'static [(&'static str, &'static str)] {
-    match tab {
-        DeckTab::Session => &[
-            ("↑ ↓", "select a message · esc clears the selection"),
-            ("⇞ ⇟", "scroll the transcript"),
-            ("⌘[ / ⌘]", "jump to transcript start / end (⌃ works too)"),
-            ("ctrl-o", "expand/collapse the selected message (none: all)"),
-            ("ctrl-r", "expand/collapse all thinking"),
-            (
-                "ctrl-f",
-                "find in the transcript — ⏎ next · ctrl-p previous",
-            ),
-            ("ctrl-n / ctrl-p", "jump to the next / previous failure"),
-            ("ctrl-z", "fold the selected turn to one line (none: all)"),
-            ("↑", "with prompts queued: open the queue editor"),
-            ("←", "SESSIONS overlay — every session on this machine"),
-            ("→", "CONTEXT overlay — active skills + MCP servers"),
-            ("ctrl-g", "INSPECT — the context sent on any recorded call"),
-            (
-                "a / t / x",
-                "plan review: approve · trim · abort — one keypress decides",
-            ),
-            (
-                "r",
-                "plan review: refine — type what to change, ⏎ re-plans from it",
-            ),
-            (
-                "esc",
-                "plan review: abort (from the refine input: back out)",
-            ),
-        ],
-        DeckTab::Agents => &[
-            ("↑ ↓", "select an installed agent"),
-            ("⏎", "edit the definition — a save is a new pinned version"),
-            ("a", "assume its identity: the lead runs as this agent"),
-            ("n", "new agent — drafted by the LLM"),
-            ("x x", "delete the agent, every version"),
-            ("v / r", "versions · reload"),
-        ],
-        DeckTab::Traces => &[
-            ("↑ ↓ ⇞ ⇟", "scroll the event log"),
-            ("f", "cycle the per-agent filter"),
-        ],
-        DeckTab::Graph => &[
-            ("← → ↑ ↓", "walk the neighborhood"),
-            ("/ or ⏎", "file picker — re-root on any indexed file"),
-        ],
-        DeckTab::Files => &[("↑ ↓", "select a file"), ("⏎", "open / close the diff")],
-        DeckTab::Skills => &[
-            ("← →", "switch panes"),
-            ("↑ ↓", "select a skill"),
-            ("space", "enable / disable"),
-            ("e", "edit the selected skill"),
-            ("p", "pin / unpin"),
-            ("n", "new skill — drafted by the LLM"),
-            ("ctrl-o", "preview"),
-            ("ctrl-x ×2", "delete (press twice to confirm)"),
-            ("type", "search skills"),
-        ],
-        DeckTab::Mcp => &[
-            ("↑ ↓", "select a server"),
-            ("space / e", "enable / disable"),
-            ("a", "authenticate (env credentials)"),
-            ("o", "OAuth login (http servers)"),
-            ("s", "search the registry"),
-            ("x", "remove the server"),
-            ("r", "refresh"),
-        ],
-        DeckTab::Issues => &[
-            ("↑ ↓", "select an issue"),
-            ("r", "refresh the list"),
-            ("/", "search the tracker"),
-            ("n", "new issue — tab cycles fields · ctrl-s creates"),
-            ("c", "comment on the selected issue"),
-            ("s", "set the selected issue's status"),
-            ("w", "start work on the selected issue"),
-        ],
-        DeckTab::Settings => &[
-            ("← →", "switch panes — agents / tools"),
-            ("e", "edit the pane you are on"),
-            ("t", "jump to the tool switches"),
-            (
-                "tab",
-                "in the editor: switch agent — global / default / worker / …",
-            ),
-            ("⏎", "in the editor: edit the selected row / pick a model"),
-            ("space", "in the editor: toggle the selected row"),
-            ("x", "in the editor: clear the selected row"),
-            ("s / S", "in the editor: save to user / project settings"),
-            ("r", "in the editor: reload from disk"),
-            ("esc", "in the editor: hand the keyboard back to the tab"),
-        ],
-    }
-}
-
-/// Deck-wide shortcuts that work on every tab.
-const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
-    ("tab / ⇧tab", "switch tabs"),
-    // Enter semantics are the inverse of the old chord-to-submit mapping (see
-    // `composer::classify_enter`): a bare ⏎ dispatches, a *modified* ⏎ breaks
-    // the line. The composer footer advertises the same pair — these rows must
-    // not drift from it.
-    // The parenthetical is load-bearing: the unqualified promise ("runs as its
-    // own agent") is what a reviewer read while a scope card was waiting, and
-    // the sidecar it describes is exactly what swallowed their answer.
-    (
-        "⏎",
-        "queue the prompt — mid-turn it runs as its own agent (unless a card waits)",
-    ),
-    ("⌘⏎ / ⌃⏎ / ⌥⏎", "insert a line break in the prompt"),
-    ("!cmd", "run a shell command NOW (skips the queue)"),
-    ("/", "slash commands — ↑↓ pick · tab completes · ⏎ runs"),
-    ("ctrl-v", "paste — a copied image is attached to the prompt"),
-    ("ctrl-t", "open the queue editor"),
-    (
-        "ctrl-a / ↓",
-        "SUB-AGENTS — ↑↓ pick a lane · →↵ open it · ^x^x kill · p pause · r restart",
-    ),
-    ("ctrl-s", "PLAN — every step of the approved plan, in full"),
-    (
-        ">text",
-        "steer the running turn — lands at the next step boundary",
-    ),
-    ("esc", "steer: your draft + queue go INTO the running turn"),
-    (
-        "esc esc",
-        "cancel NOW & hold — nothing runs until your next prompt",
-    ),
-    ("ctrl-c", "quit stella"),
-];
-
 /// The help overlay: the active tab's keys first, then the deck-wide keys —
 /// one shortcut per line, key column aligned. Context-aware on purpose: only
 /// shortcuts that work on the tab the user is looking at are shown, so the
@@ -266,19 +135,26 @@ const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
 /// composer) or `/help`; scrolls with ↑/↓/⇞/⇟/Home/End on a short terminal;
 /// closes with esc/`q`/`?`.
 pub(super) fn render_help(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
+    // Three sections, all read from `crate::keymap`: the active tab's own
+    // keys, the focus tree that is the same on every tab, then the
+    // deck-wide chords. Context-aware on purpose — only keys that work
+    // where the reader is, so the sheet stays short enough to read at a
+    // glance.
     let mut lines: Vec<Line<'static>> = Vec::new();
-    lines.push(Line::default());
-    lines.push(Line::from(Span::styled(
-        format!("  {} tab", ui.tab.title()),
-        theme::heading(),
-    )));
-    for (key, desc) in tab_shortcuts(ui.tab) {
-        lines.push(help_row(key, desc));
-    }
-    lines.push(Line::default());
-    lines.push(Line::from(Span::styled("  everywhere", theme::heading())));
-    for (key, desc) in GLOBAL_SHORTCUTS {
-        lines.push(help_row(key, desc));
+    let sections = [
+        (format!("  {} tab", ui.tab.title()), Scope::Tab(ui.tab)),
+        (
+            "  moving around — every tab, every overlay".to_string(),
+            Scope::Navigation,
+        ),
+        ("  everywhere".to_string(), Scope::Everywhere),
+    ];
+    for (heading, scope) in sections {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(heading, theme::heading())));
+        for b in keymap::in_scope(scope) {
+            lines.push(help_row(b.keys, b.does));
+        }
     }
     lines.push(Line::default());
     lines.push(Line::from(Span::styled(
@@ -291,8 +167,10 @@ pub(super) fn render_help(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, b
     // to be *here*, not to be first.
     lines.extend(metric_rows(model));
 
-    // Size the panel to its content, capped to the frame.
-    let w = area.width.min(68);
+    // Size the panel to its content, capped to the frame. Wide enough for a
+    // sentence per key on a 100-column terminal; narrower frames clip the
+    // description, never the key.
+    let w = area.width.saturating_sub(4).min(84);
     let h = area.height.min(lines.len() as u16 + 2);
     let popup = Rect {
         x: area.x + (area.width.saturating_sub(w)) / 2,
@@ -301,23 +179,35 @@ pub(super) fn render_help(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, b
         height: h,
     };
     Clear.render(popup, buf);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(theme::accent())
-        .title(format!(" help — {} · esc close ", ui.tab.title()));
-    let inner = block.inner(popup);
-    block.render(popup, buf);
-    if inner.height == 0 || inner.width == 0 {
-        return;
-    }
-
     let total = lines.len();
-    let height = inner.height as usize;
+    let height = popup.height.saturating_sub(2) as usize;
     // Record viewport metrics for the pure key handler (`handle_help_key`) —
     // when the panel is clipped, ↑/↓/⇞/⇟/Home/End scroll it.
     ui.metrics.help_total = total;
     ui.metrics.help_height = height;
     let window = ui.help_scroll.window(total, height);
+    // A clipped sheet says so on its bottom edge: on a short terminal the
+    // metric block is below the keys, and a reader who cannot see that it
+    // exists will not scroll to it.
+    let below = total.saturating_sub(window.end);
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(format!(" help — {} · esc close ", ui.tab.title()));
+    if below > 0 {
+        block = block.title_bottom(
+            Line::from(Span::styled(
+                format!(" ↓ {below} more · ⇟ space · End "),
+                theme::muted(),
+            ))
+            .right_aligned(),
+        );
+    }
+    let inner = block.inner(popup);
+    block.render(popup, buf);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
     Paragraph::new(lines)
         .scroll((window.start as u16, 0))
         .render(inner, buf);

--- a/crates/stella-tui/src/deck_render/help.rs
+++ b/crates/stella-tui/src/deck_render/help.rs
@@ -242,6 +242,10 @@ const GLOBAL_SHORTCUTS: &[(&str, &str)] = &[
     ("/", "slash commands — ↑↓ pick · tab completes · ⏎ runs"),
     ("ctrl-v", "paste — a copied image is attached to the prompt"),
     ("ctrl-t", "open the queue editor"),
+    (
+        "ctrl-a",
+        "SUB-AGENTS — dispatched lanes: stop · pause · restart · focus",
+    ),
     ("ctrl-s", "PLAN — every step of the approved plan, in full"),
     (
         ">text",

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -1528,13 +1528,18 @@ pub mod cards;
 /// 2. help overlay open — Esc/`q`/`?` close it; other keys scroll it
 /// 3. queue editor open — Esc closes the editor
 /// 4. slash popup active — Esc dismisses the popup (clears the composer)
-/// 5. plan-review dialog pending — Esc aborts the plan (from its refine
-///    input, the first Esc only backs out to the options)
+/// 5. the parked approval / question cards — Esc answers them (deny /
+///    cancel), claimed first of all by `parked`
 /// 6. Files tab with the diff open — Esc closes the diff
 /// 7. Session tab with a message highlighted — Esc clears the highlight
 /// 8. Session tab with the ctrl+o expand-ALL overlay on — Esc collapses it
 ///    (each Esc peels one layer: highlight first, then the overlay, so
 ///    every way into an expanded view has a graceful way back out)
+/// 8a. an opened sub-agent lane, empty composer — Esc returns to the agent
+///     that dispatched it ([`focus::back_to_dispatcher`]). Leaving a lane is
+///     the most common thing Esc means there, and it used to be rule 10:
+///     one press at a worker was an immediate hard cancel. With a draft in
+///     the composer Esc still steers the lane (rule 10's steer form).
 /// 9. armed by a turn-stopping Esc within [`ESC_DOUBLE_WINDOW`], no other
 ///    key in between — Esc escalates to [`WorkspaceInput::StopAndHold`]
 ///    (cancel, requeue the interrupted prompt at the front, hold dispatch
@@ -1544,13 +1549,20 @@ pub mod cards;
 ///     auto-dispatches the next queued prompt)
 /// 11. otherwise Esc is ignored
 ///
+/// Rules 6–8a are the peel half; `⌫` from an empty composer runs exactly
+/// those and never reaches 9–10 ([`focus::back`]).
+///
 /// The composer's content never gates rules 9–10: the cursor always lives in
 /// the global composer, so a stop must leave a typed draft untouched. A
 /// pending ask-user gate never reaches them either — it folds the agent to
 /// [`AgentStatus::WaitingInput`], which fails rule 10's `Running` check.
 mod create;
 pub mod dispatch;
+/// The focus tree — `←`/`→` siblings, `⏎` open, `⌫` back.
+pub mod focus;
 mod gates;
+/// `↑`/`↓`/`j`/`k`/`⇞`/`⇟`/`Home`/`End` — one vocabulary for every list and body.
+pub mod list_nav;
 mod local;
 mod parked;
 pub mod sessions;
@@ -1749,8 +1761,16 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
     // that is byte-identical to Tab on terminals without the kitty keyboard
     // protocol (which `term.rs` pushes only best-effort), and Tab is bound to
     // tab-switching — the collision would be silent and terminal-dependent.
-    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('g')) {
-        return open_inspect_overlay(ui);
+    // Ctrl-E (every session) and Ctrl-K (context) open the SESSIONS and
+    // CONTEXT overlays the same way; they lived on `←`/`→`, which the focus
+    // tree now spends on the tab strip (`focus`).
+    if ctrl {
+        match key.code {
+            KeyCode::Char('g') => return open_inspect_overlay(ui),
+            KeyCode::Char('e') => return open_sessions_overlay(ui),
+            KeyCode::Char('k') => return open_context_overlay(ui),
+            _ => {}
+        }
     }
 
     // Ctrl-T toggles the queue editor from anywhere.
@@ -1910,22 +1930,6 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
         return action;
     }
 
-    // `←` from an empty composer on the Session tab opens the SESSIONS
-    // overlay — every running stella session on this machine, grouped by
-    // status. `→` opens the CONTEXT overlay (this session's active skills +
-    // MCP servers) without leaving the transcript. Both are gated to the
-    // Session tab + full composer emptiness, so ←/→ on other tabs (Agents
-    // pane nav, Graph cursor, skills pickers) are untouched, and typing a
-    // prompt never trips them (handle_edit_key claims ←/→ once text exists).
-    if ui.tab == DeckTab::Session && ui.composer.is_empty() {
-        if matches!(key.code, KeyCode::Left) {
-            return open_sessions_overlay(ui);
-        }
-        if matches!(key.code, KeyCode::Right) {
-            return open_context_overlay(ui);
-        }
-    }
-
     // Focused-agent gates take precedence over normal composer editing, exactly
     // like the single-session shell — but they route to the focused agent.
     if let Some(agent) = focused_id(model, ui)
@@ -1971,6 +1975,28 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
         return action;
     }
 
+    // …then the focus tree (`focus`): every key the active tab declined rises
+    // here. `←`/`→` step to the sibling tab, `⌫` backs up a level, `⏎` opens
+    // the highlighted message — all from an empty composer only, where none
+    // of them is editing.
+    if composer_empty && key.modifiers.is_empty() {
+        if let Some(dir) = focus::Dir::of(key.code) {
+            return focus::step_tab(dir, ui);
+        }
+        let action = match key.code {
+            KeyCode::Backspace => focus::back(model, ui),
+            KeyCode::Enter => focus::open_selected(model, ui),
+            // Esc's peel half (rule 8a): an opened lane goes back to its
+            // dispatcher. Claimed ahead of the interrupt so leaving a lane
+            // can never cancel it.
+            KeyCode::Esc => focus::back_to_dispatcher(model, ui),
+            _ => None,
+        };
+        if let Some(action) = action {
+            return action;
+        }
+    }
+
     // …then the turn-interrupt Esc (rules 9–10 of the precedence list): it
     // fires only once every other Esc context has declined the key. The
     // composer never claims Esc, so a typed draft survives both forms.
@@ -2004,43 +2030,16 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
 /// terminal, so a plain "any key closes" dismiss would make it unreadable.
 fn handle_help_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     let (total, height) = (ui.metrics.help_total, ui.metrics.help_height);
-    match key.code {
-        // Close the overlay.
-        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-            ui.help_open = false;
-            DeckAction::Handled
-        }
-        // Scrolling — the same vocabulary every scrollable tab uses.
-        KeyCode::Up | KeyCode::Char('k') => {
-            ui.help_scroll.scroll_up(1, total, height);
-            DeckAction::Handled
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            ui.help_scroll.scroll_down(1, total, height);
-            DeckAction::Handled
-        }
-        KeyCode::PageUp => {
-            ui.help_scroll.page_up(total, height);
-            DeckAction::Handled
-        }
-        KeyCode::PageDown | KeyCode::Char(' ') => {
-            ui.help_scroll.page_down(total, height);
-            DeckAction::Handled
-        }
-        KeyCode::Home => {
-            ui.help_scroll.to_top();
-            DeckAction::Handled
-        }
-        KeyCode::End => {
-            ui.help_scroll.to_bottom();
-            DeckAction::Handled
-        }
-        // Ctrl-C is handled by the caller (quit precedes every modal context).
-        // Any other key — modified or not — is swallowed so the overlay stays
-        // open and stable; typing into the composer behind it would be
-        // invisible and confusing.
-        _ => DeckAction::Handled,
+    if list_nav::closes(key) || matches!(key.code, KeyCode::Char('?')) {
+        ui.help_open = false;
+    } else {
+        list_nav::scroll(key, &mut ui.help_scroll, total, height, true);
     }
+    // Ctrl-C is handled by the caller (quit precedes every modal context).
+    // Any other key — modified or not — is swallowed so the overlay stays
+    // open and stable; typing into the composer behind it would be
+    // invisible and confusing.
+    DeckAction::Handled
 }
 
 /// Route one submitted prompt. The first submission after a double-Esc hold
@@ -2155,21 +2154,14 @@ pub(crate) fn open_inbox_overlay(ui: &mut DeckUi) -> DeckAction {
 fn handle_inbox_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     let count = ui.notifications.len();
     ui.inbox_sel = ui.inbox_sel.min(count.saturating_sub(1));
+    if list_nav::closes(key) {
+        ui.inbox_open = false;
+        return DeckAction::Handled;
+    }
+    if list_nav::select(key, &mut ui.inbox_sel, count, true) {
+        return DeckAction::Handled;
+    }
     match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => {
-            ui.inbox_open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.inbox_sel = ui.inbox_sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.inbox_sel = (ui.inbox_sel + 1).min(count - 1);
-            }
-            DeckAction::Handled
-        }
         KeyCode::Enter => match ui.notifications.get(ui.inbox_sel).cloned() {
             Some(n) => match n.session_id {
                 // A session-linked notification: ⏎ marks it read (the
@@ -2207,91 +2199,53 @@ fn handle_inbox_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     }
 }
 
-/// The CONTEXT overlay key map: ↑/↓/PageUp/PageDown scroll, Esc/`→`/`q`
-/// close. Read-only — management lives on the SKILLS/MCP tabs. Modal.
+/// The CONTEXT overlay key map: the body scrolls ([`list_nav::scroll`]'s
+/// keys, the render clamps the offset), Esc/`q` close. Read-only —
+/// management lives on the SKILLS/MCP tabs. Modal.
 fn handle_context_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
-    match key.code {
-        KeyCode::Esc | KeyCode::Right | KeyCode::Char('q') => {
-            ui.context_open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.context_scroll = ui.context_scroll.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            // Render clamps to the content height it measures.
-            ui.context_scroll = ui.context_scroll.saturating_add(1);
-            DeckAction::Handled
-        }
-        KeyCode::PageUp => {
-            ui.context_scroll = ui.context_scroll.saturating_sub(10);
-            DeckAction::Handled
-        }
-        KeyCode::PageDown => {
-            ui.context_scroll = ui.context_scroll.saturating_add(10);
-            DeckAction::Handled
-        }
-        _ => DeckAction::Handled,
+    if list_nav::closes(key) {
+        ui.context_open = false;
+    } else {
+        list_nav::offset(key, &mut ui.context_scroll, true);
     }
+    DeckAction::Handled
 }
 
-/// The INSPECT overlay key map. Two modes: on the LIST, ↑/↓ move and Enter
-/// reconstructs the selected call; on the DETAIL, ↑/↓/PageUp/PageDown scroll
-/// and Esc/`←` returns to the list (rather than closing outright — stepping
-/// between calls is the common motion). Esc on the list closes. Modal.
+/// The INSPECT overlay key map. Two modes: on the LIST, the selection moves
+/// and `⏎`/`→` reconstructs the selected call; on the DETAIL, the body
+/// scrolls and `⌫`/`←`/Esc return to the list (rather than closing outright
+/// — stepping between calls is the common motion). `q` closes from either;
+/// Esc on the list closes. Modal.
 fn handle_inspect_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     if ui.inspect_view.is_some() || ui.inspect_pending {
-        return match key.code {
-            KeyCode::Esc | KeyCode::Left => {
+        match key.code {
+            KeyCode::Esc | KeyCode::Left | KeyCode::Backspace => {
                 // Back to the list, not out of the overlay.
                 ui.inspect_view = None;
                 ui.inspect_pending = false;
                 ui.inspect_scroll = 0;
-                DeckAction::Handled
             }
             KeyCode::Char('q') => {
                 ui.inspect_open = false;
                 ui.inspect_view = None;
                 ui.inspect_pending = false;
-                DeckAction::Handled
             }
-            KeyCode::Up => {
-                ui.inspect_scroll = ui.inspect_scroll.saturating_sub(1);
-                DeckAction::Handled
+            _ => {
+                list_nav::offset(key, &mut ui.inspect_scroll, true);
             }
-            KeyCode::Down => {
-                // Render clamps to the content height it measures.
-                ui.inspect_scroll = ui.inspect_scroll.saturating_add(1);
-                DeckAction::Handled
-            }
-            KeyCode::PageUp => {
-                ui.inspect_scroll = ui.inspect_scroll.saturating_sub(10);
-                DeckAction::Handled
-            }
-            KeyCode::PageDown => {
-                ui.inspect_scroll = ui.inspect_scroll.saturating_add(10);
-                DeckAction::Handled
-            }
-            _ => DeckAction::Handled,
-        };
+        }
+        return DeckAction::Handled;
+    }
+    if list_nav::closes(key) {
+        ui.inspect_open = false;
+        return DeckAction::Handled;
+    }
+    // The selection is clamped (unlike the scroll offsets): it indexes a
+    // vec the render must be able to trust.
+    if list_nav::select(key, &mut ui.inspect_sel, ui.inspect_calls.len(), true) {
+        return DeckAction::Handled;
     }
     match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => {
-            ui.inspect_open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.inspect_sel = ui.inspect_sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            // Clamp here (unlike the scroll offsets): the selection indexes a
-            // vec the render must be able to trust.
-            let last = ui.inspect_calls.len().saturating_sub(1);
-            ui.inspect_sel = ui.inspect_sel.saturating_add(1).min(last);
-            DeckAction::Handled
-        }
         KeyCode::Enter | KeyCode::Right => match ui.inspect_calls.get(ui.inspect_sel) {
             Some(call) => {
                 let (turn_instance, step, call_seq) = call.coordinate();
@@ -2824,34 +2778,13 @@ fn handle_skills_preview_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     let Some(preview) = ui.skills.preview.as_mut() else {
         return DeckAction::Handled;
     };
-    match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => {
-            ui.skills.preview = None;
-        }
-        KeyCode::Char('o') if ctrl => {
-            ui.skills.preview = None;
-        }
-        KeyCode::Up | KeyCode::Char('k') => {
-            preview.scroll = preview.scroll.saturating_sub(1);
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            // Upper bound is clamped to real content height at render time.
-            preview.scroll = preview.scroll.saturating_add(1);
-        }
-        KeyCode::PageUp => {
-            preview.scroll = preview.scroll.saturating_sub(10);
-        }
-        KeyCode::PageDown | KeyCode::Char(' ') => {
-            preview.scroll = preview.scroll.saturating_add(10);
-        }
-        KeyCode::Home => {
-            preview.scroll = 0;
-        }
-        KeyCode::End => {
-            // A large value; render clamps it down to the last page.
-            preview.scroll = u16::MAX;
-        }
-        _ => {}
+    // The render clamps the offset to the content it measures; `u16` is the
+    // widget's own scroll type.
+    let mut top = usize::from(preview.scroll);
+    if list_nav::closes(key) || (ctrl && matches!(key.code, KeyCode::Char('o'))) {
+        ui.skills.preview = None;
+    } else if list_nav::offset(key, &mut top, true) {
+        preview.scroll = u16::try_from(top).unwrap_or(u16::MAX);
     }
     DeckAction::Handled
 }
@@ -2871,20 +2804,13 @@ fn handle_skills_installed_key(
     if !is_ctrl_x {
         ui.skills.uninstall_armed = false;
     }
+    if list_nav::select(key, &mut ui.skills.sel, count, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
         KeyCode::Right => {
             ui.skills.focus = SkillsFocus::Search;
             ui.skills.status = None;
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Up => {
-            ui.skills.sel = ui.skills.sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.skills.sel = (ui.skills.sel + 1).min(count - 1);
-            }
             Some(DeckAction::Handled)
         }
         // space toggles enabled — but only from an empty composer, so a space
@@ -2992,15 +2918,13 @@ fn handle_skills_search_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction
             ui.skills.status = None;
             Some(DeckAction::Handled)
         }
-        KeyCode::Up => {
-            ui.skills.search_sel = ui.skills.search_sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            let n = ui.skills.hits.len();
-            if n > 0 {
-                ui.skills.search_sel = (ui.skills.search_sel + 1).min(n - 1);
-            }
+        // A query in progress is a text input, and a text input with content
+        // claims `→` like the composer does — it must not leave the tab
+        // under a half-typed search. Empty, the key rises to the tab strip.
+        KeyCode::Right if !ui.skills.query.is_empty() => Some(DeckAction::Handled),
+        // The query is typed here, so only the arrow forms move the hits.
+        KeyCode::Up | KeyCode::Down | KeyCode::PageUp | KeyCode::PageDown => {
+            list_nav::select(key, &mut ui.skills.search_sel, ui.skills.hits.len(), false);
             Some(DeckAction::Handled)
         }
         // Preview the highlighted hit's rendered SKILL.md — fetched by the
@@ -3257,6 +3181,9 @@ fn handle_installed_browse_key(
     let count = ui.installed.entries.len();
     // A delete is two presses of `x` on the same row; anything else disarms.
     let armed = ui.installed.delete_armed.take();
+    if list_nav::select(key, &mut ui.installed.sel, count, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
         KeyCode::Char('x') if composer_empty => {
             let Some(entry) = ui.installed.selected().cloned() else {
@@ -3286,16 +3213,6 @@ fn handle_installed_browse_key(
                 name: entry.name,
                 scope: entry.scope,
             }))
-        }
-        KeyCode::Up => {
-            ui.installed.sel = ui.installed.sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.installed.sel = (ui.installed.sel + 1).min(count - 1);
-            }
-            Some(DeckAction::Handled)
         }
         // ⏎ opens the editor on the selected agent — the queue editor's
         // "pull it out to edit" idiom, over the pinned version's content.
@@ -3348,23 +3265,10 @@ fn handle_traces_key(
     composer_empty: bool,
 ) -> Option<DeckAction> {
     let (total, height) = (ui.metrics.trace_total, ui.metrics.trace_height);
+    if list_nav::scroll(key, &mut ui.trace_scroll, total, height, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
-        KeyCode::Up => {
-            ui.trace_scroll.scroll_up(1, total, height);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            ui.trace_scroll.scroll_down(1, total, height);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::PageUp => {
-            ui.trace_scroll.page_up(total, height);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::PageDown => {
-            ui.trace_scroll.page_down(total, height);
-            Some(DeckAction::Handled)
-        }
         // `f` cycles the per-agent filter (only when nothing is typed).
         KeyCode::Char('f') if composer_empty => {
             ui.trace_filter = cycle_filter(model, ui.trace_filter.as_deref());
@@ -3376,17 +3280,12 @@ fn handle_traces_key(
 
 fn handle_graph_key(key: KeyEvent, ui: &mut DeckUi, composer_empty: bool) -> Option<DeckAction> {
     let node_count = ui.graph.as_ref().map(|g| g.nodes.len()).unwrap_or(0);
+    // The neighborhood is one list; `←`/`→` are the focus tree's sibling
+    // step (the tabs either side of GRAPH), not a second way to walk it.
+    if list_nav::select(key, &mut ui.graph_cursor, node_count, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
-        KeyCode::Left | KeyCode::Up => {
-            ui.graph_cursor = ui.graph_cursor.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Right | KeyCode::Down => {
-            if node_count > 0 {
-                ui.graph_cursor = (ui.graph_cursor + 1).min(node_count - 1);
-            }
-            Some(DeckAction::Handled)
-        }
         // `/` (filter-as-you-type) or Enter opens the file picker so a user can
         // re-root the neighborhood on any indexed file, not just the busiest
         // one the tab seeds. Gated on an empty composer so both keys stay
@@ -3434,19 +3333,14 @@ fn handle_graph_picker_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
         .map(|g| g.matching_files(&ui.graph_picker_query).len())
         .unwrap_or(0);
 
+    // A type-to-filter input: letters are the query, so only the arrow
+    // forms move the selection and only Esc closes.
+    if list_nav::select(key, &mut ui.graph_picker_sel, match_count, false) {
+        return DeckAction::Handled;
+    }
     match key.code {
         KeyCode::Esc => {
             ui.graph_picker_open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.graph_picker_sel = ui.graph_picker_sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            if match_count > 0 {
-                ui.graph_picker_sel = (ui.graph_picker_sel + 1).min(match_count - 1);
-            }
             DeckAction::Handled
         }
         KeyCode::Enter => {
@@ -3491,42 +3385,23 @@ fn handle_files_key(
     let count = model.ledger.records.len();
     if ui.files_diff_open {
         let (total, height) = (ui.metrics.files_diff_total, ui.metrics.files_diff_height);
-        match key.code {
-            KeyCode::Esc => {
-                ui.files_diff_open = false;
-                return Some(DeckAction::Handled);
-            }
-            KeyCode::Up => {
-                ui.files_diff_scroll.scroll_up(1, total, height);
-                return Some(DeckAction::Handled);
-            }
-            KeyCode::Down => {
-                ui.files_diff_scroll.scroll_down(1, total, height);
-                return Some(DeckAction::Handled);
-            }
-            KeyCode::PageUp => {
-                ui.files_diff_scroll.scroll_up(height.max(1), total, height);
-                return Some(DeckAction::Handled);
-            }
-            KeyCode::PageDown => {
-                ui.files_diff_scroll
-                    .scroll_down(height.max(1), total, height);
-                return Some(DeckAction::Handled);
-            }
-            _ => {}
+        if matches!(key.code, KeyCode::Esc) {
+            ui.files_diff_open = false;
+            return Some(DeckAction::Handled);
         }
+        if list_nav::scroll(
+            key,
+            &mut ui.files_diff_scroll,
+            total,
+            height,
+            composer_empty,
+        ) {
+            return Some(DeckAction::Handled);
+        }
+    } else if list_nav::select(key, &mut ui.files_sel, count, composer_empty) {
+        return Some(DeckAction::Handled);
     }
     match key.code {
-        KeyCode::Up => {
-            ui.files_sel = ui.files_sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.files_sel = (ui.files_sel + 1).min(count - 1);
-            }
-            Some(DeckAction::Handled)
-        }
         // Only an unmodified Enter with nothing typed toggles the diff — a
         // failed submit chord or a prompt in progress must never claim it.
         KeyCode::Enter if count > 0 && composer_empty && key.modifiers.is_empty() => {

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -730,6 +730,10 @@ pub struct DeckUi {
     /// Per-lane scrollback bookkeeping. Inert unless the shell armed it with
     /// a real inline viewport — see [`crate::accessible::Scrollback`].
     pub scrollback: crate::accessible::Scrollback,
+    /// The SUB-AGENTS overlay (`ctrl-a`, `/subagents`): every dispatched
+    /// lane with its purpose, its place in the task, and the stop / pause /
+    /// resume / restart verbs. Modal while open.
+    pub subagents: crate::v2::subagents::SubagentsOverlay,
     /// Whether the SESSIONS overlay is open (empty-prompt `←` on the Session
     /// tab, or `/sessions`). Modal while open: ↑/↓ move, `⏎` open (replay),
     /// `a` archive, `x` delete, `r` refresh, Esc/`←` close.
@@ -867,6 +871,7 @@ impl Default for DeckUi {
             no_anim: false,
             accessible: false,
             scrollback: crate::accessible::Scrollback::default(),
+            subagents: crate::v2::subagents::SubagentsOverlay::default(),
             sessions_open: false,
             sessions_show_all: false,
             sessions: Vec::new(),
@@ -1753,6 +1758,15 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
         ui.queue_open = !ui.queue_open;
         ui.queue_confirm_clear = false;
         return DeckAction::Handled;
+    }
+
+    // Ctrl-A opens the SUB-AGENTS overlay from anywhere — the lanes the lead
+    // dispatched, with their controls. Modal while open, like the queue.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('a')) {
+        return crate::v2::subagents::open(ui);
+    }
+    if ui.subagents.open {
+        return crate::v2::subagents::handle_key(key, model, ui);
     }
 
     // The queue editor is modal while open: the queue is a *list* the user

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -828,7 +828,11 @@ impl Default for DeckUi {
             notice: NoticeState::new(),
             index_readiness: IndexReadiness::unknown(),
             help_open: false,
-            help_scroll: ScrollState::default(),
+            // A sheet, not a log: it opens at its top, never at its tail.
+            help_scroll: ScrollState {
+                follow: false,
+                ..ScrollState::default()
+            },
             focused: 0,
             session_scroll: ScrollState::default(),
             trace_scroll: ScrollState::default(),

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -74,6 +74,20 @@ fn carries_its_own_intent(text: &str) -> bool {
     head.starts_with('>') || head.starts_with('/') || head.starts_with('!')
 }
 
+/// A lead-bound prompt typed at a finished lane, with the lane named in
+/// front: `[about sub:2 — Simplify the crate READMEs · failed] why?`. The
+/// status is in the bracket because it is the fact the question is usually
+/// about, and the lead's own view of the lane is two transcript rows old.
+pub fn about_lane(lane: &crate::deck::AgentEntry, text: &str) -> String {
+    format!(
+        "[about {} — {} · {}] {}",
+        lane.meta.id,
+        crate::v2::subagents::purpose(&lane.meta),
+        lane.status.label(),
+        text.trim()
+    )
+}
+
 /// Route one submission. `Some` is the action to take now; `None` means the
 /// card was raised and the caller should treat the key as handled.
 ///
@@ -83,20 +97,41 @@ fn carries_its_own_intent(text: &str) -> bool {
 /// driver enforces on its side (`SteeringTap::is_settling`), which is what
 /// keeps the two layers agreeing about what "still running" means.
 ///
-/// A prompt typed at a **running sub-agent lane** — the user opened it from
+/// A prompt typed at a **live sub-agent lane** — the user opened it from
 /// the SUB-AGENTS overlay — is a steer at that lane, sent as one, whatever
 /// the policy: queueing it for the lead, the card's other routes, and a
-/// sidecar are all things a lane cannot do.
+/// sidecar are all things a lane cannot do. A paused lane takes the steer
+/// too: its tap drains at the first boundary after it resumes.
+///
+/// At a **finished** lane there is no turn to steer, so the words go to the
+/// lead as its next prompt — with the lane named in front of them
+/// ([`about_lane`]), because the lead cannot see what the deck is looking at
+/// and "why did this fail?" is a different question about every lane. The
+/// prefix is visible in the transcript, never a hidden rewrite.
 pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<WorkspaceInput> {
     let focused = model.agents.get(ui.focused);
-    let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
-    if let Some(lane) = focused.filter(|a| running && a.is_subagent()) {
-        let text = text.trim_start().trim_start_matches('>').trim().to_string();
-        return Some(WorkspaceInput::Steer {
-            agent: lane.meta.id.clone(),
-            texts: vec![text],
-        });
+    if let Some(lane) = focused.filter(|a| a.is_subagent()) {
+        if lane.status.is_active() || lane.status == crate::AgentStatus::Paused {
+            let text = text.trim_start().trim_start_matches('>').trim().to_string();
+            return Some(WorkspaceInput::Steer {
+                agent: lane.meta.id.clone(),
+                texts: vec![text],
+            });
+        }
+        // The lead's state decides the route for the lead-bound prompt, so a
+        // reader parked on a finished lane while the lead works gets the same
+        // queue / card / sidecar policy they would get at the lead.
+        let text = about_lane(lane, &text);
+        let lead_running = model
+            .parent_of(ui.focused)
+            .and_then(|p| model.agents.get(p))
+            .is_some_and(|a| a.status == crate::AgentStatus::Running);
+        if !lead_running || carries_its_own_intent(&text) {
+            return Some(WorkspaceInput::Enqueue { text });
+        }
+        return Some(WorkspaceInput::EnqueueNext { text });
     }
+    let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
     if !running || carries_its_own_intent(&text) {
         return Some(WorkspaceInput::Enqueue { text });
     }
@@ -334,6 +369,68 @@ mod tests {
             })
         );
         assert!(ui.pending_dispatch.is_none(), "no card at a lane");
+    }
+
+    /// **The witness for a prompt at a finished lane.** There is no turn to
+    /// steer, so the words go to the lead with the lane named in front —
+    /// queued behind the lead's running turn, never to a sidecar and never
+    /// behind a card. A paused lane still takes a steer.
+    #[test]
+    fn a_prompt_at_a_finished_lane_asks_the_lead_about_it() {
+        let mut model = model_with_lead(crate::AgentStatus::Running);
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("sub:2", "task 2", 0)
+                .with_role("subagent")
+                .with_purpose("Simplify the crate READMEs")
+                .with_parent("lead"),
+        ));
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:2".into(),
+            status: crate::AgentStatus::Failed,
+        });
+        let mut ui = DeckUi::default();
+        ui.mid_turn_prompt = MidTurnPrompt::Ask;
+        ui.focus_agent(1);
+        assert_eq!(
+            route(&mut ui, &model, "why did it fail?".into()),
+            Some(WorkspaceInput::EnqueueNext {
+                text: "[about sub:2 — Simplify the crate READMEs · failed] why did it fail?".into(),
+            }),
+            "named, and queued as the lead's next turn"
+        );
+        assert!(
+            ui.pending_dispatch.is_none(),
+            "no card: a lane cannot answer one"
+        );
+
+        model.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: crate::AgentStatus::Done,
+        });
+        assert!(
+            matches!(
+                route(&mut ui, &model, "and now?".into()),
+                Some(WorkspaceInput::Enqueue { .. })
+            ),
+            "an idle lead takes it as its next prompt"
+        );
+
+        let mut paused = model_with_lead(crate::AgentStatus::Running);
+        paused.apply_inbound(&Inbound::Register(
+            AgentMeta::new("sub:3", "task 3", 0).with_role("subagent"),
+        ));
+        paused.apply_inbound(&Inbound::Status {
+            agent: "sub:3".into(),
+            status: crate::AgentStatus::Paused,
+        });
+        ui.focus_agent(1);
+        assert!(
+            matches!(
+                route(&mut ui, &paused, "try the other parser".into()),
+                Some(WorkspaceInput::Steer { agent, .. }) if agent == "sub:3"
+            ),
+            "a paused lane drains the steer when it resumes"
+        );
     }
 
     /// …and at rest it does not. An idle agent's next prompt is just its next

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -388,8 +388,10 @@ mod tests {
             agent: "sub:2".into(),
             status: crate::AgentStatus::Failed,
         });
-        let mut ui = DeckUi::default();
-        ui.mid_turn_prompt = MidTurnPrompt::Ask;
+        let mut ui = DeckUi {
+            mid_turn_prompt: MidTurnPrompt::Ask,
+            ..Default::default()
+        };
         ui.focus_agent(1);
         assert_eq!(
             route(&mut ui, &model, "why did it fail?".into()),

--- a/crates/stella-tui/src/deck_ui/focus.rs
+++ b/crates/stella-tui/src/deck_ui/focus.rs
@@ -35,7 +35,7 @@
 //! rises to the tab strip and moves to the next tab. Nothing in this module
 //! knows the panes: each tab's handler claims what it can and returns `None`
 //! for what it cannot, and [`handle_deck_key`](super::handle_deck_key) calls
-//! [`step_tab`] only once every handler below has declined.
+//! [`step_tab`](crate::deck_ui::focus::step_tab) only once every handler below has declined.
 //!
 //! ## The empty-composer rule
 //!

--- a/crates/stella-tui/src/deck_ui/focus.rs
+++ b/crates/stella-tui/src/deck_ui/focus.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The deck's one navigation vocabulary — the focus tree.
+//!
+//! Everything on the deck sits in a tree, and four keys walk it the same way
+//! at every level:
+//!
+//! ```text
+//! tabs ───── SESSION ── AGENTS ── TRACES ── GRAPH ── FILES ── SKILLS ── …
+//!               │                                       │        │
+//!               ├ lead ─ message ─ message ─ …          │     installed ─ search
+//!               │   └ sub:2 ─ message ─ …               │
+//!               └ queue                              file ─ diff
+//! ```
+//!
+//! | key | meaning |
+//! |---|---|
+//! | `←` `→` | the previous / next **sibling**: the pane beside this one, or — when the tab has no pane that way — the tab beside this one |
+//! | `↑` `↓` | the previous / next **item** in the list under the cursor |
+//! | `⏎` | **open** what is under the cursor: a file's diff, a lane's transcript, a message's full text |
+//! | `⌫` | **back** up one level, and nothing else — it never reaches a running turn |
+//!
+//! `Esc` is a fifth key with two halves: the first is `⌫`'s (peel one layer)
+//! and the second, once there is nothing left to peel, is the turn interrupt
+//! (`deck_ui`'s Esc precedence list). `⌫` exists so the reader who only wants
+//! *out* has a key that cannot also mean *stop*.
+//!
+//! ## Bubbling
+//!
+//! A key is offered to the deepest focused node first and rises to its parent
+//! when that node declines it — the DOM's event model, and the reason one
+//! vocabulary can serve every tab. `→` on SETTINGS's AGENTS pane moves to the
+//! TOOLS pane; `→` on TOOLS, the last pane, has no sibling there, so the key
+//! rises to the tab strip and moves to the next tab. Nothing in this module
+//! knows the panes: each tab's handler claims what it can and returns `None`
+//! for what it cannot, and [`handle_deck_key`](super::handle_deck_key) calls
+//! [`step_tab`] only once every handler below has declined.
+//!
+//! ## The empty-composer rule
+//!
+//! Every arrow here fires only from an **empty** composer. With text in it
+//! `←`/`→` are cursor motion and `⌫` deletes a character, exactly as a reader
+//! typing a prompt expects; the tree is what the keys mean when there is no
+//! prompt for them to edit. This is the deck's standing rule for bare-letter
+//! hotkeys (`crates/stella-tui/README.md`, "Keys are a precedence chain"),
+//! applied to the arrows.
+//!
+//! Tab / Shift-Tab keep cycling tabs beside `←`/`→`: the chord was taught
+//! and costs nothing to keep. #4341 asked which of the two the tui-v2
+//! renderings' `tab` should be; the answer this module gives is that Tab
+//! stays a tab key, the plan panel stays on `⌃S`, and the breadcrumb prints
+//! the key that is real.
+
+use crossterm::event::KeyCode;
+
+use super::{DeckAction, DeckUi, queue_issues_first_load};
+use crate::deck::{DeckTab, WorkspaceModel};
+
+/// Which way a sibling step goes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Dir {
+    Prev,
+    Next,
+}
+
+impl Dir {
+    /// The sibling direction an arrow key names, if it names one.
+    pub fn of(code: KeyCode) -> Option<Self> {
+        match code {
+            KeyCode::Left => Some(Dir::Prev),
+            KeyCode::Right => Some(Dir::Next),
+            _ => None,
+        }
+    }
+}
+
+/// Move to the sibling tab. The last resort of a `←`/`→` nothing deeper
+/// claimed — see the module doc on bubbling. `DeckTab::next`/`prev` wrap,
+/// so the strip is a ring and the far end is one press away.
+pub fn step_tab(dir: Dir, ui: &mut DeckUi) -> DeckAction {
+    let tab = match dir {
+        Dir::Prev => ui.tab.prev(),
+        Dir::Next => ui.tab.next(),
+    };
+    ui.set_tab(tab);
+    queue_issues_first_load(ui);
+    DeckAction::Handled
+}
+
+/// Back up one level from wherever the reader is, or `None` when there is
+/// nothing above. Checked innermost first, so each press peels exactly one
+/// layer and every way in has the same way out:
+///
+/// 1. the FILES diff — back to the file list;
+/// 2. a highlighted SESSION message — back to the unhighlighted tail;
+/// 3. the expand-all / fold-all transcript overlays — back to the plain fold;
+/// 4. an opened lane — back to the agent that dispatched it.
+///
+/// Deliberately **not** here: stopping anything. A reader who opened a lane
+/// to look at it and pressed `⌫` to leave must get the dispatcher back, never
+/// a cancelled worker — which is what the first Esc at a running lane used
+/// to be.
+pub fn back(model: &WorkspaceModel, ui: &mut DeckUi) -> Option<DeckAction> {
+    if ui.tab == DeckTab::Files && ui.files_diff_open {
+        ui.files_diff_open = false;
+        return Some(DeckAction::Handled);
+    }
+    if ui.tab == DeckTab::Session {
+        if ui.session_selected.take().is_some() {
+            return Some(DeckAction::Handled);
+        }
+        if ui.transcript_expand_all {
+            ui.transcript_expand_all = false;
+            return Some(DeckAction::Handled);
+        }
+        if ui.fold_all_turns {
+            ui.fold_all_turns = false;
+            ui.fold_rev += 1;
+            return Some(DeckAction::Handled);
+        }
+        return back_to_dispatcher(model, ui);
+    }
+    None
+}
+
+/// From an opened lane, back to the agent that dispatched it. `None` at a
+/// root or when the parent is not on the deck.
+pub fn back_to_dispatcher(model: &WorkspaceModel, ui: &mut DeckUi) -> Option<DeckAction> {
+    let parent = model.parent_of(ui.focused)?;
+    ui.focus_agent(parent);
+    Some(DeckAction::Handled)
+}
+
+/// `⏎` on the SESSION tab from an empty composer: open the highlighted
+/// message. `None` when nothing is highlighted (the blank-composer `⏎`
+/// submits nothing and stays ignored) or the message has nothing folded.
+pub fn open_selected(model: &WorkspaceModel, ui: &mut DeckUi) -> Option<DeckAction> {
+    let sel = ui.session_selected?;
+    let agent = model.agents.get(ui.focused)?;
+    if !agent
+        .model
+        .transcript
+        .get(sel)
+        .is_some_and(super::is_expandable)
+    {
+        return None;
+    }
+    super::toggle_expanded(ui, &agent.meta.id.clone(), sel);
+    Some(DeckAction::Handled)
+}

--- a/crates/stella-tui/src/deck_ui/issues_keys.rs
+++ b/crates/stella-tui/src/deck_ui/issues_keys.rs
@@ -71,17 +71,10 @@ pub(super) fn handle_issues_browse_key(
     composer_empty: bool,
 ) -> Option<DeckAction> {
     let count = ui.issues.rows.len();
+    if super::list_nav::select(key, &mut ui.issues.sel, count, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
-        KeyCode::Up => {
-            ui.issues.sel = ui.issues.sel.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.issues.sel = (ui.issues.sel + 1).min(count - 1);
-            }
-            Some(DeckAction::Handled)
-        }
         KeyCode::Char(' ') if composer_empty => {
             ui.issues.toggle_pick();
             Some(DeckAction::Handled)

--- a/crates/stella-tui/src/deck_ui/list_nav.rs
+++ b/crates/stella-tui/src/deck_ui/list_nav.rs
@@ -10,7 +10,7 @@
 //! that takes a list or a scroll calls one of them instead of matching
 //! `KeyCode` itself.
 //!
-//! | key | list ([`select`]) | body ([`scroll`]) |
+//! | key | list ([`select`](crate::deck_ui::list_nav::select)) | body ([`scroll`](crate::deck_ui::list_nav::scroll)) |
 //! |---|---|---|
 //! | `↑` `k` | previous item | one line up |
 //! | `↓` `j` | next item | one line down |

--- a/crates/stella-tui/src/deck_ui/list_nav.rs
+++ b/crates/stella-tui/src/deck_ui/list_nav.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The one vocabulary for moving through a list or a scrolling body.
+//!
+//! Every overlay and tab used to spell its own `↑`/`↓` arms, and they drifted:
+//! `j`/`k` worked in five overlays and not the other nine, `Home`/`End` in
+//! two, `space` paged one. A reader who learned the keys in one place was
+//! wrong everywhere else. These two functions are the keys, and a surface
+//! that takes a list or a scroll calls one of them instead of matching
+//! `KeyCode` itself.
+//!
+//! | key | list ([`select`]) | body ([`scroll`]) |
+//! |---|---|---|
+//! | `↑` `k` | previous item | one line up |
+//! | `↓` `j` | next item | one line down |
+//! | `⇞` `⇟` | a page of items | a page of lines |
+//! | `Home` `End` | first / last item | top / bottom |
+//! | `space` | — | a page down |
+//!
+//! `space` pages a body and does nothing to a list on purpose: on a list it
+//! is a toggle (SKILLS enable, ISSUES multiselect) and must stay one.
+//!
+//! Both return `true` when the key was one of theirs, so the caller's own
+//! arms (open, close, verbs) sit after the call and never shadow a
+//! navigation key.
+//!
+//! `letters` is the deck's empty-composer rule applied here: a modal overlay
+//! owns the keyboard and passes `true`; a tab passes `composer_empty`, so
+//! `j` and `k` build a prompt while one is being typed and move the list
+//! only when there is no prompt for them to join. The arrows are never
+//! gated — they edit nothing in an empty composer and nothing but the cursor
+//! in a full one, and the tab handlers run only once the composer declined.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::scroll::ScrollState;
+
+/// Rows one `⇞`/`⇟` moves a selection when the surface reports no height.
+const LIST_PAGE: usize = 8;
+
+/// Move a selection through `count` items. A `count` of zero leaves `sel`
+/// at zero; the caller clamps a selection that outlived its list.
+pub fn select(key: KeyEvent, sel: &mut usize, count: usize, letters: bool) -> bool {
+    if !plain(key) {
+        return false;
+    }
+    let last = count.saturating_sub(1);
+    match key.code {
+        KeyCode::Up => *sel = sel.saturating_sub(1),
+        KeyCode::Down => *sel = (*sel + 1).min(last),
+        KeyCode::Char('k') if letters => *sel = sel.saturating_sub(1),
+        KeyCode::Char('j') if letters => *sel = (*sel + 1).min(last),
+        KeyCode::PageUp => *sel = sel.saturating_sub(LIST_PAGE),
+        KeyCode::PageDown => *sel = (*sel + LIST_PAGE).min(last),
+        KeyCode::Home => *sel = 0,
+        KeyCode::End => *sel = last,
+        _ => return false,
+    }
+    true
+}
+
+/// Scroll a body of `total` lines through a viewport `height` lines tall.
+pub fn scroll(
+    key: KeyEvent,
+    state: &mut ScrollState,
+    total: usize,
+    height: usize,
+    letters: bool,
+) -> bool {
+    if !plain(key) {
+        return false;
+    }
+    match key.code {
+        KeyCode::Up => state.scroll_up(1, total, height),
+        KeyCode::Down => state.scroll_down(1, total, height),
+        KeyCode::Char('k') if letters => state.scroll_up(1, total, height),
+        KeyCode::Char('j') if letters => state.scroll_down(1, total, height),
+        KeyCode::Char(' ') if letters => state.page_down(total, height),
+        KeyCode::PageUp => state.page_up(total, height),
+        KeyCode::PageDown => state.page_down(total, height),
+        KeyCode::Home => state.to_top(),
+        KeyCode::End => state.to_bottom(),
+        _ => return false,
+    }
+    true
+}
+
+/// Lines one `⇞`/`⇟` moves an unclamped offset.
+const OFFSET_PAGE: usize = 10;
+
+/// Scroll a body whose height only its renderer knows: the offset grows
+/// unbounded here and the draw clamps it. `Home` is zero; `End` is
+/// `usize::MAX`, which the same clamp turns into the bottom.
+pub fn offset(key: KeyEvent, top: &mut usize, letters: bool) -> bool {
+    if !plain(key) {
+        return false;
+    }
+    match key.code {
+        KeyCode::Up => *top = top.saturating_sub(1),
+        KeyCode::Down => *top = top.saturating_add(1),
+        KeyCode::Char('k') if letters => *top = top.saturating_sub(1),
+        KeyCode::Char('j') if letters => *top = top.saturating_add(1),
+        KeyCode::Char(' ') if letters => *top = top.saturating_add(OFFSET_PAGE),
+        KeyCode::PageUp => *top = top.saturating_sub(OFFSET_PAGE),
+        KeyCode::PageDown => *top = top.saturating_add(OFFSET_PAGE),
+        KeyCode::Home => *top = 0,
+        KeyCode::End => *top = usize::MAX,
+        _ => return false,
+    }
+    true
+}
+
+/// Whether `key` closes a modal surface: `Esc` everywhere, and `q` as the
+/// hand-on-the-home-row synonym. Every overlay answers this the same way so
+/// the way out never has to be looked up.
+pub fn closes(key: KeyEvent) -> bool {
+    plain(key) && matches!(key.code, KeyCode::Esc | KeyCode::Char('q'))
+}
+
+/// A key with no Ctrl/Cmd/Alt on it — Shift is allowed, so `End` on a
+/// keyboard that reports it shifted still counts.
+fn plain(key: KeyEvent) -> bool {
+    !key.modifiers.intersects(
+        KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META | KeyModifiers::ALT,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// `j`/`k` and the arrows are the same key on a list, and the ends clamp.
+    #[test]
+    fn a_list_takes_arrows_and_jk_alike_and_clamps() {
+        let mut sel = 0;
+        assert!(select(key(KeyCode::Char('j')), &mut sel, 3, true));
+        assert_eq!(sel, 1);
+        assert!(select(key(KeyCode::Down), &mut sel, 3, true));
+        assert!(select(key(KeyCode::Down), &mut sel, 3, true));
+        assert_eq!(sel, 2, "clamped at the last item");
+        assert!(select(key(KeyCode::Char('k')), &mut sel, 3, true));
+        assert_eq!(sel, 1);
+        assert!(select(key(KeyCode::Home), &mut sel, 3, true));
+        assert_eq!(sel, 0);
+        assert!(select(key(KeyCode::End), &mut sel, 3, true));
+        assert_eq!(sel, 2);
+        assert!(
+            !select(key(KeyCode::Char(' ')), &mut sel, 3, true),
+            "space is not a list key"
+        );
+        assert!(!select(key(KeyCode::Enter), &mut sel, 3, true));
+        let mut empty = 0;
+        assert!(select(key(KeyCode::Down), &mut empty, 0, true));
+        assert_eq!(empty, 0, "an empty list stays at zero");
+        let mut typing = 1;
+        assert!(
+            !select(key(KeyCode::Char('j')), &mut typing, 3, false),
+            "on a tab with a prompt in progress `j` is a letter"
+        );
+        assert!(select(key(KeyCode::Down), &mut typing, 3, false));
+        assert_eq!(typing, 2, "the arrow still moves it");
+    }
+
+    /// A ctrl chord is never a list key, so `ctrl-k`/`ctrl-j` stay free for
+    /// the deck.
+    #[test]
+    fn a_modified_key_is_not_navigation() {
+        let mut sel = 1;
+        let ctrl_k = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL);
+        assert!(!select(ctrl_k, &mut sel, 3, true));
+        assert_eq!(sel, 1);
+        let mut state = ScrollState::default();
+        assert!(!scroll(ctrl_k, &mut state, 10, 3, true));
+        assert!(!closes(KeyEvent::new(
+            KeyCode::Char('q'),
+            KeyModifiers::CONTROL
+        )));
+        assert!(closes(key(KeyCode::Char('q'))));
+        assert!(closes(key(KeyCode::Esc)));
+    }
+
+    /// A body pages on space and jumps on Home/End.
+    #[test]
+    fn a_body_scrolls_pages_and_jumps() {
+        let mut state = ScrollState::default();
+        state.to_top();
+        assert!(scroll(key(KeyCode::Char('j')), &mut state, 20, 5, true));
+        assert_eq!(state.window(20, 5).start, 1);
+        assert!(scroll(key(KeyCode::Char(' ')), &mut state, 20, 5, true));
+        assert_eq!(state.window(20, 5).start, 6);
+        assert!(scroll(key(KeyCode::End), &mut state, 20, 5, true));
+        assert!(state.follow);
+        assert!(scroll(key(KeyCode::Home), &mut state, 20, 5, true));
+        assert_eq!(state.window(20, 5).start, 0);
+    }
+}

--- a/crates/stella-tui/src/deck_ui/local.rs
+++ b/crates/stella-tui/src/deck_ui/local.rs
@@ -62,6 +62,7 @@ pub(super) fn deck_local_command(text: &str, ui: &mut DeckUi) -> Option<DeckActi
         // exactly like the tab switches above (their keyboard shortcuts:
         // empty-prompt `←` / `→`, and the footer's ✉ badge for the inbox).
         "/sessions" => open_sessions_overlay(ui),
+        "/subagents" => crate::v2::subagents::open(ui),
         "/context" => open_context_overlay(ui),
         "/inspect" => open_inspect_overlay(ui),
         "/inbox" => open_inbox_overlay(ui),

--- a/crates/stella-tui/src/deck_ui/mcp_keys.rs
+++ b/crates/stella-tui/src/deck_ui/mcp_keys.rs
@@ -47,29 +47,18 @@ fn handle_mcp_inspector_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
     let Some(inspector) = ui.mcp.inspector.as_mut() else {
         return DeckAction::Handled;
     };
+    if super::list_nav::closes(key) {
+        ui.mcp.inspector = None;
+        return DeckAction::Handled;
+    }
+    // Clamped to content at render time — the view knows the height, this
+    // handler does not; `u16` is the widget's own scroll type.
+    let mut top = usize::from(inspector.scroll);
+    if super::list_nav::offset(key, &mut top, true) {
+        inspector.scroll = u16::try_from(top).unwrap_or(u16::MAX);
+        return DeckAction::Handled;
+    }
     match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => {
-            ui.mcp.inspector = None;
-            DeckAction::Handled
-        }
-        KeyCode::Up | KeyCode::Char('k') => {
-            inspector.scroll = inspector.scroll.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            // Clamped to content at render time — the view knows the height,
-            // this handler does not.
-            inspector.scroll = inspector.scroll.saturating_add(1);
-            DeckAction::Handled
-        }
-        KeyCode::PageUp => {
-            inspector.scroll = inspector.scroll.saturating_sub(10);
-            DeckAction::Handled
-        }
-        KeyCode::PageDown => {
-            inspector.scroll = inspector.scroll.saturating_add(10);
-            DeckAction::Handled
-        }
         // Ask the registry for a description this server does not carry. Only
         // when it could help: re-asking after a "no such server" would spend a
         // round-trip to redisplay the same answer.
@@ -119,17 +108,10 @@ fn handle_mcp_browse_key(
         }
         return None;
     }
+    if super::list_nav::select(key, &mut ui.mcp.selected, count, composer_empty) {
+        return Some(DeckAction::Handled);
+    }
     match key.code {
-        KeyCode::Up => {
-            ui.mcp.selected = ui.mcp.selected.saturating_sub(1);
-            Some(DeckAction::Handled)
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.mcp.selected = (ui.mcp.selected + 1).min(count - 1);
-            }
-            Some(DeckAction::Handled)
-        }
         // Enter registry-search mode. `s` sits with the tab's other letter
         // actions (e/a/x/r, all gated on an empty composer). `/` deliberately
         // does NOT enter search anymore: it belongs to the command menu

--- a/crates/stella-tui/src/deck_ui/queue_editor.rs
+++ b/crates/stella-tui/src/deck_ui/queue_editor.rs
@@ -33,15 +33,10 @@ pub(super) fn handle_queue_key(
         }
         _ => ui.queue_confirm_clear = false,
     }
+    if super::list_nav::select(key, &mut ui.queue_sel, count, true) {
+        return DeckAction::Handled;
+    }
     match key.code {
-        KeyCode::Up => {
-            ui.queue_sel = ui.queue_sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            ui.queue_sel = (ui.queue_sel + 1).min(count - 1);
-            DeckAction::Handled
-        }
         KeyCode::Char('x') if ctrl => DeckAction::Send(WorkspaceInput::QueueRemove {
             index: ui.queue_sel,
         }),
@@ -55,7 +50,7 @@ pub(super) fn handle_queue_key(
             ui.queue_open = false;
             DeckAction::Send(WorkspaceInput::QueueRemove { index })
         }
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
             ui.queue_open = false;
             DeckAction::Handled
         }

--- a/crates/stella-tui/src/deck_ui/sessions.rs
+++ b/crates/stella-tui/src/deck_ui/sessions.rs
@@ -85,21 +85,14 @@ pub(super) fn handle_sessions_key(key: KeyEvent, now_ms: u64, ui: &mut DeckUi) -
     };
     let count = visible_session_rows(ui, now_ms).len();
     ui.sessions_sel = ui.sessions_sel.min(count.saturating_sub(1));
+    if super::list_nav::closes(key) {
+        ui.sessions_open = false;
+        return DeckAction::Handled;
+    }
+    if super::list_nav::select(key, &mut ui.sessions_sel, count, true) {
+        return DeckAction::Handled;
+    }
     match key.code {
-        KeyCode::Esc | KeyCode::Left | KeyCode::Char('q') => {
-            ui.sessions_open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.sessions_sel = ui.sessions_sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.sessions_sel = (ui.sessions_sel + 1).min(count - 1);
-            }
-            DeckAction::Handled
-        }
         KeyCode::Enter => match selected(ui) {
             // Navigate INTO the chosen session live: close the overlay and
             // hand over to the driver, which adopts the durable state and

--- a/crates/stella-tui/src/deck_ui/tests.rs
+++ b/crates/stella-tui/src/deck_ui/tests.rs
@@ -12,6 +12,7 @@ use stella_protocol::AgentEvent;
 
 mod composer;
 mod esc;
+mod focus;
 mod gates;
 mod graph;
 mod help;

--- a/crates/stella-tui/src/deck_ui/tests/esc.rs
+++ b/crates/stella-tui/src/deck_ui/tests/esc.rs
@@ -26,12 +26,17 @@ fn stop_lead() -> DeckAction {
 
 /// Esc at a sub-agent lane the user opened from the overlay steers THAT lane
 /// with the draft alone: the queue is the lead's backlog and stays where it
-/// is. With no draft it is the lane's stop.
+/// is. With no draft it is **the way back to the dispatcher** (precedence
+/// rule 8a) — never the lane's stop: a reader who opened a lane to look and
+/// pressed Esc to leave used to cancel the worker with that one press. The
+/// kill is `ctrl-x ctrl-x` in the overlay, armed.
 #[test]
 fn esc_at_an_opened_lane_steers_the_draft_into_that_lane_and_leaves_the_queue() {
     let mut model = running_model();
     model.apply_inbound(&Inbound::Register(
-        AgentMeta::new("sub:2", "task 2", 0).with_role("subagent"),
+        AgentMeta::new("sub:2", "task 2", 0)
+            .with_role("subagent")
+            .with_parent("lead"),
     ));
     model.apply_inbound(&Inbound::Status {
         agent: "sub:2".into(),
@@ -49,15 +54,23 @@ fn esc_at_an_opened_lane_steers_the_draft_into_that_lane_and_leaves_the_queue() 
         })
     );
     assert_eq!(model.queue.pending(), 1, "the lead's backlog is untouched");
+    assert_eq!(ui.focused, 1, "a steer does not move focus");
     let mut ui = ready_ui();
     ui.focus_agent(1);
     assert_eq!(
         handle_deck_key(key(KeyCode::Esc), &model, &mut ui),
-        DeckAction::Send(WorkspaceInput::Control {
-            agent: "sub:2".into(),
-            control: AgentControl::Stop,
-        }),
-        "the queue alone is not something to say to a lane"
+        DeckAction::Handled,
+        "with nothing to say, Esc leaves the lane — it sends nothing"
+    );
+    assert_eq!(ui.focused, 0, "…and the lead is focused again");
+    assert!(
+        ui.esc_armed_at.is_none(),
+        "leaving a lane never arms the double-Esc stop"
+    );
+    assert_eq!(
+        model.agents[1].status,
+        AgentStatus::Running,
+        "the lane was not told anything"
     );
 }
 

--- a/crates/stella-tui/src/deck_ui/tests/focus.rs
+++ b/crates/stella-tui/src/deck_ui/tests/focus.rs
@@ -1,0 +1,220 @@
+//! The focus tree (`deck_ui::focus`): `←`/`→` walk the tab strip from every
+//! tab, `⌫` backs up one level and never stops anything, `⏎` opens the
+//! highlighted message, and the `ctrl-e`/`ctrl-k` chords that took over the
+//! SESSIONS/CONTEXT overlays from the arrows.
+
+use super::*;
+use crate::model::TranscriptEntry;
+
+/// A lead with one dispatched lane, both running.
+fn lead_and_lane() -> WorkspaceModel {
+    let mut m = model_with(&["lead"]);
+    m.apply_inbound(&Inbound::Register(
+        AgentMeta::new("sub:2", "task 2", 0)
+            .with_role("subagent")
+            .with_parent("lead"),
+    ));
+    for agent in ["lead", "sub:2"] {
+        m.apply_inbound(&Inbound::Status {
+            agent: agent.into(),
+            status: AgentStatus::Running,
+        });
+    }
+    m
+}
+
+/// How many `→` presses a tab spends on its own panes before the key rises
+/// to the strip: one per pane, so a tab with none hands the first press up.
+fn panes_to_cross(tab: DeckTab) -> usize {
+    match tab {
+        DeckTab::Settings => crate::views::settings::SettingsPane::ALL.len(),
+        DeckTab::Skills => 2, // installed → search → (rise)
+        _ => 1,
+    }
+}
+
+/// **The witness for the arrows.** From an empty composer `→` and `←` move
+/// between sibling tabs on every tab — the SESSION tab included, where they
+/// used to open two overlays — and the strip is a ring. A tab with panes
+/// spends the key on them first and hands it up at the edge (bubbling).
+#[test]
+fn left_and_right_walk_the_tab_strip_from_every_tab() {
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    assert_eq!(ui.tab, DeckTab::Session);
+    for expected in DeckTab::ALL.iter().skip(1) {
+        let from = ui.tab;
+        let mut presses = 0;
+        while ui.tab == from {
+            handle_deck_key(key(KeyCode::Right), &model, &mut ui);
+            presses += 1;
+            assert!(presses <= 4, "→ never left {from:?}");
+        }
+        assert_eq!(ui.tab, *expected, "→ steps to the next tab");
+        assert_eq!(
+            presses,
+            panes_to_cross(from),
+            "{from:?}: panes first, then the strip"
+        );
+    }
+    for _ in 0..panes_to_cross(ui.tab) {
+        handle_deck_key(key(KeyCode::Right), &model, &mut ui);
+    }
+    assert_eq!(ui.tab, DeckTab::Session, "…and wraps at the end");
+    handle_deck_key(key(KeyCode::Left), &model, &mut ui);
+    assert_eq!(
+        ui.tab,
+        *DeckTab::ALL.last().expect("tabs exist"),
+        "← wraps the other way"
+    );
+    assert!(!ui.sessions_open && !ui.context_open, "no overlay opened");
+}
+
+/// The arrows edit a draft: with text in the composer `←` is cursor motion
+/// and the tab stays put.
+#[test]
+fn with_a_draft_the_arrows_are_cursor_motion() {
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.composer.load("hello".to_string());
+    handle_deck_key(key(KeyCode::Left), &model, &mut ui);
+    handle_deck_key(key(KeyCode::Right), &model, &mut ui);
+    assert_eq!(ui.tab, DeckTab::Session);
+    assert_eq!(ui.composer.buffer(), "hello", "the draft is intact");
+}
+
+/// `ctrl-e` and `ctrl-k` are where the SESSIONS and CONTEXT overlays went.
+#[test]
+fn ctrl_e_and_ctrl_k_open_the_sessions_and_context_overlays() {
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.tab = DeckTab::Files;
+    handle_deck_key(ctrl('e'), &model, &mut ui);
+    assert!(ui.sessions_open, "ctrl-e opens SESSIONS from any tab");
+    handle_deck_key(key(KeyCode::Esc), &model, &mut ui);
+    assert!(!ui.sessions_open);
+    handle_deck_key(ctrl('k'), &model, &mut ui);
+    assert!(ui.context_open, "ctrl-k opens CONTEXT from any tab");
+    handle_deck_key(ch('q'), &model, &mut ui);
+    assert!(!ui.context_open, "q closes it like every overlay");
+}
+
+/// **The witness for `⌫`.** At an opened lane it returns to the dispatcher
+/// and sends nothing — the lane keeps running; at the lead, with nothing to
+/// peel, it is ignored rather than reaching the turn interrupt.
+#[test]
+fn backspace_backs_out_of_a_lane_and_never_stops_it() {
+    let model = lead_and_lane();
+    let mut ui = ready_ui();
+    ui.focus_agent(1);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Backspace), &model, &mut ui),
+        DeckAction::Handled
+    );
+    assert_eq!(ui.focused, 0, "back to the lead");
+    let at_root = handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    assert!(
+        !matches!(at_root, DeckAction::Send(_)),
+        "the lead has no dispatcher and nothing is open: nothing is sent ({at_root:?})"
+    );
+    assert_eq!(ui.focused, 0);
+    assert!(
+        ui.esc_armed_at.is_none(),
+        "⌫ never arms the double-Esc stop"
+    );
+}
+
+/// `⌫` peels the same layers Esc does, innermost first: the FILES diff,
+/// then a highlighted message, then the expand-all overlay.
+#[test]
+fn backspace_peels_one_layer_at_a_time() {
+    let mut model = model_with(&["lead"]);
+    with_tool_exchange(&mut model, "lead");
+    let mut ui = ready_ui();
+
+    ui.tab = DeckTab::Files;
+    ui.files_diff_open = true;
+    handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    assert!(!ui.files_diff_open, "the diff closes first");
+
+    ui.tab = DeckTab::Session;
+    ui.session_selected = Some(0);
+    ui.transcript_expand_all = true;
+    handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    assert_eq!(ui.session_selected, None, "the highlight goes first");
+    assert!(ui.transcript_expand_all, "…the overlay is still up");
+    handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    assert!(!ui.transcript_expand_all, "…and goes on the next press");
+}
+
+/// With a draft, `⌫` is a delete — the tree never sees it.
+#[test]
+fn with_a_draft_backspace_deletes() {
+    let model = lead_and_lane();
+    let mut ui = ready_ui();
+    ui.focus_agent(1);
+    ui.composer.load("ab".to_string());
+    handle_deck_key(key(KeyCode::Backspace), &model, &mut ui);
+    assert_eq!(ui.composer.buffer(), "a");
+    assert_eq!(ui.focused, 1, "focus did not move");
+}
+
+/// **The witness for `⏎`.** On a highlighted expandable message it opens
+/// (and closes) that message; on the blank tail it submits nothing.
+#[test]
+fn enter_opens_the_highlighted_message() {
+    let mut model = model_with(&["lead"]);
+    with_tool_exchange(&mut model, "lead");
+    let mut ui = ready_ui();
+    // The tool result is the expandable row.
+    let idx = model.agents[0]
+        .model
+        .transcript
+        .iter()
+        .position(|e| matches!(e, TranscriptEntry::ToolResult { .. }))
+        .expect("a tool result is on the transcript");
+    ui.session_selected = Some(idx);
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Handled
+    );
+    assert!(
+        ui.expanded.get("lead").is_some_and(|s| s.contains(&idx)),
+        "⏎ expanded the highlighted row"
+    );
+    handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert!(
+        !ui.expanded.get("lead").is_some_and(|s| s.contains(&idx)),
+        "a second ⏎ folds it again"
+    );
+    ui.session_selected = None;
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Enter), &model, &mut ui),
+        DeckAction::Ignored,
+        "nothing highlighted: a blank ⏎ does nothing"
+    );
+}
+
+/// The agent tree the deck walks: a lane's parent is the dispatcher it was
+/// registered with, a lane registered without one falls back to the lead,
+/// and the root has none.
+#[test]
+fn the_agent_tree_reads_parents_off_the_meta() {
+    let mut model = lead_and_lane();
+    model.apply_inbound(&Inbound::Register(
+        AgentMeta::new("req:1", "older driver", 0).with_role("subagent"),
+    ));
+    assert_eq!(model.parent_of(0), None, "the lead is the root");
+    assert_eq!(model.parent_of(1), Some(0));
+    assert_eq!(
+        model.parent_of(2),
+        Some(0),
+        "no parent on the row: the lead"
+    );
+    assert_eq!(model.children_of(0), vec![1, 2]);
+    assert_eq!(
+        model.ancestry(1),
+        vec!["lead", "sub:2"],
+        "the breadcrumb's path"
+    );
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -46,6 +46,13 @@ pub struct AgentMeta {
     /// One sentence on what the agent is for — the task it was handed, in
     /// the words it was handed. `None` falls back to `title` on screen.
     pub purpose: Option<String>,
+    /// The agent that dispatched this one — its place in the session's agent
+    /// tree. `None` for a root (the lead). The deck walks this for Backspace
+    /// (back to the dispatcher), the breadcrumb (`lead ▸ sub:2`), and the
+    /// SUB-AGENTS overlay's `f` (flag the lane to whoever dispatched it):
+    /// all three need the same answer, and a guess (`"lead"`) would be wrong
+    /// the day a lane dispatches a lane.
+    pub parent: Option<AgentId>,
     /// Wall-clock start (ms since epoch) for elapsed / $-per-hour.
     pub started_ms: u64,
 }
@@ -61,8 +68,15 @@ impl AgentMeta {
             model: None,
             effort: None,
             purpose: None,
+            parent: None,
             started_ms,
         }
+    }
+
+    /// Builder: name the agent that dispatched this one.
+    pub fn with_parent(mut self, parent: impl Into<AgentId>) -> Self {
+        self.parent = Some(parent.into());
+        self
     }
 
     /// Builder: set the pinned reasoning effort.

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -40,6 +40,12 @@ pub struct AgentMeta {
     pub pid: Option<u32>,
     /// The model handling this agent, once routed.
     pub model: Option<String>,
+    /// The reasoning effort the agent's calls are pinned to (`low` … `max`),
+    /// as the driver resolved it; `None` when nothing pinned one.
+    pub effort: Option<String>,
+    /// One sentence on what the agent is for — the task it was handed, in
+    /// the words it was handed. `None` falls back to `title` on screen.
+    pub purpose: Option<String>,
     /// Wall-clock start (ms since epoch) for elapsed / $-per-hour.
     pub started_ms: u64,
 }
@@ -53,8 +59,22 @@ impl AgentMeta {
             role: "agent".to_string(),
             pid: None,
             model: None,
+            effort: None,
+            purpose: None,
             started_ms,
         }
+    }
+
+    /// Builder: set the pinned reasoning effort.
+    pub fn with_effort(mut self, effort: impl Into<String>) -> Self {
+        self.effort = Some(effort.into());
+        self
+    }
+
+    /// Builder: set the one-sentence purpose.
+    pub fn with_purpose(mut self, purpose: impl Into<String>) -> Self {
+        self.purpose = Some(purpose.into());
+        self
     }
 
     /// Builder: set the role.

--- a/crates/stella-tui/src/keymap.rs
+++ b/crates/stella-tui/src/keymap.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The deck's keymap — one table, read by every surface that tells a person
+//! what a key does.
+//!
+//! The `?` sheet (`deck_render::help`), the hint row under the composer
+//! (`v2::frame::render_hint_row`) and the README's key list used to be three
+//! hand-written copies of the same facts, and the sheet had already drifted:
+//! it advertised plan-review keys (`a`/`t`/`x`/`r`) whose handler had been
+//! deleted, and never mentioned `ctrl-a`. A key a person cannot find is a
+//! key that does not exist, so the copies collapse into this table and the
+//! surfaces render it.
+//!
+//! What this table is **not**: the dispatcher. `deck_ui::handle_deck_key` is
+//! a precedence chain (the crate README says why), and a binding here is a
+//! claim about it that the witness tests under `deck_ui/tests/` establish —
+//! `focus.rs` for the navigation rows, each tab's own file for its rows. A
+//! row with no witness is the drift this table exists to stop, so add the
+//! test with the row.
+
+use crate::deck::DeckTab;
+
+/// Where a binding applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// The focus tree — the same four keys at every level (`deck_ui::focus`).
+    Navigation,
+    /// On one tab, from an empty composer unless the row says otherwise.
+    Tab(DeckTab),
+    /// On every tab.
+    Everywhere,
+}
+
+/// One row of the sheet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Binding {
+    pub keys: &'static str,
+    pub does: &'static str,
+    pub scope: Scope,
+    /// Whether the hint row under the composer carries this binding. Kept to
+    /// a handful: the hint row is one line and names what a hand reaches for
+    /// mid-turn, not everything.
+    pub hinted: bool,
+}
+
+const fn row(keys: &'static str, does: &'static str, scope: Scope) -> Binding {
+    Binding {
+        keys,
+        does,
+        scope,
+        hinted: false,
+    }
+}
+
+const fn hinted(keys: &'static str, does: &'static str, scope: Scope) -> Binding {
+    Binding {
+        keys,
+        does,
+        scope,
+        hinted: true,
+    }
+}
+
+use DeckTab as T;
+use Scope::{Everywhere, Navigation, Tab};
+
+/// Every binding the deck teaches, in the order the sheet prints them
+/// within each scope.
+pub const BINDINGS: &[Binding] = &[
+    // ── the focus tree ──────────────────────────────────────────────────
+    row(
+        "← →",
+        "the sibling: the pane beside this one, else the tab beside it",
+        Navigation,
+    ),
+    row("↑ ↓ · k j", "the item above / below", Navigation),
+    row(
+        "⏎",
+        "open it — a diff, a lane, a message's full text",
+        Navigation,
+    ),
+    row(
+        "⌫",
+        "back up one level; never reaches a running turn",
+        Navigation,
+    ),
+    row("⇞ ⇟ · Home End", "a page · the ends", Navigation),
+    row("tab / ⇧tab", "the next / previous tab", Navigation),
+    row("q / esc", "close any overlay", Navigation),
+    // ── SESSION ─────────────────────────────────────────────────────────
+    row(
+        "↑",
+        "walk the transcript — with prompts queued, the queue editor first",
+        Tab(T::Session),
+    ),
+    row(
+        "↓",
+        "the SUB-AGENTS overlay — every lane and delegate, with controls",
+        Tab(T::Session),
+    ),
+    row("⇞ ⇟", "scroll the transcript", Tab(T::Session)),
+    row(
+        "⌘[ / ⌘]",
+        "jump to transcript start / end (⌃ works too)",
+        Tab(T::Session),
+    ),
+    hinted(
+        "ctrl-n / ctrl-p",
+        "jump to the next / previous failure",
+        Tab(T::Session),
+    ),
+    hinted(
+        "ctrl-z",
+        "fold the highlighted turn to one line (none: all)",
+        Tab(T::Session),
+    ),
+    hinted(
+        "ctrl-o",
+        "expand / collapse the highlighted message (none: all)",
+        Tab(T::Session),
+    ),
+    row("ctrl-r", "expand / collapse all thinking", Tab(T::Session)),
+    row(
+        "ctrl-f",
+        "find in the transcript — ⏎ next · ctrl-p previous",
+        Tab(T::Session),
+    ),
+    row(
+        "⌫ / esc",
+        "at an opened lane: back to the agent that dispatched it",
+        Tab(T::Session),
+    ),
+    // ── AGENTS ──────────────────────────────────────────────────────────
+    row(
+        "⏎",
+        "edit the definition — a save is a new pinned version",
+        Tab(T::Agents),
+    ),
+    row(
+        "a",
+        "assume its identity: the lead runs as this agent",
+        Tab(T::Agents),
+    ),
+    row("n", "new agent — drafted by the LLM", Tab(T::Agents)),
+    row("x x", "delete the agent, every version", Tab(T::Agents)),
+    row("v / r", "versions · reload", Tab(T::Agents)),
+    // ── TRACES ──────────────────────────────────────────────────────────
+    row("f", "cycle the per-agent filter", Tab(T::Traces)),
+    // ── GRAPH ───────────────────────────────────────────────────────────
+    row("↑ ↓", "walk the neighborhood", Tab(T::Graph)),
+    row(
+        "/ or ⏎",
+        "file picker — re-root on any indexed file",
+        Tab(T::Graph),
+    ),
+    // ── FILES ───────────────────────────────────────────────────────────
+    row("⏎", "open / close the diff", Tab(T::Files)),
+    // ── SKILLS ──────────────────────────────────────────────────────────
+    row(
+        "← →",
+        "installed ↔ registry search (→ past the search leaves the tab)",
+        Tab(T::Skills),
+    ),
+    row("space", "enable / disable", Tab(T::Skills)),
+    row("e", "edit the selected skill", Tab(T::Skills)),
+    row("p", "pin / unpin", Tab(T::Skills)),
+    row("n", "new skill — drafted by the LLM", Tab(T::Skills)),
+    row("ctrl-o", "preview", Tab(T::Skills)),
+    row(
+        "ctrl-x ×2",
+        "delete (press twice to confirm)",
+        Tab(T::Skills),
+    ),
+    row("type", "search skills", Tab(T::Skills)),
+    // ── MCP ─────────────────────────────────────────────────────────────
+    row("space / e", "enable / disable", Tab(T::Mcp)),
+    row("ctrl-o", "inspect the server", Tab(T::Mcp)),
+    row("a", "authenticate (env credentials)", Tab(T::Mcp)),
+    row("o", "OAuth login (http servers)", Tab(T::Mcp)),
+    row("s", "search the registry", Tab(T::Mcp)),
+    row("x", "remove the server", Tab(T::Mcp)),
+    row("r", "refresh", Tab(T::Mcp)),
+    // ── ISSUES ──────────────────────────────────────────────────────────
+    row("space", "select several", Tab(T::Issues)),
+    row("r", "refresh the list", Tab(T::Issues)),
+    row("/", "search the tracker", Tab(T::Issues)),
+    row("] [", "next / previous page", Tab(T::Issues)),
+    row(
+        "o / p",
+        "open in the browser · push the pick to the prompt",
+        Tab(T::Issues),
+    ),
+    row(
+        "n",
+        "new issue — tab cycles fields · ctrl-s creates",
+        Tab(T::Issues),
+    ),
+    row("c", "comment on the selected issue", Tab(T::Issues)),
+    row("s", "set the selected issue's status", Tab(T::Issues)),
+    row("w", "start work on the selected issue", Tab(T::Issues)),
+    // ── SETTINGS ────────────────────────────────────────────────────────
+    row(
+        "← →",
+        "agents ↔ tools ↔ seats (past the ends leaves the tab)",
+        Tab(T::Settings),
+    ),
+    row("e", "edit the pane you are on", Tab(T::Settings)),
+    row("t", "jump to the tool switches", Tab(T::Settings)),
+    row(
+        "tab",
+        "in the editor: switch agent — global / default / worker / …",
+        Tab(T::Settings),
+    ),
+    row(
+        "⏎",
+        "in the editor: edit the selected row / pick a model",
+        Tab(T::Settings),
+    ),
+    row(
+        "space",
+        "in the editor: toggle the selected row",
+        Tab(T::Settings),
+    ),
+    row(
+        "x",
+        "in the editor: clear the selected row",
+        Tab(T::Settings),
+    ),
+    row(
+        "s / S",
+        "in the editor: save to user / project settings",
+        Tab(T::Settings),
+    ),
+    row("r", "in the editor: reload from disk", Tab(T::Settings)),
+    row(
+        "esc",
+        "in the editor: hand the keyboard back to the tab",
+        Tab(T::Settings),
+    ),
+    // ── everywhere ──────────────────────────────────────────────────────
+    // Enter semantics are the inverse of the old chord-to-submit mapping (see
+    // `composer::classify_enter`): a bare ⏎ dispatches, a *modified* ⏎ breaks
+    // the line. The parenthetical is the fact a reviewer missed while a scope
+    // card was waiting — the sidecar it describes swallowed their answer.
+    row(
+        "⏎",
+        "queue the prompt — mid-turn it waits its turn (unless a card asks)",
+        Everywhere,
+    ),
+    row(
+        "⌘⏎ / ⌃⏎ / ⌥⏎",
+        "insert a line break in the prompt",
+        Everywhere,
+    ),
+    hinted(
+        "!cmd",
+        "run a shell command NOW (skips the queue)",
+        Everywhere,
+    ),
+    hinted(
+        "/",
+        "slash commands — ↑↓ pick · tab completes · ⏎ runs",
+        Everywhere,
+    ),
+    row(
+        "ctrl-v",
+        "paste — a copied image is attached to the prompt",
+        Everywhere,
+    ),
+    row(
+        "ctrl-a",
+        "SUB-AGENTS — n nudge · f flag · ^x^x kill · p pause · r restart",
+        Everywhere,
+    ),
+    row("ctrl-t", "the queue editor", Everywhere),
+    row(
+        "ctrl-e",
+        "SESSIONS — every session on this machine",
+        Everywhere,
+    ),
+    row(
+        "ctrl-k",
+        "CONTEXT — active skills + MCP servers",
+        Everywhere,
+    ),
+    row(
+        "ctrl-g",
+        "INSPECT — the context sent on any recorded call",
+        Everywhere,
+    ),
+    row(
+        "ctrl-s",
+        "PLAN — every step of the approved plan, in full",
+        Everywhere,
+    ),
+    row(
+        ">text",
+        "steer the running turn — lands at the next step boundary",
+        Everywhere,
+    ),
+    row(
+        "esc",
+        "steer: your draft + queue go INTO the running turn",
+        Everywhere,
+    ),
+    row(
+        "esc esc",
+        "cancel NOW & hold — nothing runs until your next prompt",
+        Everywhere,
+    ),
+    row("?", "this sheet", Everywhere),
+    row("ctrl-c", "quit stella", Everywhere),
+];
+
+/// The rows for one scope, in table order.
+pub fn in_scope(scope: Scope) -> impl Iterator<Item = &'static Binding> {
+    BINDINGS.iter().filter(move |b| b.scope == scope)
+}
+
+/// The rows the hint row carries for `tab`: the tab's hinted rows, then the
+/// deck-wide hinted ones.
+pub fn hints(tab: DeckTab) -> impl Iterator<Item = &'static Binding> {
+    in_scope(Tab(tab))
+        .chain(in_scope(Everywhere))
+        .filter(|b| b.hinted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every tab has at least one row, so no tab's sheet is empty.
+    #[test]
+    fn every_tab_has_rows() {
+        for tab in DeckTab::ALL {
+            assert!(in_scope(Tab(tab)).next().is_some(), "{tab:?} has no rows");
+        }
+    }
+
+    /// A key that is navigation everywhere is not repeated per tab with a
+    /// different meaning: the tab rows may refine `↑ ↓`, `← →` and `⏎`
+    /// (what the list is, what opens) but never claim `⌫`, `q` or the tab
+    /// keys, which mean one thing.
+    #[test]
+    fn the_tree_keys_are_not_rebound_per_tab() {
+        for b in BINDINGS.iter().filter(|b| matches!(b.scope, Tab(_))) {
+            for reserved in ["⌫", "tab / ⇧tab", "q / esc", "Home"] {
+                assert!(
+                    b.keys != reserved,
+                    "{:?} rebinds {reserved}: {}",
+                    b.scope,
+                    b.does
+                );
+            }
+        }
+    }
+
+    /// The hint row stays one line: a handful of hinted rows, never the sheet.
+    #[test]
+    fn the_hint_row_is_a_handful() {
+        for tab in DeckTab::ALL {
+            let n = hints(tab).count();
+            assert!(n <= 6, "{tab:?} hints {n} rows — the hint row is one line");
+        }
+    }
+
+    /// The rows the old sheet carried for a handler that no longer exists
+    /// (plan review on SESSION) are gone, and the overlays every tab can
+    /// reach are named with their real chords.
+    #[test]
+    fn the_sheet_names_real_keys_only() {
+        let session: Vec<&str> = in_scope(Tab(T::Session)).map(|b| b.does).collect();
+        assert!(
+            !session.iter().any(|d| d.contains("plan review")),
+            "plan review keys have no handler: {session:?}"
+        );
+        let everywhere: Vec<&str> = in_scope(Everywhere).map(|b| b.keys).collect();
+        for chord in ["ctrl-a", "ctrl-e", "ctrl-k", "ctrl-g", "ctrl-t", "ctrl-s"] {
+            assert!(
+                everywhere.contains(&chord),
+                "{chord} missing: {everywhere:?}"
+            );
+        }
+    }
+}

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -53,6 +53,7 @@ pub mod clipboard;
 pub mod composer;
 pub mod debug_log;
 pub mod input;
+pub mod keymap;
 pub mod model;
 pub(crate) mod panel_guard;
 pub mod render;

--- a/crates/stella-tui/src/notice.rs
+++ b/crates/stella-tui/src/notice.rs
@@ -262,8 +262,8 @@ mod tests {
     /// this module exists to break up.
     const GRAPH: &str = "✓ code graph: 14157 symbols, 5991 imports across 640 files \
                          (150 re-parsed, 490 unchanged this pass) — skipped 2 generated files";
-    const RESUMABLE: &str = "◂ a previous session is resumable — ← (on an empty prompt) opens \
-                             SESSIONS, ⏎ reopens one; or run `stella resume`.";
+    const RESUMABLE: &str = "◂ a previous session is resumable — ctrl-e opens SESSIONS, ⏎ \
+                             reopens one; or run `stella resume`.";
 
     fn buffer_rows(buf: &Buffer) -> Vec<String> {
         let area = *buf.area();
@@ -385,7 +385,7 @@ mod tests {
         let (head, details) = split_clauses(RESUMABLE);
         assert_eq!(head, "◂ a previous session is resumable");
         assert_eq!(details.len(), 1);
-        assert!(details[0].starts_with('←'));
+        assert!(details[0].starts_with("ctrl-e"), "{details:?}");
     }
 
     #[test]

--- a/crates/stella-tui/src/v2.rs
+++ b/crates/stella-tui/src/v2.rs
@@ -25,5 +25,6 @@ pub mod graph_tab;
 pub mod sessions;
 pub mod status_bar;
 pub mod status_source;
+pub mod subagents;
 pub mod transcript;
 pub mod transcript_source;

--- a/crates/stella-tui/src/v2.rs
+++ b/crates/stella-tui/src/v2.rs
@@ -22,6 +22,7 @@ pub mod fields;
 pub mod frame;
 pub mod graph;
 pub mod graph_tab;
+pub mod pulse;
 pub mod sessions;
 pub mod status_bar;
 pub mod status_source;

--- a/crates/stella-tui/src/v2/frame.rs
+++ b/crates/stella-tui/src/v2/frame.rs
@@ -113,6 +113,12 @@ fn tab_list_spans(active: DeckTab) -> Vec<Span<'static>> {
 /// The SESSION tab's breadcrumb: `SESSION  ▸ plan · task 3 wire dedup digest
 /// · 2/6`, or `SESSION  ▸ no plan yet` (SPEC 5 item 2).
 ///
+/// At an opened lane it is the **agent path** instead — `SESSION  ▸ lead ▸
+/// sub:2 · running · ⌫ back` — because the plan is the lead's and a reader
+/// inside a lane needs to know where they are and how to get out more than
+/// they need the lead's step count. The path is [`WorkspaceModel::ancestry`],
+/// the same tree `⌫` walks.
+///
 /// The plan carries no revision number yet — the `r3` of the renderings is a
 /// plan-graph fact this deck does not fold (#4333) — so the strip names the
 /// plan by its state word when it is not simply running.
@@ -127,6 +133,25 @@ fn breadcrumb_spans(model: &WorkspaceModel, ui: &DeckUi) -> Vec<Span<'static>> {
         Span::raw("  "),
         Span::styled(format!("{} ", glyph::COLLAPSED), dim),
     ];
+    if let Some(lane) = model.agents.get(ui.focused).filter(|a| a.is_subagent()) {
+        let path = model.ancestry(ui.focused);
+        for (i, id) in path.iter().enumerate() {
+            if i > 0 {
+                spans.push(Span::styled(format!(" {} ", glyph::COLLAPSED), dim));
+            }
+            let last = i + 1 == path.len();
+            spans.push(Span::styled((*id).clone(), if last { text } else { muted }));
+        }
+        spans.push(Span::styled(" · ", dim));
+        spans.push(Span::styled(
+            lane.status.label().to_string(),
+            Style::new().fg(crate::theme::status_color(lane.status)),
+        ));
+        spans.push(Span::styled(" · ", dim));
+        spans.push(Span::styled("⌫", muted));
+        spans.push(Span::styled(" back", dim));
+        return spans;
+    }
     let Some(plan) = plan_of(model, ui).filter(|p| !p.is_empty()) else {
         spans.push(Span::styled("no plan yet", dim));
         return spans;
@@ -169,21 +194,31 @@ pub fn render_hint_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mu
     let sep = Span::styled(" · ", dim);
 
     let pending = model.queue.pending();
-    let running = model
-        .agents
-        .get(ui.focused)
-        .is_some_and(|a| a.status == crate::AgentStatus::Running);
+    let focused = model.agents.get(ui.focused);
+    let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
+    let lane = focused.filter(|a| a.is_subagent());
 
     let mut spans = vec![Span::raw(" "), Span::styled("⏎", key)];
+    // At an opened lane `⏎` steers that lane (`dispatch::route`) and the
+    // queue is the lead's, so the hint names the lane rather than promising
+    // a queue the key does not touch.
     spans.push(Span::styled(
-        match (pending, ui.dispatch_held) {
-            (0, _) => " queue".to_string(),
-            (n, true) => format!(" queue · {n} held"),
-            (n, false) => format!(" queue · {n} queued"),
+        match (lane, pending, ui.dispatch_held) {
+            (Some(l), _, _) if l.status.is_active() || l.status == crate::AgentStatus::Paused => {
+                format!(" steer {}", l.meta.id)
+            }
+            (Some(l), _, _) => format!(" ask the lead about {}", l.meta.id),
+            (None, 0, _) => " queue".to_string(),
+            (None, n, true) => format!(" queue · {n} held"),
+            (None, n, false) => format!(" queue · {n} queued"),
         },
         dim,
     ));
-    if running {
+    if lane.is_some() {
+        spans.push(sep.clone());
+        spans.push(Span::styled("⌫", key));
+        spans.push(Span::styled(" back", dim));
+    } else if running {
         spans.push(sep.clone());
         spans.push(Span::styled("esc", key));
         spans.push(Span::styled(" steer", dim));
@@ -282,6 +317,55 @@ mod tests {
         assert!(row.contains("task 3 wire dedup digest"), "{row}");
         assert!(row.contains("2/3"), "{row}");
         assert!(row.trim_end().ends_with("stella*"), "{row}");
+    }
+
+    /// At an opened lane the tab row is the agent path — where the reader is
+    /// and the key out — and the hint row names the lane `⏎` steers.
+    #[test]
+    fn at_a_lane_the_tab_row_is_the_agent_path() {
+        let mut model = planned_model();
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("sub:2", "task 2", 0)
+                .with_role("subagent")
+                .with_parent("lead"),
+        ));
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:2".into(),
+            status: crate::AgentStatus::Running,
+        });
+        let mut ui = DeckUi {
+            tab: DeckTab::Session,
+            ..Default::default()
+        };
+        ui.focus_agent(1);
+        let area = Rect::new(0, 0, 100, 1);
+        let mut buf = Buffer::empty(area);
+        render_tab_row(&model, &ui, area, &mut buf);
+        let row = text(&buf);
+        assert!(
+            row.contains("SESSION  ▸ lead ▸ sub:2 · running · ⌫ back"),
+            "{row}"
+        );
+        assert!(
+            !row.contains("plan"),
+            "the lead's plan is not this lane's: {row}"
+        );
+
+        let mut buf = Buffer::empty(area);
+        render_hint_row(&model, &ui, area, &mut buf);
+        let hint = text(&buf);
+        assert!(hint.contains("⏎ steer sub:2"), "{hint}");
+        assert!(hint.contains("⌫ back"), "{hint}");
+        assert!(!hint.contains("esc steer"), "{hint}");
+
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:2".into(),
+            status: crate::AgentStatus::Done,
+        });
+        let mut buf = Buffer::empty(area);
+        render_hint_row(&model, &ui, area, &mut buf);
+        let hint = text(&buf);
+        assert!(hint.contains("⏎ ask the lead about sub:2"), "{hint}");
     }
 
     /// Every other tab draws the list, active tab padded, wordmark right.

--- a/crates/stella-tui/src/v2/frame.rs
+++ b/crates/stella-tui/src/v2/frame.rs
@@ -232,18 +232,38 @@ pub fn render_hint_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mu
             dim,
         ));
     }
-    for (k, label) in [
-        ("^N", " failure"),
-        ("^Z", " fold turn"),
-        ("^O", " expand"),
-        ("!", " shell"),
-        ("/", " commands"),
-    ] {
+    // The rest is the keymap's hinted rows (`crate::keymap::hints`), in the
+    // short form the hint row has room for.
+    for b in crate::keymap::hints(ui.tab) {
+        let (k, label) = short_hint(b);
         spans.push(sep.clone());
         spans.push(Span::styled(k, key));
-        spans.push(Span::styled(label, dim));
+        spans.push(Span::styled(format!(" {label}"), dim));
     }
     Paragraph::new(Line::from(spans)).render(Rect { height: 1, ..area }, buf);
+}
+
+/// A hinted binding in the hint row's shorthand: the chord as `^N`, the
+/// description as a word or two. The sheet has the sentence.
+fn short_hint(b: &crate::keymap::Binding) -> (String, &'static str) {
+    let chord = match b.keys {
+        "!cmd" => "!".to_string(),
+        keys => keys
+            .split(" / ")
+            .next()
+            .unwrap_or(keys)
+            .replace("ctrl-", "^")
+            .to_uppercase(),
+    };
+    let label = match b.keys {
+        "ctrl-n / ctrl-p" => "failure",
+        "ctrl-z" => "fold turn",
+        "ctrl-o" => "expand",
+        "!cmd" => "shell",
+        "/" => "commands",
+        _ => b.does.split([' ', '—', '·']).next().unwrap_or(b.does),
+    };
+    (chord, label)
 }
 
 #[cfg(test)]

--- a/crates/stella-tui/src/v2/pulse.rs
+++ b/crates/stella-tui/src/v2/pulse.rs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The pulse row — the live agent's last real words, on every tab.
+//!
+//! ```text
+//! ◆ lead  running · quiet 0:04 · running cargo test -p stella-tui   ┆ "Wired the tap; running the tests now."   +2 lanes running
+//! ```
+//!
+//! SPEC 5 folded the v1 trace strip into the transcript's tail, which is
+//! right on the SESSION tab and leaves every other tab blind: a reader on
+//! FILES or ISSUES had no way to know whether the agent was still working,
+//! stuck, or finished, short of tabbing back. This row is that answer, one
+//! line tall, and it costs nothing — it draws in the row of air above the
+//! composer that every tab already spends.
+//!
+//! Four facts, in the order a reader asks them: **who** (the agent and its
+//! status), **how long since it last did anything** (the quiet time, which is
+//! how a stalled lane is told from a busy one), **where it is** (the same
+//! lifecycle sentence the SUB-AGENTS overlay prints), and **what it last
+//! said** — the newest assistant prose on its transcript, first line only.
+//! Tool arguments and results never appear here; "real feedback" is the
+//! model's own words or nothing.
+//!
+//! ## Which agent
+//!
+//! Off the SESSION tab, the agent most worth watching: the lead while it
+//! runs — it is the conversation, and its lanes ride the `+N running` tail —
+//! else the running lane that spoke or acted most recently, else whoever is
+//! focused. On SESSION the transcript is the pulse, so the row stays air —
+//! except at an opened lane, where it carries the **lead**: walking into a
+//! lane must never cost sight of the conversation it belongs to.
+//!
+//! Pure over `(WorkspaceModel, DeckUi)`; [`pulse`] is the decision and
+//! [`render_row`] only paints it.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
+use stella_tui_theme::token;
+
+use crate::deck::{AgentEntry, DeckTab, WorkspaceModel};
+use crate::deck_ui::DeckUi;
+use crate::envelope::AgentStatus;
+use crate::model::TranscriptEntry;
+use crate::theme;
+use crate::views::cards;
+
+/// What the row says about one agent.
+#[derive(Debug, Clone)]
+pub struct Pulse<'a> {
+    /// Index into `model.agents`.
+    pub index: usize,
+    pub entry: &'a AgentEntry,
+    /// Milliseconds since the agent's last event.
+    pub quiet_ms: u64,
+    /// Where the agent is — the SUB-AGENTS overlay's lifecycle sentence.
+    pub place: String,
+    /// The first line of the newest assistant prose, if it has said anything.
+    pub said: Option<String>,
+    /// Other agents running right now, for the `+N running` tail.
+    pub others_running: usize,
+}
+
+/// The agent the row is about, or `None` when the row should stay air.
+pub fn subject(model: &WorkspaceModel, ui: &DeckUi) -> Option<usize> {
+    if model.agents.is_empty() {
+        return None;
+    }
+    if ui.tab == DeckTab::Session {
+        // At a lane, the lead; at the lead, nothing — the transcript is it.
+        let at_lane = model
+            .agents
+            .get(ui.focused)
+            .is_some_and(|a| a.is_subagent());
+        return at_lane
+            .then(|| model.ancestry(ui.focused).first().copied())
+            .flatten()
+            .and_then(|id| model.index_of(id));
+    }
+    // The lead while it runs — it is the conversation, and the lanes ride the
+    // `+N running` tail; otherwise the lane that acted most recently.
+    let lead = model
+        .agents
+        .iter()
+        .position(|a| !a.is_subagent() && a.status == AgentStatus::Running);
+    let running = model
+        .agents
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| a.status == AgentStatus::Running)
+        .max_by_key(|(_, a)| a.last_activity_ms)
+        .map(|(i, _)| i);
+    lead.or(running)
+        .or(Some(ui.focused.min(model.agents.len() - 1)))
+}
+
+/// The row's content, or `None` when there is nothing to say.
+pub fn pulse<'a>(model: &'a WorkspaceModel, ui: &DeckUi) -> Option<Pulse<'a>> {
+    let index = subject(model, ui)?;
+    let entry = model.agents.get(index)?;
+    let others_running = model
+        .agents
+        .iter()
+        .enumerate()
+        .filter(|(i, a)| *i != index && a.status == AgentStatus::Running)
+        .count();
+    Some(Pulse {
+        index,
+        entry,
+        quiet_ms: model.now_ms.saturating_sub(entry.last_activity_ms),
+        place: crate::v2::subagents::lifecycle(entry),
+        said: last_said(entry),
+        others_running,
+    })
+}
+
+/// The first sentence-like line of the newest assistant prose on `entry`'s
+/// transcript. Blank lines, markdown headings, rules and fence markers are
+/// skipped so the quote is what the model said, not how it formatted it.
+pub fn last_said(entry: &AgentEntry) -> Option<String> {
+    entry.model.transcript.iter().rev().find_map(|e| match e {
+        TranscriptEntry::Text(text) => text
+            .lines()
+            .map(str::trim)
+            .find(|l| {
+                !l.is_empty()
+                    && !l.starts_with('#')
+                    && !l.chars().all(|c| matches!(c, '-' | '*' | '=' | '`' | '_'))
+            })
+            .map(str::to_string),
+        _ => None,
+    })
+}
+
+/// Draw the row into the top row of `area`. Draws nothing when the row
+/// should stay air.
+pub fn render_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let Some(p) = pulse(model, ui) else {
+        return;
+    };
+    let width = area.width as usize;
+    let dim = Style::new().fg(token::DIM);
+    let muted = Style::new().fg(token::MUTED);
+    let text = Style::new().fg(token::TEXT);
+    let mark = if p.entry.is_subagent() {
+        Style::new().fg(theme::SUBAGENT)
+    } else {
+        Style::new().fg(token::GOLD)
+    };
+    let sep = Span::styled(" · ", dim);
+
+    let mut left: Vec<Span<'static>> = vec![
+        Span::raw(" "),
+        Span::styled(format!("{} ", theme::status_glyph(p.entry.status)), mark),
+        Span::styled(p.entry.meta.id.clone(), mark.add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled(
+            p.entry.status.label().to_string(),
+            Style::new().fg(theme::status_color(p.entry.status)),
+        ),
+    ];
+    // Quiet time only while something is expected to happen: a finished
+    // agent is not "quiet", it is done.
+    if !p.entry.status.is_terminal() {
+        left.push(sep.clone());
+        left.push(Span::styled(
+            format!("quiet {}", cards::fmt_mss(p.quiet_ms)),
+            quiet_style(p.quiet_ms, p.entry.status),
+        ));
+    }
+    left.push(sep.clone());
+    left.push(Span::styled(p.place.clone(), muted));
+
+    let mut right: Vec<Span<'static>> = Vec::new();
+    if p.others_running > 0 {
+        right.push(Span::styled(
+            format!(" +{} running ", p.others_running),
+            muted,
+        ));
+    }
+
+    let left_w: usize = left.iter().map(Span::width).sum();
+    let right_w: usize = right.iter().map(Span::width).sum();
+    // The quote takes what is left between the facts and the tail; a quote
+    // with no room is dropped whole rather than shown as three characters.
+    if let Some(said) = &p.said {
+        let room = width.saturating_sub(left_w + right_w + 6);
+        if room >= 12 {
+            left.push(Span::styled("   ┆ ", dim));
+            left.push(Span::styled(
+                format!("“{}”", cards::truncate_cols(said, room - 2)),
+                text,
+            ));
+        }
+    }
+    let left_w: usize = left.iter().map(Span::width).sum();
+    let mut spans = left;
+    if left_w + right_w < width {
+        spans.push(Span::raw(" ".repeat(width - left_w - right_w)));
+        spans.extend(right);
+    }
+    Paragraph::new(Line::from(spans)).render(Rect { height: 1, ..area }, buf);
+}
+
+/// Quiet time past thirty seconds on a running agent is the one number on
+/// this row that should pull the eye — it is what "this one might be dead"
+/// looks like before anyone says so.
+fn quiet_style(quiet_ms: u64, status: AgentStatus) -> Style {
+    if status == AgentStatus::Running && quiet_ms >= STALL_AFTER_MS {
+        Style::new().fg(token::RED).add_modifier(Modifier::BOLD)
+    } else {
+        Style::new().fg(token::MUTED)
+    }
+}
+
+/// How long a running agent may go without an event before its quiet time
+/// is drawn as a warning. A model call under load takes tens of seconds;
+/// minutes is a stall.
+pub const STALL_AFTER_MS: u64 = 90_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{AgentMeta, Inbound};
+    use stella_protocol::{AgentEvent, ToolCall};
+
+    fn text_of(buf: &Buffer) -> String {
+        let area = *buf.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn model() -> WorkspaceModel {
+        let mut m = WorkspaceModel::new();
+        m.apply_inbound(&Inbound::Register(
+            AgentMeta::new("lead", "goal", 0).with_role("lead"),
+        ));
+        m.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::Running,
+        });
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::Text {
+                text: "## Plan\n\nWired the tap; running the tests now.\nMore.".into(),
+            },
+        });
+        m.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: "c1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({ "command": "cargo test -p stella-tui" }),
+                },
+            },
+        });
+        m.now_ms = 4_000;
+        m
+    }
+
+    fn draw(m: &WorkspaceModel, ui: &DeckUi, w: u16) -> String {
+        let area = Rect::new(0, 0, w, 1);
+        let mut buf = Buffer::empty(area);
+        render_row(m, ui, area, &mut buf);
+        text_of(&buf)
+    }
+
+    /// **The witness.** Off the SESSION tab the row carries the live agent's
+    /// status, quiet time, place, and last words — and none of the tool's
+    /// arguments beyond the humanized place.
+    #[test]
+    fn the_row_carries_who_how_long_where_and_what_it_said() {
+        let m = model();
+        let ui = DeckUi {
+            tab: DeckTab::Files,
+            ..Default::default()
+        };
+        let row = draw(&m, &ui, 140);
+        assert!(row.contains("lead  running"), "{row}");
+        assert!(row.contains("quiet 0:04"), "{row}");
+        assert!(row.contains("running cargo test -p stella-tui"), "{row}");
+        assert!(
+            row.contains("“Wired the tap; running the tests now.”"),
+            "the first real line, not the heading: {row}"
+        );
+        assert!(!row.contains("## Plan"), "{row}");
+    }
+
+    /// On SESSION at the lead the row is air; at a lane it is the lead.
+    #[test]
+    fn on_session_the_row_is_air_at_the_lead_and_the_lead_at_a_lane() {
+        let mut m = model();
+        let mut ui = DeckUi::default();
+        assert_eq!(subject(&m, &ui), None);
+        assert_eq!(draw(&m, &ui, 100).trim(), "");
+
+        m.apply_inbound(&Inbound::Register(
+            AgentMeta::new("sub:2", "task 2", 0)
+                .with_role("subagent")
+                .with_parent("lead"),
+        ));
+        ui.focus_agent(1);
+        assert_eq!(subject(&m, &ui), Some(0), "the lead, not the lane");
+        assert!(draw(&m, &ui, 100).contains("lead"));
+    }
+
+    /// Elsewhere a running agent wins over an idle one, the most recently
+    /// active among several, and the tail counts the rest.
+    #[test]
+    fn a_running_agent_wins_and_the_tail_counts_the_others() {
+        let mut m = model();
+        m.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::Done,
+        });
+        for (id, ms) in [("sub:1", 1_000), ("sub:2", 3_000)] {
+            m.apply_inbound(&Inbound::Register(
+                AgentMeta::new(id, id, 0).with_role("subagent"),
+            ));
+            m.apply_inbound(&Inbound::Status {
+                agent: id.into(),
+                status: AgentStatus::Running,
+            });
+            let idx = m.index_of(id).expect("registered");
+            m.agents[idx].last_activity_ms = ms;
+        }
+        let ui = DeckUi {
+            tab: DeckTab::Issues,
+            ..Default::default()
+        };
+        let p = pulse(&m, &ui).expect("a subject");
+        assert_eq!(
+            p.entry.meta.id, "sub:2",
+            "most recently active running agent"
+        );
+        assert_eq!(p.others_running, 1);
+        let row = draw(&m, &ui, 120);
+        assert!(row.contains("+1 running"), "{row}");
+        assert!(row.contains("quiet 0:01"), "{row}");
+    }
+
+    /// A long silence on a running agent is drawn as the warning it is.
+    #[test]
+    fn a_stalled_agent_is_drawn_in_red() {
+        let mut m = model();
+        m.now_ms = m.agents[0].last_activity_ms + STALL_AFTER_MS;
+        let ui = DeckUi {
+            tab: DeckTab::Traces,
+            ..Default::default()
+        };
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render_row(&m, &ui, area, &mut buf);
+        let row = text_of(&buf);
+        let x = row.find("quiet").expect("quiet time drawn");
+        assert_eq!(
+            buf.cell((x as u16, 0)).map(|c| c.fg),
+            Some(token::RED),
+            "{row}"
+        );
+    }
+
+    /// A narrow frame drops the quote whole rather than a three-letter stub.
+    #[test]
+    fn a_narrow_frame_drops_the_quote_whole() {
+        let m = model();
+        let ui = DeckUi {
+            tab: DeckTab::Files,
+            ..Default::default()
+        };
+        let row = draw(&m, &ui, 60);
+        assert!(row.contains("lead"), "{row}");
+        assert!(!row.contains('“'), "{row}");
+    }
+}

--- a/crates/stella-tui/src/v2/subagents.rs
+++ b/crates/stella-tui/src/v2/subagents.rs
@@ -27,7 +27,7 @@
 //! running lane, which is what "this one might be dead" looks like), clock,
 //! model, the effort its calls are pinned to, spend. The second row is
 //! **what it is for**: the sentence the lead handed it
-//! ([`AgentMeta::purpose`]), its title until the driver supplies one. The
+//! ([`crate::envelope::AgentMeta::purpose`]), its title until the driver supplies one. The
 //! third is **where it is**: one sentence derived from the lane's own fold
 //! ([`lifecycle::lifecycle`]). Nothing here is a tool's raw arguments or a
 //! JSON result; the fold's humanized one-liner is the most a row quotes.

--- a/crates/stella-tui/src/v2/subagents.rs
+++ b/crates/stella-tui/src/v2/subagents.rs
@@ -1,0 +1,633 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The SUB-AGENTS overlay (`ctrl-a`, `/subagents`): every lane the lead has
+//! dispatched, with controls.
+//!
+//! ```text
+//! ╭ sub-agents · 2 running · 1 paused ─────────────────────────────────────╮
+//! │ ▸ ◆ sub:2  running · 0:24 · moonshotai/kimi-k3 · effort high · $0.01   │
+//! │     Simplify docs/spec so every page reads in plain words.             │
+//! │     reading docs/spec/adaptive-context/adaptive-context.md             │
+//! │                                                                        │
+//! │   ◆ sub:3  paused · 1:02 · moonshotai/kimi-k3 · effort high · $0.03    │
+//! │     Simplify the crate READMEs.                                        │
+//! │     paused after edit_file crates/stella-core/README.md                │
+//! ╰ ↑↓ select · ↵ focus · s stop · p pause/resume · r restart · esc ───────╯
+//! ```
+//!
+//! Three rows per lane. The head is its vitals — status, clock, model, the
+//! effort its calls are pinned to, spend. The second row is **what it is
+//! for**: the sentence the lead handed it ([`AgentMeta::purpose`]), its title
+//! until the driver supplies one. The third is **where it is**: one sentence
+//! derived from the lane's own fold ([`lifecycle`]) — the tool it is inside,
+//! the tool it just finished, the report it is writing, or why it stopped.
+//! Nothing here is a tool's raw arguments or a JSON result; the fold's
+//! humanized one-liner is the most a row quotes.
+//!
+//! The verbs ride the wire the old AGENTS dashboard used
+//! ([`WorkspaceInput::Control`], #4334): `s` stops, `p` pauses a running lane
+//! and resumes a paused one, `r` restarts from the lane's retained spec, and
+//! `⏎` focuses the lane's transcript on the SESSION tab. The lane list is
+//! [`WorkspaceModel::agents`] filtered to sub-agents, in registration order,
+//! so the keys and the paint agree on which row is which.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget};
+use stella_tui_theme::token;
+
+use crate::deck::{AgentEntry, WorkspaceModel};
+use crate::deck_ui::{DeckAction, DeckUi};
+use crate::envelope::{AgentControl, AgentMeta, AgentStatus, WorkspaceInput};
+use crate::model::TranscriptEntry;
+use crate::theme;
+use crate::views::cards;
+
+/// Rows one lane spends, plus one blank between lanes.
+const ROWS_PER_LANE: usize = 4;
+
+/// The overlay's own state: whether it is up, and the selected row.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubagentsOverlay {
+    pub open: bool,
+    pub sel: usize,
+}
+
+/// The lanes the overlay lists, in registration order.
+pub fn lanes(model: &WorkspaceModel) -> Vec<(usize, &AgentEntry)> {
+    model
+        .agents
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| a.is_subagent())
+        .collect()
+}
+
+/// What the lane is for: the purpose the driver supplied, else its title.
+pub fn purpose(meta: &AgentMeta) -> &str {
+    meta.purpose
+        .as_deref()
+        .filter(|p| !p.trim().is_empty())
+        .unwrap_or(&meta.title)
+}
+
+/// The present participle and past tense of a built-in tool's verb. Unknown
+/// tools — MCP, custom — are called by name.
+fn verb(tool: &str) -> (String, String) {
+    let (doing, done) = match tool {
+        "read_file" => ("reading", "read"),
+        "write_file" => ("writing", "wrote"),
+        "edit_file" => ("editing", "edited"),
+        "delete_file" => ("deleting", "deleted"),
+        "search" => ("searching", "searched"),
+        "bash" => ("running", "ran"),
+        "delegate" => ("delegating", "delegated"),
+        "ask_question" => ("asking", "asked"),
+        "get_environment" => ("probing the environment", "probed the environment"),
+        _ => return (format!("calling {tool}"), format!("called {tool}")),
+    };
+    (doing.to_string(), done.to_string())
+}
+
+/// Where the lane is in its task, as one sentence.
+///
+/// A supervisor state (queued, paused, killed) is stated as such — with the
+/// last tool beside it where there is one, so a paused lane says what it was
+/// doing when it stopped. A live lane is read off the tail of its fold: an
+/// open tool call is `reading <path>`, a closed one `read <path>`, prose is
+/// the report being written, and an empty fold is a lane that has not made
+/// its first model call yet.
+pub fn lifecycle(lane: &AgentEntry) -> String {
+    let tail = last_tool(lane);
+    match lane.status {
+        AgentStatus::Queued => "waiting for a worker slot".to_string(),
+        AgentStatus::Paused => match tail {
+            Some(t) => format!("paused after {} {}", verb(&t.name).1, t.input),
+            None => "paused before its first tool call".to_string(),
+        },
+        AgentStatus::Killed => match tail {
+            Some(t) => format!("stopped after {} {}", verb(&t.name).1, t.input),
+            None => "stopped before its first tool call".to_string(),
+        },
+        AgentStatus::WaitingInput => "waiting on an answer from you".to_string(),
+        AgentStatus::Failed => lane
+            .model
+            .transcript
+            .iter()
+            .rev()
+            .find_map(|e| match e {
+                TranscriptEntry::Error { message, .. } => Some(format!("failed: {message}")),
+                _ => None,
+            })
+            .unwrap_or_else(|| "failed".to_string()),
+        AgentStatus::Done => lane
+            .model
+            .transcript
+            .iter()
+            .rev()
+            .find_map(|e| match e {
+                TranscriptEntry::Complete { cost_usd, .. } => {
+                    Some(format!("finished · report delivered · ${cost_usd:.2}"))
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| "finished · report delivered".to_string()),
+        AgentStatus::Running => running(lane),
+    }
+}
+
+/// The most recent tool call on the lane, with whether it has returned.
+struct LastTool {
+    name: String,
+    input: String,
+}
+
+fn last_tool(lane: &AgentEntry) -> Option<LastTool> {
+    lane.model.transcript.iter().rev().find_map(|e| match e {
+        TranscriptEntry::ToolStart { name, input, .. } => Some(LastTool {
+            name: name.clone(),
+            input: input.clone(),
+        }),
+        _ => None,
+    })
+}
+
+/// A running lane's sentence, from the newest entry that says anything
+/// about progress.
+fn running(lane: &AgentEntry) -> String {
+    for entry in lane.model.transcript.iter().rev() {
+        match entry {
+            TranscriptEntry::ToolResult {
+                name, ok, summary, ..
+            } => {
+                // The result names the call; the start row before it holds
+                // the input. Find it so the sentence says what was read.
+                let input = input_of(lane, name);
+                let (_, done) = verb(name);
+                return if *ok {
+                    format!("{done} {input}")
+                } else {
+                    let why = cards::truncate_cols(summary, 40);
+                    format!("{done} {input} — failed: {why}")
+                };
+            }
+            TranscriptEntry::ToolStart { name, input, .. } => {
+                // An open call is the newest entry only when no result has
+                // followed it; the `ToolResult` arm above wins otherwise.
+                let (doing, _) = verb(name);
+                return format!("{doing} {input}");
+            }
+            TranscriptEntry::Text(_) => return "writing its report".to_string(),
+            TranscriptEntry::Reasoning(_) => return "thinking".to_string(),
+            TranscriptEntry::Retry { attempt, .. } => {
+                return format!("retrying the model call · attempt {attempt}");
+            }
+            TranscriptEntry::Parked { description, .. } => {
+                return format!("parked: {description}");
+            }
+            TranscriptEntry::Compaction { .. } => {
+                return "compacting its context".to_string();
+            }
+            TranscriptEntry::User(_) => {
+                return "starting: reading its briefing".to_string();
+            }
+            _ => {}
+        }
+    }
+    "starting: no model call yet".to_string()
+}
+
+/// The input of the newest `ToolStart` named `name` on the lane.
+fn input_of(lane: &AgentEntry, name: &str) -> String {
+    lane.model
+        .transcript
+        .iter()
+        .rev()
+        .find_map(|e| match e {
+            TranscriptEntry::ToolStart { name: n, input, .. } if n == name => Some(input.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Open the overlay on the first lane.
+pub fn open(ui: &mut DeckUi) -> DeckAction {
+    ui.subagents.open = true;
+    ui.subagents.sel = 0;
+    DeckAction::Handled
+}
+
+/// The overlay's keys: ↑/↓ select, `⏎` focus the lane's transcript, `s`
+/// stop, `p` pause a running lane / resume a paused one, `r` restart,
+/// Esc/`q` close. Modal: every other key is swallowed.
+pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
+    let rows = lanes(model);
+    let count = rows.len();
+    ui.subagents.sel = ui.subagents.sel.min(count.saturating_sub(1));
+    let selected = rows.get(ui.subagents.sel).copied();
+    let control = |lane: &AgentEntry, control: AgentControl| {
+        DeckAction::Send(WorkspaceInput::Control {
+            agent: lane.meta.id.clone(),
+            control,
+        })
+    };
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            ui.subagents.open = false;
+            DeckAction::Handled
+        }
+        KeyCode::Up => {
+            ui.subagents.sel = ui.subagents.sel.saturating_sub(1);
+            DeckAction::Handled
+        }
+        KeyCode::Down => {
+            if count > 0 {
+                ui.subagents.sel = (ui.subagents.sel + 1).min(count - 1);
+            }
+            DeckAction::Handled
+        }
+        KeyCode::Enter => match selected {
+            Some((idx, _)) => {
+                ui.subagents.open = false;
+                ui.focus_agent(idx);
+                DeckAction::Handled
+            }
+            None => DeckAction::Handled,
+        },
+        KeyCode::Char('s') => match selected {
+            Some((_, lane)) if !lane.status.is_terminal() => control(lane, AgentControl::Stop),
+            _ => DeckAction::Handled,
+        },
+        KeyCode::Char('p') => match selected {
+            Some((_, lane)) if lane.status == AgentStatus::Paused => {
+                control(lane, AgentControl::Resume)
+            }
+            Some((_, lane)) if lane.status.is_active() => control(lane, AgentControl::Pause),
+            _ => DeckAction::Handled,
+        },
+        KeyCode::Char('r') => match selected {
+            Some((_, lane)) => control(lane, AgentControl::Restart),
+            None => DeckAction::Handled,
+        },
+        _ => DeckAction::Handled,
+    }
+}
+
+/// The head row's vitals after the status: clock, model, effort, spend.
+fn vitals(lane: &AgentEntry, now_ms: u64) -> String {
+    let mut parts = vec![cards::fmt_mss(lane.elapsed_ms(now_ms))];
+    if let Some(model) = &lane.meta.model {
+        parts.push(model.clone());
+    }
+    if let Some(effort) = &lane.meta.effort {
+        parts.push(format!("effort {effort}"));
+    }
+    parts.push(format!("${:.2}", lane.cost_usd));
+    parts.join(" · ")
+}
+
+/// Draw the overlay over `area`.
+pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let w = area.width.saturating_sub(6).min(110);
+    let h = area.height.saturating_sub(4).min(area.height);
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    Clear.render(popup, buf);
+
+    let rows = lanes(model);
+    let selected = ui.subagents.sel.min(rows.len().saturating_sub(1));
+    let inner_w = (w as usize).saturating_sub(4);
+    let dim = Style::new().fg(token::DIM);
+    let muted = Style::new().fg(token::MUTED);
+    let text = Style::new().fg(token::TEXT);
+    let mark = Style::new().fg(theme::SUBAGENT);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if rows.is_empty() {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            "  no sub-agents dispatched in this session yet".to_string(),
+            muted,
+        )));
+    }
+
+    let visible = ((h as usize).saturating_sub(2) / ROWS_PER_LANE).max(1);
+    let start = selected
+        .saturating_sub(visible.saturating_sub(1) / 2)
+        .min(rows.len().saturating_sub(visible));
+    for (i, (_, lane)) in rows.iter().enumerate().skip(start).take(visible) {
+        let is_sel = i == selected;
+        let mut id_style = mark;
+        if is_sel {
+            id_style = id_style.bg(token::HL).add_modifier(Modifier::BOLD);
+        }
+        let status_style = Style::new().fg(theme::status_color(lane.status));
+        let head = vec![
+            Span::styled(
+                if is_sel { "▸ " } else { "  " }.to_string(),
+                Style::new().fg(token::GOLD),
+            ),
+            Span::styled("◆ ", mark),
+            Span::styled(lane.meta.id.clone(), id_style),
+            Span::styled("  ", dim),
+            Span::styled(lane.status.label().to_string(), status_style),
+            Span::styled(" · ", dim),
+            Span::styled(
+                cards::truncate_cols(&vitals(lane, model.now_ms), inner_w.saturating_sub(24)),
+                muted,
+            ),
+        ];
+        lines.push(Line::from(head));
+        lines.push(Line::from(vec![
+            Span::raw("     "),
+            Span::styled(
+                cards::truncate_cols(purpose(&lane.meta), inner_w.saturating_sub(5)),
+                text,
+            ),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("     "),
+            Span::styled(
+                cards::truncate_cols(&lifecycle(lane), inner_w.saturating_sub(5)),
+                muted,
+            ),
+        ]));
+        lines.push(Line::default());
+    }
+
+    let running = rows
+        .iter()
+        .filter(|(_, a)| a.status == AgentStatus::Running)
+        .count();
+    let paused = rows
+        .iter()
+        .filter(|(_, a)| a.status == AgentStatus::Paused)
+        .count();
+    let done = rows.iter().filter(|(_, a)| a.status.is_terminal()).count();
+    let mut title = vec![Span::styled(" sub-agents", text)];
+    for (n, word) in [(running, "running"), (paused, "paused"), (done, "finished")] {
+        if n > 0 {
+            title.push(Span::styled(format!(" · {n} {word}"), muted));
+        }
+    }
+    title.push(Span::raw(" "));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::new().fg(token::BORDER))
+        .title(Line::from(title))
+        .title_bottom(
+            Line::from(Span::styled(
+                " ↑↓ select · ↵ focus · s stop · p pause/resume · r restart · esc ",
+                dim,
+            ))
+            .right_aligned(),
+        );
+    Paragraph::new(lines).block(block).render(popup, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Inbound;
+    use crossterm::event::KeyModifiers;
+    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn model_with(lanes: &[(&str, AgentStatus)]) -> WorkspaceModel {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("lead", "stella", 0).with_role("lead"),
+        ));
+        for (id, status) in lanes {
+            model.apply_inbound(&Inbound::Register(
+                AgentMeta::new(*id, format!("task {id}"), 0).with_role("subagent"),
+            ));
+            model.apply_inbound(&Inbound::Status {
+                agent: (*id).to_string(),
+                status: *status,
+            });
+        }
+        model
+    }
+
+    fn tool_start(model: &mut WorkspaceModel, agent: &str, name: &str, path: &str) {
+        model.apply_inbound(&Inbound::Event {
+            agent: agent.to_string(),
+            event: AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: format!("c-{name}-{path}"),
+                    name: name.to_string(),
+                    input: serde_json::json!({ "path": path }),
+                },
+            },
+        });
+    }
+
+    fn tool_result(model: &mut WorkspaceModel, agent: &str, name: &str, path: &str) {
+        model.apply_inbound(&Inbound::Event {
+            agent: agent.to_string(),
+            event: AgentEvent::ToolResult {
+                call_id: format!("c-{name}-{path}"),
+                output: ToolOutput::ok("ok"),
+                duration_ms: 3,
+                speculated: false,
+            },
+        });
+    }
+
+    fn lane<'a>(model: &'a WorkspaceModel, id: &str) -> &'a AgentEntry {
+        model
+            .agents
+            .iter()
+            .find(|a| a.meta.id == id)
+            .expect("lane registered")
+    }
+
+    /// **The witness.** The second sentence is where the lane is, read off
+    /// its fold: inside a call it is `reading <path>`; once the call returns
+    /// it is `read <path>`; once it narrates, it is writing its report. None
+    /// of those is the call's arguments or its result.
+    #[test]
+    fn the_lifecycle_sentence_follows_the_lanes_fold() {
+        let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
+        assert_eq!(
+            lifecycle(lane(&model, "sub:2")),
+            "starting: no model call yet"
+        );
+
+        tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        assert_eq!(
+            lifecycle(lane(&model, "sub:2")),
+            "reading docs/spec/a.md",
+            "an open call is the participle"
+        );
+
+        tool_result(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        // A result re-folds the lane to Running; the sentence is the past tense.
+        assert_eq!(lifecycle(lane(&model, "sub:2")), "read docs/spec/a.md");
+
+        model.apply_inbound(&Inbound::Event {
+            agent: "sub:2".into(),
+            event: AgentEvent::Text {
+                text: "Done. I simplified".into(),
+            },
+        });
+        assert_eq!(lifecycle(lane(&model, "sub:2")), "writing its report");
+    }
+
+    /// A supervisor state names itself and what the lane was doing.
+    #[test]
+    fn paused_and_stopped_lanes_say_what_they_were_doing() {
+        let mut model = model_with(&[("sub:3", AgentStatus::Running)]);
+        tool_start(&mut model, "sub:3", "edit_file", "README.md");
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:3".into(),
+            status: AgentStatus::Paused,
+        });
+        assert_eq!(
+            lifecycle(lane(&model, "sub:3")),
+            "paused after edited README.md"
+        );
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:3".into(),
+            status: AgentStatus::Killed,
+        });
+        assert_eq!(
+            lifecycle(lane(&model, "sub:3")),
+            "stopped after edited README.md"
+        );
+        // A killed lane stays killed — the fold refuses to revive a terminal
+        // lane — so the queued sentence is pinned on a lane that never ran.
+        let queued = model_with(&[("sub:4", AgentStatus::Queued)]);
+        assert_eq!(
+            lifecycle(lane(&queued, "sub:4")),
+            "waiting for a worker slot"
+        );
+    }
+
+    /// The purpose is the driver's sentence, the title until there is one.
+    #[test]
+    fn purpose_prefers_the_drivers_sentence_over_the_title() {
+        let meta = AgentMeta::new("sub:1", "task #1: Simplify", 0);
+        assert_eq!(purpose(&meta), "task #1: Simplify");
+        let meta = meta.with_purpose("Simplify the crate READMEs into plain words.");
+        assert_eq!(
+            purpose(&meta),
+            "Simplify the crate READMEs into plain words."
+        );
+    }
+
+    /// **The witness for #4334.** The verbs reach the wire for the row under
+    /// the cursor: `s` stops, `p` pauses a running lane and resumes a paused
+    /// one, `r` restarts, and `⏎` focuses the lane and closes the overlay.
+    #[test]
+    fn the_keys_control_the_selected_lane() {
+        let model = model_with(&[
+            ("sub:1", AgentStatus::Running),
+            ("sub:2", AgentStatus::Paused),
+        ]);
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+        assert!(ui.subagents.open);
+
+        let sent = |action: DeckAction| match action {
+            DeckAction::Send(WorkspaceInput::Control { agent, control }) => (agent, control),
+            other => panic!("expected a control, got {other:?}"),
+        };
+        assert_eq!(
+            sent(handle_key(key(KeyCode::Char('s')), &model, &mut ui)),
+            ("sub:1".to_string(), AgentControl::Stop)
+        );
+        assert_eq!(
+            sent(handle_key(key(KeyCode::Char('p')), &model, &mut ui)),
+            ("sub:1".to_string(), AgentControl::Pause)
+        );
+        handle_key(key(KeyCode::Down), &model, &mut ui);
+        assert_eq!(
+            sent(handle_key(key(KeyCode::Char('p')), &model, &mut ui)),
+            ("sub:2".to_string(), AgentControl::Resume),
+            "p on a paused lane resumes it"
+        );
+        assert_eq!(
+            sent(handle_key(key(KeyCode::Char('r')), &model, &mut ui)),
+            ("sub:2".to_string(), AgentControl::Restart)
+        );
+        assert_eq!(
+            handle_key(key(KeyCode::Enter), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert!(!ui.subagents.open, "enter closes the overlay");
+        assert_eq!(
+            ui.focused, 2,
+            "and focuses the lane's transcript (index into model.agents)"
+        );
+    }
+
+    /// A finished lane takes no stop; the key is swallowed rather than sent.
+    #[test]
+    fn a_finished_lane_cannot_be_stopped() {
+        let model = model_with(&[("sub:1", AgentStatus::Done)]);
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+        assert_eq!(
+            handle_key(key(KeyCode::Char('s')), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert_eq!(
+            handle_key(key(KeyCode::Char('p')), &model, &mut ui),
+            DeckAction::Handled
+        );
+    }
+
+    /// The paint carries the model, the effort, both sentences, and no
+    /// brace — the row quotes the fold's one-liner, never the call's JSON.
+    #[test]
+    fn the_overlay_paints_model_effort_purpose_and_place() {
+        let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
+        let meta = AgentMeta::new("sub:2", "task #2", 0)
+            .with_role("subagent")
+            .with_purpose("Simplify docs/spec into plain words.")
+            .with_effort("high");
+        let mut meta = meta;
+        meta.model = Some("moonshotai/kimi-k3".into());
+        model.apply_inbound(&Inbound::Register(meta));
+        tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+        let area = Rect::new(0, 0, 100, 14);
+        let mut buf = Buffer::empty(area);
+        render(&model, &ui, area, &mut buf);
+        let text: String = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("moonshotai/kimi-k3"), "{text}");
+        assert!(text.contains("effort high"), "{text}");
+        assert!(
+            text.contains("Simplify docs/spec into plain words."),
+            "{text}"
+        );
+        assert!(text.contains("reading docs/spec/a.md"), "{text}");
+        assert!(!text.contains('{'), "no JSON reaches the overlay:\n{text}");
+        assert!(
+            text.contains("s stop · p pause/resume · r restart"),
+            "{text}"
+        );
+    }
+}

--- a/crates/stella-tui/src/v2/subagents.rs
+++ b/crates/stella-tui/src/v2/subagents.rs
@@ -93,9 +93,15 @@ pub struct SubagentsOverlay {
 /// lets the key fall through: with none an empty session scrolls as it
 /// always did, and with text in the composer `↓` is cursor motion. Gated on
 /// *full* composer emptiness, chips included, like `↑`.
+///
+/// Only from the transcript's **tail**: with a message highlighted `↓` walks
+/// the highlight down (the focus tree's list step), and the overlay — the
+/// children below the last message — opens on the press after the highlight
+/// drops off the end.
 pub fn down_opens(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Option<DeckAction> {
     if ui.tab == DeckTab::Session
         && ui.composer.is_empty()
+        && ui.session_selected.is_none()
         && !rows::rows(model).is_empty()
         && matches!(key.code, KeyCode::Down)
     {
@@ -798,6 +804,13 @@ mod tests {
             "with text in the composer `↓` is cursor motion"
         );
         ui.composer.clear();
+        ui.session_selected = Some(0);
+        assert_eq!(
+            down_opens(key(KeyCode::Down), &model, &mut ui),
+            None,
+            "with a message highlighted `↓` walks the highlight, not the overlay"
+        );
+        ui.session_selected = None;
         down_opens(key(KeyCode::Down), &model, &mut ui);
         handle_key(key(KeyCode::Char('l')), &model, &mut ui);
         assert!(!ui.subagents.open);

--- a/crates/stella-tui/src/v2/subagents.rs
+++ b/crates/stella-tui/src/v2/subagents.rs
@@ -2,40 +2,48 @@
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
 //! The SUB-AGENTS overlay (`↓` from an empty prompt, `ctrl-a`, `/subagents`):
-//! every lane the lead has dispatched, with controls. It is the only place
-//! the lanes are drawn — the SESSION tab stacks nothing above the transcript
-//! for them.
+//! every lane the lead has dispatched and every `delegate` child inside a
+//! turn, with controls. It is the only place the sub-agents are drawn — the
+//! SESSION tab stacks nothing above the transcript for them.
 //!
 //! ```text
-//! ╭ sub-agents · 2 running · 1 paused ─────────────────────────────────────╮
-//! │ ▸ ◆ sub:2  running · 0:24 · moonshotai/kimi-k3 · effort high · $0.01   │
-//! │     Simplify docs/spec so every page reads in plain words.             │
-//! │     reading docs/spec/adaptive-context/adaptive-context.md             │
-//! │                                                                        │
-//! │   ◆ sub:3  paused · 1:02 · moonshotai/kimi-k3 · effort high · $0.03    │
-//! │     Simplify the crate READMEs.                                        │
-//! │     paused after edit_file crates/stella-core/README.md                │
-//! ╰ ↑↓ select · →↵ open · l lead · ^x^x kill · p pause · r restart · esc ──╯
+//! ╭ sub-agents · 2 running · 1 paused ───────────────────────────────────────╮
+//! │ ▸ ◆ sub:2  running · quiet 0:04 · 0:24 · moonshotai/kimi-k3 · effort high │
+//! │     Simplify docs/spec so every page reads in plain words.               │
+//! │     reading docs/spec/adaptive-context/adaptive-context.md               │
+//! │                                                                          │
+//! │   ◆ sub:3  running · quiet 4:12 · 5:02 · moonshotai/kimi-k3 · $0.03      │
+//! │     Simplify the crate READMEs.                                          │
+//! │     ran cargo test -p stella-core                                        │
+//! │                                                                          │
+//! │   ↳ d:1  running · inside lead's turn                                    │
+//! │     Survey how the three planes share a store.                           │
+//! │     inside lead's turn · no control plane: stop lead to stop it          │
+//! ╰ ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause · r ── esc ╯
 //! ```
 //!
-//! Three rows per lane. The head is its vitals — status, clock, model, the
-//! effort its calls are pinned to, spend. The second row is **what it is
-//! for**: the sentence the lead handed it ([`AgentMeta::purpose`]), its title
-//! until the driver supplies one. The third is **where it is**: one sentence
-//! derived from the lane's own fold ([`lifecycle`]) — the tool it is inside,
-//! the tool it just finished, the report it is writing, or why it stopped.
-//! Nothing here is a tool's raw arguments or a JSON result; the fold's
-//! humanized one-liner is the most a row quotes.
+//! Three rows per entry. The head is its vitals — status, **quiet time**
+//! (since its last event; red past [`crate::v2::pulse::STALL_AFTER_MS`] on a
+//! running lane, which is what "this one might be dead" looks like), clock,
+//! model, the effort its calls are pinned to, spend. The second row is
+//! **what it is for**: the sentence the lead handed it
+//! ([`AgentMeta::purpose`]), its title until the driver supplies one. The
+//! third is **where it is**: one sentence derived from the lane's own fold
+//! ([`lifecycle::lifecycle`]). Nothing here is a tool's raw arguments or a
+//! JSON result; the fold's humanized one-liner is the most a row quotes.
 //!
 //! The verbs ride the wire the old AGENTS dashboard used
 //! ([`WorkspaceInput::Control`], #4334): `ctrl-x` twice kills (`s` too, for
 //! the hand that knows the old key), `p` pauses a running lane and resumes a
 //! paused one, `r` restarts from the lane's retained spec, and `→` or `⏎`
 //! opens the lane — focuses its transcript on the SESSION tab, where the
-//! composer steers it and Esc steers or stops it, as for the lead. `l` is
-//! the way back to the lead. The lane list is [`WorkspaceModel::agents`]
-//! filtered to sub-agents, in registration order, so the keys and the paint
-//! agree on which row is which.
+//! composer steers it and `⌫` comes back. `l` is the way back to the lead.
+//! Two verbs are this overlay's own ([`rows`] carries their text): `n`
+//! **nudges** the lane for a one-line position report, and `f` **flags** it
+//! to whoever dispatched it, vitals attached, asking them to check, stop, or
+//! take over. A `delegate` child ([`rows::Row::Delegate`]) has no control
+//! plane: its control keys are swallowed and the footer says so; `⏎` opens
+//! its parent and `f` flags it to its parent.
 //!
 //! Kill takes two presses because it is the one verb here with no undo: a
 //! stopped worker's turn future is dropped, and Restart begins again from
@@ -43,26 +51,31 @@
 //! so; any other key disarms — the same shape the queue editor's clear-all
 //! and the SKILLS uninstall use.
 
+pub mod lifecycle;
+pub mod rows;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget};
-use stella_tui_theme::token;
+use stella_tui_theme::{glyph, token};
 
 use crate::deck::{AgentEntry, DeckTab, WorkspaceModel};
-use crate::deck_ui::{DeckAction, DeckUi};
-use crate::envelope::{AgentControl, AgentMeta, AgentStatus, WorkspaceInput};
-use crate::model::TranscriptEntry;
+use crate::deck_ui::{DeckAction, DeckUi, list_nav};
+use crate::envelope::{AgentControl, AgentStatus, WorkspaceInput};
 use crate::theme;
 use crate::views::cards;
+pub use lifecycle::{lifecycle, purpose};
+use rows::Row;
 
-/// Rows one lane spends, plus one blank between lanes.
+/// Rows one entry spends, plus one blank between entries.
 const ROWS_PER_LANE: usize = 4;
 
-/// The overlay's own state: whether it is up, the selected row, and whether
-/// the first `ctrl-x` of a kill has been pressed.
+/// The overlay's own state: whether it is up, the selected row, whether the
+/// first `ctrl-x` of a kill has been pressed, and the last thing a key did
+/// that the footer should say.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SubagentsOverlay {
     pub open: bool,
@@ -70,17 +83,20 @@ pub struct SubagentsOverlay {
     /// `ctrl-x` was pressed once on the selected lane; the next `ctrl-x`
     /// kills it, any other key disarms.
     pub kill_armed: bool,
+    /// One line the footer shows after a verb — `nudged sub:2`, `flagged
+    /// sub:2 to lead`, or why a key did nothing. Cleared by the next key.
+    pub notice: Option<String>,
 }
 
 /// `↓` from an empty composer on the Session tab opens the overlay when
-/// there are lanes to list — `↑`'s mirror (the queue editor). `None` lets
-/// the key fall through: with no lanes an empty session scrolls as it always
-/// did, and with text in the composer `↓` is cursor motion. Gated on *full*
-/// composer emptiness, chips included, like `↑`.
+/// there are sub-agents to list — `↑`'s mirror (the queue editor). `None`
+/// lets the key fall through: with none an empty session scrolls as it
+/// always did, and with text in the composer `↓` is cursor motion. Gated on
+/// *full* composer emptiness, chips included, like `↑`.
 pub fn down_opens(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Option<DeckAction> {
     if ui.tab == DeckTab::Session
         && ui.composer.is_empty()
-        && model.subagent_count() > 0
+        && !rows::rows(model).is_empty()
         && matches!(key.code, KeyCode::Down)
     {
         return Some(open(ui));
@@ -98,198 +114,72 @@ pub fn lanes(model: &WorkspaceModel) -> Vec<(usize, &AgentEntry)> {
         .collect()
 }
 
-/// What the lane is for: the purpose the driver supplied, else its title.
-pub fn purpose(meta: &AgentMeta) -> &str {
-    meta.purpose
-        .as_deref()
-        .filter(|p| !p.trim().is_empty())
-        .unwrap_or(&meta.title)
-}
-
-/// The present participle and past tense of a built-in tool's verb. Unknown
-/// tools — MCP, custom — are called by name.
-fn verb(tool: &str) -> (String, String) {
-    let (doing, done) = match tool {
-        "read_file" => ("reading", "read"),
-        "write_file" => ("writing", "wrote"),
-        "edit_file" => ("editing", "edited"),
-        "delete_file" => ("deleting", "deleted"),
-        "search" => ("searching", "searched"),
-        "bash" => ("running", "ran"),
-        "delegate" => ("delegating", "delegated"),
-        "ask_question" => ("asking", "asked"),
-        "get_environment" => ("probing the environment", "probed the environment"),
-        _ => return (format!("calling {tool}"), format!("called {tool}")),
-    };
-    (doing.to_string(), done.to_string())
-}
-
-/// Where the lane is in its task, as one sentence.
-///
-/// A supervisor state (queued, paused, killed) is stated as such — with the
-/// last tool beside it where there is one, so a paused lane says what it was
-/// doing when it stopped. A live lane is read off the tail of its fold: an
-/// open tool call is `reading <path>`, a closed one `read <path>`, prose is
-/// the report being written, and an empty fold is a lane that has not made
-/// its first model call yet.
-pub fn lifecycle(lane: &AgentEntry) -> String {
-    let tail = last_tool(lane);
-    match lane.status {
-        AgentStatus::Queued => "waiting for a worker slot".to_string(),
-        AgentStatus::Paused => match tail {
-            Some(t) => format!("paused after {} {}", verb(&t.name).1, t.input),
-            None => "paused before its first tool call".to_string(),
-        },
-        AgentStatus::Killed => match tail {
-            Some(t) => format!("stopped after {} {}", verb(&t.name).1, t.input),
-            None => "stopped before its first tool call".to_string(),
-        },
-        AgentStatus::WaitingInput => "waiting on an answer from you".to_string(),
-        AgentStatus::Failed => lane
-            .model
-            .transcript
-            .iter()
-            .rev()
-            .find_map(|e| match e {
-                TranscriptEntry::Error { message, .. } => Some(format!("failed: {message}")),
-                _ => None,
-            })
-            .unwrap_or_else(|| "failed".to_string()),
-        AgentStatus::Done => lane
-            .model
-            .transcript
-            .iter()
-            .rev()
-            .find_map(|e| match e {
-                TranscriptEntry::Complete { cost_usd, .. } => {
-                    Some(format!("finished · report delivered · ${cost_usd:.2}"))
-                }
-                _ => None,
-            })
-            .unwrap_or_else(|| "finished · report delivered".to_string()),
-        AgentStatus::Running => running(lane),
-    }
-}
-
-/// The most recent tool call on the lane, with whether it has returned.
-struct LastTool {
-    name: String,
-    input: String,
-}
-
-fn last_tool(lane: &AgentEntry) -> Option<LastTool> {
-    lane.model.transcript.iter().rev().find_map(|e| match e {
-        TranscriptEntry::ToolStart { name, input, .. } => Some(LastTool {
-            name: name.clone(),
-            input: input.clone(),
-        }),
-        _ => None,
-    })
-}
-
-/// A running lane's sentence, from the newest entry that says anything
-/// about progress.
-fn running(lane: &AgentEntry) -> String {
-    for entry in lane.model.transcript.iter().rev() {
-        match entry {
-            TranscriptEntry::ToolResult {
-                name, ok, summary, ..
-            } => {
-                // The result names the call; the start row before it holds
-                // the input. Find it so the sentence says what was read.
-                let input = input_of(lane, name);
-                let (_, done) = verb(name);
-                return if *ok {
-                    format!("{done} {input}")
-                } else {
-                    let why = cards::truncate_cols(summary, 40);
-                    format!("{done} {input} — failed: {why}")
-                };
-            }
-            TranscriptEntry::ToolStart { name, input, .. } => {
-                // An open call is the newest entry only when no result has
-                // followed it; the `ToolResult` arm above wins otherwise.
-                let (doing, _) = verb(name);
-                return format!("{doing} {input}");
-            }
-            TranscriptEntry::Text(_) => return "writing its report".to_string(),
-            TranscriptEntry::Reasoning(_) => return "thinking".to_string(),
-            TranscriptEntry::Retry { attempt, .. } => {
-                return format!("retrying the model call · attempt {attempt}");
-            }
-            TranscriptEntry::Parked { description, .. } => {
-                return format!("parked: {description}");
-            }
-            TranscriptEntry::Compaction { .. } => {
-                return "compacting its context".to_string();
-            }
-            TranscriptEntry::User(_) => {
-                return "starting: reading its briefing".to_string();
-            }
-            _ => {}
-        }
-    }
-    "starting: no model call yet".to_string()
-}
-
-/// The input of the newest `ToolStart` named `name` on the lane.
-fn input_of(lane: &AgentEntry, name: &str) -> String {
-    lane.model
-        .transcript
-        .iter()
-        .rev()
-        .find_map(|e| match e {
-            TranscriptEntry::ToolStart { name: n, input, .. } if n == name => Some(input.clone()),
-            _ => None,
-        })
-        .unwrap_or_default()
-}
-
-/// Open the overlay on the first lane.
+/// Open the overlay on the first row.
 pub fn open(ui: &mut DeckUi) -> DeckAction {
     ui.subagents.open = true;
     ui.subagents.sel = 0;
     ui.subagents.kill_armed = false;
+    ui.subagents.notice = None;
     DeckAction::Handled
 }
 
-/// The overlay's keys: ↑/↓ select, `→`/`⏎` open the lane (focus its
-/// transcript), `l` back to the lead, `ctrl-x` twice (or `s`) stop, `p`
-/// pause a running lane / resume a paused one, `r` restart, Esc/`←`/`q`
-/// close. Modal: every other key is swallowed.
+/// The overlay's keys: the list keys select, `→`/`⏎` open the row (focus
+/// its transcript — a child's parent's), `l` back to the lead, `n` nudge,
+/// `f` flag to the dispatcher, `ctrl-x` twice (or `s`) stop, `p` pause a
+/// running lane / resume a paused one, `r` restart, Esc/`←`/`q` close.
+/// Modal: every other key is swallowed.
 pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
-    let rows = lanes(model);
-    let count = rows.len();
+    let list = rows::rows(model);
+    let count = list.len();
     ui.subagents.sel = ui.subagents.sel.min(count.saturating_sub(1));
-    let selected = rows.get(ui.subagents.sel).copied();
+    ui.subagents.notice = None;
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // The kill arm survives exactly one key: the second `ctrl-x`.
+    let armed = std::mem::take(&mut ui.subagents.kill_armed);
+
+    if list_nav::closes(key) || matches!(key.code, KeyCode::Left) {
+        ui.subagents.open = false;
+        return DeckAction::Handled;
+    }
+    if list_nav::select(key, &mut ui.subagents.sel, count, true) {
+        return DeckAction::Handled;
+    }
+    let selected = list.get(ui.subagents.sel);
+    let lane = |row: &Row| match row {
+        Row::Lane(i) => model.agents.get(*i),
+        Row::Delegate(_) => None,
+    };
     let control = |lane: &AgentEntry, control: AgentControl| {
         DeckAction::Send(WorkspaceInput::Control {
             agent: lane.meta.id.clone(),
             control,
         })
     };
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    // The kill arm survives exactly one key: the second `ctrl-x`.
-    let armed = std::mem::take(&mut ui.subagents.kill_armed);
+    // A child takes no control verb; say so where the verb was pressed.
+    let no_plane = |ui: &mut DeckUi, row: &Row| {
+        if let Row::Delegate(d) = row {
+            ui.subagents.notice = Some(format!(
+                "{} runs inside {}'s turn — no control plane; f flags it, ⏎ opens {}",
+                d.agent_id,
+                model
+                    .agents
+                    .get(d.parent)
+                    .map(|a| a.meta.id.as_str())
+                    .unwrap_or("its parent"),
+                model
+                    .agents
+                    .get(d.parent)
+                    .map(|a| a.meta.id.as_str())
+                    .unwrap_or("its parent"),
+            ));
+        }
+        DeckAction::Handled
+    };
     match key.code {
-        KeyCode::Esc | KeyCode::Left | KeyCode::Char('q') => {
-            ui.subagents.open = false;
-            DeckAction::Handled
-        }
-        KeyCode::Up => {
-            ui.subagents.sel = ui.subagents.sel.saturating_sub(1);
-            DeckAction::Handled
-        }
-        KeyCode::Down => {
-            if count > 0 {
-                ui.subagents.sel = (ui.subagents.sel + 1).min(count - 1);
-            }
-            DeckAction::Handled
-        }
         KeyCode::Enter | KeyCode::Right => match selected {
-            Some((idx, _)) => {
+            Some(row) => {
                 ui.subagents.open = false;
-                ui.focus_agent(idx);
+                ui.focus_agent(row.opens());
                 DeckAction::Handled
             }
             None => DeckAction::Handled,
@@ -301,37 +191,109 @@ pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Dec
             }
             DeckAction::Handled
         }
-        KeyCode::Char('x') if ctrl => match selected {
-            Some((_, lane)) if lane.status.is_terminal() => DeckAction::Handled,
-            Some((_, lane)) if armed => control(lane, AgentControl::Stop),
-            Some(_) => {
-                ui.subagents.kill_armed = true;
+        KeyCode::Char('n') => match selected.and_then(lane) {
+            Some(l) if l.status.is_active() || l.status == AgentStatus::Paused => {
+                ui.subagents.notice = Some(format!("nudged {}", l.meta.id));
+                DeckAction::Send(rows::nudge(l))
+            }
+            Some(l) => {
+                ui.subagents.notice = Some(format!(
+                    "{} is {} — nothing to nudge",
+                    l.meta.id,
+                    l.status.label()
+                ));
                 DeckAction::Handled
             }
+            None => match selected {
+                Some(row) => no_plane(ui, row),
+                None => DeckAction::Handled,
+            },
+        },
+        KeyCode::Char('f') => match selected {
+            Some(row) => match rows::flag(model, row) {
+                Some(input) => {
+                    let to = model
+                        .agents
+                        .get(model.parent_of(row.opens()).unwrap_or(row.opens()))
+                        .map(|a| a.meta.id.clone())
+                        .unwrap_or_default();
+                    let who = match row {
+                        Row::Lane(i) => model.agents[*i].meta.id.clone(),
+                        Row::Delegate(d) => d.agent_id.clone(),
+                    };
+                    ui.subagents.notice = Some(format!("flagged {who} to {to}"));
+                    DeckAction::Send(input)
+                }
+                None => {
+                    ui.subagents.notice = Some("no dispatcher on the deck to flag to".into());
+                    DeckAction::Handled
+                }
+            },
+            None => DeckAction::Handled,
+        },
+        KeyCode::Char('x') if ctrl => match selected {
+            Some(row) if !row.controllable() => no_plane(ui, row),
+            Some(row) => match lane(row) {
+                Some(l) if l.status.is_terminal() => DeckAction::Handled,
+                Some(l) if armed => control(l, AgentControl::Stop),
+                Some(_) => {
+                    ui.subagents.kill_armed = true;
+                    DeckAction::Handled
+                }
+                None => DeckAction::Handled,
+            },
             None => DeckAction::Handled,
         },
         KeyCode::Char('s') => match selected {
-            Some((_, lane)) if !lane.status.is_terminal() => control(lane, AgentControl::Stop),
-            _ => DeckAction::Handled,
+            Some(row) if !row.controllable() => no_plane(ui, row),
+            Some(row) => match lane(row) {
+                Some(l) if !l.status.is_terminal() => control(l, AgentControl::Stop),
+                _ => DeckAction::Handled,
+            },
+            None => DeckAction::Handled,
         },
         KeyCode::Char('p') => match selected {
-            Some((_, lane)) if lane.status == AgentStatus::Paused => {
-                control(lane, AgentControl::Resume)
-            }
-            Some((_, lane)) if lane.status.is_active() => control(lane, AgentControl::Pause),
-            _ => DeckAction::Handled,
+            Some(row) if !row.controllable() => no_plane(ui, row),
+            Some(row) => match lane(row) {
+                Some(l) if l.status == AgentStatus::Paused => control(l, AgentControl::Resume),
+                Some(l) if l.status.is_active() => control(l, AgentControl::Pause),
+                _ => DeckAction::Handled,
+            },
+            None => DeckAction::Handled,
         },
         KeyCode::Char('r') => match selected {
-            Some((_, lane)) => control(lane, AgentControl::Restart),
+            Some(row) if !row.controllable() => no_plane(ui, row),
+            Some(row) => match lane(row) {
+                Some(l) => control(l, AgentControl::Restart),
+                None => DeckAction::Handled,
+            },
             None => DeckAction::Handled,
         },
         _ => DeckAction::Handled,
     }
 }
 
-/// The head row's vitals after the status: clock, model, effort, spend.
-fn vitals(lane: &AgentEntry, now_ms: u64) -> String {
-    let mut parts = vec![cards::fmt_mss(lane.elapsed_ms(now_ms))];
+/// The head row's vitals after the status: quiet time, clock, model, effort,
+/// spend. Quiet time is the first number because it is the one that changes
+/// the reader's next action.
+fn vitals(model: &WorkspaceModel, lane: &AgentEntry) -> Vec<Span<'static>> {
+    let dim = Style::new().fg(token::DIM);
+    let muted = Style::new().fg(token::MUTED);
+    let mut spans = Vec::new();
+    if !lane.status.is_terminal() {
+        let quiet = rows::quiet_ms(model, lane);
+        let style = if rows::stalled(model, lane) {
+            Style::new().fg(token::RED).add_modifier(Modifier::BOLD)
+        } else {
+            muted
+        };
+        spans.push(Span::styled(" · ", dim));
+        spans.push(Span::styled(
+            format!("quiet {}", cards::fmt_mss(quiet)),
+            style,
+        ));
+    }
+    let mut parts = vec![cards::fmt_mss(lane.elapsed_ms(model.now_ms))];
     if let Some(model) = &lane.meta.model {
         parts.push(model.clone());
     }
@@ -339,7 +301,9 @@ fn vitals(lane: &AgentEntry, now_ms: u64) -> String {
         parts.push(format!("effort {effort}"));
     }
     parts.push(format!("${:.2}", lane.cost_usd));
-    parts.join(" · ")
+    spans.push(Span::styled(" · ", dim));
+    spans.push(Span::styled(parts.join(" · "), muted));
+    spans
 }
 
 /// Draw the overlay over `area`.
@@ -354,8 +318,8 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
     };
     Clear.render(popup, buf);
 
-    let rows = lanes(model);
-    let selected = ui.subagents.sel.min(rows.len().saturating_sub(1));
+    let list = rows::rows(model);
+    let selected = ui.subagents.sel.min(list.len().saturating_sub(1));
     let inner_w = (w as usize).saturating_sub(4);
     let dim = Style::new().fg(token::DIM);
     let muted = Style::new().fg(token::MUTED);
@@ -363,7 +327,7 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
     let mark = Style::new().fg(theme::SUBAGENT);
 
     let mut lines: Vec<Line<'static>> = Vec::new();
-    if rows.is_empty() {
+    if list.is_empty() {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             "  no sub-agents dispatched in this session yet".to_string(),
@@ -374,61 +338,129 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
     let visible = ((h as usize).saturating_sub(2) / ROWS_PER_LANE).max(1);
     let start = selected
         .saturating_sub(visible.saturating_sub(1) / 2)
-        .min(rows.len().saturating_sub(visible));
-    for (i, (_, lane)) in rows.iter().enumerate().skip(start).take(visible) {
+        .min(list.len().saturating_sub(visible));
+    for (i, row) in list.iter().enumerate().skip(start).take(visible) {
         let is_sel = i == selected;
         let mut id_style = mark;
         if is_sel {
             id_style = id_style.bg(token::HL).add_modifier(Modifier::BOLD);
         }
-        let status_style = Style::new().fg(theme::status_color(lane.status));
-        let head = vec![
-            Span::styled(
-                if is_sel { "▸ " } else { "  " }.to_string(),
-                Style::new().fg(token::GOLD),
-            ),
-            Span::styled("◆ ", mark),
-            Span::styled(lane.meta.id.clone(), id_style),
-            Span::styled("  ", dim),
-            Span::styled(lane.status.label().to_string(), status_style),
-            Span::styled(" · ", dim),
-            Span::styled(
-                cards::truncate_cols(&vitals(lane, model.now_ms), inner_w.saturating_sub(24)),
-                muted,
-            ),
-        ];
-        lines.push(Line::from(head));
+        let cursor = Span::styled(
+            if is_sel { "▸ " } else { "  " }.to_string(),
+            Style::new().fg(token::GOLD),
+        );
+        let (head, what, place) = match row {
+            Row::Lane(idx) => {
+                let lane = &model.agents[*idx];
+                let status_style = Style::new().fg(theme::status_color(lane.status));
+                let mut head = vec![
+                    cursor,
+                    Span::styled(format!("{} ", glyph::MEMORY), mark),
+                    Span::styled(lane.meta.id.clone(), id_style),
+                    Span::styled("  ", dim),
+                    Span::styled(lane.status.label().to_string(), status_style),
+                ];
+                head.extend(vitals(model, lane));
+                (head, purpose(&lane.meta).to_string(), lifecycle(lane))
+            }
+            Row::Delegate(d) => {
+                let status = rows::delegate_status(d);
+                let parent = model
+                    .agents
+                    .get(d.parent)
+                    .map(|a| a.meta.id.clone())
+                    .unwrap_or_default();
+                let head = vec![
+                    cursor,
+                    Span::styled(format!("{} ", glyph::TOOL_DELEGATE), mark),
+                    Span::styled(d.agent_id.clone(), id_style),
+                    Span::styled("  ", dim),
+                    Span::styled(
+                        status.label().to_string(),
+                        Style::new().fg(theme::status_color(status)),
+                    ),
+                    Span::styled(" · ", dim),
+                    Span::styled(format!("inside {parent}'s turn"), muted),
+                    Span::styled(
+                        if d.write_access { " · writes" } else { "" }.to_string(),
+                        dim,
+                    ),
+                ];
+                (
+                    head,
+                    d.instruction_preview.clone(),
+                    rows::delegate_place(model, d),
+                )
+            }
+        };
+        // The head truncates to the row rather than wrapping into the next.
+        let mut used = 0usize;
+        let mut clipped: Vec<Span<'static>> = Vec::new();
+        for span in head {
+            let width = span.width();
+            if used + width > inner_w {
+                let room = inner_w.saturating_sub(used);
+                if room > 1 {
+                    clipped.push(Span::styled(
+                        cards::truncate_cols(&span.content, room),
+                        span.style,
+                    ));
+                }
+                break;
+            }
+            used += width;
+            clipped.push(span);
+        }
+        lines.push(Line::from(clipped));
         lines.push(Line::from(vec![
             Span::raw("     "),
-            Span::styled(
-                cards::truncate_cols(purpose(&lane.meta), inner_w.saturating_sub(5)),
-                text,
-            ),
+            Span::styled(cards::truncate_cols(&what, inner_w.saturating_sub(5)), text),
         ]));
         lines.push(Line::from(vec![
             Span::raw("     "),
             Span::styled(
-                cards::truncate_cols(&lifecycle(lane), inner_w.saturating_sub(5)),
+                cards::truncate_cols(&place, inner_w.saturating_sub(5)),
                 muted,
             ),
         ]));
         lines.push(Line::default());
     }
 
-    let running = rows
+    let lanes = lanes(model);
+    let running = lanes
         .iter()
         .filter(|(_, a)| a.status == AgentStatus::Running)
         .count();
-    let paused = rows
+    let paused = lanes
         .iter()
         .filter(|(_, a)| a.status == AgentStatus::Paused)
         .count();
-    let done = rows.iter().filter(|(_, a)| a.status.is_terminal()).count();
+    let done = lanes.iter().filter(|(_, a)| a.status.is_terminal()).count();
+    let stalled = lanes
+        .iter()
+        .filter(|(_, a)| rows::stalled(model, a))
+        .count();
+    let children = list.iter().filter(|r| !r.controllable()).count();
     let mut title = vec![Span::styled(" sub-agents", text)];
     for (n, word) in [(running, "running"), (paused, "paused"), (done, "finished")] {
         if n > 0 {
             title.push(Span::styled(format!(" · {n} {word}"), muted));
         }
+    }
+    if stalled > 0 {
+        title.push(Span::styled(
+            format!(" · {stalled} quiet"),
+            Style::new().fg(token::RED).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if children > 0 {
+        title.push(Span::styled(
+            format!(
+                " · {children} delegate{}",
+                if children == 1 { "" } else { "s" }
+            ),
+            muted,
+        ));
     }
     title.push(Span::raw(" "));
     let footer = if ui.subagents.kill_armed {
@@ -436,9 +468,11 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
             " ctrl-x again kills the selected lane · any other key keeps it ",
             Style::new().fg(token::RED).add_modifier(Modifier::BOLD),
         )
+    } else if let Some(notice) = &ui.subagents.notice {
+        Span::styled(format!(" {notice} "), Style::new().fg(token::GOLD))
     } else {
         Span::styled(
-            " ↑↓ select · →↵ open · l lead · ^x^x kill · p pause/resume · r restart · esc ",
+            " ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause/resume · r restart · esc ",
             dim,
         )
     };
@@ -454,9 +488,9 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::envelope::Inbound;
+    use crate::envelope::{AgentMeta, Inbound};
     use crossterm::event::KeyModifiers;
-    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+    use stella_protocol::{AgentEvent, SubAgentPhase, SubAgentStatus, ToolCall};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -469,7 +503,9 @@ mod tests {
         ));
         for (id, status) in lanes {
             model.apply_inbound(&Inbound::Register(
-                AgentMeta::new(*id, format!("task {id}"), 0).with_role("subagent"),
+                AgentMeta::new(*id, format!("task {id}"), 0)
+                    .with_role("subagent")
+                    .with_parent("lead"),
             ));
             model.apply_inbound(&Inbound::Status {
                 agent: (*id).to_string(),
@@ -492,98 +528,33 @@ mod tests {
         });
     }
 
-    fn tool_result(model: &mut WorkspaceModel, agent: &str, name: &str, path: &str) {
+    fn delegate_started(model: &mut WorkspaceModel, parent: &str, id: &str, preview: &str) {
         model.apply_inbound(&Inbound::Event {
-            agent: agent.to_string(),
-            event: AgentEvent::ToolResult {
-                call_id: format!("c-{name}-{path}"),
-                output: ToolOutput::ok("ok"),
-                duration_ms: 3,
-                speculated: false,
+            agent: parent.to_string(),
+            event: AgentEvent::SubAgent {
+                phase: SubAgentPhase::Started {
+                    agent_id: id.to_string(),
+                    instruction_preview: preview.to_string(),
+                    write_access: false,
+                    budget_usd: Some(0.5),
+                    depth: 1,
+                },
             },
         });
     }
 
-    fn lane<'a>(model: &'a WorkspaceModel, id: &str) -> &'a AgentEntry {
-        model
-            .agents
-            .iter()
-            .find(|a| a.meta.id == id)
-            .expect("lane registered")
-    }
-
-    /// **The witness.** The second sentence is where the lane is, read off
-    /// its fold: inside a call it is `reading <path>`; once the call returns
-    /// it is `read <path>`; once it narrates, it is writing its report. None
-    /// of those is the call's arguments or its result.
-    #[test]
-    fn the_lifecycle_sentence_follows_the_lanes_fold() {
-        let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
-        assert_eq!(
-            lifecycle(lane(&model, "sub:2")),
-            "starting: no model call yet"
-        );
-
-        tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
-        assert_eq!(
-            lifecycle(lane(&model, "sub:2")),
-            "reading docs/spec/a.md",
-            "an open call is the participle"
-        );
-
-        tool_result(&mut model, "sub:2", "read_file", "docs/spec/a.md");
-        // A result re-folds the lane to Running; the sentence is the past tense.
-        assert_eq!(lifecycle(lane(&model, "sub:2")), "read docs/spec/a.md");
-
-        model.apply_inbound(&Inbound::Event {
-            agent: "sub:2".into(),
-            event: AgentEvent::Text {
-                text: "Done. I simplified".into(),
-            },
-        });
-        assert_eq!(lifecycle(lane(&model, "sub:2")), "writing its report");
-    }
-
-    /// A supervisor state names itself and what the lane was doing.
-    #[test]
-    fn paused_and_stopped_lanes_say_what_they_were_doing() {
-        let mut model = model_with(&[("sub:3", AgentStatus::Running)]);
-        tool_start(&mut model, "sub:3", "edit_file", "README.md");
-        model.apply_inbound(&Inbound::Status {
-            agent: "sub:3".into(),
-            status: AgentStatus::Paused,
-        });
-        assert_eq!(
-            lifecycle(lane(&model, "sub:3")),
-            "paused after edited README.md"
-        );
-        model.apply_inbound(&Inbound::Status {
-            agent: "sub:3".into(),
-            status: AgentStatus::Killed,
-        });
-        assert_eq!(
-            lifecycle(lane(&model, "sub:3")),
-            "stopped after edited README.md"
-        );
-        // A killed lane stays killed — the fold refuses to revive a terminal
-        // lane — so the queued sentence is pinned on a lane that never ran.
-        let queued = model_with(&[("sub:4", AgentStatus::Queued)]);
-        assert_eq!(
-            lifecycle(lane(&queued, "sub:4")),
-            "waiting for a worker slot"
-        );
-    }
-
-    /// The purpose is the driver's sentence, the title until there is one.
-    #[test]
-    fn purpose_prefers_the_drivers_sentence_over_the_title() {
-        let meta = AgentMeta::new("sub:1", "task #1: Simplify", 0);
-        assert_eq!(purpose(&meta), "task #1: Simplify");
-        let meta = meta.with_purpose("Simplify the crate READMEs into plain words.");
-        assert_eq!(
-            purpose(&meta),
-            "Simplify the crate READMEs into plain words."
-        );
+    fn text_of(model: &WorkspaceModel, ui: &DeckUi, w: u16, h: u16) -> String {
+        let area = Rect::new(0, 0, w, h);
+        let mut buf = Buffer::empty(area);
+        render(model, ui, area, &mut buf);
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// **The witness for #4334.** The verbs reach the wire for the row under
@@ -611,11 +582,11 @@ mod tests {
             sent(handle_key(key(KeyCode::Char('p')), &model, &mut ui)),
             ("sub:1".to_string(), AgentControl::Pause)
         );
-        handle_key(key(KeyCode::Down), &model, &mut ui);
+        handle_key(key(KeyCode::Char('j')), &model, &mut ui);
         assert_eq!(
             sent(handle_key(key(KeyCode::Char('p')), &model, &mut ui)),
             ("sub:2".to_string(), AgentControl::Resume),
-            "p on a paused lane resumes it"
+            "p on a paused lane resumes it; j moved the cursor"
         );
         assert_eq!(
             sent(handle_key(key(KeyCode::Char('r')), &model, &mut ui)),
@@ -632,10 +603,172 @@ mod tests {
         );
     }
 
+    /// **The witness for `n` and `f`.** A nudge is a steer at the lane asking
+    /// where it is; a flag carries the lane's vitals to its dispatcher — as a
+    /// steer while the dispatcher runs, as its next prompt when it is idle.
+    #[test]
+    fn nudge_steers_the_lane_and_flag_tells_the_dispatcher() {
+        let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
+        model.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::Running,
+        });
+        tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        model.now_ms = model.agents[1].last_activity_ms + 252_000;
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+
+        match handle_key(key(KeyCode::Char('n')), &model, &mut ui) {
+            DeckAction::Send(WorkspaceInput::Steer { agent, texts }) => {
+                assert_eq!(agent, "sub:2");
+                assert!(texts[0].contains("say where you are"), "{texts:?}");
+            }
+            other => panic!("a nudge is a steer at the lane, got {other:?}"),
+        }
+        assert_eq!(ui.subagents.notice.as_deref(), Some("nudged sub:2"));
+
+        match handle_key(key(KeyCode::Char('f')), &model, &mut ui) {
+            DeckAction::Send(WorkspaceInput::Steer { agent, texts }) => {
+                assert_eq!(agent, "lead", "to the dispatcher, not the lane");
+                let t = &texts[0];
+                assert!(t.contains("Lane sub:2"), "{t}");
+                assert!(t.contains("quiet for 4:12"), "{t}");
+                assert!(t.contains("reading docs/spec/a.md"), "{t}");
+                assert!(
+                    t.contains("Check on it, stop it, or take the task over"),
+                    "{t}"
+                );
+            }
+            other => panic!("a flag steers the running dispatcher, got {other:?}"),
+        }
+        assert_eq!(
+            ui.subagents.notice.as_deref(),
+            Some("flagged sub:2 to lead")
+        );
+
+        model.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::Done,
+        });
+        assert!(
+            matches!(
+                handle_key(key(KeyCode::Char('f')), &model, &mut ui),
+                DeckAction::Send(WorkspaceInput::Enqueue { .. })
+            ),
+            "an idle dispatcher gets the flag as its next prompt"
+        );
+    }
+
+    /// **The witness for #4347.** A `delegate` child is a row under its
+    /// parent with the truth about what it is; its control keys are swallowed
+    /// with a notice, `⏎` opens the parent, and `f` flags it to the parent.
+    #[test]
+    fn a_delegate_child_is_listed_under_its_parent_without_a_control_plane() {
+        let mut model = model_with(&[("sub:1", AgentStatus::Running)]);
+        model.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status: AgentStatus::Running,
+        });
+        delegate_started(
+            &mut model,
+            "lead",
+            "d:1",
+            "Survey how the three planes share a store.",
+        );
+        let list = rows::rows(&model);
+        assert_eq!(list.len(), 2);
+        assert!(
+            matches!(&list[0], Row::Delegate(d) if d.parent == 0 && d.agent_id == "d:1"),
+            "the lead's child comes first, under the lead: {list:?}"
+        );
+
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+        let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        for k in [
+            key(KeyCode::Char('s')),
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('r')),
+            ctrl_x,
+            ctrl_x,
+        ] {
+            assert_eq!(
+                handle_key(k, &model, &mut ui),
+                DeckAction::Handled,
+                "swallowed, never sent"
+            );
+            assert!(!ui.subagents.kill_armed, "a child never arms a kill");
+            assert!(
+                ui.subagents
+                    .notice
+                    .as_deref()
+                    .is_some_and(|n| n.contains("no control plane")),
+                "{:?}",
+                ui.subagents.notice
+            );
+        }
+        match handle_key(key(KeyCode::Char('f')), &model, &mut ui) {
+            DeckAction::Send(WorkspaceInput::Steer { agent, texts }) => {
+                assert_eq!(agent, "lead");
+                assert!(texts[0].contains("Your delegate d:1"), "{texts:?}");
+            }
+            other => panic!("{other:?}"),
+        }
+        handle_key(key(KeyCode::Enter), &model, &mut ui);
+        assert_eq!(ui.focused, 0, "⏎ opens the parent's transcript");
+
+        let text = text_of(
+            &model,
+            &DeckUi {
+                subagents: SubagentsOverlay {
+                    open: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            110,
+            14,
+        );
+        assert!(
+            text.contains("↳ d:1  running · inside lead's turn"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Survey how the three planes share a store."),
+            "{text}"
+        );
+        assert!(
+            text.contains("no control plane: stop lead to stop it"),
+            "{text}"
+        );
+        assert!(text.contains("1 delegate"), "{text}");
+
+        model.apply_inbound(&Inbound::Event {
+            agent: "lead".into(),
+            event: AgentEvent::SubAgent {
+                phase: SubAgentPhase::Finished {
+                    agent_id: "d:1".into(),
+                    status: SubAgentStatus::Completed,
+                    summary: "three planes, one store".into(),
+                    truncated: false,
+                    cost_usd: 0.12,
+                    steps: 4,
+                    absorbed_messages: 9,
+                    reason: None,
+                },
+            },
+        });
+        let list = rows::rows(&model);
+        assert!(
+            matches!(&list[0], Row::Delegate(d) if d.finished.as_ref().is_some_and(|f| f.steps == 4)),
+            "the finish row joins the start row: {list:?}"
+        );
+    }
+
     /// **The witness for the arrow-key way in.** `↓` on an empty composer
-    /// opens the overlay when lanes exist and falls through when none do;
-    /// inside it `→` opens the selected lane like `⏎`, `←` closes like Esc,
-    /// and `l` goes back to the lead.
+    /// opens the overlay when sub-agents exist and falls through when none
+    /// do; inside it `→` opens the selected lane like `⏎`, `←` closes like
+    /// Esc, and `l` goes back to the lead.
     #[test]
     fn down_opens_the_overlay_and_the_arrows_walk_in_and_out() {
         let mut ui = DeckUi {
@@ -722,17 +855,7 @@ mod tests {
         let mut ui = DeckUi::default();
         open(&mut ui);
         ui.subagents.kill_armed = true;
-        let area = Rect::new(0, 0, 100, 12);
-        let mut buf = Buffer::empty(area);
-        render(&model, &ui, area, &mut buf);
-        let text: String = (0..area.height)
-            .map(|y| {
-                (0..area.width)
-                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let text = text_of(&model, &ui, 100, 12);
         assert!(text.contains("ctrl-x again kills"), "{text}");
     }
 
@@ -750,12 +873,27 @@ mod tests {
             handle_key(key(KeyCode::Char('p')), &model, &mut ui),
             DeckAction::Handled
         );
+        assert_eq!(
+            handle_key(key(KeyCode::Char('n')), &model, &mut ui),
+            DeckAction::Handled,
+            "nothing to nudge"
+        );
+        assert!(
+            ui.subagents
+                .notice
+                .as_deref()
+                .is_some_and(|n| n.contains("nothing to nudge")),
+            "{:?}",
+            ui.subagents.notice
+        );
     }
 
-    /// The paint carries the model, the effort, both sentences, and no
-    /// brace — the row quotes the fold's one-liner, never the call's JSON.
+    /// The paint carries the model, the effort, the quiet time, both
+    /// sentences, and no brace — the row quotes the fold's one-liner, never
+    /// the call's JSON. A long silence on a running lane is red and counted
+    /// in the title.
     #[test]
-    fn the_overlay_paints_model_effort_purpose_and_place() {
+    fn the_overlay_paints_model_effort_quiet_purpose_and_place() {
         let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
         let meta = AgentMeta::new("sub:2", "task #2", 0)
             .with_role("subagent")
@@ -765,30 +903,42 @@ mod tests {
         meta.model = Some("moonshotai/kimi-k3".into());
         model.apply_inbound(&Inbound::Register(meta));
         tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        model.now_ms = model.agents[1].last_activity_ms + 4_000;
         let mut ui = DeckUi::default();
         open(&mut ui);
-        let area = Rect::new(0, 0, 100, 14);
-        let mut buf = Buffer::empty(area);
-        render(&model, &ui, area, &mut buf);
-        let text: String = (0..area.height)
-            .map(|y| {
-                (0..area.width)
-                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let text = text_of(&model, &ui, 110, 14);
         assert!(text.contains("moonshotai/kimi-k3"), "{text}");
         assert!(text.contains("effort high"), "{text}");
+        assert!(text.contains("quiet 0:04"), "{text}");
         assert!(
             text.contains("Simplify docs/spec into plain words."),
             "{text}"
         );
         assert!(text.contains("reading docs/spec/a.md"), "{text}");
         assert!(!text.contains('{'), "no JSON reaches the overlay:\n{text}");
+        assert!(text.contains("n nudge · f flag"), "{text}");
+        assert!(!text.contains("1 quiet"), "nobody is stalled yet: {text}");
+
+        model.now_ms = model.agents[1].last_activity_ms + crate::v2::pulse::STALL_AFTER_MS;
+        let area = Rect::new(0, 0, 110, 14);
+        let mut buf = Buffer::empty(area);
+        render(&model, &ui, area, &mut buf);
+        let text = text_of(&model, &ui, 110, 14);
         assert!(
-            text.contains("^x^x kill · p pause/resume · r restart"),
-            "{text}"
+            text.contains("1 quiet"),
+            "the title counts the stalled lane: {text}"
+        );
+        let (y, row) = text
+            .lines()
+            .enumerate()
+            .find(|(_, l)| l.contains("quiet 1:30"))
+            .expect("quiet time drawn");
+        let x = row.find("quiet 1:30").expect("on this row");
+        let x = row[..x].chars().count() as u16;
+        assert_eq!(
+            buf.cell((x, y as u16)).map(|c| c.fg),
+            Some(token::RED),
+            "{row}"
         );
     }
 }

--- a/crates/stella-tui/src/v2/subagents/lifecycle.rs
+++ b/crates/stella-tui/src/v2/subagents/lifecycle.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where a lane is, as one sentence — read off its own fold.
+//!
+//! Shared by the SUB-AGENTS overlay's third row and the pulse row
+//! (`v2::pulse`), so the two surfaces never disagree about what a lane is
+//! doing. Nothing here is a tool's raw arguments or a JSON result; the
+//! fold's humanized one-liner is the most a sentence quotes.
+
+use crate::deck::AgentEntry;
+use crate::envelope::{AgentMeta, AgentStatus};
+use crate::model::TranscriptEntry;
+use crate::views::cards;
+
+/// What the lane is for: the purpose the driver supplied, else its title.
+pub fn purpose(meta: &AgentMeta) -> &str {
+    meta.purpose
+        .as_deref()
+        .filter(|p| !p.trim().is_empty())
+        .unwrap_or(&meta.title)
+}
+
+/// The present participle and past tense of a built-in tool's verb. Unknown
+/// tools — MCP, custom — are called by name.
+fn verb(tool: &str) -> (String, String) {
+    let (doing, done) = match tool {
+        "read_file" => ("reading", "read"),
+        "write_file" => ("writing", "wrote"),
+        "edit_file" => ("editing", "edited"),
+        "delete_file" => ("deleting", "deleted"),
+        "search" => ("searching", "searched"),
+        "bash" => ("running", "ran"),
+        "delegate" => ("delegating", "delegated"),
+        "ask_question" => ("asking", "asked"),
+        "get_environment" => ("probing the environment", "probed the environment"),
+        _ => return (format!("calling {tool}"), format!("called {tool}")),
+    };
+    (doing.to_string(), done.to_string())
+}
+
+/// Where the lane is in its task, as one sentence.
+///
+/// A supervisor state (queued, paused, killed) is stated as such — with the
+/// last tool beside it where there is one, so a paused lane says what it was
+/// doing when it stopped. A live lane is read off the tail of its fold: an
+/// open tool call is `reading <path>`, a closed one `read <path>`, prose is
+/// the report being written, and an empty fold is a lane that has not made
+/// its first model call yet.
+pub fn lifecycle(lane: &AgentEntry) -> String {
+    let tail = last_tool(lane);
+    match lane.status {
+        AgentStatus::Queued => "waiting for a worker slot".to_string(),
+        AgentStatus::Paused => match tail {
+            Some(t) => format!("paused after {} {}", verb(&t.name).1, t.input),
+            None => "paused before its first tool call".to_string(),
+        },
+        AgentStatus::Killed => match tail {
+            Some(t) => format!("stopped after {} {}", verb(&t.name).1, t.input),
+            None => "stopped before its first tool call".to_string(),
+        },
+        AgentStatus::WaitingInput => "waiting on an answer from you".to_string(),
+        AgentStatus::Failed => lane
+            .model
+            .transcript
+            .iter()
+            .rev()
+            .find_map(|e| match e {
+                TranscriptEntry::Error { message, .. } => Some(format!("failed: {message}")),
+                _ => None,
+            })
+            .unwrap_or_else(|| "failed".to_string()),
+        AgentStatus::Done => lane
+            .model
+            .transcript
+            .iter()
+            .rev()
+            .find_map(|e| match e {
+                TranscriptEntry::Complete { cost_usd, .. } => {
+                    Some(format!("finished · report delivered · ${cost_usd:.2}"))
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| "finished · report delivered".to_string()),
+        AgentStatus::Running => running(lane),
+    }
+}
+
+/// The most recent tool call on the lane.
+struct LastTool {
+    name: String,
+    input: String,
+}
+
+fn last_tool(lane: &AgentEntry) -> Option<LastTool> {
+    lane.model.transcript.iter().rev().find_map(|e| match e {
+        TranscriptEntry::ToolStart { name, input, .. } => Some(LastTool {
+            name: name.clone(),
+            input: input.clone(),
+        }),
+        _ => None,
+    })
+}
+
+/// A running lane's sentence, from the newest entry that says anything
+/// about progress.
+fn running(lane: &AgentEntry) -> String {
+    for entry in lane.model.transcript.iter().rev() {
+        match entry {
+            TranscriptEntry::ToolResult {
+                name, ok, summary, ..
+            } => {
+                // The result names the call; the start row before it holds
+                // the input. Find it so the sentence says what was read.
+                let input = input_of(lane, name);
+                let (_, done) = verb(name);
+                return if *ok {
+                    format!("{done} {input}")
+                } else {
+                    let why = cards::truncate_cols(summary, 40);
+                    format!("{done} {input} — failed: {why}")
+                };
+            }
+            TranscriptEntry::ToolStart { name, input, .. } => {
+                // An open call is the newest entry only when no result has
+                // followed it; the `ToolResult` arm above wins otherwise.
+                let (doing, _) = verb(name);
+                return format!("{doing} {input}");
+            }
+            TranscriptEntry::Text(_) => return "writing its report".to_string(),
+            TranscriptEntry::Reasoning(_) => return "thinking".to_string(),
+            TranscriptEntry::Retry { attempt, .. } => {
+                return format!("retrying the model call · attempt {attempt}");
+            }
+            TranscriptEntry::Parked { description, .. } => {
+                return format!("parked: {description}");
+            }
+            TranscriptEntry::Compaction { .. } => {
+                return "compacting its context".to_string();
+            }
+            TranscriptEntry::User(_) => {
+                return "starting: reading its briefing".to_string();
+            }
+            _ => {}
+        }
+    }
+    "starting: no model call yet".to_string()
+}
+
+/// The input of the newest `ToolStart` named `name` on the lane.
+fn input_of(lane: &AgentEntry, name: &str) -> String {
+    lane.model
+        .transcript
+        .iter()
+        .rev()
+        .find_map(|e| match e {
+            TranscriptEntry::ToolStart { name: n, input, .. } if n == name => Some(input.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deck::WorkspaceModel;
+    use crate::envelope::Inbound;
+    use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
+
+    fn model_with(lanes: &[(&str, AgentStatus)]) -> WorkspaceModel {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(
+            AgentMeta::new("lead", "stella", 0).with_role("lead"),
+        ));
+        for (id, status) in lanes {
+            model.apply_inbound(&Inbound::Register(
+                AgentMeta::new(*id, format!("task {id}"), 0).with_role("subagent"),
+            ));
+            model.apply_inbound(&Inbound::Status {
+                agent: (*id).to_string(),
+                status: *status,
+            });
+        }
+        model
+    }
+
+    fn tool_start(model: &mut WorkspaceModel, agent: &str, name: &str, path: &str) {
+        model.apply_inbound(&Inbound::Event {
+            agent: agent.to_string(),
+            event: AgentEvent::ToolStart {
+                call: ToolCall {
+                    call_id: format!("c-{name}-{path}"),
+                    name: name.to_string(),
+                    input: serde_json::json!({ "path": path }),
+                },
+            },
+        });
+    }
+
+    fn tool_result(model: &mut WorkspaceModel, agent: &str, name: &str, path: &str) {
+        model.apply_inbound(&Inbound::Event {
+            agent: agent.to_string(),
+            event: AgentEvent::ToolResult {
+                call_id: format!("c-{name}-{path}"),
+                output: ToolOutput::ok("ok"),
+                duration_ms: 3,
+                speculated: false,
+            },
+        });
+    }
+
+    fn lane<'a>(model: &'a WorkspaceModel, id: &str) -> &'a AgentEntry {
+        model
+            .agents
+            .iter()
+            .find(|a| a.meta.id == id)
+            .expect("lane registered")
+    }
+
+    /// **The witness.** The second sentence is where the lane is, read off
+    /// its fold: inside a call it is `reading <path>`; once the call returns
+    /// it is `read <path>`; once it narrates, it is writing its report. None
+    /// of those is the call's arguments or its result.
+    #[test]
+    fn the_lifecycle_sentence_follows_the_lanes_fold() {
+        let mut model = model_with(&[("sub:2", AgentStatus::Running)]);
+        assert_eq!(
+            lifecycle(lane(&model, "sub:2")),
+            "starting: no model call yet"
+        );
+
+        tool_start(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        assert_eq!(
+            lifecycle(lane(&model, "sub:2")),
+            "reading docs/spec/a.md",
+            "an open call is the participle"
+        );
+
+        tool_result(&mut model, "sub:2", "read_file", "docs/spec/a.md");
+        // A result re-folds the lane to Running; the sentence is the past tense.
+        assert_eq!(lifecycle(lane(&model, "sub:2")), "read docs/spec/a.md");
+
+        model.apply_inbound(&Inbound::Event {
+            agent: "sub:2".into(),
+            event: AgentEvent::Text {
+                text: "Done. I simplified".into(),
+            },
+        });
+        assert_eq!(lifecycle(lane(&model, "sub:2")), "writing its report");
+    }
+
+    /// A supervisor state names itself and what the lane was doing.
+    #[test]
+    fn paused_and_stopped_lanes_say_what_they_were_doing() {
+        let mut model = model_with(&[("sub:3", AgentStatus::Running)]);
+        tool_start(&mut model, "sub:3", "edit_file", "README.md");
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:3".into(),
+            status: AgentStatus::Paused,
+        });
+        assert_eq!(
+            lifecycle(lane(&model, "sub:3")),
+            "paused after edited README.md"
+        );
+        model.apply_inbound(&Inbound::Status {
+            agent: "sub:3".into(),
+            status: AgentStatus::Killed,
+        });
+        assert_eq!(
+            lifecycle(lane(&model, "sub:3")),
+            "stopped after edited README.md"
+        );
+        // A killed lane stays killed — the fold refuses to revive a terminal
+        // lane — so the queued sentence is pinned on a lane that never ran.
+        let queued = model_with(&[("sub:4", AgentStatus::Queued)]);
+        assert_eq!(
+            lifecycle(lane(&queued, "sub:4")),
+            "waiting for a worker slot"
+        );
+    }
+
+    /// The purpose is the driver's sentence, the title until there is one.
+    #[test]
+    fn purpose_prefers_the_drivers_sentence_over_the_title() {
+        let meta = AgentMeta::new("sub:1", "task #1: Simplify", 0);
+        assert_eq!(purpose(&meta), "task #1: Simplify");
+        let meta = meta.with_purpose("Simplify the crate READMEs into plain words.");
+        assert_eq!(
+            purpose(&meta),
+            "Simplify the crate READMEs into plain words."
+        );
+    }
+}

--- a/crates/stella-tui/src/v2/subagents/rows.rs
+++ b/crates/stella-tui/src/v2/subagents/rows.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The rows the SUB-AGENTS overlay lists, and the two messages it can send
+//! on a row's behalf.
+//!
+//! Stella has two sub-agent mechanisms and the overlay lists both:
+//!
+//! * a **lane** — `sub:<task>` / `req:<n>`, an OS-thread session the driver
+//!   spawned (`crates/stella-cli/src/subsession.rs`), registered on the deck
+//!   with a role of `subagent` and answering `WorkspaceInput::Control`;
+//! * a **`delegate` child** — a bounded turn *inside* its parent's turn
+//!   (`stella_core::subagent`), known to the deck only as the
+//!   `TranscriptEntry::SubAgent` start/finish bracket on the parent's
+//!   transcript. It has no lane, no per-event attribution, and no control
+//!   plane (#4347).
+//!
+//! A child is listed under the agent whose transcript holds its bracket,
+//! with the verbs it cannot take drawn disabled and swallowed rather than
+//! sent — a row that silently did nothing was the failure #4347 names. What
+//! *can* be done about a child is done to its parent: `⏎` opens the parent's
+//! transcript, where the child's calls are, and `f` flags it to the parent.
+//!
+//! ## Nudge and flag
+//!
+//! Two asks a person has at this overlay and had no key for:
+//!
+//! * **`n` nudge** — "are you alive?" to the lane itself: a steer at its next
+//!   step boundary asking for a one-line position report, and to continue.
+//!   The lane answers on its own transcript; the pulse row and this overlay's
+//!   lifecycle sentence move when it does.
+//! * **`f` flag** — "this one might be dead" to whoever dispatched it: the
+//!   lane's vitals as the deck sees them — status, quiet time, what it was
+//!   last doing — sent to the parent as a steer if the parent is running and
+//!   as its next prompt otherwise, asking it to check, stop, or take the task
+//!   over. The operator decides nothing here; the dispatcher is the one with
+//!   the context to decide, and this hands it the facts.
+
+use crate::deck::{AgentEntry, WorkspaceModel};
+use crate::envelope::{AgentStatus, WorkspaceInput};
+use crate::model::{SubAgentSummary, TranscriptEntry};
+use crate::v2::pulse::STALL_AFTER_MS;
+use crate::views::cards;
+
+/// One listed row.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Row {
+    /// A worker lane: an index into `model.agents`.
+    Lane(usize),
+    /// A `delegate` child, read off its parent's transcript.
+    Delegate(Delegate),
+}
+
+/// A `delegate` child as the overlay knows it — the start row's preview and
+/// the finish row's summary, joined on `agent_id`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Delegate {
+    /// Index into `model.agents` of the agent whose turn it ran inside.
+    pub parent: usize,
+    pub agent_id: String,
+    pub instruction_preview: String,
+    pub write_access: bool,
+    /// `None` while the child is still inside its parent's turn.
+    pub finished: Option<SubAgentSummary>,
+}
+
+impl Row {
+    /// The agent `⏎` opens and `f` flags to: the lane itself, or a child's
+    /// parent.
+    pub fn opens(&self) -> usize {
+        match self {
+            Row::Lane(i) => *i,
+            Row::Delegate(d) => d.parent,
+        }
+    }
+
+    /// Whether the row answers `WorkspaceInput::Control` at all.
+    pub fn controllable(&self) -> bool {
+        matches!(self, Row::Lane(_))
+    }
+}
+
+/// Every row, in registration order: each lane, followed by the children
+/// its transcript holds. The lead is not a row, but its children are listed
+/// first under it, because a `delegate` from the lead is the common case.
+pub fn rows(model: &WorkspaceModel) -> Vec<Row> {
+    let mut out = Vec::new();
+    for (idx, agent) in model.agents.iter().enumerate() {
+        if agent.is_subagent() {
+            out.push(Row::Lane(idx));
+        }
+        out.extend(delegates_of(idx, agent).into_iter().map(Row::Delegate));
+    }
+    out
+}
+
+/// The `delegate` children bracketed on `agent`'s transcript, oldest first,
+/// each start row joined with its finish row by `agent_id`.
+pub fn delegates_of(parent: usize, agent: &AgentEntry) -> Vec<Delegate> {
+    let mut out: Vec<Delegate> = Vec::new();
+    for entry in &agent.model.transcript {
+        let TranscriptEntry::SubAgent {
+            agent_id,
+            finished,
+            instruction_preview,
+            write_access,
+        } = entry
+        else {
+            continue;
+        };
+        match finished {
+            None => out.push(Delegate {
+                parent,
+                agent_id: agent_id.clone(),
+                instruction_preview: instruction_preview.clone(),
+                write_access: *write_access,
+                finished: None,
+            }),
+            Some(summary) => {
+                if let Some(d) = out
+                    .iter_mut()
+                    .rev()
+                    .find(|d| d.agent_id == *agent_id && d.finished.is_none())
+                {
+                    d.finished = Some(summary.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Milliseconds since the lane's last event.
+pub fn quiet_ms(model: &WorkspaceModel, lane: &AgentEntry) -> u64 {
+    model.now_ms.saturating_sub(lane.last_activity_ms)
+}
+
+/// Whether a running lane has been quiet long enough to call it stalled.
+pub fn stalled(model: &WorkspaceModel, lane: &AgentEntry) -> bool {
+    lane.status == AgentStatus::Running && quiet_ms(model, lane) >= STALL_AFTER_MS
+}
+
+/// The `n` message: a steer at the lane asking where it is.
+pub fn nudge(lane: &AgentEntry) -> WorkspaceInput {
+    WorkspaceInput::Steer {
+        agent: lane.meta.id.clone(),
+        texts: vec![
+            "The operator is checking on you. In one line, say where you are and what is \
+             left, then continue."
+                .to_string(),
+        ],
+    }
+}
+
+/// The `f` message: the row's vitals, to its dispatcher. `None` when the
+/// row has no dispatcher on the deck.
+pub fn flag(model: &WorkspaceModel, row: &Row) -> Option<WorkspaceInput> {
+    let (parent, text) = match row {
+        Row::Lane(idx) => {
+            let lane = model.agents.get(*idx)?;
+            let parent = model.parent_of(*idx)?;
+            let quiet = cards::fmt_mss(quiet_ms(model, lane));
+            let text = format!(
+                "[flag from the deck] Lane {} (\"{}\") looks stalled: {}, quiet for {}, last: {}. \
+                 Check on it, stop it, or take the task over — say which.",
+                lane.meta.id,
+                super::lifecycle::purpose(&lane.meta),
+                lane.status.label(),
+                quiet,
+                super::lifecycle::lifecycle(lane),
+            );
+            (parent, text)
+        }
+        Row::Delegate(d) => {
+            let text = format!(
+                "[flag from the deck] Your delegate {} (\"{}\") looks stalled: it is still \
+                 inside your turn with no report. Check on it or finish without it — say which.",
+                d.agent_id,
+                cards::truncate_cols(&d.instruction_preview, 80),
+            );
+            (d.parent, text)
+        }
+    };
+    let dispatcher = model.agents.get(parent)?;
+    Some(if dispatcher.status == AgentStatus::Running {
+        WorkspaceInput::Steer {
+            agent: dispatcher.meta.id.clone(),
+            texts: vec![text],
+        }
+    } else {
+        WorkspaceInput::Enqueue { text }
+    })
+}
+
+/// A child's lifecycle sentence — honest about what the deck knows, which
+/// is the bracket and nothing between.
+pub fn delegate_place(model: &WorkspaceModel, d: &Delegate) -> String {
+    let parent = model
+        .agents
+        .get(d.parent)
+        .map(|a| a.meta.id.as_str())
+        .unwrap_or("its parent");
+    match &d.finished {
+        None => format!("inside {parent}'s turn · no control plane: stop {parent} to stop it"),
+        Some(s) => {
+            let status = match s.status {
+                stella_protocol::SubAgentStatus::Completed => "finished",
+                stella_protocol::SubAgentStatus::Incomplete => "stopped early",
+                stella_protocol::SubAgentStatus::Refused => "refused",
+            };
+            let mut place = format!("{status} · {} steps · ${:.2}", s.steps, s.cost_usd);
+            if let Some(reason) = &s.reason {
+                place.push_str(" · ");
+                place.push_str(&cards::truncate_cols(reason, 60));
+            }
+            place
+        }
+    }
+}
+
+/// A child's status word, for the head row.
+pub fn delegate_status(d: &Delegate) -> AgentStatus {
+    match &d.finished {
+        None => AgentStatus::Running,
+        Some(s) => match s.status {
+            stella_protocol::SubAgentStatus::Completed => AgentStatus::Done,
+            stella_protocol::SubAgentStatus::Incomplete
+            | stella_protocol::SubAgentStatus::Refused => AgentStatus::Failed,
+        },
+    }
+}

--- a/crates/stella-tui/src/views/settings.rs
+++ b/crates/stella-tui/src/views/settings.rs
@@ -273,34 +273,44 @@ mod tests {
         assert!(nav.contains("←/→"), "nav teaches the switch key: {nav:?}");
     }
 
-    /// ←/→ walk the nav from browse state, and stop at each end rather than
-    /// wrapping — the AGENTS tab's contract, key-for-key.
+    /// ←/→ walk the nav from browse state; at either end the key **rises to
+    /// the tab strip** and moves to the neighbouring tab instead of wrapping
+    /// the panes — the focus tree's bubbling (`deck_ui::focus`), witnessed
+    /// on the one tab with horizontal siblings at both levels.
     ///
     /// Walks all of [`SettingsPane::ALL`] rather than naming two panes, so
     /// adding a fourth extends the walk instead of silently leaving it
     /// asserting an interior stretch of the nav.
     #[test]
-    fn left_right_walk_the_panes_from_a_blank_composer() {
+    fn left_right_walk_the_panes_then_rise_to_the_tab_strip() {
         let (model, mut ui) = open_ui();
         assert_eq!(ui.settings_pane, SettingsPane::ALL[0], "agents first");
 
         for expected in &SettingsPane::ALL[1..] {
             handle_deck_key(key(KeyCode::Right), &model, &mut ui);
+            assert_eq!(ui.tab, DeckTab::Settings, "a pane step stays on the tab");
             assert_eq!(ui.settings_pane, *expected);
         }
         let last = *SettingsPane::ALL.last().expect("panes exist");
         handle_deck_key(key(KeyCode::Right), &model, &mut ui);
-        assert_eq!(ui.settings_pane, last, "no wrap at the end");
+        assert_eq!(ui.settings_pane, last, "the panes do not wrap");
+        assert_eq!(
+            ui.tab,
+            DeckTab::Settings.next(),
+            "→ past the last pane is the next tab"
+        );
 
+        ui.set_tab(DeckTab::Settings);
         for expected in SettingsPane::ALL.iter().rev().skip(1) {
             handle_deck_key(key(KeyCode::Left), &model, &mut ui);
             assert_eq!(ui.settings_pane, *expected);
         }
         handle_deck_key(key(KeyCode::Left), &model, &mut ui);
+        assert_eq!(ui.settings_pane, SettingsPane::ALL[0]);
         assert_eq!(
-            ui.settings_pane,
-            SettingsPane::ALL[0],
-            "no wrap at the start"
+            ui.tab,
+            DeckTab::Settings.prev(),
+            "← past the first pane is the previous tab"
         );
     }
 

--- a/crates/stella-tui/src/views/subagents.rs
+++ b/crates/stella-tui/src/views/subagents.rs
@@ -175,9 +175,9 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
         let more = subs.len() - MAX_BLOCKS;
         rows.push(Line::from(Span::styled(
             if ui.accessible {
-                format!("· and {more} more subagents · AGENTS tab lists all")
+                format!("· and {more} more subagents · ctrl-a lists all")
             } else {
-                format!("└─ ◆ +{more} more · AGENTS tab lists all")
+                format!("└─ ◆ +{more} more · ctrl-a lists all")
             },
             Style::new().fg(theme::TEXT_TERTIARY),
         )));

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -1198,3 +1198,34 @@ fn deck_render_snapshots_state_a_failing_pr_on_the_issues_tab() {
         "a failing PR is not stated on the tab SPEC 5 sends it to:\n{frame}"
     );
 }
+
+/// Golden frame for the SUB-AGENTS overlay (`ctrl-a`, `/subagents`): one
+/// block per dispatched lane — status, clock, model, the effort its calls
+/// are pinned to, spend; then what the lane is for; then where it is in the
+/// task, read off its own fold. Every one of those is a word, so the
+/// style-stripped golden pins them; the bottom rule pins the verbs
+/// (stop · pause/resume · restart · focus) that #4334 lost with the AGENTS
+/// dashboard.
+#[test]
+fn deck_render_snapshots_pin_the_subagents_overlay() {
+    let mut model = fixture_model();
+    // The driver supplies a purpose and a pinned effort with the lane's
+    // registration; the demo scenario registers lanes bare, so give the first
+    // one both here and leave the second bare, pinning the fallback too.
+    let mut meta = stella_tui::AgentMeta::new("sub:auth", "wire automations triggers API", 0)
+        .with_role("subagent")
+        .with_purpose("Wire the automations triggers API to the new router.")
+        .with_effort("high");
+    meta.model = Some("glm-5.2".into());
+    model.apply_inbound(&Inbound::Register(meta));
+    let mut ui = ui_for(DeckTab::Session);
+    ui.subagents.open = true;
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "overlay_subagents",
+        "every dispatched lane: vitals with model and effort, its purpose, where it is; the control verbs on the rule",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -719,6 +719,22 @@ fn the_help_overlay_carries_the_metrics_spec_5_sends_behind_it() {
     let model = fixture_model();
     let mut ui = ui_for(DeckTab::Skills);
     ui.help_open = true;
+    // The sheet is longer than a 40-row frame since the focus-tree section
+    // joined it, and the numbers sit under the keys — so the first frame
+    // must say there is more below, and `End` must reach it.
+    let top = render_frame(&model, &mut ui, W, H);
+    assert!(
+        top.contains("more · ⇟ space · End"),
+        "a clipped sheet names what is below:\n{top}"
+    );
+    stella_tui::deck_ui::handle_deck_key(
+        crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+        &model,
+        &mut ui,
+    );
     let frame = render_frame(&model, &mut ui, W, H);
 
     for needle in [

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -308,8 +308,8 @@ fn help_overlay_shows_only_the_active_tabs_shortcuts() {
         "titled for the tab:\n{traces}"
     );
     assert!(traces.contains("cycle the per-agent filter"), "{traces}");
-    // Deck-wide keys are always present…
-    assert!(traces.contains("switch tabs"), "{traces}");
+    // The focus tree and the deck-wide keys are always present…
+    assert!(traces.contains("the next / previous tab"), "{traces}");
     assert!(traces.contains("quit stella"), "{traces}");
     // …but other tabs' keys are not.
     assert!(!traces.contains("search skills"), "{traces}");

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -39,7 +39,7 @@
                                               │                                                                  │
  space on/off · ctrl+o preview · e edit · p pi│  machine                                                         │
  4 installed · 1 learned · 3 enabled          │  engine        3 active · 3 total                                │
-                                              │  cpu           42%                                               │
+ ▶ sub:ci  running · quiet 0:00 · starting: no│  cpu           42%                                               │
 >>>                                           │  mem           148M                                              │
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fo└──────────────────────────────────────────────────────────────────┘
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -3,43 +3,43 @@
 # viewport 160×40 · rendered through render_deck, styling stripped
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
- SESSION AGENTS TRACES GRAPH FILES   SKILLS   MCP ISSUES SETTINGS                                                                                       stella*
-╭─────────────────────────────────────────────┌ help — SKILLS · esc close ───────────────────────────────────────┐─────────────────────────────────────────────╮
-│ ⌕                                           │                                                                  │                        installed + registry │
-╰─────────────────────────────────────────────│  SKILLS tab                                                      │─────────────────────────────────────────────╯
- installed · 4                                │  ← →           switch panes                                      │
-╭─────────────────────────────────────────────│  ↑ ↓           select a skill                                    │─────────────────────────────────────────────╮
-│  [x] release-checklist        v3 · project  │  space         enable / disable                                  │                                             │
-│▸ [x] rust-review              v2/4 · user   │  e             edit the selected skill                           │                                             │
-│  [ ] sql-tuning               v1 · user   Re│  p             pin / unpin                                       │                                             │
-│ learned from traces · 1   stella wrote these│  n             new skill — drafted by the LLM                    │                                             │
-│  [x] bench-rig-access         learned   Reac│  ctrl-o        preview                                           │                                             │
-│                                             │  ctrl-x ×2     delete (press twice to confirm)                   │                                             │
-│                                             │  type          search skills                                     │                                             │
-│                                             │                                                                  │                                             │
-│                                             │  everywhere                                                      │                                             │
-│                                             │  tab / ⇧tab    switch tabs                                       │                                             │
-│                                             │  ⏎             queue the prompt — mid-turn it runs as its own age│                                             │
-│                                             │  ⌘⏎ / ⌃⏎ / ⌥⏎  insert a line break in the prompt                 │                                             │
-│                                             │  !cmd          run a shell command NOW (skips the queue)         │                                             │
-│                                             │  /             slash commands — ↑↓ pick · tab completes · ⏎ runs │                                             │
-│                                             │  ctrl-v        paste — a copied image is attached to the prompt  │                                             │
-│                                             │  ctrl-t        open the queue editor                             │                                             │
-│                                             │  ctrl-a / ↓    SUB-AGENTS — ↑↓ pick a lane · →↵ open it · ^x^x ki│                                             │
-│                                             │  ctrl-s        PLAN — every step of the approved plan, in full   │                                             │
-│                                             │  >text         steer the running turn — lands at the next step bo│                                             │
-│                                             │  esc           steer: your draft + queue go INTO the running turn│                                             │
-│                                             │  esc esc       cancel NOW & hold — nothing runs until your next p│                                             │
-│                                             │  ctrl-c        quit stella                                       │                                             │
-│                                             │                                                                  │                                             │
-│                                             │  letter & arrow hotkeys apply while the prompt box is empty      │                                             │
-│                                             │                                                                  │                                             │
-╰─────────────────────────────────────────────│  model                                                           │─────────────────────────────────────────────╯
- registry · web · type a term, ↵ searches     │  worker        zai/glm-5.2-air · answering                       │
-                                              │                                                                  │
- space on/off · ctrl+o preview · e edit · p pi│  machine                                                         │
- 4 installed · 1 learned · 3 enabled          │  engine        3 active · 3 total                                │
- ▶ sub:ci  running · quiet 0:00 · starting: no│  cpu           42%                                               │
->>>                                           │  mem           148M                                              │
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fo└──────────────────────────────────────────────────────────────────┘
-zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help
+ SESSION AGENTS TRACES GRAPH FILES   S┌ help — SKILLS · esc close ───────────────────────────────────────────────────────┐                              stella*
+╭─────────────────────────────────────│                                                                                  │─────────────────────────────────────╮
+│ ⌕                                   │  SKILLS tab                                                                      │                installed + registry │
+╰─────────────────────────────────────│  ← →           installed ↔ registry search (→ past the search leaves the tab)    │─────────────────────────────────────╯
+ installed · 4                        │  space         enable / disable                                                  │
+╭─────────────────────────────────────│  e             edit the selected skill                                           │─────────────────────────────────────╮
+│  [x] release-checklist        v3 · p│  p             pin / unpin                                                       │                                     │
+│▸ [x] rust-review              v2/4 ·│  n             new skill — drafted by the LLM                                    │                                     │
+│  [ ] sql-tuning               v1 · u│  ctrl-o        preview                                                           │                                     │
+│ learned from traces · 1   stella wro│  ctrl-x ×2     delete (press twice to confirm)                                   │                                     │
+│  [x] bench-rig-access         learne│  type          search skills                                                     │                                     │
+│                                     │                                                                                  │                                     │
+│                                     │  moving around — every tab, every overlay                                        │                                     │
+│                                     │  ← →           the sibling: the pane beside this one, else the tab beside it     │                                     │
+│                                     │  ↑ ↓ · k j     the item above / below                                            │                                     │
+│                                     │  ⏎             open it — a diff, a lane, a message's full text                   │                                     │
+│                                     │  ⌫             back up one level; never reaches a running turn                   │                                     │
+│                                     │  ⇞ ⇟ · Home End a page · the ends                                                │                                     │
+│                                     │  tab / ⇧tab    the next / previous tab                                           │                                     │
+│                                     │  q / esc       close any overlay                                                 │                                     │
+│                                     │                                                                                  │                                     │
+│                                     │  everywhere                                                                      │                                     │
+│                                     │  ⏎             queue the prompt — mid-turn it waits its turn (unless a card asks)│                                     │
+│                                     │  ⌘⏎ / ⌃⏎ / ⌥⏎  insert a line break in the prompt                                 │                                     │
+│                                     │  !cmd          run a shell command NOW (skips the queue)                         │                                     │
+│                                     │  /             slash commands — ↑↓ pick · tab completes · ⏎ runs                 │                                     │
+│                                     │  ctrl-v        paste — a copied image is attached to the prompt                  │                                     │
+│                                     │  ctrl-a        SUB-AGENTS — n nudge · f flag · ^x^x kill · p pause · r restart   │                                     │
+│                                     │  ctrl-t        the queue editor                                                  │                                     │
+│                                     │  ctrl-e        SESSIONS — every session on this machine                          │                                     │
+│                                     │  ctrl-k        CONTEXT — active skills + MCP servers                             │                                     │
+╰─────────────────────────────────────│  ctrl-g        INSPECT — the context sent on any recorded call                   │─────────────────────────────────────╯
+ registry · web · type a term, ↵ searc│  ctrl-s        PLAN — every step of the approved plan, in full                   │
+                                      │  >text         steer the running turn — lands at the next step boundary          │
+ space on/off · ctrl+o preview · e edi│  esc           steer: your draft + queue go INTO the running turn                │
+ 4 installed · 1 learned · 3 enabled  │  esc esc       cancel NOW & hold — nothing runs until your next prompt           │
+ ▶ sub:ci  running · quiet 0:00 · star│  ?             this sheet                                                        │
+>>>                                   │  ctrl-c        quit stella                                                       │
+ ⏎ queue · ↓ 2 sub-agents · ! shell · │                                                                                  │
+zai/glm-5.2-air · execute · ctx ▌░░░░░└──────────────────────────────────────────────────────── ↓ 9 more · ⇟ space · End ┘                                ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -25,6 +25,7 @@
 │                                             │  /             slash commands — ↑↓ pick · tab completes · ⏎ runs │                                             │
 │                                             │  ctrl-v        paste — a copied image is attached to the prompt  │                                             │
 │                                             │  ctrl-t        open the queue editor                             │                                             │
+│                                             │  ctrl-a        SUB-AGENTS — dispatched lanes: stop · pause · rest│                                             │
 │                                             │  ctrl-s        PLAN — every step of the approved plan, in full   │                                             │
 │                                             │  >text         steer the running turn — lands at the next step bo│                                             │
 │                                             │  esc           steer: your draft + queue go INTO the running turn│                                             │
@@ -33,13 +34,12 @@
 │                                             │                                                                  │                                             │
 │                                             │  letter & arrow hotkeys apply while the prompt box is empty      │                                             │
 │                                             │                                                                  │                                             │
-│                                             │  model                                                           │                                             │
-╰─────────────────────────────────────────────│  worker        zai/glm-5.2-air · answering                       │─────────────────────────────────────────────╯
- registry · web · type a term, ↵ searches     │                                                                  │
-                                              │  machine                                                         │
- space on/off · ctrl+o preview · e edit · p pi│  engine        3 active · 3 total                                │
- 4 installed · 1 learned · 3 enabled          │  cpu           42%                                               │
-                                              │  mem           148M                                              │
->>>                                           └──────────────────────────────────────────────────────────────────┘
- ⏎ queue · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+╰─────────────────────────────────────────────│  model                                                           │─────────────────────────────────────────────╯
+ registry · web · type a term, ↵ searches     │  worker        zai/glm-5.2-air · answering                       │
+                                              │                                                                  │
+ space on/off · ctrl+o preview · e edit · p pi│  machine                                                         │
+ 4 installed · 1 learned · 3 enabled          │  engine        3 active · 3 total                                │
+                                              │  cpu           42%                                               │
+>>>                                           │  mem           148M                                              │
+ ⏎ queue · ^N failure · ^Z fold turn · ^O expa└──────────────────────────────────────────────────────────────────┘
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
@@ -41,5 +41,5 @@
  4 installed · 1 learned · 3 enabled
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_skills_create_description.txt
@@ -39,7 +39,7 @@
 
  space on/off · ctrl+o preview · e edit · p pin · n new from prompt · ctrl+x ctrl+x delete · → search
  4 installed · 1 learned · 3 enabled
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
@@ -41,5 +41,5 @@
  4 installed · 1 learned · 3 enabled
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_skills_scope.txt
@@ -39,7 +39,7 @@
 
  space on/off · ctrl+o preview · e edit · p pin · n new from prompt · ctrl+x ctrl+x delete · → search
  4 installed · 1 learned · 3 enabled
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -1,0 +1,45 @@
+# deck golden · overlay_subagents
+# every dispatched lane: vitals with model and effort, its purpose, where it is; the control verbs on the rule
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
+└─ ◆ sub:auth  subagent · needs input                                                                                                                       5:12
+     model glm-5.2 · ctx ╭ sub-agents · 1 running ────────────────────────────────────────────────────────────────────────────────────╮
+     ⚒ search_code trigge│▸ ◆ sub:auth  needs input · 5:12 · glm-5.2 · effort high · $0.01                                            │
+     returns: wire automa│     Wire the automations triggers API to the new router.                                                   │
+└─ ◆ sub:ci  subagent · r│     waiting on an answer from you                                                                          │                     5:12
+     model glm-5.2-air · │                                                                                                            │
+     ⚒ no tool calls yet │  ◆ sub:ci  running · 5:12 · glm-5.2-air · $0.00                                                            │
+     returns: watch CI + │     watch CI + open PR                                                                                     │
+── turn 1 triage ────────│     starting: no model call yet                                                                            │─────────────────────────
+                         │                                                                                                            │
+◉ recalled  2 frames · 21│                                                                                                            │
+    symbol  engine step-d│                                                                                                            │  120 tok
+    memory  event-log REP│                                                                                                            │   90 tok
+    ⋯ ctrl+o for provenan│                                                                                                            │
+                         │                                                                                                            │
+── PLAN ─────────────────│                                                                                                            │─────────────────────────
+                         │                                                                                                            │
+  Planning the automation│                                                                                                            │
+                         │                                                                                                            │
+☰  plan  4/7  ·  Wire the│                                                                                                            │
+                         │                                                                                                            │
+── EXECUTE ──────────────│                                                                                                            │─────────────────────────
+                         │                                                                                                            │
+ │ ⊙ apps/app/automations│                                                                                                            │
+ │ ⎿ 312 lines           │                                                                                                            │      42ms
+                         │                                                                                                            │
+☰  plan  5/7  ·  Workflow│                                                                                                            │
+                         │                                                                                                            │
+⏸ plan  Refactor the auto│                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+                         │                                                                                                            │
+>>>                      ╰─────────────────────────────────────────── ↑↓ select · ↵ focus · s stop · p pause/resume · r restart · esc ╯
+ ⏎ queue · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -6,11 +6,11 @@
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
 ── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                          ╭ sub-agents · 1 running ────────────────────────────────────────────────────────────────────────────────────╮
-◉ recalled  2 frames · 21│▸ ◆ sub:auth  needs input · 5:12 · glm-5.2 · effort high · $0.01                                            │
+◉ recalled  2 frames · 21│▸ ◆ sub:auth  needs input · quiet 0:00 · 5:12 · glm-5.2 · effort high · $0.01                               │
     symbol  engine step-d│     Wire the automations triggers API to the new router.                                                   │  120 tok
     memory  event-log REP│     waiting on an answer from you                                                                          │   90 tok
     ⋯ ctrl+o for provenan│                                                                                                            │
-                         │  ◆ sub:ci  running · 5:12 · glm-5.2-air · $0.00                                                            │
+                         │  ◆ sub:ci  running · quiet 0:00 · 5:12 · glm-5.2-air · $0.00                                               │
 ── PLAN ─────────────────│     watch CI + open PR                                                                                     │─────────────────────────
                          │     starting: no model call yet                                                                            │
   Planning the automation│                                                                                                            │
@@ -40,6 +40,6 @@
                          │                                                                                                            │
                          │                                                                                                            │
                          │                                                                                                            │
->>>                      ╰─────────────────────────────── ↑↓ select · →↵ open · l lead · ^x^x kill · p pause/resume · r restart · esc ╯
+>>>                      ╰─────────────────── ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause/resume · r restart · esc ╯
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
+++ b/crates/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
@@ -39,7 +39,7 @@
 │                                                                                                                                                              │
 │ e edit tool switches                                                                                                                                         │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
+++ b/crates/stella-tui/tests/snapshots/deck/pane_settings_tools.txt
@@ -41,5 +41,5 @@
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
@@ -41,5 +41,5 @@
  ↵ edit · a assume · n new · x x delete · v versions · r reload
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_agents.txt
@@ -39,7 +39,7 @@
 
 
  ↵ edit · a assume · n new · x x delete · v versions · r reload
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_files.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_files.txt
@@ -39,7 +39,7 @@
 │                                                                                                                                                              │
 │2 files   +7  -1  0 reads                                                                                                                                     │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_files.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_files.txt
@@ -41,5 +41,5 @@
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_graph.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_graph.txt
@@ -41,5 +41,5 @@
  every answer here is deterministic · $0.00
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_graph.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_graph.txt
@@ -39,7 +39,7 @@
 ╰────────────────────────────────────────────────────────╯╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
  ↵ open file · / files · ↑↓ walk
  every answer here is deterministic · $0.00
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -41,5 +41,5 @@
 
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -39,7 +39,7 @@
 
 
 
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
@@ -41,5 +41,5 @@
 
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
@@ -39,7 +39,7 @@
 
 
 
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
@@ -39,7 +39,7 @@
 │                                                                                                                                                              │
 │ e edit agents config                                                                                                                                         │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
@@ -41,5 +41,5 @@
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_skills.txt
@@ -41,5 +41,5 @@
  4 installed · 1 learned · 3 enabled
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_skills.txt
@@ -39,7 +39,7 @@
 
  space on/off · ctrl+o preview · e edit · p pin · n new from prompt · ctrl+x ctrl+x delete · → search
  4 installed · 1 learned · 3 enabled
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_traces.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_traces.txt
@@ -41,5 +41,5 @@
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
- ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_traces.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_traces.txt
@@ -39,7 +39,7 @@
 │                                                                                                                                                              │
 │                                                                                                                                                              │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.9.146"
-  version "0.9.146"
+  url "https://github.com/macanderson/stella.git", tag: "v0.9.147"
+  version "0.9.147"
   license "AGPL-3.0-only"
   head "https://github.com/macanderson/stella.git", branch: "main"
   depends_on "rust" => :build

--- a/packaging/homebrew/stella.rb
+++ b/packaging/homebrew/stella.rb
@@ -16,8 +16,8 @@
 class Stella < Formula
   desc "Fast, BYOK, model-agnostic terminal coding agent"
   homepage "https://github.com/macanderson/stella"
-  url "https://github.com/macanderson/stella.git", tag: "v0.9.145"
-  version "0.9.145"
+  url "https://github.com/macanderson/stella.git", tag: "v0.9.146"
+  version "0.9.146"
   license "AGPL-3.0-only"
   head "https://github.com/macanderson/stella.git", branch: "main"
   depends_on "rust" => :build

--- a/scripts/impacted-crates.sh
+++ b/scripts/impacted-crates.sh
@@ -38,7 +38,7 @@
 #      library does not.
 #
 #   2. Compile-time escapes. `crates/stella-parity/src/lib.rs` does
-#      `include_str!("../../stella-cli/src/subsession.rs")`, and
+#      `include_str!("../../stella-cli/src/subsession/tests.rs")`, and
 #      `crates/stella-tools/tests/doc_truth.rs` does `include_str!("../../README.md")`.
 #      No cargo edge names either one. These are resolved literally below, so
 #      touching that prompt file re-tests `stella-parity` even though nothing

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -28,6 +28,42 @@ stella chat --plain
 
 The default **Command Deck** presents the session as a set of tabs — **SESSION** (the transcript), **AGENTS** (executions & installed agents), **TRACES**, **GRAPH**, **FILES**, **SKILLS**, **MCP**, **ISSUES** (your connected GitHub/Linear tracker, with instant type-ahead), and **SETTINGS** (the home of all config, incl. the engine-config panel). Slash commands jump between tabs and run actions, and `?` opens a tab-aware key list. The **plain REPL** (`--plain`) is a single scrolling line-based loop with a smaller command set — handy for narrow terminals and recordings.
 
+### Moving around
+
+The deck is a tree — tabs, then the panes and lists inside each, then what a list item
+opens — and four keys walk it the same way at every level, from an **empty prompt**:
+
+| key | does |
+|---|---|
+| `←` `→` | the sibling: the pane beside this one, or, when the tab has none that way, the tab beside it |
+| `↑` `↓` (`k` `j`) | the item above / below in the list under the cursor |
+| `⏎` | open it — a file's diff, a lane's transcript, a message's full text |
+| `⌫` | back up one level — never stops anything |
+
+`Esc` is `⌫` plus one more step: once there is nothing left to close it interrupts the
+running turn (see below). `Tab` / `Shift-Tab` still cycle tabs. `q` or `Esc` closes any
+overlay, and `⇞` `⇟` `Home` `End` page through any list or body. With text in the prompt the
+arrows edit it and `⌫` deletes, as you would expect; the tree is what the keys mean when
+there is nothing to edit. `?` lists every key for the tab you are on.
+
+Off the SESSION tab, the row above the prompt is the **pulse row**: which agent is working,
+its status, how long since it last did anything (red once a running agent has been quiet
+for a minute and a half), where it is, and the last thing it said — so no tab is blind to the
+turn.
+
+### Sub-agents
+
+`↓` on an empty prompt (or `Ctrl-A`, or `/subagents`) opens the **SUB-AGENTS** overlay:
+every lane the lead dispatched and every `delegate` child running inside a turn, each with
+its quiet time, what it is for, and where it is. `→` or `⏎` opens a lane's transcript — the
+breadcrumb reads `SESSION ▸ lead ▸ sub:2` and `⌫` brings you back to the lead; a prompt typed
+there steers that lane. Inside the overlay `n` **nudges** the selected lane (a one-line
+"where are you?" it answers on its own transcript) and `f` **flags** it to whoever
+dispatched it, with its vitals attached, asking them to check on it, stop it, or take the
+task over. `ctrl-x ctrl-x` kills, `p` pauses / resumes, `r` restarts, `l` returns to the
+lead. A `delegate` child has no control plane of its own: its row says so, `⏎` opens its
+parent, and `f` flags it to the parent.
+
 ### Accessible mode
 
 `--accessible` is a **mode on the deck, not a smaller surface beside it**: every tab, every gate, the prompt queue, sub-agents, steering and resume are unchanged. What changes is how the deck talks to your terminal.
@@ -230,12 +266,10 @@ Open a tab or run an action:
     Search the MCP registry and install servers without leaving the deck.
   </OptionCard>
   <OptionCard name="/sessions">
-    Every stella session on this machine, grouped by status. Also reachable with `←` on an
-    empty prompt.
+    Every stella session on this machine, grouped by status. Also **Ctrl-E**.
   </OptionCard>
   <OptionCard name="/context">
-    This session's active skills and MCP servers. Also reachable with `→` on an empty
-    prompt.
+    This session's active skills and MCP servers. Also **Ctrl-K**.
   </OptionCard>
   <OptionCard name="/inspect">
     The context sent to the model on any recorded call — the deck's view of

--- a/website/content/docs/commands/resume.mdx
+++ b/website/content/docs/commands/resume.mdx
@@ -36,10 +36,10 @@ A session can only be reopened where it belongs: it must not be live in another 
 ·  ses-1752861200456-3301   Complete     webapp: fix the flaky auth test…
 
 ↩ resumable here (`stella resume [ID]`) · resumable from its own workspace
-inside the deck: `←` on an empty prompt opens SESSIONS, `⏎` reopens a session
+inside the deck: `Ctrl-E` opens SESSIONS, `⏎` reopens a session
 ```
 
-The deck's **SESSIONS** overlay (`←` on an empty prompt, or `/sessions`) is the same navigation from inside a session — `⏎` on a row reopens it.
+The deck's **SESSIONS** overlay (`Ctrl-E`, or `/sessions`) is the same navigation from inside a session — `⏎` on a row reopens it.
 
 ## Flags
 


### PR DESCRIPTION
## What & why

The Command Deck had a different way to do the same thing on every tab: `←`/`→` opened two overlays on SESSION, were `↑`/`↓` on GRAPH, switched panes on SKILLS and SETTINGS, and did nothing elsewhere; `j`/`k` worked in five overlays and not the other nine; `q` closed some; focusing a lane was a one-way trip with no key back and — worse — one Esc at a running lane hard-cancelled the worker. Off the SESSION tab nothing said whether the agent was working, stuck, or done. The `?` sheet advertised keys whose handler had been deleted.

This PR is built on #4356 (its branch is the base) and does five things:

1. **One navigation vocabulary, the focus tree** (`deck_ui/focus.rs`). From an empty composer `←`/`→` move to the sibling — the pane beside this one, or, when the tab has none that way, the tab beside it; a key the active tab declines *bubbles* to the tab strip (DOM-style), so no tab spells its own arrows. `↑`/`↓` (`j`/`k`) walk the list, `⏎` opens what is under the cursor (a highlighted message's full text, a diff, a lane), `⌫` backs up one level and **never reaches a running turn**. Esc keeps its peel-then-interrupt chain with one change (rule 8a): at an opened lane with an empty composer it returns to the dispatcher instead of cancelling the worker. `Tab`/`Shift-Tab` stay. SESSIONS and CONTEXT move to `ctrl-e` / `ctrl-k`. `deck_ui/list_nav.rs` is the one implementation of `↑`/`↓`/`j`/`k`/`⇞`/`⇟`/`Home`/`End` and of "`q` or Esc closes"; fourteen surfaces route through it (`deck_ui.rs` shrinks by 125 lines).
2. **Sub-agents are a tree.** `AgentMeta::parent` names each lane's dispatcher (stamped by `subsession::spawn` and on journal replay); `WorkspaceModel::parent_of / children_of / ancestry`. The SESSION breadcrumb at a lane reads `SESSION ▸ lead ▸ sub:2 · running · ⌫ back`; the hint row names what `⏎` does there (`steer sub:2`, or `ask the lead about sub:2` once it has finished — the words go to the lead with the lane named in front, visible in the transcript).
3. **The pulse row** (`v2/pulse.rs`): in the one row of air above the composer, on every tab but SESSION (and at an opened lane, where it is the lead): who is working, status, **quiet time** (red past 90 s on a running agent), where it is, and the first line of its last real words. Tool arguments never appear.
4. **SUB-AGENTS overlay**: every lane's head row carries `quiet m:ss` and the title counts `N quiet`; `n` **nudges** the selected lane (a steer asking for a one-line position report); `f` **flags** it to whoever dispatched it, vitals attached, as a steer while the dispatcher runs and as its next prompt when idle. `delegate` children are listed under their parent with the truth about what they are (`↳ d:1 running · inside lead's turn · no control plane: stop lead to stop it`); their control keys are swallowed with a notice naming the reason, `⏎` opens the parent, `f` flags to the parent — the honest half of #4347. The file splits into `subagents/lifecycle.rs` (the sentence the pulse row shares) and `subagents/rows.rs`.
5. **One keymap table** (`keymap.rs`) behind the `?` sheet and the hint row, so neither can drift; dead plan-review rows and the stale "mid-turn ⏎ runs as its own agent" are gone, `ctrl-a/e/k/g/t/s` are listed, and the hint row hints `^N`/`^Z` on SESSION only (where they work). A sheet longer than the frame says `↓ N more · ⇟ space · End` and opens at its top. `accessible/announce.rs` now announces every modal surface (it omitted the SUB-AGENTS overlay, the cards, the parked question/approval, the routing card, the skill preview and the MCP inspector).

Also fixed on the way: `↓` with a message highlighted opened the overlay instead of walking the highlight (#4356's binding, one key off the tree); the stale `←`/`→` teaching in the crate README, the chat/resume pages, the `/sessions` `/context` hints and the resumable notice.

Refs #4341 — the binding decision is recorded on the issue and in `focus.rs`'s module doc: the arrows are the primary tab keys, `Tab` stays as the synonym, the plan panel stays on `⌃S`; the spec should be amended rather than `Tab` rebound. Owner's call.
Refs #4347 — the overlay half; attribution and a cancel port for in-engine children remain (commented there).

## The witness

- [x] This PR includes witness tests (fail on the base, pass here):
  - `deck_ui/tests/focus.rs` — `left_and_right_walk_the_tab_strip_from_every_tab` (every tab, pane bubbling counted per tab), `backspace_backs_out_of_a_lane_and_never_stops_it`, `backspace_peels_one_layer_at_a_time`, `enter_opens_the_highlighted_message`, `ctrl_e_and_ctrl_k_open_the_sessions_and_context_overlays`, `the_agent_tree_reads_parents_off_the_meta`
  - `deck_ui/tests/esc.rs::esc_at_an_opened_lane_…` rewritten: Esc at a lane with nothing to say **sends nothing** and focuses the lead (it used to send `Control::Stop`)
  - `views/settings.rs::left_right_walk_the_panes_then_rise_to_the_tab_strip` — the bubbling witness
  - `deck_ui/list_nav.rs` — `j`/`k` are letters while a prompt is typed, arrows still move
  - `deck_ui/dispatch.rs::a_prompt_at_a_finished_lane_asks_the_lead_about_it`
  - `v2/frame.rs::at_a_lane_the_tab_row_is_the_agent_path`
  - `v2/pulse.rs` — five tests: content, air-at-lead / lead-at-lane, running-wins + tail count, red stall, narrow-frame drop
  - `v2/subagents.rs` — `nudge_steers_the_lane_and_flag_tells_the_dispatcher`, `a_delegate_child_is_listed_under_its_parent_without_a_control_plane`, quiet time in the paint and the title
  - `keymap.rs` — no dead rows, real chords listed, hint row stays a handful; `accessible/announce.rs::the_sub_agents_overlay_and_the_cards_announce_too`
- Goldens: 12 frames re-blessed for the pulse row (one row each — read, not just blessed), `overlay_subagents` for quiet time and the footer, `overlay_help_skills` for the three-section sheet.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui` (1,005 lib + integration, all green); `STELLA_HOME=$(mktemp -d) cargo test -p stella-cli` — 1,992 pass, the one failure is the pre-existing #4350; `cargo test -p stella-parity` green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --document-private-items` on both crates; `make guards` green (prose, file-size, god-files, left-behind, wire-schema, lockfile…)
- [x] Docs updated: crate README, `website/content/docs/commands/chat.mdx` ("Moving around", "Sub-agents"), `resume.mdx`, `--help` strings
- [x] CLA signed

## Nothing left behind

- [x] Filed: #4368 (keymap rows need a witness guard), #4369 (delegate child has no timestamp for quiet time), #4370 (four surfaces still spell their own arrows), #4371 (two-column `?` sheet on wide frames). Decisions commented on #4341 and #4347.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] `AgentMeta` is in-process (no serde derive), so no round-trip test applies; the new field has a builder and a replay fallback

## Anything reviewers should know?

- **Base is #4356's branch.** The diff includes two merges of `main` (#4358 and the 0.9.147 bump); when #4356 squashes, GitHub retargets this to `main` and they fall out.
- **One behaviour change worth a second look:** Esc at an opened lane with an empty composer no longer stops the worker — it returns to the lead (`⌫` does the same). Kill is `ctrl-x ctrl-x` in the overlay, `s` for the old hand. The rationale is in `deck_ui.rs`'s Esc precedence doc (rule 8a).
- The pulse row prefers the **lead** while it runs and falls back to the busiest lane; the fixture's lead is idle, which is why the goldens show `sub:ci`.
- `deck_ui.rs` is a god file; this PR is a net −125 lines there. `v2/subagents.rs` split rather than grew.

## Renamed tests (for the deleted-tests guard)

- `left_right_walk_the_panes_from_a_blank_composer` → `left_right_walk_the_panes_then_rise_to_the_tab_strip` (`views/settings.rs`): the same walk, now also asserting the bubble to the neighbouring tab at each end.
- `the_overlay_paints_model_effort_purpose_and_place` → `the_overlay_paints_model_effort_quiet_purpose_and_place` (`v2/subagents.rs`): the same paint test plus the quiet-time cell and the red stall.
