### PR TITLE
docs(claude-md): CI builds and tests; the maintainer's laptop does not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,14 @@ make watch-core          # re-test stella-core only (fastest loop)
 make watch-lint          # re-run clippy on every save
 ```
 
-### The gate — run before every push
+### The gate — what every push is held to
 
-A red gate is an automatic "not yet":
+A red gate is an automatic "not yet". CI is where it runs: on the
+maintainer's laptop an agent session does not run `make gate`, a workspace
+build, or the workspace test suite — it pushes and reads the run
+(CLAUDE.md, "CI builds and tests; this laptop does not"). The list below is
+the contract CI enforces and the command a contributor with their own
+machine runs before pushing:
 
 ```bash
 make gate                # = no-scratch + no-secrets + design-refs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,14 @@
   Search for an existing issue first; link, don't duplicate. The full policy
   is AGENTS.md § "Nothing left behind — every finding becomes a fix or a
   GitHub issue". Never end a turn with untracked half-finished work.
+- **CI builds and tests; this laptop does not.** Never run `make gate`,
+  `make check`, `make test`, `cargo build --workspace`, `cargo test
+  --workspace`, or clippy over the workspace on the maintainer's machine.
+  Push the branch and read the workflow run instead — that is what CI is
+  for, and a workspace build here competes with every other session on the
+  box. A local compile is allowed only when it is **targeted**: one crate,
+  one test filter, for a change you are iterating on right now
+  (`cargo test -p stella-core loop_detect`). `cargo fmt --check` and the
+  toolchain-free guards (`make guards-fast`) compile nothing and are always
+  fine. A PR's evidence is its CI run, so cite the run — a green workspace
+  build on this laptop is not evidence, it is a cost.


### PR DESCRIPTION
## What & why

Adds a hard rule to CLAUDE.md: no `make gate`, workspace builds, or workspace test runs on the maintainer's laptop — push and read the CI run. Targeted compiles (one crate, one test filter) stay allowed; `cargo fmt --check` and the toolchain-free guards compile nothing and are fine.

AGENTS.md's gate section is reworded in the same PR so the two files agree (CLAUDE.md says a disagreement between them is a bug).

## The witness

Docs-only; no witness. `make gate-parity` and `make prose` run green locally (toolchain-free).

## Summary by Sourcery

Document that CI is the source of evidence for workspace builds and tests while restricting maintainer-laptop validation to targeted and toolchain-free checks.

Enhancements:
- Clarify that workspace builds, tests, linting, and the full gate should run in CI rather than on the maintainer's laptop, while allowing targeted local checks.

Documentation:
- Align AGENTS.md and CLAUDE.md guidance around CI ownership of workspace validation and acceptable local checks.