### PR TITLE
fix: repair main after #4377 — compile (E0063), docs-guards, and fmt

### DIFF
--- a/AUTOFIX_HANDOFF.md
+++ b/AUTOFIX_HANDOFF.md
@@ -21,7 +21,7 @@ State: uncommitted changes in the working tree. Task board: #4 in progress, #5/#
 1. Add `autofix: None` to the two `SessionInfo` constructors in `crates/stella-tui/src/deck_ui/tests/sessions.rs` (lines ~8 and ~149) — then `cargo check --workspace`.
 2. **Watcher**: new `crates/stella-cli/src/command_deck/autofix.rs` — tokio task spawned beside `spawn_pr_monitor` (command_deck.rs ~line 858), gated on `settings.autofix_prs()`. On CI failure/conflict → `subsession::spawn` a fix worker (lane `autofix:<pr>`); on green+mergeable → `gh pr merge`. Extend `observe_pr` in `pr_observe.rs` to return checks done/total. Must not block the driver — same spawn pattern as the PR monitor.
 3. **Sessions overlay** (`crates/stella-tui/src/v2/sessions.rs`): render autofix rows (PR #, `done/total` checks, phase), `o` open-in-browser (copy `open_in_browser` from `deck_ui/issues_keys.rs`), footer update. Left-arrow-in-empty-prompt already opens this overlay (deck_ui.rs ~1921) — no key work needed.
-4. **Witness tests**: setting default-on + merge; watcher decision fold (pure, no `gh`); overlay autofix row rendering; `o` key.
+4. **Tests** (each a fail→pass witness, per AGENTS.md): setting default-on + merge; watcher decision fold (pure, no `gh`); overlay autofix row rendering; `o` key.
 5. Commit + PR. Note: push may need `--no-verify` (repo hooks run full tests and time out).
 
 ## Key landmarks

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -204,14 +204,6 @@ pub struct Settings {
     /// sighted. Last-wins across scopes, like `enable_recap`.
     #[serde(default)]
     pub ignore_gitignore: Option<Toggle>,
-    /// `on` (the default when the key is absent) = the command deck runs a
-    /// background watcher on the workspace's current-branch PR: it spawns a
-    /// fix sub-agent when CI fails or the PR goes conflicted, and merges the
-    /// PR once CI is green and it is mergeable. `off` disables the watcher —
-    /// the PR monitor still feeds the footer cell, it just never acts.
-    /// Last-wins across scopes, like `ignore_gitignore`.
-    #[serde(default)]
-    pub autofix_prs: Option<Toggle>,
     /// `always` / `ask` / `never` — whether a run does its work in a throwaway
     /// git worktree instead of the working tree. Absent, null, or empty means
     /// `ask`, and the question is put once, at triage, only when the run is
@@ -714,12 +706,6 @@ impl Settings {
     /// restores the unfiltered walk.
     pub fn ignore_gitignore(&self) -> bool {
         self.ignore_gitignore.is_none_or(Toggle::is_on)
-    }
-
-    /// `on` by default; only an explicit `"autofix_prs": "off"` in the scope
-    /// chain disables the deck's PR autofix watcher.
-    pub fn autofix_prs(&self) -> bool {
-        self.autofix_prs.is_none_or(Toggle::is_on)
     }
 
     /// The resolved reward policy for this workspace (#1043). An absent

--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -92,7 +92,6 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
         agent_engine_config,
         tools,
         ignore_gitignore,
-        autofix_prs,
         create_worktrees,
         allowed_dirs,
         ui,
@@ -119,11 +118,6 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
             "ignore_gitignore",
             Posture::Merged,
             ignore_gitignore != &d.ignore_gitignore,
-        ),
-        keyed(
-            "autofix_prs",
-            Posture::Merged,
-            autofix_prs != &d.autofix_prs,
         ),
         keyed(
             "create_worktrees",

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -256,9 +256,6 @@ impl Settings {
         if let Some(ignore) = scope.ignore_gitignore {
             self.ignore_gitignore = Some(ignore);
         }
-        if let Some(autofix) = scope.autofix_prs {
-            self.autofix_prs = Some(autofix);
-        }
         // Appearance (`ui.theme`): whole-block last-wins — a higher-precedence
         // scope that declares `ui` replaces the lower one's. Personal
         // preference, no credential/egress authority, so no trust restoration.

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -111,11 +111,6 @@ pub struct RunSection {
     /// (`ignore_gitignore`).
     #[serde(default)]
     pub ignore_gitignore: Option<Toggle>,
-    /// `on` (the default when absent) = the deck's background watcher fixes
-    /// CI failures / conflicts on the current-branch PR and merges it green.
-    /// Same name in JSON (`autofix_prs`).
-    #[serde(default)]
-    pub autofix_prs: Option<Toggle>,
 }
 
 /// `[models]` — policy over the model catalog, not a model table.
@@ -626,7 +621,6 @@ impl TomlConfig {
             agent_engine_config,
             tools,
             ignore_gitignore: run.ignore_gitignore,
-            autofix_prs: run.autofix_prs,
             create_worktrees: run.create_worktrees,
             allowed_dirs: workspace.allowed_dirs,
             ui,

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -66,7 +66,6 @@ pub(super) const ROOT_FIELDS: &[&str] = &[
     "agent_engine_config",
     "tools",
     "ignore_gitignore",
-    "autofix_prs",
     "create_worktrees",
     "allowed_dirs",
     "ui",
@@ -487,7 +486,7 @@ pub(super) const TOML_ROOT_FIELDS: &[&str] = &[
 ];
 
 const META_FIELDS: &[&str] = &["schema_version", "scope"];
-const RUN_FIELDS: &[&str] = &["create_worktrees", "ignore_gitignore", "autofix_prs"];
+const RUN_FIELDS: &[&str] = &["create_worktrees", "ignore_gitignore"];
 /// `[workspace]` — closed, like `[run]`: a mistyped `allowed_dir` grants
 /// nothing and looks exactly like a granted directory until a tool refuses a
 /// write, which is the failure this walker exists to pre-empt.

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -2448,12 +2448,7 @@ fn handle_issue_confirm_send_key(
             DeckAction::Handled
         }
         KeyCode::Enter => {
-            let rows: Vec<IssueRow> = ui
-                .issues
-                .picked_rows()
-                .into_iter()
-                .cloned()
-                .collect();
+            let rows: Vec<IssueRow> = ui.issues.picked_rows().into_iter().cloned().collect();
             ui.issues.mode = IssuesMode::Browse;
             if rows.is_empty() {
                 // The list refreshed out from under the popup — nothing to

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -102,7 +102,10 @@ fn p_opens_a_confirmation_and_enter_submits_and_forwards_to_the_transcript() {
         "Read the ENTIRE issue body and EVERY comment",
         "definition of done",
     ] {
-        assert!(text.contains(needle), "prompt is missing {needle:?}:\n{text}");
+        assert!(
+            text.contains(needle),
+            "prompt is missing {needle:?}:\n{text}"
+        );
     }
 }
 
@@ -137,7 +140,8 @@ fn p_with_no_rows_notifies_instead_of_opening_the_popup() {
 }
 
 #[test]
-fn issues_browse_keys_refresh_and_start_work() {    let model = WorkspaceModel::new();
+fn issues_browse_keys_refresh_and_start_work() {
+    let model = WorkspaceModel::new();
     let mut ui = issues_ui();
     ui.issues.rows = vec![a_issue("#7")];
     ui.issues.loaded = true;

--- a/crates/stella-tui/src/deck_ui/tests/sessions.rs
+++ b/crates/stella-tui/src/deck_ui/tests/sessions.rs
@@ -19,6 +19,7 @@ fn session_info(id: &str) -> crate::envelope::SessionInfo {
         turns: 0,
         spend_micros: 0,
         model: None,
+        autofix: None,
     }
 }
 
@@ -160,6 +161,7 @@ fn session_row(
         turns: 0,
         spend_micros: 0,
         model: None,
+        autofix: None,
     }
 }
 

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -154,7 +154,9 @@ fn render_confirm_send(ui: &DeckUi, inner: Rect, buf: &mut Buffer) {
     // +4: title, blank, footer hint, and the border's own two rows are
     // accounted by the block; the content is title + one line per issue.
     let height = (rows.len() as u16 + 4).min(inner.height.saturating_sub(2));
-    let width = (inner.width * 2 / 3).max(40).min(inner.width.saturating_sub(4));
+    let width = (inner.width * 2 / 3)
+        .max(40)
+        .min(inner.width.saturating_sub(4));
     let popup = Rect {
         x: inner.x + (inner.width.saturating_sub(width)) / 2,
         y: inner.y + (inner.height.saturating_sub(height)) / 2,

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -17,7 +17,7 @@
    ↵ open · c comment · s status · p to prompt
 
  w start work   on the selected issue → stella drafts the plan from the issue and the graph, and waits for your approval before touching code
- ↑↓ select · w start work · n new issue · / search tracker · r refresh · ]/[ page · space pick · x close / reopen
+ ↑↓ select · w start work · n new issue · / search tracker · r refresh · ]/[ page · space pick · p send to prompt · x close / reopen
 
 
 

--- a/docs/prose-quality-report.md
+++ b/docs/prose-quality-report.md
@@ -52,14 +52,14 @@ I rewrote the 23 worst-scoring files to improve readability. The fixes focused o
 | `.stella/commands/learn.md` | 64.0 | 71.8 |
 | `.stella/agents/hotpath-perf-auditor.md` | 64.0 | 70.8 |
 | `.stella/agents/kfc/spec-design.md` | 64.7 | 72.2 |
-| `docs/papers/README.md` | 65.5 | 74.1 |
+| `docs/papers/README.md` | 65.5 | 74.1 | <!-- doc-links:ignore — a scored path, not a citation -->
 | `.stella/commands/test-coverage.md` | 65.6 | 69.3 |
 | `docs/papers/self-evolving-coding-agents-assessment.md` | 66.8 | 71.5 |
 | `.stella/commands/react-review.md` | 67.5 | 69.0 |
 | `.stella/agents/marketing-agent.md` | 68.5 | 74.1 |
 | `.stella/agents/kfc/spec-test.md` | 68.9 | 72.6 |
 | `docs/spec/enterprise-authority-telemetry.md` | 69.0 | 74.1 |
-| `docs/spec/adaptive-context/context-prs-spec.md` | 69.3 | 70.4 |
+| `docs/spec/adaptive-context/context-prs-spec.md` | 69.3 | 70.4 | <!-- doc-links:ignore — a scored path, not a citation -->
 | `.stella/agents/feature-shipper.md` | 69.4 | 74.1 |
 | `.stella/commands/update-codemaps.md` | 69.8 | 71.2 |
 | `.stella/commands/audit-security.md` | 70.8 | 70.8 |


### PR DESCRIPTION
## What

`main` is red since #4377 squash-merged (`4c841be4`), on five counts from one "saving progress" commit:

1. **Compile (E0063)** — canary issue #4378. `SessionInfo` gained `autofix` but the two test constructors in `crates/stella-tui/src/deck_ui/tests/sessions.rs` were not updated. Fixed with `autofix: None`, matching the three production constructors.
2. **clippy + test** — the `autofix_prs` setting had no consumer: clippy `-D warnings` fails on the dead accessor, and `settings::completeness::every_merged_settings_field_survives_the_scope_merge` fails because a key at its default in `EVERY_KEY` cannot witness the merge (the test says so itself). Reverted the five-file settings diff exactly; the feature lands with its consumer under #4388.
3. **`docs-guards`** run 32628907204: `check-doc-links` read two paths in `docs/prose-quality-report.md`'s score table (`docs/papers/README.md`, no `id:`; `context-prs-spec`, superseded) as citations — they are scored paths, so the rows carry the checker's own `<!-- doc-links:ignore -->` marker. `check-invariants` read a bold "Witness tests" item in `AUTOFIX_HANDOFF.md:24` as a restated invariant — reworded to a pointer at AGENTS.md.
4. **Golden** — `deck_render_snapshots_cover_every_tab`: the Issues-tab footer gained `p send to prompt` but `tests/snapshots/deck/tab_issues.txt` was not re-blessed. Re-blessed; the diff is that one line.
5. **fmt** — `cargo fmt --all` over three `stella-tui` files, formatting only.

## Evidence

Local, targeted per CLAUDE.md: `cargo check -p stella-tui --tests` → Finished; `cargo test -p stella-cli --bin stella settings::` → 128 passed; `python3 scripts/check-doc-links.py check` → OK; `bash scripts/check-invariants.sh` → OK; `make guards-fast` → green. On the first push `docs guards` went green and `fmt + clippy + test` exposed item 2; this PR's final `ci` run is the evidence that main recovers.

No witness test: a compile fix, a revert of unwired code, docs, and formatting.

## Not done here

`AUTOFIX_HANDOFF.md` (a session note, now tracked), `AutofixStatus`/`SessionInfo.autofix` (set to `None` everywhere, rendered nowhere), and `scripts/prose_score.py` + its report are unwired scaffolding — tracked in #4388.

Closes #4378

