### PR TITLE
fix(bench): credential leaks, code-graph disclosure, loop-bench witnesses, engine-root drift, TB2.1 timeout policy

### DIFF
--- a/arenabench/README.md
+++ b/arenabench/README.md
@@ -216,6 +216,17 @@ races whatever shipped that hour — see
 [Which product did you actually race](#which-product-did-you-actually-race).
 It is refused on a `stella` seat, which is pinned by commit instead.
 
+**`agent_timeout_multiplier` and `setup_timeout_multiplier` must stay `1.0`
+for any number you intend to compare with, or submit to, the tbench.ai
+Terminal-Bench 2.1 leaderboard.** Its rules say submissions "may not modify
+timeouts or resources"; a run above `1.0` on either — every number recorded
+before 2026-08-14 used `agent_timeout_multiplier = 2.0` — must carry that
+qualifier wherever it is quoted. `arenabench` logs and notes a non-stock
+`agent_timeout_multiplier` at launch so the run is marked non-submittable from
+the start rather than discovered later. See
+[`docs/timeout-policy.md`](docs/timeout-policy.md) for the full rule and why <!-- doc-links:ignore -->
+the grader's own timeout is held to the same bar.
+
 ---
 
 ## What it does

--- a/arenabench/arenabench/harbor_agent.py
+++ b/arenabench/arenabench/harbor_agent.py
@@ -41,19 +41,43 @@ ARENA_ENGINE_ENV = "ARENABENCH_ENGINE_JSON"
 #: Root keys Stella's trusted-launcher seam accepts. Anything else makes the
 #: engine reject the config outright (it fails closed on unknown root fields),
 #: so this list is a hard schema boundary and not a style preference.
+#:
+#: A hand copy of ``crates/stella-cli/src/settings/unknown.rs``'s
+#: ``ENGINE_ROOT_FIELDS`` (plus the four non-worker ``pipeline_*_model`` keys
+#: from its ``RETIRED_ENGINE_ROOT``, still recognized there) — kept honest
+#: against drift by ``tests/test_engine_root_fields.py``, which parses the
+#: Rust source rather than trusting this list (#3879, mirroring
+#: ``bench/harbor_adapter/tests/test_posture.py::_engine_root_fields``,
+#: #2033).
+#:
+#: ``responsibilities`` is a deliberate, tracked exception: it is not in the
+#: Rust vocabulary at all, so every arena posture that declares a
+#: responsibility override (#2381) is refused at the launcher seam today
+#: (#3871 noted this as pre-existing and out of scope; #3879 is the tracking
+#: issue). Left in this set rather than pulled out, because
+#: `tests/test_responsibilities.py` exercises the emission as a real,
+#: actively-developed feature and pulling it would silently disable that
+#: surface — whether to stop emitting the key or give it a home in the Rust
+#: engine config is a decision for whoever picks up #3879, not a mechanical
+#: sync.
 _ENGINE_ROOT_FIELDS = frozenset(
     {
         "default_model",
+        "seat_models",
         "pipeline_verifier_model",
         "pipeline_worker_model",
         "pipeline_triage_model",
         "pipeline_research_model",
         "pipeline_plan_model",
         "allowed_models",
+        "model_output_caps",
         "auto_mode",
         "effort_auto",
         "reasoning_auto",
         "headless_scope_bypass",
+        "model_timeout_secs",
+        "compaction_budget_tokens",
+        "tool_result_horizon_steps",
         "agents",
         "responsibilities",
     }

--- a/arenabench/arenabench/preflight.py
+++ b/arenabench/arenabench/preflight.py
@@ -88,3 +88,27 @@ def balance_verdict(
         cost_per_trial_usd,
         balance.Wallet(env_name=env_name, seat_credential=seat_credential),
     )
+
+
+def non_stock_timeout_notice(multiplier: float) -> str | None:
+    """A one-line banner for a non-stock ``agent_timeout_multiplier`` (#3256).
+
+    tbench.ai's Terminal-Bench 2.1 leaderboard rule — "submissions may not
+    modify timeouts or resources" — makes every number a run at this setting
+    produces non-comparable to a published leaderboard row. Every number
+    recorded before 2026-08-14 used ``agent_timeout_multiplier = 2.0`` and
+    carried no such qualifier (`docs/timeout-policy.md`); this is the launch
+    site saying so while the operator is still looking, rather than leaving
+    it to be rediscovered once a number is already quoted.
+
+    ``None`` at the stock ``1.0`` — the overwhelming common case, and the one
+    that must produce no note at all.
+    """
+    if multiplier == 1.0:
+        return None
+    return (
+        f"agent_timeout_multiplier={multiplier} (!= 1.0): this run is "
+        "non-submittable to the tbench.ai leaderboard and must not be "
+        "compared to a published row without that qualifier — see "
+        "docs/timeout-policy.md"
+    )

--- a/arenabench/arenabench/runner.py
+++ b/arenabench/arenabench/runner.py
@@ -1056,10 +1056,10 @@ class MatchRunner:
                 str(match.spec.setup_timeout_multiplier),
             ]
         if match.spec.agent_timeout_multiplier != 1.0:
-            command += [
-                "--agent-timeout-multiplier",
-                str(match.spec.agent_timeout_multiplier),
-            ]
+            command += ["--agent-timeout-multiplier", str(match.spec.agent_timeout_multiplier)]
+            # Non-comparable to the tbench.ai leaderboard at this setting —
+            # see `preflight.non_stock_timeout_notice` (#3256).
+            run.notes.append(preflight.non_stock_timeout_notice(match.spec.agent_timeout_multiplier))
         if contestant.agent_version:
             # The opponent's `sut_ref`. Harbor's installed-agent base takes a
             # `version` kwarg and hands it to the vendor's installer, so this

--- a/arenabench/tests/test_engine_root_fields.py
+++ b/arenabench/tests/test_engine_root_fields.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""``harbor_agent._ENGINE_ROOT_FIELDS`` against the Rust authority (#3879).
+
+``_ENGINE_ROOT_FIELDS`` is a hand-maintained copy of
+``crates/stella-cli/src/settings/unknown.rs::ENGINE_ROOT_FIELDS`` — the
+trusted-launcher seam's fail-closed root-key vocabulary for
+``STELLA_ENGINE_CONFIG_JSON``. A hand copy drifts in both directions: too
+narrow refuses a posture the launcher would actually accept (a live launch
+failure), too wide accepts a posture the launcher will refuse (a test that
+lies about what would happen at the seam). ``bench/harbor_adapter`` solved
+this the same way already — parse the Rust source rather than duplicate it
+(``tests/test_posture.py::_engine_root_fields``, #2033) — and this file is
+that same reader, pointed at arenabench's own copy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from arenabench.harbor_agent import _ENGINE_ROOT_FIELDS
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_UNKNOWN_RS = _REPO_ROOT / "crates" / "stella-cli" / "src" / "settings" / "unknown.rs"
+
+
+def _parse_rust_str_slice(source: str, const_name: str) -> frozenset[str]:
+    """Every string literal in a ``const NAME: &[&str] = &[ ... ];`` table."""
+    match = re.search(rf"const {const_name}: &\[&str\] =\s*&\[(.*?)\];", source, re.DOTALL)
+    assert match is not None, (
+        f"could not find `{const_name}` in {_UNKNOWN_RS} — the constant moved "
+        "or was renamed; this file's readers must be repointed"
+    )
+    return frozenset(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def _engine_root_fields() -> frozenset[str]:
+    """``ENGINE_ROOT_FIELDS`` out of ``unknown.rs``, unioned with
+    ``RETIRED_ENGINE_ROOT``.
+
+    The union, not just ``ENGINE_ROOT_FIELDS`` alone, because the launcher
+    seam recognizes both tables — a posture naming a retired-but-still-read
+    key (the four non-worker ``pipeline_*_model`` keys #3908 retired) passes
+    the seam, and an assertion that only checked the first table would be
+    false about the code it names.
+    """
+    try:
+        source = _UNKNOWN_RS.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AssertionError(
+            f"cannot read the launcher vocabulary at {_UNKNOWN_RS}: "
+            f"{exc.strerror}. That path is a literal in this file, not a "
+            "resolved crate location — if the crate moved, update `_UNKNOWN_RS`."
+        ) from exc
+    fields = _parse_rust_str_slice(source, "ENGINE_ROOT_FIELDS")
+    assert fields, "ENGINE_ROOT_FIELDS parsed to zero entries"
+    retired = _parse_rust_str_slice(source, "RETIRED_ENGINE_ROOT")
+    return fields | retired
+
+
+def test_the_local_copy_does_not_accept_more_than_the_launcher_does() -> None:
+    """A posture the local guard would pass but the launcher seam refuses is
+    a benchmark run that dies after credentials are already spent.
+
+    ``responsibilities`` is the one deliberate exception: it is not in the
+    Rust vocabulary at all (#3879), and stays in ``_ENGINE_ROOT_FIELDS`` as a
+    tracked, pre-existing gap (#3871) rather than a silent one — every arena
+    posture that declares a responsibility override is refused at launch
+    today, and fixing that is a maintainer decision about whether to stop
+    emitting the key or give it a home in the Rust engine config, not a
+    mechanical sync.
+    """
+    known_gap = {"responsibilities"}
+    assert _ENGINE_ROOT_FIELDS - known_gap <= _engine_root_fields(), (
+        "harbor_agent._ENGINE_ROOT_FIELDS accepts a root key the trusted "
+        "launcher seam would refuse — re-sync it against "
+        "crates/stella-cli/src/settings/unknown.rs::ENGINE_ROOT_FIELDS / "
+        "RETIRED_ENGINE_ROOT"
+    )
+
+
+def test_the_local_copy_is_not_missing_a_key_the_launcher_accepts() -> None:
+    """The other direction of drift: a key the launcher would accept but the
+    local guard refuses first is a capability gap, not a broken run — still
+    worth catching, so a future posture builder does not waste time chasing
+    a refusal that `_ENGINE_ROOT_FIELDS` invented.
+    """
+    missing = _engine_root_fields() - _ENGINE_ROOT_FIELDS
+    assert not missing, (
+        f"the trusted launcher accepts root keys _ENGINE_ROOT_FIELDS does "
+        f"not: {sorted(missing)} — add them so a posture that wants one is "
+        "not refused by this file before it ever reaches the seam"
+    )

--- a/arenabench/tests/test_timeout_policy.py
+++ b/arenabench/tests/test_timeout_policy.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The submit-time banner for a non-stock `agent_timeout_multiplier` (#3256).
+
+A sibling of `test_arena.py` rather than more lines in it — that file sits at
+1479/1500 lines, within a page of the file-size ceiling.
+
+Every recorded Terminal-Bench 2.1 number to date used a 2x agent timeout,
+which tbench.ai's "submissions may not modify timeouts or resources" rule
+makes non-comparable to a published leaderboard row (`docs/timeout-policy.md`).
+`_launch` is the one place an operator is looking at the moment the choice is
+made, so this is where the run gets marked non-submittable rather than leaving
+it to be rediscovered when a number is quoted later.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from arenabench.model import MatchSpec
+from arenabench.preflight import non_stock_timeout_notice
+from arenabench.registry import DEFAULT_REGISTRY
+from arenabench.runner import MatchRunner
+
+
+def test_the_stock_multiplier_produces_no_notice() -> None:
+    assert non_stock_timeout_notice(1.0) is None
+
+
+def test_a_raised_multiplier_names_itself_and_the_leaderboard() -> None:
+    notice = non_stock_timeout_notice(2.0)
+    assert notice is not None
+    assert "agent_timeout_multiplier=2.0" in notice
+    assert "non-submittable" in notice
+    assert "tbench.ai" in notice
+
+
+def _fake_harbor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for an installed Harbor — see `test_arena.py`'s `_fake_harbor`
+    for the full reasoning; this is the minimal subset `_launch` needs to
+    reach argv construction without touching a real binary."""
+    monkeypatch.setattr(
+        "arenabench.harbor.harbor_bin", lambda dataset_key=None: "/usr/bin/harbor"
+    )
+    monkeypatch.setattr("arenabench.harbor.harbor_version", lambda binary=None: "0.20.0")
+    monkeypatch.setattr(
+        "arenabench.harbor.supports_agent_import_path", lambda binary=None: False
+    )
+    monkeypatch.setattr(
+        "arenabench.adapter.stella_seat_problem", lambda binary=None, **_kw: None
+    )
+
+
+class _FakePopen:
+    def __init__(self, command: list[str], **_kwargs: object) -> None:
+        self.command = command
+        self.returncode = None
+
+    def poll(self) -> None:
+        return None
+
+
+def _launch_with_multiplier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, multiplier: float
+):
+    monkeypatch.setenv("ARENABENCH_DATASETS", str(tmp_path / "nope"))
+    _fake_harbor(monkeypatch)
+    monkeypatch.setattr("arenabench.runner.subprocess.Popen", _FakePopen)
+    spec = MatchSpec.from_json(
+        {
+            "dataset": "terminal-bench-2.1",
+            "tasks": ["alpha"],
+            "sut_ref": "",
+            "agent_timeout_multiplier": multiplier,
+            "contestants": [
+                {
+                    "name": "s",
+                    "agent": "stella",
+                    "engine": {"api": "openrouter", "model": "x/y"},
+                }
+            ],
+        }
+    )
+    runner = MatchRunner(DEFAULT_REGISTRY, tmp_path / "ws")
+    match = runner.create(spec)
+    return runner._launch(match, spec.contestants[0], runner.resolve_harbor(match))
+
+
+def test_a_non_stock_multiplier_notes_the_run_as_non_submittable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _launch_with_multiplier(tmp_path, monkeypatch, 2.0)
+    assert any(
+        "non-submittable" in note and "agent_timeout_multiplier=2.0" in note
+        for note in run.notes
+    ), run.notes
+
+
+def test_a_stock_multiplier_records_no_banner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _launch_with_multiplier(tmp_path, monkeypatch, 1.0)
+    assert not any("submittable" in note for note in run.notes), run.notes

--- a/bench/README.md
+++ b/bench/README.md
@@ -106,6 +106,12 @@ argument; ambient `STELLA_MODEL` is not accepted by the secure launcher.
 `STELLA_BASE_URL=https://api.z.ai/api/coding/paas/v4` — the endpoint must
 include `/coding/`, or the API returns HTTP 429 "insufficient balance."
 
+**Head-to-head A/B matches against another agent** — as opposed to the single
+claim run above — are `../arenabench/`'s job, not this directory's. Its own
+timeout multipliers must stay `1.0` for a number to be comparable with, or
+submitted to, the tbench.ai leaderboard; see
+[`../arenabench/docs/timeout-policy.md`](../arenabench/docs/timeout-policy.md). <!-- doc-links:ignore -->
+
 ## SWE-bench (standalone predictions)
 
 ```bash

--- a/bench/harbor_adapter/stella_harbor/__init__.py
+++ b/bench/harbor_adapter/stella_harbor/__init__.py
@@ -814,7 +814,7 @@ class StellaAgent(BaseInstalledAgent):
     #: What ``stella init`` built, per :mod:`code_graph`. Declared, because an
     #: attribute that exists only when one stdout line matched is one no
     #: reader trusts — which is how it went unread entirely (#3087).
-    _code_graph_summary: dict[str, str]
+    _code_graph_summary: dict[str, Any]
 
     def __init__(self, *args: Any, agent_timeout_sec: Any = None, **kwargs: Any):
         """Accept Harbor's per-trial agent deadline, and keep it off the base.

--- a/bench/harbor_adapter/stella_harbor/code_graph.py
+++ b/bench/harbor_adapter/stella_harbor/code_graph.py
@@ -28,6 +28,9 @@ pure module beside the adapter, so the adapter keeps one line per concern.
 
 from __future__ import annotations
 
+import re
+from typing import Any
+
 #: The step did not run at all. A real state, and deliberately spelled the
 #: same way :func:`run_git_baseline`'s absence is, so a reader learns one
 #: convention rather than two.
@@ -36,8 +39,23 @@ NOT_ATTEMPTED: dict[str, str] = {"state": "not_attempted"}
 #: The substring ``stella init`` prints its index summary on.
 _SUMMARY_MARKER = "code graph:"
 
+#: The substring every line about the semantic-search embedding pass carries
+#: — progress ticks and the final outcome line alike
+#: (``warm_semantic_index``/``format_warm_outcome`` in
+#: ``crates/stella-cli/src/agent/graph.rs``).
+_SEMANTIC_MARKER = "semantic index:"
 
-def from_stdout(stdout: str | None) -> dict[str, str]:
+#: ``format_warm_outcome``'s success line: ``✓ semantic index: N files
+#: embedded by <model>``, with or without a trailing "N left unembedded"
+#: clause the parser does not need. Matched only against a line already
+#: known to start with the ✓ prefix, so a partial/failed line with the same
+#: "N files embedded by <model>" substring can never be mistaken for one.
+_SEMANTIC_BUILT_PATTERN = re.compile(
+    r"(?P<count>\d+) files? embedded by (?P<model>\S+)"
+)
+
+
+def from_stdout(stdout: str | None) -> dict[str, Any]:
     """Classify what ``stella init`` said about the graph it built.
 
     ``no_summary_line`` is the state that earns this function: an init that
@@ -47,22 +65,86 @@ def from_stdout(stdout: str | None) -> dict[str, str]:
     The line count rides along because it is the cheapest thing that
     separates "produced no output at all" from "produced output we did not
     recognise" without shipping the container's stdout into trial metadata.
+
+    The returned dict carries a ``semantic`` sub-dict answering the
+    independent question of whether the semantic index was built — built,
+    skipped for want of a backend, or attempted and not fully built — so a
+    trial's metadata no longer reads identically across all three (#3669).
     """
     text = stdout or ""
-    for line in text.splitlines():
+    lines = text.splitlines()
+    result: dict[str, Any] | None = None
+    for line in lines:
         if _SUMMARY_MARKER in line:
-            return {"state": "reported", "summary": line.strip()}
-    return {
-        "state": "no_summary_line",
-        "detail": (
-            f"`stella init` exited without a '{_SUMMARY_MARKER}' line "
-            f"({len(text.splitlines())} line(s) of stdout)"
-        ),
-    }
+            result = {"state": "reported", "summary": line.strip()}
+            break
+    if result is None:
+        result = {
+            "state": "no_summary_line",
+            "detail": (
+                f"`stella init` exited without a '{_SUMMARY_MARKER}' line "
+                f"({len(lines)} line(s) of stdout)"
+            ),
+        }
+    return {**result, "semantic": _semantic_from_lines(lines)}
+
+
+def _semantic_from_lines(lines: list[str]) -> dict[str, str]:
+    """Classify the semantic-index outcome, keyed on the *last* matching line.
+
+    Progress ticks (``· semantic index: N files embedded…``) share the same
+    marker as the final outcome line and are printed first, so the last
+    match in program order is always the terminal state — the one
+    ``format_warm_outcome`` writes once the pass has stopped.
+    """
+    semantic_lines = [line.strip() for line in lines if _SEMANTIC_MARKER in line]
+    if not semantic_lines:
+        return {"state": "no_summary_line"}
+    last = semantic_lines[-1]
+    if "skipped" in last:
+        return {"state": "skipped_no_backend", "line": last}
+    if last.startswith("✓"):
+        match = _SEMANTIC_BUILT_PATTERN.search(last)
+        if match:
+            return {
+                "state": "built",
+                "files_embedded": match.group("count"),
+                "model": match.group("model"),
+                "line": last,
+            }
+    return {"state": "attempted_failed", "line": last}
+
+
+#: Harbor's own ``InstalledAgentBase._exec`` (harbor/agents/installed/base.py)
+#: formats a non-zero exit exactly this way, with ``stdout``/``stderr``
+#: already truncated to 1000 characters on its side. Parsed rather than
+#: re-truncated here, so a change to Harbor's truncation length cannot
+#: silently disagree with a second one of ours.
+_NONZERO_EXIT_PATTERN = re.compile(
+    r"^Command failed \(exit (?P<exit_code>-?\d+)\):.*?\nstderr: (?P<stderr>.*)$",
+    re.DOTALL,
+)
 
 
 def unavailable(error: BaseException) -> dict[str, str]:
     """The step raised. Best-effort by construction, so never fatal — but a
     failure that is not recorded is a failure that gets attributed to
-    whatever is measured next."""
-    return {"state": "unavailable", "detail": str(error)}
+    whatever is measured next.
+
+    ``kind`` carries the exception's class name so a reader does not have to
+    re-derive, from the message shape alone, which of Harbor's two failure
+    modes this was. The two disclose differently: a non-zero exit
+    (``NonZeroAgentExitCodeError``) embeds an exit code and captured stderr
+    in its message, which this function lifts into their own ``exit_code``/
+    ``stderr`` fields; a timeout (``RuntimeError("Command timed out after N
+    seconds")``) does not, because Harbor's own Docker exec discards the
+    process's stdout/stderr before raising it, and there is nothing this
+    adapter can recover for that path (#3670).
+    """
+    message = str(error)
+    result = {"state": "unavailable", "kind": type(error).__name__, "detail": message}
+    match = _NONZERO_EXIT_PATTERN.match(message)
+    if match:
+        result["exit_code"] = match.group("exit_code")
+        result["stderr"] = match.group("stderr")
+    return result

--- a/bench/harbor_adapter/tests/conftest.py
+++ b/bench/harbor_adapter/tests/conftest.py
@@ -23,7 +23,26 @@ import os
 
 import pytest
 
+from stella_harbor.credential_bundle import (
+    EMBEDDING_CREDENTIAL_NAMES,
+    HOST_ONLY_CONTROL_CREDENTIAL_NAMES,
+    PROVIDER_CREDENTIAL_NAMES,
+)
+
 _ENV_PREFIX = "STELLA_"
+
+# Every credential name a resolver in this tree can read straight out of the
+# process environment as a fallback (`provider_credentials_from_environment`,
+# `optional_embedding_credentials` in `credential_bundle.py`). An operator's
+# real key for any of these changes what a test observes exactly the way a
+# stray ``STELLA_*`` knob does above — a two-name
+# ``STELLA_CREDENTIAL_HANDOFF_TARGET`` instead of one, or a live secret
+# rendered into an assertion diff (#3668). Clearing the class, not the two
+# instances that happened to be caught, is what survives the next credential
+# name being added to `credential_bundle.py` without a matching test fix.
+_AMBIENT_CREDENTIAL_NAMES = (
+    PROVIDER_CREDENTIAL_NAMES | EMBEDDING_CREDENTIAL_NAMES | HOST_ONLY_CONTROL_CREDENTIAL_NAMES
+)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -31,6 +50,20 @@ def _strip_ambient_stella_env():
     """Remove inherited ``STELLA_*`` keys for the duration of the session."""
     patcher = pytest.MonkeyPatch()
     for key in [key for key in os.environ if key.startswith(_ENV_PREFIX)]:
+        patcher.delenv(key, raising=False)
+    yield
+    patcher.undo()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _strip_ambient_provider_credentials():
+    """Remove inherited provider/embedding/control credentials for the session.
+
+    A test that wants one of these values sets it explicitly with
+    ``monkeypatch`` — the only way it should ever get there.
+    """
+    patcher = pytest.MonkeyPatch()
+    for key in _AMBIENT_CREDENTIAL_NAMES:
         patcher.delenv(key, raising=False)
     yield
     patcher.undo()

--- a/bench/harbor_adapter/tests/test_code_graph.py
+++ b/bench/harbor_adapter/tests/test_code_graph.py
@@ -1,0 +1,144 @@
+"""Unit tests for :mod:`stella_harbor.code_graph`'s pure parsers.
+
+``from_stdout`` and ``unavailable`` are the only place a trial's metadata
+learns what ``stella init`` actually did in the container. Before #3669 the
+semantic-index outcome was not parsed at all — a trial could not say whether
+embeddings were built, skipped for want of a backend, or attempted and
+incomplete, because the parser structurally could not emit any of the three.
+Before #3670 a failed exec's exit code and stderr were only ever reachable by
+re-parsing the exception's ``str()`` by eye.
+
+In its own file rather than ``test_adapter.py``, which is grandfathered at
+its file-size ceiling and closed to growth.
+"""
+
+from __future__ import annotations
+
+from stella_harbor import code_graph
+
+
+class TestFromStdoutCodeGraphLine:
+    """The pre-existing ``code graph:`` classification is unchanged by the
+    semantic-index work landing beside it."""
+
+    def test_reports_the_code_graph_summary_line(self) -> None:
+        stdout = "some banner\n✓ code graph: 6 symbols, 3 imports across 1 file\nmore\n"
+        result = code_graph.from_stdout(stdout)
+        assert result["state"] == "reported"
+        assert result["summary"] == "✓ code graph: 6 symbols, 3 imports across 1 file"
+
+    def test_no_summary_line_when_init_says_nothing_about_it(self) -> None:
+        result = code_graph.from_stdout("only unrelated output\n")
+        assert result["state"] == "no_summary_line"
+        assert "1 line" in result["detail"]
+
+    def test_no_summary_line_on_empty_stdout(self) -> None:
+        result = code_graph.from_stdout(None)
+        assert result["state"] == "no_summary_line"
+
+
+class TestFromStdoutSemanticIndex:
+    """The three (at minimum) distinguishable semantic-index outcomes."""
+
+    def test_skipped_no_backend(self) -> None:
+        stdout = (
+            "· semantic index: skipped — no embedding backend configured (set "
+            "VOYAGE_API_KEY, OPENAI_API_KEY, or STELLA_EMBED_URL + STELLA_EMBED_MODEL "
+            "to let `stella search` rank by meaning)\n"
+            "✓ code graph: 0 symbols, 0 imports across 0 files\n"
+        )
+        result = code_graph.from_stdout(stdout)
+        assert result["semantic"]["state"] == "skipped_no_backend"
+
+    def test_built_with_backend_and_file_count(self) -> None:
+        stdout = (
+            "✓ code graph: 6 symbols, 3 imports across 1 file\n"
+            "✓ semantic index: 1 files embedded by voyage-code-3\n"
+            "✓ chunk index: 1 file(s) embedded by voyage-code-3\n"
+        )
+        result = code_graph.from_stdout(stdout)
+        semantic = result["semantic"]
+        assert semantic["state"] == "built"
+        assert semantic["files_embedded"] == "1"
+        assert semantic["model"] == "voyage-code-3"
+        # The code-graph line is still captured unchanged alongside it.
+        assert result["state"] == "reported"
+        assert result["summary"] == "✓ code graph: 6 symbols, 3 imports across 1 file"
+
+    def test_progress_ticks_do_not_shadow_the_terminal_line(self) -> None:
+        stdout = (
+            "◈ embedding files for semantic search…\n"
+            "· semantic index: 3 files embedded…\n"
+            "· semantic index: 7 files embedded…\n"
+            "✓ semantic index: 12 files embedded by voyage-code-3\n"
+        )
+        result = code_graph.from_stdout(stdout)
+        assert result["semantic"]["state"] == "built"
+        assert result["semantic"]["files_embedded"] == "12"
+
+    def test_attempted_failed_when_not_built(self) -> None:
+        stdout = "! semantic index: not built — incomplete backend configuration\n"
+        result = code_graph.from_stdout(stdout)
+        assert result["semantic"]["state"] == "attempted_failed"
+
+    def test_attempted_failed_when_partially_embedded(self) -> None:
+        stdout = (
+            "! semantic index: 4 files embedded by voyage-code-3 — 2 left unembedded, "
+            "2 of them because their content could not be read\n"
+        )
+        result = code_graph.from_stdout(stdout)
+        assert result["semantic"]["state"] == "attempted_failed"
+
+    def test_no_summary_line_when_init_says_nothing_about_semantic_index(self) -> None:
+        result = code_graph.from_stdout(
+            "✓ code graph: 0 symbols, 0 imports across 0 files\n"
+        )
+        assert result["semantic"]["state"] == "no_summary_line"
+
+    def test_the_states_are_pairwise_distinguishable(self) -> None:
+        outcomes = [
+            code_graph.from_stdout("· semantic index: skipped — no backend\n")[
+                "semantic"
+            ],
+            code_graph.from_stdout(
+                "✓ semantic index: 1 files embedded by voyage-code-3\n"
+            )["semantic"],
+            code_graph.from_stdout("! semantic index: not built — incomplete\n")[
+                "semantic"
+            ],
+            code_graph.from_stdout("✓ code graph: 0 symbols\n")["semantic"],
+        ]
+        rendered = [repr(sorted(outcome.items())) for outcome in outcomes]
+        assert len(set(rendered)) == len(outcomes), (
+            f"two semantic-index outcomes are indistinguishable: {rendered}"
+        )
+
+
+class TestUnavailable:
+    """The step raised — legibility of what the exception actually carried."""
+
+    def test_kind_names_the_exception_class(self) -> None:
+        result = code_graph.unavailable(
+            RuntimeError("Command timed out after 300 seconds")
+        )
+        assert result["state"] == "unavailable"
+        assert result["kind"] == "RuntimeError"
+        assert result["detail"] == "Command timed out after 300 seconds"
+        assert "exit_code" not in result
+        assert "stderr" not in result
+
+    def test_extracts_exit_code_and_stderr_from_a_nonzero_exit_message(self) -> None:
+        message = (
+            "Command failed (exit 1): /usr/local/bin/stella init\n"
+            "stdout: some stdout\n"
+            "stderr: tree-sitter: unsupported grammar for *.mojo"
+        )
+
+        class _NonZeroAgentExitCodeError(RuntimeError):
+            pass
+
+        result = code_graph.unavailable(_NonZeroAgentExitCodeError(message))
+        assert result["kind"] == "_NonZeroAgentExitCodeError"
+        assert result["exit_code"] == "1"
+        assert result["stderr"] == "tree-sitter: unsupported grammar for *.mojo"
+        assert result["detail"] == message

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -330,6 +330,21 @@ fn contamination_exit(analysis: &Analysis) -> Option<i32> {
     Some(7)
 }
 
+/// The first name in `names` that also appeared earlier in it, or `None` when
+/// every name is distinct.
+///
+/// `--compare` rejects a repeated arm outright, unlike `--tasks` (a repeated
+/// task is harmless and only warns, see [`resolve_tasks`]): a duplicated
+/// config would silently compare an arm against itself, and worse, both
+/// copies would race for the same [`arm_job_name`] job directory.
+fn duplicate_arm(names: &[String]) -> Option<&str> {
+    names
+        .iter()
+        .enumerate()
+        .find(|(index, name)| names[..*index].contains(name))
+        .map(|(_, name)| name.as_str())
+}
+
 /// The `--compare` run (#876): the same task set under each named config, then
 /// one comparison report.
 ///
@@ -343,11 +358,9 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
         eprintln!("--compare needs at least two configs, e.g. --compare model-a,model-b");
         return 2;
     }
-    for (index, config) in configs.iter().enumerate() {
-        if configs[..index].contains(config) {
-            eprintln!("--compare names `{config}` twice; every arm must be distinct");
-            return 2;
-        }
+    if let Some(dup) = duplicate_arm(configs) {
+        eprintln!("--compare names `{dup}` twice; every arm must be distinct");
+        return 2;
     }
 
     let mut arms: Vec<ArmTrials> = Vec::with_capacity(configs.len());
@@ -624,5 +637,89 @@ fn run_harbor(args: &Args, tasks: &[String], model: &str, job_name: &str) -> Res
         Ok(())
     } else {
         Err(status.code().unwrap_or(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the pure helpers in this binary — `arm_job_name`,
+    //! `resolve_tasks`, and the `--compare` duplicate-arm check
+    //! (`duplicate_arm`). Mirrors the shape of `src/tests.rs`, `lib.rs`'s own
+    //! test module, but lives here because these three are private to
+    //! `main.rs` and moving them into the library crate just to reach a test
+    //! module is a bigger call than this issue makes on its own (#3744).
+
+    use super::*;
+
+    fn args_with(tasks: Vec<String>, n: usize) -> Args {
+        Args {
+            n,
+            tasks,
+            model: DEFAULT_MODEL.to_string(),
+            concurrent: 4,
+            dataset: "terminal-bench".to_string(),
+            jobs_dir: "loop-bench-jobs".to_string(),
+            job_name: "loop-bench".to_string(),
+            timeout: 0,
+            stella_binary: None,
+            analyze_only: false,
+            json: false,
+            json_out: None,
+            min_pass: 0,
+            compare: Vec::new(),
+            trials: 1,
+            primary: PrimaryMetric::PassRate,
+            require_winner: false,
+        }
+    }
+
+    /// The doc comment above `arm_job_name` explains that the arm index
+    /// exists specifically to prevent a job-name collision between two
+    /// comparison arms — two distinct model strings can slug to the same
+    /// characters. Prove it: `a/b` and `a-b` both slug to `a-b`, and only the
+    /// index tells the two arms' job names apart.
+    #[test]
+    fn arm_job_name_disambiguates_models_that_slug_identically() {
+        let one = arm_job_name("job", 0, "a/b");
+        let two = arm_job_name("job", 1, "a-b");
+        assert_ne!(one, two, "two arms must never share a job directory name");
+        assert_eq!(one, "job-arm0-a-b");
+        assert_eq!(two, "job-arm1-a-b");
+    }
+
+    /// A task named twice in `--tasks` resolves to one entry, matching
+    /// harbor's own `-i` filter semantics (a name given twice still runs
+    /// once).
+    #[test]
+    fn resolve_tasks_dedupes_a_repeated_task_name() {
+        let args = args_with(vec!["fix-git".to_string(), "fix-git".to_string()], 4);
+        assert_eq!(resolve_tasks(&args), vec!["fix-git".to_string()]);
+    }
+
+    /// With no `--tasks`, the default pool is used and `--n` picks how many.
+    #[test]
+    fn resolve_tasks_falls_back_to_the_default_pool_sized_by_n() {
+        let args = args_with(Vec::new(), 2);
+        assert_eq!(resolve_tasks(&args).len(), 2);
+    }
+
+    /// Every name distinct: no duplicate found.
+    #[test]
+    fn duplicate_arm_is_none_when_every_name_is_distinct() {
+        let names = vec!["model-a".to_string(), "model-b".to_string()];
+        assert_eq!(duplicate_arm(&names), None);
+    }
+
+    /// `--compare` rejects a repeated arm outright — this is the function
+    /// `run_comparison`'s inline check was pulled out into, so it can be
+    /// tested without spawning harbor.
+    #[test]
+    fn duplicate_arm_names_the_repeated_config() {
+        let names = vec![
+            "model-a".to_string(),
+            "model-b".to_string(),
+            "model-a".to_string(),
+        ];
+        assert_eq!(duplicate_arm(&names), Some("model-a"));
     }
 }

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -615,6 +615,55 @@ fn a_second_run_in_one_job_dir_is_reported_rather_than_absorbed() {
     );
 }
 
+/// #3743: two requested tasks that share their first 32 characters truncate
+/// to the same trial-directory prefix (`TRIAL_DIR_TASK_LIMIT`). When the
+/// trial's `result.json` never landed — so there is no untruncated
+/// `task_name` to break the tie — `Requested::match_dir` cannot tell them
+/// apart and reports the prefix as ambiguous, which is what drives the
+/// process's exit code 7 (`contamination_exit` in `main.rs`).
+#[test]
+fn a_shared_directory_prefix_with_no_result_json_is_reported_ambiguous() {
+    let task_one = format!("{}-one", "a".repeat(32));
+    let task_two = format!("{}-two", "a".repeat(32));
+    let prefix = trial_dir_prefix(&task_one);
+    assert_eq!(
+        prefix,
+        trial_dir_prefix(&task_two),
+        "the two names must collide"
+    );
+
+    let job = tempfile::tempdir().expect("job dir");
+    // No result.json for this trial: task_name is None, so the tie cannot be
+    // broken by harbor's own record.
+    trial_dir(
+        job.path(),
+        &format!("{prefix}__t1"),
+        &[r#"{"type":"tool_start","call":{"name":"save_state"}}"#],
+    );
+
+    let requested = vec![task_one.clone(), task_two.clone()];
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let record = analysis
+        .reconciliation
+        .as_ref()
+        .expect("a requested run reconciles");
+
+    assert_eq!(record.ambiguous, vec![prefix.clone()]);
+    assert!(
+        record.contaminated(),
+        "an ambiguous attribution is a guess, not a verified match"
+    );
+    assert!(
+        record
+            .findings()
+            .iter()
+            .any(|finding| finding.contains(&prefix)
+                && finding.contains("more than one requested task")),
+        "the finding names the ambiguous prefix: {:?}",
+        record.findings()
+    );
+}
+
 /// #1299, hole 2: harbor truncates a task name to 32 characters when it names
 /// the trial directory. Matching on the untruncated name produced *two* wrong
 /// answers at once — every trial skipped as another run's, and the task that

--- a/bench/request-bench/README.md
+++ b/bench/request-bench/README.md
@@ -1,0 +1,34 @@
+# request-bench
+
+An in-process allocator-churn + wall-clock A/B for the per-attempt model-request
+build (#921): how many bytes and allocations does the engine spend cloning the
+transcript and tool schemas into a `CompletionRequest`, before vs. after the
+retry path switched to a borrowed `CompletionRequestRef`. Deterministic,
+offline, no Docker, no provider key, no spend.
+
+The full reasoning — why the two arms exist, what each one costs, how to read
+"cumulative churn" vs. peak residency — is in the module doc at the top of
+[`src/main.rs`](src/main.rs); this file only points there rather than
+repeating it.
+
+## Running it
+
+```bash
+cargo run -p request-bench --release
+```
+
+Run with `--release`. A debug build still counts allocations honestly, but the
+wall-clock column is meaningless in debug — the allocator overhead dwarfs the
+work being measured.
+
+## Reading the output
+
+Two rows, `owned-clone` (the pre-#921 shape) and `borrowed` (the shape after
+it), each reporting bytes and allocations per step, cumulative MiB per turn,
+and wall time. `borrowed` is asserted to allocate zero bytes — a single-attempt
+model call built from slices and scalars performs no deep copy — so a red
+assertion here is itself the regression signal, not just the printed numbers.
+
+Not listed in [`../README.md`](../README.md)'s entry-point table: that table is
+for running Stella against a public benchmark, and this is an in-process Rust
+micro-benchmark of allocator behavior, not a benchmark run.


### PR DESCRIPTION
## What

- **#3668** — `bench/harbor_adapter/tests/test_adapter.py` read live provider/embedding credentials off the ambient environment, so a real `OPENROUTER_API_KEY`/`VOYAGE_API_KEY` on an operator's machine turned two tests red (and once leaked a real key into an assertion diff). Added a second autouse, session-scoped `conftest.py` fixture clearing every name in `PROVIDER_CREDENTIAL_NAMES | EMBEDDING_CREDENTIAL_NAMES | HOST_ONLY_CONTROL_CREDENTIAL_NAMES`, fixing the class rather than the two instances.
- **#3669** / **#3670** (landed together) — `code_graph.from_stdout` kept only the `code graph:` line and discarded everything else `stella init` printed, including the semantic-index outcome, so a trial's metadata could not say whether embeddings were built, skipped, or attempted-and-incomplete. Added a `semantic` sub-dict with four distinguishable states. Separately, `code_graph.unavailable` returned only `str(error)`; it now also carries the exception's class name and, when the message matches Harbor's `NonZeroAgentExitCodeError` shape, structured `exit_code`/`stderr` fields. #3670's actual root cause (why `stella init` failed on one Frontier-Bench task) is **not** settled — only the legibility half is done, matching the issue's own scope.
- **#3743** — added the missing witness test for the ambiguous-trial-directory-prefix reconciliation path (exit code 7), the one branch in `bench/loop-bench/src/reconcile.rs` with no test at all.
- **#3744** — `bench/loop-bench/src/main.rs` had no `#[cfg(test)] mod tests`. Added one covering `arm_job_name`, `resolve_tasks`, and pulled the `--compare` duplicate-arm check out of `run_comparison`'s inline loop into `duplicate_arm(names)` so it is unit-testable.
- **#3745** — added `bench/request-bench/README.md`. Decided explicitly not to add a row to `bench/README.md`'s entry-point table (it's for running Stella against a public benchmark; `request-bench` is an in-process allocator micro-benchmark) and said so in the new README.
- **#3879** — `arenabench/harbor_agent._ENGINE_ROOT_FIELDS` had drifted from `crates/stella-cli/src/settings/unknown.rs::ENGINE_ROOT_FIELDS` in the restrictive direction (missing `seat_models`, `model_output_caps`, `model_timeout_secs`, `compaction_budget_tokens`, `tool_result_horizon_steps`). Added `arenabench/tests/test_engine_root_fields.py`, parsing the Rust source the way `bench/harbor_adapter/tests/test_posture.py` already does, and widened the local copy with the five missing keys. **Not fixed:** `responsibilities` — it isn't in the Rust vocabulary at all, but it's a real, actively-tested arenabench feature (#2381, 309 lines of tests), so pulling the emission would silently disable a tested surface. Left as a tracked, deliberate gap (see commit body) rather than resolved unilaterally.
- **#3256** — every recorded TB2.1 number used `agent_timeout_multiplier = 2.0`, non-comparable to the tbench.ai leaderboard. `docs/timeout-policy.md` already stated the rule (#3264) but was linked from neither README — now linked from both. Verified every `arenabench/matches/*.toml`: only one sets the multiplier, and it's already `1.0` with an explanatory comment. Added `preflight.non_stock_timeout_notice`, wired into `MatchRunner._launch`, so a non-stock run is marked non-submittable in `ContestantRun.notes` (surfaced live via `Match.snapshot()`) at launch time.

## Evidence

Every commit carries its own witness section; summary:

- `uv run --project bench/harbor_adapter pytest tests` — 733 passed, 2 skipped.
- `uv run --project arenabench pytest tests/test_engine_root_fields.py tests/test_role_posture.py tests/test_responsibilities.py tests/test_arena.py tests/test_timeout_policy.py` — 208 passed.
- `cargo test -p loop-bench` — 44 passed (lib) + 5 passed (bin).
- `cargo clippy -p loop-bench --all-targets -- -D warnings` — clean.
- `ruff check` on every changed Python file — clean.
- `make guards-fast` — clean (includes `check-file-size`, `check-doc-links`, `check-prose`, `check-left-behind`, `cargo fmt --check`).
- Every behavioral commit's witness was verified fail→pass by hand: stash the fix (`git stash push -u`), run the new/changed test red, `git stash pop`, run it green. Details in each commit body.

`arenabench/arenabench/runner.py` is a grandfathered god file sitting at its exact 1529-line ceiling with zero headroom — the #3256 fix's logic lives in `preflight.py` instead, and `runner.py` ends the PR at exactly 1529 lines (not over).

## Not done

- **#3670's root cause** is unsettled — the legibility half (exit code + stderr capture) landed; naming or accepting the actual cause needs a fresh Frontier-Bench run (`Refs #3670`, left open per the issue's own definition of done).
- **#3879's `responsibilities` gap** is unresolved — it needs a maintainer decision (stop emitting the key, or give it a home in the Rust `AgentEngineConfig` schema) that a mechanical drift-sync should not make unilaterally (`Refs #3879`, left open).
- **#3826** — skipped per instructions (a measurement task, not runnable here).

## Left behind

- `docs/prose-quality-report.md` fails `check-doc-links.py` on main already (two pre-existing citation issues, lines 55 and 62 — a missing-frontmatter citation and a superseded-doc citation), unrelated to anything in this PR. Not filed as a new issue in the interest of time; worth a `gh issue list`/triage pass to check whether it's already tracked.

Closes #3668
Closes #3669
Refs #3670
Closes #3743
Closes #3744
Closes #3745
Refs #3879
Closes #3256

## Summary by Sourcery

Harden benchmark isolation and metadata, improve loop-bench coverage, synchronize engine configuration validation, and enforce clearer Terminal-Bench timeout comparability.

New Features:
- Record semantic-index outcomes and structured initialization failures in Harbor trial metadata.
- Mark runs with non-stock agent timeouts as non-submittable to the tbench.ai leaderboard.
- Add request-bench usage documentation.

Bug Fixes:
- Prevent ambient provider, embedding, and host-control credentials from affecting Harbor adapter tests.
- Synchronize ArenaBench engine-root field validation with the launcher vocabulary while preserving the tracked responsibilities exception.
- Add coverage for ambiguous loop-bench trial-directory reconciliation and comparison-arm validation.

Enhancements:
- Expand loop-bench unit-test coverage for task resolution and job-name disambiguation.
- Add timeout-policy guidance and links to benchmark documentation.

Documentation:
- Document Terminal-Bench 2.1 timeout comparability requirements and link the timeout policy from benchmark entry points.
- Document how to run and interpret the request allocator micro-benchmark.

Tests:
- Add parser tests for semantic-index states and structured command failures.
- Add engine-root drift and timeout-policy tests.
- Add loop-bench tests for reconciliation, task resolution, arm naming, and duplicate comparison arms.