### PR TITLE
fix(stella-core): six engine fixes — glued subshell parens, the stall rung's requested seconds, function-word skill selection, and three recovery rungs that never composed

### DIFF
--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -429,8 +429,17 @@ pub(crate) const STALL_STEER_PREFIX: &str = "[stuck-loop warning] this turn is s
 /// refused by policy, erroring before it slept — still contributes its full
 /// request, so this is an upper bound on wall clock and not a measurement of
 /// it. That is why [`stall_steer_text`] says "asked for" and claims nothing
-/// about what the clock was actually charged; whether the *threshold* should
-/// discount such a call is the open question in #3624. Any call carrying a
+/// about what the clock was actually charged.
+///
+/// **The threshold does not discount such a call, and that is decided rather
+/// than inherited (#3624).** Skipping errored calls reads the same transcript
+/// text and stays as deterministic, but it goes blind on the worst real
+/// shape: three `sleep 300`s that `bash` killed at its own 120s timeout burn
+/// 360s of wall clock and would count zero. Clamping to the call's own
+/// timeout would teach `stella-core` a tool's parameter name and its default,
+/// which is exactly what matching on a `command` string avoids. What is left
+/// can only steer *early*, on a rung that carries no abort and warns once per
+/// turn. Any call carrying a
 /// `command` string counts, so the shell tool and the shell-shaped custom
 /// tools are covered without `stella-core` learning a tool's name; the
 /// classifier is strict enough (`stella_core::shell_text::bare_sleep_seconds`

--- a/crates/stella-core/src/driver/loop_escalation/tests.rs
+++ b/crates/stella-core/src/driver/loop_escalation/tests.rs
@@ -624,6 +624,21 @@ mod stall {
             .collect()
     }
 
+    /// #3624's decision, pinned: a sleep the shell never ran to term
+    /// still contributes its full request, because the bound is what the
+    /// model asked for and that is what the steer names.
+    #[test]
+    fn a_sleep_the_shell_never_ran_still_counts_what_it_asked_for() {
+        let mut window = records(&["sleep 300; echo done"; 3]);
+        for record in &mut window {
+            record.output = Some(Cow::Owned(ToolOutput::error(
+                "command timed out after 120s",
+            )));
+        }
+        assert_eq!(turn_stall_seconds(&window), 900);
+        assert!(turn_stall_seconds(&window) >= STALL_STEER_THRESHOLD_SECS);
+    }
+
     /// #2022's witness, in the shape the trace recorded: three
     /// `sleep 300; echo done` calls with a poll between each, 900s of a
     /// 900s allowance spent waiting.

--- a/crates/stella-core/src/driver/model_fallback.rs
+++ b/crates/stella-core/src/driver/model_fallback.rs
@@ -6,12 +6,14 @@
 //! The engine holds one provider for the whole turn, so before this module a
 //! wedged provider ended the turn as `Aborted { Failure }` even when a
 //! healthy fallback was configured and resolvable — every completed step's
-//! work stranded in the transcript. This is the recovery rung for the
-//! failure classes [`overflow_recovery`](super::overflow_recovery) does not
-//! own: transport faults, 5xx, auth revocation, and rate limiting that
-//! outlived the parked ladder (`driver/rate_limit.rs`, #2677) — everything
-//! that surfaces as `ModelCallFailure::Exhausted`. A child module of
-//! `driver` (the `settlement.rs` pattern), so the seam stays out of the
+//! work stranded in the transcript. Its first class of failure is everything
+//! that surfaces as `ModelCallFailure::Exhausted`: transport faults, 5xx,
+//! auth revocation, and rate limiting that outlived the parked ladder
+//! (`driver/rate_limit.rs`, #2677). Its second is the one rejection
+//! [`overflow_recovery`](super::overflow_recovery) cannot compact its way out
+//! of — a transcript still too large once that ladder is spent, which a
+//! provider with a wider window may accept unchanged (#2770). A child module
+//! of `driver` (the `settlement.rs` pattern), so the seam stays out of the
 //! god-file ceiling.
 //!
 //! # How the fallback is chosen
@@ -108,6 +110,34 @@ use crate::step::TurnState;
 pub(crate) const FALLBACK_TOOL_RESULT: &str =
     "not executed — the turn switched to a fallback provider after exhausted retries";
 
+/// Why the turn is asking for a replacement provider.
+///
+/// The two failure classes that reach the fallback are true of different
+/// things, and the notice has to say which: an exhausted ladder is a claim
+/// about the provider's *health*, an overflow is a claim about its *window*.
+/// A swap announced as "exhausted its retries" when the ladder never ran once
+/// is the misclassification #2743 names elsewhere, arriving by another route.
+#[derive(Clone, Copy)]
+pub(crate) enum FallbackCause {
+    /// The retry ladder ran out against the active provider (#2679).
+    RetriesExhausted,
+    /// The transcript still exceeds the active provider's context window
+    /// after the compaction ladder is spent (#2770).
+    ContextOverflow,
+}
+
+impl FallbackCause {
+    /// What this cause says about the provider being left, for the notice.
+    fn clause(self, from: &str) -> String {
+        match self {
+            Self::RetriesExhausted => format!("`{from}` exhausted its retries"),
+            Self::ContextOverflow => {
+                format!("`{from}` rejected the transcript as too large and compaction is spent")
+            }
+        }
+    }
+}
+
 impl<'a> Engine<'a> {
     /// The provider this engine's calls go to: the constructor-time primary
     /// until a fallback latches, the replacement afterwards. Every site that
@@ -122,14 +152,21 @@ impl<'a> Engine<'a> {
     }
 
     /// Try to continue the turn on a replacement provider after `message`
-    /// exhausted the retry ladder against the active one. `true` latched the
+    /// ended the call against the active one for `cause`. `true` latched the
     /// swap — the caller re-runs the step against the replacement, terminal
     /// events withheld. `false` means the turn must surface the failure
     /// terminally: no resolver attached, the latch already spent, no healthy
     /// alternative, or resolution landing back on the failed provider.
+    ///
+    /// The set-once latch is the entire bound for both causes, which is why
+    /// the overflow rung needs no bound of its own: it can burn at most one
+    /// paid call on a replacement whose window may be no larger, and a
+    /// replacement that also overflows finds both the compaction ladder and
+    /// this latch spent, so it is terminal with no loop.
     pub(crate) fn attempt_provider_fallback(
         &self,
         message: &str,
+        cause: FallbackCause,
         state: &mut TurnState,
         events: &EventSender,
     ) -> bool {
@@ -164,8 +201,8 @@ impl<'a> Engine<'a> {
         // an observer must read this as the turn continuing, never ending.
         let _ = events.send(AgentEvent::Error {
             message: format!(
-                "{message} — `{from}` exhausted its retries; continuing the turn on `{to}` \
-                 ({reason})",
+                "{message} — {clause}; continuing the turn on `{to}` ({reason})",
+                clause = cause.clause(&from),
                 reason = resolved.reason
             ),
             retryable: true,

--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -29,10 +29,18 @@
 //! last. The clamp also never loosens once set — even after a later call
 //! commits — so a compaction budget configured above what the provider will
 //! actually accept cannot oscillate grow → overflow → recover for the rest of
-//! the turn. When the ladder is spent, the overflow surfaces exactly as an
-//! unrecovered terminal failure does. Error → recover → error can therefore
-//! burn at most `MAX_RECOVERY_RUNGS` extra calls, each of which was already
-//! billed through the ordinary `UsageIncomplete` attempt observer.
+//! the turn. Error → recover → error can therefore burn at most
+//! `MAX_RECOVERY_RUNGS` extra calls, each of which was already billed through
+//! the ordinary `UsageIncomplete` attempt observer.
+//!
+//! A spent ladder is not yet the end. The transcript that no amount of
+//! compaction shrank may simply fit a *different* provider's window, so the
+//! last thing before terminal surfacing is one try at the mid-turn fallback
+//! (`super::model_fallback`, #2770) — bounded by that seam's own set-once
+//! latch rather than a second bound of its own, and terminal the moment the
+//! replacement rejects too, since by then both the ladder and the latch are
+//! spent. Only then does the overflow surface exactly as an unrecovered
+//! terminal failure does.
 //!
 //! # What consumers see
 //!
@@ -197,7 +205,12 @@ impl<'a> Engine<'a> {
                 // `true` latched the swap — the step re-runs and the
                 // terminal events stay withheld, exactly as an armed
                 // overflow rung withholds them below.
-                if self.attempt_provider_fallback(&message, state, events) {
+                if self.attempt_provider_fallback(
+                    &message,
+                    super::model_fallback::FallbackCause::RetriesExhausted,
+                    state,
+                    events,
+                ) {
                     return None;
                 }
                 // No fallback: surface the pre-#2679 terminal shape.
@@ -285,7 +298,25 @@ impl<'a> Engine<'a> {
                 state.step += 1;
                 None
             }
-            None => Some(self.surface_unrecovered(message, attempt_reasons, state, events)),
+            // The last rung, and the one the two recovery seams had never
+            // composed (#2770): the compaction ladder is spent, but a
+            // configured fallback may carry a window that accepts this
+            // transcript as it stands. Tried once, behind #2679's set-once
+            // latch — the same bound the exhausted-ladder arm above trusts,
+            // and the reason no window-size field on `ProviderProfile` is
+            // needed to make this safe. A replacement that also rejects finds
+            // the ladder spent and the latch set, so it is terminal.
+            None => {
+                if self.attempt_provider_fallback(
+                    &message,
+                    super::model_fallback::FallbackCause::ContextOverflow,
+                    state,
+                    events,
+                ) {
+                    return None;
+                }
+                Some(self.surface_unrecovered(message, attempt_reasons, state, events))
+            }
         }
     }
 

--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -153,6 +153,15 @@ pub(crate) enum ModelCallFailure {
         /// payload if this ends up surfacing terminally.
         attempt_reasons: Vec<String>,
     },
+    /// The user asked the turn to stop while it was parked on a
+    /// park-eligible failure, and the park honored the latch (#2743). The
+    /// pending provider error is deliberately discarded: the turn ended
+    /// because a person asked, so it settles as the step-boundary soft stop
+    /// does — no `RetriesExhausted`, no `Error`, every completed step kept.
+    /// The failed attempts that opened the park already reported themselves
+    /// through the per-attempt `UsageIncomplete` observer, so nothing is lost
+    /// from the accounting by dropping the error here.
+    SoftStopped,
     /// The provider refused to fund the requested output ceiling. Withheld
     /// from the terminal channels exactly as the overflow arm is — the
     /// caller decides between a clamp rung
@@ -234,6 +243,25 @@ impl<'a> Engine<'a> {
                 message,
                 attempt_reasons,
             } => (message, attempt_reasons),
+            // Settled here rather than in the ladder so every ending of a
+            // model call leaves through one door, and byte-identical to
+            // `super::step_boundary`'s exit: the same reason string, the same
+            // `DeliberateStop`, the same tool-call repair for history a
+            // caller handed in. A park is inside the ladder, so before #2743
+            // this ending wore the parked provider's error and telemetry
+            // recorded a provider failure for a user's decision.
+            ModelCallFailure::SoftStopped => {
+                crate::step::close_open_tool_calls(
+                    &mut state.messages,
+                    super::SOFT_STOP_TOOL_RESULT,
+                    events,
+                );
+                return Some(StepOutcome::Aborted {
+                    reason: super::SOFT_STOP_REASON.to_string(),
+                    kind: AbortKind::DeliberateStop,
+                    cost_usd: state.total_cost_usd,
+                });
+            }
             // The output-side mirror, settled here rather than in a parallel
             // method so both ladders share one "withheld while recovering,
             // terminal when spent" shape — the property that matters to an

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -16,7 +16,9 @@
 //! exhausted-ladder breaker feedback. The terminal event pair itself is
 //! emitted by `Engine::settle_model_call_failure`, which may first recover
 //! the turn instead — forced compaction for a context overflow (#2680), a
-//! provider fallback for an exhausted ladder (#2679). The park honors invariant 6's spirit the
+//! provider fallback for an exhausted ladder or a spent compaction ladder
+//! (#2679, #2770) — or settle it as no failure at all, when the park ended
+//! because a person pressed Esc (#2743). The park honors invariant 6's spirit the
 //! same way `driver/waiting.rs` does: the wait sits between model attempts,
 //! never mid-tool, and the budget's deadline bounds it from the outside.
 
@@ -58,6 +60,15 @@ struct RateLimitPark<'e, 'a> {
     engine: &'e Engine<'a>,
     budget: &'e BudgetGuard,
     events: &'e EventSender,
+    /// Set when [`Self::park_tick`] ended a park because the soft-stop latch
+    /// was set. Read once the ladder returns, to tell a turn a person stopped
+    /// from one the provider failed (#2743).
+    ///
+    /// The supervisor is the only thing that knows *why* it aborted, and it
+    /// is engine-side, so recording the answer here is what keeps
+    /// [`ParkDirective`] a bare instruction and `crate::retry` free of the
+    /// steering latch it must not learn about.
+    soft_stopped: bool,
 }
 
 impl ParkSupervisor for RateLimitPark<'_, '_> {
@@ -91,6 +102,7 @@ impl ParkSupervisor for RateLimitPark<'_, '_> {
             .steering
             .is_some_and(|steering| steering.soft_stop_requested())
         {
+            self.soft_stopped = true;
             return ParkDirective::Abort;
         }
         // The per-chunk keep-alive (#2677): a multi-minute wait announces
@@ -189,8 +201,11 @@ impl<'a> Engine<'a> {
             engine: self,
             budget,
             events,
+            soft_stopped: false,
         };
-        match retry_with_backoff_observed(
+        // Bound rather than matched in place, so the future holding
+        // `&mut park` is dropped before the soft-stop answer is read below.
+        let ladder = retry_with_backoff_observed(
             &self.config.retry_policy,
             self.sleeper,
             attempt,
@@ -226,8 +241,9 @@ impl<'a> Engine<'a> {
             },
             &mut park,
         )
-        .await
-        {
+        .await;
+        let soft_stopped = park.soft_stopped;
+        match ladder {
             Ok(outcome) => {
                 cancel_guard.disarm();
                 // Call-outcome feedback (#2673): a committed step closes the
@@ -241,6 +257,17 @@ impl<'a> Engine<'a> {
                 cancel_guard.disarm();
                 let reasons =
                     std::mem::take(&mut *attempt_reasons.lock().unwrap_or_else(|p| p.into_inner()));
+                // The park ended because a person pressed Esc, so `error` is
+                // the parked rate limit or overload the wait was going to
+                // outlast — a fact about the provider, not the reason the
+                // turn is ending (#2743). Reported as a failure it
+                // misclassified a user decision in telemetry, and gave a
+                // mid-park Esc a different ending from a step-boundary one.
+                // Checked before the breaker below for the same reason: this
+                // ladder did not exhaust, so it is no evidence of ill health.
+                if soft_stopped {
+                    return Err(ModelCallFailure::SoftStopped);
+                }
                 // A context overflow is withheld from the terminal events and
                 // the breaker: the caller may still recover it, and an
                 // oversized request is the engine's accounting miss, not

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -30,6 +30,23 @@
 //! applies a paid summary purely to *shrink* the context a resumed session
 //! reloads — growing it back with restored content would spend headroom the
 //! tripped budget no longer has, for a turn that is already over.
+//!
+//! # When the summarizer's own request overflows
+//!
+//! The summarizer is a model call over the rendered span, so a span large
+//! enough to be worth folding is a request large enough to be rejected for
+//! its size. That rejection used to land in the ordinary provider-failure
+//! arm — context left intact, latch incremented — and it was the one branch
+//! `super::overflow_recovery` could not repair: the call that exists to
+//! shrink the transcript was refused for being too big, and the turn aborted
+//! two rungs later (#2751). The older head of the render is now dropped and
+//! the summarizer re-asked, bounded by [`SUMMARIZER_OVERFLOW_ATTEMPTS`]. The
+//! dropped content is lost *unsummarized*, so the splice marker says so —
+//! the model must not read a summary as covering history it never saw.
+//! Nothing about the splice bounds changes, which is what keeps the
+//! transcript well-paired: the span replaced is the same `start..end` the
+//! Tool-message walks chose, only what the summary was written from is
+//! smaller.
 
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionRequest, CompletionResult, MessageRole,
@@ -55,6 +72,26 @@ use crate::{AccountedCall, AccountedCallError, run_accounted_call};
 /// first visible token (#2503), and an empty summary here trips the give-up
 /// latch that disables compaction for the rest of the turn.
 const SUMMARY_OUTPUT_CONTRACT: u32 = 1_200;
+
+/// How many summarizer dispatches one over-budget step may make while the
+/// summarizer's *own* request keeps overflowing: the original plus two
+/// head-dropping retries, the bound the comparator's reactive ladder uses
+/// (#2751, quoted in #2680). Each rejected attempt is billed through
+/// `run_accounted_call`'s `UsageIncomplete` observer like any other, so this
+/// is a spend bound as much as a latency one — and one step of a turn that
+/// is already recovering must not spend more than a handful of calls proving
+/// the span cannot be summarized.
+pub(super) const SUMMARIZER_OVERFLOW_ATTEMPTS: u8 = 3;
+
+/// The summarizer's two-message request over an already-rendered span. Built
+/// per dispatch rather than cloned, because a head-dropping retry (#2751)
+/// sends a *different* span than the attempt before it.
+fn summary_request(rendered: &str) -> Vec<CompletionMessage> {
+    vec![
+        CompletionMessage::system(crate::summarize::SUMMARIZE_SYSTEM),
+        CompletionMessage::user(rendered),
+    ]
+}
 
 /// The synthetic `call_id` restoration replays carry — the
 /// `driver::waiting::PARKED_CALL_ID` shape: it never enters the transcript,
@@ -128,22 +165,44 @@ impl<'a> Engine<'a> {
             rendered.push_str("\n\n[PreCompact hook instructions]\n");
             rendered.push_str(extra);
         }
-        let summary_messages = vec![
-            CompletionMessage::system(crate::summarize::SUMMARIZE_SYSTEM),
-            CompletionMessage::user(&rendered),
-        ];
         // The written contract plus room to think (#2503): `max_output_tokens`
         // is one number on the wire and a reasoning model bills its thinking
         // against it, so `effort: Low` alone bounds the reasoning budget
         // without zeroing it.
         let cap = with_reasoning_headroom(SUMMARY_OUTPUT_CONTRACT);
-        // Kept only because a starved retry could change the outcome — the
-        // same one-`Vec`-copy trade `metered_raw_call` makes for a management
-        // prompt it might have to re-send (#2128).
-        let retry = starved_retry_cap(Some(cap)).map(|raised| (raised, summary_messages.clone()));
         let mut outcome = self
-            .dispatch_summarizer(summary_messages, cap, step, budget, events)
+            .dispatch_summarizer(summary_request(&rendered), cap, step, budget, events)
             .await;
+        // The one branch reactive overflow recovery could not repair (#2751):
+        // the call that exists to shrink the transcript is itself rejected as
+        // too large, and the old code recorded it as an ordinary summarizer
+        // failure, left the context intact, and let the turn abort two rungs
+        // later. Dropping the older head of the render is the only lever left
+        // — the dropped content is lost unsummarized, which is what
+        // `head_dropped` makes the splice marker say. Bounded at
+        // [`SUMMARIZER_OVERFLOW_ATTEMPTS`] dispatches, and `drop_span_head`
+        // refuses a drop that would not shrink the request, so the loop
+        // terminates on its own as well.
+        let mut head_dropped = false;
+        let mut attempts = 1u8;
+        while attempts < SUMMARIZER_OVERFLOW_ATTEMPTS
+            && matches!(
+                &outcome,
+                Err(AccountedCallError::Provider(
+                    stella_protocol::ProviderError::ContextOverflow { .. }
+                ))
+            )
+        {
+            let Some(shorter) = crate::summarize::drop_span_head(&rendered) else {
+                break;
+            };
+            rendered = shorter;
+            head_dropped = true;
+            attempts += 1;
+            outcome = self
+                .dispatch_summarizer(summary_request(&rendered), cap, step, budget, events)
+                .await;
+        }
         // What a superseded starved attempt already spent. Every arm below
         // adds it, because the retry is a real paid call: reporting only the
         // surviving attempt's cost would understate the turn by exactly what
@@ -157,12 +216,13 @@ impl<'a> Engine<'a> {
         // short of room, which one retry fixes. A retry that also comes back
         // empty falls through to the empty-summary arm below, which is where
         // that failure is recorded (#2503).
-        if let (Ok(result), Some((raised, summary_messages))) = (&outcome, retry)
+        if let Ok(result) = &outcome
             && starved_of_output(result)
+            && let Some(raised) = starved_retry_cap(Some(cap))
         {
             superseded_cost = result.cost_usd;
             outcome = self
-                .dispatch_summarizer(summary_messages, raised, step, budget, events)
+                .dispatch_summarizer(summary_request(&rendered), raised, step, budget, events)
                 .await;
         }
         let result = match outcome {
@@ -180,6 +240,7 @@ impl<'a> Engine<'a> {
                         end,
                         before_tokens,
                         text,
+                        head_dropped,
                         compaction_budget,
                         factor,
                         events,
@@ -189,7 +250,9 @@ impl<'a> Engine<'a> {
             }
             // A silent 0.0 hid a failing summarizer that re-fired every step
             // until the provider hard-failed. Surface it and count it toward
-            // the give-up latch.
+            // the give-up latch. A `ContextOverflow` reaching here has already
+            // spent the head-dropping ladder above, so it is a span whose
+            // newest half the summarizer still will not accept.
             Err(AccountedCallError::Provider(e)) => {
                 health.record_failure();
                 let _ = events.send(AgentEvent::Error {
@@ -247,6 +310,7 @@ impl<'a> Engine<'a> {
             end,
             before_tokens,
             text,
+            head_dropped,
             compaction_budget,
             factor,
             events,
@@ -344,6 +408,7 @@ impl<'a> Engine<'a> {
         end: usize,
         before_tokens: u64,
         text: &str,
+        head_dropped: bool,
         compaction_budget: u64,
         factor: f64,
         events: &EventSender,
@@ -361,9 +426,19 @@ impl<'a> Engine<'a> {
             .flat_map(|m| m.tool_results.iter())
             .map(|r| crate::receipts::tool_result_block_id(&r.output))
             .collect();
+        // A summary written from a head-dropped render covers less than the
+        // span it replaces, and the model has no other way to learn that
+        // (#2751). Named inside the marker's brackets so every consumer that
+        // recognises the marker by its prefix is unaffected.
+        let dropped = if head_dropped {
+            "; the oldest part of that history exceeded the summarizer's own context window \
+             and is not covered by this summary"
+        } else {
+            ""
+        };
         let summary = CompletionMessage::user(format!(
             "{SUMMARY_MARKER_PREFIX} to fit context — full detail was compacted away; \
-             re-read files or re-run tools for specifics]\n\n{text}"
+             re-read files or re-run tools for specifics{dropped}]\n\n{text}"
         ));
         messages.splice(start..end, std::iter::once(summary));
         let _ = events.send(AgentEvent::Compaction {

--- a/crates/stella-core/src/driver/tests/context_overflow.rs
+++ b/crates/stella-core/src/driver/tests/context_overflow.rs
@@ -22,13 +22,22 @@ use super::super::*;
 
 /// Rejects the first `overflows` calls as context overflow, then completes.
 struct OverflowThenComplete {
+    id: &'static str,
     overflows: u32,
     calls: AtomicU32,
 }
 
 impl OverflowThenComplete {
     fn new(overflows: u32) -> Self {
+        Self::named("scripted", overflows)
+    }
+
+    /// The same provider under another id — a fallback resolution landing
+    /// back on the failed provider's id is refused as "no fallback", so a
+    /// second overflowing provider has to be a different one.
+    fn named(id: &'static str, overflows: u32) -> Self {
         Self {
+            id,
             overflows,
             calls: AtomicU32::new(0),
         }
@@ -42,7 +51,7 @@ impl OverflowThenComplete {
 #[async_trait::async_trait]
 impl Provider for OverflowThenComplete {
     fn id(&self) -> &str {
-        "scripted"
+        self.id
     }
 
     async fn complete_ref(
@@ -90,11 +99,80 @@ impl crate::retry::Sleeper for NoSleep {
     async fn sleep(&self, _duration_ms: u64) {}
 }
 
+/// Completes every call — the wider-window replacement the spent ladder
+/// hands the transcript to.
+struct HealthyFallback {
+    calls: AtomicU32,
+}
+
+impl HealthyFallback {
+    fn new() -> Self {
+        Self {
+            calls: AtomicU32::new(0),
+        }
+    }
+
+    fn calls(&self) -> u32 {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for HealthyFallback {
+    fn id(&self) -> &str {
+        "wide-window"
+    }
+
+    async fn complete_ref(
+        &self,
+        _req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(CompletionResult {
+            upstream_provider: None,
+            text: "rescued".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage::default(),
+            model: "scripted-wide".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Hands out one provider on every ask.
+struct ScriptedResolver<'p> {
+    to: &'p dyn Provider,
+}
+
+impl crate::ports::FallbackResolver for ScriptedResolver<'_> {
+    fn resolve_fallback(
+        &self,
+        failed_provider_id: &str,
+    ) -> Option<crate::ports::ResolvedFallback<'_>> {
+        Some(crate::ports::ResolvedFallback {
+            provider: self.to,
+            reason: format!("scripted re-resolution away from `{failed_provider_id}`"),
+        })
+    }
+}
+
 /// One real turn against `provider`, returning the outcome and every event.
 async fn run_turn_collecting(provider: &dyn Provider) -> (TurnOutcome, Vec<AgentEvent>) {
+    run_turn_with_fallback(provider, None).await
+}
+
+/// The same turn with a fallback resolver attached, when one is given.
+async fn run_turn_with_fallback(
+    provider: &dyn Provider,
+    resolver: Option<&dyn crate::ports::FallbackResolver>,
+) -> (TurnOutcome, Vec<AgentEvent>) {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper);
+    let mut engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper);
+    if let Some(resolver) = resolver {
+        engine = engine.with_fallback_resolver(resolver);
+    }
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do the thing")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
@@ -187,6 +265,96 @@ async fn repeated_overflow_is_latched_and_aborts_after_the_ladder_is_spent() {
             e,
             AgentEvent::Error { message, retryable: false } if message.contains("context overflow")
         )),
+        "{events:?}"
+    );
+}
+
+/// The #2770 witness: the two recovery rungs compose. On `main` a spent
+/// compaction ladder aborts the turn even with a healthy fallback attached,
+/// because the `ContextOverflow` arm went straight to the terminal surfacing
+/// while the `Exhausted` arm one branch above it consulted the fallback. The
+/// transcript compaction could not shrink may simply fit another provider's
+/// window.
+#[tokio::test]
+async fn a_spent_overflow_ladder_swaps_to_the_fallback_and_the_turn_completes() {
+    let primary = OverflowThenComplete::new(u32::MAX);
+    let fallback = HealthyFallback::new();
+    let resolver = ScriptedResolver { to: &fallback };
+    let (outcome, events) = run_turn_with_fallback(&primary, Some(&resolver)).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { ref text, .. } if text == "rescued"),
+        "the turn must complete on the fallback, got {outcome:?}"
+    );
+    assert_eq!(
+        primary.calls(),
+        1 + u32::from(overflow_recovery::MAX_RECOVERY_RUNGS),
+        "the compaction ladder is spent before the fallback is consulted"
+    );
+    assert_eq!(fallback.calls(), 1, "one rescued re-issue");
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ProviderFallback { from, to, .. }
+                if from == "scripted" && to == "wide-window"
+        )),
+        "the swap must be announced (L-M7): {events:?}"
+    );
+    // The notice names the window, not a retry ladder that never ran: a swap
+    // announced as "exhausted its retries" would misreport why it happened.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, retryable: true }
+                if message.contains("rejected the transcript as too large")
+        )),
+        "the notice must name the overflow as the cause: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RetriesExhausted { .. })),
+        "a recovered overflow must not report exhausted retries: {events:?}"
+    );
+}
+
+/// The bound: a fallback whose window is no wider rejects too, and by then
+/// the compaction ladder is spent and #2679's set-once latch is set — so the
+/// turn is terminal after exactly one extra paid call, never a swap loop.
+#[tokio::test]
+async fn a_fallback_that_also_overflows_is_terminal_with_no_second_swap() {
+    let primary = OverflowThenComplete::new(u32::MAX);
+    let fallback = OverflowThenComplete::named("narrow-too", u32::MAX);
+    let resolver = ScriptedResolver { to: &fallback };
+    let (outcome, events) = run_turn_with_fallback(&primary, Some(&resolver)).await;
+
+    assert!(
+        matches!(
+            outcome,
+            TurnOutcome::Aborted { ref reason, kind: AbortKind::Failure, .. }
+                if reason.contains("context overflow")
+        ),
+        "a fallback that also overflows surfaces terminally, got {outcome:?}"
+    );
+    assert_eq!(
+        primary.calls() + fallback.calls(),
+        2 + u32::from(overflow_recovery::MAX_RECOVERY_RUNGS),
+        "the ladder plus exactly one swapped call is the bound"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ProviderFallback { .. }))
+            .count(),
+        1,
+        "the set-once latch permits one swap: {events:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::RetriesExhausted { .. }))
+            .count(),
+        1,
         "{events:?}"
     );
 }

--- a/crates/stella-core/src/driver/tests/context_overflow.rs
+++ b/crates/stella-core/src/driver/tests/context_overflow.rs
@@ -12,6 +12,14 @@
 //! (the witness), and the ladder is latched so repeated rejection aborts
 //! after a bounded number of paid attempts instead of looping (the
 //! death-spiral guard).
+//!
+//! Two later rungs settle where that ladder used to end. A spent ladder now
+//! consults the mid-turn provider fallback before surfacing terminally, since
+//! a transcript compaction cannot shrink may still fit another provider's
+//! window (#2770). And a *summarizer* request that itself overflows drops the
+//! older head of its render and re-asks, instead of leaving the context
+//! intact and letting the turn abort two rungs later (#2751). Both carry a
+//! bound test beside the witness.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -356,6 +364,171 @@ async fn a_fallback_that_also_overflows_is_terminal_with_no_second_swap() {
             .count(),
         1,
         "{events:?}"
+    );
+}
+
+/// Rejects a summarizer request until its rendered span is under
+/// `accepts_under` bytes, then writes a summary — the shape of a span large
+/// enough that the call meant to fold it is itself too large.
+struct SummarizerNarrowerThanTheSpan {
+    accepts_under: usize,
+    calls: std::sync::atomic::AtomicU32,
+    smallest_seen: std::sync::Mutex<usize>,
+}
+
+impl SummarizerNarrowerThanTheSpan {
+    fn new(accepts_under: usize) -> Self {
+        Self {
+            accepts_under,
+            calls: AtomicU32::new(0),
+            smallest_seen: std::sync::Mutex::new(usize::MAX),
+        }
+    }
+
+    fn calls(&self) -> u32 {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for SummarizerNarrowerThanTheSpan {
+    fn id(&self) -> &str {
+        "narrow-summarizer"
+    }
+
+    async fn complete_ref(
+        &self,
+        req: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let bytes: usize = req.messages.iter().map(|m| m.content.len()).sum();
+        let mut smallest = self.smallest_seen.lock().unwrap();
+        *smallest = (*smallest).min(bytes);
+        if bytes >= self.accepts_under {
+            return Err(ProviderError::ContextOverflow {
+                message: format!("prompt is too long: {bytes} bytes"),
+            });
+        }
+        Ok(CompletionResult {
+            upstream_provider: None,
+            text: "SUMMARY".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage::reported_zero(),
+            model: "narrow".to_string(),
+            cost_usd: 0.0001,
+            finish_reason: None,
+        })
+    }
+}
+
+/// The #2751 witness: a summarizer request that itself overflows used to be
+/// recorded as an ordinary summarizer failure — context left intact, latch
+/// incremented — which is the one branch reactive recovery could not repair.
+/// The older head of the render is dropped and the summarizer re-asked, so
+/// the span still folds and the turn can continue.
+#[tokio::test]
+async fn a_summarizer_request_that_overflows_drops_its_head_and_still_folds_the_span() {
+    // The full render is well over this; one head-drop halves it under.
+    let provider = SummarizerNarrowerThanTheSpan::new(3_000);
+    let tools = super::CountingTools {
+        calls: std::sync::Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoSleep;
+    let engine = Engine::with_sleeper(&provider, &tools, super::overflow_config(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    for i in 0..8 {
+        messages.push(super::big_assistant_text(&format!("t{i}")));
+    }
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    let mut health = crate::step::SummarizerHealth::default();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    let cost = engine
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            None,
+            &events,
+        )
+        .await;
+
+    assert!(cost > 0.0, "the accepted retry is paid for: {cost}");
+    assert!(provider.calls() > 1, "the first request was rejected");
+    let marker = messages
+        .iter()
+        .find(|m| m.content.starts_with(SUMMARY_MARKER_PREFIX))
+        .expect("the span must still fold");
+    assert!(
+        marker.content.contains("is not covered by this summary"),
+        "the marker must say the dropped head was never summarized: {}",
+        marker.content
+    );
+    assert_eq!(health.consecutive_failures, 0, "a fold clears the latch");
+    let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+}
+
+/// The bound: a summarizer whose window no amount of head-dropping satisfies
+/// stops after a fixed number of dispatches, records the failure toward the
+/// give-up latch, and leaves the context intact — never a retry loop.
+#[tokio::test]
+async fn head_dropping_is_bounded_when_no_span_size_is_accepted() {
+    let provider = SummarizerNarrowerThanTheSpan::new(0);
+    let tools = super::CountingTools {
+        calls: std::sync::Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoSleep;
+    let engine = Engine::with_sleeper(&provider, &tools, super::overflow_config(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    for i in 0..8 {
+        messages.push(super::big_assistant_text(&format!("t{i}")));
+    }
+    let before = messages.len();
+    let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+    let mut health = crate::step::SummarizerHealth::default();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let events = EventSender::new(tx);
+
+    engine
+        .summarize_overflow_span(
+            &mut messages,
+            &mut budget,
+            500,
+            1.0,
+            &mut health,
+            0,
+            None,
+            &events,
+        )
+        .await;
+
+    assert_eq!(
+        provider.calls(),
+        u32::from(restore::SUMMARIZER_OVERFLOW_ATTEMPTS),
+        "the attempt count is the bound"
+    );
+    assert_eq!(messages.len(), before, "the context is left intact");
+    assert_eq!(
+        health.consecutive_failures, 1,
+        "the unrepairable overflow still counts toward the give-up latch"
+    );
+    let events: Vec<AgentEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Error { message, .. } if message.contains("overflow summarizer failed")
+        )),
+        "the failure is surfaced: {events:?}"
     );
 }
 

--- a/crates/stella-core/src/driver/tests/parked_wait.rs
+++ b/crates/stella-core/src/driver/tests/parked_wait.rs
@@ -620,3 +620,91 @@ async fn a_sustained_transport_fault_still_exhausts_the_ladder_and_aborts() {
         "no park may open for a failure waiting cannot fix"
     );
 }
+
+/// A [`crate::ports::TurnSteering`] that answers "no" until the `latch_on`th
+/// ask and "yes" from then on — a person pressing Esc while the turn is
+/// already parked. The step boundary asks once before the model call, so a
+/// latch at the boundary would end the turn before any park could open.
+struct StopOnAsk {
+    asks: AtomicU32,
+    latch_on: u32,
+}
+
+impl crate::ports::TurnSteering for StopOnAsk {
+    fn drain_steering(&self) -> Vec<String> {
+        Vec::new()
+    }
+    fn soft_stop_requested(&self) -> bool {
+        self.asks.fetch_add(1, Ordering::SeqCst) + 1 >= self.latch_on
+    }
+}
+
+/// #2743's witness: a soft stop landing mid-park ends the turn the way a
+/// soft stop at a step boundary does.
+///
+/// The park sits INSIDE the model-call ladder, so aborting it surfaced the
+/// pending `RateLimited` — the turn ended as `Aborted { Failure }` with a
+/// `RetriesExhausted` + `Error` pair, recording a provider failure for what
+/// was a person's decision. The provider really was rate limiting; that is
+/// simply not why the turn ended.
+#[tokio::test]
+async fn a_soft_stop_during_a_park_ends_the_turn_as_a_deliberate_stop() {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Err(throttled())]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    // Ask 1 is the step boundary's, which must answer "no" or the turn ends
+    // before a park exists; ask 2 is the park's first per-chunk tick.
+    let steering = StopOnAsk {
+        asks: AtomicU32::new(0),
+        latch_on: 2,
+    };
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+        .with_steering(&steering);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(
+            outcome,
+            TurnOutcome::Aborted { ref reason, kind: AbortKind::DeliberateStop, .. }
+                if reason == SOFT_STOP_REASON
+        ),
+        "a mid-park Esc must settle as the step-boundary soft stop does: {outcome:?}"
+    );
+    let events = drain_events(&mut rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TurnParked { .. })),
+        "the park must have opened, or this proves nothing: {events:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::TurnWoken { reason, .. } if reason == "soft_stop"
+        )),
+        "the park closes naming the soft stop: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::RetriesExhausted { .. })),
+        "a user decision is not an exhausted ladder: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, AgentEvent::Error { .. })),
+        "a user decision surfaces no provider failure: {events:?}"
+    );
+}

--- a/crates/stella-core/src/mining.rs
+++ b/crates/stella-core/src/mining.rs
@@ -15,9 +15,11 @@ const STOPWORDS: &[&str] = &[
     "would", "should", "did",
 ];
 
-/// Terms dropped by [`score_terms`] ONLY — the low-selectivity coding
-/// vocabulary that appears in nearly every prompt a coding agent ever sees and
-/// therefore discriminates between no two skills.
+/// Terms dropped by [`score_terms`] ONLY — the low-selectivity vocabulary
+/// that appears in nearly every prompt a coding agent ever sees and therefore
+/// discriminates between no two skills: the generic coding words, the English
+/// function words that survive [`STOPWORDS`], and the two words this corpus
+/// puts in every skill description it has (`user`, `agent`).
 ///
 /// Deliberately **not** added to [`STOPWORDS`], because that constant is also
 /// consulted by [`terms`], which is the **id space**: every mined lesson's
@@ -34,13 +36,32 @@ const STOPWORDS: &[&str] = &[
 /// `SelectionConfig`'s two-shared-term corroboration floor on their own and
 /// injecting a dead-code-removal skill into a turn-loop debugging turn. The
 /// floor was never the defect; what it counted was.
+///
+/// The function words joined it the same way (#4384). [`STOPWORDS`] was
+/// written for the miners' lesson text and stops at 43 entries, so `they`,
+/// `its`, `itself`, `such` and their neighbours reached the score at full
+/// strength — and cleared the same corroboration floor in pairs. Session
+/// `ses-1787465453163-60967` recorded the selections verbatim: a TUI
+/// keybinding turn drew `source-command-update-docs` on `terms: source, such`
+/// and `find-skills` on `terms: agent, they`, and a PR-watcher turn drew
+/// `ultra-audit` on `terms: its, itself, number, user`.
+///
+/// A hand list is the cheap answer, not the durable one: what makes `user`
+/// and `agent` noise is that *every* installed skill's description carries
+/// them, which is a property of the corpus and would be measured by IDF over
+/// it rather than declared here. That is its own change — this one stops the
+/// misfires the trace shows.
 const SCORING_STOPWORDS: &[&str] = &[
     "code", "find", "fix", "add", "make", "use", "used", "using", "get", "set", "run", "check",
     "problem", "issue", "bug", "error", "test", "tests", "file", "files", "function", "method",
     "line", "lines", "change", "update", "new", "old", "work", "works", "need", "want", "help",
     "please", "can", "could", "how", "what", "why", "does", "any", "all", "some", "more", "most",
     "just", "also", "one", "two", "there", "here", "out", "off", "way", "thing", "things", "about",
-    "like", "look", "see", "show", "tell", "give", "take", "know", "think",
+    "like", "look", "see", "show", "tell", "give", "take", "know", "think", "they", "them",
+    "their", "theirs", "its", "itself", "she", "her", "hers", "herself", "him", "his", "himself",
+    "our", "ours", "your", "yours", "yourself", "such", "these", "those", "each", "every",
+    "another", "other", "others", "both", "same", "who", "whom", "whose", "been", "being",
+    "having", "very", "quite", "rather", "still", "even", "user", "agent",
 ];
 
 /// Split text into lowercased, de-stopped terms (>2 chars) for lexical
@@ -348,8 +369,8 @@ mod tests {
     }
 
     /// #3688: generic coding vocabulary is dropped from the *scoring* space
-    /// and kept in the *id* space. Both halves matter — dropping them from
-    /// `terms` would re-tokenize every minted `<slug>-<hash8>`.
+    /// and kept in the *id* space — dropping it from `terms` would re-tokenize
+    /// every minted `<slug>-<hash8>`.
     #[test]
     fn score_terms_drops_generic_coding_words_that_the_id_space_keeps() {
         let text = "find a problem with stellas turn loop code";

--- a/crates/stella-core/src/retry.rs
+++ b/crates/stella-core/src/retry.rs
@@ -77,8 +77,16 @@ const PARK_BACKOFF_CAP_MS: u64 = 300_000;
 pub enum ParkDirective {
     /// Keep waiting: sleep the next chunk.
     Continue,
-    /// End the park now and surface the parked error — the caller saw a
-    /// soft stop (or decided the wait is no longer worth it).
+    /// End the park now and surface the parked error.
+    ///
+    /// Deliberately reasonless: *why* a park ended early is the supervisor's
+    /// own knowledge, and the supervisor is caller-side, so it records the
+    /// answer where it can act on it rather than routing it back through this
+    /// module (`driver::rate_limit`'s `soft_stopped` is the engine's — it is
+    /// what lets a mid-park Esc settle as the step-boundary soft stop instead
+    /// of a provider failure, #2743). Carrying the reason here would teach
+    /// `retry` about steering, which is the coupling this port exists to
+    /// prevent.
     Abort,
 }
 

--- a/crates/stella-core/src/shell_text.rs
+++ b/crates/stella-core/src/shell_text.rs
@@ -34,6 +34,11 @@
 /// command and begins the next. Redirection tokens (`2>&1`, `>>`, `<`) are
 /// deliberately **not** operator words — they neither end a command nor start
 /// one, and `stella-tools`' `redirect_target` reads them as ordinary words.
+///
+/// Neither are the paren words [`shell_words`] emits (`(`, `)`, `$(`). They
+/// are word boundaries, not separators: `(` *introduces* a command, and a
+/// consumer that treated it as one would read `echo (cd /outside` as a
+/// directory change the shell never performs.
 pub fn is_operator_word(word: &str) -> bool {
     matches!(word, ";" | "&" | "&&" | "|" | "||" | "\n")
 }
@@ -48,6 +53,11 @@ pub fn is_operator_word(word: &str) -> bool {
 /// word, so `cd /app; ls` yields the target `/app`, not the unresolvable
 /// `/app;` a paid bench trial saw warned about as an escape from its own
 /// session root.
+///
+/// The subshell parens split for the same reason and are emitted the same
+/// way, `$(` as one opener; unlike the operators they are not
+/// [`is_operator_word`]s, because `(` starts a command rather than ending
+/// one.
 pub fn shell_words(command: &str) -> Vec<String> {
     let mut words: Vec<String> = Vec::new();
     let mut cur = String::new();
@@ -77,6 +87,35 @@ pub fn shell_words(command: &str) -> Vec<String> {
                     op.push(c);
                 }
                 words.push(op);
+            }
+            // A paren bounds a command rather than belonging to the word
+            // beside it: `(` opens a subshell, `)` closes one and also
+            // terminates a `case` pattern. Glued to the adjacent word they hid
+            // a real directory change from every consumer that reads command
+            // position — `(cd /outside; ls)` yielded `["(cd", …]`, so no word
+            // ever equalled `cd` (#3619), while the spaced `( cd /outside )`
+            // had been read correctly all along.
+            //
+            // Each is emitted alone: neither pairs the way `&&` does, so `((`
+            // is two words. The one exception is `$(`, which is a single
+            // command-substitution opener rather than a `$` word beside a
+            // subshell — split in two, the `$` sits between the opener and the
+            // command and hides it again.
+            '(' | ')' if !in_single && !in_double => {
+                let substitution = c == '(' && cur.ends_with('$');
+                if substitution {
+                    cur.pop();
+                    has_word = !cur.is_empty();
+                }
+                if has_word {
+                    words.push(std::mem::take(&mut cur));
+                    has_word = false;
+                }
+                words.push(if substitution {
+                    String::from("$(")
+                } else {
+                    String::from(c)
+                });
             }
             '\\' if !in_single => {
                 // Keep the escape literal (covers `\|`, `\"`, …); we don't
@@ -201,6 +240,28 @@ mod tests {
         assert_eq!(shell_words("cd /app; ls"), ["cd", "/app", ";", "ls"]);
         assert_eq!(shell_words("a&&b"), ["a", "&&", "b"]);
         assert_eq!(shell_words("echo 'a;b'"), ["echo", "a;b"]);
+    }
+
+    /// The paren words, which bound a command without separating two: the
+    /// glued spelling has to tokenize the way the spaced one already did, or
+    /// the `cd` inside a subshell is never a word at all (#3619).
+    #[test]
+    fn subshell_parens_are_words_of_their_own() {
+        assert_eq!(
+            shell_words("(cd /outside; ls)"),
+            ["(", "cd", "/outside", ";", "ls", ")"]
+        );
+        assert_eq!(shell_words("( cd /x )"), ["(", "cd", "/x", ")"]);
+        // `$(` is one opener; a `$` word beside a subshell would sit between
+        // the opener and the command it introduces.
+        assert_eq!(shell_words("$(cd /x)"), ["$(", "cd", "/x", ")"]);
+        assert_eq!(shell_words("out=$(pwd)"), ["out=", "$(", "pwd", ")"]);
+        // Quoted and escaped parens stay inside the word.
+        assert_eq!(shell_words("echo '(cd /x)'"), ["echo", "(cd /x)"]);
+        assert_eq!(
+            shell_words(r"find . \( -name x \)"),
+            ["find", ".", r"\(", "-name", "x", r"\)"]
+        );
     }
 
     #[test]

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -334,6 +334,66 @@ fn generic_coding_words_alone_do_not_select_a_skill() {
     );
 }
 
+/// **Witness (#4384).** English function words shared with a skill's wording
+/// no longer select it.
+///
+/// Fails on base, where `they`, `its`, `itself`, `such`, `user` and `agent`
+/// were in neither stopword list and so scored at full strength — two of them
+/// clearing the corroboration floor on their own. The three skills below are
+/// the three session `ses-1787465453163-60967` recorded, each reconstructed
+/// from the terms the `skill_usage` row gave as its reason; the prompt is a
+/// TUI keybinding task, which none of them is about.
+///
+/// The second half is what keeps it from being a blunt fix: the skill whose
+/// subject the prompt half-named (`source`) must still be reachable by a
+/// prompt that names the rest of it.
+#[test]
+fn english_function_words_alone_do_not_select_a_skill() {
+    let skills = vec![
+        skill(
+            "find-skills",
+            "help the user find the agent skills they can use",
+            &[],
+            SkillOrigin::Workspace,
+        ),
+        skill(
+            "ultra-audit",
+            "score a codebase by its number of defects, however large it is itself",
+            &[],
+            SkillOrigin::Workspace,
+        ),
+        skill(
+            "source-command-update-docs",
+            "regenerate the docs for such a source command",
+            &[],
+            SkillOrigin::Workspace,
+        ),
+    ];
+    let prompt = "fix the source file picker so that when issues are selected they are \
+                  sent to the prompt itself, such that the user can see what its state is";
+
+    let selected = select_skills(&skills, prompt, &[], &SelectionConfig::default());
+    assert!(
+        selected.is_empty(),
+        "'they', 'its', 'itself', 'such', 'user' and 'agent' carry no information \
+         about this task: {selected:?}"
+    );
+
+    // …and the skill the prompt half-named is still reachable.
+    let selected = select_skills(
+        &skills,
+        "regenerate the source command docs",
+        &[],
+        &SelectionConfig::default(),
+    );
+    assert_eq!(
+        selected.len(),
+        1,
+        "a prompt naming the skill's actual subject must still select it: {selected:?}"
+    );
+    assert_eq!(selected[0].skill.name, "source-command-update-docs");
+}
+
 /// **Witness (#3298).** A non-Latin prompt whose wording matches a skill's
 /// description selects that skill.
 ///

--- a/crates/stella-core/src/summarize.rs
+++ b/crates/stella-core/src/summarize.rs
@@ -37,6 +37,50 @@ pub(crate) fn cap_chars(s: &str, cap: usize) -> String {
     format!("{}[…]", &s[..end])
 }
 
+/// What a dropped head is replaced by, so the summarizer is told it is
+/// looking at the newer part of a longer log rather than the whole of a
+/// short one — and so a reader of the request can tell the two apart.
+const DROPPED_HEAD_MARKER: &str = "[older history dropped: it exceeded the summarizer's own \
+                                   context window and was never summarized]\n";
+
+/// The newer half of an already-rendered span, with its older head dropped.
+///
+/// The one branch reactive overflow recovery could not repair is a
+/// *summarizer request* that itself overflows: the call that exists to shrink
+/// the transcript is rejected for being too large, so the span is left intact
+/// and the turn aborts (#2751). Dropping the head is the only lever left — the
+/// content is lost unsummarized, which is why the splice marker says so.
+///
+/// The cut lands on the next line boundary at or after the halfway byte, so
+/// the tail opens on a whole rendered record rather than mid-way through one;
+/// falling back to the next char boundary when the half has no newline left
+/// in it. `None` when the drop would not actually shrink the request — an
+/// empty render, a half that leaves no tail, or one so short that the marker
+/// costs more than the head saved — so a caller looping on this always
+/// terminates.
+pub(crate) fn drop_span_head(rendered: &str) -> Option<String> {
+    let half = rendered.len() / 2;
+    if half == 0 {
+        return None;
+    }
+    let cut = match rendered[half..].find('\n') {
+        Some(offset) => half + offset + 1,
+        None => {
+            let mut cut = half;
+            while !rendered.is_char_boundary(cut) {
+                cut += 1;
+            }
+            cut
+        }
+    };
+    let tail = &rendered[cut..];
+    if tail.is_empty() {
+        return None;
+    }
+    let shorter = format!("{DROPPED_HEAD_MARKER}{tail}");
+    (shorter.len() < rendered.len()).then_some(shorter)
+}
+
 /// Flatten a message span into the summarizer's input: roles, text, tool
 /// calls with their inputs, and truncated results — enough to reconstruct
 /// WHAT happened without re-shipping the content that overflowed.
@@ -79,4 +123,49 @@ pub(crate) fn render_span_for_summary(span: &[CompletionMessage]) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DROPPED_HEAD_MARKER, drop_span_head};
+
+    /// The cut keeps the newer tail, opens it on a whole rendered record,
+    /// and names what went — and it converges, which is what lets the caller
+    /// loop on it (#2751).
+    #[test]
+    fn dropping_a_head_keeps_the_newer_tail_and_converges() {
+        let rendered: String = (0..40).map(|i| format!("assistant: line {i}\n")).collect();
+        let once = drop_span_head(&rendered).expect("a long render has a head to drop");
+        assert!(once.starts_with(DROPPED_HEAD_MARKER));
+        assert!(once.len() < rendered.len());
+        // The tail opens on a whole record and still carries the newest one.
+        let tail = once.strip_prefix(DROPPED_HEAD_MARKER).unwrap();
+        assert!(tail.starts_with("assistant: line "), "{tail}");
+        assert!(tail.ends_with("assistant: line 39\n"), "{tail}");
+        assert!(!once.contains("line 0\n"), "the oldest record is gone");
+
+        // Repeated dropping terminates rather than growing on the marker.
+        let mut current = once;
+        while let Some(shorter) = drop_span_head(&current) {
+            assert!(shorter.len() < current.len());
+            current = shorter;
+        }
+    }
+
+    /// Nothing worth dropping answers `None`, so a caller looping on this
+    /// never spins on a render it cannot shrink.
+    #[test]
+    fn a_render_with_no_head_to_drop_is_refused() {
+        assert_eq!(drop_span_head(""), None);
+        assert_eq!(drop_span_head("assistant: hi\n"), None);
+    }
+
+    /// The halfway byte can land inside a multi-byte char; the cut walks to
+    /// a boundary rather than panicking on a slice.
+    #[test]
+    fn a_multibyte_render_cuts_on_a_char_boundary() {
+        let rendered = "форматировать".repeat(40);
+        let shorter = drop_span_head(&rendered).expect("a long render can shed a head");
+        assert!(shorter.len() < rendered.len());
+    }
 }

--- a/crates/stella-tools/src/bash/words.rs
+++ b/crates/stella-tools/src/bash/words.rs
@@ -33,9 +33,11 @@
 //! same data text can refuse a read the shell never performs (#3618).
 //!
 //! Command position is read from the word *before* the `cd`, so it is only as
-//! good as the splitter's word boundaries: `(` and `)` are ordinary word
-//! characters there, which is why the glued `(cd /outside; ls)` is still
-//! missed (#3619). Every miss here is silence, never a wrong note.
+//! good as the splitter's word boundaries. `(`, `)` and `$(` became words of
+//! their own in #3619, which is what lets the glued `(cd /outside; ls)` read
+//! the same as the spaced `( cd /outside )`. A backtick substitution
+//! (`` `cd /outside` ``) is still one word and still missed. Every miss here
+//! is silence, never a wrong note.
 
 use std::path::Path;
 
@@ -280,10 +282,14 @@ fn next_word_is_a_command(word: &str, word_is_a_command: bool) -> bool {
 /// `for`, `select`, `case` and `in` are absent on purpose: what follows them
 /// is a name or a word list, not a command, and the command only starts at
 /// the `do`/`)` that closes the header.
+///
+/// `$(` is here beside `(` because a command substitution runs its body the
+/// same way a subshell does — `out=$(cd /outside && pwd)` really does leave
+/// the session root.
 fn introduces_a_command(word: &str) -> bool {
     matches!(
         word,
-        "if" | "then" | "elif" | "else" | "while" | "until" | "do" | "{" | "(" | "!"
+        "if" | "then" | "elif" | "else" | "while" | "until" | "do" | "{" | "(" | "$(" | "!"
     )
 }
 
@@ -495,6 +501,51 @@ mod tests {
                 cd_escape_target(command, &root).as_deref(),
                 Some("/outside"),
                 "{command} escapes the root and must still warn"
+            );
+        }
+    }
+
+    /// The glued spelling of the subshell, which the spaced `( cd /outside )`
+    /// above had covered since #2301 while `(cd /outside; ls)` said nothing:
+    /// the splitter kept the paren attached to the word, so no word ever
+    /// equalled `cd` and the detector had nothing to look at (#3619).
+    #[test]
+    fn a_cd_glued_to_a_subshell_paren_is_still_an_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        assert_eq!(cd_escape_target("(cd /; ls)", &root).as_deref(), Some("/"));
+        for command in [
+            "(cd /outside; ls)",
+            "(cd /outside && make)",
+            "$(cd /outside && pwd)",
+            "out=$(cd /outside && pwd)",
+        ] {
+            assert_eq!(
+                cd_escape_target(command, &root).as_deref(),
+                Some("/outside"),
+                "{command} escapes the root and must still warn"
+            );
+        }
+        // The in-root glued form stays silent, and names no `/outside;`.
+        assert_eq!(cd_escape_target("(cd .; ls)", &root), None);
+    }
+
+    /// The over-suppression counterpart of the glued form: a paren that is
+    /// *data* still promotes nothing, so a quoted or echoed `(cd` is silent.
+    #[test]
+    fn a_paren_in_data_does_not_promote_a_cd() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        for command in [
+            "echo \"(cd /outside)\"",
+            "echo '(cd /outside)'",
+            "echo (cd /outside",
+            "echo $(cd /outside",
+        ] {
+            assert_eq!(
+                cd_escape_target(command, &root),
+                None,
+                "{command} runs no cd and must stay silent"
             );
         }
     }


### PR DESCRIPTION
Six `stella-core` issues, one commit each.

## What

**#3619 — `shell_words` glued a paren onto the adjacent word.** `(cd /outside; ls)` tokenized as `["(cd", "/outside", ";", "ls)"]`, so no word ever equalled `cd` and `cd_escape_target` drew no drift note — while the *spaced* `( cd /outside )`, the same subshell, had been warned about since #2301. `(` and `)` are now words of their own, with `$(` emitted whole (split into `$` and `(`, the `$` sits between the opener and the command it introduces and hides it again). `introduces_a_command` gains `$(` beside the `(` it already accepted. They are deliberately **not** `is_operator_word`s: `(` starts a command rather than ending one, and a consumer reading it as a separator would take `echo (cd /outside` — which runs no `cd` — for a directory change.

**#3624 — the stall rung counts requested sleep seconds.** The issue's point was that the choice was made *implicitly*, and any of its three shapes is defensible. Decided: keep counting the request, and say so in the doc. Skipping errored calls stays deterministic but goes blind on the worst real shape — three `sleep 300`s that `bash` killed at 120s each burn 360s of wall clock and would count **zero**. Clamping to the call's own timeout teaches `stella-core` a tool's parameter name and default, which matching on a `command` string exists to avoid. What is left can only steer *early*, on a rung with no abort that warns once per turn. **Behaviour is unchanged by design** — the new `stall` case is a characterization test, not a witness, so the next reader inherits the decision rather than the silence. Easy to reverse if you want a different arm.

**#4384 — skill selection matched on English function words.** `they`, `its`, `itself`, `such` were in neither stopword list, so they scored at full strength and cleared the two-shared-term corroboration floor in pairs. The standard function-word set joins `SCORING_STOPWORDS` (scoring space only — `STOPWORDS` is the id space every `<slug>-<hash8>` derives from), along with `user` and `agent`, which every skill description in this corpus carries. The doc names IDF over the installed corpus as the durable answer and says why a hand list is not it.

**#2770 — the two recovery rungs now compose.** `settle_model_call_failure`'s `Exhausted` arm consulted `attempt_provider_fallback`; the `ContextOverflow` arm went straight from a spent compaction ladder to `surface_unrecovered`. Composed as an explicit try-once rather than the window-size-aware variant #2679 deferred: #2679's set-once latch is the whole bound, so no `ProviderProfile` window field and no second bound are needed. `attempt_provider_fallback` takes a `FallbackCause` because the notice was claiming the wrong thing — a swap announced as "`x` exhausted its retries" when the ladder never ran is a misreport. The exhausted arm's bytes are unchanged.

**#2751 — a summarizer request that itself overflows now repairs.** That rejection landed in the ordinary `AccountedCallError::Provider` arm ("context left intact"), the one branch reactive recovery could not fix: the call that exists to shrink the transcript was refused for being too big. The older head of the render is dropped and the summarizer re-asked, bounded at three dispatches, with `summarize::drop_span_head` refusing a drop that would not shrink the request so the loop terminates on its own too. The dropped content is lost *unsummarized*, so the splice marker says so **inside its brackets** — every consumer recognising the marker by prefix is unaffected. The splice bounds are untouched, which is what keeps the transcript well-paired: the same `start..end` the Tool-message walks chose is replaced; only what the summary was written *from* is smaller.

**#2743 — a soft stop during a rate-limit park is a deliberate stop.** `RateLimitPark` records that it was the latch that ended the park — the supervisor is the only thing that knows why it aborted, and it is engine-side, so `ParkDirective` stays a bare instruction and `retry.rs` never learns about steering. `drive_attempt_ladder` maps it to `ModelCallFailure::SoftStopped`, checked *before* the breaker feedback since a ladder that did not exhaust is no evidence of ill health. Settled in `settle_model_call_failure` so every ending of a model call leaves through one door, byte-identical to the step-boundary exit.

## Evidence

Targeted only — no workspace build, no `make gate`. CI is the evidence for the rest.

Witnesses, each run against `origin/main` (source files reverted, tests kept) and then with the change:

| Issue | Witness | On `main` | With the change |
|---|---|---|---|
| #3619 | `stella-tools` `bash::words::tests::a_cd_glued_to_a_subshell_paren_is_still_an_escape` | FAILED — `left: None, right: Some("/")` | ok |
| #4384 | `stella-core` `skills::tests::english_function_words_alone_do_not_select_a_skill` | FAILED — selected all three, with the recorded reasons reproduced verbatim: `matched_terms: ["they", "user"]`, `["source", "such"]`, `["its", "itself"]` | ok |
| #2770 | `driver::tests::context_overflow::a_spent_overflow_ladder_swaps_to_the_fallback_and_the_turn_completes` + `…a_fallback_that_also_overflows_is_terminal_with_no_second_swap` | both FAILED | both ok |
| #2751 | `driver::tests::context_overflow::a_summarizer_request_that_overflows_drops_its_head_and_still_folds_the_span` + `head_dropping_is_bounded_when_no_span_size_is_accepted` | both FAILED (the bound one: `left: 1, right: 3`) | both ok |
| #2743 | `driver::tests::parked_wait::a_soft_stop_during_a_park_ends_the_turn_as_a_deliberate_stop` | FAILED — `Aborted { reason: "model call failed: provider rate limited: throttled", kind: Failure }`, exactly the misclassification the issue describes | ok |

**#3624 ships no witness**: the decision is to keep the current behaviour, so the new test passes on `main` too. It is a characterization test and the commit body says so.

Also run:

- `cargo test -p stella-core` — 1367 + 4 + 1 + 1 + 2 + 1 pass, 0 failed.
- `cargo test -p stella-tools` — 517 lib plus every integration target pass; `write_scope_witness` 17/17 (the tokenizer change moves argument boundaries for `segment_args` and the write fence, so this is the one that mattered).
- `cargo clippy -p stella-core -p stella-tools --all-targets -- -D warnings` — clean.
- `cargo fmt --all`.
- `make guards-fast` plus every toolchain-free guard individually: `file-size` (OK — "nothing went over by this change"), `god-files`, `left-behind`, `prose` ("723 grandfathered, none added"), `typed-errors`, `dead-code-allows`, `role-names`, `stat-portability`, `module-reachability`, `diagnostic-codes`, `gate-parity`, `command-docs`, `brand-case`, `tokens`, `hue-separation`, `transcript-surfaces`, `lockfile-sync` — all OK.

Rebased onto `e1886e310` after #4395 moved `loop_escalation`'s inline `mod tests` into `driver/loop_escalation/tests.rs`; the #3624 characterization test moved with it and every command above was re-run on the rebased branch. `make invariants` and `make doc-links` were red on the previous base and both pass on this one.

No baseline file, `Cargo.lock`, or `deny.toml` was touched. No new dependency. No test was deleted.

## Not done

Nothing in the batch was skipped. Two things noticed and not fixed, for filing:

1. **`segment_args` reads past a `)`.** In `crates/stella-tools/src/bash.rs`, a command's argument reach stops at `is_operator_word`, and `)` is not one - so for `( mv /x/a /y/b )` the `rfind` for the last positional picks `)` and the real write target goes unchecked. **Pre-existing**, not introduced here: the *spaced* subshell already tokenized this way on `main`, and #3619 only makes the glued form behave the same. The fix is either `)` as an operator word (needs care: `(` must stay a non-operator or `echo (cd /outside` starts warning again) or a reach bound that knows about subshells. Done = a `write_scope_witness` case refusing `( mv x /etc/passwd )`.
2. **A backtick substitution is still missed** by `cd_escape_target`: a backticked `cd /outside` is one word to the splitter. Named in `bash/words.rs`'s module doc rather than left silent. Same class as #3619, outside its stated scope.

Three earlier findings were resolved by the rebase onto `e1886e310` and are dropped: `make invariants` and `make doc-links` were red on the old base and both pass now (#4397 deleted `AUTOFIX_HANDOFF.md` and repaired the drifted citations), and #4395's split of the inline `mod tests` leaves `loop_escalation.rs` at **582 lines**, so the 1494/1500 ceiling warning no longer applies.

Closes #3619
Closes #3624
Closes #4384
Closes #2770
Closes #2751
Closes #2743
