### PR TITLE
fix(bench,arenabench): tomllib fallback, double-fetch, staged-pipeline lie

### DIFF
--- a/arenabench/arenabench/cloud_executor.py
+++ b/arenabench/arenabench/cloud_executor.py
@@ -515,12 +515,39 @@ class CloudExecutor:
             target.write_bytes(body)
             fetched += 1
         if artifacts:
-            fetched += self._fetch_prefix(f"runs/{run_id}/", dest, out=out)
+            # A gated watch already pulled every settled job's whole prefix
+            # into `dest/<label>/` as it finished (`.gate_watch.GateWatch`).
+            # Route this run-level pass onto the same label directories
+            # rather than the raw job-id ones, so the two writers land on one
+            # tree instead of two full byte copies of every job (#3400).
+            labels = {str(job["id"]): str(job["label"]) for job in jobs}
+            fetched += self._fetch_prefix(
+                f"runs/{run_id}/", dest, out=out, relabel=labels
+            )
         return fetched
 
     def _fetch_prefix(
-        self, prefix: str, dest: Path, *, out: Callable[[str], None]
+        self,
+        prefix: str,
+        dest: Path,
+        *,
+        out: Callable[[str], None],
+        relabel: Mapping[str, str] | None = None,
     ) -> int:
+        """Download every object under ``prefix``, skipping what is already there.
+
+        ``relabel`` rewrites a key's first path segment (a job id) to that
+        job's label, so a key already fetched by a per-job caller — the gate
+        watcher's settlement fetch — lands in the same directory this pass
+        would otherwise duplicate it into. Non-job-scoped keys (the run's
+        ``match.toml``, ``jobs.json``, the ``trials/`` slices) have no entry
+        in ``relabel`` and pass through with their key's own path.
+
+        A target that already exists at the size S3 reports costs this pass
+        one ``list_objects_v2`` page and no ``get_object`` — the LIST is
+        unavoidable (this call must still discover what changed), the GET is
+        what the redundant download was spending (#3400).
+        """
         s3 = self._client("s3")
         bucket = self.bucket()
         count = 0
@@ -532,7 +559,16 @@ class CloudExecutor:
                 relative = key.removeprefix(prefix)
                 if not relative or relative.endswith("/"):
                     continue
+                if relabel:
+                    head, sep, rest = relative.partition("/")
+                    label = relabel.get(head)
+                    if label is not None and sep:
+                        relative = f"{label}/{rest}"
                 target = dest / relative
+                size = entry.get("Size")
+                if target.exists() and (size is None or target.stat().st_size == size):
+                    count += 1
+                    continue
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(
                     s3.get_object(Bucket=bucket, Key=key)["Body"].read()

--- a/arenabench/arenabench/config.py
+++ b/arenabench/arenabench/config.py
@@ -334,7 +334,7 @@ def match_from_toml(data: dict[str, Any], *, match_id: str | None = None) -> Mat
             # engine was that a match cannot lie about which one it used.
             problems.append(
                 f"{where}: bare_loop applies only to a stella seat — "
-                f"{agent!r} has no staged pipeline to switch off"
+                f"{agent!r} is a different agent entirely"
             )
         if engine.tool_set and agent and agent != "stella":
             # The same refusal, for the same reason, on the knob that arrived

--- a/arenabench/arenabench/model.py
+++ b/arenabench/arenabench/model.py
@@ -415,8 +415,8 @@ def declared_flag(value: Any) -> bool | None:
 
     ``bool(value)`` is the wrong reader for a config flag: it answers ``True``
     for the string ``"false"``, for the sole reason that it is not empty. A
-    seat spelled to run the staged pipeline would then run the bare loop — a
-    selector spelled to close must never open, which is the discipline
+    seat spelled ``bare_loop = "false"`` would then be read as having asked
+    for it — a selector spelled to close must never open, which is the discipline
     ``STELLA_TRUST_PROJECT`` paid for.
 
     Returning ``None`` for anything unrecognised is what lets each caller
@@ -486,13 +486,19 @@ class Engine:
     effort: str = "high"
     #: Explicit base URL override. ``None`` uses the api's default route.
     base_url: str | None = None
-    #: Run the agent's raw step loop instead of its staged pipeline. For Stella
-    #: that is ``--no-pipeline``, which settles triage, witness and verify at
-    #: once because all three ARE the pipeline. Declared on the engine rather
-    #: than exported at launch: the runner scrubs every ambient ``STELLA_*`` so
-    #: a host setting can never quietly reconfigure a seat, and which loop an
-    #: arm ran belongs in the match's published identity either way. Agents
-    #: with no pipeline ignore it, like the role overrides below.
+    #: Declares an explicit ask for the agent's raw step loop. Historically
+    #: this settled ``--no-pipeline`` for Stella, when ``stella run`` still had
+    #: a staged pipeline to turn off; post-#3865 that pipeline is deleted from
+    #: the workspace and the raw step loop is the only one the binary can run,
+    #: so the flag this arm carries no longer changes what the seat does (see
+    #: ``bench/harbor_adapter/stella_harbor/loop_mode.py``, #4023). Kept as a
+    #: declaration rather than retired: a template's stated intent to measure
+    #: the bare loop is still worth refusing on any non-``stella`` seat
+    #: (``arenabench/arenabench/config.py``) and still worth recording.
+    #: Declared on the engine rather than exported at launch: the runner
+    #: scrubs every ambient ``STELLA_*`` so a host setting can never quietly
+    #: reconfigure a seat. Agents with no pipeline ignore it, like the role
+    #: overrides below.
     bare_loop: bool = False
     #: The exact tools this seat's agent is offered, or ``()`` for the shipping
     #: catalog. For Stella that is ``STELLA_LEAN_TOOLS``. (Some archived

--- a/arenabench/tests/cloud_fakes.py
+++ b/arenabench/tests/cloud_fakes.py
@@ -64,7 +64,9 @@ class FakeS3:
         prefix = str(kwargs.get("Prefix") or "")
         keys = sorted(k for k in self.objects if k.startswith(prefix))
         return {
-            "Contents": [{"Key": k} for k in keys],
+            "Contents": [
+                {"Key": k, "Size": len(self.objects[k])} for k in keys
+            ],
             "IsTruncated": False,
         }
 

--- a/arenabench/tests/test_cloud.py
+++ b/arenabench/tests/test_cloud.py
@@ -782,6 +782,56 @@ class TestFetchResults:
             "a missing results.json must be said out loud, not skipped silently"
         )
 
+    def test_a_gated_runs_settlement_fetch_is_not_downloaded_twice(
+        self, tmp_path
+    ) -> None:
+        """#3400: the gate watcher and the artifacts fetch must land on one
+        tree, not two full copies of every job's prefix."""
+        s3 = FakeS3(
+            {
+                "runs/r1/match.toml": b"template",
+                "runs/r1/jobs.json": b'{"jobs": []}',
+                "runs/r1/trials/000-stella-task-a/match.toml": b"slice",
+                "runs/r1/job-001/results.json": b'{"ok": true}',
+                "runs/r1/job-001/agent/stella-events.jsonl": b"{}\n",
+            }
+        )
+        jobs = [{"id": "job-001", "label": "000-stella-task-a"}]
+        executor = _executor(s3=s3)
+
+        # The gate watcher's settlement fetch — one job's whole prefix,
+        # straight into its label directory, exactly as `GateWatch.__call__`
+        # does mid-run.
+        executor._fetch_prefix(
+            "runs/r1/job-001/", tmp_path / "000-stella-task-a", out=lambda _: None
+        )
+        events_key = "runs/r1/job-001/agent/stella-events.jsonl"
+        assert [c for c in s3.calls if c == ("get_object", BUCKET, events_key)] == [
+            ("get_object", BUCKET, events_key)
+        ]
+
+        # The run-level fetch tail `cloud run`/`cloud fetch` issues afterwards.
+        fetched = executor.fetch_results(
+            "r1", jobs, tmp_path, artifacts=True, out=lambda _: None
+        )
+
+        assert fetched >= 1
+        assert [c for c in s3.calls if c == ("get_object", BUCKET, events_key)] == [
+            ("get_object", BUCKET, events_key)
+        ], "the job's artifact must be GET at most once across both fetches"
+        assert (
+            tmp_path / "000-stella-task-a" / "agent" / "stella-events.jsonl"
+        ).read_bytes() == b"{}\n", "both writers land on the label directory"
+        assert not (tmp_path / "job-001").exists(), (
+            "no second, job-uuid-named copy of the same prefix"
+        )
+        assert (tmp_path / "match.toml").read_bytes() == b"template", (
+            "run-scoped objects outside any job prefix are still fetched"
+        )
+        assert (
+            tmp_path / "trials" / "000-stella-task-a" / "match.toml"
+        ).read_bytes() == b"slice"
+
 
 def _single_task_result(task: str, contestant_id: str, reward: float) -> bytes:
     body = {

--- a/arenabench/tests/test_sut.py
+++ b/arenabench/tests/test_sut.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -785,6 +786,16 @@ def _stub_harbor(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "arenabench.harbor.supports_agent_import_path", lambda binary=None: False
+    )
+    # The stubbed "/usr/bin/harbor" above does not exist, so
+    # `adapter.harbor_interpreter`'s shebang read fails and it falls back to
+    # walking the (nonexistent) binary's parent directory, which resolves the
+    # system `/usr/bin/python3` on macOS — 3.9, with no `tomllib` (#4117).
+    # These tests are about wiring and provenance, not about which
+    # interpreter a real Harbor install ships with, so pin the answer to the
+    # interpreter actually running the test.
+    monkeypatch.setattr(
+        "arenabench.adapter.harbor_interpreter", lambda binary: sys.executable
     )
 
 

--- a/bench/harbor_adapter/stella_harbor/loop_mode.py
+++ b/bench/harbor_adapter/stella_harbor/loop_mode.py
@@ -8,41 +8,44 @@ on an already-oversized file.
 The seam is genuine. Nothing here knows what a Harbor agent is: every function
 takes a *reader* — one callable resolving an environment key to its configured
 value — so :meth:`StellaAgent._configured_value` supplies the real one and a
-test supplies ``{...}.get``. That is also what makes the invariant below
-mechanical rather than aspirational: the argv and the manifest are two
-projections of :func:`bare_loop_selected`, so they cannot disagree about which
-loop ran.
+test supplies ``{...}.get``.
 
-**What the selector selects.** ``stella run`` runs the staged pipeline by
-default; ``--no-pipeline`` runs the agent's raw step loop instead. One flag
-settles all three management stages at once, because triage, witness and
-verify *are* the pipeline — the bare loop has no stage to turn off
-individually. This is the arm that measures the agent loop itself: with the
-pipeline in, a board number folds worker capability together with
-triage/witness/verdict behaviour, and #2128/#2129 showed those stages can
-dominate it outright.
+**There is no staged pipeline left to select (#3865, #4023).** The built-in
+staged pipeline this module used to toggle is deleted from the workspace:
+``crates/stella-cli/src/wrapper_plugin.rs``'s ``PipelineChoice::resolve``
+refuses ``--pipeline classic`` outright, and every remaining resolution —
+with or without ``--no-pipeline`` — lands on the agent's raw step loop. So
+:func:`loop_mode_name` always publishes :data:`BARE_STEP_LOOP`: that is what
+the binary structurally runs on every arm, and a manifest claiming
+:data:`STAGED_PIPELINE` for an arm that said nothing would be publishing a
+loop this binary cannot run — the defect #4023 fixed. :data:`STAGED_PIPELINE`
+stays defined for a manifest describing a pre-#3865 run, never for one this
+adapter writes today.
 
-**Why it is host-only.** :data:`NO_PIPELINE_ENV` is read on the host and
-expressed purely as argv; nothing about it is forwarded into the task
-container, so it is registered in the adapter's ``_HOST_ONLY_STELLA_ENV``.
-That registration is not bookkeeping: the ambient check fails closed, so an
-unregistered selector would have refused the run rather than quietly running
-the other arm.
+**``--no-pipeline`` is a deprecated no-op, so :func:`loop_argv` never emits
+it.** The flag still parses (unlike ``--pipeline classic``), but changes
+nothing about which loop runs — ``crates/stella-cli/src/main.rs``'s
+``print_no_pipeline_notice_if_owed`` answers it with a deprecation notice on
+every trial for no behavioural difference. :func:`bare_loop_selected` and
+:data:`NO_PIPELINE_ENV` stay in place: a match template's declared intent to
+measure the bare loop is still real and still worth recording (a stella seat
+is refused at parse time on any other agent, ``arenabench/arenabench/config.py``),
+it just no longer has a CLI flag or a manifest value to disagree with.
+
+**Why it is host-only.** :data:`NO_PIPELINE_ENV` is read on the host; nothing
+about it is forwarded into the task container, so it is registered in the
+adapter's ``_HOST_ONLY_STELLA_ENV``. That registration is not bookkeeping: the
+ambient check fails closed, so an unregistered selector would have refused the
+run rather than quietly running the other arm.
 
 **Why a selector spelled to close must not open.** :func:`is_truthy` matches
 Stella's own vocabulary (``crates/stella-cli/src/settings.rs::truthy_flag``)
 exactly, and deliberately not "any non-empty value". ``STELLA_NO_PIPELINE=false``
-has to leave the pipeline **on**, the same way ``STELLA_TRUST_PROJECT=false``
-must not open the trust boundary. It is the adapter root's historical
-``_is_truthy``, moved here rather than copied: this module briefly shipped a
-second frozenset spelling the same four words, which is the drift the move
-prevents.
-
-**Why the mode is first-class in the manifest.** It is not inferable from the
-posture: the posture still names a verifier and a triage author on a bare-loop
-arm — inputs the CLI ignores once ``--no-pipeline`` is set — so a manifest
-showing only the posture would read as a pipeline run that merely never
-authored a witness, which is #2134's shape exactly.
+has to leave :func:`bare_loop_selected` **false**, the same way
+``STELLA_TRUST_PROJECT=false`` must not open the trust boundary. It is the
+adapter root's historical ``_is_truthy``, moved here rather than copied: this
+module briefly shipped a second frozenset spelling the same four words, which
+is the drift the move prevents.
 """
 
 from __future__ import annotations
@@ -88,27 +91,43 @@ def is_truthy(value: str | None) -> bool:
 
 
 def bare_loop_selected(configured: Reader) -> bool:
-    """Whether this arm runs the raw step loop instead of the pipeline.
+    """Whether this arm *declared* an explicit ask for the raw step loop.
 
-    The single resolution point both projections below read. Absent means the
-    pipeline, which is what ``stella run`` does by default — an arm has to ask
-    for the bare loop, so a match that says nothing measures the shipping
-    configuration.
+    Kept for the declaration's own sake — ``arenabench/arenabench/config.py``
+    still refuses ``bare_loop = true`` on any agent but ``stella`` at parse
+    time, so a template's intent is worth reading regardless of what the CLI
+    does with it. Since #3865 that intent no longer changes anything
+    downstream: see :func:`loop_argv` and :func:`loop_mode_name`.
     """
     return is_truthy(configured(NO_PIPELINE_ENV))
 
 
 def loop_argv(configured: Reader) -> tuple[str, ...]:
-    """The tokens ``run`` takes for this loop mode — empty for the pipeline.
+    """The tokens ``run`` takes for this loop mode — always empty (#4023).
 
-    ``--no-pipeline`` is a flag *of* ``run``, like ``--output-format`` and for
-    the same reason (stella#1493): it is a promise about this one invocation,
-    not a session-wide setting. Returning nothing for the default is what keeps
-    the pipeline's argv byte-identical to what it was before this arm existed.
+    ``--no-pipeline`` used to be a flag *of* ``run``, like ``--output-format``
+    and for the same reason (stella#1493): a promise about this one
+    invocation, not a session-wide setting. Post-#3865 it is a deprecated
+    no-op — every invocation already runs the raw step loop, flag or not — so
+    emitting it only earns the trial a deprecation notice
+    (``print_no_pipeline_notice_if_owed``) for a difference that does not
+    exist. ``configured`` is accepted and unused so the signature stays the
+    one seam :meth:`StellaAgent._build_command` calls through.
     """
-    return ("--no-pipeline",) if bare_loop_selected(configured) else ()
+    del configured
+    return ()
 
 
 def loop_mode_name(configured: Reader) -> str:
-    """The manifest's name for this loop mode."""
-    return BARE_STEP_LOOP if bare_loop_selected(configured) else STAGED_PIPELINE
+    """The manifest's name for this loop mode — always the raw step loop.
+
+    Post-#3865 that is the only loop the binary can structurally run
+    (``crates/stella-cli/src/wrapper_plugin.rs::PipelineChoice::resolve``
+    refuses ``--pipeline classic`` and lands every other resolution here
+    too), so publishing :data:`STAGED_PIPELINE` for an arm that said nothing
+    would claim a loop this binary cannot run — the defect #4023 fixed.
+    ``configured`` is accepted and unused for the same reason as
+    :func:`loop_argv`'s.
+    """
+    del configured
+    return BARE_STEP_LOOP

--- a/bench/harbor_adapter/tests/test_loop_mode.py
+++ b/bench/harbor_adapter/tests/test_loop_mode.py
@@ -1,10 +1,12 @@
 """Which loop an arm ran: the selector, the argv it produces, and the manifest.
 
 Three levels, because the bug this guards against can enter at any of them:
-the selector could accept a word spelled to close, the argv could drop a flag
-the match declared, or the manifest could publish a mode the command never
-ran. The last is the one nothing would have caught — a manifest is read long
-after the process that wrote it is gone.
+the selector could accept a word spelled to close, the argv could emit a flag
+that no longer does anything (#4023: `--no-pipeline` is a deprecated no-op
+post-#3865), or the manifest could publish a mode the command never ran. The
+last is the one nothing would have caught before #4023 — a manifest is read
+long after the process that wrote it is gone, and every published Stella arm
+was claiming `staged_pipeline` for a binary with no staged pipeline to run.
 
 Lives beside ``test_adapter.py`` rather than inside it for the reason
 :mod:`stella_harbor.loop_mode` lives beside the package root: both files sit
@@ -22,7 +24,6 @@ from stella_harbor import StellaAgent  # noqa: E402
 from stella_harbor.loop_mode import (  # noqa: E402
     BARE_STEP_LOOP,
     NO_PIPELINE_ENV,
-    STAGED_PIPELINE,
     bare_loop_selected,
     is_truthy,
     loop_argv,
@@ -73,50 +74,40 @@ class TestSelector:
         assert not bare_loop_selected(_reader(value))
 
     @pytest.mark.parametrize("value", SPELLED_ON + SPELLED_OFF)
-    def test_both_projections_derive_from_the_one_selection(
+    def test_both_projections_agree_the_bare_loop_is_all_there_is(
         self, value: str | None
     ) -> None:
-        """argv and manifest name are two views of one boolean, never two reads."""
+        """argv and manifest name agree regardless of the declared selection.
+
+        Post-#3865 there is no staged pipeline for either projection to name
+        — see :mod:`stella_harbor.loop_mode`'s module docstring — so both are
+        constant across the whole selector vocabulary (#4023). The selector
+        itself (:func:`bare_loop_selected`) still varies; it is asserted here
+        precisely so a future reader can see that its variation no longer
+        reaches either projection below.
+        """
         selected = bare_loop_selected(_reader(value))
-        assert loop_argv(_reader(value)) == (("--no-pipeline",) if selected else ())
-        assert loop_mode_name(_reader(value)) == (
-            BARE_STEP_LOOP if selected else STAGED_PIPELINE
-        )
+        assert selected == is_truthy(value)
+        assert loop_argv(_reader(value)) == ()
+        assert loop_mode_name(_reader(value)) == BARE_STEP_LOOP
 
 
 class TestArgv:
-    """The flag has to reach the command line, in the right position."""
+    """`--no-pipeline` must never reach the command line (#4023)."""
 
-    def test_bare_loop_arm_passes_no_pipeline_after_the_run_token(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The bare-loop arm exists at all: `--no-pipeline` reaches argv.
-
-        Without it there is no way to measure the raw step loop, so a match
-        comparing agent architectures silently measured the pipeline instead.
-        """
-        cmd = _agent(monkeypatch, "1")._build_command("Fix the bug")
-
-        assert "--no-pipeline" in cmd
-        # A flag OF `run`, never a global — clap rejects it before the subcommand.
-        assert cmd.index("--no-pipeline") > cmd.index("run")
-        assert cmd[-5:] == [
-            "--no-pipeline",
-            "--output-format",
-            "stream-json",
-            "--",
-            "Fix the bug",
-        ]
-
-    @pytest.mark.parametrize("value", SPELLED_OFF)
-    def test_the_pipeline_is_the_default_and_stays_byte_identical(
+    @pytest.mark.parametrize("value", SPELLED_ON + SPELLED_OFF)
+    def test_no_arm_emits_the_deprecated_flag_and_argv_stays_byte_identical(
         self, monkeypatch: pytest.MonkeyPatch, value: str | None
     ) -> None:
-        """Absent or explicitly-off leaves the shipping configuration running.
+        """Even a `bare_loop = true` arm's argv is the plain-`run` tail.
 
-        Asserting the exact tail, not just the flag's absence: the default
-        arm's argv must be what it was before this arm existed, or every
-        already-published pipeline result is measuring something new.
+        `--no-pipeline` is a deprecated no-op post-#3865 — every invocation
+        already runs the raw step loop, flag or not — and emitting it only
+        earns the trial a deprecation notice on every run
+        (`print_no_pipeline_notice_if_owed`) for a difference that does not
+        exist. Asserting the exact tail, not just the flag's absence: this
+        arm's argv must be what a plain `stella run` invocation is, or a
+        published result is measuring something the command line does not say.
         """
         cmd = _agent(monkeypatch, value)._build_command("Fix the bug")
 
@@ -162,16 +153,41 @@ class TestManifest:
         mode that disagrees with the command is not a stale label — it is a
         published result claiming to have measured an arm it never ran. #2134
         was that shape: a record read as a pipeline run that merely never
-        authored a witness.
+        authored a witness; #4023 was the same shape in the other direction —
+        a manifest naming a loop (`staged_pipeline`) the binary structurally
+        cannot run at all.
         """
         agent = _agent(monkeypatch, value)
         flagged = "--no-pipeline" in agent._build_command("Fix the bug")
 
         mode = self._loop_mode(agent)
 
-        assert mode == (BARE_STEP_LOOP if flagged else STAGED_PIPELINE)
-        # And pinned absolutely, so a rename of both sides at once still fails.
-        assert mode == (BARE_STEP_LOOP if is_truthy(value) else STAGED_PIPELINE)
+        assert not flagged, "no arm may emit the deprecated flag (#4023)"
+        assert mode == BARE_STEP_LOOP
+
+    @pytest.mark.parametrize("value", SPELLED_ON + SPELLED_OFF)
+    def test_the_manifest_agrees_with_pipelinechoice_resolve(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ) -> None:
+        """The assertion #4023 says was missing: manifest name vs CLI reality.
+
+        `crates/stella-cli/src/wrapper_plugin.rs::PipelineChoice::resolve`
+        refuses `--pipeline classic` outright and, with no `--pipeline` flag
+        at all — which is all this adapter ever passes — resolves every
+        remaining case to the raw step loop. That Rust decision cannot be
+        called from here, so this pins the one fact this suite can check
+        instead: this adapter never emits `--pipeline`, so `resolve` always
+        lands on the raw step loop, and the manifest must say exactly that
+        for every value the loop selector can take.
+        """
+        agent = _agent(monkeypatch, value)
+        cmd = agent._build_command("Fix the bug")
+
+        assert "--pipeline" not in cmd, (
+            "this adapter names no plugin, so PipelineChoice::resolve sees "
+            "no --pipeline flag and cannot land anywhere but the raw step loop"
+        )
+        assert self._loop_mode(agent) == BARE_STEP_LOOP
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- **#4117** — `arenabench/tests/test_sut.py`'s `_stub_harbor` pointed
  `harbor_bin` at a nonexistent `/usr/bin/harbor`, so `adapter.harbor_interpreter`'s
  shebang read failed and its beside-the-binary fallback resolved the real
  `/usr/bin/python3` on the developer's machine — 3.9.6 on macOS, no `tomllib`.
  `_stub_harbor` now also pins `adapter.harbor_interpreter` to `sys.executable`.
  Production `adapter.py` is unchanged: the fallback is correct for a real
  Harbor install, the bug was only in what the test stubbed.
- **#3400** — a gated `cloud run --artifacts` downloaded every job's whole S3
  prefix twice: once via `GateWatch`'s per-settlement fetch into
  `dest/<label>/`, again via `fetch_results`' run-level `_fetch_prefix` into
  `dest/<job-uuid>/`. `_fetch_prefix` now takes an optional job-id→label
  `relabel` map (routing a job-scoped key onto its label directory) and skips
  the `GET` when the target already exists at the size S3 reports. Run-scoped
  keys (`match.toml`, `jobs.json`, `trials/`) are unaffected — a single
  `_fetch_prefix` call still covers the whole run prefix, so nothing needed to
  fan out per job.
- **#4023** — `bench/harbor_adapter/stella_harbor/loop_mode.py` still
  published `stella_loop_mode = "staged_pipeline"` for an arm that said
  nothing, and emitted the deprecated `--no-pipeline` flag for one that asked
  for the bare loop. Post-#3865 `PipelineChoice::resolve` refuses
  `--pipeline classic` outright and every remaining resolution — flag or not —
  lands on the raw step loop, so every default-arm manifest was claiming a
  loop the binary cannot run. `loop_mode_name` now always returns
  `BARE_STEP_LOOP`; `loop_argv` never emits `--no-pipeline`.
  `bare_loop_selected`/`NO_PIPELINE_ENV` stay (a template's declared intent to
  measure the bare loop is still refused on a non-stella seat at parse time).
  Chased the stale "staged pipeline" premise through
  `arenabench/arenabench/model.py`'s `Engine.bare_loop` docstring and one
  `config.py` refusal message. `stella_loop_mode` is not a parameter of
  `_benchmark_engine_posture`, so no digest in `bench/READINESS.md` §8.4 moves.
- **#4393** — already fixed on `main`, no change needed. See "Not done" below.

## Evidence

**#4117** — reproduced first against the unmodified checkout on `main`:
`uv run --project arenabench pytest -q arenabench/tests/test_sut.py` → 5
failed, identical to the issue's reported trace (`AdapterUnavailableError:
/usr/bin/python3 cannot build a Stella seat ... No module named 'tomllib'`).
With the fixed `_stub_harbor`: 52 passed.

**#3400** — new test
`TestFetchResults.test_a_gated_runs_settlement_fetch_is_not_downloaded_twice`
in `arenabench/tests/test_cloud.py`. Reverted `cloud_executor.py` to
`origin/main`: fails (`the job's artifact must be GET at most once across
both fetches` — got 2 `get_object` calls for the same key). Restored the fix:
passes, and asserts `match.toml`/`trials/000-stella-task-a/match.toml` are
still fetched and no `job-001`-named directory appears on disk.
`uv run --project arenabench pytest -q arenabench/tests/test_cloud.py
arenabench/tests/test_gate.py`: 88 passed.

**#4023** — `bench/harbor_adapter/tests/test_loop_mode.py`, rewritten.
Reverted `loop_mode.py` to `origin/main`: 45 of 75 parametrized cases fail
(the old code asserts `staged_pipeline`/`--no-pipeline` for a plain arm).
Restored the fix: 75 passed, including a new
`TestManifest.test_the_manifest_agrees_with_pipelinechoice_resolve` pinning
that this adapter never emits `--pipeline`, so
`PipelineChoice::resolve` in `crates/stella-cli/src/wrapper_plugin.rs` cannot
land anywhere but the raw step loop.
`uv run --project bench/harbor_adapter pytest bench/harbor_adapter/tests -q`:
753 passed, 2 skipped (ambient `VOYAGE_API_KEY` unset).

**All commands run**, targeted per the CLAUDE.md rule (no workspace build):
```
uv run --project arenabench pytest arenabench/tests/test_sut.py -q
uv run --project arenabench pytest arenabench/tests/test_cloud.py arenabench/tests/test_gate.py arenabench/tests/test_assemble.py -q
uv run --project bench/harbor_adapter pytest bench/harbor_adapter/tests -q
uv run --project arenabench ruff check <changed files>
uv run --project bench/harbor_adapter ruff check <changed files>
make guards-fast
cargo fmt --all --check
```
`make guards-fast`: all guards pass, including `check-file-size` (the closed
`bench/harbor_adapter/tests/test_adapter.py` god file was **not** touched —
see "Not done"). No Rust files changed in this batch.

## Not done

- **#4393** — the two tests (`test_mounted_internal_stream_is_source_of_truth_and_is_not_overwritten`,
  `test_nonzero_exit_persists_stream_context_and_atif_before_raising`) were
  flaky against an ambient `VOYAGE_API_KEY` on `main` at the time the issue
  was filed. #4400 landed on `main` first (`bench/harbor_adapter/tests/conftest.py`'s
  new session-scoped, autouse `_strip_ambient_provider_credentials` fixture)
  and already strips `VOYAGE_API_KEY` — and every other provider/embedding/
  control credential — from every test's environment. Verified independently:
  with the two tests reverted to their pre-issue state and `VOYAGE_API_KEY`
  exported ambiently, both pass unmodified against the current `main`. I
  initially wrote the issue's suggested `monkeypatch.delenv` fix directly in
  the two tests, then reverted it — `bench/harbor_adapter/tests/test_adapter.py`
  is a grandfathered god file exactly at its baseline ceiling (2356 lines),
  closed to growth, and the change was redundant on top of #4400's fixture.
  Recommend closing #4393 with a reference to #4400 rather than merging a
  no-op diff against a closed-to-growth file.
- **#4039** (arena transcript prompt row) — skipped, out of this batch's
  scope. Investigated the reader side first: `arenabench/arenabench/transcript.py`'s
  `TranscriptReader` only ever reads a trial's `stella-events.jsonl`, and
  Stella's own event stream (`crates/stella-protocol`) has no event kind that
  carries the task's instruction text — grepped for `user_message`/
  `task_instruction`/`"prompt"` and found none. Nothing in `arenabench`'s own
  data model (`model.py`, `registry.py`, `harbor.py`) resolves a task's
  instruction text from Harbor's dataset either. So "emit the task
  instruction once, at the head of the trial" (the sketch's own first step)
  needs new plumbing this batch doesn't have: a way to source the instruction
  text at all (a Harbor dataset lookup? a value already resolved and threaded
  through `MatchRunner`/`TrialPlan` at submission time that I didn't find?),
  threaded through `ArenaServer.stream_transcript`/`full_transcript` and
  `TranscriptReader.read`, before any of the four rendering-layer changes
  (`transcript-page.tsx`'s `GROUPS`, `entry.tsx`'s new arm, the CSS that
  already exists, `check-transcript-view.mjs`) are reachable at all. That is
  a design question for how arenabench should source task instructions, not
  a bug fix — flagging as a maintainer decision rather than half-shipping the
  rendering half against data that does not exist yet.

## Left behind (not filed as issues — flagging for triage)

- `arenabench/ui/components/setup/seat-card.tsx:113`'s `pipelineInert = seat.engine.bare_loop`
  is now stale in the same direction #4023 fixed: post-#3865 role overrides
  are inert for **every** stella arm (there is no staged pipeline to consult
  them), not just a `bare_loop` one, so the UI only warns about incoherent
  role overrides on the arm that happens to have set `bare_loop = true`. Not
  fixed here — it is a UI/product decision (should the warning now show for
  every stella seat, or should the whole role-override UI be reconsidered)
  and outside this batch's Python scope.

Closes #4117
Closes #3400
Closes #4023

## Summary by Sourcery

Correct test interpreter selection, eliminate redundant cloud artifact downloads, and align Stella loop reporting with the raw loop now executed by the binary.

Bug Fixes:
- Prevent duplicate artifact downloads for gated cloud runs by reusing settled job directories and skipping unchanged objects.
- Make Stella loop manifests accurately report the raw step loop and stop emitting the deprecated no-op pipeline flag.
- Stabilize SUT tests by using the interpreter running the test suite instead of an environment-dependent Harbor fallback.

Enhancements:
- Align loop-mode documentation, configuration messaging, and tests with the removal of Stella’s staged pipeline.

Tests:
- Add coverage ensuring gated artifacts are fetched at most once and run-scoped artifacts remain available.
- Update loop-mode tests to verify command and manifest consistency across all selector values.