### PR TITLE
docs(stella-plugin): say required, not load-bearing, in envelope.rs's module doc

### DIFF
--- a/crates/stella-plugin/src/wire/envelope.rs
+++ b/crates/stella-plugin/src/wire/envelope.rs
@@ -4,8 +4,8 @@
 //! Split out of [`crate::wire`] rather than grown inside it: that file is the
 //! wire *vocabulary* — the requests, responses, grants and evidence a plugin
 //! speaks — and this is the framing those types arrive in. Two subjects, and
-//! the file-size ratchet is what made the distinction load-bearing rather than
-//! tidy (AGENTS.md, "God files — plan around them, never into them").
+//! the file-size ratchet is what made the split required rather than tidy
+//! (AGENTS.md, "God files — plan around them, never into them").
 
 use serde::{Deserialize, Deserializer};
 


### PR DESCRIPTION
## What

One word in `crates/stella-plugin/src/wire/envelope.rs:7`. `make prose` fails on main since #4435 landed it; nothing in CI ran the prose guard until #4449 added the job, which now catches it on every PR that merges main.

## Evidence

`python3 scripts/check-prose.py` → OK on this branch; FAIL on main naming this line. No witness: a comment.

## Summary by Sourcery

Clarify the envelope module documentation and restore prose-check compliance.

Bug Fixes:
- Fix the envelope module documentation so it passes the prose validation check.

Documentation:
- Clarify that separating the envelope module was required rather than merely tidy.