### PR TITLE
test(wirelog): wait for the wire record's bytes, not the file's existence

### DIFF
--- a/bench/wirelog/tests/test_wirelog.py
+++ b/bench/wirelog/tests/test_wirelog.py
@@ -204,12 +204,19 @@ def test_ttfb_and_response_headers_are_recorded(tmp_path: Path) -> None:
         resp.read()
         assert resp.status == 200
 
+        # Wait for the record's bytes, not the file: the handler creates the
+        # file before it writes the line, so an existence poll can read an
+        # empty file and report 0 lines (#4506).
         deadline = time.time() + 2.0
-        while not wire_path.exists() and time.time() < deadline:
+        lines: list[str] = []
+        while time.time() < deadline:
+            if wire_path.exists():
+                lines = wire_path.read_text().strip().splitlines()
+                if lines:
+                    break
             time.sleep(0.02)
 
-        lines = wire_path.read_text().strip().splitlines()
-        assert len(lines) == 1
+        assert len(lines) == 1, f"expected one wire record within 2s, found {lines!r}"
         row = json.loads(lines[0])
         assert isinstance(row["ttfb_ms"], int)
         assert row["ttfb_ms"] >= 0


### PR DESCRIPTION
## What

`test_ttfb_and_response_headers_are_recorded` polled for the wire file to *exist* and then asserted one line; the handler creates the file before writing, so the poll could win the race and read nothing (`assert 0 == 1` on PR #4504's pytest job, whose diff had no bench change). The loop now polls for content with the same 2 s budget.

## Evidence

`uv run --with pytest --no-project pytest -q bench/wirelog/tests` × 5 → 3 passed each. The race cannot be forced deterministically, so this is the fix plus evidence the window is closed rather than a fail→pass witness; stated as such.

Closes #4506

## Summary by Sourcery

Make the wirelog test reliably wait for recorded content rather than merely waiting for the output file to exist.

Bug Fixes:
- Prevent the wirelog test from racing the handler by waiting for a written wire record before asserting its contents.

Tests:
- Improve the wirelog test failure message to include the records observed within the polling window.