### PR TITLE
fix(stella-store): hub migration slot guard + prune-skew unknown count

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -176,14 +176,23 @@ fn open_hub() -> Result<UsageStore, String> {
 }
 
 /// A cost cell for the text table, prefixed `≥` when any execution behind it
-/// is a floor (#4171).
+/// is a known floor (#4171), else `?` when at least one has no verdict at
+/// all — its rollup row was pruned before its telemetry (#4485). `≥` wins
+/// when both are present: a known lower bound is the stronger claim.
 ///
 /// The prefix rather than a column: the report is a fixed-width table a user
 /// reads against a provider bill, and the fact they need at the number is
-/// whether the number is the whole story. `floor_executions` says how many in
-/// the JSON and CSV forms, and the footnote says it once for the table.
-fn cost_cell(cost_usd: f64, floor_executions: i64) -> String {
-    let marker = if floor_executions > 0 { "≥" } else { "" };
+/// whether the number is the whole story. `floor_executions` and
+/// `unknown_executions` say how many in the JSON and CSV forms, and the
+/// footnotes say it once for the table.
+fn cost_cell(cost_usd: f64, floor_executions: i64, unknown_executions: i64) -> String {
+    let marker = if floor_executions > 0 {
+        "≥"
+    } else if unknown_executions > 0 {
+        "?"
+    } else {
+        ""
+    };
     format!("{marker}{cost_usd:.4}")
 }
 
@@ -209,6 +218,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                         "cost_usd": r.cost_usd,
                         "projects": r.projects,
                         "floor_executions": r.floor_executions,
+                        "unknown_executions": r.unknown_executions,
                     })
                 })
                 .collect();
@@ -220,7 +230,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
         StatsFormat::Csv => {
             println!(
                 "org_id,provider,model,calls,input_tokens,output_tokens,cache_read_tokens,\
-                 cache_write_tokens,cost_usd,projects,floor_executions"
+                 cache_write_tokens,cost_usd,projects,floor_executions,unknown_executions"
             );
             for r in &rows {
                 // The three text columns are config- and catalog-supplied, so
@@ -228,7 +238,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                 // — an org id or model slug carrying a comma must not silently
                 // shift every following column.
                 println!(
-                    "{},{},{},{},{},{},{},{},{},{},{}",
+                    "{},{},{},{},{},{},{},{},{},{},{},{}",
                     crate::stats::csv_escape(r.org_id.as_deref().unwrap_or("")),
                     crate::stats::csv_escape(&r.provider),
                     crate::stats::csv_escape(&r.model),
@@ -240,6 +250,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                     r.cost_usd,
                     r.projects,
                     r.floor_executions,
+                    r.unknown_executions,
                 );
             }
         }
@@ -266,6 +277,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
             );
             let mut totals = (0i64, 0i64, 0i64, 0i64, 0i64, 0f64);
             let mut floors = 0i64;
+            let mut unknowns = 0i64;
             for r in &rows {
                 println!(
                     "{:<14} {:<10} {:<28} {:>8} {:>12} {:>12} {:>12} {:>12} {:>10} {:>9}",
@@ -277,7 +289,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                     r.output_tokens,
                     r.cache_read_tokens,
                     r.cache_write_tokens,
-                    cost_cell(r.cost_usd, r.floor_executions),
+                    cost_cell(r.cost_usd, r.floor_executions, r.unknown_executions),
                     r.projects,
                 );
                 totals.0 += r.calls;
@@ -287,6 +299,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                 totals.4 += r.cache_write_tokens;
                 totals.5 += r.cost_usd;
                 floors += r.floor_executions;
+                unknowns += r.unknown_executions;
             }
             println!(
                 "{:<14} {:<10} {:<28} {:>8} {:>12} {:>12} {:>12} {:>12} {:>10} {:>9}",
@@ -298,7 +311,7 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                 totals.2,
                 totals.3,
                 totals.4,
-                cost_cell(totals.5, floors),
+                cost_cell(totals.5, floors, unknowns),
                 ""
             );
             if floors > 0 {
@@ -306,6 +319,14 @@ fn report(format: StatsFormat, org: Option<&str>) -> Result<(), String> {
                     "\n≥ marks a lower bound: {floors} execution(s) finished with a paid call \
                      whose usage envelope never landed, so their receipts prove at least this \
                      much and possibly more."
+                );
+            }
+            if unknowns > 0 {
+                println!(
+                    "\n? marks {unknowns} execution(s) with no verdict at all: their telemetry \
+                     survived a hub prune but the rollup row that would say complete-or-floor \
+                     did not — their receipts may already be exact, or may be a floor; the hub \
+                     can no longer tell which."
                 );
             }
         }

--- a/crates/stella-store/src/tests/usage_completeness.rs
+++ b/crates/stella-store/src/tests/usage_completeness.rs
@@ -202,6 +202,78 @@ fn the_hub_marks_an_incomplete_executions_spend_as_a_floor() {
     );
 }
 
+/// #4485: a telemetry row whose `execution_rollup` row `prune` deleted first
+/// must read as **unknown**, never as silently complete.
+///
+/// `execution_rollup` and `telemetry` age out on predicates they do not
+/// share (`crate::usage`'s `prune`; `usage/tool_fold.rs` documents the same
+/// asymmetry for #3411): an org-scoped, un-acked `telemetry` row survives an
+/// age cutoff its rollup row does not, because only `telemetry` consults the
+/// cloud-drain guard. This test skips reproducing that exact age-cutoff
+/// timing (env-dependent org registration, multi-connection WAL races) and
+/// goes straight to the state it produces — a hub with `telemetry` for an
+/// execution but no matching `execution_rollup` row — which is the only
+/// thing [`super::global_report`]'s query can see either way.
+#[test]
+fn a_pruned_rollup_row_reports_as_unknown_never_as_complete() {
+    let workspace = tempfile::tempdir().unwrap();
+    let hub_dir = tempfile::tempdir().unwrap();
+    let hub = crate::usage::UsageStore::open_at(&hub_dir.path().join("usage.db")).unwrap();
+    let store = Store::in_memory().unwrap();
+
+    let execution = store
+        .begin_execution("deck", "ship it", "openrouter", "kimi")
+        .unwrap();
+    store
+        .record_telemetry(execution, &telemetry_row(1, 2.40))
+        .unwrap();
+    store
+        .finish_execution_accounted(execution, "completed", 2.40, true)
+        .unwrap();
+    assert!(
+        store
+            .sync_to_usage(execution, workspace.path(), &hub)
+            .unwrap(),
+        "execution must reach the hub"
+    );
+
+    let before = hub.global_telemetry_totals(None).unwrap();
+    assert_eq!(before.len(), 1);
+    assert_eq!(before[0].floor_executions, 0, "synced complete, no floor");
+    assert_eq!(
+        before[0].unknown_executions, 0,
+        "rollup row present, no gap"
+    );
+
+    // What `prune`'s age-cutoff branch does to `execution_rollup` on its own
+    // predicate (unconditional -- `crate::usage`'s age-cutoff branch --
+    // while `telemetry` only ages out when `prunable_predicate` allows it).
+    // A second connection is deliberate: it is exactly what a real prune run
+    // is -- a write against the same WAL-mode file the open `hub` handle
+    // is still reading from.
+    {
+        let conn = rusqlite::Connection::open(hub_dir.path().join("usage.db")).unwrap();
+        let deleted = conn.execute("DELETE FROM execution_rollup", []).unwrap();
+        assert_eq!(deleted, 1, "the rollup row for this execution existed");
+    }
+
+    let after = hub.global_telemetry_totals(None).unwrap();
+    assert_eq!(after.len(), 1, "the telemetry row still reports: {after:?}");
+    assert_eq!(
+        after[0].floor_executions, 0,
+        "no rollup row left to say it IS a floor: {after:?}"
+    );
+    assert_eq!(
+        after[0].unknown_executions, 1,
+        "but it must not silently read as complete either: {after:?}"
+    );
+    assert!(
+        (after[0].cost_usd - 2.40).abs() < 1e-9,
+        "the spend is still summed from telemetry: {}",
+        after[0].cost_usd
+    );
+}
+
 /// One paid call at `cost_usd`, with everything else the shape a row needs.
 fn telemetry_row(step: u64, cost_usd: f64) -> TelemetryRow {
     TelemetryRow {

--- a/crates/stella-store/src/usage/global_report.rs
+++ b/crates/stella-store/src/usage/global_report.rs
@@ -41,6 +41,21 @@ pub struct GlobalTelemetryRow {
     /// "3 of 210 executions are floors" is the sentence a user checking a
     /// provider bill can act on.
     pub floor_executions: i64,
+    /// How many of the executions behind this line have **no verdict at
+    /// all** — their `telemetry` rows survive but the `execution_rollup` row
+    /// that would say complete-or-floor was pruned first (#4485). `prune`
+    /// ages `execution_rollup` and `telemetry` out on predicates they do not
+    /// share (`crates/stella-store/src/usage.rs`'s age-cutoff branch; the
+    /// same asymmetry `super::tool_fold` documents for #3411), so this is
+    /// not a hypothetical: an org-scoped, un-acked telemetry row survives an
+    /// age cutoff that its rollup row does not.
+    ///
+    /// Distinct from [`Self::floor_executions`] on purpose: a floor is a
+    /// **known** lower bound, this is an **unknown** verdict. Folding it into
+    /// the floor count would under-state the floor count's own meaning
+    /// (`floor_executions` used to do exactly that, by reading a missing
+    /// rollup row as complete via `COALESCE(r.usage_complete, 1)`).
+    pub unknown_executions: i64,
 }
 
 impl UsageStore {
@@ -59,11 +74,15 @@ impl UsageStore {
     /// `executions.usage_complete` in the project store and reaches the hub on
     /// the rollup row, so that is what the count reads.
     ///
-    /// A telemetry row whose rollup `prune` has already deleted reads as
-    /// complete (`COALESCE(…, 1)`). That is the pre-existing shape of hub
-    /// pruning rather than a new gap — the rollup and the replica are pruned on
-    /// predicates they do not share — and it costs a *marking*, never a
-    /// figure: the spend is summed from `telemetry` either way.
+    /// A telemetry row whose rollup `prune` has already deleted has no
+    /// verdict left to read: it counts toward
+    /// [`GlobalTelemetryRow::unknown_executions`], never silently toward
+    /// "complete" (#4485; before this it read as complete via
+    /// `COALESCE(r.usage_complete, 1)`, under-reporting how many figures were
+    /// floors). That gap is the pre-existing shape of hub pruning rather than
+    /// a new one — the rollup and the replica are pruned on predicates they
+    /// do not share — and it costs only a *marking*, never a figure: the
+    /// spend is summed from `telemetry` either way.
     pub fn global_telemetry_totals(&self, org: Option<&str>) -> Result<Vec<GlobalTelemetryRow>> {
         let conn = self.lock();
         let mut stmt = conn.prepare(
@@ -71,7 +90,9 @@ impl UsageStore {
                     SUM(t.output_tokens), SUM(t.cache_read_tokens), \
                     SUM(t.cache_write_tokens), SUM(t.cost_usd), \
                     COUNT(DISTINCT t.project_id), \
-                    COUNT(DISTINCT CASE WHEN COALESCE(r.usage_complete, 1) = 0 \
+                    COUNT(DISTINCT CASE WHEN r.usage_complete = 0 \
+                                        THEN t.project_id || ':' || t.execution_id END), \
+                    COUNT(DISTINCT CASE WHEN r.usage_complete IS NULL \
                                         THEN t.project_id || ':' || t.execution_id END) \
              FROM telemetry t \
              LEFT JOIN execution_rollup r \
@@ -93,6 +114,7 @@ impl UsageStore {
                 cost_usd: r.get(8)?,
                 projects: r.get(9)?,
                 floor_executions: r.get(10)?,
+                unknown_executions: r.get(11)?,
             })
         })?;
         let mut out = Vec::new();

--- a/crates/stella-store/src/usage/schema.rs
+++ b/crates/stella-store/src/usage/schema.rs
@@ -172,27 +172,71 @@ CREATE INDEX IF NOT EXISTS cloud_quarantine_by_org
     ON cloud_quarantine(org_id, quarantined_at);
 ";
 
-/// One hub migration: upgrades an existing `usage.db` exactly one
+/// One hub migration function: upgrades an existing `usage.db` exactly one
 /// `user_version` step, inside the transaction the runner opened for it.
 type HubMigration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
+
+/// One rung of [`HUB_MIGRATIONS`]: the function that performs the reshape,
+/// paired with the `user_version` it upgrades a hub *to*.
+///
+/// `target_version` is redundant with the entry's position under correct
+/// use -- and that redundancy is the guard. The `#[cfg(test)]` test
+/// `hub_migrations_declare_sequential_versions` (bottom of this module)
+/// asserts every entry's `target_version` equals its index + 1, so two
+/// branches that each append "the next hub migration" independently (the
+/// exact shape #4487 found: PR #4479 took hub v2 -> v3 while #4462 took the
+/// *workspace* ladder's v29 -> v30 slot) fail that test instead of silently
+/// composing into a ladder where one step runs at the other's version.
+struct HubMigrationStep {
+    /// The `user_version` this step upgrades a hub to.
+    target_version: i64,
+    apply: HubMigration,
+}
 
 /// Ordered hub migration list. `HUB_MIGRATIONS[i]` upgrades a hub at
 /// `user_version` i to i + 1.
 ///
-/// Append only. See the module doc for why position is the contract.
-const HUB_MIGRATIONS: [HubMigration; 3] = [
+/// Append only -- see the module doc for why position is the contract -- and
+/// **never renumber**: a slot is claimed by position, not by name.
+const HUB_MIGRATIONS: [HubMigrationStep; 3] = [
     // v0 -> v1: back-propagate #3388's door-only `kind` vocabulary, and give
     // the hub the `role` column #3395 gave the project store.
-    migrate_hub_v0_to_v1,
+    HubMigrationStep {
+        target_version: 1,
+        apply: migrate_hub_v0_to_v1,
+    },
     // v1 -> v2: seat the tool-fold ledger from what is already rolled up.
-    migrate_hub_v1_to_v2,
+    HubMigrationStep {
+        target_version: 2,
+        apply: migrate_hub_v1_to_v2,
+    },
     // v2 -> v3: `execution_rollup` learns whether its figures are a floor
     // (#4171). Existing rows default to 1 because the gate this replaces only
     // ever let complete executions through.
-    migrate_hub_v2_to_v3,
+    HubMigrationStep {
+        target_version: 3,
+        apply: migrate_hub_v2_to_v3,
+    },
+    // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
+    // This is an INDEX-ORDERED array and `HUB_SCHEMA_VERSION` is its length,
+    // so a slot is claimed by position, not by name. Two branches that each
+    // append "the next hub migration" merge cleanly -- git sees two additions
+    // to different lines -- and, unlike `crate::migrations::MIGRATIONS`,
+    // produce a ladder where one step silently runs at the other's version:
+    // nothing in CI catches it, because both files compile and
+    // `target_version` was never checked against position before #4487.
+    // `hub_migrations_declare_sequential_versions` (below) is what catches it
+    // now: give your new entry the correct `target_version` and the test
+    // fails loudly if a parallel merge left two entries claiming the same
+    // slot.
+    //
+    // Nothing is reserved now: take v3 -> v4 and add your own line here. If a
+    // reserved phase ships without needing its slot, delete its line rather
+    // than leaving a hole -- index order is the contract.
 ];
 
-/// The hub schema version this build writes.
+/// The hub schema version this build writes -- the `PRAGMA user_version` of
+/// every hub it has opened.
 const HUB_SCHEMA_VERSION: i64 = HUB_MIGRATIONS.len() as i64;
 
 /// Apply the schema to a freshly opened hub connection: converge the tables,
@@ -209,9 +253,23 @@ pub(super) fn apply(conn: &mut Connection) -> Result<()> {
         let index = usize::try_from(version).map_err(|_| {
             crate::StoreError::Other(format!("hub schema version is negative: {version}"))
         })?;
-        let step = HUB_MIGRATIONS[index];
+        let step = &HUB_MIGRATIONS[index];
+        // Redundant with `hub_migrations_declare_sequential_versions` by
+        // design (see [`HubMigrationStep`]): that test cannot run against a
+        // hub some *other* build already wrote, so this is the same
+        // assertion at the one moment `target_version` still matters for a
+        // running process -- a slot collision that reached a release trips
+        // this before it ever reshapes the wrong table.
+        debug_assert_eq!(
+            step.target_version,
+            version + 1,
+            "HUB_MIGRATIONS[{index}] declares target_version {} but its position \
+             implies {} -- see hub_migrations_declare_sequential_versions",
+            step.target_version,
+            version + 1
+        );
         let tx = conn.transaction()?;
-        step(&tx)?;
+        (step.apply)(&tx)?;
         // Stamped inside the same transaction as the reshape, so a crash
         // mid-migration rolls back to the old version AND the old shape,
         // never a mix. The project store's runner makes the same guarantee.
@@ -340,4 +398,39 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
         }
     }
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HUB_MIGRATIONS, HUB_SCHEMA_VERSION};
+
+    /// The #4487 witness: `HUB_MIGRATIONS` is claimed by position, and this is
+    /// what makes a slot collision loud instead of silent. Two branches that
+    /// each append "the next hub migration" merge textually clean -- each adds
+    /// one array element -- but if both declare the same `target_version` (the
+    /// shape #4487 found: PR #4479 took hub v2 -> v3 while #4462 took the
+    /// *workspace* ladder's v29 -> v30 slot, and the hub equivalent would have
+    /// composed with no textual conflict at all), the ladder ends up with two
+    /// entries claiming one version and a hole where the other should be. This
+    /// test catches that: every entry's declared `target_version` must equal
+    /// its index + 1, or the ladder is out of order or has a duplicate/missing
+    /// slot.
+    #[test]
+    fn hub_migrations_declare_sequential_versions() {
+        for (index, step) in HUB_MIGRATIONS.iter().enumerate() {
+            assert_eq!(
+                step.target_version,
+                index as i64 + 1,
+                "HUB_MIGRATIONS[{index}] declares target_version {}, but its position \
+                 says it should be {} -- a slot collision or a hole in the ladder",
+                step.target_version,
+                index + 1
+            );
+        }
+        assert_eq!(
+            HUB_SCHEMA_VERSION,
+            HUB_MIGRATIONS.len() as i64,
+            "HUB_SCHEMA_VERSION must track the ladder's length exactly"
+        );
+    }
 }


### PR DESCRIPTION
## What

- **#4487** — `HUB_MIGRATIONS` in `crates/stella-store/src/usage/schema.rs` was index-ordered like `migrations.rs`'s workspace ladder but carried no append-point warning and no test pinning position to version. Two branches each appending "the next hub migration" would have merged textually clean and applied two migrations under one `PRAGMA user_version` — the exact shape #4479 (hub v2→v3) and #4462 (workspace v29→v30) hit on the *workspace* ladder, where the collision conflicted textually (working as intended); the hub had nothing to catch the equivalent silently. Fixed by giving each entry an explicit `target_version` (`HubMigrationStep`), a test (`hub_migrations_declare_sequential_versions`) asserting every entry's declared version equals its index + 1, a `debug_assert!` re-check at the one point a running process still cares (`apply()`), and the same append-point comment block `migrations.rs` carries.
- **#4485** — `global_telemetry_totals` used `COALESCE(r.usage_complete, 1)`, so a `telemetry` row whose `execution_rollup` row `prune` had already deleted read as *complete*. `execution_rollup` and `telemetry` age out on predicates they do not share (`usage.rs`'s age-cutoff branch drops `execution_rollup` unconditionally on `started_at`; `telemetry` only drops on `recorded_at` and only when `prunable_predicate` allows it — the same asymmetry `tool_fold.rs` documents for #3411), so an org-scoped, un-acked telemetry row can outlive its rollup row. Since #4479 this under-reports how many figures in `stella usage report` are floors. Fixed with the issue's "third count" option: a new `GlobalTelemetryRow::unknown_executions`, distinct from `floor_executions` (a floor is a *known* lower bound; this is an *unknown* verdict), wired through the CLI's json/csv/text renderers (`?` marker alongside the existing `≥`, plus a footnote).

## Evidence

Targeted commands (never workspace-wide, per repo policy):

```
cargo build -p stella-store                       # clean
cargo build -p stella-cli                         # clean
cargo test  -p stella-store usage                 # 52 passed
cargo test  -p stella-cli --bin stella usage_cmd   # 4 passed
cargo clippy -p stella-store --all-targets -- -D warnings   # clean
cargo clippy -p stella-cli   --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                                  # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-store --no-deps --document-private-items   # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-store --no-deps                            # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli   --no-deps --document-private-items   # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli   --no-deps                            # clean
make guards-fast                                             # exit 0, all guards OK
```

**Witness (fail→pass), compile-level** — both new tests reference fields/items that do not exist on `origin/main` (`GlobalTelemetryRow::unknown_executions`, `HubMigrationStep`, `hub_migrations_declare_sequential_versions`); confirmed absent via `git show origin/main:<path>` + `rg` before writing the tests, so the feature is genuinely absent on `main` (a build-level failure, same acceptance as any other compile-level witness in this repo):

- `crates/stella-store/src/usage/schema.rs::tests::hub_migrations_declare_sequential_versions` — passes on this branch; does not exist / would not compile against `origin/main`.
- `crates/stella-store/src/tests/usage_completeness.rs::a_pruned_rollup_row_reports_as_unknown_never_as_complete` — passes on this branch (`floor_executions == 0`, `unknown_executions == 1` after deleting the rollup row underneath a synced execution); would not compile against `origin/main` (no `unknown_executions` field).

No wire-schema impact: `GlobalTelemetryRow` and `HubMigrationStep` are internal to `stella-store`/`stella-cli`, not `stella-protocol` wire types.

## Not done

Nothing skipped from this batch's two issues.

Closes #4487
Closes #4485

## Summary by Sourcery

Distinguish unknown usage verdicts from known floors and guard the hub migration ladder against silently conflicting version slots.

New Features:
- Expose unknown execution counts in usage reports when telemetry outlives its pruned rollup verdict, including JSON, CSV, and text output markers and footnotes.

Bug Fixes:
- Prevent pruned rollup rows from being treated as completed executions in global telemetry totals.

Enhancements:
- Add explicit hub migration target versions with validation and runtime assertions to detect migration slot collisions or gaps.

Tests:
- Add coverage for sequential hub migration version declarations and telemetry rows whose rollup records have been pruned.