### PR TITLE
fix(stella-cli,stella-core,stella-store,stella-protocol): the candidate sweep, a cancelled run's reflection, and a delegate's own calls all say who they belong to

### DIFF
--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -470,6 +470,7 @@ mod durable_stream_tests {
             tool_calls: 0,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         };
 
         sender.send(stage.clone()).unwrap();

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -758,6 +758,7 @@ pub(crate) fn persist_event_detailed(
         retries,
         tool_calls,
         complete,
+        sub_agent_id,
         ..
     } = event
     {
@@ -790,6 +791,9 @@ pub(crate) fn persist_event_detailed(
                     retries: *retries,
                     tool_calls: *tool_calls as u64,
                     usage_complete: *complete,
+                    // Whose call this was. `None` is the lead's own — the
+                    // ordinary case, and a fact rather than a gap (#4383).
+                    sub_agent_id: sub_agent_id.clone(),
                 },
             )
             .is_ok();
@@ -803,6 +807,7 @@ pub(crate) fn persist_event_detailed(
         retries,
         partial,
         reason,
+        sub_agent_id,
         ..
     } = event
     {
@@ -864,6 +869,11 @@ pub(crate) fn persist_event_detailed(
                     // The attempt died before any tool call could settle.
                     tool_calls: 0,
                     usage_complete: false,
+                    // A delegate abandoned at the engine's dispatch ceiling
+                    // lands here, and a row nobody can attribute explains the
+                    // execution's `usage_complete = 0` without saying whose
+                    // call it was.
+                    sub_agent_id: sub_agent_id.clone(),
                 },
             )
             .is_ok();
@@ -1035,6 +1045,7 @@ mod usage_recovery_tests {
             duration_ms: 4_200,
             retries: Some(1),
             partial,
+            sub_agent_id: None,
         }
     }
 
@@ -1062,6 +1073,7 @@ mod usage_recovery_tests {
             tool_calls: 0,
             complete: false,
             finish_reason: None,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -160,6 +160,7 @@ fn persist_event_records_cache_write_tokens_from_step_usage() {
         tool_calls: 1,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     };
 
     assert!(persist_event(&store, execution_id, 0, &event, "anthropic"));
@@ -913,6 +914,7 @@ fn reflection_json_preserves_full_paid_call_envelope_and_cost() {
             tool_calls: 0,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         }],
     };
 

--- a/crates/stella-cli/src/agent/tests/usage_completeness.rs
+++ b/crates/stella-cli/src/agent/tests/usage_completeness.rs
@@ -21,6 +21,7 @@ fn usage(provider: &str, model: &str, cost_usd: f64) -> AgentEvent {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     }
 }
 

--- a/crates/stella-cli/src/cache_insight.rs
+++ b/crates/stella-cli/src/cache_insight.rs
@@ -147,6 +147,7 @@ mod tests {
             tool_calls: 0,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -858,6 +858,7 @@ fn numstat_totals(numstat: &str) -> (u32, u32) {
 }
 
 mod copy_tree;
+mod isolation;
 mod modes;
 mod record;
 mod ref_guard;

--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -860,6 +860,7 @@ fn numstat_totals(numstat: &str) -> (u32, u32) {
 mod copy_tree;
 mod isolation;
 mod modes;
+mod proc_start;
 mod record;
 mod ref_guard;
 mod substrate;

--- a/crates/stella-cli/src/candidate_workspaces/isolation.rs
+++ b/crates/stella-cli/src/candidate_workspaces/isolation.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where the substrate selector is read from when there is no settings file
+//! to read it from (#4510).
+//!
+//! `candidate_isolation` reaches [`CandidateSubstrate::for_session`] through
+//! [`Settings::load`], and `Settings::load` answers `Settings::default()` under
+//! `STELLA_NO_SETTINGS=1`
+//! ([`filesystem_settings_disabled`](crate::settings::filesystem_settings_disabled)).
+//! Every benchmark launcher sets that variable — which left the one environment
+//! the copy substrate was built for, a task whose tests execute gitignored
+//! fixtures, unable to select it. The default is not a bad answer there; it is
+//! the *only* answer, which is a different thing and is the defect.
+//!
+//! So the selector also has an environment spelling. It is not a second
+//! setting: [`CandidateIsolation::from_token`] parses both, so the two cannot
+//! drift into accepting different words.
+//!
+//! # Why the environment outranks the file
+//!
+//! Because it is the narrower statement. A `stella.toml` describes the
+//! workspace for every run; the variable describes *this* launch, in the same
+//! way `--model` outranks a configured default. A launcher that exports it has
+//! said something about the process it is about to start, and a file that
+//! disagrees is describing a different occasion.
+//!
+//! # Why a malformed value is not a refusal
+//!
+//! The settings deserializer rejects an unknown token loudly, and it can: a
+//! parse error there stops a `Settings::load` a caller is holding a `Result`
+//! for. This read happens where the answer is a substrate rather than a
+//! `Result`, and the safe direction is fixed by what the two shapes do —
+//! copy-tree promotion overwrites the tree it lands on. So a value this build
+//! cannot read gets the worktree substrate, out loud: the operator is told
+//! their word was not understood *and* which substrate is running, which is the
+//! pair a silent fallback withholds.
+//!
+//! [`CandidateSubstrate::for_session`]: super::CandidateSubstrate::for_session
+//! [`Settings::load`]: crate::settings::Settings::load
+
+use crate::settings::CandidateIsolation;
+
+/// The environment spelling of `[run] candidate_isolation`.
+///
+/// Registered in the Harbor adapter's `_CLAIM_CONTAINER_ENV`
+/// (`bench/harbor_adapter/stella_harbor/__init__.py`), whose ambient check
+/// fails closed: an unregistered `STELLA_*` variable refuses the run rather
+/// than reaching the container, so a benchmark arm exporting this without that
+/// registration would select nothing at all.
+pub(super) const ISOLATION_ENV: &str = "STELLA_CANDIDATE_ISOLATION";
+
+/// The substrate this launch selects, and whatever the operator must be told
+/// about how that was decided.
+///
+/// `env` is the raw variable, unset or set; `from_settings` is what the scope
+/// chain resolved (which is [`CandidateIsolation::Worktree`] whenever the chain
+/// could not be read at all).
+///
+/// An empty or whitespace-only variable reads as unset rather than as
+/// `"worktree"`. `FOO=` is how a shell spells "I am not passing this", and
+/// letting it silently outrank a workspace that wrote `copy-tree` down would
+/// make an unset variable louder than a stated policy.
+pub(super) fn selected(
+    env: Option<&str>,
+    from_settings: CandidateIsolation,
+) -> (CandidateIsolation, Option<String>) {
+    let Some(raw) = env.map(str::trim).filter(|raw| !raw.is_empty()) else {
+        return (from_settings, None);
+    };
+    match CandidateIsolation::from_token(raw) {
+        Ok(chosen) => (chosen, None),
+        Err(why) => (
+            CandidateIsolation::Worktree,
+            Some(format!(
+                "{ISOLATION_ENV}: {why}. Candidates run on git worktrees"
+            )),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **#4510's witness.** The variable reaches the selector with no settings
+    /// file behind it, which is the whole state a benchmark launcher runs in.
+    #[test]
+    fn the_environment_selects_copy_tree_where_no_settings_scope_can() {
+        let (chosen, notice) = selected(Some("copy-tree"), CandidateIsolation::Worktree);
+        assert_eq!(chosen, CandidateIsolation::CopyTree);
+        assert!(notice.is_none(), "{notice:?}");
+    }
+
+    /// The narrower statement wins in both directions, or it is not a
+    /// per-launch override — it is a second default.
+    #[test]
+    fn the_environment_outranks_a_workspace_that_says_otherwise() {
+        assert_eq!(
+            selected(Some("worktree"), CandidateIsolation::CopyTree).0,
+            CandidateIsolation::Worktree
+        );
+    }
+
+    #[test]
+    fn an_unset_or_empty_variable_leaves_the_workspace_to_decide() {
+        assert_eq!(
+            selected(None, CandidateIsolation::CopyTree).0,
+            CandidateIsolation::CopyTree
+        );
+        assert_eq!(
+            selected(Some(""), CandidateIsolation::CopyTree).0,
+            CandidateIsolation::CopyTree
+        );
+        assert_eq!(
+            selected(Some("  "), CandidateIsolation::CopyTree).0,
+            CandidateIsolation::CopyTree
+        );
+    }
+
+    /// A word this build cannot read must not become the substrate that
+    /// overwrites a tree, and must not be swallowed either.
+    #[test]
+    fn a_token_that_did_not_parse_falls_back_out_loud() {
+        let (chosen, notice) = selected(Some("copytree"), CandidateIsolation::CopyTree);
+        assert_eq!(chosen, CandidateIsolation::Worktree);
+        let notice = notice.expect("a fallback the operator is not told about is a silent drop");
+        assert!(notice.contains(ISOLATION_ENV), "{notice}");
+        assert!(notice.contains("copytree"), "{notice}");
+        assert!(
+            notice.contains("copy-tree"),
+            "names the word it accepts: {notice}"
+        );
+    }
+
+    /// The settings key and the variable parse one vocabulary. Two `match`
+    /// arms over the same two words is how a token gets accepted on one
+    /// surface and refused on the other.
+    #[test]
+    fn both_spellings_of_the_setting_read_the_same_tokens() {
+        for token in ["worktree", "copy-tree"] {
+            let from_env = selected(Some(token), CandidateIsolation::Worktree).0;
+            let from_file: CandidateIsolation =
+                serde_json::from_value(serde_json::Value::String(token.to_string()))
+                    .expect("the settings deserializer accepts what the variable accepts");
+            assert_eq!(from_env, from_file, "{token}");
+        }
+        assert!(
+            serde_json::from_value::<CandidateIsolation>(serde_json::json!("copytree")).is_err(),
+            "and refuses what the variable refuses"
+        );
+    }
+}

--- a/crates/stella-cli/src/candidate_workspaces/isolation.rs
+++ b/crates/stella-cli/src/candidate_workspaces/isolation.rs
@@ -43,11 +43,13 @@ use crate::settings::CandidateIsolation;
 
 /// The environment spelling of `[run] candidate_isolation`.
 ///
-/// Registered in the Harbor adapter's `_CLAIM_CONTAINER_ENV`
-/// (`bench/harbor_adapter/stella_harbor/__init__.py`), whose ambient check
-/// fails closed: an unregistered `STELLA_*` variable refuses the run rather
-/// than reaching the container, so a benchmark arm exporting this without that
-/// registration would select nothing at all.
+/// **Not yet registered in the Harbor adapter** (#4515). The adapter's ambient
+/// check over `_CLAIM_CONTAINER_ENV` fails closed, so a benchmark arm that
+/// exports this today gets a refused run naming the unregistered variable — a
+/// loud, correct failure rather than a silently unselected substrate, but it
+/// does mean the bench half of #4510 is not reachable until that registration
+/// lands. Everything outside the adapter (a container, a CI job, a shell)
+/// already reads it here.
 pub(super) const ISOLATION_ENV: &str = "STELLA_CANDIDATE_ISOLATION";
 
 /// The substrate this launch selects, and whatever the operator must be told

--- a/crates/stella-cli/src/candidate_workspaces/proc_start.rs
+++ b/crates/stella-cli/src/candidate_workspaces/proc_start.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! When the process wearing a pid started (#4511).
+//!
+//! A pid alone cannot answer "is the process that wrote this record still
+//! there". Pids are recycled, and a recycled one makes a dead owner read as
+//! live — so [`record::orphans`](super::record::orphans) skipped its record and
+//! the checkout leaked with nothing naming it. The safe direction, and the
+//! documented one, but a miss.
+//!
+//! A start time closes it, because the pair `(pid, started-at)` is unique for
+//! as long as anything can observe either half: the kernel will hand the number
+//! out again, but not with the same start instant.
+//!
+//! # What the number is, and what it is not
+//!
+//! It is **an opaque token**, comparable only against another reading of the
+//! same pid from the same host and boot. Linux counts clock ticks since boot;
+//! macOS counts microseconds since the epoch. Nothing here converts between
+//! them or renders one, and a caller that treated it as a timestamp would be
+//! reading a different clock on each platform.
+//!
+//! # Where there is no reading
+//!
+//! [`of`] answers `None` — on a platform with neither interface, and on any
+//! failure of the two that exist (a `/proc` this container did not mount, a
+//! process that exited between the probe and the read, a `sysctl` that refused).
+//! `None` is not "the owner is gone": it is "this host cannot tell", and the
+//! sweep must keep the pre-existing safe direction there rather than invent an
+//! answer. See [`record`](super::record)'s own doc for the resulting rule.
+
+#[cfg(target_os = "macos")]
+use std::ffi::c_int;
+
+/// The start token of the process wearing `pid`, if this host can read one.
+#[cfg(target_os = "linux")]
+pub(super) fn of(pid: u32) -> Option<u64> {
+    parse_proc_stat(&std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?)
+}
+
+/// Pull `starttime` (field 22) out of one `/proc/<pid>/stat` line.
+///
+/// Split at the **last** `)` rather than by whitespace from the left: field 2
+/// is the executable name in parentheses, it is attacker-chosen, and it may
+/// contain both spaces and parentheses. `comm` of `a b) c` is a legal
+/// executable name and defeats every simpler split.
+#[cfg(target_os = "linux")]
+fn parse_proc_stat(line: &str) -> Option<u64> {
+    let after_comm = &line[line.rfind(')')? + 1..];
+    // `state` is the first field after the name, so `starttime` — field 22 of
+    // the line — is index 19 counting from there.
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+/// The start token of the process wearing `pid`, if this host can read one.
+///
+/// `PROC_PIDTBSDINFO` fills one [`libc::proc_bsdinfo`], whose
+/// `pbi_start_tv{sec,usec}` pair is that process's own start instant. Folded to
+/// microseconds so the token is one integer to compare, never a time to render.
+///
+/// `libproc` rather than `sysctl(KERN_PROC_PID)`: `libc` exposes this struct on
+/// Apple targets and does not expose `kinfo_proc`, so the `sysctl` route would
+/// need a hand-declared C layout — a second copy of a kernel structure to keep
+/// correct, for a number two documented fields already carry.
+#[cfg(target_os = "macos")]
+pub(super) fn of(pid: u32) -> Option<u64> {
+    // SAFETY: `proc_bsdinfo` is a plain C aggregate of integers and `c_char`
+    // arrays, for which all-zero is a valid value. `proc_pidinfo` overwrites it
+    // on success, and the size check below is what stops the zeroes being read
+    // when it did not.
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = c_int::try_from(std::mem::size_of::<libc::proc_bsdinfo>()).ok()?;
+    // SAFETY: `info` is a live `proc_bsdinfo` this frame owns and `size` is
+    // exactly its size, which is the buffer contract `proc_pidinfo(3)`
+    // documents for `PROC_PIDTBSDINFO`. It writes only into that buffer and
+    // never more than `size` bytes.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            c_int::try_from(pid).ok()?,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            std::ptr::from_mut(&mut info).cast(),
+            size,
+        )
+    };
+    // It returns the byte count it filled, and answers 0 for a pid nothing is
+    // wearing — which would otherwise read as a start time of zero shared by
+    // every dead process. A short write is a struct this build did not expect.
+    if written != size {
+        return None;
+    }
+    info.pbi_start_tvsec
+        .checked_mul(1_000_000)?
+        .checked_add(info.pbi_start_tvusec)
+}
+
+/// No reading on this platform — see the module doc for why that is a distinct
+/// answer from "the owner is gone".
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(super) fn of(_pid: u32) -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This process is alive, so whatever this host can read for it must be
+    /// readable — and stable across two reads, or it is not an identity.
+    #[test]
+    fn a_live_process_reads_the_same_token_twice() {
+        let me = std::process::id();
+        assert_eq!(of(me), of(me));
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        assert!(
+            of(me).is_some(),
+            "this host has an interface; a process reading its own start time must find it"
+        );
+    }
+
+    /// A pid nothing is wearing has no reading, which is the half that lets the
+    /// sweep tell a recycled pid from the process that wrote the record.
+    #[test]
+    fn a_pid_no_process_wears_has_no_token() {
+        // 0 is the kernel's own scheduler slot on both interfaces: `/proc/0`
+        // does not exist and `KERN_PROC_PID` resolves nothing for it, so it is
+        // the one number guaranteed not to name a process this test could race.
+        assert_eq!(of(0), None);
+    }
+
+    /// `comm` is attacker-chosen and may hold spaces and parentheses, so the
+    /// parse splits at the last `)` and counts from there.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_hostile_executable_name_does_not_move_the_field() {
+        // `state` is index 0, so eighteen fillers put `starttime` at index 19.
+        let fillers: String = (1..=18).map(|n| format!("{n} ")).collect();
+        let line = format!("42 (evil ) name) S {fillers}9876543 rest here");
+        assert_eq!(parse_proc_stat(&line), Some(9_876_543));
+    }
+}

--- a/crates/stella-cli/src/candidate_workspaces/proc_start.rs
+++ b/crates/stella-cli/src/candidate_workspaces/proc_start.rs
@@ -119,8 +119,8 @@ mod tests {
         );
     }
 
-    /// A pid nothing is wearing has no reading, which is the half that lets the
-    /// sweep tell a recycled pid from the process that wrote the record.
+    /// A pid nothing is wearing has no reading. That is what lets the sweep
+    /// tell a recycled pid from the process that wrote the record.
     #[test]
     fn a_pid_no_process_wears_has_no_token() {
         // 0 is the kernel's own scheduler slot on both interfaces: `/proc/0`

--- a/crates/stella-cli/src/candidate_workspaces/record.rs
+++ b/crates/stella-cli/src/candidate_workspaces/record.rs
@@ -31,15 +31,34 @@
 //! The recorded pid, probed with [`stella_store::sessions::pid_alive`] — the
 //! predicate the session registry already downgrades a crashed session on, so
 //! this workspace has one answer to "is that process still there" rather than
-//! two.
+//! two — **and** the start token of whatever is wearing that pid now
+//! ([`proc_start`](super::proc_start)).
 //!
-//! Its one boundary is pid reuse: a recycled pid makes a dead owner read as
-//! live, and the record is then **not** reported. That is the safe direction
-//! and the deliberate one — the failure it buys is a leak that stays until the
-//! next sweep, against a false report that would invite a user to delete a
-//! running candidate's tree. `started_at_ms` is the record's own write time,
-//! so a report can say how long the residue has been there; it is not a
-//! process start time, which nothing portable here can read.
+//! The pid alone was not enough, and the gap was documented rather than
+//! closed: a recycled pid made a dead owner read as live, so its record went
+//! unreported and its checkout leaked (#4511). `(pid, start token)` closes it,
+//! because the kernel hands the number out again but not with the same start
+//! instant.
+//!
+//! Where a start token cannot be read — a platform with neither `/proc` nor
+//! `sysctl`, a record written by a build older than the field, a container
+//! that did not mount `/proc` — the pre-existing rule stands unchanged: pid
+//! alive means owner alive. `None` is "this host cannot tell", never "the
+//! owner is gone", and inventing the second would invite a user to delete a
+//! running candidate's tree.
+//!
+//! `started_at_ms` is a different number: the record's own **write** time, so a
+//! report can say how long residue has been there. Nothing compares the two.
+//!
+//! # What the sweep names besides checkouts
+//!
+//! A run that ends before anything scores its candidates writes each one's work
+//! out as a `.patch` beside the checkout and prints where (#2651). Removal then
+//! takes the checkout *and its record*, so from the next run on there was
+//! nothing left to re-name that patch — a user who missed one stderr line had
+//! to go and find it. So the sweep also lists the patches themselves, from the
+//! directory rather than from a record, which is what makes them keep being
+//! named until somebody removes them.
 
 use std::path::{Path, PathBuf};
 
@@ -73,6 +92,15 @@ pub(super) struct CandidateRecord {
     pub(super) top: Option<PathBuf>,
     /// The process that owns it, for as long as that process exists.
     pub(super) pid: u32,
+    /// The start token of that process, where this host could read one — the
+    /// half of the owner's identity that a recycled pid does not carry over
+    /// (#4511). See [`proc_start`](super::proc_start) for what the number is.
+    ///
+    /// `default` rather than required: a record written before this field
+    /// existed parses, and reads as the "cannot tell" case, which is exactly
+    /// what it is.
+    #[serde(default)]
+    pub(super) pid_start: Option<u64>,
     /// When this record was written, in milliseconds since the epoch.
     pub(super) started_at_ms: u64,
 }
@@ -96,6 +124,7 @@ impl CandidateRecord {
             branch: None,
             top: None,
             pid: std::process::id(),
+            pid_start: super::proc_start::of(std::process::id()),
             started_at_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |since| u64::try_from(since.as_millis()).unwrap_or(0)),
@@ -142,12 +171,41 @@ pub(super) fn forget(checkout: &Path) {
     }
 }
 
+/// Whether the process that wrote `record` is gone.
+///
+/// Two questions, in the order that makes the second cheap: a pid nothing is
+/// wearing settles it, and only a live pid is worth asking whose it is now.
+///
+/// A start token on both sides that **differs** is a different process wearing
+/// the recorded number — the recycled-pid case, and the one this decides that
+/// `alive` alone could not. A token missing on either side leaves the
+/// pre-existing rule in place: alive means owner alive. See the module doc for
+/// why the absent reading is deliberately not the interesting answer.
+fn owner_is_gone(
+    record: &CandidateRecord,
+    alive: &dyn Fn(u32) -> bool,
+    started: &dyn Fn(u32) -> Option<u64>,
+) -> bool {
+    if !alive(record.pid) {
+        return true;
+    }
+    match (record.pid_start, started(record.pid)) {
+        (Some(recorded), Some(current)) => recorded != current,
+        _ => false,
+    }
+}
+
 /// Every record under `dir` whose owning process is gone, oldest first.
 ///
-/// `alive` is injected rather than called directly so the sweep is witnessable
-/// against a chosen answer — a test cannot kill a process and then be sure the
-/// pid was not reused before it looked.
-pub(super) fn orphans(dir: &Path, alive: &dyn Fn(u32) -> bool) -> Vec<CandidateRecord> {
+/// `alive` and `started` are injected rather than called directly so the sweep
+/// is witnessable against a chosen answer — a test cannot kill a process and
+/// then be sure the pid was not reused before it looked, which is the very
+/// race the pair exists to survive.
+pub(super) fn orphans(
+    dir: &Path,
+    alive: &dyn Fn(u32) -> bool,
+    started: &dyn Fn(u32) -> Option<u64>,
+) -> Vec<CandidateRecord> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         // No candidates directory is the ordinary case: a workspace that has
         // never fanned out has nothing to report.
@@ -167,7 +225,7 @@ pub(super) fn orphans(dir: &Path, alive: &dyn Fn(u32) -> bool) -> Vec<CandidateR
         // a reclaim command built from fields that did not parse is a command
         // that names the wrong path.
         .filter_map(|bytes| serde_json::from_slice::<CandidateRecord>(&bytes).ok())
-        .filter(|record| !alive(record.pid))
+        .filter(|record| owner_is_gone(record, alive, started))
         .collect();
     found.sort_by(|left, right| {
         (left.started_at_ms, &left.checkout).cmp(&(right.started_at_ms, &right.checkout))
@@ -206,13 +264,71 @@ pub(super) fn reclaim_lines(orphans: &[CandidateRecord]) -> Vec<String> {
         .collect()
 }
 
-/// One line per orphan under `dir`, for a substrate to hand its host.
+/// The extension [`SessionCandidateWorkspaces::write_patch`] keeps unscored
+/// work under, beside the checkout it came from.
+///
+/// [`SessionCandidateWorkspaces::write_patch`]: super::SessionCandidateWorkspaces
+const PATCH_EXT: &str = ".patch";
+
+/// Every preserved patch under `dir`, in a stable order.
+///
+/// Sorted by path rather than by mtime: the order a run reports its residue in
+/// must not change between two runs that found the same residue, and a
+/// filesystem's directory order is not an order at all.
+fn preserved_patches(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut found: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(PATCH_EXT))
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// What a run says about the work earlier runs kept, one line per patch.
+///
+/// Each line names the removal as well as the application, because this list
+/// is the one thing that stops repeating: a patch nobody deletes is named by
+/// every run from now until somebody does, which is the point — and a user
+/// told only how to apply it has no way to make the line go away.
+fn preserved_lines(patches: &[PathBuf]) -> Vec<String> {
+    patches
+        .iter()
+        .map(|path| {
+            let path = path.display();
+            format!(
+                "a candidate's work was kept from a run that ended before anything scored it: \
+                 {path}. Apply it with `git apply --binary {path}`, then delete it — this line \
+                 repeats until you do"
+            )
+        })
+        .collect()
+}
+
+/// One line per orphan and one per preserved patch under `dir`, for a substrate
+/// to hand its host.
 ///
 /// A free function rather than a method because both substrates keep their
 /// checkouts in the same directory and answer this question identically — the
 /// records say which shape each one was.
+///
+/// Records first: a leftover checkout is a live question about disk somebody
+/// may still be writing to, and a patch is settled work waiting to be read.
 pub(super) fn report(dir: &Path) -> Vec<String> {
-    reclaim_lines(&orphans(dir, &stella_store::sessions::pid_alive))
+    let mut lines = reclaim_lines(&orphans(
+        dir,
+        &stella_store::sessions::pid_alive,
+        &super::proc_start::of,
+    ));
+    lines.extend(preserved_lines(&preserved_patches(dir)));
+    lines
 }
 
 #[cfg(test)]
@@ -226,8 +342,15 @@ mod tests {
             branch: Some(format!("candidate/{handle}")),
             top: Some(dir.to_path_buf()),
             pid,
+            pid_start: None,
             started_at_ms: at,
         }
+    }
+
+    /// A host with no start-time interface, which is the pre-#4511 answer and
+    /// still the answer wherever neither `/proc` nor `sysctl` exists.
+    fn unreadable_start(_pid: u32) -> Option<u64> {
+        None
     }
 
     /// The record is beside the checkout, never inside it — the removal it
@@ -250,7 +373,7 @@ mod tests {
         record("dead-0", 4242, 10, dir.path()).write().unwrap();
         record("live-0", 4243, 20, dir.path()).write().unwrap();
 
-        let found = orphans(dir.path(), &|pid| pid == 4243);
+        let found = orphans(dir.path(), &|pid| pid == 4243, &unreadable_start);
         assert_eq!(found.len(), 1, "exactly the dead owner's: {found:?}");
         assert_eq!(found[0].handle, "dead-0");
     }
@@ -258,7 +381,14 @@ mod tests {
     #[test]
     fn a_workspace_that_never_fanned_out_reports_nothing() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(orphans(&dir.path().join("candidates"), &|_| false).is_empty());
+        assert!(
+            orphans(
+                &dir.path().join("candidates"),
+                &|_| false,
+                &unreadable_start
+            )
+            .is_empty()
+        );
     }
 
     /// A half-written record from the crash itself is skipped, not reported: a
@@ -274,7 +404,7 @@ mod tests {
         .unwrap();
         record("dead-0", 4242, 10, dir.path()).write().unwrap();
 
-        let found = orphans(dir.path(), &|_| false);
+        let found = orphans(dir.path(), &|_| false, &unreadable_start);
         assert_eq!(found.len(), 1, "{found:?}");
         assert_eq!(found[0].handle, "dead-0");
     }
@@ -287,10 +417,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let kept = record("dead-0", 4242, 10, dir.path());
         kept.write().unwrap();
-        assert_eq!(orphans(dir.path(), &|_| false).len(), 1);
+        assert_eq!(orphans(dir.path(), &|_| false, &unreadable_start).len(), 1);
 
         forget(&kept.checkout);
-        assert!(orphans(dir.path(), &|_| false).is_empty());
+        assert!(orphans(dir.path(), &|_| false, &unreadable_start).is_empty());
         // Twice is not an error: the sweep removes what adoption already took.
         forget(&kept.checkout);
     }
@@ -320,5 +450,118 @@ mod tests {
         .remove(0);
         assert!(line.contains("rm -rf"), "{line}");
         assert!(!line.contains("git "), "{line}");
+    }
+
+    /// **#4511's witness, half one.** A recycled pid makes a dead owner read
+    /// live; the start token is what tells the two apart, and without it this
+    /// record goes unreported and its checkout leaks.
+    #[test]
+    fn a_recycled_pid_does_not_make_a_dead_owner_read_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut leaked = record("crashed-0", 4242, 10, dir.path());
+        leaked.pid_start = Some(1_000);
+        leaked.write().unwrap();
+
+        // The number is in use again — by something that started later.
+        let found = orphans(dir.path(), &|_| true, &|_| Some(2_000));
+        assert_eq!(
+            found.len(),
+            1,
+            "a different process wears the pid: {found:?}"
+        );
+        assert_eq!(found[0].handle, "crashed-0");
+
+        // And the owner itself still reads as its own owner.
+        assert!(
+            orphans(dir.path(), &|_| true, &|_| Some(1_000)).is_empty(),
+            "a live owner's own record must never be offered for reclaim"
+        );
+    }
+
+    /// A host that cannot read a start token keeps the pre-#4511 rule, and a
+    /// record written before the field existed is exactly that host's case.
+    /// `None` is "cannot tell", never "gone".
+    #[test]
+    fn an_unreadable_start_leaves_a_live_pid_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        record("live-0", 4242, 10, dir.path()).write().unwrap();
+        assert!(orphans(dir.path(), &|_| true, &|_| Some(2_000)).is_empty());
+
+        let mut recorded = record("live-1", 4243, 20, dir.path());
+        recorded.pid_start = Some(1_000);
+        recorded.write().unwrap();
+        assert!(orphans(dir.path(), &|_| true, &unreadable_start).is_empty());
+    }
+
+    /// A record written by a build older than `pid_start` still parses, and
+    /// reads as the host that cannot tell — which is what it is.
+    #[test]
+    fn a_record_from_before_the_field_existed_still_parses() {
+        let older = serde_json::json!({
+            "handle": "old-0",
+            "checkout": "/w/.stella/private/candidates/old-0",
+            "pid": 4242,
+            "started_at_ms": 10_u64,
+        });
+        let parsed: CandidateRecord = serde_json::from_value(older).unwrap();
+        assert_eq!(parsed.pid_start, None);
+    }
+
+    /// **#4511's witness, half two.** The patch outlives the record that named
+    /// its checkout, so the sweep has to find it in the directory or it is
+    /// named exactly once, on a stderr line the user may have missed.
+    #[test]
+    fn a_preserved_patch_is_named_by_every_sweep_until_it_is_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let kept = record("scored-nothing-0", 4242, 10, dir.path());
+        kept.write().unwrap();
+        let patch = dir.path().join("scored-nothing-0.patch");
+        std::fs::write(&patch, b"diff --git a/x b/x\n").unwrap();
+
+        // Removal takes the checkout and the record with it (#2651's ending),
+        // and the patch is what is left.
+        forget(&kept.checkout);
+        let named = report(dir.path());
+        assert_eq!(named.len(), 1, "{named:?}");
+        assert!(named[0].contains("scored-nothing-0.patch"), "{}", named[0]);
+        assert!(
+            named[0].contains("git apply --binary"),
+            "a path with no way to use it is half a report: {}",
+            named[0]
+        );
+        assert!(
+            named[0].contains("delete it"),
+            "a line that repeats forever must say how to stop it: {}",
+            named[0]
+        );
+
+        // A second run finds it again — that is the whole fix.
+        assert_eq!(report(dir.path()).len(), 1);
+
+        std::fs::remove_file(&patch).unwrap();
+        assert!(report(dir.path()).is_empty(), "and stops once it is gone");
+    }
+
+    /// Patches are named in a stable order: two runs that found the same
+    /// residue must say the same thing, and a directory's own order is not an
+    /// order.
+    #[test]
+    fn preserved_patches_are_reported_in_a_stable_order() {
+        let dir = tempfile::tempdir().unwrap();
+        for slug in ["p-2-cccc", "p-0-aaaa", "p-1-bbbb"] {
+            std::fs::write(dir.path().join(format!("{slug}.patch")), b"diff\n").unwrap();
+        }
+        // A record's own file must not be mistaken for a patch.
+        record("live-0", 4242, 10, dir.path()).write().unwrap();
+
+        let found = preserved_patches(dir.path());
+        let names: Vec<String> = found
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            ["p-0-aaaa.patch", "p-1-bbbb.patch", "p-2-cccc.patch"]
+        );
     }
 }

--- a/crates/stella-cli/src/candidate_workspaces/substrate.rs
+++ b/crates/stella-cli/src/candidate_workspaces/substrate.rs
@@ -65,14 +65,33 @@ impl CandidateSubstrate {
     /// substrate, which is the direction that cannot destroy anything: the
     /// copy substrate overwrites the tree it promotes onto, and nothing may
     /// select it except an operator who wrote it down.
+    ///
+    /// Written down in a settings scope, or in
+    /// [`ISOLATION_ENV`](super::isolation::ISOLATION_ENV) — the spelling that
+    /// survives `STELLA_NO_SETTINGS=1`, under which `Settings::load` answers
+    /// its default and a launcher can otherwise say nothing at all (#4510).
+    /// See [`isolation`](super::isolation) for why the variable outranks the
+    /// file.
     pub(crate) fn for_session(
         cfg: &Config,
         plugin: &str,
         sub_agents: Arc<SessionSubAgents>,
     ) -> Self {
-        let isolation = crate::settings::Settings::load(&cfg.workspace_root)
+        let from_settings = crate::settings::Settings::load(&cfg.workspace_root)
             .map(|settings| settings.candidate_isolation())
             .unwrap_or_default();
+        let (isolation, notice) = super::isolation::selected(
+            std::env::var(super::isolation::ISOLATION_ENV)
+                .ok()
+                .as_deref(),
+            from_settings,
+        );
+        if let Some(notice) = notice {
+            // The same channel the sweep's residue lines take, for the same
+            // reason: it is a fact about how this run is configured, and the
+            // turn's own stdout belongs to the answer.
+            eprintln!("  ! wrapper: {notice}");
+        }
         Self::with_isolation(isolation, cfg, plugin, sub_agents)
     }
 

--- a/crates/stella-cli/src/candidate_workspaces/tests.rs
+++ b/crates/stella-cli/src/candidate_workspaces/tests.rs
@@ -830,7 +830,7 @@ async fn a_candidate_that_outlives_its_run_is_named_by_the_next_one() {
     };
     assert!(killed.exists(), "premise: the checkout is still on disk");
     assert_eq!(
-        record::orphans(&records, &|_| true).len(),
+        record::orphans(&records, &|_| true, &|_| None).len(),
         0,
         "an owner that is still alive is not residue"
     );
@@ -838,7 +838,7 @@ async fn a_candidate_that_outlives_its_run_is_named_by_the_next_one() {
     // The record this process wrote names this process, which is alive — so
     // the sweep of a *later* run is modelled by re-pointing the record at a
     // pid that certainly is not.
-    let mut mine = record::orphans(&records, &|_| false).remove(0);
+    let mut mine = record::orphans(&records, &|_| false, &|_| None).remove(0);
     assert_eq!(
         mine.checkout.canonicalize().unwrap(),
         killed,
@@ -876,14 +876,14 @@ async fn a_clean_removal_takes_the_record_with_it() {
 
     let candidate = subject.create("plugin:p/worker#0").await.unwrap();
     assert_eq!(
-        record::orphans(&root.join(CANDIDATES_DIR), &|_| false).len(),
+        record::orphans(&root.join(CANDIDATES_DIR), &|_| false, &|_| None).len(),
         1,
         "premise: creation wrote a record"
     );
 
     subject.remove(&candidate).await.unwrap();
     assert!(
-        record::orphans(&root.join(CANDIDATES_DIR), &|_| false).is_empty(),
+        record::orphans(&root.join(CANDIDATES_DIR), &|_| false, &|_| None).is_empty(),
         "a candidate that ended is not residue"
     );
 }

--- a/crates/stella-cli/src/candidate_workspaces/tests.rs
+++ b/crates/stella-cli/src/candidate_workspaces/tests.rs
@@ -1195,11 +1195,66 @@ async fn a_copy_candidate_is_promoted_by_replacing_the_tree() {
     assert!(!mine.exists(), "removal is the directory's");
 }
 
+/// Serializes the tests that reach `for_session`, which reads
+/// [`isolation::ISOLATION_ENV`] out of the process environment. A variable is
+/// one cell the whole test binary shares, so the pair that cares what it holds
+/// must not run at once.
+static ISOLATION_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Everything a `for_session` call needs, so the two tests below differ in the
+/// one thing under test.
+fn session_substrate(dir: &Path) -> CandidateSubstrate {
+    let mut cfg = Config::for_tests(crate::config::PROVIDERS[0].clone(), "m".to_string());
+    cfg.workspace_root = dir.to_path_buf();
+    CandidateSubstrate::for_session(
+        &cfg,
+        "candidates-plugin",
+        Arc::new(
+            crate::subagent::SessionSubAgents::new(
+                Arc::new(NoTools),
+                &Arc::new(stella_tools::ToolRegistry::new(dir.to_path_buf())),
+                EngineConfig::default(),
+                stella_protocol::BudgetMode::Observed,
+            )
+            .with_pool_limit(None),
+        ),
+    )
+}
+
+/// **#4510's witness, at the call site.** A benchmark launcher sets
+/// `STELLA_NO_SETTINGS=1`, under which no scope answers `candidate_isolation`
+/// at all — and the copy substrate exists for exactly the environment that
+/// launcher runs. This repository has no settings file either, so what
+/// `Settings::load` hands `for_session` here is the same
+/// `CandidateIsolation::default()` the isolated launcher gets; the variable is
+/// then the only thing that can select anything, and it has to arrive at the
+/// call site rather than at a function nothing calls.
+#[tokio::test]
+async fn the_environment_reaches_for_session_where_no_settings_scope_can() {
+    let _serialized = ISOLATION_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let dir = repo();
+    // SAFETY: the lock above is what makes this sound — no sibling test reads
+    // this variable while it is held, and it is removed before the lock drops.
+    unsafe { std::env::set_var(isolation::ISOLATION_ENV, "copy-tree") };
+    let subject = session_substrate(dir.path());
+    unsafe { std::env::remove_var(isolation::ISOLATION_ENV) };
+
+    assert!(
+        matches!(subject, CandidateSubstrate::CopyTree(_)),
+        "the one environment copy-tree was built for cannot reach it through settings"
+    );
+}
+
 /// The selector is the setting and nothing else — no probe, no detection —
 /// and a workspace that says nothing gets the substrate that cannot overwrite
 /// a tree.
 #[tokio::test]
 async fn the_default_substrate_is_the_one_that_cannot_overwrite_a_tree() {
+    let _serialized = ISOLATION_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_eq!(
         crate::settings::Settings::default().candidate_isolation(),
         crate::settings::CandidateIsolation::Worktree,
@@ -1210,25 +1265,11 @@ async fn the_default_substrate_is_the_one_that_cannot_overwrite_a_tree() {
     // gets a candidate under a git branch, which only the worktree substrate
     // mints.
     let dir = repo();
-    let subject = CandidateSubstrate::for_session(
-        &{
-            let mut cfg = Config::for_tests(crate::config::PROVIDERS[0].clone(), "m".to_string());
-            cfg.workspace_root = dir.path().to_path_buf();
-            cfg
-        },
-        "candidates-plugin",
-        Arc::new(
-            crate::subagent::SessionSubAgents::new(
-                Arc::new(NoTools),
-                &Arc::new(stella_tools::ToolRegistry::new(dir.path().to_path_buf())),
-                EngineConfig::default(),
-                stella_protocol::BudgetMode::Observed,
-            )
-            .with_pool_limit(None),
-        ),
-    );
     assert!(
-        matches!(subject, CandidateSubstrate::Worktree(_)),
+        matches!(
+            session_substrate(dir.path()),
+            CandidateSubstrate::Worktree(_)
+        ),
         "an unstated policy must not select the destructive substrate"
     );
 }

--- a/crates/stella-cli/src/cloud_drain.rs
+++ b/crates/stella-cli/src/cloud_drain.rs
@@ -293,6 +293,7 @@ mod tests {
                 retries: 0,
                 tool_calls: 0,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         };
         hub.replicate_telemetry(&scope, &[row(1), row(2)])

--- a/crates/stella-cli/src/diag_bridge.rs
+++ b/crates/stella-cli/src/diag_bridge.rs
@@ -334,6 +334,7 @@ impl DomainBridge {
                 duration_ms,
                 retries,
                 partial,
+                sub_agent_id: _,
             } => {
                 // Token counts are content-free, so the recovered figures ride
                 // the diagnostic timeline like any other operator id. They are
@@ -1329,6 +1330,7 @@ mod tests {
             tool_calls: 1,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         });
 
         let json = serde_json::to_string(&records.records()[0]).expect("serialize");

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -45,6 +45,7 @@ fn seed_session(root: &Path, session: &str, provider: &str, touched: &str) {
                 retries: 1,
                 tool_calls: 3,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         )
         .unwrap();
@@ -416,6 +417,7 @@ fn export_round_trips_through_a_real_store() {
                 retries: 0,
                 tool_calls: 1,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         )
         .unwrap();

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -169,6 +169,7 @@ async fn fleet_attempt_persists_usage_before_complete_closeout() {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     })
     .expect("event");
     drop(tx);

--- a/crates/stella-cli/src/fleet_spend.rs
+++ b/crates/stella-cli/src/fleet_spend.rs
@@ -108,6 +108,7 @@ mod tests {
             retries: 0,
             tool_calls: 0,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -792,11 +792,12 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             // definitions of a word end up disagreeing. Every routing and
             // ceiling flag, not the spend limit alone — `--model` was accepted
             // and dropped for as long as only that one was threaded (#4352).
-            return self_driving_cmd::run(
-                cmd,
-                &self_driving_cmd::turn_flags::TurnFlags::from_globals(&cli.globals),
-            )
-            .map_err(failure::CliFailure::from);
+            // The globals are read before anything else runs, so a flag this
+            // command cannot honour is refused before a state directory is
+            // touched or a turn is planned (#4471).
+            let flags = self_driving_cmd::turn_flags::TurnFlags::from_globals(&cli.globals)
+                .map_err(failure::CliFailure::from)?;
+            return self_driving_cmd::run(cmd, &flags).map_err(failure::CliFailure::from);
         }
         Some(Command::Memory { cmd }) => {
             // Reads local stores only (list) / writes one rule file

--- a/crates/stella-cli/src/memory/reflection/digest/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/digest/tests.rs
@@ -460,6 +460,7 @@ fn step_usage(step: usize, role: ModelCallRole, cost_usd: f64, duration_ms: u64)
         tool_calls: 2,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     }
 }
 

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -647,6 +647,7 @@ fn journal() -> Vec<stella_protocol::AgentEvent> {
             tool_calls: 1,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         },
     ]
 }
@@ -935,6 +936,7 @@ async fn the_prompt_names_where_the_turn_spent_itself() {
         tool_calls: 3,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     });
     friction.observe(&stella_protocol::AgentEvent::LoopDetected {
         turn_instance: 0,

--- a/crates/stella-cli/src/self_driving_cmd/turn_flags.rs
+++ b/crates/stella-cli/src/self_driving_cmd/turn_flags.rs
@@ -28,12 +28,35 @@
 //! `--accessible`, the animation toggles) describe the parent's terminal, and
 //! the child's stdout is a pipe.
 //!
-//! `--api-key` is deliberately **not** forwarded. It is the one global whose
-//! forwarding is a credential decision rather than a routing one — it would
-//! put the key in a second process's argv, where `ps` can read it for the
-//! whole length of a turn — and the credential chain already reaches the child
-//! by every other route (`STELLA_API_KEY`, `~/.stella/credentials.toml`). That
-//! is a judgement worth making on its own rather than inside this fix.
+//! # `--api-key` is refused rather than forwarded (#4471)
+//!
+//! It is the one global whose forwarding is a credential decision rather than a
+//! routing one — argv is readable by `ps` for the whole length of a turn — so
+//! #4405 left it out. Left out *silently*, which is the same shape #4352 had
+//! just fixed: a flag accepted and dropped. So it is now refused at the door,
+//! naming the routes that do reach a child.
+//!
+//! The alternative was the sealed credential handoff
+//! ([`crate::credential_handoff`]), which puts a secret in a child without
+//! argv or environment. It was not taken, for two reasons that are about this
+//! command rather than about the seam:
+//!
+//! - **The handoff seals a value into a named provider slot**, so the parent
+//!   would have to resolve which provider the child is going to select. This
+//!   command deliberately never does — `stella self-driving` runs with zero
+//!   API keys, and every turn is a child that resolves its own configuration.
+//!   Making a credential flag force a provider resolution in the parent would
+//!   put that whole chain (settings, catalog, an interactive prompt) in front
+//!   of a loop that today needs none of it.
+//! - **A consumed handoff is authoritative** —
+//!   [`credential_handoff::is_present`](crate::credential_handoff::is_present)
+//!   disables the child's credentials-file discovery outright, so a run
+//!   holding `~/.stella/credentials.toml` for three providers and passing
+//!   `--api-key` for one would lose the other two. That is a larger change
+//!   than `--api-key` means anywhere else.
+//!
+//! What the refusal costs a user is one exported variable; what it ends is a
+//! flag that looked like it worked.
 
 use std::process::Command;
 use std::time::Duration;
@@ -71,8 +94,16 @@ pub(crate) struct TurnFlags {
 
 impl TurnFlags {
     /// Read the parent's parsed globals.
-    pub(crate) fn from_globals(globals: &crate::cli::GlobalArgs) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// `--api-key`, which this command cannot honour — see the module doc for
+    /// why, and [`Self::api_key_refusal`] for what the sentence says.
+    pub(crate) fn from_globals(globals: &crate::cli::GlobalArgs) -> Result<Self, String> {
+        if globals.api_key.is_some() {
+            return Err(Self::api_key_refusal());
+        }
+        Ok(Self {
             model: globals.model.clone(),
             base_url: globals.base_url.clone(),
             upstream_pin: globals.upstream_pin.clone(),
@@ -80,7 +111,22 @@ impl TurnFlags {
             spend_limit: globals.spend_limit,
             turn_timeout: globals.turn_timeout,
             max_output_tokens: globals.max_output_tokens,
-        }
+        })
+    }
+
+    /// What a user who passed `--api-key` is told instead.
+    ///
+    /// Both remedies, because they are for different situations: an exported
+    /// variable is what a script wants, and `stella auth` is what a person at
+    /// a terminal wants. A refusal that named neither would be the silent drop
+    /// with extra steps.
+    fn api_key_refusal() -> String {
+        "stella self-driving does not forward --api-key to the turns it runs: a credential \
+         in a child's argv is readable by `ps` for the whole length of a turn. Export the \
+         provider's own variable instead (OPENROUTER_API_KEY, ANTHROPIC_API_KEY, …) — a \
+         child inherits the environment — or store it once with `stella auth`, which every \
+         turn reads from ~/.stella/credentials.toml."
+            .to_string()
     }
 
     /// Append every flag that was actually set to a child `stella run`.
@@ -117,5 +163,63 @@ impl TurnFlags {
         if let Some(cap) = self.max_output_tokens {
             cmd.arg("--max-output-tokens").arg(cap.to_string());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    /// The globals clap really parses out of `argv` — the same values `main`
+    /// hands this module, so a test cannot accidentally assert about a shape
+    /// the parser never produces.
+    fn globals(argv: &[&str]) -> crate::cli::GlobalArgs {
+        crate::cli::Cli::try_parse_from(argv)
+            .expect("these argv parse")
+            .globals
+    }
+
+    /// **#4471's witness.** The one session flag `TurnFlags` leaves out is now
+    /// refused rather than accepted and dropped — the silent-drop shape #4352
+    /// fixed for `--model` and #4405 left behind here by omission.
+    #[test]
+    fn an_api_key_is_refused_by_name_rather_than_silently_dropped() {
+        let refused = TurnFlags::from_globals(&globals(&[
+            "stella",
+            "self-driving",
+            "state",
+            "--api-key",
+            "sk-should-never-reach-a-child",
+        ]))
+        .expect_err("a credential this command cannot honour must not be accepted");
+
+        assert!(refused.contains("--api-key"), "{refused}");
+        assert!(
+            refused.contains("stella auth") && refused.contains("API_KEY"),
+            "a refusal that names no remedy is the silent drop with extra steps: {refused}"
+        );
+        assert!(
+            !refused.contains("sk-should-never-reach-a-child"),
+            "and it must not echo the secret it refused: {refused}"
+        );
+    }
+
+    /// The routing globals still arrive, or the refusal above would have
+    /// broken the fix it sits beside (#4352).
+    #[test]
+    fn every_other_global_still_reaches_the_turn() {
+        let flags = TurnFlags::from_globals(&globals(&[
+            "stella",
+            "self-driving",
+            "state",
+            "--model",
+            "openrouter/kimi-k3",
+            "--spend-limit",
+            "30",
+        ]))
+        .expect("no credential, no refusal");
+        assert_eq!(flags.model.as_deref(), Some("openrouter/kimi-k3"));
+        assert_eq!(flags.spend_limit, Some(30.0));
     }
 }

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -1294,6 +1294,7 @@ mod tests {
                     tool_calls: 1,
                     complete: true,
                     finish_reason: None,
+                    sub_agent_id: None,
                 },
             },
             Inbound::Event {

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -402,20 +402,38 @@ pub enum CandidateIsolation {
     CopyTree,
 }
 
+impl CandidateIsolation {
+    /// Read one written token — the settings value, or the environment
+    /// override that reaches a host no settings file can (#4510).
+    ///
+    /// One parse for both because they are one setting spelled twice, and a
+    /// second `match` over the same two words is how `"copytree"` ends up
+    /// accepted on one surface and refused on the other.
+    ///
+    /// # Errors
+    ///
+    /// The clause a surface appends to its own prefix, naming the token it was
+    /// given and the two it accepts.
+    pub fn from_token(raw: &str) -> Result<Self, String> {
+        match raw.trim() {
+            "" | "worktree" => Ok(Self::Worktree),
+            "copy-tree" => Ok(Self::CopyTree),
+            other => Err(format!(
+                "{other:?} is not one of \"worktree\", \"copy-tree\" \
+                 (empty or absent means \"worktree\")"
+            )),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for CandidateIsolation {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Through `Option<String>` so an explicit `null` lands here rather than
         // being rejected before this function sees it — `create_worktrees`'
         // shape, for its reason.
         let raw = Option::<String>::deserialize(deserializer)?;
-        match raw.as_deref().map(str::trim).unwrap_or("") {
-            "" | "worktree" => Ok(Self::Worktree),
-            "copy-tree" => Ok(Self::CopyTree),
-            other => Err(serde::de::Error::custom(format!(
-                "\"candidate_isolation\": {other:?} is not one of \"worktree\", \"copy-tree\" \
-                 (empty or absent means \"worktree\")"
-            ))),
-        }
+        Self::from_token(raw.as_deref().unwrap_or(""))
+            .map_err(|why| serde::de::Error::custom(format!("\"candidate_isolation\": {why}")))
     }
 }
 

--- a/crates/stella-cli/tests/self_driving_cli.rs
+++ b/crates/stella-cli/tests/self_driving_cli.rs
@@ -292,3 +292,41 @@ fn stop_root_targets_another_loops_state_directory() {
         "and this workspace's own loop keeps working"
     );
 }
+
+/// **#4471's witness, at the process.** `--api-key` is a session global, so
+/// clap accepts it on every subcommand; before this it was accepted here and
+/// then reached no turn — the silent-drop shape #4352 had just fixed for
+/// `--model`.
+///
+/// The refusal lands before any state directory is touched, which is what
+/// makes it a refusal rather than a warning about work already done.
+#[test]
+fn an_api_key_is_refused_before_the_loop_touches_anything() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = tmp.path().join("state");
+
+    let out = stella(
+        tmp.path(),
+        &state,
+        &["state", "--api-key", "sk-should-never-reach-a-child"],
+    );
+
+    assert!(
+        !out.status.success(),
+        "a dropped credential is not a success"
+    );
+    let said = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(said.contains("--api-key"), "{said}");
+    assert!(
+        said.contains("stella auth"),
+        "the refusal has to name a route that works: {said}"
+    );
+    assert!(
+        !said.contains("sk-should-never-reach-a-child") && !stdout(&out).contains("sk-should"),
+        "and must not echo the secret onto a terminal or a log: {said}"
+    );
+    assert!(
+        !state.exists(),
+        "nothing may be written before a flag this command cannot honour is refused"
+    );
+}

--- a/crates/stella-cli/tests/stats_prune_cli.rs
+++ b/crates/stella-cli/tests/stats_prune_cli.rs
@@ -34,6 +34,7 @@ fn telemetry(step: u64) -> TelemetryRow {
         retries: 0,
         tool_calls: 0,
         usage_complete: true,
+        sub_agent_id: None,
     }
 }
 

--- a/crates/stella-core/src/accounted_call.rs
+++ b/crates/stella-core/src/accounted_call.rs
@@ -346,6 +346,7 @@ pub async fn run_accounted_call(
         // Management calls truncate too — a verifier verdict or a plan cut off at
         // the ceiling is exactly the silent failure this field exists to name.
         finish_reason: result.finish_reason,
+        sub_agent_id: None,
     });
     let budget_outcome = budget.record_spend(result.cost_usd);
     let _ = events.send(budget.tick_event(Instant::now()));
@@ -390,6 +391,7 @@ fn emit_incomplete(
         duration_ms: duration.as_millis() as u64,
         retries,
         partial,
+        sub_agent_id: None,
     });
 }
 

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -1351,31 +1351,18 @@ impl<'a> Engine<'a> {
         // Cost and usage settle at one no-await boundary. Speculative tool
         // work may still be draining; cancellation in that interval must not
         // preserve spend while losing its per-call accounting envelope.
-        let _ = events.send(AgentEvent::StepUsage {
-            step,
-            role: self.call_role,
-            provider: self.active_provider().id().to_string(),
-            upstream_provider: result.upstream_provider.clone(),
-            // The engine's own step already streams its answer as a `Text`
-            // event; duplicating it here would double the transcript.
-            output_text: None,
-            model: result.model.clone(),
-            input_tokens: result.usage.input_tokens,
-            output_tokens: result.usage.output_tokens,
-            cached_input_tokens: result.usage.cached_input_tokens,
-            cache_write_tokens: result.usage.cache_write_tokens,
-            reasoning_tokens: result.usage.reasoning_tokens,
-            estimated_input_tokens,
-            cost_usd: result.cost_usd,
-            duration_ms: call_duration_ms,
-            retries: retries.len() as u32,
-            tool_calls: result.tool_calls.len(),
-            complete: result.usage.is_complete(),
-            // The provider's own stop reason, forwarded rather than inferred:
-            // `Length` here is the only truthful "this step hit the output
-            // ceiling" signal any consumer gets.
-            finish_reason: result.finish_reason,
-        });
+        settlement::emit_step_usage(
+            events,
+            settlement::SettledCall {
+                step,
+                role: self.call_role,
+                provider: self.active_provider().id(),
+                result: &result,
+                estimated_input_tokens,
+                duration_ms: call_duration_ms,
+                retries: retries.len() as u32,
+            },
+        );
         let speculation = speculation_future.await;
 
         Ok(CommittedStep {

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -237,6 +237,7 @@ impl<'a> Engine<'a> {
                     // returns history only for calls that COMMIT, so a doomed
                     // attempt's accounting reaches the wire here or nowhere.
                     partial: error.partial_usage().copied(),
+                    sub_agent_id: None,
                 });
             },
             &mut park,

--- a/crates/stella-core/src/driver/settlement.rs
+++ b/crates/stella-core/src/driver/settlement.rs
@@ -259,6 +259,61 @@ pub(super) fn last_assistant_text(state: &crate::step::TurnState) -> Option<Stri
         .map(|message| message.content.clone())
 }
 
+/// One committed model call, in the shape the metering record needs.
+///
+/// A struct rather than seven positional parameters: `step`, `duration_ms`
+/// and `retries` are all bare integers, and a caller that transposed two of
+/// them would compile and mis-meter every call.
+pub(super) struct SettledCall<'a> {
+    pub(super) step: usize,
+    pub(super) role: stella_protocol::event::ModelCallRole,
+    /// The provider that actually served the call, never the session default.
+    pub(super) provider: &'a str,
+    pub(super) result: &'a stella_protocol::CompletionResult,
+    pub(super) estimated_input_tokens: u64,
+    pub(super) duration_ms: u64,
+    pub(super) retries: u32,
+}
+
+/// Emit the metering record for one committed call.
+///
+/// Lives here rather than at the call site because `driver.rs` is a
+/// grandfathered god file closed to growth (AGENTS.md § "God files"), and
+/// because this is settlement: the event carries the same figures the budget
+/// settles on, at the same no-await boundary.
+pub(super) fn emit_step_usage(events: &EventSender, call: SettledCall<'_>) {
+    let result = call.result;
+    let _ = events.send(AgentEvent::StepUsage {
+        step: call.step,
+        role: call.role,
+        provider: call.provider.to_string(),
+        upstream_provider: result.upstream_provider.clone(),
+        // The engine's own step already streams its answer as a `Text`
+        // event; duplicating it here would double the transcript.
+        output_text: None,
+        model: result.model.clone(),
+        input_tokens: result.usage.input_tokens,
+        output_tokens: result.usage.output_tokens,
+        cached_input_tokens: result.usage.cached_input_tokens,
+        cache_write_tokens: result.usage.cache_write_tokens,
+        reasoning_tokens: result.usage.reasoning_tokens,
+        estimated_input_tokens: call.estimated_input_tokens,
+        cost_usd: result.cost_usd,
+        duration_ms: call.duration_ms,
+        retries: call.retries,
+        tool_calls: result.tool_calls.len(),
+        complete: result.usage.is_complete(),
+        // The provider's own stop reason, forwarded rather than inferred:
+        // `Length` here is the only truthful "this step hit the output
+        // ceiling" signal any consumer gets.
+        finish_reason: result.finish_reason,
+        // The lead's own call. A delegate's is stamped where the delegate is
+        // known — `subagent::child_sender`, the one place that can say which
+        // of several concurrent children an event belongs to (#4383).
+        sub_agent_id: None,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -363,59 +418,4 @@ mod tests {
         };
         assert!(reason.contains("exceeded by 2.0s"), "{reason}");
     }
-}
-
-/// One committed model call, in the shape the metering record needs.
-///
-/// A struct rather than seven positional parameters: `step`, `duration_ms`
-/// and `retries` are all bare integers, and a caller that transposed two of
-/// them would compile and mis-meter every call.
-pub(super) struct SettledCall<'a> {
-    pub(super) step: usize,
-    pub(super) role: stella_protocol::event::ModelCallRole,
-    /// The provider that actually served the call, never the session default.
-    pub(super) provider: &'a str,
-    pub(super) result: &'a stella_protocol::CompletionResult,
-    pub(super) estimated_input_tokens: u64,
-    pub(super) duration_ms: u64,
-    pub(super) retries: u32,
-}
-
-/// Emit the metering record for one committed call.
-///
-/// Lives here rather than at the call site because `driver.rs` is a
-/// grandfathered god file closed to growth (AGENTS.md § "God files"), and
-/// because this is settlement: the event carries the same figures the budget
-/// settles on, at the same no-await boundary.
-pub(super) fn emit_step_usage(events: &EventSender, call: SettledCall<'_>) {
-    let result = call.result;
-    let _ = events.send(AgentEvent::StepUsage {
-        step: call.step,
-        role: call.role,
-        provider: call.provider.to_string(),
-        upstream_provider: result.upstream_provider.clone(),
-        // The engine's own step already streams its answer as a `Text`
-        // event; duplicating it here would double the transcript.
-        output_text: None,
-        model: result.model.clone(),
-        input_tokens: result.usage.input_tokens,
-        output_tokens: result.usage.output_tokens,
-        cached_input_tokens: result.usage.cached_input_tokens,
-        cache_write_tokens: result.usage.cache_write_tokens,
-        reasoning_tokens: result.usage.reasoning_tokens,
-        estimated_input_tokens: call.estimated_input_tokens,
-        cost_usd: result.cost_usd,
-        duration_ms: call.duration_ms,
-        retries: call.retries,
-        tool_calls: result.tool_calls.len(),
-        complete: result.usage.is_complete(),
-        // The provider's own stop reason, forwarded rather than inferred:
-        // `Length` here is the only truthful "this step hit the output
-        // ceiling" signal any consumer gets.
-        finish_reason: result.finish_reason,
-        // The lead's own call. A delegate's is stamped where the delegate is
-        // known — `subagent::child_sender`, the one place that can say which
-        // of several concurrent children an event belongs to (#4383).
-        sub_agent_id: None,
-    });
 }

--- a/crates/stella-core/src/driver/settlement.rs
+++ b/crates/stella-core/src/driver/settlement.rs
@@ -364,3 +364,58 @@ mod tests {
         assert!(reason.contains("exceeded by 2.0s"), "{reason}");
     }
 }
+
+/// One committed model call, in the shape the metering record needs.
+///
+/// A struct rather than seven positional parameters: `step`, `duration_ms`
+/// and `retries` are all bare integers, and a caller that transposed two of
+/// them would compile and mis-meter every call.
+pub(super) struct SettledCall<'a> {
+    pub(super) step: usize,
+    pub(super) role: stella_protocol::event::ModelCallRole,
+    /// The provider that actually served the call, never the session default.
+    pub(super) provider: &'a str,
+    pub(super) result: &'a stella_protocol::CompletionResult,
+    pub(super) estimated_input_tokens: u64,
+    pub(super) duration_ms: u64,
+    pub(super) retries: u32,
+}
+
+/// Emit the metering record for one committed call.
+///
+/// Lives here rather than at the call site because `driver.rs` is a
+/// grandfathered god file closed to growth (AGENTS.md § "God files"), and
+/// because this is settlement: the event carries the same figures the budget
+/// settles on, at the same no-await boundary.
+pub(super) fn emit_step_usage(events: &EventSender, call: SettledCall<'_>) {
+    let result = call.result;
+    let _ = events.send(AgentEvent::StepUsage {
+        step: call.step,
+        role: call.role,
+        provider: call.provider.to_string(),
+        upstream_provider: result.upstream_provider.clone(),
+        // The engine's own step already streams its answer as a `Text`
+        // event; duplicating it here would double the transcript.
+        output_text: None,
+        model: result.model.clone(),
+        input_tokens: result.usage.input_tokens,
+        output_tokens: result.usage.output_tokens,
+        cached_input_tokens: result.usage.cached_input_tokens,
+        cache_write_tokens: result.usage.cache_write_tokens,
+        reasoning_tokens: result.usage.reasoning_tokens,
+        estimated_input_tokens: call.estimated_input_tokens,
+        cost_usd: result.cost_usd,
+        duration_ms: call.duration_ms,
+        retries: call.retries,
+        tool_calls: result.tool_calls.len(),
+        complete: result.usage.is_complete(),
+        // The provider's own stop reason, forwarded rather than inferred:
+        // `Length` here is the only truthful "this step hit the output
+        // ceiling" signal any consumer gets.
+        finish_reason: result.finish_reason,
+        // The lead's own call. A delegate's is stamped where the delegate is
+        // known — `subagent::child_sender`, the one place that can say which
+        // of several concurrent children an event belongs to (#4383).
+        sub_agent_id: None,
+    });
+}

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -1309,6 +1309,7 @@ impl Drop for CancelUsageGuard {
             // ever returned an error to salvage from. The server-side cost of
             // an abandoned call stays genuinely unknowable.
             partial: None,
+            sub_agent_id: None,
         });
     }
 }

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -91,7 +91,7 @@
 //!
 //! **The two metering records are the exception, and they earn it** (#4383).
 //! `StepUsage` and `UsageIncomplete` carry a `sub_agent_id`, stamped by
-//! [`child_sender`]. The bracket cannot answer for them, because independent
+//! `child_sender`. The bracket cannot answer for them, because independent
 //! delegates are dispatched *concurrently*: several children's events
 //! interleave on the parent's one stream, so no `Started`/`Finished` pair
 //! encloses any particular call. Until the field existed, a turn's whole cost

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -89,6 +89,17 @@
 //! it is the metering record, and dropping it is exactly how child cost
 //! would vanish from `stella stats` and quietly falsify `$/resolved task`.
 //!
+//! **The two metering records are the exception, and they earn it** (#4383).
+//! `StepUsage` and `UsageIncomplete` carry a `sub_agent_id`, stamped by
+//! [`child_sender`]. The bracket cannot answer for them, because independent
+//! delegates are dispatched *concurrently*: several children's events
+//! interleave on the parent's one stream, so no `Started`/`Finished` pair
+//! encloses any particular call. Until the field existed, a turn's whole cost
+//! landed under the lead — ninety telemetry rows all reading `worker` in
+//! session `ses-1787465453163-60967`, five of them a parallel delegate fan-out
+//! completing within one second — and the `(role, model)` census AGENTS.md
+//! tells a bench reader to run could not separate a lead from its delegates.
+//!
 //! The bracket survives cancellation (#1954): a caller that drops the
 //! future mid-flight — a latency ceiling, a hard cancel — still gets a
 //! `Finished` carrying the committed step count and cost (`CancelBracket`),
@@ -818,7 +829,7 @@ impl Engine<'_> {
         messages.push(CompletionMessage::user(spec.instruction.clone()));
         let seeded = messages.len();
 
-        let child_events = child_sender(events.clone(), tally.clone());
+        let child_events = child_sender(events.clone(), spec.agent_id.clone(), tally.clone());
         // The carve is handed to the turn through a guard that settles it on
         // DROP, not on return (#1850). `settle_child` used to be a statement
         // after the await, so any exit that was not a return skipped it: a
@@ -948,17 +959,39 @@ impl CommittedTally {
     }
 }
 
-/// The child's event sender: drops what must not cross ([`forwards_to_parent`])
-/// and tallies committed model calls — count and cost — on the way past.
+/// The child's event sender: drops what must not cross ([`forwards_to_parent`]),
+/// stamps whose call each metering record was, and tallies committed model
+/// calls — count and cost — on the way past.
 ///
 /// Tallying here rather than from the turn outcome is what makes the numbers
 /// truthful on an abort too — `StepUsage` is emitted per committed call, so a
 /// child that died on step 5 of 16 reports 5. See [`CommittedTally`] for why
 /// it is also the only record that survives a cancel.
-fn child_sender(parent: EventSender, tally: Arc<CommittedTally>) -> EventSender {
-    EventSender::from_fn(move |event| {
+///
+/// # Why the id is stamped here (#4383)
+///
+/// This is the one place that knows *which* child an event belongs to. The
+/// `Started`/`Finished` bracket was designed as the whole attribution
+/// mechanism and is enough for everything else, but the engine dispatches
+/// independent delegates concurrently: several children's events interleave on
+/// the parent's one stream, and no bracket pair encloses any particular call.
+/// So the two metering records carry the id, and every other event keeps the
+/// bracket as its only attribution.
+///
+/// **The innermost sender wins.** A grandchild's event passes this closure
+/// once per level on its way up; the first stamp is the grandchild's own, and
+/// the levels above leave it alone. A cost question is about who spent it, not
+/// about who delegated to whoever spent it.
+fn child_sender(parent: EventSender, agent_id: String, tally: Arc<CommittedTally>) -> EventSender {
+    EventSender::from_fn(move |mut event| {
         if let AgentEvent::StepUsage { cost_usd, .. } = &event {
             tally.observe(*cost_usd);
+        }
+        if let AgentEvent::StepUsage { sub_agent_id, .. }
+        | AgentEvent::UsageIncomplete { sub_agent_id, .. } = &mut event
+            && sub_agent_id.is_none()
+        {
+            *sub_agent_id = Some(agent_id.clone());
         }
         if forwards_to_parent(&event) {
             parent.send(event)

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -830,6 +830,13 @@ impl Engine<'_> {
         let seeded = messages.len();
 
         let child_events = child_sender(events.clone(), spec.agent_id.clone(), tally.clone());
+        // A call may never be granted more than what is left of the ceiling the
+        // whole child runs under (#4488).
+        carve.set_task_deadline(bounded_by_ceiling(
+            carve.task_deadline(),
+            self.config.tool_timeout,
+            std::time::Instant::now(),
+        ));
         // The carve is handed to the turn through a guard that settles it on
         // DROP, not on return (#1850). `settle_child` used to be a statement
         // after the await, so any exit that was not a return skipped it: a
@@ -956,6 +963,48 @@ impl CommittedTally {
 
     fn cost_usd(&self) -> f64 {
         *self.cost_usd.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// What a child must keep in hand after its deadline trips: abort at the step
+/// boundary, assemble the report, close the bracket (#4488).
+///
+/// The number's requirement is only that it be strictly positive and small
+/// against the ceiling, so the child always reaches its own deadline before
+/// the engine's dispatch ceiling reaches the tool. Thirty seconds is generous
+/// for work that is pure local computation with no model call left in it.
+const CEILING_RESERVE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The wall clock this child may spend, given what it inherited and the
+/// dispatch ceiling its whole run sits under.
+///
+/// # The defect this closes (#4488)
+///
+/// The delegate's ceiling is `EngineConfig::tool_timeout` (15 minutes), and
+/// the per-call bound underneath it is `model_timeout` — which measures
+/// **silence**, not elapsed time. So a stream that dribbles a fragment every
+/// few seconds re-arms the idle bound forever, consumes the entire ceiling
+/// with one call, and is abandoned by `execute_with_repair` with nothing
+/// salvaged: the child never got to decide anything, because nothing inside it
+/// knew what its outer ceiling was.
+///
+/// A task deadline is what the engine already bounds a dispatch by
+/// (`step::deadline_bounded_generation`, #2021), and it is a wall clock rather
+/// than an idle gap — so deriving one from the ceiling makes the child see its
+/// own limit first and report the call as timed out. The reserve is what keeps
+/// "first" true rather than a coin flip at the same instant.
+///
+/// The tighter of the two always wins, so a parent already racing a deadline
+/// never hands a child more time than the parent itself has.
+fn bounded_by_ceiling(
+    inherited: Option<std::time::Instant>,
+    ceiling: Option<std::time::Duration>,
+    now: std::time::Instant,
+) -> Option<std::time::Instant> {
+    let from_ceiling = ceiling.map(|ceiling| now + ceiling.saturating_sub(CEILING_RESERVE));
+    match (inherited, from_ceiling) {
+        (Some(inherited), Some(from_ceiling)) => Some(inherited.min(from_ceiling)),
+        (only, None) | (None, only) => only,
     }
 }
 

--- a/crates/stella-core/src/subagent/tests/failure_and_events.rs
+++ b/crates/stella-core/src/subagent/tests/failure_and_events.rs
@@ -164,6 +164,78 @@ async fn the_childs_stage_and_narration_never_reach_the_parents_stream() {
     }
 }
 
+/// **#4383's witness.** A child's metering records reach the parent naming the
+/// child. Without the stamp they are indistinguishable from the lead's own
+/// calls, which is how execution 225 of session `ses-1787465453163-60967` came
+/// to record ninety `worker` rows for a turn that fanned out five delegates.
+///
+/// The bracket cannot answer this, and that is the whole reason for the field:
+/// independent delegates are dispatched concurrently, so `Started`/`Finished`
+/// pairs interleave and enclose each other's calls.
+#[tokio::test]
+async fn a_childs_metering_records_name_the_child_that_spent_them() {
+    let parent_provider = ScriptedProvider::new(vec![]);
+    let child_provider = ScriptedProvider::new(vec![Ok(text_result("done", 0.02))]);
+    let tools = MixedTools::default();
+    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    parent
+        .run_sub_agent(
+            SubAgentHost::new(&child_provider),
+            &SubAgentSpec::read_only("researcher-7", "work"),
+            &mut budget,
+            &tx,
+        )
+        .await;
+    let events = drain(&mut rx);
+
+    let spenders: Vec<Option<String>> = events
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::StepUsage { sub_agent_id, .. } => Some(sub_agent_id.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        spenders,
+        vec![Some("researcher-7".to_string())],
+        "every call the child made must name the child"
+    );
+    // And the bracket still says the same thing, so a consumer that reads
+    // either one gets the same answer rather than two competing ones.
+    match finished(&events) {
+        SubAgentPhase::Finished { agent_id, .. } => assert_eq!(agent_id, "researcher-7"),
+        other => panic!("expected Finished, got {other:?}"),
+    }
+}
+
+/// A call the lead made itself is the lead's, and must not acquire an id from
+/// a child that ran beside it. `None` is a fact — "the lead spent this" — so a
+/// reader summing by spender gets the turn's real shape.
+#[tokio::test]
+async fn the_leads_own_calls_name_no_sub_agent() {
+    let provider = ScriptedProvider::new(vec![Ok(text_result("answered", 0.05))]);
+    let tools = MixedTools::default();
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep);
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut messages = vec![CompletionMessage::user("do it")];
+
+    let _ = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    let events = drain(&mut rx);
+
+    let spenders: Vec<Option<String>> = events
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::StepUsage { sub_agent_id, .. } => Some(sub_agent_id.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(spenders, vec![None], "{spenders:?}");
+}
+
 #[tokio::test]
 async fn step_usage_and_tool_activity_reach_the_parent_so_cost_rolls_up() {
     // Dropping StepUsage is precisely how child spend would vanish from

--- a/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
+++ b/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
@@ -305,3 +305,114 @@ async fn a_cancelled_child_closes_its_bracket_with_committed_steps_and_cost() {
         budget.session_spent_usd()
     );
 }
+
+// ---- the ceiling a child runs under (#4488) ---------------------------
+
+/// A provider that never answers — the shape of the defect, once the idle
+/// bound is out of the picture.
+///
+/// `model_timeout` measures **silence**, so a stream that dribbles a fragment
+/// every few seconds re-arms it forever and the call runs until something else
+/// stops it. Under `tokio::time::pause()` a sleep that outlasts every ceiling
+/// is the same fact with no streaming machinery in the way: whatever cuts this
+/// call is the only thing that could ever have cut a dribbling one.
+struct NeverAnswers;
+
+#[async_trait]
+impl Provider for NeverAnswers {
+    fn id(&self) -> &str {
+        "never-answers"
+    }
+
+    async fn complete_ref(
+        &self,
+        _request: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        tokio::time::sleep(std::time::Duration::from_secs(24 * 60 * 60)).await;
+        unreachable!("the deadline is what ends this call")
+    }
+}
+
+/// **#4488's witness.** A child sees its own deadline before the dispatch
+/// ceiling reaches the tool that spawned it, so one call can no longer consume
+/// the whole delegate and leave nothing salvaged.
+///
+/// The ceiling here is `tool_timeout`, the engine's whole-tool dispatch
+/// backstop (`execute_with_repair`), which is what bounds a `delegate` call.
+/// `model_timeout: None` is the dribbling stream: an idle bound that never
+/// trips. Before the fix, nothing inside the child knew the outer ceiling, so
+/// it ran until `execute_with_repair` abandoned it.
+#[tokio::test(start_paused = true)]
+async fn a_child_is_bounded_by_the_ceiling_its_whole_run_sits_under() {
+    let ceiling = std::time::Duration::from_secs(900);
+    let parent_provider = ScriptedProvider::new(vec![]);
+    let child_provider = NeverAnswers;
+    let tools = MixedTools::default();
+    let parent = Engine::with_sleeper(
+        &parent_provider,
+        &tools,
+        EngineConfig {
+            tool_timeout: Some(ceiling),
+            // The dribbling stream: an idle bound that never trips.
+            model_timeout: None,
+            ..EngineConfig::default()
+        },
+        &NoSleep,
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let started = tokio::time::Instant::now();
+    let outcome = parent
+        .run_sub_agent(
+            SubAgentHost::new(&child_provider),
+            &SubAgentSpec::read_only("dribbler", "work"),
+            &mut budget,
+            &tx,
+        )
+        .await;
+    let spent = started.elapsed();
+
+    assert!(
+        matches!(outcome, SubAgentOutcome::Incomplete { .. }),
+        "the child must end itself, not be abandoned: {outcome:?}"
+    );
+    assert!(
+        spent < ceiling,
+        "the child has to see its deadline before the dispatch ceiling sees the tool, \
+         and it spent {spent:?} of a {ceiling:?} ceiling"
+    );
+}
+
+/// The derivation, in both directions. A parent already racing a deadline
+/// never hands a child more time than the parent itself has.
+#[test]
+fn a_childs_deadline_is_the_tighter_of_what_it_inherited_and_the_ceiling() {
+    use std::time::Duration;
+    let now = std::time::Instant::now();
+    let ceiling = Duration::from_secs(900);
+
+    let from_ceiling =
+        crate::subagent::bounded_by_ceiling(None, Some(ceiling), now).expect("a ceiling bounds it");
+    assert!(
+        from_ceiling < now + ceiling,
+        "a deadline at the ceiling is a coin flip against the dispatch timeout"
+    );
+
+    let sooner = now + Duration::from_secs(10);
+    assert_eq!(
+        crate::subagent::bounded_by_ceiling(Some(sooner), Some(ceiling), now),
+        Some(sooner),
+        "the parent's own deadline is not widened by having a child"
+    );
+    assert_eq!(
+        crate::subagent::bounded_by_ceiling(Some(sooner), None, now),
+        Some(sooner),
+        "no ceiling leaves what was inherited exactly as it was"
+    );
+    assert_eq!(
+        crate::subagent::bounded_by_ceiling(None, None, now),
+        None,
+        "and an unbounded parent with no ceiling stays unbounded"
+    );
+}

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -278,6 +278,7 @@ fn real_store_workspace() -> tempfile::TempDir {
                 retries: 0,
                 tool_calls: 2,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         )
         .expect("telemetry");

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -384,6 +384,7 @@ fn real_store_workspace() -> tempfile::TempDir {
                 produced_output: true,
                 wrote_files: true,
                 truncated: false,
+                partial_run: false,
             },
         )
         .expect("reflection");

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -813,6 +813,27 @@ pub enum AgentEvent {
             )
         )]
         finish_reason: Option<crate::completion::FinishReason>,
+        /// Which sub-agent spent this call, when a sub-agent did (#4383).
+        ///
+        /// `None` is the lead's own call. It is stamped at the sub-agent
+        /// boundary (`stella_core::subagent`'s `child_sender`), so a nested
+        /// child names *itself* rather than its parent — the innermost spender
+        /// is the one a cost question is about.
+        ///
+        /// The bracket in [`crate::subagent_event::SubAgentPhase`] was meant to
+        /// be the whole attribution mechanism, and it is enough for everything
+        /// it was designed for. It is not enough for **this**: the engine
+        /// dispatches independent delegates concurrently, so several children's
+        /// events interleave on one stream and no `Started`/`Finished` pair
+        /// brackets any particular call. Session `ses-1787465453163-60967` has
+        /// five delegates completing within one second of each other; its
+        /// ninety telemetry rows all read `worker`, and no join over the
+        /// bracket can undo that.
+        ///
+        /// Content-free like the rest of this event: an opaque handle
+        /// (`plugin:vera/worker#0`), never instruction text.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sub_agent_id: Option<String>,
     },
     /// A provider call failed or timed out after dispatch, so local accounting
     /// cannot prove that no billable work occurred. Content-free by design.
@@ -856,6 +877,14 @@ pub enum AgentEvent {
         /// inside its no-prompts-no-bodies contract.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         partial: Option<crate::completion::PartialUsage>,
+        /// Which sub-agent's call died, when a sub-agent's did (#4383). Same
+        /// contract as [`AgentEvent::StepUsage`]'s field of this name, and here
+        /// for the same reason it is there: a delegate abandoned at the
+        /// engine's dispatch ceiling lands one flagged row, and a row nobody
+        /// can attribute explains an execution's `usage_complete = 0` without
+        /// saying whose call it was.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sub_agent_id: Option<String>,
     },
     /// A verifier model's assessment of a goal-driven loop after one working
     /// round. `met == true` ends the loop; `met == false` feeds `reasoning`

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -833,6 +833,12 @@ pub enum AgentEvent {
         /// Content-free like the rest of this event: an opaque handle
         /// (`plugin:vera/worker#0`), never instruction text.
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "schema",
+            schemars(
+                description = "Which sub-agent spent this call. Absent means the lead's own call, which is the ordinary case. Stamped at the sub-agent boundary, so a nested child names itself rather than its parent. The `sub_agent` started/finished bracket cannot answer this: independent delegates are dispatched concurrently, so several children's events interleave on one stream and no bracket pair encloses any particular call. An opaque handle, never instruction text."
+            )
+        )]
         sub_agent_id: Option<String>,
     },
     /// A provider call failed or timed out after dispatch, so local accounting
@@ -884,6 +890,12 @@ pub enum AgentEvent {
         /// can attribute explains an execution's `usage_complete = 0` without
         /// saying whose call it was.
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "schema",
+            schemars(
+                description = "Which sub-agent's call died. Absent means the lead's own. Same contract as a `step_usage` event's field of this name: an abandoned delegate lands one flagged row, and a row nobody can attribute explains an execution's incomplete usage without saying whose call it was."
+            )
+        )]
         sub_agent_id: Option<String>,
     },
     /// A verifier model's assessment of a goal-driven loop after one working

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -893,6 +893,7 @@ fn step_usage_roundtrips_as_a_complete_metering_record() {
         tool_calls: 4,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     };
     let json = serde_json::to_string(&event).unwrap();
     assert!(json.contains("\"type\":\"step_usage\""), "{json}");

--- a/crates/stella-protocol/src/event/tests/tag_table.rs
+++ b/crates/stella-protocol/src/event/tests/tag_table.rs
@@ -89,6 +89,7 @@ fn type_tag_matches_the_serde_type_wire_tag() {
             duration_ms: 1,
             retries: None,
             partial: None,
+            sub_agent_id: None,
         },
         AgentEvent::GoalVerdict {
             round: 1,

--- a/crates/stella-protocol/src/subagent_event.rs
+++ b/crates/stella-protocol/src/subagent_event.rs
@@ -83,8 +83,17 @@ impl SubAgentStatus {
 pub enum SubAgentPhase {
     /// A child turn is about to start. Every event between this and the
     /// matching `Finished` with the same `agent_id` belongs to the child,
-    /// not the parent — this bracket IS the attribution mechanism, which is
-    /// why no per-event agent field was added to the rest of the event vocabulary.
+    /// not the parent — this bracket is the attribution mechanism for every
+    /// event except the two metering records, which carry their own
+    /// `sub_agent_id` (#4383).
+    ///
+    /// They have to, and the reason is what bounds this bracket's reach: the
+    /// engine dispatches independent delegates **concurrently**, so several
+    /// children's events interleave here and "between `Started` and
+    /// `Finished`" no longer names one child's work. For a `Stage` or a
+    /// `ToolStart` that costs a reader a little context; for a `StepUsage` it
+    /// cost the whole cost census, which read a five-way parallel fan-out as
+    /// ninety of the lead's own calls.
     Started {
         /// Stable id for this child, unique within the parent turn.
         agent_id: String,

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -837,6 +837,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                 // The "all optional fields present" shape must actually carry
                 // the optional field, or the sample proves nothing about it.
                 finish_reason: Some(FinishReason::Stop),
+                sub_agent_id: None,
             },
             AgentEvent::StepUsage {
                 upstream_provider: None,
@@ -859,6 +860,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                 // ...and the "all absent" shape must omit it entirely, which
                 // is what `skip_serializing_if` promises consumers.
                 finish_reason: None,
+                sub_agent_id: None,
             },
         ]
     }));
@@ -888,6 +890,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: Some(finish_reason),
+                sub_agent_id: None,
             }),
     );
     events.extend(
@@ -916,6 +919,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                             cost_usd: 0.0213,
                             input_reported: true,
                         }),
+                        sub_agent_id: None,
                     },
                     // The shape that genuinely learned nothing — a failure
                     // before any usage frame. `partial` must stay absent from
@@ -929,6 +933,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                         duration_ms: 30_000,
                         retries: None,
                         partial: None,
+                        sub_agent_id: None,
                     },
                 ]
             }),

--- a/crates/stella-store/src/cache_gaps.rs
+++ b/crates/stella-store/src/cache_gaps.rs
@@ -161,6 +161,7 @@ mod tests {
             retries: 0,
             tool_calls: 0,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 }

--- a/crates/stella-store/src/cache_trend.rs
+++ b/crates/stella-store/src/cache_trend.rs
@@ -137,6 +137,7 @@ mod tests {
             retries: 0,
             tool_calls: 0,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-store/src/content_free.rs
+++ b/crates/stella-store/src/content_free.rs
@@ -481,6 +481,7 @@ pub fn poisoned_cloud_event() -> CloudTelemetryEvent {
             retries: 1,
             tool_calls: 4,
             usage_complete: true,
+            sub_agent_id: None,
         },
     }
 }

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -490,6 +490,14 @@ pub(crate) const TOOL_CALLS_INDEXES: &str = "CREATE INDEX IF NOT EXISTS tool_cal
 /// reflection response the lesson parser could not read. NULL is the normal
 /// case and means "no parse failure recorded" — never "this turn had nothing
 /// to learn", which is the distinction the whole column exists to keep.
+///
+/// `partial_run` says the turn this row assesses was **stopped**, not
+/// finished — so far, a cancel (#3808). It is what turns a stub into a stated
+/// scope: a cancelled turn never reaches the reflection model call, so the
+/// self-review half is empty for a *reason*, and until this column a reader
+/// could not tell that empty row from a turn the model declined to assess.
+/// The objective half is still true of it: the edits happened and were
+/// measured, which is why they are still derived rather than withheld.
 pub(crate) const EXECUTION_REFLECTION_DDL: &str =
     "CREATE TABLE IF NOT EXISTS execution_reflection (
        execution_id INTEGER PRIMARY KEY,
@@ -503,7 +511,8 @@ pub(crate) const EXECUTION_REFLECTION_DDL: &str =
        wrote_files INTEGER NOT NULL DEFAULT 0,
        truncated INTEGER NOT NULL DEFAULT 0,
        recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-       parse_error TEXT
+       parse_error TEXT,
+       partial_run INTEGER NOT NULL DEFAULT 0
      );";
 
 /// `reflections` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — the durable, unified home for

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -185,6 +185,14 @@ pub(crate) fn files_touched_ddl(table: &str) -> String {
 /// `StepUsage` is emitted exactly once per step that lands. `drift_samples`
 /// treats `(execution_id, step)` as insertion order and `usage_stats` sums
 /// tokens/cost per execution, so a duplicate step double-counts money.
+///
+/// `sub_agent_id` (v33) names which delegate spent the call, or NULL for the
+/// lead's own (#4383). Nullable with no default because NULL is the lead — a
+/// fact, not a gap — and because the `(role, model)` census AGENTS.md sends a
+/// bench reader to run could not otherwise separate a turn's lead from the
+/// delegates it fanned out to: sub-agents open no execution row of their own,
+/// so every one of their calls lands here under the parent id as
+/// `call_role = 'worker'`.
 pub(crate) fn telemetry_ddl(table: &str) -> String {
     format!(
         "CREATE TABLE {table} (
@@ -205,6 +213,7 @@ pub(crate) fn telemetry_ddl(table: &str) -> String {
            retries INTEGER NOT NULL,
            tool_calls INTEGER NOT NULL,
            usage_complete INTEGER NOT NULL DEFAULT 0 CHECK(usage_complete IN (0, 1)),
+           sub_agent_id TEXT,
            UNIQUE (execution_id, step)
          );"
     )

--- a/crates/stella-store/src/drain.rs
+++ b/crates/stella-store/src/drain.rs
@@ -539,6 +539,7 @@ mod tests {
                 retries: 1,
                 tool_calls: 4,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         }
     }
@@ -766,6 +767,7 @@ mod tests {
                         retries: 0,
                         tool_calls: 0,
                         usage_complete: true,
+                        sub_agent_id: None,
                     },
                 })
                 .collect();

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -167,7 +167,8 @@ const CHILD_TABLES: [(&str, &str, &str); 8] = [
     (
         "execution_reflection",
         "SELECT execution_id, prompt, delivered, self_rating, what_went_well, what_to_improve, \
-         critique, produced_output, wrote_files, truncated FROM execution_reflection",
+         critique, produced_output, wrote_files, truncated, partial_run \
+         FROM execution_reflection",
         "ORDER BY execution_id ASC",
     ),
     (

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -134,8 +134,8 @@ const CHILD_TABLES: [(&str, &str, &str); 8] = [
         "telemetry",
         "SELECT execution_id, step, ts, provider, call_role, model, input_tokens, \
          estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens, \
-         cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete \
-         FROM telemetry",
+         cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete, \
+         sub_agent_id FROM telemetry",
         "ORDER BY execution_id ASC, step ASC",
     ),
     (
@@ -540,6 +540,7 @@ mod tests {
                         retries: 0,
                         tool_calls: 0,
                         usage_complete: true,
+                        sub_agent_id: None,
                     },
                 )
                 .expect("telemetry");
@@ -722,6 +723,7 @@ mod tests {
                         retries: 0,
                         tool_calls: 0,
                         usage_complete: true,
+                        sub_agent_id: None,
                     },
                 )
                 .expect("telemetry");

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -425,6 +425,11 @@ pub struct ExecutionReflectionRow {
     pub produced_output: bool,
     pub wrote_files: bool,
     pub truncated: bool,
+    /// The turn this assesses was stopped rather than finished — so far, a
+    /// cancel (#3808). It scopes the judgement above rather than replacing it:
+    /// a cancelled turn never reaches the reflection model call, so the
+    /// self-review columns are empty for a reason a reader can now see.
+    pub partial_run: bool,
 }
 
 /// One durable reflection/lesson row. `execution_id` is `None` for cross-turn

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -61,6 +61,7 @@ mod pipeline_variant;
 pub(crate) mod pragmas;
 mod receipts;
 mod schema_removal;
+mod sub_agent_calls;
 mod task_contract;
 mod token_unit;
 
@@ -100,7 +101,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 32] = [
+pub(crate) const MIGRATIONS: [Migration; 33] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -266,6 +267,12 @@ pub(crate) const MIGRATIONS: [Migration; 32] = [
     // `executions.outcome`, so there is nothing to invent. See the module's own
     // doc.
     partial_reflection::migrate_v31_to_v32,
+    // v32 → v33: `telemetry` grows `sub_agent_id` — which delegate spent this
+    // call, or the lead (#4383). Additive, column-guarded ADD COLUMN, nullable
+    // with no default and no backfill: NULL is the lead's own call, a fact
+    // rather than a gap, and nothing in the journal can attribute a historical
+    // row without the guess the column exists to end. See the module's own doc.
+    sub_agent_calls::migrate_v32_to_v33,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -312,7 +319,8 @@ pub(crate) const MIGRATIONS: [Migration; 32] = [
     //
     //   v30 → v31: CLAIMED above by the `agent_uses.kind` discriminator (#3822).
     //   v31 → v32: CLAIMED above by `execution_reflection.partial_run` (#3808).
-    // Nothing is reserved now: take v32 → v33 and add your own line here.
+    //   v32 → v33: CLAIMED above by `telemetry.sub_agent_id` (#4383).
+    // Nothing is reserved now: take v33 → v34 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -56,6 +56,7 @@ mod execution_plane;
 mod execution_role;
 mod legacy_rebuild;
 mod live_tool_calls;
+mod partial_reflection;
 mod pipeline_variant;
 pub(crate) mod pragmas;
 mod receipts;
@@ -99,7 +100,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 31] = [
+pub(crate) const MIGRATIONS: [Migration; 32] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -258,6 +259,13 @@ pub(crate) const MIGRATIONS: [Migration; 31] = [
     // fact is known rather than guessed, because the delegation writer (#3821)
     // is younger than every row this step can see. See the module's own doc.
     agent_use_kind::migrate_v30_to_v31,
+    // v31 → v32: `execution_reflection` grows `partial_run` — whether the turn
+    // this row assesses was stopped rather than finished (#3808). Additive,
+    // column-guarded ADD COLUMN, `NOT NULL DEFAULT 0`, and backfilled: unlike
+    // v28 → v29 the historical fact is recorded one join away in
+    // `executions.outcome`, so there is nothing to invent. See the module's own
+    // doc.
+    partial_reflection::migrate_v31_to_v32,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -303,7 +311,8 @@ pub(crate) const MIGRATIONS: [Migration; 31] = [
     //              (#3621).
     //
     //   v30 → v31: CLAIMED above by the `agent_uses.kind` discriminator (#3822).
-    // Nothing is reserved now: take v31 → v32 and add your own line here.
+    //   v31 → v32: CLAIMED above by `execution_reflection.partial_run` (#3808).
+    // Nothing is reserved now: take v32 → v33 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations/partial_reflection.rs
+++ b/crates/stella-store/src/migrations/partial_reflection.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v31 → v32: `execution_reflection` grows `partial_run` — whether the turn
+//! this row assesses was stopped rather than finished (#3808).
+//!
+//! A cancelled execution used to get the same reflection row as any other, and
+//! it was always a stub: the cancel lands before the reflection model call, so
+//! `critique` is empty and `self_rating` is NULL. Nothing said why. A reader —
+//! the Improve tab, an export, the next session's miner — could not tell that
+//! row from a turn the model looked at and declined to assess, which is the
+//! reading that makes the runs most worth learning from look like the ones with
+//! nothing to say.
+//!
+//! # `NOT NULL DEFAULT 0`, and backfilled
+//!
+//! Unlike [`task_contract`](super::task_contract)'s nullable column, the
+//! historical fact here is **recorded**, one join away: `executions.outcome`
+//! has always carried `'cancelled'`. So there is nothing to invent and nothing
+//! to guess — the backfill below reads the answer rather than assuming one, and
+//! every row it does not touch really did run to its own end.
+//!
+//! # What it does not claim
+//!
+//! Not that the row is worthless, and not that the work is unassessable. The
+//! objective half — `produced_output`, `wrote_files`, `truncated` — is measured
+//! from the event and file-touch logs and is exactly as true of a cancelled
+//! turn as of any other: in the audited session (`ses-1787092335250-47513`,
+//! execution 157) the run was stopped three minutes after a passing build,
+//! having made 66 edits across 35 files. Those edits happened. This column
+//! states the scope that judgement covers; it does not withhold it.
+//!
+//! `executions.usage_complete` is a different fact and is untouched here: it is
+//! about the provider's usage envelope, which a cancel makes genuinely
+//! unknowable. This is about the reflection.
+
+use crate::Result;
+use crate::migrations::{column_exists, table_exists};
+
+/// Add `execution_reflection.partial_run` and backfill it from the outcome the
+/// store already recorded. Column-guarded, so a file that already has it is
+/// untouched.
+pub(super) fn migrate_v31_to_v32(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !table_exists(tx, "execution_reflection")?
+        || column_exists(tx, "execution_reflection", "partial_run")?
+    {
+        return Ok(());
+    }
+    tx.execute_batch(
+        "ALTER TABLE execution_reflection \
+         ADD COLUMN partial_run INTEGER NOT NULL DEFAULT 0;",
+    )?;
+    // Guarded because a file can carry the reflection table without the
+    // executions table it hangs off — the legacy rebuild path builds them one
+    // at a time — and an unguarded UPDATE would fail the whole ladder there.
+    if table_exists(tx, "executions")? {
+        tx.execute_batch(
+            "UPDATE execution_reflection SET partial_run = 1 \
+             WHERE execution_id IN (SELECT id FROM executions WHERE outcome = 'cancelled');",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    /// Seed a v31 file with one cancelled execution and one that finished,
+    /// each carrying the stub reflection row the old code wrote.
+    fn v31_file() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE executions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               prompt TEXT NOT NULL,
+               outcome TEXT
+             );
+             CREATE TABLE execution_reflection (
+               execution_id INTEGER PRIMARY KEY,
+               prompt TEXT NOT NULL DEFAULT '',
+               self_rating INTEGER,
+               critique TEXT NOT NULL DEFAULT ''
+             );
+             INSERT INTO executions (id, prompt, outcome)
+               VALUES (157, 'port the build', 'cancelled'), (158, 'and again', 'success');
+             INSERT INTO execution_reflection (execution_id, prompt)
+               VALUES (157, 'port the build'), (158, 'and again');",
+        )
+        .expect("seed a v31 file");
+        conn
+    }
+
+    fn partial_run(conn: &Connection, execution_id: i64) -> i64 {
+        conn.query_row(
+            "SELECT partial_run FROM execution_reflection WHERE execution_id = ?1",
+            [execution_id],
+            |r| r.get(0),
+        )
+        .expect("read back")
+    }
+
+    /// The historical fact is recorded rather than guessed, so the backfill
+    /// reads it: the stub rows a cancelled run already left behind become
+    /// visibly stubs *of a stopped run*.
+    #[test]
+    fn the_backfill_marks_exactly_the_cancelled_runs() {
+        let mut conn = v31_file();
+        apply_migration(&mut conn, migrate_v31_to_v32, 32).expect("migrate");
+        assert_eq!(partial_run(&conn, 157), 1);
+        assert_eq!(
+            partial_run(&conn, 158),
+            0,
+            "a run that reached its own end is not partial"
+        );
+    }
+
+    /// Running it twice is a no-op — the column guard, not the error handler,
+    /// is what makes that true.
+    #[test]
+    fn the_migration_is_idempotent() {
+        let mut conn = v31_file();
+        apply_migration(&mut conn, migrate_v31_to_v32, 32).expect("first");
+        apply_migration(&mut conn, migrate_v31_to_v32, 32).expect("second");
+        assert_eq!(partial_run(&conn, 157), 1);
+    }
+
+    /// A file with the reflection table and no executions table still migrates
+    /// — the rebuild path can present exactly that shape, and a ladder step
+    /// that failed there would strand the whole file.
+    #[test]
+    fn a_file_with_no_executions_table_still_grows_the_column() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE execution_reflection (execution_id INTEGER PRIMARY KEY);
+             INSERT INTO execution_reflection (execution_id) VALUES (1);",
+        )
+        .expect("seed");
+        apply_migration(&mut conn, migrate_v31_to_v32, 32).expect("migrate");
+        assert_eq!(partial_run(&conn, 1), 0);
+    }
+}

--- a/crates/stella-store/src/migrations/sub_agent_calls.rs
+++ b/crates/stella-store/src/migrations/sub_agent_calls.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v32 → v33: `telemetry` grows `sub_agent_id` — which delegate spent this
+//! call, or the lead (#4383).
+//!
+//! A sub-agent opens no execution row of its own, and its `StepUsage` events
+//! ride the parent's stream. So every delegate's model call was persisted under
+//! the parent `execution_id` with `call_role = 'worker'` and nothing naming the
+//! child — which makes the `(role, model)` census AGENTS.md tells a bench
+//! reader to run unable to separate a turn's lead from its fan-out. In session
+//! `ses-1787465453163-60967`, execution 225 carries ninety telemetry rows, all
+//! `worker`; five of them complete within one second of each other at
+//! ~1 950 input tokens apiece, which is a five-way parallel delegate fan-out
+//! that the table cannot say is one.
+//!
+//! # Nullable, no default, no backfill
+//!
+//! `NULL` means **the lead's own call**, which is the overwhelming majority of
+//! rows and is a fact rather than a gap — so unlike
+//! [`partial_reflection`](super::partial_reflection) there is nothing here that
+//! a default would have to invent, and every historical row reads correctly as
+//! written.
+//!
+//! There is no backfill because there is nothing to backfill *from*. The
+//! `sub_agent` bracket events are in `events`, but the engine dispatches
+//! independent delegates concurrently, so several children's events interleave
+//! and no `Started`/`Finished` pair encloses any particular call. That is the
+//! same fact that made a per-event field necessary in the first place; a
+//! backfill would be the guess the field exists to stop making.
+
+use crate::Result;
+use crate::migrations::{column_exists, table_exists};
+
+/// Add `telemetry.sub_agent_id`, column-guarded so a file that already has it
+/// is untouched.
+pub(super) fn migrate_v32_to_v33(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if table_exists(tx, "telemetry")? && !column_exists(tx, "telemetry", "sub_agent_id")? {
+        tx.execute_batch("ALTER TABLE telemetry ADD COLUMN sub_agent_id TEXT;")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    fn v32_file() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE telemetry (
+               execution_id INTEGER NOT NULL,
+               step INTEGER NOT NULL,
+               provider TEXT NOT NULL,
+               call_role TEXT NOT NULL DEFAULT 'unknown',
+               model TEXT NOT NULL,
+               cost_usd REAL NOT NULL
+             );
+             INSERT INTO telemetry (execution_id, step, provider, call_role, model, cost_usd)
+               VALUES (225, 7, 'openrouter', 'worker', 'moonshotai/kimi-k3', 0.02);",
+        )
+        .expect("seed a v32 file");
+        conn
+    }
+
+    /// Every row written before the column existed reads as the lead's own
+    /// call, which is what the overwhelming majority of them were — and the
+    /// only reading the store can make without guessing.
+    #[test]
+    fn an_existing_row_reads_as_the_leads_own_call() {
+        let mut conn = v32_file();
+        apply_migration(&mut conn, migrate_v32_to_v33, 33).expect("migrate");
+        let owner: Option<String> = conn
+            .query_row(
+                "SELECT sub_agent_id FROM telemetry WHERE step = 7",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(owner, None);
+    }
+
+    /// Running it twice is a no-op — the column guard, not the error handler,
+    /// is what makes that true.
+    #[test]
+    fn the_migration_is_idempotent() {
+        let mut conn = v32_file();
+        apply_migration(&mut conn, migrate_v32_to_v33, 33).expect("first");
+        apply_migration(&mut conn, migrate_v32_to_v33, 33).expect("second");
+    }
+
+    /// A file with no telemetry table at all still climbs the ladder — the
+    /// rebuild path can present exactly that shape.
+    #[test]
+    fn a_file_with_no_telemetry_table_still_migrates() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        apply_migration(&mut conn, migrate_v32_to_v33, 33).expect("migrate");
+    }
+}

--- a/crates/stella-store/src/prune.rs
+++ b/crates/stella-store/src/prune.rs
@@ -502,6 +502,7 @@ mod tests {
             retries: 0,
             tool_calls: 0,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-store/src/reflection.rs
+++ b/crates/stella-store/src/reflection.rs
@@ -411,9 +411,8 @@ mod tests {
     /// and had nothing to say about.
     ///
     /// The shape is the audited one (`ses-1787092335250-47513`, execution 157):
-    /// real edits landed, then a human stopped the run. Both halves have to
-    /// hold — the work is still measured, *and* the row now states the scope
-    /// that measurement covers.
+    /// real edits landed, then a human stopped the run. The work is still
+    /// measured, and the row now states the scope that measurement covers.
     #[test]
     fn a_cancelled_runs_reflection_says_it_covers_a_partial_run() {
         let store = Store::in_memory().unwrap();

--- a/crates/stella-store/src/reflection.rs
+++ b/crates/stella-store/src/reflection.rs
@@ -76,8 +76,9 @@ impl Store {
         self.lock().execute(
             "INSERT OR REPLACE INTO execution_reflection \
              (execution_id, prompt, delivered, self_rating, what_went_well, \
-              what_to_improve, critique, produced_output, wrote_files, truncated) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              what_to_improve, critique, produced_output, wrote_files, truncated, \
+              partial_run) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
                 r.prompt,
@@ -89,6 +90,7 @@ impl Store {
                 r.produced_output as i64,
                 r.wrote_files as i64,
                 r.truncated as i64,
+                r.partial_run as i64,
             ],
         )?;
         Ok(())
@@ -194,22 +196,44 @@ impl Store {
 
     /// Derive and record the objective half of this turn's
     /// `execution_reflection` — prompt, plus `produced_output` / `wrote_files`
-    /// / `truncated` computed from the event and file-touch logs.
+    /// / `truncated` computed from the event and file-touch logs, and
+    /// `partial_run` read off the outcome.
     ///
     /// Leaves the self-review columns exactly as it found them:
     /// [`Store::record_self_review`] has usually already written them by the
     /// time this runs, and the whole-row replace this used to do erased them.
+    ///
+    /// # Why a cancelled run still gets a row (#3808)
+    ///
+    /// Because the work it did is real and is measured here. A cancel lands
+    /// before the reflection model call, so the self-review half stays empty —
+    /// and until `partial_run` existed that empty row was indistinguishable
+    /// from a turn the model looked at and declined to assess, which is the
+    /// reading that made the runs most worth learning from look like the ones
+    /// with nothing to say. Marking the scope is the answer; withholding the
+    /// row would throw away the objective half as well.
+    ///
+    /// Derived here rather than passed in by the caller: the outcome is a
+    /// column this function is already inside a read of, and a parameter would
+    /// be a second copy of it for the caller to get wrong.
+    /// `executions.usage_complete` is untouched and unrelated — that one is
+    /// about the provider's usage envelope, which a cancel genuinely makes
+    /// unknowable.
     pub fn finalize_execution_reflection(&self, execution_id: i64) -> Result<()> {
-        let (prompt, produced_output, wrote_files, truncated) = {
+        let (prompt, partial_run, produced_output, wrote_files, truncated) = {
             let conn = self.lock();
-            let prompt: String = conn
+            let (prompt, outcome): (String, Option<String>) = conn
                 .query_row(
-                    "SELECT prompt FROM executions WHERE id = ?1",
+                    "SELECT prompt, outcome FROM executions WHERE id = ?1",
                     params![execution_id],
-                    |r| r.get(0),
+                    |r| Ok((r.get(0)?, r.get(1)?)),
                 )
                 .optional()?
                 .unwrap_or_default();
+            // The one outcome that stops a turn before it can be assessed.
+            // Matched against the label `record_execution_end` writes, which is
+            // the same string `terminal_usage_known` reads.
+            let partial_run = outcome.as_deref() == Some("cancelled");
             let produced_output: bool = conn.query_row(
                 "SELECT COUNT(*) FROM events \
                  WHERE execution_id = ?1 AND event_type IN ('text', 'tool_start')",
@@ -264,23 +288,25 @@ impl Store {
                 params![execution_id],
                 |r| r.get::<_, i64>(0),
             )? > 0;
-            (prompt, produced_output, wrote_files, truncated)
+            (prompt, partial_run, produced_output, wrote_files, truncated)
         };
         self.lock().execute(
             "INSERT INTO execution_reflection \
-             (execution_id, prompt, produced_output, wrote_files, truncated) \
-             VALUES (?1, ?2, ?3, ?4, ?5) \
+             (execution_id, prompt, produced_output, wrote_files, truncated, partial_run) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
              ON CONFLICT(execution_id) DO UPDATE SET \
                prompt = excluded.prompt, \
                produced_output = excluded.produced_output, \
                wrote_files = excluded.wrote_files, \
-               truncated = excluded.truncated",
+               truncated = excluded.truncated, \
+               partial_run = excluded.partial_run",
             params![
                 execution_id,
                 prompt,
                 produced_output as i64,
                 wrote_files as i64,
                 truncated as i64,
+                partial_run as i64,
             ],
         )?;
         Ok(())
@@ -292,9 +318,19 @@ mod tests {
     use super::*;
 
     fn wrote_files_of(store: &Store, execution_id: i64) -> i64 {
+        column_of(store, execution_id, "wrote_files")
+    }
+
+    fn partial_run_of(store: &Store, execution_id: i64) -> i64 {
+        column_of(store, execution_id, "partial_run")
+    }
+
+    /// One integer column of one reflection row. The column name is a literal
+    /// from this module's own tests, never caller input.
+    fn column_of(store: &Store, execution_id: i64, column: &str) -> i64 {
         let conn = store.lock();
         conn.query_row(
-            "SELECT wrote_files FROM execution_reflection WHERE execution_id = ?1",
+            &format!("SELECT {column} FROM execution_reflection WHERE execution_id = ?1"),
             params![execution_id],
             |r| r.get(0),
         )
@@ -367,6 +403,106 @@ mod tests {
             "a succeeded edit_file is a fact about whether the turn wrote, even when the \
              turn-boundary snapshot saw nothing"
         );
+    }
+
+    /// **#3808's witness.** A cancelled run's reflection used to be a silent
+    /// stub — empty critique, NULL rating, and nothing saying why — so the runs
+    /// most worth learning from read exactly like the ones the model looked at
+    /// and had nothing to say about.
+    ///
+    /// The shape is the audited one (`ses-1787092335250-47513`, execution 157):
+    /// real edits landed, then a human stopped the run. Both halves have to
+    /// hold — the work is still measured, *and* the row now states the scope
+    /// that measurement covers.
+    #[test]
+    fn a_cancelled_runs_reflection_says_it_covers_a_partial_run() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("deck", "port the build", "openrouter", "kimi-k3")
+            .unwrap();
+        store
+            .record_event(id, 0, &started("c1", "edit_file"))
+            .unwrap();
+        store
+            .record_event(id, 1, &settled("c1", ok_output("edited")))
+            .unwrap();
+        store.materialize_tool_calls(id).unwrap();
+        // A human stopped it. The label is the one `record_execution_end`
+        // writes, and `finalize_execution_reflection` runs after it on every
+        // path including this one.
+        store
+            .finish_execution_accounted(id, "cancelled", 0.0, false)
+            .unwrap();
+
+        store.finalize_execution_reflection(id).unwrap();
+
+        assert_eq!(
+            partial_run_of(&store, id),
+            1,
+            "a stopped run's reflection must say it is about a stopped run"
+        );
+        assert_eq!(
+            wrote_files_of(&store, id),
+            1,
+            "and must not throw away the half that is still true: the edits happened"
+        );
+    }
+
+    /// The other direction, or the column says nothing: a turn that reached its
+    /// own end is not partial, however it ended.
+    #[test]
+    fn a_run_that_reached_its_own_end_is_not_partial() {
+        let store = Store::in_memory().unwrap();
+        for outcome in ["success", "error", "budget_exhausted"] {
+            let id = store
+                .begin_execution("run", outcome, "openrouter", "kimi-k3")
+                .unwrap();
+            store
+                .finish_execution_accounted(id, outcome, 0.0, true)
+                .unwrap();
+            store.finalize_execution_reflection(id).unwrap();
+            assert_eq!(partial_run_of(&store, id), 0, "{outcome}");
+        }
+    }
+
+    /// The self-review producer writes first in every live path, and finalize
+    /// must add the scope without erasing the assessment — the clobber #2175's
+    /// narrowing already fixed once, now with one more column to lose.
+    #[test]
+    fn finalize_marks_a_partial_run_without_erasing_a_self_review() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("deck", "port the build", "openrouter", "kimi-k3")
+            .unwrap();
+        store
+            .record_self_review(
+                id,
+                &SelfReviewRow {
+                    delivered: Some(false),
+                    self_rating: Some(3),
+                    what_went_well: "the build passed".into(),
+                    what_to_improve: "stopped short".into(),
+                    critique: "half the migration landed".into(),
+                },
+            )
+            .unwrap();
+        store
+            .finish_execution_accounted(id, "cancelled", 0.0, false)
+            .unwrap();
+
+        store.finalize_execution_reflection(id).unwrap();
+
+        assert_eq!(partial_run_of(&store, id), 1);
+        let critique: String = {
+            let conn = store.lock();
+            conn.query_row(
+                "SELECT critique FROM execution_reflection WHERE execution_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(critique, "half the migration landed");
     }
 
     /// The other direction must not drift: a read-only turn still wrote

--- a/crates/stella-store/src/telemetry.rs
+++ b/crates/stella-store/src/telemetry.rs
@@ -27,6 +27,14 @@ pub struct TelemetryRow {
     pub retries: u32,
     pub tool_calls: u64,
     pub usage_complete: bool,
+    /// Which delegate spent this call; `None` is the lead's own (#4383).
+    ///
+    /// Local to `store.db` on purpose: it is deliberately **not** replicated
+    /// to the usage hub, which is a cross-project surface and has its own
+    /// reviewed column allowlist (`content_free.rs`). A handle like
+    /// `plugin:vera/worker#0` names a plugin and an ordinal, which is a fact
+    /// about this workspace's configuration and has no business in a rollup.
+    pub sub_agent_id: Option<String>,
 }
 
 /// One source-store telemetry row addressed for hub replication: its stable
@@ -96,8 +104,9 @@ impl Store {
         tx.execute(
             "INSERT INTO telemetry (execution_id, step, provider, call_role, model, input_tokens, \
              estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens, \
-             cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete, \
+             sub_agent_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
                 step,
@@ -115,6 +124,7 @@ impl Store {
                 row.retries,
                 tool_calls,
                 row.usage_complete,
+                row.sub_agent_id,
             ],
         )?;
         tx.execute(
@@ -141,7 +151,7 @@ impl Store {
                     t.call_role, t.model, t.input_tokens, t.estimated_input_tokens, \
                     t.output_tokens, t.cache_read_tokens, t.cache_miss_tokens, \
                     t.cache_write_tokens, t.cost_usd, t.duration_ms, t.retries, t.tool_calls, \
-                    t.usage_complete \
+                    t.usage_complete, t.sub_agent_id \
              FROM telemetry t LEFT JOIN executions e ON e.id = t.execution_id \
              WHERE t.rowid > ?1 ORDER BY t.rowid ASC LIMIT ?2",
         )?;
@@ -166,6 +176,7 @@ impl Store {
                     retries: r.get(15)?,
                     tool_calls: r.get::<_, i64>(16)? as u64,
                     usage_complete: r.get(17)?,
+                    sub_agent_id: r.get(18)?,
                 },
             })
         })?;
@@ -415,6 +426,7 @@ mod tests {
             retries: 0,
             tool_calls: 1,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -375,6 +375,7 @@ fn data_plane_tables_roundtrip_and_tool_histogram() {
                 produced_output: false,
                 wrote_files: false,
                 truncated: true,
+                partial_run: false,
             },
         )
         .unwrap();
@@ -1049,8 +1050,12 @@ fn skill_usage_records_per_execution_version_rows() {
     //       found none". v31 `agent_uses.kind` (#3822): which of the log's two
     //       writers minted the row's `agent` name, so an installed
     //       definition's repeated invocations stop reading like a pile of
-    //       one-off delegations.
-    assert_eq!(SCHEMA_VERSION, 31);
+    //       one-off delegations. v32 `execution_reflection.partial_run`
+    //       (#3808): whether the turn a reflection row assesses was stopped
+    //       rather than finished — `NOT NULL DEFAULT 0` and backfilled, because
+    //       unlike v29 the historical fact is recorded one join away in
+    //       `executions.outcome` and there is nothing to invent.
+    assert_eq!(SCHEMA_VERSION, 32);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -51,6 +51,7 @@ fn execution_lifecycle_events_and_telemetry_roundtrip() {
                 retries: 1,
                 tool_calls: 3,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         )
         .unwrap();
@@ -1055,7 +1056,11 @@ fn skill_usage_records_per_execution_version_rows() {
     //       rather than finished — `NOT NULL DEFAULT 0` and backfilled, because
     //       unlike v29 the historical fact is recorded one join away in
     //       `executions.outcome` and there is nothing to invent.
-    assert_eq!(SCHEMA_VERSION, 32);
+    //       v33 `telemetry.sub_agent_id` (#4383): which delegate spent a call,
+    //       or NULL for the lead — nullable with no backfill, since a
+    //       sub-agent opens no execution row of its own and nothing in the
+    //       journal can attribute a historical row without guessing.
+    assert_eq!(SCHEMA_VERSION, 33);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")
@@ -1142,6 +1147,7 @@ fn drift_row(step: u64, provider: &str, model: &str, estimated: u64, actual: u64
         retries: 0,
         tool_calls: 1,
         usage_complete: true,
+        sub_agent_id: None,
     }
 }
 
@@ -1803,6 +1809,7 @@ fn telemetry(
         retries: 0,
         tool_calls: 0,
         usage_complete: true,
+        sub_agent_id: None,
     }
 }
 
@@ -2058,6 +2065,7 @@ fn telemetry_replicates_to_the_hub_and_heals_missed_turns() {
             retries: 0,
             tool_calls: 1,
             usage_complete: true,
+            sub_agent_id: None,
         }
     }
 

--- a/crates/stella-store/src/tests/usage_completeness.rs
+++ b/crates/stella-store/src/tests/usage_completeness.rs
@@ -292,7 +292,61 @@ fn telemetry_row(step: u64, cost_usd: f64) -> TelemetryRow {
         retries: 0,
         tool_calls: 0,
         usage_complete: true,
+        sub_agent_id: None,
     }
+}
+
+/// **#4383's witness, at the ledger.** A turn's calls can be grouped by
+/// spender, which is what a `(role, model)` census needs and what execution 225
+/// of session `ses-1787465453163-60967` could not offer: ninety rows, all
+/// `worker`, five of them a parallel delegate fan-out.
+///
+/// A sub-agent opens no execution row of its own, so both the lead's calls and
+/// its delegates' land under one `execution_id`. The column is the only thing
+/// that separates them.
+#[test]
+fn a_turns_calls_can_be_grouped_by_the_sub_agent_that_spent_them() {
+    let store = Store::in_memory().unwrap();
+    let execution = store
+        .begin_execution("run", "research the engine", "openrouter", "kimi")
+        .unwrap();
+    store
+        .record_telemetry(execution, &telemetry_row(1, 0.10))
+        .unwrap();
+    for (step, agent) in [
+        (2, "researcher-0"),
+        (3, "researcher-1"),
+        (4, "researcher-0"),
+    ] {
+        store
+            .record_telemetry(
+                execution,
+                &TelemetryRow {
+                    sub_agent_id: Some(agent.into()),
+                    ..telemetry_row(step, 0.01)
+                },
+            )
+            .unwrap();
+    }
+
+    let mut by_spender: Vec<(Option<String>, usize)> = Vec::new();
+    for row in store.telemetry_rows_after(0, 100).unwrap() {
+        let owner = row.telemetry.sub_agent_id.clone();
+        match by_spender.iter_mut().find(|(seen, _)| *seen == owner) {
+            Some((_, count)) => *count += 1,
+            None => by_spender.push((owner, 1)),
+        }
+    }
+    by_spender.sort();
+    assert_eq!(
+        by_spender,
+        vec![
+            (None, 1),
+            (Some("researcher-0".into()), 2),
+            (Some("researcher-1".into()), 1),
+        ],
+        "the lead's own call and each delegate's must be separable"
+    );
 }
 
 #[test]

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -392,6 +392,7 @@ impl UsageStore {
                     retries: r.get(19)?,
                     tool_calls: r.get::<_, i64>(20)? as u64,
                     usage_complete: r.get(21)?,
+                    sub_agent_id: None,
                 },
             })
         })?;
@@ -1123,6 +1124,7 @@ mod tests {
                 retries: 0,
                 tool_calls: 2,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         }
     }

--- a/crates/stella-store/src/usage/backfill.rs
+++ b/crates/stella-store/src/usage/backfill.rs
@@ -94,6 +94,7 @@ mod tests {
                 retries: 0,
                 tool_calls: 2,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         }
     }

--- a/crates/stella-store/src/usage/drain_state.rs
+++ b/crates/stella-store/src/usage/drain_state.rs
@@ -160,6 +160,7 @@ mod tests {
                 retries: 0,
                 tool_calls: 0,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         };
         hub.replicate_telemetry(&scope, &[row(1), row(2), row(3)])

--- a/crates/stella-store/src/usage/rekey.rs
+++ b/crates/stella-store/src/usage/rekey.rs
@@ -130,6 +130,7 @@ mod tests {
                 retries: 0,
                 tool_calls: 0,
                 usage_complete: true,
+                sub_agent_id: None,
             },
         }
     }

--- a/crates/stella-store/tests/enterprise_telemetry.rs
+++ b/crates/stella-store/tests/enterprise_telemetry.rs
@@ -115,6 +115,7 @@ fn sqlite_integer_writes_reject_u64_overflow() {
         retries: 0,
         tool_calls: 0,
         usage_complete: true,
+        sub_agent_id: None,
     };
     assert!(store.record_telemetry(id, &telemetry).is_err());
     assert!(

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -448,6 +448,7 @@ async fn mini_run(tx: &mpsc::UnboundedSender<Inbound>, id: &str) {
             tool_calls: 1,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         }),
         ev(AgentEvent::BudgetTick {
             spent_usd: 0.008,

--- a/crates/stella-tui/src/cache_panel.rs
+++ b/crates/stella-tui/src/cache_panel.rs
@@ -313,6 +313,7 @@ mod tests {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         };
         m.apply_inbound(&step(1_000, 0));

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -338,6 +338,7 @@ fn step_usage_accumulates_tokens_and_file_change_fills_ledger() {
             tool_calls: 1,
             complete: true,
             finish_reason: None,
+            sub_agent_id: None,
         },
     ));
     w.apply_inbound(&ev(
@@ -381,6 +382,7 @@ fn an_auxiliary_call_spends_on_the_row_without_relabelling_its_model() {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     };
     let mut w = WorkspaceModel::new();
     w.apply_inbound(&reg("lead"));
@@ -474,6 +476,7 @@ fn context_tokens_track_the_latest_window_not_the_cumulative_input() {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     };
     // Three calls of 150k each: cumulative 450k dwarfs the 200k window, but
     // the window was only 150k full on the LAST call.
@@ -509,6 +512,7 @@ fn budget_tick_sets_live_spend_without_double_counting_step_usage() {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     };
     let mut w = WorkspaceModel::new();
     w.apply_inbound(&reg("lead"));

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -121,6 +121,7 @@ fn full_deck_frame_grows_a_second_status_band_row_for_a_diagnosed_agent() {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         });
     }

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -391,6 +391,7 @@ fn the_receipt_reports_what_the_turn_measured() {
         tool_calls: 0,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     });
     // files ← FileChange, distinct paths
     for path in ["src/a.rs", "src/b.rs", "src/a.rs"] {

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -266,6 +266,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         ),
         ev(
@@ -381,6 +382,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 tool_calls: 1,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         ),
         ev(
@@ -499,6 +501,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 tool_calls: 1,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         ),
         ev(
@@ -577,6 +580,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
         ),
         // ── lead proposes a larger scope change (gate) ──────────────────

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1207,6 +1207,7 @@ mod tests {
                 tool_calls: 0,
                 complete: true,
                 finish_reason: None,
+                sub_agent_id: None,
             },
             AgentEvent::GoalVerdict {
                 round: 1,

--- a/crates/stella-tui/src/transcript_build/tests.rs
+++ b/crates/stella-tui/src/transcript_build/tests.rs
@@ -79,6 +79,7 @@ fn step_usage_bills_the_step_it_paid_for() {
         tool_calls: 1,
         complete: true,
         finish_reason: None,
+        sub_agent_id: None,
     });
     b.finish_turn(Status::Ok);
 

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1754,6 +1754,28 @@ export type AgentEvent = {
    */
   role?: ModelCallRole;
   step: number;
+  /**
+   * Which sub-agent spent this call, when a sub-agent did (#4383).
+   *
+   * `None` is the lead's own call. It is stamped at the sub-agent
+   * boundary (`stella_core::subagent`'s `child_sender`), so a nested
+   * child names *itself* rather than its parent — the innermost spender
+   * is the one a cost question is about.
+   *
+   * The bracket in [`crate::subagent_event::SubAgentPhase`] was meant to
+   * be the whole attribution mechanism, and it is enough for everything
+   * it was designed for. It is not enough for **this**: the engine
+   * dispatches independent delegates concurrently, so several children's
+   * events interleave on one stream and no `Started`/`Finished` pair
+   * brackets any particular call. Session `ses-1787465453163-60967` has
+   * five delegates completing within one second of each other; its
+   * ninety telemetry rows all read `worker`, and no join over the
+   * bracket can undo that.
+   *
+   * Content-free like the rest of this event: an opaque handle
+   * (`plugin:vera/worker#0`), never instruction text.
+   */
+  sub_agent_id?: string | null;
   tool_calls: number;
   /**
    * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
@@ -1798,6 +1820,15 @@ export type AgentEvent = {
    */
   retries?: number | null;
   role: ModelCallRole;
+  /**
+   * Which sub-agent's call died, when a sub-agent's did (#4383). Same
+   * contract as [`AgentEvent::StepUsage`]'s field of this name, and here
+   * for the same reason it is there: a delegate abandoned at the
+   * engine's dispatch ceiling lands one flagged row, and a row nobody
+   * can attribute explains an execution's `usage_complete = 0` without
+   * saying whose call it was.
+   */
+  sub_agent_id?: string | null;
   /**
    * Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.
    */

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1755,25 +1755,7 @@ export type AgentEvent = {
   role?: ModelCallRole;
   step: number;
   /**
-   * Which sub-agent spent this call, when a sub-agent did (#4383).
-   *
-   * `None` is the lead's own call. It is stamped at the sub-agent
-   * boundary (`stella_core::subagent`'s `child_sender`), so a nested
-   * child names *itself* rather than its parent — the innermost spender
-   * is the one a cost question is about.
-   *
-   * The bracket in [`crate::subagent_event::SubAgentPhase`] was meant to
-   * be the whole attribution mechanism, and it is enough for everything
-   * it was designed for. It is not enough for **this**: the engine
-   * dispatches independent delegates concurrently, so several children's
-   * events interleave on one stream and no `Started`/`Finished` pair
-   * brackets any particular call. Session `ses-1787465453163-60967` has
-   * five delegates completing within one second of each other; its
-   * ninety telemetry rows all read `worker`, and no join over the
-   * bracket can undo that.
-   *
-   * Content-free like the rest of this event: an opaque handle
-   * (`plugin:vera/worker#0`), never instruction text.
+   * Which sub-agent spent this call. Absent means the lead's own call, which is the ordinary case. Stamped at the sub-agent boundary, so a nested child names itself rather than its parent. The `sub_agent` started/finished bracket cannot answer this: independent delegates are dispatched concurrently, so several children's events interleave on one stream and no bracket pair encloses any particular call. An opaque handle, never instruction text.
    */
   sub_agent_id?: string | null;
   tool_calls: number;
@@ -1821,12 +1803,7 @@ export type AgentEvent = {
   retries?: number | null;
   role: ModelCallRole;
   /**
-   * Which sub-agent's call died, when a sub-agent's did (#4383). Same
-   * contract as [`AgentEvent::StepUsage`]'s field of this name, and here
-   * for the same reason it is there: a delegate abandoned at the
-   * engine's dispatch ceiling lands one flagged row, and a row nobody
-   * can attribute explains an execution's `usage_complete = 0` without
-   * saying whose call it was.
+   * Which sub-agent's call died. Absent means the lead's own. Same contract as a `step_usage` event's field of this name: an abandoned delegate lands one flagged row, and a row nobody can attribute explains an execution's incomplete usage without saying whose call it was.
    */
   sub_agent_id?: string | null;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -2868,7 +2868,7 @@
           "type": "integer"
         },
         "sub_agent_id": {
-          "description": "Which sub-agent spent this call, when a sub-agent did (#4383).\n\n`None` is the lead's own call. It is stamped at the sub-agent\nboundary (`stella_core::subagent`'s `child_sender`), so a nested\nchild names *itself* rather than its parent — the innermost spender\nis the one a cost question is about.\n\nThe bracket in [`crate::subagent_event::SubAgentPhase`] was meant to\nbe the whole attribution mechanism, and it is enough for everything\nit was designed for. It is not enough for **this**: the engine\ndispatches independent delegates concurrently, so several children's\nevents interleave on one stream and no `Started`/`Finished` pair\nbrackets any particular call. Session `ses-1787465453163-60967` has\nfive delegates completing within one second of each other; its\nninety telemetry rows all read `worker`, and no join over the\nbracket can undo that.\n\nContent-free like the rest of this event: an opaque handle\n(`plugin:vera/worker#0`), never instruction text.",
+          "description": "Which sub-agent spent this call. Absent means the lead's own call, which is the ordinary case. Stamped at the sub-agent boundary, so a nested child names itself rather than its parent. The `sub_agent` started/finished bracket cannot answer this: independent delegates are dispatched concurrently, so several children's events interleave on one stream and no bracket pair encloses any particular call. An opaque handle, never instruction text.",
           "type": [
             "string",
             "null"
@@ -2953,7 +2953,7 @@
           "$ref": "#/$defs/ModelCallRole"
         },
         "sub_agent_id": {
-          "description": "Which sub-agent's call died, when a sub-agent's did (#4383). Same\ncontract as [`AgentEvent::StepUsage`]'s field of this name, and here\nfor the same reason it is there: a delegate abandoned at the\nengine's dispatch ceiling lands one flagged row, and a row nobody\ncan attribute explains an execution's `usage_complete = 0` without\nsaying whose call it was.",
+          "description": "Which sub-agent's call died. Absent means the lead's own. Same contract as a `step_usage` event's field of this name: an abandoned delegate lands one flagged row, and a row nobody can attribute explains an execution's incomplete usage without saying whose call it was.",
           "type": [
             "string",
             "null"

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -1713,7 +1713,7 @@
       "description": "One point in a sub-agent's lifecycle. Exactly one `Started` and exactly\none `Finished` are emitted per spawn, in that order, even when the child\nis refused before its first model call (a refusal still brackets, so a\nconsumer folding these never sees an unclosed child).",
       "oneOf": [
         {
-          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the rest of the event vocabulary.",
+          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket is the attribution mechanism for every\nevent except the two metering records, which carry their own\n`sub_agent_id` (#4383).\n\nThey have to, and the reason is what bounds this bracket's reach: the\nengine dispatches independent delegates **concurrently**, so several\nchildren's events interleave here and \"between `Started` and\n`Finished`\" no longer names one child's work. For a `Stage` or a\n`ToolStart` that costs a reader a little context; for a `StepUsage` it\ncost the whole cost census, which read a five-way parallel fan-out as\nninety of the lead's own calls.",
           "properties": {
             "agent_id": {
               "description": "Stable id for this child, unique within the parent turn.",
@@ -2867,6 +2867,13 @@
           "minimum": 0,
           "type": "integer"
         },
+        "sub_agent_id": {
+          "description": "Which sub-agent spent this call, when a sub-agent did (#4383).\n\n`None` is the lead's own call. It is stamped at the sub-agent\nboundary (`stella_core::subagent`'s `child_sender`), so a nested\nchild names *itself* rather than its parent — the innermost spender\nis the one a cost question is about.\n\nThe bracket in [`crate::subagent_event::SubAgentPhase`] was meant to\nbe the whole attribution mechanism, and it is enough for everything\nit was designed for. It is not enough for **this**: the engine\ndispatches independent delegates concurrently, so several children's\nevents interleave on one stream and no `Started`/`Finished` pair\nbrackets any particular call. Session `ses-1787465453163-60967` has\nfive delegates completing within one second of each other; its\nninety telemetry rows all read `worker`, and no join over the\nbracket can undo that.\n\nContent-free like the rest of this event: an opaque handle\n(`plugin:vera/worker#0`), never instruction text.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "tool_calls": {
           "format": "uint",
           "minimum": 0,
@@ -2944,6 +2951,13 @@
         },
         "role": {
           "$ref": "#/$defs/ModelCallRole"
+        },
+        "sub_agent_id": {
+          "description": "Which sub-agent's call died, when a sub-agent's did (#4383). Same\ncontract as [`AgentEvent::StepUsage`]'s field of this name, and here\nfor the same reason it is there: a delegate abandoned at the\nengine's dispatch ceiling lands one flagged row, and a row nobody\ncan attribute explains an execution's `usage_complete = 0` without\nsaying whose call it was.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ts": {
           "description": "Wall-clock instant at which the sink wrote this line, in milliseconds since the Unix epoch (UTC). Stamped by the sink rather than carried by the event, so it is optional forever — a line recorded before the field existed has none — and it is not monotonic, so a consumer computing an elapsed offset must clamp a negative delta rather than trust it.",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -374,6 +374,28 @@ export type AgentEvent = {
    */
   role?: ModelCallRole;
   step: number;
+  /**
+   * Which sub-agent spent this call, when a sub-agent did (#4383).
+   *
+   * `None` is the lead's own call. It is stamped at the sub-agent
+   * boundary (`stella_core::subagent`'s `child_sender`), so a nested
+   * child names *itself* rather than its parent — the innermost spender
+   * is the one a cost question is about.
+   *
+   * The bracket in [`crate::subagent_event::SubAgentPhase`] was meant to
+   * be the whole attribution mechanism, and it is enough for everything
+   * it was designed for. It is not enough for **this**: the engine
+   * dispatches independent delegates concurrently, so several children's
+   * events interleave on one stream and no `Started`/`Finished` pair
+   * brackets any particular call. Session `ses-1787465453163-60967` has
+   * five delegates completing within one second of each other; its
+   * ninety telemetry rows all read `worker`, and no join over the
+   * bracket can undo that.
+   *
+   * Content-free like the rest of this event: an opaque handle
+   * (`plugin:vera/worker#0`), never instruction text.
+   */
+  sub_agent_id?: string | null;
   tool_calls: number;
   type: "step_usage";
   /**
@@ -414,6 +436,15 @@ export type AgentEvent = {
    */
   retries?: number | null;
   role: ModelCallRole;
+  /**
+   * Which sub-agent's call died, when a sub-agent's did (#4383). Same
+   * contract as [`AgentEvent::StepUsage`]'s field of this name, and here
+   * for the same reason it is there: a delegate abandoned at the
+   * engine's dispatch ceiling lands one flagged row, and a row nobody
+   * can attribute explains an execution's `usage_complete = 0` without
+   * saying whose call it was.
+   */
+  sub_agent_id?: string | null;
   type: "usage_incomplete";
 } | {
   cost_usd: number;

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -375,25 +375,7 @@ export type AgentEvent = {
   role?: ModelCallRole;
   step: number;
   /**
-   * Which sub-agent spent this call, when a sub-agent did (#4383).
-   *
-   * `None` is the lead's own call. It is stamped at the sub-agent
-   * boundary (`stella_core::subagent`'s `child_sender`), so a nested
-   * child names *itself* rather than its parent — the innermost spender
-   * is the one a cost question is about.
-   *
-   * The bracket in [`crate::subagent_event::SubAgentPhase`] was meant to
-   * be the whole attribution mechanism, and it is enough for everything
-   * it was designed for. It is not enough for **this**: the engine
-   * dispatches independent delegates concurrently, so several children's
-   * events interleave on one stream and no `Started`/`Finished` pair
-   * brackets any particular call. Session `ses-1787465453163-60967` has
-   * five delegates completing within one second of each other; its
-   * ninety telemetry rows all read `worker`, and no join over the
-   * bracket can undo that.
-   *
-   * Content-free like the rest of this event: an opaque handle
-   * (`plugin:vera/worker#0`), never instruction text.
+   * Which sub-agent spent this call. Absent means the lead's own call, which is the ordinary case. Stamped at the sub-agent boundary, so a nested child names itself rather than its parent. The `sub_agent` started/finished bracket cannot answer this: independent delegates are dispatched concurrently, so several children's events interleave on one stream and no bracket pair encloses any particular call. An opaque handle, never instruction text.
    */
   sub_agent_id?: string | null;
   tool_calls: number;
@@ -437,12 +419,7 @@ export type AgentEvent = {
   retries?: number | null;
   role: ModelCallRole;
   /**
-   * Which sub-agent's call died, when a sub-agent's did (#4383). Same
-   * contract as [`AgentEvent::StepUsage`]'s field of this name, and here
-   * for the same reason it is there: a delegate abandoned at the
-   * engine's dispatch ceiling lands one flagged row, and a row nobody
-   * can attribute explains an execution's `usage_complete = 0` without
-   * saying whose call it was.
+   * Which sub-agent's call died. Absent means the lead's own. Same contract as a `step_usage` event's field of this name: an abandoned delegate lands one flagged row, and a row nobody can attribute explains an execution's incomplete usage without saying whose call it was.
    */
   sub_agent_id?: string | null;
   type: "usage_incomplete";

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -663,6 +663,13 @@
               "minimum": 0,
               "type": "integer"
             },
+            "sub_agent_id": {
+              "description": "Which sub-agent spent this call, when a sub-agent did (#4383).\n\n`None` is the lead's own call. It is stamped at the sub-agent\nboundary (`stella_core::subagent`'s `child_sender`), so a nested\nchild names *itself* rather than its parent — the innermost spender\nis the one a cost question is about.\n\nThe bracket in [`crate::subagent_event::SubAgentPhase`] was meant to\nbe the whole attribution mechanism, and it is enough for everything\nit was designed for. It is not enough for **this**: the engine\ndispatches independent delegates concurrently, so several children's\nevents interleave on one stream and no `Started`/`Finished` pair\nbrackets any particular call. Session `ses-1787465453163-60967` has\nfive delegates completing within one second of each other; its\nninety telemetry rows all read `worker`, and no join over the\nbracket can undo that.\n\nContent-free like the rest of this event: an opaque handle\n(`plugin:vera/worker#0`), never instruction text.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "tool_calls": {
               "format": "uint",
               "minimum": 0,
@@ -734,6 +741,13 @@
             },
             "role": {
               "$ref": "#/$defs/ModelCallRole"
+            },
+            "sub_agent_id": {
+              "description": "Which sub-agent's call died, when a sub-agent's did (#4383). Same\ncontract as [`AgentEvent::StepUsage`]'s field of this name, and here\nfor the same reason it is there: a delegate abandoned at the\nengine's dispatch ceiling lands one flagged row, and a row nobody\ncan attribute explains an execution's `usage_complete = 0` without\nsaying whose call it was.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "type": {
               "const": "usage_incomplete",
@@ -3508,7 +3522,7 @@
       "description": "One point in a sub-agent's lifecycle. Exactly one `Started` and exactly\none `Finished` are emitted per spawn, in that order, even when the child\nis refused before its first model call (a refusal still brackets, so a\nconsumer folding these never sees an unclosed child).",
       "oneOf": [
         {
-          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket IS the attribution mechanism, which is\nwhy no per-event agent field was added to the rest of the event vocabulary.",
+          "description": "A child turn is about to start. Every event between this and the\nmatching `Finished` with the same `agent_id` belongs to the child,\nnot the parent — this bracket is the attribution mechanism for every\nevent except the two metering records, which carry their own\n`sub_agent_id` (#4383).\n\nThey have to, and the reason is what bounds this bracket's reach: the\nengine dispatches independent delegates **concurrently**, so several\nchildren's events interleave here and \"between `Started` and\n`Finished`\" no longer names one child's work. For a `Stage` or a\n`ToolStart` that costs a reader a little context; for a `StepUsage` it\ncost the whole cost census, which read a five-way parallel fan-out as\nninety of the lead's own calls.",
           "properties": {
             "agent_id": {
               "description": "Stable id for this child, unique within the parent turn.",

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -664,7 +664,7 @@
               "type": "integer"
             },
             "sub_agent_id": {
-              "description": "Which sub-agent spent this call, when a sub-agent did (#4383).\n\n`None` is the lead's own call. It is stamped at the sub-agent\nboundary (`stella_core::subagent`'s `child_sender`), so a nested\nchild names *itself* rather than its parent — the innermost spender\nis the one a cost question is about.\n\nThe bracket in [`crate::subagent_event::SubAgentPhase`] was meant to\nbe the whole attribution mechanism, and it is enough for everything\nit was designed for. It is not enough for **this**: the engine\ndispatches independent delegates concurrently, so several children's\nevents interleave on one stream and no `Started`/`Finished` pair\nbrackets any particular call. Session `ses-1787465453163-60967` has\nfive delegates completing within one second of each other; its\nninety telemetry rows all read `worker`, and no join over the\nbracket can undo that.\n\nContent-free like the rest of this event: an opaque handle\n(`plugin:vera/worker#0`), never instruction text.",
+              "description": "Which sub-agent spent this call. Absent means the lead's own call, which is the ordinary case. Stamped at the sub-agent boundary, so a nested child names itself rather than its parent. The `sub_agent` started/finished bracket cannot answer this: independent delegates are dispatched concurrently, so several children's events interleave on one stream and no bracket pair encloses any particular call. An opaque handle, never instruction text.",
               "type": [
                 "string",
                 "null"
@@ -743,7 +743,7 @@
               "$ref": "#/$defs/ModelCallRole"
             },
             "sub_agent_id": {
-              "description": "Which sub-agent's call died, when a sub-agent's did (#4383). Same\ncontract as [`AgentEvent::StepUsage`]'s field of this name, and here\nfor the same reason it is there: a delegate abandoned at the\nengine's dispatch ceiling lands one flagged row, and a row nobody\ncan attribute explains an execution's `usage_complete = 0` without\nsaying whose call it was.",
+              "description": "Which sub-agent's call died. Absent means the lead's own. Same contract as a `step_usage` event's field of this name: an abandoned delegate lands one flagged row, and a row nobody can attribute explains an execution's incomplete usage without saying whose call it was.",
               "type": [
                 "string",
                 "null"


### PR DESCRIPTION
Six issues from the self-driving / sub-agent batch. Two are skipped and said so below.

## What

### #4510 — the candidate substrate has an environment spelling
`[run] candidate_isolation` reaches `CandidateSubstrate::for_session` through `Settings::load`, which answers `Settings::default()` under `STELLA_NO_SETTINGS=1`. Every bench launcher sets that variable, so the one environment the copy substrate was built for — a task whose tests execute gitignored fixtures — could not reach it. `STELLA_CANDIDATE_ISOLATION` is that selector's environment spelling; `CandidateIsolation::from_token` now parses the settings key and the variable, so the two cannot drift into accepting different words. The variable outranks the file because it is the narrower statement, the same precedence `--model` has over a configured default. An unreadable token gets the worktree substrate **and says so on stderr** — the copy substrate overwrites the tree it promotes onto.

### #4511 — the sweep keeps naming a preserved patch; a recycled pid no longer reads live
(1) An abnormal ending writes each live candidate's work to `<slug>.patch` and prints where (#2651); removal then takes the checkout **and** `record::forget`s its record, so no later sweep could re-name the patch. The sweep now lists patches from the directory rather than from a record, and each line names the deletion as well as the application — a line that repeats until you act has to say what the act is.

(2) `record::orphans` decided "owner is gone" on `pid_alive` alone. The record now carries the owning process's start token beside its pid (`/proc/<pid>/stat` on Linux, `proc_pidinfo(PROC_PIDTBSDINFO)` on macOS), and a live pid whose token differs is a different process wearing the number. Where no token can be read — no interface, an older record, no `/proc` — the previous rule stands unchanged: `None` is "cannot tell", never "gone".

`libproc` rather than `sysctl(KERN_PROC_PID)` because `libc` exposes `proc_bsdinfo` on Apple targets and does not expose `kinfo_proc`; the sysctl route would need a hand-declared kernel struct for a number two documented fields already carry.

### #3808 — a cancelled run's reflection says it covers a partial run
`record_execution_end` reads the outcome one line above (`!= "cancelled"`, to poison the usage envelope) and then throws it away before calling `finalize_execution_reflection`. **Decision taken, per the issue's open question: yes, a real row, marked as covering a partial run.** Withholding it would throw away the objective half, and that half is measured rather than claimed — in the audited session the run made 66 edits across 35 files before a human stopped it. `execution_reflection.partial_run` (v31 → v32) states the scope the judgement covers.

Derived inside `finalize_execution_reflection` rather than passed in, because the outcome is a column that function is already inside a read of. That is also why `stella-cli` needs no change. `NOT NULL DEFAULT 0` **and backfilled**, unlike v29's nullable `tasks.contract`: the historical fact is recorded one join away in `executions.outcome`. `executions.usage_complete` is untouched and still false for a cancel.

### #4383 — a metering record names the sub-agent that spent it
`StepUsage` and `UsageIncomplete` gain `sub_agent_id`, stamped in `subagent::child_sender`; innermost sender wins, so a grandchild names itself. The `Started`/`Finished` bracket could not answer this — independent delegates are dispatched **concurrently**, so several children's events interleave on one stream and no bracket pair encloses any particular call. `subagent_event`'s doc, which declared the bracket was the whole attribution mechanism, is corrected rather than left contradicting the code.

Additive with serde defaults, so `PROTOCOL_VERSION` is unchanged. `telemetry.sub_agent_id` (v32 → v33) is nullable with no backfill: NULL is the lead's own call, a fact rather than a gap, and nothing in the journal could attribute a historical row without the guess the column exists to end. **Deliberately not replicated to the usage hub** — a handle like `plugin:vera/worker#0` names a plugin and an ordinal, which has no business in a cross-project rollup.

The accounting half of #4383 (a flagged zero-usage row for an abandoned call) already landed in #4479; this is the identity half.

### #4488 — a sub-agent's calls are bounded by the ceiling its whole run sits under
The delegate's ceiling is the engine's 900 s `tool_timeout`; the per-call bound underneath it is `model_timeout`, which measures **silence**. A dribbling stream re-arms the idle bound forever, consumes the whole ceiling with one call, and is abandoned with nothing salvaged. The child's carve now takes a task deadline derived from that ceiling (`bounded_by_ceiling` — the tighter of what it inherited and `now + ceiling - reserve`), so the child sees its own limit first and reports the call as timed out. The reserve is what keeps "first" true rather than a coin flip at the same instant.

### #4471 — self-driving refuses `--api-key` instead of dropping it silently
**The issue recommends the sealed handoff; this takes the refusal branch, which its own "Done means" also accepts.** Two reasons, argued in `turn_flags.rs`:

- The handoff seals a value into a *named provider slot*, so the parent would have to resolve which provider the child selects. `stella self-driving` deliberately never does — it runs with zero API keys. A credential flag that forced settings/catalog resolution (and possibly an interactive prompt) in front of a loop that needs none of it is a worse trade than one exported variable.
- A consumed handoff is authoritative: `credential_handoff::is_present()` disables the child's credentials-file discovery outright, so a run holding credentials for three providers and passing `--api-key` for one would lose the other two.

Reopen it if the handoff is wanted anyway — the choice is stated rather than made quietly.

## Evidence

Every witness was run **both ways**: with the change (pass) and against a minimally reverted copy of the production line it depends on (fail). None is a compile-only witness.

| Issue | Witness | Reverted | With the change |
|---|---|---|---|
| #4510 | `candidate_workspaces::tests::the_environment_reaches_for_session_where_no_settings_scope_can` | FAILED | ok |
| #4511 (1) | `record::tests::a_preserved_patch_is_named_by_every_sweep_until_it_is_removed` | FAILED | ok |
| #4511 (2) | `record::tests::a_recycled_pid_does_not_make_a_dead_owner_read_live` | FAILED | ok |
| #3808 | `reflection::tests::a_cancelled_runs_reflection_says_it_covers_a_partial_run` | FAILED | ok |
| #4383 | `subagent::tests::failure_and_events::a_childs_metering_records_name_the_child_that_spent_them` | FAILED | ok |
| #4488 | `subagent::tests::spend_and_cancellation::a_child_is_bounded_by_the_ceiling_its_whole_run_sits_under` | FAILED (`unreachable!` — the call outran the ceiling) | ok |
| #4471 | `self_driving_cli::an_api_key_is_refused_before_the_loop_touches_anything` | FAILED | ok |

Supporting units beside each: the isolation vocabulary shared by both spellings, a pre-field record still parsing, patch ordering, `a_run_that_reached_its_own_end_is_not_partial`, `finalize_marks_a_partial_run_without_erasing_a_self_review`, `the_leads_own_calls_name_no_sub_agent`, `a_turns_calls_can_be_grouped_by_the_sub_agent_that_spent_them`, `a_childs_deadline_is_the_tighter_of_what_it_inherited_and_the_ceiling`, and both migrations' idempotence plus their no-table cases.

Targeted commands, all run after `git merge origin/main` and `cargo clean -p` on each touched crate (a cached green is not a green):

- `cargo test -p stella-core` / `-p stella-store` / `-p stella-protocol` / `-p stella-cli` / `-p stella-tui` / `-p stella-observatory` — exit 0
- `cargo clippy -p <crate> --all-targets -- -D warnings` for those six — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc -p <crate> --no-deps` **and** `--document-private-items` for stella-core, stella-store, stella-cli, stella-protocol — exit 0. The plain run is what caught the module doc linking to a private `child_sender`.
- `cargo fmt --all`, `make guards-fast` — exit 0. `make wire-schema` OK after `scripts/export-agentevent-schema.sh`; the artifacts gain two optional fields and one corrected description.
- `make prose` — OK, none added.

`driver.rs` is a grandfathered god file, so the metering emission moved to `driver/settlement.rs` rather than growing it by the one line the new field needed. No baseline file is touched anywhere in this PR.

## Not done

- **#4386 (`files_touched` attributes a sibling session's edits) — skipped.** The fix has to scope the measurement, which lives in `crates/stella-cli/src/turn_files.rs` and `src/durability.rs`; another agent owns `turn_files.rs` this session. The store-side slice that *is* reachable without it — promoting the `reason` already inside `files_touched.events` to a real `provenance` column, plus a read-time contested-path flag off the indexed `executions.session_id` — is real but partial, and half an attribution is worse than a documented absence.
- **#4362 (self-driving turns produce no lessons) — skipped, with the triager's leading hypothesis ruled out.** The reflection log and `context.db` resolve through the *same* helper (`stella_store::private::ensure_workspace_state_dir` → `stella_home::workspace_state_root`), so "reflections.jsonl is workspace-root-resolved while context.db is state-root-resolved" is false in this tree. The remaining asymmetry is the gate: `record_episode` (`goal.rs:349`) is gated only on `memory.is_some() && turn_warrants_reflection`, while reflection (`goal.rs:392`) additionally consults `STELLA_DISABLE_REFLECTION` — and `work.rs::turn_command` sets exactly one env var and inherits everything else, so an ambient `STELLA_DISABLE_REFLECTION=1` produces precisely the reported signature (episodes written, reflections zero). Whether it was set in the maintainer's drive environment is not something this session could settle, and guessing is worse than saying so.
- **#4510's bench-harness mirror.** Registering `STELLA_CANDIDATE_ISOLATION` in the Harbor adapter's `_CLAIM_CONTAINER_ENV` needs ~19 lines in `bench/harbor_adapter/stella_harbor/__init__.py`, a grandfathered god file at its ceiling, and no baseline is being touched here. Until it lands, a bench arm exporting the variable gets a **refused run naming it** — loud and correct, but the bench half of #4510 is not reachable. `isolation.rs` says so at the constant.

Closes #4510
Closes #4511
Closes #3808
Closes #4383
Closes #4488
Closes #4471

## Summary by Sourcery

Improve candidate cleanup, cancelled-run reflection, sub-agent accounting, execution deadlines, and self-driving flag validation so operational outcomes clearly identify their scope and owner.

New Features:
- Add environment-based candidate isolation selection with shared parsing and safe, explicit fallback behavior.
- Track the sub-agent responsible for model-call usage in protocol events and local telemetry.
- Bound sub-agent execution by the parent tool ceiling and preserve partial-call accounting.

Bug Fixes:
- Prevent recycled process IDs from hiding orphaned candidate workspaces by validating process start tokens.
- Keep preserved candidate patches visible in subsequent sweeps with instructions for applying and removing them.
- Record cancelled execution reflections as partial runs while retaining measured work.
- Reject unsupported self-driving --api-key usage instead of silently dropping the credential.

Enhancements:
- Extend candidate cleanup reporting to include stable, actionable preserved-patch notices.
- Add platform-specific process start-token detection with backward-compatible handling for older records and unsupported hosts.

Documentation:
- Update AgentEvent wire types, schemas, and attribution documentation for sub-agent usage fields.

Tests:
- Add regression coverage for candidate isolation overrides, orphan detection, preserved patch reporting, partial reflections, sub-agent usage attribution, child deadlines, and self-driving API-key refusal.
- Add migration tests for partial reflection and sub-agent telemetry columns, including idempotence and legacy schema cases.

Chores:
- Advance the store schema to version 33 with additive reflection and telemetry migrations while keeping sub-agent identity local to the workspace store.