### PR TITLE
fix(stella-cli,stella-core,stella-graph,stella-engine,stella-home): eleven recorded decisions

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -106,6 +106,10 @@ pub(crate) fn session_persistence() -> stella_runtime::Persistence {
 /// wrapper runs over the turn (`Raw` by default, #3381). `test_command`, when given, arms a
 /// bound wrapper plugin's own oracle.
 ///
+/// `require_verdict` makes a bound wrapper's non-`Met` outcome a non-zero exit
+/// (#3554); it is refused before this point on a `Raw` choice, where nothing
+/// declares a verdict for it to read.
+///
 /// `--keep-witness`/`--require-verified` used to reach this function too, back when a
 /// `Classic` arm selected the built-in staged pipeline. That pipeline is gone
 /// (#3865) and its variant with it (#3867), and `wrapper_plugin::reject_verification_flags_without_pipeline` now refuses both
@@ -118,13 +122,23 @@ pub async fn run_one_shot(
     format: OutputFormat,
     pipeline: crate::wrapper_plugin::PipelineChoice<'_>,
     test_command: Option<&str>,
+    require_verdict: bool,
 ) -> Result<(), CliFailure> {
     // A benchmark's durable sink is part of the accounting boundary. Prove the exact mounted file
     // is writable before provider construction or any code path that can make a paid call.
     preflight_durable_stream(format)?;
     // #3381 made Raw the default, so this now admits the common no-flag `stella run` case too.
     crate::enterprise_telemetry::authorize_one_shot(!pipeline.is_raw())?;
-    run_raw_one_shot(cfg, prompt, budget_limit, format, pipeline, test_command).await
+    run_raw_one_shot(
+        cfg,
+        prompt,
+        budget_limit,
+        format,
+        pipeline,
+        test_command,
+        require_verdict,
+    )
+    .await
 }
 
 /// The `--output-format json` summary of a raw (`--no-pipeline`) step-loop run.

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -116,6 +116,7 @@ pub(crate) async fn run_raw_one_shot(
     format: OutputFormat,
     pipeline: crate::wrapper_plugin::PipelineChoice<'_>,
     test_command: Option<&str>,
+    require_verdict: bool,
 ) -> Result<(), crate::failure::CliFailure> {
     let bare = bare_loop_config(full_cfg);
     let cfg = &bare;
@@ -306,6 +307,7 @@ pub(crate) async fn run_raw_one_shot(
                     budget_limit.is_some(),
                 ),
                 Some(candidate.grant.clone()),
+                require_verdict,
                 crate::wrapper_plugin::RawTurnDriver {
                     provider: &*provider,
                     base_tools,

--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -51,7 +51,12 @@ async fn build_code_graph_with(
     let root = workspace_root.to_path_buf();
     let outcome = drive_index_blocking(root, INDEX_PROGRESS_INTERVAL, emit).await;
     match outcome {
-        Ok(Ok(stats)) => emit(InitLine::Step(format_graph_stats(&stats))),
+        Ok(Ok(stats)) => {
+            emit(InitLine::Step(format_graph_stats(&stats)));
+            if let Some(line) = format_entry_points(&stats) {
+                emit(InitLine::Step(line));
+            }
+        }
         Ok(Err(warning)) => emit(InitLine::Step(warning)),
         Err(e) => emit(InitLine::Step(format!(
             "! code-graph indexing task failed: {e} — run `stella init` again to retry"
@@ -373,10 +378,18 @@ pub(super) fn index_workspace_graph_blocking(
         files_unchanged: stats.files_skipped_unchanged,
         files_skipped_generated: stats.files_skipped_generated,
         files_skipped_too_large: stats.files_skipped_too_large,
+        entry_points: graph.entry_points(ENTRY_POINT_SAMPLE).unwrap_or_default(),
     };
     graph.shutdown();
     Ok(summary)
 }
+
+/// How many entry points the orientation line names. Small on purpose: the
+/// line is a starting point for a reader, not the roster — a tree with two
+/// hundred uningested test files would otherwise print two hundred paths at
+/// the end of every `stella init`. The graph answers the full question for
+/// anyone who wants it.
+const ENTRY_POINT_SAMPLE: usize = 5;
 
 /// Whole-index totals plus this pass's parse/skip split, for the startup line.
 pub(super) struct GraphSummary {
@@ -397,6 +410,15 @@ pub(super) struct GraphSummary {
     /// whose file left the index otherwise gets no signal at all, and reads
     /// the graph's silence about it as the file having no symbols.
     pub(super) files_skipped_too_large: usize,
+    /// Up to [`ENTRY_POINT_SAMPLE`] indexed files nothing in the index
+    /// imports, shallowest path first — binaries, scripts, tests, dead code.
+    /// The orientation half of the summary: the totals say how much was
+    /// indexed, this says where a reader starts.
+    ///
+    /// Empty when the index is empty, and also when every indexed file is
+    /// imported by another — a real answer in a tree with one cyclic module
+    /// graph, not a failure to compute one.
+    pub(super) entry_points: Vec<String>,
 }
 
 /// The `✓ code graph: N symbols, M imports…` summary line, shared by `stella
@@ -435,6 +457,30 @@ pub(super) fn format_graph_stats(summary: &GraphSummary) -> String {
         return base;
     }
     format!("{base} — {}", clauses.join(", "))
+}
+
+/// The `· start here: …` line that follows [`format_graph_stats`], naming the
+/// files nothing in the index imports. `None` when the index found none,
+/// because a line reading `start here:` with nothing after it tells a reader
+/// less than no line at all.
+///
+/// Deliberately its own line rather than another clause on the stats line:
+/// the totals answer "how much is indexed" and this answers "where do I
+/// start", and a reader scanning `stella init`'s output for the second
+/// should not have to find it at the end of the first.
+pub(super) fn format_entry_points(summary: &GraphSummary) -> Option<String> {
+    if summary.entry_points.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "· start here: {} — nothing in the index imports {}",
+        summary.entry_points.join(", "),
+        if summary.entry_points.len() == 1 {
+            "it"
+        } else {
+            "them"
+        }
+    ))
 }
 
 /// A session-lifetime holder for the live code graph. It keeps the in-process
@@ -706,7 +752,12 @@ pub(crate) fn spawn_session_graph(
         let outcome =
             drive_index_blocking(root.clone(), INDEX_PROGRESS_INTERVAL, &mut status).await;
         match outcome {
-            Ok(Ok(stats)) => status(InitLine::Step(format_graph_stats(&stats))),
+            Ok(Ok(stats)) => {
+                status(InitLine::Step(format_graph_stats(&stats)));
+                if let Some(line) = format_entry_points(&stats) {
+                    status(InitLine::Step(line));
+                }
+            }
             Ok(Err(warning)) => status(InitLine::Step(warning)),
             Err(e) => status(InitLine::Step(format!(
                 "! code-graph indexing task failed: {e} — search ranks over the last good index \

--- a/crates/stella-cli/src/agent/tests/code_graph.rs
+++ b/crates/stella-cli/src/agent/tests/code_graph.rs
@@ -27,6 +27,7 @@ fn format_graph_stats_reports_generated_skip_count_when_nonzero() {
         files_unchanged: 1,
         files_skipped_generated: 5,
         files_skipped_too_large: 0,
+        entry_points: Vec::new(),
     };
     let line = format_graph_stats(&summary);
     assert!(
@@ -46,6 +47,7 @@ fn format_graph_stats_omits_the_skip_clause_when_nothing_was_skipped() {
         files_unchanged: 0,
         files_skipped_generated: 0,
         files_skipped_too_large: 0,
+        entry_points: Vec::new(),
     };
     let line = format_graph_stats(&summary);
     assert!(
@@ -64,6 +66,7 @@ fn format_graph_stats_uses_singular_file_for_a_count_of_one() {
         files_unchanged: 0,
         files_skipped_generated: 1,
         files_skipped_too_large: 0,
+        entry_points: Vec::new(),
     };
     let line = format_graph_stats(&summary);
     assert!(line.contains("skipped 1 generated file"), "{line}");
@@ -106,6 +109,7 @@ fn format_graph_stats_reports_the_size_limit_skip_count() {
         files_unchanged: 0,
         files_skipped_generated: 0,
         files_skipped_too_large: 3,
+        entry_points: Vec::new(),
     };
     let line = format_graph_stats(&summary);
     assert!(
@@ -151,5 +155,75 @@ fn index_workspace_graph_blocking_reports_size_limit_skips_end_to_end() {
     assert!(
         line.contains("skipped 1 file over the size limit"),
         "{line}"
+    );
+}
+
+/// #3719: the totals say how much was indexed; this says where to start
+/// reading. End-to-end through the real builder, because the value comes from
+/// the graph's anti-join rather than from anything this crate computes.
+#[test]
+fn index_workspace_graph_blocking_names_the_files_nothing_imports() {
+    use crate::agent::graph::format_entry_points;
+
+    let ws = tempfile::tempdir().unwrap();
+    let root = ws.path().canonicalize().unwrap();
+    // `main.rs` declares `mod helper;`, so `helper.rs` is imported and is not
+    // an entry point. `bin.rs` and the deeper `tools/probe.rs` are imported by
+    // nothing, and `main.rs` itself is imported by nothing either.
+    std::fs::write(root.join("main.rs"), "mod helper;\npub fn run() {}\n").unwrap();
+    std::fs::write(root.join("helper.rs"), "pub fn help() {}\n").unwrap();
+    std::fs::write(root.join("bin.rs"), "pub fn bin() {}\n").unwrap();
+    std::fs::create_dir_all(root.join("tools")).unwrap();
+    std::fs::write(root.join("tools").join("probe.rs"), "pub fn probe() {}\n").unwrap();
+
+    let summary = index_workspace_graph_blocking(&root, &mut |_| {}).expect("index build succeeds");
+    assert_eq!(
+        summary.entry_points,
+        vec![
+            "bin.rs".to_string(),
+            "main.rs".to_string(),
+            "tools/probe.rs".to_string()
+        ],
+        "shallowest path first, then lexicographic — and never the imported file"
+    );
+
+    let line = format_entry_points(&summary).expect("a tree with entry points gets the line");
+    assert!(
+        line.starts_with("· start here: bin.rs, main.rs, tools/probe.rs"),
+        "{line}"
+    );
+    assert!(
+        !line.contains("helper.rs"),
+        "an imported file is not where a reader starts: {line}"
+    );
+}
+
+/// The line is withheld rather than printed empty. An index where every file
+/// is imported by another is a real answer, and `start here:` followed by
+/// nothing would read as a bug in the summary.
+#[test]
+fn format_entry_points_is_silent_when_the_index_names_none() {
+    use crate::agent::graph::format_entry_points;
+
+    let summary = GraphSummary {
+        total_symbols: 0,
+        total_imports: 0,
+        total_files: 0,
+        files_parsed: 0,
+        files_unchanged: 0,
+        files_skipped_generated: 0,
+        files_skipped_too_large: 0,
+        entry_points: Vec::new(),
+    };
+    assert_eq!(format_entry_points(&summary), None);
+
+    let one = GraphSummary {
+        entry_points: vec!["main.rs".to_string()],
+        ..summary
+    };
+    let line = format_entry_points(&one).expect("one entry point still gets a line");
+    assert!(
+        line.ends_with("nothing in the index imports it"),
+        "singular, not plural, for a count of one: {line}"
     );
 }

--- a/crates/stella-cli/src/arena.rs
+++ b/crates/stella-cli/src/arena.rs
@@ -121,6 +121,10 @@ pub(crate) async fn run_arena(mut cfg: Config, args: ArenaArgs) -> Result<(), St
         OutputFormat::StreamJson,
         crate::wrapper_plugin::PipelineChoice::resolve(args.no_pipeline, args.pipeline.as_deref())?,
         args.test_command.as_deref(),
+        // The arena scores from its journal rather than the process exit
+        // (see the comment below), so a wrapper's verdict has nothing to
+        // decide here and `--require-verdict` is not offered on this door.
+        false,
     )
     .await;
 

--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -591,6 +591,13 @@ pub(crate) enum Command {
         #[arg(long)]
         require_verified: bool,
 
+        /// Exit non-zero unless the `--pipeline` wrapper declared its
+        /// requirements met (#3554). Refused without `--pipeline`, where
+        /// nothing declares a verdict; see `wrapper_plugin::verdict_gate` for
+        /// why it is opt-in.
+        #[arg(long)]
+        require_verdict: bool,
+
         /// Output shape: text, json, or stream-json
         ///
         /// Declared here rather than globally because this is a promise about

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -91,6 +91,7 @@ use crate::{agent, rules};
 
 mod add_dir;
 mod authoring;
+mod dropped_turn;
 pub(crate) mod forwarder;
 mod init_cmd;
 mod lead_control;
@@ -2214,28 +2215,14 @@ pub async fn run_deck_session(
                     // requeue and park on (see [`HoldState`]).
                     dispatch.cancelled(&submitted);
                 }
-                let cancelled_cost =
-                    agent::settled_cost_since(dispatch_spend_usd, budget.session_spent_usd());
-                if let Some((store, id)) = &execution
-                    && !agent::record_execution_end(
-                        store,
-                        *id,
-                        registry.as_ref(),
-                        "cancelled",
-                        cancelled_cost,
-                        false,
-                    )
-                {
-                    let _ = in_tx.send(Inbound::Event {
-                        agent: LEAD.to_string(),
-                        event: AgentEvent::Error {
-                            message: "store write failed — this cancelled execution was not \
-                                      recorded"
-                                .to_string(),
-                            retryable: true,
-                        },
-                    });
-                }
+                dropped_turn::close_dropped_execution(
+                    execution.as_ref(),
+                    registry.as_ref(),
+                    "cancelled",
+                    dispatch_spend_usd,
+                    &mut budget,
+                    &in_tx,
+                );
                 // Must stay AFTER the store warning above: the warning is
                 // retryable (folds to Running) while this one is not (folds
                 // to Failed), so this event is what leaves the lead in a
@@ -2266,12 +2253,12 @@ pub async fn run_deck_session(
                 }
                 dispatch.reset();
                 queue.clear();
-                let cleared_cost =
-                    agent::settled_cost_since(dispatch_spend_usd, budget.session_spent_usd());
-                session_clear::close_cleared_execution(
+                dropped_turn::close_dropped_execution(
                     execution.as_ref(),
                     registry.as_ref(),
-                    cleared_cost,
+                    "cleared",
+                    dispatch_spend_usd,
+                    &mut budget,
                     &in_tx,
                 );
                 session_clear::reset_lead(

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -166,6 +166,7 @@ mod tests {
                         retries: 0,
                         tool_calls: 1,
                         usage_complete: true,
+                        sub_agent_id: None,
                     },
                 )
                 .expect("receipt");

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Closing out the execution a dropped turn leaves behind, and reporting what
+//! it cost.
+//!
+//! Two arms drop a turn future mid-flight — a cancel and a mid-turn `/clear` —
+//! and both then owe the store a closed row and the user a number. #2570 fixed
+//! the row: `Store::finish_execution_accounted` keeps `executions.cost_usd` at
+//! or above the sum of the execution's `telemetry` receipts, so a receipt that
+//! lands after the close-out still heals the persisted figure.
+//!
+//! It did not fix the number the driver holds. The cost handed to the store is
+//! `agent::settled_cost_since(dispatch_spend_usd, budget.session_spent_usd())`
+//! — an in-memory delta read at the instant the future is dropped, when the
+//! expensive roles are still settling. Execution 99 in #2570 reported
+//! `$0.8659773` against `$5.28786465` of receipts. So the database was right
+//! and the session total the deck kept showing was the pre-cancel prefix, and
+//! the bias is one-directional and worst on the runs that cost the most.
+//!
+//! [`close_dropped_execution`] reads the truth back. The row is re-read after
+//! the close-out and the guard's session accumulator is corrected to match, so
+//! the deck's own running total stops under-reporting the turn the user just
+//! stopped.
+//!
+//! Not fixed here, and #2807's second half: nothing awaits the forwarder drain
+//! before the row closes, so a `StepUsage` can still be priced after
+//! `record_execution_end` has run. The read-back heals whatever landed by the
+//! time it runs and no more. Draining first must not reintroduce the #2290
+//! wedge `detach_event_stream` exists to fix, which is why it is a separate
+//! change.
+//!
+//! Lives here rather than inline in the driver's `TurnEnd` arms: those are in
+//! a god file closed to growth.
+
+use super::*;
+
+/// Close the execution a dropped turn left open, correct the guard from the
+/// closed row, and surface a failed store write.
+///
+/// `noun` names the drop in the warning a failed write emits — "cancelled" or
+/// "cleared". The stored outcome label is `cancelled` for both, because that
+/// is what happened to the turn either way (`session_clear`'s own note).
+pub(super) fn close_dropped_execution(
+    execution: Option<&(Arc<Store>, i64)>,
+    registry: &ToolRegistry,
+    noun: &str,
+    dispatch_spend_usd: f64,
+    budget: &mut BudgetGuard,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    let dropped_cost = agent::settled_cost_since(dispatch_spend_usd, budget.session_spent_usd());
+    let Some((store, id)) = execution else {
+        return;
+    };
+    let recorded =
+        agent::record_execution_end(store, *id, registry, "cancelled", dropped_cost, false);
+    // After the close-out, because that is when the row carries the floor over
+    // both sources. Before it, the receipts the driver missed are exactly the
+    // ones not yet folded in.
+    if let Ok(Some(summary)) = store.execution_summary(*id) {
+        budget.reseed_session_spend(reconciled_session_spend(
+            dispatch_spend_usd,
+            budget.session_spent_usd(),
+            summary.cost_usd,
+        ));
+    }
+    if recorded {
+        return;
+    }
+    let _ = in_tx.send(Inbound::Event {
+        agent: LEAD.to_string(),
+        event: AgentEvent::Error {
+            message: format!("store write failed — this {noun} execution was not recorded"),
+            retryable: true,
+        },
+    });
+}
+
+/// The session total after a dropped turn's row has settled: whichever of the
+/// two lower bounds is larger.
+///
+/// `in_memory` is what the guard accumulated, which misses the roles still
+/// settling when the future was dropped. `dispatch_spend_usd + row_cost` is
+/// what the session had spent before this turn plus what the closed row proves
+/// this turn cost. Each can miss what the other saw — the row misses a call
+/// whose telemetry write failed, which is what `usage_complete` records — so
+/// the larger is the tightest honest answer, exactly as
+/// `Store::finish_execution_accounted` argues for the row itself.
+///
+/// Never lowers the accumulator: spend within one session is monotone, and a
+/// correction that could subtract would make a `--spend-limit` gate readable
+/// as a lower number than the guard has already enforced against.
+pub(super) fn reconciled_session_spend(
+    dispatch_spend_usd: f64,
+    in_memory: f64,
+    row_cost: f64,
+) -> f64 {
+    in_memory.max(dispatch_spend_usd + row_cost.max(0.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The #2570 shape, in the numbers that issue recorded: the guard saw the
+    /// triage+research+plan prefix and the row proves the whole run.
+    #[test]
+    fn a_row_that_proves_more_than_the_guard_saw_raises_the_total() {
+        assert_eq!(
+            reconciled_session_spend(10.0, 10.8659773, 5.28786465),
+            15.28786465
+        );
+    }
+
+    /// The other direction is a real case, not a defensive one: a receipt
+    /// whose telemetry write failed is spend the guard saw and the row cannot
+    /// prove, and `usage_complete` is where that is recorded.
+    #[test]
+    fn a_guard_that_saw_more_than_the_row_proves_is_kept() {
+        assert_eq!(reconciled_session_spend(10.0, 12.0, 1.0), 12.0);
+    }
+
+    /// A row read before it settled — or a store that answered nothing useful
+    /// — must never lower a session total the guard has already gated on.
+    #[test]
+    fn the_correction_never_subtracts() {
+        assert_eq!(reconciled_session_spend(10.0, 11.0, 0.0), 11.0);
+        assert_eq!(reconciled_session_spend(10.0, 11.0, -3.0), 11.0);
+    }
+
+    /// **Witness (#2807).** The read-back is wired, not merely available.
+    ///
+    /// Execution 99's shape against a real store: the guard holds the
+    /// pre-cancel prefix, the durable receipts prove several times that, and
+    /// the close-out leaves the guard reporting what was actually spent. On
+    /// the old driver this arm computed the delta, handed it to the store and
+    /// never read anything back, so the guard kept the prefix — which is the
+    /// number the deck shows the user at the moment they cancel.
+    #[tokio::test]
+    async fn the_guard_is_corrected_from_the_row_the_closeout_settled() {
+        let root = tempfile::tempdir().expect("workspace");
+        let store = Arc::new(Store::open(root.path()).expect("store"));
+        let id = store
+            .begin_execution("chat", "a prompt", "zai", "glm-5.2")
+            .expect("execution");
+        // The two expensive roles settled their receipts while the turn future
+        // was already being dropped, so the guard below never saw them.
+        for (step, cost) in [(1u64, 0.5), (2, 4.0)] {
+            store
+                .record_telemetry(
+                    id,
+                    &stella_store::TelemetryRow {
+                        step,
+                        provider: "zai".into(),
+                        call_role: "worker".into(),
+                        model: "glm-5.2".into(),
+                        input_tokens: 1_000,
+                        estimated_input_tokens: 900,
+                        output_tokens: 100,
+                        cache_read_tokens: 0,
+                        cache_miss_tokens: 1_000,
+                        cache_write_tokens: 0,
+                        cost_usd: cost,
+                        duration_ms: 500,
+                        retries: 0,
+                        tool_calls: 1,
+                        usage_complete: true,
+                    },
+                )
+                .expect("receipt");
+        }
+
+        let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+        budget.reseed_session_spend(10.25);
+        let (in_tx, _in_rx) = tokio::sync::mpsc::unbounded_channel::<Inbound>();
+        let registry = ToolRegistry::new(std::env::temp_dir());
+
+        close_dropped_execution(
+            Some(&(Arc::clone(&store), id)),
+            &registry,
+            "cancelled",
+            10.0,
+            &mut budget,
+            &in_tx,
+        );
+
+        assert!(
+            (budget.session_spent_usd() - 14.5).abs() < 1e-9,
+            "the guard must report the $4.50 the receipts prove, not the $0.25 \
+             prefix it accumulated: {}",
+            budget.session_spent_usd()
+        );
+    }
+}

--- a/crates/stella-cli/src/command_deck/session_clear.rs
+++ b/crates/stella-cli/src/command_deck/session_clear.rs
@@ -299,36 +299,11 @@ pub(super) fn cleared_workers_note(live_lanes: &[String]) -> Option<String> {
     ))
 }
 
-/// Close out the execution a mid-turn `/clear` interrupted. It is recorded
-/// as `cancelled` — the clear drops the turn future exactly as a cancel does,
-/// so the outcome label matches the thing that happened — and a failed store
-/// write is surfaced rather than swallowed, because a clear that quietly lost
-/// its telemetry row leaves a hole in the session's journal that nothing else
-/// would report.
-///
-/// Lives here rather than inline in the driver's `TurnEnd::Cleared` arm: the
-/// arm is in a god file closed to growth, and the closeout is `/clear`'s own
-/// business.
-pub(super) fn close_cleared_execution(
-    execution: Option<&(Arc<Store>, i64)>,
-    registry: &ToolRegistry,
-    cleared_cost: f64,
-    in_tx: &UnboundedSender<Inbound>,
-) {
-    let Some((store, id)) = execution else {
-        return;
-    };
-    if agent::record_execution_end(store, *id, registry, "cancelled", cleared_cost, false) {
-        return;
-    }
-    let _ = in_tx.send(Inbound::Event {
-        agent: LEAD.to_string(),
-        event: AgentEvent::Error {
-            message: "store write failed — this cleared execution was not recorded".to_string(),
-            retryable: true,
-        },
-    });
-}
+// The closeout a mid-turn `/clear` owes its execution used to live here as
+// `close_cleared_execution`. It is `super::dropped_turn` now: a clear and a
+// cancel drop the turn future the same way, owe the store the same
+// `cancelled` row, and — since #2807 — owe the guard the same correction from
+// it, so one function does both and the noun is a parameter.
 
 #[cfg(test)]
 mod tests {

--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -67,6 +67,17 @@
 //! [`stella_store::Reconstruction::mismatch_severity`] rather than
 //! re-derived), never used to admit one.
 //!
+//! A middle tier that admitted `compaction`-severity executions *with* their
+//! reconstructed [`DatasetRecord::calls`], marked compaction-era, was
+//! considered and declined (#3613). It would recover legacy transcript data
+//! for SFT and it would cost the one property every emitted `calls` array has
+//! today: that it digest-verified. A dataset whose records mean two different
+//! things depending on a flag inside them is worth less than a smaller one
+//! whose records all mean the same thing, and the trajectory of those turns
+//! is exported already under `--include-unverified-transcripts`. Re-opening
+//! this is a decision about what a default training dataset contains, not a
+//! predicate edit.
+//!
 //! ## What a "diff" can honestly be here
 //!
 //! There is no unified diff anywhere in `store.db`. `files_touched` holds

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -1009,6 +1009,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             test_command,
             keep_witness,
             require_verified,
+            require_verdict,
             output_format,
         } => {
             let pipeline_choice =
@@ -1021,6 +1022,12 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 test_command.as_deref(),
                 keep_witness,
                 require_verified,
+            )?;
+            // Honored on `--pipeline <variant>` and meaningless without one,
+            // so it is refused here rather than accepted and ignored (#3554).
+            wrapper_plugin::reject_require_verdict_without_wrapper(
+                pipeline_choice,
+                require_verdict,
             )?;
             let prompt = prompt_source::resolve(
                 prompt,
@@ -1050,6 +1057,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                     output_format,
                     pipeline_choice,
                     test_command.as_deref(),
+                    require_verdict,
                 ),
             )?;
         }

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -122,7 +122,11 @@ impl SessionMemory {
     ) -> Option<String> {
         let (registry, rendered) = self.turn_record_rendered(prompt)?;
         for drop in stella_core::steering::adapt::record_drops(registry, &rendered) {
-            report(record_drop_message(&drop.handle));
+            // A record channel drop is never also selected — the channel's
+            // own budget cut it before the plane saw it.
+            if let Some(message) = drop_message(&drop, false) {
+                report(message);
+            }
         }
         record_section_text(rendered)
     }
@@ -216,7 +220,7 @@ impl SessionMemory {
             &selected,
             record.as_ref(),
         );
-        report_record_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
+        report_steering_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
 
         let frames = kept_frames(&recall.frames, &set);
         let kept = kept_skills(&selected.selected, &set);
@@ -334,7 +338,7 @@ impl SessionMemory {
             &selected,
             record.as_ref(),
         );
-        report_record_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
+        report_steering_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
 
         // The per-frame cut this block exists to make. It runs AFTER the plane
         // has packed, not before the query: the drop is about what the model
@@ -914,24 +918,82 @@ fn record_section_text(rendered: RenderedChannel) -> Option<String> {
     (!text.trim().is_empty()).then(|| text.trim_start().to_string())
 }
 
-/// The eviction report for one budget-dropped record — the single producer
-/// both the plane path and the test-side section entry emit through.
-fn record_drop_message(handle: &str) -> String {
-    format!(
-        "a record applying to this turn did not fit the {RECORD_CHANNEL_BUDGET}-char \
-         record budget: ^{handle} — raise its precedence, or trim the records that \
-         outrank it"
-    )
+/// The eviction report for one dropped candidate — the single producer every
+/// source emits through (#3437).
+///
+/// One sentence shape for all of them, the record channel's:
+/// *what applied, which budget refused it, its handle, and the remedy*. The
+/// remedy is the half that differs, and it has to: telling a user whose skill
+/// lost its seat to "raise its precedence" is advice for a different channel.
+///
+/// `still_selected` is the section-budget class, and it is why this takes the
+/// whole ledger rather than a handle. A skill can be in `selected` *and*
+/// `dropped` by design — top-k kept it and `skills::section_fit` then left it
+/// out of the rendered section (`adapt::skill_drops`' own doc). Both classes
+/// genuinely miss the prompt, so both are reported; only the remedy differs,
+/// because `SKILLS_SECTION_TOKEN_BUDGET` is a constant and nothing
+/// configurable widens it until #3243 Phase 4 collapses the two budgets.
+///
+/// `None` for a source this path never produces — a tool schema or a
+/// plugin-contributed candidate. Silence there is the absence of a producer,
+/// not a withheld report.
+fn drop_message(
+    drop: &stella_core::steering::DroppedCandidate,
+    still_selected: bool,
+) -> Option<String> {
+    use stella_core::steering::SteeringSource;
+    let handle = &drop.handle;
+    match drop.source {
+        SteeringSource::Record => Some(format!(
+            "a record applying to this turn did not fit the {RECORD_CHANNEL_BUDGET}-char \
+             record budget: ^{handle} — raise its precedence, or trim the records that \
+             outrank it"
+        )),
+        SteeringSource::Memory => Some(format!(
+            "a memory recalled for this turn did not fit the retrieval budget: {handle} \
+             — raise `context.retrieval.max_tokens`"
+        )),
+        SteeringSource::Skill if still_selected => Some(format!(
+            "a skill matching this turn did not fit the skills section's token budget: \
+             {handle} — nothing configurable widens that budget yet (#3243)"
+        )),
+        SteeringSource::Skill => Some(format!(
+            "a skill matching this turn did not fit the skill budget: {handle} — raise \
+             `skills.max_skills`"
+        )),
+        SteeringSource::Tool | SteeringSource::Plugin => None,
+    }
 }
 
-/// Report every record the ledger says was dropped. Records only, today:
-/// frames and skills kept their sources' existing (silent) drop behavior
-/// through the migration — generalizing the report to them is real new
-/// surface, not a refactor.
-fn report_record_drops(set: &stella_core::steering::SteeringSet, mut report: impl FnMut(String)) {
+/// Report every candidate the ledger says was dropped, whatever its source.
+///
+/// #3358 completed the *ledger* across records, skills and frames; this is the
+/// human-facing half (#3437). Before it, a skill that lost its seat every turn
+/// and a frame the recall host's merge evicted were queryable and said nothing
+/// to the person watching the run — the #2709 observability gap in its other
+/// half.
+///
+/// Two recall-side filters are deliberately **not** reported here, and that is
+/// a decision rather than an omission. `project_recalled_frame` drops a frame
+/// the citation-label rule cannot name, and `is_suppressed_local_frame` drops
+/// one the session quarantined. Neither is a budget eviction: the first is a
+/// frame this process could not cite, and the second is deliberate
+/// suppression of a memory cited untruthful twice. Reporting either as
+/// `DroppedCandidate` would tell a user their budget was too small when it was
+/// not, and quarantine in particular wants its own vocabulary rather than a
+/// line advising a bigger retrieval budget. The provider's spend on both is
+/// already accounted for by the usage report captured above the filters.
+pub(super) fn report_steering_drops(
+    set: &stella_core::steering::SteeringSet,
+    mut report: impl FnMut(String),
+) {
     for drop in &set.dropped {
-        if drop.source == stella_core::steering::SteeringSource::Record {
-            report(record_drop_message(&drop.handle));
+        let still_selected = set
+            .selected
+            .iter()
+            .any(|c| c.source == drop.source && c.handle == drop.handle);
+        if let Some(message) = drop_message(drop, still_selected) {
+            report(message);
         }
     }
 }

--- a/crates/stella-cli/src/memory/replay.rs
+++ b/crates/stella-cli/src/memory/replay.rs
@@ -349,6 +349,6 @@ impl<'a> Replayer<'a> {
         let tools = detect_tool_gaps(&self.shell_history, self.foundry);
 
         // 6. Snapshot.
-        summary.observe_turn(turn, &report, tools.len());
+        summary.observe_turn(self.root, &report, tools.len());
     }
 }

--- a/crates/stella-cli/src/memory/replay/summary.rs
+++ b/crates/stella-cli/src/memory/replay/summary.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 use stella_core::tool_foundry::{GapDetectionConfig, ShellInvocation, detect_tool_gaps};
 
-use super::trace::{ScriptedReflection, Trace, TraceTurn};
+use super::trace::{ScriptedReflection, Trace};
 use crate::memory::ReflectionReport;
 
 /// What one replay built, plus the corpus shape it was built from.
@@ -59,8 +59,15 @@ pub(crate) struct ReplaySummary {
     pub tools: Vec<String>,
     // ---- when ---------------------------------------------------------------
     /// Turn ordinal (1-based) at which each artifact class first appeared.
+    ///
+    /// All four are measured — probed per turn, `None` when the class never
+    /// appeared and rendered as an em dash. `first_skill_turn` used to be set
+    /// to the total turn count whenever any skill existed, which printed
+    /// `skill 10` beside two measured values and read as a measurement
+    /// (#2359); `first_rule_turn` did not exist at all.
     pub first_memory_turn: Option<usize>,
     pub first_skill_turn: Option<usize>,
+    pub first_rule_turn: Option<usize>,
     pub first_tool_turn: Option<usize>,
     /// Every turn's reported model error, in order — the starvation record.
     ///
@@ -92,9 +99,19 @@ impl ReplaySummary {
     }
 
     /// Fold one replayed turn into the summary.
+    ///
+    /// Skills and rules are probed on disk here rather than tallied at their
+    /// write sites, for the reason [`observe_final_state`] gives: what is on
+    /// disk is what a later session would load, and a counter incremented at
+    /// the write site keeps claiming a file a no-clobber refusal never
+    /// created. Two directory reads per turn against a workspace of a handful
+    /// of files — the cost #2350 declined to pay when nothing asserted on the
+    /// number, and the number was a placeholder for exactly as long (#2359).
+    ///
+    /// [`observe_final_state`]: ReplaySummary::observe_final_state
     pub(crate) fn observe_turn(
         &mut self,
-        _turn: &TraceTurn,
+        root: &Path,
         report: &ReflectionReport,
         tool_proposals: usize,
     ) {
@@ -105,6 +122,15 @@ impl ReplaySummary {
         }
         if tool_proposals > 0 && self.first_tool_turn.is_none() {
             self.first_tool_turn = Some(self.turns);
+        }
+        if self.first_skill_turn.is_none()
+            && !crate::memory::skill_paths_on_disk(&crate::memory::workspace_skills_dir(root))
+                .is_empty()
+        {
+            self.first_skill_turn = Some(self.turns);
+        }
+        if self.first_rule_turn.is_none() && !published_rules(root).is_empty() {
+            self.first_rule_turn = Some(self.turns);
         }
         if let Some(error) = &report.model_error {
             self.model_errors.push(error.clone());
@@ -132,12 +158,6 @@ impl ReplaySummary {
             .into_iter()
             .map(|proposal| proposal.name)
             .collect();
-        if !self.skills.is_empty() && self.first_skill_turn.is_none() {
-            // Skills are only observable on disk, so the best we can honestly
-            // say is "by the end". A per-turn probe would cost a directory walk
-            // per turn to sharpen a number nothing asserts on.
-            self.first_skill_turn = Some(self.turns);
-        }
         self.memories = memory_texts(root).len();
     }
 
@@ -179,10 +199,15 @@ impl ReplaySummary {
         out.push_str(&format!("  skills:   {}\n", render_list(&self.skills)));
         out.push_str(&format!("  rules:    {}\n", render_list(&self.rules)));
         out.push_str(&format!("  tools:    {}\n", render_list(&self.tools)));
+        // All four classes §6 names, each measured. An em dash where a class
+        // never appeared: "never" and "on the last turn" are different
+        // statements, and the old skill placeholder said the second when it
+        // meant neither.
         out.push_str(&format!(
-            "  turns-to-first: memory {}, skill {}, tool {}\n",
+            "  turns-to-first: memory {}, skill {}, rule {}, tool {}\n",
             render_turn(self.first_memory_turn),
             render_turn(self.first_skill_turn),
+            render_turn(self.first_rule_turn),
             render_turn(self.first_tool_turn),
         ));
 

--- a/crates/stella-cli/src/memory/replay/tests.rs
+++ b/crates/stella-cli/src/memory/replay/tests.rs
@@ -898,6 +898,61 @@ async fn the_committed_corpus_builds_a_memory_a_skill_a_rule_and_a_tool() {
     assert!(!summary.tools.is_empty(), "tools: {summary:?}");
 }
 
+/// **Witness (#2359).** `turns-to-first` is a measurement for all four
+/// classes, not two measurements and a placeholder.
+///
+/// `first_skill_turn` used to be set to the *total turn count* whenever any
+/// skill existed on disk at the end, and `first_rule_turn` did not exist. So
+/// the report printed `skill 10` on a ten-turn corpus however early the skill
+/// was promoted, in the same row as two genuinely measured numbers, and a
+/// reader comparing two corpora would draw a conclusion from a field that only
+/// ever reported "the last turn". Fails on the old code for exactly that
+/// reason: the strict inequality below is an equality there.
+#[tokio::test]
+async fn turns_to_first_is_measured_for_every_class_not_placed() {
+    let corpus = committed_corpus();
+    let (summary, _dir) = replay(&corpus).await;
+
+    let skill = summary
+        .first_skill_turn
+        .expect("the committed corpus builds a skill");
+    let rule = summary
+        .first_rule_turn
+        .expect("the committed corpus publishes a rule");
+    assert!(
+        skill < summary.turns,
+        "a skill promoted mid-corpus is reported where it happened, not at the \
+         end: skill {skill} of {} turns",
+        summary.turns
+    );
+    // The rule on this corpus genuinely lands on its last turn, so the same
+    // strict inequality would assert a fact about the fixture rather than
+    // about the metric. What the rule half witnesses is that the class is
+    // reported at all: the row below has three classes on the old code.
+    assert!(rule <= summary.turns, "{summary:?}");
+
+    let rendered = summary.render();
+    assert!(
+        rendered.contains(&format!("skill {skill}, rule {rule}")),
+        "and all four classes are named in the row: {rendered}"
+    );
+}
+
+/// A class that never appeared is an em dash, never a number: "never" and "on
+/// the last turn" are different statements.
+#[tokio::test]
+async fn a_class_that_never_appeared_renders_as_a_dash() {
+    let barren = trace("no artifacts", one_task_each(vec![turn(T0, "a lesson")]));
+    let (summary, _dir) = replay(&barren).await;
+    assert_eq!(summary.first_skill_turn, None, "{summary:?}");
+    assert_eq!(summary.first_rule_turn, None, "{summary:?}");
+    assert!(
+        summary.render().contains("skill —, rule —"),
+        "{}",
+        summary.render()
+    );
+}
+
 /// `make replay-learning`'s entry point — prints the §6 summary for the
 /// committed corpus.
 ///

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -535,3 +535,79 @@ fn a_touched_path_that_is_not_a_file_is_not_an_anchor() {
             .is_empty()
     );
 }
+
+/// **Witness (#3437).** One drop line per evicted candidate, whatever its
+/// source, each carrying the remedy its own channel answers to.
+///
+/// Fails on base, where `report_record_drops` filtered `SteeringSet::dropped`
+/// to `SteeringSource::Record` and emitted through a single producer that hard-
+/// coded the record channel's precedence advice. A skill that lost its seat
+/// every turn and a frame the recall host's merge evicted were both queryable
+/// on the ledger (#3358) and said nothing to the person watching the run.
+///
+/// The two skill classes are the part that needs care: a skill cut by the
+/// section's own token budget appears in `selected` **and** `dropped` by
+/// design, and its remedy is not `skills.max_skills` — that budget is a
+/// constant nothing configurable widens until #3243 Phase 4.
+#[test]
+fn every_dropped_source_gets_a_line_with_its_own_remedy() {
+    use stella_core::steering::{DroppedCandidate, SteeringCandidate, SteeringSet, SteeringSource};
+
+    fn dropped(source: SteeringSource, handle: &str) -> DroppedCandidate {
+        DroppedCandidate {
+            source,
+            handle: handle.to_string(),
+            est_tokens: 100,
+        }
+    }
+
+    let set = SteeringSet {
+        // The section-budget class: still selected on the plane, and still
+        // absent from the rendered section.
+        selected: vec![SteeringCandidate {
+            source: SteeringSource::Skill,
+            handle: "section-cut".to_string(),
+            score: 1.0,
+            why: "matched terms: deploy".to_string(),
+            est_tokens: 100,
+        }],
+        dropped: vec![
+            dropped(SteeringSource::Record, "deploy-policy"),
+            dropped(SteeringSource::Memory, "nod_evicted"),
+            dropped(SteeringSource::Skill, "seat-loser"),
+            dropped(SteeringSource::Skill, "section-cut"),
+            // Nothing on this path produces one; the silence is the absence
+            // of a producer, not a withheld report.
+            dropped(SteeringSource::Tool, "bash"),
+        ],
+    };
+
+    let mut lines = Vec::new();
+    crate::memory::recall::report_steering_drops(&set, |message| lines.push(message));
+
+    assert_eq!(lines.len(), 4, "one line per reportable source: {lines:?}");
+    let joined = lines.join("\n");
+    assert!(
+        lines[0].contains("^deploy-policy") && lines[0].contains("raise its precedence"),
+        "the record channel's own sentence is unchanged: {joined}"
+    );
+    assert!(
+        lines[1].contains("nod_evicted") && lines[1].contains("`context.retrieval.max_tokens`"),
+        "a frame the merge evicted names the retrieval budget: {joined}"
+    );
+    assert!(
+        lines[2].contains("seat-loser") && lines[2].contains("`skills.max_skills`"),
+        "a skill that lost its seat names the seat count: {joined}"
+    );
+    assert!(
+        lines[3].contains("section-cut")
+            && lines[3].contains("skills section's token budget")
+            && lines[3].contains("#3243"),
+        "and one cut by the section budget says so, rather than advising a \
+         knob that would not have saved it: {joined}"
+    );
+    assert!(
+        !joined.contains("bash"),
+        "no source invents a line it has no producer for: {joined}"
+    );
+}

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -145,31 +145,39 @@ const RETIRED: &[(&str, &str)] = &[
     // settings files in the wild, which is exactly what this list is for: the
     // operator spelled a real key correctly and the feature behind it is gone,
     // so "check the spelling" would be false advice. Retired rather than
-    // deleted silently (#3870, #3872); what each one did, and what rebuilding
-    // it on the raw loop would take, is recorded on its own issue.
+    // deleted silently (#3870, #3872).
+    //
+    // The recap and the trace were each held open while their rebuild was
+    // decided (#3893, #3894). Both are now decided against, and the sentences
+    // below say so — an operator reading "nothing does this now" has to guess
+    // whether to wait for a release that restores it.
     (
         "enable_recap",
-        "printed a deterministic end-of-run recap in text mode; the renderer \
-         read the staged pipeline's verdict types and went with that crate, so \
-         nothing assembles a recap now",
+        "printed a deterministic end-of-run recap in text mode; its one \
+         addition over the file and cost lines already printed was the word \
+         `verified`, which the raw loop cannot say, so it is retired for good \
+         rather than rebuilt (#3893)",
     ),
     (
         "run.recap",
-        "printed a deterministic end-of-run recap in text mode; the renderer \
-         read the staged pipeline's verdict types and went with that crate, so \
-         nothing assembles a recap now",
+        "printed a deterministic end-of-run recap in text mode; its one \
+         addition over the file and cost lines already printed was the word \
+         `verified`, which the raw loop cannot say, so it is retired for good \
+         rather than rebuilt (#3893)",
     ),
     (
         "trace_capture",
         "appended a per-execution trajectory trace to \
-         `.stella/private/traces.jsonl`; the module that assembled it was \
-         orphaned by the staged pipeline's removal and deleted with it",
+         `.stella/private/traces.jsonl`; retired for good, because \
+         `.stella/private/store.db` already records every step, tool call and \
+         cost this wrote and `stella observe` reads them (#3894)",
     ),
     (
         "run.trace_capture",
         "appended a per-execution trajectory trace to \
-         `.stella/private/traces.jsonl`; the module that assembled it was \
-         orphaned by the staged pipeline's removal and deleted with it",
+         `.stella/private/traces.jsonl`; retired for good, because \
+         `.stella/private/store.db` already records every step, tool call and \
+         cost this wrote and `stella observe` reads them (#3894)",
     ),
     (
         "agent_engine_config.approval_wait_secs",

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -86,8 +86,12 @@
 //! cannot be added to a gate afterwards — the two halves are therefore separate
 //! moments, not one function with an `Option` in it.
 //!
-//! And two scope limits: a plugin's `Unmet` does not fail the process
-//! (#3554), and only this driver of `doc:wrapper-socket` §6's three exists
+//! And two scope limits. A plugin's `Unmet` fails the process only under
+//! `--require-verdict`, which `stella run` alone offers — the door where an
+//! exit status is a delivery gate. `stella goal` and `stella fleet` drive
+//! wrappers too and take no such flag yet (#3554 shipped the gate on the
+//! one-shot door; see `verdict_gate` for what the default is defending). And
+//! only this driver of `doc:wrapper-socket` §6's three exists
 //! (#3551). `--pipeline <variant>` itself now reaches every door that takes
 //! it — `stella run` here, `stella goal` per judged round
 //! (`crate::agent::goal::goal_wrapped`), and `stella fleet` per worker
@@ -162,6 +166,9 @@ use candidates::ended_abnormally;
 /// Every `! wrapper:` line a run prints, in one renderer.
 mod report;
 use report::{report_to, sweep_lines};
+/// Whether a wrapper's conclusion decides the run's exit status (#3554).
+mod verdict_gate;
+use verdict_gate::verdict_refusal;
 // The renderers `report_to` composes internally. Nothing in the shipped binary
 // calls them directly — only this module's tests do, through `super::` — so the
 // re-export is `#[cfg(test)]` rather than an `#[allow(unused_imports)]`: the
@@ -378,6 +385,28 @@ pub(crate) fn reject_arbiter_wrapper_on_goal(resolved: &ResolvedWrapper) -> Resu
 /// passes it through; `keep_witness`/`require_verified` remain pipeline-only
 /// today and are refused on `Plugin` exactly as on `Raw`, both naming an
 /// installed verification wrapper plugin as the remedy.
+/// Refuse `--require-verdict` where nothing declares a verdict (#3554).
+///
+/// Unlike the three flags below, this one is honored — on
+/// [`PipelineChoice::Plugin`], where a bound wrapper's `judge` reaches an
+/// `Outcome` the flag can read. On the raw loop there is no wrapper and no
+/// verdict, so accepting it would be the silent drop CLAUDE.md forbids: the
+/// caller asked for a delivery gate and would get an unconditional exit `0`.
+pub(crate) fn reject_require_verdict_without_wrapper(
+    choice: PipelineChoice<'_>,
+    require_verdict: bool,
+) -> Result<(), String> {
+    if !require_verdict || !choice.is_raw() {
+        return Ok(());
+    }
+    Err(
+        "--require-verdict has no verdict to read on the raw loop (no --pipeline): only an \
+         installed wrapper plugin declares one. Install one (see `stella plugin install`) and \
+         pass --pipeline <variant> naming it."
+            .to_string(),
+    )
+}
+
 pub(crate) fn reject_verification_flags_without_pipeline(
     choice: PipelineChoice<'_>,
     test_command: Option<&str>,
@@ -1288,23 +1317,28 @@ impl TurnDriver for RawTurnDriver<'_> {
 
 /// Drive one wrapper plugin around as many raw turns as its verdict asks for.
 ///
-/// Returns the last round's result — the run's exit status is the turn's, not
-/// the wrapper's verdict. That is deliberate for this slice: `--require-verified`
-/// is the flag that turns "completed but unproven" into a failure, and it is
-/// wired to the staged pipeline's ladder rather than to a plugin's rule. Making
-/// a plugin's `Unmet` fail the process is a separate decision with its own
-/// blast radius — a third party's manifest failing a user's build wants an
-/// explicit flag, not a side effect of installing something — and it is #3554.
+/// Returns the last round's result, and — under `require_verdict` — the
+/// wrapper's own conclusion on top of it (#3554). Without the flag a
+/// `DispatchReport` whose outcome is `Unmet` is printed and exits `0`, which
+/// is deliberate: installing a third party's manifest must not by itself gain
+/// the power to fail somebody's build. `crate::wrapper_plugin::verdict_gate`
+/// carries the argument and the wording.
+///
+/// The turn's own failure wins when both fire. A run that aborted has a more
+/// specific thing to say than "the wrapper was not satisfied", and the wrapper
+/// was very likely not satisfied *because* it aborted.
 ///
 /// # Errors
 ///
-/// The turn's own failure, or a wrapper whose declared stage order could not be
-/// resolved — which a validated manifest cannot hit.
+/// The turn's own failure, a wrapper whose declared stage order could not be
+/// resolved — which a validated manifest cannot hit — or, under
+/// `require_verdict`, an outcome that is not `Met`.
 pub(crate) async fn run_wrapped(
     bound: &BoundWrapper,
     goal: &str,
     signals: SignalValues,
     candidate: Option<stella_plugin::CandidateGrant>,
+    require_verdict: bool,
     mut driver: RawTurnDriver<'_>,
 ) -> Result<(), CliFailure> {
     let format = driver.format;
@@ -1369,7 +1403,11 @@ pub(crate) async fn run_wrapped(
             // A round always runs, so `results` always has an entry; an empty
             // one would mean the dispatcher returned without driving anything,
             // which is a report about the wrapper and not about the work.
-            last.unwrap_or(Ok(true)).map(|_| ())
+            last.unwrap_or(Ok(true))?;
+            match verdict_refusal(require_verdict, &report.outcome) {
+                Some(refusal) => Err(CliFailure::from(refusal)),
+                None => Ok(()),
+            }
         }
         Err(error) => Err(CliFailure::from(error.to_string())),
     }

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -25,6 +25,7 @@ mod composition;
 mod report;
 mod round_driver;
 mod stage_program;
+mod verdict_gate;
 
 const WRAPPER_MANIFEST: &str = r#"
 name = "budget-keeper"

--- a/crates/stella-cli/src/wrapper_plugin/tests/verdict_gate.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests/verdict_gate.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Whose conclusion decides the exit status (#3554).
+//!
+//! `tests/run_require_verdict_cli.rs` is the end-to-end witness — it is the
+//! only place the process's actual exit code is observable. These cover the
+//! arms that test cannot reach cheaply: `Undecided`, and the wording each
+//! refusal carries.
+
+use super::*;
+use crate::wrapper_plugin::verdict_gate::verdict_refusal;
+use stella_plugin::Outcome;
+
+fn unmet(requirement: &str) -> Outcome {
+    Outcome::Unmet {
+        unmet: vec![stella_plugin::UnmetRequirement {
+            requirement: requirement.to_string(),
+            statement: "the statement".to_string(),
+            because: stella_plugin::UnmetBecause::NoFlip {
+                observed: stella_plugin::FlipObservation::NotAchieved,
+            },
+            detail: None,
+        }],
+        stopped: stella_plugin::StopReason::NotAnArbiter,
+    }
+}
+
+/// The default is the decision, not the absence of one: installing a third
+/// party's manifest must not by itself gain the power to fail a build.
+#[test]
+fn nothing_fails_without_the_flag() {
+    assert_eq!(verdict_refusal(false, &unmet("proven")), None);
+    assert_eq!(
+        verdict_refusal(
+            false,
+            &Outcome::Undecided {
+                reason: stella_plugin::UndecidedReason::NoOracle,
+            }
+        ),
+        None
+    );
+}
+
+#[test]
+fn a_met_verdict_passes_the_gate() {
+    assert_eq!(
+        verdict_refusal(
+            true,
+            &Outcome::Met {
+                evidence: stella_plugin::EvidenceProvenance::HostObserved,
+            }
+        ),
+        None
+    );
+}
+
+#[test]
+fn an_unmet_verdict_names_the_requirements_it_left() {
+    let refusal = verdict_refusal(true, &unmet("proven")).expect("unmet fails under the flag");
+    assert!(refusal.contains("--require-verdict"), "{refusal}");
+    assert!(refusal.contains("1 requirement"), "{refusal}");
+    assert!(refusal.contains("proven"), "{refusal}");
+}
+
+/// A gate whose purpose is "do not ship what the wrapper did not vouch for"
+/// cannot pass on "nothing decided it either way" — that is exactly the case
+/// where nothing vouched. The message says which of the two it was, because
+/// `Unmet` is work to redo and `Undecided` is usually a manifest problem.
+#[test]
+fn an_undecided_verdict_fails_too_and_says_why_nothing_decided() {
+    let refusal = verdict_refusal(
+        true,
+        &Outcome::Undecided {
+            reason: stella_plugin::UndecidedReason::NoOracle,
+        },
+    )
+    .expect("undecided fails under the flag");
+    assert!(refusal.contains("reached no verdict"), "{refusal}");
+    assert!(refusal.contains("[oracle]"), "{refusal}");
+}
+
+/// The flag is honored on `--pipeline <variant>` and meaningless without one,
+/// so the raw loop refuses it rather than accepting it and exiting 0 anyway.
+#[test]
+fn the_raw_loop_refuses_the_flag_and_a_wrapper_accepts_it() {
+    let raw = reject_require_verdict_without_wrapper(PipelineChoice::Raw, true)
+        .expect_err("--require-verdict reads nothing on the raw loop");
+    assert!(raw.contains("--require-verdict"), "{raw}");
+    assert!(raw.contains("--pipeline"), "{raw}");
+
+    assert!(reject_require_verdict_without_wrapper(PipelineChoice::Raw, false).is_ok());
+    assert!(reject_require_verdict_without_wrapper(PipelineChoice::Plugin("vera"), true).is_ok());
+}

--- a/crates/stella-cli/src/wrapper_plugin/verdict_gate.rs
+++ b/crates/stella-cli/src/wrapper_plugin/verdict_gate.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Whether a wrapper's conclusion decides the run's exit status.
+//!
+//! Until #3554 it never did: `run_wrapped` returned the last round's turn
+//! result, so a `DispatchReport` whose outcome was [`Outcome::Unmet`] printed
+//! to stderr and exited `0`. A delivery gate that must not ship unproven work
+//! had no way to read a plugin's refusal, and `--require-verified` — the flag
+//! that shape of user reaches for — was wired to the deleted staged
+//! pipeline's ladder and is refused unconditionally now (#3865).
+//!
+//! The default stays exit `0`, and that is the decision this module encodes
+//! rather than an oversight it works around: installing a third party's
+//! manifest must not, by itself, gain the power to fail somebody's build.
+//! `--require-verdict` is the opt-in that grants it.
+//!
+//! Pure over the outcome, so both directions are assertable without a session
+//! (`tests/verdict_gate.rs`). Split out of `wrapper_plugin.rs` rather than
+//! grown inside it: that file sits under the 1500-line ratchet.
+
+use stella_plugin::{Outcome, UndecidedReason};
+
+/// The failure `--require-verdict` owes the caller, or `None` to exit on the
+/// turn's own result.
+///
+/// Anything other than [`Outcome::Met`] fails under the flag, `Undecided`
+/// included. A gate whose whole purpose is "do not ship work the wrapper did
+/// not vouch for" cannot pass on "nothing decided it either way" — that is
+/// precisely the case where nothing vouched. The message names which of the
+/// two it was, because the remedies differ: `Unmet` is work to redo,
+/// `Undecided` is usually a manifest that declares requirements no oracle
+/// establishes.
+pub(super) fn verdict_refusal(require_verdict: bool, outcome: &Outcome) -> Option<String> {
+    if !require_verdict {
+        return None;
+    }
+    match outcome {
+        Outcome::Met { .. } => None,
+        Outcome::Unmet { unmet, .. } => {
+            let named = unmet
+                .iter()
+                .map(|requirement| requirement.requirement.as_str())
+                .collect::<Vec<_>>();
+            Some(format!(
+                "--require-verdict: the wrapper left {} unmet ({})",
+                plural(named.len(), "requirement"),
+                if named.is_empty() {
+                    "none named".to_string()
+                } else {
+                    named.join(", ")
+                }
+            ))
+        }
+        Outcome::Undecided { reason } => Some(format!(
+            "--require-verdict: the wrapper reached no verdict ({})",
+            undecided(reason)
+        )),
+    }
+}
+
+/// `1 requirement` / `2 requirements`.
+fn plural(count: usize, noun: &str) -> String {
+    if count == 1 {
+        format!("{count} {noun}")
+    } else {
+        format!("{count} {noun}s")
+    }
+}
+
+/// Why nothing decided, in the words the remedy depends on.
+fn undecided(reason: &UndecidedReason) -> String {
+    match reason {
+        UndecidedReason::NoOracle => {
+            "it declares requirements and no [oracle] to establish them".to_string()
+        }
+        UndecidedReason::Undecidable { requirement } => {
+            format!("nothing can decide `{requirement}`")
+        }
+        UndecidedReason::MeasurementMissing {
+            requirement,
+            measurement,
+        } => format!("`{requirement}` reads `{measurement}`, which the oracle did not report"),
+        UndecidedReason::UnreadableCheck {
+            requirement,
+            reason,
+        } => format!("`{requirement}`'s check could not be read: {reason}"),
+        UndecidedReason::FlipUnobservable => {
+            "the witness could not be run, so there is no flip to read".to_string()
+        }
+        UndecidedReason::WitnessUnsatisfiable => {
+            "the witness failed identically before and after, so it discriminates nothing"
+                .to_string()
+        }
+        UndecidedReason::TamperUnchecked => {
+            "the declared tamper policy wants a snapshot and none was taken".to_string()
+        }
+    }
+}

--- a/crates/stella-cli/src/wrapper_plugin/verdict_gate.rs
+++ b/crates/stella-cli/src/wrapper_plugin/verdict_gate.rs
@@ -4,7 +4,7 @@
 //! Whether a wrapper's conclusion decides the run's exit status.
 //!
 //! Until #3554 it never did: `run_wrapped` returned the last round's turn
-//! result, so a `DispatchReport` whose outcome was [`Outcome::Unmet`] printed
+//! result, so a `DispatchReport` whose outcome was `Outcome::Unmet` printed
 //! to stderr and exited `0`. A delivery gate that must not ship unproven work
 //! had no way to read a plugin's refusal, and `--require-verified` — the flag
 //! that shape of user reaches for — was wired to the deleted staged
@@ -24,7 +24,7 @@ use stella_plugin::{Outcome, UndecidedReason};
 /// The failure `--require-verdict` owes the caller, or `None` to exit on the
 /// turn's own result.
 ///
-/// Anything other than [`Outcome::Met`] fails under the flag, `Undecided`
+/// Anything other than `Outcome::Met` fails under the flag, `Undecided`
 /// included. A gate whose whole purpose is "do not ship work the wrapper did
 /// not vouch for" cannot pass on "nothing decided it either way" — that is
 /// precisely the case where nothing vouched. The message names which of the

--- a/crates/stella-cli/tests/run_require_verdict_cli.rs
+++ b/crates/stella-cli/tests/run_require_verdict_cli.rs
@@ -169,6 +169,16 @@ fn run(workspace: &Path, base_url: &str, extra: &[&str]) -> (Option<i32>, String
         .env_remove("AWS_ACCESS_KEY_ID")
         .env_remove("AWS_SECRET_ACCESS_KEY")
         .env_remove("AWS_SESSION_TOKEN")
+        // The session's code-graph build warms a semantic index, and
+        // `stella_embed::EmbedderEnv::from_process` resolves an HTTP backend
+        // from whichever of these is set (`stella-embed/src/http.rs`). Left
+        // inherited, a developer with `VOYAGE_API_KEY` exported has this test
+        // calling api.voyageai.com on their account — which is what happened
+        // the first time it ran here.
+        .env_remove("VOYAGE_API_KEY")
+        .env_remove("STELLA_EMBED_URL")
+        .env_remove("STELLA_EMBED_MODEL")
+        .env_remove("STELLA_EMBED_API_KEY")
         .output()
         .expect("spawn stella");
 

--- a/crates/stella-cli/tests/run_require_verdict_cli.rs
+++ b/crates/stella-cli/tests/run_require_verdict_cli.rs
@@ -1,0 +1,239 @@
+//! **Witness (#3554, the exit-status half).** A wrapper plugin's `Unmet`
+//! outcome decides `stella run`'s exit status — but only when the caller asks
+//! for it.
+//!
+//! Before this change `wrapper_plugin::run_wrapped` returned the last round's
+//! turn result and nothing else, so a `DispatchReport` whose outcome was
+//! `Unmet` printed to stderr and exited `0`: there was no way to make a
+//! plugin's refusal fail a delivery gate. `--require-verified`, the flag that
+//! shape of user reaches for, was wired to the deleted staged pipeline's
+//! ladder and is refused unconditionally (#3865).
+//!
+//! Three directions, because the default is as much of the decision as the
+//! flag is — installing a third party's manifest must not, by itself, gain
+//! the power to fail somebody's build:
+//!
+//! - the same unmet run without the flag still exits `0`;
+//! - with `--require-verdict` it exits non-zero and says which flag did it;
+//! - `--require-verdict` with no `--pipeline` is refused rather than
+//!   accepted and silently ignored.
+//!
+//! Deliberately a real subprocess against a real (mocked) HTTP endpoint,
+//! matching `run_exits_cli.rs` and `goal_wrapped_dispatch_cli.rs`: the
+//! property is the process's exit status, which no unit test can observe.
+//!
+//! `cfg(unix)`: the fixture wrapper is a `/bin/sh` script, same reason
+//! `goal_wrapped_dispatch_cli.rs` is unix-only.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The `[wrapper] id` the fixture declares, and what `--pipeline` names.
+const VARIANT: &str = "verdict-fixture-v1";
+
+/// An arbiter with one requirement its oracle decides on a witness flip, and
+/// no allowance to hold the completion open — so the dispatch reaches a
+/// verdict after exactly one turn and that verdict is `Unmet`.
+///
+/// Arbiter grade is what makes `[requirements]` admissible at all
+/// (`ManifestError::RequirementsRequireArbiter`), and `stella run` is the door
+/// that accepts it — `stella goal` refuses arbiter outright (#3832).
+const PLUGIN_TOML: &str = r#"
+name = "verdict-fixture"
+[loop]
+participation = "arbiter"
+# The grade's own requirement: a completion verdict is what arbiter grants, and
+# an undeclared hook is never invoked.
+hooks = ["Stop"]
+points = ["after_turn"]
+# The floor: "an arbiter that can never hold is not an arbiter". One hold, then
+# the allowance is spent and the loop stops with `proven` still unmet.
+max_holds = 1
+
+[requirements]
+proven = "a witness test failed before the change and passes after it"
+
+[oracle]
+flip = "required"
+
+[runtime]
+argv = ["/bin/sh", "${plugin_dir}/main.sh"]
+timeout_secs = 30
+env = ["PATH"]
+
+[wrapper]
+id = "verdict-fixture-v1"
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+/// The plugin answers `after_turn` with a witness that ran on both sides and
+/// did not flip — the observation that leaves `proven` genuinely **unmet**
+/// rather than undecided. (`not-attempted` and `unobservable` both make
+/// `judge` abstain instead, because each is a claim about the instrument.) It
+/// reports honestly and the host believes it; nothing here is a failure of the
+/// plugin.
+const PLUGIN_SCRIPT: &str = r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"not-achieved"}}}'
+"#;
+
+/// One SSE completion in the shape `stella-model`'s shared chat-completions
+/// adapter parses: one content delta carrying the whole answer, a trailing
+/// usage frame, then `[DONE]`.
+fn sse_completion(text: &str) -> String {
+    let content = serde_json::to_string(text).expect("text encodes");
+    format!(
+        "data: {{\"choices\":[{{\"delta\":{{\"content\":{content}}}}}]}}\n\n\
+         data: {{\"choices\":[{{\"delta\":{{}}}}],\"usage\":{{\"prompt_tokens\":8,\"completion_tokens\":3}}}}\n\n\
+         data: [DONE]\n\n"
+    )
+}
+
+/// Write the fixture wrapper into the project plugin tier.
+fn install_fixture_wrapper(workspace: &Path) {
+    let dir = workspace
+        .join(".stella")
+        .join("plugins")
+        .join("verdict-fixture");
+    std::fs::create_dir_all(&dir).expect("plugin dir");
+    std::fs::write(dir.join("plugin.toml"), PLUGIN_TOML).expect("plugin.toml");
+    let script = dir.join("main.sh");
+    std::fs::write(&script, PLUGIN_SCRIPT).expect("main.sh");
+    let mut perms = std::fs::metadata(&script)
+        .expect("script metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).expect("chmod +x");
+}
+
+/// Every worker call answers with text, so the turn ends on its first step and
+/// the run's whole content is the wrapper's verdict over it.
+async fn mock_worker() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse_completion("did the requested work"),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// One `stella run`, returning its exit status and stderr.
+///
+/// The hermeticity discipline is `goal_wrapped_dispatch_cli.rs`'s, and for the
+/// same reason: `STELLA_HOME` moves the user tier so no
+/// `~/.stella/credentials.toml` is discoverable, and every family's key is
+/// removed from the environment, so this test cannot reach a real provider
+/// with the developer's money.
+fn run(workspace: &Path, base_url: &str, extra: &[&str]) -> (Option<i32>, String) {
+    let data = tempfile::tempdir().expect("data dir");
+    let home = tempfile::tempdir().expect("stella home");
+    let mut args: Vec<&str> = vec![
+        "--model",
+        "zai/glm-5.2",
+        "--api-key",
+        "sk-test-zai",
+        "--base-url",
+        base_url,
+        "--spend-limit",
+        "5.0",
+        "run",
+        "do the thing, then stop",
+    ];
+    args.extend_from_slice(extra);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .args(&args)
+        .current_dir(workspace)
+        .env("STELLA_HOME", home.path())
+        .env("STELLA_DATA_DIR", data.path())
+        .env("STELLA_NO_ENV_FILE", "1")
+        .env("STELLA_TRUST_PROJECT", "1")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("ZAI_API_KEY")
+        .env_remove("DEEPSEEK_API_KEY")
+        .env_remove("XAI_API_KEY")
+        .env_remove("AWS_ACCESS_KEY_ID")
+        .env_remove("AWS_SECRET_ACCESS_KEY")
+        .env_remove("AWS_SESSION_TOKEN")
+        .output()
+        .expect("spawn stella");
+
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// A workspace with the fixture wrapper installed and one source file, so the
+/// session's code-graph build has something real to index.
+fn workspace() -> tempfile::TempDir {
+    let workspace = tempfile::tempdir().expect("workspace");
+    install_fixture_wrapper(workspace.path());
+    std::fs::write(workspace.path().join("lib.rs"), "pub fn hello() {}\n").expect("source file");
+    workspace
+}
+
+#[tokio::test]
+async fn an_unmet_verdict_fails_the_run_only_when_the_caller_asks() {
+    let server = mock_worker().await;
+
+    // Without the flag: the wrapper's refusal is reported and the process
+    // still exits on the turn's own result. This is the half a third party's
+    // manifest must never be able to change by itself.
+    let ws = workspace();
+    let (code, stderr) = run(ws.path(), &server.uri(), &["--pipeline", VARIANT]);
+    assert_eq!(
+        code,
+        Some(0),
+        "an unmet verdict is reported, not fatal, without --require-verdict: {stderr}"
+    );
+
+    // With it: the same run fails, and says which flag decided that.
+    let ws = workspace();
+    let (code, stderr) = run(
+        ws.path(),
+        &server.uri(),
+        &["--pipeline", VARIANT, "--require-verdict"],
+    );
+    assert_ne!(
+        code,
+        Some(0),
+        "--require-verdict must turn an unmet verdict into a failing exit: {stderr}"
+    );
+    assert!(
+        stderr.contains("--require-verdict"),
+        "the failure names the flag that caused it: {stderr}"
+    );
+    assert!(
+        stderr.contains("proven"),
+        "and the requirement that was left unmet: {stderr}"
+    );
+}
+
+/// On the raw loop nothing declares a verdict, so the flag has nothing to
+/// read. Accepting it there would be the silent drop CLAUDE.md forbids: the
+/// caller asked for a delivery gate and would get an unconditional exit 0.
+#[test]
+fn require_verdict_is_refused_without_a_wrapper() {
+    let ws = workspace();
+    let (code, stderr) = run(ws.path(), "http://127.0.0.1:1", &["--require-verdict"]);
+    assert_ne!(code, Some(0), "the refusal is a failure: {stderr}");
+    assert!(
+        stderr.contains("--require-verdict"),
+        "and it names the flag: {stderr}"
+    );
+}

--- a/crates/stella-core/src/estimator.rs
+++ b/crates/stella-core/src/estimator.rs
@@ -409,21 +409,6 @@ impl Calibration {
         let implied = (budget_f / sized).clamp(CALIBRATION_MIN_FACTOR, CALIBRATION_MAX_FACTOR);
         ((budget_f / implied) as u64, implied)
     }
-
-    /// [`estimate_message_tokens`] corrected by the current factor.
-    ///
-    /// Slope-only by construction: the fitted intercept is a **per-request**
-    /// overhead, and adding it to each message would multiply it by the
-    /// message count. Nothing outside this module's own tests calls this
-    /// today, which is why the distinction costs nothing.
-    pub fn calibrated_message_tokens(&self, message: &CompletionMessage) -> u64 {
-        (estimate_message_tokens(message) as f64 * self.factor()).ceil() as u64
-    }
-
-    /// [`estimate_conversation_tokens`] corrected by the current factor.
-    pub fn calibrated_conversation_tokens(&self, messages: &[CompletionMessage]) -> u64 {
-        (estimate_conversation_tokens(messages) as f64 * self.factor()).ceil() as u64
-    }
 }
 
 /// Per-model calibration state, keyed by the model string the provider
@@ -770,22 +755,6 @@ mod tests {
         }
         assert_eq!(cal.samples(), 0);
         assert_eq!(cal.factor(), 1.0);
-    }
-
-    #[test]
-    fn calibrated_estimates_scale_the_raw_heuristic() {
-        let mut cal = Calibration::new();
-        for _ in 0..5 {
-            cal.record(1000, 2000);
-        }
-        let msg = CompletionMessage::user("a".repeat(3500));
-        let raw = estimate_message_tokens(&msg);
-        assert_eq!(cal.calibrated_message_tokens(&msg), raw * 2);
-        let convo = vec![CompletionMessage::system("sys"), msg];
-        assert_eq!(
-            cal.calibrated_conversation_tokens(&convo),
-            (estimate_conversation_tokens(&convo) as f64 * 2.0).ceil() as u64
-        );
     }
 
     #[test]

--- a/crates/stella-engine/README.md
+++ b/crates/stella-engine/README.md
@@ -94,15 +94,23 @@ still a design question; making an already-reachable one writable is not.
 Every entry arrives with doc prose explaining its place in the host-driving
 story.
 
-**Declared exclusions.** `Engine::with_hooks` (`Hooks`, `HookRunner`) and
-`Engine::with_bus` (`HookBus`) are deliberately not closed over, and say so in
-`src/lib.rs` rather than being left as a silence. Their closure is the
-shell-command hook plane, an extension surface whose purpose is to *execute*
-things, fronted here by a crate that inherits `stella-core`'s I/O-free
-posture; the supported host-extension door is
-[`stella-runtime`](../stella-runtime)'s wrapper socket (#3380), which lives one
-layer above this facade precisely because two of its four points do I/O.
-Tracked in #3768.
+**The hook plane is the wrong layer, by design.** `Engine::with_hooks`
+(`Hooks`, `HookRunner`) and `Engine::with_bus` (`HookBus`) are not closed
+over. Their closure is the shell-command hook plane, an extension surface
+whose purpose is to *execute* things, fronted here by a crate that inherits
+`stella-core`'s I/O-free posture; the supported host-extension door is
+[`stella-runtime`](../stella-runtime)'s wrapper socket (#3380,
+`wrapper::WrapperDispatch::bind`), which lives one layer above this facade
+precisely because two of its four points do I/O.
+
+#3768 asked whether to close over both, over the observer half alone, or
+neither. **Neither**, permanently: closing over either method would let a host
+reach the engine's shell-execution authority by naming `stella_engine::` paths
+alone. Nothing is stranded by it — [`stella-serve`](../stella-serve), the
+embedded host that would have been the observer half's first caller, already
+links `stella-core` directly and mints its bus from `stella_core::bus::HookBus`.
+`tests/embedding.rs` enforces the boundary: it stops compiling if any of the
+five hook-plane names becomes reachable through `stella_engine::*`.
 
 Two contracts every consumer must know, documented at length in `src/lib.rs`:
 

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -142,11 +142,9 @@
 //! and was closed as speculative. Nothing below adds a capability; each entry
 //! makes an already-reachable one writable.
 //!
-//! ## Declared exclusions
+//! ## The hook plane is the wrong layer, by design
 //!
-//! Two of [`Engine`]'s builder methods are deliberately **not** closed over,
-//! declared here rather than left as a silence a reader has to notice
-//! (invariant 10's discipline, pointed at a re-export list):
+//! Two of [`Engine`]'s builder methods are deliberately **not** closed over:
 //!
 //! - **[`Engine::with_hooks`]** (`stella_core::hooks::{Hooks, HookRunner}`)
 //!   and **`Engine::with_bus`** (`stella_core::bus::HookBus`). Their closure
@@ -155,12 +153,29 @@
 //!   `HookEventDraft` — an extension surface whose whole purpose is to
 //!   *execute* things, fronted by a crate that inherits `stella-core`'s
 //!   I/O-free posture. The supported host-extension door is
-//!   `stella-runtime`'s wrapper socket (#3380), which lives one layer above
-//!   this facade precisely because two of its four points do I/O. A host
-//!   wanting either plane links `stella-runtime`, not this crate.
+//!   `stella-runtime`'s wrapper socket (#3380,
+//!   `stella_runtime::wrapper::WrapperDispatch::bind`), which lives one layer
+//!   above this facade precisely because two of its four points do I/O.
 //!
-//! Tracked in #3768. Re-opening the question is a `stella-runtime` decision
-//! before it is a re-export list edit.
+//! #3768 asked whether that is a permanent exclusion, whether the observer
+//! half (`with_bus`) should cross, or whether both should. **The answer is
+//! the first**, and this is the decision rather than a gap someone has yet to
+//! close. Closing over either method would let a host reach the engine's
+//! shell-execution authority by naming `stella_engine::` paths alone, which
+//! is the one thing a facade over an I/O-free engine must not make look
+//! ordinary.
+//!
+//! Nothing is stranded by that. `stella-serve` — the embedded host this crate
+//! exists for, and the one that would have been the observer half's first
+//! caller — already links `stella-core` directly and mints its bus from
+//! `stella_core::bus::HookBus` (`stella-serve/src/extensions.rs`,
+//! `session.rs`). A host that wants the plane takes the dependency that
+//! carries it and says so in its own manifest.
+//!
+//! Enforced rather than declared: `tests/embedding.rs`'s
+//! `the_hook_plane_is_still_outside_the_facade` stops compiling the moment
+//! any of `Hooks`, `HookRunner`, `HookBus`, `HookDecision` or
+//! `HookEventDraft` becomes reachable through `stella_engine::*`.
 
 #![forbid(unsafe_code)]
 

--- a/crates/stella-engine/tests/embedding.rs
+++ b/crates/stella-engine/tests/embedding.rs
@@ -373,3 +373,48 @@ async fn a_host_can_requery_its_context_plane_through_the_facade_alone() {
         "the answered block is appended to the transcript verbatim: {messages:?}"
     );
 }
+
+/// Stand-ins for the five hook-plane names #3768 declared permanently outside
+/// the closure rule. They exist only to be collided with.
+mod hook_plane {
+    pub struct Hooks;
+    pub struct HookRunner;
+    pub struct HookBus;
+    pub struct HookDecision;
+    pub struct HookEventDraft;
+}
+
+/// The closure rule's other half: what must stay *out*.
+///
+/// The rule says a host names nothing but `stella_engine::` paths to fill
+/// every builder argument, and `Engine::with_hooks` / `Engine::with_bus` are
+/// the two arguments it deliberately cannot fill (`src/lib.rs`, "The hook
+/// plane is the wrong layer, by design"). A declaration in prose is a
+/// reviewer's note; this module is the guard.
+mod the_exclusion_is_enforced {
+    use super::hook_plane::*;
+    use stella_engine::*;
+
+    /// Each name below resolves today because exactly one glob import
+    /// provides it. Re-export any of them from `stella-engine` and both globs
+    /// provide it, and the line becomes `E0659: ambiguous` — this test stops
+    /// compiling, which is the assertion. Nothing here runs anything; the
+    /// build is the check.
+    ///
+    /// The annotations are what does the work: a bare `HookBus` would resolve
+    /// in the value namespace, where a re-exported field-carrying struct is
+    /// not a candidate at all and the collision never happens. Naming each
+    /// one as a **type** asks the question in the namespace a re-export
+    /// actually lands in — traits (`HookRunner`) included.
+    #[test]
+    fn the_hook_plane_is_still_outside_the_facade() {
+        // Through the facade's own glob, so the import above is live and the
+        // collision below is a real question rather than a dead one.
+        let _config: EngineConfig = EngineConfig::default();
+        let _hooks: Hooks = Hooks;
+        let _runner: HookRunner = HookRunner;
+        let _bus: HookBus = HookBus;
+        let _decision: HookDecision = HookDecision;
+        let _draft: HookEventDraft = HookEventDraft;
+    }
+}

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -497,6 +497,11 @@ impl CodeGraph {
     /// the per-file [`importers_of`] scan this replaces. Shallowest path
     /// first, then lexicographic; empty on an empty index.
     ///
+    /// Consumed by `stella init`'s orientation line
+    /// (`stella-cli/src/agent/graph.rs`, `format_entry_points`), which names
+    /// the first few beneath the index totals: the totals say how much was
+    /// indexed, these say where a reader starts.
+    ///
     /// [`importers_of`]: CodeGraph::importers_of
     pub fn entry_points(&self, limit: usize) -> Result<Vec<String>, GraphError> {
         store::entry_points(&self.inner.read_guard(), limit)

--- a/crates/stella-graph/src/store/tests.rs
+++ b/crates/stella-graph/src/store/tests.rs
@@ -281,6 +281,58 @@ fn busiest_file_is_none_on_an_empty_index() {
     assert_eq!(busiest_file(&conn).unwrap(), None);
 }
 
+/// The anti-join behind `CodeGraph::entry_points` (#3719): the files nothing
+/// in the index imports, shallowest path first and then lexicographic.
+/// Indexed from a real tree rather than hand-inserted rows, because the
+/// question is whether resolved imports actually land in `to_path` — a query
+/// tested against synthetic rows would pass on a resolver that resolves
+/// nothing.
+#[test]
+fn entry_points_names_the_files_nothing_imports_shallowest_first() {
+    let ws = tempdir().unwrap();
+    let dbdir = tempdir().unwrap();
+    let root = canon(&ws);
+    let db = dbdir.path().join("context.db");
+    // `main.rs` declares `mod helper;`, which resolves to the sibling
+    // `helper.rs` — the one file here with an importer.
+    fs::write(root.join("main.rs"), "mod helper;\npub fn run() {}\n").unwrap();
+    fs::write(root.join("helper.rs"), "pub fn help() {}\n").unwrap();
+    fs::write(root.join("bin.rs"), "pub fn bin() {}\n").unwrap();
+    fs::create_dir_all(root.join("tools")).unwrap();
+    fs::write(root.join("tools").join("probe.rs"), "pub fn probe() {}\n").unwrap();
+
+    let grammars = Grammars::load().unwrap();
+    let mut conn = open(&db).unwrap();
+    index_tree(&mut conn, &root, &grammars).unwrap();
+
+    assert_eq!(
+        importers_of(&conn, "helper.rs").unwrap(),
+        vec!["main.rs".to_string()],
+        "the fixture's one import must actually resolve, or this proves nothing"
+    );
+    assert_eq!(
+        entry_points(&conn, 10).unwrap(),
+        vec![
+            "bin.rs".to_string(),
+            "main.rs".to_string(),
+            "tools/probe.rs".to_string()
+        ],
+        "depth first, then lexicographic — and the imported file is excluded"
+    );
+    assert_eq!(
+        entry_points(&conn, 2).unwrap(),
+        vec!["bin.rs".to_string(), "main.rs".to_string()],
+        "the limit truncates the ordering rather than reordering it"
+    );
+}
+
+#[test]
+fn entry_points_is_empty_on_an_empty_index() {
+    let dbdir = tempdir().unwrap();
+    let conn = open(&dbdir.path().join("context.db")).unwrap();
+    assert!(entry_points(&conn, 5).unwrap().is_empty());
+}
+
 #[test]
 fn kill_during_indexing_leaves_a_consistent_store() {
     let ws = tempdir().unwrap();

--- a/crates/stella-home/README.md
+++ b/crates/stella-home/README.md
@@ -69,14 +69,15 @@ is I/O with failure modes, and it stays in the CLI.
 
 `resolve_user_plugins_dir` / `resolve_project_plugins_dir` (#3380) are the same
 shape arriving **one consumer early**: `stella-cli`'s plugin loader is their
-only caller today, and it calls
-the pure `resolve_*` half directly with its own redirectable root — not the
-ambient `user_plugins_dir()` wrapper, which nothing calls yet. The second
-consumer is the wrapper socket's other drivers — `stella-serve` and an
-embedded host — which `doc:wrapper-socket` §6 makes an acceptance criterion,
-and which must find the same two-tier roster without depending on the CLI to
-spell `.stella/plugins`. If that driver never lands, these belong back in
-`stella-cli`.
+only caller today. Both ship as a pure half alone — the user tier had an
+ambient `user_plugins_dir()` wrapper and it is gone (#3720), because every
+plugin caller passes a redirectable root on purpose so a test never reads the
+developer's real `~/.stella/plugins`, which leaves the wrapper a second
+spelling nothing wants. The second consumer is the wrapper socket's other
+drivers — `stella-serve` and an embedded host — which `doc:wrapper-socket` §6
+makes an acceptance criterion, and which must find the same two-tier roster
+without depending on the CLI to spell `.stella/plugins`. If that driver never
+lands, these belong back in `stella-cli`.
 
 This crate is also the workspace's worked example of the three-case rule in
 AGENTS.md § "When a new crate is justified". It is case (b): [`stella-store`](../stella-store) and

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -261,19 +261,11 @@ pub fn resolve_workspace_state_root(
 /// reason to fall back to the working directory, because that would install
 /// third-party code into whatever repository happened to be open.
 ///
-/// Nothing calls this wrapper yet. `stella-cli`'s plugin loader calls the
-/// pure half, [`resolve_user_plugins_dir`], with its own redirectable root
-/// instead. The expected first caller is the wrapper socket's other
-/// drivers — `stella-serve` or an embedded host — which need the same
-/// roster without depending on `stella-cli` to spell the path
-/// (`doc:wrapper-socket` §6). If that never lands, this belongs back in
-/// `stella-cli`.
-#[must_use]
-pub fn user_plugins_dir() -> Option<PathBuf> {
-    resolve_user_plugins_dir(stella_home())
-}
-
-/// [`user_plugins_dir`] over the anchor the caller supplies.
+/// Pure half only, like [`resolve_project_plugins_dir`] below: the anchor is
+/// an argument. Every plugin caller already has a redirectable root of its
+/// own and passes it, so an ambient `user_plugins_dir()` wrapper reading
+/// `stella_home()` would be a second way to spell the same answer that no
+/// caller wants and that a test could not redirect.
 #[must_use]
 pub fn resolve_user_plugins_dir(stella_home: Option<PathBuf>) -> Option<PathBuf> {
     stella_home.map(|home| home.join(PLUGINS_DIR))

--- a/docs/spec/config-system/stella.today.toml
+++ b/docs/spec/config-system/stella.today.toml
@@ -52,6 +52,12 @@
 # setting either configured nothing. They are recognised as retired rather
 # than misspelled — `stella` names them and says the feature is gone.
 #
+# Neither is coming back, and the reasons differ. The recap's one addition
+# over the file and cost lines a run already prints was the word `verified`,
+# and host-run verification left this workspace with the pipeline (#3893). The
+# trace duplicated `.stella/private/store.db`, which records every step, tool
+# call and cost it wrote and which `stella observe` reads (#3894).
+#
 # `ignore_gitignore`: `on` (the default) = the workspace probe skips paths the
 #   repository's own .gitignore excludes. `off` restores the unfiltered walk.
 # `create_worktrees`: `always` / `ask` / `never` — whether a run does its work

--- a/docs/spec/trace-replay-learning-harness.md
+++ b/docs/spec/trace-replay-learning-harness.md
@@ -512,9 +512,13 @@ harness earning its keep before it shipped.
   staying retrievable by id is what separates retirement from forgetting. A test
   asserting "the memory is gone" fails against a working sweep, and one
   asserting "the count went down" re-specifies retirement as deletion.
-- **`turns-to-first` is exact for memories and tools, approximate for skills,
-  absent for rules.** Filed as **#2359**: a placeholder must not render like a
-  measurement.
+- **`turns-to-first` is exact for all four classes** (#2359). It shipped exact
+  for memories and tools, approximate for skills — set to the total turn count
+  whenever any skill existed, so `skill 10` on a ten-turn corpus was a
+  placeholder printed in the same row as two measurements — and absent for
+  rules. Both are probed on disk per turn now, two directory reads against a
+  workspace of a handful of files. A class that never appeared renders as an em
+  dash, because "never" and "on the last turn" are different statements.
 
 ### 13.3 The adapter, as built
 

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -54,7 +54,17 @@ A run typed at a terminal is [supervised](/docs/commands/daemon): it survives th
     **Refused on every resolution.** It turned "completed but unproven" into a non-zero
     exit, reading verdicts only the built-in staged pipeline reached; the raw loop
     reaches neither (see the statuses below). A delivery gate that must not ship
-    unproven work wants a verification plugin and `--pipeline <variant>` naming it.
+    unproven work wants a verification plugin, `--pipeline <variant>` naming it, and
+    `--require-verdict`.
+  </OptionCard>
+  <OptionCard name="--require-verdict">
+    Exit non-zero unless the `--pipeline` wrapper declared its requirements **met**.
+    This is the delivery gate: without it a plugin's refusal is printed to stderr and
+    the run still exits on the turn's own result, so installing somebody's plugin can
+    never fail your build by itself. Anything other than met fails under the flag,
+    including a wrapper that reached no verdict at all — a gate that passes on
+    "undecided" is not a gate. Refused without `--pipeline`, where nothing declares a
+    verdict for it to read.
   </OptionCard>
 </CardGrid>
 


### PR DESCRIPTION
Eleven issues whose definition of done accepts a recorded decision as the close. Each commit argues the option it took; this is the index.

## What

**#3706 — `Calibration`'s two uncalled estimate wrappers.** Deleted.
`calibrated_message_tokens` / `calibrated_conversation_tokens` had no caller
outside their own test and the doc comment admitted it. The decision the issue
asked for is delete rather than wire, because the engine's calibrated path goes
through `Calibration::effective_budget` — which solves the two-term fit — and
these two are slope-only by construction: they deliberately drop the intercept,
so they are the model `effective_budget` replaced, not a step toward a caller.
**This is public API of a library crate**; the workspace root sets
`publish = false`, so no outside consumer can be depending on the signature.
Deleted test: `estimator::tests::calibrated_estimates_scale_the_raw_heuristic`,
which asserted only on the two deleted functions.

**#3719 — `CodeGraph::entry_points` unwired.** Wired, with the store-level test.
The query is finished, its cost is independent of index size (one SQL anti-join
against the per-file `importers_of` scan), and it answers a question `stella
init` leaves open: the totals say how much was indexed and nothing about where
to start. `GraphSummary` gains `entry_points`, and `format_entry_points`
renders `· start here: …` beneath the totals on both surfaces that print them.
Withheld entirely when the index names none.

**#3720 — `stella_home::user_plugins_dir()`.** Deleted. Not merely unused but
unwanted: every plugin caller passes a redirectable root on purpose so a test
never reads the developer's real `~/.stella/plugins`, and a caller who took the
ambient wrapper would lose that. The crate's pattern already tolerates a pure
half alone — `resolve_project_plugins_dir` ships that way.

**#3768 — the hook plane and `stella-engine`'s closure rule.** Option (a):
permanent exclusion, and now enforced rather than declared. Closing over
`with_hooks`/`with_bus` would let a host reach the engine's shell-execution
authority by naming `stella_engine::` paths alone. The observer half looked
like the closer question and is not: `stella-serve`, the embedded host that
would have been its first caller, already links `stella-core` directly and
mints its bus from `stella_core::bus::HookBus`.

**#3893 / #3894 — `enable_recap` and `trace_capture`.** Both closed wontfix,
with the `RETIRED` entries rewritten from a state ("nothing assembles a recap
now") to a decision. The recap's one addition over the file and cost lines a
run already prints was the word `verified`, which the raw loop cannot say. The
trace's prior question answers itself: `store.db` already records the steps,
tool calls and cost it wrote, and `stella observe` reads them.

**#3613 — `MismatchSeverity::Compaction`.** Declined and recorded in
`dataset_cmd.rs`'s module doc, which the issue's DoD accepts as the close. A
compaction-only admission tier recovers legacy transcript data and ends the
property that every emitted `calls` array digest-verified. No code moves, so
`DATASET_SCHEMA_VERSION` is untouched.

**#3554 — a plugin's `Unmet` and the exit status.** Retitled to the half that
remained (part 1 shipped in #3494/#3695), then shipped. `--require-verdict` on
`stella run` makes a non-`Met` outcome a non-zero exit. The default stays exit
0 by decision: installing a third party's manifest must not by itself gain the
power to fail somebody's build. `Undecided` fails under the flag too — a gate
that passes on "nothing decided it either way" is not a gate. The raw loop
refuses the flag rather than accepting it and exiting 0 anyway.

**#2359 — `turns-to-first` for skills and rules.** `first_skill_turn` was set
to the *total turn count* whenever any skill existed, so `skill 10` on a
ten-turn corpus was a placeholder printed beside two measurements; rules had no
field. Both are probed on disk per turn now, and a class that never appeared
renders as an em dash.

**#2807 (fix 1) — the cancelled turn's in-memory cost.** After the close-out,
the row is re-read and the guard's session accumulator corrected from it, so
the deck stops showing the pre-cancel prefix. The correction takes the larger
of the two lower bounds and never subtracts. `/clear` had the same shape, so
both arms go through one `close_dropped_execution` in the new
`command_deck/dropped_turn.rs` — `command_deck.rs` is a god file, and the two
arms lose lines net. Fix 2 (awaiting the forwarder drain) is **not** done and
is named in the module doc; `Refs`, not `Closes`.

**#3437 — the drop report.** Generalized per source. `drop_message` answers for
records, memories and both skill classes in one sentence shape (the record
channel's, byte-identical), with the remedy differing per channel. The
section-budget skill class — present in both `selected` and `dropped` by design
— gets its own wording and cites #3243 rather than naming a knob that would not
have saved it. The decision the issue asked for on `project_recalled_frame` and
`is_suppressed_local_frame` is recorded in code: neither reports, because
neither is a budget eviction.

## Evidence

Local, targeted only (CI is the evidence for the workspace). All run after
`git merge origin/main` and `cargo clean -p` on the touched crates, reading exit
codes from log files rather than grepping coloured output.

| check | result |
| --- | --- |
| `cargo test -p stella-cli --bin stella` | 2175 passed, 0 failed |
| `cargo test -p stella-cli --test run_require_verdict_cli` | 2 passed |
| `cargo test -p stella-core --lib` | 1403 passed |
| `cargo test -p stella-graph --lib` | 209 passed |
| `cargo test -p stella-engine` / `-p stella-home` | pass |
| `cargo clippy -p {stella-cli,stella-core,stella-graph,stella-engine,stella-home} --all-targets -- -D warnings` | exit 0 each |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p <crate> --no-deps` and `--document-private-items` | exit 0, both forms, every touched crate |
| `cargo fmt --all --check` | exit 0 |
| `make guards-fast` | exit 0 (`check-prose`: 701 grandfathered, none added; `check-file-size`: nothing went over) |

Witness fail→pass, run both ways:

- **#3719** — `entry_points_names_the_files_nothing_imports_shallowest_first`
  (stella-graph, store level, indexed from a real tree rather than
  hand-inserted rows: a query tested on synthetic rows would pass on a resolver
  that resolves nothing) and
  `index_workspace_graph_blocking_names_the_files_nothing_imports` (stella-cli,
  end to end). Both fail to compile on main — the field and the formatter do
  not exist.
- **#3768** — `the_hook_plane_is_still_outside_the_facade`. Appending
  `pub use stella_core::bus::HookBus;` to `stella-engine/src/lib.rs` fails the
  build with `E0659: HookBus is ambiguous`; removing it passes. Verified in that
  order. The type annotations are what make it true: a bare value-position
  mention resolves in the value namespace, where a field-carrying re-exported
  struct is not a candidate and the collision never happens.
- **#3554** — `an_unmet_verdict_fails_the_run_only_when_the_caller_asks`, a real
  `stella run` subprocess against a wiremock provider with an arbiter fixture
  reporting `flip: not-achieved`: `--pipeline` alone exits 0 with the refusal
  printed; `+ --require-verdict` exits non-zero naming the flag and `proven`;
  `--require-verdict` with no `--pipeline` is refused. All three fail on main —
  the binary rejects the flag.
- **#2359** — `turns_to_first_is_measured_for_every_class_not_placed`.
  Restoring the placeholder in `observe_final_state` fails it with
  `skill 11 of 11 turns`; the per-turn probe passes it. The rule half is
  witnessed by the row containing `rule N` at all (three classes on main)
  rather than by the same inequality, because on the committed corpus the rule
  genuinely lands on the last turn and a strict inequality there would assert a
  fact about the fixture, not about the metric.
- **#2807** — `the_guard_is_corrected_from_the_row_the_closeout_settled`, a real
  store with two durable receipts totalling $4.50 and a guard holding a $0.25
  prefix. Deleting the read-back leaves the guard at 10.25 and fails with "not
  the $0.25 prefix it accumulated"; with it the guard reports 14.50.
- **#3437** — `every_dropped_source_gets_a_line_with_its_own_remedy`. Four
  lines with four remedies; on main one, because the source filter drops the
  other three and the section-budget distinction does not exist.
- **#3706 / #3720** — deletions, witnessed by the crates still building and
  testing green with no reference left (`rg` over `crates/` finds none outside
  a stella-tools symbol-name fixture, which is an index, not a call).
- **#3893 / #3894 / #3613** — no witness: explanatory strings, a module doc and
  a reference-config comment. `settings::unknown`'s existing tests still cover
  that the retired keys are recognised as retired rather than misspelled.

Deleted tests, named per the deleted-test guard's contract:
`stella-core`'s `estimator::tests::calibrated_estimates_scale_the_raw_heuristic`
(deliberate, it exercised only the two deleted functions), and
`stella-cli`'s `session_clear`'s `close_cleared_execution` — a function, not a
test, absorbed into `dropped_turn::close_dropped_execution`.

No TUI goldens re-blessed. No baseline file, `Cargo.lock` or `deny.toml`
touched. No new dependencies.

## Not done

- **#2807 fix 2** — awaiting the forwarder drain before `record_execution_end`
  closes the row, so a late `StepUsage` cannot be priced after close-out. Larger
  than fix 1 and must not reintroduce the #2290 wedge `detach_event_stream()`
  exists to fix. The read-back heals whatever landed by the time it runs and no
  more, which is stated in `dropped_turn.rs`'s module doc. Hence `Refs #2807`.
- **`--require-verdict` on `stella goal` and `stella fleet`** — both drive
  wrappers and neither takes the flag. Scoped to `stella run`, the door where an
  exit status is a delivery gate, and named in `wrapper_plugin.rs`'s
  scope-limits paragraph rather than left silent.

Closes #3706
Closes #3719
Closes #3720
Closes #3768
Closes #3893
Closes #3894
Closes #3613
Closes #3554
Closes #2359
Closes #3437
Refs #2807

## Summary by Sourcery

Resolve the recorded decisions across CLI, core, graph, engine, and home by shipping the selected behavior, removing superseded APIs, and documenting declined alternatives.

New Features:
- Add an opt-in `--require-verdict` gate that makes non-met plugin outcomes fail `stella run`.
- Show sampled code-graph entry points in initialization and session summaries.
- Measure first appearance turns for skills and rules and report all four artifact classes.
- Report budget evictions for records, memories, and skills with source-specific remedies.

Bug Fixes:
- Reconcile cancelled and cleared turn costs from durable execution records so session spending no longer under-reports settled usage.
- Unify cancelled and cleared execution closeout handling.

Enhancements:
- Permanently keep the engine hook plane outside the facade and enforce that boundary with embedding tests.
- Remove unused calibration estimate wrappers and the ambient user plugin-directory helper.
- Record decisions to retain retired recap and trace settings and reject compaction-severity dataset admission.

Documentation:
- Document the hook-plane exclusion, retired settings decisions, turns-to-first behavior, and the new verdict-gate option.

Tests:
- Add targeted coverage for entry-point discovery, verdict exit statuses, dropped-turn cost reconciliation, artifact turn measurements, steering-drop reporting, and the engine facade boundary.

Chores:
- Remove obsolete tests associated with deleted APIs and consolidate dropped-turn closeout code.