### PR TITLE
docs: retire the deleted staged pipeline's remaining doc groups (#3901, #4526)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,16 @@
 # ROADMAP — Verification Pipeline
 
+**Pre-#3865 staged pipeline, kept for reference.** `stella-pipeline` — the
+crate every file path below cites — was deleted in #3865; the raw step loop
+is the only door this workspace ships today, and verification is opt-in only
+through an installed wrapper plugin (`stella run --pipeline <plugin-id>`).
+No proposal below executes against this workspace. The design shape — flip
+oracle, evidence ladder, witness authoring, revise/evidence-demand — is what
+a verification plugin ports rather than reinvents (Oxagen's Vera is the
+private reference one, `doc:pipeline-as-plugins` §8), and this roadmap stays
+as the record of that design and which parts of it were built before the
+extraction.
+
 Improvement proposals for the verification half of `stella-pipeline` — the
 flip oracle, the evidence ladder, witness authoring, the revise/evidence-demand
 path, and best-of-N candidate scoring (`verify.rs`, `witness.rs`,

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -487,12 +487,12 @@
     },
     "prompt-plan": {
       "path": "docs/prompts/plan.md",
-      "status": "living",
+      "status": "archived",
       "title": "plan \u2014 the effective prompt"
     },
     "prompt-plan-repair": {
       "path": "docs/prompts/plan-repair.md",
-      "status": "living",
+      "status": "archived",
       "title": "plan_repair \u2014 the effective prompt"
     },
     "prompt-reflection": {
@@ -502,7 +502,7 @@
     },
     "prompt-research": {
       "path": "docs/prompts/research.md",
-      "status": "living",
+      "status": "archived",
       "title": "research \u2014 the effective prompt"
     },
     "prompt-skill-author": {
@@ -517,7 +517,7 @@
     },
     "prompt-triage": {
       "path": "docs/prompts/triage.md",
-      "status": "living",
+      "status": "archived",
       "title": "triage \u2014 the effective prompt"
     },
     "prompt-verdict": {
@@ -527,12 +527,12 @@
     },
     "prompt-witness-author": {
       "path": "docs/prompts/witness-author.md",
-      "status": "living",
+      "status": "archived",
       "title": "witness_author \u2014 the effective prompt"
     },
     "prompt-witness-repair": {
       "path": "docs/prompts/witness-repair.md",
-      "status": "living",
+      "status": "archived",
       "title": "witness_repair \u2014 the effective prompt"
     },
     "prompt-worker": {

--- a/docs/papers/stella-defensible-position.md
+++ b/docs/papers/stella-defensible-position.md
@@ -97,7 +97,7 @@ We identify seven such properties in Stella's design.
 |---|---|---|---|
 | I | Ports, not direct dependencies | The engine (`stella-core`) never imports a provider SDK, filesystem API, or terminal library | Crate-level dependency boundary; `Provider` trait (`stella-protocol`) and `ToolExecutor` trait (`stella-core::ports`) |
 | II | No I/O in the engine | All decision logic is synchronous functions over owned data | Architectural discipline; property-tested in `stella-core` |
-| III | Witness-test contract | A task is done only when a test fails on old code and passes on new | The pipeline's witness stage and flip oracle (`stella-pipeline`) |
+| III | Witness-test contract | A task is done only when a test fails on old code and passes on new | An installed verification plugin's witness stage and flip oracle (Oxagen's Vera is the reference one); the built-in staged pipeline that used to ship this in-tree (`stella-pipeline`) was deleted in #3865 |
 | IV | BYOK + zero telemetry egress by default | Community/default telemetry is local; only an explicitly enrolled Oxagen Enterprise managed deployment may send a signed-policy-authorized, content-free operational rollup | Architectural invariant; local SQLite (`stella-store`) plus the [managed enrollment boundary](../../website/content/docs/telemetry/index.mdx#oxagen-enterprise-managed-export) |
 | V | Prompt-cache-native memory | Lessons load into a byte-stable system prompt prefix at ~0.1x input price | `build_system_prompt` (`stella-cli::agent`); L-E8 cache discipline |
 | VI | Budget at safe boundaries | The budget guard consults only between model calls, never interrupts a tool | `run_turn` budget check (`stella-core::driver`); property-tested |
@@ -206,25 +206,29 @@ loops on your API budget).
 
 ### The invariant
 
-Opted into the staged pipeline (`stella run --pipeline classic`), Stella
-refuses to call a task done until a **witness test** proves it: a test
+Stella refuses to call a task done until a **witness test** proves it: a test
 that **fails on the old code** (the feature is genuinely absent) and **passes
 on the new code** (the feature is genuinely present). This is a **property of
-the path that produced the evidence, not of the binary**: the built-in staged
-pipeline's witness stage (`stella-pipeline`) runs the check itself and watches
-the fail→pass flip, as described below; verification supplied by an installed
-wrapper plugin on `--pipeline <other-variant>` is that plugin's own
-**self-reported** evidence, which Stella evaluates against a declared rule
-rather than re-running or re-checking. The raw step loop (the default on
-every door) makes no witness-test claim at all — it has no verification
-stage.
+the path that produced the evidence, not of the binary** — and, since #3865,
+that path is opt-in on every door via `stella run --pipeline <plugin-id>`,
+naming an *installed* verification plugin: the plugin's own `[oracle]` runs
+the check and reports its evidence, which Stella evaluates against the
+plugin's declared verdict rule and never re-runs or re-checks. `stella run
+--pipeline classic` is refused outright — the built-in staged pipeline that
+used to run this check itself (`stella-pipeline`) is deleted from the
+workspace, and the refusal names `stella plugin install` as the remedy. A
+plain `stella run` (the default on every door) makes no witness-test claim at
+all — it has no verification stage.
 
-The staged-pipeline mechanism, `--pipeline classic` specifically:
+The mechanism below is the built-in staged pipeline's, as it ran before
+#3865 — kept as the concrete illustration of the contract, because it is the
+shape a verification plugin (Oxagen's Vera is the reference one,
+`doc:pipeline-as-plugins` §8) ports rather than reinvents:
 
 1. The worker executes the change.
-2. When no `--test-command` is configured, an independent model — the
-   verifier's resolution, never the worker — authors the failing witness
-   test after reading the executed diff.
+2. When no oracle command is otherwise configured, an independent model —
+   never the worker — authors the failing witness test after reading the
+   executed diff.
 3. The flip oracle tracks the witness's fail→pass transition by running it:
    fail on the pre-change code, pass on the changed code.
 4. The flip is refused if the worker modified the witness files (tamper
@@ -233,8 +237,9 @@ The staged-pipeline mechanism, `--pipeline classic` specifically:
    the change is proven.
 
 The witness is scaffolding for that one run — it lives in the candidate
-workspace and is discarded with it (`stella run --keep-witness` promotes it
-instead).
+workspace and is discarded with it. `stella run --keep-witness` used to
+promote it instead; that flag, like `--pipeline classic`, is refused
+unconditionally since #3865.
 
 ### Why it is hard to copy
 
@@ -632,11 +637,14 @@ A rigorous analysis must consider what could erode Stella's position:
    safe-boundary abort gets a weaker version. The combination is harder to
    copy than the sum of its parts.
 
-4. **Scope creep.** Wiring in the remaining crates (`stella-pipeline`,
-   `stella-fleet`, `stella-tui`, `stella-graph` retrieval) is high-impact but
-   high-effort. If these layers don't ship, Stella's architecture is
-   partially realized. *Mitigation:* the shipping CLI already exercises the
-   core path; the library crates are complete and property-tested.
+4. **Scope creep.** *Resolved differently than planned.* `stella-fleet`,
+   `stella-tui`, and `stella-graph`-backed retrieval are wired and shipping
+   (`AGENTS.md § Status — what ships`). `stella-pipeline`, the crate this item
+   once named alongside them as a remaining wire-in, was instead deleted
+   (#3865): its built-in verification is now opt-in via an installed plugin
+   rather than a crate this binary links. *Mitigation:* the shipping CLI
+   already exercises the core path; the library crates are complete and
+   property-tested.
 
 ---
 

--- a/docs/prompts/plan-repair.md
+++ b/docs/prompts/plan-repair.md
@@ -1,10 +1,17 @@
 ---
 id: prompt-plan-repair
 title: "plan_repair — the effective prompt"
-status: living
+status: archived
 ---
 
 # `plan_repair`
+
+**This page documents the pre-#3865 staged pipeline, kept for reference.**
+`stella-pipeline` was deleted in #3865, so `Pipeline::plan_stage` and every
+symbol this page cites dispatch from no code in this tree. `plugins/stella-plan`
+is the installed wrapper plugin that ports the plan call itself; it does not
+reproduce this bounded repair retry (#3562) — see
+`docs/prompts/README.md § Half of this set is history`.
 
 Re-authoring a plan the parser rejected. The pipeline's one bounded repair
 retry for the plan stage (the L-V2 "bounded repair loops" pattern) — it runs at

--- a/docs/prompts/plan.md
+++ b/docs/prompts/plan.md
@@ -1,10 +1,16 @@
 ---
 id: prompt-plan
 title: "plan — the effective prompt"
-status: living
+status: archived
 ---
 
 # `plan`
+
+**This page documents the pre-#3865 staged pipeline, kept for reference; the
+shape lives in an installed wrapper plugin now (`plugins/stella-plan`).**
+`stella-pipeline` was deleted in #3865, so `Pipeline::plan_stage` and every
+symbol this page cites dispatch from no code in this tree — see
+`docs/prompts/README.md § Half of this set is history`.
 
 Authoring the ordered plan. Runs after triage, recall and research; produces a
 JSON array of step strings that becomes the task board the user watches and the

--- a/docs/prompts/research.md
+++ b/docs/prompts/research.md
@@ -1,10 +1,16 @@
 ---
 id: prompt-research
 title: "research — the effective prompt"
-status: living
+status: archived
 ---
 
 # `research`
+
+**This page documents the pre-#3865 staged pipeline, kept for reference; the
+shape lives in an installed wrapper plugin now (`plugins/stella-research`).**
+`stella-pipeline` was deleted in #3865, so `Pipeline::research_stage` and
+every symbol this page cites dispatch from no code in this tree — see
+`docs/prompts/README.md § Half of this set is history`.
 
 A read-only research sub-agent answering **one** of triage's pre-plan
 questions (#1778). Fans out one child per question, concurrently, before the

--- a/docs/prompts/triage.md
+++ b/docs/prompts/triage.md
@@ -1,10 +1,18 @@
 ---
 id: prompt-triage
 title: "triage — the effective prompt"
-status: living
+status: archived
 ---
 
 # `triage`
+
+**This page documents the pre-#3865 staged pipeline, kept for reference; the
+shape lives in installed wrapper plugins now.** `stella-pipeline` was deleted
+in #3865, so `Pipeline::triage_stage` and every symbol this page cites
+dispatch from no code in this tree. No single plugin replaces this
+classify-and-route call; the stages it decided among live on as
+`plugins/stella-research`, `plugins/stella-plan` and `plugins/stella-witness`
+— see `docs/prompts/README.md § Half of this set is history`.
 
 Prompt classification and tier routing. The first model call of a `stella run`
 turn, and the one that decides how much orchestration the rest of the turn

--- a/docs/prompts/witness-author.md
+++ b/docs/prompts/witness-author.md
@@ -1,21 +1,29 @@
 ---
 id: prompt-witness-author
 title: "witness_author — the effective prompt"
-status: living
+status: archived
 ---
 
 # `witness_author`
 
-Writing the witness test that arms the flip oracle for the staged pipeline's
-built-in path: it authors a test that must **fail on the current code** and
-**pass once the goal is met**, and that fail→pass flip is what credits the
-work — genuinely, host-run: this stage's model writes the test, but Stella
-itself executes it and watches the flip. This mechanism is being extracted
-into an installable verification plugin (Oxagen's Vera is the reference one,
-`doc:pipeline-as-plugins`, #3511); once it lands, this guarantee does not
-automatically transfer — a plugin's oracle reports its own evidence and
-Stella does not re-run it. This page documents the in-tree, host-run
-mechanism as it exists today.
+**This page documents the pre-#3865 staged pipeline, kept for reference; the
+shape lives in a verification plugin now (Vera, not the open-source
+`plugins/stella-witness`, which is the flip oracle only — see
+[witness-repair.md](witness-repair.md)).** `stella-pipeline` was deleted in
+#3865, so `crates/stella-pipeline/src/pipeline/witness_stage.rs` and every
+symbol this page cites dispatch from no code in this tree — see
+`docs/prompts/README.md § Half of this set is history`.
+
+Writing the witness test that armed the flip oracle for the staged pipeline's
+built-in path: it authored a test that had to **fail on the current code**
+and **pass once the goal was met**, and that fail→pass flip is what credited
+the work — genuinely, host-run: this stage's model wrote the test, but Stella
+itself executed it and watched the flip. This mechanism was extracted into an
+installable verification plugin (Oxagen's Vera is the reference one,
+`doc:pipeline-as-plugins`, #3511), which does not carry the same guarantee
+automatically — a plugin's oracle reports its own evidence and Stella does
+not re-run it. This page documents the in-tree, host-run mechanism as it
+existed before #3865, not a live path.
 
 The stage is **demand-driven and runs after execution** — once the warrant has
 read the executed diff and found something worth proving. The canonical stage
@@ -157,9 +165,11 @@ cost the run. It degrades — never panics, never aborts — when:
   that panics, #1789);
 - the author produces no parseable `TEST_COMMAND`.
 
-The witness is **scaffolding for one run**: it lives in the candidate workspace
-and is discarded with it, so an already-satisfied test is never left behind in
-the project's test tree. `stella run --keep-witness` promotes it instead.
+The witness was **scaffolding for one run**: it lived in the candidate
+workspace and was discarded with it, so an already-satisfied test was never
+left behind in the project's test tree. `stella run --keep-witness` used to
+promote it instead; the flag is refused unconditionally since #3865, naming
+`stella plugin install` as the remedy.
 
 ## Related
 

--- a/docs/prompts/witness-repair.md
+++ b/docs/prompts/witness-repair.md
@@ -1,10 +1,20 @@
 ---
 id: prompt-witness-repair
 title: "witness_repair — the effective prompt"
-status: living
+status: archived
 ---
 
 # `witness_repair`
+
+**This page documents the pre-#3865 staged pipeline, kept for reference.**
+`stella-pipeline` was deleted in #3865, so
+`crates/stella-pipeline/src/pipeline/witness_stage.rs` and every symbol this
+page cites dispatch from no code in this tree. `plugins/stella-witness`, the
+open-source installed plugin, is the flip oracle only — it judges a witness,
+never authors or repairs one; witness authoring is what
+`doc:pipeline-as-plugins` §8 asks a verification plugin (Oxagen's Vera is the
+reference one) to port instead — see `docs/prompts/README.md § Half of this
+set is history`.
 
 Fixing a witness that did not fail on the current code. A test that passes
 before the work is done witnesses nothing — only a fail→pass flip counts as

--- a/docs/prompts/worker.md
+++ b/docs/prompts/worker.md
@@ -200,9 +200,17 @@ Rules:
 - When a choice is ambiguous and getting it wrong would be costly, take the reversible option and name the ambiguity in your answer; otherwise proceed with your best judgment.
 ```
 
-## Opening user message
+## Opening user message — pre-#3865 staged pipeline, kept for reference
 
-The pipeline's worker gets one assembled user message before any step prompt,
+This section and "Per-step user message" below describe the deleted
+`stella-pipeline` crate's plan-walking loop (#3865): `assemble_user_message`
+and `step_prompt` dispatch from no code in this tree, unlike the personas
+above (`SYSTEM_PROMPT`/`PIPELINE_SYSTEM_PROMPT`), which are still live —
+`crates/stella-cli/src/agent/prompt.rs`. The plan-walking shape they describe
+is what `plugins/stella-plan` ports as an installed wrapper plugin instead
+(`doc:pipeline-as-plugins` §7).
+
+The pipeline's worker got one assembled user message before any step prompt,
 built by `assemble_user_message` (`crates/stella-pipeline/src/pipeline.rs`).
 Sections are conditional, in this order:
 

--- a/docs/spec/config-system/stella.next.toml
+++ b/docs/spec/config-system/stella.next.toml
@@ -265,15 +265,18 @@ prompt_file = ".stella/prompts/security-reviewer.md"
 # =============================================================================
 # PIPELINE  ── NEW
 # =============================================================================
-# The raw step loop is the default on every door; `stella run --pipeline
-# classic` opts into the staged pipeline (triage -> plan -> witness -> execute
-# -> verify -> verdict), and `--pipeline <variant>` opts into any other
-# installed wrapper plugin the same way (`--no-pipeline` is now a deprecated
-# hidden no-op). The `classic` stage order is declared, not hard-coded --
-# `crates/stella-pipeline/variants/classic.toml`'s `[wrapper]` block, resolved
-# through `schedule_wiring.rs` (#3408) -- but that manifest has no way to say
-# "skip the verdict" or "allow three revision rounds"; that is the gap this
-# proposed block still fills.
+# Pre-#3865, the raw step loop was the default on every door and `stella run
+# --pipeline classic` opted into the staged pipeline (triage -> plan ->
+# witness -> execute -> verify -> verdict). `stella-pipeline` is deleted
+# (#3865): the raw step loop is the ONLY door today, `--pipeline classic` is
+# refused outright, and `--pipeline <plugin-id>` opts an installed wrapper
+# plugin into the turn instead (`stella plugin install` is the remedy the
+# refusal names). The `classic` stage order used to be declared, not
+# hard-coded -- `crates/stella-pipeline/variants/classic.toml`'s `[wrapper]`
+# block, resolved through `schedule_wiring.rs` (#3408) -- and that manifest
+# had no way to say "skip the verdict" or "allow three revision rounds"; a
+# plugin's own manifest has the same gap today, which is what this proposed
+# block still fills.
 #
 # ONE `enabled` FLAG, NOT TWO. The original example had `[agents.*].enabled`
 # and `[pipeline.stages.*].enabled` both answering "does this run", and

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,10 +24,11 @@ and, as pointedly, what it is not yet.
 
 `Cargo.toml`'s `members` list names twenty-five crates and none of them is
 here, on purpose. The whole point of `doc:pipeline-as-plugins` is to *uncouple*
-the staged pipeline from the binary — its stated endpoint is that
-`crates/stella-cli/Cargo.toml` stops declaring `stella-pipeline` — and a plugin
-that is a workspace member is built, versioned and linked with the binary it
-was supposed to leave. It would prove the opposite of what it is here to prove.
+the staged pipeline from the binary — its endpoint was
+`crates/stella-cli/Cargo.toml` no longer declaring `stella-pipeline`, reached
+when the crate itself was deleted (#3865) — and a plugin that is a workspace
+member is built, versioned and linked with the binary it was supposed to
+leave. It would prove the opposite of what it is here to prove.
 
 A plugin is a **separate program the host spawns**: argv from `[runtime]`, a
 JSON request on stdin, a JSON response on stdout, an environment allowlist the

--- a/plugins/stella-plan/README.md
+++ b/plugins/stella-plan/README.md
@@ -13,9 +13,10 @@ yet.
 
 - At **`plan`** it asks the host for one bounded turn at the `planner` role
   intent (`doc:wrapper-socket` §6b's `child_turn` call), sends the same fixed
-  planner instructions the built-in stage uses, parses the JSON-array-of-steps
-  answer the way `crates/stella-pipeline/src/plan.rs::parse_plan` does, and
-  contributes the result as one volatile context block.
+  planner instructions the built-in stage used, parses the JSON-array-of-steps
+  answer the way `crates/stella-pipeline/src/plan.rs::parse_plan` did (that
+  crate is deleted, #3865), and contributes the result as one volatile
+  context block.
 - Every other declared stage gets an empty contribution — byte-identical to a
   host with no plugin installed.
 
@@ -40,7 +41,7 @@ same call for the same reason.
 
 ## What it replaces, and what it does not
 
-The built-in stage is two files:
+The built-in stage — deleted with `stella-pipeline` in #3865 — was two files:
 
 | Built-in | What it does |
 | --- | --- |
@@ -69,7 +70,7 @@ did not actually offer.
 `Vec<PlanStep>` field and no per-step mechanism — its only fields are
 `context`, `role`, `scope` and `publish`
 (`crates/stella-plugin/src/wire.rs`). The built-in stage's own
-`crates/stella-pipeline/src/pipeline/plan_steps.rs` walks the plan as one
+`crates/stella-pipeline/src/pipeline/plan_steps.rs` walked the plan as one
 engine turn per step, host-executed; this plugin cannot drive that walk, so
 the parsed steps ride as **one prose block the worker reads before its own
 turn**, weaker than the built-in's execution loop and said so in the text it

--- a/plugins/stella-plan/main.py
+++ b/plugins/stella-plan/main.py
@@ -41,10 +41,11 @@ doc for why that is enforced in the type rather than merely asked for.
 
 # What it does not do, and what replaced it
 
-The built-in stage this extracts is `crates/stella-pipeline/src/plan.rs`
-(the pure half — `build_planner_prompt`, `parse_plan`) plus
-`crates/stella-pipeline/src/pipeline/plan_stage.rs` (the I/O half — the model
-call, the one bounded JSON-repair retry, absolute-path resolution). This
+The built-in stage this extracts — deleted with `stella-pipeline` in #3865 —
+was `crates/stella-pipeline/src/plan.rs` (the pure half — `build_planner_prompt`,
+`parse_plan`) plus `crates/stella-pipeline/src/pipeline/plan_stage.rs` (the I/O
+half — the model call, the one bounded JSON-repair retry, absolute-path
+resolution). This
 plugin cannot make that model call itself: `doc:wrapper-socket` §7 hands a
 plugin no engine, no provider and no credential. Until #3562 it also had no
 way to *ask* for one; that gap is closed by the `child_turn` host call

--- a/plugins/stella-research/README.md
+++ b/plugins/stella-research/README.md
@@ -32,7 +32,7 @@ whole protocol.
 
 ## What it replaces, and what it does not
 
-The built-in stage is two files:
+The built-in stage — deleted with `stella-pipeline` in #3865 — was two files:
 
 | Built-in | What it does |
 | --- | --- |

--- a/plugins/stella-research/main.py
+++ b/plugins/stella-research/main.py
@@ -44,9 +44,10 @@ itself a per-turn cost regression for every user who installed it.
 # What it does not do, and what replaced it
 
 The built-in stage this extracts (`crates/stella-pipeline/src/research.rs` and
-`pipeline/research_stage.rs`) answers triage's questions by fanning out
-**read-only model sub-agents**. This plugin cannot: `doc:wrapper-socket` §7 is
-explicit that the socket hands a plugin no engine, no provider and no
+`pipeline/research_stage.rs`, deleted with `stella-pipeline` in #3865)
+answered triage's questions by fanning out **read-only model sub-agents**.
+This plugin cannot: `doc:wrapper-socket` §7 is explicit that the socket hands
+a plugin no engine, no provider and no
 credential, and the request carries no `[roles]` call it could spend. So it
 does deterministic grounding instead of model research — it reports what a
 literal scan of the granted workspace actually contains, which is the half of

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -153,16 +153,6 @@ follows is the complete map; each card links to its detail page.
     Enforced, not advisory: work aborts cleanly once spend passes the cap.
   </SpecCard>
   <SpecCard
-    title="An end-of-run recap"
-    href="/docs/configuration/settings#the-end-of-run-recap"
-    meta={[
-      { label: "Surface", value: "settings.json enable_recap" },
-      { label: "Example", value: '{ "enable_recap": "on" }' },
-    ]}
-  >
-    A deterministic outcome-and-changes panel in text mode. No model call.
-  </SpecCard>
-  <SpecCard
     title="Force the plain REPL (no TUI)"
     href="/docs/agent-modes"
     meta={[

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -52,20 +52,6 @@ merge rule across the [scope hierarchy](#the-scope-hierarchy):
     MCP registry override.
   </SpecCard>
   <SpecCard
-    title={<code>enable_recap</code>}
-    href="#the-end-of-run-recap"
-    meta={[{ label: "Values", value: '"on" | "off"' }]}
-  >
-    Print a deterministic end-of-run recap in text mode. Off unless set.
-  </SpecCard>
-  <SpecCard
-    title={<code>trace_capture</code>}
-    href="#trajectory-trace-capture"
-    meta={[{ label: "Values", value: '"on" | "off"' }]}
-  >
-    Write one training-ready trajectory record per finished run. Off unless set.
-  </SpecCard>
-  <SpecCard
     title={<code>ignore_gitignore</code>}
     href="#the-probes-gitignore-filter"
     meta={[{ label: "Values", value: '"on" | "off"' }]}
@@ -410,44 +396,20 @@ project naming `{"task_assign": "on"}`.
 
 ## The end-of-run recap
 
-`enable_recap` is a single top-level toggle using the same strict `"on"`/`"off"`
-vocabulary as the `tools` switches — a bare `true` is a hard parse error, and an absent
-key means off.
-
-```json title="~/.stella/settings.json"
-{
-  "enable_recap": "on"
-}
-```
-
-With it on, a text-mode run prints a **recap panel** after the files and cost panels: a
-deterministic synthesis of the outcome (`completed`, `completed — verified`,
-`verification failed`, `aborted`) plus a created/modified/deleted tally. It reads the
-run's own facts and costs **no model call** — it is the "so what" line that the file list
-alone does not give you.
+`enable_recap` (bare root key) and its TOML home `run.recap` were **retired** in #3870:
+the renderer read the built-in staged pipeline's verdict types and was left with that
+crate when it was deleted (#3865), so nothing assembles a recap now. Setting the key is
+not a typo and is not reported as one — the config walker names it and says what it
+used to do. There is no replacement key; a run's outcome is still visible from the
+files and cost panels a text-mode run already prints.
 
 ## Trajectory trace capture
 
-`trace_capture` uses the same strict `"on"`/`"off"` vocabulary; an absent key means off.
-
-```json title="~/.stella/settings.json"
-{
-  "trace_capture": "on"
-}
-```
-
-With it on, each finished run appends one JSON record to
-`.stella/private/traces.jsonl` (owner-only): the exact messages every model call was
-sent — reconstructed from the run's own receipts and verified against emission
-digests — plus the stage each call ran under, the tools it requested, and its token
-and dollar cost. Credentials are redacted before anything is written, and the file
-never leaves your machine — it lives beside `store.db` under the same zero-egress
-rule. The run's episodic memory carries a `[trace:exec-N]` pointer, so recall can
-surface "we did something like this before" together with the key to the full record.
-
-This is the raw material for the self-improvement track (curated dataset export
-builds on it), and it costs **no model call** — the record is assembled from what the
-store already persisted.
+`trace_capture` (bare root key) and its TOML home `run.trace_capture` were **retired**
+in #3870 for the same reason as `enable_recap` above: the module that assembled the
+per-execution trajectory record was orphaned by the staged pipeline's removal (#3865)
+and deleted with it. Setting the key is not a typo and is not reported as one — the
+config walker names it and says what it used to do. There is no replacement key today.
 
 ## The probe's gitignore filter
 
@@ -634,7 +596,6 @@ copy-paste starting point you edit down to the two or three keys you actually wa
 
 ```json title="~/.stella/settings.json"
 {
-  "enable_recap": "on",
   "context": {
     "lifecycle": { "enabled": false },
     "learning": { "mode": "off" },
@@ -877,7 +838,6 @@ defaults. Copy it, delete what you don't want:
   "mcp": {
     "registry_url": "https://registry.example.internal/mcp"
   },
-  "enable_recap": "on",
   "context": {
     "lifecycle": { "enabled": false },
     "learning": { "mode": "record_only" },

--- a/website/src/app/engine/stations-aft.tsx
+++ b/website/src/app/engine/stations-aft.tsx
@@ -140,9 +140,7 @@ export function VeraStation() {
         <FactCard title="the witness does not stay">
           It encodes a moment — &quot;this code doesn&apos;t do X yet&quot; —
           not an invariant, so it lives and dies with the candidate workspace.
-          You never inherit an already-satisfied test nobody reviewed.{" "}
-          <BrandFace>--keep-witness</BrandFace> promotes it if it is worth
-          keeping.
+          You never inherit an already-satisfied test nobody reviewed.
         </FactCard>
         <FactCard title="verification buys no model call">
           The ladder is arithmetic over measurements. Every rung is terminal,


### PR DESCRIPTION
## What

**#3901** — the remaining groups the issue ranked, after #4226 shipped the docs/spec + docs/design slice:

1. `docs/prompts/` — `triage.md`, `research.md`, `plan.md`, `plan-repair.md`, `witness-repair.md`: verified (via a `crates/` symbol search — none of `Pipeline::triage_stage`, `Pipeline::research_stage`, `Pipeline::plan_stage`, `TRIAGE_INSTRUCTIONS`, `PLANNER_INSTRUCTIONS`, `WITNESS_SYSTEM_PROMPT`, etc. exist anywhere in the tree) that these roles dispatch from no code at all — flipped `status: living` → `archived` and added a header naming the pre-#3865 pipeline and each role's actual successor (or the honest absence of one — triage and plan-repair have no direct plugin port). `witness-author.md` got the same treatment plus the exact `--keep-witness` claim #4526 named. `worker.md` stays `living` (its interactive/pipeline personas are still dispatched from `crates/stella-cli/src/agent/prompt.rs`) but its plan-walking "Opening/Per-step user message" sections are now flagged as describing dead code specifically. `verdict.md` (still live via `stella goal`) and `distress-guidance.md` (already `archived`) and `README.md` (already carries #4410's "half of this set is history" framing and still indexes several live roles) were checked and left as-is — flipping them would misstate them.
2. `bench/**` and `arenabench/**` — checked for live breakage; every remaining hit already reads as explicitly historical (cites #3865/#3944/#4103 in past tense). No falsehood found, no change made.
3. `ROADMAP.md`, `plugins/*`, `docs/spec/config-system/stella.next.toml`, `docs/papers/` — `ROADMAP.md` got a status banner (the whole 229-line document targets the deleted crate's verification machinery; kept as the design record a verification plugin ports from, not touched line-by-line). `plugins/README.md`, `stella-plan/{README.md,main.py}`, `stella-research/README.md` had several "the built-in stage is/does/uses" present-tense claims corrected to past tense. `stella.next.toml`'s PIPELINE block corrected the claim that `--pipeline classic` currently works (refused outright since #3865); left the `[agents.verifier]` design blocks alone since #3941 is an open, unresolved maintainer decision about that reshape. `docs/papers/stella-defensible-position.md`'s Property III (invariant, "Enforced by" table cell, and the "Scope creep" risk item) described the deleted mechanism as live; rewritten to lead with the current opt-in-plugin path.

**#4526** — the two `--keep-witness` "promotes" claims (`docs/prompts/witness-author.md:162`, `docs/papers/stella-defensible-position.md:236`) fixed, plus a third found during the audit (`website/src/app/engine/stations-aft.tsx`, a live marketing FactCard — removed rather than historicized). The `settings.mdx` JSON page audited against `settings/unknown.rs`'s `RETIRED` list: `enable_recap`/`trace_capture` were documented as live toggles with worked examples and two copy-paste `settings.json` blocks that set them — rewritten as retirement notices (matching `stella-toml.mdx`'s existing treatment from #4480) and the dead keys dropped from both example blocks. `docs/configuration/index.mdx` carried its own live "An end-of-run recap" quick-fact card — removed. Checked `pipeline_require_independent_verifier`, `reward.verifier_weight`, and `*.approval_wait_secs` (also `RETIRED`) — not found documented as live anywhere in `website/` or `docs/`.

## Evidence

```
$ rg -lI -e stella-pipeline -e stella_pipeline . -g '!crates/**' -g '!.git' | wc -l
64   # same 64 files as before — the string is a citation kept on purpose;
     # the fix is tense/framing, not deletion. Every hit now reads as
     # explicitly historical (dated, past-tense, or an added status banner).
```

- `make doc-links` → `OK -- 1072 citation(s) resolve across 83 identified document(s)` (ran `make doc-links-fix` once to regenerate `docs/manifest.json` for the two new `archived` statuses).
- `make prose` → `OK -- 701 grandfathered construction(s) in 463 file(s), none added.`
- `make command-docs` → `OK — 37 subcommands, each with a listed reference page and a README row.`
- `make guards-fast` → all steps green, including `cargo fmt --check` (no Rust files touched).
- Verified every role marked `archived` has zero call sites in `crates/` (`rg -n "fn assemble_user_message|fn step_prompt|RESEARCH_MAX_STEPS|fn triage_prompt|TRIAGE_INSTRUCTIONS|fn build_planner_prompt|PLANNER_INSTRUCTIONS|fn plan_repair_prompt|fn witness_repair_prompt|WITNESS_SYSTEM_PROMPT" crates/ -g '*.rs'` → no output).
- Verified `stella-pipeline` is not declared in any `Cargo.toml` (`rg -n "stella-pipeline" crates/stella-cli/Cargo.toml Cargo.toml` → no hits) before correcting `plugins/README.md`'s claim.
- Verified `plugins/stella-plan/main.py` does not implement the JSON-repair retry (`no repair retry is affordable at max_calls = 1`) and `plugins/stella-witness` implements only the flip oracle, not authoring, before writing each page's successor-plugin claim.

No witness: every change in this PR is docs/prose (frontmatter status, prose tense, example JSON/TOML content, one marketing FactCard). No behavior changed, so there is nothing to pin a fail→pass test against.

## Not done

- `docs/spec/*.md` (the "normative specs" group #3901 itself attributes to #4226) was spot-checked (`witness-protocol.md`, `verification-gate.md`, `turn-loop-wrappers.md`, `pipeline-as-plugins.md`) and found already correctly headed with removal-status banners — left untouched, out of this PR's ranked scope.
- `docs/spec/config-system/stella.next.toml`'s `[agents.verifier]`/`pipeline_*_model` blocks and `docs/spec/config-system/agent_system.toml` — left alone. #3941 (open) is the maintainer decision on how that reshape lands; not mine to make here.
- `website/content/docs/commands/migrate.mdx` documents `enable_recap` as a migration-mapping target (JSON key → TOML key) — plausibly still accurate for the migration tool's behavior even though the underlying feature is retired, and separately its "agent set is closed — default, worker, verifier, triage, research, plan" claim is stale post-#3908's role collapse to one role. Neither is a `stella-pipeline` string match and both are outside this PR's scope; filing an issue for the second (see below).
- `docs/spec/self-driving-foundry.md:204` documents a `trace_capture` config knob as forcing trace capture on for campaign runs, but `trace_capture` is `RETIRED` (dead code). Not a `stella-pipeline` string match, so outside this PR's rg-scoped sweep; filing an issue.
- `docs/design/pipeline-journey.md` — #3941 already names this as one of three docs deliberately left to a maintainer decision; not touched.

## Left behind (filing issues)

1. `website/content/docs/commands/migrate.mdx:41` claims the agent set is `default, worker, verifier, triage, research, plan` (six roles); #3908 collapsed it to one role, `default`. Fix: update the sentence to state the current single-role set and note `migrate` still renames the six legacy per-agent blocks it encounters. Verify: `rg -n "agent set is closed" website/content/docs/commands/migrate.mdx`.
2. `docs/spec/self-driving-foundry.md:204,435` documents `trace_capture`/`capture = true` as a live control for campaign runs; the setting is `RETIRED` (`crates/stella-cli/src/settings/unknown.rs`) and does nothing. Fix: correct or remove the claim, and check whether campaign trace capture needs a real replacement design. Verify: `rg -n "trace_capture" docs/spec/self-driving-foundry.md`.

Closes #3901
Closes #4526

## Summary by Sourcery

Retire stale documentation for the deleted staged pipeline and align verification, configuration, and plugin guidance with the current opt-in plugin model.

Bug Fixes:
- Correct documentation and marketing copy that described the deleted staged pipeline, witness promotion, recap, or trace-capture features as currently available.

Enhancements:
- Archive prompt documentation for removed staged-pipeline roles and clarify which worker content remains live versus historical.
- Update roadmap, plugin documentation, configuration specifications, and architectural papers to describe the post-#3865 plugin-based verification model and historical pipeline behavior.

Documentation:
- Retire the remaining inaccurate staged-pipeline and configuration claims across the documentation and website while preserving historical design references.