### PR TITLE
fix(stella-protocol): census the last 32 consumer rows and take MAX_UNCLASSIFIED to zero

### DIFF
--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -1209,13 +1209,23 @@ pub enum AgentEvent {
     /// A media generation job changed state. Video jobs are async and
     /// long-lived; this event is how the TUI shows progress without polling
     /// shared state (L-T1).
+    ///
+    /// **No producer in this workspace** (#4454): #4448 removed
+    /// `crates/stella-media`, and CLAUDE.md's tool-surface rule forbids the
+    /// media built-in that would have been its caller (#3236, #3845). This
+    /// variant and [`AgentEvent::MediaComplete`] stay as the wire contract an
+    /// out-of-tree media MCP surface speaks, and because dropping the tags
+    /// would demote an older recording's media events to
+    /// [`AgentEvent::Unknown`]. Retiring them belongs to a `PROTOCOL_VERSION`
+    /// bump, which #4454 decides.
     MediaProgress {
         artifact_id: String,
         kind: MediaKind,
         state: MediaJobState,
     },
     /// A media artifact landed under `.stella/artifacts/` with a manifest
-    /// row.
+    /// row. Producerless here for the reason
+    /// [`AgentEvent::MediaProgress`] gives (#4454).
     MediaComplete { artifact: MediaArtifactRef },
     /// A commit landed (fleet ledger / pipeline execute stage).
     Commit { sha: String, message: String },

--- a/crates/stella-protocol/src/event/consumers.rs
+++ b/crates/stella-protocol/src/event/consumers.rs
@@ -76,7 +76,7 @@ use super::KNOWN_TYPE_TAGS;
 
 /// A surface that renders some signals and not others.
 ///
-/// Deliberately narrow. Three plausible surfaces are **absent** because
+/// Deliberately narrow. Two plausible surfaces are **absent** because
 /// membership in them is not a per-variant fact:
 ///
 /// - The **TUI** matches `AgentEvent` exhaustively
@@ -85,8 +85,13 @@ use super::KNOWN_TYPE_TAGS;
 /// - **Replay** likewise tagged every variant, in the then-existing
 ///   `stella-pipeline`'s `replay::event_signature`; that crate was deleted in
 ///   #3865 and no replay tagger has replaced it yet.
-/// - **Serve** forwards the event stream opaquely rather than selecting
-///   variants.
+///
+/// `stella-serve` mostly forwards the stream opaquely, which is why it was
+/// listed here as absent until the #4501 census read its `observe/tally.rs`:
+/// `TallyFold::observe` names ten variants by hand and folds them into the
+/// `TurnTally` that rides each settle record. That fold is the per-variant
+/// fact [`Surface::Serve`] records, and a row claiming it is checkable against
+/// that match.
 ///
 /// A field whose value is the same on every row records nothing. This enum
 /// names only surfaces that *choose*, which is what makes a surface claim
@@ -146,7 +151,9 @@ pub enum ConsumerPosture {
     /// total. It is **not** a synonym for [`ConsumerPosture::RecordedOnly`] —
     /// claiming "nothing consumes this" without looking would put a false
     /// statement in the ledger, and a ledger that lies is worse than no
-    /// ledger. Under a down-only ratchet ([`MAX_UNCLASSIFIED`]).
+    /// ledger. Under a down-only ratchet ([`MAX_UNCLASSIFIED`]), which #4501
+    /// drove to zero: no shipped row holds this posture, and adding one fails
+    /// the ratchet test.
     Unclassified {
         /// The tracking issue, as `#1234`. Empty fails the audit.
         issue: &'static str,
@@ -175,16 +182,18 @@ pub use super::tags::SIGNAL_CONSUMERS;
 
 /// How many rows may still be [`ConsumerPosture::Unclassified`].
 ///
-/// A **down-only** ratchet, legitimate for the one reason a ratchet ever is
-/// here: the audit predates the guard, so this records a debt that already
-/// existed rather than granting new permission. The same argument
-/// `scripts/typed-errors-baseline.txt` makes for its own count.
+/// **Zero since #4501**, which censused the last 32 rows one at a time. A new
+/// variant therefore cannot reach `Unclassified` at all: the equality test
+/// below goes red the moment one does, and the way past it is to name what
+/// reads the signal.
 ///
-/// The test asserts equality, not `<=`. Lowering it is the point and must
-/// show up as a diff; raising it means a new variant was filed away unread,
-/// which is the exact move the ledger exists to prevent. #2703 drives it to
-/// zero, after which a new variant cannot reach `Unclassified` at all.
-pub const MAX_UNCLASSIFIED: usize = 32;
+/// It stays a **down-only** ratchet rather than an assertion so the shape is
+/// still available to a future protocol import that arrives with genuinely
+/// unaudited variants — and so that raising it remains a visible diff a
+/// reviewer has to accept. The test asserts equality, not `<=`: raising the
+/// number means a variant was filed away unread, which is the exact move the
+/// ledger exists to prevent.
+pub const MAX_UNCLASSIFIED: usize = 0;
 
 /// What the audit found wrong with one ledger row.
 ///

--- a/crates/stella-protocol/src/event/consumers/tests.rs
+++ b/crates/stella-protocol/src/event/consumers/tests.rs
@@ -40,8 +40,9 @@ fn the_ledger_row_count_equals_the_tag_count() {
 #[test]
 fn unclassified_rows_are_a_down_only_debt() {
     // A ratchet, not a budget. Equality on purpose: lowering MAX_UNCLASSIFIED
-    // is the point of #2703 and should show as a diff, and raising it means a
-    // variant was filed away unread — the move the ledger exists to prevent.
+    // was the point of #2703 and #4501 and had to show as a diff, and raising
+    // it means a variant was filed away unread — the move the ledger exists to
+    // prevent.
     let actual = unclassified_count();
     assert_eq!(
         actual, MAX_UNCLASSIFIED,
@@ -49,6 +50,29 @@ fn unclassified_rows_are_a_down_only_debt() {
          If you classified a signal, lower the constant in the same commit. \
          If you added a variant and reached for Unclassified, classify it \
          instead — the ceiling only moves down."
+    );
+}
+
+/// #4501: every wire tag names a real consumer, so no shipped row holds
+/// [`ConsumerPosture::Unclassified`].
+///
+/// Distinct from the ratchet above, which only says the count and the constant
+/// agree — it was green at 32 and would be green at 32 again. This one names
+/// the number the census reached, so a later PR that adds a variant and
+/// re-opens the debt has to argue for it here.
+#[test]
+fn no_shipped_row_is_unclassified() {
+    let unaudited: Vec<&str> = SIGNAL_CONSUMERS
+        .iter()
+        .filter(|row| matches!(row.posture, ConsumerPosture::Unclassified { .. }))
+        .map(|row| row.type_tag)
+        .collect();
+    assert!(
+        unaudited.is_empty(),
+        "#4501 censused every row; these are unaudited again: {unaudited:?}. \
+         Read what consumes the signal and declare Behavioral / Surfaced / \
+         RecordedOnly — `scripts/check-consumer-sites.sh` then holds a \
+         Behavioral row's site to naming live code."
     );
 }
 
@@ -76,6 +100,11 @@ fn the_exemplar_rows_show_each_posture_in_use() {
     // The three postures a real row can hold are each exercised by the
     // shipped ledger, so none of them is dead code the compiler keeps alive
     // and no test ever reaches.
+    //
+    // `Unclassified` is deliberately absent: #4501 emptied it, and
+    // `unclassified_rows_are_a_down_only_debt` above is what now pins that at
+    // zero. The negative controls below still construct the variant, so it is
+    // exercised without any shipped row having to hold it.
     let posture = |tag: &str| {
         SIGNAL_CONSUMERS
             .iter()
@@ -91,10 +120,6 @@ fn the_exemplar_rows_show_each_posture_in_use() {
     assert!(matches!(
         posture("proof"),
         ConsumerPosture::RecordedOnly { .. }
-    ));
-    assert!(matches!(
-        posture("stage"),
-        ConsumerPosture::Unclassified { .. }
     ));
 }
 

--- a/crates/stella-protocol/src/event/tags.rs
+++ b/crates/stella-protocol/src/event/tags.rs
@@ -124,24 +124,66 @@ macro_rules! agent_event_tags {
     };
 }
 
+// The #4501 census, which drove [`ConsumerPosture::Unclassified`] to zero by
+// reading each remaining row's consumers instead of leaving them unaudited.
+// Three consumers recur below and are described once here instead of in
+// thirty rows:
+//
+// - The **Observatory** selects `event_type` by name in four places, and a
+//   row claiming `Surface::Observatory` appears in at least one:
+//   `journal.rs::entries` (the transcript), `sessions.rs`'s
+//   `TENDENCY_EVENT_TYPES` (the behavioural fold), `db.rs::recall_timings`,
+//   and `sent_context.rs::journal_payloads`.
+// - **`stella-serve`**'s `observe/tally.rs::TallyFold::observe` folds ten
+//   variants into the `TurnTally` on each settle record — the counts a host
+//   reads to tell a wedged turn from a waiting one. That is the arm
+//   `Surface::Serve` names.
+// - **`stella-cli/src/diag_bridge.rs`** writes a diagnostic record for nearly
+//   every variant. Recording is not deciding, so it earns no posture on its
+//   own; a row whose only readers are the bridge and the exhaustive TUI
+//   renderers is `RecordedOnly`.
 agent_event_tags! {
+    // The run owner's stage boundaries. `Surfaced` on both axes: the
+    // Observatory's journal query names the tag, and serve's tally counts
+    // `StageScope::Run` boundaries as its progress axis. Nothing branches on
+    // it — the stage has already changed by the time this announces it.
     Stage => "stage",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[Surface::Observatory];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory, Surface::Serve];
     // Exemplar — `Surfaced`. Assistant prose has no behavioral consumer by
     // design: the engine does not branch on what the model said in English.
     Text => "text",
         ConsumerPosture::Surfaced,
         &[Surface::Observatory];
+    // The streaming preview. `Behavioral`: both durable writers refuse it —
+    // `spawn_renderer` skips the store write and `stella-store`'s
+    // `SessionJournal::write` skips the journal line — because the step's
+    // `Text` event carries the same bytes in full. Delete either branch and
+    // every answer doubles on disk, and the delta-coalescing runs tear into
+    // per-token flushes.
     TextDelta => "text_delta",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence.rs::spawn_renderer",
+        },
         &[];
+    // `Behavioral`: `ReasoningRun::admit` folds consecutive fragments into one
+    // block before the store write, so a page of thought costs one row instead
+    // of tens of thousands (#3969). The Observatory selects the tag and
+    // re-joins whatever fragments did land (`journal.rs::coalesce_reasoning`).
     Reasoning => "reasoning",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence/reasoning_run.rs::ReasoningRun::admit",
+        },
         &[Surface::Observatory];
+    // The other half of the `tool_result` row below: `project_event` opens the
+    // `tool_calls` row that the result settles, so severing this leaves every
+    // call unrecorded and every result orphaned. Also folded into the turn
+    // facts a wrapper plugin judges (`stella-cli/src/turn_facts.rs`).
     ToolStart => "tool_start",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[Surface::Observatory];
+        ConsumerPosture::Behavioral {
+            site: "stella-store/src/tool_calls.rs::project_event",
+        },
+        &[Surface::Observatory, Surface::Serve];
     // Exemplar — `Behavioral`. Projected into the store's `tool_calls` table
     // in the same transaction that records the event.
     //
@@ -152,50 +194,117 @@ agent_event_tags! {
     // `CompletionMessage`s), which is a different plane that happens to carry
     // the same facts. Citing it here would have described a dependency that
     // does not exist — and severing the event would not have been caught.
+    //
+    // `Surface::Serve` joined the row in the #4501 census: the tally reads
+    // `output.is_error()` off this event for its `tools_failed` count, which
+    // makes it a selecting arm the same way `tool_start` is.
     ToolResult => "tool_result",
         ConsumerPosture::Behavioral {
             site: "stella-store/src/tool_calls.rs::project_event",
         },
-        &[Surface::Observatory];
+        &[Surface::Observatory, Surface::Serve];
+    // `Behavioral`: the CGP trace recorder resolves the discarded call as
+    // `Rejected`, so its tool pairing stays truthful — the I/O ran and the
+    // model never saw it. Both Observatory lists select the tag, and serve's
+    // tally counts it rather than re-deriving discarded work.
     SpeculationDiscarded => "speculation_discarded",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[Surface::Observatory];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/arena.rs::observe",
+        },
+        &[Surface::Observatory, Surface::Serve];
+    // `Behavioral`: the reflection digest's friction fold records each attempt
+    // and its reason, which is what `Priority::Friction` selects on when a
+    // lesson is mined into memory. The retry itself is the engine's decision;
+    // `site` names the consumer that keeps it.
     Retry => "retry",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/memory/reflection/digest.rs::TurnFriction::observe",
+        },
+        &[Surface::Observatory, Surface::Serve];
+    // `Surfaced`: the message was already injected at the step boundary by the
+    // time this echoes it, so a host learns *when* it landed and nothing
+    // decides on it. The Observatory's tendencies fold names the tag.
     Steered => "steered",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory];
+    // The park pair (#1471, #1857). `Surfaced`: serve's tally counts spans,
+    // wakes, polls and licensed seconds, which is what keeps its `stages`
+    // progress axis honest — a host reading a stalled turn can tell a
+    // deliberate wait from a hang. Both tags sit in the Observatory's journal
+    // query. The park loop itself runs on `stella-core::driver::waiting`, so
+    // these events report it and never drive it.
     TurnParked => "turn_parked",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[Surface::Observatory];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory, Surface::Serve];
     TurnWoken => "turn_woken",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[Surface::Observatory];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory, Surface::Serve];
+    // `Behavioral`: the friction fold records the pattern, its repeat count and
+    // whether the loop aborted the turn, which is what a mined lesson cites.
+    // The engine's own abort is decided in `stella-core`'s loop detection, so
+    // `site` names the reflection consumer.
     LoopDetected => "loop_detected",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/memory/reflection/digest.rs::TurnFriction::observe",
+        },
+        &[Surface::Observatory, Surface::Serve];
+    // `Surfaced`: the budget guard has already refused the call by the time
+    // this reports the refusal (`stella-core/src/driver.rs`). The Observatory's
+    // tendencies fold names the tag.
     BudgetDenied => "budget_denied",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory];
+    // `Behavioral`, same fold as `retry`: a doomed sequence reports its whole
+    // run at once, and the friction entry carries the last reason — which is
+    // the sentence a mined lesson quotes when a turn died on retries.
     RetriesExhausted => "retries_exhausted",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/memory/reflection/digest.rs::TurnFriction::observe",
+        },
+        &[Surface::Observatory, Surface::Serve];
+    // `Surfaced`: the authorization bus emits a content-free record after the
+    // decision is made (`stella-core/src/bus.rs`), so the deny has already
+    // happened. The Observatory's tendencies fold names the tag.
     PolicyDecision => "policy_decision",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Surfaced,
+        &[Surface::Observatory];
+    // `Behavioral`: `journal_preimages` indexes each rewrite by content digest,
+    // which is how a reconstructed transcript resolves a compacted block back
+    // to its bytes and how the digest check over it can pass. Selected by the
+    // Observatory's tendencies fold and by its sent-context view.
     Compaction => "compaction",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-store/src/reconstruct.rs::journal_preimages",
+        },
+        &[Surface::Observatory];
+    // `Behavioral`: reflection settlement strips the sub-turn's own ticks and
+    // re-emits one from the session guard, so the remaining budget on the wire
+    // is the session's. Drop that consumer and a nested report's ceiling
+    // reaches the caller as if it were the session's.
     BudgetTick => "budget_tick",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/budget.rs::settle_reflection_budget",
+        },
         &[];
+    // The metering record. `Behavioral`: `persist_event_detailed` writes the
+    // per-call usage row every cost, cache and token figure is later read
+    // from, and carries `complete` up into the execution's accounting bit.
+    // Serve's tally counts it as the turn's model calls.
     StepUsage => "step_usage",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence.rs::persist_event_detailed",
+        },
+        &[Surface::Serve];
+    // An attempt that died and produced no usage frame, which is a different
+    // fact from a `step_usage` with `complete: false` (#4147). `Behavioral`:
+    // the same persistence hop carries it into `usage_complete`, and
+    // `settle_reflection_budget` counts it as accounting having happened. The
+    // Observatory's tendencies fold names the tag.
     UsageIncomplete => "usage_incomplete",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence.rs::persist_event_detailed",
+        },
+        &[Surface::Observatory];
     // Audited out of the #2703 backlog by #3977. `Behavioral`: the reflection
     // digest splits a goal arc's journal at each verdict and labels every
     // segment from this event's own `round`, so deleting the consumer would
@@ -230,20 +339,51 @@ agent_event_tags! {
     ProviderFallback => "provider_fallback",
         ConsumerPosture::Surfaced,
         &[Surface::Observatory];
+    // `Behavioral`: `TurnFacts::observe` folds these into the `changed_files`
+    // a wrapper plugin's verdict rule reads (#3552). Before that tap existed
+    // the field was always empty, and a wrapper gating on "did this turn touch
+    // anything" graded every run as untouched. The Observatory's journal query
+    // names the tag. The event's contract is unchanged by the posture:
+    // observability, never evidence (#2873).
     FileChange => "file_change",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/turn_facts.rs::TurnFacts::observe",
+        },
+        &[Surface::Observatory];
+    // `Behavioral`: the deck's forwarder holds the run's `Stage(Execute)`
+    // boundary until the first event that is not a recall, so a turn's recall
+    // renders ahead of the stage it opens. The Observatory's recall-timings
+    // view reads latency, frame count and token cost off the same event.
     ContextRecall => "context_recall",
-        ConsumerPosture::Unclassified { issue: "#2703" },
-        &[];
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/command_deck/forwarder.rs::spawn_forwarder",
+        },
+        &[Surface::Observatory];
+    // `RecordedOnly`: a memory write announces itself and nothing reads the
+    // announcement — the diagnostic bridge records one, the TUI's textline
+    // renders a line by exhaustive match, and no Observatory query names the
+    // tag. Wiring a real consumer (a memory-pressure view, or a reflection
+    // input) is what #4501 leaves open here.
     ContextWrite => "context_write",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4501" },
         &[];
+    // A context receipt. `Behavioral`: `persist_event_detailed` writes the
+    // `context_blocks` row that the Observatory's block registry and
+    // `stella-store`'s preimage reconstruction both resolve against — and the
+    // gap preimage that only ever exists in that row.
     BlockRegistered => "block_registered",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence.rs::persist_event_detailed",
+        },
         &[];
+    // What one model call was compiled from. `Behavioral`: the same
+    // persistence hop writes the manifest row, which is what a step's receipts
+    // and its parallel tool calls join against by `(turn_instance, step,
+    // call_seq)`.
     StepManifest => "step_manifest",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/agent/persistence.rs::persist_event_detailed",
+        },
         &[];
     // The verification pair, post-rail (#3790). Neither row is `Unclassified`
     // debt: the consumers are known and named below; what remains undecided —
@@ -271,32 +411,82 @@ agent_event_tags! {
     Verdict => "verdict",
         ConsumerPosture::RecordedOnly { issue: "#3790" },
         &[];
+    // `Behavioral`: the deck's forwarder seeds the task board from the
+    // proposal's steps as the gate is reached, so the ids already resolve when
+    // the first `task_start` arrives. Seeded on the proposal rather than on
+    // approval, and `seed_from_plan` is a no-op on a board that already has
+    // rows, so a declined or revised plan cannot clobber live work.
     ScopeReview => "scope_review",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/command_deck/forwarder.rs::spawn_forwarder",
+        },
         &[];
+    // `RecordedOnly`: the hunk gate's decision is already made when this
+    // reports it, and the readers are the diagnostic bridge and the TUI's
+    // exhaustive textline. No Observatory query names the tag. Whether a
+    // review surface should select it is what #4501 leaves open here.
     HunkReview => "hunk_review",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4501" },
         &[];
+    // `Behavioral`, and the one row where the TUI is the consumer rather than
+    // a renderer. `Model::apply` latches `pending_ask_user`, and
+    // `stella-tui/src/deck_ui/gates.rs::handle_focused_gates` reads that latch
+    // to claim the next digit or `⏎` for the answer card. Sever the arm and
+    // the question is unanswerable: the gate's channel
+    // (`stella-cli/src/command_deck/mid_turn_ask.rs`, which blocks on the
+    // answer rather than on this event) never receives a reply and the turn
+    // sits there until the session is killed.
     AskUser => "ask_user",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-tui/src/model.rs::Model::apply (latches pending_ask_user)",
+        },
         &[];
+    // The media pair (#4454). `RecordedOnly` because #4448 removed
+    // `stella-media` and left these with zero producers in this tree: they are
+    // kept as the wire contract an out-of-tree media MCP surface would speak,
+    // and removing them is a protocol break for anyone replaying a recording
+    // that carries the tag. The TUI's textline still renders both by
+    // exhaustive match. #4454 tracks the retire-or-keep decision at the next
+    // `PROTOCOL_VERSION` bump.
     MediaProgress => "media_progress",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4454" },
         &[];
     MediaComplete => "media_complete",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4454" },
         &[];
+    // The delivery artifacts. `Behavioral`: the calibration fold attaches every
+    // commit and PR a session records after a pass to that pass, and settles
+    // the unproven ones when the PR carries a terminal CI status — an
+    // unproven pass whose PR failed CI is counted as a false positive. That
+    // number is what the verifier's calibration report is.
     Commit => "commit",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/calibration.rs::calibration",
+        },
         &[];
     Pr => "pr",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-cli/src/calibration.rs::calibration",
+        },
         &[];
+    // `RecordedOnly`: the board's authority is `stella-core`'s `TaskBoard`,
+    // which `command_deck/task_tap.rs` snapshots into this event after each
+    // `task_*` call, and the durable `tasks` rows are written from that same
+    // board rather than from the stream. What reads the event is the deck —
+    // a transcript entry and the active-task elapsed/cost anchor
+    // (`stella-tui/src/deck.rs`) — which is rendering, by exhaustive match. A
+    // cross-session consumer (replay rebuilding a board from the journal) is
+    // what #4501 leaves open here.
     TaskUpdate => "task_update",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4501" },
         &[];
+    // `RecordedOnly`: the delegation itself is driven by
+    // `stella-core::subagent`'s dispatcher and this reports its phases. The
+    // deck stamps a start/finish bracket from them (`deck.rs`), which is the
+    // elapsed a human reads; nothing else consumes them. The controllable
+    // sub-session lanes are a separate mechanism and do not ride this variant.
     SubAgent => "sub_agent",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::RecordedOnly { issue: "#4501" },
         &[];
     // The delivery decision (#2942). `Surfaced` rather than `RecordedOnly`
     // because the observatory's journal query was widened to select it in the
@@ -319,8 +509,16 @@ agent_event_tags! {
     CandidateDelivery => "candidate_delivery",
         ConsumerPosture::Surfaced,
         &[Surface::Observatory];
+    // `Behavioral`, twice over in the session journal. `unsettled_prompts`
+    // treats a non-retryable error as a settle, so resume does not return an
+    // already-failed prompt to the front of the queue; `is_transition` fsyncs
+    // the record, because a power cut must not take back the fact that the
+    // turn failed. A retryable error settles nothing, which is what the
+    // `retryable: false` pattern is doing there.
     Error => "error",
-        ConsumerPosture::Unclassified { issue: "#2703" },
+        ConsumerPosture::Behavioral {
+            site: "stella-store/src/journal.rs::unsettled_prompts",
+        },
         &[];
     // The engine's per-turn ending (#3379). `Behavioral`: the diagnostic
     // bridge drains its in-flight tool-call retention map on it, because that

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -823,9 +823,9 @@ six-variant enum at `crates/stella-tui/src/envelope.rs:993`).
 
 **Net-new, not ported:** the durable flip record. Today a `LadderSnapshot` rides
 inside `AgentEvent::Verdict`, but there is no dedicated flip-transition event and
-the `verdict` tag's consumer posture is `Unclassified` (#2703) — nothing is
-declared to read it. Vera owns a declared flip record whose named consumer is
-the fine-tuning corpus. A verification signal nothing reads is the exact failure
+the `verdict` tag's consumer posture is `RecordedOnly` (#3790) — its readers all
+render, and nothing decides on it. Vera owns a declared flip record whose named
+consumer is the fine-tuning corpus. A verification signal nothing reads is the exact failure
 mode this project exists to end.
 
 ---

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -3483,7 +3483,7 @@
       "type": "object"
     },
     {
-      "description": "A media generation job changed state. Video jobs are async and\nlong-lived; this event is how the TUI shows progress without polling\nshared state (L-T1).",
+      "description": "A media generation job changed state. Video jobs are async and\nlong-lived; this event is how the TUI shows progress without polling\nshared state (L-T1).\n\n**No producer in this workspace** (#4454): #4448 removed\n`crates/stella-media`, and CLAUDE.md's tool-surface rule forbids the\nmedia built-in that would have been its caller (#3236, #3845). This\nvariant and [`AgentEvent::MediaComplete`] stay as the wire contract an\nout-of-tree media MCP surface speaks, and because dropping the tags\nwould demote an older recording's media events to\n[`AgentEvent::Unknown`]. Retiring them belongs to a `PROTOCOL_VERSION`\nbump, which #4454 decides.",
       "properties": {
         "artifact_id": {
           "type": "string"
@@ -3514,7 +3514,7 @@
       "type": "object"
     },
     {
-      "description": "A media artifact landed under `.stella/artifacts/` with a manifest\nrow.",
+      "description": "A media artifact landed under `.stella/artifacts/` with a manifest\nrow. Producerless here for the reason\n[`AgentEvent::MediaProgress`] gives (#4454).",
       "properties": {
         "artifact": {
           "$ref": "#/$defs/MediaArtifactRef"

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -1195,7 +1195,7 @@
           "type": "object"
         },
         {
-          "description": "A media generation job changed state. Video jobs are async and\nlong-lived; this event is how the TUI shows progress without polling\nshared state (L-T1).",
+          "description": "A media generation job changed state. Video jobs are async and\nlong-lived; this event is how the TUI shows progress without polling\nshared state (L-T1).\n\n**No producer in this workspace** (#4454): #4448 removed\n`crates/stella-media`, and CLAUDE.md's tool-surface rule forbids the\nmedia built-in that would have been its caller (#3236, #3845). This\nvariant and [`AgentEvent::MediaComplete`] stay as the wire contract an\nout-of-tree media MCP surface speaks, and because dropping the tags\nwould demote an older recording's media events to\n[`AgentEvent::Unknown`]. Retiring them belongs to a `PROTOCOL_VERSION`\nbump, which #4454 decides.",
           "properties": {
             "artifact_id": {
               "type": "string"
@@ -1220,7 +1220,7 @@
           "type": "object"
         },
         {
-          "description": "A media artifact landed under `.stella/artifacts/` with a manifest\nrow.",
+          "description": "A media artifact landed under `.stella/artifacts/` with a manifest\nrow. Producerless here for the reason\n[`AgentEvent::MediaProgress`] gives (#4454).",
           "properties": {
             "artifact": {
               "$ref": "#/$defs/MediaArtifactRef"


### PR DESCRIPTION
## What

### #4501 — the consumer ledger's last 32 `Unclassified` rows

Every remaining `ConsumerPosture::Unclassified` row in
`crates/stella-protocol/src/event/tags.rs` cited **#2703, which is closed**, so
the ledger's own rule ("it must cite the issue where the gap is being decided")
pointed 32 rows at nothing live. Each row was censused by reading what actually
consumes its wire tag across `stella-tui`, `stella-store`, `stella-observatory`,
`stella-serve`, `stella-cli` and `stella-core`, then re-declared with a comment
naming the consumer.

`MAX_UNCLASSIFIED` drops **32 → 0**. `Unclassified` is now unreachable for a
shipped row: the equality test goes red the moment one appears.

**20 rows are `Behavioral`**, each naming code that branches:

| tag | site |
|---|---|
| `text_delta` | `stella-cli/src/agent/persistence.rs::spawn_renderer` (both durable writers refuse it; keeping it doubles every answer on disk) |
| `reasoning` | `.../persistence/reasoning_run.rs::ReasoningRun::admit` (fragment coalescing, #3969) |
| `tool_start` | `stella-store/src/tool_calls.rs::project_event` (opens the row `tool_result` settles) |
| `speculation_discarded` | `stella-cli/src/arena.rs::observe` (resolves the pending call as `Rejected`) |
| `retry`, `retries_exhausted`, `loop_detected` | `stella-cli/src/memory/reflection/digest.rs::TurnFriction::observe` |
| `compaction` | `stella-store/src/reconstruct.rs::journal_preimages` (rewrite → preimage index) |
| `budget_tick` | `stella-cli/src/agent/budget.rs::settle_reflection_budget` |
| `step_usage`, `usage_incomplete`, `block_registered`, `step_manifest` | `stella-cli/src/agent/persistence.rs::persist_event_detailed` |
| `file_change` | `stella-cli/src/turn_facts.rs::TurnFacts::observe` (the `changed_files` a wrapper plugin's verdict rule reads, #3552) |
| `context_recall`, `scope_review` | `stella-cli/src/command_deck/forwarder.rs::spawn_forwarder` (stage hold; plan-board seed) |
| `ask_user` | `stella-tui/src/model.rs::Model::apply` — latches `pending_ask_user`, which `deck_ui/gates.rs::handle_focused_gates` reads to claim the next keystroke; sever it and the question is unanswerable |
| `commit`, `pr` | `stella-cli/src/calibration.rs::calibration` (an unproven pass whose PR failed CI is counted as a false positive) |
| `error` | `stella-store/src/journal.rs::unsettled_prompts` (a non-retryable error settles the prompt, so resume does not re-queue it) |

**6 rows are `Surfaced`** — `stage`, `steered`, `turn_parked`, `turn_woken`,
`budget_denied`, `policy_decision`. Each names a surface that genuinely selects
the tag: the Observatory's journal query, its `TENDENCY_EVENT_TYPES` fold, its
recall-timings view, or `stella-serve`'s `TallyFold::observe`. Several
`Behavioral` rows above carry surfaces too — the two axes are orthogonal.

**6 rows are `RecordedOnly`** — `context_write`, `hunk_review`, `task_update`
and `sub_agent` cite **#4501** as the live gap; `media_progress` /
`media_complete` cite **#4454** (below). Each comment names its actual readers
(the diagnostic bridge, the exhaustive TUI renderers) so the claim is
checkable, following the `proof`/`verdict` rows' precedent.

The breakdown is counted from the shipped table, not asserted: `rg -c` over
`tags.rs` gives 24 `Behavioral` / 10 `Surfaced` / 8 `RecordedOnly` across all
42 rows, of which 4 / 4 / 2 were already declared before this PR.

**`Surface::Serve` gets its first rows.** `Surface`'s doc listed serve among the
surfaces absent from the enum "because they forward opaquely" while the enum
itself already carried a `Serve` variant — a contradiction that had been sitting
there. `stella-serve/src/observe/tally.rs::TallyFold::observe` names ten variants
by hand and folds them into the `TurnTally` a host reads to tell a wedged turn
from a waiting one, which is the per-variant fact the variant was declared for.
The doc now says that instead.

Two smaller corrections in the same pass:

- `tool_result` gains `Surface::Serve` (the tally reads `output.is_error()` off
  it for `tools_failed`), so it stops under-claiming next to `tool_start`.
- `docs/spec/pipeline-as-plugins.md` said the `verdict` tag's posture is
  `Unclassified (#2703)`. It has been `RecordedOnly { issue: "#3790" }` since
  #3790; the line is corrected.

### #4454 — the media wire surface

Taken as far as the evidence honestly allows, which is the re-declaration and
not the decision. `rg` confirms zero producers: the only `MediaProgress` /
`MediaComplete` references outside `stella-protocol` are readers
(`stella-tui`'s textline / model / classify / transcript, and
`stella-cli/src/diag_bridge.rs`). Both rows are now
`RecordedOnly { issue: "#4454" }`, and the variant docs in
`crates/stella-protocol/src/event.rs` state why they stay: the contract an
out-of-tree media MCP surface speaks, and dropping the tags from
`KNOWN_TYPE_TAGS` would demote an older recording's media events to
`AgentEvent::Unknown`.

**#4454 stays open as the tracking number** — the retire-or-keep decision at the
next `PROTOCOL_VERSION` bump is a maintainer call, so this PR uses `Refs`, not
`Closes`.

## Evidence

Witness — `no_shipped_row_is_unclassified` (new,
`crates/stella-protocol/src/event/consumers/tests.rs`):

- **Fails on main.** With `origin/main`'s `tags.rs` + `consumers.rs` checked out
  over the new test:
  ```
  test event::consumers::tests::no_shipped_row_is_unclassified ... FAILED
  #4501 censused every row; these are unaudited again: ["stage", "text_delta",
  "reasoning", "tool_start", "speculation_discarded", "retry", "steered",
  "turn_parked", "turn_woken", "loop_detected", "budget_denied",
  "retries_exhausted", "policy_decision", "compaction", "budget_tick",
  "step_usage", "usage_incomplete", "file_change", "context_recall",
  "context_write", "block_registered", "step_manifest", "scope_review",
  "hunk_review", "ask_user", "media_progress", "media_complete", "commit",
  "pr", "task_update", "sub_agent", "error"]
  ```
  (all 32, which is also the census's own inventory)
- **Passes with the change**: `1 passed`.

The pre-existing `unclassified_rows_are_a_down_only_debt` is *not* the witness —
it asserts equality and was green at 32 and is green at 0. That is why the new
test names the number.

Targeted commands, all from this branch:

| command | result |
|---|---|
| `./scripts/check-consumer-sites.sh` (the #4518 site-liveness guard) | `OK — 24 Behavioral site(s) ... each name a symbol still present in the file they point at` |
| `cargo test -p stella-protocol` | exit 0 — 221 + 7 + 5 + 8 passed, 0 failed |
| `cargo clippy -p stella-protocol --all-targets -- -D warnings` | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol --no-deps --document-private-items` | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-protocol --no-deps` | exit 0 |
| `make guards-fast` | exit 0 (`check-prose: OK -- none added`; `check-file-size: OK`) |
| `cargo fmt --all` | clean |

The site-liveness guard earned its keep during the change: the first draft cited
`stella-tui/src/model.rs::WorkspaceModel::apply_inbound`, and the guard named it
as a symbol that does not appear in that file. The row now cites `Model::apply`.

No workspace build or workspace test was run here — CI is the evidence for those
(CLAUDE.md, "CI builds and tests; this laptop does not").

## Not done

- **#4454 is not closed.** Keep-versus-retire at the next `PROTOCOL_VERSION` bump
  is a maintainer decision; this PR only does the half the issue authorises
  without one (re-declare the posture, say so in the variant docs).
- **`stella-tools` typed-errors ratchet drift.** `make guards-fast` notes
  `stella-tools is down to 4 (ratchet says 5)`. Pre-existing, unrelated, and
  baselines are out of scope here.
- **`crates/stella-protocol/src/event.rs` is 1498 lines** against the 1500-line
  ceiling with no baseline entry. This PR's two-line doc addition to the media
  variants had to be rewritten twice to fit under it. The next doc comment
  anywhere in that file fails `check-file-size` outright, and the remedy the
  guard names is a split, not a baseline entry. Worth its own issue.
- **A selective-TUI surface is not modelled.** `Surface` deliberately omits the
  TUI because its renderers match exhaustively, which is right for
  `textline`/`model::apply`. But several rows here have TUI consumers that
  genuinely *select* — the Files tab (`file_change`), the sub-agent lanes
  (`sub_agent`), the ask card (`ask_user`) — and they land as `RecordedOnly` or
  as a `Behavioral` row whose site is an exhaustive matcher. Adding a `Deck`
  surface with a whitelist to check against would sharpen four rows; it needs
  its own design argument and is not folded in here.

Closes #4501

---

### Addendum — the wire schema had to be regenerated

The first push went red on `docs/wire still matches the types`. `schemars`
lifts an enum variant's doc comment into the JSON schema's `description`, so
the media-variant docs above made the committed artifacts stale.
`bash scripts/export-agentevent-schema.sh` regenerates them, and the diff is
**four `description` strings and nothing else** — no field added, removed,
renamed or made required, no variant re-tagged. `agentevent.d.ts` and
`wrapper.wire.json` are unchanged, which corroborates it: the TypeScript
surface carries no descriptions, so a real shape change would have moved it
too. `make wire-schema` is green on the branch.
