### PR TITLE
feat(stella-tools,stella-core,stella-mcp,stella-serve,stella-cli,stella-tui): classify every remaining ToolOutput::error site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,10 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-typed-errors.py
 
+      - name: no new unclassified ToolOutput::error( site (#3167)
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-tool-error-class.py
+
       - name: every dead-code suppression says why
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-dead-code-allows.py

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -198,6 +198,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-typed-errors.sh
 
+      - name: tool-error-class ratchet direction
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-tool-error-class.sh
+
       - name: wire-path guard failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-wire-paths.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + gate-parity + left-behind + role-names
                          #   + stat-portability + module-reachability
                          #   + typed-errors
+                         #   + tool-error-class (#3167 unclassified-ToolOutput::error ratchet)
                          #   + dead-code-allows
                          #   + diagnostic-codes
                          #   + consumer-sites (Behavioral 'site' strings point at live code)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ python3 ./scripts/check-doc-links.py check
 ./scripts/check-stat-portability.sh
 python3 ./scripts/check-module-reachability.py
 python3 ./scripts/check-typed-errors.py
+python3 ./scripts/check-tool-error-class.py
 python3 ./scripts/check-dead-code-allows.py
 ./scripts/check-diagnostic-codes.sh
 ./scripts/check-consumer-sites.sh

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     command-docs brand-case file-size god-files gate-parity left-behind \
                     role-names stat-portability module-reachability typed-errors \
+                    tool-error-class \
                     dead-code-allows diagnostic-codes consumer-sites bench-suites wire-paths \
                     tokens hue-separation contrast transcript-surfaces prose \
                     deck-fit-all-test deck-paths css-vars reserved-paths
@@ -392,6 +393,18 @@ typed-errors-update: ## Retighten the invariant-#5 ratchet (run after typing sig
 .PHONY: typed-errors-test
 typed-errors-test: ## Test the invariant-#5 ratchet's direction (hermetic; not part of `gate`)
 	./scripts/test-typed-errors.sh
+
+.PHONY: tool-error-class
+tool-error-class: ## Assert no NEW unclassified ToolOutput::error( site (#3167)
+	@python3 ./scripts/check-tool-error-class.py
+
+.PHONY: tool-error-class-update
+tool-error-class-update: ## Retighten the #3167 ratchet (run after classifying a site)
+	@python3 ./scripts/check-tool-error-class.py --update
+
+.PHONY: tool-error-class-test
+tool-error-class-test: ## Test the #3167 ratchet's direction (hermetic; not part of `gate`)
+	./scripts/test-tool-error-class.sh
 
 .PHONY: prose
 prose: ## Assert no content-free prose was added (down-only ratchet)

--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -273,11 +273,14 @@ impl ToolExecutor for ClaimTap<'_> {
                         .ok()
                         .flatten()
                         .unwrap_or_else(|| "(released meanwhile)".to_string());
-                    return ToolOutput::error(format!(
-                        "`{path}` is currently claimed by `{rival}` — another agent is \
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::RefusedByPolicy,
+                        format!(
+                            "`{path}` is currently claimed by `{rival}` — another agent is \
                              editing it right now. Work on a different file, or retry in a \
                              moment; the claim releases when that agent's turn ends."
-                    ));
+                        ),
+                    );
                 }
                 // Store trouble is observability loss, never a work
                 // stoppage — proceed uncoordinated.
@@ -318,12 +321,15 @@ impl ToolExecutor for ClaimTap<'_> {
                             .ok()
                             .flatten()
                             .unwrap_or_else(|| "(released meanwhile)".to_string());
-                        return ToolOutput::error(format!(
-                            "the {} lane has been held by `{rival}` for over {}s — retry \
+                        return ToolOutput::classified_error(
+                            stella_protocol::ErrorClass::RefusedByPolicy,
+                            format!(
+                                "the {} lane has been held by `{rival}` for over {}s — retry \
                                  shortly",
-                            lane_label(lane),
-                            LANE_WAIT_MS / 1000
-                        ));
+                                lane_label(lane),
+                                LANE_WAIT_MS / 1000
+                            ),
+                        );
                     }
                     // Degrade to an unserialized run rather than blocking
                     // real work on a broken store.

--- a/crates/stella-cli/src/tool_docs.rs
+++ b/crates/stella-cli/src/tool_docs.rs
@@ -270,6 +270,13 @@ fn output_schema() -> Value {
         data: None,
     })
     .expect("ToolOutput is Serialize");
+    // Deliberately the unclassified constructor (#3167): `arm()` below reads
+    // the payload's ONE field by taking `.keys().next()` on a `Value::Object`,
+    // which sorts alphabetically (this workspace does not enable
+    // serde_json's `preserve_order`). A classified error's `class` key sorts
+    // before `message`, so `arm()` would report the wrong field name for the
+    // documented schema. Keep the pre-#3145 shape here; see
+    // `scripts/check-tool-error-class.py`'s `TEST_ONLY_FILES`.
     let error =
         serde_json::to_value(ToolOutput::error(String::new())).expect("ToolOutput is Serialize");
     let (ok_tag, ok_field) = arm(&ok);

--- a/crates/stella-cli/src/tool_foundry/adopt.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt.rs
@@ -395,7 +395,10 @@ impl ToolExecutor for Builtins {
     }
 
     async fn execute(&self, name: &str, _: &Value) -> ToolOutput {
-        ToolOutput::error(format!("no tool named `{name}` is available"))
+        ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Internal,
+            format!("no tool named `{name}` is available"),
+        )
     }
 }
 

--- a/crates/stella-cli/src/tool_policy.rs
+++ b/crates/stella-cli/src/tool_policy.rs
@@ -92,8 +92,12 @@ impl ToolExecutor for PolicyToolSet<'_> {
     async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
         if !self.policy.allows(name) {
             // Same wording shape as an unknown tool: a disabled tool must not
-            // advertise itself through its own refusal.
-            return ToolOutput::error(format!("unknown tool: {name}"));
+            // advertise itself through its own refusal. The wording hides it,
+            // but the true cause is `self.policy.allows` declining the call.
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!("unknown tool: {name}"),
+            );
         }
         self.inner.get().execute(name, input).await
     }

--- a/crates/stella-core/src/compaction.rs
+++ b/crates/stella-core/src/compaction.rs
@@ -409,15 +409,21 @@ fn age_stale_tool_results(
         let before = estimate_message_tokens(message);
         let mut touched = false;
         for result in message.tool_results.iter_mut() {
-            let (payload, is_error) = match &result.output {
-                ToolOutput::Ok { content, .. } => (content, false),
-                ToolOutput::Error { message, .. } => (message, true),
+            let (payload, is_error, class) = match &result.output {
+                ToolOutput::Ok { content, .. } => (content, false, None),
+                ToolOutput::Error { message, class } => (message, true, *class),
             };
             if payload.len() > AGE_THRESHOLD_CHARS {
                 aged_blocks.push(tool_result_block_id(&result.output));
                 let aged_payload = age_content(payload);
+                // Aging shrinks the payload; it must not silently launder an
+                // already-classified failure back to "unaudited" (#3167) —
+                // `class` rides along with whatever prose survives the trim.
                 result.output = if is_error {
-                    ToolOutput::error(aged_payload)
+                    ToolOutput::Error {
+                        message: aged_payload,
+                        class,
+                    }
                 } else {
                     ToolOutput::Ok {
                         content: aged_payload,
@@ -741,14 +747,21 @@ pub fn compact_measured(
             }
             let before = estimate_message_tokens(message);
             for (ridx, result) in message.tool_results.iter_mut().enumerate() {
-                let (payload, is_error) = match &result.output {
-                    ToolOutput::Ok { content, .. } => (content, false),
-                    ToolOutput::Error { message, .. } => (message, true),
+                let (payload, is_error, class) = match &result.output {
+                    ToolOutput::Ok { content, .. } => (content, false, None),
+                    ToolOutput::Error { message, class } => (message, true, *class),
                 };
                 if payload.len() > AGE_THRESHOLD_CHARS {
                     let aged_payload = age_content(payload);
+                    // Preserve whatever class (or lack of one) the failure
+                    // already carried — aging trims prose, it must not
+                    // launder a classified failure back to "unaudited"
+                    // (#3167).
                     result.output = if is_error {
-                        ToolOutput::error(aged_payload)
+                        ToolOutput::Error {
+                            message: aged_payload,
+                            class,
+                        }
                     } else {
                         ToolOutput::Ok {
                             content: aged_payload,
@@ -782,14 +795,19 @@ pub fn compact_measured(
             }
             let before = estimate_message_tokens(message);
             for (ridx, result) in message.tool_results.iter_mut().enumerate() {
-                let (payload_len, is_error) = match &result.output {
-                    ToolOutput::Ok { content, .. } => (content.len(), false),
-                    ToolOutput::Error { message, .. } => (message.len(), true),
+                let (payload_len, is_error, class) = match &result.output {
+                    ToolOutput::Ok { content, .. } => (content.len(), false, None),
+                    ToolOutput::Error { message, class } => (message.len(), true, *class),
                 };
                 if payload_len > 400 {
                     evicted_blocks.push(id_at(idx, ridx));
+                    // Same preservation as the aging pass above: eviction
+                    // replaces the prose, not the audited class (#3167).
                     result.output = if is_error {
-                        ToolOutput::error(EVICTION_STUB.to_string())
+                        ToolOutput::Error {
+                            message: EVICTION_STUB.to_string(),
+                            class,
+                        }
                     } else {
                         ToolOutput::Ok {
                             content: EVICTION_STUB.to_string(),

--- a/crates/stella-core/src/compaction/tests.rs
+++ b/crates/stella-core/src/compaction/tests.rs
@@ -3,7 +3,7 @@
 //! stay reachable, split out to keep `compaction.rs` under the size gate.
 
 use super::*;
-use stella_protocol::{ToolCall, ToolResult};
+use stella_protocol::{ErrorClass, ToolCall, ToolResult};
 
 fn tool_msg(call_id: &str, content: String) -> CompletionMessage {
     CompletionMessage {
@@ -897,6 +897,77 @@ fn large_error_output_is_evicted_like_large_ok() {
     match &messages[2].tool_results[0].output {
         ToolOutput::Error { message, .. } => assert!(message.contains("evicted")),
         _ => panic!("expected an eviction stub that keeps the error variant"),
+    }
+}
+
+#[test]
+fn aging_preserves_the_original_errors_class() {
+    // #3167: aging must not launder an already-classified failure back to
+    // "unaudited" by reconstructing it through the unclassified `error()`
+    // constructor. Witness: on the pre-fix code this assertion sees `None`
+    // (aging always rebuilt via `ToolOutput::error`, dropping `class`).
+    let body = format!("HEADLINE\n{}\nTAILLINE", "filler ".repeat(6000));
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        assistant_with_call("c1"),
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::classified_error(ErrorClass::NotFound, body),
+            }],
+            attachments: Vec::new(),
+        },
+        assistant_with_call("c2"),
+        tool_msg("c2", "recent ".repeat(50)),
+    ];
+    let report = compact(&mut messages, 2_000).expect("should compact");
+    assert!(report.aged >= 1, "{report:?}");
+    match &messages[2].tool_results[0].output {
+        ToolOutput::Error { class, .. } => {
+            assert_eq!(
+                *class,
+                Some(ErrorClass::NotFound),
+                "class must survive aging"
+            );
+        }
+        other => panic!("expected an aged Error, got {other:?}"),
+    }
+}
+
+#[test]
+fn eviction_preserves_the_original_errors_class() {
+    // Same witness as aging, for the eviction pass (#3167): reconstructing
+    // via `ToolOutput::error` on the old code reset `class` to `None`.
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        assistant_with_call("c1"),
+        CompletionMessage {
+            role: MessageRole::Tool,
+            content: String::new(),
+            tool_calls: vec![],
+            tool_results: vec![ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::classified_error(ErrorClass::Environment, "boom ".repeat(300)),
+            }],
+            attachments: Vec::new(),
+        },
+        assistant_with_call("c2"),
+        tool_msg("c2", "recent ".repeat(50)),
+    ];
+    let report = compact(&mut messages, 200).expect("should compact");
+    assert!(report.evicted >= 1, "{report:?}");
+    match &messages[2].tool_results[0].output {
+        ToolOutput::Error { class, .. } => {
+            assert_eq!(
+                *class,
+                Some(ErrorClass::Environment),
+                "class must survive eviction"
+            );
+        }
+        other => panic!("expected an evicted Error, got {other:?}"),
     }
 }
 

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -1612,15 +1612,18 @@ impl<'a> Engine<'a> {
         };
         match tokio::time::timeout(limit, self.dispatch_tool_call(call, read_only, events)).await {
             Ok(output) => output,
-            Err(_) => ToolOutput::error(format!(
-                "tool `{}` exceeded the engine's {}s dispatch ceiling and was abandoned \
+            Err(_) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Timeout,
+                format!(
+                    "tool `{}` exceeded the engine's {}s dispatch ceiling and was abandoned \
                      before it returned — it produced no result, and any work it had already \
                      done outside this process may or may not have landed. This backstop fires \
                      only when a tool overruns its own timeout, so an identical retry will \
                      likely hang the same way: narrow the input, or reach the goal another way.",
-                call.name,
-                limit.as_secs()
-            )),
+                    call.name,
+                    limit.as_secs()
+                ),
+            ),
         }
     }
 }

--- a/crates/stella-core/src/driver/dispatch.rs
+++ b/crates/stella-core/src/driver/dispatch.rs
@@ -209,7 +209,14 @@ impl<'a> Engine<'a> {
                 if answered.contains(&index) {
                     continue;
                 }
-                let output = ToolOutput::error(HALTED_TOOL_RESULT.to_string());
+                // The engine chose not to run this call because the goal was
+                // already proven met — working as designed, mirroring
+                // `close_open_tool_calls`' own `RefusedByPolicy` for the same
+                // shape of synthetic closure, never `Internal`.
+                let output = ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    HALTED_TOOL_RESULT.to_string(),
+                );
                 let _ = events.send(AgentEvent::ToolResult {
                     call_id: call.call_id.clone(),
                     output: output.clone(),

--- a/crates/stella-core/src/driver/user_hooks.rs
+++ b/crates/stella-core/src/driver/user_hooks.rs
@@ -209,12 +209,15 @@ impl<'a> Engine<'a> {
         events: Option<&EventSender>,
     ) -> ToolOutput {
         if call.input.is_null() {
-            return ToolOutput::error(format!(
-                "malformed tool call: `{}`'s arguments were not valid JSON (the model's \
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                format!(
+                    "malformed tool call: `{}`'s arguments were not valid JSON (the model's \
                      streamed output didn't parse) — retry this call with well-formed JSON \
                      arguments",
-                call.name
-            ));
+                    call.name
+                ),
+            );
         }
         match self.hooks {
             None => self.tools.execute(&call.name, &call.input).await,
@@ -263,19 +266,25 @@ impl<'a> Engine<'a> {
         // either feed the same ladder with them.
         match pre.verdict(&OperatorPosture::NoOpinion, false) {
             GateVerdict::Deny { reason } => {
-                return ToolOutput::error(format!(
-                    "tool `{}` was blocked by a PreToolUse hook: {reason}",
-                    call.name
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "tool `{}` was blocked by a PreToolUse hook: {reason}",
+                        call.name
+                    ),
+                );
             }
             GateVerdict::RequireApproval { reason } => {
                 let Some(route) = self.hook_approvals else {
-                    return ToolOutput::error(format!(
-                        "tool `{}` requires approval — a PreToolUse hook asked for a human \
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::RefusedByPolicy,
+                        format!(
+                            "tool `{}` requires approval — a PreToolUse hook asked for a human \
                              decision ({reason}), but no interactive surface is attached to \
                              answer it; grant the call via policy or rerun interactively",
-                        call.name
-                    ));
+                            call.name
+                        ),
+                    );
                 };
                 let request = ApprovalRouteRequest {
                     subject: ApprovalSubject::Tool {
@@ -287,10 +296,10 @@ impl<'a> Engine<'a> {
                 match route.resolve(&request).await {
                     ApprovalRouteResolution::Approved => {}
                     ApprovalRouteResolution::Denied { reason } => {
-                        return ToolOutput::error(format!(
-                            "tool `{}` requires approval — {reason}",
-                            call.name
-                        ));
+                        return ToolOutput::classified_error(
+                            stella_protocol::ErrorClass::RefusedByPolicy,
+                            format!("tool `{}` requires approval — {reason}", call.name),
+                        );
                     }
                 }
             }

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -359,10 +359,13 @@ impl ToolExecutor for ReadOnlyTools<'_> {
     async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
         let allowed = self.read_only_names.contains(name);
         if !allowed {
-            return ToolOutput::error(format!(
-                "`{name}` is not available here: this context is read-only (verification/\
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "`{name}` is not available here: this context is read-only (verification/\
                      judging) and may only use read-only tools"
-            ));
+                ),
+            );
         }
         self.inner.execute(name, input).await
     }
@@ -463,10 +466,13 @@ impl ToolExecutor for GrantedTools<'_> {
 
     async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
         if !self.granted.contains(name) {
-            return ToolOutput::error(format!(
-                "`{name}` is not available here: this context is scoped to an \
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "`{name}` is not available here: this context is scoped to an \
                      explicitly granted tool set (a skill's allowed-tools)"
-            ));
+                ),
+            );
         }
         self.inner.execute(name, input).await
     }

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -759,7 +759,14 @@ pub(crate) fn close_open_tool_calls(
             .into_iter()
             .map(|call| ToolResult {
                 call_id: call.call_id.clone(),
-                output: ToolOutput::error(message.to_string()),
+                // Every caller closes an open call here because the *engine*
+                // decided to stop the turn (cancel, budget abort, soft-stop,
+                // provider fallback) — working as designed, never a tool
+                // defect, so this is a policy-plane refusal, not `Internal`.
+                output: ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    message.to_string(),
+                ),
             })
             .collect()
     };

--- a/crates/stella-mcp/src/client.rs
+++ b/crates/stella-mcp/src/client.rs
@@ -869,7 +869,10 @@ mod tests {
         );
 
         let err = client.call_tool("t", serde_json::json!({})).await.unwrap();
-        assert_eq!(err, ToolOutput::error("boom"));
+        assert_eq!(
+            err,
+            ToolOutput::classified_error(stella_protocol::ErrorClass::Environment, "boom")
+        );
     }
 
     #[tokio::test]

--- a/crates/stella-mcp/src/client/ingest.rs
+++ b/crates/stella-mcp/src/client/ingest.rs
@@ -209,11 +209,14 @@ pub(super) fn decode_call_result(tool: &str, raw: Value) -> Result<ToolOutput, M
         rendered
     };
     if result.is_error {
-        Ok(ToolOutput::error(if rendered.is_empty() {
-            format!("tool `{tool}` reported an error with no detail")
-        } else {
-            rendered
-        }))
+        Ok(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            if rendered.is_empty() {
+                format!("tool `{tool}` reported an error with no detail")
+            } else {
+                rendered
+            },
+        ))
     } else {
         Ok(ToolOutput::Ok {
             content: rendered,

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -612,11 +612,14 @@ impl McpToolSet {
                 }
                 output
             }
-            Err(err) => ToolOutput::error(format!(
-                "mcp server `{}` failed calling `{raw_tool}`: {}",
-                client.name(),
-                err.user_message()
-            )),
+            Err(err) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!(
+                    "mcp server `{}` failed calling `{raw_tool}`: {}",
+                    client.name(),
+                    err.user_message()
+                ),
+            ),
         }
     }
 }
@@ -810,10 +813,13 @@ impl McpToolSet {
         if let Some((idx, raw_tool)) = self.routes.get(name) {
             let client = &self.clients[*idx];
             if self.is_disabled(client.name()) {
-                return ToolOutput::error(format!(
-                    "mcp server `{}` is disabled for this session — tool `{name}` unavailable",
-                    client.name()
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "mcp server `{}` is disabled for this session — tool `{name}` unavailable",
+                        client.name()
+                    ),
+                );
             }
             return self.execute_mcp(client, raw_tool, input).await;
         }
@@ -829,9 +835,10 @@ impl McpToolSet {
         }
         // A namespaced name we don't recognize is an MCP miss, not a native
         // tool — never fall through to native for it.
-        ToolOutput::error(format!(
-            "unknown MCP tool `{name}` — not advertised by any connected server"
-        ))
+        ToolOutput::classified_error(
+            stella_protocol::ErrorClass::NotFound,
+            format!("unknown MCP tool `{name}` — not advertised by any connected server"),
+        )
     }
 }
 
@@ -915,9 +922,10 @@ impl ToolExecutor for McpToolSet {
         }
         match &self.native {
             Some(native) => native.execute(name, input).await,
-            None => ToolOutput::error(format!(
-                "unknown tool `{name}` (no native tools configured)"
-            )),
+            None => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::NotFound,
+                format!("unknown tool `{name}` (no native tools configured)"),
+            ),
         }
     }
 
@@ -1018,10 +1026,13 @@ impl ToolExecutor for CandidateMcpView {
             return if self.inner.is_candidate_safe_tool(name) {
                 self.inner.execute(name, input).await
             } else {
-                ToolOutput::error(format!(
-                    "mcp tool `{name}` is withheld from Best-of-N candidates — its \
+                ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "mcp tool `{name}` is withheld from Best-of-N candidates — its \
                          server is not marked `candidate_safe` in .stella/mcp.toml"
-                ))
+                    ),
+                )
             };
         }
         self.native.execute(name, input).await

--- a/crates/stella-mcp/src/toolset/needs_auth.rs
+++ b/crates/stella-mcp/src/toolset/needs_auth.rs
@@ -60,9 +60,12 @@ pub(super) fn route(set: &super::McpToolSet, name: &str) -> Option<ToolOutput> {
         .iter()
         .find(|(server, _)| name == login_required_tool_name(server))?;
     if set.is_disabled(server) {
-        return Some(ToolOutput::error(format!(
-            "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
-        )));
+        return Some(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::RefusedByPolicy,
+            format!(
+                "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
+            ),
+        ));
     }
     Some(login_required_output(server))
 }
@@ -235,6 +238,29 @@ mod tests {
         // Re-enabling brings the placeholder back, live.
         disabled.lock().unwrap().clear();
         assert_eq!(set.schemas().len(), 1);
+    }
+
+    /// #3167 witness: a session-disabled server's placeholder answer is
+    /// classified `RefusedByPolicy`, byte-identical to the pre-#3167 message.
+    /// Fails on the pre-#3167 tree, where `class` is always `None`.
+    #[tokio::test]
+    async fn a_disabled_servers_placeholder_error_is_classified_refused_by_policy() {
+        use stella_core::ports::ToolExecutor as _;
+        let disabled: DisabledServers = Arc::new(Mutex::new(HashSet::new()));
+        disabled.lock().unwrap().insert("github".to_string());
+        let set = suppressed_set("github").with_disabled_servers(disabled);
+
+        let result = set
+            .execute("mcp__github__login_required", &serde_json::Value::Null)
+            .await;
+        assert_eq!(
+            result,
+            ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                "mcp server `github` is disabled for this session — tool \
+                 `mcp__github__login_required` unavailable"
+            )
+        );
     }
 
     #[test]

--- a/crates/stella-mcp/src/toolset/resources.rs
+++ b/crates/stella-mcp/src/toolset/resources.rs
@@ -112,9 +112,12 @@ pub(super) async fn route(
             continue;
         }
         if set.is_disabled(server) {
-            return Some(ToolOutput::error(format!(
-                "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
-            )));
+            return Some(ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
+                ),
+            ));
         }
         let output = if is_list {
             run_list(client, input).await
@@ -211,7 +214,10 @@ async fn run_list(client: &McpClient, input: &Value) -> ToolOutput {
         None | Some(Value::Null) => None,
         Some(Value::String(cursor)) => Some(cursor.as_str()),
         Some(other) => {
-            return ToolOutput::error(format!("argument `cursor` must be a string, got: {other}"));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                format!("argument `cursor` must be a string, got: {other}"),
+            );
         }
     };
     match client.list_resources(cursor).await {
@@ -219,11 +225,14 @@ async fn run_list(client: &McpClient, input: &Value) -> ToolOutput {
             content: bounded(render_listing(client.name(), &page)),
             data: None,
         },
-        Err(err) => ToolOutput::error(format!(
-            "mcp server `{}` failed listing resources: {}",
-            client.name(),
-            err.user_message()
-        )),
+        Err(err) => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            format!(
+                "mcp server `{}` failed listing resources: {}",
+                client.name(),
+                err.user_message()
+            ),
+        ),
     }
 }
 
@@ -232,10 +241,13 @@ async fn run_read(client: &McpClient, input: &Value) -> ToolOutput {
     let uri = match input.get("uri") {
         Some(Value::String(uri)) if !uri.is_empty() => uri.as_str(),
         _ => {
-            return ToolOutput::error(format!(
-                "tool `{}` requires a string `uri` argument naming the resource to read",
-                read_resource_tool_name(client.name())
-            ));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                format!(
+                    "tool `{}` requires a string `uri` argument naming the resource to read",
+                    read_resource_tool_name(client.name())
+                ),
+            );
         }
     };
     match client.read_resource(uri).await {
@@ -243,11 +255,14 @@ async fn run_read(client: &McpClient, input: &Value) -> ToolOutput {
             content: bounded(render_read(client.name(), uri, &read)),
             data: None,
         },
-        Err(err) => ToolOutput::error(format!(
-            "mcp server `{}` failed reading resource `{uri}`: {}",
-            client.name(),
-            err.user_message()
-        )),
+        Err(err) => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            format!(
+                "mcp server `{}` failed reading resource `{uri}`: {}",
+                client.name(),
+                err.user_message()
+            ),
+        ),
     }
 }
 

--- a/crates/stella-mcp/src/toolset/tests.rs
+++ b/crates/stella-mcp/src/toolset/tests.rs
@@ -875,9 +875,13 @@ async fn an_under_budget_json_rpc_error_message_is_passed_through_verbatim() {
     client.initialize().await.unwrap();
     let set = McpToolSet::from_clients(vec![client]);
 
+    // Byte-equality witness for #3167: classifying this site must not perturb
+    // the message a caller already depended on being passed through verbatim
+    // — only the new `class` field may differ from the pre-#3167 shape.
     assert_eq!(
         set.execute("mcp__files__boom", &Value::Null).await,
-        ToolOutput::error(
+        ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
             "mcp server `files` failed calling `boom`: json-rpc error -32602: \
                       unknown argument `pth`"
         )

--- a/crates/stella-serve/src/remote.rs
+++ b/crates/stella-serve/src/remote.rs
@@ -538,7 +538,8 @@ impl ToolExecutor for RemoteToolExecutor {
         // data. Cancellation therefore ends the turn one step later, at the
         // provider port, which *can* report `ProviderError::Cancelled`.
         if self.pending.is_cancelled() {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "turn cancelled before the tool call could be dispatched".to_string(),
             );
         }
@@ -647,7 +648,8 @@ impl RemoteToolExecutor {
         // landing between the check above and this call must not park the step
         // until its deadline.
         if !self.pending.register_tool(request_id.clone(), tx) {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "turn cancelled before the tool call could be dispatched".to_string(),
             );
         }
@@ -661,7 +663,8 @@ impl RemoteToolExecutor {
             .is_err()
         {
             self.pending.abandon(&request_id);
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "serve host disconnected before the tool call could be dispatched".to_string(),
             );
         }
@@ -671,20 +674,25 @@ impl RemoteToolExecutor {
                 answered(&self.pending, &request_id, ReverseKind::Tool, started);
                 output
             }
-            Ok(Err(_)) if self.pending.is_cancelled() => {
-                ToolOutput::error("turn cancelled while the tool call was in flight".to_string())
-            }
-            Ok(Err(_)) => {
-                ToolOutput::error("serve host dropped the tool call without answering".to_string())
-            }
+            Ok(Err(_)) if self.pending.is_cancelled() => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                "turn cancelled while the tool call was in flight".to_string(),
+            ),
+            Ok(Err(_)) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                "serve host dropped the tool call without answering".to_string(),
+            ),
             Err(_) => {
                 self.pending.abandon(&request_id);
                 timed_out(&self.pending, &request_id, ReverseKind::Tool, started);
-                ToolOutput::error(format!(
-                    "serve host did not answer the `{name}` tool call within {:?} \
+                ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Timeout,
+                    format!(
+                        "serve host did not answer the `{name}` tool call within {:?} \
                          (reverse-request deadline)",
-                    self.timeout
-                ))
+                        self.timeout
+                    ),
+                )
             }
         }
     }

--- a/crates/stella-serve/src/remote/tests.rs
+++ b/crates/stella-serve/src/remote/tests.rs
@@ -199,6 +199,44 @@ async fn a_tool_call_the_host_never_answers_still_reports_an_outcome() {
     );
 }
 
+/// #3167 witness: a reverse-request deadline is classified `Timeout`, and the
+/// message bytes are exactly what they were before classification — the loop
+/// detector and prompt cache compare these bytes. Fails on the pre-#3167
+/// tree, where `class` is always `None`.
+#[tokio::test]
+async fn a_reverse_request_deadline_is_classified_timeout_with_unchanged_message_bytes() {
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let sink = crate::backlog::FrameSink::new(
+        tx,
+        crate::backlog::FrameBacklog::new(crate::backlog::DEFAULT_MAX_QUEUED_FRAMES),
+    );
+    let pending = Pending::new(
+        crate::observe::null_observer(),
+        TurnRef::new("turn-remotetest-timeout-class"),
+    );
+    let timeout = std::time::Duration::from_millis(20);
+    let port = RemoteToolExecutor::new(
+        Vec::new(),
+        std::sync::Arc::new(stella_core::ports::NoAuthz),
+        stella_core::ports::Principal::Host("test".to_string()),
+        sink,
+        pending,
+        timeout,
+        None,
+    );
+    let output = port.execute("echo", &serde_json::json!({})).await;
+    assert_eq!(
+        output,
+        ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Timeout,
+            format!(
+                "serve host did not answer the `echo` tool call within {timeout:?} \
+                 (reverse-request deadline)"
+            ),
+        )
+    );
+}
+
 /// A fresh, connected reverse-RPC channel triple: the pending registry, a
 /// frame receiver a test can drain, and the sink both new ports
 /// (#1288) are constructed over.

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -471,7 +471,8 @@ impl ToolExecutor for DelegatingTools<'_> {
             .map(str::trim)
             .filter(|prompt| !prompt.is_empty())
         else {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
                 "missing required string field `prompt` — the sub-agent cannot see \
                      this conversation, so the question must be self-contained",
             );
@@ -569,14 +570,20 @@ fn render(outcome: &SubAgentOutcome) -> ToolOutput {
                 data: None,
             }
         }
-        SubAgentOutcome::Incomplete { reason, .. } => ToolOutput::error(format!(
-            "the sub-agent stopped before producing anything: {reason} — do the work \
+        SubAgentOutcome::Incomplete { reason, .. } => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            format!(
+                "the sub-agent stopped before producing anything: {reason} — do the work \
                  directly, or ask a narrower question"
-        )),
-        SubAgentOutcome::Refused { reason } => ToolOutput::error(format!(
-            "the sub-agent was not started: {reason} — do the work directly with your \
+            ),
+        ),
+        SubAgentOutcome::Refused { reason } => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::RefusedByPolicy,
+            format!(
+                "the sub-agent was not started: {reason} — do the work directly with your \
                  own tools"
-        )),
+            ),
+        ),
     }
 }
 

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -511,7 +511,10 @@ impl Tool for Bash {
         // Read `shell_write_audit` on why this permits far more than it
         // refuses, and on why it is not a sandbox.
         if let Some(refusal) = shell_write_audit(command, ctx) {
-            return ToolOutput::error(refusal);
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                refusal,
+            );
         }
 
         let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
@@ -562,7 +565,10 @@ impl Tool for Bash {
         let child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
-                return ToolOutput::error(format!("failed to spawn: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("failed to spawn: {e}"),
+                );
             }
         };
 
@@ -591,7 +597,10 @@ impl Tool for Bash {
             // Wait failure leaves the child's state unknown — the still-armed
             // guard kills the group on return rather than leak it.
             Ok(Err(e)) => {
-                return ToolOutput::error(format!("command failed: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("command failed: {e}"),
+                );
             }
             Err(_) => {
                 // Timeout — kill the process group.
@@ -641,7 +650,7 @@ impl Tool for Bash {
         if output.status.success() {
             ToolOutput::ok(combined)
         } else {
-            ToolOutput::error(combined)
+            ToolOutput::classified_error(stella_protocol::ErrorClass::Environment, combined)
         }
     }
 }
@@ -794,6 +803,25 @@ mod tests {
         }
     }
 
+    /// #3167 witness: a nonzero exit is classified `Environment` and the
+    /// message bytes are exactly what they were before classification — the
+    /// loop detector and prompt cache compare these bytes. Fails on the
+    /// pre-#3167 tree, where `class` is always `None`.
+    #[tokio::test]
+    async fn nonzero_exit_is_classified_environment_with_unchanged_message_bytes() {
+        let dir = std::env::temp_dir();
+        let result = Bash::new(None)
+            .execute(&serde_json::json!({"command": "exit 42"}), &cx(&dir))
+            .await;
+        assert_eq!(
+            result,
+            ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                "\n[exit code: 42]"
+            )
+        );
+    }
+
     #[tokio::test]
     async fn timeout_kills_command() {
         let dir = std::env::temp_dir();
@@ -807,6 +835,27 @@ mod tests {
         if let ToolOutput::Error { message, .. } = result {
             assert!(message.contains("timed out"))
         }
+    }
+
+    /// #3167 witness: a timeout is classified `Timeout` and the message bytes
+    /// are exactly what they were before classification. Fails on the
+    /// pre-#3167 tree, where `class` is always `None`.
+    #[tokio::test]
+    async fn timeout_is_classified_timeout_with_unchanged_message_bytes() {
+        let dir = std::env::temp_dir();
+        let result = Bash::new(None)
+            .execute(
+                &serde_json::json!({"command": "sleep 30", "timeout_secs": 1}),
+                &cx(&dir),
+            )
+            .await;
+        assert_eq!(
+            result,
+            ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Timeout,
+                "command timed out after 1s"
+            )
+        );
     }
 
     /// Dropping the future mid-wait (a cancelled turn) must kill the whole

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -815,7 +815,7 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
     // and this is the point of use, so the approval is checked against what is
     // about to be spawned rather than against what was scanned.
     if let Err(message) = crate::foundry_gate::recheck_before_launch(tool, workspace_root) {
-        return ToolOutput::error(message);
+        return ToolOutput::classified_error(stella_protocol::ErrorClass::RefusedByPolicy, message);
     }
 
     let mut cmd = Command::new(&tool.command[0]);
@@ -862,12 +862,15 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
     let mut child = match spawn_retrying_etxtbsy(&mut cmd).await {
         Ok(c) => c,
         Err(e) => {
-            return ToolOutput::error(format!(
-                "custom tool `{}` failed to spawn `{}` (cwd {}): {e}",
-                tool.name,
-                tool.command[0],
-                workspace_root.display()
-            ));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!(
+                    "custom tool `{}` failed to spawn `{}` (cwd {}): {e}",
+                    tool.name,
+                    tool.command[0],
+                    workspace_root.display()
+                ),
+            );
         }
     };
 
@@ -905,14 +908,20 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
         // Wait failure leaves the child's state unknown — the still-armed
         // guard kills the group on return rather than leak it.
         Ok(Err(e)) => {
-            return ToolOutput::error(format!("custom tool `{}` failed: {e}", tool.name));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("custom tool `{}` failed: {e}", tool.name),
+            );
         }
         Err(_) => {
             guard.kill_now();
-            return ToolOutput::error(format!(
-                "custom tool `{}` timed out after {}ms",
-                tool.name, tool.timeout_ms
-            ));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Timeout,
+                format!(
+                    "custom tool `{}` timed out after {}ms",
+                    tool.name, tool.timeout_ms
+                ),
+            );
         }
     };
 
@@ -967,10 +976,13 @@ async fn run_custom(tool: &CustomTool, input: &Value, workspace_root: &Path) -> 
             .map(|c| c.to_string())
             .unwrap_or_else(|| "signal".to_string());
         let tail = crate::exec::truncate_middle_capped(&stderr, MAX_OUTPUT_BYTES);
-        ToolOutput::error(format!(
-            "custom tool `{}` exited with code {code}\n[stderr]\n{tail}",
-            tool.name
-        ))
+        ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            format!(
+                "custom tool `{}` exited with code {code}\n[stderr]\n{tail}",
+                tool.name
+            ),
+        )
     }
 }
 

--- a/crates/stella-tools/src/delete.rs
+++ b/crates/stella-tools/src/delete.rs
@@ -132,14 +132,20 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         let (scope_root, path) = match ctx.resolve_for_write(target) {
             Ok(resolved) => resolved,
             Err(refusal) => {
-                return ToolOutput::error(format!(
-                    "`{FILES_KEY}`[{index}] (`{target}`): {refusal} — nothing was deleted"
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    format!("`{FILES_KEY}`[{index}] (`{target}`): {refusal} — nothing was deleted"),
+                );
             }
         };
         let handle = match RootHandle::open(&scope_root) {
             Ok(handle) => std::sync::Arc::new(handle),
-            Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+            Err(e) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("cannot open workspace root: {e}"),
+                );
+            }
         };
         let kind = tokio::task::spawn_blocking({
             let (handle, path) = (std::sync::Arc::clone(&handle), path.clone());
@@ -157,19 +163,41 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
             // single form has always said so. Collapsing them here would tell
             // a model that `sub/..` "is not a file", which is true and useless.
             Ok(Err(e)) if e.is_escape() => {
-                return ToolOutput::error(format!(
-                    "`{FILES_KEY}`[{index}]: path `{path}` escapes the workspace root ({e}) — \
-                     nothing was deleted"
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    format!(
+                        "`{FILES_KEY}`[{index}]: path `{path}` escapes the workspace root ({e}) — \
+                         nothing was deleted"
+                    ),
+                );
             }
-            Ok(Ok(_)) | Ok(Err(_)) => {
-                return ToolOutput::error(format!(
-                    "`{FILES_KEY}`[{index}]: `{path}` is not a file (directories and missing \
-                     paths are not deletable with this tool) — nothing was deleted"
-                ));
+            // Split from the escape arm above so a genuine mistake ("that's a
+            // directory") and a race ("it's gone already") each carry their
+            // own class, even though both still read as the one message this
+            // tool has always given a caller that named a non-file target.
+            Ok(Ok(_)) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "`{FILES_KEY}`[{index}]: `{path}` is not a file (directories and missing \
+                         paths are not deletable with this tool) — nothing was deleted"
+                    ),
+                );
+            }
+            Ok(Err(_)) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::NotFound,
+                    format!(
+                        "`{FILES_KEY}`[{index}]: `{path}` is not a file (directories and missing \
+                         paths are not deletable with this tool) — nothing was deleted"
+                    ),
+                );
             }
             Err(e) => {
-                return ToolOutput::error(format!("could not inspect `{path}`: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Internal,
+                    format!("could not inspect `{path}`: {e}"),
+                );
             }
         }
     }
@@ -196,7 +224,7 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         // the unlink itself failed. Nothing can be undone at this point, so
         // the report names exactly what is already gone rather than implying
         // the batch was atomic.
-        let failure = match outcome {
+        let (class, failure) = match outcome {
             Ok(Ok(before)) => {
                 if let Some(before) = before {
                     changes.push(crate::own_change::own_delete(
@@ -207,15 +235,22 @@ async fn delete_batch(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
                 removed.push(path);
                 continue;
             }
-            Ok(Err(e)) => e.to_string(),
-            Err(e) => e.to_string(),
+            // The checks all passed, so a failed unlink here is the
+            // filesystem itself refusing (readonly, immutable, a race) —
+            // distinct from the join failure below, which is our own
+            // runtime, not the filesystem.
+            Ok(Err(e)) => (stella_protocol::ErrorClass::PermissionDenied, e.to_string()),
+            Err(e) => (stella_protocol::ErrorClass::Internal, e.to_string()),
         };
-        return ToolOutput::error(format!(
-            "could not delete `{path}`: {failure} — this batch had already deleted {} file(s): \
-             {}",
-            removed.len(),
-            removed.join(", ")
-        ));
+        return ToolOutput::classified_error(
+            class,
+            format!(
+                "could not delete `{path}`: {failure} — this batch had already deleted {} \
+                 file(s): {}",
+                removed.len(),
+                removed.join(", ")
+            ),
+        );
     }
     crate::own_change::attach(
         ToolOutput::ok(format!(
@@ -238,13 +273,21 @@ async fn delete_one(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
     // scope is consulted before the descriptor walk starts.
     let (scope_root, path) = match ctx.resolve_for_write(path) {
         Ok(resolved) => resolved,
-        Err(refusal) => return ToolOutput::error(refusal.to_string()),
+        Err(refusal) => {
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::PermissionDenied,
+                refusal.to_string(),
+            );
+        }
     };
     let path = path.as_str();
     let handle = match RootHandle::open(&scope_root) {
         Ok(handle) => std::sync::Arc::new(handle),
         Err(e) => {
-            return ToolOutput::error(format!("cannot open workspace root: {e}"));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("cannot open workspace root: {e}"),
+            );
         }
     };
     // Classify, read the link, and unlink on one blocking worker. All three
@@ -289,23 +332,36 @@ async fn delete_one(input: &Value, ctx: &crate::ctx::ToolCtx) -> ToolOutput {
             "deleted symlink {path} — the link only; its target `{}` is untouched",
             target.display()
         )),
-        Ok(Ok(None)) => ToolOutput::error(format!(
-            "`{path}` is not a file (directories and missing paths are not deletable \
+        Ok(Ok(None)) => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
+            format!(
+                "`{path}` is not a file (directories and missing paths are not deletable \
                      with this tool)"
-        )),
-        Ok(Err(e)) if e.is_escape() => {
-            ToolOutput::error(format!("path `{path}` escapes the workspace root ({e})"))
-        }
+            ),
+        ),
+        Ok(Err(e)) if e.is_escape() => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::PermissionDenied,
+            format!("path `{path}` escapes the workspace root ({e})"),
+        ),
         // A missing path reaches here as the `stat` failing, and must read
         // as the same refusal a directory gets — this tool deletes files.
         Ok(Err(crate::rootfd::RootError::Io(e))) if e.kind() == std::io::ErrorKind::NotFound => {
-            ToolOutput::error(format!(
-                "`{path}` is not a file (directories and missing paths are not deletable \
+            ToolOutput::classified_error(
+                stella_protocol::ErrorClass::NotFound,
+                format!(
+                    "`{path}` is not a file (directories and missing paths are not deletable \
                          with this tool)"
-            ))
+                ),
+            )
         }
-        Ok(Err(e)) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
-        Err(e) => ToolOutput::error(format!("could not delete `{path}`: {e}")),
+        Ok(Err(e)) => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::PermissionDenied,
+            format!("could not delete `{path}`: {e}"),
+        ),
+        Err(e) => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Internal,
+            format!("could not delete `{path}`: {e}"),
+        ),
     }
 }
 
@@ -318,6 +374,47 @@ mod tests {
     /// context rather than the bare root path it used to (#3284).
     fn cx(root: impl AsRef<std::path::Path>) -> crate::ctx::ToolCtx {
         crate::ctx::ToolCtx::bare(root.as_ref().to_path_buf())
+    }
+
+    /// The #3167 witness: a directory and a missing path both render the
+    /// exact refusal `delete_file` has always given — the loop detector and
+    /// the prompt cache compare those bytes — but now each carries the
+    /// [`stella_protocol::ErrorClass`] its own cause earns, rather than the
+    /// `class: None` every refusal shared before this sweep classified them.
+    #[tokio::test]
+    async fn a_directory_and_a_missing_path_keep_their_shared_prose_but_split_their_class() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+        let on_a_directory = DeleteFile
+            .execute(&serde_json::json!({"path": "sub"}), &cx(dir.path()))
+            .await;
+        match on_a_directory {
+            ToolOutput::Error { message, class } => {
+                assert_eq!(
+                    message,
+                    "`sub` is not a file (directories and missing paths are not deletable \
+                     with this tool)"
+                );
+                assert_eq!(class, Some(stella_protocol::ErrorClass::InvalidInput));
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
+
+        let on_a_missing_path = DeleteFile
+            .execute(&serde_json::json!({"path": "ghost.txt"}), &cx(dir.path()))
+            .await;
+        match on_a_missing_path {
+            ToolOutput::Error { message, class } => {
+                assert_eq!(
+                    message,
+                    "`ghost.txt` is not a file (directories and missing paths are not \
+                     deletable with this tool)"
+                );
+                assert_eq!(class, Some(stella_protocol::ErrorClass::NotFound));
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -305,7 +305,8 @@ impl EditFile {
         // every char boundary — shredding the file (and allocating O(len^2)).
         // On an empty file it would silently overwrite. Refuse it outright.
         if old_string.is_empty() {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
                 "old_string must not be empty — use write_file to create or replace a \
                           whole file",
             );
@@ -325,7 +326,12 @@ impl EditFile {
         // anything is opened.
         let (scope_root, path) = match ctx.resolve_for_write(path) {
             Ok(resolved) => resolved,
-            Err(refusal) => return ToolOutput::error(refusal.to_string()),
+            Err(refusal) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    refusal.to_string(),
+                );
+            }
         };
         let path = path.as_str();
 
@@ -336,17 +342,26 @@ impl EditFile {
         let handle = match crate::rootfd::RootHandle::open(&scope_root) {
             Ok(handle) => std::sync::Arc::new(handle),
             Err(e) => {
-                return ToolOutput::error(format!("cannot open workspace root: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("cannot open workspace root: {e}"),
+                );
             }
         };
 
         let content = match crate::rootfd::read_to_string_async(&handle, path).await {
             Ok(c) => c,
             Err(e) if e.is_escape() => {
-                return ToolOutput::error(format!("path `{path}` escapes workspace root ({e})"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    format!("path `{path}` escapes workspace root ({e})"),
+                );
             }
             Err(e) => {
-                return ToolOutput::error(format!("failed to read `{path}`: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("failed to read `{path}`: {e}"),
+                );
             }
         };
 
@@ -378,42 +393,57 @@ impl EditFile {
                     // more than was shown; the unchanged-file message below
                     // still steers a confused model back to read_file.
                     self.ledger.record_known(&scope_root, path, &content);
-                    ToolOutput::error(format!(
-                        "old_string not found in `{path}` — the file CHANGED after you last \
+                    ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::NotFound,
+                        format!(
+                            "old_string not found in `{path}` — the file CHANGED after you last \
                              read it (out-of-band modification); the copy in your context is \
                              stale. Current content follows — re-issue the edit against these \
                              bytes.\n\n--- {path} (current) ---\n{}",
-                        drift_echo(&content)
-                    ))
+                            drift_echo(&content)
+                        ),
+                    )
                 }
                 Some(_) => match indentation_only_match(&content, old_string) {
                     // The needle is right and only its indentation is wrong.
                     // The generic message below is accurate but costs a ranged
                     // re-read to act on; naming the cause and echoing the
                     // file's own bytes for the span removes that round trip.
-                    Some(actual) => ToolOutput::error(format!(
-                        "old_string not found in `{path}` — but the same text IS present with \
+                    Some(actual) => ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::NotFound,
+                        format!(
+                            "old_string not found in `{path}` — but the same text IS present with \
                          different leading whitespace, so the needle was re-indented. The file \
                          is unchanged since you last saw it. Copy this span byte-exact:\n\n--- \
                          {path} (actual indentation) ---\n{actual}"
-                    )),
-                    None => ToolOutput::error(format!(
-                        "old_string not found in `{path}` — the file is unchanged since you last \
+                        ),
+                    ),
+                    None => ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::NotFound,
+                        format!(
+                            "old_string not found in `{path}` — the file is unchanged since you last \
                              saw it, so the copy in your context matches disk; check for exact \
                              whitespace/newline differences"
-                    )),
+                        ),
+                    ),
                 },
-                None => ToolOutput::error(format!(
-                    "old_string not found in `{path}` — no read of this file is recorded \
+                None => ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::NotFound,
+                    format!(
+                        "old_string not found in `{path}` — no read of this file is recorded \
                          this session; read it first and copy old_string byte-exact"
-                )),
+                    ),
+                ),
             };
         };
         let count = content.matches(old_string).count();
         if count > 1 && !replace_all {
-            return ToolOutput::error(format!(
-                "old_string appears {count} times in `{path}` — set replace_all=true or provide a more specific string"
-            ));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                format!(
+                    "old_string appears {count} times in `{path}` — set replace_all=true or provide a more specific string"
+                ),
+            );
         }
 
         let new_content = if replace_all {
@@ -455,7 +485,10 @@ impl EditFile {
                     &[change],
                 )
             }
-            Err(e) => ToolOutput::error(format!("failed to write `{path}`: {e}")),
+            Err(e) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("failed to write `{path}`: {e}"),
+            ),
         }
     }
 
@@ -488,17 +521,23 @@ impl EditFile {
             let (scope_root, path) = match ctx.resolve_for_write(&target.path) {
                 Ok(resolved) => resolved,
                 Err(refusal) => {
-                    return ToolOutput::error(format!(
-                        "`{EDITS_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
-                        target.path
-                    ));
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::PermissionDenied,
+                        format!(
+                            "`{EDITS_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
+                            target.path
+                        ),
+                    );
                 }
             };
             if target.old_string.is_empty() {
-                return ToolOutput::error(format!(
-                    "`{EDITS_KEY}`[{index}] (`{path}`): old_string must not be empty — use \
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "`{EDITS_KEY}`[{index}] (`{path}`): old_string must not be empty — use \
                      write_file to create or replace a whole file. Nothing was written."
-                ));
+                    ),
+                );
             }
 
             // One load per file. Every later edit to it composes on the
@@ -513,16 +552,22 @@ impl EditFile {
                     let handle = match crate::rootfd::RootHandle::open(&scope_root) {
                         Ok(handle) => Arc::new(handle),
                         Err(e) => {
-                            return ToolOutput::error(format!("cannot open workspace root: {e}"));
+                            return ToolOutput::classified_error(
+                                stella_protocol::ErrorClass::Environment,
+                                format!("cannot open workspace root: {e}"),
+                            );
                         }
                     };
                     let content = match crate::rootfd::read_to_string_async(&handle, &path).await {
                         Ok(content) => content,
                         Err(e) => {
-                            return ToolOutput::error(format!(
-                                "`{EDITS_KEY}`[{index}]: failed to read `{path}`: {e} — nothing \
+                            return ToolOutput::classified_error(
+                                stella_protocol::ErrorClass::Environment,
+                                format!(
+                                    "`{EDITS_KEY}`[{index}]: failed to read `{path}`: {e} — nothing \
                                  was written"
-                            ));
+                                ),
+                            );
                         }
                     };
                     pending.push(Pending {
@@ -550,15 +595,21 @@ impl EditFile {
 
             let current = &pending[slot].content;
             if !current.contains(old_string) {
-                return ToolOutput::error(self.batch_miss(&pending[slot], index, old_string));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::NotFound,
+                    self.batch_miss(&pending[slot], index, old_string),
+                );
             }
             let count = current.matches(old_string).count();
             if count > 1 && !target.replace_all {
-                return ToolOutput::error(format!(
-                    "`{EDITS_KEY}`[{index}]: old_string appears {count} times in `{}` — set \
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "`{EDITS_KEY}`[{index}]: old_string appears {count} times in `{}` — set \
                      replace_all=true or provide a more specific string. Nothing was written.",
-                    pending[slot].path
-                ));
+                        pending[slot].path
+                    ),
+                );
             }
             pending[slot].content = if target.replace_all {
                 current.replace(old_string, new_string)
@@ -575,7 +626,12 @@ impl EditFile {
         for file in &pending {
             let handle = match crate::rootfd::RootHandle::open(&file.scope_root) {
                 Ok(handle) => Arc::new(handle),
-                Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+                Err(e) => {
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::Environment,
+                        format!("cannot open workspace root: {e}"),
+                    );
+                }
             };
             if let Err(e) = crate::durable_write::write_file_durably_at(
                 handle,
@@ -585,7 +641,10 @@ impl EditFile {
             )
             .await
             {
-                return ToolOutput::error(format!("failed to write `{}`: {e}", file.path));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("failed to write `{}`: {e}", file.path),
+                );
             }
             // The model knows the bytes it just produced — record them so its
             // own edit is never later misattributed as drift.
@@ -699,6 +758,35 @@ mod tests {
         assert_eq!(indentation_only_match("  keep  \n", "keep"), None);
         // Nothing to have mis-indented.
         assert_eq!(indentation_only_match("\n\n", "   "), None);
+    }
+
+    /// The #3167 witness: `edit_file`'s "no read recorded" refusal renders
+    /// the exact prose it always has — the loop detector and the prompt
+    /// cache compare those bytes — but now carries the honest
+    /// [`stella_protocol::ErrorClass::NotFound`] instead of the `class: None`
+    /// every refusal shared before this sweep classified them.
+    #[tokio::test]
+    async fn a_needle_missing_with_no_prior_read_keeps_its_prose_and_gains_a_class() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.rs"), "fn main() {}\n").unwrap();
+
+        let result = EditFile::default()
+            .execute(
+                &serde_json::json!({"path": "f.rs", "old_string": "nope", "new_string": "x"}),
+                &cx(dir.path()),
+            )
+            .await;
+        match result {
+            ToolOutput::Error { message, class } => {
+                assert_eq!(
+                    message,
+                    "old_string not found in `f.rs` — no read of this file is recorded \
+                     this session; read it first and copy old_string byte-exact"
+                );
+                assert_eq!(class, Some(stella_protocol::ErrorClass::NotFound));
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -515,7 +515,10 @@ impl ReadFile {
         // `stella_core::workspace_scope` on why a parallel checkout of the
         // same repository is the read an agent must not silently get.
         if let Some(refusal) = ctx.refuse_read(path) {
-            return ToolOutput::error(refusal);
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::PermissionDenied,
+                refusal,
+            );
         }
 
         // Read from whichever allowed root holds this path, not from the
@@ -541,7 +544,10 @@ impl ReadFile {
         let handle = match crate::rootfd::RootHandle::open(&root) {
             Ok(handle) => std::sync::Arc::new(handle),
             Err(e) => {
-                return ToolOutput::error(format!("cannot open workspace root: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("cannot open workspace root: {e}"),
+                );
             }
         };
 
@@ -576,28 +582,43 @@ impl ReadFile {
         let bytes = match loaded {
             Ok(Ok(Loaded::Bytes(bytes))) => bytes,
             Ok(Ok(Loaded::Directory)) => {
-                return ToolOutput::error(format!(
-                    "`{path}` is a directory, not a file — list it with \
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "`{path}` is a directory, not a file — list it with \
                          glob({{\"pattern\": \"*\", \"path\": \"{path}\"}})"
-                ));
+                    ),
+                );
             }
             Ok(Ok(Loaded::TooLarge { bytes })) => {
-                return ToolOutput::error(format!(
-                    "`{path}` is {} MB, past read_file's {} MB ceiling — the whole file is \
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "`{path}` is {} MB, past read_file's {} MB ceiling — the whole file is \
                          loaded to render any range, so offset/limit would not help. Search it \
                          with grep, or page it with bash (`sed -n '1,200p' {path}`).",
-                    bytes / (1024 * 1024),
-                    MAX_FILE_BYTES / (1024 * 1024)
-                ));
+                        bytes / (1024 * 1024),
+                        MAX_FILE_BYTES / (1024 * 1024)
+                    ),
+                );
             }
             Ok(Err(e)) if e.is_escape() => {
-                return ToolOutput::error(format!("path `{path}` escapes workspace root ({e})"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    format!("path `{path}` escapes workspace root ({e})"),
+                );
             }
             Ok(Err(e)) => {
-                return ToolOutput::error(format!("failed to read `{path}`: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("failed to read `{path}`: {e}"),
+                );
             }
             Err(e) => {
-                return ToolOutput::error(format!("failed to read `{path}`: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Internal,
+                    format!("failed to read `{path}`: {e}"),
+                );
             }
         };
 
@@ -642,7 +663,10 @@ impl ReadFile {
                 // it toward an action that can never succeed via `read_file`.
                 let whole_file_read = start == 0 && end == lines.len();
                 if !whole_file_read && tally.since_change > MAX_UNCHANGED_READS {
-                    return ToolOutput::error(unchanged_read_ceiling(path, lines.len()));
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::RefusedByPolicy,
+                        unchanged_read_ceiling(path, lines.len()),
+                    );
                 }
 
                 if start >= lines.len() {
@@ -746,7 +770,9 @@ impl ReadFile {
                 );
                 ToolOutput::ok(numbered)
             }
-            Err(message) => ToolOutput::error(message),
+            Err(message) => {
+                ToolOutput::classified_error(stella_protocol::ErrorClass::InvalidInput, message)
+            }
         }
     }
 }

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -352,6 +352,7 @@ async fn a_monotonic_paging_sweep_is_refused_before_it_burns_a_turn() {
 
     let mut refused_at = None;
     let mut refusals = Vec::new();
+    let mut classes = Vec::new();
     for step in 0..40u64 {
         let out = tool
             .execute(
@@ -363,9 +364,10 @@ async fn a_monotonic_paging_sweep_is_refused_before_it_burns_a_turn() {
                 &ctx,
             )
             .await;
-        if let ToolOutput::Error { message, .. } = out {
+        if let ToolOutput::Error { message, class } = out {
             refused_at.get_or_insert(step);
             refusals.push(message);
+            classes.push(class);
         }
     }
     let refused_at = refused_at.expect("the sweep must be refused, not run to the cap");
@@ -388,6 +390,15 @@ async fn a_monotonic_paging_sweep_is_refused_before_it_burns_a_turn() {
     // ceiling is a wall rather than a redirection.
     assert!(refusals[0].contains("omitting `limit`"), "{}", refusals[0]);
     assert!(refusals[0].contains("`search`"), "{}", refusals[0]);
+    // The #3167 witness: this ceiling is a tool policy working as designed
+    // (never a tool defect), so it earns `RefusedByPolicy` — the same class
+    // as the four approval/extension-policy denials, and never `Internal`.
+    assert!(
+        classes
+            .iter()
+            .all(|c| *c == Some(stella_protocol::ErrorClass::RefusedByPolicy)),
+        "{classes:?}"
+    );
 }
 
 /// The remedy the refusal advertises has to actually work: once the

--- a/crates/stella-tools/src/scratch.rs
+++ b/crates/stella-tools/src/scratch.rs
@@ -126,20 +126,28 @@ impl Tool for SaveState {
     async fn execute(&self, input: &Value, _ctx: &crate::ctx::ToolCtx) -> ToolOutput {
         let (key, content) = match (str_field(input, "key"), str_field(input, "content")) {
             (Ok(k), Ok(c)) => (k, c),
-            (Err(m), _) | (_, Err(m)) => return ToolOutput::error(m),
+            (Err(m), _) | (_, Err(m)) => {
+                return ToolOutput::classified_error(stella_protocol::ErrorClass::InvalidInput, m);
+            }
         };
         if content.len() > MAX_SAVE_BYTES {
-            return ToolOutput::error(format!(
-                "content is {} bytes; save_state caps at {MAX_SAVE_BYTES}. Save the \
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                format!(
+                    "content is {} bytes; save_state caps at {MAX_SAVE_BYTES}. Save the \
                      artifact in smaller keyed pieces, or keep it in the workspace and \
                      reference it by path.",
-                content.len()
-            ));
+                    content.len()
+                ),
+            );
         }
         let path = match self.0.resolve(key) {
             Ok(p) => p,
             Err(message) => {
-                return ToolOutput::error(message);
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    message,
+                );
             }
         };
         match std::fs::write(&path, content) {
@@ -157,7 +165,10 @@ impl Tool for SaveState {
                     data: None,
                 }
             }
-            Err(e) => ToolOutput::error(format!("failed to save {key}: {e}")),
+            Err(e) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("failed to save {key}: {e}"),
+            ),
         }
     }
 }
@@ -192,13 +203,19 @@ impl Tool for GetState {
         let key = match str_field(input, "key") {
             Ok(k) => k,
             Err(message) => {
-                return ToolOutput::error(message);
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    message,
+                );
             }
         };
         let path = match self.0.resolve(key) {
             Ok(p) => p,
             Err(message) => {
-                return ToolOutput::error(message);
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    message,
+                );
             }
         };
         let offset = input.get("offset").and_then(Value::as_u64).unwrap_or(0);
@@ -210,14 +227,18 @@ impl Tool for GetState {
         let mut file = match std::fs::File::open(&path) {
             Ok(f) => f,
             Err(_) => {
-                return ToolOutput::error(format!(
-                    "no state saved under {key:?} — list_state shows what exists"
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::NotFound,
+                    format!("no state saved under {key:?} — list_state shows what exists"),
+                );
             }
         };
         let total = file.metadata().map(|m| m.len()).unwrap_or(0);
         if let Err(e) = file.seek(SeekFrom::Start(offset)) {
-            return ToolOutput::error(format!("seek failed on {key}: {e}"));
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("seek failed on {key}: {e}"),
+            );
         }
         let mut buf = vec![0u8; limit];
         let mut read = 0usize;
@@ -226,7 +247,10 @@ impl Tool for GetState {
                 Ok(0) => break,
                 Ok(n) => read += n,
                 Err(e) => {
-                    return ToolOutput::error(format!("read failed on {key}: {e}"));
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::Environment,
+                        format!("read failed on {key}: {e}"),
+                    );
                 }
             }
             if read == buf.len() {
@@ -273,7 +297,10 @@ impl Tool for ListState {
         let entries = match std::fs::read_dir(self.0.path()) {
             Ok(e) => e,
             Err(e) => {
-                return ToolOutput::error(format!("scratch dir unreadable: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("scratch dir unreadable: {e}"),
+                );
             }
         };
         for entry in entries.flatten() {
@@ -330,13 +357,19 @@ impl Tool for DeleteState {
         let key = match str_field(input, "key") {
             Ok(k) => k,
             Err(message) => {
-                return ToolOutput::error(message);
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    message,
+                );
             }
         };
         let path = match self.0.resolve(key) {
             Ok(p) => p,
             Err(message) => {
-                return ToolOutput::error(message);
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    message,
+                );
             }
         };
         match std::fs::remove_file(&path) {
@@ -344,7 +377,41 @@ impl Tool for DeleteState {
                 content: format!("deleted {key}"),
                 data: None,
             },
-            Err(_) => ToolOutput::error(format!("no state saved under {key:?} — nothing deleted")),
+            Err(_) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::NotFound,
+                format!("no state saved under {key:?} — nothing deleted"),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The #3167 witness: `get_state`'s "no such key" refusal renders the
+    /// exact prose it always has — the loop detector and the prompt cache
+    /// compare those bytes — but now carries the honest
+    /// [`stella_protocol::ErrorClass::NotFound`] instead of the `class: None`
+    /// every scratch refusal shared before this sweep classified them.
+    #[tokio::test]
+    async fn an_unsaved_key_keeps_its_prose_and_gains_a_class() {
+        let dir = Arc::new(ScratchDir::new().unwrap());
+        let out = GetState(dir)
+            .execute(
+                &json!({"key": "never-saved"}),
+                &crate::ctx::ToolCtx::bare(std::env::temp_dir()),
+            )
+            .await;
+        match out {
+            ToolOutput::Error { message, class } => {
+                assert_eq!(
+                    message,
+                    "no state saved under \"never-saved\" — list_state shows what exists"
+                );
+                assert_eq!(class, Some(stella_protocol::ErrorClass::NotFound));
+            }
+            other => panic!("expected an error, got {other:?}"),
         }
     }
 }

--- a/crates/stella-tools/src/search.rs
+++ b/crates/stella-tools/src/search.rs
@@ -320,7 +320,10 @@ impl Tool for Search {
             Err(err) => return ToolOutput::from(err),
         };
         if query.trim().is_empty() {
-            return ToolOutput::error(QUERY_REQUIRED);
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::InvalidInput,
+                QUERY_REQUIRED,
+            );
         }
         // The cache is moved out, used, and put back rather than held across
         // the await: a `MutexGuard` is not `Send`, and holding one over the

--- a/crates/stella-tools/src/search/codegraph.rs
+++ b/crates/stella-tools/src/search/codegraph.rs
@@ -107,7 +107,13 @@ pub fn with_index_warning(output: ToolOutput, warning: Option<String>) -> ToolOu
             content: format!("({warning})\n{content}"),
             data: None,
         },
-        ToolOutput::Error { message, .. } => ToolOutput::error(format!("{message}\n({warning})")),
+        // The warning is appended to the prose; whatever class the failure
+        // already carried rides along unchanged (#3167) — this wrapper must
+        // not launder a classified failure back to "unaudited".
+        ToolOutput::Error { message, class } => ToolOutput::Error {
+            message: format!("{message}\n({warning})"),
+            class,
+        },
     }
 }
 

--- a/crates/stella-tools/src/search/engine.rs
+++ b/crates/stella-tools/src/search/engine.rs
@@ -240,12 +240,12 @@ impl SearchReport {
 
     /// A search that never reached dispatch: no hits, no strategies, just
     /// the error the caller must surface.
-    fn failed(message: &str) -> Self {
+    fn failed(class: stella_protocol::ErrorClass, message: &str) -> Self {
         Self {
             hits: Vec::new(),
             strategies: Vec::new(),
             note: None,
-            rendered: ToolOutput::error(message),
+            rendered: ToolOutput::classified_error(class, message),
         }
     }
 }
@@ -292,7 +292,7 @@ pub async fn report_with(
 ) -> SearchReport {
     let query = query.trim();
     if query.is_empty() {
-        return SearchReport::failed(QUERY_REQUIRED);
+        return SearchReport::failed(stella_protocol::ErrorClass::InvalidInput, QUERY_REQUIRED);
     }
 
     let owned_root = root.to_path_buf();
@@ -304,7 +304,10 @@ pub async fn report_with(
         // workspace the indexer cannot serve.
         Ok(Err(error)) => (None, Some(error.to_string())),
         Err(join_error) => {
-            return SearchReport::failed(&worker_failure("the search", join_error));
+            return SearchReport::failed(
+                stella_protocol::ErrorClass::Internal,
+                &worker_failure("the search", join_error),
+            );
         }
     };
 

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -266,7 +266,8 @@ impl Tool for SpawnSubAgent {
         let prompt = match input.get("prompt").and_then(Value::as_str) {
             Some(prompt) if !prompt.trim().is_empty() => prompt.trim(),
             _ => {
-                return ToolOutput::error(
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
                     "missing required string field `prompt` — the sub-agent cannot \
                          see this conversation, so the question must be self-contained",
                 );
@@ -284,7 +285,8 @@ impl Tool for SpawnSubAgent {
             slot.clone()
         };
         let Some(dispatcher) = dispatcher else {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "sub-agents are unavailable in this session — do the work directly \
                      with your own tools",
             );
@@ -365,7 +367,8 @@ impl Tool for SpawnSubAgent {
 fn render(outcome: &SubAgentOutcome) -> ToolOutput {
     match outcome {
         SubAgentOutcome::Completed(report) if report.summary.trim().is_empty() => {
-            ToolOutput::error(
+            ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "the sub-agent finished without reporting anything — its answer was empty. \
                  Do the work directly, or re-ask with a narrower, self-contained question.",
             )
@@ -392,14 +395,20 @@ fn render(outcome: &SubAgentOutcome) -> ToolOutput {
                 data: Some(metrics("partial", report)),
             }
         }
-        SubAgentOutcome::Incomplete { reason, .. } => ToolOutput::error(format!(
-            "the sub-agent stopped before producing anything: {reason} — do the work \
+        SubAgentOutcome::Incomplete { reason, .. } => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::Environment,
+            format!(
+                "the sub-agent stopped before producing anything: {reason} — do the work \
                  directly, or ask a narrower question"
-        )),
-        SubAgentOutcome::Refused { reason } => ToolOutput::error(format!(
-            "the sub-agent was not started: {reason} — do the work directly with your \
+            ),
+        ),
+        SubAgentOutcome::Refused { reason } => ToolOutput::classified_error(
+            stella_protocol::ErrorClass::RefusedByPolicy,
+            format!(
+                "the sub-agent was not started: {reason} — do the work directly with your \
                  own tools"
-        )),
+            ),
+        ),
     }
 }
 

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -46,12 +46,31 @@ pub type SpawnDispatch = Arc<AtomicBool>;
 fn require_str<'a>(input: &'a Value, field: &str) -> Result<&'a str, ToolOutput> {
     match input.get(field).and_then(|v| v.as_str()) {
         Some(s) if !s.trim().is_empty() => Ok(s),
-        Some(_) => Err(ToolOutput::error(format!(
-            "field `{field}` must be a non-empty string"
-        ))),
-        None => Err(ToolOutput::error(format!(
-            "missing required string field `{field}`"
-        ))),
+        Some(_) => Err(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
+            format!("field `{field}` must be a non-empty string"),
+        )),
+        None => Err(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
+            format!("missing required string field `{field}`"),
+        )),
+    }
+}
+
+/// Map a task-board state-machine refusal to its [`stella_protocol::ErrorClass`]
+/// (#3167): an unknown id is the model naming a task that is not on the board
+/// at all, while every other variant is the model attempting a transition the
+/// board's current state does not allow.
+fn board_error_class(e: &stella_core::tasks::TaskBoardError) -> stella_protocol::ErrorClass {
+    match e {
+        stella_core::tasks::TaskBoardError::UnknownTask { .. } => {
+            stella_protocol::ErrorClass::NotFound
+        }
+        stella_core::tasks::TaskBoardError::Terminal { .. }
+        | stella_core::tasks::TaskBoardError::AnotherTaskInProgress { .. }
+        | stella_core::tasks::TaskBoardError::ContractUnsatisfied { .. } => {
+            stella_protocol::ErrorClass::InvalidInput
+        }
     }
 }
 
@@ -158,7 +177,10 @@ impl Tool for TaskCreate {
         // to write four lines that changed no file and read nothing.
         if let Some(entries) = input.get("tasks").and_then(Value::as_array) {
             if entries.is_empty() {
-                return ToolOutput::error("field `tasks` was empty — pass at least one task");
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    "field `tasks` was empty — pass at least one task",
+                );
             }
             let mut board = self.0.lock().unwrap_or_else(|p| p.into_inner());
             let mut created: Vec<String> = Vec::with_capacity(entries.len());
@@ -172,9 +194,12 @@ impl Tool for TaskCreate {
                         Err(e) => return e,
                     },
                     _ => {
-                        return ToolOutput::error(format!(
-                            "tasks[{i}] must be a non-empty string or an object with `subject`"
-                        ));
+                        return ToolOutput::classified_error(
+                            stella_protocol::ErrorClass::InvalidInput,
+                            format!(
+                                "tasks[{i}] must be a non-empty string or an object with `subject`"
+                            ),
+                        );
                     }
                 };
                 let contract = match parse_contract(entry) {
@@ -310,7 +335,7 @@ impl Tool for TaskStart {
                 content: format!("task #{} `{}` is now in_progress", item.id, item.subject),
                 data: None,
             },
-            Err(e) => ToolOutput::error(e.to_string()),
+            Err(e) => ToolOutput::classified_error(board_error_class(&e), e.to_string()),
         }
     }
 }
@@ -342,7 +367,8 @@ fn parse_contract(input: &Value) -> Result<Option<TaskContract>, ToolOutput> {
         return Ok(Some(TaskContract::ReadOnly));
     }
     let Some(items) = raw.as_array() else {
-        return Err(ToolOutput::error(
+        return Err(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
             "definition_of_done must be \"read_only\" for a task that produces no \
              diff, or a non-empty array of checks",
         ));
@@ -352,9 +378,12 @@ fn parse_contract(input: &Value) -> Result<Option<TaskContract>, ToolOutput> {
         let statement = match item.get("statement").and_then(Value::as_str) {
             Some(t) if !t.trim().is_empty() => t.to_string(),
             _ => {
-                return Err(ToolOutput::error(format!(
-                    "definition_of_done[{i}] needs a non-empty `statement` saying what must be true"
-                )));
+                return Err(ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "definition_of_done[{i}] needs a non-empty `statement` saying what must be true"
+                    ),
+                ));
             }
         };
         let mechanism = item
@@ -367,16 +396,20 @@ fn parse_contract(input: &Value) -> Result<Option<TaskContract>, ToolOutput> {
             Some("model") => Judge::Model,
             Some("deterministic") | None => Judge::Deterministic,
             Some(other) => {
-                return Err(ToolOutput::error(format!(
-                    "definition_of_done[{i}].judge must be \"deterministic\" or \"model\", got {other:?}"
-                )));
+                return Err(ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::InvalidInput,
+                    format!(
+                        "definition_of_done[{i}].judge must be \"deterministic\" or \"model\", got {other:?}"
+                    ),
+                ));
             }
         };
         checks.push(Check::new(statement, CheckMechanism::new(mechanism, judge)));
     }
     match DefinitionOfDone::from_vec(checks) {
         Some(dod) => Ok(Some(TaskContract::DefinitionOfDone(dod))),
-        None => Err(ToolOutput::error(
+        None => Err(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::InvalidInput,
             "definition_of_done was an empty array — a task that produces diffs \
              must say what would make it done, or declare \"read_only\"",
         )),
@@ -421,7 +454,7 @@ impl Tool for TaskComplete {
                 content: format!("task #{} `{}` completed", item.id, item.subject),
                 data: None,
             },
-            Err(e) => ToolOutput::error(e.to_string()),
+            Err(e) => ToolOutput::classified_error(board_error_class(&e), e.to_string()),
         }
     }
 }
@@ -469,7 +502,7 @@ impl Tool for TaskCancel {
                     data: None,
                 }
             }
-            Err(e) => ToolOutput::error(e.to_string()),
+            Err(e) => ToolOutput::classified_error(board_error_class(&e), e.to_string()),
         }
     }
 }
@@ -524,7 +557,8 @@ impl Tool for TaskAssign {
         // session came to believe six sub-agents were working for it while its
         // queue grew and nothing ran.
         if !self.2.load(Ordering::Acquire) {
-            return ToolOutput::error(
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
                 "delegation is unavailable in this session — nothing will run the \
                  sub-agent, so the task would sit unstarted; do the work directly \
                  with your own tools",
@@ -538,7 +572,7 @@ impl Tool for TaskAssign {
             match board.assign(id, owner.clone()) {
                 Ok(item) => (item.subject.clone(), item.description.clone()),
                 Err(e) => {
-                    return ToolOutput::error(e.to_string());
+                    return ToolOutput::classified_error(board_error_class(&e), e.to_string());
                 }
             }
         };
@@ -818,6 +852,27 @@ mod tests {
         // Unknown ids also surface the board's own message.
         let unknown = error(exec(&TaskComplete(board), serde_json::json!({"id": "9"})).await);
         assert!(unknown.contains("no task with id 9"), "{unknown}");
+    }
+
+    /// The #3167 witness: `TaskBoardError`'s own `Display` reaches the model
+    /// byte-for-byte — the loop detector and the prompt cache compare it —
+    /// but an unknown id now carries `ErrorClass::NotFound` rather than the
+    /// `class: None` every board refusal shared before this sweep classified
+    /// them via `board_error_class`.
+    #[tokio::test]
+    async fn an_unknown_task_id_keeps_the_boards_own_prose_and_gains_a_class() {
+        let (board, _queue) = handles();
+        let out = exec(&TaskComplete(board), serde_json::json!({"id": "9"})).await;
+        match out {
+            ToolOutput::Error { message, class } => {
+                assert_eq!(
+                    message,
+                    "no task with id 9 — call task_list to see the board"
+                );
+                assert_eq!(class, Some(stella_protocol::ErrorClass::NotFound));
+            }
+            other => panic!("expected an error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -144,23 +144,34 @@ impl WriteFile {
             let (scope_root, path) = match ctx.resolve_for_write(&target.path) {
                 Ok(resolved) => resolved,
                 Err(refusal) => {
-                    return ToolOutput::error(format!(
-                        "`{FILES_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
-                        target.path
-                    ));
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::PermissionDenied,
+                        format!(
+                            "`{FILES_KEY}`[{index}] (`{}`): {refusal} — nothing was written",
+                            target.path
+                        ),
+                    );
                 }
             };
             let handle = match crate::rootfd::RootHandle::open(&scope_root) {
                 Ok(handle) => Arc::new(handle),
-                Err(e) => return ToolOutput::error(format!("cannot open workspace root: {e}")),
+                Err(e) => {
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::Environment,
+                        format!("cannot open workspace root: {e}"),
+                    );
+                }
             };
             if handle.stat(&path).is_ok() && !self.ledger.saw_whole_file(&scope_root, &path) {
-                return ToolOutput::error(format!(
-                    "`{FILES_KEY}`[{index}]: refusing to overwrite `{path}`: this session has \
-                     not been shown the whole file, and `write_file` replaces all of it. Read \
-                     it first (`read_file` with no offset/limit), then write — or use \
-                     `edit_file` to change part of it in place. Nothing was written."
-                ));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "`{FILES_KEY}`[{index}]: refusing to overwrite `{path}`: this session has \
+                         not been shown the whole file, and `write_file` replaces all of it. Read \
+                         it first (`read_file` with no offset/limit), then write — or use \
+                         `edit_file` to change part of it in place. Nothing was written."
+                    ),
+                );
             }
             planned.push((handle, scope_root, path, target.content.as_str()));
         }
@@ -188,7 +199,12 @@ impl WriteFile {
                         content,
                     ));
                 }
-                Err(e) => return ToolOutput::error(format!("failed to write `{path}`: {e}")),
+                Err(e) => {
+                    return ToolOutput::classified_error(
+                        stella_protocol::ErrorClass::Environment,
+                        format!("failed to write `{path}`: {e}"),
+                    );
+                }
             }
         }
         crate::own_change::attach(
@@ -221,7 +237,12 @@ impl WriteFile {
         // the bytes are on disk is a report, not a boundary.
         let (scope_root, path) = match ctx.resolve_for_write(path) {
             Ok(resolved) => resolved,
-            Err(refusal) => return ToolOutput::error(refusal.to_string()),
+            Err(refusal) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::PermissionDenied,
+                    refusal.to_string(),
+                );
+            }
         };
         let path = path.as_str();
 
@@ -233,7 +254,10 @@ impl WriteFile {
         let handle = match crate::rootfd::RootHandle::open(&scope_root) {
             Ok(handle) => Arc::new(handle),
             Err(e) => {
-                return ToolOutput::error(format!("cannot open workspace root: {e}"));
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("cannot open workspace root: {e}"),
+                );
             }
         };
 
@@ -246,11 +270,14 @@ impl WriteFile {
         // something is there to destroy, and the write below answers it
         // properly.
         if handle.stat(path).is_ok() && !self.ledger.saw_whole_file(&scope_root, path) {
-            return ToolOutput::error(format!(
-                "refusing to overwrite `{path}`: this session has not been shown the whole file, \
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "refusing to overwrite `{path}`: this session has not been shown the whole file, \
                  and `write_file` replaces all of it. Read it first (`read_file` with no \
                  offset/limit), then write — or use `edit_file` to change part of it in place."
-            ));
+                ),
+            );
         }
 
         let previous = before(&handle, path);
@@ -280,10 +307,14 @@ impl WriteFile {
                     &[change],
                 )
             }
-            Err(e) if e.is_escape() => {
-                ToolOutput::error(format!("path `{path}` escapes workspace root ({e})"))
-            }
-            Err(e) => ToolOutput::error(format!("failed to write `{path}`: {e}")),
+            Err(e) if e.is_escape() => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::PermissionDenied,
+                format!("path `{path}` escapes workspace root ({e})"),
+            ),
+            Err(e) => ToolOutput::classified_error(
+                stella_protocol::ErrorClass::Environment,
+                format!("failed to write `{path}`: {e}"),
+            ),
         }
     }
 }
@@ -432,6 +463,15 @@ mod tests {
             )
             .await;
         assert!(result.is_error());
+        // The #3167 witness: a workspace-containment refusal is
+        // `PermissionDenied` (the doc comment's own "filesystem permissions,
+        // containment" bucket), never `RefusedByPolicy` — the class reserved
+        // for a working-as-designed policy-plane decision, like the
+        // no-clobber ledger check above.
+        let ToolOutput::Error { class, .. } = result else {
+            unreachable!("checked above");
+        };
+        assert_eq!(class, Some(stella_protocol::ErrorClass::PermissionDenied));
     }
 
     /// A fresh empty directory unique to one test. The no-clobber tests below
@@ -460,7 +500,7 @@ mod tests {
             )
             .await;
 
-        let ToolOutput::Error { message, .. } = result else {
+        let ToolOutput::Error { message, class } = result else {
             panic!("expected the no-clobber refusal");
         };
         assert!(message.contains("refusing to overwrite"), "{message}");
@@ -468,6 +508,11 @@ mod tests {
             message.contains("read_file"),
             "the refusal names the way out: {message}"
         );
+        // The #3167 witness: the no-clobber ledger check is a policy the
+        // tool itself enforces (working as designed, never a tool defect),
+        // never the workspace-containment `PermissionDenied` a `resolve_for_write`
+        // or `is_escape` refusal earns elsewhere in this file.
+        assert_eq!(class, Some(stella_protocol::ErrorClass::RefusedByPolicy));
         // The boundary holds before the bytes move, not after.
         assert_eq!(
             std::fs::read_to_string(dir.join("notes.md")).expect("still there"),

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -260,7 +260,7 @@ fn spawn_shell_command(
                 data: None,
             }
         } else {
-            ToolOutput::error(content)
+            ToolOutput::classified_error(stella_protocol::ErrorClass::Environment, content)
         };
         let _ = tx.send(envelope(
             agent_id.clone(),

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -141,6 +141,7 @@ step_command() {
   doc-links) echo 'check-doc-links' ;;
   module-reachability) echo 'check-module-reachability' ;;
   typed-errors) echo 'check-typed-errors' ;;
+  tool-error-class) echo 'check-tool-error-class' ;;
   dead-code-allows) echo 'check-dead-code-allows' ;;
   tokens) echo 'check-tokens' ;;
   hue-separation) echo 'check-hue-separation' ;;

--- a/scripts/check-tool-error-class.py
+++ b/scripts/check-tool-error-class.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Guard: a down-only ratchet on unclassified `ToolOutput::error(` sites.
+
+#3145 gave `ToolOutput::Error` an optional `class: Option<ErrorClass>`
+(`crates/stella-protocol/src/tool.rs`) so a per-tool error rate can attribute
+failures to *whose problem they are* instead of counting every refusal the
+same way. `ToolOutput::error(msg)` is the pre-#3145 constructor, kept as the
+migration-friendly default: it leaves `class: None`, meaning "not audited
+yet" -- deliberately not a class of its own. #3167 is the sweep that audits
+those sites into `ToolOutput::classified_error(class, msg)`, and this is its
+ratchet: nothing stops the unclassified count drifting back up once nobody is
+looking, so a crate may shrink its count, never grow it, exactly the shape
+`scripts/check-typed-errors.py` (AGENTS.md invariant #5) uses for the same
+reason -- the rule predates the guard, so the baseline records a debt that
+already existed rather than granting new permission.
+
+Two scoping decisions, both different from `check-typed-errors.py`'s:
+
+  * **Every crate, not just libraries.** A tool can report an unclassified
+    error from a binary crate (`stella-cli`) as easily as a library one --
+    `ToolExecutor` is not library-scoped -- so this walks `crates/*/src`
+    without requiring a `lib.rs`.
+
+  * **Every call site, not just `pub fn`s.** The hazard invariant #5 guards is
+    a caller across a crate boundary that cannot branch; the hazard here is a
+    site that never got read for its real failure cause, public or not. A
+    private helper's unclassified error is exactly as unaudited as a public
+    one.
+
+Test code is excluded the same way `check-typed-errors.py` excludes it: a
+path with a `tests` component or named `tests.rs` is skipped outright, and a
+`#[cfg(test)]` (or `#[cfg(all(test, ...))]`) block inside a kept file is
+stripped before scanning -- classifying a test's fixture data audits nothing
+real, and would make the ratchet a function of test coverage rather than of
+production error handling.
+
+The one thing this guard cannot check, by construction: whether the class
+assigned to an already-classified site is the *honest* one. That is a review
+question (does this failure really belong to the model, the policy plane, the
+world, or us?), not a mechanical one -- the guard only counts what is still
+`class: None`.
+
+The baseline is a down-only ratchet, the same shape as
+`scripts/typed-errors-baseline.txt`: a crate may shrink its count, never grow
+it, and a crate absent from the baseline must be at zero. Regenerate with
+`make tool-error-class-update` after classifying sites -- which only ever
+tightens, because the writer refuses to raise a count.
+
+This is a fact about the repository rather than about a crate, so it is never
+scoped by CARGO_SCOPE (AGENTS.md § "The gate"), and a text-level walk keeps it
+in the toolchain-free `guards-fast` rung.
+
+Usage:
+    ./scripts/check-tool-error-class.py [--update] [ROOT]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BASELINE = "scripts/tool-error-class-baseline.txt"
+
+# The pre-#3145 constructor: `ToolOutput::error(`. Deliberately does NOT match
+# `ToolOutput::classified_error(` -- the literal text immediately after
+# `ToolOutput::` differs (`error` vs `classified_error`), so an already-audited
+# site never counts twice.
+UNCLASSIFIED = re.compile(r"ToolOutput::error\(")
+
+CFG_TEST = re.compile(r"#\[cfg\((?:all\()?test\b")
+
+
+def strip_cfg_test(src: str) -> str:
+    """Drop `#[cfg(test)]` / `#[cfg(all(test, ...))]` blocks.
+
+    A classified/unclassified split inside a test fixture audits nothing --
+    counting it would make the ratchet a measure of test-fixture style
+    instead of production error handling.
+    """
+    out: list[str] = []
+    i = 0
+    while True:
+        m = CFG_TEST.search(src, i)
+        if not m:
+            out.append(src[i:])
+            return "".join(out)
+        out.append(src[i : m.start()])
+        brace = src.find("{", m.start())
+        if brace < 0:
+            return "".join(out)
+        depth = 0
+        j = brace
+        while j < len(src):
+            if src[j] == "{":
+                depth += 1
+            elif src[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        i = j + 1
+
+
+#  A file whose OWN `mod` declaration is `#[cfg(test)]`-gated in a sibling
+# file -- so every line in it is test code even though nothing inside the
+# file itself says so. A per-file text scan cannot see across that boundary
+# (neither can check-typed-errors.py's, which has the identical blind spot).
+# `crates/stella-cli/src/tool_docs.rs` is declared `#[cfg(test)] mod
+# tool_docs;` in `crates/stella-cli/src/main.rs` -- its own module doc names
+# the reason ("Why this lives in a #[cfg(test)] module of a binary crate").
+# Its one `ToolOutput::error(` site deliberately exercises the pre-#3145
+# (unclassified) wire shape to pin the generated docs' schema, so converting
+# it would misrepresent the site AND change what the test proves. Declared
+# here, by exact path, rather than silently miscounted.
+TEST_ONLY_FILES = frozenset({"crates/stella-cli/src/tool_docs.rs"})
+
+
+def violations(root: Path) -> list[tuple[str, Path, int]]:
+    """Every still-unclassified `ToolOutput::error(` site, by crate."""
+    found: list[tuple[str, Path, int]] = []
+    for crate_dir in sorted((root / "crates").glob("*")):
+        src_dir = crate_dir / "src"
+        if not src_dir.is_dir():
+            continue
+        crate = crate_dir.name
+        for path in sorted(src_dir.rglob("*.rs")):
+            rel = path.relative_to(root)
+            # Integration tests and the `tests.rs` submodule convention are
+            # test code by another name -- same skip `check-typed-errors.py`
+            # uses.
+            if "tests" in rel.parts or path.name == "tests.rs":
+                continue
+            if rel.as_posix() in TEST_ONLY_FILES:
+                continue
+            src = strip_cfg_test(path.read_text(encoding="utf-8", errors="replace"))
+            for m in UNCLASSIFIED.finditer(src):
+                line = src.count("\n", 0, m.start()) + 1
+                found.append((crate, rel, line))
+    return found
+
+
+def read_baseline(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        return {}
+    counts: dict[str, int] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        crate, _, count = line.rpartition(" ")
+        counts[crate.strip()] = int(count)
+    return counts
+
+
+HEADER = """\
+# Down-only ratchet for #3167: every `ToolOutput::error(` construction is
+# either classified (`ToolOutput::classified_error(class, msg)`, #3145) or
+# accounted for here.
+#
+# Each line is `<crate> <count>` -- the number of still-unclassified sites in
+# that crate. A crate may shrink its count; it may never grow it, and a crate
+# absent from this file must be at zero. Regenerate with
+# `make tool-error-class-update`, which refuses to raise a number.
+#
+# This file is meant to reach empty -- see #3167 for the remaining sweep.
+# Do not add a crate here to turn the gate green; classify the sites instead.
+"""
+
+
+def main() -> int:
+    argv = [a for a in sys.argv[1:] if a != "--update"]
+    update = "--update" in sys.argv[1:]
+    root = Path(argv[0]) if argv else Path(__file__).resolve().parent.parent
+    root = root.resolve()
+
+    found = violations(root)
+    counts: dict[str, int] = {}
+    for crate, _, _ in found:
+        counts[crate] = counts.get(crate, 0) + 1
+
+    baseline_path = root / BASELINE
+    baseline = read_baseline(baseline_path)
+
+    if update:
+        # An absent crate's allowance is ZERO, never "whatever it happens to
+        # have now" -- see check-typed-errors.py's #3750 postmortem, the same
+        # defect shape this mirrors the fix for.
+        merged = {c: min(n, baseline.get(c, 0)) for c, n in counts.items()}
+        raised = {
+            c: (baseline.get(c, 0), n)
+            for c, n in counts.items()
+            if n > baseline.get(c, 0)
+        }
+        if raised:
+            for crate, (was, now) in sorted(raised.items()):
+                note = (
+                    f"refusing to raise {crate} from {was} to {now}."
+                    if crate in baseline
+                    else (
+                        f"refusing to add {crate} at {now} -- a crate absent "
+                        "from the ratchet must be at zero."
+                    )
+                )
+                print(f"check-tool-error-class: {note}", file=sys.stderr)
+            print(
+                "check-tool-error-class: the ratchet only tightens -- "
+                "classify the new sites instead (#3167).",
+                file=sys.stderr,
+            )
+            return 1
+        body = "".join(f"{c} {n}\n" for c, n in sorted(merged.items()) if n)
+        baseline_path.write_text(HEADER + body, encoding="utf-8")
+        print(
+            f"check-tool-error-class: wrote {BASELINE} ({sum(merged.values())} remaining)."
+        )
+        return 0
+
+    # The verdict is decided before anything is written: a guard that prints as
+    # it scans dies mid-report when its reader exits early, and whatever partial
+    # state it had reached becomes the exit status (#1815).
+    report: list[str] = []
+    status = 0
+    by_crate: dict[str, list[tuple[Path, int]]] = {}
+    for crate, rel, line in found:
+        by_crate.setdefault(crate, []).append((rel, line))
+
+    for crate in sorted(set(counts) | set(baseline)):
+        now = counts.get(crate, 0)
+        allowed = baseline.get(crate, 0)
+        if now > allowed:
+            status = 1
+            report.append(
+                f"{crate}: {now} unclassified ToolOutput::error( site(s), "
+                f"ratchet allows {allowed}."
+            )
+            for rel, line in by_crate.get(crate, [])[:20]:
+                report.append(f"    {rel}:{line}")
+        elif now < allowed:
+            report.append(
+                f"note: {crate} is down to {now} (ratchet says {allowed}) -- "
+                f"run `make tool-error-class-update` to lock the win in."
+            )
+
+    if status:
+        report.append("")
+        report.append(
+            "#3167: give the site an honest ErrorClass -- "
+            "ToolOutput::classified_error(class, message) -- without changing "
+            "the message bytes (the loop detector and prompt cache compare "
+            "them). See crates/stella-protocol/src/tool.rs's ErrorClass doc "
+            "comment for the vocabulary."
+        )
+
+    if report:
+        sys.stderr.write("\n".join(report) + "\n")
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-tool-error-class.sh
+++ b/scripts/test-tool-error-class.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Tests for check-tool-error-class.py's ratchet direction (#3167), mirroring
+# scripts/test-typed-errors.sh -- see that script's header for why the
+# defect it guards against (#3750, the same writer-default bug repeated in a
+# second ratchet) is worth two assertions per case rather than one.
+#
+#   ./scripts/test-tool-error-class.sh
+#
+# Run it after touching that script. Not part of `make gate`: it builds
+# throwaway workspace trees under $TMP, the same posture as
+# `make typed-errors-test`.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-tool-error-class.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway workspace root: `crates/<name>/src` for the guard to walk, and
+# the `scripts/` directory it reads its baseline from and writes it back to.
+# $1 = case name. Echoes the root path.
+new_root() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/scripts"
+  printf '# test baseline\n' >"$dir/scripts/tool-error-class-baseline.txt"
+  echo "$dir"
+}
+
+# A crate's src/lib.rs with $3 unclassified sites, plus one classified site
+# so a case is never satisfied by a guard that counts every ToolOutput
+# construction. $1 = root, $2 = crate, $3 = unclassified count.
+crate() {
+  local src="$1/crates/$2/src"
+  mkdir -p "$src"
+  {
+    printf '//! Fixture crate.\n'
+    awk -v n="$3" 'BEGIN {
+      for (i = 0; i < n; i++)
+        printf "fn v%d() -> ToolOutput { ToolOutput::error(\"boom\") }\n", i
+    }'
+    printf 'fn typed() -> ToolOutput { ToolOutput::classified_error(ErrorClass::Internal, "boom") }\n'
+  } >"$src/lib.rs"
+}
+
+# Overwrite the baseline. $1 = root, then one "<crate> <count>" per entry.
+set_baseline() {
+  local dir="$1"
+  shift
+  {
+    printf '# test baseline\n'
+    for entry in "$@"; do printf '%s\n' "$entry"; done
+  } >"$dir/scripts/tool-error-class-baseline.txt"
+}
+
+# want <name> <expect-pass|expect-fail> <root> [substring] [flag]
+want() {
+  local name="$1" expect="$2" root="$3" sub="${4:-}" flag="${5:-}" out rc
+  out="$(python3 "$SCRIPT" ${flag:+"$flag"} "$root" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -ne 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+      return
+    fi
+    case "$out" in
+      *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+      *) fail=$((fail + 1)); echo "FAIL $name — passed, but did not report '$sub':"; echo "$out" ;;
+    esac
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed a violation it should have flagged:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — flagged the wrong thing (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# entry_is <name> <root> <crate> <count|absent>
+entry_is() {
+  local name="$1" file="$2/scripts/tool-error-class-baseline.txt" crate="$3" expect="$4" got
+  got="$(awk -v c="$crate" '$1 == c { print $2; exit }' "$file")"
+  [ -n "$got" ] || got=absent
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — baseline says '$got', wanted '$expect':"; cat "$file"
+  fi
+}
+
+# ── U: the #3750-shaped defect — a crate with NO baseline entry ──────────────
+r="$(new_root new_crate)"
+crate "$r" stella-fixture 1
+
+want "U1 a crate absent from the baseline is flagged on its first unclassified site" \
+  expect-fail "$r" "stella-fixture: 1 unclassified"
+
+want "U2 --update refuses it rather than grandfathering it" \
+  expect-fail "$r" "refusing to add stella-fixture at 1" "--update"
+
+entry_is "U3 the refused --update wrote no entry for it" "$r" stella-fixture absent
+
+r="$(new_root raise_existing)"
+crate "$r" stella-fixture 3
+set_baseline "$r" "stella-fixture 1"
+want "U4 raising an existing entry is still refused" \
+  expect-fail "$r" "refusing to raise stella-fixture from 1 to 3" "--update"
+entry_is "U5 the refused --update left the existing entry alone" "$r" stella-fixture 1
+
+# ── D: the down-only direction ────────────────────────────────────────────────
+r="$(new_root down_only)"
+crate "$r" stella-fixture 1
+set_baseline "$r" "stella-fixture 3"
+want "D1 the check notes a crate that dropped below its ceiling" \
+  expect-pass "$r" "note: stella-fixture is down to 1 (ratchet says 3)"
+want "D2 --update locks the win in" \
+  expect-pass "$r" "(1 remaining)" "--update"
+entry_is "D3 the entry was lowered to what is really there" "$r" stella-fixture 1
+
+r="$(new_root cleared)"
+crate "$r" stella-fixture 0
+set_baseline "$r" "stella-fixture 2"
+want "D4 --update drops a crate that reached zero" \
+  expect-pass "$r" "(0 remaining)" "--update"
+entry_is "D5 the cleared crate is gone from the baseline" "$r" stella-fixture absent
+
+# ── N: the negative direction ─────────────────────────────────────────────────
+r="$(new_root at_ceiling)"
+crate "$r" stella-fixture 2
+set_baseline "$r" "stella-fixture 2"
+want "N1 a crate exactly at its ceiling passes" expect-pass "$r"
+
+r="$(new_root clean)"
+crate "$r" stella-fixture 0
+want "N2 a crate with only classified sites passes with no entry" expect-pass "$r"
+
+# A classified site must never be counted, however many there are — the
+# whole point of the migration-friendly `error()` vs. `classified_error()`
+# split (#3145).
+r="$(new_root classified_only)"
+mkdir -p "$r/crates/stella-fixture/src"
+{
+  printf '//! Fixture crate.\n'
+  for i in 1 2 3; do
+    printf 'fn v%d() -> ToolOutput { ToolOutput::classified_error(ErrorClass::NotFound, "boom") }\n' "$i"
+  done
+} >"$r/crates/stella-fixture/src/lib.rs"
+want "N3 classified_error sites are never counted" expect-pass "$r"
+
+# Test code is out of scope, the same way check-typed-errors.py excludes it:
+# a fixture must not inflate the audit backlog.
+r="$(new_root test_code)"
+mkdir -p "$r/crates/stella-fixture/src"
+{
+  printf '//! Fixture crate.\n'
+  printf 'fn prod() -> ToolOutput { ToolOutput::classified_error(ErrorClass::NotFound, "boom") }\n'
+  printf '#[cfg(test)]\n'
+  printf 'mod tests {\n'
+  printf '    fn t() -> ToolOutput { ToolOutput::error("boom") }\n'
+  printf '}\n'
+} >"$r/crates/stella-fixture/src/lib.rs"
+want "N4 a #[cfg(test)] block is out of scope" expect-pass "$r"
+
+mkdir -p "$r/crates/stella-fixture/src/tests"
+printf 'fn t() -> ToolOutput { ToolOutput::error("boom") }\n' \
+  >"$r/crates/stella-fixture/src/tests/helpers.rs"
+want "N5 a tests/ directory is out of scope" expect-pass "$r"
+
+printf 'fn t() -> ToolOutput { ToolOutput::error("boom") }\n' \
+  >"$r/crates/stella-fixture/src/tests.rs"
+want "N6 a tests.rs file is out of scope" expect-pass "$r"
+
+# Unlike check-typed-errors.py this guard is NOT library-only: a binary
+# crate's unclassified site is exactly as real a gap as a library one.
+r="$(new_root binary_crate)"
+mkdir -p "$r/crates/stella-bin/src"
+{
+  printf 'fn run() -> ToolOutput { ToolOutput::error("boom") }\n'
+  printf 'fn main() {}\n'
+} >"$r/crates/stella-bin/src/main.rs"
+want "N7 a binary crate IS counted (unlike the typed-errors guard)" \
+  expect-fail "$r" "stella-bin: 1 unclassified"
+
+# ── R: the real workspace ─────────────────────────────────────────────────────
+# Check mode only. Never `--update` here: that would rewrite this
+# repository's baseline as a side effect of running the tests.
+want "R1 this repository still matches its baseline" expect-pass "$repo_root"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/tool-error-class-baseline.txt
+++ b/scripts/tool-error-class-baseline.txt
@@ -1,0 +1,11 @@
+# Down-only ratchet for #3167: every `ToolOutput::error(` construction is
+# either classified (`ToolOutput::classified_error(class, msg)`, #3145) or
+# accounted for here.
+#
+# Each line is `<crate> <count>` -- the number of still-unclassified sites in
+# that crate. A crate may shrink its count; it may never grow it, and a crate
+# absent from this file must be at zero. Regenerate with
+# `make tool-error-class-update`, which refuses to raise a number.
+#
+# This file is meant to reach empty -- see #3167 for the remaining sweep.
+# Do not add a crate here to turn the gate green; classify the sites instead.


### PR DESCRIPTION
## What

#3167, both remaining slices this PR takes on:

1. **Classified every remaining production `ToolOutput::error(` site** across
   `stella-tools`, `stella-mcp`, `stella-serve`, `stella-core`, `stella-cli`,
   and `stella-tui` — 155 sites at the time of filing, 0 unclassified in
   production code left when this PR is applied. Each site got an honest
   `ErrorClass` per the "whose problem is this" rule in
   `crates/stella-protocol/src/tool.rs`'s doc comment: `InvalidInput`/`NotFound`
   for the model's mistakes, `PermissionDenied` for filesystem/workspace-
   containment refusals and `RefusedByPolicy` for approval/extension/claims-lock
   refusals (the two policy-adjacent classes, kept distinct per the enum's own
   doc), `Timeout`/`Environment` for the world, `Internal` sparingly for this
   crate's own bugs. Refusal message **bytes are unchanged everywhere** — every
   site is a pure `ToolOutput::error(msg)` -> `ToolOutput::classified_error(class,
   msg)` wrap, never a reword, because the loop detector and prompt cache
   compare those bytes.

   One real defect found and fixed along the way: `compaction.rs`'s aging and
   eviction passes reconstructed a rewritten error through the unclassified
   `ToolOutput::error()` constructor, silently discarding whatever class the
   original failure carried. Both passes now preserve the original `class`
   through the rewrite.

2. **The down-only ratchet**: `scripts/check-tool-error-class.py` +
   `scripts/tool-error-class-baseline.txt`, modelled directly on
   `scripts/check-typed-errors.py` (AGENTS.md invariant #5's guard). Unlike
   that guard, this one is not library-only and not `pub`-only — every crate,
   every call site, because an unclassified error in a binary crate or a
   private helper is exactly as real a gap. Wired into `GATE_STEPS`
   (`tool-error-class`), both AGENTS.md's and CONTRIBUTING.md's gate blocks,
   `ci.yml`, and `guard-self-tests.yml` (`test-tool-error-class.sh`) —
   `check-gate-parity.sh` verifies all of it stays in sync. The baseline is
   now empty.

## Not done

Slice 3 (the per-class usage-hub rollup and the Observatory's per-tool error-rate
split) is **deliberately skipped** — the issue itself calls this "explicitly
out of scope in #3145": the content-free allowlist edit it needs
(`crates/stella-store/src/content_free.rs`, invariant #3) is a human decision
about what's safe to export, and this PR is already large (43 files) without
it. Filing it as a follow-up is the honest move rather than cramming a third
unrelated concern into an already-large diff. Tracked as #4550.

## Evidence

Targeted, per-crate (never a workspace build — CI is the full gate):

- `cargo check -p {stella-core,stella-tools,stella-mcp,stella-serve,stella-cli,stella-tui} --all-targets` — clean.
- `cargo clippy -p <same six> --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p <same six> --no-deps[--document-private-items]` — clean, both forms.
- `cargo test -p stella-core --lib` — 1406 passed.
- `cargo test -p stella-tools --lib` — 545 passed.
- `cargo test -p stella-mcp --lib` — 167 passed.
- `cargo test -p stella-serve --lib` — 173 passed.
- `cargo test -p stella-cli --bin stella` — 2163 passed.
- `cargo test -p stella-tui --lib` — 1063 passed, 1 ignored (pre-existing).
- `cargo test -p stella-tui --test deck_render_snapshots` — 19 passed, no golden diffs.
- `make guards-fast` — every toolchain-free guard green, including `check-gate-parity` (43 steps, named in both documents, each run by a workflow).
- `python3 scripts/check-tool-error-class.py` — exit 0, baseline at zero.
- `bash scripts/test-tool-error-class.sh` — 18/18 (the ratchet's own direction tests, mirroring `test-typed-errors.sh`'s #3750 coverage).

**Witness (compaction class-preservation fix)** — `git stash`-style A/B via
`git show origin/main:crates/stella-core/src/compaction.rs` swapped in for
the new file, tests re-run:
- `aging_preserves_the_original_errors_class` / `eviction_preserves_the_original_errors_class`:
  **fail on old code** (`left: None, right: Some(NotFound/Environment)`),
  **pass on new code**.

**Witness (classification, per file)** — each touched production file carries
its own byte-equality + class assertion test (e.g.
`bash::tests::nonzero_exit_is_classified_environment_with_unchanged_message_bytes`,
`remote::tests::a_reverse_request_deadline_is_classified_timeout_with_unchanged_message_bytes`,
plus assertions in `delete.rs`, `scratch.rs`, `tasks.rs`), all passing.

Closes #3167

## Summary by Sourcery

Classify every remaining production tool error and enforce the zero-unclassified invariant across repository gates.

Bug Fixes:
- Preserve error classifications when compaction ages or evicts tool results instead of resetting them to unclassified errors.

Enhancements:
- Classify all remaining production ToolOutput errors across the core, tools, MCP, serve, CLI, and TUI crates using the appropriate ErrorClass while preserving existing message bytes.
- Add a repository-wide down-only ratchet to prevent new unclassified ToolOutput errors, with baseline, update/test commands, and gate parity checks.

CI:
- Run the tool-error classification ratchet in CI and validate its direction in guard self-tests.

Documentation:
- Document the new tool-error classification guard in AGENTS.md and CONTRIBUTING.md.

Tests:
- Add coverage verifying error classes, unchanged messages, and preservation through compaction and wrappers.
