### PR TITLE
chore(guards): retighten the typed-errors ratchet — stella-tools earned 5 → 4

### DIFF
--- a/scripts/typed-errors-baseline.txt
+++ b/scripts/typed-errors-baseline.txt
@@ -9,5 +9,5 @@
 # This file is meant to reach empty. The remaining conversions are tracked in
 # #2392 -- do not add a crate here to turn the gate green.
 stella-model 10
-stella-tools 5
+stella-tools 4
 stella-tui 1


### PR DESCRIPTION
## What

`scripts/typed-errors-baseline.txt` granted stella-tools 5 `Result<_, String>` signatures; the tree is at 4 (the fifth went with `foundry_author.rs` in #4512). Generated by `make typed-errors-update`, down-only.

## Evidence

`make typed-errors` on main prints the "down to 4" note; after the update it prints OK (15 remaining workspace-wide). Own PR from a fresh main — the baseline is a shared cell. No witness: baseline only.

Refs #2392

## Summary by Sourcery

Enhancements:
- Retighten the typed-errors baseline to reflect the reduction of stella-tools violations from five to four.