### PR TITLE
feat(stella-tui,stella-cli): lane verbs on the SUB-AGENTS overlay — o opens, x stops then deletes, r resumes then restarts

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -106,6 +106,7 @@ mod slash_pump;
 mod steering;
 mod task_tap;
 mod theme_cmd;
+mod worker_control;
 use pr_observe::{ci_status_token, observe_pr, pr_status_token};
 
 use crate::memory::{SessionMemory, TurnFriction, inject_recall_block};
@@ -837,7 +838,7 @@ pub async fn run_deck_session(
     let mut pending_spawns: VecDeque<stella_core::tasks::SpawnRequest> = VecDeque::new();
     // Lanes whose Restart arrived while the worker was still live: stop
     // first, respawn on its Ended.
-    let mut pending_restarts: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut pending_controls = worker_control::Pending::default();
     // Worker spend not yet metered into the session budget guard — applied
     // at the loop top, where the guard is free (budget aborts happen at
     // safe boundaries only).
@@ -915,7 +916,7 @@ pub async fn run_deck_session(
                         handle_supervisor_msg(
                             msg,
                             &mut subs,
-                            &mut pending_restarts,
+                            &mut pending_controls,
                             &mut pending_spawns,
                             &mut queue,
                             dispatch.held(),
@@ -940,11 +941,11 @@ pub async fn run_deck_session(
                     // Worker controls work between lead turns too — the
                     // lead being idle says nothing about a running worker.
                     Some(WorkspaceInput::Control { agent, control }) if agent != LEAD => {
-                        service_worker_control(
+                        worker_control::service(
                             &agent,
                             control,
                             &mut subs,
-                            &mut pending_restarts,
+                            &mut pending_controls,
                             cfg,
                             budget_limit,
                             &session_record.id,
@@ -1641,7 +1642,7 @@ pub async fn run_deck_session(
                         handle_supervisor_msg(
                             msg,
                             &mut subs,
-                            &mut pending_restarts,
+                            &mut pending_controls,
                             &mut pending_spawns,
                             &mut queue,
                             dispatch.held(),
@@ -1776,13 +1777,13 @@ pub async fn run_deck_session(
                                 subs.stop(&agent);
                             }
                         }
-                        // Worker Pause/Resume/Restart while the lead works.
+                        // Worker Pause/Resume/Restart/Delete while the lead works.
                         Some(WorkspaceInput::Control { agent, control }) if agent != LEAD => {
-                            service_worker_control(
+                            worker_control::service(
                                 &agent,
                                 control,
                                 &mut subs,
-                                &mut pending_restarts,
+                                &mut pending_controls,
                                 cfg,
                                 budget_limit,
                                 &session_record.id,
@@ -2656,7 +2657,7 @@ fn notifications_inbound(store: &stella_store::NotificationStore) -> Inbound {
 fn handle_supervisor_msg(
     msg: SupervisorMsg,
     subs: &mut SubSessions,
-    pending_restarts: &mut std::collections::HashSet<String>,
+    pending_controls: &mut worker_control::Pending,
     pending_spawns: &mut VecDeque<stella_core::tasks::SpawnRequest>,
     queue: &mut crate::session_persist::DurableQueue,
     dispatch_held: bool,
@@ -2713,9 +2714,14 @@ fn handle_supervisor_msg(
             // from a replaced worker must not steal its replacement's slot
             // (or, below, respawn the lane a second time).
             let freed = subs.ended(&lane, generation);
+            // A Delete accepted while this worker was live takes the row
+            // down now — and outranks a Restart armed earlier: the later
+            // intent won at `worker_control::service`.
+            let deleted =
+                freed && worker_control::finish_delete(&lane, pending_controls, subs, in_tx);
             // A Restart that arrived while this worker was live respawns it
             // now — restart takes the freed slot ahead of parked spawns.
-            if freed && pending_restarts.remove(&lane) {
+            if freed && !deleted && pending_controls.restarts.remove(&lane) {
                 let _ = subsession::respawn(
                     &lane,
                     subs,
@@ -2778,63 +2784,6 @@ fn handle_supervisor_msg(
                 in_tx,
                 sup_tx,
             );
-        }
-    }
-}
-
-/// Route one Pause/Resume/Stop/Restart at a worker lane. Pause parks the
-/// worker at its next step boundary (never mid-tool — the engine's
-/// `TurnGate`); Resume releases it; Restart respawns the lane from its
-/// retained spec, stopping the live worker first when necessary.
-#[allow(clippy::too_many_arguments)]
-fn service_worker_control(
-    lane: &str,
-    control: stella_tui::AgentControl,
-    subs: &mut SubSessions,
-    pending_restarts: &mut std::collections::HashSet<String>,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
-) {
-    match control {
-        stella_tui::AgentControl::Stop => {
-            subs.stop(lane);
-        }
-        stella_tui::AgentControl::Pause => {
-            if subs.set_paused(lane, true) {
-                let _ = in_tx.send(Inbound::Status {
-                    agent: lane.to_string(),
-                    status: AgentStatus::Paused,
-                });
-            }
-        }
-        stella_tui::AgentControl::Resume => {
-            if subs.set_paused(lane, false) {
-                let _ = in_tx.send(Inbound::Status {
-                    agent: lane.to_string(),
-                    status: AgentStatus::Running,
-                });
-            }
-        }
-        stella_tui::AgentControl::Restart => {
-            if subs.is_live(lane) {
-                pending_restarts.insert(lane.to_string());
-                subs.stop(lane);
-            } else {
-                let _ = subsession::respawn(
-                    lane,
-                    subs,
-                    cfg,
-                    budget_limit,
-                    session_id,
-                    workspace_name,
-                    in_tx,
-                    sup_tx,
-                );
-            }
         }
     }
 }

--- a/crates/stella-cli/src/command_deck/lead_control.rs
+++ b/crates/stella-cli/src/command_deck/lead_control.rs
@@ -94,10 +94,11 @@ impl LeadPause {
     ///
     /// `Restart` is not a lead verb, by the fleet's own rule: a restart is the
     /// caller re-dispatching, which the deck already offers (stop, then submit
-    /// again), and there is no retained lead spec to respawn from. `Stop`
-    /// never arrives here — the driver's own arm claims it, for both lanes —
-    /// and is matched only so a newly added control cannot be silently
-    /// swallowed.
+    /// again), and there is no retained lead spec to respawn from. `Delete`
+    /// is not one either: the lead's row IS the session, and taking the
+    /// session down is quit, not a row removal. `Stop` never arrives here —
+    /// the driver's own arm claims it, for both lanes — and is matched only
+    /// so a newly added control cannot be silently swallowed.
     pub(super) fn control(&self, control: AgentControl, in_tx: &UnboundedSender<Inbound>) {
         let status = match control {
             AgentControl::Pause => {
@@ -110,7 +111,7 @@ impl LeadPause {
                 self.painted_paused.store(false, Ordering::SeqCst);
                 AgentStatus::Running
             }
-            AgentControl::Restart | AgentControl::Stop => return,
+            AgentControl::Restart | AgentControl::Stop | AgentControl::Delete => return,
         };
         let _ = in_tx.send(Inbound::Status {
             agent: LEAD.to_string(),

--- a/crates/stella-cli/src/command_deck/worker_control.rs
+++ b/crates/stella-cli/src/command_deck/worker_control.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where a worker lane's control verbs land, driver-side.
+//!
+//! Split out of [`super`] (a god file, closed to growth) following the
+//! `settle`/`steer` pattern. The deck's half — which key sends which verb,
+//! and the two-press arming — lives in `stella_tui`'s SUB-AGENTS overlay;
+//! this file is only what the driver does with a [`stella_tui::AgentControl`]
+//! once it arrives, plus the ledger of verbs that must wait for a live
+//! worker's `Ended` before they can finish.
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::config::Config;
+use crate::subsession::{self, SubSessions, SupervisorMsg};
+use stella_tui::{AgentStatus, Inbound};
+
+/// Verbs accepted while a lane's worker was live, finished when its `Ended`
+/// arrives. Restart must wait because a respawn before the old worker
+/// settles would put two workers on one lane, sharing (and corrupting) its
+/// channels; Delete must wait because a row removed ahead of the worker's
+/// terminal status would be re-registered by it.
+#[derive(Default)]
+pub(super) struct Pending {
+    pub(super) restarts: std::collections::HashSet<String>,
+    pub(super) deletes: std::collections::HashSet<String>,
+}
+
+/// Route one Pause/Resume/Stop/Restart/Delete at a worker lane. Pause parks
+/// the worker at its next step boundary (never mid-tool — the engine's
+/// `TurnGate`); Resume releases it; Restart respawns the lane from its
+/// retained spec, stopping the live worker first when necessary; Delete
+/// takes the lane's row off the deck for good — stopping a live worker
+/// first, spec dropped either way so a later Restart cannot revive it.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn service(
+    lane: &str,
+    control: stella_tui::AgentControl,
+    subs: &mut SubSessions,
+    pending: &mut Pending,
+    cfg: &Config,
+    budget_limit: Option<f64>,
+    session_id: &str,
+    workspace_name: &str,
+    in_tx: &UnboundedSender<Inbound>,
+    sup_tx: &UnboundedSender<SupervisorMsg>,
+) {
+    match control {
+        stella_tui::AgentControl::Stop => {
+            subs.stop(lane);
+        }
+        stella_tui::AgentControl::Pause => {
+            if subs.set_paused(lane, true) {
+                let _ = in_tx.send(Inbound::Status {
+                    agent: lane.to_string(),
+                    status: AgentStatus::Paused,
+                });
+            }
+        }
+        stella_tui::AgentControl::Resume => {
+            if subs.set_paused(lane, false) {
+                let _ = in_tx.send(Inbound::Status {
+                    agent: lane.to_string(),
+                    status: AgentStatus::Running,
+                });
+            }
+        }
+        stella_tui::AgentControl::Restart => {
+            if subs.is_live(lane) {
+                pending.restarts.insert(lane.to_string());
+                subs.stop(lane);
+            } else {
+                let _ = subsession::respawn(
+                    lane,
+                    subs,
+                    cfg,
+                    budget_limit,
+                    session_id,
+                    workspace_name,
+                    in_tx,
+                    sup_tx,
+                );
+            }
+        }
+        stella_tui::AgentControl::Delete => delete(lane, subs, pending, in_tx),
+    }
+}
+
+/// Delete a lane: stop a live worker and park the deregister for its
+/// `Ended` ([`finish_delete`]) — a row removed ahead of the worker's
+/// terminal status would be re-registered by it — or, with no worker
+/// behind the lane, drop the spec and take the row down now.
+fn delete(
+    lane: &str,
+    subs: &mut SubSessions,
+    pending: &mut Pending,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    if subs.is_live(lane) {
+        pending.deletes.insert(lane.to_string());
+        pending.restarts.remove(lane);
+        subs.stop(lane);
+    } else {
+        subs.forget(lane);
+        let _ = in_tx.send(Inbound::Deregister {
+            agent: lane.to_string(),
+        });
+    }
+}
+
+/// The Delete verb's second half, at the freed lane's `Ended`: `true` when a
+/// delete was pending — the spec is dropped and the row deregistered, and
+/// the caller must not respawn a restart that was armed earlier (the later
+/// intent won at [`service`]).
+pub(super) fn finish_delete(
+    lane: &str,
+    pending: &mut Pending,
+    subs: &mut SubSessions,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    if !pending.deletes.remove(lane) {
+        return false;
+    }
+    pending.restarts.remove(lane);
+    subs.forget(lane);
+    let _ = in_tx.send(Inbound::Deregister {
+        agent: lane.to_string(),
+    });
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    /// **The witness for Delete on an idle lane.** The row comes down at
+    /// once — deregister sent, spec forgotten, so a later Restart has
+    /// nothing to respawn from.
+    #[tokio::test]
+    async fn delete_on_an_ended_lane_deregisters_and_forgets_the_spec() {
+        let mut subs = SubSessions::new();
+        let generation = subs.started_for_test("req:1");
+        subs.stop("req:1");
+        assert!(subs.ended("req:1", generation), "the worker settled");
+        assert!(subs.spec("req:1").is_some(), "the spec outlives the end");
+
+        let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+        let mut pending = Pending::default();
+        delete("req:1", &mut subs, &mut pending, &in_tx);
+        assert!(subs.spec("req:1").is_none(), "delete drops the spec");
+        assert!(pending.deletes.is_empty(), "nothing to wait for");
+        match in_rx.recv().await {
+            Some(Inbound::Deregister { agent }) => assert_eq!(agent, "req:1"),
+            other => panic!("expected the row's deregister, got {other:?}"),
+        }
+    }
+
+    /// **The witness for Delete on a live lane.** The verb stops the worker
+    /// and parks the deregister; `finish_delete` at `Ended` sends it, drops
+    /// the spec, and outranks a Restart armed earlier.
+    #[tokio::test]
+    async fn delete_on_a_live_lane_waits_for_ended_and_outranks_a_restart() {
+        let mut subs = SubSessions::new();
+        let generation = subs.started_for_test("req:1");
+        let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+        let mut pending = Pending::default();
+        pending.restarts.insert("req:1".to_string());
+
+        delete("req:1", &mut subs, &mut pending, &in_tx);
+        assert!(pending.deletes.contains("req:1"), "parked for Ended");
+        assert!(
+            pending.restarts.is_empty(),
+            "the delete wins over the earlier restart"
+        );
+        assert!(
+            subs.spec("req:1").is_some(),
+            "a winding-down lane keeps its spec — the worker still owns it"
+        );
+
+        assert!(subs.ended("req:1", generation));
+        assert!(finish_delete("req:1", &mut pending, &mut subs, &in_tx));
+        assert!(subs.spec("req:1").is_none(), "spec dropped");
+        match in_rx.recv().await {
+            Some(Inbound::Deregister { agent }) => assert_eq!(agent, "req:1"),
+            other => panic!("expected the row's deregister, got {other:?}"),
+        }
+        assert!(
+            !finish_delete("req:1", &mut pending, &mut subs, &in_tx),
+            "a delete finishes once"
+        );
+    }
+}

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -302,6 +302,18 @@ impl SubSessions {
         self.specs.get(lane).cloned()
     }
 
+    /// Drop `lane`'s retained spec — Delete's half of the ledger, so a later
+    /// Restart cannot revive a row the user removed. `false` (and the spec
+    /// kept) while a worker is live on the lane: the delete's deregister is
+    /// deferred to its `Ended`, and the spec goes with it.
+    pub(crate) fn forget(&mut self, lane: &str) -> bool {
+        if self.is_live(lane) {
+            return false;
+        }
+        self.cleared.remove(lane);
+        self.specs.remove(lane).is_some()
+    }
+
     /// Signal one worker to stop (clean cancel: its turn future drops at the
     /// next await point, exactly the lead's cancel semantics). `false` when
     /// no such worker is live — a stale stop is a no-op, never an error.

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -115,10 +115,15 @@ async fn main() -> std::io::Result<()> {
                     }
                 }
                 WorkspaceInput::Control { agent, control } => {
+                    // Delete answers with the row's removal, like the driver.
+                    if control == AgentControl::Delete {
+                        let _ = react_tx.send(Inbound::Deregister { agent });
+                        continue;
+                    }
                     let status = match control {
                         AgentControl::Pause => AgentStatus::Paused,
                         AgentControl::Resume | AgentControl::Restart => AgentStatus::Running,
-                        AgentControl::Stop => AgentStatus::Killed,
+                        AgentControl::Stop | AgentControl::Delete => AgentStatus::Killed,
                     };
                     let _ = react_tx.send(Inbound::Status { agent, status });
                 }

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -1110,19 +1110,21 @@ impl std::fmt::Debug for Secret {
 }
 
 /// The agent-control verbs surfaced by the dashboard, each sent as a
-/// [`WorkspaceInput::Control`]. All four are live: the Agents tab binds `s`
+/// [`WorkspaceInput::Control`]. All five are live: the Agents tab binds `s`
 /// (Stop), `p` (Pause/Resume, toggled by the row's current status), and `r`
 /// (Restart), and Esc sends Stop for the focused agent. The driver honors
-/// Pause/Resume/Restart on worker lanes — pause parks the worker at its next
-/// step boundary (never mid-tool), restart respawns the lane from its
-/// retained spec — and treats them as no-ops on the lead, whose interrupt is
-/// Esc (Stop).
+/// Pause/Resume/Restart/Delete on worker lanes — pause parks the worker at
+/// its next step boundary (never mid-tool), restart respawns the lane from
+/// its retained spec, delete stops the worker if one is live and then takes
+/// the lane's row off the deck for good, spec included — and treats them as
+/// no-ops on the lead, whose interrupt is Esc (Stop).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AgentControl {
     Pause,
     Resume,
     Stop,
     Restart,
+    Delete,
 }
 
 impl AgentControl {
@@ -1132,6 +1134,7 @@ impl AgentControl {
             AgentControl::Resume => "resume",
             AgentControl::Stop => "stop",
             AgentControl::Restart => "restart",
+            AgentControl::Delete => "delete",
         }
     }
 }

--- a/crates/stella-tui/src/keymap.rs
+++ b/crates/stella-tui/src/keymap.rs
@@ -517,13 +517,15 @@ pub const BINDINGS: &[Binding] = &[
     ),
     row(
         "ctrl-a",
-        "SUB-AGENTS — n nudge · f flag · ^x^x kill · p pause · r restart",
+        "SUB-AGENTS — o open · n nudge · f flag · x stop · xx delete · r resume · rr restart",
         Everywhere,
         &[
             "ctrl_a_opens_the_sub_agents_overlay_from_any_tab",
             "the_keys_control_the_selected_lane",
             "nudge_steers_the_lane_and_flag_tells_the_dispatcher",
             "ctrl_x_twice_kills_the_selected_lane_and_any_other_key_disarms",
+            "x_stops_the_lane_and_a_second_x_deletes_it",
+            "o_opens_the_selected_lane_like_enter",
         ],
     ),
     row(

--- a/crates/stella-tui/src/v2/subagents.rs
+++ b/crates/stella-tui/src/v2/subagents.rs
@@ -19,7 +19,7 @@
 //! │   ↳ d:1  running · inside lead's turn                                    │
 //! │     Survey how the three planes share a store.                           │
 //! │     inside lead's turn · no control plane: stop lead to stop it          │
-//! ╰ ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause · r ── esc ╯
+//! ╰ ↑↓ · o↵ open · n nudge · f flag · x stop·xx delete · r resume·rr restart ─ esc ╯
 //! ```
 //!
 //! Three rows per entry. The head is its vitals — status, **quiet time**
@@ -33,11 +33,14 @@
 //! JSON result; the fold's humanized one-liner is the most a row quotes.
 //!
 //! The verbs ride the wire the old AGENTS dashboard used
-//! ([`WorkspaceInput::Control`], #4334): `ctrl-x` twice kills (`s` too, for
-//! the hand that knows the old key), `p` pauses a running lane and resumes a
-//! paused one, `r` restarts from the lane's retained spec, and `→` or `⏎`
-//! opens the lane — focuses its transcript on the SESSION tab, where the
-//! composer steers it and `⌫` comes back. `l` is the way back to the lead.
+//! ([`WorkspaceInput::Control`], #4334): `x` stops the selected lane and a
+//! second `x` **deletes** it — its row leaves the deck for good, retained
+//! spec included (`ctrl-x` twice and `s` still stop, for the hand that knows
+//! the old keys); `r` resumes a paused lane and a second `r` **restarts** it
+//! from the retained spec — back to step 1, not to where it was; `p` pauses
+//! a running lane and resumes a paused one; and `o`, `→` or `⏎` opens the
+//! lane — focuses its transcript on the SESSION tab, where the composer
+//! steers it and `⌫` or Esc comes back. `l` is the way back to the lead.
 //! Two verbs are this overlay's own ([`rows`] carries their text): `n`
 //! **nudges** the lane for a one-line position report, and `f` **flags** it
 //! to whoever dispatched it, vitals attached, asking them to check, stop, or
@@ -45,12 +48,13 @@
 //! plane: its control keys are swallowed and the footer says so; `⏎` opens
 //! its parent and `f` flags it to its parent.
 //!
-//! Kill takes two presses because it is the one verb here with no undo: a
+//! A verb with no undo takes two presses: a deleted row cannot come back, a
 //! stopped worker's turn future is dropped, and Restart begins again from
-//! the spec, not from where it was. The first press arms and the footer says
-//! so; any other key disarms — the same shape the queue editor's clear-all
-//! and the SKILLS uninstall use.
+//! the spec, not from where it was. The first press arms — on the row it was
+//! pressed on ([`arm`]) — and the footer says what the second press does;
+//! any other key disarms, moving the cursor included.
 
+pub mod arm;
 pub mod lifecycle;
 pub mod rows;
 
@@ -73,16 +77,16 @@ use rows::Row;
 /// Rows one entry spends, plus one blank between entries.
 const ROWS_PER_LANE: usize = 4;
 
-/// The overlay's own state: whether it is up, the selected row, whether the
-/// first `ctrl-x` of a kill has been pressed, and the last thing a key did
-/// that the footer should say.
+/// The overlay's own state: whether it is up, the selected row, which
+/// two-press verb (if any) is armed on which lane, and the last thing a key
+/// did that the footer should say.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SubagentsOverlay {
     pub open: bool,
     pub sel: usize,
-    /// `ctrl-x` was pressed once on the selected lane; the next `ctrl-x`
-    /// kills it, any other key disarms.
-    pub kill_armed: bool,
+    /// A two-press verb's first press landed on a lane; its second press
+    /// fires, any other key disarms. See [`arm`].
+    pub armed: Option<arm::Armed>,
     /// One line the footer shows after a verb — `nudged sub:2`, `flagged
     /// sub:2 to lead`, or why a key did nothing. Cleared by the next key.
     pub notice: Option<String>,
@@ -124,24 +128,25 @@ pub fn lanes(model: &WorkspaceModel) -> Vec<(usize, &AgentEntry)> {
 pub fn open(ui: &mut DeckUi) -> DeckAction {
     ui.subagents.open = true;
     ui.subagents.sel = 0;
-    ui.subagents.kill_armed = false;
+    ui.subagents.armed = None;
     ui.subagents.notice = None;
     DeckAction::Handled
 }
 
-/// The overlay's keys: the list keys select, `→`/`⏎` open the row (focus
-/// its transcript — a child's parent's), `l` back to the lead, `n` nudge,
-/// `f` flag to the dispatcher, `ctrl-x` twice (or `s`) stop, `p` pause a
-/// running lane / resume a paused one, `r` restart, Esc/`←`/`q` close.
-/// Modal: every other key is swallowed.
+/// The overlay's keys: the list keys select, `o`/`→`/`⏎` open the row
+/// (focus its transcript — a child's parent's), `l` back to the lead, `n`
+/// nudge, `f` flag to the dispatcher, `x` stop and `x x` delete the row
+/// (`ctrl-x` twice or `s` stop too), `p` pause a running lane / resume a
+/// paused one, `r` resume and `r r` restart from the spec, Esc/`←`/`q`
+/// close. Modal: every other key is swallowed.
 pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
     let list = rows::rows(model);
     let count = list.len();
     ui.subagents.sel = ui.subagents.sel.min(count.saturating_sub(1));
     ui.subagents.notice = None;
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    // The kill arm survives exactly one key: the second `ctrl-x`.
-    let armed = std::mem::take(&mut ui.subagents.kill_armed);
+    // A two-press arm survives exactly one key: its verb's second press.
+    let armed = ui.subagents.armed.take();
 
     if list_nav::closes(key) || matches!(key.code, KeyCode::Left) {
         ui.subagents.open = false;
@@ -182,7 +187,8 @@ pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Dec
         DeckAction::Handled
     };
     match key.code {
-        KeyCode::Enter | KeyCode::Right => match selected {
+        KeyCode::Enter | KeyCode::Right | KeyCode::Char('o') | KeyCode::Char('O') => match selected
+        {
             Some(row) => {
                 ui.subagents.open = false;
                 ui.focus_agent(row.opens());
@@ -241,10 +247,33 @@ pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Dec
             Some(row) if !row.controllable() => no_plane(ui, row),
             Some(row) => match lane(row) {
                 Some(l) if l.status.is_terminal() => DeckAction::Handled,
-                Some(l) if armed => control(l, AgentControl::Stop),
-                Some(_) => {
-                    ui.subagents.kill_armed = true;
+                Some(l) if arm::fires(&armed, arm::ArmedVerb::Kill, &l.meta.id) => {
+                    control(l, AgentControl::Stop)
+                }
+                Some(l) => {
+                    ui.subagents.armed = Some(arm::Armed::new(arm::ArmedVerb::Kill, &l.meta.id));
                     DeckAction::Handled
+                }
+                None => DeckAction::Handled,
+            },
+            None => DeckAction::Handled,
+        },
+        // `x` stops the lane where it stands; a second `x` deletes it — the
+        // row leaves the deck for good, spec included. On a lane already
+        // finished the first press only arms: there is nothing to stop.
+        KeyCode::Char('x') => match selected {
+            Some(row) if !row.controllable() => no_plane(ui, row),
+            Some(row) => match lane(row) {
+                Some(l) if arm::fires(&armed, arm::ArmedVerb::Delete, &l.meta.id) => {
+                    control(l, AgentControl::Delete)
+                }
+                Some(l) => {
+                    ui.subagents.armed = Some(arm::Armed::new(arm::ArmedVerb::Delete, &l.meta.id));
+                    if l.status.is_terminal() {
+                        DeckAction::Handled
+                    } else {
+                        control(l, AgentControl::Stop)
+                    }
                 }
                 None => DeckAction::Handled,
             },
@@ -267,10 +296,23 @@ pub fn handle_key(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> Dec
             },
             None => DeckAction::Handled,
         },
+        // `r` resumes a paused lane; a second `r` restarts — respawns the
+        // lane from its retained spec, back to step 1. On a lane that is not
+        // paused the first press only arms the restart.
         KeyCode::Char('r') => match selected {
             Some(row) if !row.controllable() => no_plane(ui, row),
             Some(row) => match lane(row) {
-                Some(l) => control(l, AgentControl::Restart),
+                Some(l) if arm::fires(&armed, arm::ArmedVerb::Restart, &l.meta.id) => {
+                    control(l, AgentControl::Restart)
+                }
+                Some(l) => {
+                    ui.subagents.armed = Some(arm::Armed::new(arm::ArmedVerb::Restart, &l.meta.id));
+                    if l.status == AgentStatus::Paused {
+                        control(l, AgentControl::Resume)
+                    } else {
+                        DeckAction::Handled
+                    }
+                }
                 None => DeckAction::Handled,
             },
             None => DeckAction::Handled,
@@ -501,16 +543,16 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
         ));
     }
     title.push(Span::raw(" "));
-    let footer = if ui.subagents.kill_armed {
+    let footer = if let Some(armed) = &ui.subagents.armed {
         Span::styled(
-            " ctrl-x again kills the selected lane · any other key keeps it ",
+            armed.footer(),
             Style::new().fg(token::RED).add_modifier(Modifier::BOLD),
         )
     } else if let Some(notice) = &ui.subagents.notice {
         Span::styled(format!(" {notice} "), Style::new().fg(token::GOLD))
     } else {
         Span::styled(
-            " ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause/resume · r restart · esc ",
+            " ↑↓ · o↵ open · n nudge · f flag · l lead · x stop·xx delete · r resume·rr restart · p pause · esc ",
             dim,
         )
     };
@@ -597,7 +639,8 @@ mod tests {
 
     /// **The witness for #4334.** The verbs reach the wire for the row under
     /// the cursor: `s` stops, `p` pauses a running lane and resumes a paused
-    /// one, `r` restarts, and `⏎` focuses the lane and closes the overlay.
+    /// one, `r` resumes and a second `r` restarts, and `⏎` focuses the lane
+    /// and closes the overlay.
     #[test]
     fn the_keys_control_the_selected_lane() {
         let model = model_with(&[
@@ -628,7 +671,13 @@ mod tests {
         );
         assert_eq!(
             sent(handle_key(key(KeyCode::Char('r')), &model, &mut ui)),
-            ("sub:2".to_string(), AgentControl::Restart)
+            ("sub:2".to_string(), AgentControl::Resume),
+            "the first r on a paused lane resumes it and arms the restart"
+        );
+        assert_eq!(
+            sent(handle_key(key(KeyCode::Char('r')), &model, &mut ui)),
+            ("sub:2".to_string(), AgentControl::Restart),
+            "the second r restarts from the retained spec"
         );
         assert_eq!(
             handle_key(key(KeyCode::Enter), &model, &mut ui),
@@ -639,6 +688,81 @@ mod tests {
             ui.focused, 2,
             "and focuses the lane's transcript (index into model.agents)"
         );
+    }
+
+    /// **The witness for `x` and `x x`.** The first `x` stops the selected
+    /// lane and arms its deletion; the second `x` deletes — the row-removal
+    /// verb the driver answers with a deregister. The arm is scoped to the
+    /// row, so moving the cursor between presses disarms, and on a finished
+    /// lane the first press only arms: there is nothing left to stop.
+    #[test]
+    fn x_stops_the_lane_and_a_second_x_deletes_it() {
+        let model = model_with(&[
+            ("sub:1", AgentStatus::Running),
+            ("sub:2", AgentStatus::Done),
+        ]);
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+
+        assert_eq!(
+            handle_key(key(KeyCode::Char('x')), &model, &mut ui),
+            DeckAction::Send(WorkspaceInput::Control {
+                agent: "sub:1".into(),
+                control: AgentControl::Stop,
+            }),
+            "the first x stops the running lane"
+        );
+        assert!(
+            arm::fires(&ui.subagents.armed, arm::ArmedVerb::Delete, "sub:1"),
+            "…and arms its deletion: {:?}",
+            ui.subagents.armed
+        );
+        let text = text_of(&model, &ui, 110, 14);
+        assert!(text.contains("x again removes sub:1"), "{text}");
+        assert_eq!(
+            handle_key(key(KeyCode::Char('x')), &model, &mut ui),
+            DeckAction::Send(WorkspaceInput::Control {
+                agent: "sub:1".into(),
+                control: AgentControl::Delete,
+            }),
+            "the second x deletes"
+        );
+        assert!(ui.subagents.armed.is_none());
+
+        // The arm is the row's: moving the cursor stands it down.
+        handle_key(key(KeyCode::Char('x')), &model, &mut ui);
+        handle_key(key(KeyCode::Char('j')), &model, &mut ui);
+        assert!(ui.subagents.armed.is_none(), "moving the cursor disarms");
+
+        // A finished lane has nothing to stop: the first press only arms.
+        assert_eq!(
+            handle_key(key(KeyCode::Char('x')), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert_eq!(
+            handle_key(key(KeyCode::Char('x')), &model, &mut ui),
+            DeckAction::Send(WorkspaceInput::Control {
+                agent: "sub:2".into(),
+                control: AgentControl::Delete,
+            }),
+            "…and the second press removes the finished row"
+        );
+    }
+
+    /// **The witness for `o`.** `o` opens the selected lane exactly like `⏎`
+    /// — closes the overlay and focuses the lane's transcript, where the
+    /// composer steers it.
+    #[test]
+    fn o_opens_the_selected_lane_like_enter() {
+        let model = model_with(&[("sub:1", AgentStatus::Running)]);
+        let mut ui = DeckUi::default();
+        open(&mut ui);
+        assert_eq!(
+            handle_key(key(KeyCode::Char('o')), &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert!(!ui.subagents.open, "o closes the overlay");
+        assert_eq!(ui.focused, 1, "and focuses the lane's transcript");
     }
 
     /// **The witness for `n` and `f`.** A nudge is a steer at the lane asking
@@ -727,6 +851,7 @@ mod tests {
             key(KeyCode::Char('s')),
             key(KeyCode::Char('p')),
             key(KeyCode::Char('r')),
+            key(KeyCode::Char('x')),
             ctrl_x,
             ctrl_x,
         ] {
@@ -735,7 +860,7 @@ mod tests {
                 DeckAction::Handled,
                 "swallowed, never sent"
             );
-            assert!(!ui.subagents.kill_armed, "a child never arms a kill");
+            assert!(ui.subagents.armed.is_none(), "a child never arms a verb");
             assert!(
                 ui.subagents
                     .notice
@@ -938,7 +1063,10 @@ mod tests {
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
 
         assert_eq!(handle_key(ctrl_x, &model, &mut ui), DeckAction::Handled);
-        assert!(ui.subagents.kill_armed, "the first press arms");
+        assert!(
+            arm::fires(&ui.subagents.armed, arm::ArmedVerb::Kill, "sub:1"),
+            "the first press arms"
+        );
         assert_eq!(
             handle_key(ctrl_x, &model, &mut ui),
             DeckAction::Send(WorkspaceInput::Control {
@@ -947,21 +1075,21 @@ mod tests {
             }),
             "the second press kills"
         );
-        assert!(!ui.subagents.kill_armed);
+        assert!(ui.subagents.armed.is_none());
 
         handle_key(ctrl_x, &model, &mut ui);
         handle_key(key(KeyCode::Up), &model, &mut ui);
-        assert!(!ui.subagents.kill_armed, "another key disarms");
+        assert!(ui.subagents.armed.is_none(), "another key disarms");
         assert_eq!(
             handle_key(ctrl_x, &model, &mut ui),
             DeckAction::Handled,
             "…so the next ctrl-x only arms again"
         );
 
-        ui.subagents.kill_armed = false;
+        ui.subagents.armed = None;
         handle_key(key(KeyCode::Down), &model, &mut ui);
         handle_key(ctrl_x, &model, &mut ui);
-        assert!(!ui.subagents.kill_armed, "a finished lane never arms");
+        assert!(ui.subagents.armed.is_none(), "a finished lane never arms");
     }
 
     /// The armed state is visible: the footer says the next ctrl-x kills.
@@ -970,7 +1098,7 @@ mod tests {
         let model = model_with(&[("sub:1", AgentStatus::Running)]);
         let mut ui = DeckUi::default();
         open(&mut ui);
-        ui.subagents.kill_armed = true;
+        ui.subagents.armed = Some(arm::Armed::new(arm::ArmedVerb::Kill, "sub:1"));
         let text = text_of(&model, &ui, 100, 12);
         assert!(text.contains("ctrl-x again kills"), "{text}");
     }

--- a/crates/stella-tui/src/v2/subagents/arm.rs
+++ b/crates/stella-tui/src/v2/subagents/arm.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The SUB-AGENTS overlay's two-press verbs. A verb with no undo — kill,
+//! delete, restart — takes two presses of its key: the first arms, the
+//! second fires, any other key disarms. The arm is scoped to the lane it was
+//! pressed on, so moving the cursor between presses disarms too — the same
+//! per-row shape the AGENTS tab's uninstall uses, chosen over a bare flag
+//! because a fire aimed at whatever the cursor lands on is exactly the
+//! misfire the second press exists to prevent.
+
+/// Which verb the first press armed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArmedVerb {
+    /// `ctrl-x` — the next `ctrl-x` stops the lane's worker.
+    Kill,
+    /// `x` — the next `x` removes the lane's row from the deck for good.
+    Delete,
+    /// `r` — the next `r` respawns the lane from its retained spec.
+    Restart,
+}
+
+/// One armed verb on one lane. Held by the overlay for exactly one key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Armed {
+    pub verb: ArmedVerb,
+    pub lane: String,
+}
+
+impl Armed {
+    pub fn new(verb: ArmedVerb, lane: &str) -> Self {
+        Self {
+            verb,
+            lane: lane.to_string(),
+        }
+    }
+
+    /// The footer line shown while this arm is up: what the second press
+    /// does, and that any other key stands down.
+    pub fn footer(&self) -> String {
+        match self.verb {
+            ArmedVerb::Kill => format!(
+                " ctrl-x again kills {} · any other key keeps it ",
+                self.lane
+            ),
+            ArmedVerb::Delete => format!(
+                " x again removes {}'s row from the deck · any other key keeps it ",
+                self.lane
+            ),
+            ArmedVerb::Restart => format!(
+                " r again restarts {} from step 1 · any other key leaves it ",
+                self.lane
+            ),
+        }
+    }
+}
+
+/// Whether a press of `verb` on `lane` is the second press — i.e. the arm
+/// taken from the overlay matches both. The caller has already `take`n the
+/// arm, so a mismatch leaves the overlay disarmed by construction.
+pub fn fires(taken: &Option<Armed>, verb: ArmedVerb, lane: &str) -> bool {
+    taken
+        .as_ref()
+        .is_some_and(|a| a.verb == verb && a.lane == lane)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The arm fires only for the same verb on the same lane.
+    #[test]
+    fn an_arm_fires_only_for_its_own_verb_and_lane() {
+        let armed = Some(Armed::new(ArmedVerb::Delete, "sub:2"));
+        assert!(fires(&armed, ArmedVerb::Delete, "sub:2"));
+        assert!(!fires(&armed, ArmedVerb::Restart, "sub:2"), "other verb");
+        assert!(!fires(&armed, ArmedVerb::Delete, "sub:3"), "other lane");
+        assert!(!fires(&None, ArmedVerb::Delete, "sub:2"), "nothing armed");
+    }
+
+    /// Each armed footer names the lane and the key that fires.
+    #[test]
+    fn the_armed_footer_names_the_lane_and_the_key() {
+        let kill = Armed::new(ArmedVerb::Kill, "sub:1").footer();
+        assert!(kill.contains("ctrl-x again kills sub:1"), "{kill}");
+        let delete = Armed::new(ArmedVerb::Delete, "sub:1").footer();
+        assert!(delete.contains("x again removes sub:1"), "{delete}");
+        let restart = Armed::new(ArmedVerb::Restart, "sub:1").footer();
+        assert!(restart.contains("r again restarts sub:1"), "{restart}");
+    }
+}

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -15,7 +15,7 @@
 │ │  e               edit the selected skill                                       !cmd            run a shell command NOW (skips the queue)                 │ │
 │ │  p               pin / unpin                                                   /               slash commands — ↑↓ pick · tab completes · ⏎ runs         │ │
 │ │  n               new skill — drafted by the LLM                                ctrl-v          paste — a copied image is attached to the prompt          │ │
-│ │  ctrl-o          preview                                                       ctrl-a          SUB-AGENTS — n nudge · f flag · ^x^x kill · p pause · r … │ │
+│ │  ctrl-o          preview                                                       ctrl-a          SUB-AGENTS — o open · n nudge · f flag · x stop · xx del… │ │
 │ │  ctrl-x ×2       delete (press twice to confirm)                               ctrl-t          the queue editor                                          │ │
 │ │  type            search skills                                                 ctrl-e          SESSIONS — every session on this machine                  │ │
 │ │                                                                                ctrl-k          CONTEXT — active skills + MCP servers                     │ │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -40,6 +40,6 @@
                          │                                                                                                            │
                          │                                                                                                            │
                          │                                                                                                            │
->>>                      ╰─────────────────── ↑↓ · →↵ open · n nudge · f flag · l lead · ^x^x kill · p pause/resume · r restart · esc ╯
+>>>                      ╰───────── ↑↓ · o↵ open · n nudge · f flag · l lead · x stop·xx delete · r resume·rr restart · p pause · esc ╯
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
## What

Full keyboard control of sub-agent lanes from the SUB-AGENTS overlay (already reached with `↓` from an empty prompt, or `ctrl-a`):

- **`o`** opens the selected lane exactly like `⏎`/`→` — its transcript on the SESSION tab, where the composer is the steering input and `⌫`/Esc goes back.
- **`x`** stops (interrupts) the selected lane; a second **`x`** deletes it — the row leaves the deck for good, retained spec included. Deletion is a **new verb end to end**: `AgentControl::Delete` in the envelope, driver handling that stops a live worker first and defers the deregister to its `Ended` (a row removed ahead of the worker's terminal status would be re-registered by it).
- **`r`** resumes a paused lane; a second **`r`** restarts — respawns from the lane's retained spec, back to step 1.
- `ctrl-x ctrl-x` (kill), `s` (stop) and `p` (pause/resume) keep their meanings.

## Design

- The overlay's single `kill_armed: bool` generalizes to a **row-scoped armed verb** (`v2/subagents/arm.rs`): the arm names the lane it was pressed on, so moving the cursor between presses disarms. Exemplar: the AGENTS tab's per-row `delete_armed: Option<String>` (deck_ui.rs), the in-repo shape for exactly this hazard — a two-press verb firing at whatever the cursor lands on.
- Driver-side control routing moves out of the `command_deck.rs` god file into a new sibling `command_deck/worker_control.rs` (the `settle`/`steer` pattern); the god file shrinks. `Pending` now carries both deferred restarts and deferred deletes; a delete outranks a restart armed earlier (the later intent wins).
- `SubSessions::forget` drops a lane's retained spec so a later Restart cannot revive a deleted row; a live lane keeps its spec until its `Ended`.
- The lead refuses `Delete` the same way it refuses `Restart`/`Stop` (`lead_control.rs`); a `delegate` child has no control plane and swallows the verbs with a notice, as before.

## Evidence

- Witnesses (all fail without the change — the keys/verbs did not exist):
  - `x_stops_the_lane_and_a_second_x_deletes_it`, `o_opens_the_selected_lane_like_enter`, updated `the_keys_control_the_selected_lane` (single `r` now resumes; the old assertion that a single `r` restarts fails on this branch by design), `an_arm_fires_only_for_its_own_verb_and_lane` (stella-tui)
  - `delete_on_an_ended_lane_deregisters_and_forgets_the_spec`, `delete_on_a_live_lane_waits_for_ended_and_outranks_a_restart` (stella-cli)
- `cargo test -p stella-tui` — 1067 lib + all integration suites green, including the keymap witness sweep and re-blessed goldens (`overlay_subagents.txt`, `overlay_help_skills.txt`; both diffs read — footer line and one help-sheet row only).
- `cargo test -p stella-cli --bin stella command_deck` — 128 green; `subsession` — 24 green.
- `make guards-fast` green; CI is the full gate.

## Deleted tests

None. `the_keys_control_the_selected_lane` changes behaviorally (single `r` = Resume, `r r` = Restart) but survives under its name.

## Summary by Sourcery

Provide complete keyboard control for sub-agent lanes from the SUB-AGENTS overlay, including opening, stopping, deleting, resuming, and restarting selected lanes.

New Features:
- Add `o` as an alternate shortcut for opening the selected sub-agent lane in the session view.
- Add `x`/`xx` controls to stop and then delete sub-agent lanes, including their retained specifications.
- Change `r`/`rr` controls to resume paused lanes and require a second press to restart them from their retained specification.

Bug Fixes:
- Ensure deletion of live lanes waits for worker termination before deregistration and cannot be overridden by an earlier restart request.
- Prevent deleted lanes from being revived by later restart handling.

Enhancements:
- Generalize two-press confirmation to row-scoped verbs and move worker-control routing into a dedicated module.
- Keep existing lead, delegate, and legacy control-key behavior intact while extending the control envelope with Delete.

Documentation:
- Update SUB-AGENTS overlay help text, footer guidance, and snapshots for the new lane controls.

Tests:
- Add coverage for opening lanes, stop-then-delete behavior, resume-then-restart behavior, row-scoped arming, and driver-side deletion lifecycle handling.