### PR TITLE
fix(stella-model): settle two parity questions from recorded field data — OpenRouter root-level cache_control is honoured; no seventh axis for the in-flight 402

### DIFF
--- a/crates/stella-model/src/http.rs
+++ b/crates/stella-model/src/http.rs
@@ -485,7 +485,14 @@ pub(crate) const HTTP_OVERLOADED: u16 = 529;
 ///   retryable `RateLimited`; a bare out-of-credit body is non-retryable
 ///   `Terminal`, called out explicitly as a billing failure (some gateways
 ///   use Payment Required for out-of-credits rather than folding it into a
-///   403).
+///   403). For the in-flight deferral this classification and its witnesses
+///   (`classify_http_status_402_naming_in_flight_requests_is_retryable`, plus
+///   the wiremock round-trip in `zai/tests/error_classify.rs`) are the whole
+///   contract — decided in #4414: no parity-axis row is owed, because the
+///   refusal is one gateway's transient account state, not a per-provider
+///   feature divergence, and a seventh axis would oblige every other provider
+///   to declare an evidence-free row for a behavior only OpenRouter has ever
+///   exhibited.
 /// - 429 → retryable `RateLimited` carrying the Retry-After hint.
 /// - 529 → retryable `Overloaded` carrying the Retry-After hint. Anthropic
 ///   and Z.ai return this non-standard status to shed load, and it is the

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -191,7 +191,16 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
                         over one 17-minute session it held for the last 17 calls and not \
                         the first 32, leaving 20 of 69 calls reading zero cached tokens \
                         for 54% of the spend. Only a non-empty upstream_pin \
-                        (provider.order + allow_fallbacks:false) actually fixes the route",
+                        (provider.order + allow_fallbacks:false) actually fixes the route. \
+                        The gateway honours the root-level placement for Anthropic routes, \
+                        verified from recorded field usage rather than a live probe \
+                        (#1854): of 1,684 anthropic/* calls this adapter made between \
+                        2026-07-26 and 2026-08-16, 1,373 read cached tokens (95.8M of \
+                        107.5M input, 89%) and 1,557 recorded cache writes — and the \
+                        adapter has only ever sent the root-level form, never per-part \
+                        markers, so with Anthropic caching being explicit opt-in through \
+                        the gateway those reads could not occur if the root field were \
+                        dropped",
             witness: "openrouter_identity_sends_root_level_cache_control",
         },
     ),


### PR DESCRIPTION
## What

### #1854 — OpenRouter root-level cache_control on Anthropic routes
The open question was whether the gateway honours the request-root `cache_control` this adapter sends (the parity witness only proves the field reaches the wire). Settled from recorded field usage instead of a live probe: the usage hub (`~/.stella/usage.db`, `telemetry` table) holds 1,684 `anthropic/*` calls made through the `openrouter` provider id between 2026-07-26 and 2026-08-16 — 1,373 read cached tokens (95,845,062 of 107,525,720 input tokens, 89%) and 1,557 recorded cache writes. The verified links: the adapter has sent only the root-level form since the opt-in landed (349e3a571, and `git log -S cache_control` shows no placement change since); every telemetry row postdates that commit. The premise carried from OpenRouter's contract (and 349e3a571's own rationale): Anthropic caching through the gateway is explicit opt-in, so cache reads cannot occur with the opt-in dropped. If root-level were dead the census would read 0% cache on those routes; it reads 89% of input tokens. The fix is the row update the issue's honoured-outcome branch asked for: the `CachePosture` mechanism note in `crates/stella-model/src/provider_parity.rs` now records the observation. The parts-form fallback (issue items 2–3) is not needed.

### #4414 — 402 in-flight refusal: recorded decision, no seventh axis
Took the second branch of the issue's "Done means": a sentence on the `PAYMENT_REQUIRED` arm's doc comment (`crates/stella-model/src/http.rs`) recording that the classification plus its two witnesses is the whole contract and no parity-axis row is owed. Reasoning (in the commit body): the matrix guards feature divergence that fails silently; the in-flight refusal is one gateway's transient account state that fails loudly when mishandled, and a seventh axis would oblige nine evidence-free rows for a behavior only OpenRouter has exhibited. Reversible — a later PR can still add the axis.

## Evidence

- Census (#1854): `sqlite3 ~/.stella/usage.db "select count(*), sum(cache_read_tokens>0), sum(cache_write_tokens>0), sum(input_tokens), sum(cache_read_tokens) from telemetry where provider='openrouter' and model like 'anthropic/%'"` → `1684|1373|1557|107525720|95845062`; date range `2026-07-26 23:16 → 2026-08-16 16:12`.
- Placement history (#1854): `git log --follow -S cache_control -- crates/stella-model/src/zai.rs` → opt-in born root-level in 349e3a571; no later commit changes the placement.
- `cargo clippy -p stella-model --all-targets -- -D warnings` → exit 0 (re-run after `cargo clean -p stella-model` post-merge; exit read from a log file).
- `cargo test -p stella-model provider_parity` → 19 passed, 0 failed (witness-existence and completeness tests over all axes).
- `cargo test -p stella-model classify_http_status_402` → 5 passed; `an_unrelated_400_never_classifies_as_context_overflow` → 1 passed.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-model --no-deps` and the `--document-private-items` form → both exit 0.
- `cargo fmt --check`, `make guards-fast` → exit 0.
- No witness test on either commit: both are declaration/doc changes with no behavior change — the #1854 evidence is the recorded field census the note cites, and #4414's deliverable is the recorded decision its definition of done names; the behavior's own witnesses stay green (run above).

## Not done

- **#2750** (verify wire overflow signatures for zai/xai/deepseek/openrouter/local): skipped — requires provoking real overflows on the live wire. Checked offline first: this repo's `store.db` holds 80 `error` events and none carries a context-overflow body from any of the five providers (the recorded provider errors are 402s, 404s, and stream aborts). The five rows stay declared `BestEffort` gaps; no signature was invented. The `local` row already documents that local servers have no single distinguishable shape.
- **#4172** (default `upstream_pin` for the built-in openrouter row): skipped — a product decision the issue itself says is deliberately not being made in a PR, with no recommended config-reversible default (its strongest option, pin-on-first-success, needs the served upstream read out of the response, a separate unbuilt gap). Left for the maintainer.

Closes #1854
Closes #4414

## Summary by Sourcery

Settle the OpenRouter cache-control and in-flight payment-required parity decisions using recorded evidence and explicit contract documentation.

Enhancements:
- Record field evidence that OpenRouter honours root-level cache control for Anthropic routes.
- Document that the in-flight HTTP 402 classification is complete without adding a seventh provider-parity axis.