### PR TITLE
fix(arenabench,stella-cli): the transcript's prompt row, and fleet wrapper reports held past the live grid

### DIFF
--- a/.github/workflows/diff-view-parity.yml
+++ b/.github/workflows/diff-view-parity.yml
@@ -51,8 +51,10 @@ on:
       - "crates/stella-transcript/**"
       - "arenabench/ui/lib/diff-view.ts"
       - "arenabench/ui/lib/word-highlight.ts"
+      - "arenabench/ui/lib/transcript-view.ts"
       - "arenabench/ui/scripts/check-diff-view-parity.mjs"
       - "arenabench/ui/scripts/check-word-highlight-parity.mjs"
+      - "arenabench/ui/scripts/check-transcript-view.mjs"
       - ".github/workflows/diff-view-parity.yml"
   push:
     branches: [main]
@@ -61,8 +63,10 @@ on:
       - "crates/stella-transcript/**"
       - "arenabench/ui/lib/diff-view.ts"
       - "arenabench/ui/lib/word-highlight.ts"
+      - "arenabench/ui/lib/transcript-view.ts"
       - "arenabench/ui/scripts/check-diff-view-parity.mjs"
       - "arenabench/ui/scripts/check-word-highlight-parity.mjs"
+      - "arenabench/ui/scripts/check-transcript-view.mjs"
       - ".github/workflows/diff-view-parity.yml"
   workflow_dispatch:
 
@@ -96,3 +100,14 @@ jobs:
         if: '!cancelled()'
         working-directory: arenabench/ui
         run: node scripts/check-word-highlight-parity.mjs
+
+      # Not a Rust-parity check like the two above, but the same shape — pure
+      # functions, zero dependencies, needs Node — and until #4039 wired it
+      # here it ran in no workflow at all: the reading-tool decisions in
+      # `lib/transcript-view.ts` (errors-only pairing, prompt-first ordering,
+      # call/result folding, JSON folds) were guarded only on a developer's
+      # own initiative. Same `!cancelled()` reasoning as its sibling.
+      - name: the transcript reading-tool checks pass
+        if: '!cancelled()'
+        working-directory: arenabench/ui
+        run: node scripts/check-transcript-view.mjs

--- a/arenabench/.github/workflows/ci.yml
+++ b/arenabench/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
           cache: npm
           cache-dependency-path: ui/package-lock.json
 
+      # No dependencies — Node strips the type annotations natively — so it
+      # runs before `npm ci` and fails fast on a reading-tools regression.
+      - name: the transcript reading-tool checks pass
+        working-directory: ui
+        run: node scripts/check-transcript-view.mjs
+
       - name: npm ci
         working-directory: ui
         run: npm ci

--- a/arenabench/arenabench/server.py
+++ b/arenabench/arenabench/server.py
@@ -744,12 +744,15 @@ class ArenaServer:
         #
         # Last write wins, because the last emission is the complete one: the
         # accumulator only ever grows, and the consolidated `text` event
-        # replaces the fragment run outright. Insertion order is preserved so
-        # the transcript still reads in the order it happened.
+        # replaces the fragment run outright. Ordered by `seq` rather than by
+        # insertion: the two agree for every entry except the `prompt` row,
+        # which carries the reserved seq 0 however late its `block_registered`
+        # lands in the stream (#4039) — and the SSE client sorts, while this
+        # endpoint's caller renders the list as given.
         collapsed: dict[int, dict[str, Any]] = {}
         for entry in entries:
             collapsed[entry["seq"]] = entry
-        return {"entries": list(collapsed.values())}
+        return {"entries": sorted(collapsed.values(), key=lambda e: e["seq"])}
 
     def video(self, match_id: str, contestant_id: str, task: str) -> Path | None:
         match = self.runner.matches.get(match_id)

--- a/arenabench/arenabench/transcript.py
+++ b/arenabench/arenabench/transcript.py
@@ -447,6 +447,11 @@ class TranscriptState:
     #: ``step_usage`` routinely closes the run *before* the consolidated
     #: event arrives, and the consolidation must still find its run.
     pending_text: int | None = None
+    #: Whether the trial's ``prompt`` entry has been emitted. Once: the
+    #: engine registers the ``user_goal`` block once per turn and a trial is
+    #: one turn, but the guard costs nothing and a re-registered goal must
+    #: not print the question twice.
+    prompt_emitted: bool = False
 
 
 class TranscriptReader:
@@ -638,6 +643,37 @@ class TranscriptReader:
         # Any non-delta event closes the open text/reasoning runs, so the next
         # fragment starts a fresh entry rather than reopening a finished one.
         state.open_entries.clear()
+
+        if kind == "block_registered":
+            # The task instruction, as its own `prompt` entry — the anchor the
+            # whole transcript is read against (#4039). The wire has carried
+            # it all along: the engine registers the goal as a `user_goal`
+            # context block whose `content` is the exact text the model was
+            # handed, and this reader dropped every `block_registered` on the
+            # floor — which is why every arena transcript showed stages and
+            # tool calls with nothing saying what was asked.
+            #
+            # `seq` 0, which no other entry can hold (`_next_seq` counts from
+            # 1) and `t` 0.0: the question predates everything the trial did,
+            # and the page sorts by `seq`, so the prompt heads the transcript
+            # however late its block event lands in the stream. Every other
+            # block kind stays unrendered — the manifest/receipt plane is a
+            # reconstruction record, not reading material.
+            if (
+                state.prompt_emitted
+                or str(event.get("kind") or "") != "user_goal"
+            ):
+                return []
+            content = str(event.get("content") or "")
+            if not content:
+                # A content-free projection registers the block without its
+                # preimage; a prompt row with an empty body would read as a
+                # rendering bug rather than an honest absence.
+                return []
+            state.prompt_emitted = True
+            prompt = entry(0, "prompt", "prompt", content)
+            prompt["t"] = 0.0
+            return [prompt]
 
         if kind == "tool_start":
             call = event.get("call") if isinstance(event.get("call"), dict) else {}

--- a/arenabench/tests/test_transcript_prompt.py
+++ b/arenabench/tests/test_transcript_prompt.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 the ArenaBench authors
+"""The trial's prompt row — the ``YOU`` half of the conversation (#4039).
+
+The transcript-spec addendum §1 renders a turn as Prompt → Prose → Steps →
+Answer, with the prompt "never folded away by default (it's the anchor for
+everything below)". The arena transcript rendered **no prompt row at all**: a
+reader opening a trial saw stages, tool calls and responses with nothing
+saying what was asked.
+
+The wire has carried the instruction all along. The engine registers the task
+text as a ``block_registered`` event of kind ``user_goal`` whose ``content``
+is the exact prompt the model was handed, and
+:class:`~arenabench.transcript.TranscriptReader` dropped every
+``block_registered`` on the floor. These assertions pin the recovery:
+
+* the instruction becomes one ``prompt`` entry on the reserved seq 0, so the
+  page's seq-ordered render puts it first even though the block event lands
+  *after* the trial's first stage rule on the wire;
+* it is emitted once, at ``t`` 0.0, and never re-emitted on a later read;
+* the other block kinds stay unrendered — the receipt plane is a
+  reconstruction record, not reading material;
+* a content-free stream (the block registered without its preimage) emits no
+  prompt row rather than an empty one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from arenabench.transcript import TranscriptReader
+
+
+def write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+
+
+def goal_block(content: str | None = "Fix the bug in parser.py.") -> dict:
+    """A ``user_goal`` ``block_registered``, in the shape Stella emits
+    (``stella_protocol::event::AgentEvent::BlockRegistered``)."""
+    event = {
+        "ts": 1786450724282,
+        "type": "block_registered",
+        "block_id": "blk_d3ce1b6ca63b572bc4b013e6",
+        "kind": "user_goal",
+        "origin": {"turn_instance": 0, "step": 0},
+        "token_cost": 12,
+        "content_digest": "sha256:25c3bcdb",
+    }
+    if content is not None:
+        event["content"] = content
+    return event
+
+
+def test_the_user_goal_block_becomes_the_prompt_row(tmp_path: Path) -> None:
+    """The stream's real order — stage first, goal block after — still yields
+    a prompt entry that sorts to the head of the transcript."""
+    path = tmp_path / "stella-events.jsonl"
+    write_events(
+        path,
+        [
+            {"ts": 1786450720000, "type": "stage", "name": "context_recall"},
+            goal_block(),
+            {"ts": 1786450724290, "type": "stage", "name": "execute"},
+        ],
+    )
+    entries = TranscriptReader().read(path)
+    prompts = [e for e in entries if e["kind"] == "prompt"]
+    assert len(prompts) == 1
+    prompt = prompts[0]
+    assert prompt["seq"] == 0, "the reserved seq is what puts the anchor first"
+    assert prompt["t"] == 0.0
+    assert prompt["body"] == "Fix the bug in parser.py."
+    assert min(e["seq"] for e in entries if e["kind"] != "prompt") >= 1
+    ordered = sorted(entries, key=lambda e: e["seq"])
+    assert ordered[0]["kind"] == "prompt", (
+        "seq order must open on the prompt even though the wire led with a stage"
+    )
+
+
+def test_the_prompt_is_emitted_once(tmp_path: Path) -> None:
+    """A second read, and even a re-registered goal, must not print the
+    question twice."""
+    path = tmp_path / "stella-events.jsonl"
+    reader = TranscriptReader()
+    write_events(path, [goal_block()])
+    first = reader.read(path)
+    assert [e["kind"] for e in first] == ["prompt"]
+    write_events(
+        path,
+        [goal_block(), {"ts": 1786450724300, "type": "stage", "name": "execute"}],
+    )
+    second = reader.read(path)
+    assert [e["kind"] for e in second] == ["stage"]
+
+
+def test_other_block_kinds_stay_unrendered(tmp_path: Path) -> None:
+    path = tmp_path / "stella-events.jsonl"
+    events = []
+    for kind in ("system_prefix", "assistant_text", "tool_call", "tool_result"):
+        block = goal_block("not the prompt")
+        block["kind"] = kind
+        events.append(block)
+    write_events(path, events)
+    assert TranscriptReader().read(path) == []
+
+
+def test_a_content_free_goal_block_emits_no_prompt(tmp_path: Path) -> None:
+    """The content-free projection registers the block without its preimage;
+    an empty prompt row would read as a rendering bug, not an absence."""
+    path = tmp_path / "stella-events.jsonl"
+    write_events(path, [goal_block(content=None)])
+    assert TranscriptReader().read(path) == []
+
+
+def test_the_goal_block_does_not_break_text_coalescing(tmp_path: Path) -> None:
+    """The prompt arm sits on the non-delta path, which closes open
+    text/reasoning runs — exactly as every ``block_registered`` already did.
+    What must hold: the consolidated ``text`` event still supersedes its
+    fragment run afterwards."""
+    path = tmp_path / "stella-events.jsonl"
+    write_events(
+        path,
+        [
+            goal_block(),
+            {"ts": 1786450724300, "type": "text_delta", "text": "half an ans"},
+            {"ts": 1786450724400, "type": "text", "delta": "half an answer, whole"},
+        ],
+    )
+    entries = TranscriptReader().read(path)
+    texts = [e for e in entries if e["kind"] == "text"]
+    assert texts, f"no consolidated text entry in {entries!r}"
+    assert texts[-1]["body"] == "half an answer, whole"

--- a/arenabench/ui/components/arena/transcript-page.tsx
+++ b/arenabench/ui/components/arena/transcript-page.tsx
@@ -15,6 +15,7 @@ import {
   erroredSeqs,
   indexByCallId,
   mergeToolRows,
+  orderEntries,
   rawExchange,
   type RawExchange,
 } from "@/lib/transcript-view";
@@ -75,6 +76,10 @@ function pacedDelay(gapSeconds: number, speed: number): number {
 
 /** Filterable groups, in reading order. Unknown kinds always render. */
 const GROUPS: Array<{ key: string; label: string; kinds: string[] }> = [
+  // Its own group, never bundled with "responses": the prompt is the question
+  // the whole page is read against (#4039), and turning the agent's prose off
+  // must not also hide what was asked.
+  { key: "prompt", label: "prompt", kinds: ["prompt"] },
   { key: "text", label: "responses", kinds: ["text"] },
   { key: "reasoning", label: "thinking", kinds: ["reasoning"] },
   { key: "tool", label: "tools", kinds: ["tool"] },
@@ -119,7 +124,7 @@ function useTranscript(matchId: string, contestantId: string, task: string) {
       for (const entry of payload.entries) bySeq.set(entry.seq, entry);
       if (bySeq.size) {
         setWaiting(false);
-        setEntries([...bySeq.values()].sort((a, b) => a.seq - b.seq));
+        setEntries(orderEntries([...bySeq.values()]));
       }
     });
     source.addEventListener("end", () => {

--- a/arenabench/ui/components/arena/transcript/entry.tsx
+++ b/arenabench/ui/components/arena/transcript/entry.tsx
@@ -275,6 +275,54 @@ export function usageLine(entry: TranscriptEntry): string {
 
 const THINKING_PREVIEW_LINES = 5;
 
+/** Lines of the task instruction shown before the rest sits behind "more".
+ *
+ * Generous where `THINKING_PREVIEW_LINES` is tight, because the two fold for
+ * different reasons: thinking is the quietest text on the page, while the
+ * prompt is the anchor everything below is read against and is *never*
+ * folded away — a Frontier-Bench instruction runs to hundreds of lines, and
+ * the fold exists only so one of those cannot push the trial itself off
+ * screen. The remainder is a disclosure away, not gone. */
+const PROMPT_PREVIEW_LINES = 30;
+
+/**
+ * The trial's task instruction — the `YOU` half of the conversation the
+ * transcript-spec addendum §1 lays out (Prompt → Prose → Steps → Answer).
+ *
+ * Its own component because the long-instruction fold is component-local
+ * state: the page's per-`seq` fold maps (`openResults`/`thinkingOverrides`)
+ * are the machinery a prompt row deliberately does not participate in — those
+ * reset per trial and default closed, and the prompt must default open.
+ */
+function PromptEntry({ entry, query }: { entry: TranscriptEntry; query: string }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const body = entry.body || entry.title || "";
+  const lines = body.split("\n");
+  const folded = !expanded && lines.length > PROMPT_PREVIEW_LINES;
+  const shown = folded ? lines.slice(0, PROMPT_PREVIEW_LINES) : lines;
+  return (
+    <div className="tx-role you">
+      <div className="tx-rolegut">
+        <span className="tx-roletag">YOU</span>
+      </div>
+      <div className="tx-prose">
+        <Highlight text={shown.join("\n")} query={query} />
+        {folded && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="cursor-pointer text-[10.5px] text-dim hover:text-muted"
+            >
+              ⋯ {lines.length - PROMPT_PREVIEW_LINES} more lines
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /** Collapsed-result line budgets, matching the deck and the export surfaces:
  * six lines either way, anchored on the salient point.
  *
@@ -847,6 +895,14 @@ export function Entry({
   isAnswer?: boolean;
 }) {
   const body = entry.body || "";
+
+  if (entry.kind === "prompt") {
+    // The question the whole page is read against, first and role-badged
+    // (#4039). The `.tx-role.you` styles sat in `transcript-surface.css`
+    // unreferenced from the day they were written — only the `agent` half of
+    // the conversation was ever emitted.
+    return <PromptEntry entry={entry} query={query} />;
+  }
 
   if (entry.kind === "stage") {
     // A section rule, not a row: the label is the stage.

--- a/arenabench/ui/lib/transcript-view.ts
+++ b/arenabench/ui/lib/transcript-view.ts
@@ -18,6 +18,22 @@ export function isFailedResult(entry: TranscriptEntry): boolean {
 }
 
 /**
+ * The reading order of a transcript: ascending `seq`.
+ *
+ * One function rather than an inline sort at the SSE fold, because the order
+ * carries a policy (#4039): the `prompt` row rides the reserved seq 0, and its
+ * `block_registered` event lands *after* the trial's first stage rule on the
+ * wire — so arrival order would render the question below a row of the answer,
+ * and only a sort keyed on `seq` puts the anchor first. Non-mutating: the SSE
+ * fold hands in a Map's values, but nothing says a future caller will.
+ */
+export function orderEntries(
+  entries: readonly TranscriptEntry[],
+): TranscriptEntry[] {
+  return [...entries].sort((a, b) => a.seq - b.seq);
+}
+
+/**
  * The `seq`s an errors-only view keeps.
  *
  * Not simply "every entry with an error flag". A failed result read alone is

--- a/arenabench/ui/package.json
+++ b/arenabench/ui/package.json
@@ -9,7 +9,8 @@
     "build": "next build && node scripts/sync-web.mjs",
     "typecheck": "tsc --noEmit",
     "check:diff-parity": "node scripts/check-diff-view-parity.mjs",
-    "check:word-parity": "node scripts/check-word-highlight-parity.mjs"
+    "check:word-parity": "node scripts/check-word-highlight-parity.mjs",
+    "check:transcript-view": "node scripts/check-transcript-view.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",

--- a/arenabench/ui/scripts/check-transcript-view.mjs
+++ b/arenabench/ui/scripts/check-transcript-view.mjs
@@ -13,6 +13,9 @@
  *
  * What is checked here is what a reader would notice being wrong:
  *
+ * - a transcript that opens on anything but the prompt — the task instruction
+ *   rides the reserved seq 0 and must head the reading order however late its
+ *   `block_registered` lands in the stream (#4039);
  * - an errors-only view that shows a failure without the call that caused it;
  * - a JSON fold whose close is on the wrong line, which silently swallows the
  *   rest of the payload;
@@ -30,6 +33,7 @@ import {
   isFailedResult,
   lineText,
   mergeToolRows,
+  orderEntries,
   rawExchange,
 } from "../lib/transcript-view.ts";
 
@@ -56,6 +60,33 @@ const entry = (seq, kind, extra = {}) => ({
   body: extra.body ?? "",
   meta: extra.meta ?? {},
 });
+
+// -- the prompt heads the transcript ---------------------------------------
+
+// The wire carries the task instruction as a `block_registered` event that
+// lands AFTER the trial's first stage rule, so arrival order buries the
+// question under a row of the answer. The reader stamps it with the reserved
+// seq 0 (`arenabench/arenabench/transcript.py`), and this is the other half of
+// that contract: the reading order is `seq` order, so the entry list begins
+// with the prompt row.
+console.log("prompt ordering");
+{
+  const arrived = [
+    entry(1, "stage", { title: "execute" }),
+    entry(2, "tool", { title: "bash", meta: { call_id: "c1" } }),
+    entry(0, "prompt", { title: "prompt", body: "Fix the bug." }),
+  ];
+  const ordered = orderEntries(arrived);
+  eq("the entry list begins with the prompt row", ordered[0].kind, "prompt");
+  eq("and everything else keeps its order", ordered.map((e) => e.seq), [0, 1, 2]);
+  eq("the input list is not reordered in place", arrived[2].kind, "prompt");
+
+  // The prompt is its own row: nothing folds into it, and it does not
+  // displace the call/result pairing behind it.
+  const rows = mergeToolRows(ordered);
+  eq("the prompt is its own row and stays first", rows[0].entry.kind, "prompt");
+  check("with nothing folded into it", rows[0].result === undefined);
+}
 
 // -- one row per call ------------------------------------------------------
 

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -190,6 +190,10 @@ pub async fn run_fleet(
         None
     };
 
+    // Wrapper report lines cannot print while the grid owns the alternate
+    // screen; the workers hold them here and the live arm below prints them
+    // once the dashboard has restored the terminal (#3883).
+    let held_reports = live.then(|| Arc::new(wrapped::HeldReports::default()));
     let worker = EngineWorker {
         cfg: cfg.clone(),
         // Divide the aggregate cap across the concurrency width so one wave's
@@ -198,6 +202,7 @@ pub async fn run_fleet(
         run_id: run_id.clone(),
         dash: worker_dash,
         wrapper_variant: wrapper_variant.map(str::to_string),
+        held_reports: held_reports.clone(),
     };
     let fleet = Fleet::new(
         worker,
@@ -299,6 +304,14 @@ pub async fn run_fleet(
         let report = run_result.map_err(|e| format!("fleet run failed: {e}"))?;
         if let Ok(res) = dash_result {
             print_dash_summary(&res);
+        }
+        // The wrapper reports the workers held while the grid was up. Each
+        // line already names its task, so printing them together after
+        // teardown loses no attribution (#3883).
+        if let Some(held) = &held_reports {
+            for line in held.drain() {
+                eprintln!("{line}");
+            }
         }
         report
     } else {
@@ -528,6 +541,13 @@ struct EngineWorker {
     /// own from this name, in its own tree, and `run_fleet`'s pre-flight has
     /// already proven the name resolves.
     wrapper_variant: Option<String>,
+    /// Where an attempt's wrapper report goes while the live grid owns the
+    /// terminal: held here and printed by [`run_fleet`] after teardown,
+    /// because an `eprintln!` onto the alternate screen is destroyed by the
+    /// next frame (#3883). `Some` exactly when `dash` is — both exist because
+    /// the run is live — and `None` keeps the headless path printing at
+    /// settle time, as it always has.
+    held_reports: Option<Arc<wrapped::HeldReports>>,
 }
 
 #[async_trait::async_trait]
@@ -547,6 +567,7 @@ impl FleetWorker for EngineWorker {
         let cfg = self.cfg.clone();
         let per_child_budget = self.per_child_budget;
         let wrapper_variant = self.wrapper_variant.clone();
+        let held_reports = self.held_reports.clone();
         let task = task.clone();
         let root = workspace_root.to_path_buf();
         let claim_holder = format!("{}/{}", self.run_id, task.id);
@@ -593,6 +614,7 @@ impl FleetWorker for EngineWorker {
                         worker_dash,
                         worker_spend,
                         wrapper_variant.as_deref(),
+                        held_reports.as_deref(),
                     ))
                 });
             let _ = tx.send(result);
@@ -915,6 +937,7 @@ async fn run_task(
     dash: Option<mpsc::UnboundedSender<FleetMsg>>,
     spend: crate::fleet_spend::SpendRecovery,
     wrapper_variant: Option<&str>,
+    held_reports: Option<&wrapped::HeldReports>,
 ) -> Result<WorkerOutcome, String> {
     // Where this workspace starts. In an ISOLATED worktree this is the whole
     // attribution story — one writer, so the whole advance to `HEAD` is this
@@ -1170,7 +1193,9 @@ async fn run_task(
                         _ = stop_wait => None,
                     };
                     let raced = match dispatched {
-                        Some(report) => Raced::Outcome(wrapper.settle(report, driver)),
+                        Some(report) => {
+                            Raced::Outcome(wrapper.settle(report, driver, held_reports))
+                        }
                         None => Raced::Stopped,
                     };
                     // What the plugin's last point spent has no engine turn

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -955,3 +955,33 @@ async fn two_attempts_at_one_task_are_one_task_to_governance() {
          retry wave at one task: {distinct:?}"
     );
 }
+
+/// **Witness (#3883, live-dashboard half).** Wrapper report lines are held
+/// while the grid owns the terminal — appended per attempt under one lock so
+/// two concurrent workers' reports interleave per report, never per line —
+/// and drained once, in arrival order, when the grid tears down.
+#[test]
+fn held_wrapper_reports_stay_whole_per_attempt_and_drain_once() {
+    let held = wrapped::HeldReports::default();
+    // Two attempts' reports, arriving whole — the shape `AttemptWrapper::
+    // settle` hands over, each line already naming its task.
+    held.hold(vec![
+        "  ! [t1] wrapper: fault".to_string(),
+        "  ◇ [t1] met".to_string(),
+    ]);
+    held.hold(vec!["  ◇ [t2] met".to_string()]);
+    // An empty report holds nothing — a clean attempt must not cost a lock
+    // entry or an empty line at teardown.
+    held.hold(Vec::new());
+
+    let drained = held.drain();
+    assert_eq!(
+        drained,
+        ["  ! [t1] wrapper: fault", "  ◇ [t1] met", "  ◇ [t2] met",],
+        "arrival order, attempts contiguous"
+    );
+    assert!(
+        held.drain().is_empty(),
+        "a second drain finds nothing — teardown prints each line once"
+    );
+}

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -214,6 +214,7 @@ impl AttemptWrapper {
         &self,
         report: Result<DispatchReport, stella_runtime::wrapper::WrapperError>,
         driver: AttemptDriver<'_, '_>,
+        held: Option<&HeldReports>,
     ) -> Result<TurnOutcome, String> {
         let report = report
             .map_err(|error| format!("wrapper \"{}\" cannot be driven: {error}", self.variant()))?;
@@ -223,14 +224,64 @@ impl AttemptWrapper {
         // the human's only view of what a plugin concluded about this attempt,
         // and scoped to this attempt's task because `--max-concurrency > 1`
         // puts N workers' lines on one stream (#3883).
-        self.bound
-            .report(Some(&self.task), crate::OutputFormat::Text, &report);
+        let lines = self
+            .bound
+            .report_lines(Some(&self.task), crate::OutputFormat::Text, &report);
+        match held {
+            // The live grid owns the terminal: an `eprintln!` now lands on the
+            // alternate screen it is painting and is destroyed by the next
+            // frame. Held, never suppressed — a refusal reported nowhere is
+            // the silence #3561 closed (#3883).
+            Some(held) => held.hold(lines),
+            None => {
+                for line in &lines {
+                    eprintln!("{line}");
+                }
+            }
+        }
         driver.driven.ok_or_else(|| {
             format!(
                 "wrapper \"{}\" drove this attempt with no turn",
                 self.variant()
             )
         })
+    }
+}
+
+/// Wrapper report lines held while the live dashboard owns the terminal,
+/// printed by `run_fleet` once the grid tears down (#3883).
+///
+/// The lines already name their task (`BoundWrapper::report_lines` is called
+/// with the attempt's task as its scope), so deferring them costs no
+/// attribution — only immediacy, which the alternate screen was destroying
+/// anyway. Suppressing them instead is not acceptable: a refusal reported
+/// nowhere is the silence #3561 closed. Whether these lines should *also*
+/// reach a dashboard pane while the run is live is a `FleetMsg` design of its
+/// own; holding is the half every run needs regardless.
+///
+/// One buffer per run, shared by every worker thread. [`Self::hold`] appends
+/// an attempt's whole report under one lock, so concurrent attempts' lines
+/// interleave per report, never per line.
+#[derive(Debug, Default)]
+pub(super) struct HeldReports(std::sync::Mutex<Vec<String>>);
+
+impl HeldReports {
+    /// Append one attempt's report, atomically.
+    pub(super) fn hold(&self, lines: Vec<String>) {
+        if lines.is_empty() {
+            return;
+        }
+        // A poisoned lock means a worker thread panicked mid-`extend`; the
+        // lines already in the buffer are still worth printing, so take the
+        // data rather than the poison.
+        let mut all = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
+        all.extend(lines);
+    }
+
+    /// Everything held, in arrival order, leaving the buffer empty.
+    pub(super) fn drain(&self) -> Vec<String> {
+        let mut all = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
+        std::mem::take(&mut *all)
     }
 }
 

--- a/crates/stella-cli/src/wrapper_plugin/report.rs
+++ b/crates/stella-cli/src/wrapper_plugin/report.rs
@@ -87,6 +87,35 @@ pub(super) fn report_lines(
     lines
 }
 
+impl super::BoundWrapper {
+    /// [`super::BoundWrapper::report`]'s lines, composed but not printed.
+    ///
+    /// For the one door where printing is a decision rather than a default: a
+    /// fleet attempt under the live dashboard must not `eprintln!` onto the
+    /// alternate screen the grid is painting, so it takes the lines and holds
+    /// them until the grid tears down (#3883,
+    /// `crate::fleet_cmd::wrapped::HeldReports`). Composed by [`report_lines`]
+    /// like everything `report` prints, so the held lines and the printed ones
+    /// share one wording. Defined here rather than beside `report` because
+    /// `wrapper_plugin.rs` sits under the 1500-line ratchet — the reason this
+    /// module exists.
+    pub(crate) fn report_lines(
+        &self,
+        scope: Option<&str>,
+        format: OutputFormat,
+        report: &DispatchReport,
+    ) -> Vec<String> {
+        report_lines(
+            scope,
+            format,
+            report,
+            &self.gates,
+            &self.child_spends(),
+            &self.fanout_spends(),
+        )
+    }
+}
+
 /// The one rendering of a `! wrapper:` line, marker and scope tag included.
 ///
 /// A free function rather than a closure inside [`report_lines`] because it


### PR DESCRIPTION
## What

**#4039 — arena transcript: no prompt row.** The wire has carried the task
instruction all along: the engine registers it as a `block_registered` event of
kind `user_goal` whose `content` is the exact prompt the model was handed, and
`arenabench/arenabench/transcript.py` dropped every `block_registered` on the
floor. The reader now emits it as one `prompt` entry on the reserved seq 0
(`_next_seq` counts from 1), at `t` 0.0, once per trial — so the page's
seq-ordered render opens on it even though the block lands after the trial's
first stage rule on the wire. `full_transcript` sorts its collapsed entries by
seq for the same reason. On the page: a `prompt` kind-group chip of its own
(turning responses off cannot hide the question), a `PromptEntry` component
using the `tx-role you` / `YOU` markup whose CSS had been dead since it was
written, no participation in the per-seq fold machinery, and a long instruction
folds to a 30-line preview rather than to nothing (§1: the prompt is never
folded away). `check-transcript-view.mjs` gains the ordering checks and — it
ran in **no workflow at all** — is now wired into `diff-view-parity.yml` (the
monorepo's Node-but-no-deps job, `!cancelled()` like its siblings) and
arenabench's own dormant `.github/workflows/ci.yml`, plus a
`check:transcript-view` package script.

**#3883 — fleet wrapper report lines under the live grid.** The
task-attribution half landed in #4416 (`Refs`); this is the half it left
behind: under the live dashboard the lines still `eprintln!`'d onto the
alternate screen the grid was painting. Of the issue's two acceptable designs
(a dashboard pane, or hold until teardown) this ships **hold until teardown**:
`AttemptWrapper::settle` composes its lines through the new
`BoundWrapper::report_lines` (same single renderer `report_to` prints from, so
the wordings cannot drift) and either prints immediately (headless — unchanged)
or appends to a run-wide `HeldReports` buffer that `run_fleet` drains to stderr
after the dashboard restores the terminal. Lines already name their task, so
deferral costs no attribution; appends are whole-report under one lock, so
concurrent attempts interleave per report, never per line. Never suppressed —
a refusal reported nowhere is the silence #3561 closed.

## Evidence

- **#4039 witness, run both ways**: `git checkout origin/main --
  arenabench/arenabench/transcript.py` →
  `uv run --with pytest --no-project pytest -q tests/test_transcript_prompt.py`
  **fails** (`test_the_user_goal_block_becomes_the_prompt_row`,
  `test_the_prompt_is_emitted_once`); restored to this branch → all 5 pass.
  The extended `node scripts/check-transcript-view.mjs` passes on this branch
  (53 checks) and cannot run on main (`orderEntries` does not exist there).
- **#3883**: `cargo test -p stella-cli --bin stella fleet_cmd::` → 20 passed
  (includes the new
  `held_wrapper_reports_stay_whole_per_attempt_and_drain_once`);
  `cargo test -p stella-cli --bin stella wrapper_plugin::` → 45 passed.
  The witness is compile-level in the fail direction: `HeldReports` and
  `BoundWrapper::report_lines` do not exist on main, so the test cannot build
  there. The held-vs-print decision itself lives in `run_task`'s settle call,
  which has no unit seam; the buffer semantics are what the test pins.
- Full arenabench suite (the step `bench.yml` runs for an `arenabench/**`
  diff): `uv run --with pytest --no-project pytest -q` in `arenabench/` —
  exit 0. `uv run --with ruff --no-project ruff check` on the touched Python —
  clean. `npm run typecheck` in `arenabench/ui` — clean.
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — exit 0.
  `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps` and the same
  with `--document-private-items` — both exit 0. `cargo fmt --all` run;
  `make guards-fast` — exit 0 (prose gate included; one construction it caught
  was rewritten, no baseline touched).
- `wrapper_plugin.rs` sits at 1492 lines on main, under the 1500 ratchet:
  `report_lines` therefore lives in `wrapper_plugin/report.rs`
  (`impl super::BoundWrapper`), not in the parent file.

## Not done

- **#3879 — skipped (maintainer decision).** Everything mechanical landed in
  #4400 while this batch was queued: `arenabench/tests/test_engine_root_fields.py`
  parses `ENGINE_ROOT_FIELDS`/`RETIRED_ENGINE_ROOT` out of `unknown.rs` and both
  drift directions are green today (re-run on this branch: 2 passed). What
  remains is exactly the `responsibilities` question, and it is a genuine
  feature decision, not a sync: the key was in the Rust vocabulary from #2462
  until #3865 deleted the pipeline, and arenabench can pin an older SUT
  (`sut_ref`) on which a declared roster still works — so silently dropping the
  emission would un-ablate a legitimately-working pinned arm (the dead-arm
  trap), refusing at posture build would break that same arm, and adding the
  key back to today's vocabulary would record ablations nothing performs.
  #3871 and #4400 both deferred it for the same reason. Needs a call between:
  retire the arena responsibilities surface (config, model, server, web form,
  309 lines of tests), or give the roster a live home in Stella's engine
  config.
- **#3670 — skipped (needs a live bench rig).** The legibility half the sketch
  asked for is already on main (#4400: `code_graph.unavailable` carries `kind`,
  `exit_code`, and Harbor's captured `stderr`). What remains is naming the
  actual cause of the `stella init` non-zero exit on frontier-bench
  `risk-scorer-replay`, which requires re-running the task; this batch is
  forbidden to launch bench runs.

Refs #3879
Refs #3670
Refs #4578
Closes #4039
Closes #3883

## Summary by Sourcery

Restore prompt visibility in arena transcripts and preserve fleet wrapper reports across live dashboard teardown.

New Features:
- Add a prompt row to arena transcripts using the task’s user-goal content, with prompt-first ordering and an expandable long-instruction view.
- Defer fleet wrapper reports during live dashboard runs and print them after terminal restoration while preserving headless output behavior.

Bug Fixes:
- Ensure transcript endpoints and the live transcript UI render entries in sequence order so prompts appear before subsequent trial activity.
- Prevent concurrent wrapper reports from being lost or visually corrupted while the alternate-screen dashboard is active.

Enhancements:
- Give prompts their own transcript filter group and role-styled presentation independent of response and fold state.
- Centralize wrapper report-line composition so deferred and immediate reports use identical wording.

CI:
- Run transcript-view validation checks in the monorepo parity workflow and ArenaBench CI workflow.

Tests:
- Add coverage for prompt extraction, deduplication, missing content, block filtering, and text coalescing.
- Add coverage ensuring held wrapper reports remain contiguous, drain once, and preserve arrival order.
