### PR TITLE
chore(prose): retighten the baseline after #3135's context_event trim

### DIFF
--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -163,7 +163,6 @@ crates/stella-plugin/src/driver.rs 1
 crates/stella-plugin/src/error.rs 1
 crates/stella-plugin/tests/non_witness_done.rs 1
 crates/stella-protocol/src/candidate.rs 1
-crates/stella-protocol/src/context_event.rs 1
 crates/stella-protocol/src/event.rs 1
 crates/stella-protocol/src/issue.rs 2
 crates/stella-protocol/src/stage.rs 1


### PR DESCRIPTION
PR #4570 deleted the unwired lifecycle-envelope half of `crates/stella-protocol/src/context_event.rs` (Closes'd #3135), taking its one grandfathered prose construction with it. This retightens `scripts/prose-baseline.txt` 356 → 355 via `make prose-update` — one line deleted, no counts raised. `make prose` green.

Down-only ratchet maintenance; no code change, no witness owed (the guard's own run is the evidence).

## Summary by Sourcery

Enhancements:
- Retighten the prose baseline by removing the obsolete grandfathered entry left behind after the lifecycle-envelope cleanup.