### PR TITLE
feat(website): copy-page menu, /llms.mdx markdown export, print styles

### DIFF
--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -1,9 +1,69 @@
 import { execSync } from "node:child_process";
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 import lastModified from "fumadocs-mdx/plugins/last-modified";
+import { DIAGRAM_PLACEHOLDER_NAMES } from "./src/lib/page-markdown";
 
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    postprocess: {
+      // Export each page's rendered markdown as `_markdown` (see
+      // src/lib/page-markdown.ts — the Copy page menu and /llms.mdx serve it).
+      // The three component kinds whose meaning lives outside their children
+      // are emitted as placeholders and re-rendered to markdown there.
+      includeProcessedMarkdown: {
+        mdxAsPlaceholder: [
+          ...DIAGRAM_PLACEHOLDER_NAMES,
+          "ProviderGrid",
+          "CommandDeckExplorer",
+        ],
+        // The default stringifier keeps unknown JSX elements as literal tags
+        // in the output (only their children are dropped) — so a page full of
+        // <SpecCard> exported as nested JSX. Every element we render is a
+        // container whose children are the content; the tags themselves are
+        // presentation and do not belong in markdown.
+        //
+        // This is done in `stringify` rather than `filterElement` because
+        // remarkLLMs spreads user options and then declares its own
+        // `filterElement`, silently replacing any one passed in — while a
+        // `stringify` callback is wrapped and honored. Returning the
+        // stringified children is exactly what `children-only` would do.
+        stringify(node, _parent, state, info) {
+          switch (node.type) {
+            case "mdxJsxFlowElement": {
+              // Cards carry their identity in an attribute, not in their
+              // children — a children-only render would export "Exploring,
+              // iterating, supervising." with no name attached. Emit the
+              // attribute as a heading above the children instead.
+              const name = node.name;
+              const attr = (key: string) =>
+                node.attributes.find(
+                  (a: { type: string; name?: unknown }) =>
+                    a.type === "mdxJsxAttribute" && a.name === key,
+                )?.value;
+              const heading =
+                name === "SpecCard" || name === "OptionCard" || name === "ToolCard"
+                  ? (attr("title") ?? attr("name"))
+                  : undefined;
+              const body = state.containerFlow(node, info);
+              return typeof heading === "string" && heading
+                ? `#### ${heading}\n\n${body}`
+                : body;
+            }
+            case "mdxJsxTextElement": {
+              // Inline logomarks are decorative — every call site has the
+              // provider's name in text beside them — so they export as
+              // nothing rather than as a literal tag.
+              if (node.name === "ProviderMark" || node.name === "ProviderLogo") return "";
+              return state.containerPhrasing(node, info);
+            }
+            default:
+              return undefined;
+          }
+        },
+      },
+    },
+  },
 });
 
 /**

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -4,7 +4,7 @@ import { HeroTerminal } from "@/components/command-deck";
 import { AnimatedLockup } from "@/components/animated-lockup";
 import { Mark } from "@/components/brand";
 import { InstallBlock } from "@/components/install-block";
-import { PROVIDER_CATALOG } from "@/components/provider-cards";
+import { PROVIDER_CATALOG } from "@/components/provider-catalog";
 import { REPO_URL, SITE_URL } from "@/lib/site";
 
 // The root layout's metadata is titled/described for the docs section it

--- a/website/src/app/docs/[[...slug]]/page.tsx
+++ b/website/src/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import {
   DocsTitle,
 } from "fumadocs-ui/page";
 import { getMDXComponents } from "@/mdx-components";
+import { PageActions } from "@/components/page-actions";
 import { PageFooter } from "@/components/page-footer";
 import { source } from "@/lib/source";
 import { SITE_URL } from "@/lib/site";
@@ -89,6 +90,9 @@ export default async function Page(props: {
       <span id="content" tabIndex={-1} />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="mb-6 mt-4 flex flex-row items-center gap-2 border-b border-fd-border pb-4">
+        <PageActions slug={page.slugs} />
+      </div>
       <DocsBody>
         <MDX components={getMDXComponents()} />
         <PageFooter path={page.url} title={page.data.title} />

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -1396,3 +1396,37 @@ figure.shiki > div:has(figcaption) {
 .sdg .sdg-icon-accent {
   stroke: var(--stella-accent-text);
 }
+
+/* ── Print ─────────────────────────────────────────────────────────────────
+ * The "Print / Save as PDF" item in the Copy page menu is the browser's own
+ * print path; these rules are what make its output the article rather than a
+ * screenshot of the app. Chrome (sidebar, header, TOC, the menu itself, the
+ * footer) goes away, the article takes the full width, and code blocks and
+ * cards are kept on one page where they fit.
+ */
+@media print {
+  #nd-sidebar,
+  #nd-sidebar-mobile,
+  #nd-nav,
+  #nd-subnav,
+  #nd-toc,
+  .stella-page-actions,
+  footer {
+    display: none !important;
+  }
+  article,
+  #nd-page {
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  pre,
+  .sc-card,
+  figure {
+    break-inside: avoid;
+  }
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+}

--- a/website/src/app/llms.mdx/[...slug]/route.ts
+++ b/website/src/app/llms.mdx/[...slug]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * `/llms.mdx/<slug>` — one docs page as a markdown file, the endpoint behind
+ * the "Copy page" menu's *View as Markdown* / *Download as Markdown* items.
+ * The dotted folder name follows the same convention as `/llms.txt` and
+ * `/llms-full.txt`: a machine-readable sibling of the page tree, not part of
+ * the human navigation.
+ *
+ * The body is the page's own `_markdown` export (see `page-markdown.ts` for
+ * why that and not the raw `.mdx` on disk), so this route and the menu's
+ * *Copy page* item can never disagree about what the page's markdown is.
+ */
+import { notFound } from "next/navigation";
+import { source } from "@/lib/source";
+import { pageMarkdown } from "@/lib/page-markdown";
+import { SITE_URL } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+interface RouteParams {
+  params: Promise<{ slug: string[] }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams): Promise<Response> {
+  const { slug } = await params;
+  // `/llms.mdx/index` is the docs root — see generateStaticParams.
+  const page = source.getPage(slug.length === 1 && slug[0] === "index" ? [] : slug);
+  if (!page) notFound();
+
+  const markdown = page.data._exports._markdown;
+  if (typeof markdown !== "string") notFound(); // a page without MDX source has no markdown form
+
+  const body = await pageMarkdown({
+    title: page.data.title,
+    description: page.data.description,
+    url: `${SITE_URL}${page.url}`,
+    markdown,
+  });
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}
+
+export function generateStaticParams(): { slug: string[] }[] {
+  // The docs root's slugs are `[]`, which Next would prerender as `/llms.mdx`
+  // itself and then reject as an export-path mismatch — so the root page's
+  // markdown lives at `/llms.mdx/index`, and the menu links there.
+  return (source.generateParams() as { slug: string[] }[]).map(({ slug }) => ({
+    slug: slug.length === 0 ? ["index"] : slug,
+  }));
+}

--- a/website/src/components/command-deck-explorer.tsx
+++ b/website/src/components/command-deck-explorer.tsx
@@ -18,151 +18,16 @@
 
 import { useRef, useState } from "react";
 
-interface DeckTabSpec {
-  key: string;
-  label: string;
-  blurb: string;
-  lines: string[];
-}
+import { COMMAND_DECK_TABS } from "@/components/command-deck-tabs";
 
-const TABS: DeckTabSpec[] = [
-  {
-    key: "session",
-    label: "SESSION",
-    blurb:
-      "The transcript for the turn in flight — prompts, the live plan, and each stage as it runs.",
-    lines: [
-      "? lead  ·  needs input                                     0:00:00",
-      "└─ ◆ sub:auth  needs input · model glm-5.2 · spend $0.01",
-      "     ⚒ mcp__fs__grep trigger → wire automations triggers API",
-      "└─ ◆ sub:ci    running    · model glm-5.2-air · spend $0.00",
-      "     ⚒ no tool calls yet → watch CI + open PR",
-      "",
-      "  Planning the automations cluster: list, editor, triggers, workflows.",
-      "☰  plan  4/7 · Wire the triggers API",
-      "── WITNESS ──",
-      "── EXECUTE ──",
-      "● mcp__fs__read  apps/app/automations/page.tsx  ⎿ 312 lines · 42ms",
-    ],
-  },
-  {
-    key: "agents",
-    label: "AGENTS",
-    blurb:
-      "Every execution — lead and sub-agents — with live cost, context %, and cache warmth. Paired with your installed agents.",
-    lines: [
-      "EXECUTIONS │ INSTALLED AGENTS",
-      "Agent        Goal                          Status        Cost    $/hr",
-      "  lead       web-app-2.0 · phase           needs input   $0.04   $0.45",
-      "  sub:auth   wire automations triggers     needs input   $0.01   $0.13",
-      "▶ sub:ci      watch CI + open PR            running       $0.00   $0.05",
-    ],
-  },
-  {
-    key: "traces",
-    label: "TRACES",
-    blurb:
-      "One scrollable, filterable timeline of every agent's tool calls, verdicts, and spend, interleaved by time.",
-    lines: [
-      "traces · all · 33 events · following",
-      "00:00 lead      [stage] witness",
-      "00:00 lead      [verdict] witness authored: automations/triggers.test.ts",
-      "00:00 lead      [verdict] oracle: fail on base",
-      "00:00 lead      [tool] mcp__fs__read() → ok in 42ms",
-      "00:00 lead      [file] modified automations/page.tsx +4/-1",
-      "00:00 lead      [verdict] oracle: pass on new",
-      "00:00 sub:auth  [stage] wire the automations triggers API",
-      "00:00 sub:ci    [vcs] pr open",
-    ],
-  },
-  {
-    key: "graph",
-    label: "GRAPH",
-    blurb:
-      "The tree-sitter code graph — pick a symbol, see its file, its relations, and its neighborhood. Answered offline, no key needed.",
-    lines: [
-      "nodes · 6 · /files",
-      "ƒ run_turn   ◆ Engine   ◆ Router   ◆ AgentEvent   ◆ Ledger   ▤ driver.rs",
-      "",
-      "Engine — struct · stella-core/src/engine.rs:48",
-      "relations · 3",
-      "called by ← run_turn",
-      "uses      → Router",
-      "writes    → Ledger",
-    ],
-  },
-  {
-    key: "files",
-    label: "FILES",
-    blurb: "Every file this session touched, by agent, with lines added and removed.",
-    lines: [
-      "Files · 2",
-      "File                                     Agent      Op   +    -",
-      "apps/app/automations/page.tsx            lead       U    +4   -1",
-      "apps/api/routes/v1/automations.ts        sub:auth   C    +3   -0",
-      "2 files  +7  -1  0 reads",
-    ],
-  },
-  {
-    key: "skills",
-    label: "SKILLS",
-    blurb:
-      "Installed skills you can toggle on or off, plus a live search of the skills registry — install without leaving the deck.",
-    lines: [
-      "Installed — 4 (user + project)",
-      "[x] release-checklist v3  (project·workspace)  Cut a release…",
-      "[x] rust-review v2/4      (user·user)          Review Rust diffs…",
-      "[ ] sql-tuning v1         (user·installed)     Read a query plan…",
-      "[x] bench-rig-access v1   (project·auto)       Reach the bench rig…",
-      "",
-      "Registry search — find: _   (⏎ to search)",
-    ],
-  },
-  {
-    key: "mcp",
-    label: "MCP",
-    blurb:
-      "Configured MCP servers — connection state, tool counts, auth — enable, disable, or authenticate without leaving the deck.",
-    lines: [
-      "MCP — 3 configured / 2 connected",
-      "● Stripe   http   live      ⚿ oauth ✓  · 21 tools · 14×",
-      "● fs       stdio  live      · 4 tools",
-      "○ Linear   http   disabled  ⚿ oauth: o to log in · 0 tools",
-    ],
-  },
-  {
-    key: "issues",
-    label: "ISSUES",
-    blurb:
-      "Your connected GitHub or Linear tracker, with instant search and the ability to start work on an issue.",
-    lines: [
-      "ISSUES — 3 listed",
-      "#874 [open]    Command-deck render golden tests · enhancement",
-      "#826 [open]    run_deck event-loop pty harness · enhancement",
-      "#689 [closed]  Surface per-server MCP tool truncation · bug",
-    ],
-  },
-  {
-    key: "settings",
-    label: "SETTINGS",
-    blurb: "The home of all config — agents, tools, models, credentials — including the engine-config editor.",
-    lines: [
-      "AGENTS │ TOOLS",
-      "GLOBAL   default   worker   verifier   triage   research   plan",
-      "",
-      "waiting for the engine config snapshot — r to reload",
-      "e edit agents config",
-    ],
-  },
-];
 
 export function CommandDeckExplorer() {
-  const [activeKey, setActiveKey] = useState(TABS[0].key);
+  const [activeKey, setActiveKey] = useState(COMMAND_DECK_TABS[0].key);
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
-  const active = TABS.find((tab) => tab.key === activeKey) ?? TABS[0];
+  const active = COMMAND_DECK_TABS.find((tab) => tab.key === activeKey) ?? COMMAND_DECK_TABS[0];
 
   function focusTab(index: number) {
-    const wrapped = TABS[(index + TABS.length) % TABS.length];
+    const wrapped = COMMAND_DECK_TABS[(index + COMMAND_DECK_TABS.length) % COMMAND_DECK_TABS.length];
     setActiveKey(wrapped.key);
     tabRefs.current[wrapped.key]?.focus();
   }
@@ -180,7 +45,7 @@ export function CommandDeckExplorer() {
   return (
     <div className="dke">
       <div className="dke-tabs" role="tablist" aria-label="Command Deck tabs">
-        {TABS.map((tab, index) => (
+        {COMMAND_DECK_TABS.map((tab, index) => (
           <button
             key={tab.key}
             ref={(el) => {

--- a/website/src/components/command-deck-tabs.ts
+++ b/website/src/components/command-deck-tabs.ts
@@ -1,0 +1,150 @@
+/**
+ * The nine Command Deck panes the explorer on `/docs/agent-modes` shows, as
+ * data. Each pane's content is trimmed straight out of
+ * `crates/stella-tui/tests/snapshots/deck/tab_*.txt`, the golden renders that
+ * `make gate` checks on every PR touching the TUI, so what is on screen is
+ * the deck's own output rather than a redrawn mock of it.
+ *
+ * The data lives in a plain `.ts` module — not beside the component — because
+ * `src/lib/page-markdown.ts` renders the same panes as fenced code blocks when
+ * the page is exported to markdown (Copy page / llms.mdx), and that path is
+ * exercised by `node --test`, which strips types but cannot parse JSX.
+ */
+
+export interface DeckTabSpec {
+  key: string;
+  label: string;
+  blurb: string;
+  lines: string[];
+}
+
+export const COMMAND_DECK_TABS: DeckTabSpec[] = [
+  {
+    key: "session",
+    label: "SESSION",
+    blurb:
+      "The transcript for the turn in flight — prompts, the live plan, and each stage as it runs.",
+    lines: [
+      "? lead  ·  needs input                                     0:00:00",
+      "└─ ◆ sub:auth  needs input · model glm-5.2 · spend $0.01",
+      "     ⚒ mcp__fs__grep trigger → wire automations triggers API",
+      "└─ ◆ sub:ci    running    · model glm-5.2-air · spend $0.00",
+      "     ⚒ no tool calls yet → watch CI + open PR",
+      "",
+      "  Planning the automations cluster: list, editor, triggers, workflows.",
+      "☰  plan  4/7 · Wire the triggers API",
+      "── WITNESS ──",
+      "── EXECUTE ──",
+      "● mcp__fs__read  apps/app/automations/page.tsx  ⎿ 312 lines · 42ms",
+    ],
+  },
+  {
+    key: "agents",
+    label: "AGENTS",
+    blurb:
+      "Every execution — lead and sub-agents — with live cost, context %, and cache warmth. Paired with your installed agents.",
+    lines: [
+      "EXECUTIONS │ INSTALLED AGENTS",
+      "Agent        Goal                          Status        Cost    $/hr",
+      "  lead       web-app-2.0 · phase           needs input   $0.04   $0.45",
+      "  sub:auth   wire automations triggers     needs input   $0.01   $0.13",
+      "▶ sub:ci      watch CI + open PR            running       $0.00   $0.05",
+    ],
+  },
+  {
+    key: "traces",
+    label: "TRACES",
+    blurb:
+      "One scrollable, filterable timeline of every agent's tool calls, verdicts, and spend, interleaved by time.",
+    lines: [
+      "traces · all · 33 events · following",
+      "00:00 lead      [stage] witness",
+      "00:00 lead      [verdict] witness authored: automations/triggers.test.ts",
+      "00:00 lead      [verdict] oracle: fail on base",
+      "00:00 lead      [tool] mcp__fs__read() → ok in 42ms",
+      "00:00 lead      [file] modified automations/page.tsx +4/-1",
+      "00:00 lead      [verdict] oracle: pass on new",
+      "00:00 sub:auth  [stage] wire the automations triggers API",
+      "00:00 sub:ci    [vcs] pr open",
+    ],
+  },
+  {
+    key: "graph",
+    label: "GRAPH",
+    blurb:
+      "The tree-sitter code graph — pick a symbol, see its file, its relations, and its neighborhood. Answered offline, no key needed.",
+    lines: [
+      "nodes · 6 · /files",
+      "ƒ run_turn   ◆ Engine   ◆ Router   ◆ AgentEvent   ◆ Ledger   ▤ driver.rs",
+      "",
+      "Engine — struct · stella-core/src/engine.rs:48",
+      "relations · 3",
+      "called by ← run_turn",
+      "uses      → Router",
+      "writes    → Ledger",
+    ],
+  },
+  {
+    key: "files",
+    label: "FILES",
+    blurb: "Every file this session touched, by agent, with lines added and removed.",
+    lines: [
+      "Files · 2",
+      "File                                     Agent      Op   +    -",
+      "apps/app/automations/page.tsx            lead       U    +4   -1",
+      "apps/api/routes/v1/automations.ts        sub:auth   C    +3   -0",
+      "2 files  +7  -1  0 reads",
+    ],
+  },
+  {
+    key: "skills",
+    label: "SKILLS",
+    blurb:
+      "Installed skills you can toggle on or off, plus a live search of the skills registry — install without leaving the deck.",
+    lines: [
+      "Installed — 4 (user + project)",
+      "[x] release-checklist v3  (project·workspace)  Cut a release…",
+      "[x] rust-review v2/4      (user·user)          Review Rust diffs…",
+      "[ ] sql-tuning v1         (user·installed)     Read a query plan…",
+      "[x] bench-rig-access v1   (project·auto)       Reach the bench rig…",
+      "",
+      "Registry search — find: _   (⏎ to search)",
+    ],
+  },
+  {
+    key: "mcp",
+    label: "MCP",
+    blurb:
+      "Configured MCP servers — connection state, tool counts, auth — enable, disable, or authenticate without leaving the deck.",
+    lines: [
+      "MCP — 3 configured / 2 connected",
+      "● Stripe   http   live      ⚿ oauth ✓  · 21 tools · 14×",
+      "● fs       stdio  live      · 4 tools",
+      "○ Linear   http   disabled  ⚿ oauth: o to log in · 0 tools",
+    ],
+  },
+  {
+    key: "issues",
+    label: "ISSUES",
+    blurb:
+      "Your connected GitHub or Linear tracker, with instant search and the ability to start work on an issue.",
+    lines: [
+      "ISSUES — 3 listed",
+      "#874 [open]    Command-deck render golden tests · enhancement",
+      "#826 [open]    run_deck event-loop pty harness · enhancement",
+      "#689 [closed]  Surface per-server MCP tool truncation · bug",
+    ],
+  },
+  {
+    key: "settings",
+    label: "SETTINGS",
+    blurb: "The home of all config — agents, tools, models, credentials — including the engine-config editor.",
+    lines: [
+      "AGENTS │ TOOLS",
+      "GLOBAL   default   worker   verifier   triage   research   plan",
+      "",
+      "waiting for the engine config snapshot — r to reload",
+      "e edit agents config",
+    ],
+  },
+];

--- a/website/src/components/diagram-descriptions.ts
+++ b/website/src/components/diagram-descriptions.ts
@@ -1,0 +1,39 @@
+/**
+ * The one-sentence description of every SVG diagram in `diagrams.tsx`,
+ * keyed by the component's name. Two consumers:
+ *
+ *  - `diagrams.tsx` sets it as the `<svg>`'s `aria-label`, so a screen
+ *    reader hears what the picture says;
+ *  - `src/lib/page-markdown.ts` emits it as the diagram's stand-in when a
+ *    docs page is exported to markdown (Copy page / llms.mdx), where the
+ *    SVG itself cannot go.
+ *
+ * It lives in a plain `.ts` module — not beside the components — because
+ * the markdown path is exercised by `node --test`, which strips types but
+ * cannot parse JSX. `diagrams.test.ts` asserts the record and the
+ * component file stay in lockstep, so a diagram added here without a
+ * sentence (or vice versa) fails the suite.
+ */
+export const DIAGRAM_DESCRIPTIONS: Record<string, string> = {
+  HeroFlowDiagram: "Your prompt flows through stella to the provider you chose; telemetry stays on your machine.",
+  RecallLoopDiagram: "Memories and the code graph feed the recall block, the model works, citations and reflections feed back into the stores.",
+  FleetFanoutDiagram: "A pinned base commit fans out to isolated worktree branches; finished branches converge on your review.",
+  QuickstartDiagram: "Four steps: install, authenticate, init, run.",
+  CredentialChainDiagram: "Five credential sources tried in order — flag, environment variable, settings.json, credentials.toml, interactive prompt — and the first one that resolves is used.",
+  SettingsCascadeDiagram: "Org-managed, project, and user settings merge per key into the effective settings; the org layer is a ceiling that lower scopes can narrow but never re-open.",
+  PermissionGateDiagram: "A tool call passes through the PreToolUse hook and the permission rules; allowed calls execute and fire PostToolUse, denied calls come back to the model as a refusal.",
+  EngineOwnershipDiagram: "Your app keeps keys, tools, and data; the engine keeps the loop, compaction, and retries. Only requests and results cross between them.",
+  EngineTestHarnessDiagram: "One host drives either your real gateway or a scripted reply function; both exercise the identical agent loop, but only one of them spends money.",
+  EngineGateDiagram: "One committed task set runs through both Stella and Claude Code; the comparison produces a blocking loop-correctness verdict and an advisory quality delta.",
+  LoopVerdictDiagram: "Four verdicts checked in order: solved, silent death, zero work, ran but unsolved. The middle two — a turn that did nothing — are the ones that fail the gate.",
+  TelemetryFlowDiagram: "Each session turn writes a receipt into .stella/ on your disk, which stella stats and the observatory read back. No arrow leaves the machine.",
+  McpTopologyDiagram: "At session start Stella connects to each configured MCP server — stdio servers as local subprocesses, http servers as remote endpoints — and merges their tools into one namespaced tool set. A server that fails to connect within ten seconds is skipped, and the session continues without its tools.",
+  HookLifecycleDiagram: "Three hooks fire across a turn: SessionStart, whose stdout becomes context; PreToolUse, whose non-zero exit blocks the tool; and PostToolUse, whose exit status is ignored. Only PreToolUse can stop anything.",
+  SingleThreadDiagram: "A swarm is a coordinator and four agents joined by many edges, every one of them a handoff that summarizes. Stella is one ordered loop — plan, act, observe, compact — with a single return edge and one transcript.",
+  EventContractDiagram: "Each line is parsed alone. An unrecognized event type is inert — skip it and keep reading. A recognized type whose body does not fit is a real error and must fail loudly.",
+  BudgetGuardDiagram: "A plan meets the scope review first, which stops it before the first edit at zero cost. Steps that get past it are metered between steps and stages, never inside a tool call, so a spend-limit abort never leaves a half-applied edit.",
+  CostChainDiagram: "Five commands, each narrowing the question: stats for which model and how much, observe for which run, inspect for which call, inspect with a step for what it was sent, and diff for what changed since the previous call.",
+  ClaimLockDiagram: "Two tasks declaring the same path meet a shared claim table. The first holds the path for its attempt and runs; the second fails its dispatch by name, in under a second, with the rival identified.",
+  EngineSequenceDiagram: "Your app starts a turn. The engine asks it to run a model call and waits for the result, then asks it to run a tool and waits again, then reports the turn complete. Every outbound call is made by your app; the engine only asks.",
+  EnginePathsDiagram: "Six ways a session starts. stella, stella run, stella goal and stella fleet can bind an installed wrapper plugin, which contributes context before the turn and gathers evidence after it before calling the engine's turn loop. stella --plain and stella-serve take no wrapper: the plain REPL drives run_turn, and stella-serve drives run_step itself. Every path ends in the same step loop.",
+};

--- a/website/src/components/diagrams.test.ts
+++ b/website/src/components/diagrams.test.ts
@@ -4,6 +4,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
+import { DIAGRAM_DESCRIPTIONS } from "./diagram-descriptions.ts";
+
 /**
  * Guards the glyph trap in `src/components/diagrams.tsx`.
  *
@@ -71,6 +73,7 @@ function paintedSource(): string {
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/^[ \t]*\/\/.*$/gm, "")
     .replace(/aria-label="[^"]*"/g, "")
+    .replace(/aria-label=\{[^}]*\}/g, "")
     .replace(/<title>[\s\S]*?<\/title>/g, "");
 }
 
@@ -132,4 +135,29 @@ test("the allowlist itself stays honest about the missing arrows", () => {
   // the allowlist" fails loudly instead of quietly restoring the bug.
   assert.ok(!ALLOWED_NON_ASCII.has("→"), "U+2192 is not in the font subset");
   assert.ok(!ALLOWED_NON_ASCII.has("←"), "U+2190 is not in the font subset");
+});
+
+test("every diagram component has a description, and vice versa", () => {
+  // The aria-labels moved to `diagram-descriptions.ts` so the markdown export
+  // (Copy page / llms.mdx) can reuse them; this is what keeps the record and
+  // the components in lockstep — a diagram added on one side only fails here.
+  const source = readFileSync(DIAGRAMS, "utf8");
+  const components = [...source.matchAll(/export function (\w+Diagram)\(\)/g)].map((m) => m[1]).sort();
+  const described = Object.keys(DIAGRAM_DESCRIPTIONS).sort();
+  assert.deepEqual(
+    described,
+    components,
+    "diagram-descriptions.ts and diagrams.tsx disagree: " +
+      `only in descriptions: ${described.filter((n) => !components.includes(n)).join(", ") || "—"}; ` +
+      `only in components: ${components.filter((n) => !described.includes(n)).join(", ") || "—"}`,
+  );
+  // And each component actually reads its own entry — a copy-pasted
+  // `DIAGRAM_DESCRIPTIONS.OtherDiagram` would pass the set check above while
+  // labelling the picture with the wrong sentence.
+  for (const name of components) {
+    assert.ok(
+      source.includes(`aria-label={DIAGRAM_DESCRIPTIONS.${name}}`),
+      `${name} does not read DIAGRAM_DESCRIPTIONS.${name} as its aria-label`,
+    );
+  }
 });

--- a/website/src/components/diagrams.tsx
+++ b/website/src/components/diagrams.tsx
@@ -1,3 +1,4 @@
+import { DIAGRAM_DESCRIPTIONS } from "@/components/diagram-descriptions";
 /**
  * Inline-SVG diagrams for the docs.
  *
@@ -201,7 +202,7 @@ export function HeroFlowDiagram() {
       className="sdg"
       viewBox="0 0 720 190"
       role="img"
-      aria-label="Your prompt flows through stella to the provider you chose; telemetry stays on your machine."
+      aria-label={DIAGRAM_DESCRIPTIONS.HeroFlowDiagram}
     >
       <title>How Stella fits together</title>
       <Defs />
@@ -223,7 +224,7 @@ export function RecallLoopDiagram() {
       className="sdg"
       viewBox="0 0 720 200"
       role="img"
-      aria-label="Memories and the code graph feed the recall block, the model works, citations and reflections feed back into the stores."
+      aria-label={DIAGRAM_DESCRIPTIONS.RecallLoopDiagram}
     >
       <title>The context loop</title>
       <Defs />
@@ -255,7 +256,7 @@ export function FleetFanoutDiagram() {
       className="sdg"
       viewBox="0 0 720 180"
       role="img"
-      aria-label="A pinned base commit fans out to isolated worktree branches; finished branches converge on your review."
+      aria-label={DIAGRAM_DESCRIPTIONS.FleetFanoutDiagram}
     >
       <title>Fleet fan-out over git worktrees</title>
       <Defs />
@@ -297,7 +298,7 @@ export function QuickstartDiagram() {
       className="sdg"
       viewBox="0 0 720 132"
       role="img"
-      aria-label="Four steps: install, authenticate, init, run."
+      aria-label={DIAGRAM_DESCRIPTIONS.QuickstartDiagram}
     >
       <title>From empty shell to first change</title>
       <Defs />
@@ -335,7 +336,7 @@ export function CredentialChainDiagram() {
       className="sdg"
       viewBox="0 0 720 228"
       role="img"
-      aria-label="Five credential sources tried in order — flag, environment variable, settings.json, credentials.toml, interactive prompt — and the first one that resolves is used."
+      aria-label={DIAGRAM_DESCRIPTIONS.CredentialChainDiagram}
     >
       <title>The credential chain</title>
       <Defs />
@@ -382,7 +383,7 @@ export function SettingsCascadeDiagram() {
       className="sdg"
       viewBox="0 0 720 216"
       role="img"
-      aria-label="Org-managed, project, and user settings merge per key into the effective settings; the org layer is a ceiling that lower scopes can narrow but never re-open."
+      aria-label={DIAGRAM_DESCRIPTIONS.SettingsCascadeDiagram}
     >
       <title>How settings scopes merge</title>
       <Defs />
@@ -414,7 +415,7 @@ export function PermissionGateDiagram() {
       className="sdg"
       viewBox="0 0 720 200"
       role="img"
-      aria-label="A tool call passes through the PreToolUse hook and the permission rules; allowed calls execute and fire PostToolUse, denied calls come back to the model as a refusal."
+      aria-label={DIAGRAM_DESCRIPTIONS.PermissionGateDiagram}
     >
       <title>How a tool call is gated</title>
       <Defs />
@@ -462,7 +463,7 @@ export function EngineOwnershipDiagram() {
       className="sdg"
       viewBox="0 0 720 232"
       role="img"
-      aria-label="Your app keeps keys, tools, and data; the engine keeps the loop, compaction, and retries. Only requests and results cross between them."
+      aria-label={DIAGRAM_DESCRIPTIONS.EngineOwnershipDiagram}
     >
       <title>What the engine owns, and what never leaves your app</title>
       <Defs />
@@ -524,7 +525,7 @@ export function EngineTestHarnessDiagram() {
       className="sdg"
       viewBox="0 0 720 196"
       role="img"
-      aria-label="One host drives either your real gateway or a scripted reply function; both exercise the identical agent loop, but only one of them spends money."
+      aria-label={DIAGRAM_DESCRIPTIONS.EngineTestHarnessDiagram}
     >
       <title>The same host, with and without a model</title>
       <Defs />
@@ -555,7 +556,7 @@ export function EngineGateDiagram() {
       className="sdg"
       viewBox="0 0 720 244"
       role="img"
-      aria-label="One committed task set runs through both Stella and Claude Code; the comparison produces a blocking loop-correctness verdict and an advisory quality delta."
+      aria-label={DIAGRAM_DESCRIPTIONS.EngineGateDiagram}
     >
       <title>Two engines, one task set, two kinds of exit</title>
       <Defs />
@@ -595,7 +596,7 @@ export function LoopVerdictDiagram() {
       className="sdg"
       viewBox="0 0 720 224"
       role="img"
-      aria-label="Four verdicts checked in order: solved, silent death, zero work, ran but unsolved. The middle two — a turn that did nothing — are the ones that fail the gate."
+      aria-label={DIAGRAM_DESCRIPTIONS.LoopVerdictDiagram}
     >
       <title>The loop-correctness verdict ladder</title>
       <Defs />
@@ -644,7 +645,7 @@ export function TelemetryFlowDiagram() {
       className="sdg"
       viewBox="0 0 720 196"
       role="img"
-      aria-label="Each session turn writes a receipt into .stella/ on your disk, which stella stats and the observatory read back. No arrow leaves the machine."
+      aria-label={DIAGRAM_DESCRIPTIONS.TelemetryFlowDiagram}
     >
       <title>Where telemetry goes</title>
       <Defs />
@@ -678,7 +679,7 @@ export function McpTopologyDiagram() {
       className="sdg"
       viewBox="0 0 720 252"
       role="img"
-      aria-label="At session start Stella connects to each configured MCP server — stdio servers as local subprocesses, http servers as remote endpoints — and merges their tools into one namespaced tool set. A server that fails to connect within ten seconds is skipped, and the session continues without its tools."
+      aria-label={DIAGRAM_DESCRIPTIONS.McpTopologyDiagram}
     >
       <title>How MCP servers reach the agent</title>
       <Defs />
@@ -755,7 +756,7 @@ export function HookLifecycleDiagram() {
       className="sdg"
       viewBox="0 0 720 224"
       role="img"
-      aria-label="Three hooks fire across a turn: SessionStart, whose stdout becomes context; PreToolUse, whose non-zero exit blocks the tool; and PostToolUse, whose exit status is ignored. Only PreToolUse can stop anything."
+      aria-label={DIAGRAM_DESCRIPTIONS.HookLifecycleDiagram}
     >
       <title>The three hook points on a turn</title>
       <Defs />
@@ -800,7 +801,7 @@ export function SingleThreadDiagram() {
       className="sdg"
       viewBox="0 0 720 226"
       role="img"
-      aria-label="A swarm is a coordinator and four agents joined by many edges, every one of them a handoff that summarizes. Stella is one ordered loop — plan, act, observe, compact — with a single return edge and one transcript."
+      aria-label={DIAGRAM_DESCRIPTIONS.SingleThreadDiagram}
     >
       <title>A swarm, and one deterministic loop, at the same scale</title>
       <Defs />
@@ -883,7 +884,7 @@ export function EventContractDiagram() {
       className="sdg"
       viewBox="0 0 720 232"
       role="img"
-      aria-label="Each line is parsed alone. An unrecognized event type is inert — skip it and keep reading. A recognized type whose body does not fit is a real error and must fail loudly."
+      aria-label={DIAGRAM_DESCRIPTIONS.EventContractDiagram}
     >
       <title>The two rules a conforming client follows</title>
       <Defs />
@@ -932,7 +933,7 @@ export function BudgetGuardDiagram() {
       className="sdg"
       viewBox="0 0 720 220"
       role="img"
-      aria-label="A plan meets the scope review first, which stops it before the first edit at zero cost. Steps that get past it are metered between steps and stages, never inside a tool call, so a spend-limit abort never leaves a half-applied edit."
+      aria-label={DIAGRAM_DESCRIPTIONS.BudgetGuardDiagram}
     >
       <title>The two places a run is stopped</title>
       <Defs />
@@ -982,7 +983,7 @@ export function CostChainDiagram() {
       className="sdg"
       viewBox="0 0 720 246"
       role="img"
-      aria-label="Five commands, each narrowing the question: stats for which model and how much, observe for which run, inspect for which call, inspect with a step for what it was sent, and diff for what changed since the previous call."
+      aria-label={DIAGRAM_DESCRIPTIONS.CostChainDiagram}
     >
       <title>From a dollar figure down to the exact bytes</title>
       <Defs />
@@ -1035,7 +1036,7 @@ export function ClaimLockDiagram() {
       className="sdg"
       viewBox="0 0 720 218"
       role="img"
-      aria-label="Two tasks declaring the same path meet a shared claim table. The first holds the path for its attempt and runs; the second fails its dispatch by name, in under a second, with the rival identified."
+      aria-label={DIAGRAM_DESCRIPTIONS.ClaimLockDiagram}
     >
       <title>Claims: one shared tree, one lock table</title>
       <Defs />
@@ -1087,7 +1088,7 @@ export function EngineSequenceDiagram() {
       className="sdg"
       viewBox="0 0 720 346"
       role="img"
-      aria-label="Your app starts a turn. The engine asks it to run a model call and waits for the result, then asks it to run a tool and waits again, then reports the turn complete. Every outbound call is made by your app; the engine only asks."
+      aria-label={DIAGRAM_DESCRIPTIONS.EngineSequenceDiagram}
     >
       <title>One turn, as a sequence</title>
       <Defs />
@@ -1158,7 +1159,7 @@ export function EnginePathsDiagram() {
       className="sdg"
       viewBox="0 0 720 382"
       role="img"
-      aria-label="Six ways a session starts. stella, stella run, stella goal and stella fleet can bind an installed wrapper plugin, which contributes context before the turn and gathers evidence after it before calling the engine's turn loop. stella --plain and stella-serve take no wrapper: the plain REPL drives run_turn, and stella-serve drives run_step itself. Every path ends in the same step loop."
+      aria-label={DIAGRAM_DESCRIPTIONS.EnginePathsDiagram}
     >
       <title>Six doors, one step loop underneath</title>
       <Defs />

--- a/website/src/components/page-actions.tsx
+++ b/website/src/components/page-actions.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * The "Copy page" menu at the top of every docs page — the dropdown docs
+ * readers reach for when they want the page somewhere else: as markdown in
+ * the clipboard (to paste into a model's context), as a markdown file, or on
+ * paper.
+ *
+ * The markdown items all resolve to the same artifact — the page's
+ * `/llms.mdx/<slug>` endpoint, which serves the page's own `_markdown` export
+ * (see `src/lib/page-markdown.ts`) — so what lands in the clipboard is
+ * byte-identical to what *View as Markdown* shows and *Download* saves.
+ * *Print / Save as PDF* is the browser's own print path; the print rules in
+ * `src/app/global.css` strip the chrome so what comes out is the article.
+ *
+ * A client component for the same reason the share menu is: open state, an
+ * outside-click listener, and the clipboard are all browser-only. Styling
+ * follows the footer's taste rules — quiet chrome, Fumadocs tokens only.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Copy, Download, ExternalLink, Printer } from "lucide-react";
+
+export function PageActions({ slug }: { slug: string[] }) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Close on an outside click or on Escape — the usual dropdown contract.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // The docs root has no slug segments; its markdown lives at /llms.mdx/index
+  // (see the route's generateStaticParams for why).
+  const mdPath = slug.length === 0 ? "/llms.mdx/index" : `/llms.mdx/${slug.join("/")}`;
+
+  const copyMarkdown = async () => {
+    try {
+      const res = await fetch(mdPath);
+      if (!res.ok) return;
+      await navigator.clipboard.writeText(await res.text());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+      setOpen(false);
+    } catch {
+      /* network or clipboard unavailable — the other menu items still work */
+    }
+  };
+
+  const itemClass =
+    "flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-left text-xs text-fd-popover-foreground hover:bg-fd-accent";
+
+  return (
+    <div ref={rootRef} className="stella-page-actions relative not-prose">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-md border border-fd-border px-2.5 py-1.5 text-xs text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground"
+      >
+        <Copy className="size-3.5" aria-hidden />
+        Copy page
+        <ChevronDown className="size-3.5" aria-hidden />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-20 mt-2 w-56 rounded-md border border-fd-border bg-fd-popover p-1"
+        >
+          <button type="button" role="menuitem" onClick={copyMarkdown} className={itemClass}>
+            {copied ? <Check className="size-3.5" aria-hidden /> : <Copy className="size-3.5" aria-hidden />}
+            {copied ? "Copied" : "Copy page as Markdown"}
+          </button>
+          <a
+            role="menuitem"
+            href={mdPath}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            className={itemClass}
+          >
+            <ExternalLink className="size-3.5" aria-hidden />
+            View as Markdown
+          </a>
+          <a
+            role="menuitem"
+            href={mdPath}
+            download={`${slug[slug.length - 1] ?? "index"}.md`}
+            onClick={() => setOpen(false)}
+            className={itemClass}
+          >
+            <Download className="size-3.5" aria-hidden />
+            Download as Markdown
+          </a>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              window.print();
+            }}
+            className={itemClass}
+          >
+            <Printer className="size-3.5" aria-hidden />
+            Print / Save as PDF
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/page-footer.tsx
+++ b/website/src/components/page-footer.tsx
@@ -4,9 +4,10 @@
  * The per-page footer every docs page renders: a share menu, the repository
  * link, the sponsor link, and the licence line.
  *
- * This is the only client component on the site. It earns that: the share menu
- * needs an open/closed state, an outside-click listener, and the clipboard —
- * none of which a server component can do. Everything else here is static.
+ * One of the two client components on the site (the other is the "Copy page"
+ * menu in `page-actions.tsx`). It earns that: the share menu needs an
+ * open/closed state, an outside-click listener, and the clipboard — none of
+ * which a server component can do. Everything else here is static.
  *
  * Taste rules: quiet chrome (a rule and muted text, no fills and no gradients),
  * share targets are plain text rows rather than a wall of faux brand icons, and

--- a/website/src/components/provider-cards.tsx
+++ b/website/src/components/provider-cards.tsx
@@ -1,140 +1,16 @@
 import { CardGrid, SpecCard } from "@/components/cards";
 import { ProviderLogo } from "@/components/provider-logos";
+import { PROVIDER_CATALOG, type ProviderSpec } from "@/components/provider-catalog";
 
 /**
- * The provider catalog, rendered as cards.
- *
- * This file is the single place the per-provider facts live. They used to be
- * repeated in a five-column table on the API Providers index *and* again in
- * prose on `getting-started/providers`, which is how the two drifted: a table
- * cell is invisible to every check the repo runs, so a renamed env var is only
- * ever found by a reader who tries it and fails. One typed record, two call
- * sites.
+ * The provider catalog, rendered as cards. The facts live in
+ * `provider-catalog.ts`; this file is only the rendering.
  *
  * The card shows the provider's name as text beside its logomark rather than
  * as a wordmark lockup. The name is then selectable, searchable, and indexed;
  * a wordmark is none of those, and ten of them side by side turned the grid
  * into a logo wall.
- *
- * The wire `dialect` is worth carrying per provider: it is what "vendor-
- * agnostic" actually cashes out to. Stella speaks each vendor's own protocol
- * rather than normalizing everything through one OpenAI-shaped adapter, so the
- * dialect tells you which provider quirks (thinking blocks, cache-control,
- * tool-call shapes) are native rather than emulated.
  */
-
-export interface ProviderSpec {
-  /** Registry id — the `provider` half of `--model provider/model`. */
-  id: string;
-  name: string;
-  /**
-   * Deep link into the single API Providers page. These were ten separate
-   * pages until the provider docs were consolidated; the anchors are the
-   * heading ids that page actually emits, so a reworded heading breaks a link
-   * here and must be re-checked against the rendered HTML, not guessed from
-   * the heading text.
-   */
-  href: string;
-  /** One line on when you would pick this provider over the others. */
-  blurb: string;
-  /** The primary credential variable; aliases in parentheses. */
-  env: string;
-  defaultModel: string;
-  dialect: string;
-}
-
-export const PROVIDER_CATALOG: ProviderSpec[] = [
-  {
-    id: "anthropic",
-    name: "Anthropic",
-    href: "/docs/api-providers#anthropic",
-    blurb: "The strongest coding and agentic models in the catalog, with first-class prompt caching.",
-    env: "ANTHROPIC_API_KEY",
-    defaultModel: "claude-fable-5",
-    dialect: "Anthropic Messages",
-  },
-  {
-    id: "openai",
-    name: "OpenAI",
-    href: "/docs/api-providers#openai",
-    blurb: "A strong worker and the usual second family for cross-family judging.",
-    env: "OPENAI_API_KEY",
-    defaultModel: "gpt-5.5",
-    dialect: "OpenAI Responses",
-  },
-  {
-    id: "gemini",
-    name: "Google Gemini",
-    href: "/docs/api-providers#google-gemini",
-    blurb: "Very large context windows at a low price — the long-document worker.",
-    env: "GEMINI_API_KEY (GOOGLE_API_KEY)",
-    defaultModel: "gemini-3-pro",
-    dialect: "Gemini generateContent",
-  },
-  {
-    id: "vertex",
-    name: "Google Vertex AI",
-    href: "/docs/api-providers#google-vertex-ai",
-    blurb: "The same Gemini models billed through your GCP project, for enterprises that require it.",
-    env: "VERTEX_ACCESS_TOKEN",
-    defaultModel: "gemini-3-pro",
-    dialect: "Gemini via Vertex",
-  },
-  {
-    id: "bedrock",
-    name: "Amazon Bedrock",
-    href: "/docs/api-providers#amazon-bedrock",
-    blurb: "Claude and friends inside your AWS account, on your existing IAM and billing.",
-    env: "AWS_ACCESS_KEY_ID",
-    defaultModel: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    dialect: "Bedrock Converse",
-  },
-  {
-    id: "xai",
-    name: "xAI",
-    href: "/docs/api-providers#xai",
-    blurb: "Grok, over the OpenAI-compatible dialect.",
-    env: "XAI_API_KEY",
-    defaultModel: "grok-4",
-    dialect: "OpenAI-compatible",
-  },
-  {
-    id: "deepseek",
-    name: "DeepSeek",
-    href: "/docs/api-providers#deepseek",
-    blurb: "Very cheap per token — the reference budget worker.",
-    env: "DEEPSEEK_API_KEY",
-    defaultModel: "deepseek-chat",
-    dialect: "OpenAI-compatible",
-  },
-  {
-    id: "zai",
-    name: "Z.ai",
-    href: "/docs/api-providers#zai",
-    blurb: "GLM models, and a flat-rate coding plan that decouples cost from token count.",
-    env: "ZAI_API_KEY",
-    defaultModel: "glm-5.2",
-    dialect: "OpenAI-compatible",
-  },
-  {
-    id: "openrouter",
-    name: "OpenRouter",
-    href: "/docs/api-providers#openrouter",
-    blurb: "One key, hundreds of models — the gateway when you would rather not manage keys.",
-    env: "OPENROUTER_API_KEY",
-    defaultModel: "moonshotai/kimi-k3",
-    dialect: "OpenAI-compatible",
-  },
-  {
-    id: "local",
-    name: "Local server",
-    href: "/docs/api-providers#local-servers",
-    blurb: "Ollama, llama.cpp, vLLM, LM Studio — anything that serves the OpenAI shape. No key, no egress.",
-    env: "none (optional LOCAL_API_KEY)",
-    defaultModel: "you choose",
-    dialect: "OpenAI-compatible",
-  },
-];
 
 /**
  * Every supported provider as a card grid.

--- a/website/src/components/provider-catalog.ts
+++ b/website/src/components/provider-catalog.ts
@@ -1,0 +1,135 @@
+/**
+ * The provider catalog — the single place the per-provider facts live. They
+ * used to be repeated in a five-column table on the API Providers index *and*
+ * again in prose on `getting-started/providers`, which is how the two drifted:
+ * a table cell is invisible to every check the repo runs, so a renamed env var
+ * is only ever found by a reader who tries it and fails. One typed record,
+ * three call sites now:
+ *
+ *  - `provider-cards.tsx` renders it as the card grid;
+ *  - `src/lib/page-markdown.ts` renders it as a markdown table when a docs
+ *    page is exported (Copy page / llms.mdx), where the cards cannot go.
+ *
+ * It lives in a plain `.ts` module — not beside the components — because the
+ * markdown path is exercised by `node --test`, which strips types but cannot
+ * parse JSX.
+ *
+ * The wire `dialect` is worth carrying per provider: it is what "vendor-
+ * agnostic" actually cashes out to. Stella speaks each vendor's own protocol
+ * rather than normalizing everything through one OpenAI-shaped adapter, so the
+ * dialect tells you which provider quirks (thinking blocks, cache-control,
+ * tool-call shapes) are native rather than emulated.
+ */
+
+export interface ProviderSpec {
+  /** Registry id — the `provider` half of `--model provider/model`. */
+  id: string;
+  name: string;
+  /**
+   * Deep link into the single API Providers page. These were ten separate
+   * pages until the provider docs were consolidated; the anchors are the
+   * heading ids that page actually emits, so a reworded heading breaks a link
+   * here and must be re-checked against the rendered HTML, not guessed from
+   * the heading text.
+   */
+  href: string;
+  /** One line on when you would pick this provider over the others. */
+  blurb: string;
+  /** The primary credential variable; aliases in parentheses. */
+  env: string;
+  defaultModel: string;
+  dialect: string;
+}
+
+export const PROVIDER_CATALOG: ProviderSpec[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    href: "/docs/api-providers#anthropic",
+    blurb: "The strongest coding and agentic models in the catalog, with first-class prompt caching.",
+    env: "ANTHROPIC_API_KEY",
+    defaultModel: "claude-fable-5",
+    dialect: "Anthropic Messages",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    href: "/docs/api-providers#openai",
+    blurb: "A strong worker and the usual second family for cross-family judging.",
+    env: "OPENAI_API_KEY",
+    defaultModel: "gpt-5.5",
+    dialect: "OpenAI Responses",
+  },
+  {
+    id: "gemini",
+    name: "Google Gemini",
+    href: "/docs/api-providers#google-gemini",
+    blurb: "Very large context windows at a low price — the long-document worker.",
+    env: "GEMINI_API_KEY (GOOGLE_API_KEY)",
+    defaultModel: "gemini-3-pro",
+    dialect: "Gemini generateContent",
+  },
+  {
+    id: "vertex",
+    name: "Google Vertex AI",
+    href: "/docs/api-providers#google-vertex-ai",
+    blurb: "The same Gemini models billed through your GCP project, for enterprises that require it.",
+    env: "VERTEX_ACCESS_TOKEN",
+    defaultModel: "gemini-3-pro",
+    dialect: "Gemini via Vertex",
+  },
+  {
+    id: "bedrock",
+    name: "Amazon Bedrock",
+    href: "/docs/api-providers#amazon-bedrock",
+    blurb: "Claude and friends inside your AWS account, on your existing IAM and billing.",
+    env: "AWS_ACCESS_KEY_ID",
+    defaultModel: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    dialect: "Bedrock Converse",
+  },
+  {
+    id: "xai",
+    name: "xAI",
+    href: "/docs/api-providers#xai",
+    blurb: "Grok, over the OpenAI-compatible dialect.",
+    env: "XAI_API_KEY",
+    defaultModel: "grok-4",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    href: "/docs/api-providers#deepseek",
+    blurb: "Very cheap per token — the reference budget worker.",
+    env: "DEEPSEEK_API_KEY",
+    defaultModel: "deepseek-chat",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "zai",
+    name: "Z.ai",
+    href: "/docs/api-providers#zai",
+    blurb: "GLM models, and a flat-rate coding plan that decouples cost from token count.",
+    env: "ZAI_API_KEY",
+    defaultModel: "glm-5.2",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    href: "/docs/api-providers#openrouter",
+    blurb: "One key, hundreds of models — the gateway when you would rather not manage keys.",
+    env: "OPENROUTER_API_KEY",
+    defaultModel: "moonshotai/kimi-k3",
+    dialect: "OpenAI-compatible",
+  },
+  {
+    id: "local",
+    name: "Local server",
+    href: "/docs/api-providers#local-servers",
+    blurb: "Ollama, llama.cpp, vLLM, LM Studio — anything that serves the OpenAI shape. No key, no egress.",
+    env: "none (optional LOCAL_API_KEY)",
+    defaultModel: "you choose",
+    dialect: "OpenAI-compatible",
+  },
+];

--- a/website/src/lib/page-markdown.test.ts
+++ b/website/src/lib/page-markdown.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { DIAGRAM_DESCRIPTIONS } from "../components/diagram-descriptions.ts";
+import { COMMAND_DECK_TABS } from "../components/command-deck-tabs.ts";
+import { PROVIDER_CATALOG } from "../components/provider-catalog.ts";
+import {
+  DIAGRAM_PLACEHOLDER_NAMES,
+  PLACEHOLDER_RENDERERS,
+  pageMarkdown,
+} from "./page-markdown.ts";
+
+/**
+ * The markdown export behind the "Copy page" menu and `/llms.mdx/<slug>`.
+ *
+ *   pnpm test          (from website/)
+ *
+ * ## Why this file exists
+ *
+ * Every failure mode of the export is silent: a placeholder renderer that
+ * stops matching the name `source.config.ts` emits degrades to the
+ * component's *children* — for a diagram, that is nothing, so the exported
+ * markdown just quietly loses the diagram. A `ProviderGrid` whose `only`
+ * attribute stops parsing renders the full catalog on a page that shows
+ * three. Nothing in the build fails either way; only a reader comparing the
+ * page to its export would notice. These tests are that comparison, run on
+ * every change.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SOURCE_CONFIG = readFileSync(join(HERE, "../../source.config.ts"), "utf8");
+
+test("every placeholder name source.config.ts emits has a renderer", () => {
+  // The config builds its list from DIAGRAM_PLACEHOLDER_NAMES plus two string
+  // literals; assert the literals are still there and the combined set is
+  // exactly the renderer set, so neither side can drift.
+  assert.match(SOURCE_CONFIG, /"ProviderGrid"/);
+  assert.match(SOURCE_CONFIG, /"CommandDeckExplorer"/);
+  assert.deepEqual(
+    Object.keys(PLACEHOLDER_RENDERERS).sort(),
+    [...DIAGRAM_PLACEHOLDER_NAMES, "ProviderGrid", "CommandDeckExplorer"].sort(),
+  );
+});
+
+test("every diagram placeholder renders its aria-label sentence", async () => {
+  for (const name of DIAGRAM_PLACEHOLDER_NAMES) {
+    const render = PLACEHOLDER_RENDERERS[name];
+    assert.ok(render, `no renderer for ${name}`);
+    const out = await render({ name, attributes: {}, children: "" });
+    assert.equal(out, `*${DIAGRAM_DESCRIPTIONS[name]}*`);
+    assert.ok(out.length > 20, `${name} rendered suspiciously short`);
+  }
+});
+
+test("ProviderGrid renders the full catalog as a GFM table", async () => {
+  const out = await PLACEHOLDER_RENDERERS.ProviderGrid({
+    name: "ProviderGrid",
+    attributes: {},
+    children: "",
+  });
+  assert.match(out, /^\| Provider \| id \| Env var \|/);
+  for (const p of PROVIDER_CATALOG) {
+    assert.ok(out.includes(`\`${p.id}\``), `missing provider ${p.id}`);
+    assert.ok(out.includes(p.name), `missing name for ${p.id}`);
+  }
+  // One header row, one separator, one row per provider.
+  assert.equal(out.trim().split("\n").length, PROVIDER_CATALOG.length + 2);
+});
+
+test("ProviderGrid honours the `only` attribute", async () => {
+  const only = PROVIDER_CATALOG.slice(0, 2).map((p) => p.id);
+  const out = await PLACEHOLDER_RENDERERS.ProviderGrid({
+    name: "ProviderGrid",
+    attributes: { only },
+    children: "",
+  });
+  assert.equal(out.trim().split("\n").length, only.length + 2);
+  assert.ok(out.includes(`\`${only[0]}\``));
+  assert.ok(!out.includes(`\`${PROVIDER_CATALOG[2].id}\``));
+});
+
+test("CommandDeckExplorer renders every tab as a fenced block", async () => {
+  const out = await PLACEHOLDER_RENDERERS.CommandDeckExplorer({
+    name: "CommandDeckExplorer",
+    attributes: {},
+    children: "",
+  });
+  for (const tab of COMMAND_DECK_TABS) {
+    assert.ok(out.includes(`### ${tab.label}`), `missing tab ${tab.label}`);
+    assert.ok(out.includes(tab.lines[0]), `missing lines for ${tab.label}`);
+  }
+});
+
+test("pageMarkdown assembles header, source line, and rendered body", async () => {
+  const placeholder = `\0${JSON.stringify({
+    name: "HeroFlowDiagram",
+    attributes: {},
+    children: "",
+  })}\0`;
+  const out = await pageMarkdown({
+    title: "Agent modes",
+    description: "Pick the loop that fits the work.",
+    url: "https://stella.oxagen.sh/docs/agent-modes",
+    markdown: `Some prose.\n\n${placeholder}\n\nMore prose.`,
+  });
+  assert.ok(out.startsWith("# Agent modes\n\n> Pick the loop that fits the work.\n\nSource: https://stella.oxagen.sh/docs/agent-modes\n\n"));
+  assert.ok(out.includes("Some prose."));
+  assert.ok(out.includes(`*${DIAGRAM_DESCRIPTIONS.HeroFlowDiagram}*`));
+  assert.ok(!out.includes("\0"), "an unrendered placeholder survived");
+  assert.ok(out.endsWith("\n"));
+});
+
+test("a page with no description omits the blockquote line", async () => {
+  const out = await pageMarkdown({
+    title: "Reference",
+    url: "https://stella.oxagen.sh/docs/reference",
+    markdown: "Body.",
+  });
+  assert.ok(out.startsWith("# Reference\n\nSource:"));
+});
+
+test("residual self-closing logomark tags are stripped from the body", async () => {
+  // remarkLLMs re-serializes self-closing inline JSX as literal tags even when
+  // the stringify callback returns "" for them (see page-markdown.ts); the
+  // strip pass in pageMarkdown is what keeps them out of the export.
+  const out = await pageMarkdown({
+    title: "Models",
+    url: "https://stella.oxagen.sh/docs/api-providers/models",
+    markdown:
+      '| <ProviderMark id="anthropic" /> `claude-fable-5` | `anthropic` |\n\n<ProviderLogo id="openai" /> inline',
+  });
+  assert.ok(!out.includes("<ProviderMark"), "a ProviderMark tag survived");
+  assert.ok(!out.includes("<ProviderLogo"), "a ProviderLogo tag survived");
+  assert.ok(out.includes("`claude-fable-5`"), "the text beside the mark was stripped too");
+});

--- a/website/src/lib/page-markdown.ts
+++ b/website/src/lib/page-markdown.ts
@@ -1,0 +1,111 @@
+/**
+ * The markdown a docs page exports — the body behind the "Copy page" menu on
+ * every docs page and the `/llms.mdx/<slug>` endpoint.
+ *
+ * The source of truth is the `_markdown` export fumadocs-mdx attaches to every
+ * page when `postprocess.includeProcessedMarkdown` is on (see
+ * `source.config.ts`): the page's own MDX, rendered back to markdown by the
+ * same remark pipeline that renders it to HTML, so includes are resolved and
+ * GFM tables survive. Reading the raw `.mdx` off disk instead would leak JSX
+ * tags a markdown consumer cannot read.
+ *
+ * Three component kinds carry meaning outside their children — the SVG
+ * diagrams (their content is the picture), `ProviderGrid` (its content is the
+ * catalog data), and `CommandDeckExplorer` (nine tabbed panes). Those are
+ * emitted as placeholders at build time and re-rendered to markdown here by
+ * `renderPlaceholder`, from the same records the components render from, so
+ * the export can never drift from what the page shows.
+ *
+ * This module is pure and `.ts`-only — no JSX, no `node:fs` — because it is
+ * exercised by `node --test` (which strips types but cannot parse JSX) and
+ * imported by `source.config.ts` (which runs before the path alias `@/` is
+ * meaningful, hence the relative imports).
+ */
+import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+import { DIAGRAM_DESCRIPTIONS } from "../components/diagram-descriptions.ts";
+import { COMMAND_DECK_TABS } from "../components/command-deck-tabs.ts";
+import { PROVIDER_CATALOG } from "../components/provider-catalog.ts";
+
+/**
+ * The diagram component names `source.config.ts` lists as `mdxAsPlaceholder`.
+ * Derived from the descriptions record so a diagram added to `diagrams.tsx`
+ * (and therefore to the record — `diagrams.test.ts` enforces that) is
+ * placeholder-rendered without a second edit here.
+ */
+export const DIAGRAM_PLACEHOLDER_NAMES = Object.keys(DIAGRAM_DESCRIPTIONS);
+
+/** Escape the two characters that would break a GFM table cell. */
+function cell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function providerGridMarkdown(only: unknown): string {
+  const ids = Array.isArray(only) ? only.filter((v): v is string => typeof v === "string") : undefined;
+  const providers = ids
+    ? ids.flatMap((id) => PROVIDER_CATALOG.filter((p) => p.id === id))
+    : PROVIDER_CATALOG;
+  const rows = providers.map(
+    (p) =>
+      `| ${cell(p.name)} | \`${p.id}\` | \`${cell(p.env)}\` | \`${cell(p.defaultModel)}\` | ${cell(p.dialect)} | ${cell(p.blurb)} |`,
+  );
+  return [
+    "| Provider | id | Env var | Default model | Dialect | When to pick it |",
+    "|---|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+function commandDeckMarkdown(): string {
+  return COMMAND_DECK_TABS.map(
+    (tab) => `### ${tab.label}\n\n${tab.blurb}\n\n\`\`\`text\n${tab.lines.join("\n")}\n\`\`\``,
+  ).join("\n\n");
+}
+
+/**
+ * Renderers for the placeholders `includeProcessedMarkdown` emits. A name
+ * absent here degrades to the placeholder's children (fumadocs' default),
+ * which for these three would be nothing — so the record is exhaustive by
+ * construction: the placeholder list in `source.config.ts` is exactly these
+ * keys, and `page-markdown.test.ts` asserts it.
+ */
+export const PLACEHOLDER_RENDERERS: Record<
+  string,
+  (data: { name: string | null; attributes: Record<string, unknown>; children: string }) => string
+> = Object.fromEntries([
+  ...DIAGRAM_PLACEHOLDER_NAMES.map((name) => [
+    name,
+    () => `*${DIAGRAM_DESCRIPTIONS[name]}*`,
+  ]),
+  ["ProviderGrid", (data: { attributes: Record<string, unknown> }) => providerGridMarkdown(data.attributes.only)],
+  ["CommandDeckExplorer", () => commandDeckMarkdown()],
+]);
+
+export interface PageMarkdownInput {
+  title: string;
+  description?: string;
+  /** The page's canonical path, e.g. `/docs/agent-tools`. */
+  url: string;
+  /** The page's `_markdown` export, with placeholders still embedded. */
+  markdown: string;
+}
+
+/**
+ * Assemble the final markdown document for one page: a header naming the page
+ * and where it came from (so a pasted copy is attributable), then the body
+ * with every placeholder rendered.
+ */
+export async function pageMarkdown(page: PageMarkdownInput): Promise<string> {
+  const rendered = await renderPlaceholder(page.markdown, PLACEHOLDER_RENDERERS);
+  // remarkLLMs' own filterElement runs ahead of any user-supplied one and
+  // re-serializes self-closing inline JSX (the ProviderMark logomarks in the
+  // model tables) as literal tags, ignoring the stringify callback's "" for
+  // them. They are decorative — the provider's name is in the text beside
+  // them — so they are stripped here, after rendering, where the result is
+  // fully under this module's control.
+  const body = rendered.replace(/<Provider(?:Mark|Logo)\b[^/]*\/>\s*/g, "");
+  const parts = [`# ${page.title}`, ""];
+  if (page.description) parts.push(`> ${page.description}`, "");
+  parts.push(`Source: ${page.url}`, "", body.trim(), "");
+  return parts.join("\n");
+}


### PR DESCRIPTION
## What & why

Rescues the abandoned `fix/rescue-abandoned-code` work: a complete "Copy page" feature for the docs site, website-only.

- **`/llms.mdx/<slug>` route** — every docs page as a static markdown file, generated from the page's own `_markdown` export (fumadocs `postprocess.includeProcessedMarkdown`) so the export can never disagree with the rendered page.
- **`PageActions` ("Copy page") menu** on every docs page — copy as markdown, view/download as markdown, print / save as PDF. Print CSS in `global.css` strips the chrome so print output is the article.
- **`src/lib/page-markdown.ts`** — renders the three component kinds whose meaning lives outside their children (SVG diagrams, `ProviderGrid`, `CommandDeckExplorer`) into markdown from the same records the components render from.
- **Data extraction refactor** to make that possible: provider catalog → `provider-catalog.ts`, deck tabs → `command-deck-tabs.ts`, diagram aria-labels → `diagram-descriptions.ts` (all plain `.ts` so `node --test` can exercise the markdown path). Component behavior unchanged.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`website/src/lib/page-markdown.test.ts` (7 tests: placeholder/renderer parity with `source.config.ts`, diagram sentences, `ProviderGrid` table + `only` attribute, deck-tab fences, document assembly, logomark stripping) and a new lockstep test in `diagrams.test.ts` (every diagram has a description and reads it as its own `aria-label`). All fail on `main` because the modules under test do not exist there.

## The gate

Rust untouched — website-only diff. Verified on this branch:

- `pnpm test` (website): 35 pass, 0 fail
- `pnpm typecheck`: clean
- `pnpm build` (production): green; `/llms.mdx/*` prerenders all ~90 docs pages, and a spot-check of `.next/server/app/llms.mdx/agent-modes.body` shows the expected export (title/description/Source header, `SpecCard` titles as headings, deck tabs as fenced blocks)

- [x] Docs updated where behavior changed
- [x] CLA signed

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The `stringify` callback in `source.config.ts` (rather than `filterElement`) and the post-render logomark strip in `page-markdown.ts` both work around fumadocs' `remarkLLMs` replacing any user-supplied `filterElement` — the comments at each site carry the detail.

## Summary by Sourcery

Add consistent Markdown and print export capabilities to the documentation website.

New Features:
- Add a Copy page menu to every documentation page with Markdown copy, viewing, downloading, and print/PDF options.
- Expose statically generated `/llms.mdx/<slug>` Markdown exports for documentation pages.
- Render diagrams, provider catalogs, and command-deck tabs into meaningful Markdown during page export.

Enhancements:
- Centralize provider, command-deck, and diagram description data so rendered documentation and Markdown exports share the same sources.
- Improve diagram accessibility by sharing descriptive aria-labels with Markdown export text.

Tests:
- Add coverage for Markdown placeholder rendering, document assembly, provider filtering, command-deck tab exports, logomark removal, and diagram-description consistency.

Chores:
- Add print styling that removes website chrome and formats documentation content for printing.