### PR TITLE
fix(stella-observatory): show the time-window control only on the tabs it filters

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -447,6 +447,7 @@ nav.bar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
 .tabs button:hover{color:var(--text);background:var(--accent-wash)}
 .tabs button[aria-selected="true"]{color:var(--text);border-bottom-color:var(--accent)}
 .tf-wrap{margin-left:auto;display:flex;align-items:center;gap:var(--sp1);padding:6px 0}
+.tf-wrap[hidden]{display:none}
 .tf-label{font:var(--fs-micro)/1 var(--mono);color:var(--text-3)}
 .tf{display:flex;align-items:stretch;border:1px solid var(--control-edge);
     border-radius:var(--radius-sm);overflow:hidden}
@@ -870,7 +871,10 @@ footer b{color:var(--identity);font-weight:600}
       <button role="tab" id="tab-hub" aria-controls="panel-hub" data-tab="hub">Org / hub</button>
       <button role="tab" id="tab-config" aria-controls="panel-config" data-tab="config">Config</button>
     </div>
-    <div class="tf-wrap">
+    <!-- Shown only on the tabs whose surfaces the window actually filters
+         (TF_TABS in the script below). Everywhere else the control used to
+         sit in the nav and silently do nothing, which reads as broken. -->
+    <div class="tf-wrap" id="tfWrap">
       <span class="tf-label" id="tfLabel">Window</span>
       <div class="tf" id="tf" role="radiogroup" aria-labelledby="tfLabel">
         <button role="radio" data-tf="24h">24h</button>
@@ -4073,11 +4077,19 @@ const TABS = [...document.querySelectorAll('#tabs button[role="tab"]')];
    must not park focus on a `hidden` button — so the arrow keys walk the
    visible tabs, which is also the set the reader can see. */
 const visibleTabs = () => TABS.filter(b => !b.hidden);
+/* The tabs whose surfaces re-render under the time window (inTf/inTfDay):
+   Overview's KPIs, timeline and executions table, and Activity's daily
+   charts. Every other tab shows all-time or configuration state, so the
+   window control hides there — a visible control that filters nothing on
+   the tab in front of the reader is indistinguishable from a broken one.
+   The selection itself survives in state.tf while hidden. */
+const TF_TABS = new Set(["overview", "activity"]);
 function switchTab(tab, arg = "") {
   // A transcript route with no execution behind it is not a route.
   if (tab === "transcript" && !arg) { location.hash = "sessions"; return; }
   const left = state.tab === "transcript" && tab !== "transcript";
   state.tab = tab;
+  $("tfWrap").hidden = !TF_TABS.has(tab);
   if (tab === "transcript") $("tab-transcript").hidden = false;
   TABS.forEach(b => {
     const on = b.dataset.tab === tab;

--- a/crates/stella-observatory/tests/window_scope.rs
+++ b/crates/stella-observatory/tests/window_scope.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! **The time-window control appears only where it filters something.**
+//!
+//! The nav's Window radiogroup (`24h` / `7d` / `30d` / `All`) drives
+//! `state.tf`, and `state.tf` is consulted by exactly two tabs' surfaces:
+//! Overview (KPI tiles, the token timeline, the executions table, via
+//! `inTf`) and Activity (the daily charts, via `inTfDay`). Every other tab
+//! renders all-time aggregates or configuration state.
+//!
+//! The control nevertheless sat in the global nav on all twelve tabs, and on
+//! ten of them clicking it changed nothing — no error, no re-render, no
+//! acknowledgement beyond the highlight moving. That is indistinguishable
+//! from a broken control, and it was reported as one ("the window time
+//! filter is not working"). The fix scopes the control's visibility to the
+//! tabs it governs: `switchTab` hides `#tfWrap` unless the destination tab
+//! is in `TF_TABS`.
+//!
+//! Like the sibling asset tests, this reads the served page as text — the
+//! Rust side never executes the script — and pins the three pieces the fix
+//! is made of, each of which is absent on the code that shipped the defect:
+//!
+//! 1. the wrapper is addressable (`id="tfWrap"`), so the script can hide it;
+//! 2. hiding works at all: `.tf-wrap` is `display:flex`, which overrides the
+//!    `hidden` attribute's default styling unless a `[hidden]` rule wins —
+//!    delete that rule and the attribute becomes a silent no-op;
+//! 3. `switchTab` toggles the wrapper from a `TF_TABS` set whose members are
+//!    real tabs, and that set names only tabs whose panels the window
+//!    actually re-renders.
+
+/// The page exactly as the binary embeds and serves it.
+const INDEX_HTML: &str = include_str!("../src/assets/index.html");
+
+#[test]
+fn window_control_is_addressable_and_hideable() {
+    assert!(
+        INDEX_HTML.contains(r#"<div class="tf-wrap" id="tfWrap">"#),
+        "the Window control's wrapper must carry id=\"tfWrap\" so switchTab can hide it"
+    );
+    assert!(
+        INDEX_HTML.contains(".tf-wrap[hidden]{display:none}"),
+        ".tf-wrap is display:flex, which beats the hidden attribute's UA styling; \
+         without this rule, hiding the control is a silent no-op"
+    );
+}
+
+#[test]
+fn switch_tab_scopes_the_window_to_the_tabs_it_filters() {
+    assert!(
+        INDEX_HTML.contains(r#"const TF_TABS = new Set(["overview", "activity"]);"#),
+        "TF_TABS must name exactly the tabs whose surfaces consult state.tf \
+         (inTf / inTfDay); widening it without wiring the window into the new \
+         tab's renders recreates the do-nothing control this test exists for"
+    );
+    assert!(
+        INDEX_HTML.contains(r#"$("tfWrap").hidden = !TF_TABS.has(tab);"#),
+        "switchTab must hide the Window control on tabs it does not govern"
+    );
+    // Both governed tabs are real: each has a section panel to filter.
+    for tab in ["overview", "activity"] {
+        assert!(
+            INDEX_HTML.contains(&format!(r#"<section data-tab="{tab}""#)),
+            "TF_TABS names {tab:?}, but no <section data-tab={tab:?}> exists"
+        );
+    }
+}


### PR DESCRIPTION
## What & why

The Observatory's Window radiogroup (24h / 7d / 30d / All) drives `state.tf`, which exactly two tabs consult: **Overview** (KPI tiles, token timeline, executions table — `inTf`) and **Activity** (daily charts — `inTfDay`). The control nevertheless sat in the global nav on all twelve tabs, so on the other ten clicking it changed nothing: no error, no re-render, just the highlight moving. That is indistinguishable from a broken control, and it was reported as one ("the window time filter is not working").

Diagnosed by driving the live dashboard headlessly: the filter itself is correct wherever it is wired (24h/7d/30d produced 123/186/314 rows against a 314-execution store, surviving refresh ticks, no exceptions) — the defect is the control's unscoped visibility. `switchTab` now hides `#tfWrap` unless the destination tab is in `TF_TABS = {overview, activity}`; the selection survives in `state.tf` while hidden. `.tf-wrap` is `display:flex`, which beats the `hidden` attribute's UA styling, so a `.tf-wrap[hidden]{display:none}` rule backs it (same shape as `.err[hidden]`).

Verified end-to-end: the modified page served against the live `/api` shows the control on Overview and Activity, hides it on Sessions / Self-Driving / Config, and still filters (24h → 123 rows).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-observatory/tests/window_scope.rs` pins the wrapper id, the `[hidden]` CSS rule, and the `TF_TABS` scoping line in `switchTab` — `git show origin/main:…/index.html | rg 'tfWrap|TF_TABS'` matches nothing, so every assertion fails on main. Exemplar for the shape: the sibling asset tests (`inline_script_backticks.rs`, `light_mode.rs`), which read the served asset as text rather than executing it.

## The gate

- [x] `cargo test -p stella-observatory` (116+ tests green locally); full gate runs in CI per repo policy
- [x] `make prose`, `make left-behind` green
- [ ] Docs: none needed (no flags or commands changed)

## Nothing left behind

Follow-up filed for the judgement this PR deliberately does not make: whether Sessions / Self-Driving / Hub should gain real window filtering (their aggregates are all-time SQL server-side), or stay all-time by design. See #4590.

## Summary by Sourcery

Scope the Observatory time-window control to the tabs it filters and add regression coverage for its visibility.

Bug Fixes:
- Limit the Observatory time-window control to the Overview and Activity tabs where it affects displayed data, preventing a non-functional control from appearing elsewhere.

Tests:
- Add asset-level witness tests covering the time-window control's addressability, hidden-state styling, and tab scoping.
