### PR TITLE
fix(stella-observatory): partial-run reflections, sticky transcript folds, model-card tests, pre-cache_write stores

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2658,7 +2658,12 @@ function openCtxDialog(step, role) {
    `after_seq` probe still decides whether anything happened; when it did,
    the rendered fragment is re-fetched whole and repainted, because the
    shared renderer draws a tree, not an appendable list. The renderer pins
-   running work open, so the repaint lands the reader back on the live step. */
+   running work open, so the repaint lands the reader back on the live step —
+   and every fold the reader toggled by hand is put back the way they left it
+   (#4566): fold ids are stable NodeId keys (`t0s3`…), so the open/closed
+   state of each identified fold is read out of the shadow DOM before the
+   repaint and reapplied after. Folds new to this paint (the args fold has no
+   id) keep the renderer's own pin-open rules. */
 async function refreshTranscriptJournal() {
   if (!tx || tx.finished) return;
   if (state.tab !== "transcript") { tx = null; return; }
@@ -2679,7 +2684,15 @@ async function refreshTranscriptJournal() {
   } catch {
     return;
   }
-  if (frag && tx && tx.id === id) await paintRenderedTranscript(frag);
+  if (!frag || !tx || tx.id !== id) return;
+  const folds = { open: new Set(), shut: new Set() };
+  for (const d of $("tx-render")?.shadowRoot?.querySelectorAll("details[id]") ?? [])
+    (d.open ? folds.open : folds.shut).add(d.id);
+  await paintRenderedTranscript(frag);
+  for (const d of $("tx-render")?.shadowRoot?.querySelectorAll("details[id]") ?? []) {
+    if (folds.open.has(d.id)) d.open = true;
+    else if (folds.shut.has(d.id)) d.open = false;
+  }
 }
 /* The main poll already re-fetches `/api/executions` (with `finished_at`)
    on every cursor move — reuse that instead of a dedicated per-tick

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2601,7 +2601,11 @@ async function openTranscript(id, full = false) {
       fileRows || `<div class="empty">This run touched no files.</div>`)
     + (rf ? sect("tx-reflection", "Self-reflection",
       "What the agent said about its own turn once it was over.",
+      /* `partial_run` leads: a cancelled run's reflection covers only what
+         ran, and a cancelled run with NO self-review still gets this section
+         so the reader sees why there is nothing to grade (#4538). */
       `<p style="font:var(--fs-base)/1.7 var(--mono);color:var(--text-2)">
+        ${rf.partial_run ? `<span class="badge warn">partial run</span> the turn was cancelled before it finished<br>` : ""}
         ${rf.self_rating != null ? `rated ${esc(String(rf.self_rating))}/10 · ` : ""}
         ${rf.delivered != null ? (rf.delivered ? "delivered" : "not delivered") : ""}
         ${rf.what_went_well ? `<br>went well: ${esc(rf.what_went_well)}` : ""}

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -390,15 +390,37 @@ impl Observatory {
                 }))
             },
         ))?;
+        // `partial_run` (schema v32, #3808): whether the reflection covers a
+        // run that was cancelled partway. Probed on its own rather than folded
+        // into the gated query above, for two reasons: a pre-v32 store must
+        // lose this flag and nothing else (the gated query still resolves,
+        // so real reflections keep rendering), and a cancelled run whose only
+        // row came from finalize fails `HAS_SELF_REVIEW` — yet "cancelled
+        // before it could be graded" is a reason the panel owes the reader,
+        // where `reflection: null` alone says nothing (#4538).
+        let partial_run = match conn.query_row(
+            "SELECT partial_run FROM execution_reflection WHERE execution_id = ?1",
+            [id],
+            |r| r.get::<_, i64>(0),
+        ) {
+            Ok(v) => v != 0,
+            Err(rusqlite::Error::QueryReturnedNoRows) => false,
+            Err(e) if is_missing_schema(&e) => false,
+            Err(e) => return Err(e.into()),
+        };
         let mut out = head;
         out["steps"] = Value::Array(steps);
         out["tools"] = Value::Array(tools);
         out["files"] = Value::Array(files);
         out["recall"] = Value::Array(recall_timings(&conn, id)?);
-        out["reflection"] = if reflection == json!({}) {
-            Value::Null
-        } else {
-            reflection
+        out["reflection"] = match (reflection == json!({}), partial_run) {
+            (true, false) => Value::Null,
+            (true, true) => json!({ "partial_run": true }),
+            (false, _) => {
+                let mut graded = reflection;
+                graded["partial_run"] = json!(partial_run);
+                graded
+            }
         };
         Ok(out)
     }

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -315,7 +315,7 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
             else {
                 return Response::error("400 Bad Request", "missing ?provider=&slug=");
             };
-            model_card::model_card(&provider, &slug)
+            model_card::model_card(&model_card::default_catalog_db(), &provider, &slug)
         }
         // The transcript replay (#1461). `full=1` lifts the per-body clip —
         // fetched whole on drawer-open. `after_seq=<n>` (#1476) narrows to

--- a/crates/stella-observatory/src/model_card.rs
+++ b/crates/stella-observatory/src/model_card.rs
@@ -16,24 +16,35 @@
 //! from `model_provider` (whose silicon — `anthropic`), which is exactly the
 //! split the profile card has to print for a gateway-routed seat.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::{Value, json};
 
 use crate::db::{DbError, open_read_only};
 
-/// The user-tier catalog database, or wherever `STELLA_HOME` points.
-fn catalog_db() -> PathBuf {
+/// The user-tier catalog database, or wherever `STELLA_HOME` points — the
+/// default the route applies. [`model_card`] takes the path as a parameter
+/// instead of resolving it itself because `stella_home::data_dir()` reads
+/// process-wide env (`STELLA_HOME`/`STELLA_DATA_DIR`): a test that set it
+/// would race every parallel test in the binary, so the tests thread a temp
+/// path and only the route touches the environment — the same
+/// pure-resolver-half pattern `stella-home` itself uses (#4567).
+pub(crate) fn default_catalog_db() -> PathBuf {
     stella_home::data_dir().join("catalog.db")
 }
 
-/// The newest catalog card for `(api_provider, slug)`.
+/// The newest catalog card for `(api_provider, slug)` in the catalog at
+/// `catalog_db` ([`default_catalog_db`] on the live route).
 ///
 /// `found: false` when the catalog is absent or holds no such card — a state,
 /// not a failure: a workspace that never synced the catalog still gets a
 /// profile card, just one that says the offered defaults are unknown.
-pub(crate) fn model_card(api_provider: &str, slug: &str) -> Result<Value, DbError> {
-    let Some(conn) = open_read_only(&catalog_db()) else {
+pub(crate) fn model_card(
+    catalog_db: &Path,
+    api_provider: &str,
+    slug: &str,
+) -> Result<Value, DbError> {
+    let Some(conn) = open_read_only(catalog_db) else {
         return Ok(json!({ "found": false, "note": "no model catalog on this machine" }));
     };
     let mut stmt = match conn.prepare(

--- a/crates/stella-observatory/src/sessions.rs
+++ b/crates/stella-observatory/src/sessions.rs
@@ -736,11 +736,34 @@ fn bump(out: &mut Value, key: &str) {
     out[key] = json!(n + 1);
 }
 
+/// Whether this store's `telemetry` table carries `cache_write_tokens`.
+///
+/// [`session_turns`] sums it for the turn table's cache tooltip, and it is the
+/// youngest telemetry column that query touches: a store written before the
+/// column existed would fail the whole prepare, degrading the session's turn
+/// list to *empty* — the established per-query degrade, but paid here by a
+/// view that renders fine without the one figure. The cross-project switcher
+/// (`?project=`) is exactly where such old stores appear, so the sum is
+/// selected only when the column exists and reads 0 otherwise (#4567).
+///
+/// The probe is a prepare of a statement that fetches nothing; a missing
+/// *table* also fails it, and that case answers the same either way — the
+/// outer query degrades to no turns on a store with no telemetry at all.
+fn telemetry_has_cache_write(conn: &Connection) -> bool {
+    conn.prepare("SELECT cache_write_tokens FROM telemetry LIMIT 0")
+        .is_ok()
+}
+
 /// The session's turns from the three long-lived tables, newest first (the
 /// caller reverses after capping). Younger per-turn attachments — skills,
 /// MCP servers, receipt counts, the reflection verdict — ride in afterwards
 /// through [`fold_turn_extras`].
 fn session_turns(conn: &Connection, id: &str) -> Result<Vec<Value>, DbError> {
+    let cache_write_sum = if telemetry_has_cache_write(conn) {
+        "sum(cache_write_tokens)"
+    } else {
+        "0"
+    };
     let sql = format!(
         "SELECT e.id, e.kind, e.prompt, e.provider, e.model, e.outcome,
                 e.cost_usd, e.started_at, e.finished_at,
@@ -758,7 +781,7 @@ fn session_turns(conn: &Connection, id: &str) -> Result<Vec<Value>, DbError> {
                            sum(cache_miss_tokens) AS cache_miss_tokens,
                            sum(retries)           AS retries,
                            sum(duration_ms)       AS duration_ms,
-                           sum(cache_write_tokens) AS cache_write_tokens
+                           {cache_write_sum}      AS cache_write_tokens
                     FROM telemetry GROUP BY execution_id) t
            ON t.execution_id = e.id
          LEFT JOIN (SELECT execution_id, count(*) AS calls,

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -1348,6 +1348,81 @@ fn the_agents_panel_counts_definitions_and_collapses_delegations() {
     assert_eq!(delegations["distinct"], 3, "{delegations}");
 }
 
+/// **The #4567 witness.** A store whose `telemetry` predates
+/// `cache_write_tokens` still lists its session's turns.
+///
+/// `session_turns` sums that column for the turn table's cache tooltip, and a
+/// prepare over a missing column fails the whole query — the established
+/// per-query degrade, but here it blanked the entire turn list to buy one
+/// tooltip figure. The cross-project switcher (`?project=`) is exactly where
+/// stores that old appear. The sum is probed per store and reads 0 when the
+/// column is absent; everything else the query serves must still arrive.
+#[test]
+fn a_store_without_cache_write_tokens_still_lists_its_turns() {
+    let dir = TempDir::new().unwrap();
+    let dot = dir.path().join(".stella");
+    std::fs::create_dir_all(dot.join("private")).unwrap();
+    let conn = Connection::open(dot.join("private/store.db")).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE executions (
+           id INTEGER PRIMARY KEY AUTOINCREMENT,
+           kind TEXT NOT NULL, prompt TEXT NOT NULL,
+           provider TEXT NOT NULL, model TEXT NOT NULL,
+           started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+           finished_at TEXT, outcome TEXT, session_id TEXT,
+           cost_usd REAL NOT NULL DEFAULT 0);
+         -- The pre-cache_write telemetry shape: every column the turn query
+         -- reads except the one under test.
+         CREATE TABLE telemetry (
+           execution_id INTEGER NOT NULL, step INTEGER NOT NULL,
+           provider TEXT NOT NULL, model TEXT NOT NULL,
+           input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+           cache_read_tokens INTEGER NOT NULL,
+           cache_miss_tokens INTEGER NOT NULL,
+           cost_usd REAL NOT NULL, duration_ms INTEGER NOT NULL,
+           retries INTEGER NOT NULL, tool_calls INTEGER NOT NULL);
+         -- Present but empty: the turn query joins both, and a missing table
+         -- fails the whole prepare — that degrade is not what this test is
+         -- about.
+         CREATE TABLE tool_calls (
+           execution_id INTEGER NOT NULL, seq INTEGER NOT NULL,
+           name TEXT NOT NULL, error TEXT NOT NULL DEFAULT '');
+         CREATE TABLE files_touched (
+           execution_id INTEGER NOT NULL, path TEXT NOT NULL,
+           lines_added INTEGER NOT NULL DEFAULT 0,
+           lines_removed INTEGER NOT NULL DEFAULT 0);
+         INSERT INTO executions
+           (kind, prompt, provider, model, outcome, session_id, cost_usd)
+         VALUES ('run', 'add a function', 'zai', 'glm-5.2', 'completed',
+                 'ses-1', 0.03);
+         INSERT INTO telemetry
+           (execution_id, step, provider, model, input_tokens, output_tokens,
+            cache_read_tokens, cache_miss_tokens, cost_usd, duration_ms,
+            retries, tool_calls)
+         VALUES (1, 1, 'zai', 'glm-5.2', 1000, 200, 400, 600, 0.03, 1500, 0, 2);",
+    )
+    .unwrap();
+    drop(conn);
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&respond(dir.path(), "/api/session?id=ses-1").body).unwrap();
+    let turns = v["turns"].as_array().expect("turns");
+    assert_eq!(
+        turns.len(),
+        1,
+        "the turn list must survive the old store: {v}"
+    );
+    assert_eq!(turns[0]["id"], 1);
+    assert_eq!(
+        turns[0]["input_tokens"], 1000,
+        "the surviving sums stay real"
+    );
+    assert_eq!(
+        turns[0]["cache_write_tokens"], 0,
+        "the absent column reads as zero, not as an empty session: {v}"
+    );
+}
+
 /// A store written before v30 cannot answer which writer minted a name, and
 /// says so: the panel still lists what it has, with `kind` null. Degrading to
 /// an empty panel would blank a surface that works today.

--- a/crates/stella-observatory/src/tests/execution_routes.rs
+++ b/crates/stella-observatory/src/tests/execution_routes.rs
@@ -290,6 +290,49 @@ fn transcript_route_names_the_parameter_it_is_missing() {
     assert!(body.contains("id"), "{body}");
 }
 
+/// **The #4538 witness.** `execution_reflection.partial_run` (schema v32,
+/// #3808) reaches the panel: a cancelled run whose only reflection row came
+/// from finalize — no self-review to gate on — must render the flag instead
+/// of `reflection: null`, and a graded reflection must carry the flag beside
+/// its grade, so the panel can say "this covers a partial run" either way.
+///
+/// The shared fixture predates the column on purpose (every other test in
+/// this file is the pre-v32 degrade witness: the flag is silently absent and
+/// nothing else changes); this one migrates its own copy forward.
+#[test]
+fn a_cancelled_runs_reflection_reads_partial_run_not_null() {
+    let ws = seeded_workspace();
+    let conn = Connection::open(ws.path().join(".stella/private/store.db")).unwrap();
+    conn.execute_batch(
+        "ALTER TABLE execution_reflection
+           ADD COLUMN partial_run INTEGER NOT NULL DEFAULT 0;
+         INSERT INTO executions
+           (kind, prompt, provider, model, outcome, session_id, cost_usd)
+         VALUES ('run', 'refactor the parser', 'zai', 'glm-5.2',
+                 'cancelled', 'ses-1', 0.01);
+         INSERT INTO execution_reflection (execution_id, partial_run)
+         VALUES (3, 1);",
+    )
+    .unwrap();
+    drop(conn);
+
+    let cancelled = respond(ws.path(), "/api/execution?id=3");
+    let v: serde_json::Value = serde_json::from_slice(&cancelled.body).unwrap();
+    assert_eq!(
+        v["reflection"],
+        serde_json::json!({ "partial_run": true }),
+        "a finalize-only row on a cancelled run is a reason, not a null: {v}"
+    );
+
+    let graded = respond(ws.path(), "/api/execution?id=1");
+    let v: serde_json::Value = serde_json::from_slice(&graded.body).unwrap();
+    assert_eq!(v["reflection"]["self_rating"], 8);
+    assert_eq!(
+        v["reflection"]["partial_run"], false,
+        "a graded full-run reflection states the flag rather than omitting it: {v}"
+    );
+}
+
 /// `/api/model-card` names its missing parameters; the card itself is read
 /// from the user-tier catalog, which a seeded workspace deliberately does not
 /// fabricate.

--- a/crates/stella-observatory/src/tests/execution_routes.rs
+++ b/crates/stella-observatory/src/tests/execution_routes.rs
@@ -345,6 +345,123 @@ fn model_card_route_names_its_missing_parameters() {
     assert!(body.contains("slug"), "{body}");
 }
 
+/// A catalog file shaped like `stella-store::catalog`'s DDL (the hand-written
+/// subset discipline `seeded_workspace` documents), holding one card with two
+/// versions so the newest-version pick is observable.
+fn seeded_catalog(dir: &TempDir) -> std::path::PathBuf {
+    let path = dir.path().join("catalog.db");
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE model_cards (
+           id INTEGER PRIMARY KEY AUTOINCREMENT,
+           api_provider TEXT NOT NULL, model_provider TEXT NOT NULL,
+           slug TEXT NOT NULL, display_name TEXT, family TEXT,
+           source TEXT NOT NULL DEFAULT 'test');
+         CREATE TABLE model_card_versions (
+           id INTEGER PRIMARY KEY AUTOINCREMENT,
+           model_card_id INTEGER NOT NULL, version INTEGER NOT NULL,
+           input_usd_per_mtok REAL, output_usd_per_mtok REAL,
+           cached_input_usd_per_mtok REAL, cache_write_usd_per_mtok REAL,
+           context_window INTEGER, max_output_tokens INTEGER,
+           release_date TEXT, last_updated TEXT,
+           supports_reasoning INTEGER, supports_tools INTEGER, knowledge TEXT,
+           source TEXT NOT NULL DEFAULT 'test',
+           content_hash TEXT NOT NULL DEFAULT '');
+         INSERT INTO model_cards
+           (api_provider, model_provider, slug, display_name, family)
+         VALUES ('openrouter', 'anthropic', 'claude-x', 'Claude X', 'claude');
+         INSERT INTO model_card_versions
+           (model_card_id, version, input_usd_per_mtok, output_usd_per_mtok,
+            cached_input_usd_per_mtok, cache_write_usd_per_mtok,
+            context_window, max_output_tokens, release_date, last_updated,
+            supports_reasoning, supports_tools, knowledge)
+         VALUES
+           (1, 1, 1.0, 4.0, 0.1, 1.25, 100000, 32000,
+            '2026-01-01', '2026-02-01', 0, 1, '2025-04'),
+           (1, 2, 3.0, 15.0, 0.3, 3.75, 200000, 64000,
+            '2026-03-01', '2026-04-01', 1, 1, '2025-10');",
+    )
+    .unwrap();
+    path
+}
+
+/// **The found path (#4567).** Against a seeded catalog, the card resolves
+/// the newest version's row — every column the route serves, including the
+/// api-provider/model-provider split the profile card exists to print.
+///
+/// Calls [`model_card::model_card`] with the catalog path threaded as a
+/// parameter: the env-derived default (`stella_home::data_dir()`) reads
+/// process-wide `STELLA_HOME`/`STELLA_DATA_DIR`, and setting those in one
+/// test races every parallel test in the binary.
+#[test]
+fn model_card_serves_the_newest_version_of_a_seeded_card() {
+    let dir = TempDir::new().unwrap();
+    let path = seeded_catalog(&dir);
+    let card = crate::model_card::model_card(&path, "openrouter", "claude-x").unwrap();
+    assert_eq!(
+        card,
+        serde_json::json!({
+            "found": true,
+            "api_provider": "openrouter",
+            "model_provider": "anthropic",
+            "slug": "claude-x",
+            "display_name": "Claude X",
+            "family": "claude",
+            "context_window": 200_000,
+            "max_output_tokens": 64_000,
+            "supports_reasoning": true,
+            "supports_tools": true,
+            "knowledge": "2025-10",
+            "release_date": "2026-03-01",
+            "last_updated": "2026-04-01",
+            "input_usd_per_mtok": 3.0,
+            "output_usd_per_mtok": 15.0,
+            "cached_input_usd_per_mtok": 0.3,
+            "cache_write_usd_per_mtok": 3.75,
+        }),
+        "version 2's figures, version 1's nowhere"
+    );
+
+    // A card the catalog does not hold, and a catalog that does not exist:
+    // both are states, not failures.
+    let missing = crate::model_card::model_card(&path, "openrouter", "no-such").unwrap();
+    assert_eq!(missing["found"], false, "{missing}");
+    let absent =
+        crate::model_card::model_card(&dir.path().join("nowhere.db"), "openrouter", "claude-x")
+            .unwrap();
+    assert_eq!(absent["found"], false, "{absent}");
+    assert_eq!(absent["note"], "no model catalog on this machine");
+}
+
+/// **The degrade path (#4567).** A catalog written before the capability
+/// columns (`supports_reasoning` et al, added by `CATALOG_MIGRATIONS`) fails
+/// the prepare, and that must read as the same state as no catalog — never a
+/// 500 on the turn page.
+#[test]
+fn model_card_degrades_a_catalog_older_than_its_columns() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("catalog.db");
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch(
+            "CREATE TABLE model_cards (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               api_provider TEXT NOT NULL, model_provider TEXT NOT NULL,
+               slug TEXT NOT NULL);
+             CREATE TABLE model_card_versions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               model_card_id INTEGER NOT NULL, version INTEGER NOT NULL);
+             INSERT INTO model_cards (api_provider, model_provider, slug)
+             VALUES ('openrouter', 'anthropic', 'claude-x');
+             INSERT INTO model_card_versions (model_card_id, version)
+             VALUES (1, 1);",
+        )
+        .unwrap();
+    let card = crate::model_card::model_card(&path, "openrouter", "claude-x").unwrap();
+    assert_eq!(card["found"], false, "{card}");
+    assert_eq!(card["note"], "catalog schema too old");
+}
+
 /// `after_seq` (#1476) narrows the transcript to rows newer than the
 /// drawer's last-seen `seq` — the incremental fetch a still-running
 /// execution's poll uses instead of re-downloading the whole transcript


### PR DESCRIPTION
Three observatory issues, one crate, read-only posture unchanged throughout — every query stays hand-written SQL over a `SQLITE_OPEN_READ_ONLY` handle, and `stella-store` stays a dev-dependency only.

## What

### #4538 — surface `execution_reflection.partial_run`
`crates/stella-observatory/src/db.rs` gated the whole reflection panel on `HAS_SELF_REVIEW`, so a cancelled run rendered `reflection: null` with no reason; the v32 column reached the export but not the dashboard. The flag is now read in its own degradable probe (folding it into the gated query would blank real reflections on pre-v32 stores): a finalize-only row on a cancelled run answers `{"partial_run": true}` instead of `null`, and a graded reflection carries the flag beside its grade. The turn page leads the Self-reflection section with a `partial run` badge when set.

### #4566 — live transcript repaint resets hand-toggled folds
The still-running poll repaints the whole fragment on any news (the shared renderer draws a tree, not an appendable list), which re-collapsed any old step the reader had opened by hand. `refreshTranscriptJournal` (`assets/index.html`) now reads the open/closed state of every `details[id]` in the shadow DOM before repainting and reapplies it after — fold ids are the renderer's stable NodeId keys (`t0s3`…). Folds new to a paint keep the renderer's pin-open rules. This is the issue's fix shape **(b)**; the server-cost half — fix shape (a), the incremental fragment protocol needing a streaming API on `stella_transcript::html::render_run` — deliberately remains, so this PR uses `Refs` and leaves #4566 open to track it.

### #4567 — model-card testability + pre-`cache_write_tokens` stores
- `model_card` (`src/model_card.rs`) now takes the catalog path as a parameter, with the env-derived default (`stella_home::data_dir()`) applied at the route in `lib.rs` — the pure-resolver-half pattern `stella-home` itself uses, because `data_dir()` reads process-wide env and setting it in one test races every parallel test in the binary. Tests now cover the newest-version found row (all 16 columns), no-such-card, no-catalog, and the schema-too-old degrade.
- `session_turns` (`src/sessions.rs`) summed `telemetry.cache_write_tokens`; on a store older than that column the whole prepare failed `is_missing_schema` and the session's **entire turn list degraded to empty** to buy one tooltip figure — and the cross-project switcher (`?project=`) is exactly where old stores appear. The sum is now probed per store (`telemetry_has_cache_write`, a prepare that fetches nothing) and selected as `0` when absent.

## Evidence

Targeted commands only (CI is the workspace evidence):

- `cargo test -p stella-observatory` — **all green**: 120 lib tests + every integration suite (`schema_conformance` 15, `live_stream` 4, `page_clipper` 4, `rules_ledger` 4, `journal_era` 2, …).
- **Witness fail→pass**, run by checking `crates/stella-observatory/src/{db.rs,sessions.rs}` out from `origin/main` against the new tests (work committed first), then restoring:
  - `tests::execution_routes::a_cancelled_runs_reflection_reads_partial_run_not_null` — **fails on main** (`left: Null, right: Object {"partial_run": Bool(true)}`), passes with the fix.
  - `tests::a_store_without_cache_write_tokens_still_lists_its_turns` — **fails on main** (turn list empty: `left: 0, right: 1`), passes with the fix.
  - The model-card tests (`model_card_serves_the_newest_version_of_a_seeded_card`, `model_card_degrades_a_catalog_older_than_its_columns`) are compile-level witnesses: main's signature resolves the path from process env inside the function, so the threaded-path tests cannot exist against it — which is the untestability #4567 names.
- `cargo clippy -p stella-observatory --all-targets -- -D warnings` — exit 0.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-observatory --no-deps` and the same with `--document-private-items` — both exit 0.
- `cargo fmt --all` + `make guards-fast` — exit 0.
- #4566's client half has **no witness**: it is browser-side JS in an embedded asset with no DOM harness in this repo, and a text-match over `index.html` would be a changelog, not a test. Verified by reading the renderer's fold markup (`stella-transcript/src/html.rs` emits `<details id="<NodeId>">` for every identified fold) against the new capture/reapply pairing; the manual check is the issue's own: open a live run's turn page in `stella observe`, toggle an old step, watch it survive ticks.

## Not done

- #4566's fix shape (a) — the fragment-diff protocol (`/api/transcript-html?after_seq=N`) that would make server work per tick O(new events). It needs `render_run` to grow a per-turn streaming API in `stella-transcript` following `grid::render_turn_lines`' shape, plus the transcript-surfaces guard — a cross-crate design change beyond this batch. The issue stays open for it (`Refs #4566`).

Closes #4538
Closes #4567
Refs #4566

## Summary by Sourcery

Improve observatory resilience and live-run usability across legacy stores, partial executions, and model-card lookups.

Bug Fixes:
- Expose partial-run status for cancelled execution reflections, including runs without self-review, while preserving compatibility with older stores.
- Preserve manually toggled transcript fold states across live transcript refreshes.
- Keep session turn listings available for stores that predate cache-write telemetry fields.

Enhancements:
- Make model-card catalog resolution independently testable and cover current, missing, and outdated catalog states.

Tests:
- Add coverage for partial-run reflections, legacy telemetry stores, and model-card resolution and degradation scenarios.