### PR TITLE
fix(stella-cli): pass test runs through BoundWrapper::report_lines

### DIFF
--- a/crates/stella-cli/src/wrapper_plugin/report.rs
+++ b/crates/stella-cli/src/wrapper_plugin/report.rs
@@ -119,6 +119,7 @@ impl super::BoundWrapper {
             &self.gates,
             &self.child_spends(),
             &self.fanout_spends(),
+            &self.test_runs(),
         )
     }
 }


### PR DESCRIPTION
## What

Heals the red `main` the canary filed as #4591: #4577 added `BoundWrapper::report_lines` with a six-argument call to the free `report_lines`, and #4582 widened that function with a seventh parameter (`test_runs: &[TestRunRecord]`). Each PR was green alone; the merged tree fails workspace compile with E0061 at `crates/stella-cli/src/wrapper_plugin/report.rs:115`.

One line: pass `&self.test_runs()` — the same argument the sibling `BoundWrapper::report` already passes (`wrapper_plugin.rs:579`), so the held lines and the printed ones keep sharing one wording, test-run lines included.

## Evidence

- `cargo check -p stella-cli` on this branch — clean, exit 0 (the base fails it with the E0061 above).
- `cargo check -p stella-cli --all-targets` on PR #4586's merge of this same line — clean, exit 0.
- No witness test: this is a composition break between two already-tested PRs, not a behavior change — the compile itself is the fail→pass flip.

Closes #4591

## Summary by Sourcery

Bug Fixes:
- Fix the Stella CLI build by passing test-run records through bound report generation.